### PR TITLE
Copy .codeclimate.yml from the manageiq repo

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,67 @@
+---
+exclude_paths:
+- ".git/"
+- "**.gif"
+- "**.html"
+- "**.json"
+- "**.png"
+- "**.svg"
+- "**.xml"
+- "**.yaml"
+- "**.yml"
+- "app/assets/javascripts/dhtmlx*/"
+- "config/dictionary_strings.rb"
+- "config/model_attributes.rb"
+- "config/yaml_strings.rb"
+- "db/schema.rb"
+- "db/schema.yml"
+- "db/fixtures/**/*.yml"
+- "db/migrate/20130923182042_collapsed_initial_migration.rb"
+- "locale/"
+- "public/javascripts/timeline/"
+- "spec/"
+- "test/"
+- "tmp/"
+- "vendor/assets/"
+engines:
+  brakeman:
+    # very slow :sad_panda:
+    enabled: false
+  bundler-audit:
+    # requires Gemfile.lock
+    enabled: false
+  csslint:
+    enabled: false
+  duplication:
+    enabled: true
+    config:
+      concurrency: 1
+      languages:
+      - ruby
+      - javascript
+  eslint:
+    enabled: true
+    channel: "eslint-3"
+  fixme:
+    # let's enable later
+    enabled: false
+  markdownlint:
+    # let's enable later
+    enabled: false
+  rubocop:
+    enabled: true
+    config: '.rubocop_cc.yml'
+ratings:
+  paths:
+  - Gemfile.lock
+  - "**.erb"
+  - "**.haml"
+  - "**.rake"
+  - "**.rb"
+  - "**.rhtml"
+  - "**.slim"
+  - "**.css"
+  - "**.inc"
+  - "**.js"
+  - "**.jsx"
+  - "**.module"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg/
 spec/manageiq
 spec/reports/
 tmp/
+.rubocop-*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,47 @@
+inherit_from:
+- .rubocop_base.yml
+#
+# Overrides
+#
+GlobalVars:
+  AllowedVariables:
+  # Loggers
+  - $audit_log
+  - $api_log
+  - $aws_log
+  - $azure_log
+  - $fog_log
+  - $lenovo_log
+  - $log
+  - $miq_ae_logger
+  - $policy_log
+  - $rails_log
+  - $rhevm_log
+  - $kube_log
+  - $mw_log
+  - $scvmm_log
+  - $vim_log
+  - $websocket_log
+  # In Automate methods
+  - $evm
+#
+# Special Exclusions
+#
+AllCops:
+  TargetRubyVersion: 2.2
+  Exclude:
+    - lib/generators/provider/templates/**/*
+    - db/schema.rb
+    - vendor/**/*
+ClassAndModuleCamelCase:
+  Exclude:
+    - lib/miq_automation_engine/service_models/*.rb
+FileName:
+  Exclude:
+    - lib/miq_automation_engine/service_models/*.rb
+Metrics/LineLength:
+  Exclude:
+    - Gemfile
+Style/ExtraSpacing:
+  Exclude:
+    - Gemfile

--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -1,0 +1,97 @@
+Rails:
+  Enabled: true
+
+Lint/DefEndAlignment:
+  AutoCorrect: true
+Lint/EndAlignment:
+  AutoCorrect: true
+Metrics/AbcSize:
+  Max: 20
+  Severity: refactor
+Metrics/BlockNesting:
+  Severity: refactor
+Metrics/ClassLength:
+  Severity: refactor
+Metrics/CyclomaticComplexity:
+  Severity: refactor
+Metrics/LineLength:
+  Max: 120
+  Severity: refactor
+Metrics/MethodLength:
+  Max: 25
+  Severity: refactor
+Metrics/ParameterLists:
+  Severity: refactor
+Metrics/PerceivedComplexity:
+  Severity: refactor
+Performance/Casecmp:
+  Enabled: false
+Rails/FindEach:
+  Enabled: false
+Rails/ReadWriteAttribute:
+  AutoCorrect: false
+Style/AlignHash:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/ClassCheck:
+  EnforcedStyle: kind_of?
+Style/CollectionMethods:
+  PreferredMethods:
+    find: detect
+    find_all: select
+    map: collect
+    reduce: inject
+Style/Documentation:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/ExtraSpacing:
+  AutoCorrect: true
+Style/FormatString:
+  EnforcedStyle: percent
+Style/GuardClause:
+  Enabled: false
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+Style/IfUnlessModifier:
+  Enabled: false
+Style/NumericLiterals:
+  AutoCorrect: false
+Style/PerlBackrefs:
+  Enabled: false
+Style/ParallelAssignment:
+  Enabled: false
+Style/RedundantReturn:
+  AllowMultipleReturnValues: true
+Style/RescueModifier:
+  AutoCorrect: false
+Style/SignalException:
+  EnforcedStyle: only_raise
+Style/SingleLineBlockParams:
+  Enabled: false
+Style/SingleLineMethods:
+  AllowIfMethodIsEmpty: false
+Style/SpaceBeforeFirstArg:
+  Enabled: false
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: false
+Style/SpecialGlobalVars:
+  AutoCorrect: false
+Style/StringLiterals:
+  Enabled: false
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+Style/TrailingCommaInArguments:
+  Enabled: false
+Style/TrailingCommaInLiteral:
+  Enabled: false
+Style/TrivialAccessors:
+  AllowPredicates: true
+Style/WhileUntilModifier:
+  Enabled: false
+Style/WordArray:
+  AutoCorrect: false

--- a/.rubocop_cc.yml
+++ b/.rubocop_cc.yml
@@ -1,0 +1,600 @@
+inherit_from:
+- .rubocop_base.yml
+AllCops:
+  TargetRubyVersion: 2.2
+
+Lint/AmbiguousOperator:
+  Enabled: true
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+Lint/AssignmentInCondition:
+  Enabled: true
+Lint/BlockAlignment:
+  Enabled: true
+Lint/CircularArgumentReference:
+  Enabled: true
+Lint/ConditionPosition:
+  Enabled: true
+Lint/Debugger:
+  Enabled: true
+Lint/DefEndAlignment:
+  Enabled: true
+Lint/DeprecatedClassMethods:
+  Enabled: true
+Lint/DuplicateMethods:
+  Enabled: true
+Lint/DuplicatedKey:
+  Enabled: true
+Lint/EachWithObjectArgument:
+  Enabled: true
+Lint/ElseLayout:
+  Enabled: true
+Lint/EmptyEnsure:
+  Enabled: true
+Lint/EmptyInterpolation:
+  Enabled: true
+Lint/EndAlignment:
+  Enabled: true
+Lint/EndInMethod:
+  Enabled: true
+Lint/EnsureReturn:
+  Enabled: true
+Lint/Eval:
+  Enabled: true
+Lint/FloatOutOfRange:
+  Enabled: true
+Lint/FormatParameterMismatch:
+  Enabled: true
+Lint/HandleExceptions:
+  Enabled: true
+Lint/ImplicitStringConcatenation:
+  Enabled: true
+Lint/IneffectiveAccessModifier:
+  Enabled: true
+Lint/InheritException:
+  Enabled: true
+Lint/InvalidCharacterLiteral:
+  Enabled: true
+Lint/LiteralInCondition:
+  Enabled: true
+Lint/LiteralInInterpolation:
+  Enabled: true
+Lint/Loop:
+  Enabled: true
+Lint/NestedMethodDefinition:
+  Enabled: true
+Lint/NextWithoutAccumulator:
+  Enabled: true
+Lint/NonLocalExitFromIterator:
+  Enabled: true
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+Lint/PercentStringArray:
+  Enabled: true
+Lint/PercentSymbolArray:
+  Enabled: true
+Lint/RandOne:
+  Enabled: true
+Lint/RequireParentheses:
+  Enabled: true
+Lint/RescueException:
+  Enabled: true
+Lint/ShadowedException:
+  Enabled: true
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+Lint/StringConversionInInterpolation:
+  Enabled: true
+Lint/UnderscorePrefixedVariableName:
+  Enabled: true
+Lint/UnneededDisable:
+  Enabled: true
+Lint/UnreachableCode:
+  Enabled: true
+Lint/UnusedBlockArgument:
+  Enabled: true
+Lint/UnusedMethodArgument:
+  Enabled: true
+Lint/UselessAccessModifier:
+  Enabled: true
+Lint/UselessArraySplat:
+  Enabled: true
+Lint/UselessAssignment:
+  Enabled: true
+Lint/UselessComparison:
+  Enabled: true
+Lint/UselessElseWithoutRescue:
+  Enabled: true
+Lint/UselessSetterCall:
+  Enabled: true
+Lint/Void:
+  Enabled: true
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockNesting:
+  Enabled: true
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: true
+  Max: 11
+Metrics/LineLength:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: true
+Metrics/PerceivedComplexity:
+  Enabled: false
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/Count:
+  Enabled: true
+Performance/Detect:
+  Enabled: true
+Performance/DoubleStartEndWith:
+  Enabled: true
+Performance/EndWith:
+  Enabled: true
+Performance/FixedSize:
+  Enabled: true
+Performance/FlatMap:
+  Enabled: true
+Performance/HashEachMethods:
+  Enabled: true
+Performance/LstripRstrip:
+  Enabled: true
+Performance/PushSplat:
+  Enabled: true
+Performance/RangeInclude:
+  Enabled: true
+Performance/RedundantBlockCall:
+  Enabled: true
+Performance/RedundantMatch:
+  Enabled: true
+Performance/RedundantMerge:
+  Enabled: true
+Performance/RedundantSortBy:
+  Enabled: true
+Performance/ReverseEach:
+  Enabled: true
+Performance/Sample:
+  Enabled: true
+Performance/Size:
+  Enabled: true
+Performance/StartWith:
+  Enabled: true
+Performance/StringReplacement:
+  Enabled: true
+Performance/TimesMap:
+  Enabled: true
+Rails/ActionFilter:
+  Enabled: false
+Rails/Date:
+  Enabled: false
+Rails/Delegate:
+  Enabled: false
+Rails/Exit:
+  Enabled: false
+Rails/FindBy:
+  Enabled: false
+Rails/FindEach:
+  Enabled: false
+Rails/HasAndBelongsToMany:
+  Enabled: false
+Rails/Output:
+  Enabled: false
+Rails/OutputSafety:
+  Enabled: false
+Rails/PluralizationGrammar:
+  Enabled: false
+Rails/ReadWriteAttribute:
+  Enabled: false
+Rails/RequestReferer:
+  Enabled: false
+Rails/SaveBang:
+  Enabled: false
+Rails/ScopeArgs:
+  Enabled: false
+Rails/TimeZone:
+  Enabled: false
+Rails/UniqBeforePluck:
+  Enabled: false
+Rails/Validation:
+  Enabled: false
+Style/AccessModifierIndentation:
+  Enabled: false
+Style/AccessorMethodName:
+  Enabled: false
+Style/Alias:
+  Enabled: false
+Style/AlignArray:
+  Enabled: false
+Style/AlignHash:
+  Enabled: false
+Style/AlignParameters:
+  Enabled: false
+Style/AndOr:
+  Enabled: false
+Style/ArrayJoin:
+  Enabled: false
+Style/AsciiComments:
+  Enabled: false
+Style/AsciiIdentifiers:
+  Enabled: false
+Style/Attr:
+  Enabled: false
+Style/AutoResourceCleanup:
+  Enabled: false
+Style/BarePercentLiterals:
+  Enabled: false
+Style/BeginBlock:
+  Enabled: false
+Style/BlockComments:
+  Enabled: false
+Style/BlockDelimiters:
+  Enabled: false
+Style/BlockEndNewline:
+  Enabled: false
+Style/BracesAroundHashParameters:
+  Enabled: false
+Style/CaseEquality:
+  Enabled: false
+Style/CaseIndentation:
+  Enabled: false
+Style/CharacterLiteral:
+  Enabled: false
+Style/ClassAndModuleCamelCase:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/ClassCheck:
+  Enabled: false
+Style/ClassMethods:
+  Enabled: false
+Style/ClassVars:
+  Enabled: false
+Style/ClosingParenthesisIndentation:
+  Enabled: false
+Style/CollectionMethods:
+  Enabled: false
+Style/ColonMethodCall:
+  Enabled: false
+Style/CommandLiteral:
+  Enabled: false
+Style/CommentAnnotation:
+  Enabled: false
+Style/CommentIndentation:
+  Enabled: false
+Style/ConditionalAssignment:
+  Enabled: false
+Style/ConstantName:
+  Enabled: false
+Style/Copyright:
+  Enabled: false
+Style/DefWithParentheses:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/DotPosition:
+  Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/EachForSimpleLoop:
+  Enabled: false
+Style/EachWithObject:
+  Enabled: false
+Style/ElseAlignment:
+  Enabled: false
+Style/EmptyCaseCondition:
+  Enabled: false
+Style/EmptyElse:
+  Enabled: false
+Style/EmptyLineBetweenDefs:
+  Enabled: false
+Style/EmptyLines:
+  Enabled: false
+Style/EmptyLinesAroundAccessModifier:
+  Enabled: false
+Style/EmptyLinesAroundBlockBody:
+  Enabled: false
+Style/EmptyLinesAroundClassBody:
+  Enabled: false
+Style/EmptyLinesAroundMethodBody:
+  Enabled: false
+Style/EmptyLinesAroundModuleBody:
+  Enabled: false
+Style/EmptyLiteral:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/EndBlock:
+  Enabled: false
+Style/EndOfLine:
+  Enabled: false
+Style/EvenOdd:
+  Enabled: false
+Style/ExtraSpacing:
+  Enabled: false
+Style/FileName:
+  Enabled: false
+Style/FirstArrayElementLineBreak:
+  Enabled: false
+Style/FirstHashElementLineBreak:
+  Enabled: false
+Style/FirstMethodArgumentLineBreak:
+  Enabled: false
+Style/FirstMethodParameterLineBreak:
+  Enabled: false
+Style/FirstParameterIndentation:
+  Enabled: false
+Style/FlipFlop:
+  Enabled: false
+Style/For:
+  Enabled: false
+Style/FormatString:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalVars:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/HashSyntax:
+  Enabled: false
+Style/IdenticalConditionalBranches:
+  Enabled: false
+Style/IfInsideElse:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: false
+Style/IfWithSemicolon:
+  Enabled: false
+Style/ImplicitRuntimeError:
+  Enabled: false
+Style/IndentArray:
+  Enabled: false
+Style/IndentAssignment:
+  Enabled: false
+Style/IndentHash:
+  Enabled: false
+Style/IndentationConsistency:
+  Enabled: false
+Style/IndentationWidth:
+  Enabled: false
+Style/InfiniteLoop:
+  Enabled: false
+Style/InitialIndentation:
+  Enabled: false
+Style/InlineComment:
+  Enabled: false
+Style/Lambda:
+  Enabled: false
+Style/LambdaCall:
+  Enabled: false
+Style/LeadingCommentSpace:
+  Enabled: false
+Style/LineEndConcatenation:
+  Enabled: false
+Style/MethodCallParentheses:
+  Enabled: false
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+Style/MethodDefParentheses:
+  Enabled: false
+Style/MethodMissing:
+  Enabled: false
+Style/MethodName:
+  Enabled: false
+Style/MissingElse:
+  Enabled: false
+Style/ModuleFunction:
+  Enabled: false
+Style/MultilineArrayBraceLayout:
+  Enabled: false
+Style/MultilineAssignmentLayout:
+  Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false
+Style/MultilineBlockLayout:
+  Enabled: false
+Style/MultilineHashBraceLayout:
+  Enabled: false
+Style/MultilineIfThen:
+  Enabled: false
+Style/MultilineMethodCallBraceLayout:
+  Enabled: false
+Style/MultilineMethodCallIndentation:
+  Enabled: false
+Style/MultilineMethodDefinitionBraceLayout:
+  Enabled: false
+Style/MultilineOperationIndentation:
+  Enabled: false
+Style/MultilineTernaryOperator:
+  Enabled: false
+Style/MutableConstant:
+  Enabled: false
+Style/NegatedIf:
+  Enabled: false
+Style/NegatedWhile:
+  Enabled: false
+Style/NestedModifier:
+  Enabled: false
+Style/NestedParenthesizedCalls:
+  Enabled: false
+Style/NestedTernaryOperator:
+  Enabled: false
+Style/Next:
+  Enabled: false
+Style/NilComparison:
+  Enabled: false
+Style/NonNilCheck:
+  Enabled: false
+Style/Not:
+  Enabled: false
+Style/NumericLiteralPrefix:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/OneLineConditional:
+  Enabled: false
+Style/OpMethod:
+  Enabled: false
+Style/OptionHash:
+  Enabled: false
+Style/OptionalArguments:
+  Enabled: false
+Style/ParallelAssignment:
+  Enabled: false
+Style/ParenthesesAroundCondition:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Style/PercentQLiterals:
+  Enabled: false
+Style/PerlBackrefs:
+  Enabled: false
+Style/PredicateName:
+  Enabled: false
+Style/PreferredHashMethods:
+  Enabled: false
+Style/Proc:
+  Enabled: false
+Style/RaiseArgs:
+  Enabled: false
+Style/RedundantBegin:
+  Enabled: false
+Style/RedundantException:
+  Enabled: false
+Style/RedundantFreeze:
+  Enabled: false
+Style/RedundantParentheses:
+  Enabled: false
+Style/RedundantReturn:
+  Enabled: false
+Style/RedundantSelf:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
+Style/RescueEnsureAlignment:
+  Enabled: false
+Style/RescueModifier:
+  Enabled: false
+Style/SelfAssignment:
+  Enabled: false
+Style/Semicolon:
+  Enabled: false
+Style/Send:
+  Enabled: false
+Style/SignalException:
+  Enabled: false
+Style/SingleLineBlockParams:
+  Enabled: false
+Style/SingleLineMethods:
+  Enabled: false
+Style/SpaceAfterColon:
+  Enabled: false
+Style/SpaceAfterComma:
+  Enabled: false
+Style/SpaceAfterMethodName:
+  Enabled: false
+Style/SpaceAfterNot:
+  Enabled: false
+Style/SpaceAfterSemicolon:
+  Enabled: false
+Style/SpaceAroundBlockParameters:
+  Enabled: false
+Style/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+Style/SpaceAroundKeyword:
+  Enabled: false
+Style/SpaceAroundOperators:
+  Enabled: false
+Style/SpaceBeforeBlockBraces:
+  Enabled: false
+Style/SpaceBeforeComma:
+  Enabled: false
+Style/SpaceBeforeComment:
+  Enabled: false
+Style/SpaceBeforeFirstArg:
+  Enabled: false
+Style/SpaceBeforeSemicolon:
+  Enabled: false
+Style/SpaceInsideArrayPercentLiteral:
+  Enabled: false
+Style/SpaceInsideBlockBraces:
+  Enabled: false
+Style/SpaceInsideBrackets:
+  Enabled: false
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: false
+Style/SpaceInsideParens:
+  Enabled: false
+Style/SpaceInsidePercentLiteralDelimiters:
+  Enabled: false
+Style/SpaceInsideRangeLiteral:
+  Enabled: false
+Style/SpaceInsideStringInterpolation:
+  Enabled: false
+Style/SpecialGlobalVars:
+  Enabled: false
+Style/StabbyLambdaParentheses:
+  Enabled: false
+Style/StringLiterals:
+  Enabled: false
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+Style/StringMethods:
+  Enabled: false
+Style/StructInheritance:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/SymbolLiteral:
+  Enabled: false
+Style/SymbolProc:
+  Enabled: false
+Style/Tab:
+  Enabled: false
+Style/TernaryParentheses:
+  Enabled: false
+Style/TrailingBlankLines:
+  Enabled: false
+Style/TrailingCommaInArguments:
+  Enabled: false
+Style/TrailingCommaInLiteral:
+  Enabled: false
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+Style/TrailingWhitespace:
+  Enabled: false
+Style/TrivialAccessors:
+  Enabled: false
+Style/UnlessElse:
+  Enabled: false
+Style/UnneededCapitalW:
+  Enabled: false
+Style/UnneededInterpolation:
+  Enabled: false
+Style/UnneededPercentQ:
+  Enabled: false
+Style/VariableInterpolation:
+  Enabled: false
+Style/VariableName:
+  Enabled: false
+Style/WhenThen:
+  Enabled: false
+Style/WhileUntilDo:
+  Enabled: false
+Style/WhileUntilModifier:
+  Enabled: false
+Style/WordArray:
+  Enabled: false
+Style/ZeroLengthPredicate:
+  Enabled: false


### PR DESCRIPTION
..needed to make codeclimate use the same engines, and prevent a failure with..

```
ESLint is running with the espree parser.
/usr/src/app/node_modules/eslint/lib/config/config-validator.js:102
        throw new Error(message.join(""));
        ^

Error: /code/app/assets/javascripts/controllers/.eslintrc.json:
	Configuration for rule "angular/watchers-execution" is invalid:
	Severity should be one of the following: 0 = off, 1 = warning, 2 = error (you passed "warn").
```