### PR TITLE
Fix issue with travis setup script

### DIFF
--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -7,6 +7,10 @@ source tools/ci/setup_vmdb_configs.sh
 source tools/ci/setup_js_env.sh
 cd -
 
-source spec/manageiq/tools/ci/setup_ruby_env.sh
+# HACK: Temporary workaround until we can get the cross-repo scripts working properly
+# source spec/manageiq/tools/ci/setup_ruby_env.sh
+spec/manageiq/tools/ci/setup_ruby_environment.rb
+export BUNDLE_WITHOUT=development
+export BUNDLE_GEMFILE=${PWD}/Gemfile
 
 set +v


### PR DESCRIPTION
The setup_ruby_env.sh script in the manageiq repo uses incorrect
relative pathing.  For now, just make sure we cd into the directory
before sourcing it in.