### PR TITLE
Support for fonticons using the icon attribute in TreeNode subclasses

### DIFF
--- a/app/presenters/tree_node/hash.rb
+++ b/app/presenters/tree_node/hash.rb
@@ -4,6 +4,8 @@ module TreeNode
 
     set_attribute(:image) { @object[:image] }
 
+    set_attribute(:icon) { @object[:icon] }
+
     set_attribute(:no_click) { @object.key?(:cfmeNoClick) && @object[:cfmeNoClick] ? true : nil }
 
     set_attribute(:hide_checkbox) { @object.key?(:hideCheckbox) && @object[:hideCheckbox] ? true : nil }

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -67,6 +67,10 @@ module TreeNode
       nil
     end
 
+    def icon
+      nil
+    end
+
     def klass
       nil
     end
@@ -112,6 +116,7 @@ module TreeNode
       node = {
         :key          => key,
         :title        => text ? text : title,
+        :icon         => icon,
         :expand       => expand,
         :hideCheckbox => hide_checkbox ? hide_checkbox : nil,
         :addClass     => klass,


### PR DESCRIPTION
This will allow to use both icons and images in our trees managed by `TreeBuilder`. The images have a higher priority, therefore, specifying both attributes will always display images.

https://www.pivotaltracker.com/n/projects/1613907/stories/129371557

To convert existing images to icons in `TreeNode::` subclasses, you will have to search for `set_attribute(:image)` calls and replace them analogously with `set_attribute(:icon)`. When the `set_attributes` call is used (mostly because of multiple attributes are evaluated based on a single condition) both the `:image` argument and returned `image` variable with its value has to be replaced.

For hash nodes it's much simpler: just replace the `:image` key with an `:icon`.