### PR TITLE
Remove setup task for Javascript suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ load 'jasmine/tasks/jasmine.rake'
 namespace :spec do
   namespace :javascript do
     desc "Setup environment for javascript specs"
-    task :setup => "app:test:setup_db"
+    task :setup
   end
 
   desc "Run all javascript specs"


### PR DESCRIPTION
The `spec:javascript:setup` task does not seem to be necessary, and should do nothing.