### PR TITLE
Refactor - Replace .success calls with .then/.catch

### DIFF
--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope', 'keyPairFormId', 'miqService', function($http, $scope, keyPairFormId, miqService) {
+ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope', 'keyPairFormId', 'miqService', '$log', '$q', function($http, $scope, keyPairFormId, miqService, $log, $q) {
     var init = function() {
         $scope.keyPairModel = {
             name: '',
@@ -13,14 +13,9 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
         ManageIQ.angular.scope = $scope;
 
         miqService.sparkleOn();
-        $http.get('/auth_key_pair_cloud/ems_form_choices').success(function(data) {
-            $scope.ems_choices = data.ems_choices;
-            if($scope.ems_choices.length > 0) {
-                $scope.keyPairModel.ems = $scope.ems_choices[0];
-            }
-            $scope.afterGet = true;
-            miqService.sparkleOff();
-        });
+        $http.get('/auth_key_pair_cloud/ems_form_choices')
+          .then(getAuthKeyPairCloudFormDataComplete)
+          .catch(getAuthKeyPairCloudFormDataFailed);
 
         if (keyPairFormId == 'new') {
             $scope.newRecord = true;
@@ -61,6 +56,25 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
     $scope.addClicked = function() {
         $scope.saveClicked();
     };
+
+    function getAuthKeyPairCloudFormDataComplete(response) {
+      var data = response.data;
+
+      $scope.ems_choices = data.ems_choices;
+      if($scope.ems_choices.length > 0) {
+        $scope.keyPairModel.ems = $scope.ems_choices[0];
+      }
+      $scope.afterGet = true;
+      miqService.sparkleOff();
+    }
+
+    function getAuthKeyPairCloudFormDataFailed(e) {
+      miqService.sparkleOff();
+      if (e.message) {
+        $log.log(e.message);
+      }
+      return $q.reject(e);
+    }
 
     init();
 }]);

--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope', 'keyPairFormId', 'miqService', '$log', '$q', function($http, $scope, keyPairFormId, miqService, $log, $q) {
+ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope', 'keyPairFormId', 'miqService', function($http, $scope, keyPairFormId, miqService) {
     var init = function() {
         $scope.keyPairModel = {
             name: '',
@@ -15,7 +15,7 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
         miqService.sparkleOn();
         $http.get('/auth_key_pair_cloud/ems_form_choices')
           .then(getAuthKeyPairCloudFormDataComplete)
-          .catch(getAuthKeyPairCloudFormDataFailed);
+          .catch(miqService.handleFailure);
 
         if (keyPairFormId == 'new') {
             $scope.newRecord = true;
@@ -66,14 +66,6 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
       }
       $scope.afterGet = true;
       miqService.sparkleOff();
-    }
-
-    function getAuthKeyPairCloudFormDataFailed(e) {
-      miqService.sparkleOff();
-      if (e.message) {
-        $log.log(e.message);
-      }
-      return $q.reject(e);
     }
 
     init();

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '$attrs', 'emsCommonFormId', 'miqService', '$q', function($http, $scope, $attrs, emsCommonFormId, miqService, $q) {
+ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '$attrs', 'emsCommonFormId', 'miqService', '$q', '$log', function($http, $scope, $attrs, emsCommonFormId, miqService, $q, $log) {
   var init = function() {
     $scope.emsCommonModel = {
       name: '',
@@ -195,7 +195,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     function getEmsFormDataFailed(e) {
       miqService.sparkleOff();
       if (e.message) {
-        console.log(e.message);
+        $log.log(e.message);
       }
       return $q.reject(e);
     }

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -71,7 +71,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.newRecord                  = true;
 
       miqService.sparkleOn();
-      $http.get($scope.formFieldsUrl + emsCommonFormId).success(function(data) {
+      $http.get($scope.formFieldsUrl + emsCommonFormId).then(function(response) {
+        var data = response.data;
+
         $scope.emsCommonModel.zone                            = data.zone;
         $scope.emsCommonModel.tenant_mapping_enabled          = data.tenant_mapping_enabled;
         $scope.emsCommonModel.emstype_vm                      = data.emstype_vm;
@@ -97,7 +99,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.newRecord = false;
       miqService.sparkleOn();
 
-      $http.get($scope.formFieldsUrl + emsCommonFormId).success(function(data) {
+      $http.get($scope.formFieldsUrl + emsCommonFormId).then(function(response) {
+        var data = response.data;
+
         $scope.emsCommonModel.name                            = data.name;
         $scope.emsCommonModel.emstype                         = data.emstype;
         $scope.emsCommonModel.zone                            = data.zone;

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '$attrs', 'emsCommonFormId', 'miqService', '$q', '$log', function($http, $scope, $attrs, emsCommonFormId, miqService, $q, $log) {
+ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '$attrs', 'emsCommonFormId', 'miqService', function($http, $scope, $attrs, emsCommonFormId, miqService) {
   var init = function() {
     $scope.emsCommonModel = {
       name: '',
@@ -73,14 +73,14 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       miqService.sparkleOn();
       $http.get($scope.formFieldsUrl + emsCommonFormId)
         .then(getNewEmsFormDataComplete)
-        .catch(getEmsFormDataFailed);
+        .catch(miqService.handleFailure);
     } else {
       $scope.newRecord = false;
       miqService.sparkleOn();
 
       $http.get($scope.formFieldsUrl + emsCommonFormId)
         .then(getEmsFormIdDataComplete)
-        .catch(getEmsFormDataFailed);
+        .catch(miqService.handleFailure);
     }
     $scope.actionUrl = $scope.newRecord ? $scope.createUrl : $scope.updateUrl;
     $scope.currentTab = "default";
@@ -190,14 +190,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
       $scope.afterGet  = true;
       $scope.modelCopy = angular.copy( $scope.emsCommonModel );
-    }
-
-    function getEmsFormDataFailed(e) {
-      miqService.sparkleOff();
-      if (e.message) {
-        $log.log(e.message);
-      }
-      return $q.reject(e);
     }
   };
 

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '$attrs', 'emsCommonFormId', 'miqService', function($http, $scope, $attrs, emsCommonFormId, miqService) {
+ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '$attrs', 'emsCommonFormId', 'miqService', '$q', function($http, $scope, $attrs, emsCommonFormId, miqService, $q) {
   var init = function() {
     $scope.emsCommonModel = {
       name: '',
@@ -71,7 +71,11 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.newRecord                  = true;
 
       miqService.sparkleOn();
-      $http.get($scope.formFieldsUrl + emsCommonFormId).then(function(response) {
+      $http.get($scope.formFieldsUrl + emsCommonFormId)
+        .then(getNewEmsFormDataComplete)
+        .catch(getEmsFormDataFailed);
+
+      function getNewEmsFormDataComplete(response, status, headers, config) {
         var data = response.data;
 
         $scope.emsCommonModel.zone                            = data.zone;
@@ -92,14 +96,19 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         $scope.emsCommonModel.hawkular_auth_status            = true;
         $scope.emsCommonModel.vmware_cloud_api_version        = '9.0';
         miqService.sparkleOff();
-      });
-      $scope.afterGet  = true;
-      $scope.modelCopy = angular.copy( $scope.emsCommonModel );
+
+        $scope.afterGet  = true;
+        $scope.modelCopy = angular.copy( $scope.emsCommonModel );
+      }
     } else {
       $scope.newRecord = false;
       miqService.sparkleOn();
 
-      $http.get($scope.formFieldsUrl + emsCommonFormId).then(function(response) {
+      $http.get($scope.formFieldsUrl + emsCommonFormId)
+        .then(getEmsFormIdDataComplete)
+        .catch(getEmsFormDataFailed);
+
+      function getEmsFormIdDataComplete(response, status, headers, config) {
         var data = response.data;
 
         $scope.emsCommonModel.name                            = data.name;
@@ -178,10 +187,16 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         $scope.populatePostValidationModel();
 
         miqService.sparkleOff();
-      });
+      }
     }
     $scope.actionUrl = $scope.newRecord ? $scope.createUrl : $scope.updateUrl;
     $scope.currentTab = "default";
+
+    function getEmsFormDataFailed(e) {
+      miqService.sparkleOff();
+      console.log(e.message);
+      return $q.reject(e);
+    }
   };
 
   $scope.changeAuthTab = function(id) {

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -103,16 +103,16 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
       $scope.emsCommonModel.provider_id                     = angular.isDefined(data.provider_id) ? data.provider_id.toString() : "";
 
-      $scope.emsCommonModel.default_api_port                = angular.isDefined(data.default_api_port) && data.default_api_port != '' ? data.default_api_port.toString() : $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
-      $scope.emsCommonModel.amqp_api_port                   = angular.isDefined(data.amqp_api_port) && data.amqp_api_port != '' ? data.amqp_api_port.toString() : '5672';
-      $scope.emsCommonModel.hawkular_api_port               = angular.isDefined(data.hawkular_api_port) && data.hawkular_api_port != '' ? data.hawkular_api_port.toString() : '443';
-      $scope.emsCommonModel.metrics_api_port                = angular.isDefined(data.metrics_api_port) && data.metrics_api_port != '' ? data.metrics_api_port.toString() : '';
-      $scope.emsCommonModel.metrics_database_name           = angular.isDefined(data.metrics_database_name) && data.metrics_database_name != '' ? data.metrics_database_name : data.metrics_default_database_name;
+      $scope.emsCommonModel.default_api_port                = angular.isDefined(data.default_api_port) && data.default_api_port !== '' ? data.default_api_port.toString() : $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
+      $scope.emsCommonModel.amqp_api_port                   = angular.isDefined(data.amqp_api_port) && data.amqp_api_port !== '' ? data.amqp_api_port.toString() : '5672';
+      $scope.emsCommonModel.hawkular_api_port               = angular.isDefined(data.hawkular_api_port) && data.hawkular_api_port !== '' ? data.hawkular_api_port.toString() : '443';
+      $scope.emsCommonModel.metrics_api_port                = angular.isDefined(data.metrics_api_port) && data.metrics_api_port !== '' ? data.metrics_api_port.toString() : '';
+      $scope.emsCommonModel.metrics_database_name           = angular.isDefined(data.metrics_database_name) && data.metrics_database_name !== '' ? data.metrics_database_name : data.metrics_default_database_name;
       $scope.emsCommonModel.api_version                     = data.api_version;
       $scope.emsCommonModel.default_security_protocol       = data.default_security_protocol;
       $scope.emsCommonModel.realm                           = data.realm;
       $scope.emsCommonModel.security_protocol               = data.security_protocol;
-      $scope.emsCommonModel.amqp_security_protocol          = data.amqp_security_protocol != '' ? data.amqp_security_protocol : 'non-ssl';
+      $scope.emsCommonModel.amqp_security_protocol          = data.amqp_security_protocol !== '' ? data.amqp_security_protocol : 'non-ssl';
       $scope.emsCommonModel.provider_region                 = data.provider_region;
       $scope.emsCommonModel.default_userid                  = data.default_userid;
       $scope.emsCommonModel.amqp_userid                     = data.amqp_userid;
@@ -141,16 +141,16 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.ssh_keypair_auth_status         = data.ssh_keypair_auth_status;
       $scope.emsCommonModel.hawkular_auth_status            = data.hawkular_auth_status;
 
-      if ($scope.emsCommonModel.default_userid != '') {
+      if ($scope.emsCommonModel.default_userid !== '') {
         $scope.emsCommonModel.default_password = $scope.emsCommonModel.default_verify = miqService.storedPasswordPlaceholder;
       }
-      if ($scope.emsCommonModel.amqp_userid != '') {
+      if ($scope.emsCommonModel.amqp_userid !== '') {
         $scope.emsCommonModel.amqp_password = $scope.emsCommonModel.amqp_verify = miqService.storedPasswordPlaceholder;
       }
-      if ($scope.emsCommonModel.metrics_userid != '') {
+      if ($scope.emsCommonModel.metrics_userid !== '') {
         $scope.emsCommonModel.metrics_password = $scope.emsCommonModel.metrics_verify = miqService.storedPasswordPlaceholder;
       }
-      if ($scope.emsCommonModel.ssh_keypair_userid != '') {
+      if ($scope.emsCommonModel.ssh_keypair_userid !== '') {
         $scope.emsCommonModel.ssh_keypair_password = miqService.storedPasswordPlaceholder;
       }
       if ($scope.emsCommonModel.bearer_token_exists) {
@@ -178,7 +178,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.hawkular_api_port               = '443';
       $scope.emsCommonModel.api_version                     = 'v2';
       $scope.emsCommonModel.ems_controller                  = data.ems_controller;
-      $scope.emsCommonModel.ems_controller == 'ems_container' ? $scope.emsCommonModel.default_api_port = '8443' : $scope.emsCommonModel.default_api_port = '';
+      $scope.emsCommonModel.ems_controller === 'ems_container' ? $scope.emsCommonModel.default_api_port = '8443' : $scope.emsCommonModel.default_api_port = '';
       $scope.emsCommonModel.default_auth_status             = data.default_auth_status;
       $scope.emsCommonModel.amqp_auth_status                = data.amqp_auth_status;
       $scope.emsCommonModel.service_account_auth_status     = data.service_account_auth_status;

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -85,7 +85,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     $scope.actionUrl = $scope.newRecord ? $scope.createUrl : $scope.updateUrl;
     $scope.currentTab = "default";
 
-    function getEmsFormIdDataComplete(response, status, headers, config) {
+    function getEmsFormIdDataComplete(response) {
       var data = response.data;
 
       $scope.emsCommonModel.name                            = data.name;
@@ -166,7 +166,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       miqService.sparkleOff();
     }
 
-    function getNewEmsFormDataComplete(response, status, headers, config) {
+    function getNewEmsFormDataComplete(response) {
       var data = response.data;
 
       $scope.emsCommonModel.zone                            = data.zone;
@@ -194,7 +194,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
     function getEmsFormDataFailed(e) {
       miqService.sparkleOff();
-      console.log(e.message);
+      if (e.message) {
+        console.log(e.message);
+      }
       return $q.reject(e);
     }
   };

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -74,32 +74,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $http.get($scope.formFieldsUrl + emsCommonFormId)
         .then(getNewEmsFormDataComplete)
         .catch(getEmsFormDataFailed);
-
-      function getNewEmsFormDataComplete(response, status, headers, config) {
-        var data = response.data;
-
-        $scope.emsCommonModel.zone                            = data.zone;
-        $scope.emsCommonModel.tenant_mapping_enabled          = data.tenant_mapping_enabled;
-        $scope.emsCommonModel.emstype_vm                      = data.emstype_vm;
-        $scope.emsCommonModel.openstack_infra_providers_exist = data.openstack_infra_providers_exist;
-        $scope.emsCommonModel.default_api_port                = '';
-        $scope.emsCommonModel.amqp_api_port                   = '5672';
-        $scope.emsCommonModel.hawkular_api_port               = '443';
-        $scope.emsCommonModel.api_version                     = 'v2';
-        $scope.emsCommonModel.ems_controller                  = data.ems_controller;
-        $scope.emsCommonModel.ems_controller == 'ems_container' ? $scope.emsCommonModel.default_api_port = '8443' : $scope.emsCommonModel.default_api_port = '';
-        $scope.emsCommonModel.default_auth_status             = data.default_auth_status;
-        $scope.emsCommonModel.amqp_auth_status                = data.amqp_auth_status;
-        $scope.emsCommonModel.service_account_auth_status     = data.service_account_auth_status;
-        $scope.emsCommonModel.metrics_auth_status             = true;
-        $scope.emsCommonModel.ssh_keypair_auth_status         = true;
-        $scope.emsCommonModel.hawkular_auth_status            = true;
-        $scope.emsCommonModel.vmware_cloud_api_version        = '9.0';
-        miqService.sparkleOff();
-
-        $scope.afterGet  = true;
-        $scope.modelCopy = angular.copy( $scope.emsCommonModel );
-      }
     } else {
       $scope.newRecord = false;
       miqService.sparkleOn();
@@ -107,90 +81,116 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $http.get($scope.formFieldsUrl + emsCommonFormId)
         .then(getEmsFormIdDataComplete)
         .catch(getEmsFormDataFailed);
-
-      function getEmsFormIdDataComplete(response, status, headers, config) {
-        var data = response.data;
-
-        $scope.emsCommonModel.name                            = data.name;
-        $scope.emsCommonModel.emstype                         = data.emstype;
-        $scope.emsCommonModel.zone                            = data.zone;
-        $scope.emsCommonModel.tenant_mapping_enabled          = data.tenant_mapping_enabled;
-        $scope.emsCommonModel.hostname                        = data.hostname;
-        $scope.emsCommonModel.default_hostname                = data.default_hostname;
-        $scope.emsCommonModel.amqp_hostname                   = data.amqp_hostname;
-        $scope.emsCommonModel.hawkular_hostname               = data.hawkular_hostname;
-        $scope.emsCommonModel.metrics_hostname                = data.metrics_hostname;
-        $scope.emsCommonModel.project                         = data.project;
-
-        $scope.emsCommonModel.openstack_infra_providers_exist = data.openstack_infra_providers_exist;
-
-        $scope.emsCommonModel.provider_id                     = angular.isDefined(data.provider_id) ? data.provider_id.toString() : "";
-
-        $scope.emsCommonModel.default_api_port                = angular.isDefined(data.default_api_port) && data.default_api_port != '' ? data.default_api_port.toString() : $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
-        $scope.emsCommonModel.amqp_api_port                   = angular.isDefined(data.amqp_api_port) && data.amqp_api_port != '' ? data.amqp_api_port.toString() : '5672';
-        $scope.emsCommonModel.hawkular_api_port               = angular.isDefined(data.hawkular_api_port) && data.hawkular_api_port != '' ? data.hawkular_api_port.toString() : '443';
-        $scope.emsCommonModel.metrics_api_port                = angular.isDefined(data.metrics_api_port) && data.metrics_api_port != '' ? data.metrics_api_port.toString() : '';
-        $scope.emsCommonModel.metrics_database_name           = angular.isDefined(data.metrics_database_name) && data.metrics_database_name != '' ? data.metrics_database_name : data.metrics_default_database_name;
-        $scope.emsCommonModel.api_version                     = data.api_version;
-        $scope.emsCommonModel.default_security_protocol       = data.default_security_protocol;
-        $scope.emsCommonModel.realm                           = data.realm;
-        $scope.emsCommonModel.security_protocol               = data.security_protocol;
-        $scope.emsCommonModel.amqp_security_protocol          = data.amqp_security_protocol != '' ? data.amqp_security_protocol : 'non-ssl';
-        $scope.emsCommonModel.provider_region                 = data.provider_region;
-        $scope.emsCommonModel.default_userid                  = data.default_userid;
-        $scope.emsCommonModel.amqp_userid                     = data.amqp_userid;
-        $scope.emsCommonModel.metrics_userid                  = data.metrics_userid;
-        $scope.emsCommonModel.vmware_cloud_api_version        = data.api_version;
-
-        $scope.emsCommonModel.ssh_keypair_userid              = data.ssh_keypair_userid;
-
-        $scope.emsCommonModel.service_account                 = data.service_account;
-        $scope.emsCommonModel.azure_tenant_id                 = data.azure_tenant_id;
-        $scope.emsCommonModel.keystone_v3_domain_id           = data.keystone_v3_domain_id;
-        $scope.emsCommonModel.subscription                    = data.subscription;
-
-        $scope.emsCommonModel.host_default_vnc_port_start     = data.host_default_vnc_port_start;
-        $scope.emsCommonModel.host_default_vnc_port_end       = data.host_default_vnc_port_end;
-
-        $scope.emsCommonModel.event_stream_selection          = data.event_stream_selection;
-
-        $scope.emsCommonModel.bearer_token_exists             = data.bearer_token_exists;
-
-        $scope.emsCommonModel.ems_controller                  = data.ems_controller;
-        $scope.emsCommonModel.default_auth_status             = data.default_auth_status;
-        $scope.emsCommonModel.amqp_auth_status                = data.amqp_auth_status;
-        $scope.emsCommonModel.service_account_auth_status     = data.service_account_auth_status;
-        $scope.emsCommonModel.metrics_auth_status             = data.metrics_auth_status;
-        $scope.emsCommonModel.ssh_keypair_auth_status         = data.ssh_keypair_auth_status;
-        $scope.emsCommonModel.hawkular_auth_status            = data.hawkular_auth_status;
-
-        if ($scope.emsCommonModel.default_userid != '') {
-          $scope.emsCommonModel.default_password = $scope.emsCommonModel.default_verify = miqService.storedPasswordPlaceholder;
-        }
-        if ($scope.emsCommonModel.amqp_userid != '') {
-          $scope.emsCommonModel.amqp_password = $scope.emsCommonModel.amqp_verify = miqService.storedPasswordPlaceholder;
-        }
-        if ($scope.emsCommonModel.metrics_userid != '') {
-          $scope.emsCommonModel.metrics_password = $scope.emsCommonModel.metrics_verify = miqService.storedPasswordPlaceholder;
-        }
-        if ($scope.emsCommonModel.ssh_keypair_userid != '') {
-          $scope.emsCommonModel.ssh_keypair_password = miqService.storedPasswordPlaceholder;
-        }
-        if ($scope.emsCommonModel.bearer_token_exists) {
-          $scope.emsCommonModel.default_userid = "_";
-          $scope.emsCommonModel.default_password = $scope.emsCommonModel.default_verify = miqService.storedPasswordPlaceholder;
-        }
-
-        $scope.afterGet  = true;
-        $scope.modelCopy = angular.copy( $scope.emsCommonModel );
-
-        $scope.populatePostValidationModel();
-
-        miqService.sparkleOff();
-      }
     }
     $scope.actionUrl = $scope.newRecord ? $scope.createUrl : $scope.updateUrl;
     $scope.currentTab = "default";
+
+    function getEmsFormIdDataComplete(response, status, headers, config) {
+      var data = response.data;
+
+      $scope.emsCommonModel.name                            = data.name;
+      $scope.emsCommonModel.emstype                         = data.emstype;
+      $scope.emsCommonModel.zone                            = data.zone;
+      $scope.emsCommonModel.tenant_mapping_enabled          = data.tenant_mapping_enabled;
+      $scope.emsCommonModel.hostname                        = data.hostname;
+      $scope.emsCommonModel.default_hostname                = data.default_hostname;
+      $scope.emsCommonModel.amqp_hostname                   = data.amqp_hostname;
+      $scope.emsCommonModel.hawkular_hostname               = data.hawkular_hostname;
+      $scope.emsCommonModel.metrics_hostname                = data.metrics_hostname;
+      $scope.emsCommonModel.project                         = data.project;
+
+      $scope.emsCommonModel.openstack_infra_providers_exist = data.openstack_infra_providers_exist;
+
+      $scope.emsCommonModel.provider_id                     = angular.isDefined(data.provider_id) ? data.provider_id.toString() : "";
+
+      $scope.emsCommonModel.default_api_port                = angular.isDefined(data.default_api_port) && data.default_api_port != '' ? data.default_api_port.toString() : $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
+      $scope.emsCommonModel.amqp_api_port                   = angular.isDefined(data.amqp_api_port) && data.amqp_api_port != '' ? data.amqp_api_port.toString() : '5672';
+      $scope.emsCommonModel.hawkular_api_port               = angular.isDefined(data.hawkular_api_port) && data.hawkular_api_port != '' ? data.hawkular_api_port.toString() : '443';
+      $scope.emsCommonModel.metrics_api_port                = angular.isDefined(data.metrics_api_port) && data.metrics_api_port != '' ? data.metrics_api_port.toString() : '';
+      $scope.emsCommonModel.metrics_database_name           = angular.isDefined(data.metrics_database_name) && data.metrics_database_name != '' ? data.metrics_database_name : data.metrics_default_database_name;
+      $scope.emsCommonModel.api_version                     = data.api_version;
+      $scope.emsCommonModel.default_security_protocol       = data.default_security_protocol;
+      $scope.emsCommonModel.realm                           = data.realm;
+      $scope.emsCommonModel.security_protocol               = data.security_protocol;
+      $scope.emsCommonModel.amqp_security_protocol          = data.amqp_security_protocol != '' ? data.amqp_security_protocol : 'non-ssl';
+      $scope.emsCommonModel.provider_region                 = data.provider_region;
+      $scope.emsCommonModel.default_userid                  = data.default_userid;
+      $scope.emsCommonModel.amqp_userid                     = data.amqp_userid;
+      $scope.emsCommonModel.metrics_userid                  = data.metrics_userid;
+      $scope.emsCommonModel.vmware_cloud_api_version        = data.api_version;
+
+      $scope.emsCommonModel.ssh_keypair_userid              = data.ssh_keypair_userid;
+
+      $scope.emsCommonModel.service_account                 = data.service_account;
+      $scope.emsCommonModel.azure_tenant_id                 = data.azure_tenant_id;
+      $scope.emsCommonModel.keystone_v3_domain_id           = data.keystone_v3_domain_id;
+      $scope.emsCommonModel.subscription                    = data.subscription;
+
+      $scope.emsCommonModel.host_default_vnc_port_start     = data.host_default_vnc_port_start;
+      $scope.emsCommonModel.host_default_vnc_port_end       = data.host_default_vnc_port_end;
+
+      $scope.emsCommonModel.event_stream_selection          = data.event_stream_selection;
+
+      $scope.emsCommonModel.bearer_token_exists             = data.bearer_token_exists;
+
+      $scope.emsCommonModel.ems_controller                  = data.ems_controller;
+      $scope.emsCommonModel.default_auth_status             = data.default_auth_status;
+      $scope.emsCommonModel.amqp_auth_status                = data.amqp_auth_status;
+      $scope.emsCommonModel.service_account_auth_status     = data.service_account_auth_status;
+      $scope.emsCommonModel.metrics_auth_status             = data.metrics_auth_status;
+      $scope.emsCommonModel.ssh_keypair_auth_status         = data.ssh_keypair_auth_status;
+      $scope.emsCommonModel.hawkular_auth_status            = data.hawkular_auth_status;
+
+      if ($scope.emsCommonModel.default_userid != '') {
+        $scope.emsCommonModel.default_password = $scope.emsCommonModel.default_verify = miqService.storedPasswordPlaceholder;
+      }
+      if ($scope.emsCommonModel.amqp_userid != '') {
+        $scope.emsCommonModel.amqp_password = $scope.emsCommonModel.amqp_verify = miqService.storedPasswordPlaceholder;
+      }
+      if ($scope.emsCommonModel.metrics_userid != '') {
+        $scope.emsCommonModel.metrics_password = $scope.emsCommonModel.metrics_verify = miqService.storedPasswordPlaceholder;
+      }
+      if ($scope.emsCommonModel.ssh_keypair_userid != '') {
+        $scope.emsCommonModel.ssh_keypair_password = miqService.storedPasswordPlaceholder;
+      }
+      if ($scope.emsCommonModel.bearer_token_exists) {
+        $scope.emsCommonModel.default_userid = "_";
+        $scope.emsCommonModel.default_password = $scope.emsCommonModel.default_verify = miqService.storedPasswordPlaceholder;
+      }
+
+      $scope.afterGet  = true;
+      $scope.modelCopy = angular.copy( $scope.emsCommonModel );
+
+      $scope.populatePostValidationModel();
+
+      miqService.sparkleOff();
+    }
+
+    function getNewEmsFormDataComplete(response, status, headers, config) {
+      var data = response.data;
+
+      $scope.emsCommonModel.zone                            = data.zone;
+      $scope.emsCommonModel.tenant_mapping_enabled          = data.tenant_mapping_enabled;
+      $scope.emsCommonModel.emstype_vm                      = data.emstype_vm;
+      $scope.emsCommonModel.openstack_infra_providers_exist = data.openstack_infra_providers_exist;
+      $scope.emsCommonModel.default_api_port                = '';
+      $scope.emsCommonModel.amqp_api_port                   = '5672';
+      $scope.emsCommonModel.hawkular_api_port               = '443';
+      $scope.emsCommonModel.api_version                     = 'v2';
+      $scope.emsCommonModel.ems_controller                  = data.ems_controller;
+      $scope.emsCommonModel.ems_controller == 'ems_container' ? $scope.emsCommonModel.default_api_port = '8443' : $scope.emsCommonModel.default_api_port = '';
+      $scope.emsCommonModel.default_auth_status             = data.default_auth_status;
+      $scope.emsCommonModel.amqp_auth_status                = data.amqp_auth_status;
+      $scope.emsCommonModel.service_account_auth_status     = data.service_account_auth_status;
+      $scope.emsCommonModel.metrics_auth_status             = true;
+      $scope.emsCommonModel.ssh_keypair_auth_status         = true;
+      $scope.emsCommonModel.hawkular_auth_status            = true;
+      $scope.emsCommonModel.vmware_cloud_api_version        = '9.0';
+      miqService.sparkleOff();
+
+      $scope.afterGet  = true;
+      $scope.modelCopy = angular.copy( $scope.emsCommonModel );
+    }
 
     function getEmsFormDataFailed(e) {
       miqService.sparkleOff();

--- a/app/assets/javascripts/controllers/host/host_form_controller.js
+++ b/app/assets/javascripts/controllers/host/host_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attrs', 'hostFormId', 'miqService', function($http, $scope, $attrs, hostFormId, miqService) {
+ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attrs', 'hostFormId', 'miqService', '$log', '$q', function($http, $scope, $attrs, hostFormId, miqService, $log, $q) {
   var init = function() {
     $scope.hostModel = {
       name: '',
@@ -58,38 +58,9 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
       $scope.afterGet = true;
     } else if (hostFormId.split(",").length == 1) {
         miqService.sparkleOn();
-        $http.get($scope.formFieldsUrl + hostFormId).success(function (data) {
-          $scope.hostModel.name = data.name;
-          $scope.hostModel.hostname = data.hostname;
-          $scope.hostModel.ipmi_address = data.ipmi_address;
-          $scope.hostModel.custom_1 = data.custom_1;
-          $scope.hostModel.user_assigned_os = data.user_assigned_os;
-          $scope.hostModel.operating_system = data.operating_system;
-          $scope.hostModel.mac_address = data.mac_address;
-          $scope.hostModel.default_userid = data.default_userid;
-          $scope.hostModel.remote_userid = data.remote_userid;
-          $scope.hostModel.ws_userid = data.ws_userid;
-          $scope.hostModel.ipmi_userid = data.ipmi_userid;
-          $scope.hostModel.validate_id = data.validate_id;
-
-          if($scope.hostModel.default_userid != '') {
-            $scope.hostModel.default_password = $scope.hostModel.default_verify = miqService.storedPasswordPlaceholder;
-          }
-          if($scope.hostModel.remote_userid != '') {
-            $scope.hostModel.remote_password = $scope.hostModel.remote_verify = miqService.storedPasswordPlaceholder;
-          }
-          if($scope.hostModel.ws_userid != '') {
-            $scope.hostModel.ws_password = $scope.hostModel.ws_verify = miqService.storedPasswordPlaceholder;
-          }
-          if($scope.hostModel.ipmi_userid != '') {
-            $scope.hostModel.ipmi_password = $scope.hostModel.ipmi_verify = miqService.storedPasswordPlaceholder;
-          }
-
-          $scope.afterGet = true;
-
-          $scope.modelCopy = angular.copy( $scope.hostModel );
-          miqService.sparkleOff();
-        });
+        $http.get($scope.formFieldsUrl + hostFormId)
+          .then(getHostFormDataComplete)
+          .catch(getHostFormDataFailed);
      } else if (hostFormId.split(",").length > 1) {
       $scope.afterGet = true;
     }
@@ -207,6 +178,49 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
       return true;
     } else
       return false;
+  }
+
+  function getHostFormDataComplete(response) {
+    var data = response.data;
+
+    $scope.hostModel.name = data.name;
+    $scope.hostModel.hostname = data.hostname;
+    $scope.hostModel.ipmi_address = data.ipmi_address;
+    $scope.hostModel.custom_1 = data.custom_1;
+    $scope.hostModel.user_assigned_os = data.user_assigned_os;
+    $scope.hostModel.operating_system = data.operating_system;
+    $scope.hostModel.mac_address = data.mac_address;
+    $scope.hostModel.default_userid = data.default_userid;
+    $scope.hostModel.remote_userid = data.remote_userid;
+    $scope.hostModel.ws_userid = data.ws_userid;
+    $scope.hostModel.ipmi_userid = data.ipmi_userid;
+    $scope.hostModel.validate_id = data.validate_id;
+
+    if ($scope.hostModel.default_userid !== '') {
+      $scope.hostModel.default_password = $scope.hostModel.default_verify = miqService.storedPasswordPlaceholder;
+    }
+    if ($scope.hostModel.remote_userid !== '') {
+      $scope.hostModel.remote_password = $scope.hostModel.remote_verify = miqService.storedPasswordPlaceholder;
+    }
+    if ($scope.hostModel.ws_userid !== '') {
+      $scope.hostModel.ws_password = $scope.hostModel.ws_verify = miqService.storedPasswordPlaceholder;
+    }
+    if ($scope.hostModel.ipmi_userid !== '') {
+      $scope.hostModel.ipmi_password = $scope.hostModel.ipmi_verify = miqService.storedPasswordPlaceholder;
+    }
+
+    $scope.afterGet = true;
+
+    $scope.modelCopy = angular.copy( $scope.hostModel );
+    miqService.sparkleOff();
+  }
+
+  function getHostFormDataFailed(e) {
+    miqService.sparkleOff();
+    if (e.message) {
+      $log.log(e.message);
+    }
+    return $q.reject(e);
   }
 
   init();

--- a/app/assets/javascripts/controllers/host/host_form_controller.js
+++ b/app/assets/javascripts/controllers/host/host_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attrs', 'hostFormId', 'miqService', '$log', '$q', function($http, $scope, $attrs, hostFormId, miqService, $log, $q) {
+ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attrs', 'hostFormId', 'miqService', function($http, $scope, $attrs, hostFormId, miqService) {
   var init = function() {
     $scope.hostModel = {
       name: '',
@@ -60,7 +60,7 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
         miqService.sparkleOn();
         $http.get($scope.formFieldsUrl + hostFormId)
           .then(getHostFormDataComplete)
-          .catch(getHostFormDataFailed);
+          .catch(miqService.handleFailure);
      } else if (hostFormId.split(",").length > 1) {
       $scope.afterGet = true;
     }
@@ -213,14 +213,6 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
 
     $scope.modelCopy = angular.copy( $scope.hostModel );
     miqService.sparkleOff();
-  }
-
-  function getHostFormDataFailed(e) {
-    miqService.sparkleOff();
-    if (e.message) {
-      $log.log(e.message);
-    }
-    return $q.reject(e);
   }
 
   init();

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 'scheduleFormId', 'oneMonthAgo', 'miqService', 'timerOptionService', '$log', '$q', function($http, $scope, scheduleFormId, oneMonthAgo, miqService, timerOptionService, $log, $q) {
+ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 'scheduleFormId', 'oneMonthAgo', 'miqService', 'timerOptionService', function($http, $scope, scheduleFormId, oneMonthAgo, miqService, timerOptionService) {
   var init = function() {
     $scope.scheduleModel = {
       action_typ: '',
@@ -50,7 +50,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
 
       $http.get('/ops/schedule_form_fields/' + scheduleFormId)
         .then(getScheduleFormDataComplete)
-        .catch($scope.handleFailure);
+        .catch(miqService.handleFailure);
     }
 
     function getScheduleFormDataComplete(response) {
@@ -111,14 +111,6 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
 
       miqService.sparkleOff();
     }
-
-    $scope.handleFailure = function(e) {
-      miqService.sparkleOff();
-      if (e.message) {
-        $log.log(e.message);
-      }
-      return $q.reject(e);
-    };
 
     miqService.buildCalendar(oneMonthAgo.year, parseInt(oneMonthAgo.month, 10) + 1, oneMonthAgo.date);
   };
@@ -223,7 +215,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
 
       $http.post('/ops/automate_schedules_set_vars/' + scheduleFormId)
         .then(postAutomateSchedulesSetVarsComplete)
-        .catch($scope.handleFailure);
+        .catch(miqService.handleFailure);
     } else {
       $scope.scheduleModel.filter_typ = 'all';
     }
@@ -254,7 +246,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     miqService.sparkleOn();
     $http.post('/ops/fetch_target_ids/?target_class=' + $scope.scheduleModel.target_class)
       .then(postFetchTargetIdsComplete)
-      .catch($scope.handleFailure);
+      .catch(miqService.handleFailure);
 
     function postFetchTargetIdsComplete(response) {
       var data = response.data;
@@ -272,7 +264,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         {filter_type: $scope.scheduleModel.filter_typ,
           action_type: $scope.scheduleModel.action_typ})
         .then(postScheduleFormFilterTypeComplete)
-        .catch($scope.handleFailure);
+        .catch(miqService.handleFailure);
     } else {
       $scope.scheduleModel.filter_value = '';
       $scope.filterValuesEmpty = true;

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -62,7 +62,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
       $scope.scheduleModel.log_userid   = data.log_userid;
       $scope.scheduleModel.log_protocol = data.protocol;
       $scope.scheduleModel.description  = data.schedule_description;
-      $scope.scheduleModel.enabled      = data.schedule_enabled === '1' ? true : false;
+      $scope.scheduleModel.enabled      = data.schedule_enabled == 1 ? true : false;
       $scope.scheduleModel.name         = data.schedule_name;
       $scope.scheduleModel.timer_typ    = data.schedule_timer_type;
       $scope.scheduleModel.timer_value  = data.schedule_timer_value;
@@ -87,7 +87,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
 
       $scope.timer_items        = timerOptionService.getOptions($scope.scheduleModel.timer_typ);
 
-      if (data.filter_type === 'all' || (data.protocol !== undefined && data.protocol !== null)) {
+      if (data.filter_type === 'all' || (angular.isDefined(data.protocol) && data.protocol !== null)) {
         $scope.filterValuesEmpty = true;
       } else {
         buildFilterList(data);
@@ -96,12 +96,13 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         $scope.scheduleModel.filter_value     = data.filter_value;
       }
 
-      if(data.filter_type == null &&
-        (data.protocol !== undefined && data.protocol !== null && data.protocol != 'Samba'))
+      if (data.filter_type === null &&
+        (angular.isDefined(data.protocol) && data.protocol !== null && data.protocol !== 'Samba')) {
         $scope.scheduleModel.filter_typ = 'all';
+      }
 
-      $scope.scheduleModel.log_password = $scope.scheduleModel.log_verify = "";
-      if($scope.scheduleModel.log_userid != '') {
+      $scope.scheduleModel.log_password = $scope.scheduleModel.log_verify = '';
+      if ($scope.scheduleModel.log_userid !== '') {
         $scope.scheduleModel.log_password = $scope.scheduleModel.log_verify = miqService.storedPasswordPlaceholder;
       }
 
@@ -221,7 +222,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
       miqService.sparkleOn();
 
       $http.post('/ops/automate_schedules_set_vars/' + scheduleFormId)
-        .then(postAutomateSchedulesSetVarsComplete) 
+        .then(postAutomateSchedulesSetVarsComplete)
         .catch($scope.handleFailure);
     } else {
       $scope.scheduleModel.filter_typ = 'all';

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -1,6 +1,6 @@
 /* global miqAjaxButton miqBuildCalendar miqButtons miqJqueryRequest miqRESTAjaxButton miqSparkleOff miqSparkleOn */
 
-ManageIQ.angular.app.service('miqService', ['$timeout', '$document', function($timeout, $document) {
+ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', '$log', function($timeout, $document, $q, $log) {
   this.storedPasswordPlaceholder = "●●●●●●●●";
 
   this.showButtons = function() {
@@ -123,5 +123,13 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', function($t
     }
 
     return serializedObj;
+  };
+  
+  this.handleFailure = function(e) {
+    miqSparkleOff();
+    if (e.message) {
+      $log.log(e.message);
+    }
+    return $q.reject(e);
   };
 }]);


### PR DESCRIPTION
With Angular 1.6+, the `$http .success` and `$http .error` would not be supported anymore.

The PR currently addresses the `.success` calls in one controller.
The other controllers will follow suit.

Tackling the following controllers in this PR:
- auth_key_pair_cloud_controller.js
- ems_common_form_controller.js
- host_form_controller.js
- schedule_form_controller.js