### PR TITLE
Remove download_pdf from show.haml

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -153,6 +153,7 @@ class ApplicationController < ActionController::Base
 
   def download_summary_pdf
     @record = identify_record(params[:id])
+    get_tagdata(@record)
     yield if block_given?
     return if record_no_longer_exists?(@record)
     @display = "download_pdf"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -153,9 +153,9 @@ class ApplicationController < ActionController::Base
 
   def download_summary_pdf
     @record = identify_record(params[:id])
-    get_tagdata(@record)
     yield if block_given?
     return if record_no_longer_exists?(@record)
+    get_tagdata(@record)
     @display = "download_pdf"
     set_summary_pdf_data
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -153,8 +153,8 @@ class ApplicationController < ActionController::Base
 
   def download_summary_pdf
     @record = identify_record(params[:id])
-    return if record_no_longer_exists?(@record)
     yield if block_given?
+    return if record_no_longer_exists?(@record)
     @display = "download_pdf"
     set_summary_pdf_data
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -151,6 +151,14 @@ class ApplicationController < ActionController::Base
     redirect_to(:action => params[:tab], :id => params[:id])
   end
 
+  def download_summary_pdf
+    @record = identify_record(params[:id])
+    return if record_no_longer_exists?(@record)
+    yield if block_given?
+    @display = "download_pdf"
+    set_summary_pdf_data
+  end
+
   def build_targets_hash(items, typ = true)
     @targets_hash ||= {}
     if typ

--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -7,6 +7,12 @@ class AvailabilityZoneController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
 
+  def download_summary_pdf
+    super do
+      @availability_zone = @record
+    end
+  end
+
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?
@@ -20,12 +26,12 @@ class AvailabilityZoneController < ApplicationController
     drop_breadcrumb({:name => _("Availabilty Zones"),
                      :url  => "/availability_zones/show_list?page=#{@current_page}&refresh=y"}, true)
     case @display
-    when "download_pdf", "main", "summary_only"
+    when "main", "summary_only"
       get_tagdata(@availability_zone)
       drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @availability_zone.name},
                       :url  => "/availability_zone/show/#{@availability_zone.id}")
       @showtype = "main"
-      set_summary_pdf_data if ["download_pdf", "summary_only"].include?(@display)
+      set_summary_pdf_data if @display == "summary_only"
 
     when "performance"
       @showtype = "performance"

--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -7,12 +7,6 @@ class AvailabilityZoneController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
 
-  def download_summary_pdf
-    super do
-      @availability_zone = @record
-    end
-  end
-
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?

--- a/app/controllers/cim_instance_controller.rb
+++ b/app/controllers/cim_instance_controller.rb
@@ -114,13 +114,13 @@ class CimInstanceController < ApplicationController
     @gtl_url = "/show"
 
     case @display
-    when "download_pdf", "main", "summary_only"
+    when "main", "summary_only"
       get_tagdata(@record)
       drop_breadcrumb({:name => ui_lookup(:tables => self.class.table_name), :url => "/#{self.class.table_name}/show_list?page=#{@current_page}&refresh=y"}, true)
       drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @record.evm_display_name},
                       :url  => "/#{self.class.table_name}/show/#{@record.id}")
       @showtype = "main"
-      set_summary_pdf_data if ["download_pdf", "summary_only"].include?(@display)
+      set_summary_pdf_data if @display == "summary_only"
 
     when "performance"
       @showtype = "performance"

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -17,12 +17,6 @@ class CloudObjectStoreObjectController < ApplicationController
     return tag("CloudObjectStoreObject") if params[:pressed] == 'cloud_object_store_object_tag'
   end
 
-  def download_summary_pdf
-    super do
-      @object_store_object = @record
-    end
-  end
-
   def show
     @display = params[:display] || "main" unless pagination_or_gtl_request?
     @showtype = @display

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -17,6 +17,12 @@ class CloudObjectStoreObjectController < ApplicationController
     return tag("CloudObjectStoreObject") if params[:pressed] == 'cloud_object_store_object_tag'
   end
 
+  def download_summary_pdf
+    super do
+      @object_store_object = @record
+    end
+  end
+
   def show
     @display = params[:display] || "main" unless pagination_or_gtl_request?
     @showtype = @display
@@ -33,14 +39,14 @@ class CloudObjectStoreObjectController < ApplicationController
       true
     )
     case @display
-    when "download_pdf", "main", "summary_only"
+    when "main", "summary_only"
       get_tagdata(@object_store_object)
       drop_breadcrumb(
         :name => _("%{name} (Summary)") % {:name => @object_store_object.key.to_s},
         :url  => "/cloud_object_store_object/show/#{@object_store_object.id}"
       )
       @showtype = "main"
-      set_summary_pdf_data if %w(download_pdf summary_only).include?(@display)
+      set_summary_pdf_data if @display == "summary_only"
     end
 
     replace_gtl_main_div if pagination_request?

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -66,6 +66,12 @@ class CloudVolumeController < ApplicationController
     end
   end
 
+  def download_summary_pdf
+    super do
+      @volume = @record
+    end
+  end
+
   def show
     @display = params[:display] || "main" unless pagination_or_gtl_request?
     @showtype = @display
@@ -81,14 +87,14 @@ class CloudVolumeController < ApplicationController
                     true)
 
     case @display
-    when "download_pdf", "main", "summary_only"
+    when "main", "summary_only"
       get_tagdata(@volume)
       drop_breadcrumb(
         :name => _("%{name} (Summary)") % {:name => @volume.name.to_s},
         :url  => "/cloud_volume/show/#{@volume.id}"
       )
       @showtype = "main"
-      set_summary_pdf_data if %w(download_pdf summary_only).include?(@display)
+      set_summary_pdf_data if @display == 'summary_only'
     when "cloud_volume_snapshots"
       title = ui_lookup(:tables => 'cloud_volume_snapshots')
       kls   = CloudVolumeSnapshot

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -66,12 +66,6 @@ class CloudVolumeController < ApplicationController
     end
   end
 
-  def download_summary_pdf
-    super do
-      @volume = @record
-    end
-  end
-
   def show
     @display = params[:display] || "main" unless pagination_or_gtl_request?
     @showtype = @display

--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -19,12 +19,6 @@ class ConfigurationJobController < ApplicationController
     ems_configprovider_path(*args)
   end
 
-  def download_summary_pdf
-    super do
-      @configuration_job = @record
-    end
-  end
-
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?

--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -19,6 +19,12 @@ class ConfigurationJobController < ApplicationController
     ems_configprovider_path(*args)
   end
 
+  def download_summary_pdf
+    super do
+      @configuration_job = @record
+    end
+  end
+
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?
@@ -31,12 +37,12 @@ class ConfigurationJobController < ApplicationController
     drop_breadcrumb({:name => _("Configuration_Jobs"),
                      :url  => "/configuration_job/show_list?page=#{@current_page}&refresh=y"}, true)
     case @display
-    when "download_pdf", "main", "summary_only"
+    when "main", "summary_only"
       get_tagdata(@configuration_job)
       drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @configuration_job.name},
                       :url  => "/configuration_job/show/#{@configuration_job.id}")
       @showtype = "main"
-      set_summary_pdf_data if %w(download_pdf summary_only).include?(@display)
+      set_summary_pdf_data if @display == 'summary_only'
     end
 
     replace_gtl_main_div if pagination_request?

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -17,7 +17,6 @@ class EmsClusterController < ApplicationController
     end
   end
 
-
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -11,12 +11,6 @@ class EmsClusterController < ApplicationController
     super
   end
 
-  def download_summary_pdf
-    super do
-      @ems_cluster = @record
-    end
-  end
-
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -11,6 +11,13 @@ class EmsClusterController < ApplicationController
     super
   end
 
+  def download_summary_pdf
+    super do
+      @ems_cluster = @record
+    end
+  end
+
+
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?
@@ -23,12 +30,12 @@ class EmsClusterController < ApplicationController
     @gtl_url = "/show"
 
     case @display
-    when "download_pdf", "main", "summary_only"
+    when "main", "summary_only"
       get_tagdata(@ems_cluster)
       drop_breadcrumb({:name => _("Clusters"), :url => "/ems_cluster/show_list?page=#{@current_page}&refresh=y"}, true)
       drop_breadcrumb(:name => @ems_cluster.name + _(" (Summary)"), :url => "/ems_cluster/show/#{@ems_cluster.id}")
       @showtype = "main"
-      set_summary_pdf_data if ["download_pdf", "summary_only"].include?(@display)
+      set_summary_pdf_data if @display == "summary_only"
 
     when "descendant_vms"
       drop_breadcrumb(:name => @ems_cluster.name + _(" (All VMs - Tree View)"),

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -118,6 +118,12 @@ module EmsCommon
     view_setup_helper(display, *view_setup_params[display])
   end
 
+  def download_summary_pdf
+    super do
+      @ems = @record
+    end
+  end
+
   def show
     return unless init_show
     session[:vm_summary_cool] = (settings(:views, :vm_summary_cool).to_s == "summary")
@@ -128,7 +134,7 @@ module EmsCommon
 
     case params[:display]
     when 'main'                          then show_main
-    when 'download_pdf', 'summary_only'  then show_download
+    when 'summary_only'                  then show_download
     when 'props'                         then show_props
     when 'ems_folders'                   then show_ems_folders
     when 'timeline'                      then show_timeline

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -118,12 +118,6 @@ module EmsCommon
     view_setup_helper(display, *view_setup_params[display])
   end
 
-  def download_summary_pdf
-    super do
-      @ems = @record
-    end
-  end
-
   def show
     return unless init_show
     session[:vm_summary_cool] = (settings(:views, :vm_summary_cool).to_s == "summary")

--- a/app/controllers/flavor_controller.rb
+++ b/app/controllers/flavor_controller.rb
@@ -13,11 +13,5 @@ class FlavorController < ApplicationController
     %w(instances)
   end
 
-  def download_summary_pdf
-    @record = identify_record(params[:id])
-    @display = "download_pdf"
-    set_summary_pdf_data
-  end
-
   menu_section :clo
 end

--- a/app/controllers/flavor_controller.rb
+++ b/app/controllers/flavor_controller.rb
@@ -13,5 +13,11 @@ class FlavorController < ApplicationController
     %w(instances)
   end
 
+  def download_summary_pdf
+    @record = identify_record(params[:id])
+    @display = "download_pdf"
+    set_summary_pdf_data
+  end
+
   menu_section :clo
 end

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -8,12 +8,6 @@ class HostAggregateController < ApplicationController
   include Mixins::CheckedIdMixin
   include Mixins::GenericSessionMixin
 
-  def download_summary_pdf
-    super do
-      @host_aggregate = @record
-    end
-  end
-
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -8,6 +8,12 @@ class HostAggregateController < ApplicationController
   include Mixins::CheckedIdMixin
   include Mixins::GenericSessionMixin
 
+  def download_summary_pdf
+    super do
+      @host_aggregate = @record
+    end
+  end
+
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?
@@ -21,12 +27,12 @@ class HostAggregateController < ApplicationController
     drop_breadcrumb({:name => _("Host Aggregates"),
                      :url  => "/host_aggregate/show_list?page=#{@current_page}&refresh=y"}, true)
     case @display
-    when "download_pdf", "main", "summary_only"
+    when "main", "summary_only"
       get_tagdata(@host_aggregate)
       drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @host_aggregate.name},
                       :url  => "/availability_zone/show/#{@host_aggregate.id}")
       @showtype = "main"
-      set_summary_pdf_data if %w(download_pdf summary_only).include?(@display)
+      set_summary_pdf_data if @display == 'summary_only'
 
     when "performance"
       @showtype = "performance"

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -13,7 +13,7 @@ class HostController < ApplicationController
 
   def download_summary_pdf
     super do
-      @host = @record
+      set_config(@record)
     end
   end
 

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -11,6 +11,12 @@ class HostController < ApplicationController
     super
   end
 
+  def download_summary_pdf
+    super do
+      @host = @record
+    end
+  end
+
   def show
     return if perfmenu_click?
 
@@ -26,12 +32,12 @@ class HostController < ApplicationController
     @showtype = "config"
     set_config(@host)
     case @display
-    when "download_pdf", "main", "summary_only"
+    when "main", "summary_only"
       get_tagdata(@host)
       drop_breadcrumb({:name => _("Hosts"), :url => "/host/show_list?page=#{@current_page}&refresh=y"}, true)
       drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @host.name }, :url => "/host/show/#{@host.id}")
       @showtype = "main"
-      set_summary_pdf_data if ["download_pdf", "summary_only"].include?(@display)
+      set_summary_pdf_data if @display == "summary_only"
 
     when "devices"
       drop_breadcrumb(:name => _("%{name} (Devices)") % {:name => @host.name},

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -19,12 +19,6 @@ class InfraNetworkingController < ApplicationController
     redirect_to :action => 'explorer', :flash_msg => @flash_array ? @flash_array[0][:message] : nil
   end
 
-  def download_summary_pdf
-    super do
-      @switch = @record
-    end
-  end
-
   def show(id = nil)
     @explorer = true
     @display = params[:display] || "main" unless pagination_or_gtl_request?

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -19,6 +19,12 @@ class InfraNetworkingController < ApplicationController
     redirect_to :action => 'explorer', :flash_msg => @flash_array ? @flash_array[0][:message] : nil
   end
 
+  def download_summary_pdf
+    super do
+      @switch = @record
+    end
+  end
+
   def show(id = nil)
     @explorer = true
     @display = params[:display] || "main" unless pagination_or_gtl_request?
@@ -57,12 +63,11 @@ class InfraNetworkingController < ApplicationController
       drop_breadcrumb(:name => _("%{name} (All Registered Hosts)") % {:name => @record.name},
                       :url  => "/infra_networking/x_show/#{@record.id}?display=hosts")
       @showtype = "hosts"
-    when "download_pdf", "main"
+    when "main"
       get_tagdata(@configuration_job)
       drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @record..name},
                       :url  => "/infra_networking/show/#{@record.id}")
       @showtype = "main"
-      set_summary_pdf_data if %w(download_pdf).include?(@display)
     end
     @lastaction = "show"
   end

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -53,11 +53,11 @@ module ContainersCommonMixin
     drop_breadcrumb({:name => display_name,
                      :url  => "/#{controller_name}/show_list?page=#{@current_page}&refresh=y"},
                     true)
-    if %w(download_pdf main summary_only).include? @display
+    if %w(main summary_only).include? @display
       get_tagdata(@record)
       drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => record.name},
                       :url  => "/#{controller_name}/show/#{record.id}")
-      set_summary_pdf_data if %w(download_pdf summary_only).include?(@display)
+      set_summary_pdf_data if @display == 'summary_only'
     elsif @display == "timeline"
       @showtype = "timeline"
       session[:tl_record_id] = params[:id] if params[:id]

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -4,7 +4,7 @@ module Mixins
       return unless init_show
 
       case @display
-      when "download_pdf", "summary_only" then show_download
+      when "summary_only"                 then show_download
       when "main"                         then show_main
       when *self.class.display_methods    then display_nested_list(@display)
       end

--- a/app/controllers/mixins/middleware_common_mixin.rb
+++ b/app/controllers/mixins/middleware_common_mixin.rb
@@ -37,7 +37,7 @@ module MiddlewareCommonMixin
                     }, true)
     case @display
     when 'main'                          then show_main
-    when 'download_pdf', 'summary_only'  then show_download
+    when 'summary_only'                  then show_download
     when 'timeline'                      then show_timeline
     when 'performance'                   then show_performance
     end

--- a/app/controllers/ontap_file_share_controller.rb
+++ b/app/controllers/ontap_file_share_controller.rb
@@ -3,8 +3,6 @@ class OntapFileShareController < CimInstanceController
     process_button
   end
 
-  # TODO add download_summary_pdf
-
   def show
     process_show(
       'cim_base_storage_extents' => :base_storage_extents,

--- a/app/controllers/ontap_file_share_controller.rb
+++ b/app/controllers/ontap_file_share_controller.rb
@@ -3,6 +3,8 @@ class OntapFileShareController < CimInstanceController
     process_button
   end
 
+  # TODO add download_summary_pdf
+
   def show
     process_show(
       'cim_base_storage_extents' => :base_storage_extents,

--- a/app/controllers/ontap_logical_disk_controller.rb
+++ b/app/controllers/ontap_logical_disk_controller.rb
@@ -3,6 +3,8 @@ class OntapLogicalDiskController < CimInstanceController
     process_button
   end
 
+  # TODO add download_summary_pdf
+
   def show
     process_show(
       'cim_base_storage_extents' => :base_storage_extents,

--- a/app/controllers/ontap_logical_disk_controller.rb
+++ b/app/controllers/ontap_logical_disk_controller.rb
@@ -3,8 +3,6 @@ class OntapLogicalDiskController < CimInstanceController
     process_button
   end
 
-  # TODO add download_summary_pdf
-
   def show
     process_show(
       'cim_base_storage_extents' => :base_storage_extents,

--- a/app/controllers/ontap_storage_system_controller.rb
+++ b/app/controllers/ontap_storage_system_controller.rb
@@ -3,8 +3,6 @@ class OntapStorageSystemController < CimInstanceController
     process_button
   end
 
-  # TODO add download_summary_pdf
-
   def show
     process_show(
       'cim_base_storage_extents' => :base_storage_extents,

--- a/app/controllers/ontap_storage_system_controller.rb
+++ b/app/controllers/ontap_storage_system_controller.rb
@@ -3,6 +3,8 @@ class OntapStorageSystemController < CimInstanceController
     process_button
   end
 
+  # TODO add download_summary_pdf
+
   def show
     process_show(
       'cim_base_storage_extents' => :base_storage_extents,

--- a/app/controllers/ontap_storage_volume_controller.rb
+++ b/app/controllers/ontap_storage_volume_controller.rb
@@ -3,6 +3,8 @@ class OntapStorageVolumeController < CimInstanceController
     process_button
   end
 
+  # TODO add download_summary_pdf
+
   def show
     process_show(
       'cim_base_storage_extents' => :base_storage_extents,

--- a/app/controllers/ontap_storage_volume_controller.rb
+++ b/app/controllers/ontap_storage_volume_controller.rb
@@ -3,8 +3,6 @@ class OntapStorageVolumeController < CimInstanceController
     process_button
   end
 
-  # TODO add download_summary_pdf
-
   def show
     process_show(
       'cim_base_storage_extents' => :base_storage_extents,

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -14,12 +14,6 @@ class OrchestrationStackController < ApplicationController
     redirect_to :action => 'show_list'
   end
 
-  def download_summary_pdf
-    super do
-      @orchestration_stack = @record
-    end
-  end
-
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -14,6 +14,12 @@ class OrchestrationStackController < ApplicationController
     redirect_to :action => 'show_list'
   end
 
+  def download_summary_pdf
+    super do
+      @orchestration_stack = @record
+    end
+  end
+
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?
@@ -26,12 +32,12 @@ class OrchestrationStackController < ApplicationController
     drop_breadcrumb({:name => _("Orchestration Stacks"),
                      :url  => "/orchestration_stack/show_list?page=#{@current_page}&refresh=y"}, true)
     case @display
-    when "download_pdf", "main", "summary_only"
+    when "main", "summary_only"
       get_tagdata(@orchestration_stack)
       drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @orchestration_stack.name},
                       :url  => "/orchestration_stack/show/#{@orchestration_stack.id}")
       @showtype = "main"
-      set_summary_pdf_data if %w(download_pdf summary_only).include?(@display)
+      set_summary_pdf_data if @display == 'summary_only'
     when "instances"
       title = ui_lookup(:tables => "vm_cloud")
       drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @orchestration_stack.name, :title => title},

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -259,7 +259,6 @@ class ProviderForemanController < ApplicationController
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
     @gtl_url = "/show"
-    set_summary_pdf_data if "download_pdf" == @display
   end
 
   def tree_select
@@ -408,7 +407,7 @@ class ProviderForemanController < ApplicationController
     if @record.kind_of?(ConfiguredSystem)
       rec_cls = "#{model_to_type_name(@record.ext_management_system.class.to_s)}_configured_system"
     end
-    return unless %w(download_pdf main).include?(@display)
+    return unless @display == 'main'
     @showtype     = "main"
     @button_group = case x_active_accord
                     when :cs_filter

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -20,13 +20,13 @@ class ResourcePoolController < ApplicationController
                      :url  => "/resource_pool/show_list?page=#{@current_page}&refresh=y"}, true)
 
     case @display
-    when "download_pdf", "main", "summary_only"
+    when "main", "summary_only"
       get_tagdata(@record)
       txt = @record.vapp ? _("(vApp)") : ""
       drop_breadcrumb(:name => _("%{name} %{text} (Summary)") % {:name => @record.name, :text => txt},
                       :url  => "/resource_pool/show/#{@record.id}")
       @showtype = "main"
-      set_summary_pdf_data if ["download_pdf", "summary_only"].include?(@display)
+      set_summary_pdf_data if @display == "summary_only"
 
     when "vms"
       drop_breadcrumb(:name => _("%{name} (Direct VMs)") % {:name => @record.name},

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -27,12 +27,6 @@ class StorageController < ApplicationController
     @gtl_url = "/show"
   end
 
-  def download_summary_pdf
-    super do
-      @storage = @record
-    end
-  end
-
   def show(record = nil)
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -25,7 +25,12 @@ class StorageController < ApplicationController
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
     @gtl_url = "/show"
-    set_summary_pdf_data if "download_pdf" == @display
+  end
+
+  def download_summary_pdf
+    super do
+      @storage = @record
+    end
   end
 
   def show(record = nil)
@@ -74,7 +79,7 @@ class StorageController < ApplicationController
                       :url  => "/storage/x_show/#{@storage.id}?display=hosts")
       @showtype = "hosts"
 
-    when "download_pdf", "main", "summary_only"
+    when "main", "summary_only"
       get_tagdata(@storage)
       session[:vm_summary_cool] = (@settings[:views][:vm_summary_cool] == "summary")
       @summary_view = session[:vm_summary_cool]
@@ -82,7 +87,7 @@ class StorageController < ApplicationController
       drop_breadcrumb(:name => "%{name} (Summary)" % {:name => @storage.name},
                       :url  => "/storage/x_show/#{@storage.id}?display=main")
       @showtype = "main"
-      set_summary_pdf_data if ["download_pdf", "summary_only"].include?(@display)
+      set_summary_pdf_data if @display == "summary_only"
 
     when "performance"
       @showtype = "performance"
@@ -364,7 +369,7 @@ class StorageController < ApplicationController
     if @record.class.base_model.to_s == "Storage"
       rec_cls = @record.class.base_model.to_s.underscore
     end
-    return unless %w(download_pdf main).include?(@display)
+    return unless @display == 'main'
     @showtype = "main"
     @button_group = "storage_pod_#{rec_cls}" if x_active_accord == :storage_pod
     @button_group = "storage_#{rec_cls}" if x_active_accord == :storage

--- a/app/controllers/storage_manager_controller.rb
+++ b/app/controllers/storage_manager_controller.rb
@@ -202,12 +202,6 @@ class StorageManagerController < ApplicationController
     end
   end
 
-  def download_summary_pdf
-    super do
-      @sm = @record
-    end
-  end
-
   def show
     @display = params[:display] || "main" unless pagination_or_gtl_request?
 

--- a/app/controllers/storage_manager_controller.rb
+++ b/app/controllers/storage_manager_controller.rb
@@ -202,6 +202,12 @@ class StorageManagerController < ApplicationController
     end
   end
 
+  def download_summary_pdf
+    super do
+      @sm = @record
+    end
+  end
+
   def show
     @display = params[:display] || "main" unless pagination_or_gtl_request?
 
@@ -214,11 +220,11 @@ class StorageManagerController < ApplicationController
     @showtype = "config"
     drop_breadcrumb({:name => ui_lookup(:tables => "storage_managers"), :url => "/storage_manager/show_list?page=#{@current_page}&refresh=y"}, true)
 
-    if ["download_pdf", "main", "summary_only"].include?(@display)
+    if ["main", "summary_only"].include?(@display)
       # get_tagdata(StorageManager)
       drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @sm.name}, :url => "/storage_manager/show/#{@sm.id}")
       @showtype = "main"
-      set_summary_pdf_data if ["download_pdf", "summary_only"].include?(@display)
+      set_summary_pdf_data if @display == 'summary_only'
     end
     @lastaction = "show"
     session[:tl_record_id] = @record.id

--- a/app/controllers/storage_manager_controller.rb
+++ b/app/controllers/storage_manager_controller.rb
@@ -220,7 +220,7 @@ class StorageManagerController < ApplicationController
     @showtype = "config"
     drop_breadcrumb({:name => ui_lookup(:tables => "storage_managers"), :url => "/storage_manager/show_list?page=#{@current_page}&refresh=y"}, true)
 
-    if ["main", "summary_only"].include?(@display)
+    if %w(main summary_only).include?(@display)
       # get_tagdata(StorageManager)
       drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @sm.name}, :url => "/storage_manager/show/#{@sm.id}")
       @showtype = "main"

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -200,7 +200,7 @@ module VmCommon
 
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
-    if !@explorer && @display != "download_pdf"
+    if !@explorer
       tree_node_id = TreeBuilder.build_node_id(@record)
       session[:exp_parms] = {:display => @display, :refresh => params[:refresh], :id => tree_node_id}
       controller_name = controller_for_vm(model_for_vm(@record))
@@ -239,14 +239,14 @@ module VmCommon
       rec_cls = "vm"
     end
     @gtl_url = "/show"
-    if ["download_pdf", "main", "summary_only"].include?(@display)
+    if ["main", "summary_only"].include?(@display)
       get_tagdata(@record)
       drop_breadcrumb({:name => _("Virtual Machines"),
                        :url  => "/#{rec_cls}/show_list?page=#{@current_page}&refresh=y"}, true)
       drop_breadcrumb(:name => @record.name + _(" (Summary)"), :url => "/#{rec_cls}/show/#{@record.id}")
       @showtype = "main"
       @button_group = rec_cls
-      set_summary_pdf_data if ["download_pdf", "summary_only"].include?(@display)
+      set_summary_pdf_data if @display == "summary_only"
     elsif @display == "networks"
       drop_breadcrumb(:name => @record.name + _(" (Networks)"),
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
@@ -346,7 +346,7 @@ module VmCommon
 
     if @explorer
       @refresh_partial = "layouts/performance"
-      replace_right_cell unless ["download_pdf", "performance"].include?(params[:display])
+      replace_right_cell unless params[:display] == "performance"
     end
   end
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -180,6 +180,13 @@ module VmCommon
     generic_x_show
   end
 
+  def download_summary_pdf
+    super do
+      @flash_array = []
+      @record = identify_record(params[:id], VmOrTemplate)
+    end
+  end
+
   def show(id = nil)
     @flash_array = [] if params[:display] && params[:display] != "snapshot_info"
     @sb[:action] = params[:display]
@@ -200,7 +207,7 @@ module VmCommon
 
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
-    if !@explorer
+    unless @explorer
       tree_node_id = TreeBuilder.build_node_id(@record)
       session[:exp_parms] = {:display => @display, :refresh => params[:refresh], :id => tree_node_id}
       controller_name = controller_for_vm(model_for_vm(@record))
@@ -239,7 +246,7 @@ module VmCommon
       rec_cls = "vm"
     end
     @gtl_url = "/show"
-    if ["main", "summary_only"].include?(@display)
+    if %w(main summary_only).include?(@display)
       get_tagdata(@record)
       drop_breadcrumb({:name => _("Virtual Machines"),
                        :url  => "/#{rec_cls}/show_list?page=#{@current_page}&refresh=y"}, true)

--- a/app/helpers/application_helper/toolbar/summary_view.rb
+++ b/app/helpers/application_helper/toolbar/summary_view.rb
@@ -5,9 +5,8 @@ class ApplicationHelper::Toolbar::SummaryView < ApplicationHelper::Toolbar::Basi
       'fa fa-file-pdf-o fa-lg',
       N_('Download summary in PDF format'),
       nil,
-      :klass     => ApplicationHelper::Button::Pdf,
-      :url       => "/download_summary_pdf",
-      :url_parms => ''
+      :klass => ApplicationHelper::Button::Pdf,
+      :url   => "/download_summary_pdf"
     ),
   ])
 end

--- a/app/helpers/application_helper/toolbar/summary_view.rb
+++ b/app/helpers/application_helper/toolbar/summary_view.rb
@@ -6,7 +6,7 @@ class ApplicationHelper::Toolbar::SummaryView < ApplicationHelper::Toolbar::Basi
       N_('Download summary in PDF format'),
       nil,
       :klass     => ApplicationHelper::Button::Pdf,
-      :url       => "/show",
-      :url_parms => "?display=download_pdf"),
+      :url       => "/download_summary_pdf",
+      :url_parms => ''),
   ])
 end

--- a/app/helpers/application_helper/toolbar/summary_view.rb
+++ b/app/helpers/application_helper/toolbar/summary_view.rb
@@ -7,6 +7,7 @@ class ApplicationHelper::Toolbar::SummaryView < ApplicationHelper::Toolbar::Basi
       nil,
       :klass     => ApplicationHelper::Button::Pdf,
       :url       => "/download_summary_pdf",
-      :url_parms => ''),
+      :url_parms => ''
+    ),
   ])
 end

--- a/app/helpers/application_helper/toolbar/summary_view_restful.rb
+++ b/app/helpers/application_helper/toolbar/summary_view_restful.rb
@@ -5,9 +5,8 @@ class ApplicationHelper::Toolbar::SummaryViewRestful < ApplicationHelper::Toolba
       'fa fa-file-pdf-o fa-lg',
       N_('Download summary in PDF format'),
       nil,
-      :klass     => ApplicationHelper::Button::Pdf,
-      :url       => "/download_summary_pdf",
-      :url_parms => " "
+      :klass => ApplicationHelper::Button::Pdf,
+      :url   => "/download_summary_pdf"
     ),
   ])
 end

--- a/app/helpers/application_helper/toolbar/summary_view_restful.rb
+++ b/app/helpers/application_helper/toolbar/summary_view_restful.rb
@@ -7,6 +7,7 @@ class ApplicationHelper::Toolbar::SummaryViewRestful < ApplicationHelper::Toolba
       nil,
       :klass     => ApplicationHelper::Button::Pdf,
       :url       => "/download_summary_pdf",
-      :url_parms => " "),
+      :url_parms => " "
+    ),
   ])
 end

--- a/app/helpers/application_helper/toolbar/summary_view_restful.rb
+++ b/app/helpers/application_helper/toolbar/summary_view_restful.rb
@@ -6,7 +6,7 @@ class ApplicationHelper::Toolbar::SummaryViewRestful < ApplicationHelper::Toolba
       N_('Download summary in PDF format'),
       nil,
       :klass     => ApplicationHelper::Button::Pdf,
-      :url       => "/",
-      :url_parms => "?display=download_pdf"),
+      :url       => "/download_summary_pdf",
+      :url_parms => " "),
   ])
 end

--- a/app/helpers/application_helper/toolbar/x_summary_view.rb
+++ b/app/helpers/application_helper/toolbar/x_summary_view.rb
@@ -7,6 +7,7 @@ class ApplicationHelper::Toolbar::XSummaryView < ApplicationHelper::Toolbar::Bas
       nil,
       :klass     => ApplicationHelper::Button::Pdf,
       :url       => "/download_summary_pdf",
-      :url_parms => ''),
+      :url_parms => ''
+    ),
   ])
 end

--- a/app/helpers/application_helper/toolbar/x_summary_view.rb
+++ b/app/helpers/application_helper/toolbar/x_summary_view.rb
@@ -5,9 +5,8 @@ class ApplicationHelper::Toolbar::XSummaryView < ApplicationHelper::Toolbar::Bas
       'fa fa-file-pdf-o fa-lg',
       N_('Download summary in PDF format'),
       nil,
-      :klass     => ApplicationHelper::Button::Pdf,
-      :url       => "/download_summary_pdf",
-      :url_parms => ''
+      :klass => ApplicationHelper::Button::Pdf,
+      :url   => "/download_summary_pdf"
     ),
   ])
 end

--- a/app/helpers/application_helper/toolbar/x_summary_view.rb
+++ b/app/helpers/application_helper/toolbar/x_summary_view.rb
@@ -6,7 +6,7 @@ class ApplicationHelper::Toolbar::XSummaryView < ApplicationHelper::Toolbar::Bas
       N_('Download summary in PDF format'),
       nil,
       :klass     => ApplicationHelper::Button::Pdf,
-      :url       => "/show",
-      :url_parms => "?display=download_pdf"),
+      :url       => "/download_summary_pdf",
+      :url_parms => ''),
   ])
 end

--- a/app/helpers/availability_zone_helper/textual_summary.rb
+++ b/app/helpers/availability_zone_helper/textual_summary.rb
@@ -22,7 +22,7 @@ module AvailabilityZoneHelper::TextualSummary
     num   = @record.number_of(:cloud_volumes)
     h     = {:label => label, :icon => "pficon pficon-volume", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_volume_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @availability_zone, :display => 'cloud_volumes')
+      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'cloud_volumes')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -33,7 +33,7 @@ module AvailabilityZoneHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @availability_zone, :display => 'instances')
+      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/cloud_volume_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_helper/textual_summary.rb
@@ -99,7 +99,7 @@ module CloudVolumeHelper::TextualSummary
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show all attached %{models}") % {:models => label}
-      h[:link]  = url_for(:action => 'show', :id => @volume, :display => 'instances')
+      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
     end
     h
   end

--- a/app/helpers/ems_cinder_helper/textual_summary.rb
+++ b/app/helpers/ems_cinder_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module EmsCinderHelper::TextualSummary
   end
 
   def textual_group_status
-    textual_authentications(@ems.authentication_for_summary) + %i(refresh_status)
+    textual_authentications(@record.authentication_for_summary) + %i(refresh_status)
   end
 
   def textual_group_smart_management
@@ -27,29 +27,29 @@ module EmsCinderHelper::TextualSummary
   # Items
   #
   def textual_provider_region
-    return nil if @ems.provider_region.nil?
-    {:label => _("Region"), :value => @ems.description}
+    return nil if @record.provider_region.nil?
+    {:label => _("Region"), :value => @record.description}
   end
 
   def textual_hostname
-    @ems.hostname
+    @record.hostname
   end
 
   def textual_ipaddress
-    return nil if @ems.ipaddress.blank?
-    {:label => _("Discovered IP Address"), :value => @ems.ipaddress}
+    return nil if @record.ipaddress.blank?
+    {:label => _("Discovered IP Address"), :value => @record.ipaddress}
   end
 
   def textual_type
-    @ems.emstype_description
+    @record.emstype_description
   end
 
   def textual_port
-    @ems.supports_port? ? {:label => _("API Port"), :value => @ems.port} : nil
+    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_guid
-    {:label => _("Management Engine GUID"), :value => @ems.guid}
+    {:label => _("Management Engine GUID"), :value => @record.guid}
   end
 
   def textual_parent_ems_cloud
@@ -69,6 +69,6 @@ module EmsCinderHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @ems.zone.try(:name)}
+    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @record.zone.try(:name)}
   end
 end

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -18,7 +18,7 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_group_status
-    textual_authentications(@ems.authentication_for_summary) + %i(refresh_status)
+    textual_authentications(@record.authentication_for_summary) + %i(refresh_status)
   end
 
   def textual_group_smart_management
@@ -34,50 +34,50 @@ module EmsCloudHelper::TextualSummary
   # Items
   #
   def textual_provider_region
-    return nil if @ems.provider_region.nil?
-    label_val = (@ems.type.include? "Google") ? _("Preferred Region") : _("Region")
-    {:label => label_val, :value => @ems.description}
+    return nil if @record.provider_region.nil?
+    label_val = (@record.type.include? "Google") ? _("Preferred Region") : _("Region")
+    {:label => label_val, :value => @record.description}
   end
 
   def textual_region
-    return nil if @ems.provider_region.blank?
+    return nil if @record.provider_region.blank?
     label_val = _('Region')
-    {:label => label_val, :value => @ems.provider_region}
+    {:label => label_val, :value => @record.provider_region}
   end
 
   def textual_keystone_v3_domain_id
-    return nil if !@ems.respond_to?(:keystone_v3_domain_id) || @ems.keystone_v3_domain_id.nil?
+    return nil if !@record.respond_to?(:keystone_v3_domain_id) || @record.keystone_v3_domain_id.nil?
     label_val = _("Keystone V3 Domain ID")
-    {:label => label_val, :value => @ems.keystone_v3_domain_id}
+    {:label => label_val, :value => @record.keystone_v3_domain_id}
   end
 
   def textual_hostname
-    @ems.hostname
+    @record.hostname
   end
 
   def textual_ipaddress
-    return nil if @ems.ipaddress.blank?
-    {:label => _("Discovered IP Address"), :value => @ems.ipaddress}
+    return nil if @record.ipaddress.blank?
+    {:label => _("Discovered IP Address"), :value => @record.ipaddress}
   end
 
   def textual_type
-    @ems.emstype_description
+    @record.emstype_description
   end
 
   def textual_port
-    @ems.supports_port? ? {:label => _("API Port"), :value => @ems.port} : nil
+    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_guid
-    {:label => _("Management Engine GUID"), :value => @ems.guid}
+    {:label => _("Management Engine GUID"), :value => @record.guid}
   end
 
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
-    num   = @ems.number_of(:vms)
+    num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = ems_cloud_path(@ems.id, :display => 'instances')
+      h[:link]  = ems_cloud_path(@record.id, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -85,10 +85,10 @@ module EmsCloudHelper::TextualSummary
 
   def textual_images
     label = ui_lookup(:tables => "template_cloud")
-    num = @ems.number_of(:miq_templates)
+    num = @record.number_of(:miq_templates)
     h = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "miq_template_show_list")
-      h[:link] = ems_cloud_path(@ems.id, :display => 'images')
+      h[:link] = ems_cloud_path(@record.id, :display => 'images')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -104,11 +104,11 @@ module EmsCloudHelper::TextualSummary
 
   def textual_storage_managers
     label = _("Storage Managers")
-    num   = @ems.try(:storage_managers) ?  @ems.number_of(:storage_managers) : 0
+    num   = @record.try(:storage_managers) ? @record.number_of(:storage_managers) : 0
     h     = {:label => label, :icon => "fa fa-database", :value => num}
     if num > 0 && role_allows?(:feature => "ems_storage_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
-      h[:link] = ems_cloud_path(@ems.id, :display => 'storage_managers')
+      h[:link] = ems_cloud_path(@record.id, :display => 'storage_managers')
     end
     h
   end
@@ -135,10 +135,10 @@ module EmsCloudHelper::TextualSummary
 
   def textual_security_groups
     label = ui_lookup(:tables => "security_group")
-    num = @ems.number_of(:security_groups)
+    num = @record.number_of(:security_groups)
     h = {:label => label, :icon => "pficon pficon-cloud-security", :value => num}
     if num > 0 && role_allows?(:feature => "security_group_show_list")
-      h[:link] = ems_cloud_path(@ems.id, :display => 'security_groups')
+      h[:link] = ems_cloud_path(@record.id, :display => 'security_groups')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -159,13 +159,13 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @ems.zone.name}
+    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @record.zone.name}
   end
 
   def textual_topology
     {:label => _('Topology'),
      :icon  => "pficon pficon-topology",
-     :link  => url_for(:controller => 'cloud_topology', :action => 'show', :id => @ems.id),
+     :link  => url_for(:controller => 'cloud_topology', :action => 'show', :id => @record.id),
      :title => _("Show topology")}
   end
 end

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -35,7 +35,7 @@ module EmsCloudHelper::TextualSummary
   #
   def textual_provider_region
     return nil if @record.provider_region.nil?
-    label_val = (@record.type.include? "Google") ? _("Preferred Region") : _("Region")
+    label_val = @record.type.include?("Google") ? _("Preferred Region") : _("Region")
     {:label => label_val, :value => @record.description}
   end
 

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -14,7 +14,7 @@ module EmsContainerHelper::TextualSummary
     # Order of items should be from parent to child
     items = []
     items.concat(%i(container_projects))
-    items.concat(%i(container_routes)) if @ems.respond_to?(:container_routes)
+    items.concat(%i(container_routes)) if @record.respond_to?(:container_routes)
     items.concat(%i(container_services container_replicators container_groups containers container_nodes
                     container_image_registries container_images volumes container_builds container_templates))
     items
@@ -50,61 +50,61 @@ module EmsContainerHelper::TextualSummary
   #
 
   def textual_name
-    @ems.name
+    @record.name
   end
 
   def textual_type
-    @ems.emstype_description
+    @record.emstype_description
   end
 
   def textual_hostname
-    @ems.hostname
+    @record.hostname
   end
 
   def textual_memory_resources
     {:label => _("Aggregate Node Memory"),
-     :value => number_to_human_size(@ems.aggregate_memory * 1.megabyte,
+     :value => number_to_human_size(@record.aggregate_memory * 1.megabyte,
                                     :precision => 0)}
   end
 
   def textual_cpu_cores
     {:label => _("Aggregate Node CPU Cores"),
-     :value => @ems.aggregate_cpu_total_cores}
+     :value => @record.aggregate_cpu_total_cores}
   end
 
   def textual_port
-    @ems.supports_port? ? @ems.port : nil
+    @record.supports_port? ? @record.port : nil
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @ems.zone.name}
+    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @record.zone.name}
   end
 
   def textual_topology
     {:label => _('Topology'),
      :icon  => "pficon pficon-topology",
-     :link  => polymorphic_path(@ems, :display => 'topology'),
+     :link  => polymorphic_path(@record, :display => 'topology'),
      :title => _("Show topology")}
   end
 
   def textual_volumes
-    count_of_volumes = @ems.number_of(:persistent_volumes)
+    count_of_volumes = @record.number_of(:persistent_volumes)
     label = ui_lookup(:tables => "volume")
     h     = {:label => label, :icon => "pficon pficon-volume", :value => count_of_volumes}
     if count_of_volumes > 0 && role_allows?(:feature => "persistent_volume_show_list")
-      h[:link]  = ems_container_path(@ems.id, :display => 'persistent_volumes')
+      h[:link]  = ems_container_path(@record.id, :display => 'persistent_volumes')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
   end
 
   def textual_endpoints
-    return unless @ems.connection_configurations.hawkular
+    return unless @record.connection_configurations.hawkular
 
     [{:label => _('Hawkular Host Name'),
-      :value => @ems.connection_configurations.hawkular.endpoint.hostname},
+      :value => @record.connection_configurations.hawkular.endpoint.hostname},
      {:label => _('Hawkular API Port'),
-      :value => @ems.connection_configurations.hawkular.endpoint.port}]
+      :value => @record.connection_configurations.hawkular.endpoint.port}]
   end
 
   def textual_miq_custom_attributes

--- a/app/helpers/ems_datawarehouse_helper/textual_summary.rb
+++ b/app/helpers/ems_datawarehouse_helper/textual_summary.rb
@@ -26,18 +26,18 @@ module EmsDatawarehouseHelper::TextualSummary
   #
 
   def textual_name
-    @ems.name
+    @record.name
   end
 
   def textual_type
-    @ems.emstype_description
+    @record.emstype_description
   end
 
   def textual_hostname
-    @ems.hostname
+    @record.hostname
   end
 
   def textual_port
-    @ems.supports_port? ? @ems.port : nil
+    @record.supports_port? ? @record.port : nil
   end
 end

--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module EmsInfraHelper::TextualSummary
   end
 
   def textual_group_status
-    textual_authentications(@ems.authentication_userid_passwords) + %i(refresh_status orchestration_stacks_status)
+    textual_authentications(@record.authentication_userid_passwords) + %i(refresh_status orchestration_stacks_status)
   end
 
   def textual_group_smart_management
@@ -30,50 +30,51 @@ module EmsInfraHelper::TextualSummary
   #
 
   def textual_hostname
-    @ems.hostname
+    @record.hostname
   end
 
   def textual_ipaddress
-    {:label => _("Discovered IP Address"), :value => @ems.ipaddress}
+    {:label => _("Discovered IP Address"), :value => @record.ipaddress}
   end
 
   def textual_type
-    {:label => _("Type"), :value => @ems.emstype_description}
+    {:label => _("Type"), :value => @record.emstype_description}
   end
 
   def textual_port
-    @ems.supports_port? ? {:label => _("API Port"), :value => @ems.port} : nil
+    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_cpu_resources
     {:label => _("Aggregate %{title} CPU Resources") % {:title => title_for_host},
-     :value => mhz_to_human_size(@ems.aggregate_cpu_speed)}
+     :value => mhz_to_human_size(@record.aggregate_cpu_speed)}
   end
 
   def textual_memory_resources
     {:label => _("Aggregate %{title} Memory") % {:title => title_for_host},
-     :value => number_to_human_size(@ems.aggregate_memory * 1.megabyte, :precision => 0)}
+     :value => number_to_human_size(@record.aggregate_memory * 1.megabyte, :precision => 0)}
   end
 
   def textual_cpus
-    {:label => _("Aggregate %{title} CPUs") % {:title => title_for_host}, :value => @ems.aggregate_physical_cpus}
+    {:label => _("Aggregate %{title} CPUs") % {:title => title_for_host}, :value => @record.aggregate_physical_cpus}
   end
 
   def textual_cpu_cores
-    {:label => _("Aggregate %{title} CPU Cores") % {:title => title_for_host}, :value => @ems.aggregate_cpu_total_cores}
+    {:label => _("Aggregate %{title} CPU Cores") % {:title => title_for_host},
+     :value => @record.aggregate_cpu_total_cores}
   end
 
   def textual_guid
-    {:label => _("Management Engine GUID"), :value => @ems.guid}
+    {:label => _("Management Engine GUID"), :value => @record.guid}
   end
 
   def textual_infrastructure_folders
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
     label     = "#{title_for_hosts} & #{title_for_clusters}"
-    available = @ems.number_of(:ems_folders) > 0 && @ems.ems_folder_root
+    available = @record.number_of(:ems_folders) > 0 && @record.ems_folder_root
     h         = {:label => label, :icon => "pficon pficon-virtual-machine", :value => available ? _("Available") : _("N/A")}
     if available
-      h[:link]  = ems_infra_path(@ems.id, :display => 'ems_folders')
+      h[:link]  = ems_infra_path(@record.id, :display => 'ems_folders')
       h[:title] = _("Show %{label}") % {:label => label}
     end
     h
@@ -82,10 +83,10 @@ module EmsInfraHelper::TextualSummary
   def textual_folders
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
     label     = _("VMs & Templates")
-    available = @ems.number_of(:ems_folders) > 0 && @ems.ems_folder_root
+    available = @record.number_of(:ems_folders) > 0 && @record.ems_folder_root
     h         = {:label => label, :icon => "pficon pficon-virtual-machine", :value => available ? _("Available") : _("N/A")}
     if available
-      h[:link]  = ems_infra_path(@ems.id, :display => 'ems_folders', :vat => true)
+      h[:link]  = ems_infra_path(@record.id, :display => 'ems_folders', :vat => true)
       h[:title] = _("Show Virtual Machines & Templates")
     end
     h
@@ -93,10 +94,10 @@ module EmsInfraHelper::TextualSummary
 
   def textual_clusters
     label = title_for_clusters
-    num   = @ems.number_of(:ems_clusters)
+    num   = @record.number_of(:ems_clusters)
     h     = {:label => label, :icon => "pficon pficon-cluster", :value => num}
     if num > 0 && role_allows?(:feature => "ems_cluster_show_list")
-      h[:link] = ems_infra_path(@ems.id, :display => 'ems_clusters', :vat => true)
+      h[:link] = ems_infra_path(@record.id, :display => 'ems_clusters', :vat => true)
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -104,10 +105,10 @@ module EmsInfraHelper::TextualSummary
 
   def textual_hosts
     label = title_for_hosts
-    num   = @ems.number_of(:hosts)
+    num   = @record.number_of(:hosts)
     h     = {:label => label, :icon => "pficon pficon-screen", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
-      h[:link]  = ems_infra_path(@ems.id, :display => 'hosts')
+      h[:link]  = ems_infra_path(@record.id, :display => 'hosts')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -146,42 +147,42 @@ module EmsInfraHelper::TextualSummary
   def textual_vms
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
 
-    textual_link(@ems.vms, :label => _("Virtual Machines"))
+    textual_link(@record.vms, :label => _("Virtual Machines"))
   end
 
   def textual_templates
-    textual_link(@ems.miq_templates, :label => _("Templates"))
+    textual_link(@record.miq_templates, :label => _("Templates"))
   end
 
   def textual_orchestration_stacks_status
-    return nil if !@ems.respond_to?(:orchestration_stacks) || !@ems.orchestration_stacks
+    return nil if !@record.respond_to?(:orchestration_stacks) || !@record.orchestration_stacks
 
     label         = _("States of Root Orchestration Stacks")
-    stacks_states = @ems.direct_orchestration_stacks.collect { |x| "#{x.name} status: #{x.status}" }.join(", ")
+    stacks_states = @record.direct_orchestration_stacks.collect { |x| "#{x.name} status: #{x.status}" }.join(", ")
 
     {:label => label, :value => stacks_states}
   end
 
   def textual_orchestration_stacks
-    return nil unless @ems.respond_to?(:orchestration_stacks)
+    return nil unless @record.respond_to?(:orchestration_stacks)
 
-    @ems.orchestration_stacks
+    @record.orchestration_stacks
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @ems.zone.name}
+    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @record.zone.name}
   end
 
   def textual_host_default_vnc_port_range
-    return nil if @ems.host_default_vnc_port_start.blank?
-    value = "#{@ems.host_default_vnc_port_start} - #{@ems.host_default_vnc_port_end}"
+    return nil if @record.host_default_vnc_port_start.blank?
+    value = "#{@record.host_default_vnc_port_start} - #{@record.host_default_vnc_port_end}"
     {:label => _("%{title} Default VNC Port Range") % {:title => title_for_host}, :value => value}
   end
 
   def textual_topology
     {:label => _('Topology'),
      :icon  => "pficon pficon-topology",
-     :link  => url_for(:controller => '/infra_topology', :action => 'show', :id => @ems.id),
+     :link  => url_for(:controller => '/infra_topology', :action => 'show', :id => @record.id),
      :title => _("Show topology")}
   end
 end

--- a/app/helpers/ems_middleware_helper/textual_summary.rb
+++ b/app/helpers/ems_middleware_helper/textual_summary.rb
@@ -33,25 +33,25 @@ module EmsMiddlewareHelper::TextualSummary
   #
 
   def textual_name
-    @ems.name
+    @record.name
   end
 
   def textual_type
-    @ems.emstype_description
+    @record.emstype_description
   end
 
   def textual_hostname
-    @ems.hostname
+    @record.hostname
   end
 
   def textual_port
-    @ems.supports_port? ? @ems.port : nil
+    @record.supports_port? ? @record.port : nil
   end
 
   def textual_topology
     {:label => _('Topology'),
      :icon  => "pficon pficon-topology",
-     :link  => url_for(:controller => 'middleware_topology', :action => 'show', :id => @ems.id),
+     :link  => url_for(:controller => 'middleware_topology', :action => 'show', :id => @record.id),
      :title => _('Show topology')}
   end
 end

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -14,7 +14,7 @@ module EmsNetworkHelper::TextualSummary
   end
 
   def textual_group_status
-    textual_authentications(@ems.authentication_for_summary) + %i(refresh_status)
+    textual_authentications(@record.authentication_for_summary) + %i(refresh_status)
   end
 
   def textual_group_smart_management
@@ -30,29 +30,29 @@ module EmsNetworkHelper::TextualSummary
   # Items
   #
   def textual_provider_region
-    return nil if @ems.provider_region.nil?
-    {:label => _("Region"), :value => @ems.description}
+    return nil if @record.provider_region.nil?
+    {:label => _("Region"), :value => @record.description}
   end
 
   def textual_hostname
-    @ems.hostname
+    @record.hostname
   end
 
   def textual_ipaddress
-    return nil if @ems.ipaddress.blank?
-    {:label => _("Discovered IP Address"), :value => @ems.ipaddress}
+    return nil if @record.ipaddress.blank?
+    {:label => _("Discovered IP Address"), :value => @record.ipaddress}
   end
 
   def textual_type
-    {:label => _("Type"), :value => @ems.emstype_description}
+    {:label => _("Type"), :value => @record.emstype_description}
   end
 
   def textual_port
-    @ems.supports_port? ? {:label => _("API Port"), :value => @ems.port} : nil
+    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_guid
-    {:label => _("Management Engine GUID"), :value => @ems.guid}
+    {:label => _("Management Engine GUID"), :value => @record.guid}
   end
 
   def textual_parent_ems_cloud
@@ -89,11 +89,11 @@ module EmsNetworkHelper::TextualSummary
   def textual_topology
     {:label => _('Topology'),
      :icon  => "pficon pficon-topology",
-     :link  => url_for(:controller => 'network_topology', :action => 'show', :id => @ems.id),
+     :link  => url_for(:controller => 'network_topology', :action => 'show', :id => @record.id),
      :title => _("Show topology")}
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @ems.zone.try(:name)}
+    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @record.zone.try(:name)}
   end
 end

--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module EmsStorageHelper::TextualSummary
   end
 
   def textual_group_status
-    textual_authentications(@ems.authentication_for_summary) + %i(refresh_status)
+    textual_authentications(@record.authentication_for_summary) + %i(refresh_status)
   end
 
   def textual_group_smart_management
@@ -27,29 +27,29 @@ module EmsStorageHelper::TextualSummary
   # Items
   #
   def textual_provider_region
-    return nil if @ems.provider_region.nil?
-    {:label => _("Region"), :value => @ems.description}
+    return nil if @record.provider_region.nil?
+    {:label => _("Region"), :value => @record.description}
   end
 
   def textual_hostname
-    @ems.hostname
+    @record.hostname
   end
 
   def textual_ipaddress
-    return nil if @ems.ipaddress.blank?
-    {:label => _("Discovered IP Address"), :value => @ems.ipaddress}
+    return nil if @record.ipaddress.blank?
+    {:label => _("Discovered IP Address"), :value => @record.ipaddress}
   end
 
   def textual_type
-    @ems.emstype_description
+    @record.emstype_description
   end
 
   def textual_port
-    @ems.supports_port? ? {:label => _("API Port"), :value => @ems.port} : nil
+    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_guid
-    {:label => _("Management Engine GUID"), :value => @ems.guid}
+    {:label => _("Management Engine GUID"), :value => @record.guid}
   end
 
   def textual_parent_ems_cloud
@@ -57,7 +57,7 @@ module EmsStorageHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @ems.zone.try(:name)}
+    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @record.zone.try(:name)}
   end
 
   def textual_cloud_volumes

--- a/app/helpers/ems_swift_helper/textual_summary.rb
+++ b/app/helpers/ems_swift_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module EmsSwiftHelper::TextualSummary
   end
 
   def textual_group_status
-    textual_authentications(@ems.authentication_for_summary) + %i(refresh_status)
+    textual_authentications(@record.authentication_for_summary) + %i(refresh_status)
   end
 
   def textual_group_smart_management
@@ -27,29 +27,29 @@ module EmsSwiftHelper::TextualSummary
   # Items
   #
   def textual_provider_region
-    return nil if @ems.provider_region.nil?
-    {:label => _("Region"), :value => @ems.description}
+    return nil if @record.provider_region.nil?
+    {:label => _("Region"), :value => @record.description}
   end
 
   def textual_hostname
-    @ems.hostname
+    @record.hostname
   end
 
   def textual_ipaddress
-    return nil if @ems.ipaddress.blank?
-    {:label => _("Discovered IP Address"), :value => @ems.ipaddress}
+    return nil if @record.ipaddress.blank?
+    {:label => _("Discovered IP Address"), :value => @record.ipaddress}
   end
 
   def textual_type
-    @ems.emstype_description
+    @record.emstype_description
   end
 
   def textual_port
-    @ems.supports_port? ? {:label => _("API Port"), :value => @ems.port} : nil
+    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_guid
-    {:label => _("Management Engine GUID"), :value => @ems.guid}
+    {:label => _("Management Engine GUID"), :value => @record.guid}
   end
 
   def textual_parent_ems_cloud
@@ -65,6 +65,6 @@ module EmsSwiftHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @ems.zone.try(:name)}
+    {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @record.zone.try(:name)}
   end
 end

--- a/app/helpers/host_aggregate_helper/textual_summary.rb
+++ b/app/helpers/host_aggregate_helper/textual_summary.rb
@@ -18,7 +18,7 @@ module HostAggregateHelper::TextualSummary
     num   = @record.number_of(:hosts)
     h     = {:label => label, :icon => "pficon pficon-screen", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @host_aggregate, :display => 'hosts')
+      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hosts')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -29,7 +29,7 @@ module HostAggregateHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @host_aggregate, :display => 'instances')
+      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -77,7 +77,7 @@ module OrchestrationStackHelper::TextualSummary
     h = {:label => label, :icon => "product product-template", :value => template.name}
     if role_allows?(:feature => "orchestration_templates_view")
       h[:title] = _("Show this Orchestration Template")
-      h[:link] = url_for(:action => 'show', :id => @orchestration_stack, :display => 'stack_orchestration_template')
+      h[:link] = url_for(:action => 'show', :id => @record, :display => 'stack_orchestration_template')
     end
     h
   end
@@ -87,7 +87,7 @@ module OrchestrationStackHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @orchestration_stack, :display => 'instances')
+      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/textual_mixins/textual_refresh_status.rb
+++ b/app/helpers/textual_mixins/textual_refresh_status.rb
@@ -1,15 +1,15 @@
 module TextualMixins::TextualRefreshStatus
   def textual_refresh_status
-    last_refresh_status = @ems.last_refresh_status.titleize
-    if @ems.last_refresh_date
-      last_refresh_date = time_ago_in_words(@ems.last_refresh_date.in_time_zone(Time.zone)).titleize
+    last_refresh_status = @record.last_refresh_status.titleize
+    if @record.last_refresh_date
+      last_refresh_date = time_ago_in_words(@record.last_refresh_date.in_time_zone(Time.zone)).titleize
       last_refresh_status << _(" - %{last_refresh_date} Ago") % {:last_refresh_date => last_refresh_date}
     end
     {
       :label => _("Last Refresh"),
       :value => [{:value => last_refresh_status},
-                 {:value => @ems.last_refresh_error.try(:truncate, 120)}],
-      :title => @ems.last_refresh_error
+                 {:value => @record.last_refresh_error.try(:truncate, 120)}],
+      :title => @record.last_refresh_error
     }
   end
 end

--- a/app/views/ems_cluster/show.html.haml
+++ b/app/views/ems_cluster/show.html.haml
@@ -8,8 +8,6 @@
       = render(:partial => "layouts/performance")
       :javascript
         ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
-    - when "download_pdf"
-      = render(:partial => "layouts/show_pdf")
     - when "details"
       = render(:partial => "layouts/gtl", :locals => {:action_url => @lastaction})
     - when "compare", "drift"

--- a/app/views/host/show.html.haml
+++ b/app/views/host/show.html.haml
@@ -20,8 +20,6 @@
       = render(:partial => "layouts/tl_show")
       :javascript
         ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
-    - when "download_pdf"
-      = render(:partial => "layouts/show_pdf")
     - when "dialog_provision"
       = render(:partial => "shared/dialogs/dialog_provision")
     - when "compliance_history"

--- a/app/views/infra_networking/show.html.haml
+++ b/app/views/infra_networking/show.html.haml
@@ -5,7 +5,5 @@
     - case @showtype
       - when "details"
         = render(:partial => "layouts/x_gtl", :locals => {:action_url => @lastaction})
-      - when "download_pdf"
-        = render(:partial => "layouts/show_pdf")
       - else
         = render :partial => @showtype

--- a/app/views/miq_template/show.html.haml
+++ b/app/views/miq_template/show.html.haml
@@ -23,8 +23,6 @@
       = render :partial => "layouts/performance_summary"
     - when "timeline"
       = render :partial => "layouts/tl_show"
-    - when "download_pdf"
-      = render :partial => "layouts/show_pdf"
     - when "compliance_history"
       = render :partial => "shared/views/#{@showtype}"
     - else

--- a/app/views/resource_pool/show.html.haml
+++ b/app/views/resource_pool/show.html.haml
@@ -5,8 +5,6 @@
     - case @showtype
     - when "details"
       = render :partial => "layouts/gtl", :locals => {:action_url => @lastaction}
-    - when "download_pdf"
-      = render :partial => "layouts/show_pdf"
     - when "compare"
       = raise 'compare partial called through "show"'
       = render :partial => "layouts/#{@showtype}"

--- a/app/views/storage/show.html.haml
+++ b/app/views/storage/show.html.haml
@@ -14,8 +14,6 @@
       = render(:partial => "layouts/performance")
       :javascript
         ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
-    - when "download_pdf"
-      = render(:partial => "layouts/show_pdf")
     - when "dialog_provision"
       = render(:partial => "shared/dialogs/dialog_provision")
     - else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2298,6 +2298,7 @@ Rails.application.routes.draw do
         cim_base_storage_extents
         create_ds
         download_data
+        download_summary_pdf
         index
         protect
         show
@@ -2327,6 +2328,7 @@ Rails.application.routes.draw do
       :get  => %w(
         cim_base_storage_extents
         download_data
+        download_summary_pdf
         index
         protect
         show
@@ -2357,6 +2359,7 @@ Rails.application.routes.draw do
         cim_base_storage_extents
         create_ld
         download_data
+        download_summary_pdf
         index
         protect
         show
@@ -2386,6 +2389,7 @@ Rails.application.routes.draw do
       :get  => %w(
         cim_base_storage_extents
         download_data
+        download_summary_pdf
         index
         protect
         show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,7 @@ Rails.application.routes.draw do
     :auth_key_pair_cloud      => {
       :get  => %w(
         download_data
+        download_summary_pdf
         index
         new
         show
@@ -157,6 +158,7 @@ Rails.application.routes.draw do
     :availability_zone        => {
       :get  => %w(
         download_data
+        download_summary_pdf
         index
         perf_top_chart
         show
@@ -182,6 +184,7 @@ Rails.application.routes.draw do
       :get  => %w(
         add_host_select
         download_data
+        download_summary_pdf
         edit
         host_aggregate_form_fields
         index
@@ -308,6 +311,7 @@ Rails.application.routes.draw do
     :configuration_job      => {
       :get  => %w(
         download_data
+        download_summary_pdf
         index
         outputs
         parameters
@@ -346,6 +350,7 @@ Rails.application.routes.draw do
     :cloud_object_store_container => {
       :get => %w(
         download_data
+        download_summary_pdf
         index
         show
         show_list
@@ -369,6 +374,7 @@ Rails.application.routes.draw do
       :get => %w(
         cloud_tenant_form_fields
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -398,6 +404,7 @@ Rails.application.routes.draw do
     :cloud_object_store_object => {
       :get => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -425,6 +432,7 @@ Rails.application.routes.draw do
       :get  => %w(
         delete_volumes
         download_data
+        download_summary_pdf
         attach
         detach
         backup_new
@@ -539,6 +547,7 @@ Rails.application.routes.draw do
     :container                => {
       :get  => %w(
         download_data
+        download_summary_pdf
         explorer
         perf_top_chart
         show
@@ -572,6 +581,7 @@ Rails.application.routes.draw do
     :container_group          => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -609,6 +619,7 @@ Rails.application.routes.draw do
     :container_node           => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -647,6 +658,7 @@ Rails.application.routes.draw do
     :container_replicator     => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -684,6 +696,7 @@ Rails.application.routes.draw do
     :container_image          => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -719,6 +732,7 @@ Rails.application.routes.draw do
     :container_image_registry => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -746,6 +760,7 @@ Rails.application.routes.draw do
     :container_service        => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -779,6 +794,7 @@ Rails.application.routes.draw do
     :container_project        => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -813,6 +829,7 @@ Rails.application.routes.draw do
     :container_route          => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -867,6 +884,7 @@ Rails.application.routes.draw do
     :container_build          => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -894,6 +912,7 @@ Rails.application.routes.draw do
     :container_template          => {
       :get  => %w(
         download_data
+        download_summary_pdf
         index
         show
         show_list
@@ -1006,6 +1025,7 @@ Rails.application.routes.draw do
         dialog_load
         discover
         download_data
+        download_summary_pdf
         ems_cloud_form_fields
         protect
         show_list
@@ -1049,6 +1069,7 @@ Rails.application.routes.draw do
         columns_json
         dialog_load
         download_data
+        download_summary_pdf
         index
         perf_top_chart
         protect
@@ -1087,6 +1108,7 @@ Rails.application.routes.draw do
         dialog_load
         discover
         download_data
+        download_summary_pdf
         ems_infra_form_fields
         register_nodes
         introspect_nodes
@@ -1138,6 +1160,7 @@ Rails.application.routes.draw do
     :ems_container            => {
       :get  => %w(
         download_data
+        download_summary_pdf
         perf_top_chart
         protect
         show_list
@@ -1174,6 +1197,7 @@ Rails.application.routes.draw do
     :ems_middleware            => {
       :get  => %w(
         download_data
+        download_summary_pdf
         ems_middleware_form_fields
         show_list
         tagging_edit
@@ -1205,6 +1229,7 @@ Rails.application.routes.draw do
     :middleware_server            => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -1246,6 +1271,7 @@ Rails.application.routes.draw do
     :middleware_deployment            => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -1280,6 +1306,7 @@ Rails.application.routes.draw do
     :middleware_datasource => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -1316,6 +1343,7 @@ Rails.application.routes.draw do
     :middleware_domain => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         show
@@ -1349,6 +1377,7 @@ Rails.application.routes.draw do
     :middleware_server_group => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         show
@@ -1382,6 +1411,7 @@ Rails.application.routes.draw do
     :middleware_messaging => {
       :get  => %w(
         download_data
+        download_summary_pdf
         index
         perf_chart_chooser
         show
@@ -1411,6 +1441,7 @@ Rails.application.routes.draw do
     :ems_datawarehouse => {
       :get  => %w(
         download_data
+        download_summary_pdf
         ems_datawarehouse_form_fields
         show_list
         tagging_edit
@@ -1443,6 +1474,7 @@ Rails.application.routes.draw do
       :get  => %w(
         dialog_load
         download_data
+        download_summary_pdf
         ems_network_form_fields
         index
         protect
@@ -1546,6 +1578,7 @@ Rails.application.routes.draw do
       :get  => %w(
         delete_subnets
         download_data
+        download_summary_pdf
         cloud_subnet_form_fields
         cloud_subnet_networks_by_ems
         cloud_tenants_by_ems
@@ -1582,6 +1615,7 @@ Rails.application.routes.draw do
         cloud_network_form_fields
         delete_networks
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -1710,6 +1744,7 @@ Rails.application.routes.draw do
       # Then remove this route from all other controllers too.
       :get  => %w(
         download_data
+        download_summary_pdf
         index
         show
         show_list
@@ -1737,6 +1772,7 @@ Rails.application.routes.draw do
         advanced_settings
         dialog_load
         download_data
+        download_summary_pdf
         edit
         filesystem_download
         filesystems
@@ -1809,6 +1845,7 @@ Rails.application.routes.draw do
     :infra_networking         => {
       :get  => %w(
         download_data
+        download_summary_pdf
         explorer
         hosts
         show
@@ -2109,6 +2146,7 @@ Rails.application.routes.draw do
 
     :miq_template             => {
       :get  => %w(
+        download_summary_pdf
         edit
         show
         ownership
@@ -2126,6 +2164,7 @@ Rails.application.routes.draw do
       :get  => %w(
         dialog_load
         download_data
+        download_summary_pdf
         edit
         ems_storage_form_fields
         index
@@ -2170,6 +2209,7 @@ Rails.application.routes.draw do
       :get  => %w(
         dialog_load
         download_data
+        download_summary_pdf
         edit
         ems_storage_form_fields
         index
@@ -2213,6 +2253,7 @@ Rails.application.routes.draw do
       :get  => %w(
         dialog_load
         download_data
+        download_summary_pdf
         edit
         ems_storage_form_fields
         index
@@ -2499,6 +2540,7 @@ Rails.application.routes.draw do
       :get  => %w(
         cloud_networks
         download_data
+        download_summary_pdf
         retirement_info
         index
         outputs
@@ -2536,6 +2578,7 @@ Rails.application.routes.draw do
     :provider_foreman         => {
       :get  => %w(
         download_data
+        download_summary_pdf
         explorer
         provider_foreman_form_fields
         show
@@ -2675,6 +2718,7 @@ Rails.application.routes.draw do
     :resource_pool            => {
       :get  => %w(
         download_data
+        download_summary_pdf
         index
         protect
         show
@@ -2749,6 +2793,7 @@ Rails.application.routes.draw do
         dialog_load
         disk_files
         download_data
+        download_summary_pdf
         explorer
         files
         perf_chart_chooser
@@ -2805,6 +2850,7 @@ Rails.application.routes.draw do
     :storage_manager          => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         index
         new
@@ -2831,6 +2877,7 @@ Rails.application.routes.draw do
     :vm                       => {
       :get  => %w(
         download_data
+        download_summary_pdf
         edit
         retirement_info
         ownership
@@ -2883,6 +2930,7 @@ Rails.application.routes.draw do
     :vm_cloud                 => {
       :get  => %w(
         download_data
+        download_summary_pdf
         drift_to_csv
         drift_to_pdf
         drift_to_txt
@@ -2987,6 +3035,7 @@ Rails.application.routes.draw do
     :vm_infra                 => {
       :get  => %w(
         download_data
+        download_summary_pdf
         drift_to_csv
         drift_to_pdf
         drift_to_txt
@@ -3079,6 +3128,7 @@ Rails.application.routes.draw do
     :vm_or_template           => {
       :get  => %w(
         download_data
+        download_summary_pdf
         drift_to_csv
         drift_to_pdf
         drift_to_txt

--- a/spec/controllers/availability_zone_controller_spec.rb
+++ b/spec/controllers/availability_zone_controller_spec.rb
@@ -19,4 +19,6 @@ describe AvailabilityZoneController do
       end
     end
   end
+
+  include_examples '#download_summary_pdf', :availability_zone
 end

--- a/spec/controllers/cloud_object_store_container_spec.rb
+++ b/spec/controllers/cloud_object_store_container_spec.rb
@@ -47,4 +47,6 @@ describe CloudObjectStoreContainerController do
       expect(assigns(:edit)).to be_nil
     end
   end
+
+  include_examples '#download_summary_pdf', :cloud_object_store_container
 end

--- a/spec/controllers/cloud_object_store_object_spec.rb
+++ b/spec/controllers/cloud_object_store_object_spec.rb
@@ -47,4 +47,6 @@ describe CloudObjectStoreObjectController do
       expect(assigns(:edit)).to be_nil
     end
   end
+
+  include_examples '#download_summary_pdf', :cloud_object_store_object
 end

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -200,4 +200,6 @@ describe CloudSubnetController do
       end
     end
   end
+
+  include_examples '#download_summary_pdf', :cloud_subnet_openstack
 end

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -201,4 +201,6 @@ describe CloudTenantController do
       end
     end
   end
+
+  include_examples '#download_summary_pdf', :cloud_tenant
 end

--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -176,4 +176,6 @@ describe CloudVolumeController do
       end
     end
   end
+
+  include_examples '#download_summary_pdf', :cloud_volume
 end

--- a/spec/controllers/configuration_job_controller_spec.rb
+++ b/spec/controllers/configuration_job_controller_spec.rb
@@ -86,4 +86,6 @@ describe ConfigurationJobController do
       expect(assigns(:edit)).to be_nil
     end
   end
+
+  include_examples '#download_summary_pdf', :ansible_tower_job
 end

--- a/spec/controllers/container_group_controller_spec.rb
+++ b/spec/controllers/container_group_controller_spec.rb
@@ -55,4 +55,6 @@ describe ContainerGroupController do
       end
     end
   end
+
+  include_examples '#download_summary_pdf', :container_group_with_assoc
 end

--- a/spec/controllers/container_image_controller_spec.rb
+++ b/spec/controllers/container_image_controller_spec.rb
@@ -78,4 +78,6 @@ describe ContainerImageController do
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
   end
+
+  include_examples '#download_summary_pdf', :container_image
 end

--- a/spec/controllers/container_image_registry_controller_spec.rb
+++ b/spec/controllers/container_image_registry_controller_spec.rb
@@ -54,4 +54,6 @@ describe ContainerImageRegistryController do
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
   end
+
+  include_examples '#download_summary_pdf', :container_image_registry
 end

--- a/spec/controllers/container_node_controller_spec.rb
+++ b/spec/controllers/container_node_controller_spec.rb
@@ -52,4 +52,6 @@ describe ContainerNodeController do
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
   end
+
+  include_examples '#download_summary_pdf', :container_node
 end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -572,4 +572,6 @@ describe EmsCloudController do
       }
     end
   end
+
+  include_examples '#download_summary_pdf', :ems_amazon
 end

--- a/spec/controllers/ems_cluster_controller_spec.rb
+++ b/spec/controllers/ems_cluster_controller_spec.rb
@@ -80,4 +80,6 @@ describe EmsClusterController do
       end
     end
   end
+
+  include_examples '#download_summary_pdf', :ems_cluster
 end

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -154,7 +154,7 @@ describe EmsCloudController do
     end
   end
 
-  describe "#show" do
+  describe "#download_summary_pdf" do
     let(:provider_openstack) { FactoryGirl.create(:provider_openstack, :name => "Undercloud") }
     let(:ems_openstack) { FactoryGirl.create(:ems_openstack, :name => "overcloud", :provider => provider_openstack) }
     let(:pdf_options) { controller.instance_variable_get(:@options) }
@@ -163,7 +163,7 @@ describe EmsCloudController do
       before :each do
         stub_user(:features => :all)
         allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
-        get :show, :id => ems_openstack.id, :display => "download_pdf"
+        get :download_summary_pdf, :id => ems_openstack.id
       end
 
       it "should not contains string 'ManageIQ' in the title of summary report" do
@@ -269,7 +269,7 @@ describe EmsContainerController do
       end
     end
 
-    describe "#show" do
+    describe "#download_summary_pdf" do
       let(:ems_kubernetes_container) { FactoryGirl.create(:ems_kubernetes, :name => "test") }
       let(:pdf_options) { controller.instance_variable_get(:@options) }
 
@@ -277,7 +277,7 @@ describe EmsContainerController do
         before :each do
           stub_user(:features => :all)
           allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
-          get :show, :id => ems_kubernetes_container.id, :display => "download_pdf"
+          get :download_summary_pdf, :id => ems_kubernetes_container.id
         end
 
         it "should not contains string 'ManageIQ' in the title of summary report" do
@@ -318,7 +318,7 @@ describe EmsInfraController do
     end
   end
 
-  describe "#show" do
+  describe "#download_summary_pdf" do
     let(:ems_openstack_infra) { FactoryGirl.create(:ems_openstack_infra, :name => "test") }
     let(:pdf_options) { controller.instance_variable_get(:@options) }
 
@@ -326,7 +326,7 @@ describe EmsInfraController do
       before :each do
         stub_user(:features => :all)
         allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
-        get :show, :id => ems_openstack_infra.id, :display => "download_pdf"
+        get :download_summary_pdf, :id => ems_openstack_infra.id
       end
 
       it "should not contains string 'ManageIQ' in the title of summary report" do

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -163,7 +163,7 @@ describe EmsCloudController do
       before :each do
         stub_user(:features => :all)
         allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
-        get :download_summary_pdf, :id => ems_openstack.id
+        get :download_summary_pdf, :params => {:id => ems_openstack.id}
       end
 
       it "should not contains string 'ManageIQ' in the title of summary report" do
@@ -277,7 +277,7 @@ describe EmsContainerController do
         before :each do
           stub_user(:features => :all)
           allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
-          get :download_summary_pdf, :id => ems_kubernetes_container.id
+          get :download_summary_pdf, :params => {:id => ems_kubernetes_container.id}
         end
 
         it "should not contains string 'ManageIQ' in the title of summary report" do
@@ -317,25 +317,5 @@ describe EmsInfraController do
       end
     end
   end
-
-  describe "#download_summary_pdf" do
-    let(:ems_openstack_infra) { FactoryGirl.create(:ems_openstack_infra, :name => "test") }
-    let(:pdf_options) { controller.instance_variable_get(:@options) }
-
-    context "download pdf file" do
-      before :each do
-        stub_user(:features => :all)
-        allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
-        get :download_summary_pdf, :id => ems_openstack_infra.id
-      end
-
-      it "should not contains string 'ManageIQ' in the title of summary report" do
-        expect(pdf_options[:title]).not_to include('ManageIQ')
-      end
-
-      it "should match proper title of report" do
-        expect(pdf_options[:title]).to eq('Infrastructure Provider (OpenStack) "test"')
-      end
-    end
-  end
+  include_examples '#download_summary_pdf', :ems_openstack_infra
 end

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -54,4 +54,6 @@ describe EmsContainerController do
       end
     end
   end
+
+  include_examples '#download_summary_pdf', :ems_kubernetes
 end

--- a/spec/controllers/ems_datawarehouse_controller_spec.rb
+++ b/spec/controllers/ems_datawarehouse_controller_spec.rb
@@ -98,4 +98,6 @@ describe EmsDatawarehouseController do
       expect(dwh.authentications.first).to have_attributes(:auth_key => "MUCH_WOW")
     end
   end
+
+  include_examples '#download_summary_pdf', :ems_hawkular_datawarehouse
 end

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -819,4 +819,6 @@ describe EmsInfraController do
       expect(vmware.authentications.first).to have_attributes(:userid => "bar", :password => "[FILTERED]")
     end
   end
+
+  include_examples '#download_summary_pdf', :ems_vmware
 end

--- a/spec/controllers/ems_middleware_controller_spec.rb
+++ b/spec/controllers/ems_middleware_controller_spec.rb
@@ -95,4 +95,6 @@ describe EmsMiddlewareController do
       expect(hawkular.authentications.first).to have_attributes(:userid => "bar", :password => "[FILTERED]")
     end
   end
+
+  include_examples '#download_summary_pdf', :ems_hawkular
 end

--- a/spec/controllers/flavor_controller_spec.rb
+++ b/spec/controllers/flavor_controller_spec.rb
@@ -15,4 +15,6 @@ describe FlavorController do
       end
     end
   end
+
+  include_examples '#download_summary_pdf', :flavor
 end

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -20,6 +20,8 @@ describe HostAggregateController do
     end
   end
 
+  include_examples '#download_summary_pdf', :host_aggregate_openstack
+
   describe "#create" do
     before do
       stub_user(:features => :all)

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -192,6 +192,8 @@ describe HostController do
     end
   end
 
+  include_examples '#download_summary_pdf', :host
+
   context "#set_credentials" do
     let(:mocked_host) { double(Host) }
     it "uses params[:default_password] for validation if one exists" do

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -294,4 +294,6 @@ describe StorageController do
       expect(assigns(:flash_array).first[:message]).to include("All changes have been reset")
     end
   end
+
+  include_examples '#download_summary_pdf', :storage
 end

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -183,4 +183,7 @@ describe VmCloudController do
                                                                        "fingerprint"
     end
   end
+
+  include_examples '#download_summary_pdf', :vm_cloud
+  include_examples '#download_summary_pdf', :template_azure
 end

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -263,4 +263,7 @@ describe VmOrTemplateController do
       vm_common.resolve_node_info("v-#{@vm_arch[:id]}")
     end
   end
+
+  include_examples '#download_summary_pdf', :vm_cloud
+  include_examples '#download_summary_pdf', :vm_infra
 end

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -472,4 +472,7 @@ describe VmInfraController do
                                :id          => vm_vmware.id}
     expect(assigns(:flash_array).first[:message]).to include("Create Snapshot")
   end
+
+  include_examples '#download_summary_pdf', :vm_vmware
+  include_examples '#download_summary_pdf', :template_vmware
 end

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -1,27 +1,27 @@
 describe EmsCloudHelper::TextualSummary do
   context "#textual_instances and #textual_images" do
     before do
-      @ems = FactoryGirl.create(:ems_openstack, :zone => FactoryGirl.build(:zone))
+      @record = FactoryGirl.create(:ems_openstack, :zone => FactoryGirl.build(:zone))
       allow_any_instance_of(described_class).to receive(:role_allows?).and_return(true)
       allow(controller).to receive(:restful?).and_return(true)
       allow(controller).to receive(:controller_name).and_return("ems_cloud")
     end
 
     it "sets restful path for instances in summary for restful controllers" do
-      FactoryGirl.create(:vm_openstack, :ems_id => @ems.id)
+      FactoryGirl.create(:vm_openstack, :ems_id => @record.id)
 
-      expect(textual_instances[:link]).to eq("/ems_cloud/#{@ems.id}?display=instances")
+      expect(textual_instances[:link]).to eq("/ems_cloud/#{@record.id}?display=instances")
     end
 
     it "sets restful path for images in summary for restful controllers" do
-      FactoryGirl.create(:template_cloud, :ems_id => @ems.id)
+      FactoryGirl.create(:template_cloud, :ems_id => @record.id)
 
-      expect(textual_images[:link]).to eq("/ems_cloud/#{@ems.id}?display=images")
+      expect(textual_images[:link]).to eq("/ems_cloud/#{@record.id}?display=images")
     end
 
     it "sets correct path for security_groups on summary screen" do
-      FactoryGirl.create(:security_group, :name => "sq_1", :ext_management_system => @ems.network_manager)
-      expect(textual_security_groups[:link]).to eq("/ems_cloud/#{@ems.id}?display=security_groups")
+      FactoryGirl.create(:security_group, :name => "sq_1", :ext_management_system => @record.network_manager)
+      expect(textual_security_groups[:link]).to eq("/ems_cloud/#{@record.id}?display=security_groups")
     end
   end
 end

--- a/spec/presenters/tree_node_spec.rb
+++ b/spec/presenters/tree_node_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode do
   # Force load all the TreeNode:: subclasses
-  Dir[Rails.root.join('app', 'presenters', 'tree_node', '*.rb')].each { |f| require f }
+  Dir[ManageIQ::UI::Classic::Engine.root.join('app', 'presenters', 'tree_node', '*.rb')].each { |f| require f }
 
   # FIXME: rewrite this to FactoryGirl
   let(:object) do

--- a/spec/shared/controllers/shared_example_for_download_summary_pdf.rb
+++ b/spec/shared/controllers/shared_example_for_download_summary_pdf.rb
@@ -1,0 +1,23 @@
+shared_examples '#download_summary_pdf' do |object|
+  context 'download pdf file' do
+    let(:record) { FactoryGirl.create(object) }
+    let(:pdf_options) { controller.instance_variable_get(:@options) }
+
+    before :each do
+      allow(PdfGenerator).to receive(:pdf_from_string).and_return("")
+      allow(controller).to receive(:server_timezone).and_return('UTC')
+      allow(controller).to receive(:tagdata).and_return(nil)
+      login_as FactoryGirl.create(:user_admin)
+      stub_user(:features => :all)
+      get :download_summary_pdf, :params => {:id => record.id}
+    end
+
+    it 'request returns 200' do
+      expect(response.status).to eq(200)
+    end
+
+    it 'title is set correctly' do
+      expect(pdf_options[:title]).to eq("#{ui_lookup(:model => record.class.name)} \"#{record.name}\"")
+    end
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1613907/stories/135588177

Called when on summary page.

 - [x] Remove = render :partial => "layouts/show_pdf" They were never ever called.
 - [x] Change URL from /show/10000000000001?display=download_pdf to /download_summary_pdf/10000000000001
  - [x] ResourcePool cannot generate pdf. Fixed in https://github.com/ManageIQ/manageiq/pull/13214
  - [x] StorageController has download summary pdf button?
  - [x] EmsCommon
  - [x] Template download not working
  - [x] Get rid of @* = @record so we don't need it anymore
 - [x] Add more specs
 
@miq-bot add_label wip, ui, technical debt