### PR TITLE
[WIP] Fix TreeBuilder i18n

### DIFF
--- a/app/presenters/tree_builder_action.rb
+++ b/app/presenters/tree_builder_action.rb
@@ -7,7 +7,7 @@ class TreeBuilderAction < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Actions"), t]
+    [t = _("All Actions"), t]
   end
 
   # level 1 - actions

--- a/app/presenters/tree_builder_alert.rb
+++ b/app/presenters/tree_builder_alert.rb
@@ -7,7 +7,7 @@ class TreeBuilderAlert < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Alerts"), t]
+    [t = _("All Alerts"), t]
   end
 
   # level 1 - alerts

--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -18,7 +18,7 @@ class TreeBuilderAlertProfile < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Alert Profiles"), t]
+    [t = _("All Alert Profiles"), t]
   end
 
   # level 1 - * alert profiles

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -12,7 +12,7 @@ class TreeBuilderCondition < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Conditions"), t]
+    [t = _("All Conditions"), t]
   end
 
   # level 1 - host / vm

--- a/app/presenters/tree_builder_event.rb
+++ b/app/presenters/tree_builder_event.rb
@@ -7,7 +7,7 @@ class TreeBuilderEvent < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Events"), t]
+    [t = _("All Events"), t]
   end
 
   # level 1 - events

--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -17,7 +17,7 @@ class TreeBuilderPolicyProfile < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Policy Profiles"), t]
+    [t = _("All Policy Profiles"), t]
   end
 
   # level 1 - policy profiles


### PR DESCRIPTION
Old TreeBuilder conversions used `N_` and `PostponedTranslation`, but since then we've settled on directly doing the translating with `_`.

Fixing the remaining..

(WIP because this was originally a part of #13272, and depends on it.)

also TODO: app/presenters/tree_builder_alert_profile.rb:31:    text = PostponedTranslation.new(N_("%{model} Alert Profiles")) do

and make the commits nice :)

(converted from ManageIQ/manageiq#13292)