### PR TITLE
[WIP] Use nested routes for sub-lists

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,7 @@
 //= require cable
 //= require miq_api
 //= require rxjs/dist/rx.all
+//= require miq_observable
 //= require miq_angular_application
 //= require_tree ./angular_modules/
 //= require_tree ./controllers/

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,7 +20,7 @@
 //= require numeral
 //= require cable
 //= require miq_api
-//= require rxjs/dist/rx.all
+//= require rxjs/rx.global
 //= require miq_observable
 //= require miq_angular_application
 //= require_tree ./angular_modules/
@@ -89,5 +89,4 @@
 //= require miq_timeline
 // Bower packages
 //= require manageiq-ui-components/dist/js/ui-components
-//= require rx-angular/dist/rx.angular
 //= require patternfly-timeline/dist/timeline

--- a/app/assets/javascripts/controllers/error_modal_controller.js
+++ b/app/assets/javascripts/controllers/error_modal_controller.js
@@ -5,7 +5,7 @@ function ErrorModalController($timeout) {
   $ctrl.error = null;
   $ctrl.isHtml = false;
 
-  ManageIQ.angular.rxSubject.subscribe(function(event) {
+  listenToRx(function(event) {
     if ('serverError' in event) {
       $timeout(function() {
         $ctrl.show(event.serverError);

--- a/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
+++ b/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
@@ -28,7 +28,7 @@ MwServerController.$inject = ['$scope', 'miqService' ];
 function MwServerController($scope, miqService) {
   ManageIQ.angular.scope = $scope;
 
-  ManageIQ.angular.rxSubject.subscribe(function(event) {
+  listenToRx(function(event) {
     var eventType = event.type,
         operation = event.operation,
         timeout = event.timeout;
@@ -139,7 +139,7 @@ MwServerOpsController.$inject = ['miqService', 'serverOpsService'];
  */
 function MwServerOpsController( miqService, serverOpsService) {
 
-    ManageIQ.angular.rxSubject.subscribe(function(event) {
+    listenToRx(function(event) {
 
       if(event.type == 'mwSeverOpsEvent') {
         miqService.sparkleOn();

--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -13,7 +13,7 @@
   * For success functuon @see ToolbarController#onRowSelect()
   */
   function subscribeToSubject() {
-    ManageIQ.angular.rxSubject.subscribe(function(event) {
+    listenToRx(function(event) {
       if (event.rowSelect) {
         this.onRowSelect(event.rowSelect);
       } else if (event.redrawToolbar) {

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -8,8 +8,6 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
 ]);
 miqHttpInject(ManageIQ.angular.app);
 
-ManageIQ.angular.rxSubject = new Rx.Subject();
-
 function miqHttpInject(angular_app) {
   angular_app.config(['$httpProvider', function($httpProvider) {
     $httpProvider.defaults.headers.common['X-Angular-Request'] = true;
@@ -44,8 +42,4 @@ function miqCallAngular(data) {
   ManageIQ.angular.scope.$apply(function() {
     ManageIQ.angular.scope[data.name].apply(ManageIQ.angular.scope, data.args);
   });
-}
-
-function sendDataWithRx(data) {
-  ManageIQ.angular.rxSubject.onNext(data);
 }

--- a/app/assets/javascripts/miq_debug.js
+++ b/app/assets/javascripts/miq_debug.js
@@ -91,7 +91,7 @@ angular.module('miq.debug', [])
       var $ctrl = this;
       this.items = [];
 
-      ManageIQ.angular.rxSubject.subscribe(function(event) {
+      listenToRx(function(event) {
         if (!event.error || !event.error.data) {
           return;
         }

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -221,7 +221,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
   }
 
   if (_.isArray(data.reloadToolbars) && data.reloadToolbars.length) {
-    ManageIQ.angular.rxSubject.onNext({
+    sendDataWithRx({
       redrawToolbar: data.reloadToolbars
     });
   } else if (_.isObject(data.reloadToolbars) && !_.isArray(data.reloadToolbars)) {

--- a/app/assets/javascripts/miq_observable.js
+++ b/app/assets/javascripts/miq_observable.js
@@ -3,3 +3,7 @@ ManageIQ.angular.rxSubject = new Rx.Subject();
 function sendDataWithRx(data) {
   ManageIQ.angular.rxSubject.onNext(data);
 }
+
+function listenToRx(callback) {
+  ManageIQ.angular.rxSubject.subscribe(callback);
+}

--- a/app/assets/javascripts/miq_observable.js
+++ b/app/assets/javascripts/miq_observable.js
@@ -1,0 +1,5 @@
+ManageIQ.angular.rxSubject = new Rx.Subject();
+
+function sendDataWithRx(data) {
+  ManageIQ.angular.rxSubject.onNext(data);
+}

--- a/app/assets/javascripts/miq_observable.js
+++ b/app/assets/javascripts/miq_observable.js
@@ -1,7 +1,7 @@
 ManageIQ.angular.rxSubject = new Rx.Subject();
 
 function sendDataWithRx(data) {
-  ManageIQ.angular.rxSubject.onNext(data);
+  ManageIQ.angular.rxSubject.next(data);
 }
 
 function listenToRx(callback) {

--- a/app/assets/javascripts/miq_toolbar.js
+++ b/app/assets/javascripts/miq_toolbar.js
@@ -6,35 +6,35 @@ ManageIQ.toolbars.findByDataClick = function (toolbar, attr_click) {
 
 ManageIQ.toolbars.enableItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).removeClass('disabled');
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'enabled', value: true});
+  sendDataWithRx({update: attr_click, type: 'enabled', value: true});
 };
 
 ManageIQ.toolbars.disableItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).addClass('disabled');
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'enabled', value: false});
+  sendDataWithRx({update: attr_click, type: 'enabled', value: false});
 };
 
 ManageIQ.toolbars.setItemTooltip = function (toolbar, attr_click, tooltip) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).attr('title', tooltip);
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'title', value: tooltip});
+  sendDataWithRx({update: attr_click, type: 'title', value: tooltip});
 };
 
 ManageIQ.toolbars.showItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).show();
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'hidden', value: true});
+  sendDataWithRx({update: attr_click, type: 'hidden', value: true});
 };
 
 ManageIQ.toolbars.hideItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).hide();
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'hidden', value: true});
+  sendDataWithRx({update: attr_click, type: 'hidden', value: true});
 };
 
 ManageIQ.toolbars.markItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).addClass('active');
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'selected', value: true});
+  sendDataWithRx({update: attr_click, type: 'selected', value: true});
 };
 
 ManageIQ.toolbars.unmarkItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).removeClass('active');
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'selected', value: false});
+  sendDataWithRx({update: attr_click, type: 'selected', value: false});
 };

--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -315,7 +315,7 @@ function eventNotifications($timeout) {
 
   this.doReset(true);
 
-  ManageIQ.angular.rxSubject.subscribe(function (data) {
+  listenToRx(function (data) {
     if (data.notification) {
       var msg = miqFormatNotification(data.notification.text, data.notification.bindings);
       _this.add('event', data.notification.level, msg, {message: msg}, data.notification.id);

--- a/app/assets/javascripts/services/subscription_service.js
+++ b/app/assets/javascripts/services/subscription_service.js
@@ -1,6 +1,6 @@
 ManageIQ.angular.app.service('subscriptionService', ['$timeout', function($timeout) {
   this.subscribeToEventType = function(eventType, callback) {
-    ManageIQ.angular.rxSubject.subscribe(function(event) {
+    listenToRx(function(event) {
       if (event.eventType === eventType) {
         $timeout(function() {
           callback(event.response);

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -78,13 +78,13 @@ module Mixins
       nested_list("template_cloud", ManageIQ::Providers::CloudManager::Template)
     end
 
-    def nested_list(table_name, model)
+    def nested_list(table_name, model, parent_table = self.class.table_name, parent_record = @record)
       title = ui_lookup(:tables => table_name)
-      drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @record.name},
-                      :url  => "/#{self.class.table_name}/show/#{@record.id}")
-      drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @record.name, :title => title},
-                      :url  => "/#{self.class.table_name}/show/#{@record.id}?display=#{@display}")
-      @view, @pages = get_view(model, :parent => @record) # Get the records (into a view) and the paginator
+      drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => parent_record.name},
+                      :url  => "/#{parent_table}/show/#{parent_record.id}")
+      drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => parent_record.name, :title => title},
+                      :url  => "/#{parent_table}/show/#{parent_record.id}?display=#{@display}")
+      @view, @pages = get_view(model, :parent => parent_record) # Get the records (into a view) and the paginator
       @showtype     = @display
     end
   end

--- a/app/controllers/mixins/nested_list_mixin.rb
+++ b/app/controllers/mixins/nested_list_mixin.rb
@@ -1,0 +1,11 @@
+module Mixins
+  module NestedListMixin
+    def show_nested
+      render :json => {
+        :parent_collection => params[:parent_collection],
+        :parent_id => from_cid(params[:parent_id]),
+      }
+    end
+
+  end
+end

--- a/app/controllers/mixins/nested_list_mixin.rb
+++ b/app/controllers/mixins/nested_list_mixin.rb
@@ -1,10 +1,26 @@
 module Mixins
   module NestedListMixin
     def show_nested
-      render :json => {
-        :parent_collection => params[:parent_collection],
-        :parent_id => from_cid(params[:parent_id]),
-      }
+      parent_table = params[:parent_collection]
+      parent_id = from_cid(params[:parent_id])
+
+      parent_controller = "#{parent_table}_controller".camelcase.constantize
+      parent_model = controller_to_model(parent_controller)
+      parent_record = identify_record(parent_id, parent_model)
+
+      return render :json => {
+        :parent_table => parent_table,
+        :parent_id => parent_id,
+        :my_table => self.class.table_name,
+        :my_model => controller_to_model.name,
+        :parent_record => parent_record,
+        :parent_model => parent_model.name,
+      } if params[:debug]
+
+      @display = 'main'
+      nested_list(self.class.table_name, controller_to_model, parent_table, parent_record)
+      #show_list
+      render :action => 'show_list' unless performed?
     end
 
   end

--- a/app/controllers/network_port_controller.rb
+++ b/app/controllers/network_port_controller.rb
@@ -8,6 +8,7 @@ class NetworkPortController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
+  include Mixins::NestedListMixin
 
   def self.display_methods
     %w(cloud_subnets floating_ips)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -148,12 +148,12 @@ module ApplicationHelper
     record.class.base_model.name.underscore
   end
 
-  def controller_to_model
-    case self.class.model.to_s
+  def controller_to_model(klass = self.class)
+    case klass.model.to_s
     when "ManageIQ::Providers::CloudManager::Template", "ManageIQ::Providers::CloudManager::Vm", "ManageIQ::Providers::InfraManager::Template", "ManageIQ::Providers::InfraManager::Vm"
       VmOrTemplate
     else
-      self.class.model
+      klass.model
     end
   end
 

--- a/bower.json
+++ b/bower.json
@@ -47,8 +47,6 @@
     "patternfly-timeline": "~1.0.3",
     "phantomjs-polyfill": "~0.0.2",
     "qs": "~0.3.10",
-    "rx-angular": "rx.angular#~1.1.3",
-    "rxjs": "~4.1.0",
     "spice-html5-bower": "himdel/spice-html5-bower#~0.1.6",
     "spin.js": "~2.3.2",
     "sprintf": "~1.0.3",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3200,6 +3200,22 @@ Rails.application.routes.draw do
     end
   end
 
+  nested_routes = {
+    # TODO: controller_name.to_sym => self.display_methods
+    :security_group => %i(instances network_ports),
+  }
+  nested_routes.each do |collection, display_methods|
+    display_methods.each do |plural|
+      singular = plural.to_s.singularize.to_sym
+      get "#{collection}/:parent_id/#{plural}",
+        :controller => singular,
+        :action => 'show_nested',
+        :parent_collection => collection,
+        :constraints => { :parent_id => /(\d+r)?\d+/ }
+    end
+  end
+
+
   # pure-angular templates
   get '/static/*id' => 'static#show', :format => false
 

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-react": "^5.1.1",
     "eslint-plugin-standard": "^2.0.1"
+  },
+  "dependencies": {
+    "rxjs": "~5.0.1"
   }
 }

--- a/rx
+++ b/rx
@@ -1,0 +1,13 @@
+
+rx angular introduced in e416daa91c8dcf8b8ddc42eddc91aa4cfa7727f4
+never used?
+not moduled anywhere in our code
+nor in ui-components
+
+
+
+rx.js 5
+https://github.com/ReactiveX/rxjs/blob/master/MIGRATION.md
+
+
+

--- a/spec/javascripts/controllers/toolbar_controller_spec.js
+++ b/spec/javascripts/controllers/toolbar_controller_spec.js
@@ -75,7 +75,7 @@ describe('toolbarController', function () {
        expect(middleware_toolbar_list !== $controller.toolbarItems).toBeTruthy();
      });
    });
-   
+
    describe('event data toolbar', function() {
      beforeEach(function() {
        spyOn($controller, 'onUpdateItem');
@@ -83,7 +83,7 @@ describe('toolbarController', function () {
      })
 
      it('should call update toolbar', function() {
-       ManageIQ.angular.rxSubject.onNext({update: 'someButton', type: 'hidden', value: true})
+       sendDataWithRx({ update: 'someButton', type: 'hidden', value: true });
        expect($controller.onUpdateItem).toHaveBeenCalled();
      })
    });

--- a/spec/javascripts/services/subscription_service_spec.js
+++ b/spec/javascripts/services/subscription_service_spec.js
@@ -12,7 +12,7 @@ describe('subscriptionService', function() {
     $timeout = _$timeout_;
 
     spyOn(test, 'callback');
-    spyOn(ManageIQ.angular.rxSubject, 'subscribe').and.callFake(function(callback) {
+    spyOn(window, 'listenToRx').and.callFake(function(callback) {
       loadedReactionFunction = callback;
     });
   }));
@@ -27,7 +27,7 @@ describe('subscriptionService', function() {
     });
 
     it('subscribes', function() {
-      expect(ManageIQ.angular.rxSubject.subscribe).toHaveBeenCalledWith(loadedReactionFunction);
+      expect(listenToRx).toHaveBeenCalledWith(loadedReactionFunction);
     });
 
     describe('#subscribeToEventType reaction function', function() {


### PR DESCRIPTION
Parent issue: https://github.com/ManageIQ/manageiq/issues/13050
(Related to toolbar actions refactoring.)

Right now, if we want to display (for example) a list of network ports under a specific security group, the route is `/security_group/show/10000000000009?display=network_ports`, and displaying the list is handled in `SecurityGroupController`.

However, `NetworkPortController` is the controller that can do actions on network ports, knows how to render them, etc. etc. So right now, we're duplicating that functionality in any controller that needs to show network ports.

The new plan is to use routes like `/security_group/10000000000009/network_ports`, which would be routed to the `NetworkPortController` (right now, `#show_nested`, with `parent_collection` (= `:security_group`) and `parent_id` (= `10000000000009`) in params).

---

WIP for now, only that specific route mentioned actually does something, doesn't support non-generic things, should probably offload the `get_view` call to `process_show_list`, just preparing @parent_record for it.

(converted from ManageIQ/manageiq#13171)