### PR TITLE
[WIP] Orchestration stack naming in case of VMware

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -70,7 +70,7 @@ module EmsCommon
                                           :storage_managers],
       "miq_templates"                 => [MiqTemplate,            _("Templates")],
       "vms"                           => [Vm,                     _("VMs")],
-      "orchestration_stacks"          => [OrchestrationStack,     _("Stacks")],
+      "orchestration_stacks"          => [OrchestrationStack,     title_for_stacks],
       # "configuration_jobs"            => [ConfigurationJob, _("Configuration Jobs")],
       "cloud_object_store_containers" => [CloudObjectStoreContainer, _('Cloud Object Store Containers')],
       'containers'                    => [Container,              _('Containers')],

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -21,7 +21,8 @@ class OrchestrationStackController < ApplicationController
     return if record_no_longer_exists?(@orchestration_stack)
 
     @gtl_url = "/show"
-    drop_breadcrumb({:name => _("Orchestration Stacks"),
+    stacks_title = title_for_stacks
+    drop_breadcrumb({:name => stacks_title,
                      :url  => "/orchestration_stack/show_list?page=#{@current_page}&refresh=y"}, true)
     case @display
     when "download_pdf", "main", "summary_only"
@@ -37,9 +38,8 @@ class OrchestrationStackController < ApplicationController
       @view, @pages = get_view(ManageIQ::Providers::CloudManager::Vm, :parent => @orchestration_stack)
       @showtype = @display
     when "children"
-      title = ui_lookup(:tables => "orchestration_stack")
       kls   = OrchestrationStack
-      drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @orchestration_stack.name, :title => title},
+      drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @orchestration_stack.name, :title => stacks_title},
                       :url  => "/orchestration_stack/show/#{@orchestration_stack.id}?display=#{@display}")
       @view, @pages = get_view(kls, :parent => @orchestration_stack)
       @showtype = @display
@@ -271,8 +271,12 @@ class OrchestrationStackController < ApplicationController
     javascript_redirect :controller => 'catalog', :action => 'ot_show', :id => template.id
   end
 
+  def breadcrumb_name(_model)
+    title_for_stacks
+  end
+
   def get_session_data
-    @title      = _("Stack")
+    @title      = title_for_stack
     @layout     = "orchestration_stack"
     @lastaction = session[:orchestration_stack_lastaction]
     @display    = session[:orchestration_stack_display]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -489,6 +489,8 @@ module ApplicationHelper
     elsif layout == "login"
       title += _(": Login")
     # Assume layout is a table name and look up the plural version
+    elsif layout == "orchestration_stack"
+      title += _(": #{title_for_stacks}")
     else
       title += ": #{ui_lookup(:tables => layout)}"
     end
@@ -1549,6 +1551,36 @@ module ApplicationHelper
 
   def title_for_cluster_record(record)
     record.openstack_cluster? ? _("Deployment Role") : _("Cluster")
+  end
+
+  def title_for_stacks
+    title_for_stack(true)
+  end
+
+  def title_for_stack(plural = false)
+    case ManageIQ::Providers::CloudManager.connected_provider_types
+    when :vcloud
+      plural ? _("vApps") : _("vApp")
+    else
+      plural ? _("Stacks") : _("Stack")
+    end
+  end
+
+  def start_page_allowed?(start_page)
+    storage_start_pages = %w(cim_storage_extent_show_list
+                             ontap_file_share_show_list
+                             ontap_logical_disk_show_list
+                             ontap_storage_system_show_list
+                             ontap_storage_volume_show_list
+                             storage_manager_show_list)
+    return false if storage_start_pages.include?(start_page) && !::Settings.product.storage
+    containers_start_pages = %w(ems_container_show_list
+                                container_node_show_list
+                                container_group_show_list
+                                container_service_show_list
+                                container_view)
+    return false if containers_start_pages.include?(start_page) && !::Settings.product.containers
+    role_allows?(:feature => start_page, :any => true)
   end
 
   def miq_tab_header(id, active = nil, options = {}, &_block)

--- a/app/helpers/application_helper/toolbar/orchestration_stack_center.rb
+++ b/app/helpers/application_helper/toolbar/orchestration_stack_center.rb
@@ -9,10 +9,10 @@ class ApplicationHelper::Toolbar::OrchestrationStackCenter < ApplicationHelper::
         button(
           :orchestration_stack_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Orchestration Stack'),
+          t = N_('Remove this item'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Orchestration Stack and ALL of its components will be permanently removed!")),
+          :confirm   => N_("Warning: This item and ALL of its components will be permanently removed!")),
       ]
     ),
   ])
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::OrchestrationStackCenter < ApplicationHelper::
         button(
           :orchestration_stack_tag,
           'pficon pficon-edit fa-lg',
-          N_('Edit Tags for this Orchestration Stack'),
+          N_('Edit Tags for this item'),
           N_('Edit Tags')),
       ]
     ),
@@ -41,14 +41,14 @@ class ApplicationHelper::Toolbar::OrchestrationStackCenter < ApplicationHelper::
         button(
           :orchestration_stack_retire,
           'fa fa-clock-o fa-lg',
-          N_('Set Retirement Dates for this Orchestration Stack'),
+          N_('Set Retirement Dates for this item'),
           N_('Set Retirement Date')),
         button(
           :orchestration_stack_retire_now,
           'fa fa-clock-o fa-lg',
-          t = N_('Retire this Orchestration Stack'),
+          t = N_('Retire this item'),
           t,
-          :confirm => N_("Retire this Orchestration Stack")),
+          :confirm => N_("Retire this item")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/orchestration_stacks_center.rb
+++ b/app/helpers/application_helper/toolbar/orchestration_stacks_center.rb
@@ -9,10 +9,10 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
         button(
           :orchestration_stack_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Orchestration Stacks'),
-          N_('Remove Orchestration Stacks'),
+          N_('Remove selected items'),
+          N_('Remove items'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Orchestration Stacks and ALL of their components will be permanently removed!"),
+          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]
@@ -30,7 +30,7 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
         button(
           :orchestration_stack_tag,
           'pficon pficon-edit fa-lg',
-          N_('Edit Tags for the selected Orchestration Stacks'),
+          N_('Edit Tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
           :enabled   => false,
@@ -50,7 +50,7 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
         button(
           :orchestration_stack_retire,
           'fa fa-clock-o fa-lg',
-          N_('Set Retirement Dates for the selected Orchestration Stacks'),
+          N_('Set Retirement Dates for the selected items'),
           N_('Set Retirement Dates'),
           :enabled   => false,
           :onwhen    => "1+",
@@ -58,9 +58,9 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
         button(
           :orchestration_stack_retire_now,
           'fa fa-clock-o fa-lg',
-          t = N_('Retire selected Orchestration Stacks'),
+          t = N_('Retire selected items'),
           t,
-          :confirm   => N_("Retire the selected Orchestration Stacks?"),
+          :confirm   => N_("Retire the selected items?"),
           :enabled   => false,
           :onwhen    => "1+",
           :url_parms => "main_div"),

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -51,7 +51,7 @@ module Menu
           Menu::Item.new('cloud_tenant',        N_('Tenants'),            'cloud_tenant',        {:feature => 'cloud_tenant_show_list'},          '/cloud_tenant'),
           Menu::Item.new('flavor',              N_('Flavors'),            'flavor',              {:feature => 'flavor_show_list'},                '/flavor'),
           Menu::Item.new('vm_cloud',            N_('Instances'),          'vm_cloud_explorer',   {:feature => 'vm_cloud_explorer', :any => true}, '/vm_cloud/explorer'),
-          Menu::Item.new('orchestration_stack', N_('Stacks'),             'orchestration_stack', {:feature => 'orchestration_stack_show_list'},   '/orchestration_stack'),
+          Menu::Item.new('orchestration_stack', hybrid_stack_name,        'orchestration_stack', {:feature => 'orchestration_stack_show_list'},   '/orchestration_stack'),
           Menu::Item.new('auth_key_pair_cloud', N_('Key Pairs'),          'auth_key_pair_cloud', {:feature => 'auth_key_pair_cloud_show_list'},   '/auth_key_pair_cloud'),
           Menu::Item.new('cloud_topology',      N_('Topology'),           'cloud_topology',      {:feature => 'cloud_topology'},                  '/cloud_topology'),
         ])
@@ -85,6 +85,16 @@ module Menu
         end
       end
       private :hybrid_name
+
+      def hybrid_stack_name
+        lambda do
+          case ManageIQ::Providers::CloudManager.connected_provider_types
+          when :vcloud then N_("vApps")
+          else              N_("Stacks")
+          end
+        end
+      end
+      private :hybrid_stack_name
 
       def deferred_ui_lookup(args)
         -> () { ui_lookup(args) }

--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -106,7 +106,7 @@
                                                               "instances_filter_accord"], _('Instances')],
                :manageiq_providers_cloudmanager_template => [["images_accord",
                                                               "images_filter_accord"],    _('Images')],
-               :orchestrationstack        => ["orchestration_stack_show_list",          _('Stacks')],
+               :orchestrationstack        => ["orchestration_stack_show_list",          title_for_stacks],
                :cloudvolume               => ["cloud_volume_show_list",                 _('Volumes')],
                :authkeypaircloud          => ["auth_key_pair_cloud_show_list",          _('Key Pairs')],
                :cloudobjectstorecontainer => ["cloud_object_store_container_show_list", _('Object Store')]}.each do |resource, (feature, view_name)|

--- a/app/views/layouts/listnav/_ems_cloud.html.haml
+++ b/app/views/layouts/listnav/_ems_cloud.html.haml
@@ -50,7 +50,10 @@
             :display       => 'images',
             :tables        => 'template_cloud')
         - if role_allows?(:feature => "orchestration_stack_show_list")
+          - stacks_title = title_for_stacks
           = li_link(:count => @record.number_of(:orchestration_stacks),
             :record        => @record,
             :display       => 'orchestration_stacks',
-            :tables        => 'orchestration_stack')
+            :tables        => 'orchestration_stack',
+            :link_text     => stacks_title,
+            :title         => _("Show all %{stacks}") % {:stacks => stacks_title})


### PR DESCRIPTION
Each provider should use its own terminology if only a single provider is used. In case of VMware only provider, Stack should be called vApp.

PR for the background part: https://github.com/ManageIQ/manageiq/pull/12645

I've implemented it in a way how similar logic was introduced for OpenStack:
https://github.com/ManageIQ/manageiq/pull/2708 Model methods to determine host/clusters types.
https://github.com/ManageIQ/manageiq/pull/2762 Changes to display appropriate Host/Cluster titles in UI.
https://github.com/ManageIQ/manageiq/pull/2764 Menu items changing names on show time for infra.

Open questions:
1. Is it still the right way how to do things?
2. Which part of application shouldn't be changed?

@h-kataria  please review.

**Compute->Clouds->Providers section**
Before: 
![before_vapp1](https://cloud.githubusercontent.com/assets/435679/20397412/e7ce4ecc-ace9-11e6-99f3-edb8c904c452.png)
After:
![vapp1](https://cloud.githubusercontent.com/assets/435679/20397458/193c356e-acea-11e6-82ea-799f91076abe.png)


**Compute->Clouds sub-menu**
Before:
![before_vapp2](https://cloud.githubusercontent.com/assets/435679/20397489/3309a04e-acea-11e6-8f18-af6bc274f833.png)
After:
![vapp2](https://cloud.githubusercontent.com/assets/435679/20397494/386482fc-acea-11e6-9816-44086093775c.png)

**Compute->Clouds->Stacks(vApps) section**
Before:
![before_vapp4](https://cloud.githubusercontent.com/assets/435679/20397553/6ff0ed28-acea-11e6-8b93-5559aa95f86e.png)
After:
![vapp4](https://cloud.githubusercontent.com/assets/435679/20397562/773129ae-acea-11e6-844c-2a8b53802a95.png)

