### PR TITLE
[Ad hoc metrics for OPS] Remove the apply button

### DIFF
--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -40,6 +40,14 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
         $scope.filtersText += filter.title + " : " + filter.value + "\n";
         $scope.tags[filter.id] = filter.value;
       });
+
+      if (Object.keys($scope.tags).length > 0) {
+        $scope.doApply();
+      } else {
+        $scope.items = [];
+        $scope.applied = false;
+        $scope.filterConfig.resultsCount = 0;
+      }
     };
 
     var selectionChange = function() {

--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -1,83 +1,84 @@
 /* global miqHttpInject */
 
 miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'patternfly', 'patternfly.charts']))
-  .controller('containerLiveDashboardController', ['$scope', 'pfViewUtils', '$http', '$interval', '$timeout', '$window',
-  function ($scope, pfViewUtils, $http, $interval, $timeout, $window) {
-    $scope.tenant = '_ops';
+  .controller('containerLiveDashboardController', ['pfViewUtils', '$http', '$interval', '$timeout', '$window',
+  function (pfViewUtils, $http, $interval, $timeout, $window) {
+    var dash = this; 
+    dash.tenant = '_ops';
 
     // get the pathname and remove trailing / if exist
     var pathname = $window.location.pathname.replace(/\/$/, '');
     var id = '/' + (/^\/[^\/]+\/(\d+)$/.exec(pathname)[1]);
 
     var initialization = function() {
-      $scope.filtersText = '';
-      $scope.definitions = [];
-      $scope.items = [];
-      $scope.tags = {};
-      $scope.tagsLoaded = false;
+      dash.filtersText = '';
+      dash.definitions = [];
+      dash.items = [];
+      dash.tags = {};
+      dash.tagsLoaded = false;
 
-      $scope.applied = false;
-      $scope.filterChanged = true;
-      $scope.viewGraph = false;
-      $scope.chartData = {};
+      dash.applied = false;
+      dash.filterChanged = true;
+      dash.viewGraph = false;
+      dash.chartData = {};
 
-      $scope.filterConfig.fields = [];
-      $scope.filterConfig.resultsCount = $scope.items.length;
-      $scope.filterConfig.appliedFilters = [];
-      $scope.filterConfig.onFilterChange = filterChange;
+      dash.filterConfig.fields = [];
+      dash.filterConfig.resultsCount = dash.items.length;
+      dash.filterConfig.appliedFilters = [];
+      dash.filterConfig.onFilterChange = filterChange;
 
-      $scope.toolbarConfig.filterConfig = $scope.filterConfig;
-      $scope.toolbarConfig.actionsConfig = $scope.actionsConfig;
+      dash.toolbarConfig.filterConfig = dash.filterConfig;
+      dash.toolbarConfig.actionsConfig = dash.actionsConfig;
 
-      $scope.url = '/container_dashboard/data' + id + '/?live=true&tenant=' + $scope.tenant;
+      dash.url = '/container_dashboard/data' + id + '/?live=true&tenant=' + dash.tenant;
     }
 
     var filterChange = function (filters) {
-      $scope.filterChanged = true;
-      $scope.filtersText = "";
-      $scope.tags = {};
-      $scope.filterConfig.appliedFilters.forEach(function (filter) {
-        $scope.filtersText += filter.title + " : " + filter.value + "\n";
-        $scope.tags[filter.id] = filter.value;
+      dash.filterChanged = true;
+      dash.filtersText = "";
+      dash.tags = {};
+      dash.filterConfig.appliedFilters.forEach(function (filter) {
+        dash.filtersText += filter.title + " : " + filter.value + "\n";
+        dash.tags[filter.id] = filter.value;
       });
 
-      if (Object.keys($scope.tags).length > 0) {
-        $scope.doApply();
+      if (Object.keys(dash.tags).length > 0) {
+        dash.doApply();
       } else {
-        $scope.items = [];
-        $scope.applied = false;
-        $scope.filterConfig.resultsCount = 0;
+        dash.items = [];
+        dash.applied = false;
+        dash.filterConfig.resultsCount = 0;
       }
     };
 
     var selectionChange = function() {
-      $scope.itemSelected = false;
-      for (var i = 0; i < $scope.items.length && !$scope.itemSelected; i++) {
-        if ($scope.items[i].selected) {
-          $scope.itemSelected = true;
+      dash.itemSelected = false;
+      for (var i = 0; i < dash.items.length && !dash.itemSelected; i++) {
+        if (dash.items[i].selected) {
+          dash.itemSelected = true;
         }
       }
     };
 
-    $scope.doApply = function() {
-      $scope.applied = true;
-      $scope.filterChanged = false;
-      $scope.refresh();
+    dash.doApply = function() {
+      dash.applied = true;
+      dash.filterChanged = false;
+      dash.refresh();
     };
 
-    $scope.doViewGraph = function() {
-      $scope.viewGraph = true;
-      $scope.chartDataInit = false;
-      $scope.refresh_graph_data();
+    dash.doViewGraph = function() {
+      dash.viewGraph = true;
+      dash.chartDataInit = false;
+      dash.refresh_graph_data();
     };
 
-    $scope.doViewMetrics = function() {
-      $scope.viewGraph = false;
-      $scope.refresh();
+    dash.doViewMetrics = function() {
+      dash.viewGraph = false;
+      dash.refresh();
     };
 
     var doRefreshTenant = function (action) {
-      $scope.tenant = action.tenant;
+      dash.tenant = action.tenant;
 
       initialization();
       filterChange();
@@ -85,12 +86,12 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
     };
 
     var getMetricTags = function() {
-      $http.get($scope.url + '&query=metric_tags').success(function(response) {
-        $scope.tagsLoaded = true;
+      $http.get(dash.url + '&query=metric_tags').success(function(response) {
+        dash.tagsLoaded = true;
         if (response && angular.isArray(response.metric_tags)) {
           response.metric_tags.sort();
           for (var i = 0; i < response.metric_tags.length; i++) {
-            $scope.filterConfig.fields.push(
+            dash.filterConfig.fields.push(
               {
                 id: response.metric_tags[i],
                 title:  response.metric_tags[i],
@@ -100,8 +101,8 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
           }
         } else {
           // No filters available, apply without filtering
-          $scope.toolbarConfig.filterConfig = undefined;
-          $scope.doApply();
+          dash.toolbarConfig.filterConfig = undefined;
+          dash.doApply();
         }
       });
     };
@@ -109,7 +110,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
     var getLatestData = function(item) {
       var params = '&query=get_data&metric_id=' + item.id + '&limit=5&order=DESC';
 
-      $http.get($scope.url + params).success(function (response) {
+      $http.get(dash.url + params).success(function (response) {
         'use strict';
         if (response.error) {
           add_flash(response.error, 'error');
@@ -148,37 +149,37 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       });
     };
 
-    $scope.refresh = function() {
-      $scope.loadingMetrics = true;
-      var _tags = $scope.tags != {} ? '&tags=' + JSON.stringify($scope.tags) : '';
-      $http.get($scope.url + '&query=metric_definitions' + _tags).success(function (response) {
+    dash.refresh = function() {
+      dash.loadingMetrics = true;
+      var _tags = dash.tags != {} ? '&tags=' + JSON.stringify(dash.tags) : '';
+      $http.get(dash.url + '&query=metric_definitions' + _tags).success(function (response) {
         'use strict';
-        $scope.loadingMetrics = false;
+        dash.loadingMetrics = false;
         if (response.error) {
           add_flash(response.error, 'error');
           return;
         }
 
-        $scope.items = response.metric_definitions.filter(function(item) {
+        dash.items = response.metric_definitions.filter(function(item) {
           return item.id && item.type;
         });
 
-        angular.forEach($scope.items, getLatestData);
+        angular.forEach(dash.items, getLatestData);
 
-        $scope.filterConfig.resultsCount = $scope.items.length;
+        dash.filterConfig.resultsCount = dash.items.length;
       });
     };
 
-    $scope.refresh_graph = function(metric_id, n) {
+    dash.refresh_graph = function(metric_id, n) {
       // TODO: replace with a datetimepicker, until then add 24 hours to the date
-      var ends = $scope.timeFilter.date.valueOf() + 24 * 60 * 60;
-      var diff = $scope.timeFilter.time_range * $scope.timeFilter.range_count * 60 * 60 * 1000; // time_range is in hours
+      var ends = dash.timeFilter.date.valueOf() + 24 * 60 * 60;
+      var diff = dash.timeFilter.time_range * dash.timeFilter.range_count * 60 * 60 * 1000; // time_range is in hours
       var starts = ends - diff;
       var bucket_duration = parseInt(diff / 1000 / 200); // bucket duration is in seconds
       var params = '&query=get_data&metric_id=' + metric_id + '&ends=' + ends +
                    '&starts=' + starts+ '&bucket_duration=' + bucket_duration + 's';
 
-      $http.get($scope.url + params).success(function(response) {
+      $http.get(dash.url + params).success(function(response) {
         'use strict';
         if (response.error) {
           add_flash(response.error, 'error');
@@ -193,59 +194,59 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
         yData.unshift(metric_id);
 
         // TODO: Use time buckets
-        $scope.chartData.xData = xData;
-        $scope.chartData['yData'+n] = yData;
+        dash.chartData.xData = xData;
+        dash.chartData['yData'+n] = yData;
 
-        $scope.chartDataInit = true;
-        $scope.loadCount++;
-        if ($scope.loadCount >= $scope.selectedItems.length) {
-          $scope.loadingData = false;
+        dash.chartDataInit = true;
+        dash.loadCount++;
+        if (dash.loadCount >= dash.selectedItems.length) {
+          dash.loadingData = false;
         }
       });
     };
 
-    $scope.refresh_graph_data = function() {
-      $scope.loadCount = 0;
-      $scope.loadingData = true;
-      $scope.chartData = {};
+    dash.refresh_graph_data = function() {
+      dash.loadCount = 0;
+      dash.loadingData = true;
+      dash.chartData = {};
 
-      $scope.selectedItems = $scope.items.filter(function(item) { return item.selected });
+      dash.selectedItems = dash.items.filter(function(item) { return item.selected });
 
-      for (var i = 0; i < $scope.selectedItems.length; i++) {
-        var metric_id = $scope.selectedItems[i].id;
-        $scope.refresh_graph(metric_id, i);
+      for (var i = 0; i < dash.selectedItems.length; i++) {
+        var metric_id = dash.selectedItems[i].id;
+        dash.refresh_graph(metric_id, i);
       }
     };
 
-    $scope.timeRanges = [
+    dash.timeRanges = [
       {title: _("Hours"), value: 1},
       {title: _("Days"), value: 24},
       {title: _("Weeks"), value: 168},
       {title: _("Months"), value: 672}
     ];
 
-    $scope.timeFilter = {
+    dash.timeFilter = {
       time_range: 24,
       range_count: 1,
       date: moment()
     };
 
-    $scope.dateOptions = {
+    dash.dateOptions = {
       format: __('MM/DD/YYYY HH:mm')
     };
 
-    $scope.countDecrement = function() {
-      if ($scope.timeFilter.range_count > 1) {
-        $scope.timeFilter.range_count--;
+    dash.countDecrement = function() {
+      if (dash.timeFilter.range_count > 1) {
+        dash.timeFilter.range_count--;
       }
     };
 
-    $scope.countIncrement = function() {
-      $scope.timeFilter.range_count++;
+    dash.countIncrement = function() {
+      dash.timeFilter.range_count++;
     };
 
     // Graphs
-    $scope.chartConfig = {
+    dash.chartConfig = {
       legend       : { show: false },
       chartId      : 'adHocMetricsChart',
       point        : { r: 1 },
@@ -267,7 +268,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       }
     };
 
-    $scope.actionsConfig = {
+    dash.actionsConfig = {
       actionsInclude: true,
       moreActions: [
         {
@@ -285,21 +286,21 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       ]
     };
 
-    $scope.graphToolbarConfig = {
-      actionsConfig: $scope.actionsConfig
+    dash.graphToolbarConfig = {
+      actionsConfig: dash.actionsConfig
     };
 
-    $scope.itemSelected = false;
+    dash.itemSelected = false;
 
-    $scope.listConfig = {
+    dash.listConfig = {
       selectionMatchProp: 'id',
       showSelectBox: true,
       useExpandingRows: true,
       onCheckBoxChange: selectionChange
     };
 
-    $scope.filterConfig = {};
-    $scope.toolbarConfig = {};
+    dash.filterConfig = {};
+    dash.toolbarConfig = {};
 
     initialization();
     getMetricTags();

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -33,7 +33,9 @@ class HawkularProxyService
   def metric_definitions
     tags = @params['tags'].blank? ? nil : JSON.parse(@params['tags'])
     tags = nil if tags == {}
-    client.gauges.query(tags).compact.map { |m| m.json if m.json }.sort { |a, b| a["id"].downcase <=> b["id"].downcase }
+    definitions = client.gauges.query(tags).compact.map { |m| m.json if m.json }.sort { |a, b| a["id"] <=> b["id"] }
+
+    definitions[0..100]
   end
 
   def metric_tags
@@ -45,12 +47,14 @@ class HawkularProxyService
     starts = @params['starts'] || (ends - 8 * 60 * 60 * 1000)
     bucket_duration = @params['bucket_duration'] || nil
     order = @params['order'] || 'ASC'
+    limit = @params['limit'].to_i || 500
 
-    client.gauges.get_data(id,
-                           :limit          => @params['limit'] || 100,
-                           :starts         => starts.to_i,
-                           :ends           => ends.to_i,
-                           :bucketDuration => bucket_duration,
-                           :order          => order)
+    data = client.gauges.get_data(id,
+                                  :limit          => limit,
+                                  :starts         => starts.to_i,
+                                  :ends           => ends.to_i,
+                                  :bucketDuration => bucket_duration,
+                                  :order          => order)
+    data[0..(limit - 1)]
   end
 end

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -1,17 +1,17 @@
 = render :partial => "layouts/flash_msg"
 
-.containers-live-dashboard.row.miq-dashboard-view.miq-metrics{"ng-controller" => "containerLiveDashboardController"}
-  %div{"ng-if" => "!viewGraph"}
-    %div{"pf-toolbar" => "", "id" => "exampleToolbar", "config" => "toolbarConfig", "ng-if" => "tagsLoaded"}
+.containers-live-dashboard.row.miq-dashboard-view.miq-metrics{"ng-controller" => "containerLiveDashboardController as dash"}
+  %div{"ng-if" => "!dash.viewGraph"}
+    %div{"pf-toolbar" => "", "id" => "exampleToolbar", "config" => "dash.toolbarConfig", "ng-if" => "dash.tagsLoaded"}
       %actions
         %button.btn.btn-default{"type" => "button",
-                                "ng-click" => "doViewGraph()",
-                                "ng-disabled" => "!itemSelected"}
+                                "ng-click" => "dash.doViewGraph()",
+                                "ng-disabled" => "!dash.itemSelected"}
           = _("View Graph")
-    .list-view-container.list-view-compact{"ng-if" => "applied",
-                                           "ng-class" => "{'no-filters': filterConfig.fields.length === 0}"}
-      .spinner.spinner-lg.loading{"ng-if" => "loadingMetrics"}
-      .col-md-12{"pf-list-view" => "", "config" => "listConfig", "items" => "items"}
+    .list-view-container.list-view-compact{"ng-if" => "dash.applied",
+                                           "ng-class" => "{'no-filters': dash.filterConfig.fields.length === 0}"}
+      .spinner.spinner-lg.loading{"ng-if" => "dash.loadingMetrics"}
+      .col-md-12{"pf-list-view" => "", "config" => "dash.listConfig", "items" => "dash.items"}
         .list-view-pf-body.row
           .col-md-6.col-sm-6.no-wrap
             {{item.id}}
@@ -50,54 +50,54 @@
                   %span.last-value
                     {{value}}
     .blank-slate-pf{"ng-if" => "!applied",
-                    "ng-class" => "{'no-filters': filterConfig.fields.length === 0,
-                                    'loading': !tagsLoaded}"}
-      .spinner.spinner-lg.loading{"ng-if" => "!tagsLoaded"}
+                    "ng-class" => "{'no-filters': dash.filterConfig.fields.length === 0,
+                                    'loading': !dash.tagsLoaded}"}
+      .spinner.spinner-lg.loading{"ng-if" => "!dash.tagsLoaded"}
       .blank-slate-pf-icon
         %span.fa.fa-info-circle
       %h1
         = _("Metrics")
-      %p{"ng-if" => "!tagsLoaded"}
+      %p{"ng-if" => "!dash.tagsLoaded"}
         = _("Loading available tags")
-      %p{"ng-if" => "tagsLoaded"}
+      %p{"ng-if" => "dash.tagsLoaded"}
         = _("Add tags and click the Apply button to view available metrics")
-  .metrics-graph{"ng-if" => "viewGraph"}
-    %div{"pf-toolbar" => "", "config" => "graphToolbarConfig"}
+  .metrics-graph{"ng-if" => "dash.viewGraph"}
+    %div{"pf-toolbar" => "", "config" => "dash.graphToolbarConfig"}
       %actions
-        %button.btn.btn-primary{"type" => "button", "ng-click" => "refresh_graph_data()"}
+        %button.btn.btn-primary{"type" => "button", "ng-click" => "dash.refresh_graph_data()"}
           = _("Refresh")
-        %button.btn.btn-default{"type" => "button", "ng-click" => "doViewMetrics()"}
+        %button.btn.btn-default{"type" => "button", "ng-click" => "dash.doViewMetrics()"}
           = _("Change Metrics")
 
     %form.time-range-form#form_div{:name => 'angularForm'}
       .form-group.pull-left
         .input-group.bootstrap-touchspin.timeline-stepper.pull-left
           %span.input-group-btn
-            %button.btn.btn-default.bootstrap-touchspin-down{"ng-click" => "countDecrement()",
+            %button.btn.btn-default.bootstrap-touchspin-down{"ng-click" => "dash.countDecrement()",
                                                              :type      => "button"} -
-          %input.timeline-range-input.bootstrap-touchspin.form-control{"ng-model" => "timeFilter.range_count",
+          %input.timeline-range-input.bootstrap-touchspin.form-control{"ng-model" => "dash.timeFilter.range_count",
                                                                         :readonly => "readonly",
                                                                         :type     => "text"}
           %span.input-group-btn
-            %button.btn.btn-default.bootstrap-touchspin-up{"ng-click" => "countIncrement()",
+            %button.btn.btn-default.bootstrap-touchspin-up{"ng-click" => "dash.countIncrement()",
                                                            :type => "button"} +
       .form-group.pull-left
         %select{"pf-select"  => "",
                 "id" => "timeRange",
-                "ng-model" => "timeFilter.time_range",
-                "ng-options" => "range.value as range.title for range in timeRanges",
+                "ng-model" => "dash.timeFilter.time_range",
+                "ng-options" => "range.value as range.title for range in dash.timeRanges",
                 "class"   => "timeline-date-input"}
       .form-group.pull-left
         %input{"pf-date-timepicker" => "",
-               "options" => "dateOptions",
-               "date"    => "timeFilter.date",
-               "class"   => "timeline-date-input"}
+               "options" => "dash.dateOptions",
+               "date"    => "dash.timeFilter.date",
+               "class"   => "dash.timeline-date-input"}
     .line-chart
-      .spinner.spinner-lg.loading{"ng-if" => "loadingData"}
+      .spinner.spinner-lg.loading{"ng-if" => "dash.loadingData"}
       #adHocMetricsChart{"pf-line-chart" => "",
-                             "ng-if" => "chartDataInit",
-                             "chart-data" => "chartData",
-                             "config" => "chartConfig",
+                             "ng-if" => "dash.chartDataInit",
+                             "chart-data" => "dash.chartData",
+                             "config" => "dash.chartConfig",
                              "show-x-axis" => true,
                              "show-y-axis" => true}
 

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -1,17 +1,22 @@
 = render :partial => "layouts/flash_msg"
 
-.containers-live-dashboard.row.miq-dashboard-view.miq-metrics{"ng-controller" => "containerLiveDashboardController as dash"}
-  %div{"ng-if" => "!dash.viewGraph"}
-    %div{"pf-toolbar" => "", "id" => "exampleToolbar", "config" => "dash.toolbarConfig", "ng-if" => "dash.tagsLoaded"}
+.containers-live-dashboard.row.miq-dashboard-view.miq-metrics{ "ng-controller" => "containerLiveDashboardController as dash" }
+  %div{ "ng-if" => "!dash.viewGraph" }
+    %div{ "pf-toolbar" => "",
+          "id" => "exampleToolbar",
+          "config" => "dash.toolbarConfig",
+          "ng-if" => "dash.tagsLoaded" }
       %actions
-        %button.btn.btn-default{"type" => "button",
+        %button.btn.btn-default{ "type" => "button",
                                 "ng-click" => "dash.doViewGraph()",
-                                "ng-disabled" => "!dash.itemSelected"}
+                                "ng-disabled" => "!dash.itemSelected" }
           = _("View Graph")
-    .list-view-container.list-view-compact{"ng-if" => "dash.applied",
-                                           "ng-class" => "{'no-filters': dash.filterConfig.fields.length === 0}"}
-      .spinner.spinner-lg.loading{"ng-if" => "dash.loadingMetrics"}
-      .col-md-12{"pf-list-view" => "", "config" => "dash.listConfig", "items" => "dash.items"}
+    .list-view-container.list-view-compact{ "ng-if" => "dash.applied",
+        "ng-class" => "{'no-filters': dash.filterConfig.fields.length === 0}" }
+      .spinner.spinner-lg.loading{ "ng-if" => "dash.loadingMetrics" }
+      .col-md-12{ "pf-list-view" => "",
+                  "config" => "dash.listConfig",
+                  "items" => "dash.items" }
         .list-view-pf-body.row
           .col-md-6.col-sm-6.no-wrap
             {{item.id}}
@@ -36,70 +41,72 @@
                 = _("Recent values")
           .row
             .col-md-8.col-sm-12.no-wrap
-              .row{"ng-repeat" => "(key, value) in $parent.item.tags"}
+              .row{ "ng-repeat" => "(key, value) in $parent.item.tags" }
                 .col-md-3.col-sm-6.no-wrap.metric-no-padding
                   %strong.pull-right
                     {{key}}
                 .col-md-9.col-sm-6.no-wrap
                   {{value}}
             .col-md-4.col-sm-12.no-wrap
-              .row{"ng-repeat" => "(timestamp, value) in $parent.item.lastValues"}
+              .row{ "ng-repeat" => "(timestamp, value) in $parent.item.lastValues" }
                 .col-md-12
                   %strong.pull-left.metric-no-padding
                     {{timestamp | date:'yyyy-MM-dd hh:mm:ss'}}
                   %span.last-value
                     {{value}}
-    .blank-slate-pf{"ng-if" => "!applied",
-                    "ng-class" => "{'no-filters': dash.filterConfig.fields.length === 0,
-                                    'loading': !dash.tagsLoaded}"}
-      .spinner.spinner-lg.loading{"ng-if" => "!dash.tagsLoaded"}
+    .blank-slate-pf{ "ng-if" => "!applied",
+                     "ng-class" => "{'no-filters': dash.filterConfig.fields.length === 0,
+                                     'loading': !dash.tagsLoaded}" }
+      .spinner.spinner-lg.loading{ "ng-if" => "!dash.tagsLoaded" }
       .blank-slate-pf-icon
         %span.fa.fa-info-circle
       %h1
         = _("Metrics")
-      %p{"ng-if" => "!dash.tagsLoaded"}
+      %p{ "ng-if" => "!dash.tagsLoaded" }
         = _("Loading available tags")
-      %p{"ng-if" => "dash.tagsLoaded"}
+      %p{ "ng-if" => "dash.tagsLoaded" }
         = _("Add tags and click the Apply button to view available metrics")
-  .metrics-graph{"ng-if" => "dash.viewGraph"}
-    %div{"pf-toolbar" => "", "config" => "dash.graphToolbarConfig"}
+  .metrics-graph{ "ng-if" => "dash.viewGraph" }
+    %div{ "pf-toolbar" => "", "config" => "dash.graphToolbarConfig" }
       %actions
-        %button.btn.btn-primary{"type" => "button", "ng-click" => "dash.refresh_graph_data()"}
+        %button.btn.btn-primary{ "type" => "button",
+                                 "ng-click" => "dash.refresh_graph_data()" }
           = _("Refresh")
-        %button.btn.btn-default{"type" => "button", "ng-click" => "dash.doViewMetrics()"}
+        %button.btn.btn-default{ "type" => "button",
+                                 "ng-click" => "dash.doViewMetrics()" }
           = _("Change Metrics")
 
-    %form.time-range-form#form_div{:name => 'angularForm'}
+    %form.time-range-form#form_div{ :name => 'angularForm' }
       .form-group.pull-left
         .input-group.bootstrap-touchspin.timeline-stepper.pull-left
           %span.input-group-btn
-            %button.btn.btn-default.bootstrap-touchspin-down{"ng-click" => "dash.countDecrement()",
-                                                             :type      => "button"} -
-          %input.timeline-range-input.bootstrap-touchspin.form-control{"ng-model" => "dash.timeFilter.range_count",
-                                                                        :readonly => "readonly",
-                                                                        :type     => "text"}
+            %button.btn.btn-default.bootstrap-touchspin-down{ "ng-click" => "dash.countDecrement()",
+                :type => "button" } -
+          %input.timeline-range-input.bootstrap-touchspin.form-control{ "ng-model" => "dash.timeFilter.range_count",
+              :readonly => "readonly",
+              :type => "text" }
           %span.input-group-btn
-            %button.btn.btn-default.bootstrap-touchspin-up{"ng-click" => "dash.countIncrement()",
-                                                           :type => "button"} +
+            %button.btn.btn-default.bootstrap-touchspin-up{ "ng-click" => "dash.countIncrement()",
+                :type => "button" } +
       .form-group.pull-left
-        %select{"pf-select"  => "",
-                "id" => "timeRange",
-                "ng-model" => "dash.timeFilter.time_range",
-                "ng-options" => "range.value as range.title for range in dash.timeRanges",
-                "class"   => "timeline-date-input"}
+        %select{ "pf-select" => "",
+            "id" => "timeRange",
+            "ng-model" => "dash.timeFilter.time_range",
+            "ng-options" => "range.value as range.title for range in dash.timeRanges",
+            "class" => "timeline-date-input" }
       .form-group.pull-left
-        %input{"pf-date-timepicker" => "",
-               "options" => "dash.dateOptions",
-               "date"    => "dash.timeFilter.date",
-               "class"   => "dash.timeline-date-input"}
+        %input{ "pf-date-timepicker" => "",
+                "options" => "dash.dateOptions",
+                "date" => "dash.timeFilter.date",
+                "class" => "dash.timeline-date-input" }
     .line-chart
-      .spinner.spinner-lg.loading{"ng-if" => "dash.loadingData"}
-      #adHocMetricsChart{"pf-line-chart" => "",
-                             "ng-if" => "dash.chartDataInit",
-                             "chart-data" => "dash.chartData",
-                             "config" => "dash.chartConfig",
-                             "show-x-axis" => true,
-                             "show-y-axis" => true}
+      .spinner.spinner-lg.loading{ "ng-if" => "dash.loadingData" }
+      #adHocMetricsChart{ "pf-line-chart" => "",
+                          "ng-if" => "dash.chartDataInit",
+                          "chart-data" => "dash.chartData",
+                          "config" => "dash.chartConfig",
+                          "show-x-axis" => true,
+                          "show-y-axis" => true }
 
 :javascript
   miq_bootstrap('.containers-live-dashboard', 'containerLiveDashboard');

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -4,11 +4,6 @@
   %div{"ng-if" => "!viewGraph"}
     %div{"pf-toolbar" => "", "id" => "exampleToolbar", "config" => "toolbarConfig", "ng-if" => "tagsLoaded"}
       %actions
-        %button.btn.btn-primary{"type" => "button",
-                                "ng-click" => "doApply()",
-                                "ng-if" => "toolbarConfig.filterConfig",
-                                "ng-disabled" => "!filterChanged"}
-          = _("Apply")
         %button.btn.btn-default{"type" => "button",
                                 "ng-click" => "doViewGraph()",
                                 "ng-disabled" => "!itemSelected"}

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -14,19 +14,17 @@ describe('containerLiveDashboardController', function() {
     });
   });
 
-  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _pfViewUtils_) {
+  beforeEach(inject(function(_$httpBackend_, _$controller_, _pfViewUtils_) {
     pfViewUtils = _pfViewUtils_;
-    $scope = $rootScope.$new();
     $httpBackend = _$httpBackend_;
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_tags').respond(mock_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_definitions&tags={}').respond(mock_metrics_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
     $controller = _$controller_('containerLiveDashboardController', {
-        $scope: $scope,
         pfViewUtils: pfViewUtils
     });
-    $scope.refresh();
+    $controller.refresh();
     $httpBackend.flush();
   }));
 
@@ -37,34 +35,34 @@ describe('containerLiveDashboardController', function() {
 
   describe('loading page data', function() {
     it('should load tag list', function() {
-      expect($scope.filterConfig.fields.length).toBe(12);
+      expect($controller.filterConfig.fields.length).toBe(12);
     });
 
     it('should load metrics definitions', function() {
-      expect($scope.loadingMetrics).toBeDefined();
-      expect($scope.loadingMetrics).toBe(false);
-      expect($scope.items.length).toBe(2);
+      expect($controller.loadingMetrics).toBeDefined();
+      expect($controller.loadingMetrics).toBe(false);
+      expect($controller.items.length).toBe(2);
     });
   });
 
   describe('count increment', function() {    
     it('should increment the count', function() {
-      $scope.countIncrement();
-      expect($scope.timeFilter.range_count).toBe(2);
+      $controller.countIncrement();
+      expect($controller.timeFilter.range_count).toBe(2);
     });
 
     it('should decrement the count', function() {
-      $scope.timeFilter.range_count = 10;
-      $scope.countDecrement();
-      expect($scope.timeFilter.range_count).toBe(9);
+      $controller.timeFilter.range_count = 10;
+      $controller.countDecrement();
+      expect($controller.timeFilter.range_count).toBe(9);
     });
   });
 
   describe('check numeric formater', function() {    
     it('should fomrat numbers correctly', function() {
-      expect($scope.items[0].lastValues[1480424640000]).toBe("10.00");
-      expect($scope.items[0].lastValues[1480424630000]).toBe("1.01k");
-      expect($scope.items[0].lastValues[1480424620000]).toBe("20.00t");
+      expect($controller.items[0].lastValues[1480424640000]).toBe("10.00");
+      expect($controller.items[0].lastValues[1480424630000]).toBe("1.01k");
+      expect($controller.items[0].lastValues[1480424620000]).toBe("20.00t");
     });
   });
 });


### PR DESCRIPTION
**Description**
Refactor https://github.com/ManageIQ/manageiq/pull/12165 

- [x] Apply filters immediately, no need to push apply.
- [x] Remove the apply button
- [x] Limit the maximum number of items in one page.

**Screenshots**
Before we set tags, we have no items:
![screenshot-localhost 3000-2016-12-07-20-30-26](https://cloud.githubusercontent.com/assets/2181522/20981260/930a6b36-bcbc-11e6-9357-43cd948b9d13.png)

After we added a filter, a spinner apear:
![screenshot-localhost 3000-2016-12-07-20-33-11](https://cloud.githubusercontent.com/assets/2181522/20981262/9319b852-bcbc-11e6-8450-7bd1df99f11d.png)

After we get the items:
![screenshot-localhost 3000-2016-12-07-20-31-41](https://cloud.githubusercontent.com/assets/2181522/20981261/93164456-bcbc-11e6-9417-9ab8a114d6b0.png)

If we clear the tags again we have no items:
![screenshot-localhost 3000-2016-12-07-20-30-26](https://cloud.githubusercontent.com/assets/2181522/20981260/930a6b36-bcbc-11e6-9357-43cd948b9d13.png)

(converted from ManageIQ/manageiq#13038)