### PR TITLE
[Ad hoc metrics for OPS] Add option to show counters data

### DIFF
--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -4,6 +4,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
   .controller('containerLiveDashboardController', ['$scope', 'pfViewUtils', '$http', '$interval', '$timeout', '$window',
   function ($scope, pfViewUtils, $http, $interval, $timeout, $window) {
     $scope.tenant = '_ops';
+    $scope.metricsType = 'gauges';
 
     // get the pathname and remove trailing / if exist
     var pathname = $window.location.pathname.replace(/\/$/, '');
@@ -29,7 +30,8 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       $scope.toolbarConfig.filterConfig = $scope.filterConfig;
       $scope.toolbarConfig.actionsConfig = $scope.actionsConfig;
 
-      $scope.url = '/container_dashboard/data' + id + '/?live=true&tenant=' + $scope.tenant;
+      $scope.url = '/container_dashboard/data' + id + 
+        '/?live=true&type=' + $scope.metricsType + '&tenant=' + $scope.tenant;
     }
 
     var filterChange = function (filters) {
@@ -73,6 +75,13 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
 
       initialization();
       filterChange();
+      getMetricTags();
+    };
+
+    var doRefreshCounters = function (action) {
+      $scope.metricsType = action.type;
+
+      initialization();
       getMetricTags();
     };
 
@@ -273,6 +282,18 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
           tenant: '_ops',
           title: __("Use the Ops Tenant Metrics"),
           actionFn: doRefreshTenant
+        },
+        {
+          name: 'Gauges',
+          type: 'gauges',
+          title: __("Gauges Metrics"),
+          actionFn: doRefreshCounters
+        },
+        {
+          name: 'Counters',
+          type: 'counters',
+          title: __("Counters Metrics"),
+          actionFn: doRefreshCounters
         }
       ]
     };

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -11,7 +11,12 @@ class HawkularProxyService
   end
 
   def client
-    ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::HawkularClient.new(@ems, @tenant)
+    cli = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::HawkularClient.new(@ems, @tenant)
+    if @params['type'] == "counters"
+      cli.hawkular_client.counters
+    else
+      cli.hawkular_client.gauges
+    end
   end
 
   def data(query)
@@ -33,7 +38,7 @@ class HawkularProxyService
   def metric_definitions
     tags = @params['tags'].blank? ? nil : JSON.parse(@params['tags'])
     tags = nil if tags == {}
-    client.gauges.query(tags).compact.map { |m| m.json if m.json }.sort { |a, b| a["id"].downcase <=> b["id"].downcase }
+    client.query(tags).compact.map { |m| m.json if m.json }.sort { |a, b| a["id"].downcase <=> b["id"].downcase }
   end
 
   def metric_tags
@@ -46,11 +51,11 @@ class HawkularProxyService
     bucket_duration = @params['bucket_duration'] || nil
     order = @params['order'] || 'ASC'
 
-    client.gauges.get_data(id,
-                           :limit          => @params['limit'] || 100,
-                           :starts         => starts.to_i,
-                           :ends           => ends.to_i,
-                           :bucketDuration => bucket_duration,
-                           :order          => order)
+    client.get_data(id,
+                    :limit          => @params['limit'] || 100,
+                    :starts         => starts.to_i,
+                    :ends           => ends.to_i,
+                    :bucketDuration => bucket_duration,
+                    :order          => order)
   end
 end

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -18,10 +18,10 @@ describe('containerLiveDashboardController', function() {
     pfViewUtils = _pfViewUtils_;
     $scope = $rootScope.$new();
     $httpBackend = _$httpBackend_;
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_tags').respond(mock_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_definitions&tags={}').respond(mock_metrics_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=metric_tags').respond(mock_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=metric_definitions&tags={}').respond(mock_metrics_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
     $controller = _$controller_('containerLiveDashboardController', {
         $scope: $scope,
         pfViewUtils: pfViewUtils


### PR DESCRIPTION
**Description**
Refactor https://github.com/ManageIQ/manageiq/pull/12165 

- [x] Add option to show counter metrics (currently only gauges visible)
- [x] Add option to get counter metrics (currently we only get gauges)

**Screenshot**
![screenshot-2016-12-12-13-42-28](https://cloud.githubusercontent.com/assets/2181522/21098247/f8657392-c070-11e6-8a62-bc90f6ec5c0f.png)

(converted from ManageIQ/manageiq#13110)