### PR TITLE
[Ad hoc metrics for OPS] Add an autocomplete input box for changing the tenant

### DIFF
--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -99,7 +99,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
     };
 
     var getLatestData = function(item) {
-      var params = '&query=get_data&type=' + item.type + 's&metric_id=' + item.id +
+      var params = '&query=get_data&type=' + item.type + '&metric_id=' + item.id +
         '&limit=5&order=DESC';
 
       $http.get(dash.url + params).success(function (response) {
@@ -168,7 +168,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       var diff = dash.timeFilter.time_range * dash.timeFilter.range_count * 60 * 60 * 1000; // time_range is in hours
       var starts = ends - diff;
       var bucket_duration = parseInt(diff / 1000 / 200); // bucket duration is in seconds
-      var params = '&query=get_data&type=' + metric_type + 's&metric_id=' + metric_id + '&ends=' + ends +
+      var params = '&query=get_data&type=' + metric_type + '&metric_id=' + metric_id + '&ends=' + ends +
                    '&starts=' + starts+ '&bucket_duration=' + bucket_duration + 's';
 
       $http.get(dash.url + params).success(function(response) {

--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -1,88 +1,88 @@
 /* global miqHttpInject */
 
 miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'patternfly', 'patternfly.charts']))
-  .controller('containerLiveDashboardController', ['$scope', 'pfViewUtils', '$http', '$interval', '$timeout', '$window',
-  function ($scope, pfViewUtils, $http, $interval, $timeout, $window) {
-    $scope.tenant = '_ops';
+  .controller('containerLiveDashboardController', ['pfViewUtils', '$http', '$interval', '$timeout', '$window',
+  function (pfViewUtils, $http, $interval, $timeout, $window) {
+    var dash = this;
+    dash.tenant = '_ops';
 
     // get the pathname and remove trailing / if exist
     var pathname = $window.location.pathname.replace(/\/$/, '');
     var id = '/' + (/^\/[^\/]+\/(\d+)$/.exec(pathname)[1]);
 
     var initialization = function() {
-      $scope.filtersText = '';
-      $scope.definitions = [];
-      $scope.items = [];
-      $scope.tags = {};
-      $scope.tagsLoaded = false;
+      dash.tenantChanged = false;
 
-      $scope.applied = false;
-      $scope.filterChanged = true;
-      $scope.viewGraph = false;
-      $scope.chartData = {};
+      dash.filtersText = '';
+      dash.definitions = [];
+      dash.items = [];
+      dash.tags = {};
+      dash.tagsLoaded = false;
 
-      $scope.filterConfig.fields = [];
-      $scope.filterConfig.resultsCount = $scope.items.length;
-      $scope.filterConfig.appliedFilters = [];
-      $scope.filterConfig.onFilterChange = filterChange;
+      dash.applied = false;
+      dash.filterChanged = true;
+      dash.viewGraph = false;
+      dash.chartData = {};
 
-      $scope.toolbarConfig.filterConfig = $scope.filterConfig;
-      $scope.toolbarConfig.actionsConfig = $scope.actionsConfig;
+      dash.filterConfig.fields = [];
+      dash.filterConfig.resultsCount = dash.items.length;
+      dash.filterConfig.appliedFilters = [];
+      dash.filterConfig.onFilterChange = filterChange;
 
-      $scope.url = '/container_dashboard/data' + id + '/?live=true&tenant=' + $scope.tenant;
+      dash.toolbarConfig.filterConfig = dash.filterConfig;
+      dash.toolbarConfig.actionsConfig = dash.actionsConfig;
+
+      dash.url = '/container_dashboard/data' + id + '/?live=true&tenant=' + dash.tenant;
     }
 
     var filterChange = function (filters) {
-      $scope.filterChanged = true;
-      $scope.filtersText = "";
-      $scope.tags = {};
-      $scope.filterConfig.appliedFilters.forEach(function (filter) {
-        $scope.filtersText += filter.title + " : " + filter.value + "\n";
-        $scope.tags[filter.id] = filter.value;
+      dash.filterChanged = true;
+      dash.filtersText = "";
+      dash.tags = {};
+      dash.filterConfig.appliedFilters.forEach(function (filter) {
+        dash.filtersText += filter.title + " : " + filter.value + "\n";
+        dash.tags[filter.id] = filter.value;
       });
     };
 
     var selectionChange = function() {
-      $scope.itemSelected = false;
-      for (var i = 0; i < $scope.items.length && !$scope.itemSelected; i++) {
-        if ($scope.items[i].selected) {
-          $scope.itemSelected = true;
+      dash.itemSelected = false;
+      for (var i = 0; i < dash.items.length && !dash.itemSelected; i++) {
+        if (dash.items[i].selected) {
+          dash.itemSelected = true;
         }
       }
     };
 
-    $scope.doApply = function() {
-      $scope.applied = true;
-      $scope.filterChanged = false;
-      $scope.refresh();
+    dash.doApply = function() {
+      dash.applied = true;
+      dash.filterChanged = false;
+      dash.refresh();
     };
 
-    $scope.doViewGraph = function() {
-      $scope.viewGraph = true;
-      $scope.chartDataInit = false;
-      $scope.refresh_graph_data();
+    dash.doViewGraph = function() {
+      dash.viewGraph = true;
+      dash.chartDataInit = false;
+      dash.refresh_graph_data();
     };
 
-    $scope.doViewMetrics = function() {
-      $scope.viewGraph = false;
-      $scope.refresh();
+    dash.doViewMetrics = function() {
+      dash.viewGraph = false;
+      dash.refresh();
     };
 
-    var doRefreshTenant = function (action) {
-      $scope.tenant = action.tenant;
-
+    dash.doRefreshTenant = function() {
       initialization();
-      filterChange();
       getMetricTags();
     };
 
     var getMetricTags = function() {
-      $http.get($scope.url + '&query=metric_tags').success(function(response) {
-        $scope.tagsLoaded = true;
+      $http.get(dash.url + '&query=metric_tags').success(function(response) {
+        dash.tagsLoaded = true;
         if (response && angular.isArray(response.metric_tags)) {
           response.metric_tags.sort();
           for (var i = 0; i < response.metric_tags.length; i++) {
-            $scope.filterConfig.fields.push(
+            dash.filterConfig.fields.push(
               {
                 id: response.metric_tags[i],
                 title:  response.metric_tags[i],
@@ -92,8 +92,8 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
           }
         } else {
           // No filters available, apply without filtering
-          $scope.toolbarConfig.filterConfig = undefined;
-          $scope.doApply();
+          dash.toolbarConfig.filterConfig = undefined;
+          dash.doApply();
         }
       });
     };
@@ -101,7 +101,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
     var getLatestData = function(item) {
       var params = '&query=get_data&metric_id=' + item.id + '&limit=5&order=DESC';
 
-      $http.get($scope.url + params).success(function (response) {
+      $http.get(dash.url + params).success(function (response) {
         'use strict';
         if (response.error) {
           add_flash(response.error, 'error');
@@ -140,37 +140,37 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       });
     };
 
-    $scope.refresh = function() {
-      $scope.loadingMetrics = true;
-      var _tags = $scope.tags != {} ? '&tags=' + JSON.stringify($scope.tags) : '';
-      $http.get($scope.url + '&query=metric_definitions' + _tags).success(function (response) {
+    dash.refresh = function() {
+      dash.loadingMetrics = true;
+      var _tags = dash.tags != {} ? '&tags=' + JSON.stringify(dash.tags) : '';
+      $http.get(dash.url + '&query=metric_definitions' + _tags).success(function (response) {
         'use strict';
-        $scope.loadingMetrics = false;
+        dash.loadingMetrics = false;
         if (response.error) {
           add_flash(response.error, 'error');
           return;
         }
 
-        $scope.items = response.metric_definitions.filter(function(item) {
+        dash.items = response.metric_definitions.filter(function(item) {
           return item.id && item.type;
         });
 
-        angular.forEach($scope.items, getLatestData);
+        angular.forEach(dash.items, getLatestData);
 
-        $scope.filterConfig.resultsCount = $scope.items.length;
+        dash.filterConfig.resultsCount = dash.items.length;
       });
     };
 
-    $scope.refresh_graph = function(metric_id, n) {
+    dash.refresh_graph = function(metric_id, n) {
       // TODO: replace with a datetimepicker, until then add 24 hours to the date
-      var ends = $scope.timeFilter.date.valueOf() + 24 * 60 * 60;
-      var diff = $scope.timeFilter.time_range * $scope.timeFilter.range_count * 60 * 60 * 1000; // time_range is in hours
+      var ends = dash.timeFilter.date.valueOf() + 24 * 60 * 60;
+      var diff = dash.timeFilter.time_range * dash.timeFilter.range_count * 60 * 60 * 1000; // time_range is in hours
       var starts = ends - diff;
       var bucket_duration = parseInt(diff / 1000 / 200); // bucket duration is in seconds
       var params = '&query=get_data&metric_id=' + metric_id + '&ends=' + ends +
                    '&starts=' + starts+ '&bucket_duration=' + bucket_duration + 's';
 
-      $http.get($scope.url + params).success(function(response) {
+      $http.get(dash.url + params).success(function(response) {
         'use strict';
         if (response.error) {
           add_flash(response.error, 'error');
@@ -185,59 +185,66 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
         yData.unshift(metric_id);
 
         // TODO: Use time buckets
-        $scope.chartData.xData = xData;
-        $scope.chartData['yData'+n] = yData;
+        dash.chartData.xData = xData;
+        dash.chartData['yData'+n] = yData;
 
-        $scope.chartDataInit = true;
-        $scope.loadCount++;
-        if ($scope.loadCount >= $scope.selectedItems.length) {
-          $scope.loadingData = false;
+        dash.chartDataInit = true;
+        dash.loadCount++;
+        if (dash.loadCount >= dash.selectedItems.length) {
+          dash.loadingData = false;
         }
       });
     };
 
-    $scope.refresh_graph_data = function() {
-      $scope.loadCount = 0;
-      $scope.loadingData = true;
-      $scope.chartData = {};
+    dash.refresh_graph_data = function() {
+      dash.loadCount = 0;
+      dash.loadingData = true;
+      dash.chartData = {};
 
-      $scope.selectedItems = $scope.items.filter(function(item) { return item.selected });
+      dash.selectedItems = dash.items.filter(function(item) { return item.selected });
 
-      for (var i = 0; i < $scope.selectedItems.length; i++) {
-        var metric_id = $scope.selectedItems[i].id;
-        $scope.refresh_graph(metric_id, i);
+      for (var i = 0; i < dash.selectedItems.length; i++) {
+        var metric_id = dash.selectedItems[i].id;
+        dash.refresh_graph(metric_id, i);
       }
     };
 
-    $scope.timeRanges = [
+    dash.getTenants = function(include) {
+      dash.tenantChanged = true;
+      return $http.get(dash.url + "&query=get_tenants&limit=7&include=" + include).then(function(response) {
+        return response.data.tenants;
+      });
+    }
+
+    dash.timeRanges = [
       {title: _("Hours"), value: 1},
       {title: _("Days"), value: 24},
       {title: _("Weeks"), value: 168},
       {title: _("Months"), value: 672}
     ];
 
-    $scope.timeFilter = {
+    dash.timeFilter = {
       time_range: 24,
       range_count: 1,
       date: moment()
     };
 
-    $scope.dateOptions = {
+    dash.dateOptions = {
       format: __('MM/DD/YYYY HH:mm')
     };
 
-    $scope.countDecrement = function() {
-      if ($scope.timeFilter.range_count > 1) {
-        $scope.timeFilter.range_count--;
+    dash.countDecrement = function() {
+      if (dash.timeFilter.range_count > 1) {
+        dash.timeFilter.range_count--;
       }
     };
 
-    $scope.countIncrement = function() {
-      $scope.timeFilter.range_count++;
+    dash.countIncrement = function() {
+      dash.timeFilter.range_count++;
     };
 
     // Graphs
-    $scope.chartConfig = {
+    dash.chartConfig = {
       legend       : { show: false },
       chartId      : 'adHocMetricsChart',
       point        : { r: 1 },
@@ -259,39 +266,25 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       }
     };
 
-    $scope.actionsConfig = {
-      actionsInclude: true,
-      moreActions: [
-        {
-          name: 'System',
-          tenant: '_system',
-          title: __("Use the System Tenant Metrics"),
-          actionFn: doRefreshTenant
-        },
-        {
-          name: 'Ops',
-          tenant: '_ops',
-          title: __("Use the Ops Tenant Metrics"),
-          actionFn: doRefreshTenant
-        }
-      ]
+    dash.actionsConfig = {
+      actionsInclude: true
     };
 
-    $scope.graphToolbarConfig = {
-      actionsConfig: $scope.actionsConfig
+    dash.graphToolbarConfig = {
+      actionsConfig: dash.actionsConfig
     };
 
-    $scope.itemSelected = false;
+    dash.itemSelected = false;
 
-    $scope.listConfig = {
+    dash.listConfig = {
       selectionMatchProp: 'id',
       showSelectBox: true,
       useExpandingRows: true,
       onCheckBoxChange: selectionChange
     };
 
-    $scope.filterConfig = {};
-    $scope.toolbarConfig = {};
+    dash.filterConfig = {};
+    dash.toolbarConfig = {};
 
     initialization();
     getMetricTags();

--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -5,6 +5,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
   function (pfViewUtils, $http, $interval, $timeout, $window) {
     var dash = this;
     dash.tenant = '_ops';
+    dash.metricType = 'gauges';
 
     // get the pathname and remove trailing / if exist
     var pathname = $window.location.pathname.replace(/\/$/, '');
@@ -32,7 +33,8 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       dash.toolbarConfig.filterConfig = dash.filterConfig;
       dash.toolbarConfig.actionsConfig = dash.actionsConfig;
 
-      dash.url = '/container_dashboard/data' + id + '/?live=true&tenant=' + dash.tenant;
+      dash.url = '/container_dashboard/data' + id + '/?live=true&tenant=' + dash.tenant + 
+        '&type=' + dash.metricType;
     }
 
     var filterChange = function (filters) {

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -55,6 +55,17 @@
   .timeline-date-input {
     width: 250px;
   }
+  .ad-hoc-tenant {
+    margin-left: 5px;
+    margin-bottom: 10px;
+  }
+  .ad-hoc-tenant-button{
+    vertical-align: top;
+  }
+  #ad-hoc-tenant {
+    display: inline;
+    width: 200px;
+  }
   h3 {
     margin-top: 5px;
   }

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -23,6 +23,8 @@ class HawkularProxyService
     when 'get_data'
       { :id   => @params['metric_id'],
         :data => get_data(@params['metric_id']).compact }
+    when 'get_tenants'
+      { :tenants => tenants }
     else
       {}
     end
@@ -52,5 +54,17 @@ class HawkularProxyService
                            :ends           => ends.to_i,
                            :bucketDuration => bucket_duration,
                            :order          => order)
+  end
+
+  def tenants
+    tenants = client.hawkular_client.http_get('/tenants')
+    tenants = if @params['include'].blank?
+                tenants.map { |x| x["id"] }.compact
+              else
+                tenants.map { |x| x["id"] if x["id"].include?(@params['include']) }.compact
+              end
+
+    limit = @params['limit'].to_i || 7
+    tenants[0..limit]
   end
 end

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -13,7 +13,7 @@ class HawkularProxyService
   end
 
   def client
-    if @params['type'] == "counters"
+    if @params['type'] == "counter"
       @cli.hawkular_client.counters
     else
       @cli.hawkular_client.gauges

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -16,13 +16,22 @@
       "typeahead-wait-ms" => 1000}
     %i.glyphicon.glyphicon-refresh{"ng-show" => "dash.loadingTenants"}
 
+    %select.ad-hoc-tenant-button{"pf-select" => "",
+                                 "ng-model" => "dash.metricType",
+                                 "id" => "metric_type",
+                                 "ng-change" => "dash.tenantChanged = true"}
+      %option{:value => "gauges"}
+        = _("Gauges")
+      %option{:value => "counters"}
+        = _("Counters")
+
   %div{"ng-if" => "!dash.viewGraph"}
     %div{"pf-toolbar" => "", "id" => "exampleToolbar", "config" => "dash.toolbarConfig", "ng-if" => "dash.tagsLoaded"}
       %actions
         %button.btn.btn-primary{"type" => "button",
                                 "ng-click" => "dash.doApply()",
                                 "ng-if" => "dash.toolbarConfig.filterConfig",
-                                "ng-disabled" => "!dash.filterChanged"}
+                                "ng-disabled" => "!dash.filterChanged || dash.tenantChanged"}
           = _("Apply")
         %button.btn.btn-default{"type" => "button",
                                 "ng-click" => "dash.doViewGraph()",

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -1,22 +1,37 @@
 = render :partial => "layouts/flash_msg"
 
-.containers-live-dashboard.row.miq-dashboard-view.miq-metrics{"ng-controller" => "containerLiveDashboardController"}
-  %div{"ng-if" => "!viewGraph"}
-    %div{"pf-toolbar" => "", "id" => "exampleToolbar", "config" => "toolbarConfig", "ng-if" => "tagsLoaded"}
+.containers-live-dashboard.row.miq-dashboard-view.miq-metrics{"ng-controller" => "containerLiveDashboardController as dash"}
+
+  .col-md-12.ad-hoc-tenant{"ng-if" => "!dash.viewGraph"}
+    %button.btn.btn-primary.ad-hoc-tenant-button{"type" => "button",
+        "ng-disabled" => "!dash.tenantChanged",
+        "ng-click" => "dash.doRefreshTenant()"}
+      = _("Set tenant")
+    %input.form-control{"id" => "ad-hoc-tenant",
+      "type" => "text",
+      "ng-model" => "dash.tenant",
+      "placeholder" => _("Choose Tenants"),
+      "typeahead" => "tenenat for tenenat in dash.getTenants($viewValue)",
+      "typeahead-loading" => "dash.loadingTenants",
+      "typeahead-wait-ms" => 1000}
+    %i.glyphicon.glyphicon-refresh{"ng-show" => "dash.loadingTenants"}
+
+  %div{"ng-if" => "!dash.viewGraph"}
+    %div{"pf-toolbar" => "", "id" => "exampleToolbar", "config" => "dash.toolbarConfig", "ng-if" => "dash.tagsLoaded"}
       %actions
         %button.btn.btn-primary{"type" => "button",
-                                "ng-click" => "doApply()",
-                                "ng-if" => "toolbarConfig.filterConfig",
-                                "ng-disabled" => "!filterChanged"}
+                                "ng-click" => "dash.doApply()",
+                                "ng-if" => "dash.toolbarConfig.filterConfig",
+                                "ng-disabled" => "!dash.filterChanged"}
           = _("Apply")
         %button.btn.btn-default{"type" => "button",
-                                "ng-click" => "doViewGraph()",
-                                "ng-disabled" => "!itemSelected"}
+                                "ng-click" => "dash.doViewGraph()",
+                                "ng-disabled" => "!dash.itemSelected"}
           = _("View Graph")
-    .list-view-container.list-view-compact{"ng-if" => "applied",
-                                           "ng-class" => "{'no-filters': filterConfig.fields.length === 0}"}
-      .spinner.spinner-lg.loading{"ng-if" => "loadingMetrics"}
-      .col-md-12{"pf-list-view" => "", "config" => "listConfig", "items" => "items"}
+    .list-view-container.list-view-compact{"ng-if" => "dash.applied",
+                                           "ng-class" => "{'no-filters': dash.filterConfig.fields.length === 0}"}
+      .spinner.spinner-lg.loading{"ng-if" => "dash.loadingMetrics"}
+      .col-md-12{"pf-list-view" => "", "config" => "dash.listConfig", "items" => "dash.items"}
         .list-view-pf-body.row
           .col-md-6.col-sm-6.no-wrap
             {{item.id}}
@@ -54,55 +69,55 @@
                     {{timestamp | date:'yyyy-MM-dd hh:mm:ss'}}
                   %span.last-value
                     {{value}}
-    .blank-slate-pf{"ng-if" => "!applied",
-                    "ng-class" => "{'no-filters': filterConfig.fields.length === 0,
-                                    'loading': !tagsLoaded}"}
-      .spinner.spinner-lg.loading{"ng-if" => "!tagsLoaded"}
+    .blank-slate-pf{"ng-if" => "!dash.applied",
+                    "ng-class" => "{'no-filters': dash.filterConfig.fields.length === 0,
+                                    'loading': !dash.tagsLoaded}"}
+      .spinner.spinner-lg.loading{"ng-if" => "!dash.tagsLoaded"}
       .blank-slate-pf-icon
         %span.fa.fa-info-circle
       %h1
         = _("Metrics")
-      %p{"ng-if" => "!tagsLoaded"}
+      %p{"ng-if" => "!dash.tagsLoaded"}
         = _("Loading available tags")
-      %p{"ng-if" => "tagsLoaded"}
+      %p{"ng-if" => "dash.tagsLoaded"}
         = _("Add tags and click the Apply button to view available metrics")
-  .metrics-graph{"ng-if" => "viewGraph"}
-    %div{"pf-toolbar" => "", "config" => "graphToolbarConfig"}
+  .metrics-graph{"ng-if" => "dash.viewGraph"}
+    %div{"pf-toolbar" => "", "config" => "dash.graphToolbarConfig"}
       %actions
-        %button.btn.btn-primary{"type" => "button", "ng-click" => "refresh_graph_data()"}
+        %button.btn.btn-primary{"type" => "button", "ng-click" => "dash.refresh_graph_data()"}
           = _("Refresh")
-        %button.btn.btn-default{"type" => "button", "ng-click" => "doViewMetrics()"}
+        %button.btn.btn-default{"type" => "button", "ng-click" => "dash.doViewMetrics()"}
           = _("Change Metrics")
 
     %form.time-range-form#form_div{:name => 'angularForm'}
       .form-group.pull-left
         .input-group.bootstrap-touchspin.timeline-stepper.pull-left
           %span.input-group-btn
-            %button.btn.btn-default.bootstrap-touchspin-down{"ng-click" => "countDecrement()",
+            %button.btn.btn-default.bootstrap-touchspin-down{"ng-click" => "dash.countDecrement()",
                                                              :type      => "button"} -
-          %input.timeline-range-input.bootstrap-touchspin.form-control{"ng-model" => "timeFilter.range_count",
+          %input.timeline-range-input.bootstrap-touchspin.form-control{"ng-model" => "dash.timeFilter.range_count",
                                                                         :readonly => "readonly",
                                                                         :type     => "text"}
           %span.input-group-btn
-            %button.btn.btn-default.bootstrap-touchspin-up{"ng-click" => "countIncrement()",
+            %button.btn.btn-default.bootstrap-touchspin-up{"ng-click" => "dash.countIncrement()",
                                                            :type => "button"} +
       .form-group.pull-left
         %select{"pf-select"  => "",
                 "id" => "timeRange",
-                "ng-model" => "timeFilter.time_range",
-                "ng-options" => "range.value as range.title for range in timeRanges",
+                "ng-model" => "dash.timeFilter.time_range",
+                "ng-options" => "range.value as range.title for range in dash.timeRanges",
                 "class"   => "timeline-date-input"}
       .form-group.pull-left
         %input{"pf-date-timepicker" => "",
-               "options" => "dateOptions",
-               "date"    => "timeFilter.date",
+               "options" => "dash.dateOptions",
+               "date"    => "dash.timeFilter.date",
                "class"   => "timeline-date-input"}
     .line-chart
-      .spinner.spinner-lg.loading{"ng-if" => "loadingData"}
+      .spinner.spinner-lg.loading{"ng-if" => "dash.loadingData"}
       #adHocMetricsChart{"pf-line-chart" => "",
-                             "ng-if" => "chartDataInit",
-                             "chart-data" => "chartData",
-                             "config" => "chartConfig",
+                             "ng-if" => "dash.chartDataInit",
+                             "chart-data" => "dash.chartData",
+                             "config" => "dash.chartConfig",
                              "show-x-axis" => true,
                              "show-y-axis" => true}
 

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -13,17 +13,9 @@
       "placeholder" => _("Choose Tenants"),
       "typeahead" => "tenenat for tenenat in dash.getTenants($viewValue)",
       "typeahead-loading" => "dash.loadingTenants",
+      "ng-change" => "dash.tenantChanged = true",
       "typeahead-wait-ms" => 1000}
     %i.glyphicon.glyphicon-refresh{"ng-show" => "dash.loadingTenants"}
-
-    %select.ad-hoc-tenant-button{"pf-select" => "",
-                                 "ng-model" => "dash.metricType",
-                                 "id" => "metric_type",
-                                 "ng-change" => "dash.tenantChanged = true"}
-      %option{:value => "gauges"}
-        = _("Gauges")
-      %option{:value => "counters"}
-        = _("Counters")
 
   %div{"ng-if" => "!dash.viewGraph"}
     %div{"pf-toolbar" => "", "id" => "exampleToolbar", "config" => "dash.toolbarConfig", "ng-if" => "dash.tagsLoaded"}
@@ -43,6 +35,10 @@
       .col-md-12{"pf-list-view" => "", "config" => "dash.listConfig", "items" => "dash.items"}
         .list-view-pf-body.row
           .col-md-6.col-sm-6.no-wrap
+            %span{"ng-if" => "item.type == 'gauge'"}
+              %i.fa.fa-tachometer
+            %span{"ng-if" => "item.type == 'counter'"}
+              %i.pficon.pficon-trend-up
             {{item.id}}
           .col-md-6.col-sm-12.no-wrap
             .row
@@ -52,8 +48,8 @@
                 %span.time-stamp
                   {{item.last_timestamp | date:'yyyy-MM-dd hh:mm:ss'}}
               .col-md-5.col-sm-6.no-wrap
-                .spinner.spinner-sm.loading{ "ng-if" => "!item.last_value" }
-                %span.last-value{ "ng-if" => "item.last_value" }
+                .spinner.spinner-sm.loading{"ng-if" => "!item.last_value"}
+                %span.last-value{"ng-if" => "item.last_value"}
                   {{item.last_value}}
         %list-expanded-content
           .row

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -14,16 +14,13 @@ describe('containerLiveDashboardController', function() {
     });
   });
 
-  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _pfViewUtils_) {
-    pfViewUtils = _pfViewUtils_;
+  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_) {
     $httpBackend = _$httpBackend_;
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=metric_tags').respond(mock_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=metric_definitions&tags={}').respond(mock_metrics_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_tags&limit=250').respond(mock_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_definitions&tags={}').respond(mock_metrics_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
-    $controller = _$controller_('containerLiveDashboardController', {
-        pfViewUtils: pfViewUtils
-    });
+    $controller = _$controller_('containerLiveDashboardController');
     $controller.refresh();
     $httpBackend.flush();
   }));

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -16,17 +16,15 @@ describe('containerLiveDashboardController', function() {
 
   beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _pfViewUtils_) {
     pfViewUtils = _pfViewUtils_;
-    $scope = $rootScope.$new();
     $httpBackend = _$httpBackend_;
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_tags').respond(mock_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_definitions&tags={}').respond(mock_metrics_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
     $controller = _$controller_('containerLiveDashboardController', {
-        $scope: $scope,
         pfViewUtils: pfViewUtils
     });
-    $scope.refresh();
+    $controller.refresh();
     $httpBackend.flush();
   }));
 
@@ -37,34 +35,34 @@ describe('containerLiveDashboardController', function() {
 
   describe('loading page data', function() {
     it('should load tag list', function() {
-      expect($scope.filterConfig.fields.length).toBe(12);
+      expect($controller.filterConfig.fields.length).toBe(12);
     });
 
     it('should load metrics definitions', function() {
-      expect($scope.loadingMetrics).toBeDefined();
-      expect($scope.loadingMetrics).toBe(false);
-      expect($scope.items.length).toBe(2);
+      expect($controller.loadingMetrics).toBeDefined();
+      expect($controller.loadingMetrics).toBe(false);
+      expect($controller.items.length).toBe(2);
     });
   });
 
-  describe('count increment', function() {    
+  describe('count increment', function() {
     it('should increment the count', function() {
-      $scope.countIncrement();
-      expect($scope.timeFilter.range_count).toBe(2);
+      $controller.countIncrement();
+      expect($controller.timeFilter.range_count).toBe(2);
     });
 
     it('should decrement the count', function() {
-      $scope.timeFilter.range_count = 10;
-      $scope.countDecrement();
-      expect($scope.timeFilter.range_count).toBe(9);
+      $controller.timeFilter.range_count = 10;
+      $controller.countDecrement();
+      expect($controller.timeFilter.range_count).toBe(9);
     });
   });
 
-  describe('check numeric formater', function() {    
+  describe('check numeric formater', function() {
     it('should fomrat numbers correctly', function() {
-      expect($scope.items[0].lastValues[1480424640000]).toBe("10.00");
-      expect($scope.items[0].lastValues[1480424630000]).toBe("1.01k");
-      expect($scope.items[0].lastValues[1480424620000]).toBe("20.00t");
+      expect($controller.items[0].lastValues[1480424640000]).toBe("10.00");
+      expect($controller.items[0].lastValues[1480424630000]).toBe("1.01k");
+      expect($controller.items[0].lastValues[1480424620000]).toBe("20.00t");
     });
   });
 });

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -18,8 +18,8 @@ describe('containerLiveDashboardController', function() {
     $httpBackend = _$httpBackend_;
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_tags&limit=250').respond(mock_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_definitions&tags={}').respond(mock_metrics_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauge&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauge&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
     $controller = _$controller_('containerLiveDashboardController');
     $controller.refresh();
     $httpBackend.flush();

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -17,10 +17,10 @@ describe('containerLiveDashboardController', function() {
   beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _pfViewUtils_) {
     pfViewUtils = _pfViewUtils_;
     $httpBackend = _$httpBackend_;
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_tags').respond(mock_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_definitions&tags={}').respond(mock_metrics_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=metric_tags').respond(mock_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=metric_definitions&tags={}').respond(mock_metrics_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
     $controller = _$controller_('containerLiveDashboardController', {
         pfViewUtils: pfViewUtils
     });


### PR DESCRIPTION
**Description**
Refactor #12165
- [x] Add auto-complete text widget to change tenant in ad-hoc metrics page
- [x] Add icon to identify tenant metric type

**Screenshots**
_Navigation from container provider summary page_
![screenshot-localhost 3000-2017-01-20-13-59-50](https://cloud.githubusercontent.com/assets/2181522/22148799/ed84a210-df18-11e6-891c-c119cbdd81b9.png)


_Usage of the auto-complete feature_
![screenshot-localhost 3000-2017-01-18-16-32-38](https://cloud.githubusercontent.com/assets/2181522/22067903/d4116aa8-dd9b-11e6-876f-e83180ac6ebc.png)

(converted from ManageIQ/manageiq#13016)