### PR TITLE
Resolve symlinks before evaluating spec/manageiq/Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ source 'https://rubygems.org'
 dev_gemfile = File.expand_path("Gemfile.dev.rb", __dir__)
 eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
 
-manageiq_gemfile = File.expand_path("spec/manageiq/Gemfile", __dir__)
+manageiq_gemfile = File.realpath("spec/manageiq/Gemfile", __dir__)
 if File.exist?(manageiq_gemfile)
   eval_gemfile(manageiq_gemfile)
 else


### PR DESCRIPTION
A possibly cleaner alternative to https://github.com/ManageIQ/guides/commit/59086ea2312df84fe684ab4757658ae30cb312b8

This way manageiq/Gemfile, manageiq/Gemfile.dev.rb etc are evaluated from this Gemfile with same `__dir__` as when running bundler directly in the manageiq dir.
This allows relative paths to work, avoiding confusing errors such as:

    The path `/home/bpaskinc/miq/manageiq-ui-classic/spec/manageiq-ui-classic` does not exist.

That specific circular problem can be similarly solved by doing:
```
gem "manageiq-ui-classic", :path => File.realpath("../manageiq-ui-classic", __dir__)
```
in Gemfile.dev.rb — or just using an absolute path there — but I think normalizing it here will prevent other surprises...