### PR TITLE
Adding External Logging  links to container providers and nodes

### DIFF
--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -1,5 +1,6 @@
 class ContainerNodeController < ApplicationController
   include ContainersCommonMixin
+  include ContainersExternalLoggingSupportMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -5,6 +5,7 @@ class EmsContainerController < ApplicationController
   include Mixins::EmsCommonAngular
   include Mixins::GenericSessionMixin
   include Mixins::DashboardViewMixin
+  include ContainersExternalLoggingSupportMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/mixins/containers_external_logging_support_mixin.rb
+++ b/app/controllers/mixins/containers_external_logging_support_mixin.rb
@@ -1,0 +1,17 @@
+module ContainersExternalLoggingSupportMixin
+  def launch_external_logging_support
+    record = self.class.model.find(params[:id])
+    ems = record.ext_management_system
+    route_name = ems.external_logging_route_name
+    logging_route = ContainerRoute.find_by(:name => route_name, :ems_id => ems.id) if route_name
+    if logging_route
+      url = "https://#{logging_route.host_name}#{record.external_logging_path}"
+      javascript_open_window(url)
+    else
+      javascript_flash(:text        => _("A route named '#{route_name}' is configured to connect to the " \
+                                          "external logging server but it doesn't exist"),
+                       :severity    => :error,
+                       :spinner_off => true)
+    end
+  end
+end

--- a/app/helpers/application_helper/button/ems_container_launch_external_logging_support.rb
+++ b/app/helpers/application_helper/button/ems_container_launch_external_logging_support.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Button::EmsContainerLaunchExternalLoggingSupport < ApplicationHelper::Button::GenericFeatureButton
+  def initialize(view_context, view_binding, instance_data, props)
+    props ||= {}
+    props.store_path(:options, :feature, :external_logging_support)
+    super(view_context, view_binding, instance_data, props)
+  end
+
+  def disabled?
+    ems = @record.ext_management_system
+    !visible? || ContainerRoute.find_by(:name   => ems.external_logging_route_name,
+                                        :ems_id => ems.id).blank?
+  end
+end

--- a/app/helpers/application_helper/toolbar/container_node_center.rb
+++ b/app/helpers/application_helper/toolbar/container_node_center.rb
@@ -53,6 +53,15 @@ class ApplicationHelper::Toolbar::ContainerNodeCenter < ApplicationHelper::Toolb
   ])
   button_group('vm_access', [
     button(
+      :ems_container_launch_external_logging_support,
+      'product product-monitoring fa-lg',
+      N_('Open a new browser window with the External Logging Logging Presentation UI. ' \
+         'This requires the External Logging logging to be deployed on this Proider.'),
+      N_('External Logging'),
+      :klass => ApplicationHelper::Button::EmsContainerLaunchExternalLoggingSupport,
+      :url   => "launch_external_logging_support"
+    ),
+    button(
       :cockpit_console,
       'pficon pficon-screen fa-lg',
       N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -5,6 +5,15 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
       'fa fa-repeat fa-lg',
       N_('Reload Current Display'),
       nil),
+    button(
+      :ems_container_launch_external_logging_support,
+      'product product-monitoring fa-lg',
+      N_('Open a new browser window with the External Logging Logging Presentation UI. ' \
+         'This requires the External Logging logging to be deployed on this Proider.'),
+      N_('External Logging'),
+      :klass => ApplicationHelper::Button::EmsContainerLaunchExternalLoggingSupport,
+      :url   => "launch_external_logging_support"
+    ),
     select(
       :ems_container_vmdb_choice,
       'fa fa-cog fa-lg',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -691,6 +691,7 @@ Rails.application.routes.draw do
         protect
         squash_toggle
         launch_cockpit
+        launch_external_logging_support
       ) +
                adv_search_post +
                exp_post +
@@ -1225,6 +1226,7 @@ Rails.application.routes.draw do
         tagging_edit
         tag_edit_form_field_changed
         squash_toggle
+        launch_external_logging_support
       ) +
                adv_search_post +
                compare_post +


### PR DESCRIPTION
Adds links to kibana as the common logging viewer for container providers and nodes.

It sends the openshift-auth-proxy that supposes to authenticate for kibana the management-token through the /auth/sso-setup endpoint that is added in [1] and then redirects the user with a generated user-token to /auth/sso-login endpoint that will add that management-token to that session.

![launch_kibana](https://cloud.githubusercontent.com/assets/3123328/23356531/e7edcbf0-fce2-11e6-9089-5897aaa7dd9f.png)

Backend PR: https://github.com/ManageIQ/manageiq/issues/13319

*** This is the UI part of https://github.com/ManageIQ/manageiq/pull/13319 previously known as https://github.com/ManageIQ/manageiq/pull/10648