### PR TITLE
Automatic detection of hawkular endpoint

### DIFF
--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -178,7 +178,24 @@ describe EmsCloudController do
 end
 
 describe EmsContainerController do
+  before :each do
+    allow(controller).to receive(:get_hostname_from_routes).and_return("myhawkularoute.com")
+  end
   context "::EmsCommon" do
+    context "#create" do
+      it "adding new provider without hawkular endpoint" do
+        controller.instance_variable_set(:@_params,
+                                         :name             => 'NimiCule',
+                                         :default_userid   => '_',
+                                         :default_hostname => 'mytest.com',
+                                         :default_api_port => '8443',
+                                         :default_password => 'valid-token',
+                                         :emstype          => @type)
+        ems = ManageIQ::Providers::Openshift::ContainerManager.new
+        controller.send(:set_ems_record_vars, ems)
+        expect(ems.connection_configurations.hawkular.endpoint.hostname).to eq('myhawkularoute.com')
+      end
+    end
     context "#update" do
       context "updates provider with new token" do
         after :each do


### PR DESCRIPTION
Added automatic detection of Hawkular hostname from route when endpoint is not specified.

When the user does not specify the Hawkular client hostname upon adding a new container provider (i.e. Hawkular endpoint is left blank) we had taken it from the hostname - this behavior is changed in this PR - now we are taking the hostname from the Route. 

cc: @yaacov @enoodle @simon3z 

(converted from [ManageIQ/manageiq#12530](https://github.com/ManageIQ/manageiq/pull/12530))