### PR TITLE
Fix typo in filter.rb

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -311,7 +311,7 @@ module ApplicationController::Filter
           @edit[@expkey][:expression] = copy_hash(@edit[:new][@expkey])
           # Build the expression table
           @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression])
-          @efit[@expkey].history.reset(@edit[@expkey][:expression])
+          @edit[@expkey].history.reset(@edit[@expkey][:expression])
           # Clear the current selected token
           @edit[@expkey][:exp_token] = nil
         else


### PR DESCRIPTION
Before: `Error caught: [NoMethodError] undefined method '[]' for nil:NilClass`
After: New filter can be saved.