### PR TITLE
Fix missing "Selected Day Percent Utilization" charts

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -249,7 +249,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
 
   if (_.isObject(data.chartData)) {
     ManageIQ.charts.chartData = data.chartData;
-    // FIXME:  @out << Charting.js_load_statement(true)
+    load_c3_charts();
   }
 
   if (data.resetChanges) { ManageIQ.changes = null; }


### PR DESCRIPTION
Chart was missing when you came to this page for the first time. When you click on `Details` and back to `Summary` you get this chart. 

Now is chart always visible when its available.

Screenshots
----------------

Before:
![utilizaton](https://cloud.githubusercontent.com/assets/9535558/21316334/86c27556-c600-11e6-87ce-03c5452ab61d.png)

After:
![screencapture-localhost-3000-miq_capacity-utilization-1482158083984 1](https://cloud.githubusercontent.com/assets/9535558/21316381/bf09cc98-c600-11e6-8ce4-46d1398e59c2.png)



Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1401441

Steps for Testing/QA
-------------------------------
Go to Optimize -> Utillization

(cherry picked from commit b18bc4ed950bd1161d0d874a1b34655d012b84b3)