### PR TITLE
Fix units in C&U grouped charts

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -249,7 +249,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
 
   if (_.isObject(data.chartData)) {
     ManageIQ.charts.chartData = data.chartData;
-    // FIXME:  @out << Charting.js_load_statement(true)
+    load_c3_charts();
   }
 
   if (data.resetChanges) { ManageIQ.changes = null; }

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -859,7 +859,7 @@ module ApplicationController::Performance
     # Grab the first (and should be only) chart column
     col = chart[:columns].first
     # Create the new chart columns for each tag
-    chart[:columns] = rpt.extras[:group_by_tags].collect { |t| col + "_" + t }
+    chart[:columns] ||= rpt.extras[:group_by_tags].collect { |t| col + "_" + t }
   end
 
   def gen_perf_chart(chart, rpt, idx, zoom_action)


### PR DESCRIPTION
"Fix" units in C&U grouped charts. More like hack grouped chart to look like it's working...
I am dealing with duplicate values in #40 

Screenshots
----------------
Before:

![screencapture-localhost-3000-host-show-10000000000017-1482244822367 1](https://cloud.githubusercontent.com/assets/9535558/21354509/b2638310-c6ca-11e6-9d76-9b0dbcd0e0db.png)

After:
![screencapture-localhost-3000-host-show-10000000000017-1482244721276](https://cloud.githubusercontent.com/assets/9535558/21354447/6d56c390-c6ca-11e6-828a-6d565172bdc5.png)

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1367560

(converted from ManageIQ/manageiq#13273)