### PR TITLE
Fixed missing images in unconverted trees using generic_tree_node

### DIFF
--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -6,7 +6,7 @@ class TreeNodeBuilder
       :key   => key,
       :title => text,
     }
-    node[:icon]         = ActionController::Base.helpers.image_path(image) if image
+    node[:image]         = ActionController::Base.helpers.image_path(image) if image
     node[:addClass]     = options[:style_class]      if options[:style_class]
     node[:cfmeNoClick]  = true                       if options[:cfme_no_click]
     node[:expand]       = options[:expand]           if options[:expand]


### PR DESCRIPTION
Forgot to rename it in: https://github.com/ManageIQ/manageiq/pull/13297