### PR TITLE
Moved UI gem dependencies from the main repo

### DIFF
--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -1,5 +1,10 @@
 require 'rails/all'
+require 'sass-rails'
+require 'coffee-rails'
 require 'patternfly-sass'
+require 'lodash-rails'
+require 'angular-ui-bootstrap-rails'
+require 'jquery-hotkeys-rails'
 
 module ManageIQ
   module UI

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -21,6 +21,13 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.0.0", ">= 5.0.0.1"
 
+  s.add_dependency "angular-ui-bootstrap-rails", "~>0.13.0"
+  s.add_dependency "coffee-rails"
+  s.add_dependency "jquery-hotkeys-rails"
+  s.add_dependency "lodash-rails", "~>3.10.0"
+  s.add_dependency "patternfly-sass", "~> 3.15.0"
+  s.add_dependency "sass-rails"
+
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
The jquery-rjs is included from our fork on GitHub and there is no
support for unreleased gems in a gemspec. I also tried to move it
to the UI Gemfile, without any success. So until we don't push it
to Rubygems.org, it needs to stay in the main repo's Gemfile.

Parent issue:
https://github.com/ManageIQ/manageiq-ui-classic/issues/1

Merge before:
https://github.com/ManageIQ/manageiq/pull/13332