### PR TITLE
Fix the path to the bower directory to make bower caching work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ sudo: false
 cache:
   bundler: true
   directories:
-    - vendor/assets/bower_components
+    - spec/manageiq/vendor/assets/bower_components
 before_cache:
-- cat bower.json > vendor/assets/bower_components/bower.json
+- cat bower.json > spec/manageiq/vendor/assets/bower_components/bower.json
 addons:
   postgresql: '9.4'
 env:

--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -1,6 +1,14 @@
 set -e
 
-git clone https://github.com/ManageIQ/manageiq.git --depth 1 spec/manageiq
+# The bower cache already exists under spec/manageiq/vendor/assets/bower_components
+# and unfortunately it is not possible to git clone to a non-empty directory.
+mkdir -p spec/manageiq
+cd spec/manageiq
+git init
+git remote add origin https://github.com/ManageIQ/manageiq.git
+git pull origin master --depth=1
+cd -
+
 echo 'unless dependencies.detect { |d| d.name == "manageiq-ui-classic" }' >> spec/manageiq/Gemfile.dev.rb
 echo '  gem "manageiq-ui-classic", :path => "'$(/bin/pwd)'"' >> spec/manageiq/Gemfile.dev.rb
 echo 'end' >> spec/manageiq/Gemfile.dev.rb

--- a/tools/ci/setup_js_env.sh
+++ b/tools/ci/setup_js_env.sh
@@ -1,0 +1,18 @@
+which bower || npm install -g bower
+
+# Check if the bower cache is valid, otherwise delete it
+if ! cmp --silent bower.json spec/manageiq/vendor/assets/bower_components/bower.json; then
+  rm -rf spec/manageiq/vendor/assets/bower_components
+fi
+
+if [ -d spec/manageiq/vendor/assets/bower_components ]; then
+  echo "bower assets installed... moving on."
+else
+  bower install --allow-root -F --config.analytics=false
+  STATUS=$?
+  echo bower exit code: $STATUS
+
+  # fail the whole test suite if bower install failed
+  [ $STATUS = 0 ] || exit 1
+  [ -d spec/manageiq/vendor/assets/bower_components ] || exit 1
+fi


### PR DESCRIPTION
This caused random failures when Travis does bower install. Also the Travis required some adjustments while cloning the main repo to the `spec/manageiq` folder which is now not empty thanks to the caching.