### PR TITLE
Enable provision instances button via providers

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -426,7 +426,7 @@ class ApplicationHelper::ToolbarBuilder
   def hide_button?(id)
     # need to hide add buttons when on sub-list view screen of a CI.
     return true if id.ends_with?("_new", "_discover") &&
-                   @lastaction == "show" && !["main", "vms"].include?(@display)
+                   @lastaction == "show" && !%w(main vms instances).include?(@display)
 
     # user can see the buttons if they can get to Policy RSOP/Automate Simulate screen
     return false if ["miq_ae_tools"].include?(@layout)

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -314,6 +314,16 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       end
     end
 
+    context "when with instance_miq_request_new" do
+      it "and @lastaction = show, @display = instances" do
+        @id = "instance_miq_request_new"
+        @lastaction = "show"
+        @display = "instances"
+        stub_user(:features => :all)
+        expect(subject).to be_falsey
+      end
+    end
+
     context "when with vm_console" do
       before do
         @id = "vm_console"

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -304,23 +304,17 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       end
     end
 
-    context "when with vm_miq_request_new" do
-      it "and @lastaction = show, @display = vms" do
-        @id = "vm_miq_request_new"
-        @lastaction = "show"
-        @display = "vms"
-        stub_user(:features => :all)
-        expect(subject).to be_falsey
-      end
-    end
-
-    context "when with instance_miq_request_new" do
-      it "and @lastaction = show, @display = instances" do
-        @id = "instance_miq_request_new"
-        @lastaction = "show"
-        @display = "instances"
-        stub_user(:features => :all)
-        expect(subject).to be_falsey
+    context 'last action set to show' do
+      let(:lastaction) { 'show' }
+      context 'requested to display instances' do
+        let(:display) { 'instances' }
+        it 'returns with false' do
+          @lastaction = lastaction
+          @display = display
+          @id = 'vm_miq_request_new'
+          stub_user(:features => :all)
+          expect(subject).to be_falsey
+        end
       end
     end
 


### PR DESCRIPTION
This is the Instances version of #11836 and moved from the ManageIQ repo PR https://github.com/ManageIQ/manageiq/pull/13152

https://bugzilla.redhat.com/show_bug.cgi?id=1386342
