### PR TITLE
[WIP] Allow multiple select states in hash node

### DIFF
--- a/app/presenters/tree_node/hash.rb
+++ b/app/presenters/tree_node/hash.rb
@@ -10,7 +10,7 @@ module TreeNode
 
     set_attribute(:hide_checkbox) { @object.key?(:hideCheckbox) && @object[:hideCheckbox] ? true : nil }
 
-    set_attribute(:selected) { @object.key?(:select) && @object[:select] ? true : nil }
+    set_attribute(:selected) { @object[:select] if @object.key?(:select) }
 
     set_attribute(:klass) { @object.key?(:addClass) ? @object[:addClass] : nil }
 


### PR DESCRIPTION
Some trees like the role menu tree under configuration have more than 2 select states and need to pass `true`, `false`, or `undefined` to Bootstrap Tree. Not sure the best way to address this, but this works for the particular tree. I may find a way to use a different node builder, but creating this for now.

@miq-bot assign @skateman 