### PR TITLE
[WIP] converting rbac_tree to tree builder

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -954,13 +954,20 @@ module OpsController::OpsRbac
   def rbac_role_get_details(id)
     @edit = nil
     @record = @role = MiqUserRole.find_by_id(from_cid(id))
-    @role_features = @role.feature_identifiers.sort
-    @features_tree = rbac_build_features_tree
+    @rbac_menu_tree = build_rbac_menu_tree
   end
 
-  def rbac_build_features_tree
+  def build_rbac_menu_tree
     @role = @sb[:typ] == "copy" ? @record.dup : @record if @role.nil? # if on edit screen use @record
-    TreeBuilder.convert_bs_tree(OpsController::RbacTree.build(@role, @role_features, !@edit.nil?)).to_json
+    # TreeBuilder.convert_bs_tree(OpsController::RbacTree.build(@role, @role_features, !@edit.nil?)).to_json
+    TreeBuilderOpsRbacMenu.new(
+      "features_tree",
+      "features",
+      @sb,
+      true,
+      role: @role,
+      editable: @edit.present?
+    )
   end
 
   # Set form variables for role edit
@@ -1176,7 +1183,7 @@ module OpsController::OpsRbac
     @edit[:current] = copy_hash(@edit[:new])
 
     @role_features = @record.feature_identifiers.sort
-    @features_tree = rbac_build_features_tree
+    @rbac_menu_tree = build_rbac_menu_tree
   end
 
   # Get array of total set of features from the children of selected features

--- a/app/presenters/tree_builder_ops_rbac_menu.rb
+++ b/app/presenters/tree_builder_ops_rbac_menu.rb
@@ -1,0 +1,249 @@
+class TreeBuilderOpsRbacMenu < TreeBuilder
+  include CompressedIds
+
+  has_kids_for Hash, [:x_get_tree_hash_kids]
+
+  attr_reader :role, :features, :editable
+
+  def initialize(name, type, sandbox, build, role:, editable: false)
+    @role     = role
+    @editable = editable
+    @features = @role.miq_product_features.order(:identifier).pluck(:identifier)
+
+    super(name, type, sandbox, build)
+  end
+
+  private
+
+  def menu_tree
+    recurse_menu_items(filtered_menus, root_select)
+  end
+
+  def filtered_menus
+    menus = []
+
+    Menu::Manager.each do |section|
+      next if section.id == :cons && !Settings.product.consumption
+      next if section.name.nil?
+      next unless Vmdb::PermissionStores.instance.can?(section.id)
+
+      menus.push(section)
+    end
+
+    menus
+  end
+
+  def recurse_menu_items(items, checked = false)
+    items.map do |item|
+      case item
+      when Menu::Section
+        menu_section_to_node(item)
+      when Menu::Item
+        if item.feature.nil? || !MiqProductFeature.feature_exists?(item.feature)
+          next
+        end
+        menu_item_to_node(item, checked)
+      when String
+        feature_name_to_node(item, checked)
+      else
+        item
+      end
+    end
+  end
+
+  def menu_section_to_node(section)
+    node = default_node.merge!(
+      :id      => "#{node_id}___tab_#{section.id}",
+      :text    => _(section.name),
+      :tooltip => _("%{title} Main Tab") % {:title => section.name},
+      :data    => {}
+    )
+
+    node[:data][:kids] = recurse_menu_items(section.items).compact
+    select_if_kids_selected(node, node[:data][:kids])
+
+    node
+  end
+
+  def menu_item_to_node(item, checked = false)
+    details = MiqProductFeature.feature_details(item.feature)
+
+    node = default_node.merge!(
+      :id      => "#{node_id}__#{item.feature}",
+      :text    => _(details[:name]),
+      :tooltip => _(details[:description]) || _(details[:name]),
+      :select  => checked,
+      :data    => {}
+    )
+
+    node[:select] ||= features.include?(item.feature)
+
+    kids = MiqProductFeature.feature_children(item.feature)
+    node[:data][:kids] = recurse_menu_items(kids, node[:select])
+
+    select_if_kids_selected(node, node[:data][:kids])
+
+    node
+  end
+
+  def feature_name_to_node(feature, checked = false)
+    details = MiqProductFeature.feature_details(feature)
+    return if details[:hidden]
+
+    checked ||= features.include?(remove_accords_suffix(feature))
+
+    node = default_node.merge!(
+      :id      => "#{node_id}__#{feature}",
+      :image   => "feature_#{details[:feature_type]}",
+      :text    => _(details[:name]),
+      :tooltip => _(details[:description]) || _(details[:name]),
+      :select  => checked,
+      :data    => {}
+    )
+
+    children = MiqProductFeature.feature_children(feature).map do |child|
+      name = remove_accords_suffix(child)
+      name if MiqProductFeature.feature_exists?(name)
+    end
+
+    node[:data][:kids] = recurse_menu_items(children, checked)
+
+    select_if_kids_selected(node, node[:data][:kids])
+
+    node
+  end
+
+  def select_if_kids_selected(node, kids)
+    return if kids.none?
+
+    if all_checked?(kids)
+      node[:select] = true
+      return
+    end
+
+    if any_checked?(kids)
+      node[:select] = 'undefined'
+    end
+  end
+
+  def set_locals_for_render
+    locals = {
+      :checkboxes   => true,
+      :three_checks => true,
+      :check_url    => "/ops/rbac_role_field_changed/"
+    }
+
+    if editable
+      locals[:oncheck] = "miqOnCheckHandler"
+    end
+
+    super.merge!(locals)
+  end
+
+  def x_get_tree_roots(count_only = false, _options)
+    top_nodes = menu_tree
+    top_nodes << all_vm_node
+
+    select_if_kids_selected(root_node, top_nodes.first[:data][:kids])
+
+    count_only_or_objects(count_only, top_nodes)
+  end
+
+  def x_get_tree_hash_kids(parent, count_only = false)
+    count_only_or_objects(count_only, parent[:data][:kids])
+  end
+
+  def tree_init_options(_tree_name)
+    { :lazy => false, :add_root => true }
+  end
+
+  def root_options
+    [
+      root_title,
+      root_tooltip,
+      "100/feature_node",
+      @root_node
+    ]
+  end
+
+  def root_node
+    @root_node ||= {
+      :key         => root_key,
+      :expand      => true,
+      :cfmeNoClick => true,
+      :select      => root_select,
+      :checkable   => editable
+    }
+  end
+
+  def root_tooltip
+    _(root[:description]) || _(root[:name])
+  end
+
+  def root_title
+    _(root[:name])
+  end
+
+  def root_key
+    "#{node_id}__#{root_feature}"
+  end
+
+  def root_select
+    features.include?(root_feature)
+  end
+
+  def node_id
+    role.id ? to_cid(role.id) : "new"
+  end
+
+  def remove_accords_suffix(name)
+    name.sub(/_accords$/, '')
+  end
+
+  def root_feature
+    @root_feature ||= MiqProductFeature.feature_root
+  end
+
+  def root
+    @root ||= MiqProductFeature.feature_details(root_feature)
+  end
+
+  def all_vm_node
+    @all_vm_node ||= begin
+      text = _("Access Rules for all Virtual Machines")
+      feat_kids = MiqProductFeature.feature_children("all_vm_rules")
+      checked = root_select || features.include?("all_vm_rules")
+
+      default_node.merge!(
+        :id      => "#{node_id}___tab_all_vm_rules",
+        :text    => text,
+        :tooltip => text,
+        :select  => checked,
+        :data    => {
+          :kids => recurse_menu_items(feat_kids, checked)
+        }
+      )
+    end
+  end
+
+  def default_node
+    {
+      :id          => node_id,
+      :image       => "100/feature_node",
+      :text        => "",
+      :cfmeNoClick => true,
+      :select      => false,
+      :checkable   => editable
+    }
+  end
+
+  def all_checked?(kids)
+    return false if kids.empty? # empty list is considered not checked
+    kids.length == kids.collect { |k| k if k[:select] }.compact.length
+  end
+
+  def any_checked?(kids)
+    return false if kids.empty?
+    kids.any? { |k| k[:select] }
+  end
+end

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -2,72 +2,62 @@
   - url = url_for(:action => 'rbac_role_field_changed',
                   :id     => "#{@edit[:role_id] || "new"}")
 = render :partial => "layouts/flash_msg"
-#main_div
-  .row
-    .col-md-12.col-lg-6
-      %h3
-        = _("Role Information")
-      .form-horizontal
-        .form-group
-          %label.col-md-4.control-label
-            = _("Name")
-          .col-md-8
-            - if !@edit
-              %p.form-control-static
-                = h(@role.name)
+
+.row
+  .col-md-12.col-lg-6
+    %h3
+      = _("Role Information")
+    .form-horizontal
+      .form-group
+        %label.col-md-4.control-label
+          = _("Name")
+        .col-md-8
+          - if !@edit
+            %p.form-control-static
+              = h(@role.name)
+          - else
+            = text_field_tag("name",
+                             @edit[:new][:name],
+                             :maxlength         => 50,
+                             :class => "form-control",
+                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+            = javascript_tag(javascript_focus('name'))
+      .form-group
+        %label.col-md-4.control-label
+          = _('Access Restriction for Services, VMs, and Templates')
+        .col-md-8
+          - if !@edit
+            - if @role.settings.kind_of?(Hash) && @role.settings.fetch_path(:restrictions, :vms)
+              = h(MiqUserRole::RESTRICTIONS[@role.settings.fetch_path(:restrictions, :vms)])
             - else
-              = text_field_tag("name",
-                               @edit[:new][:name],
-                               :maxlength         => 50,
-                               :class => "form-control",
-                               "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-              = javascript_tag(javascript_focus('name'))
+              = _("None")
+          - else
+            = select_tag('vm_restriction',
+                         options_for_select([[_("None"), _("none")]] + MiqUserRole::RESTRICTIONS.invert.sort_by { |name, _value| name.downcase },
+                         @edit[:new][:vm_restriction].to_sym),
+                         :class    => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent('vm_restriction', "#{url}")
+      - unless @edit
         .form-group
           %label.col-md-4.control-label
-            = _('Access Restriction for Services, VMs, and Templates')
+            = _("Groups Using this Role")
           .col-md-8
-            - if !@edit
-              - if @role.settings.kind_of?(Hash) && @role.settings.fetch_path(:restrictions, :vms)
-                = h(MiqUserRole::RESTRICTIONS[@role.settings.fetch_path(:restrictions, :vms)])
+            - @role.miq_groups.sort_by { |a| a.description.downcase }.each do |g|
+              - if role_allows?(:feature => "rbac_group_show")
+                - params = {:class   => "pointer",
+                            :onclick => "miqTreeActivateNode('rbac_tree', 'g-#{to_cid(g.id)}');",
+                            :title   => _("View this Group")}
               - else
-                = _("None")
-            - else
-              = select_tag('vm_restriction',
-                           options_for_select([[_("None"), _("none")]] + MiqUserRole::RESTRICTIONS.invert.sort_by { |name, _value| name.downcase },
-                           @edit[:new][:vm_restriction].to_sym),
-                           :class    => "selectpicker")
-          :javascript
-            miqInitSelectPicker();
-            miqSelectPickerEvent('vm_restriction', "#{url}")
-        - unless @edit
-          .form-group
-            %label.col-md-4.control-label
-              = _("Groups Using this Role")
-            .col-md-8
-              - @role.miq_groups.sort_by { |a| a.description.downcase }.each do |g|
-                - if role_allows?(:feature => "rbac_group_show")
-                  - params = {:class   => "pointer",
-                              :onclick => "miqTreeActivateNode('rbac_tree', 'g-#{to_cid(g.id)}');",
-                              :title   => _("View this Group")}
-                - else
-                  - params = {}
-                %i.product.product-group{params}
-                = link_to(g.description, "#", params)
-    .col-md-12.col-lg-6
-      %hr
-      - if @edit
-        = _("Product Features (Editing)")
-      - else
-        = _("Product Features (Read Only)")
-      %h3
-      #features_treebox.treeview-pf-hover.treeview-pf-select{:style => "width:100%;height:100%;color:#000"}
-      = render(:partial => "layouts/tree",
-               :locals  => {:tree_id        => "features_treebox",
-                            :tree_name      => "features_tree",
-                            :bs_tree        => @features_tree,
-                            :checkboxes     => true,
-                            :three_checks   => true,
-                            :check_url      => "/ops/rbac_role_field_changed/",
-                            :oncheck        => @edit.nil? ? nil : "miqOnCheckHandler"})
-      &nbsp;&nbsp;*
-      = _("Double click a feature to open/close all children.")
+                - params = {}
+              %i.product.product-group{params}
+              = link_to(g.description, "#", params)
+  .col-md-12.col-lg-6
+    %hr
+    - if @edit
+      = _("Product Features (Editing)")
+    - else
+      = _("Product Features (Read Only)")
+    %h3
+    = render(:partial => "shared/tree", :locals => {:tree => @rbac_menu_tree, :name => @rbac_menu_tree.name})

--- a/spec/presenters/tree_builder_ops_rbac_menu_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_menu_spec.rb
@@ -1,0 +1,63 @@
+describe TreeBuilderOpsRbacMenu do
+  let(:features) do
+    %w{
+      all_vm_rules
+      instance
+      instance_view
+      instance_show_list
+      instance_control
+      instance_scan
+    }
+  end
+
+  let(:cid) { ApplicationRecord.uncompress_id("10r2") }
+
+  let(:role) do
+    FactoryGirl.create(:miq_user_role, :id => cid, :features => features)
+  end
+
+  let(:tree) do
+    TreeBuilderOpsRbacMenu.new(
+      "features_tree",
+      "features",
+      {},
+      true,
+      role: role,
+      editable: false
+    )
+  end
+
+  let(:main_keys) { bs_tree.first["nodes"].map{|n| n['key']} }
+
+  describe 'bs_tree' do
+    subject(:bs_tree) { JSON.parse(tree.locals_for_render[:bs_tree]) }
+
+    it 'builds the bs_tree' do
+      t = bs_tree.first
+
+      expect(t['key']).to match(/all_vm_rules/)
+      expect(t['title']).to be_nil
+      expect(t['tooltip']).to be_nil
+      expect(t['checkable']).to eq(false)
+    end
+    #
+    it 'includes main sections' do
+      expect(main_keys).to include("xx-10r2___tab_aut")
+      expect(main_keys).to include("xx-10r2___tab_compute")
+      expect(main_keys).to include("xx-10r2___tab_con")
+      expect(main_keys).to include("xx-10r2___tab_conf")
+      expect(main_keys).to include("xx-10r2___tab_mdl")
+      expect(main_keys).to include("xx-10r2___tab_net")
+      expect(main_keys).to include("xx-10r2___tab_opt")
+      expect(main_keys).to include("xx-10r2___tab_set")
+      expect(main_keys).to include("xx-10r2___tab_sto")
+      expect(main_keys).to include("xx-10r2___tab_svc")
+      expect(main_keys).to include("xx-10r2___tab_vi")
+    end
+
+    it 'does not include blank nodes' do
+      expect(main_keys).not_to include("xx-10r2__")
+      expect(main_keys).not_to include("xx-10r2___tab_")
+    end
+  end
+end


### PR DESCRIPTION
Convert RbacTree to use TreeBuilderOpsRbacMenu

Also fixes some tree rendering bugs:

![tree_before](https://cloud.githubusercontent.com/assets/39493/21039041/ab961dca-bd8f-11e6-89cb-5bd80b58d183.png)

**After**

![tree_after](https://cloud.githubusercontent.com/assets/39493/21039044/b43fc444-bd8f-11e6-9c03-623ba1a7a423.png)

Plus removes a duplicate DOM element.

This is a copy of https://github.com/ManageIQ/manageiq/pull/13048 and is a work in progress addressing feedback from that PR.