### PR TITLE
Don't lookup category names if tag tree view all

### DIFF
--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -45,16 +45,23 @@ class TreeBuilderTags < TreeBuilder
 
   def x_get_tree_roots(count_only, _options)
     # open node if at least one of his kids is selected
-    @categories.each do |c|
-      open_node("cl-#{to_cid(c.id)}") if contain_selected_kid(c)
+    if @edit.present? || @filters.present?
+      @categories.each do |c|
+        open_node("cl-#{to_cid(c.id)}") if contain_selected_kid(c)
+      end
     end
     count_only_or_objects(count_only, @categories)
   end
 
   def x_get_classification_kids(parent, count_only)
+    return parent.entries.size if count_only
     kids = parent.entries.map do |kid|
-      kid_id = "#{parent.name}-#{kid.name}"
-      select = (@edit && @edit.fetch_path(:new, :filters, kid_id)) || (@filters && @filters.key?(kid_id))
+      select = if @edit.blank? && @filters.blank?
+                 false
+               else
+                 kid_id = "#{parent.name}-#{kid.name}"
+                 (@edit && @edit.fetch_path(:new, :filters, kid_id)) || (@filters && @filters.key?(kid_id))
+               end
       {:id          => kid.id,
        :image       => '100/tag.png',
        :text        => kid.description,


### PR DESCRIPTION
When building the tag tree in access control groups, the tag tree is not expandable. But building the node name (using `category.name`) executes a few hundred extra queries (20%).

This skips those queries.

Numbers are for small 5_7 db. numbers in larger DBS will increase for each tag and node in the db. They were timing out for me

|       ms |queries | query (ms) |     rows |comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  2,604.9 |  591 |   289.8 |      869 |`/ops/explorer` before
|  2,591.2 |  471 |   225.9 |      749 |`/ops/explorer` after
| | 20% | 22.0% | 14%

- https://bugzilla.redhat.com/show_bug.cgi?id=1399345
- originally https://github.com/ManageIQ/manageiq/pull/13301
- `euwe`: https://github.com/ManageIQ/manageiq/pull/13308

