### PR TITLE
Merge all timeline accordions under a single tree

### DIFF
--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -49,7 +49,7 @@ module ApplicationController::Timelines
     @tree_type = tree_type
 
     tree = rpt_menu.map do |r|
-      root = TreeNodeBuilder.generic_tree_node("r__#{r[0]}", r[0], "100/folder.png", r[0], :cfme_no_click => true)
+      root = TreeNodeBuilder.generic_tree_node("r__#{r[0]}", r[0], "100/folder.png", r[0], :cfme_no_click => true, :expand => true)
 
       @group_idx.push(r[0]) unless @group_idx.include?(r[0])
       @report_groups.push(r[0]) unless @report_groups.include?(r[0])

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -43,12 +43,14 @@ module ApplicationController::Timelines
 
   # Gather information for the report/timeline menu trees accordians
   def build_timeline_tree(rpt_menu, tree_type)
-    @rep_tree = {}
     @group_idx = []
     @report_groups = []
     @branch = []
     @tree_type = tree_type
-    rpt_menu.each do |r|
+
+    tree = rpt_menu.map do |r|
+      root = TreeNodeBuilder.generic_tree_node("r__#{r[0]}", r[0], "100/folder.png", r[0], :cfme_no_click => true)
+
       @group_idx.push(r[0]) unless @group_idx.include?(r[0])
       @report_groups.push(r[0]) unless @report_groups.include?(r[0])
       r.each_slice(2) do |menu, section|
@@ -89,10 +91,12 @@ module ApplicationController::Timelines
             @branch.push(temp) unless temp.nil? || temp.empty?
           end
         end
-        @rep_tree[menu] = TreeBuilder.convert_bs_tree(@branch).to_json unless @branch.nil? || @branch.empty?
+        root[:children] = @branch unless @branch.nil? || @branch.empty?
         @branch = []
       end
+      root
     end
+    @rep_tree = TreeBuilder.convert_bs_tree(tree).to_json
   end
 
   def timeline_kids_tree(rec, node_color)

--- a/app/views/layouts/listnav/_timeline.html.haml
+++ b/app/views/layouts/listnav/_timeline.html.haml
@@ -1,13 +1,10 @@
 - if @tree_type == "timeline" && @rep_tree
-  #accordion.panel-group
-    - @report_groups.each_with_index do |rg, rg_idx|
-      = miq_accordion_panel(h(rg),
-        @panels["timelines_#{rg_idx}"].nil? || @panels["timelines_#{rg_idx}"] == false, "timelines_#{rg_idx}") do
-        - tree_id = "timeline_treebox#{rg_idx}"
-        .treeview-pf-hover.treeview-pf-select{:id => tree_id}
-        = render(:partial => "layouts/tree",
-          :locals         => {:tree_id => tree_id,
-            :tree_name                 => "#{tree_id}_#{rg_idx}",
-            :bs_tree                   => @rep_tree[@report_groups[rg_idx]],
-            :click_url                 => "/dashboard/show_timeline/",
-            :onclick                   => "miqOnClickTimelineSelection"})
+  .panel-group#accordion
+    = miq_accordion_panel(_("Timelines"), true, "timelines_tree") do
+      .treeview-pf-hover.treeview-pf-select{:id => "timeline_treebox"}
+      = render(:partial => "layouts/tree",
+        :locals         => {:tree_id => "timeline_treebox",
+          :tree_name                 => "timeline_tree",
+          :bs_tree                   => @rep_tree,
+          :click_url                 => "/dashboard/show_timeline/",
+          :onclick                   => "miqOnClickTimelineSelection"})


### PR DESCRIPTION
Selecting an accordion in Cloud Intel -> Timelines is not making an AJAX call. If there is more than one accordion with a tree, it is possible to mark an item in each tree. This feature is not desired and the easiest solution was to merge the accordions under a single tree.

**Before:**
![screenshot from 2017-01-04 13-56-34](https://cloud.githubusercontent.com/assets/649130/21642913/ae44fb58-d285-11e6-9f4c-c430172c4057.png)

**After:**
![screenshot from 2017-01-04 13-58-28](https://cloud.githubusercontent.com/assets/649130/21642956/e51148e4-d285-11e6-9bb5-5ef86693d877.png)


Fixes https://github.com/ManageIQ/manageiq/issues/10793
https://bugzilla.redhat.com/show_bug.cgi?id=1396063