### PR TITLE
Limit codeclimate-test-reporter to just the spec suite.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_cache:
 - mkdir -p vendor/assets
 - mv spec/manageiq/vendor/assets/bower_components vendor/assets
 - cp bower.json vendor/assets/bower_components
-after_script: bundle exec codeclimate-test-reporter
+after_script: if [ "$TEST_SUITE" = "spec" ]; then bundle exec codeclimate-test-reporter; fi
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
Normally, codeclimate-test-reporter exits 0 when it shouldn't execute,
such as when the token is missing, however if there are no coverage
results, as in the javascript test suite, then it will exit 1 failing
the test suite.

@martinpovolny @skateman Please review.