### PR TITLE
Clean up TreeNode:: title and tooltip evaluation, escaping and gettext

### DIFF
--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -26,11 +26,7 @@ class TreeBuilderAlertProfile < TreeBuilder
     objects = alert_profile_kinds.map do |db|
       # Set alert profile folder nodes to open so we pre-load all children
       open_node("xx-#{db}")
-
-      # Actual translation should happen in TreeNodeBuilder
-      text = PostponedTranslation.new(N_("%{model} Alert Profiles")) do
-        {:model => ui_lookup(:model => db)}
-      end.to_proc
+      text = _("%{model} Alert Profiles") % {:model => ui_lookup(:model => db)}
       {:id => db, :text => text, :image => "100/#{db.underscore.downcase}.png", :tip => text}
     end
 

--- a/app/presenters/tree_node/hash.rb
+++ b/app/presenters/tree_node/hash.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class Hash < Node
-    set_attribute(:title) { @object[:text].kind_of?(Proc) ? @object[:text].call : _(@object[:text]) }
+    set_attribute(:title) { @object[:text] }
 
     set_attribute(:image) { @object[:image] }
 

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -110,6 +110,7 @@ module TreeNode
       node = {
         :key          => key,
         :title        => title,
+        :tooltip      => tooltip,
         :icon         => icon,
         :expand       => expand,
         :hideCheckbox => hide_checkbox ? hide_checkbox : nil,
@@ -118,10 +119,6 @@ module TreeNode
         :select       => selected,
         :checkable    => checkable ? nil : false,
       }
-      unless tooltip.blank?
-        tip = tooltip.kind_of?(Proc) ? tooltip.call : _(tooltip)
-        node[:tooltip] = tip
-      end
 
       node[:image] = if !image
                        nil

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -106,11 +106,16 @@ module TreeNode
       end
     end
 
+    def escape(string)
+      return string if string.nil? || string.blank? || string.html_safe?
+      ERB::Util.html_escape(string)
+    end
+
     def to_h
       node = {
         :key          => key,
-        :title        => title,
-        :tooltip      => tooltip,
+        :title        => escape(title),
+        :tooltip      => escape(tooltip),
         :icon         => icon,
         :expand       => expand,
         :hideCheckbox => hide_checkbox ? hide_checkbox : nil,

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -120,7 +120,6 @@ module TreeNode
       }
       unless tooltip.blank?
         tip = tooltip.kind_of?(Proc) ? tooltip.call : _(tooltip)
-        tip = ERB::Util.html_escape(URI.unescape(tip)) unless tip.html_safe?
         node[:tooltip] = tip
       end
 

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -107,10 +107,9 @@ module TreeNode
     end
 
     def to_h
-      text = ERB::Util.html_escape(title ? URI.unescape(title) : title) unless title.html_safe?
       node = {
         :key          => key,
-        :title        => text ? text : title,
+        :title        => title,
         :icon         => icon,
         :expand       => expand,
         :hideCheckbox => hide_checkbox ? hide_checkbox : nil,

--- a/spec/presenters/tree_node/node_spec.rb
+++ b/spec/presenters/tree_node/node_spec.rb
@@ -5,13 +5,36 @@ describe TreeNode::Node do
   let(:options) { Hash.new }
   subject { described_class.new(object, parent, options) }
 
+  describe '#escape' do
+    let(:object) { nil }
+
+    [nil, "", ViewHelper.content_tag(:strong, "x")].each do |string|
+      context "input is #{string.inspect}" do
+        let(:input) { string }
+
+        it 'returns with the argument without any modification' do
+          expect(subject.escape(input)).to eq(input)
+        end
+      end
+    end
+
+    context 'input is unsafe' do
+      let(:input) { "<script>alert('hacked');</script>" }
+
+      it 'returns with the escaped argument' do
+        expect(subject.escape(input)).not_to eq(input)
+        expect(subject.escape(input)).to eq("&lt;script&gt;alert(&#39;hacked&#39;);&lt;/script&gt;")
+      end
+    end
+  end
+
   describe '#to_h' do
     before { allow(subject).to receive(:image).and_return('') }
     context 'title contains %2f' do
       let(:object) { OpenStruct.new(:name => 'foo %2f bar') }
 
-      it 'unescapes it to slash' do
-        expect(subject.to_h[:title]).to eq('foo / bar')
+      it 'does not escape' do
+        expect(subject.to_h[:title]).to eq('foo %2f bar')
       end
     end
 


### PR DESCRIPTION
All the node titles and tooltips are marked as `html_safe`, except the nodes generated by user input. Also the postponed translations are obsolete and they were removed, but maybe @mzazrivec could verify it.