### PR TITLE
Created a new helper for Controllers/Presenters capable of calling UI helper methods

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,0 +1,6 @@
+module ViewHelper
+  extend ActionView::Context
+  extend ActionView::Helpers::TagHelper
+  extend ActionView::Helpers::TextHelper
+  extend ActionView::Helpers::CaptureHelper
+end

--- a/app/presenters/tree_node/assigned_server_role.rb
+++ b/app/presenters/tree_node/assigned_server_role.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class AssignedServerRole < Node
     set_attributes(:title, :image, :klass) do
-      title = content_tag(:strong) do
+      title = ViewHelper.content_tag(:strong) do
         if @options[:tree] == :servers_by_role_tree
           "#{_('Server')}: #{ERB::Util.html_escape(@object.name)} [#{@object.id}]"
         else

--- a/app/presenters/tree_node/compliance.rb
+++ b/app/presenters/tree_node/compliance.rb
@@ -1,9 +1,9 @@
 module TreeNode
   class Compliance < Node
     set_attribute(:title) do
-      capture do
-        concat content_tag(:strong, "#{_('Compliance Check on')}: ")
-        concat format_timezone(@object.timestamp, Time.zone, 'gtl')
+      ViewHelper.capture do
+        ViewHelper.concat ViewHelper.content_tag(:strong, "#{_('Compliance Check on')}: ")
+        ViewHelper.concat format_timezone(@object.timestamp, Time.zone, 'gtl')
       end
     end
 

--- a/app/presenters/tree_node/compliance_detail.rb
+++ b/app/presenters/tree_node/compliance_detail.rb
@@ -1,9 +1,9 @@
 module TreeNode
   class ComplianceDetail < Node
     set_attribute(:title) do
-      capture do
-        concat content_tag(:strong, "#{_('Policy')}: ")
-        concat @object.miq_policy_desc
+      ViewHelper.capture do
+        ViewHelper.concat ViewHelper.content_tag(:strong, "#{_('Policy')}: ")
+        ViewHelper.concat @object.miq_policy_desc
       end
     end
 

--- a/app/presenters/tree_node/miq_policy.rb
+++ b/app/presenters/tree_node/miq_policy.rb
@@ -3,9 +3,9 @@ module TreeNode
     set_attribute(:image) { "100/miq_policy_#{@object.towhat.downcase}#{@object.active ? '' : '_inactive'}.png" }
     set_attribute(:title) do
       if @options[:tree] == :policy_profile_tree
-        capture do
-          concat content_tag(:strong, "#{ui_lookup(:model => @object.towhat)} #{@object.mode.titleize}: ")
-          concat ERB::Util.html_escape(@object.description)
+        ViewHelper.capture do
+          ViewHelper.concat ViewHelper.content_tag(:strong, "#{ui_lookup(:model => @object.towhat)} #{@object.mode.titleize}: ")
+          ViewHelper.concat ERB::Util.html_escape(@object.description)
         end
       else
         @object.description

--- a/app/presenters/tree_node/miq_server.rb
+++ b/app/presenters/tree_node/miq_server.rb
@@ -8,7 +8,7 @@ module TreeNode
         tooltip  = _("%{server}: %{server_name} [%{server_id}] (current)") %
                    {:server => ui_lookup(:model => @object.class.to_s), :server_name => @object.name, :server_id => @object.id}
         tooltip += " (#{@object.status})" if @options[:tree] == :roles_by_server_tree
-        title = content_tag(:strong, ERB::Util.html_escape(tooltip))
+        title = ViewHelper.content_tag(:strong, ERB::Util.html_escape(tooltip))
       else
         tooltip  = "#{ui_lookup(:model => @object.class.to_s)}: #{@object.name} [#{@object.id}]"
         tooltip += " (#{@object.status})" if @options[:tree] == :roles_by_server_tree

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -1,10 +1,5 @@
 module TreeNode
   class Node
-    include ActionView::Context
-    include ActionView::Helpers::TagHelper
-    include ActionView::Helpers::TextHelper
-    include ActionView::Helpers::CaptureHelper
-
     def initialize(object, parent_id, options)
       @object = object
       @parent_id = parent_id

--- a/app/presenters/tree_node/zone.rb
+++ b/app/presenters/tree_node/zone.rb
@@ -4,7 +4,7 @@ module TreeNode
     set_attributes(:title, :tooltip) do
       if @options[:is_current]
         tooltip = "#{ui_lookup(:model => @object.class.to_s)}: #{@object.description} (#{_('current')})"
-        title   = content_tag(:strong, ERB::Util.html_escape(tooltip))
+        title   = ViewHelper.content_tag(:strong, ERB::Util.html_escape(tooltip))
       else
         title   = "#{ui_lookup(:model => @object.class.to_s)}: #{@object.description}"
         tooltip = title


### PR DESCRIPTION
ActionView helper methods like `content_tag`, `concat` and `capture` require more than one module to be included and they can't be called directly. The new `ViewHelper` extends all these three helper methods and it is possible to call e.g. `ViewHelper.content_tag`. This will allow us to not include the same helpers over and over, producing a more readable codebase when operating with HTML tags in controllers and presenters.

The second commit demonstrates its functionality in `TreeNode::` subclasses.