### PR TITLE
Dont use table for styling

### DIFF
--- a/app/views/cloud_network/edit.html.haml
+++ b/app/views/cloud_network/edit.html.haml
@@ -30,11 +30,7 @@
                             :miqrequired   => true,
                             :checkchange   => true,
                             'ng-readonly'  => "!newRecord"}
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('cloudNetworkFormId', '#{@network.id}');

--- a/app/views/cloud_network/new.html.haml
+++ b/app/views/cloud_network/new.html.haml
@@ -43,11 +43,7 @@
                       :miqrequired                  => true,
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('cloudNetworkFormId', '#{@network.id || "new"}');

--- a/app/views/cloud_subnet/edit.html.haml
+++ b/app/views/cloud_subnet/edit.html.haml
@@ -27,11 +27,7 @@
                             :disabled      => true,
                             :checkchange   => true}
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('cloudSubnetFormId', '#{@subnet.id}');

--- a/app/views/cloud_subnet/new.html.haml
+++ b/app/views/cloud_subnet/new.html.haml
@@ -69,11 +69,7 @@
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 :javascript
   ManageIQ.angular.app.value('cloudSubnetFormId', '#{@subnet.id || "new"}');
   miq_bootstrap('#form_div');

--- a/app/views/cloud_tenant/edit.html.haml
+++ b/app/views/cloud_tenant/edit.html.haml
@@ -14,11 +14,7 @@
                             :miqrequired   => false,
                             :checkchange   => true}
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('cloudTenantFormId', '#{@tenant.id}');

--- a/app/views/cloud_tenant/new.html.haml
+++ b/app/views/cloud_tenant/new.html.haml
@@ -26,11 +26,7 @@
                             :miqrequired   => true,
                             :checkchange   => true}
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('cloudTenantFormId', '#{@tenant.id || "new"}');

--- a/app/views/floating_ip/edit.haml
+++ b/app/views/floating_ip/edit.haml
@@ -14,11 +14,7 @@
                             "ng-maxlength" => 40,
                             :checkchange   => true}
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('floatingIpFormId', '#{@floating_ip.id}');

--- a/app/views/floating_ip/new.html.haml
+++ b/app/views/floating_ip/new.html.haml
@@ -76,11 +76,7 @@
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('floatingIpFormId', '#{@floating_ip.id || "new"}');

--- a/app/views/host_aggregate/add_host_select.html.haml
+++ b/app/views/host_aggregate/add_host_select.html.haml
@@ -14,13 +14,9 @@
                       :miqrequired                  => true,
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_custom_form_buttons_angular",
-                   :locals  => {:button_label           => _("Add"),
-                                :button_click           => "addHostClicked()"}
+  = render :partial => "layouts/angular/x_custom_form_buttons_angular",
+           :locals  => {:button_label           => _("Add"),
+                        :button_click           => "addHostClicked()"}
 
 :javascript
   ManageIQ.angular.app.value('hostAggregateFormId', '#{@host_aggregate.id}');

--- a/app/views/host_aggregate/remove_host_select.html.haml
+++ b/app/views/host_aggregate/remove_host_select.html.haml
@@ -14,13 +14,9 @@
                       :miqrequired                  => true,
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_custom_form_buttons_angular",
-                   :locals  => {:button_label           => _("Remove"),
-                                :button_click           => "removeHostClicked()"}
+  = render :partial => "layouts/angular/x_custom_form_buttons_angular",
+           :locals  => {:button_label           => _("Remove"),
+                        :button_click           => "removeHostClicked()"}
 
 :javascript
   ManageIQ.angular.app.value('hostAggregateFormId', '#{@host_aggregate.id}');

--- a/app/views/layouts/angular/_x_custom_form_buttons_angular.html.haml
+++ b/app/views/layouts/angular/_x_custom_form_buttons_angular.html.haml
@@ -1,4 +1,5 @@
-.button-group{"ng-controller" => "buttonGroupController"}
+.clearfix
+.pull-right.button-group{"ng-controller" => "buttonGroupController"}
   = button_tag(button_label,
                "class"       => "btn btn-primary disabled",
                :alt          => button_label,

--- a/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
+++ b/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
@@ -1,4 +1,5 @@
-.button-group{"ng-controller" => "buttonGroupController"}
+.clearfix
+.pull-right.button-group{"ng-controller" => "buttonGroupController"}
   = button_tag(_("Add"),
                "class"       => "btn btn-primary disabled",
                :alt          => _("Add"),

--- a/app/views/network_router/edit.html.haml
+++ b/app/views/network_router/edit.html.haml
@@ -14,11 +14,7 @@
                             :miqrequired   => true,
                             :checkchange   => true}
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('networkRouterFormId', '#{@router.id}');

--- a/app/views/network_router/new.html.haml
+++ b/app/views/network_router/new.html.haml
@@ -58,11 +58,7 @@
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('networkRouterFormId', '#{@router.id || "new"}');

--- a/app/views/security_group/edit.html.haml
+++ b/app/views/security_group/edit.html.haml
@@ -17,11 +17,7 @@
                             :checkchange   => true,
                             "readonly"     => true}
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('securityGroupFormId', '#{@security_group.id}');

--- a/app/views/security_group/new.html.haml
+++ b/app/views/security_group/new.html.haml
@@ -30,11 +30,7 @@
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('securityGroupFormId', '#{@security_group.id || "new"}');


### PR DESCRIPTION
We don't want to use table for placing / styling angular buttons. We want to use regular divs
with bootstrap's styling (`pull-right` in this case).

Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/66