### PR TITLE
Add Rubymine directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ spec/manageiq
 spec/reports/
 tmp/
 .rubocop-*
+.idea/


### PR DESCRIPTION
.idea/ is a settings directory for Rubymine that should be in .gitignore. As it was done before https://github.com/ManageIQ/manageiq/blob/master/.gitignore#L10.

