### PR TITLE
Add .editorconfig to (hopefully) prevent common stylistic problems

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = off


### PR DESCRIPTION
The editorconfig file is respected by multiple editors by default (including RubyMine), and more when using plugins.

The config should ensure consistent newlines, indents, etc.