### PR TITLE
Refactored the ExpressionHTML helper to build <tags> using ViewHelper

### DIFF
--- a/app/controllers/application_controller/expression_html.rb
+++ b/app/controllers/application_controller/expression_html.rb
@@ -1,72 +1,71 @@
 module ApplicationController::ExpressionHtml
   # Build a string from an array of expression symbols by recursively traversing the MiqExpression object
   #   and inserting sequential tokens for each expression part
-  def exp_build_string(exp)
-    exp_string = ""
-    exp_tooltip = "" # string for tooltip without fonts tags
-    if exp["and"]
-      fcolor = calculate_font_color(exp["result"])
-      exp_string << "<font color=#{fcolor}><b>(</b></font>"
-      exp_tooltip << "("
-      exp["and"].each do |e|
-        fcolor = calculate_font_color(e["result"])
-        exp_str, exp_tip = exp_build_string(e)
-        if exp["result"] && !e["result"]
-          exp_string << "<font color=#{fcolor}><i>" << exp_str << "</i></font>"
-        else
-          exp_string << "<font color=#{fcolor}>" << exp_str << "</font>"
-        end
-        exp_tooltip << exp_tip
-        fcolor = calculate_font_color(exp["result"])
-        exp_string << "<font color=#{fcolor}> <b>AND</b> </font>" unless e == exp["and"].last
-        exp_tooltip << " AND " unless e == exp["and"].last
-      end
-      exp_string << "<font color=#{fcolor}><b>)</b></font>"
-      exp_tooltip << ")"
-    elsif exp["or"]
-      fcolor = calculate_font_color(exp["result"])
-      exp_string << "<font color=#{fcolor}><b>(</b></font>"
-      exp["or"].each do |e|
-        fcolor = calculate_font_color(e["result"])
-        exp_str, exp_tip = exp_build_string(e)
-        if exp["result"] && !e["result"]
-          exp_string << "<font color=#{fcolor}><i>" << exp_str << "</i></font>"
-        else
-          exp_string << "<font color=#{fcolor}>" << exp_str << "</font>"
-        end
-        exp_tooltip << exp_tip
-        fcolor = calculate_font_color(exp["result"])
-        exp_string << "<font color=#{fcolor}> <b>OR</b> </font>" unless e == exp["or"].last
-        exp_tooltip << " OR " unless e == exp["or"].last
-      end
-      exp_string << "<font color=#{fcolor}><b>)</b></font>"
-      exp_tooltip << ")"
-    elsif exp["not"]
-      fcolor = calculate_font_color(exp["result"])
-      exp_string << "<font color=#{fcolor}> <b>NOT</b> </font>"
-      exp_tooltip << " NOT "
-      # No parens if and/or under me
-      exp_string << "<font color=#{fcolor}><b>(</b></font>" unless %w(and or).include?(exp["not"].keys.first)
-      exp_tooltip << "(" unless %w(and or).include?(exp["not"].keys.first) # No parens if and/or under me
-      exp_str, exp_tip = exp_build_string(exp["not"])
-      if exp["result"] && !exp["not"]["result"]
-        exp_string << "<font color=#{fcolor}><i>" << exp_str << "</i></font>"
-      else
-        exp_string << "<font color=#{fcolor}>" << exp_str << "</font>"
+
+  def join_binary(exp, operation, color)
+    ViewHelper.capture do
+      ViewHelper.concat_tag(:font, :color => color) do
+        ViewHelper.content_tag(:strong, '(')
       end
 
-      exp_tooltip << exp_tip
-      # No parens if and/or under me
-      exp_string << "<font color=#{fcolor}><b>)</b></font>" unless %w(and or).include?(exp["not"].keys.first)
-      exp_tooltip << ")" unless %w(and or).include?(exp["not"].keys.first) # No parens if and/or under me
+      exps = exp[operation].map do |e|
+        ViewHelper.content_tag(:font, :color => calculate_font_color(e['result'])) do
+          exp_str, = exp_build_string(e)
+          exp['result'] && !e['result'] ? ViewHelper.content_tag(:i, exp_str) : exp_str
+        end
+      end
+
+      glue = ViewHelper.content_tag(:font, :color => color) do
+        ViewHelper.content_tag(:strong, " #{operation.upcase} ")
+      end
+
+      ViewHelper.concat ViewHelper.safe_join(exps, glue)
+
+      ViewHelper.concat_tag(:font, :color => color) do
+        ViewHelper.content_tag(:strong, ')')
+      end
+    end
+  end
+
+  def exp_build_string(exp)
+    main_font = calculate_font_color(exp['result'])
+
+    if exp['and']
+      exp_string = join_binary(exp, 'and', main_font)
+    elsif exp['or']
+      exp_string = join_binary(exp, 'or', main_font)
+    elsif exp['not']
+      exp_string = ViewHelper.capture do
+        ViewHelper.concat_tag(:font, :color => main_font) do
+          ViewHelper.content_tag(:strong, ' NOT ')
+        end
+
+        unless %w(and or).include?(exp["not"].keys.first)
+          ViewHelper.concat_tag(:font, :color => main_font) do
+            ViewHelper.content_tag(:strong, '(')
+          end
+        end
+
+        exp_str, = exp_build_string(exp["not"])
+        ViewHelper.concat_tag(:font, :color => main_font) do
+          exp['result'] && !e['result'] ? ViewHelper.content_tag(:i, exp_str) : exp_str
+        end
+
+        unless %w(and or).include?(exp["not"].keys.first)
+          ViewHelper.concat_tag(:font, :color => main_font) do
+            ViewHelper.content_tag(:strong, ')')
+          end
+        end
+      end
     else
-      fcolor = calculate_font_color(exp["result"])
       temp_exp = copy_hash(exp)
       temp_exp.delete("result")
-      exp_string << "<font color=#{fcolor}>" << MiqExpression.to_human(temp_exp) << "</font>"
-      exp_tooltip << MiqExpression.to_human(temp_exp)
+      exp_string = ViewHelper.content_tag(:font, :color => main_font) do
+        MiqExpression.to_human(temp_exp)
+      end
     end
-    return exp_string, exp_tooltip
+
+    return exp_string, ActionController::Base.helpers.strip_tags(exp_string)
   end
 
   def calculate_font_color(result)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -3,4 +3,11 @@ module ViewHelper
   extend ActionView::Helpers::TagHelper
   extend ActionView::Helpers::TextHelper
   extend ActionView::Helpers::CaptureHelper
+  extend ActionView::Helpers::OutputSafetyHelper
+
+  class << self
+    def concat_tag(*args, &block)
+      concat content_tag(*args, &block)
+    end
+  end
 end

--- a/spec/presenters/tree_builder_policy_simulation_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_spec.rb
@@ -101,12 +101,12 @@ describe TreeBuilderPolicySimulation do
       parent_two = @policy_simulation_tree.send(:x_get_tree_hash_kids, grand_parent_two, false).first
       kid_one = @policy_simulation_tree.send(:x_get_tree_hash_kids, parent_one, false).first
       kid_two = @policy_simulation_tree.send(:x_get_tree_hash_kids, parent_two, false).first
-      expect(kid_one[:text]).to eq("<b>Scope: </b> <font color=red>FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT >= 1</font>")
+      expect(kid_one[:text]).to eq("<b>Scope: </b> <font color=\"red\">FIND VM and Instance.Files : Name INCLUDES &quot;nb&quot; CHECK COUNT &gt;= 1</font>")
       expect(kid_one[:image]).to eq('100/na.png')
-      expect(kid_one[:tip]).to eq("FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT >= 1")
-      expect(kid_two[:text]).to eq("<b>Expression: </b> <font color=red>FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT >= 1</font>")
+      expect(kid_one[:tip]).to eq("FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT &gt;= 1")
+      expect(kid_two[:text]).to eq("<b>Expression: </b> <font color=\"red\">FIND VM and Instance.Files : Name INCLUDES &quot;nb&quot; CHECK COUNT &gt;= 1</font>")
       expect(kid_two[:image]).to eq('100/na.png')
-      expect(kid_two[:tip]).to eq("FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT >= 1")
+      expect(kid_two[:tip]).to eq("FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT &gt;= 1")
     end
   end
   context 'TreeBuilderPolicySimulation without data' do


### PR DESCRIPTION
- Use `map` and `safe_join` to join multiple expressions with `AND` and `OR` 
- Use methods from `ViewHelper` to generate and concatenate HTML tags
- Generalize the building of `AND` and `OR` expressions in a separate method
- Created a new helper method for concatenating `content_tag`s
- Simplify the tooltip generation to stripping the HTML tags from the expression