### PR TITLE
Add missing features required for using fonticons in tree nodes

### DIFF
--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -33,7 +33,7 @@ class TreeBuilderMenuRoles < TreeBuilder
   end
 
   def root_options
-    [t = _("Top Level"), t, "100/folder.png", {:key => "xx-b__Report Menus for #{role_choice}"}]
+    [t = _("Top Level"), t, nil, {:key => "xx-b__Report Menus for #{role_choice}"}]
   end
 
   # Typically another method will populate the children of a root object.

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -62,6 +62,10 @@ module TreeNode
       nil
     end
 
+    def image
+      nil
+    end
+
     def icon
       nil
     end

--- a/spec/shared/presenters/tree_node/common.rb
+++ b/spec/shared/presenters/tree_node/common.rb
@@ -14,6 +14,14 @@ shared_examples 'TreeNode::Node#image' do |image|
   end
 end
 
+shared_examples 'TreeNode::Node#icon' do |icon|
+  describe '#icon' do
+    it "returns with #{icon}" do
+      expect(subject.icon).to eq(icon)
+    end
+  end
+end
+
 shared_examples 'TreeNode::Node#tooltip same as #title' do
   describe '#tooltip' do
     it 'returns the same as node title' do


### PR DESCRIPTION
- Nullify root node images that are explicitly set to default
- Set the default node image to `nil`
- Add a `shared_example` for testing node icons