### PR TITLE
Validate dialog children while edit is in progress

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -205,7 +205,7 @@ module MiqAeCustomizationController::Dialogs
       end
 
       begin
-        dialog_set_record_vars(dialog)
+        dialog_set_record_vars(dialog, false)
       rescue => @bang
         add_flash(@bang.message, :error)
         @changed = true
@@ -702,6 +702,16 @@ module MiqAeCustomizationController::Dialogs
       if needs_dropdown_values?
         add_flash(_("Dropdown elements require some entries"), :error)
         res = false
+      end
+    end
+
+    # validate dialog's children when changing tree node or trying to add another items under a node
+    if params[:typ] == @sb[:node_typ] || params[:action] == "tree_select"
+      begin
+        dialog_set_record_vars(@edit[:dialog], true)
+      rescue => bang
+        res = false
+        add_flash(bang.message, :error)
       end
     end
     res
@@ -1232,7 +1242,7 @@ module MiqAeCustomizationController::Dialogs
     session[:edit] = @edit
   end
 
-  def dialog_set_record_vars(dialog)
+  def dialog_set_record_vars(dialog, validate)
     dialog.label       = @edit[:new][:label]
     dialog.description = @edit[:new][:description]
     temp_buttons = []
@@ -1326,8 +1336,7 @@ module MiqAeCustomizationController::Dialogs
           dialog.dialog_tabs << dt
         end
       end
-
-      dialog.save!
+      validate ? dialog.validate! : dialog.save!
     end
   end
 


### PR DESCRIPTION
Validate dialog children when adding another one of same type of elements/tab/box to same parent. When adding a new tab/box/element to same parent validate if the one being added/edited already has children before adding a new empty one. Previously this validation was only done at ehe end when Add/Save buttons were pressed.

https://bugzilla.redhat.com/show_bug.cgi?id=1396583

@dclarizio please review.

before user was able to add as many new tabs/boxes without any children, validation was done when add/save button was pressed:
![before](https://cloud.githubusercontent.com/assets/3450808/21729346/b778477c-d418-11e6-854b-c561641f4ecd.png)


after user is forced to finish adding children under tab/box before they could move on to to adding more elements:
![after](https://cloud.githubusercontent.com/assets/3450808/21729353/bb7fd9ca-d418-11e6-85d8-5aa7591bc701.png)
