### PR TITLE
Limit number of objects on topology views

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -124,6 +124,16 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
      * added: Just the ones that were added
      */
 
+    /*
+      If we remove some kinds beforehand, and then try to bring them back we
+      get the hash {kind: undefined} instead of {kind: true}.
+    */
+    if ($scope.kinds) {
+      Object.keys($scope.kinds).forEach(function (key) {
+        $scope.kinds[key] = true
+      });
+    }
+
     added.attr("class", function(d) {
       return d.item.kind;
     });
@@ -284,9 +294,21 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
     $scope.relations = data.data.relations;
     $scope.kinds = data.data.kinds;
     icons = data.data.icons;
+    var size_limit = data.data.settings.containers_max_objects;
 
     if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys($scope.kinds).length)) {
       $scope.kinds = currentSelectedKinds;
+    } else if (size_limit > 0) {
+      var remove_hierarchy = ['Container',
+        'ContainerGroup',
+        'ContainerReplicator',
+        'ContainerService',
+        'ContainerRoute',
+        'Host',
+        'Vm',
+        'ContainerNode',
+        'ContainerManager'];
+      $scope.kinds = topologyService.reduce_kinds($scope.items, $scope.kinds, size_limit, remove_hierarchy);
     }
   }
 }

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -99,4 +99,18 @@ ManageIQ.angular.app.service('topologyService', function() {
         return "unknown";
     }
   };
+
+  this.reduce_kinds = function(items, kinds, size_limit, remove_hierarchy) {
+    var tmp_list = _.values(items);
+    var kind_index = 0;
+    while ((tmp_list.length > size_limit) && kind_index < remove_hierarchy.length) {
+      var kind_to_hide = remove_hierarchy[kind_index];
+      tmp_list = tmp_list.filter(function(item) {
+        return item['kind'] != kind_to_hide;
+      });
+      kind_index++;
+      delete kinds[kind_to_hide]
+    }
+    return kinds
+  };
 });

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -576,6 +576,7 @@ class ConfigurationController < ApplicationController
       @edit[:new][:perpage][:tile] = params[:perpage_tile].to_i if params[:perpage_tile]
       @edit[:new][:perpage][:list] = params[:perpage_list].to_i if params[:perpage_list]
       @edit[:new][:perpage][:reports] = params[:perpage_reports].to_i if params[:perpage_reports]
+      @edit[:new][:topology][:containers_max_objects] = params[:topology_containers_max_objects].to_i if params[:topology_containers_max_objects]
       @edit[:new][:display][:theme] = params[:display_theme] unless params[:display_theme].nil?
       @edit[:new][:display][:bg_color] = params[:bg_color] unless params[:bg_color].nil?
       @edit[:new][:display][:reporttheme] = params[:display_reporttheme] unless params[:display_reporttheme].nil?

--- a/app/controllers/topology_controller.rb
+++ b/app/controllers/topology_controller.rb
@@ -46,6 +46,6 @@ class TopologyController < ApplicationController
   end
 
   def generate_topology(provider_id)
-    self.class.service_class.new(provider_id).build_topology
+    self.class.service_class.new(provider_id).build_topology.merge(:settings => current_user.settings[:topology])
   end
 end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -261,6 +261,9 @@ module UiConstants
       :list    => 20,
       :reports => 20
     },
+    :topology  => {
+      :containers_max_items => 0
+    },
     :display   => {
       :startpage     => "/dashboard/show",
       :reporttheme   => "MIQ",

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -77,6 +77,19 @@
               miqSelectPickerEvent("#{item_per_page[1]}", "#{url}")
         %fieldset
           %h3
+            = _('Topology Default Items in View')
+          - [[_("Containers"), "topology_containers_max_objects", :containers_max_objects]].each do |item_per_page|
+            .form-group
+              %label.col-md-3.control-label
+                = _(item_per_page[0])
+              .col-md-8
+                = select_tag(_(item_per_page[1]),
+                             options_for_select([[N_("Unlimited"), 0]].concat(PPCHOICES), @edit[:new][:topology][item_per_page[2]]),
+                             :class    => "selectpicker")
+            :javascript
+              miqSelectPickerEvent("#{item_per_page[1]}", "#{url}")
+        %fieldset
+          %h3
             = _('Display Settings')
           - [[_("Chart Theme"), "display_reporttheme", Charting.chart_themes_for_select, :reporttheme, false],
              [_("Time Zone"),   "display_timezone",    ALL_TIMEZONES,                    :timezone, true],

--- a/spec/javascripts/fixtures/json/container_topology_response.json
+++ b/spec/javascripts/fixtures/json/container_topology_response.json
@@ -349,5 +349,8 @@
       "Vm":{"type":"glyph","icon":"","fontfamily":"PatternFlyIcons-webfont"},
       "Kubernetes":{"type":"image","icon":"...kubernetes..."},
       "Openshift":{"type":"image","icon":"...openshift..."},
-      "OpenshiftEnterprise":{"type":"image","icon":"...openshift_enterprise..."}}}
+      "OpenshiftEnterprise":{"type":"image","icon":"...openshift_enterprise..."}
+    },
+    "settings": { "containers_max_objects":100}
+  }
 }


### PR DESCRIPTION
Set object limit in settings:
![screencapture-localhost-3000-configuration-index-1485269167360](https://cloud.githubusercontent.com/assets/11256940/22251744/8f4f145c-e254-11e6-8350-b1a8c88685c5.png)

Objects kinds are hidden by order of granularity. Since `containers` are the least major entity they will be hidden first, then pods, then similarly other types until we are below the set object limit.
Edit: you can bring back each hidden type separately (containers, pods, etc.) using the filter buttons on top
![screencapture-localhost-3000-container_topology-show-1483886321675](https://cloud.githubusercontent.com/assets/11256940/21750643/dd032904-d5c0-11e6-913d-22bfeba52938.png)


@dclarizio @simon3z The code here is bad but in general, this is a possible approach towards scaling in topology. If this policy is good enough Ill go forward with it.