### PR TITLE
Move controller specs

### DIFF
--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -1,5 +1,3 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_cloud_network_controller')
-
 describe CloudNetworkController do
   include_examples :shared_examples_for_cloud_network_controller, %w(openstack azure google)
 

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -1,5 +1,5 @@
 describe CloudNetworkController do
-  include_examples :shared_examples_for_cloud_network_controller, %w(openstack azure google)
+  include_examples :shared_examples_for_cloud_network_controller, %w(openstack azure google amazon)
 
   context "#button" do
     before(:each) do

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -1,5 +1,5 @@
 describe CloudSubnetController do
-  include_examples :shared_examples_for_cloud_subnet_controller, %w(openstack azure google)
+  include_examples :shared_examples_for_cloud_subnet_controller, %w(openstack azure google amazon)
 
   context "#button" do
     before(:each) do

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -1,5 +1,3 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_cloud_subnet_controller')
-
 describe CloudSubnetController do
   include_examples :shared_examples_for_cloud_subnet_controller, %w(openstack azure google)
 

--- a/spec/controllers/ems_block_storage_controller_spec.rb
+++ b/spec/controllers/ems_block_storage_controller_spec.rb
@@ -1,5 +1,3 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_ems_block_storage_controller')
-
 describe EmsBlockStorageController do
   include_examples :shared_examples_for_ems_block_storage_controller, %w(openstack)
 end

--- a/spec/controllers/ems_network_controller_spec.rb
+++ b/spec/controllers/ems_network_controller_spec.rb
@@ -1,3 +1,3 @@
 describe EmsNetworkController do
-  include_examples :shared_examples_for_ems_network_controller, %w(openstack azure google)
+  include_examples :shared_examples_for_ems_network_controller, %w(openstack azure google amazon)
 end

--- a/spec/controllers/ems_network_controller_spec.rb
+++ b/spec/controllers/ems_network_controller_spec.rb
@@ -1,5 +1,3 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_ems_network_controller')
-
 describe EmsNetworkController do
   include_examples :shared_examples_for_ems_network_controller, %w(openstack azure google)
 end

--- a/spec/controllers/ems_object_storage_controller_spec.rb
+++ b/spec/controllers/ems_object_storage_controller_spec.rb
@@ -1,5 +1,3 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_ems_object_storage_controller')
-
 describe EmsObjectStorageController do
   include_examples :shared_examples_for_ems_object_storage_controller, %w(openstack)
 end

--- a/spec/controllers/ems_storage_controller_spec.rb
+++ b/spec/controllers/ems_storage_controller_spec.rb
@@ -1,5 +1,3 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_ems_storage_controller')
-
 describe EmsStorageController do
   include_examples :shared_examples_for_ems_storage_controller, %w(openstack)
 end

--- a/spec/controllers/floating_ip_controller_spec.rb
+++ b/spec/controllers/floating_ip_controller_spec.rb
@@ -1,5 +1,3 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_floating_ip_controller')
-
 describe FloatingIpController do
   include_examples :shared_examples_for_floating_ip_controller, %w(openstack azure google)
 

--- a/spec/controllers/floating_ip_controller_spec.rb
+++ b/spec/controllers/floating_ip_controller_spec.rb
@@ -1,5 +1,5 @@
 describe FloatingIpController do
-  include_examples :shared_examples_for_floating_ip_controller, %w(openstack azure google)
+  include_examples :shared_examples_for_floating_ip_controller, %w(openstack azure google amazon)
 
   context "#button" do
     before(:each) do

--- a/spec/controllers/load_balancer_controller_spec.rb
+++ b/spec/controllers/load_balancer_controller_spec.rb
@@ -1,3 +1,3 @@
 describe LoadBalancerController do
-  include_examples :shared_examples_for_load_balancer_controller, %w()
+  include_examples :shared_examples_for_load_balancer_controller, %w(amazon)
 end

--- a/spec/controllers/load_balancer_controller_spec.rb
+++ b/spec/controllers/load_balancer_controller_spec.rb
@@ -1,5 +1,3 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_load_balancer_controller')
-
 describe LoadBalancerController do
   include_examples :shared_examples_for_load_balancer_controller, %w()
 end

--- a/spec/controllers/network_port_controller_spec.rb
+++ b/spec/controllers/network_port_controller_spec.rb
@@ -1,5 +1,3 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_network_port_controller')
-
 describe NetworkPortController do
   include_examples :shared_examples_for_network_port_controller, %w(openstack azure google)
 end

--- a/spec/controllers/network_port_controller_spec.rb
+++ b/spec/controllers/network_port_controller_spec.rb
@@ -1,3 +1,3 @@
 describe NetworkPortController do
-  include_examples :shared_examples_for_network_port_controller, %w(openstack azure google)
+  include_examples :shared_examples_for_network_port_controller, %w(openstack azure google amazon)
 end

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -1,5 +1,5 @@
 describe NetworkRouterController do
-  include_examples :shared_examples_for_network_router_controller, %w(openstack azure google)
+  include_examples :shared_examples_for_network_router_controller, %w(openstack azure google amazon)
 
   context "#button" do
     before(:each) do

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -1,5 +1,3 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_network_router_controller')
-
 describe NetworkRouterController do
   include_examples :shared_examples_for_network_router_controller, %w(openstack azure google)
 

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -1,5 +1,5 @@
 describe SecurityGroupController do
-  include_examples :shared_examples_for_security_group_controller, %w(openstack azure google)
+  include_examples :shared_examples_for_security_group_controller, %w(openstack azure google amazon)
 
   context "#button" do
     before(:each) do

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -1,5 +1,3 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_security_group_controller')
-
 describe SecurityGroupController do
   include_examples :shared_examples_for_security_group_controller, %w(openstack azure google)
 

--- a/spec/shared/controllers/shared_examples_for_cloud_network_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_cloud_network_controller.rb
@@ -1,0 +1,69 @@
+require_relative 'shared_network_manager_context'
+
+shared_examples :shared_examples_for_cloud_network_controller do |providers|
+  include CompressedIds
+
+  render_views
+  before :each do
+    stub_user(:features => :all)
+    setup_zone
+  end
+
+  providers.each do |t|
+    context "for #{t}" do
+      include_context :shared_network_manager_context, t
+
+      describe "#show_list" do
+        it "renders index" do
+          get :index
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(:action => 'show_list')
+        end
+
+        it "renders show_list" do
+          # TODO(lsmola) figure out why I have to mock pdf available here, but not in other Manager's lists
+          allow(PdfGenerator).to receive_messages(:available? => false)
+          session[:settings] = {:default_search => 'foo',
+                                :views          => {},
+                                :perpage        => {:list => 10}}
+          get :show_list
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+
+      describe "#show" do
+        it "renders show screen" do
+          get :show, :params => {:id => @cloud_network.id}
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Cloud Networks",
+                                                :url  => "/cloud_network/show_list?page=&refresh=y"},
+                                               {:name => "Cloud Network (Summary)",
+                                                :url  => "/cloud_network/show/#{@cloud_network.id}"}])
+
+          is_expected.to render_template(:partial => "layouts/listnav/_cloud_network")
+        end
+
+        it "show associated cloud_subnets" do
+          assert_nested_list(@cloud_network, [@cloud_subnet], 'cloud_subnets', 'All Cloud Subnets')
+        end
+
+        it "show associated network routers" do
+          assert_nested_list(@cloud_network, [@network_router], 'network_routers', 'All Network Routers')
+        end
+
+        it "show associated instances" do
+          assert_nested_list(@cloud_network, [@vm], 'instances', 'All Instances', :child_path => 'vm_cloud')
+        end
+      end
+
+      describe "#test_toolbars" do
+        it 'edit Cloud Network tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@cloud_network.id), :pressed => "cloud_network_tag"}
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_examples_for_cloud_subnet_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_cloud_subnet_controller.rb
@@ -1,0 +1,65 @@
+require_relative 'shared_network_manager_context'
+
+shared_examples :shared_examples_for_cloud_subnet_controller do |providers|
+  include CompressedIds
+
+  render_views
+  before :each do
+    stub_user(:features => :all)
+    setup_zone
+  end
+
+  providers.each do |t|
+    context "for #{t}" do
+      include_context :shared_network_manager_context, t
+
+      describe "#show_list" do
+        it "renders index" do
+          get :index
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(:action => 'show_list')
+        end
+
+        it "renders show_list" do
+          # TODO(lsmola) figure out why I have to mock pdf available here, but not in other Manager's lists
+          allow(PdfGenerator).to receive_messages(:available? => false)
+          session[:settings] = {:default_search => 'foo',
+                                :views          => {},
+                                :perpage        => {:list => 10}}
+          get :show_list
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+
+      describe "#show" do
+        it "renders show screen" do
+          get :show, :params => {:id => @cloud_subnet.id}
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Cloud Subnets",
+                                                :url  => "/cloud_subnet/show_list?page=&refresh=y"},
+                                               {:name => "Cloud Subnet (Summary)",
+                                                :url  => "/cloud_subnet/show/#{@cloud_subnet.id}"}])
+
+          is_expected.to render_template(:partial => "layouts/listnav/_cloud_subnet")
+        end
+
+        it "show associated cloud_subnets" do
+          assert_nested_list(@cloud_subnet, [@child_subnet], 'cloud_subnets', 'All Cloud Subnets')
+        end
+
+        it "show associated instances" do
+          assert_nested_list(@cloud_subnet, [@vm], 'instances', 'All Instances', :child_path => 'vm_cloud')
+        end
+      end
+
+      describe "#test_toolbars" do
+        it 'edit cloud subnet tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@cloud_subnet.id), :pressed => "cloud_subnet_tag"}
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_examples_for_ems_block_storage_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_block_storage_controller.rb
@@ -1,0 +1,35 @@
+require_relative 'shared_storage_manager_context'
+
+shared_examples :shared_examples_for_ems_block_storage_controller do |providers|
+  include CompressedIds
+  render_views
+  before :each do
+    stub_user(:features => :all)
+    setup_zone
+  end
+
+  providers.each do |t|
+    context "for #{t}" do
+      include_context :shared_storage_manager_context, t
+
+      describe "#show_list" do
+        it "renders index" do
+          get :index
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(:action => 'show_list')
+        end
+
+        it "renders show_list" do
+          # TODO(lsmola) figure out why I have to mock pdf available here, but not in other Manager's lists
+          allow(PdfGenerator).to receive_messages(:available? => false)
+          session[:settings] = {:default_search => 'foo',
+                                :views          => {},
+                                :perpage        => {:list => 10}}
+          get :show_list
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
@@ -1,0 +1,135 @@
+require_relative 'shared_network_manager_context'
+
+shared_examples :shared_examples_for_ems_network_controller do |providers|
+  include CompressedIds
+  render_views
+  before :each do
+    stub_user(:features => :all)
+    setup_zone
+  end
+
+  providers.each do |t|
+    context "for #{t}" do
+      include_context :shared_network_manager_context, t
+
+      describe "#show_list" do
+        it "renders index" do
+          get :index
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(:action => 'show_list')
+        end
+
+        it "renders show_list" do
+          # TODO(lsmola) figure out why I have to mock pdf available here, but not in other Manager's lists
+          allow(PdfGenerator).to receive_messages(:available? => false)
+          session[:settings] = {:default_search => 'foo',
+                                :views          => {},
+                                :perpage        => {:list => 10}}
+          get :show_list
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+
+      describe "#show" do
+        it "renders show screen" do
+          get :show, :params => {:id => @ems.id}
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Network Providers",
+                                                :url  => "/ems_network/show_list?page=&refresh=y"},
+                                               {:name => "Cloud Manager Network Manager (Summary)",
+                                                :url  => "/ems_network/#{@ems.id}"}])
+
+          is_expected.to render_template(:partial => "layouts/listnav/_ems_network")
+        end
+
+        it "show associated cloud_networks" do
+          assert_nested_list(@ems, [@cloud_network], 'cloud_networks', 'All Cloud Networks')
+        end
+
+        it "show associated cloud_subnets" do
+          assert_nested_list(@ems, [@cloud_subnet], 'cloud_subnets', 'All Cloud Subnets')
+        end
+
+        it "show associated network routers" do
+          assert_nested_list(@ems, [@network_router], 'network_routers', 'All Network Routers')
+        end
+
+        it "show associated security_groups" do
+          assert_nested_list(@ems, [@security_group], 'security_groups', 'All Security Groups')
+        end
+
+        it "show associated floating_ips" do
+          assert_nested_list(@ems, [@floating_ip], 'floating_ips', 'All Floating IPs')
+        end
+
+        it "show associated network_ports" do
+          assert_nested_list(@ems, [@network_port], 'network_ports', 'All Network Ports')
+        end
+
+        it "show associated load balancers" do
+          # TODO: add more cloud providers as the LBaaS is implemented
+          skip unless %w(amazon).include? t
+          assert_nested_list(@ems, [@load_balancer], 'load_balancers', 'All Load Balancers')
+        end
+      end
+
+      describe "#ems_network_form_fields" do
+        it "renders ems_network_form_fields json" do
+          get :ems_network_form_fields, :params => {:id => @ems.id}
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+
+      describe "#create" do
+        it "adds a new provider" do
+          controller.instance_variable_set(:@breadcrumbs, [])
+          get :new
+          expect(response.status).to eq(200)
+          expect(allow(controller).to(receive(:edit))).to_not be_nil
+        end
+      end
+
+      describe "#test_toolbars" do
+        it "refresh relationships and power states" do
+          post :button, :params => {:id => @ems.id, :pressed => "ems_network_refresh"}
+          expect(response.status).to eq(200)
+        end
+
+        it 'edit selected network provider' do
+          post :button, :params => {:miq_grid_checks => to_cid(@ems.id), :pressed => "ems_network_edit"}
+          expect(response.status).to eq(200)
+        end
+
+        it 'edit network provider tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@ems.id), :pressed => "ems_network_tag"}
+          expect(response.status).to eq(200)
+        end
+
+        it 'manage network provider policies' do
+          allow(controller).to receive(:protect_build_tree).and_return(nil)
+          controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name"))
+
+          post :button, :params => {:miq_grid_checks => to_cid(@ems.id), :pressed => "ems_network_protect"}
+          expect(response.status).to eq(200)
+
+          get :protect
+          expect(response.status).to eq(200)
+          expect(response).to render_template('shared/views/protect')
+        end
+
+        it 'edit network provider timeline' do
+          get :show, :params => {:display => "timeline", :id => @ems.id}
+          expect(response.status).to eq(200)
+        end
+
+        it 'edit network providers' do
+          post :button, :params => {:miq_grid_checks => to_cid(@ems.id), :pressed => "ems_network_edit"}
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_examples_for_ems_object_storage_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_object_storage_controller.rb
@@ -1,0 +1,35 @@
+require_relative 'shared_storage_manager_context'
+
+shared_examples :shared_examples_for_ems_object_storage_controller do |providers|
+  include CompressedIds
+  render_views
+  before :each do
+    stub_user(:features => :all)
+    setup_zone
+  end
+
+  providers.each do |t|
+    context "for #{t}" do
+      include_context :shared_storage_manager_context, t
+
+      describe "#show_list" do
+        it "renders index" do
+          get :index
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(:action => 'show_list')
+        end
+
+        it "renders show_list" do
+          # TODO(lsmola) figure out why I have to mock pdf available here, but not in other Manager's lists
+          allow(PdfGenerator).to receive_messages(:available? => false)
+          session[:settings] = {:default_search => 'foo',
+                                :views          => {},
+                                :perpage        => {:list => 10}}
+          get :show_list
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_examples_for_ems_storage_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_storage_controller.rb
@@ -1,0 +1,73 @@
+require_relative 'shared_storage_manager_context'
+
+shared_examples :shared_examples_for_ems_storage_controller do |providers|
+  include CompressedIds
+  render_views
+  before :each do
+    stub_user(:features => :all)
+    setup_zone
+  end
+
+  providers.each do |t|
+    context "for #{t}" do
+      include_context :shared_storage_manager_context, t
+
+      describe "#show_list" do
+        it "renders index" do
+          get :index
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(:action => 'show_list')
+        end
+
+        it "renders show_list" do
+          # TODO(lsmola) figure out why I have to mock pdf available here, but not in other Manager's lists
+          allow(PdfGenerator).to receive_messages(:available? => false)
+          session[:settings] = {:default_search => 'foo',
+                                :views          => {},
+                                :perpage        => {:list => 10}}
+          get :show_list
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+
+      describe "#show" do
+        it "renders show screen" do
+          get :show, :params => {:id => @ems.id}
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Storage Managers",
+                                                :url  => "/ems_storage/show_list?page=&refresh=y"},
+                                               {:name => "Test Cloud Manager Cinder Manager (Summary)",
+                                                :url  => "/ems_storage/show/#{@ems.id}"}])
+
+          is_expected.to render_template(:partial => "layouts/listnav/_ems_storage")
+        end
+      end
+
+      describe "#test_toolbars" do
+        it "refresh relationships and power states" do
+          post :button, :params => {:id => @ems.id, :pressed => "ems_storage_refresh"}
+          expect(response.status).to eq(200)
+        end
+
+        it 'edit network provider tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@ems.id), :pressed => "ems_storage_tag"}
+          expect(response.status).to eq(200)
+        end
+
+        it 'manage storage provider policies' do
+          allow(controller).to receive(:protect_build_tree).and_return(nil)
+          controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name"))
+
+          post :button, :params => {:miq_grid_checks => to_cid(@ems.id), :pressed => "ems_storage_protect"}
+          expect(response.status).to eq(200)
+
+          get :protect
+          expect(response.status).to eq(200)
+          expect(response).to render_template('shared/views/protect')
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_examples_for_floating_ip_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_floating_ip_controller.rb
@@ -1,0 +1,56 @@
+require_relative 'shared_network_manager_context'
+
+shared_examples :shared_examples_for_floating_ip_controller do |providers|
+  include CompressedIds
+  render_views
+  before :each do
+    stub_user(:features => :all)
+    setup_zone
+  end
+
+  providers.each do |t|
+    context "for #{t}" do
+      include_context :shared_network_manager_context, t
+
+      describe "#show_list" do
+        it "renders index" do
+          get :index
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(:action => 'show_list')
+        end
+
+        it "renders show_list" do
+          # TODO(lsmola) figure out why I have to mock pdf available here, but not in other Manager's lists
+          allow(PdfGenerator).to receive_messages(:available? => false)
+          session[:settings] = {:default_search => 'foo',
+                                :views          => {},
+                                :perpage        => {:list => 10}}
+          get :show_list
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+
+      describe "#show" do
+        it "renders show screen" do
+          get :show, :params => {:id => @floating_ip.id}
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Floating IPs",
+                                                :url  => "/floating_ip/show_list?page=&refresh=y"},
+                                               {:name => "192.0.2.1 (Summary)",
+                                                :url  => "/floating_ip/show/#{@floating_ip.id}"}])
+
+          is_expected.to render_template(:partial => "layouts/listnav/_floating_ip")
+        end
+      end
+
+      describe "#test_toolbars" do
+        it 'edit floating ip tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@floating_ip.id), :pressed => "floating_ip_tag"}
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_examples_for_load_balancer_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_load_balancer_controller.rb
@@ -1,0 +1,61 @@
+require_relative 'shared_network_manager_context'
+
+shared_examples :shared_examples_for_load_balancer_controller do |providers|
+  include CompressedIds
+
+  render_views
+  before :each do
+    stub_user(:features => :all)
+    setup_zone
+  end
+
+  providers.each do |t|
+    context "for #{t}" do
+      include_context :shared_network_manager_context, t
+
+      describe "#show_list" do
+        it "renders index" do
+          get :index
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(:action => 'show_list')
+        end
+
+        it "renders show_list" do
+          # TODO(lsmola) figure out why I have to mock pdf available here, but not in other Manager's lists
+          allow(PdfGenerator).to receive_messages(:available? => false)
+          session[:settings] = {:default_search => 'foo',
+                                :views          => {},
+                                :perpage        => {:list => 10}}
+          get :show_list
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+
+      describe "#show" do
+        it "renders show screen" do
+          get :show, :params => {:id => @load_balancer.id}
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Load Balancers",
+                                                :url  => "/load_balancer/show_list?page=&refresh=y"},
+                                               {:name => "Load Balancer (Summary)",
+                                                :url  => "/load_balancer/show/#{@load_balancer.id}"}])
+
+          is_expected.to render_template(:partial => "layouts/listnav/_load_balancer")
+        end
+
+        it "show associated instances" do
+          assert_nested_list(@load_balancer, [@vm], 'instances', 'All Instances', :child_path => 'vm_cloud')
+        end
+      end
+
+      describe "#test_toolbars" do
+        it 'edit cloud subnet tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@load_balancer.id), :pressed => "load_balancer_tag"}
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_examples_for_network_port_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_network_port_controller.rb
@@ -1,0 +1,64 @@
+require_relative 'shared_network_manager_context'
+
+shared_examples :shared_examples_for_network_port_controller do |providers|
+  include CompressedIds
+  render_views
+  before :each do
+    stub_user(:features => :all)
+    setup_zone
+  end
+
+  providers.each do |t|
+    context "for #{t}" do
+      include_context :shared_network_manager_context, t
+
+      describe "#show_list" do
+        it "renders index" do
+          get :index
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(:action => 'show_list')
+        end
+
+        it "renders show_list" do
+          # TODO(lsmola) figure out why I have to mock pdf available here, but not in other Manager's lists
+          allow(PdfGenerator).to receive_messages(:available? => false)
+          session[:settings] = {:default_search => 'foo',
+                                :views          => {},
+                                :perpage        => {:list => 10}}
+          get :show_list
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+
+      describe "#show" do
+        it "renders show screen" do
+          get :show, :params => {:id => @network_port.id}
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Network Ports",
+                                                :url  => "/network_port/show_list?page=&refresh=y"},
+                                               {:name => "eth0 (Summary)",
+                                                :url  => "/network_port/show/#{@network_port.id}"}])
+
+          is_expected.to render_template(:partial => "layouts/listnav/_network_port")
+        end
+
+        it "show associated cloud_subnets" do
+          assert_nested_list(@network_port, [@cloud_subnet], 'cloud_subnets', 'All Cloud Subnets')
+        end
+
+        it "show associated floating ips" do
+          assert_nested_list(@network_port, [@floating_ip], 'floating_ips', 'All Floating Ips')
+        end
+      end
+
+      describe "#test_toolbars" do
+        it 'edit Network Port tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@network_port.id), :pressed => "network_port_tag"}
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_examples_for_network_router_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_network_router_controller.rb
@@ -1,0 +1,65 @@
+require_relative 'shared_network_manager_context'
+
+shared_examples :shared_examples_for_network_router_controller do |providers|
+  include CompressedIds
+
+  render_views
+  before :each do
+    stub_user(:features => :all)
+    setup_zone
+  end
+
+  providers.each do |t|
+    context "for #{t}" do
+      include_context :shared_network_manager_context, t
+
+      describe "#show_list" do
+        it "renders index" do
+          get :index
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(:action => 'show_list')
+        end
+
+        it "renders show_list" do
+          # TODO(lsmola) figure out why I have to mock pdf available here, but not in other Manager's lists
+          allow(PdfGenerator).to receive_messages(:available? => false)
+          session[:settings] = {:default_search => 'foo',
+                                :views          => {},
+                                :perpage        => {:list => 10}}
+          get :show_list
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+
+      describe "#show" do
+        it "renders show screen" do
+          get :show, :params => {:id => @network_router.id}
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Network Routers",
+                                                :url  => "/network_router/show_list?page=&refresh=y"},
+                                               {:name => "Network Router (Summary)",
+                                                :url  => "/network_router/show/#{@network_router.id}"}])
+
+          is_expected.to render_template(:partial => "layouts/listnav/_network_router")
+        end
+
+        it "show associated instances" do
+          assert_nested_list(@network_router, [@vm], 'instances', 'All Instances', :child_path => 'vm_cloud')
+        end
+
+        it "show associated cloud_subnets" do
+          assert_nested_list(@network_router, [@cloud_subnet], 'cloud_subnets', 'All Cloud Subnets')
+        end
+      end
+
+      describe "#test_toolbars" do
+        it 'edit network router tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@network_router.id), :pressed => "network_router_tag"}
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_examples_for_security_group_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_security_group_controller.rb
@@ -1,0 +1,65 @@
+require_relative 'shared_network_manager_context'
+
+shared_examples :shared_examples_for_security_group_controller do |providers|
+  include CompressedIds
+
+  render_views
+  before :each do
+    stub_user(:features => :all)
+    setup_zone
+  end
+
+  providers.each do |t|
+    context "for #{t}" do
+      include_context :shared_network_manager_context, t
+
+      describe "#show_list" do
+        it "renders index" do
+          get :index
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(:action => 'show_list')
+        end
+
+        it "renders show_list" do
+          # TODO(lsmola) figure out why I have to mock pdf available here, but not in other Manager's lists
+          allow(PdfGenerator).to receive_messages(:available? => false)
+          session[:settings] = {:default_search => 'foo',
+                                :views          => {},
+                                :perpage        => {:list => 10}}
+          get :show_list
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+
+      describe "#show" do
+        it "renders show screen" do
+          get :show, :params => {:id => @security_group.id}
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Security Groups",
+                                                :url  => "/security_group/show_list?page=&refresh=y"},
+                                               {:name => "Security Group (Summary)",
+                                                :url  => "/security_group/show/#{@security_group.id}"}])
+
+          is_expected.to render_template(:partial => "layouts/listnav/_security_group")
+        end
+
+        it "show associated instances" do
+          assert_nested_list(@security_group, [@vm], 'instances', 'All Instances', :child_path => 'vm_cloud')
+        end
+
+        it "show associated network ports" do
+          assert_nested_list(@security_group, [@network_port], 'network_ports', 'All Network Ports')
+        end
+      end
+
+      describe "#test_toolbars" do
+        it 'edit security group tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@security_group.id), :pressed => "security_group_tag"}
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_network_manager_context.rb
+++ b/spec/shared/controllers/shared_network_manager_context.rb
@@ -1,0 +1,78 @@
+shared_context :shared_network_manager_context do |t|
+  before :each do
+    @ems_cloud      = FactoryGirl.create("ems_#{t}".to_sym,
+                                         :name => "Cloud Manager")
+    @ems            = @ems_cloud.network_manager
+    @security_group = FactoryGirl.create("security_group_#{t}".to_sym,
+                                         :ext_management_system => @ems,
+                                         :name                  => 'Security Group')
+    @vm             = FactoryGirl.create("vm_#{t}".to_sym,
+                                         :name                  => "Instance",
+                                         :ext_management_system => @ems)
+    if t == 'openstack'
+      @cloud_network        = FactoryGirl.create("cloud_network_private_#{t}".to_sym,
+                                                 :name                  => "Cloud Network",
+                                                 :ext_management_system => @ems)
+      @cloud_network_public = FactoryGirl.create("cloud_network_public_#{t}".to_sym,
+                                                 :name                  => "Cloud Network Public",
+                                                 :ext_management_system => @ems)
+    else
+      @cloud_network        = FactoryGirl.create("cloud_network_#{t}".to_sym,
+                                                 :name                  => "Cloud Network",
+                                                 :ext_management_system => @ems)
+      @cloud_network_public = nil
+    end
+
+    @network_router = FactoryGirl.create("network_router_#{t}".to_sym,
+                                         :cloud_network         => @cloud_network_public,
+                                         :name                  => "Network Router",
+                                         :ext_management_system => @ems)
+    @cloud_subnet   = FactoryGirl.create("cloud_subnet_#{t}".to_sym,
+                                         :network_router        => @network_router,
+                                         :cloud_network         => @cloud_network,
+                                         :ext_management_system => @ems,
+                                         :name                  => "Cloud Subnet")
+    @child_subnet   = FactoryGirl.create("cloud_subnet_#{t}".to_sym,
+                                         :name                  => "Child Cloud Subnet",
+                                         :parent_cloud_subnet   => @cloud_subnet,
+                                         :ext_management_system => @ems)
+    @floating_ip    = FactoryGirl.create("floating_ip_#{t}".to_sym,
+                                         :address               => "192.0.2.1",
+                                         :ext_management_system => @ems)
+
+    @vm.network_ports << @network_port = FactoryGirl.create("network_port_#{t}".to_sym,
+                                                            :name                  => "eth0",
+                                                            :mac_address           => "06:04:25:40:8e:79",
+                                                            :device                => @vm,
+                                                            :security_groups       => [@security_group],
+                                                            :floating_ip           => @floating_ip,
+                                                            :ext_management_system => @ems)
+    FactoryGirl.create(:cloud_subnet_network_port,
+                       :cloud_subnet => @cloud_subnet,
+                       :network_port => @network_port,
+                       :address      => "10.10.0.2")
+
+    if %w(amazon).include? t
+      @load_balancer              = FactoryGirl.create("load_balancer_#{t}".to_sym,
+                                                       :ems_id => @ems.id,
+                                                       :name   => "Load Balancer")
+      @load_balancer_2            = FactoryGirl.create("load_balancer_#{t}".to_sym)
+      @load_balancer_pool         = FactoryGirl.create("load_balancer_pool_#{t}".to_sym)
+      @load_balancer_listener     = FactoryGirl.create("load_balancer_listener_#{t}".to_sym,
+                                                       :load_balancer => @load_balancer)
+      @load_balancer_pool_member  = FactoryGirl.create("load_balancer_pool_member_#{t}".to_sym,
+                                                       :vm => @vm)
+      @load_balancer_health_check = FactoryGirl.create("load_balancer_health_check_#{t}".to_sym)
+
+      FactoryGirl.create("load_balancer_listener_pool".to_sym,
+                         :load_balancer_pool     => @load_balancer_pool,
+                         :load_balancer_listener => @load_balancer_listener)
+      FactoryGirl.create("load_balancer_pool_member_pool".to_sym,
+                         :load_balancer_pool        => @load_balancer_pool,
+                         :load_balancer_pool_member => @load_balancer_pool_member)
+      FactoryGirl.create("load_balancer_health_check_member".to_sym,
+                         :load_balancer_health_check => @load_balancer_health_check,
+                         :load_balancer_pool_member  => @load_balancer_pool_member)
+    end
+  end
+end

--- a/spec/shared/controllers/shared_storage_manager_context.rb
+++ b/spec/shared/controllers/shared_storage_manager_context.rb
@@ -1,0 +1,18 @@
+shared_context :shared_storage_manager_context do |t|
+  before :each do
+    @ems_cloud = FactoryGirl.create("ems_#{t}".to_sym,
+                                    :name => "Test Cloud Manager")
+    if t == 'openstack'
+      @swift_manager    = @cinder_manager = nil
+      @storage_managers = @ems_cloud.storage_managers
+      @storage_managers.each do |sm|
+        if sm.type == "ManageIQ::Providers::StorageManager::SwiftManager"
+          @swift_manager = sm
+        else
+          @cinder_manager = sm
+        end
+      end
+    end
+    @ems = @cinder_manager
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,7 @@ support_path = Rails.root.join('spec', 'support')
 # require support_path.join("rake_task_example_group.rb")
 Dir[support_path.join("**/*.rb")].each { |f| require f }
 
-Dir[Rails.root.join("spec/shared/controllers/**/*.rb")].each { |f| require f }
+Dir[ManageIQ::UI::Classic::Engine.root.join('spec/shared/controllers/**/*.rb')].each { |f| require f }
 Dir[ManageIQ::Gems::Pending.root.join("spec/support/custom_matchers/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|


### PR DESCRIPTION
* moving shared controller specs from manageiq core
* require all shared controller specs in spec_helper from UI engine rather than miq core
* move amazon to some tested controllers, they have been removed from the amazon provider repo here https://github.com/ManageIQ/manageiq-providers-amazon/pull/97/commits/be4f55abdc337fb76ae9fb8451133c81d69d97b8

to decouple those shared example from provider implementations one could 
a) check subclasses of e.g. CloudSubnet and test for all that are implemented or
b) try to make the specs work for the base class of CloudSubnet

@miq-bot assign @martinpovolny 
@miq-bot add_labels test

cc @Fryguy @bdunne 