### PR TITLE
Make created filters in Datastores visible and fix commiting filters

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -307,7 +307,7 @@ module ApplicationController::Filter
             {:model => ui_lookup(:model => @edit[@expkey][:exp_model]),
              :name => @edit[:new_search_name]})
           @edit[@expkey].select_filter(s)
-          @edit[:new_search_name] = @edit[:adv_search_name] = @edit[@expkey][:exp_last_loaded][:description]
+          @edit[:new_search_name] = @edit[:adv_search_name] = @edit[@expkey][:exp_last_loaded][:description] unless @edit[@expkey][:exp_model] == "Storage"
           @edit[@expkey][:expression] = copy_hash(@edit[:new][@expkey])
           # Build the expression table
           @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression])

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -24,8 +24,13 @@ class TreeBuilderStorage < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    return count_only ? 0 : [] if object[:id] != "global"
-    objects = MiqSearch.where(:db => options[:leaf]).visible_to_all
+    objects = MiqSearch.where(:db => options[:leaf])
+    objects = case object[:id]
+              when "global" # Global filters
+                objects.visible_to_all
+              when "my"     # My filters
+                objects.where(:search_type => "user", :search_key => User.current_user.userid)
+              end
     count_only_or_objects(count_only, objects, "description")
   end
 end

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -23,24 +23,20 @@
     %fieldset
       .toolbar-pf-actions
         .form-group
-          %button
-            - t = _('Commit expression element changes')
-            = link_to(image_tag(image_path('toolbars/commit.png'), :alt => t),
-              {:action => 'exp_button', :pressed => 'commit'},
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              :remote                => true,
-              "data-method"          => :post,
-              :title                 => t)
-          %button
-            - t = _("Discard expression element changes")
-            = link_to(image_tag(image_path('toolbars/discard.png'), :alt => t),
-              {:action => 'exp_button', :pressed  => 'discard'},
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              :remote                => true,
-              "data-method"          => :post,
-              :title                 => t)
+          - t = _('Commit expression element changes')
+          %button.btn.btn-default{"data-method" => :post,
+          "data-miq_sparkle_on" => true,
+          :onclick              => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'commit')}');",
+          :remote               => true,
+          :title                => t}
+            %i.fa.fa-lg.fa-check
+          - t = _("Discard expression element changes")
+          %button.btn.btn-default{"data-method" => :post,
+          "data-miq_sparkle_on" => true,
+          :onclick              => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'discard')}');",
+          :remote               => true,
+          :title                => t}
+            %i.fa-lg.pficon.pficon-close
 
       - if @edit[@expkey][:exp_key] == "NOT"
         %font{:color => "black"}


### PR DESCRIPTION
fixing
https://bugzilla.redhat.com/show_bug.cgi?id=1398748
https://bugzilla.redhat.com/show_bug.cgi?id=1382768

Make created filters (not global) in Compute -> Infrastructure -> Datastores
visible under My Filters in accordion, no need to refresh the page
after creating a new filter.
Fix commiting a new filter which is related to its creating and saving.

Commiting filters was broken by
https://github.com/ManageIQ/manageiq/pull/12998

Before:
![datastores2](https://cloud.githubusercontent.com/assets/13417815/21766729/7bd07546-d670-11e6-8f02-8c03fdcb0199.png)
![datastores4](https://cloud.githubusercontent.com/assets/13417815/21766748/9188ac32-d670-11e6-8cae-22b731344493.png)

After:
![datastores1](https://cloud.githubusercontent.com/assets/13417815/21766762/9c96ff34-d670-11e6-9baf-2ea7f4c80bdc.png)
![datastores3](https://cloud.githubusercontent.com/assets/13417815/21766764/a07e7d0c-d670-11e6-8615-3f94521f8b56.png)
![datastores5](https://cloud.githubusercontent.com/assets/13417815/21766784/b05b204a-d670-11e6-8f74-54f572c4a62a.png)

