### PR TITLE
Converted HTML tags in TreeBuilders to use ViewHelper

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -334,6 +334,14 @@ class TreeBuilder
     open_nodes.push(id) unless open_nodes.include?(id)
   end
 
+  def prefixed_title(prefix, title)
+    ViewHelper.capture do
+      ViewHelper.concat_tag(:strong, "#{prefix}:")
+      ViewHelper.concat ' '
+      ViewHelper.concat title
+    end
+  end
+
   def resolve_object_lambdas(count_only, objects)
     if objects.respond_to?(:call)
       # works with a no-param lambda OR a lambda that requests the count_only

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -52,7 +52,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
 
   def get_policy_elm(parent, node)
     {:id          => "#{parent.id}-p_#{node.miq_policy_id}",
-     :text        => ("<b>" + _("Condition: ") + "</b>" + node.condition_desc).html_safe,
+     :text        => prefixed_title(_('Condition'), node.condition_desc),
      :image       => node.condition_result ? "100/check.png" : "100/x.png",
      :tip         => nil,
      :cfmeNoClick => true}

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -35,8 +35,16 @@ class TreeBuilderDatastores < TreeBuilder
           {:name => kid.name}
         end
       end
+
+      title = ViewHelper.capture do
+        ViewHelper.concat_tag(:strong, node[:name])
+        ViewHelper.concat ' ['
+        ViewHelper.concat node[:location]
+        ViewHelper.concat ']'
+      end
+
       { :id          => node[:id].to_s,
-        :text        => "<b>#{node[:name]}</b> [#{node[:location]}]".html_safe,
+        :text        => title,
         :image       => '100/storage.png',
         :tip         => "#{node[:name]} [#{node[:location]}]",
         :select      => node[:capture] == true,

--- a/app/presenters/tree_builder_policy_simulation.rb
+++ b/app/presenters/tree_builder_policy_simulation.rb
@@ -24,7 +24,7 @@ class TreeBuilderPolicySimulation < TreeBuilder
   end
 
   def root_options
-    ["<b>#{@root_name}</b>".html_safe, @root_name, '100/vm.png', {:cfmeNoClick => true}]
+    [ViewHelper.content_tag(:strong, @root_name), @root_name, '100/vm.png', {:cfmeNoClick => true}]
   end
 
   def node_icon(result)
@@ -44,9 +44,8 @@ class TreeBuilderPolicySimulation < TreeBuilder
   def x_get_tree_roots(count_only = false, _options = {})
     if @data.present?
       nodes = reject_na_nodes(@data).map do |node|
-        name = "<b>" + _("Policy Profile:") + "</b> #{node['description']}"
         {:id          => node['id'],
-         :text        => name.html_safe,
+         :text        => prefixed_title(_('Policy Profile'), node['description']),
          :image       => node_icon(node["result"]),
          :tip         => node['description'],
          :cfmeNoClick => true,
@@ -81,9 +80,8 @@ class TreeBuilderPolicySimulation < TreeBuilder
   def policy_nodes(parent)
     parent[:policies].reject { |node| skip_node?(node) }.sort_by { |a| a["description"] }.map do |node|
       active_caption = get_active_caption(node)
-      name = "<b>" + _("Policy%{caption}: ") % {:caption => active_caption} + "</b> #{node['description']}"
       {:id         => node['id'],
-       :text        => name.html_safe,
+       :text        => prefixed_title(_('Policy%{caption}') % {:caption => active_caption}, node['description']),
        :image       => node_icon(node["result"]),
        :tip         => node['description'],
        :scope       => node['scope'],
@@ -95,9 +93,8 @@ class TreeBuilderPolicySimulation < TreeBuilder
   def condition_node(parent)
     nodes = reject_na_nodes parent[:conditions]
     nodes = nodes.sort_by { |a| a["description"] }.map do |node|
-      name = "<b>" + _("Condition: ") + "</b> #{node['description']}"
       {:id          => node['id'],
-       :text        => name.html_safe,
+       :text        => prefixed_title(_('Condition'), node['description']),
        :image       => node_icon(node["result"]),
        :tip         => node['description'],
        :scope       => node['scope'],
@@ -109,16 +106,14 @@ class TreeBuilderPolicySimulation < TreeBuilder
 
   def scope_node(parent)
     icon = parent[:scope]["result"] ? "100/checkmark.png" : "100/na.png"
-    name, tip = exp_build_string(parent[:scope])
-    name = "<b>" + _("Scope: ") + "</b> " + name
-    {:id => nil, :text => name.html_safe, :image => icon, :tip => tip.html_safe, :cfmeNoClick => true}
+    text, tip = exp_build_string(parent[:scope])
+    {:id => nil, :text => prefixed_title(_('Scope'), text), :image => icon, :tip => tip, :cfmeNoClick => true}
   end
 
   def expression_node(parent)
     icon = parent[:expression]["result"] ? "100/checkmark.png" : "100/na.png"
-    name, tip = exp_build_string(parent[:expression])
-    name = "<b>" + _("Expression: ") + "</b> " +  name
-    {:id => nil, :text => name.html_safe, :image => icon, :tip => tip.html_safe, :cfmeNoClick => true}
+    text, tip = exp_build_string(parent[:expression])
+    {:id => nil, :text => prefixed_title(_('Expression'), text), :image => icon, :tip => tip, :cfmeNoClick => true}
   end
 
   def get_correct_node(parent, node_name)

--- a/app/presenters/tree_builder_policy_simulation_results.rb
+++ b/app/presenters/tree_builder_policy_simulation_results.rb
@@ -36,14 +36,6 @@ class TreeBuilderPolicySimulationResults < TreeBuilder
     end
   end
 
-  def prefixed_title(prefix, title)
-    ViewHelper.capture do
-      ViewHelper.concat ViewHelper.content_tag(:strong, "#{prefix}:")
-      ViewHelper.concat ' '
-      ViewHelper.concat title
-    end
-  end
-
   def vm_nodes(data)
     data.sort_by! { |a| a[:name].downcase }.map do |node|
       {:id          => node[:id],

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -40,9 +40,8 @@ class TreeBuilderProtect < TreeBuilder
 
   def x_get_tree_hash_kids(parent, count_only)
     nodes = parent[:children].map do |policy|
-      text = "<b>#{ui_lookup(:model => policy.towhat)} #{policy.mode.capitalize}:</b> #{policy.description}"
       {:id           => "policy_#{policy.id}",
-       :text         => text.html_safe,
+       :text         => prefixed_title("#{ui_lookup(:model => policy.towhat)} #{policy.mode.capitalize}", policy.description),
        :image        => "100/miq_policy_#{policy.towhat.downcase}#{policy.active ? "" : "_inactive"}.png",
        :tip          => policy.description,
        :hideCheckbox => true,

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -21,7 +21,7 @@ describe TreeBuilderDatastores do
     end
     it 'sets Datastore node correctly' do
       parent = @datastores_tree.send(:x_get_tree_roots, false, nil)
-      expect(parent.first[:text]).to eq("<b>Datastore</b> [#{@datastore.first[:location]}]")
+      expect(parent.first[:text]).to eq("<strong>Datastore</strong> [#{@datastore.first[:location]}]")
       expect(parent.first[:tip]).to eq("Datastore [#{@datastore.first[:location]}]")
       expect(parent.first[:image]).to eq('100/storage.png')
     end

--- a/spec/presenters/tree_builder_policy_simulation_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_spec.rb
@@ -46,7 +46,7 @@ describe TreeBuilderPolicySimulation do
 
     it 'sets root correctly' do
       root = @policy_simulation_tree.send(:root_options)
-      expect(root).to eq(["<b>Policy Simulation</b>".html_safe, 'Policy Simulation', '100/vm.png', { :cfmeNoClick => true }])
+      expect(root).to eq(["<strong>Policy Simulation</strong>", 'Policy Simulation', '100/vm.png', { :cfmeNoClick => true }])
     end
 
     it 'sets icon correctly' do
@@ -60,7 +60,7 @@ describe TreeBuilderPolicySimulation do
 
     it 'sets Policy Profile node correctly' do
       node = @policy_simulation_tree.send(:x_get_tree_roots, false).first
-      expect(node[:text]).to eq("<b>Policy Profile:</b> #{@data.first['description']}")
+      expect(node[:text]).to eq("<strong>Policy Profile:</strong> #{@data.first['description']}")
       expect(node[:image]).to eq("100/checkmark.png")
       expect(node[:tip]).to eq(@data.first['description'])
       expect(node[:policies].count).to eq(2)
@@ -69,11 +69,11 @@ describe TreeBuilderPolicySimulation do
     it 'sets Policy nodes correctly' do
       node = @policy_simulation_tree.send(:x_get_tree_roots, false).first
       kids = @policy_simulation_tree.send(:x_get_tree_hash_kids, node, false)
-      expect(kids.first[:text]).to eq("<b>Policy: </b> #{@data.first['policies'].first['description']}")
+      expect(kids.first[:text]).to eq("<strong>Policy:</strong> #{@data.first['policies'].first['description']}")
       expect(kids.first[:image]).to eq('100/na.png')
       expect(kids.first[:tip]).to eq(@data.first['policies'].first['description'])
       expect(kids.first[:conditions].count).to eq(1)
-      expect(kids.last[:text]).to eq("<b>Policy: </b> #{@data.first['policies'].last['description']}")
+      expect(kids.last[:text]).to eq("<strong>Policy:</strong> #{@data.first['policies'].last['description']}")
       expect(kids.last[:image]).to eq('100/x.png')
       expect(kids.last[:tip]).to eq(@data.first['policies'].last['description'])
       expect(kids.last[:conditions].count).to eq(1)
@@ -85,10 +85,10 @@ describe TreeBuilderPolicySimulation do
       kid_one = @policy_simulation_tree.send(:x_get_tree_hash_kids, parent_one, false).first
       parent_two = @policy_simulation_tree.send(:x_get_tree_hash_kids, root, false).last
       kid_two = @policy_simulation_tree.send(:x_get_tree_hash_kids, parent_two, false).first
-      expect(kid_one[:text]).to eq("<b>Condition: </b> #{@data.first['policies'].first['conditions'].first['description']}")
+      expect(kid_one[:text]).to eq("<strong>Condition:</strong> #{@data.first['policies'].first['conditions'].first['description']}")
       expect(kid_one[:image]).to eq('100/x.png')
       expect(kid_one[:tip]).to eq(@data.first['policies'].first['conditions'].first['description'])
-      expect(kid_two[:text]).to eq("<b>Condition: </b> #{@data.first['policies'].last['conditions'].first['description']}")
+      expect(kid_two[:text]).to eq("<strong>Condition:</strong> #{@data.first['policies'].last['conditions'].first['description']}")
       expect(kid_two[:image]).to eq('100/na.png')
       expect(kid_two[:tip]).to eq(@data.first['policies'].last['conditions'].first['description'])
     end
@@ -101,10 +101,10 @@ describe TreeBuilderPolicySimulation do
       parent_two = @policy_simulation_tree.send(:x_get_tree_hash_kids, grand_parent_two, false).first
       kid_one = @policy_simulation_tree.send(:x_get_tree_hash_kids, parent_one, false).first
       kid_two = @policy_simulation_tree.send(:x_get_tree_hash_kids, parent_two, false).first
-      expect(kid_one[:text]).to eq("<b>Scope: </b> <font color=\"red\">FIND VM and Instance.Files : Name INCLUDES &quot;nb&quot; CHECK COUNT &gt;= 1</font>")
+      expect(kid_one[:text]).to eq("<strong>Scope:</strong> <font color=\"red\">FIND VM and Instance.Files : Name INCLUDES &quot;nb&quot; CHECK COUNT &gt;= 1</font>")
       expect(kid_one[:image]).to eq('100/na.png')
       expect(kid_one[:tip]).to eq("FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT &gt;= 1")
-      expect(kid_two[:text]).to eq("<b>Expression: </b> <font color=\"red\">FIND VM and Instance.Files : Name INCLUDES &quot;nb&quot; CHECK COUNT &gt;= 1</font>")
+      expect(kid_two[:text]).to eq("<strong>Expression:</strong> <font color=\"red\">FIND VM and Instance.Files : Name INCLUDES &quot;nb&quot; CHECK COUNT &gt;= 1</font>")
       expect(kid_two[:image]).to eq('100/na.png')
       expect(kid_two[:tip]).to eq("FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT &gt;= 1")
     end

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -50,7 +50,7 @@ describe TreeBuilderProtect do
       roots = @protect_tree.send(:x_get_tree_roots, false)
       kids = @protect_tree.send(:x_get_tree_hash_kids, roots[0], false)
       expect(kids[0][:id]).to eq("policy_#{@kids[0].id}")
-      expect(kids[0][:text]).to eq("<b>#{ui_lookup(:model => @kids[0].towhat)} #{@kids[0].mode.capitalize}:</b> #{@kids[0].description}".html_safe)
+      expect(kids[0][:text]).to eq("<strong>#{ui_lookup(:model => @kids[0].towhat)} #{@kids[0].mode.capitalize}:</strong> #{@kids[0].description}".html_safe)
       expect(kids[0][:image]).to eq("100/miq_policy_#{@kids[0].towhat.downcase}#{@kids[0].active ? "" : "_inactive"}.png")
       expect(kids[0][:tip]).to eq(@kids[0].description)
       expect(kids[0][:hideCheckbox]).to eq(true)


### PR DESCRIPTION
This makes the `html_safe` calls on strings obsolete.