### PR TITLE
Add support for fonticons in TreeBuilder root nodes

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -175,7 +175,11 @@ class TreeBuilder
 
   def add_root_node(nodes)
     root = nodes.first.merge!(root_options)
-    root[:image] = ActionController::Base.helpers.image_path(root[:image] || "100/folder.png")
+    if root[:image]
+      root[:image] = ActionController::Base.helpers.image_path(root[:image])
+    else
+      root[:icon] ||= 'pficon pficon-folder-close' # Fall back to the folder fonticon
+    end
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -174,12 +174,8 @@ class TreeBuilder
   end
 
   def add_root_node(nodes)
-    root = nodes.first
-    root[:title], root[:tooltip], icon, options = root_options
-    root[:image] = ActionController::Base.helpers.image_path(icon || "100/folder.png")
-    if options.present?
-      root.merge!(options)
-    end
+    root = nodes.first.merge!(root_options)
+    root[:image] = ActionController::Base.helpers.image_path(root[:image] || "100/folder.png")
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_action.rb
+++ b/app/presenters/tree_builder_action.rb
@@ -7,7 +7,10 @@ class TreeBuilderAction < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Actions"), t]
+    {
+      :title   => t = N_("All Actions"),
+      :tooltip => t
+    }
   end
 
   # level 1 - actions

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -14,7 +14,10 @@ class TreeBuilderAeClass < TreeBuilder
   end
 
   def root_options
-    [t = _("Datastore"), t]
+    {
+      :title   => t = _("Datastore"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_ae_customization.rb
+++ b/app/presenters/tree_builder_ae_customization.rb
@@ -11,7 +11,10 @@ class TreeBuilderAeCustomization < TreeBuilder
   end
 
   def root_options
-    [t = _("Service Dialog Import/Export"), t]
+    {
+      :title   => t = _("Service Dialog Import/Export"),
+      :tooltip => t
+    }
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_alert.rb
+++ b/app/presenters/tree_builder_alert.rb
@@ -7,7 +7,10 @@ class TreeBuilderAlert < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Alerts"), t]
+    {
+      :title   => t = N_("All Alerts"),
+      :tooltip => t
+    }
   end
 
   # level 1 - alerts

--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -18,7 +18,10 @@ class TreeBuilderAlertProfile < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Alert Profiles"), t]
+    {
+      :title   => t = N_("All Alert Profiles"),
+      :tooltip => t
+    }
   end
 
   # level 1 - * alert profiles

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -19,7 +19,11 @@ class TreeBuilderAutomate < TreeBuilderAeClass
   end
 
   def root_options
-    [t = _("Datastore"), t, nil, {:cfmeNoClick => true}]
+    {
+      :title       => t = _("Datastore"),
+      :tooltip     => t,
+      :cfmeNoClick => true
+    }
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -22,7 +22,7 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
   end
 
   def root_options
-    []
+    {}
   end
 
   def x_get_tree_roots(_count_only = false, _options = {})
@@ -71,7 +71,7 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
     object = {:id          => "e_#{idx}",
               :text        => title,
               :image       => get_element_icon(el),
-              :tip         => title,
+              :tooltip     => title,
               :elements    => el.each_element { |e| e },
               :cfmeNoClick => true
              }

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -44,7 +44,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
   end
 
   def root_options
-    []
+    {}
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -8,7 +8,10 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
   end
 
   def root_options
-    [t = _("Object Types"), t]
+    {
+      :title   => t = _("Object Types"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -14,7 +14,10 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
   end
 
   def root_options
-    [t = _("All Catalog Items"), t]
+    {
+      :title   => t = _("All Catalog Items"),
+      :tooltip => t
+    }
   end
 
   def x_get_tree_stc_kids(object, count_only)

--- a/app/presenters/tree_builder_catalogs.rb
+++ b/app/presenters/tree_builder_catalogs.rb
@@ -11,6 +11,9 @@ class TreeBuilderCatalogs < TreeBuilderCatalogsClass
   end
 
   def root_options
-    [t = _("All Catalogs"), t]
+    {
+      :title   => t = _("All Catalogs"),
+      :tooltip => t
+    }
   end
 end

--- a/app/presenters/tree_builder_chargeback_assignments.rb
+++ b/app/presenters/tree_builder_chargeback_assignments.rb
@@ -6,7 +6,10 @@ class TreeBuilderChargebackAssignments < TreeBuilder
   end
 
   def root_options
-    [t = _("Assignments"), t]
+    {
+      :title   => t = _("Assignments"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_chargeback_rates.rb
+++ b/app/presenters/tree_builder_chargeback_rates.rb
@@ -6,7 +6,10 @@ class TreeBuilderChargebackRates < TreeBuilder
   end
 
   def root_options
-    [t = _("Rates"), t]
+    {
+      :title   => t = _("Rates"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -11,7 +11,10 @@ class TreeBuilderChargebackReports < TreeBuilder
   end
 
   def root_options
-    [t = _("Saved Chargeback Reports"), t]
+    {
+      :title   => t = _("Saved Chargeback Reports"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -25,7 +25,7 @@ class TreeBuilderClusters < TreeBuilder
   end
 
   def root_options
-    []
+    {}
   end
 
   def non_cluster_selected

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -25,7 +25,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
   end
 
   def root_options
-    []
+    {}
   end
 
   def x_get_tree_roots(count_only = false, _options = {})

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -12,7 +12,10 @@ class TreeBuilderCondition < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Conditions"), t]
+    {
+      :title   => t = N_("All Conditions"),
+      :tooltip => t
+    }
   end
 
   # level 1 - host / vm

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -16,7 +16,10 @@ class TreeBuilderConfigurationManager < TreeBuilder
   end
 
   def root_options
-    [t = _("All Configuration Manager Providers"), t]
+    {
+      :title   => t = _("All Configuration Manager Providers"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_configuration_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_configuration_manager_configuration_scripts.rb
@@ -14,7 +14,10 @@ class TreeBuilderConfigurationManagerConfigurationScripts < TreeBuilder
   end
 
   def root_options
-    [t = _("All Ansible Tower Job Templates"), t]
+    {
+      :title   => t = _("All Ansible Tower Job Templates"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_configuration_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_configuration_manager_configured_systems.rb
@@ -13,7 +13,10 @@ class TreeBuilderConfigurationManagerConfiguredSystems < TreeBuilder
   end
 
   def root_options
-    [t = _("All Configured Systems"), t]
+    {
+      :title   => t = _("All Configured Systems"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_containers.rb
+++ b/app/presenters/tree_builder_containers.rb
@@ -16,7 +16,10 @@ class TreeBuilderContainers < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = _("All Containers (by Pods)"), t]
+    {
+      :title   => t = _("All Containers (by Pods)"),
+      :tooltip => t
+    }
   end
 
   # level 1 - pods

--- a/app/presenters/tree_builder_containers_filter.rb
+++ b/app/presenters/tree_builder_containers_filter.rb
@@ -14,7 +14,10 @@ class TreeBuilderContainersFilter < TreeBuilder
   end
 
   def root_options
-    [t = _("All Containers"), t]
+    {
+      :title   => t = _("All Containers"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -46,9 +46,17 @@ class TreeBuilderDatacenter < TreeBuilder
 
   def root_options
     if @root.kind_of?(EmsCluster)
-      [@root.name, _("Cluster: %{name}") % {:name => @root.name}, "100/cluster.png"]
+      {
+        :title   => @root.name,
+        :tooltip => _("Cluster: %{name}") % {:name => @root.name},
+        :image   => "100/cluster.png"
+      }
     elsif @root.kind_of?(ResourcePool)
-      [@root.name, _("Resource Pool: %{name}") % {:name => @root.name}, @root.vapp ? "100/vapp.png" : "100/resource_pool.png"]
+      {
+        :title   => @root.name,
+        :tooltip => _("Resource Pool: %{name}") % {:name => @root.name},
+        :image   => @root.vapp ? "100/vapp.png" : "100/resource_pool.png"
+      }
     end
   end
 

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -24,7 +24,7 @@ class TreeBuilderDatastores < TreeBuilder
   end
 
   def root_options
-    []
+    {}
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -46,7 +46,7 @@ class TreeBuilderDefaultFilters < TreeBuilder
   end
 
   def root_options
-    []
+    {}
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -28,6 +28,6 @@ class TreeBuilderDiagnostics < TreeBuilder
   end
 
   def root_options
-    []
+    {}
   end
 end

--- a/app/presenters/tree_builder_event.rb
+++ b/app/presenters/tree_builder_event.rb
@@ -7,7 +7,10 @@ class TreeBuilderEvent < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Events"), t]
+    {
+      :title   => t = N_("All Events"),
+      :tooltip => t
+    }
   end
 
   # level 1 - events

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -20,7 +20,10 @@ class TreeBuilderImages < TreeBuilder
   end
 
   def root_options
-    [_("Images by Provider"), _("All Images by Provider that I can see")]
+    {
+      :title   => _("Images by Provider"),
+      :tooltip => _("All Images by Provider that I can see")
+    }
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_images_filter.rb
+++ b/app/presenters/tree_builder_images_filter.rb
@@ -13,6 +13,9 @@ class TreeBuilderImagesFilter < TreeBuilderVmsFilter
   end
 
   def root_options
-    [_("All Images"), _("All of the Images that I can see")]
+    {
+      :title   => _("All Images"),
+      :tooltip => _("All of the Images that I can see")
+    }
   end
 end

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -20,7 +20,10 @@ class TreeBuilderInfraNetworking < TreeBuilder
   end
 
   def root_options
-    [t = _("All Distributed Switches"), t]
+    {
+      :title   => t = _("All Distributed Switches"),
+      :tooltip => t
+    }
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -22,7 +22,10 @@ class TreeBuilderInstances < TreeBuilder
   end
 
   def root_options
-    [_("Instances by Provider"), _("All Instances by Provider that I can see")]
+    {
+      :title   => _("Instances by Provider"),
+      :tooltip => _("All Instances by Provider that I can see")
+    }
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_instances_filter.rb
+++ b/app/presenters/tree_builder_instances_filter.rb
@@ -13,6 +13,9 @@ class TreeBuilderInstancesFilter < TreeBuilderVmsFilter
   end
 
   def root_options
-    [_("All Instances"), _("All of the Instances that I can see")]
+    {
+      :title   => _("All Instances"),
+      :tooltip => _("All of the Instances that I can see")
+    }
   end
 end

--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -13,7 +13,10 @@ class TreeBuilderIsoDatastores < TreeBuilder
   end
 
   def root_options
-    [t = _("All ISO Datastores"), t]
+    {
+      :title   => t = _("All ISO Datastores"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -33,7 +33,11 @@ class TreeBuilderMenuRoles < TreeBuilder
   end
 
   def root_options
-    [t = _("Top Level"), t, nil, {:key => "xx-b__Report Menus for #{role_choice}"}]
+    {
+      :title   => t = _("Top Level"),
+      :tooltip => t,
+      :key     => "xx-b__Report Menus for #{role_choice}"
+    }
   end
 
   # Typically another method will populate the children of a root object.

--- a/app/presenters/tree_builder_miq_action_category.rb
+++ b/app/presenters/tree_builder_miq_action_category.rb
@@ -33,7 +33,11 @@ class TreeBuilderMiqActionCategory < TreeBuilder
   end
 
   def root_options
-    [title = @tenant_name, title, "100/tag.png"]
+    {
+      :title   => @tenant_name,
+      :tooltip => @tenant_name,
+      :image   => "100/tag.png"
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -29,7 +29,12 @@ class TreeBuilderNetwork < TreeBuilder
   end
 
   def root_options
-    [@root.name, _("Host: %{name}") % {:name => @root.name}, '100/host.png', {:cfmeNoClick => true}]
+    {
+      :title       => @root.name,
+      :tooltip     => _("Host: %{name}") % {:name => @root.name},
+      :image       => '100/host.png',
+      :cfmeNoClick => true
+    }
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_ops_diagnostics.rb
+++ b/app/presenters/tree_builder_ops_diagnostics.rb
@@ -18,6 +18,10 @@ class TreeBuilderOpsDiagnostics < TreeBuilderOps
     title =  _("%{product} Region: %{region_description} [%{region}]") % {:region_description => region.description,
                                                                           :region             => region.region,
                                                                           :product            => I18n.t('product.name')}
-    [title, title, '100/miq_region.png']
+    {
+      :title   => title,
+      :tooltip => title,
+      :image   => '100/miq_region.png'
+    }
   end
 end

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -21,7 +21,11 @@ class TreeBuilderOpsRbac < TreeBuilder
     title =  _("%{product} Region: %{region_description} [%{region}]") % {:region_description => region.description,
                                                                           :region             => region.region,
                                                                           :product            => I18n.t('product.name')}
-    [title, title, '100/miq_region.png']
+    {
+      :title   => title,
+      :tooltip => title,
+      :image   => '100/miq_region.png'
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -18,7 +18,11 @@ class TreeBuilderOpsSettings < TreeBuilderOps
     title =  _("%{product} Region: %{region_description} [%{region}]") % {:region_description => region.description,
                                                                           :region             => region.region,
                                                                           :product            => I18n.t('product.name')}
-    [title, title, '100/miq_region.png']
+    {
+      :title   => title,
+      :tooltip => title,
+      :image   => '100/miq_region.png'
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -16,7 +16,11 @@ class TreeBuilderOpsVmdb < TreeBuilderOps
   end
 
   def root_options
-    [t = _("VMDB"), t, '100/miq_database.png']
+    {
+      :title   => t = _("VMDB"),
+      :tooltip => t,
+      :image   => '100/miq_database.png'
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -12,7 +12,10 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
   end
 
   def root_options
-    [t = _("All Orchestration Templates"), t]
+    {
+      :title   => t = _("All Orchestration Templates"),
+      :tooltip => t
+    }
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -41,7 +41,10 @@ class TreeBuilderPolicy < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = _("All Policies"), t]
+    {
+      :title   => t = _("All Policies"),
+      :tooltip => t
+    }
   end
 
   # level 1 - compliance & control

--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -17,7 +17,10 @@ class TreeBuilderPolicyProfile < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Policy Profiles"), t]
+    {
+      :title   => t = N_("All Policy Profiles"),
+      :tooltip => t
+    }
   end
 
   # level 1 - policy profiles

--- a/app/presenters/tree_builder_policy_simulation.rb
+++ b/app/presenters/tree_builder_policy_simulation.rb
@@ -24,7 +24,12 @@ class TreeBuilderPolicySimulation < TreeBuilder
   end
 
   def root_options
-    [ViewHelper.content_tag(:strong, @root_name), @root_name, '100/vm.png', {:cfmeNoClick => true}]
+    {
+      :title       => ViewHelper.content_tag(:strong, @root_name),
+      :tooltip     => @root_name,
+      :image       => '100/vm.png',
+      :cfmeNoClick => true
+    }
   end
 
   def node_icon(result)

--- a/app/presenters/tree_builder_policy_simulation_results.rb
+++ b/app/presenters/tree_builder_policy_simulation_results.rb
@@ -22,10 +22,11 @@ class TreeBuilderPolicySimulationResults < TreeBuilder
 
   def root_options
     event = MiqEventDefinition.find(@root[:event_value])
-    [_("Policy Simulation Results for Event [%{description}]") % {:description => event.description},
-     nil,
-     "100/event-#{event.name}.png",
-     {:cfmeNoClick => true}]
+    {
+      :title       => _("Policy Simulation Results for Event [%{description}]") % {:description => event.description},
+      :image       => "100/event-#{event.name}.png",
+      :cfmeNoClick => true
+    }
   end
 
   def node_icon(result)

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -21,7 +21,7 @@ class TreeBuilderProtect < TreeBuilder
   end
 
   def root_options
-    []
+    {}
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_provisioning_dialogs.rb
+++ b/app/presenters/tree_builder_provisioning_dialogs.rb
@@ -6,7 +6,10 @@ class TreeBuilderProvisioningDialogs < TreeBuilderAeCustomization
   end
 
   def root_options
-    [t = _("All Dialogs"), t]
+    {
+      :title   => t = _("All Dialogs"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_pxe_customization_templates.rb
+++ b/app/presenters/tree_builder_pxe_customization_templates.rb
@@ -13,7 +13,10 @@ class TreeBuilderPxeCustomizationTemplates < TreeBuilder
   def root_options
     title = _("All %{template} - %{type}") % {:template => ui_lookup(:models => 'CustomizationTemplate'),
                                               :type     => ui_lookup(:models => 'PxeImageType')}
-    [title, title]
+    {
+      :title   => title,
+      :tooltip => title
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_pxe_image_types.rb
+++ b/app/presenters/tree_builder_pxe_image_types.rb
@@ -11,7 +11,10 @@ class TreeBuilderPxeImageTypes < TreeBuilder
   end
 
   def root_options
-    [t = _("All System Image Types"), t]
+    {
+      :title   => t = _("All System Image Types"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_pxe_servers.rb
+++ b/app/presenters/tree_builder_pxe_servers.rb
@@ -13,7 +13,10 @@ class TreeBuilderPxeServers < TreeBuilder
   end
 
   def root_options
-    [t = _("All PXE Servers"), t]
+    {
+      :title   => t = _("All PXE Servers"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -16,7 +16,10 @@ class TreeBuilderReportDashboards < TreeBuilder
   end
 
   def root_options
-    [t = _("All Dashboards"), t]
+    {
+      :title   => t = _("All Dashboards"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_report_export.rb
+++ b/app/presenters/tree_builder_report_export.rb
@@ -15,7 +15,11 @@ class TreeBuilderReportExport < TreeBuilder
   end
 
   def root_options
-    [t = _("Import / Export"), t, '100/report.png']
+    {
+      :title   => t = _("Import / Export"),
+      :tooltip => t,
+      :image   => '100/report.png'
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -20,7 +20,10 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
   end
 
   def root_options
-    [t = _("All Reports"), t]
+    {
+      :title   => t = _("All Reports"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_report_roles.rb
+++ b/app/presenters/tree_builder_report_roles.rb
@@ -20,7 +20,11 @@ class TreeBuilderReportRoles < TreeBuilder
             else
               _("My %{models}") % {:models => ui_lookup(:models => "MiqGroup")}
             end
-    [title, title, '100/miq_group.png']
+    {
+      :title   => title,
+      :tooltip => title,
+      :image   => '100/miq_group.png'
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -14,7 +14,10 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   end
 
   def root_options
-    [t = _("All Saved Reports"), t]
+    {
+      :title   => t = _("All Saved Reports"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_report_schedules.rb
+++ b/app/presenters/tree_builder_report_schedules.rb
@@ -14,7 +14,11 @@ class TreeBuilderReportSchedules < TreeBuilder
   end
 
   def root_options
-    [t = _("All Schedules"), t, '100/miq_schedule.png']
+    {
+      :title   => t = _("All Schedules"),
+      :tooltip => t,
+      :image   => '100/miq_schedule.png'
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -10,7 +10,10 @@ class TreeBuilderReportWidgets < TreeBuilder
   end
 
   def root_options
-    [t = _("All Widgets"), t]
+    {
+      :title   => t = _("All Widgets"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -24,7 +24,7 @@ class TreeBuilderSections < TreeBuilder
   end
 
   def root_options
-    []
+    {}
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -14,7 +14,10 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
   end
 
   def root_options
-    [t = _("All Services"), t]
+    {
+      :title   => t = _("All Services"),
+      :tooltip => t
+    }
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_service_dialogs.rb
+++ b/app/presenters/tree_builder_service_dialogs.rb
@@ -9,7 +9,10 @@ class TreeBuilderServiceDialogs < TreeBuilderAeCustomization
   end
 
   def root_options
-    [t = _("All Dialogs"), t]
+    {
+      :title   => t = _("All Dialogs"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -16,7 +16,10 @@ class TreeBuilderServices < TreeBuilder
   end
 
   def root_options
-    [t = _("All Services"), t]
+    {
+      :title   => t = _("All Services"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -28,7 +28,7 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   end
 
   def root_options
-    []
+    {}
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -27,7 +27,12 @@ class TreeBuilderSnapshots < TreeBuilder
   end
 
   def root_options
-    [@record.name, @record.name, '100/vm.png', {:cfmeNoClick => true}]
+    {
+      :title       => @record.name,
+      :tooltip     => @record.name,
+      :image       => '100/vm.png',
+      :cfmeNoClick => true
+    }
   end
 
   def x_get_tree_roots(count_only = false, _options = {})

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -11,7 +11,10 @@ class TreeBuilderStorage < TreeBuilder
   end
 
   def root_options
-    [t = _("All Datastores"), t]
+    {
+      :title   => t = _("All Datastores"),
+      :tooltip => t
+    }
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -20,7 +20,11 @@ class TreeBuilderStorageAdapters < TreeBuilder
   end
 
   def root_options
-    [@root.name, _("Host: %{name}") % {:name => @root.name}, "100/host.png"]
+    {
+      :title   => @root.name,
+      :tooltip => _("Host: %{name}") % {:name => @root.name},
+      :image   => "100/host.png"
+    }
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -11,7 +11,10 @@ class TreeBuilderStoragePod < TreeBuilder
   end
 
   def root_options
-    [t = _("All Datastore Clusters"), t]
+    {
+      :title   => t = _("All Datastore Clusters"),
+      :tooltip => t
+    }
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -40,7 +40,7 @@ class TreeBuilderTags < TreeBuilder
   end
 
   def root_options
-    []
+    {}
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_template_filter.rb
+++ b/app/presenters/tree_builder_template_filter.rb
@@ -13,6 +13,9 @@ class TreeBuilderTemplateFilter < TreeBuilderVmsFilter
   end
 
   def root_options
-    [_("All Templates"), _("All of the Templates that I can see")]
+    {
+      :title   => _("All Templates"),
+      :tooltip => _("All of the Templates that I can see")
+    }
   end
 end

--- a/app/presenters/tree_builder_templates_images_filter.rb
+++ b/app/presenters/tree_builder_templates_images_filter.rb
@@ -9,6 +9,9 @@ class TreeBuilderTemplatesImagesFilter < TreeBuilderVmsFilter
   end
 
   def root_options
-    [_("All Templates & Images"), _("All of the Templates & Images that I can see")]
+    {
+      :title   => _("All Templates & Images"),
+      :tooltip => _("All of the Templates & Images that I can see")
+    }
   end
 end

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -28,7 +28,11 @@ class TreeBuilderUtilization < TreeBuilderRegion
                                                                            :product => I18n.t('product.name')}
       icon  = '100/miq_region.png'
     end
-    [title, title, icon]
+    {
+      :title   => title,
+      :tooltip => title,
+      :image   => icon
+    }
   end
 
   def x_get_tree_ems_kids(object, count_only)

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -12,7 +12,10 @@ class TreeBuilderVandt < TreeBuilder
   end
 
   def root_options
-    [_("All VMs & Templates"), _("All VMs & Templates that I can see")]
+    {
+      :title   => _("All VMs & Templates"),
+      :tooltip => _("All VMs & Templates that I can see")
+    }
   end
 
   def x_get_tree_roots(count_only, options)

--- a/app/presenters/tree_builder_vat.rb
+++ b/app/presenters/tree_builder_vat.rb
@@ -12,8 +12,11 @@ class TreeBuilderVat < TreeBuilderDatacenter
   private
 
   def root_options
-    image = "100/vendor-#{@root.image_name}.png"
-    [@root.name, @root.name, image]
+    {
+      :title   => @root.name,
+      :tooltip => @root.name,
+      :image   => "100/vendor-#{@root.image_name}.png"
+    }
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -12,7 +12,10 @@ class TreeBuilderVmsFilter < TreeBuilder
   end
 
   def root_options
-    [_("All VMs"), _("All of the VMs that I can see")]
+    {
+      :title   => _("All VMs"),
+      :tooltip => _("All of the VMs that I can see")
+    }
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_vms_instances_filter.rb
+++ b/app/presenters/tree_builder_vms_instances_filter.rb
@@ -9,6 +9,9 @@ class TreeBuilderVmsInstancesFilter < TreeBuilderVmsFilter
   end
 
   def root_options
-    [_("All VMs & Instances"), _("All of the VMs & Instances that I can see")]
+    {
+      :title   => _("All VMs & Instances"),
+      :tooltip => _("All of the VMs & Instances that I can see")
+    }
   end
 end

--- a/spec/presenters/tree_builder_automate_simulation_results_spec.rb
+++ b/spec/presenters/tree_builder_automate_simulation_results_spec.rb
@@ -7,7 +7,7 @@ describe TreeBuilderAutomateSimulationResults do
 
     it 'no root is set' do
       root_options = @ae_simulation_tree.send(:root_options)
-      expect(root_options).to eq([])
+      expect(root_options).to eq({})
     end
 
     it 'sets attribute nodes correctly' do
@@ -15,7 +15,7 @@ describe TreeBuilderAutomateSimulationResults do
       tree_data = {:id          => "e_1",
                    :text        => "ManageIQ/SYSTEM / PROCESS / Automation",
                    :image       => "100/q.png",
-                   :tip         => "ManageIQ/SYSTEM / PROCESS / Automation",
+                   :tooltip     => "ManageIQ/SYSTEM / PROCESS / Automation",
                    :elements    => [],
                    :cfmeNoClick => true
                   }

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -89,7 +89,7 @@ describe TreeBuilderBelongsToHac do
 
   describe '#root_options' do
     it 'sets root to empty one' do
-      expect(subject.send(:root_options)).to eq([])
+      expect(subject.send(:root_options)).to eq({})
     end
   end
 

--- a/spec/presenters/tree_builder_compliance_history_spec.rb
+++ b/spec/presenters/tree_builder_compliance_history_spec.rb
@@ -28,7 +28,7 @@ describe TreeBuilderComplianceHistory do
       tree_options = @ch_tree.send(:tree_init_options, :ch)
       root = @ch_tree.send(:root_options)
       expect(tree_options[:add_root]).to eq(false)
-      expect(root).to eq([])
+      expect(root).to eq({})
     end
     it 'returns Compliance as root kids' do
       kids = @ch_tree.send(:x_get_tree_roots, false)

--- a/spec/presenters/tree_builder_datacenter_spec.rb
+++ b/spec/presenters/tree_builder_datacenter_spec.rb
@@ -18,9 +18,11 @@ describe TreeBuilderDatacenter do
 
     it 'returns EmsCluster as root' do
       root = @datacenter_tree.send(:root_options)
-      expect(root[0]).to eq(@datacenter_tree.instance_variable_get(:@root).name)
-      expect(root[1]).to eq("Cluster: #{@datacenter_tree.instance_variable_get(:@root).name}")
-      expect(root[2]).to eq("100/cluster.png")
+      expect(root).to eq(
+        :title   => @datacenter_tree.instance_variable_get(:@root).name,
+        :tooltip => "Cluster: #{@datacenter_tree.instance_variable_get(:@root).name}",
+        :image   => "100/cluster.png"
+      )
     end
 
     it 'returns right kind of children' do
@@ -53,9 +55,11 @@ describe TreeBuilderDatacenter do
 
     it 'returns ResourcePool as root' do
       root = @datacenter_tree.send(:root_options)
-      expect(root[0]).to eq(@datacenter_tree.instance_variable_get(:@root).name)
-      expect(root[1]).to eq("Resource Pool: #{@datacenter_tree.instance_variable_get(:@root).name}")
-      expect(root[2]).to eq(@datacenter_tree.instance_variable_get(:@root).vapp ? '100/vapp.png' : '100/resource_pool.png')
+      expect(root).to eq(
+        :title   => @datacenter_tree.instance_variable_get(:@root).name,
+        :tooltip => "Resource Pool: #{@datacenter_tree.instance_variable_get(:@root).name}",
+        :image   => @datacenter_tree.instance_variable_get(:@root).vapp ? '100/vapp.png' : '100/resource_pool.png'
+      )
     end
 
     it 'returns right kind of children' do

--- a/spec/presenters/tree_builder_default_filters_spec.rb
+++ b/spec/presenters/tree_builder_default_filters_spec.rb
@@ -73,7 +73,7 @@ describe TreeBuilderDefaultFilters do
       tree_options = @default_filters_tree.send(:tree_init_options, :df)
       root = @default_filters_tree.send(:root_options)
       expect(tree_options[:add_root]).to eq(false)
-      expect(root).to eq([])
+      expect(root).to eq({})
     end
 
     it 'returns folders as root kids' do

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -25,7 +25,10 @@ describe TreeBuilderImages do
 
   it 'sets root correctly' do
     root = @images_tree.root_options
-    expect(root).to eq(["Images by Provider", "All Images by Provider that I can see"])
+    expect(root).to eq(
+      :title   => "Images by Provider",
+      :tooltip => "All Images by Provider that I can see"
+    )
   end
 
   it 'sets providers nodes correctly' do

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -32,7 +32,7 @@ describe TreeBuilderInstances do
   it 'sets root correctly' do
     root = @instances_tree.root_options
 
-    expect(root).to eq(["Instances by Provider", "All Instances by Provider that I can see"])
+    expect(root).to eq(:title => "Instances by Provider", :tooltip => "All Instances by Provider that I can see")
   end
 
   it 'sets providers nodes correctly' do

--- a/spec/presenters/tree_builder_miq_action_category_spec.rb
+++ b/spec/presenters/tree_builder_miq_action_category_spec.rb
@@ -51,7 +51,11 @@ describe TreeBuilderMiqActionCategory do
 
   describe '#root_options' do
     it 'sets root_options correctly' do
-      expect(subject.send(:root_options)).to eq([tenant, tenant, "100/tag.png"])
+      expect(subject.send(:root_options)).to eq(
+        :title   => tenant,
+        :tooltip => tenant,
+        :image   => "100/tag.png"
+      )
     end
   end
 

--- a/spec/presenters/tree_builder_network_spec.rb
+++ b/spec/presenters/tree_builder_network_spec.rb
@@ -15,9 +15,12 @@ describe TreeBuilderNetwork do
     end
     it 'returns Host as root' do
       root = @network_tree.send(:root_options)
-      expect(root[0]).to eq(@network_tree.instance_variable_get(:@root).name)
-      expect(root[1]).to eq(_("Host: %{name}") % {:name => @network_tree.instance_variable_get(:@root).name})
-      expect(root[2]).to eq('100/host.png')
+      expect(root).to eq(
+        :title       => @network_tree.instance_variable_get(:@root).name,
+        :tooltip     => _("Host: %{name}") % {:name => @network_tree.instance_variable_get(:@root).name},
+        :image       => '100/host.png',
+        :cfmeNoClick => true
+      )
     end
     it 'returns Switch as root child' do
       kid = @network_tree.send(:x_get_tree_roots, false)

--- a/spec/presenters/tree_builder_policy_simulation_results_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_results_spec.rb
@@ -32,11 +32,11 @@ describe TreeBuilderPolicySimulationResults do
 
     it 'sets root correctly' do
       root_options = @rsop_tree.send(:root_options)
-      expect(root_options).to eq([_("Policy Simulation Results for Event [%{description}]") %
-                                    {:description => @event.description},
-                                  nil,
-                                  "100/event-#{@event.name}.png",
-                                  {:cfmeNoClick => true}])
+      expect(root_options).to eq(
+        :title       => _("Policy Simulation Results for Event [%{description}]") % {:description => @event.description},
+        :image       => "100/event-#{@event.name}.png",
+        :cfmeNoClick => true
+      )
     end
 
     it 'sets vm nodes correctly' do

--- a/spec/presenters/tree_builder_policy_simulation_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_spec.rb
@@ -46,7 +46,12 @@ describe TreeBuilderPolicySimulation do
 
     it 'sets root correctly' do
       root = @policy_simulation_tree.send(:root_options)
-      expect(root).to eq(["<strong>Policy Simulation</strong>", 'Policy Simulation', '100/vm.png', { :cfmeNoClick => true }])
+      expect(root).to eq(
+        :title       => "<strong>Policy Simulation</strong>",
+        :tooltip     => 'Policy Simulation',
+        :image       => '100/vm.png',
+        :cfmeNoClick => true
+      )
     end
 
     it 'sets icon correctly' do

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -43,7 +43,7 @@ describe TreeBuilderRolesByServer do
       tree_options = @server_tree.send(:tree_init_options, :roles_by_server)
       root = @server_tree.send(:root_options)
       expect(tree_options[:add_root]).to eq(false)
-      expect(root).to eq([])
+      expect(root).to eq({})
     end
 
     it 'returns server nodes as root kids' do

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -45,7 +45,7 @@ describe TreeBuilderServersByRole do
       tree_options = @server_tree.send(:tree_init_options, :servers_by_role)
       root = @server_tree.send(:root_options)
       expect(tree_options[:add_root]).to eq(false)
-      expect(root).to eq([])
+      expect(root).to eq({})
     end
 
     it 'returns server nodes as root kids' do

--- a/spec/presenters/tree_builder_snapshots_spec.rb
+++ b/spec/presenters/tree_builder_snapshots_spec.rb
@@ -17,7 +17,12 @@ describe TreeBuilderSnapshots do
     end
     it 'sets root correctly' do
       root = @s_tree.send(:root_options)
-      expect(root).to eq([@record.name, @record.name, '100/vm.png', {:cfmeNoClick => true}])
+      expect(root).to eq(
+        :title       => @record.name,
+        :tooltip     => @record.name,
+        :image       => '100/vm.png',
+        :cfmeNoClick => true
+      )
     end
     it 'returns Snapshot as kids of root' do
       snapshot_nodes = @s_tree.send(:x_get_tree_roots, false)

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -19,10 +19,11 @@ describe TreeBuilder do
   context "title_and_tip" do
     it "sets title and tooltip for the passed in root node" do
       tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
-      title, tooltip, icon = tree.send(:root_options)
-      expect(title).to eq("Rates")
-      expect(tooltip).to eq("Rates")
-      expect(icon).to be_nil
+      root = tree.send(:root_options)
+      expect(root).to eq(
+        :title   => 'Rates',
+        :tooltip => 'Rates'
+      )
     end
   end
 
@@ -46,7 +47,7 @@ describe TreeBuilder do
                 'text'    => "Rates",
                 'tooltip' => "Rates",
                 'class'   => '',
-                'image'   => ActionController::Base.helpers.image_path('100/folder.png')
+                'icon'   => 'pficon pficon-folder-close'
               }]
       tree.locals_for_render.key?(:bs_tree)
       expect(JSON.parse(tree.locals_for_render[:bs_tree])).to eq(nodes)
@@ -77,7 +78,10 @@ describe TreeBuilder do
     let(:tree) do
       Class.new(TreeBuilderChargebackRates) do
         def root_options
-          ["Foo", "Bar", nil]
+          {
+            :title   => "Foo",
+            :tooltip => "Bar"
+          }
         end
       end.new("cb_rates_tree", "cb_rates", {})
     end

--- a/spec/presenters/tree_builder_storage_adapters_spec.rb
+++ b/spec/presenters/tree_builder_storage_adapters_spec.rb
@@ -19,9 +19,11 @@ describe TreeBuilderStorageAdapters do
 
     it 'returns Host as root' do
       root = @sa_tree.send(:root_options)
-      expect(root[0]).to eq(@sa_tree.instance_variable_get(:@root).name)
-      expect(root[1]).to eq("Host: #{@sa_tree.instance_variable_get(:@root).name}")
-      expect(root[2]).to eq('100/host.png')
+      expect(root).to eq(
+        :title   => @sa_tree.instance_variable_get(:@root).name,
+        :tooltip => "Host: #{@sa_tree.instance_variable_get(:@root).name}",
+        :image   => '100/host.png'
+      )
     end
 
     it 'returns MiqScsiTarget as children of root' do

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -41,7 +41,7 @@ describe TreeBuilderTags do
     end
     it 'sets root to nothing' do
       roots = @tags_tree.send(:root_options)
-      expect(roots).to eq([])
+      expect(roots).to eq({})
     end
     it 'sets first level nodes correctly' do
       roots = @tags_tree.send(:x_get_tree_roots, false, nil)

--- a/spec/presenters/tree_builder_vat_spec.rb
+++ b/spec/presenters/tree_builder_vat_spec.rb
@@ -22,9 +22,11 @@ describe TreeBuilderVat do
     it 'returns EmsCluster as root' do
       root = @vat_tree.send(:root_options)
       image = "100/vendor-#{@vat_tree.instance_variable_get(:@root).image_name}.png"
-      expect(root[0]).to eq(@vat_tree.instance_variable_get(:@root).name)
-      expect(root[1]).to eq(@vat_tree.instance_variable_get(:@root).name)
-      expect(root[2]).to eq(image)
+      expect(root).to eq(
+        :title   => @vat_tree.instance_variable_get(:@root).name,
+        :tooltip => @vat_tree.instance_variable_get(:@root).name,
+        :image   => image
+      )
     end
 
     it 'returns children correctly' do


### PR DESCRIPTION
Because we're supporting images and icons at the same time, it was necessary to modify all the `root_options` methods to return with a Hash instead of an Array. This way it will be possible to specify an `:icon` or an `:image` the same way as for `TreeNode::Hash`. Also the fallback folder image has been changed to a folder fonticon.