### PR TITLE
Refactoring code of x_get_tree_custom_kids method

### DIFF
--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -27,13 +27,7 @@ class TreeBuilderStorage < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    objects = MiqSearch.where(:db => options[:leaf])
-    objects = case object[:id]
-              when "global" # Global filters
-                objects.visible_to_all
-              when "my"     # My filters
-                objects.where(:search_type => "user", :search_key => User.current_user.userid)
-              end
-    count_only_or_objects(count_only, objects, "description")
+    objects = MiqSearch.where(:db => options[:leaf]).filters_by_type(object[:id])
+    count_only_or_objects(count_only, objects, 'description')
   end
 end

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -28,13 +28,7 @@ class TreeBuilderVmsFilter < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    objects = MiqSearch.where(:db => options[:leaf])
-    objects = case object[:id]
-              when "global" # Global filters
-                objects.visible_to_all
-              when "my"     # My filters
-                objects.where(:search_type => "user", :search_key => User.current_user.userid)
-              end
+    objects = MiqSearch.where(:db => options[:leaf]).filters_by_type(object[:id])
     count_only_or_objects(count_only, objects, 'description')
   end
 end


### PR DESCRIPTION
Refactoring code of x_get_tree_custom_kidsmethod as the
same code needs to be in the method in tree_builder_vms_filter.rb
and in tree_builder_storage.rb;
moving the code to new methods in miq_search.rb.

Depends on 
https://github.com/ManageIQ/manageiq/pull/13402 (the second part of this refactoring)