### PR TITLE
Remove unnecessary @config_tab variable

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -13,7 +13,6 @@ class ConfigurationController < ApplicationController
 
   def index
     @breadcrumbs = []
-    @config_tab = params[:config_tab] ? params[:config_tab] : "ui"
     active_tab = nil
     if role_allows?(:feature => "my_settings_visuals")
       active_tab = 1 if active_tab.nil?
@@ -24,24 +23,8 @@ class ConfigurationController < ApplicationController
     elsif role_allows?(:feature => "my_settings_time_profiles")
       active_tab = 4 if active_tab.nil?
     end
-    @tabform = params[:load_edit_err] ? @tabform : @config_tab + "_#{active_tab}"
-    case @config_tab
-    when "operations", "ui", "filters"
-      if @tabform == "operations_1" || @tabform == "operations_2"
-        init_server_options
-        @server_options[:server_id] = MiqServer.my_server.id
-        @server_options[:remote] = false
-      end
-      if (@tabform == "filters_1")
-        @tabform = @config_tab + "_2"
-      end
-      if (@tabform == "filters_2")
-        @tabform = @config_tab + "_3"
-      end
-      edit
-    when "admin"
-      show_users
-    end
+    @tabform = params[:load_edit_err] ? @tabform : "ui_#{active_tab}"
+    edit
     render :action => "show"
   end
 
@@ -79,7 +62,7 @@ class ConfigurationController < ApplicationController
 
   # New tab was pressed
   def change_tab
-    @tabform = @config_tab + "_" + params[:tab] if params[:tab] != "5"
+    @tabform = "ui_" + params[:tab] if params[:tab] != "5"
     edit
     render :action => "show"
   end
@@ -490,19 +473,17 @@ class ConfigurationController < ApplicationController
 
   def build_tabs
     @breadcrumbs = []
-    if @config_tab == "ui"
-      if @tabform != "ui_4"
-        drop_breadcrumb({:name => _("User Interface Configuration"), :url => "/configuration/edit"}, true)
-      end
-
-      @active_tab = @tabform.split("_").last
-
-      @tabs = []
-      @tabs.push(["1", _("Visual")])          if role_allows?(:feature => "my_settings_visuals")
-      @tabs.push(["2", _("Default Views")])   if role_allows?(:feature => "my_settings_default_views")
-      @tabs.push(["3", _("Default Filters")]) if role_allows?(:feature => "my_settings_default_filters")
-      @tabs.push(["4", _("Time Profiles")])   if role_allows?(:feature => "my_settings_time_profiles")
+    if @tabform != "ui_4"
+      drop_breadcrumb({:name => _("User Interface Configuration"), :url => "/configuration/edit"}, true)
     end
+
+    @active_tab = @tabform.split("_").last
+
+    @tabs = []
+    @tabs.push(["1", _("Visual")])          if role_allows?(:feature => "my_settings_visuals")
+    @tabs.push(["2", _("Default Views")])   if role_allows?(:feature => "my_settings_default_views")
+    @tabs.push(["3", _("Default Filters")]) if role_allows?(:feature => "my_settings_default_filters")
+    @tabs.push(["4", _("Time Profiles")])   if role_allows?(:feature => "my_settings_time_profiles")
   end
 
   def merge_in_user_settings(settings)
@@ -621,14 +602,12 @@ class ConfigurationController < ApplicationController
   def get_session_data
     @title        = session[:config_title] ? _("Configuration") : session[:config_title]
     @layout       = "configuration"
-    @config_tab   = session[:config_tab]        if session[:config_tab]
     @tabform      = session[:config_tabform]    if session[:config_tabform]
     @schema_ver   = session[:config_schema_ver] if session[:config_schema_ver]
     @zone_options = session[:zone_options]      if session[:zone_options]
   end
 
   def set_session_data
-    session[:config_tab]        = @config_tab
     session[:config_tabform]    = @tabform
     session[:config_schema_ver] = @schema_ver
     session[:vm_filters]        = @filters

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -246,7 +246,7 @@ module Menu
 
       def settings_menu_section
         Menu::Section.new(:set, N_("Settings"), 'pficon pficon-settings fa-2x', [
-          Menu::Item.new('configuration', N_('My Settings'),   'my_settings',  {:feature => 'my_settings', :any => true},  '/configuration/index?config_tab=ui'),
+          Menu::Item.new('configuration', N_('My Settings'),   'my_settings',  {:feature => 'my_settings', :any => true},  '/configuration/index'),
           Menu::Item.new('my_tasks',      N_('Tasks'),         'tasks',        {:feature => 'tasks', :any => true},        '/miq_task/index?jobs_tab=tasks'),
           Menu::Item.new('ops',           N_('Configuration'), 'ops_explorer', {:feature => 'ops_explorer', :any => true}, '/ops/explorer')
         ], :top_right)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -39,8 +39,7 @@
         API.autorenew();
         miqInitNotifications(); // ActionCable causes live reload crashes
 
-    - id = %w(configuration policy).include?(@layout) ? @config_tab : @layout
-    %body{:id => id, :onload => is_browser_ie? ? '' : 'miqOnLoad();', 'data-controller' => controller_name}
+    %body{:onload => is_browser_ie? ? '' : 'miqOnLoad();', 'data-controller' => controller_name}
       = render :partial => "layouts/header"
       = render :partial => "layouts/content"
       = render :partial => 'layouts/footer'

--- a/spec/controllers/configuration_controller_spec.rb
+++ b/spec/controllers/configuration_controller_spec.rb
@@ -16,7 +16,6 @@ describe ConfigurationController do
   describe "building tabs" do
     before(:each) do
       controller.instance_variable_set(:@tabform, "ui_2")
-      controller.instance_variable_set(:@config_tab, "ui")
     end
 
     it 'sets the active tab' do


### PR DESCRIPTION
Currently, the `@config_tab` variable can only have one value (`"ui"`)
and therefore is not really needed.

Besides, it's stored in session and will cause havoc when the session
expires and the code still refers to that session-stored value (which
is now voided) and we want to switch tabs in 'My Settings' screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1346287