### PR TITLE
Use ::Settings directly instead of MiqServer#get_config for local server

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -531,9 +531,7 @@ class ConfigurationController < ApplicationController
 
       current_tz = @edit.fetch_path(:current, :display, :timezone)
       if current_tz.blank?
-        new_tz = MiqServer.my_server.get_config("vmdb").config[:server][:timezone]
-        new_tz = 'UTC' if new_tz.blank?
-        @edit.store_path(:current, :display, :timezone, new_tz)
+        @edit.store_path(:current, :display, :timezone, ::Settings.server.timezone)
       end
     when 'ui_2'
       @edit = {

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -555,8 +555,7 @@ module OpsController::Diagnostics
     # @edit[:new][:end_date] = "#{t.month}/#{t.day}/#{t.year}" # Set the start date
     @edit[:new][:end_date] = ""
 
-    tz = MiqServer.my_server.get_config("vmdb").config[:server][:timezone]
-    @edit[:new][:timezone] = tz.blank? ? "UTC" : tz
+    @edit[:new][:timezone] = ::Settings.server.timezone
   end
 
   def cu_repair_get_form_vars


### PR DESCRIPTION
Use ```::Settings``` directly instead of  ```MiqServer#get_config```.
On local server ```MiqServer#get_config``` will trigger call to deprecated ```VMDB::Config.new```

@miq-bot add-label core

\cc @Fryguy 