### PR TITLE
Ignore binstubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .yardoc
 Gemfile.lock
 _yardoc/
+bin/*
 coverage/
 doc/
 pkg/


### PR DESCRIPTION
I should be able to use whatever binstubs I want, matches pattern in ManageIQ repo