### PR TITLE
Policy Event must have at least one action assigned to it

### DIFF
--- a/app/controllers/miq_policy_controller/events.rb
+++ b/app/controllers/miq_policy_controller/events.rb
@@ -32,6 +32,12 @@ module MiqPolicyController::Events
       event = MiqEventDefinition.find(@event.id)                        # Get event record
       action_list = @edit[:new][:actions_true].collect { |a| [MiqAction.find(a.last), {:qualifier => :success, :synchronous => a[1]}] } +
                     @edit[:new][:actions_false].collect { |a| [MiqAction.find(a.last), {:qualifier => :failure, :synchronous => a[1]}] }
+      add_flash(_("At least one action must be selected to save this Policy Event"), :error) if action_list.blank?
+      if @flash_array
+        javascript_flash
+        return
+      end
+
       policy.replace_actions_for_event(event, action_list)
       AuditEvent.success(build_saved_audit(event))
       add_flash(_("Actions for Policy Event \"%{events}\" were saved") % {:events => event.description})

--- a/spec/controllers/miq_policy_controller/events_spec.rb
+++ b/spec/controllers/miq_policy_controller/events_spec.rb
@@ -1,0 +1,61 @@
+describe MiqPolicyController do
+  context "::Events" do
+    context "#event_edit" do
+      before :each do
+        stub_user(:features => :all)
+        @action = FactoryGirl.create(:miq_action, :name => "compliance_failed")
+        @event = FactoryGirl.create(:miq_event_definition, :name => "vm_compliance_check")
+        @policy = FactoryGirl.create(:miq_policy, :name => "Foo")
+
+        controller.instance_variable_set(:@sb,
+                                         :node_ids    => {
+                                           :policy_tree => {"p" => @policy.id}
+                                         },
+                                         :active_tree => :policy_tree
+                                        )
+        allow(controller).to receive(:replace_right_cell)
+      end
+
+      it "saves Policy Event with an action" do
+        new_hash = {
+          :name          => "New Name",
+          :description   => "New Description",
+          :actions_true  => [[@action.name, true, @action.id]],
+          :actions_false => []
+        }
+        edit = {
+          :new      => new_hash,
+          :current  => new_hash,
+          :key      => "event_edit__#{@event.id}",
+          :event_id => @event.id
+        }
+        controller.instance_variable_set(:@edit, edit)
+        session[:edit] = edit
+        controller.instance_variable_set(:@_params, :id => @event.id.to_s, :button => "save")
+        controller.event_edit
+        expect(@policy.actions_for_event(@event, :success)).to include(@action)
+      end
+
+      it "does not allow to save Policy Event without an action" do
+        new_hash = {
+          :name          => "New Name",
+          :description   => "New Description",
+          :actions_true  => [],
+          :actions_false => []
+        }
+        edit = {
+          :new      => new_hash,
+          :current  => new_hash,
+          :key      => "event_edit__#{@event.id}",
+          :event_id => @event.id
+        }
+        controller.instance_variable_set(:@edit, edit)
+        session[:edit] = edit
+        controller.instance_variable_set(:@_params, :id => @event.id.to_s, :button => "save")
+        expect(controller).to receive(:render)
+        controller.event_edit
+        expect(assigns(:flash_array).first[:message]).to include("At least one action must be selected to save this Policy Event")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Made changes to not allow deleting all actions from a Policy Event, at least one action should be there.

https://bugzilla.redhat.com/show_bug.cgi?id=1395965

before:
![before](https://cloud.githubusercontent.com/assets/3450808/21783865/102e6b9c-d687-11e6-9a6e-2f7b1c06579c.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/21783869/18ab61d0-d687-11e6-9e58-9afa44973c87.png)

@dclarizio please review