### PR TITLE
Use 'test' task name convention

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ addons:
   postgresql: '9.4'
 env:
   matrix:
-  - TEST_SUITE=spec
-  - TEST_SUITE=spec:javascript
+  - TEST_SUITE=test
+  - TEST_SUITE=test:javascript
 before_install: source tools/ci/before_install.sh
 before_script: bundle exec rake $TEST_SUITE:setup
 script: bundle exec rake $TEST_SUITE
@@ -19,7 +19,7 @@ before_cache:
 - mkdir -p vendor/assets
 - mv spec/manageiq/vendor/assets/bower_components vendor/assets
 - cp bower.json vendor/assets/bower_components
-after_script: if [ "$TEST_SUITE" = "spec" ]; then bundle exec codeclimate-test-reporter; fi
+after_script: if [ "$TEST_SUITE" = "test" ]; then bundle exec codeclimate-test-reporter; fi
 notifications:
   webhooks:
     urls:

--- a/Rakefile
+++ b/Rakefile
@@ -13,12 +13,12 @@ rescue LoadError
 end
 
 if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
-  namespace :spec do
+  namespace :test do
     desc "Setup environment for specs"
     task :setup => ["app:test:initialize", "app:test:verify_no_db_access_loading_rails_environment", "app:test:setup_db"]
   end
 
-  RSpec::Core::RakeTask.new(:spec => ["app:test:initialize", "app:evm:compile_sti_loader"]) do |t|
+  RSpec::Core::RakeTask.new(:test => ["app:test:initialize", "app:evm:compile_sti_loader"]) do |t|
     spec_dir = File.expand_path("spec", __dir__)
     EvmTestHelper.init_rspec_task(t, ['--require', File.join(spec_dir, 'spec_helper')])
     t.pattern = FileList[spec_dir + '/**/*_spec.rb'].exclude(spec_dir + '/manageiq/**/*_spec.rb')
@@ -28,7 +28,7 @@ end
 require 'jasmine'
 load 'jasmine/tasks/jasmine.rake'
 
-namespace :spec do
+namespace :test do
   namespace :javascript do
     desc "Setup environment for javascript specs"
     task :setup
@@ -38,4 +38,4 @@ namespace :spec do
   task :javascript => ["app:test:initialize", :environment, "jasmine:ci"]
 end
 
-task :default => :spec
+task :default => :test

--- a/Rakefile
+++ b/Rakefile
@@ -39,3 +39,8 @@ namespace :test do
 end
 
 task :default => :test
+
+task :spec => :test
+namespace :spec do
+  task :javascript => "test:javascript"
+end


### PR DESCRIPTION
Coming from another ManageIQ project I would expect that `rake test` would be the standard command to use to run the tests for whatever project I'm opening. This repo seems to have split from that and uses 'spec' instead.

This changes the command to 'test'. However, to not throw off the UI team's current workflow, 'spec' is now just an alias.