### PR TITLE
Remove all remaining N_ from TreeBuilders, in favour of _

### DIFF
--- a/app/presenters/tree_builder_action.rb
+++ b/app/presenters/tree_builder_action.rb
@@ -8,7 +8,7 @@ class TreeBuilderAction < TreeBuilder
   # level 0 - root
   def root_options
     {
-      :title   => t = N_("All Actions"),
+      :title   => t = _("All Actions"),
       :tooltip => t
     }
   end

--- a/app/presenters/tree_builder_alert.rb
+++ b/app/presenters/tree_builder_alert.rb
@@ -8,7 +8,7 @@ class TreeBuilderAlert < TreeBuilder
   # level 0 - root
   def root_options
     {
-      :title   => t = N_("All Alerts"),
+      :title   => t = _("All Alerts"),
       :tooltip => t
     }
   end

--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -19,7 +19,7 @@ class TreeBuilderAlertProfile < TreeBuilder
   # level 0 - root
   def root_options
     {
-      :title   => t = N_("All Alert Profiles"),
+      :title   => t = _("All Alert Profiles"),
       :tooltip => t
     }
   end

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -13,20 +13,20 @@ class TreeBuilderCondition < TreeBuilder
   # level 0 - root
   def root_options
     {
-      :title   => t = N_("All Conditions"),
+      :title   => t = _("All Conditions"),
       :tooltip => t
     }
   end
 
   # level 1 - host / vm
   def x_get_tree_roots(count_only, _options)
-    text_i18n = {:Host                => N_("Host Conditions"),
-                 :Vm                  => N_("VM and Instance Conditions"),
-                 :ContainerReplicator => N_("Replicator Conditions"),
-                 :ContainerGroup      => N_("Pod Conditions"),
-                 :ContainerNode       => N_("Container Node Conditions"),
-                 :ContainerImage      => N_("Container Image Conditions"),
-                 :ExtManagementSystem => N_("Container Provider Conditions")}
+    text_i18n = {:Host                => _("Host Conditions"),
+                 :Vm                  => _("VM and Instance Conditions"),
+                 :ContainerReplicator => _("Replicator Conditions"),
+                 :ContainerGroup      => _("Pod Conditions"),
+                 :ContainerNode       => _("Container Node Conditions"),
+                 :ContainerImage      => _("Container Image Conditions"),
+                 :ExtManagementSystem => _("Container Provider Conditions")}
 
     objects = MiqPolicyController::UI_FOLDERS.collect do |model|
       text = text_i18n[model.name.to_sym]

--- a/app/presenters/tree_builder_event.rb
+++ b/app/presenters/tree_builder_event.rb
@@ -8,7 +8,7 @@ class TreeBuilderEvent < TreeBuilder
   # level 0 - root
   def root_options
     {
-      :title   => t = N_("All Events"),
+      :title   => t = _("All Events"),
       :tooltip => t
     }
   end

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -15,20 +15,20 @@ class TreeBuilderPolicy < TreeBuilder
   end
 
   def compliance_control_kids(mode)
-    text_i18n = {:compliance => {:Host                => N_("Host Compliance Policies"),
-                                 :Vm                  => N_("Vm Compliance Policies"),
-                                 :ContainerReplicator => N_("Replicator Compliance Policies"),
-                                 :ContainerGroup      => N_("Pod Compliance Policies"),
-                                 :ContainerNode       => N_("Container Node Compliance Policies"),
-                                 :ContainerImage      => N_("Container Image Compliance Policies"),
-                                 :ExtManagementSystem => N_("Provider Compliance Policies")},
-                 :control    => {:Host                => N_("Host Control Policies"),
-                                 :Vm                  => N_("Vm Control Policies"),
-                                 :ContainerReplicator => N_("Replicator Control Policies"),
-                                 :ContainerGroup      => N_("Pod Control Policies"),
-                                 :ContainerNode       => N_("Container Node Control Policies"),
-                                 :ContainerImage      => N_("Container Image Control Policies"),
-                                 :ExtManagementSystem => N_("Provider Control Policies")}}
+    text_i18n = {:compliance => {:Host                => _("Host Compliance Policies"),
+                                 :Vm                  => _("Vm Compliance Policies"),
+                                 :ContainerReplicator => _("Replicator Compliance Policies"),
+                                 :ContainerGroup      => _("Pod Compliance Policies"),
+                                 :ContainerNode       => _("Container Node Compliance Policies"),
+                                 :ContainerImage      => _("Container Image Compliance Policies"),
+                                 :ExtManagementSystem => _("Provider Compliance Policies")},
+                 :control    => {:Host                => _("Host Control Policies"),
+                                 :Vm                  => _("Vm Control Policies"),
+                                 :ContainerReplicator => _("Replicator Control Policies"),
+                                 :ContainerGroup      => _("Pod Control Policies"),
+                                 :ContainerNode       => _("Container Node Control Policies"),
+                                 :ContainerImage      => _("Container Image Control Policies"),
+                                 :ExtManagementSystem => _("Provider Control Policies")}}
 
     MiqPolicyController::UI_FOLDERS.collect do |model|
       text = text_i18n[mode.to_sym][model.name.to_sym]
@@ -50,8 +50,8 @@ class TreeBuilderPolicy < TreeBuilder
   # level 1 - compliance & control
   def x_get_tree_roots(count_only, _options)
     objects = []
-    objects << {:id => "compliance", :text => N_("Compliance Policies"), :icon => "pficon pficon-history", :tip => N_("Compliance Policies")}
-    objects << {:id => "control", :text => N_("Control Policies"), :icon => "fa fa-shield", :tip => N_("Control Policies")}
+    objects << {:id => "compliance", :text => _("Compliance Policies"), :icon => "pficon pficon-history", :tip => _("Compliance Policies")}
+    objects << {:id => "control", :text => _("Control Policies"), :icon => "fa fa-shield", :tip => _("Control Policies")}
 
     # Push folder node ids onto open_nodes array
     objects.each { |o| open_node("xx-#{o[:id]}") }

--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -18,7 +18,7 @@ class TreeBuilderPolicyProfile < TreeBuilder
   # level 0 - root
   def root_options
     {
-      :title   => t = N_("All Policy Profiles"),
+      :title   => t = _("All Policy Profiles"),
       :tooltip => t
     }
   end


### PR DESCRIPTION
Originally, the trees were supposed to use `N_` and do the actual translation in TreeBuilder.

That has since changed and now, TreeBuilders call `_` directly.

Fixing the old ones which still do `N_`.. :)

Cc @mzazrivec :)