### PR TITLE
Topology for Container Projects

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -16,16 +16,27 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
   $scope.d3 = d3;
 
   $scope.refresh = function() {
-    var id;
+    var id, type;
     var pathname = $window.location.pathname.replace(/\/$/, '');
-    if (pathname.match(/show$/)) {
+    if (pathname.match('/container_topology/show$')) {
+      // specifically the container_topology page - all container ems's
+      type = 'container_topology';
       id = '';
-    } else {
-      // search for pattern ^/<controler>/<id>$ in the pathname
-      id = '/' + (/^\/[^\/]+\/(\d+)$/.exec(pathname)[1]);
+    } else if (pathname.match('/(.+)/show/([0-9]+)')) {
+      // any container entity except the ems
+      // search for pattern ^/<controller>/show/<id>$ in the pathname - /container_project/show/11
+      var arr = pathname.match('/(.+)/show/([0-9]+)');
+      type = arr[1] + '_topology';
+      id = '/' + arr[2]
+    } else if (pathname.match('/(.+)/([0-9]+)')) {
+      // single entity topology of ems_container
+      // search for pattern ^/<controller>/<id>$ in the pathname - /ems_container/4
+      var arr = pathname.match('/(.+)/([0-9]+)');
+      type = 'container_topology';
+      id = '/' + arr[2]
     }
 
-    var url = '/container_topology/data' + id;
+    var url = '/' + type + '/data' + id;
 
     $http.get(url)
       .then(getContainerTopologyData)
@@ -254,6 +265,8 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
     switch (d.item.kind) {
       case "ContainerManager":
         return { x: -20, y: -20, r: 28 };
+      case "ContainerProject":
+        return { x: defaultDimensions.x, y: defaultDimensions.y, r: 28 };
       case "Container":
         return { x: 1, y: 5, r: 13 };
       case "ContainerGroup":

--- a/app/controllers/container_project_topology_controller.rb
+++ b/app/controllers/container_project_topology_controller.rb
@@ -1,0 +1,6 @@
+class ContainerProjectTopologyController < TopologyController
+  @layout = "container_topology"
+  @service_class = ContainerProjectTopologyService
+
+  menu_section :cnt
+end

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -17,6 +17,8 @@ module Mixins
         show_performance if respond_to?(:performance)
       when "compliance_history"
         show_compliance_history if respond_to?(:compliance_history)
+      when "topology"
+        show_topology
 
       # nested list methods as enabled by 'display_methods'
       when *self.class.display_methods

--- a/app/controllers/mixins/more_show_actions.rb
+++ b/app/controllers/mixins/more_show_actions.rb
@@ -27,6 +27,12 @@ module Mixins
       @showtype = @display
     end
 
+    def show_topology
+      @showtype = "topology"
+      drop_breadcrumb(:name => @record.name + _(" (Topology)"),
+                      :url  => show_link(@record, :display => "topology"))
+    end
+
     def update_session_for_compliance_history(count)
       @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, @record)
       session[:ch_tree] = @ch_tree.tree_nodes

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -73,7 +73,8 @@ module ApplicationHelper::PageLayouts
        (@layout == "report" && ["new", "create", "edit", "copy", "update", "explorer"].include?(controller.action_name))
       return false
     elsif %w(container_dashboard dashboard ems_infra_dashboard).include?(@layout) ||
-          (%w(dashboard topology).include?(@showtype) && @lastaction.ends_with?("_dashboard"))
+          (%w(dashboard).include?(@showtype) && @lastaction.ends_with?("_dashboard")) ||
+          %w(topology).include?(@showtype)
       # Dashboard tabs are located in taskbar because they are otherwise hidden behind the taskbar regardless of z-index
       return false
     end

--- a/app/helpers/application_helper/toolbar/container_project_view.rb
+++ b/app/helpers/application_helper/toolbar/container_project_view.rb
@@ -1,0 +1,21 @@
+class ApplicationHelper::Toolbar::ContainerProjectView < ApplicationHelper::Toolbar::Basic
+  button_group('container_project', [
+    twostate(
+      :view_summary,
+      'fa fa-th-list',
+      N_('Summary View'),
+      nil,
+      :url       => "/show",
+      :url_parms => ""
+    ),
+    twostate(
+      :view_topology,
+      'fa pficon-topology',
+      N_('Topology View'),
+      nil,
+      :url       => "/show",
+      :url_parms => "?display=topology",
+      :klass     => ApplicationHelper::Button::TopologyFeatureButton
+    )
+  ])
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -43,6 +43,8 @@ class ApplicationHelper::ToolbarChooser
       'drift_view_tb'
     elsif %w(ems_container ems_infra).include?(@layout) && %w(main dashboard topology).include?(@display)
       'dashboard_summary_toggle_view_tb'
+    elsif %w(container_project).include?(@layout)
+      "#{@layout}_view_tb"
     elsif !%w(all_tasks all_ui_tasks timeline diagnostics my_tasks my_ui_tasks miq_server usage).include?(@layout) &&
           (!@layout.starts_with?("miq_request")) && !@treesize_buttons &&
           @display == "main" && @showtype == "main" && !@in_a_form

--- a/app/services/container_project_topology_service.rb
+++ b/app/services/container_project_topology_service.rb
@@ -1,0 +1,38 @@
+class ContainerProjectTopologyService < TopologyService
+  include UiServiceMixin
+  include ContainerTopologyServiceMixin
+
+  @provider_class = ContainerProject
+
+  def build_topology
+    topo_items = {}
+    links = []
+
+    entity_relationships = { :ContainerProject => { :ContainerGroups => {
+                                                      :Containers          => nil,
+                                                      :ContainerReplicator => nil,
+                                                      :ContainerServices   => { :ContainerRoutes => nil },
+                                                      :ContainerNode      => { :lives_on => {:Host => nil}}
+                                                    }
+                                                  }
+                           }
+
+    preloaded = @providers.includes(:container_groups => [:containers,
+                                                          :container_replicator,
+                                                          :container_node => [:lives_on => [:host]],
+                                                          :container_services => [:container_routes]])
+
+    preloaded.each do |entity|
+      topo_items, links = build_recursive_topology(entity, entity_relationships[:ContainerProject], topo_items, links)
+    end
+
+    populate_topology(topo_items, links, build_kinds, icons)
+  end
+
+
+  def build_kinds
+    kinds = [:ContainerReplicator, :ContainerGroup, :Container, :ContainerNode,
+             :ContainerService, :Host, :Vm, :ContainerRoute, :ContainerManager, :ContainerProject]
+    build_legend_kinds(kinds)
+  end
+end

--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -1,5 +1,6 @@
 class ContainerTopologyService < TopologyService
   include UiServiceMixin
+  include ContainerTopologyServiceMixin
 
   @provider_class = ManageIQ::Providers::ContainerManager
 
@@ -20,68 +21,6 @@ class ContainerTopologyService < TopologyService
     end
 
     populate_topology(topo_items, links, build_kinds, icons)
-  end
-
-  def entity_display_type(entity)
-    if entity.kind_of?(ManageIQ::Providers::ContainerManager)
-      entity.class.short_token
-    elsif entity.kind_of?(ContainerGroup)
-      "Pod"
-    else
-      name = entity.class.name.demodulize
-      if name.start_with? "Container"
-        if name.length > "Container".length # container related entities such as ContainerService
-          name["Container".length..-1]
-        else
-          "Container" # the container entity itself
-        end
-      else
-        if entity.kind_of?(Vm)
-          name.upcase # turn Vm to VM because it's an abbreviation
-        else
-          name # non container entities such as Host
-        end
-      end
-    end
-  end
-
-  def build_entity_data(entity)
-    data = build_base_entity_data(entity)
-    data.merge!(:status       => entity_status(entity),
-                :display_kind => entity_display_type(entity))
-
-    if (entity.kind_of?(Host) || entity.kind_of?(Vm)) && entity.ext_management_system.present?
-      data.merge!(:provider => entity.ext_management_system.name)
-    end
-
-    data
-  end
-
-  def entity_status(entity)
-    if entity.kind_of?(Host) || entity.kind_of?(Vm)
-      status = entity.power_state.capitalize
-    elsif entity.kind_of?(ContainerNode)
-      node_ready_status = entity.container_conditions.find_by_name('Ready').try(:status)
-      status = case node_ready_status
-               when 'True'
-                 'Ready'
-               when 'False'
-                 'NotReady'
-               else
-                 'Unknown'
-               end
-    elsif entity.kind_of?(ContainerGroup)
-      status = entity.phase
-    elsif entity.kind_of?(Container)
-      status = entity.state.capitalize
-    elsif entity.kind_of?(ContainerReplicator)
-      status = (entity.current_replicas == entity.replicas) ? 'OK' : 'Warning'
-    elsif entity.kind_of?(ManageIQ::Providers::ContainerManager)
-      status = entity.authentications.empty? ? 'Unknown' : entity.default_authentication.status.capitalize
-    else
-      status = 'Unknown'
-    end
-    status
   end
 
   def build_kinds

--- a/app/services/container_topology_service_mixin.rb
+++ b/app/services/container_topology_service_mixin.rb
@@ -1,0 +1,63 @@
+module ContainerTopologyServiceMixin
+  def entity_display_type(entity)
+    if entity.kind_of?(ManageIQ::Providers::ContainerManager)
+      entity.class.short_token
+    elsif entity.kind_of?(ContainerGroup)
+      "Pod"
+    else
+      name = entity.class.name.demodulize
+      if name.start_with? "Container"
+        if name.length > "Container".length # container related entities such as ContainerService
+          name["Container".length..-1]
+        else
+          "Container" # the container entity itself
+        end
+      else
+        if entity.kind_of?(Vm)
+          name.upcase # turn Vm to VM because it's an abbreviation
+        else
+          name # non container entities such as Host
+        end
+      end
+    end
+  end
+
+  def build_entity_data(entity)
+    data = build_base_entity_data(entity)
+    data.merge!(:status       => entity_status(entity),
+                :display_kind => entity_display_type(entity))
+
+    if (entity.kind_of?(Host) || entity.kind_of?(Vm)) && entity.ext_management_system.present?
+      data.merge!(:provider => entity.ext_management_system.name)
+    end
+
+    data
+  end
+
+  def entity_status(entity)
+    if entity.kind_of?(Host) || entity.kind_of?(Vm)
+      status = entity.power_state.capitalize
+    elsif entity.kind_of?(ContainerNode)
+      node_ready_status = entity.container_conditions.find_by_name('Ready').try(:status)
+      status = case node_ready_status
+                 when 'True'
+                   'Ready'
+                 when 'False'
+                   'NotReady'
+                 else
+                   'Unknown'
+               end
+    elsif entity.kind_of?(ContainerGroup)
+      status = entity.phase
+    elsif entity.kind_of?(Container)
+      status = entity.state.capitalize
+    elsif entity.kind_of?(ContainerReplicator)
+      status = (entity.current_replicas == entity.replicas) ? 'OK' : 'Warning'
+    elsif entity.kind_of?(ManageIQ::Providers::ContainerManager)
+      status = entity.authentications.empty? ? 'Unknown' : entity.default_authentication.status.capitalize
+    else
+      status = 'Unknown'
+    end
+    status
+  end
+end

--- a/app/views/container_project/show.html.haml
+++ b/app/views/container_project/show.html.haml
@@ -6,3 +6,5 @@
   = render :partial => "layouts/performance_async"
 - elsif @showtype == "main"
   = render :partial => "layouts/textual_groups_generic"
+- elsif @showtype == "topology"
+  = render :file => 'container_topology/show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -984,6 +984,13 @@ Rails.application.routes.draw do
       )
     },
 
+    :container_project_topology => {
+      :get => %w(
+        show
+        data
+      )
+    },
+
     :middleware_topology       => {
       :get => %w(
         show


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1426229
From projects summary page click on the topology view toggle button:
![screencapture-localhost-3000-container_project-show-7-1484060335913](https://cloud.githubusercontent.com/assets/11256940/21810827/0a357382-d756-11e6-8b95-4e38e4549aee.png)

Land here:
![screencapture-localhost-3000-container_project-show-7-1484060193857](https://cloud.githubusercontent.com/assets/11256940/21810788/dd72875e-d755-11e6-96e9-102ffc7a9d6a.png)

@martinpovolny PTAL, I remember you refactored topology recently
  * `ContainerProjectTopologyService` is `ContainerTopologyService` with a different `build_topology` method but i can throw the shared code into a mixin. I also couldnt get around creating `ContainerProjectTopologyController` which is more of the same.
  * we should probably have a system in `toolbar_chooser` to figure out which entities have topology\dashboard views and show the upper right toolbar icons accordingly. Im guessing a `role_allows?(:feature => 'topologyview')`


cc @simon3z 
@miq-bot add_label topology, providers/containers, ui, wip
