### PR TITLE
Remove dead @tree_vms, @tree_hosts, build_vm_host_array

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2166,11 +2166,6 @@ class ApplicationController < ActionController::Base
     @sb[:detail_sortcol] = @detail_sortcol
     @sb[:detail_sortdir] = @detail_sortdir
 
-    @sb[:tree_hosts_hash] = nil if !%w(ems_folders descendant_vms).include?(params[:display]) &&
-                                   !%w(treesize tree_autoload).include?(params[:action])
-    @sb[:tree_vms_hash] = nil if !%w(ems_folders descendant_vms).include?(params[:display]) &&
-                                 !%w(treesize tree_autoload).include?(params[:action])
-
     # Set/clear sandbox (@sb) per controller in the session object
     session[:sandboxes] ||= HashWithIndifferentAccess.new
     session[:sandboxes][controller_name] = @sb.blank? ? nil : copy_hash(@sb)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -296,11 +296,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def build_vm_host_array
-    @tree_hosts = Host.where(:id => (@sb[:tree_hosts_hash] || {}).keys)
-    @tree_vms   = Vm.where(:id => (@sb[:tree_vms_hash] || {}).keys)
-  end
-
   # Common method to show a standalone report
   def report_only
     @report_only = true                 # Indicate stand alone report for views

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -49,8 +49,7 @@ class HostController < ApplicationController
       drop_breadcrumb(:name => _("%{name} (Network)") % {:name => @host.name},
                       :url  => "/host/show/#{@host.id}?display=network")
 
-      @tree_vms = []
-      @network_tree = TreeBuilderNetwork.new(:network_tree, :network, @sb, true, @host, @tree_vms)
+      @network_tree = TreeBuilderNetwork.new(:network_tree, :network, @sb, true, @host)
       self.x_active_tree = :network_tree
 
     when "performance"

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -6,9 +6,8 @@ class TreeBuilderNetwork < TreeBuilder
     node[:cfmeNoClick] = true unless node[:image].include?('100/currentstate-')
   end
 
-  def initialize(name, type, sandbox, build = true, root = nil, vm_kids = [])
+  def initialize(name, type, sandbox, build = true, root = nil)
     sandbox[:network_root] = TreeBuilder.build_node_id(root) if root
-    @tree_vms = vm_kids
     @root = root
     unless @root
       model, id = TreeBuilder.extract_node_model_and_id(sandbox[:network_root])
@@ -55,7 +54,6 @@ class TreeBuilderNetwork < TreeBuilder
     if parent.respond_to?("vms_and_templates") && parent.vms_and_templates.present?
       kids = count_only_or_objects(count_only, parent.vms_and_templates, "name")
     end
-    @tree_vms.concat(kids) unless count_only
     kids
   end
 end

--- a/spec/presenters/tree_builder_network_spec.rb
+++ b/spec/presenters/tree_builder_network_spec.rb
@@ -13,6 +13,7 @@ describe TreeBuilderNetwork do
       network = FactoryGirl.create(:host, :switches => [switch])
       @network_tree = TreeBuilderNetwork.new(:network_tree, :network, {}, true, network)
     end
+
     it 'returns Host as root' do
       root = @network_tree.send(:root_options)
       expect(root).to eq(
@@ -22,21 +23,25 @@ describe TreeBuilderNetwork do
         :cfmeNoClick => true
       )
     end
+
     it 'returns Switch as root child' do
       kid = @network_tree.send(:x_get_tree_roots, false)
       expect(kid.first).to be_a_kind_of(Switch)
     end
+
     it 'returns GuestDevice and Lan as Switch children' do
       parent = @network_tree.send(:x_get_tree_roots, false).first
       kids = @network_tree.send(:x_get_tree_switch_kids, parent, false)
       expect(kids[0]).to be_a_kind_of(GuestDevice)
       expect(kids[1]).to be_a_kind_of(Lan)
     end
+
     it 'returns Vm as Lan child' do
       parent = @network_tree.send(:x_get_tree_roots, false).first.lans.first
       kid = @network_tree.send(:x_get_tree_lan_kids, parent, false)
       expect(kid.first).to be_a_kind_of(Vm)
     end
+
     it 'returns nothing as GuestDevice child' do
       parent = @network_tree.send(:x_get_tree_roots, false).first.guest_devices.first
       number_of_kids = @network_tree.send(:x_get_tree_objects, parent, {}, true, nil)


### PR DESCRIPTION
Not useful outside of vm_common, and there, it is being removed in #14.

`build_vm_host_array` is never called

`TreeBuilderNetwork` only appends to `@tree_vms`, without ever reading it.

Cc @ZitaNemeckova (thanks for the find.. :))