### PR TITLE
Add special handling for `image?` column in ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -895,6 +895,8 @@ class ApplicationController < ActionController::Base
           celltext = row[col].titleize
         when 'hardware.bitness'
           celltext = row[col] ? "#{row[col]} bit" : ''
+        when 'image?'
+          celltext = row[col] ? _("Image") : _("Snapshot")
         else
           # Use scheduled tz for formatting, if configured
           if ['miqschedule'].include?(view.db.downcase)


### PR DESCRIPTION
This allows views using the `image?` predicate to display the column properly.

Relies on https://github.com/ManageIQ/manageiq/pull/12970, which this change was split from.