### PR TITLE
Fix placeholders

### DIFF
--- a/locale/es/ManageIQ_UI_Classic.po
+++ b/locale/es/ManageIQ_UI_Classic.po
@@ -30286,7 +30286,7 @@ msgstr "No hay paneles definidos para este grupo. Se mostrará el panel predeter
 
 #: ../app/views/report/_db_list.html.haml:99
 msgid "Click to view '%{widgetset_description} (%{widgetset_name})'"
-msgstr "Haga clic para ver '%{asistenteset_description} (%{asistenteset_name})'"
+msgstr "Haga clic para ver '%{widgetset_description} (%{widgetset_name})'"
 
 #: ../app/views/report/_db_seq_form.html.haml:11
 msgid "Dashboards:"

--- a/locale/zh_CN/ManageIQ_UI_Classic.po
+++ b/locale/zh_CN/ManageIQ_UI_Classic.po
@@ -6097,7 +6097,7 @@ msgstr "已删除数据源"
 #: ../app/controllers/middleware_deployment_controller.rb:31
 #: ../app/controllers/middleware_deployment_controller.rb:38
 msgid "Not %{operation_name} for %{record_name} on the provider itself"
-msgstr "不是供应商中用于 %{page_number} 的 %{operation_name} "
+msgstr "不是供应商中用于 %{record_name} 的 %{operation_name} "
 
 #: ../app/controllers/middleware_datasource_controller.rb:18
 msgid "The selected datasources were removed"


### PR DESCRIPTION
These mismatching placeholders are causing the build on the main repo to
fail:

```
>> /home/tim/src/manageiq/vendor/bundle/ruby/2.3.0/bundler/gems/manageiq-ui-classic-f62afc96e703/locale/zh_CN/ManageIQ_UI_Classic.po
Not %{operation_name} for %{record_name} on the provider itself
不是供应商中用于 %{page_number} 的 %{operation_name}

>> /home/tim/src/manageiq/vendor/bundle/ruby/2.3.0/bundler/gems/manageiq-ui-classic-f62afc96e703/locale/es/ManageIQ_UI_Classic.po
Click to view '%{widgetset_description} (%{widgetset_name})'
Haga clic para ver '%{asistenteset_description} (%{asistenteset_name})'

F

Failures:

  1) Placeholders in strings translations preserve placeholders in strings
     Failure/Error: expect(errors).to be_empty
       expected `{"/home/tim/src/manageiq/vendor/bundle/ruby/2.3.0/bundler/gems/manageiq-ui-classic-f62afc96e703/local...} (%{widgetset_name})'"=>"Haga clic para ver '%{asistenteset_description} (%{asistenteset_name})'"}}.empty?` to return true, got false
     # ./spec/i18n/placeholders_spec.rb:44:in `block (2 levels) in <top (required)>'

Finished in 2.53 seconds (files took 5.04 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/i18n/placeholders_spec.rb:2 # Placeholders in strings translations preserve placeholders in strings

```