### PR TITLE
Fix missing tree view in Datastore Clusters accordion

### DIFF
--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -622,6 +622,9 @@ class StorageController < ApplicationController
   end
 
   def display_adv_searchbox
+    if !@record.nil? && @record[:type] == 'StorageCluster'
+      return false
+    end
     !(@in_a_form || (x_active_tree == :storage_tree && @record) || (x_active_tree == :storage_pod_tree && (x_node == 'root' || @storage)))
   end
 


### PR DESCRIPTION
fixing  https://bugzilla.redhat.com/show_bug.cgi?id=1404259

Fix missing tree view in Datastore Clusters accordion in
Compute -> Infrastructure -> Datastores -> Datastore Clusters
by removing Advanced searchbox which should not be available
when reaching Datastore Clusters accordion. Advanced search
should only be available on Datastores accordion that displays
filters in tree.

This bug is fixed by adding a condition to `display_adv_searchbox` method
in storage controller which has a role to hide/show advanced searchbox.
Originally it was designed to show advanced searchbox all the time in
Compute -> Infrastructure -> Datastores .

This bug was also mentioned in https://github.com/ManageIQ/manageiq/pull/13140

Before:
![datastore_clusters](https://cloud.githubusercontent.com/assets/13417815/21852365/18474492-d813-11e6-845f-a9834f250d07.png)

After:
![datastore_clusters2](https://cloud.githubusercontent.com/assets/13417815/21852486/8a0af074-d813-11e6-869f-e75ef099bc43.png)
