### PR TITLE
Refactor x button in container controller

### DIFF
--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -154,9 +154,8 @@ class ContainerController < ApplicationController
     # resetting action that was stored during edit to determine what is being edited
     @sb[:action] = nil
     if x_node == "root" || TreeBuilder.get_model_for_prefix(@nodetype) == "MiqSearch"
-      typ = "Container"
       process_show_list(:where_clause => 'containers.deleted_on IS NULL')
-      @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => typ)}
+      @right_cell_text = _("All Containers")
     else
       show_record(from_cid(id))
       @right_cell_text = _("%{model} \"%{name}\" (Summary)") % {
@@ -183,7 +182,7 @@ class ContainerController < ApplicationController
     case action
     when "tag"
       partial = "layouts/tagging"
-      header = _("Edit Tags for %{model}") % {:model => ui_lookup(:model => "Container")}
+      header = _("Edit Tags for Container")
       action = "container_tag"
     when "perf"
       partial = "layouts/performance"

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -7,8 +7,6 @@ class ContainerController < ApplicationController
   after_action :set_session_data
 
   CONTAINER_X_BUTTON_ALLOWED_ACTIONS = {
-    'container_delete'   => :container_delete,
-    'container_edit'     => :container_edit,
     'container_tag'      => :container_tag,
     'container_timeline' => :show_timeline,
     'container_perf'     => :show
@@ -26,7 +24,6 @@ class ContainerController < ApplicationController
     model, action = pressed2model_action(params[:pressed])
 
     performed_action = generic_x_button(CONTAINER_X_BUTTON_ALLOWED_ACTIONS)
-    return if [:container_delete, :container_edit].include?(performed_action)
 
     if @refresh_partial
       replace_right_cell(:action => action)
@@ -192,11 +189,6 @@ class ContainerController < ApplicationController
   # set partial name and cell header for edit screens
   def set_right_cell_vars(action)
     case action
-    when "container_edit"
-      partial = "container_form"
-      header = _("Editing %{model} \"%{name}\"") % {:name  => @record.name,
-                                                    :model => ui_lookup(:model => "Container")}
-      action = "container_edit"
     when "tag"
       partial = "layouts/tagging"
       header = _("Edit Tags for %{model}") % {:model => ui_lookup(:model => "Container")}
@@ -236,7 +228,7 @@ class ContainerController < ApplicationController
 
     replace_trees_by_presenter(presenter, trees)
 
-    if action == "container_edit" || action == "tag"
+    if action == "tag"
       presenter.update(:main_div, r[:partial => partial])
     elsif params[:display]
       partial_locals = {:controller => "container", :action_url => @lastaction}

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -12,12 +12,6 @@ class ContainerController < ApplicationController
     'container_perf'     => :show_performance
   }
 
-  def button
-    custom_buttons if params[:pressed] == "custom_button"
-    # custom button screen, so return, let custom_buttons method handle everything
-    return if ["custom_button"].include?(params[:pressed])
-  end
-
   def x_button
     generic_x_button(CONTAINER_X_BUTTON_ALLOWED_ACTIONS)
   end

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -64,7 +64,7 @@ class ContainerController < ApplicationController
 
   # ST clicked on in the explorer right cell
   def x_show
-    get_tagdata(Container.find_by_id(from_cid(params[:id])))
+    get_tagdata(Container.find(from_cid(params[:id])))
     identify_container(from_cid(params[:id]))
     generic_x_show(x_tree(:containers_tree))
   end
@@ -129,7 +129,7 @@ class ContainerController < ApplicationController
   def show_timeline
     @showtype = "timeline"
     session[:tl_record_id] = params[:id]
-    @record = Container.find_by_id(from_cid(params[:id]))
+    @record = Container.find(from_cid(params[:id]))
     @timeline = @timeline_filter = true
     @lastaction = "show_timeline"
     tl_build_timeline # Create the timeline report

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -551,7 +551,6 @@ Rails.application.routes.draw do
       :post => %w(
         accordion_select
         button
-        container_edit
         container_form_field_changed
         explorer
         tl_chooser

--- a/spec/controllers/container_controller_spec.rb
+++ b/spec/controllers/container_controller_spec.rb
@@ -40,6 +40,7 @@ describe ContainerController do
     end
 
     it "builds tagging screen" do
+      controller.instance_variable_set(:@explorer, true)
       post :x_button, :params => { :pressed => "container_tag", :format => :js, :id => @ct.id }
       expect(assigns(:flash_array)).to be_nil
       expect(assigns(:entries)).not_to be_nil


### PR DESCRIPTION
* Remove unused `container_edit` & `container_delete` actions (they're not implemented)
* Refactor `x_button()` in `ContainerController`
    * `split show()` into `show()` and `show_performance()`
    * refactor `container_tag()`
    * make routines private wherever possible
* Don't use `ui_lookup()` on static string
* Remove button() from ContainerController: it was was handling custom buttons, which we currently
cannot define for Containers.
