### PR TITLE
Use task queue for CRUD operations on auth key pair

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,7 @@ Rails.application.routes.draw do
         show_list
         tagging_edit
         tag_edit_form_field_changed
+        wait_for_task
       ) + adv_search_post + compare_post + exp_post + save_post
     },
 


### PR DESCRIPTION
Uses task queue instead of making direct provider API calls from the UI. This PR contains the necessary UI changes.

Depends on model changes in https://github.com/ManageIQ/manageiq/pull/13464