### PR TITLE
Remove `#html_safe` from Policy Simulation Results tree tooltips

### DIFF
--- a/app/presenters/tree_builder_policy_simulation_results.rb
+++ b/app/presenters/tree_builder_policy_simulation_results.rb
@@ -93,7 +93,7 @@ class TreeBuilderPolicySimulationResults < TreeBuilder
     name, tip = exp_build_string(data)
     {:id          => nil,
      :text        => prefixed_title(_('Scope'), name),
-     :tip         => tip.html_safe,
+     :tip         => tip,
      :icon        => node_icon(data[:result]),
      :cfmeNoClick => true}
   end
@@ -110,7 +110,7 @@ class TreeBuilderPolicySimulationResults < TreeBuilder
             end
     {:id          => nil,
      :text        => prefixed_title(_('Expression'), name),
-     :tip         => tip.html_safe,
+     :tip         => tip,
      :icon        => image,
      :cfmeNoClick => true}
   end


### PR DESCRIPTION
We don't need this because of the [stripping of html tags](https://github.com/ManageIQ/manageiq-ui-classic/pull/87/files#diff-1ac22d1566c1df0e8e5d76f6e7eeb65bR68) introduced by #87 