### PR TITLE
Add Dashboard settings to General

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1426,6 +1426,10 @@ class ApplicationController < ActionController::Base
     gtl_type
   end
 
+  def dashboard_view
+    false
+  end
+
   def get_view_process_search_text(view)
     # Check for new search by name text entered
     if params[:search] &&

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -102,7 +102,6 @@ class ConfigurationController < ApplicationController
   # AJAX driven routine for gtl view selection
   def view_selected
     # ui2 form
-    binding.pry
     return unless load_edit("config_edit__ui2", "configuration")
     @edit[:new][:views][VIEW_RESOURCES[params[:resource]]] = params[:view] # Capture the new view setting
     @edit[:new][:display][:display_vms] = params[:display_vms] == 'true' if params.key?(:display_vms)

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -102,6 +102,7 @@ class ConfigurationController < ApplicationController
   # AJAX driven routine for gtl view selection
   def view_selected
     # ui2 form
+    binding.pry
     return unless load_edit("config_edit__ui2", "configuration")
     @edit[:new][:views][VIEW_RESOURCES[params[:resource]]] = params[:view] # Capture the new view setting
     @edit[:new][:display][:display_vms] = params[:display_vms] == 'true' if params.key?(:display_vms)

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -38,7 +38,13 @@ module EmsCommon
     @showtype = "dashboard"
     @lastaction = "show_dashboard"
     drop_breadcrumb(:name => @ems.name + _(" (Dashboard)"), :url => show_link(@ems))
+    @sb[:summary_mode] = 'dashboard' unless @sb[:summary_mode] == 'dashboard'
     render :action => "show_dashboard"
+  end
+
+  def show_main
+    @sb[:summary_mode] = 'textual' unless @sb[:summary_mode] == 'textual'
+    super
   end
 
   def show_ad_hoc_metrics
@@ -118,6 +124,10 @@ module EmsCommon
     view_setup_helper(display, *view_setup_params[display])
   end
 
+  def dashboard_view
+    false
+  end
+
   def show
     return unless init_show
     session[:vm_summary_cool] = (settings(:views, :vm_summary_cool).to_s == "summary")
@@ -125,7 +135,6 @@ module EmsCommon
     @ems = @record
 
     drop_breadcrumb({:name => ui_lookup(:tables => @table_name), :url => "/#{@table_name}/show_list?page=#{@current_page}&refresh=y"}, true)
-
     case params[:display]
     when 'main'                          then show_main
     when 'download_pdf', 'summary_only'  then show_download
@@ -140,7 +149,7 @@ module EmsCommon
       if pagination_or_gtl_request? # pagination controls
         show_entities(@display) # display loaded from session
       else                 # or default display
-        show_main
+        dashboard_view ? show_dashboard : show_main
       end
     else show_entities(params[:display])
     end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -124,10 +124,6 @@ module EmsCommon
     view_setup_helper(display, *view_setup_params[display])
   end
 
-  def dashboard_view
-    false
-  end
-
   def show
     return unless init_show
     session[:vm_summary_cool] = (settings(:views, :vm_summary_cool).to_s == "summary")

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -4,6 +4,7 @@ class EmsContainerController < ApplicationController
   include EmsCommon        # common methods for EmsInfra/Cloud/Container controllers
   include Mixins::EmsCommonAngular
   include Mixins::GenericSessionMixin
+  include Mixins::DashboardViewMixin
 
   before_action :check_privileges
   before_action :get_session_data
@@ -16,14 +17,6 @@ class EmsContainerController < ApplicationController
 
   def self.table_name
     @table_name ||= "ems_container"
-  end
-
-  def dashboard_view
-    if @sb[:summary_mode].present?
-      @sb[:summary_mode] == 'dashboard'
-    else
-      current_user[:settings][:views][:summary_mode] == 'dashboard'
-    end
   end
 
   def show_list

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -18,6 +18,14 @@ class EmsContainerController < ApplicationController
     @table_name ||= "ems_container"
   end
 
+  def dashboard_view
+    if @sb[:summary_mode].present?
+      @sb[:summary_mode] == 'dashboard'
+    else
+      current_user[:settings][:views][:summary_mode] == 'dashboard'
+    end
+  end
+
   def show_list
     process_show_list(:gtl_dbname => 'emscontainer')
   end

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -3,6 +3,7 @@ class EmsInfraController < ApplicationController
   include Mixins::GenericShowMixin
   include EmsCommon        # common methods for EmsInfra/Cloud controllers
   include Mixins::EmsCommonAngular
+  include Mixins::DashboardViewMixin
 
   before_action :check_privileges
   before_action :get_session_data
@@ -23,14 +24,6 @@ class EmsInfraController < ApplicationController
 
   def new_ems_path
     new_ems_infra_path
-  end
-
-  def dashboard_view
-    if @sb[:summary_mode].present?
-      @sb[:summary_mode] == 'dashboard'
-    else
-      current_user[:settings][:views][:summary_mode] == 'dashboard'
-    end
   end
 
   def index

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -25,6 +25,14 @@ class EmsInfraController < ApplicationController
     new_ems_infra_path
   end
 
+  def dashboard_view
+    if @sb[:summary_mode].present?
+      @sb[:summary_mode] == 'dashboard'
+    else
+      current_user[:settings][:views][:summary_mode] == 'dashboard'
+    end
+  end
+
   def index
     redirect_to :action => 'show_list'
   end

--- a/app/controllers/mixins/dashboard_view_mixin.rb
+++ b/app/controllers/mixins/dashboard_view_mixin.rb
@@ -1,0 +1,11 @@
+module Mixins
+  module DashboardViewMixin
+    def dashboard_view
+      if @sb[:summary_mode].present?
+        @sb[:summary_mode] == 'dashboard'
+      else
+        (@settings.fetch_path(:views, :summary_mode) || "dashboard") == 'dashboard'
+      end
+    end
+  end
+end

--- a/app/helpers/application_helper/toolbar/dashboard_summary_toggle_view.rb
+++ b/app/helpers/application_helper/toolbar/dashboard_summary_toggle_view.rb
@@ -13,7 +13,8 @@ class ApplicationHelper::Toolbar::DashboardSummaryToggleView < ApplicationHelper
       N_('Summary View'),
       nil,
       :url       => "/",
-      :url_parms => ""),
+      :url_parms => "?display=main"
+    ),
     twostate(
       :view_topology,
       'fa pficon-topology',

--- a/app/helpers/configuration_helper/configuration_view_helper.rb
+++ b/app/helpers/configuration_helper/configuration_view_helper.rb
@@ -1,7 +1,6 @@
 module ConfigurationHelper
   module ConfigurationViewHelper
     def render_view_buttons(resource, view)
-      #binding.pry
       (case resource
        when :compare, :drift
          view == "compressed" ? compare_or_drift_compressed(resource) : compare_or_drift_expanded(resource)
@@ -10,7 +9,6 @@ module ConfigurationHelper
        when :treesize
          view == "20" ? treesize_small : treesize_large
        when :summary_mode
-         #binding.pry
          view == "dashboard" ? summary_mode_dashboard(resource) : summary_mode_textual(resource)
        else
          case view

--- a/app/helpers/configuration_helper/configuration_view_helper.rb
+++ b/app/helpers/configuration_helper/configuration_view_helper.rb
@@ -1,6 +1,7 @@
 module ConfigurationHelper
   module ConfigurationViewHelper
     def render_view_buttons(resource, view)
+      #binding.pry
       (case resource
        when :compare, :drift
          view == "compressed" ? compare_or_drift_compressed(resource) : compare_or_drift_expanded(resource)
@@ -8,6 +9,9 @@ module ConfigurationHelper
          view == "details" ? compare_or_drift_mode_details(resource) : compare_or_drift_mode_exists(resource)
        when :treesize
          view == "20" ? treesize_small : treesize_large
+       when :summary_mode
+         #binding.pry
+         view == "dashboard" ? summary_mode_dashboard(resource) : summary_mode_textual(resource)
        else
          case view
          when "grid" then grid_view(resource)
@@ -56,6 +60,16 @@ module ConfigurationHelper
     def compare_or_drift_mode_details(resource)
       active_icon("fa fa-bars fa-rotate-90", _('Details Mode')) +
         inactive_icon("product product-exists", _('Exists Mode'), resource, "exists")
+    end
+
+    def summary_mode_textual(resource)
+      inactive_icon("fa fa-tachometer fa-1xplus", _('Dashboard View'), resource, "dashboard") +
+        active_icon("fa fa-th-list", _('Textual View'))
+    end
+
+    def summary_mode_dashboard(resource)
+      active_icon("fa fa-tachometer fa-1xplus", _('Dashboard View')) +
+        inactive_icon("fa fa-th-list", _('Textual View'), resource, "textual")
     end
 
     def treesize_small

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -245,6 +245,7 @@ module UiConstants
       :scanhistory                              => "list",
       :snialocalfilesystem                      => "list",
       :storage_files                            => "list",
+      :summary_mode                             => "dashboard",
       :registryitems                            => "list",
       :serverbuild                              => "list",
       :storage                                  => "grid",

--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -15,7 +15,8 @@
              :compare      => _('Compare'),
              :compare_mode => _('Compare Mode'),
              :drift        => _('Drift'),
-             :drift_mode   => _('Drift Mode')}.each do |resource, view_name|
+             :drift_mode   => _('Drift Mode'),
+             :summary_mode => _('Summary Screens')}.each do |resource, view_name|
             .form-group
               %label.col-md-3.control-label
                 #{view_name}

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -21,11 +21,9 @@ describe EmsContainerController do
     context "render" do
       subject { get :show, :params => { :id => @container.id } }
       render_views
-      it { is_expected.to render_template('shared/views/ems_common/show') }
-
       it do
         is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_ems_container")
+        is_expected.to render_template(:partial => 'ems_container/_show_dashboard')
       end
 
       it "renders topology view" do

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -310,7 +310,7 @@ describe EmsInfraController do
 
       it do
         is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_ems_infra")
+        is_expected.not_to render_template(:partial => "layouts/listnav/_ems_infra")
       end
     end
 
@@ -413,7 +413,7 @@ describe EmsInfraController do
         breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
         expect(breadcrumbs).to eq([{:name => "Infrastructure Providers",
                                     :url  => "/ems_infra/show_list?page=&refresh=y"},
-                                   {:name => "#{ems.name} (Summary)",
+                                   {:name => "#{ems.name} (Dashboard)",
                                     :url  => "/ems_infra/#{ems.id}"}])
       end
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1613907/stories/137402263

Add option to Summary Screen:
<img width="244" alt="screen shot 2017-01-12 at 3 47 39 pm" src="https://cloud.githubusercontent.com/assets/9210860/21894179/85565c50-d8de-11e6-8d9b-9c4aba15eef9.png">

Default value is `Dashboard`.

If user changes it on provider's summary page to textual it's remembered for that page in session(lost after logging out).

@miq-bot add_label wip