### PR TITLE
Filter Recent VMs/Hosts charts by provider

### DIFF
--- a/app/services/ems_infra_dashboard_service.rb
+++ b/app/services/ems_infra_dashboard_service.rb
@@ -129,7 +129,7 @@ class EmsInfraDashboardService
   def recentHosts
     # Get recent hosts
     all_hosts = Hash.new(0)
-    hosts = Host.where('created_on > ?', 30.day.ago.utc)
+    hosts = Host.where('created_on > ? and ems_id = ?', 30.days.ago.utc, @ems.id)
     hosts = hosts.includes(:resource => [:ext_management_system]) unless @ems.present?
     hosts.sort_by { |h| h.created_on }.uniq.each do |h|
       date = h.created_on.strftime("%Y-%m-%d")
@@ -145,7 +145,7 @@ class EmsInfraDashboardService
   def recentVms
     # Get recent VMs
     all_vms = Hash.new(0)
-    vms = VmOrTemplate.where('created_on > ?', 30.day.ago.utc)
+    vms = VmOrTemplate.where('created_on > ? and ems_id = ?', 30.days.ago.utc, @ems.id)
     vms = vms.includes(:resource => [:ext_management_system]) unless @ems.present?
     vms.sort_by { |v| v.created_on }.uniq.each do |v|
       date = v.created_on.strftime("%Y-%m-%d")

--- a/spec/services/ems_infra_dashboard_service_spec.rb
+++ b/spec/services/ems_infra_dashboard_service_spec.rb
@@ -1,0 +1,29 @@
+describe EmsInfraDashboardService do
+  context '#recentVms' do
+    before(:each) do
+      @ems1 = FactoryGirl.create(:ems_infra)
+      @vm1 = FactoryGirl.create(:vm_infra, :ext_management_system => @ems1)
+      @vm2 = FactoryGirl.create(:vm_infra, :ext_management_system => @ems1, :created_on => 1.day.ago.utc)
+
+      @host1 = FactoryGirl.create(:host, :ext_management_system => @ems1)
+      @host2 = FactoryGirl.create(:host, :ext_management_system => @ems1, :created_on => 1.day.ago.utc)
+
+      @ems2 = FactoryGirl.create(:ems_infra)
+      @vm3 = FactoryGirl.create(:vm_infra, :ext_management_system => @ems2)
+
+      @host4 = FactoryGirl.create(:host, :ext_management_system => @ems2)
+    end
+
+    subject { EmsInfraDashboardService.new(@ems1.id, "ems_infra") }
+
+    it 'returns vms for a specified provider' do
+      expect(subject.recentVms[:xData].count).to eq(2)
+      expect(subject.recentVms[:yData].count).to eq(2)
+    end
+
+    it 'returns hosts for a specified provider' do
+      expect(subject.recentHosts[:xData].count).to eq(2)
+      expect(subject.recentHosts[:yData].count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
On Infrastructure Provider Dashboard view, Recent hosts and Recent VMs should be filtered by selected provider.

https://bugzilla.redhat.com/show_bug.cgi?id=1410251

before:
![dashboard_infra_before](https://cloud.githubusercontent.com/assets/3450808/21900454/d22436b4-d8c1-11e6-97f5-04a917c883b2.png)

after:
![dashboard_infra_after](https://cloud.githubusercontent.com/assets/3450808/21900459/d6f17d3c-d8c1-11e6-908a-0dd8d1f4d0cb.png)

@dclarizio please review.