### PR TITLE
Tenant admin should not be able to create groups in other tenants.

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1027,6 +1027,11 @@ module OpsController::OpsRbac
     valid
   end
 
+  def valid_tenant?(tenant_id)
+    all_tenants, = Tenant.tenant_and_project_names
+    all_tenants.include?(tenant_id)
+  end
+
   # Get variables from group edit form
   def rbac_group_get_form_vars
     if %w(up down).include?(params[:button])
@@ -1036,7 +1041,15 @@ module OpsController::OpsRbac
       @edit[:new][:ldap_groups_user] = params[:ldap_groups_user]  if params[:ldap_groups_user]
       @edit[:new][:description]      = params[:description]       if params[:description]
       @edit[:new][:role]             = params[:group_role]        if params[:group_role]
-      @edit[:new][:group_tenant]     = params[:group_tenant].to_i if params[:group_tenant]
+
+      if params[:group_tenant]
+        if valid_tenant?(new_tenant_id = params[:group_tenant].to_i)
+          @edit[:new][:group_tenant] = new_tenant_id
+        else
+          raise "Invalid tenant selected."
+        end
+      end
+
       @edit[:new][:lookup]           = (params[:lookup] == "1")   if params[:lookup]
       @edit[:new][:user]             = params[:user]              if params[:user]
       @edit[:new][:user_id]          = params[:user_id]           if params[:user_id]


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-ui-classic/issues/134

This is only a part of the fix. The 2nd part needs fixing on the
manageiq core side: https://github.com/ManageIQ/manageiq/pull/13483