### PR TITLE
Move spec/services from main repo to classic UI repo

### DIFF
--- a/spec/services/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/services/ansible_tower_job_template_dialog_service_spec.rb
@@ -1,0 +1,91 @@
+describe AnsibleTowerJobTemplateDialogService do
+  let(:template) { FactoryGirl.create(:configuration_script) }
+
+  describe "#create_dialog" do
+    it "creates a dialog from a job template" do
+      survey =
+        "{\"spec\":[{\"index\": 0, \"question_name\": \"Param1\", \"min\": 10, \
+        \"default\": \"19\", \"max\": 100, \"question_description\": \"param 1\", \"required\": true, \"variable\": \
+        \"param1\", \"choices\": \"\", \"type\": \"integer\"}, {\"index\": 1, \"question_name\": \"Param2\", \"min\": \
+        2, \"default\": \"as\", \"max\": 5, \"question_description\": \"param 2\", \"required\": true, \"variable\": \
+        \"param2\", \"choices\": \"\", \"type\": \"text\"}, {\"index\": 2, \"question_name\": \"Param3\", \"min\": \
+        \"\", \"default\": \"no\\nhello\", \"max\": \"\", \"question_description\": \"param 3\", \"required\": false, \
+        \"variable\": \"param3\", \"choices\": \"\", \"type\": \"textarea\"}, {\"index\": 3, \"question_name\": \
+        \"Param4\", \"min\": \"\", \"default\": \"mypassword\", \"max\": \"\", \"question_description\": \"param 4\", \
+        \"required\": true, \"variable\": \"param4\", \"choices\": \"\", \"type\": \"password\"}, {\"index\": 4, \
+        \"question_name\": \"Param5\", \"min\": \"\", \"default\": \"Peach\", \"max\": \"\", \"question_description\": \
+        \"param 5\", \"required\": true, \"variable\": \"param5\", \"choices\": \"Apple\\nBanana\\nPeach\", \"type\": \
+        \"multiplechoice\"}, {\"index\": 5, \"question_description\": \"param 6\", \"min\": \"\", \"default\": \
+        \"opt1\\n222\", \"max\": \"\", \"question_name\": \"Param6\", \"required\": true, \"variable\": \"param6\", \
+        \"choices\": \"opt1\\n222\\nopt3\", \"type\": \"multiselect\"}, {\"index\": 6, \"question_name\": \"Param7\", \
+        \"min\": \"\", \"default\": \"14.5\", \"max\": \"\", \"question_description\": \"param 7\", \
+        \"required\": true, \"variable\": \"param7\", \"choices\": \"\", \"type\": \"float\"}],\"name\":\"\", \
+        \"description\":\"\"}"
+      allow(template).to receive(:survey_spec).and_return(JSON.parse(survey))
+
+      allow(template).to receive(:variables).and_return('some_extra_var'  => 'blah',
+                                                        'other_extra_var' => {'name' => 'some_value'},
+                                                        'array_extra_var' => [{'name' => 'some_value'}]
+                                                       )
+      dialog = subject.create_dialog(template)
+
+      expect(dialog).to have_attributes(:label => template.name, :buttons => "submit,cancel")
+
+      tabs = dialog.dialog_tabs
+      expect(tabs.size).to eq(1)
+      assert_main_tab(tabs[0])
+    end
+  end
+
+  def assert_main_tab(tab)
+    assert_tab_attributes(tab)
+
+    groups = tab.dialog_groups
+    expect(groups.size).to eq(3)
+
+    assert_option_group(groups[0])
+    assert_survey_group(groups[1])
+    assert_variables_group(groups[2])
+  end
+
+  def assert_tab_attributes(tab)
+    expect(tab).to have_attributes(:label => "Basic Information", :display => "edit")
+  end
+
+  def assert_option_group(group)
+    expect(group).to have_attributes(:label => "Options", :display => "edit")
+    fields = group.dialog_fields
+    expect(fields.size).to eq(1)
+    expect(fields[0]).to have_attributes(:label => "Limit", :name => "limit", :required => false, :data_type => 'string')
+  end
+
+  def assert_field(field, clss, attributes)
+    expect(field).to be_kind_of clss
+    expect(field).to have_attributes(attributes)
+  end
+
+  def assert_survey_group(group)
+    expect(group).to have_attributes(:label => "Survey", :display => "edit")
+    fields = group.dialog_fields
+    expect(fields.size).to eq(7)
+
+    assert_field(fields[0], DialogFieldTextBox,      :name => 'param_param1', :data_type => 'integer',   :default_value => "19")
+    assert_field(fields[1], DialogFieldTextBox,      :name => 'param_param2', :data_type => 'string',    :default_value => "as")
+    assert_field(fields[2], DialogFieldTextAreaBox,  :name => 'param_param3', :data_type => 'string',    :default_value => "no\nhello")
+    assert_field(fields[3], DialogFieldTextBox,      :name => 'param_param4', :data_type => 'string',    :default_value => "mypassword", :options => {:protected => true})
+    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :default_value => "Peach", :values => [%w(Apple Apple), %w(Banana Banana), %w(Peach Peach)])
+    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :default_value => "opt1",  :values => [%w(222 222), %w(opt1 opt1), %w(opt3 opt3)])
+    assert_field(fields[6], DialogFieldTextBox,      :name => 'param_param7', :data_type => 'string',    :default_value => "14.5")
+  end
+
+  def assert_variables_group(group)
+    expect(group).to have_attributes(:label => "Extra Variables", :display => "edit")
+
+    fields = group.dialog_fields
+    expect(fields.size).to eq(3)
+
+    assert_field(fields[0], DialogFieldTextBox, :name => 'param_some_extra_var', :default_value => 'blah', :data_type => 'string', :read_only => true)
+    assert_field(fields[1], DialogFieldTextBox, :name => 'param_other_extra_var', :default_value => '{"name":"some_value"}', :data_type => 'string', :read_only => true)
+    assert_field(fields[2], DialogFieldTextBox, :name => 'param_array_extra_var', :default_value => '[{"name":"some_value"}]', :data_type => 'string', :read_only => true)
+  end
+end

--- a/spec/services/auto_placement_visibility_service_spec.rb
+++ b/spec/services/auto_placement_visibility_service_spec.rb
@@ -1,0 +1,47 @@
+describe AutoPlacementVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when auto placement is enabled" do
+      let(:auto_placement) { true }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(auto_placement)).to eq(
+          :hide => [
+            :placement_host_name,
+            :placement_ds_name,
+            :host_filter,
+            :ds_filter,
+            :cluster_filter,
+            :placement_cluster_name,
+            :rp_filter,
+            :placement_rp_name,
+            :placement_dc_name
+          ],
+          :edit => []
+        )
+      end
+    end
+
+    context "when auto placement is not enabled" do
+      let(:auto_placement) { false }
+
+      it "adds values to the field names to edit" do
+        expect(subject.determine_visibility(auto_placement)).to eq(
+          :hide => [],
+          :edit => [
+            :placement_host_name,
+            :placement_ds_name,
+            :host_filter,
+            :ds_filter,
+            :cluster_filter,
+            :placement_cluster_name,
+            :rp_filter,
+            :placement_rp_name,
+            :placement_dc_name
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/services/automate_import_service_spec.rb
+++ b/spec/services/automate_import_service_spec.rb
@@ -1,0 +1,136 @@
+describe AutomateImportService do
+  let(:automate_import_service) { described_class.new }
+
+  describe "#cancel_import" do
+    let(:import_file_upload) { double("ImportFileUpload", :id => 42) }
+
+    before do
+      allow(ImportFileUpload).to receive(:find).with("42").and_return(import_file_upload)
+      allow(import_file_upload).to receive(:destroy)
+
+      allow(MiqQueue).to receive(:unqueue)
+    end
+
+    it "destroys the import file upload" do
+      expect(import_file_upload).to receive(:destroy)
+      automate_import_service.cancel_import("42")
+    end
+
+    it "destroys the queued deletion" do
+      expect(MiqQueue).to receive(:unqueue).with(
+        :class_name  => "ImportFileUpload",
+        :instance_id => 42,
+        :method_name => "destroy"
+      )
+      automate_import_service.cancel_import("42")
+    end
+  end
+
+  describe "#import_datastore" do
+    let(:import_file_upload) { double("ImportFileUpload", :binary_blob => binary_blob) }
+    let(:binary_blob) { double("BinaryBlob", :binary => "binary") }
+    let(:miq_ae_import) { double("MiqAeYamlImportZipfs", :import_stats => "import stats") }
+    let(:removable_entry) { double(:name => "carrot/something_else/namespace.yaml") }
+    let(:removable_class_entry) { double(:name => "carrot/something_else.class/class.yaml") }
+    let(:user) { FactoryGirl.create(:user_with_group) }
+
+    before do
+      User.current_user = user
+      import_options = {
+        "import_as" => "potato",
+        "overwrite" => true,
+        "zip_file"  => "automate_temporary_zip.zip",
+        "tenant_id" => user.current_tenant.id
+      }
+      allow(MiqAeImport).to receive(:new).with("carrot", import_options).and_return(miq_ae_import)
+      allow(miq_ae_import).to receive(:remove_unrelated_entries)
+      allow(miq_ae_import).to receive(:all_namespace_files).and_return([
+        removable_entry,
+        double(:name => "something_else/carrot"),
+      ])
+      allow(miq_ae_import).to receive(:all_class_files).and_return([
+        removable_class_entry,
+        double(:name => "something_else/carrot.class/class.yaml")
+      ])
+      allow(miq_ae_import).to receive(:remove_entry)
+      allow(miq_ae_import).to receive(:update_sorted_entries)
+      allow(miq_ae_import).to receive(:import).and_return(true)
+    end
+
+    it "removes unrelated entries" do
+      expect(miq_ae_import).to receive(:remove_unrelated_entries).with("carrot")
+      automate_import_service.import_datastore(import_file_upload, "carrot", "potato", ["starch"])
+    end
+
+    it "removes the correct namespace file" do
+      expect(miq_ae_import).to receive(:remove_entry).with(removable_entry)
+      automate_import_service.import_datastore(import_file_upload, "carrot", "potato", ["starch"])
+    end
+
+    it "removes the correct class file" do
+      expect(miq_ae_import).to receive(:remove_entry).with(removable_class_entry)
+      automate_import_service.import_datastore(import_file_upload, "carrot", "potato", ["starch"])
+    end
+
+    it "updates the sorted entries" do
+      expect(miq_ae_import).to receive(:update_sorted_entries)
+      automate_import_service.import_datastore(import_file_upload, "carrot", "potato", ["starch"])
+    end
+
+    it "calls import" do
+      expect(miq_ae_import).to receive(:import)
+      automate_import_service.import_datastore(import_file_upload, "carrot", "potato", ["starch"])
+    end
+
+    it "returns the import stats" do
+      expect(automate_import_service.import_datastore(import_file_upload, "carrot", "potato", ["starch"])).to eq(
+        "import stats"
+      )
+    end
+
+    context "when the domain name to import to is blank" do
+      it "creates a new MiqAeImport with the correct import options" do
+        expect(MiqAeImport).to receive(:new).with(
+          "carrot",
+          "import_as" => "carrot",
+          "overwrite" => true,
+          "zip_file"  => "automate_temporary_zip.zip",
+          "tenant_id" => user.current_tenant.id
+        ).and_return(miq_ae_import)
+        automate_import_service.import_datastore(import_file_upload, "carrot", "", ["starch"])
+      end
+    end
+  end
+
+  describe "#store_for_import" do
+    let(:import_file_upload) { double("ImportFileUpload", :id => 42).as_null_object }
+
+    before do
+      allow(ImportFileUpload).to receive(:create).and_return(import_file_upload)
+      allow(import_file_upload).to receive(:store_binary_data_as_yml)
+      allow(MiqQueue).to receive(:put)
+    end
+
+    it "stores the data" do
+      expect(import_file_upload).to receive(:store_binary_data_as_yml).with("the data", "Automation import")
+      automate_import_service.store_for_import("the data")
+    end
+
+    it "returns the imported file upload" do
+      expect(automate_import_service.store_for_import("the data")).to eq(import_file_upload)
+    end
+
+    it "queues a deletion" do
+      Timecop.freeze(2014, 3, 5) do
+        expect(MiqQueue).to receive(:put).with(
+          :class_name  => "ImportFileUpload",
+          :instance_id => 42,
+          :deliver_on  => 1.day.from_now,
+          :method_name => "destroy"
+        )
+
+        automate_import_service.store_for_import("the data")
+      end
+    end
+  end
+end

--- a/spec/services/charts_layout_service_spec.rb
+++ b/spec/services/charts_layout_service_spec.rb
@@ -1,0 +1,57 @@
+describe ChartsLayoutService do
+  let(:host_openstack_infra) { FactoryGirl.create(:host_openstack_infra) }
+  let(:host_redhat) { FactoryGirl.create(:host_redhat) }
+  let(:vm_openstack) { FactoryGirl.create(:vm_openstack) }
+  let(:host_openstack_infra_chart) do
+    YAML.load(File.open(File.join(UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'ManageIQ_Providers_Openstack_InfraManager_Host') + '.yaml'))
+  end
+  let(:host_chart) do
+    YAML.load(File.open(File.join(UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host') + '.yaml'))
+  end
+  let(:layout_chart) do
+    YAML.load(File.open(File.join(UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_util_charts') + '.yaml'))
+  end
+
+  describe "#layout" do
+    it "returns layout for specific class if exists" do
+      chart = ChartsLayoutService.layout(host_openstack_infra,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host')
+      expect(chart).to eq(host_openstack_infra_chart)
+    end
+
+    it "returns layout for fname if specific class does not exist" do
+      chart = ChartsLayoutService.layout(host_redhat,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host')
+      expect(chart).to eq(host_chart)
+    end
+
+    it "returns base layout if fname is missing" do
+      chart = ChartsLayoutService.layout(host_openstack_infra,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_util_charts')
+      expect(chart).to eq(layout_chart)
+    end
+  end
+
+  describe "#layout applies_to_method functionality" do
+    it "shows CPU (%) by default for VmOpenstack" do
+      # By default percent is visible and mhz not
+      chart = ChartsLayoutService.layout(vm_openstack,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
+      expect(chart.count { |x| x[:title] == "CPU (%)" }).to equal 1
+      expect(chart.count { |x| x[:title] == "CPU (Mhz)" }).to equal 0
+    end
+
+    it "shows CPU (Mhz) instead of CPU (%), when applies_to_method methods are changed" do
+      # Stub it so mhz is visible and percent not
+      allow(vm_openstack).to receive(:cpu_percent_available?).and_return(false)
+      allow(vm_openstack).to receive(:cpu_mhz_available?).and_return(true)
+      chart = ChartsLayoutService.layout(vm_openstack,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
+      expect(chart.count { |x| x[:title] == "CPU (%)" }).to equal 0
+      expect(chart.count { |x| x[:title] == "CPU (Mhz)" }).to equal 1
+    end
+
+    it "includes Memory (MB) chart for azure instance" do
+      ems_azure = FactoryGirl.create(:ems_azure)
+      host = FactoryGirl.create(:host, :ext_management_system => ems_azure)
+      vm_azure =  FactoryGirl.create(:vm_azure, :ext_management_system => ems_azure, :host => host)
+      chart = ChartsLayoutService.layout(vm_azure,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
+      expect(chart.count { |x| x[:title] == "Memory (MB)" }).to equal 1
+    end
+  end
+end

--- a/spec/services/cloud_topology_service_spec.rb
+++ b/spec/services/cloud_topology_service_spec.rb
@@ -1,0 +1,132 @@
+describe CloudTopologyService do
+  let(:cloud_topology_service) { described_class.new(nil) }
+
+  describe "#build_kinds" do
+    it "creates the expected number of entity types" do
+      expect(cloud_topology_service.build_kinds.keys).to match_array(
+        [:AvailabilityZone, :CloudManager, :CloudTenant, :Tag, :Vm])
+    end
+  end
+
+  describe "#build_link" do
+    it "creates link between source to target" do
+      expect(cloud_topology_service.build_link(
+               "95e49048-3e00-11e5-a0d2-18037327aaeb",
+               "96c35f65-3e00-11e5-a0d2-18037327aaeb")).to eq(:source => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                                              :target => "96c35f65-3e00-11e5-a0d2-18037327aaeb")
+    end
+  end
+
+  describe "#build_topology" do
+    subject { cloud_topology_service.build_topology }
+
+    let(:ems) { FactoryGirl.create(:ems_openstack) }
+
+    before :each do
+      @availability_zone = FactoryGirl.create(:availability_zone_openstack, :ext_management_system => ems)
+      @cloud_tenant = FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems)
+      @vm = FactoryGirl.create(:vm_openstack, :cloud_tenant => @cloud_tenant, :ext_management_system => ems)
+    end
+
+    it "topology contains only the expected keys" do
+      expect(subject.keys).to match_array([:items, :kinds, :relations, :icons])
+    end
+
+    it "provider has unknown status when no authentication exists" do
+      ems = FactoryGirl.create(:ems_openstack)
+
+      allow(cloud_topology_service)
+        .to receive(:retrieve_providers)
+        .with(anything, ManageIQ::Providers::CloudManager)
+        .and_return([ems])
+
+      cloud_topology_service
+        .instance_variable_set(:@providers, ManageIQ::Providers::CloudManager.where(:id => ems.id))
+
+      expect(subject[:items]).to eq(
+        "CloudManager" + ems.compressed_id.to_s =>   {:name         => ems.name,
+                                                      :status       => "Unknown",
+                                                      :kind         => "CloudManager",
+                                                      :display_kind => "Openstack",
+                                                      :miq_id       => ems.id})
+    end
+
+    it "topology contains the expected structure and content" do
+      allow(cloud_topology_service).to receive(:retrieve_providers).and_return([ems])
+      cloud_topology_service.instance_variable_set(:@entity, ems)
+
+      expect(subject[:items]).to eq(
+        "CloudManager" + ems.compressed_id.to_s                         => {:name         => ems.name,
+                                                                            :kind         => "CloudManager",
+                                                                            :miq_id       => ems.id,
+                                                                            :status       => "Unknown",
+                                                                            :display_kind => "Openstack"},
+        "AvailabilityZone" + @availability_zone.compressed_id.to_s      => {:name         => @availability_zone.name,
+                                                                            :kind         => "AvailabilityZone",
+                                                                            :miq_id       => @availability_zone.id,
+                                                                            :status       => "OK",
+                                                                            :display_kind => "AvailabilityZone",
+                                                                            :provider     => ems.name},
+        "CloudTenant" + @cloud_tenant.compressed_id.to_s                => {:name         => @cloud_tenant.name,
+                                                                            :kind         => "CloudTenant",
+                                                                            :miq_id       => @cloud_tenant.id,
+                                                                            :status       => "Unknown",
+                                                                            :display_kind => "CloudTenant",
+                                                                            :provider     => ems.name},
+        "Vm" + @vm.compressed_id.to_s                                   => {:name         => @vm.name,
+                                                                            :kind         => "Vm",
+                                                                            :miq_id       => @vm.id,
+                                                                            :status       => "On",
+                                                                            :display_kind => "VM",
+                                                                            :provider     => ems.name},
+      )
+
+      expect(subject[:relations].size).to eq(3)
+      expect(subject[:relations]).to include(
+        {:source => "CloudManager" + ems.compressed_id.to_s, :target => "AvailabilityZone" + @availability_zone.compressed_id.to_s},
+        {:source => "CloudManager" + ems.compressed_id.to_s, :target => "CloudTenant" + @cloud_tenant.compressed_id.to_s},
+        {:source => "CloudTenant" + @cloud_tenant.compressed_id.to_s, :target => "Vm" + @vm.compressed_id.to_s},
+      )
+    end
+
+    it "topology contains the expected structure when vm is off" do
+      # vm and host test cross provider correlation to infra provider
+      @vm.update_attributes(:raw_power_state => "SHUTOFF")
+      allow(cloud_topology_service).to receive(:retrieve_providers).and_return([ems])
+      cloud_topology_service.instance_variable_set(:@entity, ems)
+
+      expect(subject[:items]).to eq(
+        "CloudManager" + ems.compressed_id.to_s                         => {:name         => ems.name,
+                                                                            :kind         => "CloudManager",
+                                                                            :miq_id       => ems.id,
+                                                                            :status       => "Unknown",
+                                                                            :display_kind => "Openstack"},
+        "AvailabilityZone" + @availability_zone.compressed_id.to_s      => {:name         => @availability_zone.name,
+                                                                            :kind         => "AvailabilityZone",
+                                                                            :miq_id       => @availability_zone.id,
+                                                                            :status       => "OK",
+                                                                            :display_kind => "AvailabilityZone",
+                                                                            :provider     => ems.name},
+        "CloudTenant" + @cloud_tenant.compressed_id.to_s                => {:name         => @cloud_tenant.name,
+                                                                            :kind         => "CloudTenant",
+                                                                            :miq_id       => @cloud_tenant.id,
+                                                                            :status       => "Unknown",
+                                                                            :display_kind => "CloudTenant",
+                                                                            :provider     => ems.name},
+        "Vm" + @vm.compressed_id.to_s                                   => {:name         => @vm.name,
+                                                                            :kind         => "Vm",
+                                                                            :miq_id       => @vm.id,
+                                                                            :status       => "Off",
+                                                                            :display_kind => "VM",
+                                                                            :provider     => ems.name},
+      )
+
+      expect(subject[:relations].size).to eq(3)
+      expect(subject[:relations]).to include(
+        {:source => "CloudManager" + ems.compressed_id.to_s, :target => "AvailabilityZone" + @availability_zone.compressed_id.to_s},
+        {:source => "CloudManager" + ems.compressed_id.to_s, :target => "CloudTenant" + @cloud_tenant.compressed_id.to_s},
+        {:source => "CloudTenant" + @cloud_tenant.compressed_id.to_s, :target => "Vm" + @vm.compressed_id.to_s},
+      )
+    end
+  end
+end

--- a/spec/services/container_dashboard_service_spec.rb
+++ b/spec/services/container_dashboard_service_spec.rb
@@ -1,0 +1,362 @@
+require 'recursive-open-struct'
+
+describe ContainerDashboardService do
+  let(:controller) { RecursiveOpenStruct.new(:current_user => {:get_timezone => "UTC"}) }
+  let(:time_profile) { FactoryGirl.create(:time_profile_utc) }
+
+  before(:each) do
+    MiqRegion.seed
+    @zone = EvmSpecHelper.create_guid_miq_server_zone[2]
+  end
+
+  context "providers" do
+    it "filters containers providers with zero entity count and sorts providers by type correctly" do
+      FactoryGirl.create(:ems_openshift, :hostname => "test2.com")
+      FactoryGirl.create(:ems_openshift_enterprise, :hostname => "test3.com")
+
+      providers_data = ContainerDashboardService.new(nil, nil).providers
+
+      # Kubernetes should not appear
+      providers_data.each do |p|
+        expect(p[:iconImage]).not_to be_nil
+        expect(p[:count]).to eq(1)
+      end
+    end
+  end
+
+  context "ems_utilization" do
+    it "shows aggregated metrics from last 30 days only" do
+      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
+      ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :zone => @zone)
+
+      current_date = 7.days.ago
+      old_date = 35.days.ago
+
+      current_metric_openshift = FactoryGirl.create(
+        :metric_rollup_cm_daily,
+        :timestamp                => current_date,
+        :derived_memory_used      => 1024,
+        :derived_vm_numvcpus      => 2,
+        :derived_memory_available => 2048,
+        :cpu_usage_rate_average   => 100,
+        :time_profile             => time_profile)
+
+      current_metric_kubernetes = FactoryGirl.create(
+        :metric_rollup_cm_daily,
+        :timestamp                => current_date,
+        :derived_memory_used      => 512,
+        :derived_vm_numvcpus      => 1,
+        :derived_memory_available => 1024,
+        :cpu_usage_rate_average   => 100,
+        :time_profile             => time_profile)
+
+      old_metric = FactoryGirl.create(
+        :metric_rollup_cm_daily,
+        :timestamp                => old_date,
+        :derived_memory_used      => 1024,
+        :derived_vm_numvcpus      => 2,
+        :derived_memory_available => 2048,
+        :cpu_usage_rate_average   => 100,
+        :time_profile             => time_profile)
+
+      nil_fielded_metric = FactoryGirl.create(
+        :metric_rollup_cm_daily,
+        :timestamp    => old_date,
+        :time_profile => time_profile)
+
+      ems_openshift.metric_rollups << current_metric_openshift
+      ems_openshift.metric_rollups << old_metric
+      ems_openshift.metric_rollups << nil_fielded_metric
+      ems_kubernetes.metric_rollups << current_metric_kubernetes
+      ems_kubernetes.metric_rollups << old_metric.dup
+      ems_kubernetes.metric_rollups << nil_fielded_metric.dup
+
+      node_utilization_all_providers = described_class.new(nil, controller).ems_utilization
+      node_utilization_single_provider = described_class.new(ems_openshift.id, controller).ems_utilization
+
+      expect(node_utilization_single_provider).to eq(
+        :cpu => {
+          :used  => 2,
+          :total => 2,
+          :xData => [current_date.strftime("%Y-%m-%d")],
+          :yData => [2]
+        },
+        :mem => {
+          :used  => 1,
+          :total => 2,
+          :xData => [current_date.strftime("%Y-%m-%d")],
+          :yData => [1]
+        }
+      )
+
+      expect(node_utilization_all_providers).to eq(
+        :cpu => {
+          :used  => 3,
+          :total => 3,
+          :xData => [current_date.strftime("%Y-%m-%d")],
+          :yData => [3]
+        },
+        :mem => {
+          :used  => 2,
+          :total => 3,
+          :xData => [current_date.strftime("%Y-%m-%d")],
+          :yData => [2]
+        }
+      )
+    end
+
+    it "returns hash with nil values when no metrics available" do
+      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
+      node_utilization_all_providers = described_class.new(nil, controller).ems_utilization
+      node_utilization_single_provider = described_class.new(ems_openshift.id, controller).ems_utilization
+      expect(node_utilization_all_providers).to eq(:cpu => nil, :mem => nil)
+      expect(node_utilization_single_provider).to eq(:cpu => nil, :mem => nil)
+    end
+  end
+
+  context "heatmaps" do
+    it "shows aggregated metrics from last 30 days only" do
+      ems_openshift = FactoryGirl.create(:ems_openshift, :name => 'openshift', :zone => @zone)
+      ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :name => 'kubernetes', :zone => @zone)
+
+      @node1 = FactoryGirl.create(:container_node, :name => 'node1')
+      @node2 = FactoryGirl.create(:container_node, :name => 'node2')
+      @node3 = FactoryGirl.create(:container_node, :name => 'node3')
+      @node4 = FactoryGirl.create(:container_node, :name => 'node4')
+      ems_openshift.container_nodes << @node1 << @node2
+      ems_kubernetes.container_nodes << @node3 << @node4
+
+      [ems_kubernetes, ems_openshift].each do |p|
+        p.container_nodes.each do |node|
+          node.metric_rollups << FactoryGirl.create(
+            :metric_rollup_cm_hr,
+            :timestamp                  => 1.hour.ago.utc,
+            :cpu_usage_rate_average     => 90,
+            :mem_usage_absolute_average => 90,
+            :derived_vm_numvcpus        => 4,
+            :net_usage_rate_average     => 90,
+            :derived_memory_available   => 8192,
+            :derived_memory_used        => 4096)
+        end
+      end
+
+      heatmaps_all_providers = described_class.new(nil, controller).heatmaps
+      heatmaps_single_provider = described_class.new(ems_openshift, controller).heatmaps
+
+      expect(heatmaps_all_providers).to eq(
+        :nodeCpuUsage    => [
+          {
+            :id       => @node1.id,
+            :node     => "node1",
+            :provider => "openshift",
+            :total    => 4,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node2.id,
+            :node     => "node2",
+            :provider => "openshift",
+            :total    => 4,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node3.id,
+            :node     => "node3",
+            :provider => "kubernetes",
+            :total    => 4,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node4.id,
+            :node     => "node4",
+            :provider => "kubernetes",
+            :total    => 4,
+            :percent  => 0.9
+          }],
+        :nodeMemoryUsage => [
+          {
+            :id       => @node1.id,
+            :node     => "node1",
+            :provider => "openshift",
+            :total    => 8192,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node2.id,
+            :node     => "node2",
+            :provider => "openshift",
+            :total    => 8192,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node3.id,
+            :node     => "node3",
+            :provider => "kubernetes",
+            :total    => 8192,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node4.id,
+            :node     => "node4",
+            :provider => "kubernetes",
+            :total    => 8192,
+            :percent  => 0.9
+          }]
+      )
+
+      expect(heatmaps_single_provider).to eq(
+        :nodeCpuUsage    => [
+          {
+            :id       => @node1.id,
+            :node     => "node1",
+            :provider => "openshift",
+            :total    => 4,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node2.id,
+            :node     => "node2",
+            :provider => "openshift",
+            :total    => 4,
+            :percent  => 0.9
+          }
+        ],
+        :nodeMemoryUsage => [
+          {
+            :id       => @node1.id,
+            :node     => "node1",
+            :provider => "openshift",
+            :total    => 8192,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node2.id,
+            :node     => "node2",
+            :provider => "openshift",
+            :total    => 8192,
+            :percent  => 0.9
+          }
+        ]
+      )
+    end
+
+    it "returns hash with nil values when no metrics available" do
+      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
+      heatmaps_all_providers = described_class.new(nil, controller).heatmaps
+      heatmaps_single_provider = described_class.new(ems_openshift.id, controller).heatmaps
+      expect(heatmaps_all_providers).to eq(:nodeCpuUsage => nil, :nodeMemoryUsage => nil)
+      expect(heatmaps_single_provider).to eq(:nodeCpuUsage => nil, :nodeMemoryUsage => nil)
+    end
+  end
+
+  context "network trends" do
+    it "shows daily network trends from last 30 days only" do
+      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
+      ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :zone => @zone)
+
+      current_date = 7.days.ago
+      old_date = 35.days.ago
+
+      current_metric_openshift = FactoryGirl.create(
+        :metric_rollup_cm_daily,
+        :timestamp              => current_date,
+        :net_usage_rate_average => 1000,
+        :time_profile           => time_profile)
+
+      current_metric_kubernetes = FactoryGirl.create(
+        :metric_rollup_cm_daily,
+        :timestamp              => current_date,
+        :net_usage_rate_average => 1500,
+        :time_profile           => time_profile)
+
+      old_metric = FactoryGirl.create(
+        :metric_rollup_cm_daily,
+        :timestamp              => old_date,
+        :net_usage_rate_average => 1500,
+        :time_profile           => time_profile)
+
+      ems_openshift.metric_rollups << current_metric_openshift
+      ems_openshift.metric_rollups << old_metric
+      ems_kubernetes.metric_rollups << current_metric_kubernetes
+      ems_kubernetes.metric_rollups << old_metric.dup
+
+      daily_network_trends = described_class.new(nil, controller).daily_network_metrics
+      daily_network_trends_single_provider = described_class.new(ems_openshift.id, controller).daily_network_metrics
+
+      expect(daily_network_trends_single_provider).to eq(
+        :xData => [current_date.strftime("%Y-%m-%d")],
+        :yData => [1000]
+      )
+
+      expect(daily_network_trends).to eq(
+        :xData => [current_date.strftime("%Y-%m-%d")],
+        :yData => [2500]
+      )
+    end
+
+    it "show daily hourly network trends from last 24 hours only" do
+      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
+      ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :zone => @zone)
+
+      current_date = 2.hours.ago
+      old_date = 2.days.ago
+
+      current_metric_openshift = FactoryGirl.create(
+        :metric_rollup_cm_hr,
+        :timestamp              => current_date,
+        :net_usage_rate_average => 1000,
+        :time_profile           => time_profile)
+
+      current_metric_kubernetes = FactoryGirl.create(
+        :metric_rollup_cm_hr,
+        :timestamp              => current_date,
+        :net_usage_rate_average => 1500,
+        :time_profile           => time_profile)
+
+      old_metric = FactoryGirl.create(
+        :metric_rollup_cm_hr,
+        :timestamp              => old_date,
+        :net_usage_rate_average => 1500,
+        :time_profile           => time_profile)
+
+      nil_fields_metric = FactoryGirl.create(
+        :metric_rollup_cm_hr,
+        :timestamp    => old_date,
+        :time_profile => time_profile)
+
+      ems_openshift.metric_rollups << current_metric_openshift
+      ems_openshift.metric_rollups << old_metric
+      ems_openshift.metric_rollups << nil_fields_metric
+      ems_kubernetes.metric_rollups << current_metric_kubernetes
+      ems_kubernetes.metric_rollups << old_metric.dup
+      ems_kubernetes.metric_rollups << nil_fields_metric.dup
+
+      hourly_network_trends = described_class.new(nil, controller).hourly_network_metrics
+      hourly_network_trends_single_provider = described_class.new(ems_openshift.id, controller).hourly_network_metrics
+
+      expect(hourly_network_trends_single_provider).to eq(
+        :xData => [current_date.beginning_of_hour.utc],
+        :yData => [1000]
+      )
+
+      expect(hourly_network_trends).to eq(
+        :xData => [current_date.beginning_of_hour.utc],
+        :yData => [2500]
+      )
+    end
+
+    it "returns hash with nil values when no metrics available" do
+      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
+      hourly_network_trends = described_class.new(nil, controller).hourly_network_metrics
+      hourly_network_trends_single_provider = described_class.new(ems_openshift.id, controller).hourly_network_metrics
+
+      daily_network_trends = described_class.new(nil, controller).daily_network_metrics
+      daily_network_trends_single_provider = described_class.new(ems_openshift.id, controller).daily_network_metrics
+
+      expect(hourly_network_trends).to eq(nil)
+      expect(hourly_network_trends_single_provider).to eq(nil)
+      expect(daily_network_trends).to eq(nil)
+      expect(daily_network_trends_single_provider).to eq(nil)
+    end
+  end
+end

--- a/spec/services/container_deployment_service_spec.rb
+++ b/spec/services/container_deployment_service_spec.rb
@@ -1,0 +1,38 @@
+require 'recursive-open-struct'
+
+describe ContainerDeploymentService do
+  before do
+    %w(amazon openstack google azure redhat vmware).each do |p|
+      network = FactoryGirl.create(:network, :ipaddress => "127.0.0.1")
+      hardware = FactoryGirl.create(:hardware)
+      hardware.networks << network
+      vm = FactoryGirl.create("vm_#{p}".to_sym, :hardware => hardware)
+      if %w(amazon redhat).include?(p)
+        template = FactoryGirl.create("template_#{p}".to_sym)
+        provider = FactoryGirl.create("ems_#{p}".to_sym, :miq_templates => [template])
+      else
+        provider = FactoryGirl.create("ems_#{p}".to_sym)
+      end
+      provider.vms << vm
+    end
+    @foreman_provider = FactoryGirl.create(:configuration_manager_foreman)
+  end
+
+  context "possible_providers_and_vms" do
+    it "finds all Cloud and Infra providers and their existing VMs" do
+      providers = ContainerDeploymentService.new.possible_providers_and_vms
+      vms = providers.collect_concat { |p| p[:vms] }
+      expect(providers.size).to eq(6)
+      expect(vms.size).to eq(6)
+    end
+  end
+
+  context "possible_provision_providers" do
+    it "finds all providers with provision ability supported by deployment, and their templates" do
+      providers = ContainerDeploymentService.new.possible_provision_providers
+      templates = providers.collect_concat { |p| p[:templates] }
+      expect(providers.size).to eq(2)
+      expect(templates.size).to eq(2)
+    end
+  end
+end

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -1,0 +1,205 @@
+describe ContainerTopologyService do
+
+  let(:container_topology_service) { described_class.new(nil) }
+  let(:long_id) { "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest" }
+
+  describe "#build_kinds" do
+    it "creates the expected number of entity types" do
+      expect(container_topology_service.build_kinds.keys).to match_array([:Container, :Host, :ContainerManager, :ContainerNode, :ContainerGroup, :ContainerReplicator, :ContainerRoute, :ContainerService, :Vm])
+    end
+  end
+
+  describe "#build_link" do
+    it "creates link between source to target" do
+      expect(container_topology_service.build_link("95e49048-3e00-11e5-a0d2-18037327aaeb", "96c35f65-3e00-11e5-a0d2-18037327aaeb")).to eq(:source => "95e49048-3e00-11e5-a0d2-18037327aaeb", :target => "96c35f65-3e00-11e5-a0d2-18037327aaeb")
+    end
+  end
+
+  describe "#build_topology" do
+    subject { container_topology_service.build_topology }
+
+    it "topology contains only the expected keys" do
+      expect(subject.keys).to match_array([:items, :kinds, :relations, :icons])
+    end
+
+    let(:container) { Container.create(:name => "ruby-example", :ems_ref => long_id, :state => 'running') }
+    let(:container_condition) { ContainerCondition.create(:name => 'Ready', :status => 'True') }
+    let(:container_def) { ContainerDefinition.create(:name => "ruby-example", :ems_ref => 'b6976f84-5184-11e5-950e-001a4a231290_ruby-helloworld_172.30.194.30:5000/test/origin-ruby-sample@sha256:0cd076c9beedb3b1f5cf3ba43da6b749038ae03f5886b10438556e36ec2a0dd9', :container => container) }
+    let(:container_node) { ContainerNode.create(:ext_management_system => ems_kube, :name => "127.0.0.1", :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb", :container_conditions => [container_condition], :lives_on => vm_rhev) }
+    let(:ems_kube) { FactoryGirl.create(:ems_kubernetes_with_authentication_err) }
+    let(:ems_openshift) { FactoryGirl.create(:ems_openshift) }
+    let(:ems_rhev) { FactoryGirl.create(:ems_redhat) }
+    let(:vm_rhev) { FactoryGirl.create(:vm_redhat, :uid_ems => "558d9a08-7b13-11e5-8546-129aa6621998", :ext_management_system => ems_rhev) }
+
+    it "provider has unknown status when no authentication exists" do
+      allow(container_topology_service).to receive(:retrieve_providers).with(anything, ManageIQ::Providers::ContainerManager).and_return([ems_openshift])
+      container_topology_service.instance_variable_set(:@entity, ems_openshift)
+      expect(subject[:items]).to eq(
+        "ContainerManager" + ems_openshift.compressed_id.to_s         => {:name         => ems_openshift.name,
+                                                                          :status       => "Unknown",
+                                                                          :kind         => "ContainerManager",
+                                                                          :display_kind => "Openshift",
+                                                                          :miq_id       => ems_openshift.id})
+
+    end
+
+    it "topology contains the expected structure and content" do
+      # vm and host test cross provider correlation to infra provider
+      hardware = FactoryGirl.create(:hardware, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8)
+      host = FactoryGirl.create(:host_redhat,
+                                :uid_ems => "abcd9a08-7b13-11e5-8546-129aa6621999",
+                                :ext_management_system => ems_rhev,
+                                :hardware => hardware)
+      vm_rhev.update_attributes(:host => host, :raw_power_state => "up")
+
+      allow(container_topology_service).to receive(:retrieve_providers).and_return([ems_kube])
+      container_topology_service.instance_variable_set(:@entity, ems_kube)
+      container_replicator = ContainerReplicator.create(:ext_management_system => ems_kube,
+                                                        :ems_ref               => "8f8ca74c-3a41-11e5-a79a-001a4a231290",
+                                                        :name                  => "replicator1")
+      container_route = ContainerRoute.create(:ext_management_system => ems_kube,
+                                              :ems_ref               => "ab5za74c-3a41-11e5-a79a-001a4a231290",
+                                              :name                  => "route-edge")
+      container_group = ContainerGroup.create(:ext_management_system => ems_kube,
+                                              :container_node        => container_node, :container_replicator => container_replicator,
+                                              :name                  => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
+                                              :phase                 => "Running", :container_definitions => [container_def])
+      container_service = ContainerService.create(:ext_management_system => ems_kube, :container_groups => [container_group],
+                                                  :ems_ref               => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                                  :name                  => "service1", :container_routes => [container_route])
+      expect(subject[:items]).to eq(
+        "ContainerManager" + ems_kube.compressed_id.to_s                => {:name         => ems_kube.name,
+                                                                            :status       => "Error",
+                                                                            :kind         => "ContainerManager",
+                                                                            :display_kind => "Kubernetes",
+                                                                            :miq_id       => ems_kube.id},
+
+        "ContainerNode" + container_node.compressed_id.to_s             => {:name         => container_node.name,
+                                                                            :status       => "Ready",
+                                                                            :kind         => "ContainerNode",
+                                                                            :display_kind => "Node",
+                                                                            :miq_id       => container_node.id},
+
+        "ContainerReplicator" + container_replicator.compressed_id.to_s => {:name         => container_replicator.name,
+                                                                            :status       => "OK",
+                                                                            :kind         => "ContainerReplicator",
+                                                                            :display_kind => "Replicator",
+                                                                            :miq_id       => container_replicator.id},
+
+        "ContainerService" + container_service.compressed_id.to_s       => {:name         => container_service.name,
+                                                                            :status       => "Unknown",
+                                                                            :kind         => "ContainerService",
+                                                                            :display_kind => "Service",
+                                                                            :miq_id       => container_service.id},
+
+        "ContainerGroup" + container_group.compressed_id.to_s           => {:name         => container_group.name,
+                                                                            :status       => "Running",
+                                                                            :kind         => "ContainerGroup",
+                                                                            :display_kind => "Pod",
+                                                                            :miq_id       => container_group.id},
+
+        "ContainerRoute" + container_route.compressed_id.to_s           => {:name         => container_route.name,
+                                                                            :status       => "Unknown",
+                                                                            :kind         => "ContainerRoute",
+                                                                            :display_kind => "Route",
+                                                                            :miq_id       => container_route.id},
+
+        "Container" + container.compressed_id.to_s                      => {:name         => container.name,
+                                                                            :status       => "Running",
+                                                                            :kind         => "Container",
+                                                                            :display_kind => "Container",
+                                                                            :miq_id       => container.id},
+
+        "Vm" + vm_rhev.compressed_id.to_s                               => {:name         => vm_rhev.name,
+                                                                            :status       => "On",
+                                                                            :kind         => "Vm",
+                                                                            :display_kind => "VM",
+                                                                            :miq_id       => vm_rhev.id,
+                                                                            :provider     => ems_rhev.name},
+
+        "Host" + host.compressed_id.to_s                                => {:name         => host.name,
+                                                                            :status       => "On",
+                                                                            :kind         => "Host",
+                                                                            :display_kind => "Host",
+                                                                            :miq_id       => host.id,
+                                                                            :provider     => ems_rhev.name}
+      )
+
+      expect(subject[:relations].size).to eq(8)
+      expect(subject[:relations]).to include(
+        {:source => "ContainerGroup" + container_group.compressed_id.to_s, :target => "ContainerReplicator" + container_replicator.compressed_id.to_s},
+        {:source => "ContainerService" + container_service.compressed_id.to_s, :target => "ContainerRoute" + container_route.compressed_id.to_s},
+        # cross provider correlations
+        {:source => "Vm" + vm_rhev.compressed_id.to_s, :target => "Host" + host.compressed_id.to_s},
+        {:source => "ContainerNode" + container_node.compressed_id.to_s, :target => "Vm" + vm_rhev.compressed_id.to_s},
+        {:source => "ContainerNode" + container_node.compressed_id.to_s, :target => "ContainerGroup" + container_group.compressed_id.to_s},
+        {:source => "ContainerManager" + ems_kube.compressed_id.to_s, :target => "ContainerNode" + container_node.compressed_id.to_s},
+        {:source => "ContainerGroup" + container_group.compressed_id.to_s, :target => "Container" + container.compressed_id.to_s},
+        {:source => "ContainerGroup" + container_group.compressed_id.to_s, :target => "ContainerService" + container_service.compressed_id.to_s}
+      )
+    end
+
+    it "topology contains the expected structure when vm is off" do
+      # vm and host test cross provider correlation to infra provider
+      vm_rhev.update_attributes(:raw_power_state => "down")
+      allow(container_topology_service).to receive(:retrieve_providers).and_return([ems_kube])
+      container_topology_service.instance_variable_set(:@entity, ems_kube)
+      container_group = ContainerGroup.create(:ext_management_system => ems_kube, :container_node => container_node,
+                                              :name => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
+                                              :phase => "Running", :container_definitions => [container_def])
+      container_service = ContainerService.create(:ext_management_system => ems_kube, :container_groups => [container_group],
+                                                  :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                                  :name => "service1")
+      allow(container_topology_service).to receive(:entities).and_return([[container_node], [container_service]])
+
+      expect(subject[:items]).to eq(
+        "ContainerNode" + container_node.compressed_id.to_s       => {:name         => container_node.name,
+                                                                      :status       => "Ready",
+                                                                      :kind         => "ContainerNode",
+                                                                      :display_kind => "Node",
+                                                                      :miq_id       => container_node.id},
+
+        "ContainerService" + container_service.compressed_id.to_s => {:name         => container_service.name,
+                                                                      :status       => "Unknown",
+                                                                      :kind         => "ContainerService",
+                                                                      :display_kind => "Service",
+                                                                      :miq_id       => container_service.id},
+
+        "ContainerGroup" + container_group.compressed_id.to_s     => {:name         => container_group.name,
+                                                                      :status       => "Running",
+                                                                      :kind         => "ContainerGroup",
+                                                                      :display_kind => "Pod",
+                                                                      :miq_id       => container_group.id},
+
+        "Container" + container.compressed_id.to_s                => {:name         => container.name,
+                                                                      :status       => "Running",
+                                                                      :kind         => "Container",
+                                                                      :display_kind => "Container",
+                                                                      :miq_id       => container.id},
+
+        "Vm" + vm_rhev.compressed_id.to_s                         => {:name         => vm_rhev.name,
+                                                                      :status       => "Off",
+                                                                      :kind         => "Vm",
+                                                                      :display_kind => "VM",
+                                                                      :miq_id       => vm_rhev.id,
+                                                                      :provider     => ems_rhev.name},
+
+        "ContainerManager" + ems_kube.compressed_id.to_s          => {:name         => ems_kube.name,
+                                                                      :status       => "Error",
+                                                                      :kind         => "ContainerManager",
+                                                                      :display_kind => "Kubernetes",
+                                                                      :miq_id       => ems_kube.id}
+      )
+
+      expect(subject[:relations].size).to eq(5)
+      expect(subject[:relations]).to include(
+        {:source => "ContainerGroup" + container_group.compressed_id.to_s, :target => "ContainerService" + container_service.compressed_id.to_s},
+        # cross provider correlation
+        {:source => "ContainerNode" + container_node.compressed_id.to_s, :target => "Vm" + vm_rhev.compressed_id.to_s},
+        {:source => "ContainerManager" + ems_kube.compressed_id.to_s, :target => "ContainerNode" + container_node.compressed_id.to_s},
+        {:source => "ContainerNode" + container_node.compressed_id.to_s, :target => "ContainerGroup" + container_group.compressed_id.to_s},
+        {:source => "ContainerGroup" + container_group.compressed_id.to_s, :target => "Container" + container.compressed_id.to_s},
+      )
+    end
+  end
+end

--- a/spec/services/customize_fields_visibility_service_spec.rb
+++ b/spec/services/customize_fields_visibility_service_spec.rb
@@ -1,0 +1,89 @@
+describe CustomizeFieldsVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when the customization template is supported" do
+      let(:supports_customization_template) { true }
+      let(:platform) { "potato" }
+      let(:customize_fields_list) { "potato" }
+
+      it "returns a list of pxe customization fields to edit" do
+        expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq(
+          :hide => [],
+          :edit => [
+            :addr_mode,
+            :customization_template_id,
+            :customization_template_script,
+            :dns_servers,
+            :dns_suffixes,
+            :gateway,
+            :hostname,
+            :ip_addr,
+            :root_password,
+            :subnet_mask
+          ]
+        )
+      end
+    end
+
+    context "when the customization template is not supported" do
+      let(:supports_customization_template) { false }
+
+      context "when the customize_fields_list contains only items from exclude list" do
+        let(:customize_fields_list) do
+          [
+            :sysprep_spec_override,
+            :sysprep_custom_spec,
+            :sysprep_enabled,
+            :sysprep_upload_file,
+            :sysprep_upload_text,
+            :linux_host_name,
+            :sysprep_computer_name,
+            :ip_addr,
+            :subnet_mask,
+            :gateway,
+            :dns_servers,
+            :dns_suffixes
+          ]
+        end
+        let(:platform) { "linux" }
+
+        it "returns an empty hide/edit hash" do
+          expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq(
+            :hide => [], :edit => []
+          )
+        end
+      end
+
+      context "when the customize_fields_list contains linux_domain_name" do
+        let(:customize_fields_list) { [:linux_domain_name, :potato] }
+
+        context "when the platform is linux" do
+          let(:platform) { "linux" }
+
+          it "returns the correct list of things to edit/hide" do
+            expect(subject.determine_visibility(
+              platform,
+              supports_customization_template,
+              customize_fields_list)).to eq(
+                :hide => [:potato], :edit => [:linux_domain_name]
+              )
+          end
+        end
+
+        context "when the platform is not linux" do
+          let(:platform) { "potato" }
+
+          it "returns an empty hide/edit hash" do
+            expect(subject.determine_visibility(
+              platform,
+              supports_customization_template,
+              customize_fields_list)).to eq(
+                :hide => [], :edit => []
+              )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -1,0 +1,260 @@
+describe DialogFieldVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    let(:subject) do
+      described_class.new(
+        auto_placement_visibility_service,
+        number_of_vms_visibility_service,
+        service_template_fields_visibility_service,
+        network_visibility_service,
+        sysprep_auto_logon_visibility_service,
+        retirement_visibility_service,
+        customize_fields_visibility_service,
+        sysprep_custom_spec_visibility_service,
+        request_type_visibility_service,
+        pxe_iso_visibility_service,
+        linked_clone_visibility_service
+      )
+    end
+
+    let(:options) do
+      {
+        :addr_mode                       => addr_mode,
+        :auto_placement_enabled          => auto_placement_enabled,
+        :customize_fields_list           => customize_fields_list,
+        :linked_clone                    => linked_clone,
+        :number_of_vms                   => number_of_vms,
+        :platform                        => platform,
+        :provision_type                  => provision_type,
+        :request_type                    => request_type,
+        :retirement                      => retirement,
+        :service_template_request        => service_template_request,
+        :snapshot_count                  => snapshot_count,
+        :supports_customization_template => supports_customization_template,
+        :supports_iso                    => supports_iso,
+        :supports_pxe                    => supports_pxe,
+        :sysprep_auto_logon              => sysprep_auto_logon,
+        :sysprep_custom_spec             => sysprep_custom_spec,
+        :sysprep_enabled                 => sysprep_enabled
+      }
+    end
+
+    let(:service_template_fields_visibility_service) { double("ServiceTemplateFieldsVisibilityService") }
+    let(:service_template_request) { "service_template_request" }
+
+    let(:auto_placement_visibility_service) { double("AutoPlacementVisibilityService") }
+    let(:auto_placement_enabled) { "auto_placement_enabled" }
+
+    let(:number_of_vms_visibility_service) { double("NumberOfVmsVisibilityService") }
+    let(:number_of_vms) { "number_of_vms" }
+    let(:platform) { "platform" }
+
+    let(:network_visibility_service) { double("NetworkVisibilityService") }
+    let(:sysprep_enabled) { "sysprep_enabled" }
+    let(:supports_pxe) { "supports_pxe" }
+    let(:supports_iso) { "supports_iso" }
+    let(:addr_mode) { "addr_mode" }
+
+    let(:sysprep_auto_logon_visibility_service) { double("SysprepAutoLogonVisibilityService") }
+    let(:sysprep_auto_logon) { "sysprep_auto_logon" }
+
+    let(:retirement_visibility_service) { double("RetirementVisibilityService") }
+    let(:retirement) { "retirement" }
+
+    let(:customize_fields_visibility_service) { double("CustomizeFieldsVisibilityService") }
+    let(:supports_customization_template) { "supports_customization_template" }
+    let(:customize_fields_list) { "customize_fields_list" }
+
+    let(:sysprep_custom_spec_visibility_service) { double("SysprepCustomSpecVisibilityService") }
+    let(:sysprep_custom_spec) { "sysprep_custom_spec" }
+
+    let(:request_type_visibility_service) { double("RequestTypeVisibilityService") }
+    let(:request_type) { "request_type" }
+
+    let(:pxe_iso_visibility_service) { double("PxeIsoVisibilityService") }
+
+    let(:linked_clone_visibility_service) { double("LinkedCloneVisibilityService") }
+    let(:provision_type) { "provision_type" }
+    let(:linked_clone) { "linked_clone" }
+    let(:snapshot_count) { "snapshot_count" }
+
+    before do
+      allow(service_template_fields_visibility_service)
+        .to receive(:determine_visibility).with(service_template_request).and_return(
+          :hide => [:service_template_request_hide]
+        )
+
+      allow(auto_placement_visibility_service)
+        .to receive(:determine_visibility).with(auto_placement_enabled).and_return(
+          :hide => [:auto_hide], :edit => [:auto_edit]
+        )
+
+      allow(number_of_vms_visibility_service)
+        .to receive(:determine_visibility).with(number_of_vms, platform).and_return(
+          :hide => [:number_hide], :edit => [:number_edit]
+        )
+
+      allow(network_visibility_service)
+        .to receive(:determine_visibility).with(sysprep_enabled, supports_pxe, supports_iso, addr_mode).and_return(
+          :hide => [:network_hide], :edit => [:network_edit]
+        )
+
+      allow(sysprep_auto_logon_visibility_service)
+        .to receive(:determine_visibility).with(sysprep_auto_logon).and_return(
+          :hide => [:sysprep_auto_logon_hide], :edit => [:sysprep_auto_logon_edit]
+        )
+
+      allow(retirement_visibility_service)
+        .to receive(:determine_visibility).with(retirement).and_return(
+          :hide => [:retirement_hide], :edit => [:retirement_edit]
+        )
+
+      allow(customize_fields_visibility_service)
+        .to receive(:determine_visibility).with(
+          platform, supports_customization_template, customize_fields_list
+        ).and_return(
+          :hide => [:customize_fields_hide, :number_hide], # Forces uniq
+          :edit => [:customize_fields_edit, :number_edit, :retirement_hide] # Forces uniq and removal of intersection
+        )
+
+      allow(sysprep_custom_spec_visibility_service)
+        .to receive(:determine_visibility).with(sysprep_custom_spec).and_return(
+          :hide => [:sysprep_custom_spec_hide],
+          :edit => [:sysprep_custom_spec_edit]
+        )
+
+      allow(request_type_visibility_service)
+        .to receive(:determine_visibility).with(request_type).and_return(:hide => [:request_type_hide])
+
+      allow(pxe_iso_visibility_service)
+        .to receive(:determine_visibility).with(supports_iso, supports_pxe).and_return(
+          :hide => [:pxe_iso_hide],
+          :edit => [:pxe_iso_edit]
+        )
+
+      allow(linked_clone_visibility_service)
+        .to receive(:determine_visibility).with(provision_type, linked_clone, snapshot_count).and_return(
+          :hide => [:linked_clone_hide],
+          :edit => [:linked_clone_edit],
+          :show => [:linked_clone_show]
+        )
+    end
+
+    it "adds the values to the field names to hide, edit, and show without duplicates or intersections" do
+      result = subject.determine_visibility(options)
+      expect(result[:hide]).to match_array([
+        :auto_hide,
+        :customize_fields_hide,
+        :linked_clone_hide,
+        :network_hide,
+        :number_hide,
+        :pxe_iso_hide,
+        :request_type_hide,
+        :service_template_request_hide,
+        :sysprep_auto_logon_hide,
+        :sysprep_custom_spec_hide
+      ])
+      expect(result[:edit]).to match_array([
+        :auto_edit,
+        :customize_fields_edit,
+        :linked_clone_edit,
+        :network_edit,
+        :number_edit,
+        :pxe_iso_edit,
+        :retirement_hide,
+        :retirement_edit,
+        :sysprep_auto_logon_edit,
+        :sysprep_custom_spec_edit
+      ])
+      expect(result[:show]).to match_array([:linked_clone_show])
+    end
+  end
+
+  describe "#set_visibility_for_field" do
+    let(:field) { {:display_override => display_override} }
+    let(:visibility_hash) { {:edit => "edit_me", :hide => "hide_me", :show => "show_me"} }
+
+    before do
+      subject.set_visibility_for_field(visibility_hash, field_name, field)
+    end
+
+    shared_examples_for "#set_visibility_for_field with a display override" do
+      context "when the field has a display override" do
+        let(:display_override) { :potato }
+
+        it "sets the display value to the override" do
+          expect(field[:display]).to eq(:potato)
+        end
+      end
+    end
+
+    context "when the field name is contained in the field names to edit" do
+      let(:field_name) { "edit_me" }
+
+      it_behaves_like "#set_visibility_for_field with a display override"
+
+      context "when the field display override is blank" do
+        let(:display_override) { "" }
+
+        it "sets the display value to edit" do
+          expect(field[:display]).to eq(:edit)
+        end
+      end
+    end
+
+    context "when the field name is contained in the field names to hide" do
+      let(:field_name) { "hide_me" }
+
+      it_behaves_like "#set_visibility_for_field with a display override"
+
+      context "when the field display override is blank" do
+        let(:display_override) { "" }
+
+        it "sets the display value to hide" do
+          expect(field[:display]).to eq(:hide)
+        end
+      end
+    end
+
+    context "when the field name is contained in the field names to show" do
+      let(:field_name) { "show_me" }
+
+      it_behaves_like "#set_visibility_for_field with a display override"
+
+      context "when the field display override is blank" do
+        let(:display_override) { "" }
+
+        it "sets the display value to show" do
+          expect(field[:display]).to eq(:show)
+        end
+      end
+    end
+
+    context "when the field name is not contained in either the field names to edit or hide or show" do
+      let(:field_name) { "potato" }
+
+      it_behaves_like "#set_visibility_for_field with a display override"
+
+      context "when the field display override is blank" do
+        let(:display_override) { "" }
+
+        context "when the field does not have a display value" do
+          let(:display) { nil }
+
+          it "sets the display value to edit" do
+            expect(field[:display]).to eq(:edit)
+          end
+        end
+
+        context "when the field does have a display value" do
+          let(:field) { {:display_override => display_override, :display => :hide} }
+
+          it "uses the given display value" do
+            expect(field[:display]).to eq(:hide)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/dialog_import_service_spec.rb
+++ b/spec/services/dialog_import_service_spec.rb
@@ -1,0 +1,450 @@
+require "dialog_field_importer"
+require "dialog_import_validator"
+
+describe DialogImportService do
+  let(:dialog_import_service) { described_class.new(dialog_field_importer, dialog_import_validator) }
+  let(:dialog_field_importer) { double("DialogFieldImporter") }
+  let(:dialog_import_validator) { double("DialogImportValidator") }
+
+  shared_context "DialogImportService dialog setup" do
+    let(:dialog_fields) do
+      [{"name" => "FavoriteColor", "label" => "Favorite Color"}]
+    end
+
+    let(:dialog_groups) do
+      [{"label" => "New Box", "dialog_fields" => dialog_fields}]
+    end
+
+    let(:dialog_tabs) do
+      [{"label" => "New Tab", "dialog_groups" => dialog_groups}]
+    end
+
+    let(:dialogs) do
+      [{"label" => "Test", "dialog_tabs" => dialog_tabs},
+       {"label" => "Test2", "dialog_tabs" => dialog_tabs, "description" => "potato"}]
+    end
+
+    let(:not_dialogs) { [{"this is not" => "a dialog"}] }
+
+    before do
+      built_dialog_field = DialogField.create(:name => "dialog_field")
+      allow(dialog_field_importer).to receive(:import_field).and_return(built_dialog_field)
+    end
+  end
+
+  describe "#cancel_import" do
+    let(:import_file_upload) { double("ImportFileUpload", :id => 123) }
+    let(:miq_queue) { double("MiqQueue") }
+
+    before do
+      allow(ImportFileUpload).to receive(:find).with("123").and_return(import_file_upload)
+      allow(import_file_upload).to receive(:destroy)
+
+      allow(MiqQueue).to receive(:unqueue)
+    end
+
+    it "destroys the import file upload" do
+      expect(import_file_upload).to receive(:destroy)
+      dialog_import_service.cancel_import("123")
+    end
+
+    it "destroys the queued deletion" do
+      expect(MiqQueue).to receive(:unqueue).with(
+        :class_name  => "ImportFileUpload",
+        :instance_id => 123,
+        :method_name => "destroy"
+      )
+      dialog_import_service.cancel_import("123")
+    end
+  end
+
+  describe "#import_from_file" do
+    include_context "DialogImportService dialog setup"
+
+    let(:filename) { "filename" }
+
+    context "when the loaded yaml returns dialogs" do
+      before do
+        allow(YAML).to receive(:load_file).with(filename).and_return(dialogs)
+      end
+
+      context "when there is an existing dialog" do
+        before do
+          FactoryGirl.create(:dialog, :label => "Test2")
+        end
+
+        it "does not create a third dialog" do
+          dialog_import_service.import_from_file(filename)
+          expect(Dialog.count).to eq(2)
+        end
+
+        it "yields the given block" do
+          block_called = false
+          dialog_import_service.import_from_file(filename) do |_|
+            block_called = true
+          end
+
+          expect(block_called).to be_truthy
+        end
+      end
+
+      context "when there is not an existing dialog" do
+        it "builds a new dialog" do
+          dialog_import_service.import_from_file(filename)
+          expect(Dialog.first).not_to be_nil
+        end
+
+        it "builds a dialog tab associated to the dialog" do
+          dialog_import_service.import_from_file(filename)
+          dialog = Dialog.first
+          expect(DialogTab.first.dialog).to eq(dialog)
+        end
+
+        it "builds a dialog group associated to the dialog tab" do
+          dialog_import_service.import_from_file(filename)
+          dialog_tab = DialogTab.first
+          expect(DialogGroup.first.dialog_tab).to eq(dialog_tab)
+        end
+
+        it "imports the dialog fields" do
+          expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0])
+          dialog_import_service.import_from_file(filename)
+        end
+      end
+    end
+
+    context "when the dialog_field_importer raises an InvalidDialogFieldTypeError" do
+      before do
+        allow(YAML).to receive(:load_file).with(filename).and_return(dialogs)
+        allow(dialog_field_importer).to receive(:import_field).and_raise(
+          DialogFieldImporter::InvalidDialogFieldTypeError.new("Custom Message")
+        )
+      end
+
+      it "re-raises" do
+        expect do
+          dialog_import_service.import_from_file(filename)
+        end.to raise_error(DialogFieldImporter::InvalidDialogFieldTypeError, "Custom Message")
+      end
+    end
+
+    context "when the loaded yaml does not return dialogs" do
+      before do
+        allow(YAML).to receive(:load_file).with(filename).and_return(not_dialogs)
+      end
+
+      it "raises a ParsedNonDialogYamlError" do
+        expect do
+          dialog_import_service.import_from_file(filename)
+        end.to raise_error(DialogImportService::ParsedNonDialogYamlError)
+      end
+    end
+  end
+
+  describe "#import_all_service_dialogs_from_yaml_file" do
+    include_context "DialogImportService dialog setup"
+
+    before do
+      allow(YAML).to receive(:load_file).with("filename").and_return(dialogs)
+    end
+
+    context "when there is already an existing dialog" do
+      before do
+        FactoryGirl.create(:dialog, :label => "Test2", :description => "not potato")
+      end
+
+      it "overwrites the existing dialog" do
+        dialog_import_service.import_all_service_dialogs_from_yaml_file("filename")
+        expect(Dialog.where(:label => "Test2").first.description).to eq("potato")
+      end
+    end
+
+    context "when there are no existing dialogs" do
+      it "builds a new dialog" do
+        dialog_import_service.import_all_service_dialogs_from_yaml_file("filename")
+        expect(Dialog.first).not_to be_nil
+      end
+
+      it "builds a dialog tab associated to the dialog" do
+        dialog_import_service.import_all_service_dialogs_from_yaml_file("filename")
+        dialog = Dialog.first
+        expect(DialogTab.first.dialog).to eq(dialog)
+      end
+
+      it "builds a dialog group associated to the dialog tab" do
+        dialog_import_service.import_all_service_dialogs_from_yaml_file("filename")
+        dialog_tab = DialogTab.first
+        expect(DialogGroup.first.dialog_tab).to eq(dialog_tab)
+      end
+
+      it "imports the dialog fields" do
+        expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0])
+        dialog_import_service.import_all_service_dialogs_from_yaml_file("filename")
+      end
+    end
+  end
+
+  describe "#import_service_dialogs" do
+    include_context "DialogImportService dialog setup"
+
+    let(:miq_queue) { double("MiqQueue") }
+    let(:yaml_data) { "the yaml" }
+    let(:import_file_upload) do
+      double("ImportFileUpload", :id => 123, :uploaded_content => yaml_data)
+    end
+    let(:dialogs_to_import) { %w(Test Test2) }
+
+    before do
+      allow(import_file_upload).to receive(:destroy)
+      allow(MiqQueue).to receive(:unqueue)
+    end
+
+    shared_examples_for "DialogImportService#import_service_dialogs that destroys temporary data" do
+      it "destroys the import file upload" do
+        expect(import_file_upload).to receive(:destroy)
+        dialog_import_service.import_service_dialogs(import_file_upload, dialogs_to_import)
+      end
+
+      it "unqueues the miq_queue item" do
+        expect(MiqQueue).to receive(:unqueue).with(
+          :class_name  => "ImportFileUpload",
+          :instance_id => 123,
+          :method_name => "destroy"
+        )
+        dialog_import_service.import_service_dialogs(import_file_upload, dialogs_to_import)
+      end
+    end
+
+    context "when the YAML loaded is dialogs" do
+      before do
+        allow(YAML).to receive(:load).with(yaml_data).and_return(dialogs)
+      end
+
+      context "when the list of dialogs to import from the yaml includes an existing dialog" do
+        before do
+          FactoryGirl.create(:dialog, :label => "Test2", :description => "not potato")
+        end
+
+        it_behaves_like "DialogImportService#import_service_dialogs that destroys temporary data"
+
+        it "overwrites the existing dialog" do
+          dialog_import_service.import_service_dialogs(import_file_upload, dialogs_to_import)
+          expect(Dialog.where(:label => "Test2").first.description).to eq("potato")
+        end
+      end
+
+      context "when the list of dialogs to import from the yaml do not include an existing dialog" do
+        it_behaves_like "DialogImportService#import_service_dialogs that destroys temporary data"
+
+        it "builds a new dialog" do
+          dialog_import_service.import_service_dialogs(import_file_upload, dialogs_to_import)
+          expect(Dialog.first).not_to be_nil
+        end
+
+        it "builds a dialog tab associated to the dialog" do
+          dialog_import_service.import_service_dialogs(import_file_upload, dialogs_to_import)
+          dialog = Dialog.first
+          expect(DialogTab.first.dialog).to eq(dialog)
+        end
+
+        it "builds a dialog group associated to the dialog tab" do
+          dialog_import_service.import_service_dialogs(import_file_upload, dialogs_to_import)
+          dialog_tab = DialogTab.first
+          expect(DialogGroup.first.dialog_tab).to eq(dialog_tab)
+        end
+
+        it "imports the dialog fields" do
+          expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0])
+          dialog_import_service.import_service_dialogs(import_file_upload, dialogs_to_import)
+        end
+      end
+
+      context "when the list of dialogs is nil" do
+        let(:dialogs_to_import) { nil }
+
+        it_behaves_like "DialogImportService#import_service_dialogs that destroys temporary data"
+
+        it "does not error" do
+          expect do
+            dialog_import_service.import_service_dialogs(import_file_upload, dialogs_to_import)
+          end.to_not raise_error
+        end
+      end
+    end
+
+    context "when the YAML loaded is not dialog format" do
+      before do
+        allow(YAML).to receive(:load).with(yaml_data).and_return(not_dialogs)
+      end
+
+      it "raises a ParsedNonDialogYamlError" do
+        expect do
+          dialog_import_service.import_service_dialogs(import_file_upload, dialogs_to_import)
+        end.to raise_error(DialogImportService::ParsedNonDialogYamlError)
+      end
+    end
+  end
+
+  describe "#store_for_import" do
+    let(:import_file_upload) { double("ImportFileUpload", :id => 123).as_null_object }
+
+    before do
+      allow(MiqQueue).to receive(:put)
+      allow(ImportFileUpload).to receive(:create).and_return(import_file_upload)
+      allow(import_file_upload).to receive(:store_binary_data_as_yml)
+    end
+
+    context "when the imported file does not raise any errors while determining validity" do
+      before do
+        allow(dialog_import_validator).to receive(:determine_validity).with(import_file_upload).and_return(nil)
+      end
+
+      it "stores the data" do
+        expect(import_file_upload).to receive(:store_binary_data_as_yml).with("the data", "Service dialog import")
+        dialog_import_service.store_for_import("the data")
+      end
+
+      it "returns the imported file upload" do
+        expect(dialog_import_service.store_for_import("the data")).to eq(import_file_upload)
+      end
+
+      it "queues a deletion" do
+        Timecop.freeze(2014, 3, 5) do
+          expect(MiqQueue).to receive(:put).with(
+            :class_name  => "ImportFileUpload",
+            :instance_id => 123,
+            :deliver_on  => 1.day.from_now,
+            :method_name => "destroy"
+          )
+
+          dialog_import_service.store_for_import("the data")
+        end
+      end
+    end
+
+    context "when the imported file raises an error while determining validity" do
+      before do
+        error_to_be_raised = DialogImportValidator::InvalidDialogFieldTypeError.new("Test message")
+        allow(dialog_import_validator).to receive(:determine_validity).with(import_file_upload).and_raise(error_to_be_raised)
+      end
+
+      it "reraises with the original error" do
+        expect do
+          dialog_import_service.store_for_import("the data")
+        end.to raise_error(DialogImportValidator::InvalidDialogFieldTypeError, "Test message")
+      end
+
+      it "queues a deletion" do
+        Timecop.freeze(2014, 3, 5) do
+          expect(MiqQueue).to receive(:put).with(
+            :class_name  => "ImportFileUpload",
+            :instance_id => 123,
+            :deliver_on  => 1.day.from_now,
+            :method_name => "destroy"
+          )
+
+          begin
+            dialog_import_service.store_for_import("the data")
+          rescue DialogImportValidator::InvalidDialogFieldTypeError
+            nil
+          end
+        end
+      end
+    end
+
+    describe '#build_dialog_tabs' do
+      let(:dialog_tabs) do
+        {
+          'dialog_tabs' => [
+            {
+              'label'         => 'new dialog tab',
+              'dialog_groups' => [
+                {
+                  'label'         => 'group label',
+                  'dialog_fields' => [
+                    {
+                      'name'  => 'field name',
+                      'label' => 'field label'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'creates a new dialog_tab' do
+        expect do
+          DialogImportService.new.build_dialog_tabs(dialog_tabs)
+        end.to change(DialogTab, :count).by(1)
+      end
+    end
+
+    describe '#build_dialog_groups' do
+      let(:dialog_groups) do
+        {
+          'dialog_groups' => [
+            {
+              'label'         => 'new group',
+              'dialog_fields' => [
+                {
+                  'name'  => 'field name',
+                  'label' => 'field label'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'creates a new dialog_group' do
+        expect do
+          DialogImportService.new.build_dialog_groups(dialog_groups)
+        end.to change(DialogGroup, :count).by(1)
+      end
+    end
+
+    describe '#build_dialog_fields' do
+      let(:dialog_fields) do
+        {
+          'dialog_fields' => [
+            {'name' => 'field name', 'label' => 'field label', 'options' => {'name' => 'foo'}}
+          ]
+        }
+      end
+
+      it 'creates a new dialog_field' do
+        expect do
+          DialogImportService.new.build_dialog_fields(dialog_fields)
+        end.to change(DialogField, :count).by(1)
+      end
+
+      it 'symbolizes the dialog field options' do
+        fields = DialogImportService.new.build_dialog_fields(dialog_fields)
+        expect(fields.first.options).to eq(:name => 'foo')
+      end
+    end
+  end
+
+  context '#import' do
+    include_context "DialogImportService dialog setup"
+    before do
+      allow(dialog_import_validator).to receive(:determine_dialog_validity).with(dialogs.first).and_return(true)
+    end
+
+    it 'creates a new dialog with valid input' do
+      expect do
+        dialog_import_service.import(dialogs.first)
+      end.to change(Dialog, :count).by(1)
+    end
+
+    it 'will raise record invalid for invalid dialog' do
+      dialog_import_service.import(dialogs.first)
+
+      expect do
+        dialog_import_service.import(dialogs.first)
+      end.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Label is not unique within region/)
+    end
+  end
+end

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -1,0 +1,247 @@
+describe GitBasedDomainImportService do
+  shared_context "import setup" do
+    let(:git_repo) do
+      double("GitRepository", :git_branches => git_branches,
+                              :id           => 123,
+                              :url          => 'http://www.example.com')
+    end
+    let(:user) { double("User", :userid => userid, :id => 123) }
+    let(:domain) { FactoryGirl.build(:miq_ae_git_domain, :id => 999) }
+    let(:userid) { "fred" }
+    let(:task) { double("MiqTask", :id => 123) }
+    let(:ref_name) { 'the_branch_name' }
+    let(:ref_type) { 'branch' }
+    let(:method_name) { 'import_git_repo' }
+    let(:action) { 'Import git repository' }
+    let(:task_options) { {:action => action, :userid => userid} }
+    let(:queue_options) do
+      {
+        :class_name  => "MiqAeDomain",
+        :method_name => method_name,
+        :role        => "git_owner",
+        :args        => [import_options]
+      }
+    end
+    let(:import_options) do
+      {
+        "git_repository_id" => git_repo.id,
+        "ref"               => ref_name,
+        "ref_type"          => ref_type,
+        "tenant_id"         => 321,
+        "overwrite"         => true
+      }
+    end
+    let(:status) { "Ok" }
+    let(:message) { "Success" }
+  end
+
+  shared_context "repository setup" do
+    let(:git_branches) { [] }
+    let(:queue_options) do
+      {
+        :class_name  => "GitRepository",
+        :instance_id => git_repo.id,
+        :method_name => method_name,
+        :role        => "git_owner",
+        :args        => []
+      }
+    end
+  end
+
+  shared_context "domain setup" do
+    let(:git_branches) { [] }
+    let(:queue_options) do
+      {
+        :class_name  => "MiqAeDomain",
+        :instance_id => domain.id,
+        :method_name => method_name,
+        :role        => "git_owner",
+        :args        => []
+      }
+    end
+  end
+
+  describe "#import" do
+    include_context "import setup"
+    before do
+      allow(GitRepository).to receive(:find_by).with(:id => git_repo.id).and_return(git_repo)
+      allow(domain).to receive(:update_attribute).with(:enabled, true)
+      allow(MiqTask).to receive(:wait_for_taskid).with(task.id).and_return(task)
+      allow(User).to receive(:current_user).and_return(user)
+    end
+
+    context "when git branches that match the given name exist" do
+      let(:git_branches) { [double("GitBranch", :name => ref_name)] }
+
+      it "calls 'import' with the correct options" do
+        allow(task).to receive(:task_results).and_return(domain)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(domain).to receive(:update_attribute).with(:enabled, true)
+
+        subject.import(git_repo.id, ref_name, 321)
+      end
+    end
+
+    context "when git branches that match the given name do not exist" do
+      let(:git_branches) { [] }
+      let(:ref_name) { "the_tag_name" }
+      let(:ref_type) { "tag" }
+
+      it "calls 'import' with the correct options" do
+        allow(task).to receive(:task_results).and_return(domain)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(domain).to receive(:update_attribute).with(:enabled, true)
+
+        subject.import(git_repo.id, ref_name, 321)
+      end
+    end
+
+    context "when import fails and the task result is nil" do
+      let(:git_branches) { [double("GitBranch", :name => ref_name)] }
+
+      it "raises an exception with a message" do
+        allow(task).to receive(:task_results).and_return(nil)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+        expect { subject.import(git_repo.id, ref_name, 321) }.to raise_exception(
+          MiqException::Error, "Selected branch or tag does not contain a valid domain"
+        )
+      end
+    end
+  end
+
+  describe "#queue_import" do
+    include_context "import setup"
+    before do
+      allow(GitRepository).to receive(:find_by).with(:id => git_repo.id).and_return(git_repo)
+      allow(User).to receive(:current_user).and_return(user)
+    end
+
+    context "when git branches that match the given name exist" do
+      let(:git_branches) { [double("GitBranch", :name => ref_name)] }
+
+      it "calls 'queue_import' with the correct options" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+        expect(subject.queue_import(git_repo.id, ref_name, 321)).to eq(task.id)
+      end
+    end
+
+    context "when git branches that match the given name do not exist" do
+      let(:git_branches) { [] }
+      let(:ref_name) { "the_tag_name" }
+      let(:ref_type) { "tag" }
+
+      it "calls 'queue_import' with the correct options" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+        expect(subject.queue_import(git_repo.id, ref_name, 321)).to eq(task.id)
+      end
+    end
+  end
+
+  describe "#queue_refresh_and_import" do
+    include_context "import setup"
+    before do
+      allow(User).to receive(:current_user).and_return(user)
+    end
+
+    context "when git branches that match the given name do not exist" do
+      let(:git_branches) { [] }
+      let(:ref_name) { "the_tag_name" }
+      let(:ref_type) { "tag" }
+      let(:method_name) { 'import_git_url' }
+      let(:action) { 'Refresh and import git repository' }
+      let(:import_options) do
+        {
+          "git_url"   => git_repo.url,
+          "ref"       => ref_name,
+          "ref_type"  => ref_type,
+          "tenant_id" => 321,
+          "overwrite" => true
+        }
+      end
+
+      it "calls 'queue_import' with the correct options" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+        expect(subject.queue_refresh_and_import(git_repo.url, ref_name, ref_type, 321)).to eq(task.id)
+      end
+    end
+  end
+
+  describe "#queue_refresh" do
+    include_context "import setup"
+    include_context "repository setup"
+    let(:action) { 'Refresh git repository' }
+    let(:method_name) { 'refresh' }
+    before do
+      allow(User).to receive(:current_user).and_return(user)
+    end
+
+    it "calls 'queue_refresh' with the correct options" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+      expect(subject.queue_refresh(git_repo.id)).to eq(task.id)
+    end
+  end
+
+  describe "#refresh" do
+    include_context "import setup"
+    include_context "repository setup"
+    let(:action) { 'Refresh git repository' }
+    let(:method_name) { 'refresh' }
+    let(:task) { double("MiqTask", :id => 123, :status => status, :message => message) }
+
+    before do
+      allow(MiqTask).to receive(:wait_for_taskid).with(task.id).and_return(task)
+      allow(MiqTask).to receive(:find).with(task.id).and_return(task)
+      allow(User).to receive(:current_user).and_return(user)
+    end
+
+    context "success" do
+      it "calls 'refresh' with the correct options and succeeds" do
+        allow(task).to receive(:task_results).and_return(true)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+        expect(subject.refresh(git_repo.id)).to be_truthy
+      end
+    end
+
+    context "failure" do
+      let(:status) { "Failed" }
+      let(:message) { "My Error Message" }
+      it "calls 'refresh' with the correct options and fails" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+        expect { subject.refresh(git_repo.id) }.to raise_exception(MiqException::Error, message)
+      end
+    end
+  end
+
+  describe "destroy domain" do
+    include_context "import setup"
+    include_context "domain setup"
+    let(:action) { 'Destroy domain' }
+    let(:method_name) { 'destroy' }
+    let(:task) { double("MiqTask", :id => 123, :status => status, :message => message) }
+
+    before do
+      allow(MiqTask).to receive(:wait_for_taskid).with(task.id).and_return(task)
+      allow(User).to receive(:current_user).and_return(user)
+      allow(task).to receive(:task_results).and_return(true)
+    end
+
+    it "#destroy_domain" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+      expect(subject.destroy_domain(domain.id)).to be_truthy
+    end
+
+    it "#queue_destroy_domain" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+      expect(subject.queue_destroy_domain(domain.id)).to eq(task.id)
+    end
+  end
+end

--- a/spec/services/git_repository_service_spec.rb
+++ b/spec/services/git_repository_service_spec.rb
@@ -1,0 +1,109 @@
+describe GitRepositoryService do
+  let(:git_repository_service) { described_class.new }
+  describe "#setup" do
+    let(:git_url) { "http://example.com/" }
+    let(:git_username) { nil }
+    let(:git_password) { nil }
+    let(:new_record) { false }
+
+    context "when the git repository already exists" do
+      let!(:git_repo) { GitRepository.create!(:url => "http://example.com/") }
+
+      shared_examples_for "GitRepositoryService#setup when verify_ssl is 'true'" do
+        it "sets the verify_ssl setting to verify_peer" do
+          git_repository_service.setup(git_url, git_username, git_password, verify_ssl)
+          expect(git_repo.reload.verify_ssl).to eq(OpenSSL::SSL::VERIFY_PEER)
+        end
+      end
+
+      shared_examples_for "GitRepositoryService#setup with an existing repo" do
+        it "returns the id and the fact that it is not a new repo" do
+          expect(git_repository_service.setup(git_url, git_username, git_password, verify_ssl)).to eq(
+            :git_repo_id => git_repo.id, :new_git_repo? => false
+          )
+        end
+      end
+
+      context "when verify_ssl is 'true'" do
+        let(:verify_ssl) { "true" }
+
+        context "when git username is present" do
+          let(:git_username) { "username" }
+
+          context "when git password is present" do
+            let(:git_password) { "password" }
+
+            before do
+              allow(MiqQueue).to receive(:put_unless_exists)
+            end
+
+            it "updates the authentication" do
+              git_repository_service.setup(git_url, git_username, git_password, verify_ssl)
+              authentication = git_repo.authentications.first
+              expect(authentication.userid).to eq("username")
+              expect(authentication.password).to eq("password")
+            end
+
+            it_behaves_like "GitRepositoryService#setup when verify_ssl is 'true'"
+            it_behaves_like "GitRepositoryService#setup with an existing repo"
+          end
+
+          context "when git password is not present" do
+            it_behaves_like "GitRepositoryService#setup when verify_ssl is 'true'"
+            it_behaves_like "GitRepositoryService#setup with an existing repo"
+          end
+        end
+
+        context "when git username is not present" do
+          it_behaves_like "GitRepositoryService#setup when verify_ssl is 'true'"
+          it_behaves_like "GitRepositoryService#setup with an existing repo"
+        end
+      end
+
+      context "when verify_ssl is not 'true'" do
+        let(:verify_ssl) { "not true" }
+
+        it "sets the verify_ssl setting to verify_none" do
+          git_repository_service.setup(git_url, git_username, git_password, verify_ssl)
+          expect(git_repo.reload.verify_ssl).to eq(OpenSSL::SSL::VERIFY_NONE)
+        end
+
+        it_behaves_like "GitRepositoryService#setup with an existing repo"
+      end
+    end
+
+    context "when the git repository does not already exist" do
+      shared_examples_for "GitRepositoryService#setup when a git repo does not exist" do
+        it "returns the id and the fact that it is a new repo" do
+          expect(git_repository_service.setup(git_url, git_username, git_password, verify_ssl)).to eq(
+            :git_repo_id => GitRepository.first.id, :new_git_repo? => true
+          )
+        end
+      end
+
+      context "when verify_ssl is 'true'" do
+        let(:verify_ssl) { "true" }
+
+        it "creates a git repository with verify_peer" do
+          git_repository_service.setup(git_url, git_username, git_password, verify_ssl)
+          git_repo = GitRepository.first
+          expect(git_repo.verify_ssl).to eq(OpenSSL::SSL::VERIFY_PEER)
+        end
+
+        it_behaves_like "GitRepositoryService#setup when a git repo does not exist"
+      end
+
+      context "when verify_ssl is not 'true'" do
+        let(:verify_ssl) { "not true" }
+
+        it "creates a git repository with verify_none" do
+          git_repository_service.setup(git_url, git_username, git_password, verify_ssl)
+          git_repo = GitRepository.first
+          expect(git_repo.verify_ssl).to eq(OpenSSL::SSL::VERIFY_NONE)
+        end
+
+        it_behaves_like "GitRepositoryService#setup when a git repo does not exist"
+      end
+    end
+  end
+end

--- a/spec/services/infra_topology_service_spec.rb
+++ b/spec/services/infra_topology_service_spec.rb
@@ -1,0 +1,82 @@
+describe InfraTopologyService do
+  let(:infra_topology_service) { described_class.new(nil) }
+
+  describe "#build_kinds" do
+    it "creates the expected number of entity types" do
+      expect(infra_topology_service.build_kinds.keys).to match_array(
+        [:InfraManager, :EmsCluster, :Host])
+    end
+  end
+
+  describe "#build_link" do
+    it "creates link between source to target" do
+      expect(infra_topology_service.build_link(
+               "95e49048-3e00-11e5-a0d2-18037327aaeb",
+               "96c35f65-3e00-11e5-a0d2-18037327aaeb")).to eq(:source => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                                              :target => "96c35f65-3e00-11e5-a0d2-18037327aaeb")
+    end
+  end
+
+  describe "#build_topology" do
+    subject { infra_topology_service.build_topology }
+
+    let(:ems) { FactoryGirl.create(:ems_openstack_infra) }
+
+    before :each do
+      @cluster = FactoryGirl.create(:ems_cluster_openstack, :ext_management_system => ems)
+      @host = FactoryGirl.create(:host_openstack_infra, :ems_cluster => @cluster, :ext_management_system => ems)
+    end
+
+    it "topology contains only the expected keys" do
+      expect(subject.keys).to match_array([:items, :kinds, :relations, :icons])
+    end
+
+    it "provider has unknown status when no authentication exists" do
+      ems = FactoryGirl.create(:ems_openstack_infra)
+
+      allow(infra_topology_service).to receive(:retrieve_providers)
+        .with(anything, ManageIQ::Providers::InfraManager)
+        .and_return([ems])
+
+      infra_topology_service.instance_variable_set(:@providers, ManageIQ::Providers::InfraManager
+        .where(:id => ems.id))
+
+      expect(subject[:items]).to eq(
+        "InfraManager" + ems.compressed_id.to_s   => {:name         => ems.name,
+                                                      :status       => "Unknown",
+                                                      :kind         => "InfraManager",
+                                                      :display_kind => "Openstack",
+                                                      :miq_id       => ems.id})
+    end
+
+    it "topology contains the expected structure and content" do
+      allow(infra_topology_service).to receive(:retrieve_providers).and_return([ems])
+      infra_topology_service.instance_variable_set(:@entity, ems)
+
+      expect(subject[:items]).to eq(
+        "InfraManager" + ems.compressed_id.to_s             =>  {:name         => ems.name,
+                                                                 :kind         => "InfraManager",
+                                                                 :miq_id       => ems.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "Openstack"},
+        "EmsCluster" + @cluster.compressed_id.to_s          =>  {:name         => @cluster.name,
+                                                                 :kind         => "EmsCluster",
+                                                                 :miq_id       => @cluster.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "EmsCluster",
+                                                                 :provider     => ems.name},
+        "Host" + @host.compressed_id.to_s                   =>  {:name         => @host.name,
+                                                                 :kind         => "Host",
+                                                                 :miq_id       => @host.id,
+                                                                 :status       => "On",
+                                                                 :display_kind => "Host",
+                                                                 :provider     => ems.name},
+      )
+
+      expect(subject[:relations].size).to eq(2)
+      expect(subject[:relations]).to include(
+        {:source => "InfraManager" + ems.compressed_id.to_s, :target => "EmsCluster" + @cluster.compressed_id.to_s},
+        {:source => "EmsCluster" + @cluster.compressed_id.to_s, :target => "Host" + @host.compressed_id.to_s},)
+    end
+  end
+end

--- a/spec/services/linked_clone_visibility_service_spec.rb
+++ b/spec/services/linked_clone_visibility_service_spec.rb
@@ -1,0 +1,64 @@
+describe LinkedCloneVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when provision type is vmware" do
+      let(:provision_type) { "vmware" }
+
+      context "when there are snapshots to show" do
+        let(:snapshot_count) { 1 }
+
+        context "when linked clone is true" do
+          let(:linked_clone) { true }
+
+          it "adds values to the field names to edit" do
+            expect(subject.determine_visibility(provision_type, linked_clone, snapshot_count)).to eq(
+              :hide => [],
+              :edit => [:linked_clone, :snapshot],
+              :show => []
+            )
+          end
+        end
+
+        context "when linked clone is not true" do
+          let(:linked_clone) { false }
+
+          it "adds values to the field names to hide" do
+            expect(subject.determine_visibility(provision_type, linked_clone, snapshot_count)).to eq(
+              :hide => [:snapshot],
+              :edit => [:linked_clone],
+              :show => []
+            )
+          end
+        end
+      end
+
+      context "when there are no snapshots to show" do
+        let(:snapshot_count) { 0 }
+        let(:linked_clone) { "potato" }
+
+        it "adds values to the field names to hide and show" do
+          expect(subject.determine_visibility(provision_type, linked_clone, snapshot_count)).to eq(
+            :hide => [:snapshot],
+            :edit => [],
+            :show => [:linked_clone]
+          )
+        end
+      end
+    end
+
+    context "when provision type is not vmware" do
+      let(:provision_type) { nil }
+      let(:linked_clone) { nil }
+      let(:snapshot_count) { "potato" }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(provision_type, linked_clone, snapshot_count)).to eq(
+          :hide => [:linked_clone, :snapshot],
+          :edit => [],
+          :show => []
+        )
+      end
+    end
+  end
+end

--- a/spec/services/middleware_topology_service_spec.rb
+++ b/spec/services/middleware_topology_service_spec.rb
@@ -1,0 +1,116 @@
+describe MiddlewareTopologyService do
+  let(:middleware_topology_service) { described_class.new(nil) }
+  let(:long_id_0) { "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;e055631d-c1a5-4a2d-926a-1dfdcff5137c/r;Local~~" }
+  let(:long_id_1) { "#{long_id_0}/r;Local~%2Fdeployment=hawkular-command-gateway-war.war" }
+  let(:long_id_2) { "#{long_id_0}/r;Local~%2Fdeployment=hawkular-wildfly-agent-download.war" }
+  let(:long_id_3) { "#{long_id_0}/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS" }
+  let(:long_id_4) { "Local~/deployment=hawkular-wildfly-agent-download.war" }
+  let(:long_id_5) { "Local~/deployment=hawkular-command-gateway-war.war" }
+  let(:long_id_6) { "Local~/subsystem=datasources/data-source=ExampleDS" }
+  let(:long_id_7) { "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularMetricData" }
+
+  describe "#build_kinds" do
+    it "creates the expected number of entity types" do
+      supported_kinds = [:MiddlewareServer, :MiddlewareDeployment, :MiddlewareDatasource, :MiddlewareManager, :Vm,
+                         :MiddlewareDomain, :MiddlewareServerGroup, :MiddlewareMessaging]
+      expect(middleware_topology_service.build_kinds.keys).to match_array(supported_kinds)
+    end
+  end
+
+  describe "#build_topology" do
+    subject { middleware_topology_service.build_topology }
+
+    let(:ems_hawkular) { FactoryGirl.create(:ems_hawkular) }
+    let(:mw_server) do
+      FactoryGirl.create(:hawkular_middleware_server,
+                         :name                  => 'Local',
+                         :feed                  => '70c798a0-6985-4f8a-a525-012d8d28e8a3',
+                         :ems_ref               => long_id_0,
+                         :nativeid              => 'Local~~',
+                         :ext_management_system => ems_hawkular)
+    end
+
+    it "topology contains the expected structure and content" do
+      allow(middleware_topology_service).to receive(:retrieve_providers).and_return([ems_hawkular])
+
+      mw_deployment1 = MiddlewareDeployment.create(:ext_management_system => ems_hawkular,
+                                                   :middleware_server     => mw_server,
+                                                   :ems_ref               => long_id_2,
+                                                   :name                  => "hawkular-wildfly-agent-download.war",
+                                                   :nativeid              => long_id_4)
+
+      mw_deployment2 = MiddlewareDeployment.create(:ext_management_system => ems_hawkular,
+                                                   :middleware_server     => mw_server,
+                                                   :ems_ref               => long_id_1,
+                                                   :name                  => "hawkular-command-gateway-war.war",
+                                                   :nativeid              => long_id_5)
+
+      mw_datasource = MiddlewareDatasource.create(:ext_management_system => ems_hawkular,
+                                                  :middleware_server     => mw_server,
+                                                  :ems_ref               => long_id_3,
+                                                  :name                  => "ExampleDS",
+                                                  :nativeid              => long_id_6)
+
+      mw_messaging = MiddlewareMessaging.create(:ext_management_system => ems_hawkular,
+                                                :middleware_server     => mw_server,
+                                                :ems_ref               => long_id_2,
+                                                :name                  => "JMS Topic [HawkularMetricData]",
+                                                :nativeid              => long_id_7)
+
+      expect(subject[:items]).to eq(
+        "MiddlewareManager" + ems_hawkular.compressed_id.to_s      => {:name         => ems_hawkular.name,
+                                                                       :status       => "Unknown",
+                                                                       :kind         => "MiddlewareManager",
+                                                                       :display_kind => "Hawkular",
+                                                                       :miq_id       => ems_hawkular.id,
+                                                                       :icon         => "vendor-hawkular"},
+
+        "MiddlewareServer" + mw_server.compressed_id.to_s          => {:name         => mw_server.name,
+                                                                       :status       => "Unknown",
+                                                                       :kind         => "MiddlewareServer",
+                                                                       :display_kind => "MiddlewareServer",
+                                                                       :miq_id       => mw_server.id,
+                                                                       :icon         => "vendor-wildfly"},
+
+        "MiddlewareDeployment" + mw_deployment1.compressed_id.to_s => {:name         => mw_deployment1.name,
+                                                                       :status       => "Unknown",
+                                                                       :kind         => "MiddlewareDeployment",
+                                                                       :display_kind => "MiddlewareDeploymentWar",
+                                                                       :miq_id       => mw_deployment1.id},
+
+        "MiddlewareDeployment" + mw_deployment2.compressed_id.to_s => {:name         => mw_deployment2.name,
+                                                                       :status       => "Unknown",
+                                                                       :kind         => "MiddlewareDeployment",
+                                                                       :display_kind => "MiddlewareDeploymentWar",
+                                                                       :miq_id       => mw_deployment2.id},
+
+        "MiddlewareDatasource" + mw_datasource.compressed_id.to_s  => {:name         => mw_datasource.name,
+                                                                       :status       => "Unknown",
+                                                                       :kind         => "MiddlewareDatasource",
+                                                                       :display_kind => "MiddlewareDatasource",
+                                                                       :miq_id       => mw_datasource.id},
+
+        "MiddlewareMessaging" + mw_messaging.compressed_id.to_s    => {:name         => mw_messaging.name,
+                                                                       :status       => "Unknown",
+                                                                       :kind         => "MiddlewareMessaging",
+                                                                       :display_kind => "MiddlewareMessaging",
+                                                                       :miq_id       => mw_messaging.id},
+
+      )
+
+      expect(subject[:relations].size).to eq(5)
+      expect(subject[:relations]).to include(
+        {:source => "MiddlewareManager" + ems_hawkular.compressed_id.to_s,
+         :target => "MiddlewareServer" + mw_server.compressed_id.to_s},
+        {:source => "MiddlewareServer" + mw_server.compressed_id.to_s,
+         :target => "MiddlewareDeployment" + mw_deployment1.compressed_id.to_s},
+        {:source => "MiddlewareServer" + mw_server.compressed_id.to_s,
+         :target => "MiddlewareDeployment" + mw_deployment2.compressed_id.to_s},
+        {:source => "MiddlewareServer" + mw_server.compressed_id.to_s,
+         :target => "MiddlewareDatasource" + mw_datasource.compressed_id.to_s},
+        {:source => "MiddlewareServer" + mw_server.compressed_id.to_s,
+         :target => "MiddlewareMessaging" + mw_messaging.compressed_id.to_s}
+      )
+    end
+  end
+end

--- a/spec/services/miq_policy_import_service_spec.rb
+++ b/spec/services/miq_policy_import_service_spec.rb
@@ -1,0 +1,97 @@
+describe MiqPolicyImportService do
+  let(:miq_policy_import_service) { described_class.new }
+  let(:import_file_upload) { double("ImportFileUpload") }
+  let(:miq_queue) do
+    FactoryGirl.create(:miq_queue, :class_name => "ImportFileUpload", :instance_id => 123, :method_name => "destroy")
+  end
+
+  describe "#cancel_import" do
+    before do
+      allow(import_file_upload).to receive(:destroy)
+      allow(ImportFileUpload).to receive(:find).with(123).and_return(import_file_upload)
+      miq_queue
+    end
+
+    it "destroys the import file upload" do
+      expect(import_file_upload).to receive(:destroy)
+      miq_policy_import_service.cancel_import(123)
+    end
+
+    it "destroys the queue item" do
+      miq_policy_import_service.cancel_import(123)
+      expect(MiqQueue.where(:id => miq_queue.id)).not_to be_exists
+    end
+  end
+
+  describe "#import_policy" do
+    before do
+      miq_queue
+      allow(import_file_upload).to receive(:destroy)
+      allow(import_file_upload).to receive(:uploaded_yaml_content).and_return("upload_content")
+
+      allow(ImportFileUpload).to receive(:find).with(123).and_return(import_file_upload)
+      allow(MiqPolicy).to receive(:import_from_array)
+    end
+
+    it "imports the policy using MiqPolicy" do
+      expect(MiqPolicy).to receive(:import_from_array).with("upload_content", :save => true)
+      miq_policy_import_service.import_policy(123)
+    end
+
+    it "destroys the import file upload" do
+      expect(import_file_upload).to receive(:destroy)
+      miq_policy_import_service.import_policy(123)
+    end
+
+    it "destroys the queue item" do
+      miq_policy_import_service.import_policy(123)
+      expect(MiqQueue.where(:id => miq_queue.id)).not_to be_exists
+    end
+  end
+
+  describe "#store_for_import" do
+    let(:file_contents) { "file contents" }
+    let(:import_file_upload) { double("ImportFileUpload", :id => 1).as_null_object }
+
+    context "when the import does not raise an error" do
+      before do
+        allow(MiqPolicy).to receive(:import).with("file contents", :preview => true).and_return(:uploaded => "content")
+        allow(MiqQueue).to receive(:put)
+        allow(ImportFileUpload).to receive(:create).and_return(import_file_upload)
+      end
+
+      it "stores the import file upload" do
+        expect(import_file_upload).to receive(:store_binary_data_as_yml).with("---\n:uploaded: content\n", "Policy import")
+        miq_policy_import_service.store_for_import(file_contents)
+      end
+
+      it "returns the import file upload" do
+        expect(miq_policy_import_service.store_for_import(file_contents)).to eq(import_file_upload)
+      end
+
+      it "queues deletion of the object" do
+        Timecop.freeze(2014, 3, 4) do
+          expect(MiqQueue).to receive(:put).with(
+            :class_name  => "ImportFileUpload",
+            :instance_id => 1,
+            :deliver_on  => 1.day.from_now,
+            :method_name => "destroy"
+          )
+          miq_policy_import_service.store_for_import(file_contents)
+        end
+      end
+    end
+
+    context "when the import does raise an error" do
+      before do
+        allow(MiqPolicy).to receive(:import).with("file contents", :preview => true).and_raise
+      end
+
+      it "reraises an InvalidMiqPolicyYaml error with a message" do
+        expect { miq_policy_import_service.store_for_import(file_contents) }.to raise_error(
+          MiqPolicyImportService::InvalidMiqPolicyYaml, "Invalid YAML file"
+        )
+      end
+    end
+  end
+end

--- a/spec/services/network_topology_service_spec.rb
+++ b/spec/services/network_topology_service_spec.rb
@@ -1,0 +1,202 @@
+describe NetworkTopologyService do
+  let(:network_topology_service) { described_class.new(nil) }
+
+  describe "#build_kinds" do
+    it "creates the expected number of entity types" do
+      expect(network_topology_service.build_kinds.keys).to match_array([
+        :CloudNetwork, :CloudSubnet, :CloudTenant, :FloatingIp, :LoadBalancer, :NetworkManager, :NetworkPort, :NetworkRouter,
+        :SecurityGroup, :Tag, :Vm])
+    end
+  end
+
+  describe "#build_link" do
+    it "creates link between source to target" do
+      expect(network_topology_service.build_link(
+               "95e49048-3e00-11e5-a0d2-18037327aaeb",
+               "96c35f65-3e00-11e5-a0d2-18037327aaeb")).to eq(:source => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                                              :target => "96c35f65-3e00-11e5-a0d2-18037327aaeb")
+    end
+  end
+
+  describe "#build_topology" do
+    subject { network_topology_service.build_topology }
+
+    let(:ems_cloud) { FactoryGirl.create(:ems_openstack) }
+    let(:ems) { ems_cloud.network_manager }
+
+    before :each do
+      @cloud_tenant = FactoryGirl.create(:cloud_tenant_openstack)
+      @vm = FactoryGirl.create(:vm_openstack, :cloud_tenant => @cloud_tenant, :ext_management_system => ems_cloud)
+      @cloud_network = FactoryGirl.create(:cloud_network_openstack)
+      @public_network = FactoryGirl.create(:cloud_network_openstack)
+      @cloud_subnet = FactoryGirl.create(:cloud_subnet_openstack, :cloud_network         => @cloud_network,
+                                                                  :ext_management_system => ems)
+      @network_router = FactoryGirl.create(:network_router_openstack, :cloud_subnets => [@cloud_subnet],
+                                                                      :cloud_network => @public_network)
+      @floating_ip = FactoryGirl.create(:floating_ip_openstack, :vm => @vm, :cloud_network => @public_network)
+      @security_group = FactoryGirl.create(:security_group_openstack)
+      @network_port = FactoryGirl.create(:network_port_openstack, :device          => @vm,
+                                                                  :security_groups => [@security_group],
+                                                                  :floating_ip     => @floating_ip)
+      @cloud_subnet_network_port = FactoryGirl.create(:cloud_subnet_network_port, :cloud_subnet => @cloud_subnet,
+                                                                                  :network_port => @network_port)
+    end
+
+    it "topology contains only the expected keys" do
+      expect(subject.keys).to match_array([:items, :kinds, :relations, :icons])
+    end
+
+    it "provider has unknown status when no authentication exists" do
+      ems = FactoryGirl.create(:ems_openstack).network_manager
+
+      allow(network_topology_service).to receive(:retrieve_providers).with(
+                                           anything, ManageIQ::Providers::NetworkManager).and_return([ems])
+      network_topology_service.instance_variable_set(:@providers,
+                                                     ManageIQ::Providers::NetworkManager.where(:id => ems.id))
+
+      expect(subject[:items]).to eq(
+        "NetworkManager" + ems.compressed_id.to_s => {:name         => ems.name,
+                                                      :status       => "Unknown",
+                                                      :kind         => "NetworkManager",
+                                                      :display_kind => "Openstack",
+                                                      :miq_id       => ems.id})
+    end
+
+    it "topology contains the expected structure and content" do
+      allow(network_topology_service).to receive(:retrieve_providers).and_return([ems])
+      network_topology_service.instance_variable_set(:@entity, ems)
+
+      expect(subject[:items]).to eq(
+        "NetworkManager" + ems.compressed_id.to_s            => {:name         => ems.name,
+                                                                 :kind         => "NetworkManager",
+                                                                 :miq_id       => ems.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "Openstack"},
+        "CloudTenant" + @cloud_tenant.compressed_id.to_s     => {:name         => @cloud_tenant.name,
+                                                                 :kind         => "CloudTenant",
+                                                                 :miq_id       => @cloud_tenant.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "CloudTenant"},
+        "CloudNetwork" + @cloud_network.compressed_id.to_s   => {:name         => @cloud_network.name,
+                                                                 :kind         => "CloudNetwork",
+                                                                 :miq_id       => @cloud_network.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "CloudNetwork"},
+        "CloudNetwork" + @public_network.compressed_id.to_s  => {:name         => @public_network.name,
+                                                                 :kind         => "CloudNetwork",
+                                                                 :miq_id       => @public_network.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "CloudNetwork"},
+        "CloudSubnet" + @cloud_subnet.compressed_id.to_s     => {:name         => @cloud_subnet.name,
+                                                                 :kind         => "CloudSubnet",
+                                                                 :miq_id       => @cloud_subnet.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "CloudSubnet"},
+        "FloatingIp" + @floating_ip.compressed_id.to_s       => {:name         => @floating_ip.name,
+                                                                 :kind         => "FloatingIp",
+                                                                 :miq_id       => @floating_ip.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "FloatingIp"},
+        "NetworkRouter" + @network_router.compressed_id.to_s => {:name         => @network_router.name,
+                                                                 :kind         => "NetworkRouter",
+                                                                 :miq_id       => @network_router.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "NetworkRouter"},
+
+        "SecurityGroup" + @security_group.compressed_id.to_s => {:name         => @security_group.name,
+                                                                 :kind         => "SecurityGroup",
+                                                                 :miq_id       => @security_group.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "SecurityGroup"},
+        "Vm" + @vm.compressed_id.to_s                        => {:name         => @vm.name,
+                                                                 :kind         => "Vm",
+                                                                 :miq_id       => @vm.id,
+                                                                 :status       => "On",
+                                                                 :display_kind => "VM",
+                                                                 :provider     => ems_cloud.name},
+      )
+
+      expect(subject[:relations].size).to eq(9)
+      expect(subject[:relations]).to include(
+        {:source => "NetworkManager" + ems.compressed_id.to_s, :target => "CloudSubnet" + @cloud_subnet.compressed_id.to_s},
+        {:source => "CloudSubnet" + @cloud_subnet.compressed_id.to_s, :target => "CloudNetwork" + @cloud_network.compressed_id.to_s},
+        {:source => "CloudSubnet" + @cloud_subnet.compressed_id.to_s, :target => "Vm" + @vm.compressed_id.to_s},
+        {:source => "Vm" + @vm.compressed_id.to_s, :target => "FloatingIp" + @floating_ip.compressed_id.to_s},
+        {:source => "Vm" + @vm.compressed_id.to_s, :target => "CloudTenant" + @cloud_tenant.compressed_id.to_s},
+        {:source => "Vm" + @vm.compressed_id.to_s, :target => "SecurityGroup" + @security_group.compressed_id.to_s},
+        {:source => "CloudSubnet" + @cloud_subnet.compressed_id.to_s, :target => "NetworkRouter" + @network_router.compressed_id.to_s},
+        {:source => "NetworkRouter" + @network_router.compressed_id.to_s, :target => "CloudNetwork" + @public_network.compressed_id.to_s},
+        {:source => "CloudNetwork" + @public_network.compressed_id.to_s, :target => "FloatingIp" + @floating_ip.compressed_id.to_s},
+      )
+    end
+
+    it "topology contains the expected structure when vm is off" do
+      # vm and host test cross provider correlation to infra provider
+      @vm.update_attributes(:raw_power_state => "SHUTOFF")
+      allow(network_topology_service).to receive(:retrieve_providers).and_return([ems])
+      network_topology_service.instance_variable_set(:@entity, ems)
+
+      expect(subject[:items]).to eq(
+        "NetworkManager" + ems.compressed_id.to_s            => {:name         => ems.name,
+                                                                 :kind         => "NetworkManager",
+                                                                 :miq_id       => ems.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "Openstack"},
+        "CloudTenant" + @cloud_tenant.compressed_id.to_s     => {:name         => @cloud_tenant.name,
+                                                                 :kind         => "CloudTenant",
+                                                                 :miq_id       => @cloud_tenant.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "CloudTenant"},
+        "CloudNetwork" + @cloud_network.compressed_id.to_s   => {:name         => @cloud_network.name,
+                                                                 :kind         => "CloudNetwork",
+                                                                 :miq_id       => @cloud_network.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "CloudNetwork"},
+        "CloudNetwork" + @public_network.compressed_id.to_s  => {:name         => @public_network.name,
+                                                                 :kind         => "CloudNetwork",
+                                                                 :miq_id       => @public_network.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "CloudNetwork"},
+        "CloudSubnet" + @cloud_subnet.compressed_id.to_s     => {:name         => @cloud_subnet.name,
+                                                                 :kind         => "CloudSubnet",
+                                                                 :miq_id       => @cloud_subnet.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "CloudSubnet"},
+        "FloatingIp" + @floating_ip.compressed_id.to_s       => {:name         => @floating_ip.name,
+                                                                 :kind         => "FloatingIp",
+                                                                 :miq_id       => @floating_ip.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "FloatingIp"},
+        "NetworkRouter" + @network_router.compressed_id.to_s => {:name         => @network_router.name,
+                                                                 :kind         => "NetworkRouter",
+                                                                 :miq_id       => @network_router.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "NetworkRouter"},
+        "SecurityGroup" + @security_group.compressed_id.to_s => {:name         => @security_group.name,
+                                                                 :kind         => "SecurityGroup",
+                                                                 :miq_id       => @security_group.id,
+                                                                 :status       => "Unknown",
+                                                                 :display_kind => "SecurityGroup"},
+        "Vm" + @vm.compressed_id.to_s                        => {:name         => @vm.name,
+                                                                 :kind         => "Vm",
+                                                                 :miq_id       => @vm.id,
+                                                                 :status       => "Off",
+                                                                 :display_kind => "VM",
+                                                                 :provider     => ems_cloud.name},
+      )
+
+      expect(subject[:relations].size).to eq(9)
+      expect(subject[:relations]).to include(
+        {:source => "NetworkManager" + ems.compressed_id.to_s, :target => "CloudSubnet" + @cloud_subnet.compressed_id.to_s},
+        {:source => "CloudSubnet" + @cloud_subnet.compressed_id.to_s, :target => "CloudNetwork" + @cloud_network.compressed_id.to_s},
+        {:source => "CloudSubnet" + @cloud_subnet.compressed_id.to_s, :target => "Vm" + @vm.compressed_id.to_s},
+        {:source => "Vm" + @vm.compressed_id.to_s, :target => "FloatingIp" + @floating_ip.compressed_id.to_s},
+        {:source => "Vm" + @vm.compressed_id.to_s, :target => "CloudTenant" + @cloud_tenant.compressed_id.to_s},
+        {:source => "Vm" + @vm.compressed_id.to_s, :target => "SecurityGroup" + @security_group.compressed_id.to_s},
+        {:source => "CloudSubnet" + @cloud_subnet.compressed_id.to_s, :target => "NetworkRouter" + @network_router.compressed_id.to_s},
+        {:source => "NetworkRouter" + @network_router.compressed_id.to_s, :target => "CloudNetwork" + @public_network.compressed_id.to_s},
+        {:source => "CloudNetwork" + @public_network.compressed_id.to_s, :target => "FloatingIp" + @floating_ip.compressed_id.to_s},
+      )
+    end
+  end
+end

--- a/spec/services/network_visibility_service_spec.rb
+++ b/spec/services/network_visibility_service_spec.rb
@@ -1,0 +1,130 @@
+describe NetworkVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    let(:supports_pxe) { nil }
+    let(:supports_iso) { nil }
+    let(:addr_mode) { nil }
+
+    shared_examples_for "NetworkVisibilityService#determine_visibility that shows everything" do
+      it "adds the network values to the edit values" do
+        expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq(
+          :hide => [],
+          :edit => [:addr_mode, :dns_suffixes, :dns_servers, :ip_addr, :subnet_mask, :gateway]
+        )
+      end
+    end
+
+    shared_examples_for "NetworkVisibilityService#determine_visibility sysprep_enabled is 'fields' or 'file'" do
+      context "when addr_mode is static" do
+        let(:addr_mode) { "static" }
+
+        it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+      end
+
+      context "when addr_mode is not static" do
+        let(:addr_mode) { "not static" }
+
+        context "when supports_pxe is true" do
+          let(:supports_pxe) { true }
+
+          it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+        end
+
+        context "when supports_pxe is false" do
+          let(:supports_pxe) { false }
+
+          context "when supports_iso is true" do
+            let(:supports_iso) { true }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+
+          context "when supports_iso is false" do
+            let(:supports_iso) { false }
+
+            it "adds the correct values to the edit and hide values" do
+              expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq(
+                :hide => [:ip_addr, :subnet_mask, :gateway],
+                :edit => [:addr_mode, :dns_suffixes, :dns_servers]
+              )
+            end
+          end
+        end
+      end
+    end
+
+    context "when sysprep_enabled is 'fields'" do
+      let(:sysprep_enabled) { "fields" }
+
+      it_behaves_like "NetworkVisibilityService#determine_visibility sysprep_enabled is 'fields' or 'file'"
+    end
+
+    context "when sysprep_enabled is 'file'" do
+      let(:sysprep_enabled) { "file" }
+
+      it_behaves_like "NetworkVisibilityService#determine_visibility sysprep_enabled is 'fields' or 'file'"
+    end
+
+    context "when sysprep_enabled is something else" do
+      let(:sysprep_enabled) { "potato" }
+
+      context "when supports_pxe is true" do
+        let(:supports_pxe) { true }
+
+        context "when addr_mode is static" do
+          let(:addr_mode) { "static" }
+
+          it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+        end
+
+        context "when addr_mode is not static" do
+          let(:addr_mode) { "not static" }
+
+          context "when supports_iso is true" do
+            let(:supports_iso) { true }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+
+          context "when supports_iso is false" do
+            let(:supports_iso) { false }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+        end
+      end
+
+      context "when supports_pxe is false" do
+        let(:supports_pxe) { false }
+
+        context "when supports_iso is true" do
+          let(:supports_iso) { true }
+
+          context "when addr_mode is static" do
+            let(:addr_mode) { "static" }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+
+          context "when addr_mode is not static" do
+            let(:addr_mode) { "not static" }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+        end
+
+        context "when supports_iso is false" do
+          let(:supports_iso) { false }
+
+          it "adds the correct values to the hide values" do
+            expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq(
+              :hide => [:addr_mode, :ip_addr, :subnet_mask, :gateway, :dns_servers, :dns_suffixes],
+              :edit => []
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/number_of_vms_visibility_service_spec.rb
+++ b/spec/services/number_of_vms_visibility_service_spec.rb
@@ -1,0 +1,57 @@
+describe NumberOfVmsVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when the number of vms is greater than 1" do
+      let(:number_of_vms) { 2 }
+
+      context "when the platform is linux" do
+        let(:platform) { "linux" }
+
+        it "adds values to field names to hide and edit" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => [:sysprep_computer_name, :linux_host_name],
+            :edit => [:ip_addr]
+          )
+        end
+      end
+
+      context "when the platform is not linux" do
+        let(:platform) { "not linux" }
+
+        it "adds values to field names to hide and edit" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => [:sysprep_computer_name, :linux_host_name],
+            :edit => [:ip_addr]
+          )
+        end
+      end
+    end
+
+    context "when the number of vms is not greater than 1" do
+      let(:number_of_vms) { 1 }
+
+      context "when the platform is linux" do
+        let(:platform) { "linux" }
+
+        it "adds values to field names to hide and edit" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => [:ip_addr, :sysprep_computer_name],
+            :edit => [:linux_host_name]
+          )
+        end
+      end
+
+      context "when the platform is not linux" do
+        let(:platform) { "not linux" }
+
+        it "adds values to field names to hide and edit" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => [:ip_addr, :linux_host_name],
+            :edit => [:sysprep_computer_name]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -1,0 +1,238 @@
+describe OrchestrationTemplateDialogService do
+  let(:dialog_service) { described_class.new }
+  let(:template_hot)   { FactoryGirl.create(:orchestration_template_hot_with_content) }
+  let(:template_azure) { FactoryGirl.create(:orchestration_template_azure_with_content) }
+  let(:empty_template) { FactoryGirl.create(:orchestration_template_cfn) }
+  let(:template_vapp)  { FactoryGirl.create(:orchestration_template_vmware_cloud_with_content) }
+
+  describe "#create_dialog" do
+    it "creates a dialog from hot template with stack basic info and parameters" do
+      dialog = dialog_service.create_dialog("test", template_hot)
+
+      expect(dialog).to have_attributes(
+        :label   => "test",
+        :buttons => "submit,cancel"
+      )
+
+      tabs = dialog.dialog_tabs
+      expect(tabs.size).to eq(1)
+      assert_stack_tab(tabs[0])
+    end
+
+    it "creates a dialog from azure template with stack basic info and parameters" do
+      dialog = dialog_service.create_dialog("test", template_azure)
+
+      tabs = dialog.dialog_tabs
+      assert_tab_attributes(tabs[0])
+      assert_azure_stack_group(tabs[0].dialog_groups[0])
+    end
+
+    it "creates a dialog from a template without parameters" do
+      dialog = dialog_service.create_dialog("test", empty_template)
+
+      tabs = dialog.dialog_tabs
+      assert_tab_attributes(tabs[0])
+      assert_aws_openstack_stack_group(tabs[0].dialog_groups[0])
+    end
+
+    it "creates a dialog from VMware vCloud vApp template with stack basic info and parameters" do
+      dialog = dialog_service.create_dialog("test", template_vapp)
+
+      tabs = dialog.dialog_tabs
+      assert_tab_attributes(tabs[0])
+      expect(tabs[0].dialog_groups.size).to eq(4)
+      assert_vmware_cloud_stack_group(tabs[0].dialog_groups[0])
+      assert_vmware_cloud_parameters_group(tabs[0].dialog_groups[1])
+    end
+  end
+
+  describe "creation of dropdown parameter fields" do
+    context "when allowed values are given" do
+      it "creates a dropdown field with pairs of values" do
+        # Create a simple dialog with one dropdown parameter.
+        constraint = OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => %w(val1 val2))
+        param_groups = create_dropdown_param(constraint)
+        allow(empty_template).to receive(:parameter_groups).and_return(param_groups)
+        dialog = dialog_service.create_dialog("test", empty_template)
+
+        # Get the dropdown field
+        field = dropdown_field(dialog)
+        # Ensure the allowed values are properly stored.
+        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [%w(val1 val1), %w(val2 val2)])
+      end
+    end
+
+    context "when a hash of allowed values is given" do
+      it "creates pairs from hashes" do
+        # Create a simple dialog with one dropdown parameter.
+        constraint = OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => {"key1" => "val1", "key2" => "val2"})
+        param_groups = create_dropdown_param(constraint)
+        allow(empty_template).to receive(:parameter_groups).and_return(param_groups)
+        dialog = dialog_service.create_dialog("test", empty_template)
+
+        # Get the dropdown field
+        field = dropdown_field(dialog)
+        # Ensure the allowed values are properly stored.
+        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [%w(key1 val1), %w(key2 val2)])
+      end
+    end
+
+    context "when automate method is given" do
+      it "creates a dropdown field requested resource_action" do
+        # Create a simple dialog with one dropdown parameter.
+        constraint = OrchestrationTemplate::OrchestrationParameterAllowedDynamic.new(:fqname => "/Path/To/Method")
+        param_groups = create_dropdown_param(constraint)
+        allow(empty_template).to receive(:parameter_groups).and_return(param_groups)
+        dialog = dialog_service.create_dialog("test", empty_template)
+
+        # Get the dropdown field
+        field = dropdown_field(dialog)
+        # Ensure the field is properly defined with the resource action.
+        expect(field.resource_action.fqname).to eq("/Path/To/Method")
+        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown")
+      end
+    end
+  end
+
+  def assert_stack_tab(tab)
+    assert_tab_attributes(tab)
+
+    groups = tab.dialog_groups
+    expect(groups.size).to eq(3)
+
+    assert_aws_openstack_stack_group(groups[0])
+    assert_parameter_group1(groups[1])
+    assert_parameter_group2(groups[2])
+  end
+
+  def assert_tab_attributes(tab)
+    expect(tab).to have_attributes(
+      :label   => "Basic Information",
+      :display => "edit"
+    )
+  end
+
+  def assert_aws_openstack_stack_group(group)
+    expect(group).to have_attributes(
+      :label   => "Options",
+      :display => "edit",
+    )
+
+    fields = group.dialog_fields
+    expect(fields.size).to eq(4)
+
+    expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
+    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
+    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+    assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [%w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
+    assert_field(fields[3], DialogFieldTextBox,      :name => "stack_timeout",   :data_type => 'integer')
+  end
+
+  def assert_azure_stack_group(group)
+    expect(group).to have_attributes(
+      :label   => "Options",
+      :display => "edit",
+    )
+
+    fields = group.dialog_fields
+    expect(fields.size).to eq(5)
+
+    expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
+    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",        :dynamic => true)
+    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",         :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+    assert_field(fields[2], DialogFieldDropDownList, :name => "resource_group",     :dynamic => true)
+    assert_field(fields[3], DialogFieldTextBox,      :name => "new_resource_group", :validator_rule => '^[A-Za-z][A-Za-z0-9\-_]*$')
+
+    mode_values = [["Complete",    "Complete (Delete other resources in the group)"],
+                   ["Incremental", "Incremental (Default)"]]
+    assert_field(fields[4], DialogFieldDropDownList, :name => "deploy_mode", :values => mode_values)
+    expect(fields[4].default_value).to eq("Incremental")
+  end
+
+  def assert_vmware_cloud_stack_group(group)
+    expect(group).to have_attributes(
+      :label   => "Options",
+      :display => "edit",
+    )
+
+    fields = group.dialog_fields
+    expect(fields.size).to eq(3)
+
+    expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
+    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",       :dynamic => true)
+    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",        :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+    expect(fields[2].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Availability_Zones")
+    assert_field(fields[2], DialogFieldDropDownList, :name => "availability_zone", :dynamic => true)
+  end
+
+  def assert_vmware_cloud_parameters_group(group)
+    expect(group).to have_attributes(
+      :label   => "vApp Parameters",
+      :display => "edit",
+    )
+
+    fields = group.dialog_fields
+    expect(fields.size).to eq(2)
+
+    assert_field(fields[0], DialogFieldCheckBox, :name => "param_deploy",  :default_value => "t", :data_type => "boolean")
+    assert_field(fields[1], DialogFieldCheckBox, :name => "param_powerOn", :default_value => "f", :data_type => "boolean")
+  end
+
+  def assert_field(field, clss, attributes)
+    expect(field).to be_kind_of clss
+    expect(field).to have_attributes(attributes)
+  end
+
+  def assert_parameter_group1(group)
+    expect(group).to have_attributes(
+      :label   => "General parameters",
+      :display => "edit",
+    )
+
+    fields = group.dialog_fields
+    expect(fields.size).to eq(3)
+
+    assert_field(fields[0], DialogFieldTextBox,      :name => "param_flavor",     :default_value => "m1.small")
+    assert_field(fields[1], DialogFieldDropDownList, :name => "param_image_id",   :default_value => "F18-x86_64-cfntools", :values => [%w(F18-i386-cfntools F18-i386-cfntools), %w(F18-x86_64-cfntools F18-x86_64-cfntools)])
+    assert_field(fields[2], DialogFieldTextBox,      :name => "param_cartridges", :default_value => "cron,diy,haproxy,mysql,nodejs,perl,php,postgresql,python,ruby")
+  end
+
+  def assert_parameter_group2(group)
+    expect(group).to have_attributes(
+      :label   => "Parameter Group2",
+      :display => "edit",
+    )
+
+    fields = group.dialog_fields
+    expect(fields.size).to eq(3)
+
+    assert_field(fields[0], DialogFieldTextBox,     :name => "param_admin_pass", :validator_rule => '[a-zA-Z0-9]+')
+    assert_field(fields[1], DialogFieldTextBox,     :name => "param_db_port",    :label => 'Port Number')
+    assert_field(fields[2], DialogFieldTextAreaBox, :name => "param_metadata")
+  end
+
+  def dropdown_field(dialog)
+    # First ensure that the dialog is properly constructed.
+    tabs = dialog.dialog_tabs
+    expect(tabs.size).to eq(1)
+    expect(tabs[0].dialog_groups.size).to eq(2)
+    expect(tabs[0].dialog_groups[1].dialog_fields.size).to eq(1)
+    fields = tabs[0].dialog_groups[1].dialog_fields
+    # Return the first field; it should be the only field.
+    fields[0]
+  end
+
+  def create_dropdown_param(constraint)
+    [OrchestrationTemplate::OrchestrationParameterGroup.new(
+      :label      => "group",
+      :parameters => [
+        OrchestrationTemplate::OrchestrationParameter.new(
+          :name          => "dropdown",
+          :label         => "Drop down",
+          :data_type     => "string",
+          :default_value => "val1",
+          :constraints   => [constraint])
+      ])
+    ]
+  end
+end

--- a/spec/services/privilege_checker_service_spec.rb
+++ b/spec/services/privilege_checker_service_spec.rb
@@ -1,0 +1,94 @@
+describe PrivilegeCheckerService do
+  let(:privilege_checker) { described_class.new }
+
+  describe "#valid_session?" do
+    shared_examples_for "PrivilegeCheckerService#valid_session? that returns false" do
+      it "returns false" do
+        expect(privilege_checker.valid_session?(session, user)).to be_falsey
+      end
+    end
+
+    let(:session) do
+      {
+        :last_trans_time => last_trans_time
+      }
+    end
+
+    context "when the user is signed out" do
+      let(:user) { nil }
+      let(:last_trans_time) { nil }
+
+      it_behaves_like "PrivilegeCheckerService#valid_session? that returns false"
+    end
+
+    context "when the user is signed in" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      context "when the session is timed out" do
+        let(:last_trans_time) { 2.hours.ago }
+
+        it_behaves_like "PrivilegeCheckerService#valid_session? that returns false"
+      end
+
+      context "when the session has not timed out" do
+        let(:last_trans_time) { Time.current }
+        let(:server) { double("MiqServer", :logon_status => logon_status) }
+
+        before do
+          allow(MiqServer).to receive(:my_server).and_return(server)
+        end
+
+        context "when the server is not ready" do
+          let(:logon_status) { :not_ready }
+
+          it_behaves_like "PrivilegeCheckerService#valid_session? that returns false"
+        end
+
+        context "when the server is ready" do
+          let(:logon_status) { :ready }
+
+          it "returns true" do
+            expect(privilege_checker.valid_session?(session, user)).to be_truthy
+          end
+        end
+      end
+    end
+  end
+
+  describe "#user_session_timed_out?" do
+    let(:session) do
+      {
+        :last_trans_time => last_trans_time
+      }
+    end
+
+    context "when a user exists" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      context "when the session is timed out" do
+        let(:last_trans_time) { 2.hours.ago }
+
+        it "returns true" do
+          expect(privilege_checker.user_session_timed_out?(session, user)).to be_truthy
+        end
+      end
+
+      context "when the session has not timed out" do
+        let(:last_trans_time) { Time.current }
+
+        it "returns false" do
+          expect(privilege_checker.user_session_timed_out?(session, user)).to be_falsey
+        end
+      end
+    end
+
+    context "when a user does not exist" do
+      let(:user) { nil }
+      let(:last_trans_time) { nil }
+
+      it "returns false" do
+        expect(privilege_checker.user_session_timed_out?(session, user)).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/services/pxe_iso_visibility_service_spec.rb
+++ b/spec/services/pxe_iso_visibility_service_spec.rb
@@ -1,0 +1,57 @@
+describe PxeIsoVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when pxe is supported" do
+      let(:supports_pxe) { true }
+
+      context "when iso is supported" do
+        let(:supports_iso) { true }
+
+        it "returns the values to be edit and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
+            :hide => [],
+            :edit => [:pxe_image_id, :pxe_server_id, :iso_image_id]
+          )
+        end
+      end
+
+      context "when iso is not supported" do
+        let(:supports_iso) { false }
+
+        it "returns the values to be edit and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
+            :hide => [:iso_image_id],
+            :edit => [:pxe_image_id, :pxe_server_id]
+          )
+        end
+      end
+    end
+
+    context "when pxe is not supported" do
+      let(:supports_pxe) { false }
+
+      context "when iso is supported" do
+        let(:supports_iso) { true }
+
+        it "returns the values to be edit and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
+            :hide => [:pxe_image_id, :pxe_server_id],
+            :edit => [:iso_image_id]
+          )
+        end
+      end
+
+      context "when iso is not supported" do
+        let(:supports_iso) { false }
+
+        it "returns the values to be edit and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
+            :hide => [:pxe_image_id, :pxe_server_id, :iso_image_id],
+            :edit => []
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/request_type_visibility_service_spec.rb
+++ b/spec/services/request_type_visibility_service_spec.rb
@@ -1,0 +1,29 @@
+describe RequestTypeVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when the request type is 'clone_to_template'" do
+      let(:request_type) { :clone_to_template }
+
+      it "returns the values to be hidden" do
+        expect(subject.determine_visibility(request_type)).to eq(:hide => [:vm_filter, :vm_auto_start])
+      end
+    end
+
+    context "when the request type is 'clone_to_vm'" do
+      let(:request_type) { :clone_to_vm }
+
+      it "returns the values to be hidden" do
+        expect(subject.determine_visibility(request_type)).to eq(:hide => [:vm_filter])
+      end
+    end
+
+    context "when the request type is anything else" do
+      let(:request_type) { :potato }
+
+      it "returns an empty list of values to be hidden" do
+        expect(subject.determine_visibility(request_type)).to eq(:hide => [])
+      end
+    end
+  end
+end

--- a/spec/services/retirement_visibility_service_spec.rb
+++ b/spec/services/retirement_visibility_service_spec.rb
@@ -1,0 +1,27 @@
+describe RetirementVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when retirement to_i is greater than 0" do
+      let(:retirement) { 123 }
+
+      it "adds the retirement warn to the edit fields" do
+        expect(subject.determine_visibility(retirement)).to eq(
+          :hide => [],
+          :edit => [:retirement_warn]
+        )
+      end
+    end
+
+    context "when retirement to_i is not greater than 0" do
+      let(:retirement) { 0 }
+
+      it "adds the retirement warn to the hide fields" do
+        expect(subject.determine_visibility(retirement)).to eq(
+          :hide => [:retirement_warn],
+          :edit => []
+        )
+      end
+    end
+  end
+end

--- a/spec/services/service_template_fields_visibility_service_spec.rb
+++ b/spec/services/service_template_fields_visibility_service_spec.rb
@@ -1,0 +1,25 @@
+describe ServiceTemplateFieldsVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when service_template_request exists" do
+      let(:service_template_request) { "a service template request" }
+
+      it "adds values to field names to hide" do
+        expect(subject.determine_visibility(service_template_request)).to eq(
+          :hide => [:vm_description, :schedule_type, :schedule_time]
+        )
+      end
+    end
+
+    context "when service_template_request does not exist" do
+      let(:service_template_request) { nil }
+
+      it "returns an empty hide/show hash" do
+        expect(subject.determine_visibility(service_template_request)).to eq(
+          :hide => []
+        )
+      end
+    end
+  end
+end

--- a/spec/services/sysprep_auto_logon_visibility_service_spec.rb
+++ b/spec/services/sysprep_auto_logon_visibility_service_spec.rb
@@ -1,0 +1,27 @@
+describe SysprepAutoLogonVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when sysprep_auto_logon is false" do
+      let(:sysprep_auto_logon) { false }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(sysprep_auto_logon)).to eq(
+          :hide => [:sysprep_auto_logon_count],
+          :edit => []
+        )
+      end
+    end
+
+    context "when sysprep auto logon is true" do
+      let(:sysprep_auto_logon) { true }
+
+      it "adds values to the field names to edit" do
+        expect(subject.determine_visibility(sysprep_auto_logon)).to eq(
+          :hide => [],
+          :edit => [:sysprep_auto_logon_count]
+        )
+      end
+    end
+  end
+end

--- a/spec/services/sysprep_custom_spec_visibility_service_spec.rb
+++ b/spec/services/sysprep_custom_spec_visibility_service_spec.rb
@@ -1,0 +1,27 @@
+describe SysprepCustomSpecVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when sysprep custom spec is not blank" do
+      let(:sysprep_custom_spec) { "foo" }
+
+      it "adds values to the field names to edit" do
+        expect(subject.determine_visibility(sysprep_custom_spec)).to eq(
+          :hide => [],
+          :edit => [:sysprep_spec_override]
+        )
+      end
+    end
+
+    context "when sysprep custom spec is blank" do
+      let(:sysprep_custom_spec) { nil }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(sysprep_custom_spec)).to eq(
+          :hide => [:sysprep_spec_override],
+          :edit => []
+        )
+      end
+    end
+  end
+end

--- a/spec/services/widget_import_service_spec.rb
+++ b/spec/services/widget_import_service_spec.rb
@@ -1,0 +1,375 @@
+describe WidgetImportService do
+  let(:widget_import_service) { described_class.new(widget_import_validator) }
+  let(:widget_import_validator) { double("WidgetImportValidator") }
+
+  before do
+    allow(MiqServer).to receive(:my_server).and_return(double("MiqServer", :zone_id => 1))
+  end
+
+  describe "#cancel_import" do
+    let(:import_file_upload) { double("ImportFileUpload", :id => 42) }
+    let(:miq_queue) { double("MiqQueue") }
+
+    before do
+      allow(ImportFileUpload).to receive(:find).with("42").and_return(import_file_upload)
+      allow(import_file_upload).to receive(:destroy)
+
+      allow(MiqQueue).to receive(:unqueue)
+    end
+
+    it "destroys the import file upload" do
+      expect(import_file_upload).to receive(:destroy)
+      widget_import_service.cancel_import("42")
+    end
+
+    it "destroys the queued deletion" do
+      expect(MiqQueue).to receive(:unqueue).with(
+        :class_name  => "ImportFileUpload",
+        :instance_id => 42,
+        :method_name => "destroy"
+      )
+      widget_import_service.cancel_import("42")
+    end
+  end
+
+  describe "#import_widget_from_hash" do
+    let(:widget_to_import) do
+      {
+        "description" => "Test2",
+        "title"       => "potato"
+      }
+    end
+
+    it "builds a new widget" do
+      expect(MiqWidget.first).to be_nil
+      widget_import_service.import_widget_from_hash(widget_to_import)
+      expect(MiqWidget.first).not_to be_nil
+    end
+  end
+
+  describe "#import_widgets" do
+    let(:miq_queue) { double("MiqQueue") }
+    let(:yaml_data) { "the yaml" }
+    let(:import_file_upload) do
+      double("ImportFileUpload", :id => 42, :uploaded_content => yaml_data)
+    end
+    let(:widgets_to_import) { %w(potato not_potato) }
+
+    let(:miq_report_contents) do
+      [{
+        "MiqReport" => {
+          "menu_name" => "menu name",
+          "title"     => "title",
+          "db"        => "Vm",
+          "rpt_group" => "Custom",
+          "rpt_type"  => "Custom"
+        }
+      }]
+    end
+
+    let(:miq_schedule_contents) do
+      {
+        "name"        => "schedule name",
+        "description" => "new schedule description",
+        "towhat"      => "MiqWidget",
+        "run_at"      => {
+          :start_time => Time.now,
+          :tz         => "UTC",
+          :interval   => {
+            :unit  => "daily",
+            :value => "6"
+          }
+        }
+      }
+    end
+
+    let(:widgets) do
+      [{
+        "MiqWidget" => {
+          "description"      => "Test",
+          "MiqReportContent" => miq_report_contents,
+          "MiqSchedule"      => miq_schedule_contents,
+          "resource_id"      => "123",
+          "title"            => "not_potato"
+        }
+      }, {
+        "MiqWidget" => {
+          "description" => "Test2",
+          "title"       => "potato"
+        }
+      }]
+    end
+
+    before do
+      allow(import_file_upload).to receive(:destroy)
+      allow(MiqQueue).to receive(:unqueue)
+    end
+
+    shared_examples_for "WidgetImportService#import_widgets that destroys temporary data" do
+      it "destroys the import file upload" do
+        expect(import_file_upload).to receive(:destroy)
+        widget_import_service.import_widgets(import_file_upload, widgets_to_import)
+      end
+
+      it "unqueues the miq_queue item" do
+        expect(MiqQueue).to receive(:unqueue).with(
+          :class_name  => "ImportFileUpload",
+          :instance_id => 42,
+          :method_name => "destroy"
+        )
+        widget_import_service.import_widgets(import_file_upload, widgets_to_import)
+      end
+    end
+
+    shared_examples_for "WidgetImportService#import_widgets with a non existing widget" do
+      it "builds a new widget" do
+        widget_import_service.import_widgets(import_file_upload, widgets_to_import)
+        expect(MiqWidget.first).not_to be_nil
+      end
+    end
+
+    context "when the YAML loaded is widgets" do
+      context "when the list of widgets to import from the yaml includes an existing widget" do
+        before do
+          MiqWidget.create!(:description => "Test2", :title => "potato", :content_type => "report")
+          allow(YAML).to receive(:load).with(yaml_data) do
+            allow(YAML).to receive(:load).and_call_original
+            widgets
+          end
+        end
+
+        it_behaves_like "WidgetImportService#import_widgets that destroys temporary data"
+
+        it "overwrites the existing widget" do
+          widget_import_service.import_widgets(import_file_upload, widgets_to_import)
+          expect(MiqWidget.where(:description => "Test2").first.title).to eq("potato")
+        end
+      end
+
+      context "when the list of widgets to import from the yaml do not include an existing widget" do
+        context "when the report is an RssFeed" do
+          let(:miq_report_contents) do
+            [{
+              "RssFeed" => {
+                "name"  => "name",
+                "title" => "new title"
+              }
+            }]
+          end
+
+          context "when the RssFeed already exists" do
+            before do
+              RssFeed.create!(:name => "name", :title => "old title")
+              allow(YAML).to receive(:load).with(yaml_data) do
+                allow(YAML).to receive(:load).and_call_original
+                widgets
+              end
+            end
+
+            it_behaves_like "WidgetImportService#import_widgets with a non existing widget"
+
+            it "does not update the rss feed" do
+              widget_import_service.import_widgets(import_file_upload, widgets_to_import)
+              expect(RssFeed.first.title).to eq("old title")
+            end
+          end
+
+          context "when the RssFeed does not already exist" do
+            before do
+              allow(YAML).to receive(:load).with(yaml_data) do
+                allow(YAML).to receive(:load).and_call_original
+                widgets
+              end
+            end
+
+            it_behaves_like "WidgetImportService#import_widgets with a non existing widget"
+
+            it "builds a new RssFeed" do
+              widget_import_service.import_widgets(import_file_upload, widgets_to_import)
+              expect(RssFeed.first.title).to eq("new title")
+            end
+          end
+        end
+
+        context "when the report with the same name already exists" do
+          before do
+            MiqReport.create!(
+              :db        => "Vm",
+              :name      => "menu name",
+              :rpt_group => "Custom",
+              :rpt_type  => "Custom",
+              :title     => "original report title"
+            )
+            allow(YAML).to receive(:load).with(yaml_data) do
+              allow(YAML).to receive(:load).and_call_original
+              widgets
+            end
+          end
+
+          it_behaves_like "WidgetImportService#import_widgets that destroys temporary data"
+          it_behaves_like "WidgetImportService#import_widgets with a non existing widget"
+
+          it "uses the existing report" do
+            widget_import_service.import_widgets(import_file_upload, widgets_to_import)
+            widget = MiqWidget.first
+            expect(widget.resource).to eq(MiqReport.first)
+            expect(MiqReport.first.title).to eq("original report title")
+          end
+        end
+
+        context "when the report does not exist" do
+          before do
+            allow(YAML).to receive(:load).with(yaml_data) do
+              allow(YAML).to receive(:load).and_call_original
+              widgets
+            end
+          end
+
+          it_behaves_like "WidgetImportService#import_widgets that destroys temporary data"
+          it_behaves_like "WidgetImportService#import_widgets with a non existing widget"
+
+          it "builds a report associated to the widget" do
+            widget_import_service.import_widgets(import_file_upload, widgets_to_import)
+            widget = MiqWidget.first
+            expect(widget.resource).to eq(MiqReport.first)
+          end
+        end
+
+        context "when the schedule does not exist" do
+          before do
+            allow(YAML).to receive(:load).with(yaml_data) do
+              allow(YAML).to receive(:load).and_call_original
+              widgets
+            end
+          end
+
+          it_behaves_like "WidgetImportService#import_widgets with a non existing widget"
+
+          it "builds a new miq schedule associated to the widget" do
+            widget_import_service.import_widgets(import_file_upload, widgets_to_import)
+            widget = MiqWidget.first
+            expect(widget.miq_schedule.description).to eq("new schedule description")
+          end
+        end
+
+        context "when the schedule does exist" do
+          before do
+            MiqSchedule.create!(
+              :name        => "schedule name",
+              :description => "old schedule description",
+              :towhat      => "MiqWidget",
+              :run_at      => {
+                :start_time => Time.now,
+                :tz         => "UTC",
+                :interval   => {:unit => "daily", :value => "6"}
+              }
+            )
+
+            allow(YAML).to receive(:load).with(yaml_data) do
+              allow(YAML).to receive(:load).and_call_original
+              widgets
+            end
+          end
+
+          it_behaves_like "WidgetImportService#import_widgets with a non existing widget"
+
+          it "uses the existing schedule" do
+            widget_import_service.import_widgets(import_file_upload, widgets_to_import)
+            widget = MiqWidget.first
+            expect(widget.miq_schedule.description).to eq("old schedule description")
+          end
+        end
+      end
+
+      context "when the list of widgets is nil" do
+        let(:widgets_to_import) { nil }
+
+        it_behaves_like "WidgetImportService#import_widgets that destroys temporary data"
+
+        it "does not error" do
+          expect { widget_import_service.import_widgets(import_file_upload, widgets_to_import) }.to_not raise_error
+        end
+      end
+    end
+
+    context "when the loaded yaml does not return widgets" do
+      before do
+        allow(YAML).to receive(:load).with(yaml_data).and_return([{"MiqWidget" => {"not a" => "widget"}}])
+      end
+
+      it "raises a ParsedNonWidgetYamlError" do
+        expect { widget_import_service.import_widgets(import_file_upload, widgets_to_import) }.to raise_error(
+          WidgetImportService::ParsedNonWidgetYamlError
+        )
+      end
+    end
+  end
+
+  describe "#store_for_import" do
+    let(:import_file_upload) { double("ImportFileUpload", :id => 42).as_null_object }
+
+    before do
+      allow(ImportFileUpload).to receive(:create).and_return(import_file_upload)
+      allow(import_file_upload).to receive(:store_binary_data_as_yml)
+      allow(MiqQueue).to receive(:put)
+    end
+
+    context "when the imported file does not raise any errors while determining validity" do
+      before do
+        allow(widget_import_validator).to receive(:determine_validity).with(import_file_upload).and_return(nil)
+      end
+
+      it "stores the data" do
+        expect(import_file_upload).to receive(:store_binary_data_as_yml).with("the data", "Widget import")
+        widget_import_service.store_for_import("the data")
+      end
+
+      it "returns the imported file upload" do
+        expect(widget_import_service.store_for_import("the data")).to eq(import_file_upload)
+      end
+
+      it "queues a deletion" do
+        Timecop.freeze(2014, 3, 5) do
+          expect(MiqQueue).to receive(:put).with(
+            :class_name  => "ImportFileUpload",
+            :instance_id => 42,
+            :deliver_on  => 1.day.from_now,
+            :method_name => "destroy"
+          )
+
+          widget_import_service.store_for_import("the data")
+        end
+      end
+    end
+
+    context "when the imported file raises an error while determining validity" do
+      before do
+        error_to_be_raised = WidgetImportValidator::NonYamlError.new("Test message")
+        allow(widget_import_validator).to receive(:determine_validity).with(import_file_upload).and_raise(error_to_be_raised)
+      end
+
+      it "reraises with the original error" do
+        expect do
+          widget_import_service.store_for_import("the data")
+        end.to raise_error(WidgetImportValidator::NonYamlError, "Test message")
+      end
+
+      it "queues a deletion" do
+        Timecop.freeze(2014, 3, 5) do
+          expect(MiqQueue).to receive(:put).with(
+            :class_name  => "ImportFileUpload",
+            :instance_id => 42,
+            :deliver_on  => 1.day.from_now,
+            :method_name => "destroy"
+          )
+
+          begin
+            widget_import_service.store_for_import("the data")
+          rescue WidgetImportValidator::NonYamlError
+            nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `spec/services` directory was missed in the initial move over, so a change in `app/services` in this repo could produce a test failure in the main repo. This PR just includes all the current (as of the commits in https://github.com/ManageIQ/manageiq-ui-classic/pull/155#issuecomment-272485932) versions of the service specs.

/cc @gmcculloug