### PR TITLE
sending model name to ui_lookup

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -573,8 +573,8 @@ module EmsCommon
   def check_compliance(model)
     emss = find_checked_items
     if emss.empty?
-      add_flash(_("No %{record} were selected for %{task}") % {model => ui_lookup(:models => model),
-                                                               :task  => "Compliance Check"}, :error)
+      add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:models => model.to_s),
+                                                              :task  => "Compliance Check"}, :error)
     end
     process_emss(emss, "check_compliance")
     @lastaction == "show_list" ? show_list : show


### PR DESCRIPTION
`ui_lookup` should only get strings as the names of models and not the models themselves.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1412558