### PR TITLE
Refactoring - Alert profile build obj tree

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -209,9 +209,9 @@ module MiqPolicyController::AlertProfiles
                                             :object,
                                             @sb,
                                             true,
-                                            @assign[:new][:assign_to],
-                                            @assign[:new][:cat],
-                                            @assign[:new][:objects])
+                                            :assign_to => @assign[:new][:assign_to],
+                                            :cat       => @assign[:new][:cat],
+                                            :objects   => @assign[:new][:objects])
     end
     tree
   end

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -169,17 +169,10 @@ module MiqPolicyController::AlertProfiles
   end
 
   def alert_profile_get_assign_to_objects_empty?
-    empty = true
-    unless @assign[:new][:assign_to] == "enterprise"          # No further selection needed for enterprise
-      if @assign[:new][:assign_to]                            # Assign to selected
-        if @assign[:new][:assign_to].ends_with?("-tags")
-          empty = false if @assign[:new][:cat]
-        else
-          empty = false
-        end
-      end
-    end
-    empty
+    return true if @assign[:new][:assign_to].blank?
+    return true if @assign[:new][:assign_to] == "enterprise"
+    return true if @assign[:new][:assign_to].ends_with?("-tags") && @assign[:new][:cat].blank?
+    false
   end
 
   # Build the assign objects selection tree

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -144,6 +144,7 @@ module MiqPolicyController::AlertProfiles
       @assign[:new][:assign_to] = params[:chosen_assign_to].blank? ? nil : params[:chosen_assign_to]
       @assign[:new][:cat] = nil                                 # Clear chosen tag category
     end
+
     @assign[:new][:cat] = params[:chosen_cat].blank? ? nil : params[:chosen_cat].to_i if params.key?(:chosen_cat)
     if params.key?(:chosen_assign_to) || params.key?(:chosen_cat)
       @assign[:new][:objects] = []                       # Clear selected objects

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -209,14 +209,6 @@ module MiqPolicyController::AlertProfiles
     tree
   end
 
-  def choose_node_identifier(o)
-    identifier = (o.name.presence || o.description)
-    if o.kind_of?(MiddlewareServer)
-      identifier += "-" + o.hostname
-    end
-    identifier
-  end
-
   def alert_profile_build_edit_screen
     @edit = {}
     @edit[:new] = {}

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -205,7 +205,13 @@ module MiqPolicyController::AlertProfiles
                                          :group    => @group,
                                          :selected => @assign[:new][:objects].collect { |f| "ResourcePool_#{f}" })
     else
-      tree = TreeBuilderAlertProfileObj.new(:object_tree, :object, @sb, true, @assign)
+      tree = TreeBuilderAlertProfileObj.new(:object_tree,
+                                            :object,
+                                            @sb,
+                                            true,
+                                            @assign[:new][:assign_to],
+                                            @assign[:new][:cat],
+                                            @assign[:new][:objects])
     end
     tree
   end

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -202,9 +202,9 @@ module MiqPolicyController::AlertProfiles
                                             :object,
                                             @sb,
                                             true,
-                                            :assign_to  => @assign[:new][:assign_to],
-                                            :cat        => @assign[:new][:cat],
-                                            :selected   => @assign[:new][:objects])
+                                            :assign_to => @assign[:new][:assign_to],
+                                            :cat       => @assign[:new][:cat],
+                                            :selected  => @assign[:new][:objects])
     end
     tree
   end

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -147,7 +147,6 @@ module MiqPolicyController::AlertProfiles
     @assign[:new][:cat] = params[:chosen_cat].blank? ? nil : params[:chosen_cat].to_i if params.key?(:chosen_cat)
     if params.key?(:chosen_assign_to) || params.key?(:chosen_cat)
       @assign[:new][:objects] = []                       # Clear selected objects
-      @objects = alert_profile_get_assign_to_objects   # Get the assigned objects
       @assign[:obj_tree] = alert_profile_build_obj_tree         # Build the selection tree
     end
     if params.key?(:id)
@@ -168,81 +167,46 @@ module MiqPolicyController::AlertProfiles
     process_elements(alert_profiles, MiqAlertSet, task)
   end
 
-  # Gather up the object ids based on the assignment selections
-  def alert_profile_get_assign_to_objects
-    objs = []
+  def alert_profile_get_assign_to_objects_empty?
+    empty = true
     unless @assign[:new][:assign_to] == "enterprise"          # No further selection needed for enterprise
       if @assign[:new][:assign_to]                            # Assign to selected
         if @assign[:new][:assign_to].ends_with?("-tags")
-          if @assign[:new][:cat]                              # Tag category selected
-            objs = Classification.find(@assign[:new][:cat]).entries
+          if @assign[:new][:cat]
+            empty = false
           end
-        else                                                  # Model selected
-          objs = @assign[:new][:assign_to].camelize.constantize.all
+        else
+          empty = false
         end
       end
     end
-    objs
+    empty
   end
 
   # Build the assign objects selection tree
   def alert_profile_build_obj_tree
     tree = nil
-    unless @objects.empty?               # Build object tree
-      if @assign[:new][:assign_to] == "ems_folder"
-        tree = TreeBuilderBelongsToHac.new(:vat_tree,
-                                           :vat,
-                                           @sb,
-                                           true,
-                                           :edit     => @edit,
-                                           :filters  => @filters,
-                                           :group    => @group,
-                                           :selected => @assign[:new][:objects].collect { |f| "EmsFolder_#{f}" })
-      elsif @assign[:new][:assign_to] == "resource_pool"
-        tree = TreeBuilderBelongsToHac.new(:hac_tree,
-                                           :hac,
-                                           @sb,
-                                           true,
-                                           :edit     => @edit,
-                                           :filters  => @filters,
-                                           :group    => @group,
-                                           :selected => @assign[:new][:objects].collect { |f| "ResourcePool_#{f}" })
-      else
-        root_node = TreeNodeBuilder.generic_tree_node(
-          "OBJROOT",
-          @assign[:new][:assign_to].ends_with?("-tags") ? "Tags" : ui_lookup(:tables => @assign[:new][:assign_to]),
-          "100/folder_open.png",
-          "",
-          :cfme_no_click => true,
-          :expand        => true,
-          :hideCheckbox  => true
-        )
-        root_node[:children] = []
-        @objects.sort_by { |o| (o.name.presence || o.description).downcase }.each do |o|
-          if @assign[:new][:assign_to].ends_with?("-tags")
-            icon = "100/tag.png"
-          else
-            if @assign[:new][:assign_to] == "ext_management_system"
-              icon = "svg/vendor-#{o.image_name}.svg"
-            elsif @assign[:new][:assign_to] == "resource_pool"
-              icon = o.vapp ? "100/vapp.png" : "100/resource_pool.png"
-            else
-              icon = "100/#{@assign[:new][:assign_to]}.png"
-            end
-          end
-          node = TreeNodeBuilder.generic_tree_node(
-            o.id,
-            choose_node_identifier(o),
-            icon,
-            "",
-            :cfme_no_click => true,
-            :select        => @assign[:new][:objects].include?(o.id) # Check if tag is assigned
-          )
-          root_node[:children].push(node)
-        end
-        tree = TreeBuilder.convert_bs_tree(root_node).to_json
-        @new_tree = TreeBuilderAlertProfileObj.new(:object_tree, :object, @sb, true, @assign)
-      end
+    return nil if alert_profile_get_assign_to_objects_empty?
+    if @assign[:new][:assign_to] == "ems_folder"
+      tree = TreeBuilderBelongsToHac.new(:vat_tree,
+                                         :vat,
+                                         @sb,
+                                         true,
+                                         :edit     => @edit,
+                                         :filters  => @filters,
+                                         :group    => @group,
+                                         :selected => @assign[:new][:objects].collect { |f| "EmsFolder_#{f}" })
+    elsif @assign[:new][:assign_to] == "resource_pool"
+      tree = TreeBuilderBelongsToHac.new(:hac_tree,
+                                         :hac,
+                                         @sb,
+                                         true,
+                                         :edit     => @edit,
+                                         :filters  => @filters,
+                                         :group    => @group,
+                                         :selected => @assign[:new][:objects].collect { |f| "ResourcePool_#{f}" })
+    else
+      tree = TreeBuilderAlertProfileObj.new(:object_tree, :object, @sb, true, @assign)
     end
     tree
   end
@@ -321,7 +285,6 @@ module MiqPolicyController::AlertProfiles
       @assign[:new][:cat] = aa[:tags].first.first.parent_id
       @assign[:new][:objects] = aa[:tags].collect { |o| o.first.id }
     end
-    @objects = alert_profile_get_assign_to_objects   # Get the assigned objects
     @assign[:obj_tree] = alert_profile_build_obj_tree         # Build the selection tree
 
     @assign[:current] = copy_hash(@assign[:new])

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -172,9 +172,7 @@ module MiqPolicyController::AlertProfiles
     unless @assign[:new][:assign_to] == "enterprise"          # No further selection needed for enterprise
       if @assign[:new][:assign_to]                            # Assign to selected
         if @assign[:new][:assign_to].ends_with?("-tags")
-          if @assign[:new][:cat]
-            empty = false
-          end
+          empty = false if @assign[:new][:cat]
         else
           empty = false
         end

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -152,10 +152,10 @@ module MiqPolicyController::AlertProfiles
     end
     if params.key?(:id)
       if params[:check] == "1"
-        @assign[:new][:objects].push(from_cid(params[:id].split("-").last).to_i)
+        @assign[:new][:objects].push(from_cid(params[:id].split("-").last))
         @assign[:new][:objects].sort!
       else
-        @assign[:new][:objects].delete(from_cid(params[:id].split("-").last).to_i)
+        @assign[:new][:objects].delete(from_cid(params[:id].split("-").last))
       end
     end
 
@@ -202,9 +202,9 @@ module MiqPolicyController::AlertProfiles
                                             :object,
                                             @sb,
                                             true,
-                                            :assign_to => @assign[:new][:assign_to],
-                                            :cat       => @assign[:new][:cat],
-                                            :objects   => @assign[:new][:objects])
+                                            :assign_to  => @assign[:new][:assign_to],
+                                            :cat        => @assign[:new][:cat],
+                                            :selected   => @assign[:new][:objects])
     end
     tree
   end

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -152,10 +152,10 @@ module MiqPolicyController::AlertProfiles
     end
     if params.key?(:id)
       if params[:check] == "1"
-        @assign[:new][:objects].push(params[:id].split("-").last.to_i)
+        @assign[:new][:objects].push(from_cid(params[:id].split("-").last).to_i)
         @assign[:new][:objects].sort!
       else
-        @assign[:new][:objects].delete(params[:id].split("-").last.to_i)
+        @assign[:new][:objects].delete(from_cid(params[:id].split("-").last).to_i)
       end
     end
 

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -152,10 +152,10 @@ module MiqPolicyController::AlertProfiles
     end
     if params.key?(:id)
       if params[:check] == "1"
-        @assign[:new][:objects].push(params[:id].split("_").last.to_i)
+        @assign[:new][:objects].push(params[:id].split("-").last.to_i)
         @assign[:new][:objects].sort!
       else
-        @assign[:new][:objects].delete(params[:id].split("_").last.to_i)
+        @assign[:new][:objects].delete(params[:id].split("-").last.to_i)
       end
     end
 
@@ -241,6 +241,7 @@ module MiqPolicyController::AlertProfiles
           root_node[:children].push(node)
         end
         tree = TreeBuilder.convert_bs_tree(root_node).to_json
+        @new_tree = TreeBuilderAlertProfileObj.new(:object_tree, :object, @sb, true, @assign)
       end
     end
     tree

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -343,6 +343,7 @@ class StorageController < ApplicationController
 
 
   def explorer
+    binding.pry
     @breadcrumbs = []
     @explorer = true
     @lastaction = "explorer"

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -343,7 +343,6 @@ class StorageController < ApplicationController
 
 
   def explorer
-    binding.pry
     @breadcrumbs = []
     @explorer = true
     @lastaction = "explorer"

--- a/app/decorators/classification_decorator.rb
+++ b/app/decorators/classification_decorator.rb
@@ -4,6 +4,6 @@ class ClassificationDecorator < MiqDecorator
   end
 
   def fonticon
-    entries.present? ? 'pficon pficon-folder-close' : 'fa fa-tag'
+    category? ? 'pficon pficon-folder-close' : 'fa fa-tag'
   end
 end

--- a/app/decorators/classification_decorator.rb
+++ b/app/decorators/classification_decorator.rb
@@ -1,9 +1,9 @@
 class ClassificationDecorator < MiqDecorator
   def self.fonticon
-    super
+    'pficon pficon-folder-close'
   end
 
   def fonticon
-    category? ? 'pficon pficon-folder-close' : 'fa fa-tag'
+    category? ? super : 'fa fa-tag'
   end
 end

--- a/app/decorators/classification_decorator.rb
+++ b/app/decorators/classification_decorator.rb
@@ -2,4 +2,8 @@ class ClassificationDecorator < MiqDecorator
   def self.fonticon
     'pficon pficon-folder-close'
   end
+
+  def fonticon
+    entries.present? ? 'pficon pficon-folder-close' : 'fa fa-tag'
+  end
 end

--- a/app/decorators/classification_decorator.rb
+++ b/app/decorators/classification_decorator.rb
@@ -1,6 +1,6 @@
 class ClassificationDecorator < MiqDecorator
   def self.fonticon
-    'pficon pficon-folder-close'
+    super
   end
 
   def fonticon

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -11,7 +11,6 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     node[:title] = (object.name.presence || object.description) unless object.kind_of?(MiddlewareServer)
     node[:hideCheckbox] = false
     node[:select] = @objects.include?(object.id)
-    node
   end
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -3,26 +3,16 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     @assign_to = assign_to
     @cat = cat
     @objects = objects
+    @cat_tree = true if @assign_to.ends_with?("-tags")
     build = false unless @assign_to
     super(name, type, sandbox, build)
   end
 
   def override(node, object, _pid, _options)
     identifier = (object.name.presence || object.description)
-    if object.kind_of?(MiddlewareServer)
-      identifier += "-" + object.hostname
-    end
-
-    if @assign_to.ends_with?("-tags")
-      node[:icon] = "fa fa-tag"
-    elsif @assign_to == "tenant"
-      node[:icon] = "pficon pficon-tenant"
-    else
-      node[:image] = ActionController::Base.helpers.image_path("100/#{@assign_to}.png")
-    end
-
+    identifier += "-" + object.hostname if object.kind_of?(MiddlewareServer)
     node[:title] = identifier
-    node[:cfmeNoClick] = true
+    node[:icon] = "fa fa-tag" if @cat_tree
     node[:hideCheckbox] = false
     node[:select] = @objects.include?(object.id)
     node
@@ -45,7 +35,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def root_options
-    t = @assign_to.ends_with?("-tags") ? "Tags" : ui_lookup(:tables => @assign_to)
+    t = @cat_tree ? "Tags" : ui_lookup(:tables => @assign_to)
     {
       :title        => t,
       :tooltip      => "",
@@ -59,7 +49,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     obj = if !@assign_to || @assign_to == "enterprise"
                  []
-               elsif @assign_to.ends_with?("-tags")
+               elsif @cat_tree
                  @cat ? Classification.find(@cat).entries : []
                else
                  @assign_to.camelize.constantize.all

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -17,10 +17,6 @@ class TreeBuilderAlertProfileObj < TreeBuilder
 
     if @assign[:new][:assign_to].ends_with?("-tags")
       node[:icon] = "fa fa-tag"
-    elsif @assign[:new][:assign_to] == "ext_management_system"
-      node[:image] = "svg/vendor-#{object.image_name}.svg"
-    elsif @assign[:new][:assign_to] == "resource_pool"
-      node[:icon] = "pficon pficon-resource_pool"
     elsif @assign[:new][:assign_to] == "tenant"
       node[:icon] = "pficon pficon-tenant"
     else
@@ -63,21 +59,6 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-=begin
-    @objects = []
-    if !(@assign[:new][:assign_to] == "enterprise") && @assign[:new][:assign_to]
-      # No further selection needed for enterprise
-      # Assign to selected
-      if @assign[:new][:assign_to].ends_with?("-tags") && @assign[:new][:cat]
-        # Tag category selected
-        @objects = Classification.find(@assign[:new][:cat]).entries
-      else
-        # Model selected
-        @objects = @assign[:new][:assign_to].camelize.constantize.all
-      end
-    end
-=end
-    #binding.pry
     @objects = if !@assign[:new][:assign_to] || @assign[:new][:assign_to] == "enterprise"
                  []
                elsif @assign[:new][:assign_to].ends_with?("-tags")
@@ -85,7 +66,6 @@ class TreeBuilderAlertProfileObj < TreeBuilder
                else
                  @assign[:new][:assign_to].camelize.constantize.all
                end
-
 
     count_only_or_objects(count_only, @objects.sort_by { |o| (o.name.presence || o.description).downcase })
   end

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -20,9 +20,9 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     elsif @assign[:new][:assign_to] == "ext_management_system"
       node[:image] = "svg/vendor-#{object.image_name}.svg"
     elsif @assign[:new][:assign_to] == "resource_pool"
-      node[:icon] = "pficon-resource_pool"
+      node[:icon] = "pficon pficon-resource_pool"
     elsif @assign[:new][:assign_to] == "tenant"
-      node[:image] = ActionController::Base.helpers.image_path("100/tenant.png")
+      node[:icon] = "pficon pficon-tenant"
     else
       node[:image] = ActionController::Base.helpers.image_path("100/#{@assign[:new][:assign_to]}.png")
     end
@@ -63,6 +63,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
+=begin
     @objects = []
     if !(@assign[:new][:assign_to] == "enterprise") && @assign[:new][:assign_to]
       # No further selection needed for enterprise
@@ -75,6 +76,17 @@ class TreeBuilderAlertProfileObj < TreeBuilder
         @objects = @assign[:new][:assign_to].camelize.constantize.all
       end
     end
+=end
+    #binding.pry
+    @objects = if !@assign[:new][:assign_to] || @assign[:new][:assign_to] == "enterprise"
+                 []
+               elsif @assign[:new][:assign_to].ends_with?("-tags")
+                 @assign[:new][:cat] ? Classification.find(@assign[:new][:cat]).entries : []
+               else
+                 @assign[:new][:assign_to].camelize.constantize.all
+               end
+
+
     count_only_or_objects(count_only, @objects.sort_by { |o| (o.name.presence || o.description).downcase })
   end
 end

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -8,7 +8,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def override(node, object, _pid, _options)
-    node[:title] = (object.name.presence || object.description) if !object.kind_of?(MiddlewareServer)
+    node[:title] = (object.name.presence || object.description) unless object.kind_of?(MiddlewareServer)
     node[:hideCheckbox] = false
     node[:select] = @objects.include?(object.id)
     node

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -12,7 +12,6 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     identifier = (object.name.presence || object.description)
     identifier += "-" + object.hostname if object.kind_of?(MiddlewareServer)
     node[:title] = identifier
-    node[:icon] = "fa fa-tag" if @cat_tree
     node[:hideCheckbox] = false
     node[:select] = @objects.include?(object.id)
     node
@@ -27,10 +26,12 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   def set_locals_for_render
     locals = super
     locals.merge!(
-      :id_prefix  => "obj_treebox2",
-      :oncheck    => "miqOnCheckHandler",
-      :check_url  => "alert_profile_assign_changed/",
-      :checkboxes => true,
+      :id_prefix   => "obj_treebox2",
+      :oncheck     => "miqOnCheckHandler",
+      :check_url   => "alert_profile_assign_changed/",
+      :checkboxes  => true,
+      :cfmeNoClick => true,
+      :onclick     => false
     )
   end
 

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -17,14 +17,12 @@ class TreeBuilderAlertProfileObj < TreeBuilder
 
     if @assign[:new][:assign_to].ends_with?("-tags")
       icon = "tag.png"
+    elsif @assign[:new][:assign_to] == "ext_management_system"
+      icon = "vendor-#{object.image_name}.png"
+    elsif @assign[:new][:assign_to] == "resource_pool"
+      icon = object.vapp ? "vapp.png" : "resource_pool.png"
     else
-      if @assign[:new][:assign_to] == "ext_management_system"
-        icon = "vendor-#{object.image_name}.png"
-      elsif @assign[:new][:assign_to] == "resource_pool"
-        icon = object.vapp ? "vapp.png" : "resource_pool.png"
-      else
-        icon = "#{@assign[:new][:assign_to]}.png"
-      end
+      icon = "#{@assign[:new][:assign_to]}.png"
     end
 
     node[:title] = identifier
@@ -37,7 +35,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
 
   def tree_init_options(_tree_name)
     {
-      :expand        => true
+      :expand => true
     }
   end
 
@@ -53,25 +51,27 @@ class TreeBuilderAlertProfileObj < TreeBuilder
 
   def root_options
     t = @assign[:new][:assign_to].ends_with?("-tags") ? "Tags" : ui_lookup(:tables => @assign[:new][:assign_to])
-    options = {
-      :hideCheckbox => true,
-      :cfmeNoClick  => true
+    #[t, "", "100/folder_open", options]
+    {
+      :title          => t,
+      :tooltip        => "",
+      :image          => "100/folder_open",
+      :hideCheckbox   => true,
+      :cfmeNoClick    => true,
+      :expand         => true
     }
-    [t, "", "100/folder_open", options]
   end
 
   def x_get_tree_roots(count_only, _options)
     @objects = []
-    unless @assign[:new][:assign_to] == "enterprise"          # No further selection needed for enterprise
-      if @assign[:new][:assign_to]                            # Assign to selected
-        if @assign[:new][:assign_to].ends_with?("-tags")
-          if @assign[:new][:cat]                              # Tag category selected
-            @objects = Classification.find(@assign[:new][:cat]).entries
-          end
-        else
-          # Model selected
-          @objects = @assign[:new][:assign_to].camelize.constantize.all
-        end
+    if !(@assign[:new][:assign_to] == "enterprise") && @assign[:new][:assign_to]           # No further selection needed for enterprise
+      # Assign to selected
+      if @assign[:new][:assign_to].ends_with?("-tags") && @assign[:new][:cat]
+        # Tag category selected
+        @objects = Classification.find(@assign[:new][:cat]).entries
+      else
+        # Model selected
+        @objects = @assign[:new][:assign_to].camelize.constantize.all
       end
     end
     count_only_or_objects(count_only, @objects.sort_by { |o| (o.name.presence || o.description).downcase })

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -68,7 +68,8 @@ class TreeBuilderAlertProfileObj < TreeBuilder
           if @assign[:new][:cat]                              # Tag category selected
             @objects = Classification.find(@assign[:new][:cat]).entries
           end
-        else                                                  # Model selected
+        else
+          # Model selected
           @objects = @assign[:new][:assign_to].camelize.constantize.all
         end
       end

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -1,12 +1,11 @@
 class TreeBuilderAlertProfileObj < TreeBuilder
-
   def initialize(name, type, sandbox, build = true, assign = nil)
     @assign = {
       :new     => assign[:new],
       :current => assign[:current]
     }
 
-    build = false if !@assign[:new][:assign_to]
+    build = false unless @assign[:new][:assign_to]
     super(name, type, sandbox, build)
   end
 
@@ -28,12 +27,14 @@ class TreeBuilderAlertProfileObj < TreeBuilder
       end
     end
 
+    node[:title] = identifier
     node[:image] = ActionController::Base.helpers.image_path("100/#{icon}")
     node[:cfmeNoClick] = true
     node[:hideCheckbox] = false
     node[:select] = @assign[:new][:objects].include?(object.id)
     node
   end
+
   def tree_init_options(_tree_name)
     {
       :expand        => true
@@ -56,7 +57,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
       :hideCheckbox => true,
       :cfmeNoClick  => true
     }
-    ["Tags", "", "100/folder_open", options]
+    [t, "", "100/folder_open", options]
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -1,10 +1,9 @@
 class TreeBuilderAlertProfileObj < TreeBuilder
-  def initialize(name, type, sandbox, build = true, assign_to = nil, cat = nil, objects = nil)
+  def initialize(name, type, sandbox, build = true, assign_to: nil, cat: nil, objects: nil)
     @assign_to = assign_to
     @cat = cat
     @objects = objects
     @cat_tree = true if @assign_to.ends_with?("-tags")
-    build = false unless @assign_to
     super(name, type, sandbox, build)
   end
 
@@ -49,13 +48,12 @@ class TreeBuilderAlertProfileObj < TreeBuilder
 
   def x_get_tree_roots(count_only, _options)
     obj = if !@assign_to || @assign_to == "enterprise"
-                 []
-               elsif @cat_tree
-                 @cat ? Classification.find(@cat).entries : []
-               else
-                 @assign_to.camelize.constantize.all
-               end
-
+            []
+          elsif @cat_tree
+            @cat ? Classification.find(@cat).entries : []
+          else
+            @assign_to.camelize.constantize.all
+          end
     count_only_or_objects(count_only, obj.sort_by { |o| (o.name.presence || o.description).downcase })
   end
 end

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -18,7 +18,8 @@ class TreeBuilderAlertProfileObj < TreeBuilder
 
   def tree_init_options(_tree_name)
     {
-      :expand => true
+      :expand => true,
+      :hideCheckox => false
     }
   end
 

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -1,0 +1,77 @@
+class TreeBuilderAlertProfileObj < TreeBuilder
+
+  def initialize(name, type, sandbox, build = true, assign = nil)
+    @assign = {
+      :new     => assign[:new],
+      :current => assign[:current]
+    }
+
+    build = false if !@assign[:new][:assign_to]
+    super(name, type, sandbox, build)
+  end
+
+  def override(node, object, _pid, _options)
+    identifier = (object.name.presence || object.description)
+    if object.kind_of?(MiddlewareServer)
+      identifier += "-" + object.hostname
+    end
+
+    if @assign[:new][:assign_to].ends_with?("-tags")
+      icon = "tag.png"
+    else
+      if @assign[:new][:assign_to] == "ext_management_system"
+        icon = "vendor-#{object.image_name}.png"
+      elsif @assign[:new][:assign_to] == "resource_pool"
+        icon = object.vapp ? "vapp.png" : "resource_pool.png"
+      else
+        icon = "#{@assign[:new][:assign_to]}.png"
+      end
+    end
+
+    node[:image] = ActionController::Base.helpers.image_path("100/#{icon}")
+    node[:cfmeNoClick] = true
+    node[:hideCheckbox] = false
+    node[:select] = @assign[:new][:objects].include?(object.id)
+    node
+  end
+  def tree_init_options(_tree_name)
+    {
+      :expand        => true
+    }
+  end
+
+  def set_locals_for_render
+    locals = super
+    locals.merge!(
+      :id_prefix  => "obj_treebox2",
+      :oncheck    => "miqOnCheckHandler",
+      :check_url  => "alert_profile_assign_changed/",
+      :checkboxes => true,
+    )
+  end
+
+  def root_options
+    t = @assign[:new][:assign_to].ends_with?("-tags") ? "Tags" : ui_lookup(:tables => @assign[:new][:assign_to])
+    options = {
+      :hideCheckbox => true,
+      :cfmeNoClick  => true
+    }
+    ["Tags", "", "folder_open", options]
+  end
+
+  def x_get_tree_roots(count_only, _options)
+    @objects = []
+    unless @assign[:new][:assign_to] == "enterprise"          # No further selection needed for enterprise
+      if @assign[:new][:assign_to]                            # Assign to selected
+        if @assign[:new][:assign_to].ends_with?("-tags")
+          if @assign[:new][:cat]                              # Tag category selected
+            @objects = Classification.find(@assign[:new][:cat]).entries
+          end
+        else                                                  # Model selected
+          @objects = @assign[:new][:assign_to].camelize.constantize.all
+        end
+      end
+    end
+    count_only_or_objects(count_only, @objects.sort_by { |o| (o.name.presence || o.description).downcase })
+  end
+end

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -21,8 +21,10 @@ class TreeBuilderAlertProfileObj < TreeBuilder
       node[:image] = "svg/vendor-#{object.image_name}.svg"
     elsif @assign[:new][:assign_to] == "resource_pool"
       node[:icon] = "pficon-resource_pool"
+    elsif @assign[:new][:assign_to] == "tenant"
+      node[:image] = ActionController::Base.helpers.image_path("100/tenant.png")
     else
-      node[:image] = "100/#{@assign[:new][:assign_to]}.png"
+      node[:image] = ActionController::Base.helpers.image_path("100/#{@assign[:new][:assign_to]}.png")
     end
 
     node[:title] = identifier
@@ -53,7 +55,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     {
       :title        => t,
       :tooltip      => "",
-      :image        => "100/folder_open",
+      :icon        => "pficon pficon-folder-open",
       :hideCheckbox => true,
       :cfmeNoClick  => true,
       :expand       => true

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -16,17 +16,16 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     end
 
     if @assign[:new][:assign_to].ends_with?("-tags")
-      icon = "tag.png"
+      node[:icon] = "fa fa-tag"
     elsif @assign[:new][:assign_to] == "ext_management_system"
-      icon = "vendor-#{object.image_name}.png"
+      node[:image] = "svg/vendor-#{object.image_name}.svg"
     elsif @assign[:new][:assign_to] == "resource_pool"
-      icon = object.vapp ? "vapp.png" : "resource_pool.png"
+      node[:icon] = "pficon-resource_pool"
     else
-      icon = "#{@assign[:new][:assign_to]}.png"
+      node[:image] = "100/#{@assign[:new][:assign_to]}.png"
     end
 
     node[:title] = identifier
-    node[:image] = ActionController::Base.helpers.image_path("100/#{icon}")
     node[:cfmeNoClick] = true
     node[:hideCheckbox] = false
     node[:select] = @assign[:new][:objects].include?(object.id)
@@ -51,20 +50,20 @@ class TreeBuilderAlertProfileObj < TreeBuilder
 
   def root_options
     t = @assign[:new][:assign_to].ends_with?("-tags") ? "Tags" : ui_lookup(:tables => @assign[:new][:assign_to])
-    #[t, "", "100/folder_open", options]
     {
-      :title          => t,
-      :tooltip        => "",
-      :image          => "100/folder_open",
-      :hideCheckbox   => true,
-      :cfmeNoClick    => true,
-      :expand         => true
+      :title        => t,
+      :tooltip      => "",
+      :image        => "100/folder_open",
+      :hideCheckbox => true,
+      :cfmeNoClick  => true,
+      :expand       => true
     }
   end
 
   def x_get_tree_roots(count_only, _options)
     @objects = []
-    if !(@assign[:new][:assign_to] == "enterprise") && @assign[:new][:assign_to]           # No further selection needed for enterprise
+    if !(@assign[:new][:assign_to] == "enterprise") && @assign[:new][:assign_to]
+      # No further selection needed for enterprise
       # Assign to selected
       if @assign[:new][:assign_to].ends_with?("-tags") && @assign[:new][:cat]
         # Tag category selected

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -18,8 +18,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
 
   def tree_init_options(_tree_name)
     {
-      :expand => true,
-      :hideCheckox => false
+      :expand => true
     }
   end
 
@@ -35,7 +34,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def root_options
-    t = @cat_tree ? "Tags" : ui_lookup(:tables => @assign_to)
+    t = @cat_tree ? _("Tags") : ui_lookup(:tables => @assign_to)
     {
       :title        => t,
       :tooltip      => "",

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -56,7 +56,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
       :hideCheckbox => true,
       :cfmeNoClick  => true
     }
-    ["Tags", "", "folder_open", options]
+    ["Tags", "", "100/folder_open", options]
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -3,7 +3,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     @assign_to = assign_to
     @cat = cat
     @objects = objects
-    @cat_tree = true if @assign_to.ends_with?("-tags")
+    @cat_tree = @assign_to.ends_with?("-tags")
     super(name, type, sandbox, build)
   end
 
@@ -44,7 +44,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    obj = if !@assign_to || @assign_to == "enterprise"
+    obj = if @assign_to.blank? || @assign_to == "enterprise"
             []
           elsif @cat_tree
             @cat ? Classification.find(@cat).entries : []

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -8,9 +8,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def override(node, object, _pid, _options)
-    identifier = (object.name.presence || object.description)
-    identifier += "-" + object.hostname if object.kind_of?(MiddlewareServer)
-    node[:title] = identifier
+    node[:title] = (object.name.presence || object.description) if !object.kind_of?(MiddlewareServer)
     node[:hideCheckbox] = false
     node[:select] = @objects.include?(object.id)
     node

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -26,9 +26,8 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   def set_locals_for_render
     locals = super
     locals.merge!(
-      :id_prefix   => "obj_treebox2",
       :oncheck     => "miqOnCheckHandler",
-      :check_url   => "alert_profile_assign_changed/",
+      :check_url   => "/miq_policy/alert_profile_assign_changed/",
       :checkboxes  => true,
       :cfmeNoClick => true,
       :onclick     => false

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -55,7 +55,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     {
       :title        => t,
       :tooltip      => "",
-      :icon        => "pficon pficon-folder-open",
+      :icon         => "pficon pficon-folder-open",
       :hideCheckbox => true,
       :cfmeNoClick  => true,
       :expand       => true

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -1,8 +1,8 @@
 class TreeBuilderAlertProfileObj < TreeBuilder
-  def initialize(name, type, sandbox, build = true, assign_to: nil, cat: nil, objects: nil)
+  def initialize(name, type, sandbox, build = true, assign_to: nil, cat: nil, selected: nil)
     @assign_to = assign_to
     @cat = cat
-    @objects = objects
+    @selected = selected
     @cat_tree = @assign_to.ends_with?("-tags")
     super(name, type, sandbox, build)
   end
@@ -10,7 +10,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   def override(node, object, _pid, _options)
     node[:title] = (object.name.presence || object.description) unless object.kind_of?(MiddlewareServer)
     node[:hideCheckbox] = false
-    node[:select] = @objects.include?(object.id)
+    node[:select] = @selected.include?(object.id)
   end
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -20,8 +20,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(
+    super.merge!(
       :oncheck     => "miqOnCheckHandler",
       :check_url   => "/miq_policy/alert_profile_assign_changed/",
       :checkboxes  => true,
@@ -31,9 +30,8 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def root_options
-    t = @cat_tree ? _("Tags") : ui_lookup(:tables => @assign_to)
     {
-      :title        => t,
+      :title        => @cat_tree ? _("Tags") : ui_lookup(:tables => @assign_to),
       :tooltip      => "",
       :icon         => "pficon pficon-folder-open",
       :hideCheckbox => true,

--- a/app/presenters/tree_node/middleware_server.rb
+++ b/app/presenters/tree_node/middleware_server.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class MiddlewareServer < Node
-    set_attribute(:title) { |object| object.name.presence + '-' + object.host_name }
+    set_attribute(:title) { |object| "#{object.name.presence} - #{object.host_name}" }
   end
 end

--- a/app/presenters/tree_node/middleware_server.rb
+++ b/app/presenters/tree_node/middleware_server.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class MiddlewareServer < Node
-    set_attribute(:title) { [@object.name.presence, @object.host_name].join(" - ") }
+    set_attribute(:title) { [@object.name.presence, @object.hostname].join(" - ") }
   end
 end

--- a/app/presenters/tree_node/middleware_server.rb
+++ b/app/presenters/tree_node/middleware_server.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class MiddlewareServer < Node
-    set_attribute(:title) { |object| "#{object.name.presence} - #{object.host_name}" }
+    set_attribute(:title) { [@object.name.presence, @object.host_name].join(" - ") }
   end
 end

--- a/app/presenters/tree_node/middleware_server.rb
+++ b/app/presenters/tree_node/middleware_server.rb
@@ -1,0 +1,5 @@
+module TreeNode
+  class MiddlewareServer < Node
+    set_attribute(:title, @object.name.presence + '-' + @object.host_name)
+  end
+end

--- a/app/presenters/tree_node/middleware_server.rb
+++ b/app/presenters/tree_node/middleware_server.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class MiddlewareServer < Node
-    set_attribute(:title, @object.name.presence + '-' + @object.host_name)
+    set_attribute(:title) { |object| object.name.presence + '-' + object.host_name }
   end
 end

--- a/app/views/miq_policy/_alert_profile_assign.html.haml
+++ b/app/views/miq_policy/_alert_profile_assign.html.haml
@@ -35,6 +35,7 @@
     %h3
       = _('Selections')
     - if @assign[:obj_tree]
+      = render(:partial => 'shared/tree', :locals => {:tree => @new_tree, :name => @new_tree.name})
       #obj_treebox.treeview-pf-hover.treeview-pf-select{:style => "width: 100%; color: #000;"}
       = render(:partial => "layouts/tree",
         :locals         => {:tree_id    => "obj_treebox",

--- a/app/views/miq_policy/_alert_profile_assign.html.haml
+++ b/app/views/miq_policy/_alert_profile_assign.html.haml
@@ -35,9 +35,9 @@
     %h3
       = _('Selections')
     - if @assign[:obj_tree]
-      = render(:partial => 'shared/tree', :locals => {:tree => @new_tree, :name => @new_tree.name})
+      = render(:partial => 'shared/tree', :locals => {:tree => @assign[:obj_tree], :name => @assign[:obj_tree].name})
       #obj_treebox.treeview-pf-hover.treeview-pf-select{:style => "width: 100%; color: #000;"}
-      = render(:partial => "layouts/tree",
+      -#= render(:partial => "layouts/tree",
         :locals         => {:tree_id    => "obj_treebox",
           :tree_name                    => "obj_tree",
           :bs_tree                      => @assign[:obj_tree],

--- a/app/views/miq_policy/_alert_profile_assign.html.haml
+++ b/app/views/miq_policy/_alert_profile_assign.html.haml
@@ -36,11 +36,4 @@
       = _('Selections')
     - if @assign[:obj_tree]
       = render(:partial => 'shared/tree', :locals => {:tree => @assign[:obj_tree], :name => @assign[:obj_tree].name})
-      #obj_treebox.treeview-pf-hover.treeview-pf-select{:style => "width: 100%; color: #000;"}
-      -#= render(:partial => "layouts/tree",
-        :locals         => {:tree_id    => "obj_treebox",
-          :tree_name                    => "obj_tree",
-          :bs_tree                      => @assign[:obj_tree],
-          :oncheck                      => "miqOnCheckHandler",
-          :check_url                    => "alert_profile_assign_changed/",
-          :checkboxes                   => true})
+

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -39,8 +39,7 @@ describe TreeBuilderAlertProfileObj do
     describe '#set_locals_for_render' do
       it 'set locals for render correctly' do
         locals = subject.send(:set_locals_for_render)
-        expect(locals[:id_prefix]).to eq('obj_treebox2')
-        expect(locals[:check_url]).to eq("alert_profile_assign_changed/")
+        expect(locals[:check_url]).to eq("/miq_policy/alert_profile_assign_changed/")
         expect(locals[:oncheck]).to eq("miqOnCheckHandler")
         expect(locals[:checkboxes]).to eq(true)
         expect(locals[:cfmeNoClick]).to eq(true)

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -27,8 +27,7 @@ describe TreeBuilderAlertProfileObj do
                           true,
                           :assign_to => 'storage-tags',
                           :cat       => folder1a.id,
-                          :objects   => [tag1a.id, tag2a.id]
-                          )
+                          :objects   => [tag1a.id, tag2a.id])
     end
 
     describe '#tree_init_options' do
@@ -95,8 +94,7 @@ describe TreeBuilderAlertProfileObj do
                           true,
                           :assign_to => 'tenant',
                           :cat       => nil,
-                          :objects   => [tag1b.id]
-                          )
+                          :objects   => [tag1b.id])
     end
 
     describe '#x_get_tree_roots' do

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -43,6 +43,8 @@ describe TreeBuilderAlertProfileObj do
         expect(locals[:check_url]).to eq("alert_profile_assign_changed/")
         expect(locals[:oncheck]).to eq("miqOnCheckHandler")
         expect(locals[:checkboxes]).to eq(true)
+        expect(locals[:cfmeNoClick]).to eq(true)
+        expect(locals[:onclick]).to eq(false)
       end
     end
 

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -25,9 +25,10 @@ describe TreeBuilderAlertProfileObj do
       described_class.new(:alert_profile_obj_tree, :alert_profile_obj,
                           {},
                           true,
-                          'storage-tags',
-                          folder1a.id,
-                          [tag1a.id, tag2a.id])
+                          :assign_to => 'storage-tags',
+                          :cat       => folder1a.id,
+                          :objects   => [tag1a.id, tag2a.id]
+                          )
     end
 
     describe '#tree_init_options' do
@@ -92,9 +93,10 @@ describe TreeBuilderAlertProfileObj do
                           :alert_profile_obj,
                           {},
                           true,
-                          'tenant',
-                          nil,
-                          [tag1b.id])
+                          :assign_to => 'tenant',
+                          :cat       => nil,
+                          :objects   => [tag1b.id]
+                          )
     end
 
     describe '#x_get_tree_roots' do

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -1,14 +1,19 @@
 describe TreeBuilderAlertProfileObj do
-  before do
-    role = MiqUserRole.find_by(:name => "EvmRole-operator")
-    group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
-    login_as FactoryGirl.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
+  let(:role) do
+    MiqUserRole.find_by(:name => "EvmRole-operator")
+  end
+  let(:group) do
+    FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
   end
 
-  let!(:tag1a) { FactoryGirl.create(:classification, :name => 'tag1a') }
-  let!(:tag2a) { FactoryGirl.create(:classification, :name => 'tag2a') }
-  let!(:tag3a) { FactoryGirl.create(:classification, :name => 'tag3a') }
-  let!(:folder1a) do
+  before do
+   login_as FactoryGirl.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
+  end
+
+  let(:tag1a) { FactoryGirl.create(:classification, :name => 'tag1a') }
+  let(:tag2a) { FactoryGirl.create(:classification, :name => 'tag2a') }
+  let(:tag3a) { FactoryGirl.create(:classification, :name => 'tag3a') }
+  let(:folder1a) do
     f1 = FactoryGirl.create(:classification, :name => 'folder1a', :show => true)
     f1.entries.push(tag1a)
     f1.entries.push(tag2a)
@@ -18,7 +23,6 @@ describe TreeBuilderAlertProfileObj do
   let!(:tag1b) { FactoryGirl.create(:tenant, :name => 'tag1b') }
   let!(:tag2b) { FactoryGirl.create(:tenant, :name => 'tag2b') }
   let!(:tag3b) { FactoryGirl.create(:tenant, :name => 'tag3b') }
-  let!(:tree_name) { :alert_profile_obj }
 
   context 'classification tree' do
     subject do
@@ -32,7 +36,7 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#tree_init_options' do
       it 'set init options correctly' do
-        expect(subject.send(:tree_init_options, tree_name)).to eq(:expand => true)
+        expect(subject.send(:tree_init_options, :alert_profile_obj)).to eq(:expand => true)
       end
     end
 
@@ -41,42 +45,40 @@ describe TreeBuilderAlertProfileObj do
         locals = subject.send(:set_locals_for_render)
         expect(locals[:check_url]).to eq("/miq_policy/alert_profile_assign_changed/")
         expect(locals[:oncheck]).to eq("miqOnCheckHandler")
-        expect(locals[:checkboxes]).to eq(true)
-        expect(locals[:cfmeNoClick]).to eq(true)
-        expect(locals[:onclick]).to eq(false)
+        expect(locals[:checkboxes]).to be_truthy
+        expect(locals[:cfmeNoClick]).to be_truthy
+        expect(locals[:onclick]).to be_falsey
       end
     end
 
     describe '#override' do
-      it 'set node' do
+      it 'set node1' do
         node = {}
         subject.send(:override, node, tag1a, nil, nil)
-        expect(node[:hideCheckbox]).to eq(false)
-        expect(node[:select]).to eq(true)
-
+        expect(node[:hideCheckbox]).to be_falsey
+        expect(node[:select]).to be_truthy
+      end
+      it 'set node2' do
         node = {}
         subject.send(:override, node, tag2a, nil, nil)
-        expect(node[:select]).to eq(true)
-
+        expect(node[:select]).to be_truthy
+      end
+      it 'set node3' do
         node = {}
         subject.send(:override, node, tag3a, nil, nil)
-        expect(node[:select]).to eq(false)
+        expect(node[:select]).to be_falsey
       end
     end
 
     describe '#root_options' do
       it 'sets root_options correctly' do
-        assign_to = 'storage-tags'
-        t = assign_to.ends_with?("-tags") ? "Tags" : ui_lookup(:tables => assign_to)
-        opt = {
-          :title        => t,
-          :tooltip      => "",
-          :icon         => "pficon pficon-folder-open",
-          :hideCheckbox => true,
-          :cfmeNoClick  => true,
-          :expand       => true
-        }
-        expect(subject.send(:root_options)).to eq(opt)
+        res = subject.send(:root_options)
+        expect(res[:title]).to eq("Tags")
+        expect(res[:tooltip]).to eq("")
+        expect(res[:icon]).to eq("pficon pficon-folder-open")
+        expect(res[:hideCheckbox]).to be_truthy
+        expect(res[:cfmeNoClick]).to be_truthy
+        expect(res[:expand]).to be_truthy
       end
     end
 
@@ -107,19 +109,21 @@ describe TreeBuilderAlertProfileObj do
     end
 
     describe '#override' do
-      it 'set node' do
+      it 'set node1' do
         node = {}
         subject.send(:override, node, tag1b, nil, nil)
-        expect(node[:hideCheckbox]).to eq(false)
-        expect(node[:select]).to eq(true)
-
+        expect(node[:hideCheckbox]).to be_falsey
+        expect(node[:select]).to be_truthy
+      end
+      it 'set node2' do
         node = {}
         subject.send(:override, node, tag2b, nil, nil)
-        expect(node[:select]).to eq(false)
-
+        expect(node[:select]).to be_falsey
+      end
+      it 'set node3' do
         node = {}
         subject.send(:override, node, tag3b, nil, nil)
-        expect(node[:select]).to eq(false)
+        expect(node[:select]).to be_falsey
       end
     end
   end

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -49,14 +49,17 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#override' do
       it 'set node' do
-        node = subject.send(:override, {}, tag1a, nil, nil)
+        node = {}
+        subject.send(:override, node, tag1a, nil, nil)
         expect(node[:hideCheckbox]).to eq(false)
         expect(node[:select]).to eq(true)
 
-        node = subject.send(:override, {}, tag2a, nil, nil)
+        node = {}
+        subject.send(:override, node, tag2a, nil, nil)
         expect(node[:select]).to eq(true)
 
-        node = subject.send(:override, {}, tag3a, nil, nil)
+        node = {}
+        subject.send(:override, node, tag3a, nil, nil)
         expect(node[:select]).to eq(false)
       end
     end
@@ -105,14 +108,17 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#override' do
       it 'set node' do
-        node = subject.send(:override, {}, tag1b, nil, nil)
+        node = {}
+        subject.send(:override, node, tag1b, nil, nil)
         expect(node[:hideCheckbox]).to eq(false)
         expect(node[:select]).to eq(true)
 
-        node = subject.send(:override, {}, tag2b, nil, nil)
+        node = {}
+        subject.send(:override, node, tag2b, nil, nil)
         expect(node[:select]).to eq(false)
 
-        node = subject.send(:override, {}, tag3b, nil, nil)
+        node = {}
+        subject.send(:override, node, tag3b, nil, nil)
         expect(node[:select]).to eq(false)
       end
     end

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -1,6 +1,6 @@
 describe TreeBuilderAlertProfileObj do
   before do
-    role = MiqUserRole.find_by_name("EvmRole-operator")
+    role = MiqUserRole.find_by(name: "EvmRole-operator")
     group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
     login_as FactoryGirl.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
   end
@@ -70,7 +70,7 @@ describe TreeBuilderAlertProfileObj do
     describe '#x_get_tree_roots' do
       it 'sets first level nodes correctly' do
         s = subject.send(:x_get_tree_roots, false, nil)
-        expect(s).to eq([tag1a, tag2a, tag3a].sort_by { |o| (o.name.presence || o.description).downcase } )
+        expect(s).to eq([tag1a, tag2a, tag3a].sort_by { |o| (o.name.presence || o.description).downcase })
       end
     end
   end
@@ -87,7 +87,7 @@ describe TreeBuilderAlertProfileObj do
     describe '#x_get_tree_roots' do
       it 'sets first level nodes correctly' do
         s = subject.send(:x_get_tree_roots, false, nil)
-        expect(s).to eq(Tenant.all.sort_by { |o| (o.name.presence || o.description).downcase } )
+        expect(s).to eq(Tenant.all.sort_by { |o| (o.name.presence || o.description).downcase })
       end
     end
 

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -1,6 +1,6 @@
 describe TreeBuilderAlertProfileObj do
   before do
-    role = MiqUserRole.find_by(name: "EvmRole-operator")
+    role = MiqUserRole.find_by(:name => "EvmRole-operator")
     group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
     login_as FactoryGirl.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
   end

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -49,7 +49,6 @@ describe TreeBuilderAlertProfileObj do
     describe '#override' do
       it 'set node' do
         node = subject.send(:override, {}, tag1a, nil, nil)
-        expect(node[:cfmeNoClick]).to eq(true)
         expect(node[:hideCheckbox]).to eq(false)
         expect(node[:select]).to eq(true)
 
@@ -106,7 +105,6 @@ describe TreeBuilderAlertProfileObj do
     describe '#override' do
       it 'set node' do
         node = subject.send(:override, {}, tag1b, nil, nil)
-        expect(node[:cfmeNoClick]).to eq(true)
         expect(node[:hideCheckbox]).to eq(false)
         expect(node[:select]).to eq(true)
 

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -1,15 +1,11 @@
 describe TreeBuilderAlertProfileObj do
-  let(:role) do
-    MiqUserRole.find_by(:name => "EvmRole-operator")
-  end
-  let(:group) do
-    FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
-  end
-
+  
   before do
+   role = MiqUserRole.find_by(:name => "EvmRole-operator")
+   group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
    login_as FactoryGirl.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
   end
-
+  
   let(:tag1a) { FactoryGirl.create(:classification, :name => 'tag1a') }
   let(:tag2a) { FactoryGirl.create(:classification, :name => 'tag2a') }
   let(:tag3a) { FactoryGirl.create(:classification, :name => 'tag3a') }
@@ -35,13 +31,13 @@ describe TreeBuilderAlertProfileObj do
     end
 
     describe '#tree_init_options' do
-      it 'set init options correctly' do
+      it 'sets init options correctly' do
         expect(subject.send(:tree_init_options, :alert_profile_obj)).to eq(:expand => true)
       end
     end
 
     describe '#set_locals_for_render' do
-      it 'set locals for render correctly' do
+      it 'sets locals for render correctly' do
         locals = subject.send(:set_locals_for_render)
         expect(locals[:check_url]).to eq("/miq_policy/alert_profile_assign_changed/")
         expect(locals[:oncheck]).to eq("miqOnCheckHandler")
@@ -52,18 +48,18 @@ describe TreeBuilderAlertProfileObj do
     end
 
     describe '#override' do
-      it 'set node1' do
+      it 'sets node1' do
         node = {}
         subject.send(:override, node, tag1a, nil, nil)
         expect(node[:hideCheckbox]).to be_falsey
         expect(node[:select]).to be_truthy
       end
-      it 'set node2' do
+      it 'sets node2' do
         node = {}
         subject.send(:override, node, tag2a, nil, nil)
         expect(node[:select]).to be_truthy
       end
-      it 'set node3' do
+      it 'sets node3' do
         node = {}
         subject.send(:override, node, tag3a, nil, nil)
         expect(node[:select]).to be_falsey
@@ -109,18 +105,18 @@ describe TreeBuilderAlertProfileObj do
     end
 
     describe '#override' do
-      it 'set node1' do
+      it 'sets node1' do
         node = {}
         subject.send(:override, node, tag1b, nil, nil)
         expect(node[:hideCheckbox]).to be_falsey
         expect(node[:select]).to be_truthy
       end
-      it 'set node2' do
+      it 'sets node2' do
         node = {}
         subject.send(:override, node, tag2b, nil, nil)
         expect(node[:select]).to be_falsey
       end
-      it 'set node3' do
+      it 'sets node3' do
         node = {}
         subject.send(:override, node, tag3b, nil, nil)
         expect(node[:select]).to be_falsey

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -1,0 +1,65 @@
+describe TreeBuilderAlertProfileObj do
+  before do
+    role = MiqUserRole.find_by_name("EvmRole-operator")
+    group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
+    login_as FactoryGirl.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
+  end
+
+  let!(:tag1a) { FactoryGirl.create(:classification, :name => 'tag1a') }
+  let!(:tag2a) { FactoryGirl.create(:classification, :name => 'tag2a') }
+  let!(:tag3a) { FactoryGirl.create(:classification, :name => 'tag3a') }
+  let!(:folder1a) do
+    f1 = FactoryGirl.create(:classification, :name => 'folder1a', :show => true)
+    f1.entries.push(tag1a)
+    f1.entries.push(tag2a)
+    f1.entries.push(tag3a)
+    f1
+  end
+  let!(:tree_name) { :alert_profile_obj }
+
+  subject do
+    @assign = {}
+    @assign[:new] = {}
+    @assign[:new][:assign_to] = 'storage-tags'
+    @assign[:new][:cat] = folder1a.id
+    @assign[:new][:objects] = []
+    described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, @assign)
+  end
+
+  describe '#tree_init_options' do
+    it 'set init options correctly' do
+      expect(subject.send(:tree_init_options, tree_name)).to eq(:expand => true)
+    end
+  end
+
+  describe '#set_locals_for_render' do
+    it 'set locals for render correctly' do
+      locals = subject.send(:set_locals_for_render)
+      expect(locals[:id_prefix]).to eq('obj_treebox2')
+      expect(locals[:check_url]).to eq("alert_profile_assign_changed/")
+      expect(locals[:oncheck]).to eq("miqOnCheckHandler")
+      expect(locals[:checkboxes]).to eq(true)
+    end
+  end
+
+  describe '#override' do
+    it 'set node' do
+      node = subject.send(:override, {}, tag1a, nil, nil)
+      expect(node[:cfmeNoClick]).to eq(true)
+      expect(node[:hideCheckbox]).to eq(false)
+    end
+  end
+
+  describe '#root_options' do
+    it 'sets root_options correctly' do
+      #expect(subject.send(:root_options)).to eq([tenant, tenant, "100/folder_open])
+    end
+  end
+
+  describe '#x_get_tree_roots' do
+    it 'sets first level nodes correctly' do
+      s = subject.send(:x_get_tree_roots, false, nil)
+      expect(s).to eq([tag1a, tag2a, tag3a].sort_by { |o| (o.name.presence || o.description).downcase } )
+    end
+  end
+end

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -1,11 +1,9 @@
 describe TreeBuilderAlertProfileObj do
-  
   before do
-   role = MiqUserRole.find_by(:name => "EvmRole-operator")
-   group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
-   login_as FactoryGirl.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
+    role = MiqUserRole.find_by(:name => "EvmRole-operator")
+    group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
+    login_as FactoryGirl.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
   end
-  
   let(:tag1a) { FactoryGirl.create(:classification, :name => 'tag1a') }
   let(:tag2a) { FactoryGirl.create(:classification, :name => 'tag2a') }
   let(:tag3a) { FactoryGirl.create(:classification, :name => 'tag3a') }
@@ -48,19 +46,18 @@ describe TreeBuilderAlertProfileObj do
     end
 
     describe '#override' do
+      let(:node) { {} }
+
       it 'sets node1' do
-        node = {}
         subject.send(:override, node, tag1a, nil, nil)
         expect(node[:hideCheckbox]).to be_falsey
         expect(node[:select]).to be_truthy
       end
       it 'sets node2' do
-        node = {}
         subject.send(:override, node, tag2a, nil, nil)
         expect(node[:select]).to be_truthy
       end
       it 'sets node3' do
-        node = {}
         subject.send(:override, node, tag3a, nil, nil)
         expect(node[:select]).to be_falsey
       end
@@ -101,25 +98,6 @@ describe TreeBuilderAlertProfileObj do
       it 'sets first level nodes correctly' do
         s = subject.send(:x_get_tree_roots, false, nil)
         expect(s).to eq(Tenant.all.sort_by { |o| (o.name.presence || o.description).downcase })
-      end
-    end
-
-    describe '#override' do
-      it 'sets node1' do
-        node = {}
-        subject.send(:override, node, tag1b, nil, nil)
-        expect(node[:hideCheckbox]).to be_falsey
-        expect(node[:select]).to be_truthy
-      end
-      it 'sets node2' do
-        node = {}
-        subject.send(:override, node, tag2b, nil, nil)
-        expect(node[:select]).to be_falsey
-      end
-      it 'sets node3' do
-        node = {}
-        subject.send(:override, node, tag3b, nil, nil)
-        expect(node[:select]).to be_falsey
       end
     end
   end

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -20,91 +20,90 @@ describe TreeBuilderAlertProfileObj do
   let!(:tag3b) { FactoryGirl.create(:tenant, :name => 'tag3b') }
   let!(:tree_name) { :alert_profile_obj }
 
-  subject do
-    @assign = {}
-    @assign[:new] = {}
-    @assign[:new][:assign_to] = 'storage-tags'
-    @assign[:new][:cat] = folder1a.id
-    @assign[:new][:objects] = [tag1a.id, tag2a.id]
-    described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, @assign)
-  end
+  context 'classification tree' do
+    subject do
+      @assign = {}
+      @assign[:new] = {}
+      @assign[:new][:assign_to] = 'storage-tags'
+      @assign[:new][:cat] = folder1a.id
+      @assign[:new][:objects] = [tag1a.id, tag2a.id]
+      described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, @assign)
+    end
 
-  describe '#tree_init_options' do
-    it 'set init options correctly' do
-      expect(subject.send(:tree_init_options, tree_name)).to eq(:expand => true)
+    describe '#tree_init_options' do
+      it 'set init options correctly' do
+        expect(subject.send(:tree_init_options, tree_name)).to eq(:expand => true)
+      end
+    end
+
+    describe '#set_locals_for_render' do
+      it 'set locals for render correctly' do
+        locals = subject.send(:set_locals_for_render)
+        expect(locals[:id_prefix]).to eq('obj_treebox2')
+        expect(locals[:check_url]).to eq("alert_profile_assign_changed/")
+        expect(locals[:oncheck]).to eq("miqOnCheckHandler")
+        expect(locals[:checkboxes]).to eq(true)
+      end
+    end
+
+    describe '#override' do
+      it 'set node' do
+        node = subject.send(:override, {}, tag1a, nil, nil)
+        expect(node[:cfmeNoClick]).to eq(true)
+        expect(node[:hideCheckbox]).to eq(false)
+        expect(node[:select]).to eq(true)
+
+        node = subject.send(:override, {}, tag2a, nil, nil)
+        expect(node[:select]).to eq(true)
+
+        node = subject.send(:override, {}, tag3a, nil, nil)
+        expect(node[:select]).to eq(false)
+      end
+    end
+
+    describe '#root_options' do
+      it 'sets root_options correctly' do
+        #expect(subject.send(:root_options)).to eq([tenant, tenant, "100/folder_open])
+      end
+    end
+
+    describe '#x_get_tree_roots' do
+      it 'sets first level nodes correctly' do
+        s = subject.send(:x_get_tree_roots, false, nil)
+        expect(s).to eq([tag1a, tag2a, tag3a].sort_by { |o| (o.name.presence || o.description).downcase } )
+      end
     end
   end
 
-  describe '#set_locals_for_render' do
-    it 'set locals for render correctly' do
-      locals = subject.send(:set_locals_for_render)
-      expect(locals[:id_prefix]).to eq('obj_treebox2')
-      expect(locals[:check_url]).to eq("alert_profile_assign_changed/")
-      expect(locals[:oncheck]).to eq("miqOnCheckHandler")
-      expect(locals[:checkboxes]).to eq(true)
+  context 'tenant tree' do
+    subject do
+      @assign = {}
+      @assign[:new] = {}
+      @assign[:new][:assign_to] = 'tenant'
+      @assign[:new][:objects] = [tag1b.id]
+      described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, @assign)
+    end
+
+    describe '#x_get_tree_roots' do
+      it 'sets first level nodes correctly' do
+        s = subject.send(:x_get_tree_roots, false, nil)
+        expect(s).to eq(Tenant.all.sort_by { |o| (o.name.presence || o.description).downcase } )
+      end
+    end
+
+    describe '#override' do
+      it 'set node' do
+        node = subject.send(:override, {}, tag1b, nil, nil)
+        expect(node[:cfmeNoClick]).to eq(true)
+        expect(node[:hideCheckbox]).to eq(false)
+        expect(node[:select]).to eq(true)
+
+        node = subject.send(:override, {}, tag2b, nil, nil)
+        expect(node[:select]).to eq(false)
+
+        node = subject.send(:override, {}, tag3b, nil, nil)
+        expect(node[:select]).to eq(false)
+      end
     end
   end
-
-  describe '#override' do
-    it 'set node' do
-      binding.pry
-      node = subject.send(:override, {}, tag1a, nil, nil)
-      expect(node[:cfmeNoClick]).to eq(true)
-      expect(node[:hideCheckbox]).to eq(false)
-      expect(node[:select]).to eq(true)
-
-      node = subject.send(:override, {}, tag2a, nil, nil)
-      expect(node[:select]).to eq(true)
-
-      node = subject.send(:override, {}, tag3a, nil, nil)
-      expect(node[:select]).to eq(false)
-    end
-  end
-
-  describe '#root_options' do
-    it 'sets root_options correctly' do
-      #expect(subject.send(:root_options)).to eq([tenant, tenant, "100/folder_open])
-    end
-  end
-
-  describe '#x_get_tree_roots' do
-    it 'sets first level nodes correctly' do
-      s = subject.send(:x_get_tree_roots, false, nil)
-      expect(s).to eq([tag1a, tag2a, tag3a].sort_by { |o| (o.name.presence || o.description).downcase } )
-    end
-  end
-
-=begin
-  subject do
-    @assign = {}
-    @assign[:new] = {}
-    @assign[:new][:assign_to] = 'tenant'
-    @assign[:new][:objects] = [tag1b.id]
-    described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, @assign)
-  end
-
-  describe '#x_get_tree_roots' do
-    it 'sets first level nodes correctly' do
-      binding.pry
-      s = subject.send(:x_get_tree_roots, false, nil)
-      expect(s).to eq([tag1b, tag2b, tag3b].sort_by { |o| (o.name.presence || o.description).downcase } )
-    end
-  end
-
-  describe '#override' do
-    it 'set node' do
-      node = subject.send(:override, {}, tag1b, nil, nil)
-      expect(node[:cfmeNoClick]).to eq(true)
-      expect(node[:hideCheckbox]).to eq(false)
-      expect(node[:select]).to eq(true)
-
-      node = subject.send(:override, {}, tag2b, nil, nil)
-      expect(node[:select]).to eq(false)
-
-      node = subject.send(:override, {}, tag3b, nil, nil)
-      expect(node[:select]).to eq(false)
-    end
-  end
-=end
-
 end

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -22,12 +22,12 @@ describe TreeBuilderAlertProfileObj do
 
   context 'classification tree' do
     subject do
-      @assign = {}
-      @assign[:new] = {}
-      @assign[:new][:assign_to] = 'storage-tags'
-      @assign[:new][:cat] = folder1a.id
-      @assign[:new][:objects] = [tag1a.id, tag2a.id]
-      described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, @assign)
+      assign = {}
+      assign[:new] = {}
+      assign[:new][:assign_to] = 'storage-tags'
+      assign[:new][:cat] = folder1a.id
+      assign[:new][:objects] = [tag1a.id, tag2a.id]
+      described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, assign)
     end
 
     describe '#tree_init_options' do
@@ -63,7 +63,17 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#root_options' do
       it 'sets root_options correctly' do
-        #expect(subject.send(:root_options)).to eq([tenant, tenant, "100/folder_open])
+        assign_to = 'storage-tags'
+        t = assign_to.ends_with?("-tags") ? "Tags" : ui_lookup(:tables => assign_to)
+        opt = {
+          :title        => t,
+          :tooltip      => "",
+          :icon         => "pficon pficon-folder-open",
+          :hideCheckbox => true,
+          :cfmeNoClick  => true,
+          :expand       => true
+        }
+        expect(subject.send(:root_options)).to eq(opt)
       end
     end
 
@@ -77,11 +87,11 @@ describe TreeBuilderAlertProfileObj do
 
   context 'tenant tree' do
     subject do
-      @assign = {}
-      @assign[:new] = {}
-      @assign[:new][:assign_to] = 'tenant'
-      @assign[:new][:objects] = [tag1b.id]
-      described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, @assign)
+      assign = {}
+      assign[:new] = {}
+      assign[:new][:assign_to] = 'tenant'
+      assign[:new][:objects] = [tag1b.id]
+      described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, assign)
     end
 
     describe '#x_get_tree_roots' do

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -25,7 +25,7 @@ describe TreeBuilderAlertProfileObj do
                           true,
                           :assign_to => 'storage-tags',
                           :cat       => folder1a.id,
-                          :objects   => [tag1a.id, tag2a.id])
+                          :selected  => [tag1a.id, tag2a.id])
     end
 
     describe '#tree_init_options' do
@@ -91,7 +91,7 @@ describe TreeBuilderAlertProfileObj do
                           true,
                           :assign_to => 'tenant',
                           :cat       => nil,
-                          :objects   => [tag1b.id])
+                          :selected  => [tag1b.id])
     end
 
     describe '#x_get_tree_roots' do

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -15,6 +15,9 @@ describe TreeBuilderAlertProfileObj do
     f1.entries.push(tag3a)
     f1
   end
+  let!(:tag1b) { FactoryGirl.create(:tenant, :name => 'tag1b') }
+  let!(:tag2b) { FactoryGirl.create(:tenant, :name => 'tag2b') }
+  let!(:tag3b) { FactoryGirl.create(:tenant, :name => 'tag3b') }
   let!(:tree_name) { :alert_profile_obj }
 
   subject do
@@ -22,7 +25,7 @@ describe TreeBuilderAlertProfileObj do
     @assign[:new] = {}
     @assign[:new][:assign_to] = 'storage-tags'
     @assign[:new][:cat] = folder1a.id
-    @assign[:new][:objects] = []
+    @assign[:new][:objects] = [tag1a.id, tag2a.id]
     described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, @assign)
   end
 
@@ -44,9 +47,17 @@ describe TreeBuilderAlertProfileObj do
 
   describe '#override' do
     it 'set node' do
+      binding.pry
       node = subject.send(:override, {}, tag1a, nil, nil)
       expect(node[:cfmeNoClick]).to eq(true)
       expect(node[:hideCheckbox]).to eq(false)
+      expect(node[:select]).to eq(true)
+
+      node = subject.send(:override, {}, tag2a, nil, nil)
+      expect(node[:select]).to eq(true)
+
+      node = subject.send(:override, {}, tag3a, nil, nil)
+      expect(node[:select]).to eq(false)
     end
   end
 
@@ -62,4 +73,38 @@ describe TreeBuilderAlertProfileObj do
       expect(s).to eq([tag1a, tag2a, tag3a].sort_by { |o| (o.name.presence || o.description).downcase } )
     end
   end
+
+=begin
+  subject do
+    @assign = {}
+    @assign[:new] = {}
+    @assign[:new][:assign_to] = 'tenant'
+    @assign[:new][:objects] = [tag1b.id]
+    described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, @assign)
+  end
+
+  describe '#x_get_tree_roots' do
+    it 'sets first level nodes correctly' do
+      binding.pry
+      s = subject.send(:x_get_tree_roots, false, nil)
+      expect(s).to eq([tag1b, tag2b, tag3b].sort_by { |o| (o.name.presence || o.description).downcase } )
+    end
+  end
+
+  describe '#override' do
+    it 'set node' do
+      node = subject.send(:override, {}, tag1b, nil, nil)
+      expect(node[:cfmeNoClick]).to eq(true)
+      expect(node[:hideCheckbox]).to eq(false)
+      expect(node[:select]).to eq(true)
+
+      node = subject.send(:override, {}, tag2b, nil, nil)
+      expect(node[:select]).to eq(false)
+
+      node = subject.send(:override, {}, tag3b, nil, nil)
+      expect(node[:select]).to eq(false)
+    end
+  end
+=end
+
 end

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -22,12 +22,12 @@ describe TreeBuilderAlertProfileObj do
 
   context 'classification tree' do
     subject do
-      assign = {}
-      assign[:new] = {}
-      assign[:new][:assign_to] = 'storage-tags'
-      assign[:new][:cat] = folder1a.id
-      assign[:new][:objects] = [tag1a.id, tag2a.id]
-      described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, assign)
+      described_class.new(:alert_profile_obj_tree, :alert_profile_obj,
+                          {},
+                          true,
+                          'storage-tags',
+                          folder1a.id,
+                          [tag1a.id, tag2a.id])
     end
 
     describe '#tree_init_options' do
@@ -87,11 +87,13 @@ describe TreeBuilderAlertProfileObj do
 
   context 'tenant tree' do
     subject do
-      assign = {}
-      assign[:new] = {}
-      assign[:new][:assign_to] = 'tenant'
-      assign[:new][:objects] = [tag1b.id]
-      described_class.new(:alert_profile_obj_tree, :alert_profile_obj, {}, true, assign)
+      described_class.new(:alert_profile_obj_tree,
+                          :alert_profile_obj,
+                          {},
+                          true,
+                          'tenant',
+                          nil,
+                          [tag1b.id])
     end
 
     describe '#x_get_tree_roots' do


### PR DESCRIPTION
@miq-bot add_label wip

Refactoring of tree located in: miq_policy_controller/alert_profiles.rb
In method alert_profile_build_obj_tree

Location in UI:
Menu-Control-Explorer
Select Alert Profiles, then Select some node in the tree
Configuration - Add new data store alert profile, continue to create it
Then select this new node and again Configuration - Edit assignments to this profile
Now select Assign to: Tagged datastores or tenants



