### PR TITLE
Cloud Subnet: network and cloud tenants filtering

### DIFF
--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -57,7 +57,7 @@ class CloudSubnetController < ApplicationController
     networks = []
     available_networks = CloudNetwork.where(:ems_id => params[:id]).find_each
     available_networks.each do |network|
-      networks << { 'name' => network.name, 'id' => network.id }
+      networks << { 'name' => network.name, 'id' => network.ems_ref }
     end
     render :json => {
       :available_networks => networks
@@ -66,9 +66,9 @@ class CloudSubnetController < ApplicationController
 
   def cloud_tenants_by_ems
     assert_privileges("cloud_subnet_new")
+    network_manager = ExtManagementSystem.find(params[:id])
     tenants = []
-    available_tenants = CloudTenant.where(:ems_id => params[:id]).find_each
-    available_tenants.each do |tenant|
+    CloudTenant.where(:ems_id => network_manager.parent_ems_id).find_each do |tenant|
       tenants << { 'name' => tenant.name, 'id' => tenant.id }
     end
     render :json => {


### PR DESCRIPTION
Uses the parent provider (of the network provider) to build the list of the cloud tenants for the placement instead of filtered using the network provider itself. 

Replace network_id with ems_ref.

https://bugzilla.redhat.com/show_bug.cgi?id=1394289