### PR TITLE
Check Compliance UI crush fix

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -571,12 +571,14 @@ module EmsCommon
   end
 
   def check_compliance(model)
-    emss = find_checked_items
-    if emss.empty?
+    showlist = @lastaction == "show_list"
+    ids = showlist ? find_checked_items : [params[:id]]
+    if ids.blank?
       add_flash(_("No %{model} were selected for Compliance Check") % {:model => ui_lookup(:models => model.to_s)}, :error)
     end
-    process_emss(emss, "check_compliance")
-    @lastaction == "show_list" ? show_list : show
+    process_emss(ids, "check_compliance")
+    params[:display] = "main"
+    showlist ? show_list : show
   end
 
   def arbitration_profile_edit


### PR DESCRIPTION
I noticed that in [1] due to changing code and `params[:display]` not being set we get to `show_entities` with a wrong value of `display`. This patch will set `params[:display] = "main"` to avoid that.
It will also attempt to get the ID of the current provider to scan it to.

BZ https://bugzilla.redhat.com/show_bug.cgi?id=1412558
fllow up for https://github.com/ManageIQ/manageiq-ui-classic/pull/157


[1]https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ems_common.rb#L136