### PR TITLE
Refactor - Replace .success calls with .then/.catch (Round 2)

### DIFF
--- a/app/assets/javascripts/controllers/cloud_network/cloud_network_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_network/cloud_network_form_controller.js
@@ -17,20 +17,26 @@ ManageIQ.angular.app.controller('cloudNetworkFormController', ['$http', '$scope'
   } else {
     miqService.sparkleOn();
 
-    $http.get('/cloud_network/cloud_network_form_fields/' + cloudNetworkFormId).success(function(data) {
-      $scope.afterGet = true;
-      $scope.cloudNetworkModel.name = data.name;
-      $scope.cloudNetworkModel.cloud_tenant_name = data.cloud_tenant_name;
-      $scope.cloudNetworkModel.enabled = data.enabled;
-      $scope.cloudNetworkModel.external_facing = data.external_facing;
-      $scope.cloudNetworkModel.port_security_enabled = data.port_security_enabled;
-      $scope.cloudNetworkModel.provider_network_type = data.provider_network_type;
-      $scope.cloudNetworkModel.qos_policy_id = data.qos_policy_id;
-      $scope.cloudNetworkModel.shared = data.shared;
-      $scope.cloudNetworkModel.vlan_transparent = data.vlan_transparent;
-      $scope.modelCopy = angular.copy( $scope.cloudNetworkModel );
-      miqService.sparkleOff();
-    });
+    $http.get('/cloud_network/cloud_network_form_fields/' + cloudNetworkFormId)
+      .then(getCloudNetworkFormDataComplete)
+      .catch(miqService.handleFailure);
+  }
+
+  function getCloudNetworkFormDataComplete(response) {
+    var data = response.data;
+
+    $scope.afterGet = true;
+    $scope.cloudNetworkModel.name = data.name;
+    $scope.cloudNetworkModel.cloud_tenant_name = data.cloud_tenant_name;
+    $scope.cloudNetworkModel.enabled = data.enabled;
+    $scope.cloudNetworkModel.external_facing = data.external_facing;
+    $scope.cloudNetworkModel.port_security_enabled = data.port_security_enabled;
+    $scope.cloudNetworkModel.provider_network_type = data.provider_network_type;
+    $scope.cloudNetworkModel.qos_policy_id = data.qos_policy_id;
+    $scope.cloudNetworkModel.shared = data.shared;
+    $scope.cloudNetworkModel.vlan_transparent = data.vlan_transparent;
+    $scope.modelCopy = angular.copy( $scope.cloudNetworkModel );
+    miqService.sparkleOff();
   }
 
   $scope.addClicked = function() {

--- a/app/assets/javascripts/controllers/cloud_subnet/cloud_subnet_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_subnet/cloud_subnet_form_controller.js
@@ -15,17 +15,23 @@ ManageIQ.angular.app.controller('cloudSubnetFormController', ['$http', '$scope',
   } else {
     miqService.sparkleOn();
 
-    $http.get('/cloud_subnet/cloud_subnet_form_fields/' + cloudSubnetFormId).success(function(data) {
-      $scope.afterGet = true;
-      $scope.cloudSubnetModel.name = data.name;
-      $scope.cloudSubnetModel.dhcp_enabled = data.dhcp_enabled;
-      $scope.cloudSubnetModel.cidr = data.cidr;
-      $scope.cloudSubnetModel.gateway = data.gateway;
-      $scope.cloudSubnetModel.ip_version = data.ip_version;
+    $http.get('/cloud_subnet/cloud_subnet_form_fields/' + cloudSubnetFormId)
+      .then(getCloudSubnetFormDataComplete)
+      .catch(miqService.handleFailure);
+  }
 
-      $scope.modelCopy = angular.copy( $scope.cloudSubnetModel );
-      miqService.sparkleOff();
-    });
+  function getCloudSubnetFormDataComplete(response) {
+    var data = response.data;
+
+    $scope.afterGet = true;
+    $scope.cloudSubnetModel.name = data.name;
+    $scope.cloudSubnetModel.dhcp_enabled = data.dhcp_enabled;
+    $scope.cloudSubnetModel.cidr = data.cidr;
+    $scope.cloudSubnetModel.gateway = data.gateway;
+    $scope.cloudSubnetModel.ip_version = data.ip_version;
+
+    $scope.modelCopy = angular.copy( $scope.cloudSubnetModel );
+    miqService.sparkleOff();
   }
 
   $scope.addClicked = function() {
@@ -55,12 +61,27 @@ ManageIQ.angular.app.controller('cloudSubnetFormController', ['$http', '$scope',
 
   $scope.filterNetworkManagerChanged = function(id) {
     miqService.sparkleOn();
-    $http.get('/cloud_subnet/cloud_subnet_networks_by_ems/' + id).success(function(data) {
-      $scope.available_networks = data.available_networks;
-    });
-    $http.get('/cloud_subnet/cloud_tenants_by_ems/' + id).success(function(data) {
-      $scope.available_tenants = data.available_tenants;
-    });
+
+    $http.get('/cloud_subnet/cloud_subnet_networks_by_ems/' + id)
+      .then(getCloudSubnetNetworksByEmsComplete)
+      .catch(miqService.handleFailure);
+
+    $http.get('/cloud_subnet/cloud_tenants_by_ems/' + id)
+      .then(getCloudTenantsByEmsComplete)
+      .catch(miqService.handleFailure);
+
     miqService.sparkleOff();
   };
+
+  function getCloudSubnetNetworksByEmsComplete(response) {
+    var data = response.data;
+
+    $scope.available_networks = data.available_networks;
+  }
+
+  function getCloudTenantsByEmsComplete(response) {
+    var data = response.data;
+
+    $scope.available_tenants = data.available_tenants;
+  }
 }]);

--- a/app/assets/javascripts/controllers/cloud_tenant/cloud_tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_tenant/cloud_tenant_form_controller.js
@@ -12,13 +12,19 @@ ManageIQ.angular.app.controller('cloudTenantFormController', ['$http', '$scope',
   } else {
     miqService.sparkleOn();
 
-    $http.get('/cloud_tenant/cloud_tenant_form_fields/' + cloudTenantFormId).success(function(data) {
-      $scope.afterGet = true;
-      $scope.cloudTenantModel.name = data.name;
+    $http.get('/cloud_tenant/cloud_tenant_form_fields/' + cloudTenantFormId)
+      .then(getCloudTenantFormDataComplete)
+      .catch(miqService.handleFailure);
+  }
 
-      $scope.modelCopy = angular.copy( $scope.cloudTenantModel );
-      miqService.sparkleOff();
-    });
+  function getCloudTenantFormDataComplete(response) {
+    var data = response.data;
+
+    $scope.afterGet = true;
+    $scope.cloudTenantModel.name = data.name;
+
+    $scope.modelCopy = angular.copy( $scope.cloudTenantModel );
+    miqService.sparkleOff();
   }
 
   $scope.cancelClicked = function() {

--- a/app/assets/javascripts/controllers/cloud_topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/cloud_topology/cloud_topology_controller.js
@@ -3,9 +3,9 @@
 miqHttpInject(angular.module('cloudTopologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
 .controller('cloudTopologyController', CloudTopologyCtrl);
 
-CloudTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService'];
+CloudTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
 
-function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService) {
+function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
   var self = this;
   $scope.vs = null;
   var icons = null;
@@ -19,7 +19,6 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService)
       id = '/' + (/cloud_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
     }
 
-    var currentSelectedKinds = $scope.kinds;
     var url = '/cloud_topology/data' + id;
 
     $http.get(url)
@@ -30,12 +29,14 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService)
   function getCloudTopologyFormDataComplete(response) {
     var data = response.data;
 
+    var currentSelectedKinds = $scope.kinds;
+
     $scope.items = data.data.items;
     $scope.relations = data.data.relations;
     $scope.kinds = data.data.kinds;
     icons = data.data.icons;
 
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys($scope.kinds).length)) {
       $scope.kinds = currentSelectedKinds;
     }
   }

--- a/app/assets/javascripts/controllers/cloud_topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/cloud_topology/cloud_topology_controller.js
@@ -22,17 +22,23 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService)
     var currentSelectedKinds = $scope.kinds;
     var url = '/cloud_topology/data' + id;
 
-    $http.get(url).success(function(data) {
-      $scope.items = data.data.items;
-      $scope.relations = data.data.relations;
-      $scope.kinds = data.data.kinds;
-      icons = data.data.icons;
-
-      if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
-        $scope.kinds = currentSelectedKinds;
-      }
-    });
+    $http.get(url)
+      .then(getCloudTopologyFormDataComplete)
+      .catch(miqService.handleFailure);
   };
+
+  function getCloudTopologyFormDataComplete(response) {
+    var data = response.data;
+
+    $scope.items = data.data.items;
+    $scope.relations = data.data.relations;
+    $scope.kinds = data.data.kinds;
+    icons = data.data.icons;
+
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
+      $scope.kinds = currentSelectedKinds;
+    }
+  }
 
   $scope.checkboxModel = {
     value: false

--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -11,14 +11,20 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
     $scope.cloudVolumeModel.name = "";
   } else {
     miqService.sparkleOn();
+    
+    $http.get('/cloud_volume/cloud_volume_form_fields/' + cloudVolumeFormId)
+      .then(getCloudVolumeFormDataComplete)
+      .catch(miqService.handleFailure);
+  }
 
-    $http.get('/cloud_volume/cloud_volume_form_fields/' + cloudVolumeFormId).success(function(data) {
-      $scope.afterGet = true;
-      $scope.cloudVolumeModel.name = data.name;
+  function getCloudVolumeFormDataComplete(response) {
+    var data = response.data;
 
-      $scope.modelCopy = angular.copy( $scope.cloudVolumeModel );
-      miqService.sparkleOff();
-    });
+    $scope.afterGet = true;
+    $scope.cloudVolumeModel.name = data.name;
+
+    $scope.modelCopy = angular.copy( $scope.cloudVolumeModel );
+    miqService.sparkleOff();
   }
 
   $scope.addClicked = function() {

--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -11,7 +11,6 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
     $scope.cloudVolumeModel.name = "";
   } else {
     miqService.sparkleOn();
-    
     $http.get('/cloud_volume/cloud_volume_form_fields/' + cloudVolumeFormId)
       .then(getCloudVolumeFormDataComplete)
       .catch(miqService.handleFailure);


### PR DESCRIPTION
Replace `.success` calls in angular controllers with `.then` / `.catch`
This is Round 2 of refactoring. The following controllers have been covered here --

- cloud_network_form_controller.js
- cloud_subnet_form_controller.js
- cloud_tenant_form_controller.js
- cloud_topology_controller.js
- cloud_volume_form_controller.js

(Round 1 done here -- https://github.com/ManageIQ/manageiq-ui-classic/pull/13)