### PR TITLE
Reset selected snapshot in session when deleting the snapshot

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -269,6 +269,7 @@ module VmCommon
     elsif @display == "snapshot_info"
       drop_breadcrumb(:name => @record.name + _(" (Snapshots)"),
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
+      session[:snap_selected] = nil if Snapshot.find_by(:id => session[:snap_selected]).nil?
       @sb[@sb[:active_accord]] = TreeBuilder.build_node_id(@record)
       @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, :root => @record)
       @active = if @snapshot_tree.selected_node

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -122,6 +122,26 @@ describe VmOrTemplateController do
       expect(response.status).to eq(302)
       expect(response).to redirect_to(:controller => "dashboard", :action => 'show')
     end
+
+    it 'set session[:snap_selected] to nil if Snapshot does not exist' do
+      tree_hash = {
+        :trees         => {
+          :vandt_tree => {
+            :active_node => "v-#{@vm.id}"
+          }
+        },
+        :active_tree   => :vandt_tree,
+        :active_accord => :vandt
+      }
+      session[:sandboxes] = {'vm_or_template' => tree_hash}
+      @lastaction = 'show'
+      @display = 'snapshot_info'
+      @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
+
+      session[:snap_selected] = '21'
+      get :show, :params => {:id => @vm.id, :display => 'snapshot_info'}
+      expect(session[:snap_selected]).to be(nil)
+    end
   end
 
   describe '#console_after_task' do


### PR DESCRIPTION
Fixes an error in the logs and the page not loading when the currently selected snapshot is deleted and attempting to view the Snapshot Summary page.

Closes #209

https://bugzilla.redhat.com/show_bug.cgi?id=1395116