### PR TITLE
Add latest VMRC API version

### DIFF
--- a/app/views/vm_common/console_vmrc.html.haml
+++ b/app/views/vm_common/console_vmrc.html.haml
@@ -1,7 +1,7 @@
 = render :partial => 'layouts/doctype'
 %html{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
-    - if %w(5.1 5.5).include?(api_version) && is_browser_ie?
+    - if %w(5.1 5.5 6.0).include?(api_version) && is_browser_ie?
       - if browser_info(:version).to_i > 10
         %meta{:content => "IE=EmulateIE8", "http-equiv" => "X-UA-Compatible"}
       - elsif browser_info(:version).to_i > 9


### PR DESCRIPTION
Latest VMware Client Integration Plugin identifies as version 6.0

https://bugzilla.redhat.com/show_bug.cgi?id=1389560