### PR TITLE
Escape special HTML characters in right cell header

### DIFF
--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -253,7 +253,7 @@ class ExplorerPresenter
     data[:ajaxUrl] = ajax_action_url(@options[:ajax_action]) if @options[:ajax_action]
     data[:clearGtlListGrid] = !!@options[:clear_gtl_list_grid]
     data[:setVisibility] = @options[:set_visible_elements]
-    data[:rightCellText] = @options[:right_cell_text] if @options[:right_cell_text]
+    data[:rightCellText] = ERB::Util.html_escape(@options[:right_cell_text]) if @options[:right_cell_text]
 
     data[:reloadToolbars] = @options[:reload_toolbars].collect do |_div_name, toolbar|
       toolbar


### PR DESCRIPTION
Visible for example Under Control -> Policy Profiles

https://bugzilla.redhat.com/show_bug.cgi?id=1405350

Closes https://github.com/ManageIQ/manageiq-ui-classic/pull/166