### PR TITLE
Remove nonsensical stub at the end of specs

### DIFF
--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -14,7 +14,6 @@ describe EmsCloudController do
       controller.instance_variable_set(:@breadcrumbs, [])
       get :new
       expect(response.status).to eq(200)
-      expect(allow(controller).to receive(:edit)).to_not be_nil
     end
 
     render_views

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -8,7 +8,6 @@ describe EmsContainerController do
     get :new
 
     expect(response.status).to eq(200)
-    expect(allow(controller).to receive(:edit)).to_not be_nil
   end
 
   describe "#show" do

--- a/spec/controllers/ems_datawarehouse_controller_spec.rb
+++ b/spec/controllers/ems_datawarehouse_controller_spec.rb
@@ -10,7 +10,6 @@ describe EmsDatawarehouseController do
     get :new
 
     expect(response.status).to eq(200)
-    expect(allow(controller).to receive(:edit)).to_not be_nil
   end
 
   describe "#show" do

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -97,7 +97,6 @@ describe EmsInfraController do
       controller.instance_variable_set(:@breadcrumbs, [])
       get :new
       expect(response.status).to eq(200)
-      expect(allow(controller).to receive(:edit)).to_not be_nil
     end
   end
 

--- a/spec/controllers/ems_middleware_controller_spec.rb
+++ b/spec/controllers/ems_middleware_controller_spec.rb
@@ -10,7 +10,6 @@ describe EmsMiddlewareController do
     get :new
 
     expect(response.status).to eq(200)
-    expect(allow(controller).to receive(:edit)).to_not be_nil
   end
 
   describe "#show" do

--- a/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
@@ -88,7 +88,6 @@ shared_examples :shared_examples_for_ems_network_controller do |providers|
           controller.instance_variable_set(:@breadcrumbs, [])
           get :new
           expect(response.status).to eq(200)
-          expect(allow(controller).to(receive(:edit))).to_not be_nil
         end
       end
 


### PR DESCRIPTION
`allow(controller).to receive(:edit)` stubs `controller.edit` .. which makes very little sense to do as the last line of a test (that stub is never called).

Taking the return value of that stubbing and testing for nil makes even less sense.

Removing :).