### PR TITLE
Delegate locale resolution to LocaleResolver

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2351,24 +2351,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_gettext_locale
-    user_settings =  current_user.try(:settings)
-    user_locale = user_settings[:display][:locale] if user_settings &&
-                                                      user_settings.key?(:display) &&
-                                                      user_settings[:display].key?(:locale)
-    if user_locale == 'default' || user_locale.nil?
-      server_locale = ::Settings.server.locale
-      # user settings && server settings == 'default'
-      # OR not defined
-      # use HTTP_ACCEPT_LANGUAGE
-      locale = if server_locale == "default" || server_locale.nil?
-                 request.headers['Accept-Language']
-               else
-                 server_locale
-               end
-    else
-      locale = user_locale
-    end
-    FastGettext.set_locale(locale)
+    FastGettext.set_locale(LocaleResolver.resolve(current_user, request.headers))
   end
 
   def flip_sort_direction(direction)


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/13582 extracted this logic in
the main repo so it could be reused without inheriting all of
`ApplicationController`. This PR updates `ApplicationController` to
delegate to the newly extracted service.

@miq-bot add-label refactoring