### PR TITLE
Use full paths to images in decorators, remove item_image in favor of listicon_image

### DIFF
--- a/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
@@ -129,10 +129,11 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     if (d.item.icon) {
       return {
         'type': 'image',
-        'icon': '/assets/svg/' + d.item.icon + '.svg'
-      }
+        'icon': d.item.icon,
+      };
     }
-    return icons[d.item.display_kind]
+
+    return icons[d.item.display_kind];
   };
 
   this.dblclick = function dblclick(d) {

--- a/app/decorators/auth_private_key_decorator.rb
+++ b/app/decorators/auth_private_key_decorator.rb
@@ -6,12 +6,6 @@ class AuthPrivateKeyDecorator < Draper::Decorator
   end
 
   def listicon_image
-    "100/#{item_image}.png"
-  end
-
-  private
-
-  def item_image
-    'auth_key_pair'
+    "100/auth_key_pair.png"
   end
 end

--- a/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
@@ -5,11 +5,7 @@ module ManageIQ::Providers::Hawkular
     end
 
     def listicon_image
-      "svg/#{item_image}.svg"
-    end
-
-    def item_image
-      'vendor-hawkular'
+      "svg/vendor-hawkular.svg"
     end
   end
 end

--- a/app/decorators/middleware_datasource_decorator.rb
+++ b/app/decorators/middleware_datasource_decorator.rb
@@ -1,6 +1,5 @@
 class MiddlewareDatasourceDecorator < Draper::Decorator
   delegate_all
-  include MiddlewareDecoratorMixin
 
   def fonticon
     'fa fa-database'.freeze

--- a/app/decorators/middleware_datasource_decorator.rb
+++ b/app/decorators/middleware_datasource_decorator.rb
@@ -6,8 +6,7 @@ class MiddlewareDatasourceDecorator < Draper::Decorator
     'fa fa-database'.freeze
   end
 
-  # Determine the icon
-  def item_image
-    'middleware_datasource'
+  def listicon_image
+    '100/middleware_datasource.png'
   end
 end

--- a/app/decorators/middleware_decorator_mixin.rb
+++ b/app/decorators/middleware_decorator_mixin.rb
@@ -1,5 +1,0 @@
-module MiddlewareDecoratorMixin
-  def listicon_image
-    "100/#{item_image}.png"
-  end
-end

--- a/app/decorators/middleware_deployment_decorator.rb
+++ b/app/decorators/middleware_deployment_decorator.rb
@@ -1,6 +1,5 @@
 class MiddlewareDeploymentDecorator < Draper::Decorator
   delegate_all
-  include MiddlewareDecoratorMixin
 
   def fonticon
     if name.end_with? '.ear'

--- a/app/decorators/middleware_deployment_decorator.rb
+++ b/app/decorators/middleware_deployment_decorator.rb
@@ -12,16 +12,13 @@ class MiddlewareDeploymentDecorator < Draper::Decorator
     end
   end
 
-  # Determine the icon
-  # we want to display a different icon depending of the type
-  # of server we have.
-  def item_image
+  def listicon_image
     if name.end_with? '.ear'
-      'middleware_deployment_ear'
+      '100/middleware_deployment_ear.png'
     elsif name.end_with? '.war'
-      'middleware_deployment_war'
+      '100/middleware_deployment_war.png'
     else
-      'middleware_deployment'
+      '100/middleware_deployment.png'
     end
   end
 end

--- a/app/decorators/middleware_domain_decorator.rb
+++ b/app/decorators/middleware_domain_decorator.rb
@@ -6,8 +6,7 @@ class MiddlewareDomainDecorator < Draper::Decorator
     'pficon-domain'.freeze
   end
 
-  # Determine the icon
-  def item_image
-    'middleware_domain'
+  def listicon_image
+    '100/middleware_domain.png'
   end
 end

--- a/app/decorators/middleware_domain_decorator.rb
+++ b/app/decorators/middleware_domain_decorator.rb
@@ -1,6 +1,5 @@
 class MiddlewareDomainDecorator < Draper::Decorator
   delegate_all
-  include MiddlewareDecoratorMixin
 
   def fonticon
     'pficon-domain'.freeze

--- a/app/decorators/middleware_messaging_decorator.rb
+++ b/app/decorators/middleware_messaging_decorator.rb
@@ -6,8 +6,7 @@ class MiddlewareMessagingDecorator < Draper::Decorator
     'fa fa-exchange'.freeze
   end
 
-  # Determine the icon
-  def item_image
-    'middleware_messaging'
+  def listicon_image
+    '100/middleware_messaging.png'
   end
 end

--- a/app/decorators/middleware_messaging_decorator.rb
+++ b/app/decorators/middleware_messaging_decorator.rb
@@ -1,6 +1,5 @@
 class MiddlewareMessagingDecorator < Draper::Decorator
   delegate_all
-  include MiddlewareDecoratorMixin
 
   def fonticon
     'fa fa-exchange'.freeze

--- a/app/decorators/middleware_server_decorator.rb
+++ b/app/decorators/middleware_server_decorator.rb
@@ -6,18 +6,14 @@ class MiddlewareServerDecorator < Draper::Decorator
     nil
   end
 
-  # Determine the icon
-  # we want to display a different icon depending of the type
-  # of server we have.
-  def item_image
+  def listicon_image
     case product
     when 'Hawkular'
-      'vendor-hawkular'
+      'svg/vendor-hawkular.svg'
     when 'JBoss EAP'
-      'vendor-jboss-eap'
+      'svg/vendor-jboss-eap.svg'
     else
-      'vendor-wildfly'
+      'svg/vendor-wildfly.svg'
     end
   end
-
 end

--- a/app/decorators/middleware_server_decorator.rb
+++ b/app/decorators/middleware_server_decorator.rb
@@ -1,6 +1,5 @@
 class MiddlewareServerDecorator < Draper::Decorator
   delegate_all
-  include MiddlewareDecoratorMixin
 
   def fonticon
     nil

--- a/app/decorators/middleware_server_group_decorator.rb
+++ b/app/decorators/middleware_server_group_decorator.rb
@@ -6,8 +6,7 @@ class MiddlewareServerGroupDecorator < Draper::Decorator
     'pficon-server-group'.freeze
   end
 
-  # Determine the icon
-  def item_image
-    'middleware_server_group'
+  def listicon_image
+    '100/middleware_server_group.png'
   end
 end

--- a/app/decorators/middleware_server_group_decorator.rb
+++ b/app/decorators/middleware_server_group_decorator.rb
@@ -1,6 +1,5 @@
 class MiddlewareServerGroupDecorator < Draper::Decorator
   delegate_all
-  include MiddlewareDecoratorMixin
 
   def fonticon
     'pficon-server-group'.freeze

--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -58,11 +58,16 @@ class MiddlewareTopologyService < TopologyService
     data = build_base_entity_data(entity)
     data[:status] = 'Unknown'
     data[:display_kind] = entity_display_type(entity)
-    data[:icon] = entity.decorate.try(:item_image) unless glyph? entity
+
+    unless glyph? entity
+      data[:icon] = ActionController::Base.helpers.image_path(entity.decorate.try(:listicon_image))
+    end
+
     if entity.kind_of?(Vm)
       data[:status] = entity.power_state.capitalize
       data[:provider] = entity.ext_management_system.name
     end
+
     data
   end
 


### PR DESCRIPTION
In all our decorators, `listicon_image` is the function that returns the correct image, in the `svg/foo.svg` or `100/foo.png` format.

In some hawkular code, there was also `item_image` which only returned `foo`, relying on various means to interpret what that means. That doesn't work when we want to convert some images.

Replaced `item_image` with `listicon_image`, removed `MiddlewareDecoratorMixin` which provided the default `listicon_image`, and fixed `MiddlewareTopologyService` to use `listicon_image` instead of `item_image`.


So whereas before, `"foo"` would get sent to the client as the image name, relying on JS to (incorrectly) assume that `/assets/svg/foo.svg` is the right path, now we send the full path, including the hash.

@epwinchell can you review the icon changes please?