### PR TITLE
Deduplicate textual summaries a bit.

### DIFF
--- a/app/views/auth_key_pair_cloud/_main.html.haml
+++ b/app/views/auth_key_pair_cloud/_main.html.haml
@@ -1,7 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/cloud_network/_main.html.haml
+++ b/app/views/cloud_network/_main.html.haml
@@ -1,9 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/cloud_object_store_container/_main.html.haml
+++ b/app/views/cloud_object_store_container/_main.html.haml
@@ -1,7 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/cloud_object_store_object/_main.html.haml
+++ b/app/views/cloud_object_store_object/_main.html.haml
@@ -1,7 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/cloud_subnet/_main.html.haml
+++ b/app/views/cloud_subnet/_main.html.haml
@@ -1,9 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/cloud_volume/_main.html.haml
+++ b/app/views/cloud_volume/_main.html.haml
@@ -1,7 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/cloud_volume_backup/_main.html.haml
+++ b/app/views/cloud_volume_backup/_main.html.haml
@@ -1,7 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/cloud_volume_snapshot/_main.html.haml
+++ b/app/views/cloud_volume_snapshot/_main.html.haml
@@ -1,7 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/configuration_job/_main.html.haml
+++ b/app/views/configuration_job/_main.html.haml
@@ -1,7 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/flavor/_main.html.haml
+++ b/app/views/flavor/_main.html.haml
@@ -1,7 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/floating_ip/_main.html.haml
+++ b/app/views/floating_ip/_main.html.haml
@@ -1,9 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/layouts/_textual_main.html.haml
+++ b/app/views/layouts/_textual_main.html.haml
@@ -1,0 +1,8 @@
+= render :partial => "layouts/flash_msg"
+.row
+  .col-md-12.col-lg-6
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
+  .col-md-12.col-lg-6
+    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+  .col-md-12.col-lg-6
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}

--- a/app/views/load_balancer/_main.html.haml
+++ b/app/views/load_balancer/_main.html.haml
@@ -1,9 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/network_port/_main.html.haml
+++ b/app/views/network_port/_main.html.haml
@@ -1,9 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"

--- a/app/views/network_router/_main.html.haml
+++ b/app/views/network_router/_main.html.haml
@@ -1,9 +1,1 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+= render :partial => "layouts/textual_main"


### PR DESCRIPTION
Remotely related to https://github.com/ManageIQ/manageiq-ui-classic/issues/163.

By removing stuff that is actually generic and handling it in the base class or mixin it will be easier to support the partial updates for related controller.

And it's less code.

![textual](https://cloud.githubusercontent.com/assets/51095/22151959/c89bfb58-df20-11e6-875a-9497c9c4e9a6.png)

In some of the files the columns or order is changed. But at least not it's unified and we can work on the layout in a generic way in follow up PRs.
