### PR TITLE
rhv: removed the option to migrate the VMs outside of the cluster.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1790,6 +1790,17 @@ class ApplicationController < ActionController::Base
     end
 
     vms = VmOrTemplate.where(:id => vm_ids)
+    if typ == "migrate"
+      # if one of the providers in question cannot support simultaneous migration of his subset of
+      # the selected VMs, we abort
+      if vms.group_by(&:ext_management_system).except(nil).any? do |ems, ems_vms|
+        ems.respond_to?(:supports_migrate_for_all?) && !ems.supports_migrate_for_all?(ems_vms)
+      end
+        add_flash(_("These VMs can not be migrated together."), :error)
+        return
+      end
+    end
+
     vms.each do |vm|
       if vm.respond_to?("supports_#{typ}?")
         render_flash_not_applicable_to_model(typ) unless vm.send("supports_#{typ}?")

--- a/app/views/miq_request/_prov_vm_migrate_dialog.html.haml
+++ b/app/views/miq_request/_prov_vm_migrate_dialog.html.haml
@@ -29,12 +29,13 @@
           :label                      => _("Datacenter"),
           :keys                       => keys})
 
-    - keys = [:cluster_filter, :placement_cluster_name]
-    = render(:partial => "/miq_request/prov_dialog_fieldset",
-      :locals         => {:workflow => wf,
-        :dialog                     => dialog,
-        :label                      => title_for_cluster,
-        :keys                       => keys})
+    - if wf.field_supported(:cluster)
+      - keys = [:cluster_filter, :placement_cluster_name]
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
+        :locals         => {:workflow => wf,
+          :dialog                     => dialog,
+          :label                      => title_for_cluster,
+          :keys                       => keys})
 
     - if wf.field_supported(:respool)
       - keys = [:rp_filter, :placement_rp_name]


### PR DESCRIPTION
The support for cross cluster migrations was added to oVirt only as a
workaround for el6->el7 migrations but should not be exposed. Since the current
code in manageiq anyway did not work properly, removing the support for it
completely - it is a low level functionality, it is obsoleted and discouraged
to be used.

Links
https://bugzilla.redhat.com/show_bug.cgi?id=1398287