### PR TITLE
Add Live Migrate actions to the task queue.

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -513,7 +513,7 @@ module ApplicationController::CiProcessing
         }
         task_id = @record.class.live_migrate_queue(session[:userid], @record, options)
         unless task_id.kind_of?(Integer)
-          add_flash(_("Instance live migration task %{id} failed.") % {:id => task_id.to_s}, :error)
+          add_flash(_("Instance live migration task failed."), :error)
         end
 
         return javascript_flash(:spinner_off => true) if @flash_array

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -517,6 +517,7 @@ module ApplicationController::CiProcessing
 
         if @flash_array
           javascript_flash(:spinner_off => true)
+          return
         else
           initiate_wait_for_task(:task_id => task_id, :action => "live_migrate_finished")
           return

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2927,6 +2927,7 @@ Rails.application.routes.draw do
         tree_autoload
         genealogy_tree_selected
         ownership_update
+        wait_for_task
       ) +
                ownership_post +
                pre_prov_post
@@ -3024,6 +3025,7 @@ Rails.application.routes.draw do
         ownership_update
         associate_floating_ip_vm
         disassociate_floating_ip_vm
+        wait_for_task
       ) +
                adv_search_post +
                compare_post +

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -105,7 +105,7 @@ describe VmCloudController do
       controller.instance_variable_set(:@edit,
                                        :new      => {},
                                        :explorer => false)
-      expect_any_instance_of(VmCloud).to receive(:live_migrate)
+      expect(VmCloud).to receive(:live_migrate_queue)
       post :live_migrate_vm, :params => {
         :button => 'submit',
         :id     => vm_openstack.id


### PR DESCRIPTION
Use the task queue for Live Migrate instead of calling the action directly from the UI.

Depends on https://github.com/ManageIQ/manageiq/pull/13491 which contains the backend changes.