### PR TITLE
Only show Disable local login checkbox with SAML is enabled.

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -95,6 +95,10 @@ module OpsController::Settings::Common
           page << set_element_visible("httpd_div", verb)
           page << set_element_visible("httpd_role_div", verb)
         end
+        if @saml_enabled_changed
+          verb = @edit[:new][:authentication][:saml_enabled]
+          page << set_element_visible("saml_local_login_div", verb)
+        end
         if @authusertype_changed
           verb = @edit[:new][:authentication][:user_type] == 'samaccountname'
           page << set_element_visible("user_type_samaccountname", verb)
@@ -764,6 +768,9 @@ module OpsController::Settings::Common
       @sb[:newrole] = (params[:ldap_role].to_s == "1") if params[:ldap_role]
       @sb[:new_amazon_role] = (params[:amazon_role].to_s == "1") if params[:amazon_role]
       @sb[:new_httpd_role] = (params[:httpd_role].to_s == "1") if params[:httpd_role]
+      if params[:saml_enabled] && params[:saml_enabled] != auth[:saml_enabled]
+        @saml_enabled_changed = true
+      end
       if params[:authentication_user_type] && params[:authentication_user_type] != auth[:user_type]
         @authusertype_changed = true
       end

--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -247,12 +247,14 @@
           = check_box_tag("saml_enabled", "1",
                           @edit[:new][:authentication][:saml_enabled],
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
-        %label.col-md-2.control-label
-          = _("Disable Local Login")
-        .col-md-4
-          = check_box_tag("local_login_disabled", "1",
-                          @edit[:new][:authentication][:local_login_disabled],
-                          "data-miq_observe_checkbox" => {:url => url}.to_json)
+      = hidden_div_if(@edit[:new][:authentication][:saml_enabled] == false, :id => "saml_local_login_div") do
+        .form-group
+          %label.col-md-2.control-label
+            = _("Disable Local Login")
+          .col-md-4
+            = check_box_tag("local_login_disabled", "1",
+                            @edit[:new][:authentication][:local_login_disabled],
+                            "data-miq_observe_checkbox" => {:url => url}.to_json)
     %hr
 
   = hidden_div_if(@edit[:new][:authentication][:mode] != "httpd", :id => "httpd_role_div") do


### PR DESCRIPTION
The disable local login option is only in effect when External
authentication mode and SAML and enabled.

https://bugzilla.redhat.com/show_bug.cgi?id=1389122