### PR TITLE
Fix Chart pie clicking when part of it is hidden

### DIFF
--- a/app/assets/javascripts/miq_c3.js
+++ b/app/assets/javascripts/miq_c3.js
@@ -25,8 +25,10 @@ function load_c3_chart(data, chart_id, height) {
   var generate_args = chartData(data.miqChart, data, { bindto: "#" + chart_id, size: {height: height}})
 
   generate_args.data.onclick = function (data, _i) {
-    var seriesIndex = _.findIndex(generate_args.data.columns, function(col) { return col[0] == data.id; }) - 1
-    var pointIndex = data.index;
+    var index = _.findIndex(generate_args.data.columns, function(col) { return col[0] == data.id; });
+    // when not Pie/Donut chart, first column doesn't contain actual data.
+    var seriesIndex = _.contains(['Pie', 'Donut'], generate_args.miqChart) ? index : index - 1;
+    var pointIndex = _.contains(['Pie', 'Donut'], generate_args.miqChart) ? index : data.index;
     var value = data.value;
 
     var parts = chart_id.split('_'); // miq_chart_candu_2


### PR DESCRIPTION
In C&U pie charts, when part of chart is hidden, indexes are badly calculated. That result in bad navigation.

Screenshots
---------------

Before:
![screencast from 2017-01-23 13-15-11](https://cloud.githubusercontent.com/assets/9535558/22203582/165d6e9a-e16e-11e6-93d0-ed28a3f19324.gif)

After:
![screencast from 2017-01-23 13-11-40](https://cloud.githubusercontent.com/assets/9535558/22203585/183e8d3e-e16e-11e6-9117-92ece7161976.gif)

