### PR TITLE
Fix check_box_tag parameters for snap_memory

### DIFF
--- a/app/views/vm_common/_snap.html.haml
+++ b/app/views/vm_common/_snap.html.haml
@@ -20,7 +20,7 @@
         %label.control-label.col-md-2
           = _('Snapshot VM memory')
         .col-md-8
-          = check_box_tag("snap_memory", :value => "1", :checked => false)
+          = check_box_tag("snap_memory", "1", false)
   - unless @edit
     %hr
     %table{:width => "100%"}


### PR DESCRIPTION
The checkbox for `:snap_memory` was incorrectly setting the value leading to it being interpreted as always false.

Before:
```
params[:snap_memory]
"{:value=>\"1\", :checked=>false}"
```

After:
```
params[:snap_memory]
"1"
```

This value is being compared to `"1"` [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/a3238d127e7a0089ecdd8428f1992d9e1f61bb26/app/controllers/vm_common.rb#L531) so we were never creating a VM snapshot with memory.

https://bugzilla.redhat.com/show_bug.cgi?id=1413678