### PR TITLE
ReportFormatter::Timeline - remove timeline/*png image references

### DIFF
--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -96,14 +96,11 @@ module ReportFormatter
         when "BottleneckEvent"
           #         e_title = "#{ui_lookup(:model=>rec[:resource_type])}: #{rec[:resource_name]}"
           e_title = rec[:resource_name]
-          e_image = ActionController::Base.helpers.image_path("100/#{bubble_icon(rec)}.png")
         #         e_text = e_title # Commented out since name is showing in the columns anyway
         when "Vm"
           e_title = rec[:name]
-          e_image = ActionController::Base.helpers.image_path("svg/os-#{rec.os_image_name.downcase}.svg")
         when "Host"
           e_title = rec[:name]
-          e_image = ActionController::Base.helpers.image_path("svg/os-#{rec.os_image_name.downcase}.svg")
         when "EventStream"
           ems_cloud = false
           if rec[:ems_id] && ExtManagementSystem.exists?(rec[:ems_id])
@@ -134,13 +131,8 @@ module ReportFormatter
             e_title = rec[title_col] unless title_col.nil?
           end
           e_title ||= ems ? ems.name : "No VM, Host, or MS"
-          # See if this is EVM's special event
-          if rec[:vm_or_template_id] && Vm.exists?(rec[:vm_or_template_id])
-            e_image = ActionController::Base.helpers.image_path("svg/os-#{Vm.find(rec[:vm_or_template_id]).os_image_name.downcase}.svg")
-          end
         else
           e_title = rec[:name] ? rec[:name] : row[mri.col_order.first].to_s
-          e_icon = image = nil
         end
       end
 
@@ -193,27 +185,7 @@ module ReportFormatter
       # Add the event to the timeline
       @events_data.push("start"       => format_timezone(row[col], tz, 'view'),
                         "title"       => e_title.length < 20 ? e_title : e_title[0...17] + "...",
-                        "icon"        => e_icon,
-                        "image"       => e_image,
                         "description" => e_text)
     end
-
-    def bubble_icon(rec)
-      case rec.resource_type.downcase
-      when "emscluster"
-        return "cluster"
-      when "miqenterprise"
-        return "enterprise"
-      when "extmanagementsystem"
-        if rec.resource.kind_of?(ExtManagementSystem) && rec.resource.emstype == "rhevm"
-          return "vendor-redhat"
-        else
-          return "ems"
-        end
-      else
-        return rec.resource_type.downcase
-      end
-    end
-
   end
 end

--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -215,24 +215,5 @@ module ReportFormatter
       end
     end
 
-    # Return the name of an icon for a specific table, event pair
-    def timeline_icon(table, event_text)
-      # Create the icon hash, if it doesn't exist yet
-      unless @icon_hash
-        icon_dir = "#{TIMELINES_FOLDER}/icons"
-        begin
-          data = File.read(File.join(icon_dir, "#{table}.csv")).split("\n")
-        rescue
-          return table    # If we can't read the file, return the table name as the icon name
-        end
-        @icon_hash = {}
-        data.each do |rec|
-          evt, txt = rec.split(",")
-          @icon_hash[evt] = txt
-        end
-      end
-      return @icon_hash[event_text] if @icon_hash[event_text]
-      table
-    end
   end
 end

--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -97,15 +97,12 @@ module ReportFormatter
           #         e_title = "#{ui_lookup(:model=>rec[:resource_type])}: #{rec[:resource_name]}"
           e_title = rec[:resource_name]
           e_image = ActionController::Base.helpers.image_path("100/#{bubble_icon(rec)}.png")
-          e_icon = ActionController::Base.helpers.image_path("timeline/#{rec.event_type.downcase}_#{rec[:severity]}.png")
         #         e_text = e_title # Commented out since name is showing in the columns anyway
         when "Vm"
           e_title = rec[:name]
-          e_icon = ActionController::Base.helpers.image_path("timeline/vendor-#{rec.vendor.downcase}.png")
           e_image = ActionController::Base.helpers.image_path("svg/os-#{rec.os_image_name.downcase}.svg")
         when "Host"
           e_title = rec[:name]
-          e_icon = ActionController::Base.helpers.image_path("timeline/vendor-#{rec.vmm_vendor_display.downcase}.png")
           e_image = ActionController::Base.helpers.image_path("svg/os-#{rec.os_image_name.downcase}.svg")
         when "EventStream"
           ems_cloud = false
@@ -137,13 +134,7 @@ module ReportFormatter
             e_title = rec[title_col] unless title_col.nil?
           end
           e_title ||= ems ? ems.name : "No VM, Host, or MS"
-          e_icon = ActionController::Base.helpers.image_path("timeline/#{timeline_icon("vm_event", rec.event_type.downcase)}.png")
           # See if this is EVM's special event
-          if rec.event_type == "GeneralUserEvent"
-            if rec.message.include?("EVM SmartState Analysis")
-              e_icon =  ActionController::Base.helpers.image_path("timeline/evm_analysis.png")
-            end
-          end
           if rec[:vm_or_template_id] && Vm.exists?(rec[:vm_or_template_id])
             e_image = ActionController::Base.helpers.image_path("svg/os-#{Vm.find(rec[:vm_or_template_id]).os_image_name.downcase}.svg")
           end

--- a/spec/lib/report_formater/timeline_spec.rb
+++ b/spec/lib/report_formater/timeline_spec.rb
@@ -1,33 +1,3 @@
-describe ReportFormatter::ReportTimeline do
-  context '#bubble_icon' do
-    def stub_bottleneck_event(resource_type, ems_type = nil)
-      bottleneck_event = BottleneckEvent.create!(:resource_type => resource_type)
-      unless ems_type.nil?
-        ems = FactoryGirl.create(:ems_redhat)
-        allow(ems).to receive(:emstype).and_return(ems_type)
-        allow(bottleneck_event).to receive(:resource).and_return(ems)
-      end
-      bottleneck_event
-    end
-
-    it 'shows a generic icon for MiqEnterprise' do
-      expect(ReportFormatter::ReportTimeline.new.bubble_icon(stub_bottleneck_event(MiqEnterprise))).to eq('enterprise')
-    end
-
-    it 'shows a generic icon for EmsCluster' do
-      expect(ReportFormatter::ReportTimeline.new.bubble_icon(stub_bottleneck_event(EmsCluster))).to eq('cluster')
-    end
-
-    it 'shows a generic icon for ExtManagementSystem' do
-      expect(ReportFormatter::ReportTimeline.new.bubble_icon(stub_bottleneck_event(ExtManagementSystem))).to eq('ems')
-    end
-
-    it 'shows a Red Hat logo for RHEVM EMS' do
-      expect(ReportFormatter::ReportTimeline.new.bubble_icon(stub_bottleneck_event(ExtManagementSystem, 'rhevm'))).to eq('vendor-redhat')
-    end
-  end
-end
-
 describe ReportFormatter::TimelineMessage do
   describe '#message_html on container event' do
     row = {}


### PR DESCRIPTION
Last we had any `timeline/` images was before 6e634daf45f6dc0540ef3d1ae79780f5aafd1780 (https://github.com/ManageIQ/manageiq/pull/11832), but they're still being referenced.

@PanSpagetka are these (icon and image in timelines) even still being used?
@epwinchell (If it turns out they are..) I could fix those `vendor` to point to the svg versions, but not that sure about `#{event_type}_#{severity}` or `evm_analysis` or `vm_event...`.