### PR TITLE
Allow local ruby-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ spec/reports/
 tmp/
 .rubocop-*
 .idea/
+.ruby-version


### PR DESCRIPTION
Ignore `.ruby-version` so devs can set their Ruby version to something compatible. (This mainly matters for running specs)