### PR TITLE
Add control that saved report exists

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -299,7 +299,12 @@ class ApplicationController < ActionController::Base
   # Common method to show a standalone report
   def report_only
     @report_only = true                 # Indicate stand alone report for views
-
+    # Render error message if report doesn't exist
+    if params[:rr_id].nil? && @sb.fetch_path(:pages, :rr_id).nil?
+      add_flash(_("This report isn't generated yet. It cannot be rendered."), :error)
+      render :partial => "layouts/flash_msg"
+      return
+    end
     # Dashboard widget will send in report result id else, find report result in the sandbox
     search_id = params[:rr_id] ? params[:rr_id].to_i : @sb[:pages][:rr_id]
     rr = MiqReportResult.find(search_id)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1399599

Before:
<img width="1065" alt="screen shot 2017-01-23 at 2 33 40 pm" src="https://cloud.githubusercontent.com/assets/9210860/22205858/f773d266-e178-11e6-8a07-e6af5f27ac40.png">
After:
<img width="380" alt="screen shot 2017-01-23 at 2 32 55 pm" src="https://cloud.githubusercontent.com/assets/9210860/22205859/f7917f14-e178-11e6-9f8a-d3d621adb636.png">

Cloud Intel -> Reports -> Saved Reports -> select unfinished report (see picture below) -> Configuration -> Show full screen Report  
<img width="722" alt="screen shot 2017-01-24 at 10 29 55 am" src="https://cloud.githubusercontent.com/assets/9210860/22241550/1cf0bdf4-e220-11e6-9a2c-4fc8fcbf2e1a.png">

Toolbar cannot know that  input is invalid. As `report_only` opens a new page `render_flash` couldn't be used.

@miq-bot add_label bug