### PR TITLE
Fix typo in miq_request_center

### DIFF
--- a/app/helpers/application_helper/toolbar/miq_request_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_request_center.rb
@@ -35,7 +35,7 @@ class ApplicationHelper::Toolbar::MiqRequestCenter < ApplicationHelper::Toolbar:
       N_('Approve this Request'),
       nil,
       :klass     => ApplicationHelper::Button::MiqRequestApproval,
-      :options   => {:feature => 'miq_request_copy'},
+      :options   => {:feature => 'miq_request_approve'},
       :url       => "/stamp",
       :url_parms => "?typ=a"),
     button(
@@ -44,7 +44,7 @@ class ApplicationHelper::Toolbar::MiqRequestCenter < ApplicationHelper::Toolbar:
       N_('Deny this Request'),
       nil,
       :klass     => ApplicationHelper::Button::MiqRequestApproval,
-      :options   => {:feature => 'miq_request_copy'},
+      :options   => {:feature => 'miq_request_deny'},
       :url       => "/stamp",
       :url_parms => "?typ=d"),
   ])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1404837

`miq_request_copy` was used instead of `miq_request_approve` and `miq_request_deny`

Introduced by https://github.com/ManageIQ/manageiq/pull/10865 -> Euwe/Yes

Before:
<img width="492" alt="screen shot 2017-01-24 at 3 21 03 pm" src="https://cloud.githubusercontent.com/assets/9210860/22250840/c1a87ec2-e248-11e6-8c2c-c6b30395d2f1.png">

After:
<img width="1178" alt="screen shot 2017-01-24 at 3 10 14 pm" src="https://cloud.githubusercontent.com/assets/9210860/22250773/76298b08-e248-11e6-91a2-c26268a161eb.png">

Steps to reproduced:
- Create pending Automation Request
- Automation -> Automate -> Requests -> choose a pending request

@miq-bot add_label bug, euwe/yes
