### PR TITLE
Remove CimBaseStorageExtendStatistic button cases

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -474,11 +474,6 @@ class ApplicationHelper::ToolbarBuilder
           return N_("No Timeline data has been collected for this Availability Zone")
         end
       end
-    when "CimBaseStorageExtent"
-      case id
-      when "cim_base_storage_extent_statistics"
-        return N_("No Statistics Collected") unless @record.latest_derived_metrics
-      end
     when "SniaLocalFileSystem"
       case id
       when "snia_local_file_system_statistics"

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -414,19 +414,6 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       expect(subject).to match(/No.*are available/)
     end
 
-    context "when record class = CimBaseStorageExtent" do
-      before do
-        @record = CimBaseStorageExtent.new
-        allow(@record).to receive_messages(:latest_derived_metrics => true)
-      end
-
-      context "and id = cim_base_storage_extent_statistics" do
-        before { @id = "cim_base_storage_extent_statistics" }
-        it_behaves_like 'record without latest derived metrics', "No Statistics Collected"
-        it_behaves_like 'default case'
-      end
-    end
-
     context "when record class = SniaLocalFileSystem" do
       before do
         @record = SniaLocalFileSystem.new


### PR DESCRIPTION
Remove case for CimBaseStorageExtendStatistic from disable button and spec for it, because this button isn't present in any toolbar.

If this button will magically appear somewhere, result of this PR will be that this button will...be enabled even if it should be disabled.