### PR TITLE
include GenericShowMixin to fix loading of summary screen

### DIFF
--- a/app/controllers/cloud_volume_snapshot_controller.rb
+++ b/app/controllers/cloud_volume_snapshot_controller.rb
@@ -5,6 +5,7 @@ class CloudVolumeSnapshotController < ApplicationController
   after_action :set_session_data
 
   include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericButtonMixin
 


### PR DESCRIPTION
show method was removed from controller in 63376bfbccec606f6ecc3b4c0f749cb9c8d66786 but GenericShowMixin was not included.

@martinpovolny @dclarizio please review. @martinpovolny marked it as euwe/no as i don't think Mixins were backported to EUWE

before:
![before](https://cloud.githubusercontent.com/assets/3450808/22266850/91853e72-e24f-11e6-87dc-73cf9f7cf79a.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/22266855/951013a0-e24f-11e6-894a-dfdd0b560158.png)
