### PR TITLE
Add volume snapshot summary to block storage manager

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -99,6 +99,7 @@ module EmsCommon
       'middleware_messagings'         => [MiddlewareMessaging,    _('Middleware Messagings')],
       'cloud_tenants'                 => [CloudTenant,            _('Cloud Tenants')],
       'cloud_volumes'                 => [CloudVolume,            _('Cloud Volumes')],
+      'cloud_volume_snapshots'        => [CloudVolumeSnapshot,    _('Cloud Volume Snapshots')],
       'flavors'                       => [Flavor,                 _('Flavors')],
       'security_groups'               => [SecurityGroup,          _('Security Groups')],
       'floating_ips'                  => [FloatingIp,             _('Floating IPs')],

--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module EmsStorageHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(parent_ems_cloud cloud_volumes cloud_object_store_containers)
+    %i(parent_ems_cloud cloud_volumes cloud_volume_snapshots cloud_object_store_containers)
   end
 
   def textual_group_status
@@ -62,6 +62,10 @@ module EmsStorageHelper::TextualSummary
 
   def textual_cloud_volumes
     @record.try(:cloud_volumes)
+  end
+
+  def textual_cloud_volume_snapshots
+    @record.try(:cloud_volume_snapshots)
   end
 
   def textual_cloud_object_store_containers


### PR DESCRIPTION
Existing summary view of a block storage manager shows only the number
of available cloud volumes. This patch adds cloud volume snapshots
summary as well.

The highlighted row in the following screen is added by this PR.

<img width="1364" alt="screen shot 2017-01-24 at 22 57 49" src="https://cloud.githubusercontent.com/assets/1437960/22268675/adf6e4b4-e288-11e6-93e5-f9cf133eeb36.png">
