### PR TITLE
Refactor - Replace .success calls with .then/.catch (Round 3)

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -3,9 +3,9 @@
 miqHttpInject(angular.module('topologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
 .controller('containerTopologyController', ContainerTopologyCtrl);
 
-ContainerTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', '$window', 'miqService'];
+ContainerTopologyCtrl.$inject = ['$scope', '$http', '$interval', 'topologyService', '$window', 'miqService'];
 
-function ContainerTopologyCtrl($scope, $http, $interval, $location, topologyService, $window, miqService) {
+function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $window, miqService) {
   ManageIQ.angular.scope = $scope;
   miqHideSearchClearButton();
   var self = this;
@@ -285,7 +285,7 @@ function ContainerTopologyCtrl($scope, $http, $interval, $location, topologyServ
     $scope.kinds = data.data.kinds;
     icons = data.data.icons;
 
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys($scope.kinds).length)) {
       $scope.kinds = currentSelectedKinds;
     }
   }

--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -3,9 +3,9 @@
 miqHttpInject(angular.module('topologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
 .controller('containerTopologyController', ContainerTopologyCtrl);
 
-ContainerTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', '$window'];
+ContainerTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', '$window', 'miqService'];
 
-function ContainerTopologyCtrl($scope, $http, $interval, $location, topologyService, $window) {
+function ContainerTopologyCtrl($scope, $http, $interval, $location, topologyService, $window, miqService) {
   ManageIQ.angular.scope = $scope;
   miqHideSearchClearButton();
   var self = this;
@@ -27,18 +27,9 @@ function ContainerTopologyCtrl($scope, $http, $interval, $location, topologyServ
 
     var url = '/container_topology/data' + id;
 
-    var currentSelectedKinds = $scope.kinds;
-
-    $http.get(url).success(function(data) {
-      $scope.items = data.data.items;
-      $scope.relations = data.data.relations;
-      $scope.kinds = data.data.kinds;
-      icons = data.data.icons;
-
-      if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
-        $scope.kinds = currentSelectedKinds;
-      }
-    });
+    $http.get(url)
+      .then(getContainerTopologyData)
+      .catch(miqService.handleFailure);
   };
 
   $scope.checkboxModel = {
@@ -283,4 +274,19 @@ function ContainerTopologyCtrl($scope, $http, $interval, $location, topologyServ
     // Reset the search term in search input
     $('input#search_topology')[0].value = "";
   };
+
+  function getContainerTopologyData(response) {
+    var data = response.data;
+
+    var currentSelectedKinds = $scope.kinds;
+
+    $scope.items = data.data.items;
+    $scope.relations = data.data.relations;
+    $scope.kinds = data.data.kinds;
+    icons = data.data.icons;
+
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
+      $scope.kinds = currentSelectedKinds;
+    }
+  }
 }

--- a/app/assets/javascripts/controllers/infra_topology/infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/infra_topology/infra_topology_controller.js
@@ -3,9 +3,9 @@
 miqHttpInject(angular.module('infraTopologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
 .controller('infraTopologyController', InfraTopologyCtrl);
 
-InfraTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService'];
+InfraTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
 
-function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService) {
+function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
   var self = this;
   $scope.vs = null;
   var icons = null;
@@ -19,19 +19,11 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService)
       id = '/' + (/infra_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
     }
 
-    var currentSelectedKinds = $scope.kinds;
     var url = '/infra_topology/data' + id;
 
-    $http.get(url).success(function(data) {
-      $scope.items = data.data.items;
-      $scope.relations = data.data.relations;
-      $scope.kinds = data.data.kinds;
-      icons = data.data.icons;
-
-      if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
-        $scope.kinds = currentSelectedKinds;
-      }
-    });
+    $http.get(url)
+      .then(getInfraTopologyData)
+      .catch(miqService.handleFailure);
   };
 
   $scope.checkboxModel = {
@@ -274,4 +266,19 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService)
     // Reset the search term in search input
     $scope.search.query = "";
   };
+
+  function getInfraTopologyData(response) {
+    var data = response.data;
+
+    var currentSelectedKinds = $scope.kinds;
+
+    $scope.items = data.data.items;
+    $scope.relations = data.data.relations;
+    $scope.kinds = data.data.kinds;
+    icons = data.data.icons;
+
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
+      $scope.kinds = currentSelectedKinds;
+    }
+  }
 }

--- a/app/assets/javascripts/controllers/infra_topology/infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/infra_topology/infra_topology_controller.js
@@ -277,7 +277,7 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService,
     $scope.kinds = data.data.kinds;
     icons = data.data.icons;
 
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys($scope.kinds).length)) {
       $scope.kinds = currentSelectedKinds;
     }
   }

--- a/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
@@ -194,7 +194,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     $scope.relations = data.data.relations;
     $scope.kinds = data.data.kinds;
     icons = data.data.icons;
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys($scope.kinds).length)) {
       $scope.kinds = currentSelectedKinds;
     }
   }

--- a/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
@@ -2,9 +2,9 @@
 miqHttpInject(angular.module('mwTopologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
   .controller('middlewareTopologyController', MiddlewareTopologyCtrl);
 
-MiddlewareTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService'];
+MiddlewareTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
 
-function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologyService) {
+function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
   var self = this;
   $scope.vs = null;
   var d3 = window.d3;
@@ -17,17 +17,10 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     } else {
       id = '/' + (/middleware_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
     }
-    var currentSelectedKinds = $scope.kinds;
     var url = '/middleware_topology/data' + id;
-    $http.get(url).success(function(data) {
-      $scope.items = data.data.items;
-      $scope.relations = data.data.relations;
-      $scope.kinds = data.data.kinds;
-      icons = data.data.icons;
-      if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
-        $scope.kinds = currentSelectedKinds;
-      }
-    });
+    $http.get(url)
+      .then(getMiddlewareTopologyData)
+      .catch(miqService.handleFailure);
   };
 
   $scope.checkboxModel = {
@@ -191,4 +184,18 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     // Reset the search term in search input
     $scope.search.query = '';
   };
+
+  function getMiddlewareTopologyData(response) {
+    var data = response.data;
+
+    var currentSelectedKinds = $scope.kinds;
+
+    $scope.items = data.data.items;
+    $scope.relations = data.data.relations;
+    $scope.kinds = data.data.kinds;
+    icons = data.data.icons;
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
+      $scope.kinds = currentSelectedKinds;
+    }
+  }
 }

--- a/app/assets/javascripts/controllers/network_topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/network_topology/network_topology_controller.js
@@ -279,7 +279,7 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
     $scope.kinds = data.data.kinds;
     icons = data.data.icons;
 
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys($scope.kinds).length)) {
       $scope.kinds = currentSelectedKinds;
     }
   }

--- a/app/assets/javascripts/controllers/network_topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/network_topology/network_topology_controller.js
@@ -3,9 +3,9 @@
 miqHttpInject(angular.module('netTopologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
 .controller('networkTopologyController', NetworkTopologyCtrl);
 
-NetworkTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService'];
+NetworkTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
 
-function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyService) {
+function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
   var self = this;
   $scope.vs = null;
   var icons = null;
@@ -19,19 +19,11 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
       id = '/' + (/network_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
     }
 
-    var currentSelectedKinds = $scope.kinds;
     var url = '/network_topology/data' + id;
 
-    $http.get(url).success(function(data) {
-      $scope.items = data.data.items;
-      $scope.relations = data.data.relations;
-      $scope.kinds = data.data.kinds;
-      icons = data.data.icons;
-
-      if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
-        $scope.kinds = currentSelectedKinds;
-      }
-    });
+    $http.get(url)
+      .then(getNetworkTopologyData)
+      .catch(miqService.handleFailure);
   };
 
   $scope.checkboxModel = {
@@ -277,4 +269,18 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
     // Reset the search term in search input
     $scope.search.query = "";
   };
+
+  function getNetworkTopologyData(response) {
+    var data = response.data;
+
+    var currentSelectedKinds = $scope.kinds;
+    $scope.items = data.data.items;
+    $scope.relations = data.data.relations;
+    $scope.kinds = data.data.kinds;
+    icons = data.data.icons;
+
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
+      $scope.kinds = currentSelectedKinds;
+    }
+  }
 }

--- a/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
@@ -102,14 +102,15 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
     $scope.diagnosticsDatabaseModel.uri_prefix = data.uri_prefix;
     $scope.diagnosticsDatabaseModel.log_userid = data.log_userid;
 
-    if($scope.diagnosticsDatabaseModel.uri_prefix == 'nfs')
+    if ($scope.diagnosticsDatabaseModel.uri_prefix === 'nfs') {
       $scope.diagnosticsDatabaseModel.log_protocol = 'Network File System';
-    else
+    } else {
       $scope.diagnosticsDatabaseModel.log_protocol = 'Samba';
+    }
 
     $scope.diagnosticsDatabaseModel.action_typ = 'db_backup';
 
-    if($scope.diagnosticsDatabaseModel.log_userid != '') {
+    if ($scope.diagnosticsDatabaseModel.log_userid !== '') {
       $scope.diagnosticsDatabaseModel.log_password = $scope.diagnosticsDatabaseModel.log_verify = miqService.storedPasswordPlaceholder;
     }
 

--- a/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
@@ -36,30 +36,9 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
     miqService.sparkleOn();
 
     var url = $scope.dbBackupFormFieldChangedUrl;
-    $http.post(url + $scope.diagnosticsDatabaseModel.backup_schedule_type).success(function(data) {
-      $scope.$broadcast('resetClicked');
-      $scope.diagnosticsDatabaseModel.depot_name = data.depot_name;
-      $scope.diagnosticsDatabaseModel.uri = data.uri;
-      $scope.diagnosticsDatabaseModel.uri_prefix = data.uri_prefix;
-      $scope.diagnosticsDatabaseModel.log_userid = data.log_userid;
-
-      if($scope.diagnosticsDatabaseModel.uri_prefix == 'nfs')
-        $scope.diagnosticsDatabaseModel.log_protocol = 'Network File System';
-      else
-        $scope.diagnosticsDatabaseModel.log_protocol = 'Samba';
-
-      $scope.diagnosticsDatabaseModel.action_typ = 'db_backup';
-
-      if($scope.diagnosticsDatabaseModel.log_userid != '') {
-        $scope.diagnosticsDatabaseModel.log_password = $scope.diagnosticsDatabaseModel.log_verify = miqService.storedPasswordPlaceholder;
-      }
-
-      $scope.$broadcast('setNewRecord', { newRecord: false });
-      $scope.$broadcast('setUserId', { userIdName: 'log_userid',
-                                       userIdValue: $scope.diagnosticsDatabaseModel.log_userid });
-
-      miqService.sparkleOff();
-    });
+    $http.post(url + $scope.diagnosticsDatabaseModel.backup_schedule_type)
+      .then(postdiagnosticsDatabaseFormData)
+      .catch(miqService.handleFailure);
   };
 
   $scope.showSubmitButton = function() {
@@ -113,6 +92,33 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
   $scope.sambaRequired = function(value) {
     return miqDBBackupService.sambaRequired($scope.diagnosticsDatabaseModel, value);
   };
+
+  function postdiagnosticsDatabaseFormData(response) {
+    var data = response.data;
+
+    $scope.$broadcast('resetClicked');
+    $scope.diagnosticsDatabaseModel.depot_name = data.depot_name;
+    $scope.diagnosticsDatabaseModel.uri = data.uri;
+    $scope.diagnosticsDatabaseModel.uri_prefix = data.uri_prefix;
+    $scope.diagnosticsDatabaseModel.log_userid = data.log_userid;
+
+    if($scope.diagnosticsDatabaseModel.uri_prefix == 'nfs')
+      $scope.diagnosticsDatabaseModel.log_protocol = 'Network File System';
+    else
+      $scope.diagnosticsDatabaseModel.log_protocol = 'Samba';
+
+    $scope.diagnosticsDatabaseModel.action_typ = 'db_backup';
+
+    if($scope.diagnosticsDatabaseModel.log_userid != '') {
+      $scope.diagnosticsDatabaseModel.log_password = $scope.diagnosticsDatabaseModel.log_verify = miqService.storedPasswordPlaceholder;
+    }
+
+    $scope.$broadcast('setNewRecord', { newRecord: false });
+    $scope.$broadcast('setUserId', { userIdName: 'log_userid',
+      userIdValue: $scope.diagnosticsDatabaseModel.log_userid });
+
+    miqService.sparkleOff();
+  }
 
   init();
 }]);

--- a/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
@@ -35,22 +35,9 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
       miqService.sparkleOn();
 
       var url = $scope.logCollectionFormFieldsUrl;
-      $http.get(url + serverId).success(function(data) {
-        $scope.logCollectionModel.log_protocol = data.log_protocol;
-        $scope.logCollectionModel.depot_name = data.depot_name;
-        $scope.logCollectionModel.uri = data.uri;
-        $scope.logCollectionModel.uri_prefix = data.uri_prefix;
-        $scope.logCollectionModel.log_userid = data.log_userid;
-
-        if($scope.logCollectionModel.log_userid != '') {
-          $scope.logCollectionModel.log_password = $scope.logCollectionModel.log_verify = miqService.storedPasswordPlaceholder;
-        }
-
-        $scope.afterGet = true;
-        $scope.modelCopy = angular.copy( $scope.logCollectionModel );
-
-        miqService.sparkleOff();
-      });
+      $http.get(url + serverId)
+        .then(getLogCollectionFormData)
+        .catch(miqService.handleFailure);
     }
   };
 
@@ -61,12 +48,9 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
        $scope.logCollectionModel.log_protocol != '') {
       var url = $scope.logProtocolChangedUrl;
       miqService.sparkleOn();
-      $http.get(url + serverId + '?log_protocol=' + $scope.logCollectionModel.log_protocol).success(function (data) {
-        $scope.logCollectionModel.depot_name = data.depot_name;
-        $scope.logCollectionModel.uri = data.uri;
-        $scope.logCollectionModel.uri_prefix = data.uri_prefix;
-        miqService.sparkleOff();
-      });
+      $http.get(url + serverId + '?log_protocol=' + $scope.logCollectionModel.log_protocol)
+        .then(getLogProtocolData)
+        .catch(miqService.handleFailure);
     }
     $scope.$broadcast('reactiveFocus');
     miqDBBackupService.logProtocolChanged($scope.logCollectionModel);
@@ -113,6 +97,34 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
       return true;
     else
       return false;
+  }
+
+  function getLogCollectionFormData(response) {
+    var data = response.data;
+
+    $scope.logCollectionModel.log_protocol = data.log_protocol;
+    $scope.logCollectionModel.depot_name = data.depot_name;
+    $scope.logCollectionModel.uri = data.uri;
+    $scope.logCollectionModel.uri_prefix = data.uri_prefix;
+    $scope.logCollectionModel.log_userid = data.log_userid;
+
+    if($scope.logCollectionModel.log_userid != '') {
+      $scope.logCollectionModel.log_password = $scope.logCollectionModel.log_verify = miqService.storedPasswordPlaceholder;
+    }
+
+    $scope.afterGet = true;
+    $scope.modelCopy = angular.copy( $scope.logCollectionModel );
+
+    miqService.sparkleOff();
+  }
+
+  function getLogProtocolData(response) {
+    var data = response.data;
+
+    $scope.logCollectionModel.depot_name = data.depot_name;
+    $scope.logCollectionModel.uri = data.uri;
+    $scope.logCollectionModel.uri_prefix = data.uri_prefix;
+    miqService.sparkleOff();
   }
 
   init();

--- a/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
@@ -108,7 +108,7 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
     $scope.logCollectionModel.uri_prefix = data.uri_prefix;
     $scope.logCollectionModel.log_userid = data.log_userid;
 
-    if($scope.logCollectionModel.log_userid != '') {
+    if ($scope.logCollectionModel.log_userid !== '') {
       $scope.logCollectionModel.log_password = $scope.logCollectionModel.log_verify = miqService.storedPasswordPlaceholder;
     }
 

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -368,8 +368,9 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
     $scope.pglogicalReplicationModel.subscriptions = angular.copy(data.subscriptions);
     $scope.pglogicalReplicationModel.exclusion_list = angular.copy(data.exclusion_list);
 
-    if ($scope.pglogicalReplicationModel.replication_type == "none")
-      miqService.miqFlash("warn", __("No replication role has been set"));
+    if ($scope.pglogicalReplicationModel.replication_type === 'none') {
+      miqService.miqFlash('warn', __("No replication role has been set"));
+    }
 
     $scope.afterGet = true;
     $scope.modelCopy = angular.copy( $scope.pglogicalReplicationModel );

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -16,18 +16,9 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
     $scope.newRecord = false;
 
     miqService.sparkleOn();
-    $http.get('/ops/pglogical_subscriptions_form_fields/' + pglogicalReplicationFormId).success(function(data) {
-      $scope.pglogicalReplicationModel.replication_type = data.replication_type;
-      $scope.pglogicalReplicationModel.subscriptions = angular.copy(data.subscriptions);
-      $scope.pglogicalReplicationModel.exclusion_list = angular.copy(data.exclusion_list);
-
-      if ($scope.pglogicalReplicationModel.replication_type == "none")
-        miqService.miqFlash("warn", __("No replication role has been set"));
-
-      $scope.afterGet = true;
-      $scope.modelCopy = angular.copy( $scope.pglogicalReplicationModel );
-      miqService.sparkleOff();
-    });
+    $http.get('/ops/pglogical_subscriptions_form_fields/' + pglogicalReplicationFormId)
+      .then(getPgLogicalFormData)
+      .catch(miqService.handleFailure);
   };
 
   var pglogicalManageSubscriptionsButtonClicked = function(buttonName, serializeFields) {
@@ -369,6 +360,21 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
   $ctrl.toggleAnimation = function () {
     $ctrl.animationsEnabled = !$ctrl.animationsEnabled;
   };
+
+  function getPgLogicalFormData(response) {
+    var data = response.data;
+
+    $scope.pglogicalReplicationModel.replication_type = data.replication_type;
+    $scope.pglogicalReplicationModel.subscriptions = angular.copy(data.subscriptions);
+    $scope.pglogicalReplicationModel.exclusion_list = angular.copy(data.exclusion_list);
+
+    if ($scope.pglogicalReplicationModel.replication_type == "none")
+      miqService.miqFlash("warn", __("No replication role has been set"));
+
+    $scope.afterGet = true;
+    $scope.modelCopy = angular.copy( $scope.pglogicalReplicationModel );
+    miqService.sparkleOff();
+  }
 
   init();
 }]);

--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -26,18 +26,9 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
       } else {
         $scope.newRecord = false;
         miqService.sparkleOn();
-        $http.get('/ops/tenant_form_fields/' + tenantFormId).success(function(data) {
-          $scope.tenantModel.name                      = data.name;
-          $scope.tenantModel.description               = data.description;
-          $scope.tenantModel.default                   = data.default;
-          $scope.tenantModel.divisible                 = data.divisible;
-          $scope.tenantModel.use_config_for_attributes = data.use_config_for_attributes;
-
-          $scope.afterGet = true;
-          $scope.modelCopy = angular.copy( $scope.tenantModel );
-
-          miqService.sparkleOff();
-        });
+        $http.get('/ops/tenant_form_fields/' + tenantFormId)
+          .then(getTenantFormData)
+          .catch(miqService.handleFailure);
       }
     };
 
@@ -71,6 +62,21 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
     $scope.addClicked = function() {
       $scope.saveClicked();
     };
+
+    function getTenantFormData(response) {
+      var data = response.data;
+
+      $scope.tenantModel.name                      = data.name;
+      $scope.tenantModel.description               = data.description;
+      $scope.tenantModel.default                   = data.default;
+      $scope.tenantModel.divisible                 = data.divisible;
+      $scope.tenantModel.use_config_for_attributes = data.use_config_for_attributes;
+
+      $scope.afterGet = true;
+      $scope.modelCopy = angular.copy( $scope.tenantModel );
+
+      miqService.sparkleOff();
+    }
 
     init();
 }]);

--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -12,30 +12,9 @@ ManageIQ.angular.app.controller('tenantQuotaFormController', ['$http', '$scope',
     ManageIQ.angular.scope = $scope;
     $scope.newRecord = false;
     miqService.sparkleOn();
-    $http.get('/ops/tenant_quotas_form_fields/' + tenantQuotaFormId).success(function(data) {
-      $scope.tenantQuotaModel.name = data.name;
-      $scope.tenantQuotaModel.quotas = angular.copy(data.quotas);
-      var GIGABYTE = 1024 * 1024 * 1024;
-      for (var key in $scope.tenantQuotaModel.quotas) {
-        if($scope.tenantQuotaModel.quotas.hasOwnProperty(key)) {
-          var quota =  $scope.tenantQuotaModel.quotas[key];
-          if (quota['value']) {
-            if (quota['unit'] === "bytes")
-              quota['value'] = quota['value'] / GIGABYTE;
-            quota['enforced'] = true;
-          } else
-            quota['enforced'] = false;
-
-          if (quota['format'] === "general_number_precision_0")
-            quota['valpattern'] = "^[1-9][0-9]*$";
-          else
-            quota['valpattern'] = /^\s*(?=.*[1-9])\d*(?:\.\d{1,6})?\s*$/;
-        }
-      }
-      $scope.afterGet = true;
-      $scope.modelCopy = angular.copy( $scope.tenantQuotaModel );
-      miqService.sparkleOff();
-    });
+    $http.get('/ops/tenant_quotas_form_fields/' + tenantQuotaFormId)
+      .then(getTenantQuotaData)
+      .catch(miqService.handleFailure);
   };
 
   var tenantManageQuotasButtonClicked = function(buttonName, serializeFields) {
@@ -112,6 +91,33 @@ ManageIQ.angular.app.controller('tenantQuotaFormController', ['$http', '$scope',
     if (!$scope.check_quotas_changed())
       $scope.angularForm.$setPristine(true);
   };
+
+  function getTenantQuotaData(response) {
+    var data = response.data;
+
+    $scope.tenantQuotaModel.name = data.name;
+    $scope.tenantQuotaModel.quotas = angular.copy(data.quotas);
+    var GIGABYTE = 1024 * 1024 * 1024;
+    for (var key in $scope.tenantQuotaModel.quotas) {
+      if($scope.tenantQuotaModel.quotas.hasOwnProperty(key)) {
+        var quota =  $scope.tenantQuotaModel.quotas[key];
+        if (quota['value']) {
+          if (quota['unit'] === "bytes")
+            quota['value'] = quota['value'] / GIGABYTE;
+          quota['enforced'] = true;
+        } else
+          quota['enforced'] = false;
+
+        if (quota['format'] === "general_number_precision_0")
+          quota['valpattern'] = "^[1-9][0-9]*$";
+        else
+          quota['valpattern'] = /^\s*(?=.*[1-9])\d*(?:\.\d{1,6})?\s*$/;
+      }
+    }
+    $scope.afterGet = true;
+    $scope.modelCopy = angular.copy( $scope.tenantQuotaModel );
+    miqService.sparkleOff();
+  }
 
   init();
 }]);

--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -99,19 +99,22 @@ ManageIQ.angular.app.controller('tenantQuotaFormController', ['$http', '$scope',
     $scope.tenantQuotaModel.quotas = angular.copy(data.quotas);
     var GIGABYTE = 1024 * 1024 * 1024;
     for (var key in $scope.tenantQuotaModel.quotas) {
-      if($scope.tenantQuotaModel.quotas.hasOwnProperty(key)) {
+      if ($scope.tenantQuotaModel.quotas.hasOwnProperty(key)) {
         var quota =  $scope.tenantQuotaModel.quotas[key];
-        if (quota['value']) {
-          if (quota['unit'] === "bytes")
-            quota['value'] = quota['value'] / GIGABYTE;
-          quota['enforced'] = true;
-        } else
-          quota['enforced'] = false;
+        if (quota.value) {
+          if (quota.unit === 'bytes') {
+            quota.value = quota.value / GIGABYTE;
+          }
+          quota.enforced = true;
+        } else {
+          quota.enforced = false;
+        }
 
-        if (quota['format'] === "general_number_precision_0")
-          quota['valpattern'] = "^[1-9][0-9]*$";
-        else
-          quota['valpattern'] = /^\s*(?=.*[1-9])\d*(?:\.\d{1,6})?\s*$/;
+        if (quota.format === 'general_number_precision_0') {
+          quota.valpattern = '^[1-9][0-9]*$';
+        } else {
+          quota.valpattern = /^\s*(?=.*[1-9])\d*(?:\.\d{1,6})?\s*$/;
+        }
       }
     }
     $scope.afterGet = true;

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -21,43 +21,17 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
       if (providerForemanFormId == 'new') {
         $scope.newRecord = true;
 
-        $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId).success(function(data) {
-          $scope.providerForemanModel.provtype = '';
-          $scope.providerForemanModel.name = '';
-          $scope.providerForemanModel.zone = data.zone;
-          $scope.providerForemanModel.url = '';
-          $scope.providerForemanModel.verify_ssl = false;
-
-          $scope.providerForemanModel.log_userid = '';
-          $scope.providerForemanModel.log_password = '';
-          $scope.providerForemanModel.log_verify = '';
-          $scope.afterGet = true;
-          $scope.modelCopy = angular.copy($scope.providerForemanModel);
-
-        });
+        $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId)
+          .then(getProviderForemanFormData)
+          .catch(miqService.handleFailure);
       } else {
         $scope.newRecord = false;
 
         miqService.sparkleOn();
 
-        $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId).success(function(data) {
-          $scope.providerForemanModel.provtype        = data.provtype;
-          $scope.providerForemanModel.name            = data.name;
-          $scope.providerForemanModel.zone            = data.zone;
-          $scope.providerForemanModel.url             = data.url;
-          $scope.providerForemanModel.verify_ssl      = data.verify_ssl == "1";
-
-          $scope.providerForemanModel.log_userid   = data.log_userid;
-
-          if($scope.providerForemanModel.log_userid != '') {
-            $scope.providerForemanModel.log_password = $scope.providerForemanModel.log_verify = miqService.storedPasswordPlaceholder;
-          }
-
-          $scope.afterGet = true;
-          $scope.modelCopy = angular.copy( $scope.providerForemanModel );
-
-          miqService.sparkleOff();
-        });
+        $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId)
+          .then(getProviderForemanFormData)
+          .catch(miqService.handleFailure);
       }
     };
 
@@ -108,6 +82,29 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
     $scope.addClicked = function() {
       $scope.saveClicked();
     };
+
+    function getProviderForemanFormData(response) {
+      var data = response.data;
+
+      if (!$scope.newRecord) {
+        $scope.providerForemanModel.provtype = data.provtype;
+        $scope.providerForemanModel.name = data.name;
+        $scope.providerForemanModel.url = data.url;
+        $scope.providerForemanModel.verify_ssl = data.verify_ssl == "1";
+
+        $scope.providerForemanModel.log_userid = data.log_userid;
+
+        if ($scope.providerForemanModel.log_userid != '') {
+          $scope.providerForemanModel.log_password = $scope.providerForemanModel.log_verify = miqService.storedPasswordPlaceholder;
+        }
+      }
+
+      $scope.providerForemanModel.zone = data.zone;
+      $scope.afterGet = true;
+      $scope.modelCopy = angular.copy( $scope.providerForemanModel );
+
+      miqService.sparkleOff();
+    }
 
     init();
 }]);

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -86,15 +86,15 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
     function getProviderForemanFormData(response) {
       var data = response.data;
 
-      if (!$scope.newRecord) {
+      if (! $scope.newRecord) {
         $scope.providerForemanModel.provtype = data.provtype;
         $scope.providerForemanModel.name = data.name;
         $scope.providerForemanModel.url = data.url;
-        $scope.providerForemanModel.verify_ssl = data.verify_ssl == "1";
+        $scope.providerForemanModel.verify_ssl = data.verify_ssl === 1;
 
         $scope.providerForemanModel.log_userid = data.log_userid;
 
-        if ($scope.providerForemanModel.log_userid != '') {
+        if ($scope.providerForemanModel.log_userid !== '') {
           $scope.providerForemanModel.log_password = $scope.providerForemanModel.log_verify = miqService.storedPasswordPlaceholder;
         }
       }

--- a/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
+++ b/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
@@ -16,7 +16,7 @@ describe('providerForemanFormController', function() {
       name: '',
       url: '',
       zone: 'foo_zone',
-      verify_ssl: false,
+      verify_ssl: 0,
       log_userid: ''
     };
 
@@ -65,7 +65,7 @@ describe('providerForemanFormController', function() {
         name: 'Foreman',
         url: '10.10.10.10',
         zone: 'My Test Zone',
-        verify_ssl: true,
+        verify_ssl: 1,
         log_userid: 'admin'
       };
 


### PR DESCRIPTION
Replace `.success` calls in angular controllers with `.then`  `.catch`
This is Round 3 of refactoring. The following controllers have been covered here --

- container_topology_controller.js
- infra_topology_controller.js
- middleware_topology_controller.js
- network_topology_controller.js
- diagnostics_database_form_controller.js
- log_collection_form_controller.js
- pglogical_replication_form_controller.js
- tenant_form_controller.js
- tenant_quota_form_controller.js
- provider_foreman_form_controller.js

(Round 1 done here -- #13, 
 Round 2 done here -- https://github.com/ManageIQ/manageiq-ui-classic/pull/179 )

@himdel Almost getting there...
