### PR TITLE
[WIP] [POC] Refactor controllers to use generic button methods

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -2816,47 +2816,6 @@ module ApplicationController::CiProcessing
     end
   end
 
-  def process_vm_buttons(pfx)
-    case params[:pressed]
-    when "#{pfx}_policy_sim"                then polsimvms
-    when "#{pfx}_compare"                   then comparemiq
-    when "#{pfx}_scan"                      then scanvms
-    when "#{pfx}_collect_running_processes" then getprocessesvms
-    when "#{pfx}_sync"                      then syncvms
-    when "#{pfx}_tag"                       then tag(VmOrTemplate)
-    when "#{pfx}_delete"                    then deletevms
-    when "#{pfx}_protect"                   then assign_policies(VmOrTemplate)
-    when "#{pfx}_edit"                      then edit_record
-    when "#{pfx}_refresh"                   then refreshvms
-    when "#{pfx}_start"                     then startvms
-    when "#{pfx}_stop"                      then stopvms
-    when "#{pfx}_suspend"                   then suspendvms
-    when "#{pfx}_pause"                     then pausevms
-    when "#{pfx}_shelve"                    then shelvevms
-    when "#{pfx}_shelveoffloadvms"          then shelveoffloadvms
-    when "#{pfx}_reset"                     then resetvms
-    when "#{pfx}_check_compliance"          then check_compliance_vms
-    when "#{pfx}_reconfigure"               then reconfigurevms
-    when "#{pfx}_resize"                    then resizevms
-    when "#{pfx}_evacuate"                  then evacuatevms
-    when "#{pfx}_live_migrate"              then livemigratevms
-    when "#{pfx}_associate_floating_ip"     then associate_floating_ip_vms
-    when "#{pfx}_disassociate_floating_ip"  then disassociate_floating_ip_vms
-    when "#{pfx}_retire"                    then retirevms
-    when "#{pfx}_retire_now"                then retirevms_now
-    when "#{pfx}_right_size"                then vm_right_size
-    when "#{pfx}_ownership"                 then set_ownership
-    when "#{pfx}_guest_shutdown"            then guestshutdown
-    when "#{pfx}_guest_standby"             then gueststandby
-    when "#{pfx}_guest_restart"             then guestreboot
-    when "#{pfx}_miq_request_new"           then prov_redirect
-    when "#{pfx}_clone"                     then prov_redirect("clone")
-    when "#{pfx}_migrate"                   then prov_redirect("migrate")
-    when "#{pfx}_publish"                   then prov_redirect("publish")
-    when "#{pfx}_terminate"                 then terminatevms
-    end
-  end
-
   def owner_changed?(owner)
     return false if @edit[:new][owner].blank?
     @edit[:new][owner] != @edit[:current][owner]

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -2816,6 +2816,47 @@ module ApplicationController::CiProcessing
     end
   end
 
+  def process_vm_buttons(pfx)
+    case params[:pressed]
+    when "#{pfx}_policy_sim"                then polsimvms
+    when "#{pfx}_compare"                   then comparemiq
+    when "#{pfx}_scan"                      then scanvms
+    when "#{pfx}_collect_running_processes" then getprocessesvms
+    when "#{pfx}_sync"                      then syncvms
+    when "#{pfx}_tag"                       then tag(VmOrTemplate)
+    when "#{pfx}_delete"                    then deletevms
+    when "#{pfx}_protect"                   then assign_policies(VmOrTemplate)
+    when "#{pfx}_edit"                      then edit_record
+    when "#{pfx}_refresh"                   then refreshvms
+    when "#{pfx}_start"                     then startvms
+    when "#{pfx}_stop"                      then stopvms
+    when "#{pfx}_suspend"                   then suspendvms
+    when "#{pfx}_pause"                     then pausevms
+    when "#{pfx}_shelve"                    then shelvevms
+    when "#{pfx}_shelveoffloadvms"          then shelveoffloadvms
+    when "#{pfx}_reset"                     then resetvms
+    when "#{pfx}_check_compliance"          then check_compliance_vms
+    when "#{pfx}_reconfigure"               then reconfigurevms
+    when "#{pfx}_resize"                    then resizevms
+    when "#{pfx}_evacuate"                  then evacuatevms
+    when "#{pfx}_live_migrate"              then livemigratevms
+    when "#{pfx}_associate_floating_ip"     then associate_floating_ip_vms
+    when "#{pfx}_disassociate_floating_ip"  then disassociate_floating_ip_vms
+    when "#{pfx}_retire"                    then retirevms
+    when "#{pfx}_retire_now"                then retirevms_now
+    when "#{pfx}_right_size"                then vm_right_size
+    when "#{pfx}_ownership"                 then set_ownership
+    when "#{pfx}_guest_shutdown"            then guestshutdown
+    when "#{pfx}_guest_standby"             then gueststandby
+    when "#{pfx}_guest_restart"             then guestreboot
+    when "#{pfx}_miq_request_new"           then prov_redirect
+    when "#{pfx}_clone"                     then prov_redirect("clone")
+    when "#{pfx}_migrate"                   then prov_redirect("migrate")
+    when "#{pfx}_publish"                   then prov_redirect("publish")
+    when "#{pfx}_terminate"                 then terminatevms
+    end
+  end
+
   def owner_changed?(owner)
     return false if @edit[:new][owner].blank?
     @edit[:new][owner] != @edit[:current][owner]

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -34,8 +34,6 @@ class AuthKeyPairCloudController < ApplicationController
     restore_edit_for_search
     save_current_page_for_refresh
 
-    handle_tag_presses(params[:pressed])
-
     handle_button_pressed(params[:pressed]) do
       return if performed?
     end
@@ -251,6 +249,7 @@ class AuthKeyPairCloudController < ApplicationController
     %w(
       auth_key_pair_cloud_delete
       auth_key_pair_cloud_new
+      auth_key_pair_cloud_tag
     )
   end
 end

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -34,19 +34,15 @@ class AuthKeyPairCloudController < ApplicationController
     restore_edit_for_search
     save_current_page_for_refresh
 
-    case params[:pressed]
-    when 'auth_key_pair_cloud_tag'
-      return tag("ManageIQ::Providers::CloudManager::AuthKeyPair")
-    when 'auth_key_pair_cloud_delete'
-      handle_delete_button
-    when 'auth_key_pair_cloud_new'
-      handle_new_button
+    handle_tag_presses(params[:pressed])
+    handle_button_pressed(params[:pressed])
+
+    return if performed?
+
+    if button_replace_gtl_main?
+      replace_gtl_main_div
     else
-      if button_replace_gtl_main?
-        replace_gtl_main_div
-      else
-        render_flash
-      end
+      render_flash
     end
   end
 
@@ -235,7 +231,7 @@ class AuthKeyPairCloudController < ApplicationController
 
   private
 
-  def handle_delete_button
+  def handle_auth_key_pair_cloud_delete
     delete_auth_key_pairs
 
     if @flash_array.present? && @single_delete
@@ -243,7 +239,7 @@ class AuthKeyPairCloudController < ApplicationController
     end
   end
 
-  def handle_new_button
+  def handle_auth_key_pair_cloud_new
     new
 
     if @flash_array.present?
@@ -252,5 +248,12 @@ class AuthKeyPairCloudController < ApplicationController
     else
       javascript_redirect :action => "new"
     end
+  end
+
+  def handled_buttons
+    %w(
+      auth_key_pair_cloud_delete
+      auth_key_pair_cloud_new
+    )
   end
 end

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -6,6 +6,7 @@ class AuthKeyPairCloudController < ApplicationController
 
   include Mixins::GenericShowMixin
   include Mixins::GenericListMixin
+  include Mixins::GenericButtonMixin
   include Mixins::GenericSessionMixin
 
   def self.display_methods
@@ -30,25 +31,22 @@ class AuthKeyPairCloudController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    @edit = session[:edit] # Restore @edit for adv search box
-    params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
-    return tag("ManageIQ::Providers::CloudManager::AuthKeyPair") if params[:pressed] == 'auth_key_pair_cloud_tag'
-    delete_auth_key_pairs if params[:pressed] == 'auth_key_pair_cloud_delete'
-    new if params[:pressed] == 'auth_key_pair_cloud_new'
+    restore_edit_for_search
+    save_current_page_for_refresh
 
-    if !@flash_array.nil? && params[:pressed] == "auth_key_pair_cloud_delete" && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
-    elsif params[:pressed] == "auth_key_pair_cloud_new"
-      if @flash_array
-        show_list
+    case params[:pressed]
+    when 'auth_key_pair_cloud_tag'
+      return tag("ManageIQ::Providers::CloudManager::AuthKeyPair")
+    when 'auth_key_pair_cloud_delete'
+      handle_delete_button
+    when 'auth_key_pair_cloud_new'
+      handle_new_button
+    else
+      if button_replace_gtl_main?
         replace_gtl_main_div
       else
-        javascript_redirect :action => "new"
+        render_flash
       end
-    elsif @refresh_div == "main_div" && @lastaction == "show_list"
-      replace_gtl_main_div
-    else
-      render_flash
     end
   end
 
@@ -234,4 +232,25 @@ class AuthKeyPairCloudController < ApplicationController
   helper_method :textual_group_list
 
   menu_section :clo
+
+  private
+
+  def handle_delete_button
+    delete_auth_key_pairs
+
+    if @flash_array.present? && @single_delete
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
+    end
+  end
+
+  def handle_new_button
+    new
+
+    if @flash_array.present?
+      show_list
+      replace_gtl_main_div
+    else
+      javascript_redirect :action => "new"
+    end
+  end
 end

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -243,7 +243,7 @@ class AuthKeyPairCloudController < ApplicationController
       show_list
       replace_gtl_main_div
     else
-      javascript_redirect :action => "new"
+      js_redirect_to_new
     end
   end
 

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -35,15 +35,12 @@ class AuthKeyPairCloudController < ApplicationController
     save_current_page_for_refresh
 
     handle_tag_presses(params[:pressed])
-    handle_button_pressed(params[:pressed])
 
-    return if performed?
-
-    if button_replace_gtl_main?
-      replace_gtl_main_div
-    else
-      render_flash
+    handle_button_pressed(params[:pressed]) do
+      return if performed?
     end
+
+    button_render_fallback
   end
 
   def set_form_vars

--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -5,6 +5,7 @@ class AvailabilityZoneController < ApplicationController
   after_action :set_session_data
 
   include Mixins::GenericListMixin
+  include Mixins::GenericButtonMixin
   include Mixins::GenericSessionMixin
   include Mixins::MoreShowActions
 
@@ -66,64 +67,34 @@ class AvailabilityZoneController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    @edit = session[:edit]                          # Restore @edit for adv search box
+    restore_edit_for_search
+    copy_sub_item_display_value_to_params
+    save_current_page_for_refresh
 
-    params[:display] = @display if ["images", "instances"].include?(@display)  # Were we displaying vms/hosts/storages
-    params[:page] = @current_page unless @current_page.nil?   # Save current page for list refresh
-
-    if params[:pressed].starts_with?("image_", # Handle buttons from sub-items screen
-                                     "instance_")
-
-      pfx = pfx_for_vm_button_pressed(params[:pressed])
+    handle_sub_item_presses(params[:pressed]) do |pfx|
       process_vm_buttons(pfx)
+      return if button_control_transferred?(params[:pressed])
 
-      # Control transferred to another screen, so return
-      return if ["#{pfx}_policy_sim", "#{pfx}_compare", "#{pfx}_tag",
-                 "#{pfx}_retire", "#{pfx}_protect", "#{pfx}_ownership",
-                 "#{pfx}_refresh", "#{pfx}_right_size",
-                 "#{pfx}_reconfigure"].include?(params[:pressed]) &&
-                @flash_array.nil?
-
-      unless ["#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
-              "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-        @refresh_div = "main_div"
-        @refresh_partial = "layouts/gtl"
-        show                                                        # Handle VMs buttons
+      unless button_skip_show_render?(params[:pressed])
+        set_refresh_and_show
       end
-    else
-      tag(AvailabilityZone) if params[:pressed] == "availability_zone_tag"
-      return if ["availability_zone_tag"].include?(params[:pressed]) &&
-                @flash_array.nil? # Tag screen showing, so return
     end
 
-    unless @refresh_partial # if no button handler ran, show not implemented msg
-      add_flash(_("Button not yet implemented"), :error)
-      @refresh_partial = "layouts/flash_msg"
-      @refresh_div = "flash_msg_div"
+    if params[:pressed] == "availability_zone_tag"
+      tag(AvailabilityZone)
+
+      return if @flash_array.nil?
     end
 
-    if params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
-                                                "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-      render_or_redirect_partial(pfx)
+    check_if_button_is_implemented
+
+    if button_has_redirect_suffix?(params[:pressed])
+      render_or_redirect_partial_for(params[:pressed])
     else
-      if @refresh_div == "main_div" && @lastaction == "show_list"
+      if button_replace_gtl_main?
         replace_gtl_main_div
       else
-        render :update do |page|
-          page << javascript_prologue
-          unless @refresh_partial.nil?
-            if @refresh_div == "flash_msg_div"
-              page.replace(@refresh_div, :partial => @refresh_partial)
-            else
-              if ["images", "instances"].include?(@display) # If displaying vms, action_url s/b show
-                page << "miqSetButtons(0, 'center_tb');"
-                page.replace_html("main_div", :partial => "layouts/gtl", :locals => {:action_url => "show/#{@availability_zone.id}"})
-              else
-                page.replace_html(@refresh_div, :partial => @refresh_partial)
-              end
-            end
-          end
-        end
+        availability_zone_render_update
       end
     end
   end

--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -9,6 +9,14 @@ class AvailabilityZoneController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::MoreShowActions
 
+  def self.table_name
+    "availability_zone"
+  end
+
+  def self.model
+    AvailabilityZone
+  end
+
   def show
     return if perfmenu_click?
     @display = params[:display] || "main" unless pagination_or_gtl_request?
@@ -80,9 +88,7 @@ class AvailabilityZoneController < ApplicationController
       end
     end
 
-    if params[:pressed] == "availability_zone_tag"
-      tag(AvailabilityZone)
-
+    handle_tag_presses(params[:pressed]) do
       return if @flash_array.nil?
     end
 

--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -77,6 +77,10 @@ class AvailabilityZoneController < ApplicationController
   def button
     generic_button_setup
 
+    handle_button_pressed(params[:pressed]) do
+      return if @flash_array.nil?
+    end
+
     handle_sub_item_presses(params[:pressed]) do |pfx|
       process_vm_buttons(pfx)
       return if button_control_transferred?(params[:pressed])
@@ -86,20 +90,14 @@ class AvailabilityZoneController < ApplicationController
       end
     end
 
-    handle_tag_presses(params[:pressed]) do
-      return if @flash_array.nil?
-    end
-
     check_if_button_is_implemented
 
     if button_has_redirect_suffix?(params[:pressed])
       render_or_redirect_partial_for(params[:pressed])
+    elsif button_replace_gtl_main?
+      replace_gtl_main_div
     else
-      if button_replace_gtl_main?
-        replace_gtl_main_div
-      else
-        availability_zone_render_update
-      end
+      availability_zone_render_update
     end
   end
 

--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -75,9 +75,7 @@ class AvailabilityZoneController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    save_current_page_for_refresh
+    generic_button_setup
 
     handle_sub_item_presses(params[:pressed]) do |pfx|
       process_vm_buttons(pfx)
@@ -111,6 +109,27 @@ class AvailabilityZoneController < ApplicationController
     [%i(relationships), %i(availability_zone_totals tags)]
   end
   helper_method :textual_group_list
+
+  def availability_zone_render_update
+    render_update_with_prologue do |page|
+      return if @refresh_partial.nil?
+
+      refresh_flash_msg_or_block(page) do |pg|
+        if button_sub_item_display_values.include?(@display) # If displaying vms, action_url s/b show
+          button_center_toolbar(pg)
+          pg.replace_html(
+            "main_div",
+            :partial => "layouts/gtl",
+            :locals  => {
+              :action_url => "show/#{@availability_zone.id}"
+            }
+          )
+        else
+          replace_refresh_div_contents_with_partial(pg)
+        end
+      end
+    end
+  end
 
   menu_section :clo
 end

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -305,11 +305,11 @@ class CloudNetworkController < ApplicationController
   end
 
   def handle_cloud_network_edit
-    javascript_redirect :action => "edit", :id => checked_item_id
+    js_redirect_to_edit_for_checked_id
   end
 
   def handle_cloud_network_new
-    javascript_redirect :action => "new"
+    js_redirect_to_new
   end
 
   menu_section :net

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -24,11 +24,10 @@ class CloudNetworkController < ApplicationController
   end
 
   def button
-    @edit = session[:edit] # Restore @edit for adv search box
-    params[:display] = @display if %w(vms instances images).include?(@display)
-    params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
-
-    @refresh_div = "main_div"
+    restore_edit_for_search
+    copy_sub_item_display_value_to_params
+    save_current_page_for_refresh
+    set_default_refresh_div
 
     case params[:pressed]
     when "cloud_network_tag"
@@ -40,11 +39,7 @@ class CloudNetworkController < ApplicationController
     when "cloud_network_new"
       javascript_redirect :action => "new"
     else
-      if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
-        replace_gtl_main_div
-      else
-        render_flash
-      end
+      button_render_fallback
     end
   end
 

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -37,11 +37,9 @@ class CloudNetworkController < ApplicationController
     save_current_page_for_refresh
     set_default_refresh_div
 
-    handle_tag_presses(params[:pressed]) do
-      return if @flash_array.nil?
+    handle_button_pressed(params[:pressed]) do |pressed|
+      return if @flash_array.nil? && pressed.ends_with?("tag")
     end
-
-    handle_button_pressed(params[:pressed])
 
     button_render_fallback
   end
@@ -301,6 +299,7 @@ class CloudNetworkController < ApplicationController
       cloud_network_delete
       cloud_network_edit
       cloud_network_new
+      cloud_network_tag
     )
   end
 

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -23,24 +23,27 @@ class CloudNetworkController < ApplicationController
     %w(instances cloud_networks network_routers cloud_subnets)
   end
 
+  def self.table_name
+    "cloud_network"
+  end
+
+  def self.model
+    CloudNetwork
+  end
+
   def button
     restore_edit_for_search
     copy_sub_item_display_value_to_params
     save_current_page_for_refresh
     set_default_refresh_div
 
-    case params[:pressed]
-    when "cloud_network_tag"
-      return tag("CloudNetwork")
-    when 'cloud_network_delete'
-      delete_networks
-    when "cloud_network_edit"
-      javascript_redirect :action => "edit", :id => checked_item_id
-    when "cloud_network_new"
-      javascript_redirect :action => "new"
-    else
-      button_render_fallback
+    handle_tag_presses(params[:pressed]) do
+      return if @flash_array.nil?
     end
+
+    handle_button_pressed(params[:pressed])
+
+    button_render_fallback
   end
 
   def cloud_network_form_fields
@@ -108,7 +111,7 @@ class CloudNetworkController < ApplicationController
     javascript_redirect :action => "show_list"
   end
 
-  def delete_networks
+  def handle_cloud_network_delete
     assert_privileges("cloud_network_delete")
 
     networks = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "cloud_network") || @lastaction.nil?
@@ -291,6 +294,22 @@ class CloudNetworkController < ApplicationController
                    "Delete initiated for %{number} Cloud Networks.",
                    networks.length) % {:number => networks.length})
     end
+  end
+
+  def handled_buttons
+    %w(
+      cloud_network_delete
+      cloud_network_edit
+      cloud_network_new
+    )
+  end
+
+  def handle_cloud_network_edit
+    javascript_redirect :action => "edit", :id => checked_item_id
+  end
+
+  def handle_cloud_network_new
+    javascript_redirect :action => "new"
   end
 
   menu_section :net

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -17,17 +17,16 @@ class CloudObjectStoreContainerController < ApplicationController
     restore_edit_for_search
     save_current_page_for_refresh
 
+    # FIXME: Handle this in GenericButtonMixin
     process_cloud_object_storage_buttons(params[:pressed])
 
-    if !@flash_array.nil? && params[:pressed].ends_with?("delete")
-      javascript_redirect :action      => 'show_list',
-                          :flash_msg   => @flash_array[0][:message],
-                          :flash_error => @flash_array[0][:level] == :error
-    elsif !@flash_array.nil?
-      render_flash unless performed?
-    end
+    @single_delete = params[:pressed].ends_with?("delete")
 
-    # handle_tag_presses(params[:pressed])
+    redirect_to_retire_screen_if_single_delete
+
+    if !performed? && @flash_array.present?
+      render_flash
+    end
   end
 
   def self.display_methods

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -6,6 +6,7 @@ class CloudObjectStoreContainerController < ApplicationController
 
   include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
+  include Mixins::GenericButtonMixin
   include Mixins::GenericSessionMixin
 
   def breadcrumb_name(_model)
@@ -14,8 +15,8 @@ class CloudObjectStoreContainerController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    @edit = session[:edit] # Restore @edit for adv search box
-    params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
+    restore_edit_for_search
+    save_current_page_for_refresh
 
     process_cloud_object_storage_buttons(params[:pressed])
 

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -13,7 +13,6 @@ class CloudObjectStoreContainerController < ApplicationController
     ui_lookup(:tables => "cloud_object_store_container")
   end
 
-  # handle buttons pressed on the button bar
   def button
     restore_edit_for_search
     save_current_page_for_refresh
@@ -27,6 +26,8 @@ class CloudObjectStoreContainerController < ApplicationController
     elsif !@flash_array.nil?
       render_flash unless performed?
     end
+
+    # handle_tag_presses(params[:pressed])
   end
 
   def self.display_methods

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -16,16 +16,17 @@ class CloudObjectStoreObjectController < ApplicationController
     restore_edit_for_search
     save_current_page_for_refresh
 
-    handle_tag_presses(params[:pressed])
+    # FIXME: Change process_cloud_object_storage_buttons to handle_button_pressed
+    # handle_tag_presses(params[:pressed])
 
     process_cloud_object_storage_buttons(params[:pressed])
 
-    if !@flash_array.nil? && params[:pressed].ends_with?("delete")
-      javascript_redirect :action      => 'show_list',
-                          :flash_msg   => @flash_array[0][:message],
-                          :flash_error => @flash_array[0][:level] == :error
-    elsif !@flash_array.nil?
-      render_flash unless performed?
+    @single_delete = params[:pressed].ends_with?("delete")
+
+    redirect_to_retire_screen_if_single_delete
+
+    unless @flash_array.nil? || performed?
+      render_flash
     end
   end
 

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -5,6 +5,7 @@ class CloudObjectStoreObjectController < ApplicationController
   after_action :set_session_data
 
   include Mixins::GenericListMixin
+  include Mixins::GenericButtonMixin
   include Mixins::GenericSessionMixin
 
   def breadcrumb_name(_model)
@@ -14,6 +15,8 @@ class CloudObjectStoreObjectController < ApplicationController
   def button
     restore_edit_for_search
     save_current_page_for_refresh
+
+    handle_tag_presses(params[:pressed])
 
     process_cloud_object_storage_buttons(params[:pressed])
 

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -16,9 +16,7 @@ class CloudObjectStoreObjectController < ApplicationController
     restore_edit_for_search
     save_current_page_for_refresh
 
-    # FIXME: Change process_cloud_object_storage_buttons to handle_button_pressed
-    # handle_tag_presses(params[:pressed])
-
+    # FIXME: Handle this in GenericButtonMixin
     process_cloud_object_storage_buttons(params[:pressed])
 
     @single_delete = params[:pressed].ends_with?("delete")

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -12,8 +12,8 @@ class CloudObjectStoreObjectController < ApplicationController
   end
 
   def button
-    @edit = session[:edit]
-    params[:page] = @current_page unless @current_page.nil?
+    restore_edit_for_search
+    save_current_page_for_refresh
 
     process_cloud_object_storage_buttons(params[:pressed])
 

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -16,11 +16,10 @@ class CloudSubnetController < ApplicationController
   end
 
   def button
-    @edit = session[:edit] # Restore @edit for adv search box
-    params[:display] = @display if %w(vms instances images).include?(@display)
-    params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
-
-    @refresh_div = "main_div"
+    restore_edit_for_search
+    copy_sub_item_display_value_to_params
+    save_current_page_for_refresh
+    set_default_refresh_div
 
     case params[:pressed]
     when "cloud_subnet_tag"
@@ -29,14 +28,10 @@ class CloudSubnetController < ApplicationController
       delete_subnets
     when "cloud_subnet_edit"
       javascript_redirect :action => "edit", :id => checked_item_id
+    when "cloud_subnet_new"
+      javascript_redirect :action => "new"
     else
-      if params[:pressed] == "cloud_subnet_new"
-        javascript_redirect :action => "new"
-      elsif !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
-        replace_gtl_main_div
-      else
-        render_flash
-      end
+      button_render_fallback
     end
   end
 

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -292,11 +292,11 @@ class CloudSubnetController < ApplicationController
   end
 
   def handle_cloud_subnet_edit
-    javascript_redirect :action => "edit", :id => checked_item_id
+    js_redirect_to_edit_for_checked_id
   end
 
   def handle_cloud_subnet_new
-    javascript_redirect :action => "new"
+    js_redirect_to_new
   end
 
   def handled_buttons

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -16,14 +16,8 @@ class CloudSubnetController < ApplicationController
   end
 
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    save_current_page_for_refresh
-    set_default_refresh_div
-
-    handle_tag_presses(params[:pressed])
+    generic_button_setup
     handle_button_pressed(params[:pressed])
-
     button_render_fallback unless performed?
   end
 
@@ -304,6 +298,7 @@ class CloudSubnetController < ApplicationController
       cloud_subnet_delete
       cloud_subnet_edit
       cloud_subnet_new
+      cloud_subnet_tag
     )
   end
 

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -21,18 +21,10 @@ class CloudSubnetController < ApplicationController
     save_current_page_for_refresh
     set_default_refresh_div
 
-    case params[:pressed]
-    when "cloud_subnet_tag"
-      return tag("CloudSubnet")
-    when 'cloud_subnet_delete'
-      delete_subnets
-    when "cloud_subnet_edit"
-      javascript_redirect :action => "edit", :id => checked_item_id
-    when "cloud_subnet_new"
-      javascript_redirect :action => "new"
-    else
-      button_render_fallback
-    end
+    handle_tag_presses(params[:pressed])
+    handle_button_pressed(params[:pressed])
+
+    button_render_fallback unless performed?
   end
 
   def cloud_subnet_form_fields
@@ -128,7 +120,7 @@ class CloudSubnetController < ApplicationController
     javascript_redirect :action => "show_list"
   end
 
-  def delete_subnets
+  def handle_cloud_subnet_delete
     assert_privileges("cloud_subnet_delete")
 
     subnets = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "cloud_subnet") || @lastaction.nil?
@@ -297,6 +289,22 @@ class CloudSubnetController < ApplicationController
         subnet.delete_cloud_subnet_queue(session[:userid])
       end
     end
+  end
+
+  def handle_cloud_subnet_edit
+    javascript_redirect :action => "edit", :id => checked_item_id
+  end
+
+  def handle_cloud_subnet_new
+    javascript_redirect :action => "new"
+  end
+
+  def handled_buttons
+    %w(
+      cloud_subnet_delete
+      cloud_subnet_edit
+      cloud_subnet_new
+    )
   end
 
   menu_section :net

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -272,6 +272,35 @@ class CloudTenantController < ApplicationController
     )
   end
 
+  def cloud_tenant_javascript_redirect
+    if params[:pressed].starts_with?(*editable_objects)
+      target_controller = editable_objects.detect { |n| params[:pressed].starts_with?(n) }
+      action = params[:pressed].sub("#{target_controller}_", '')
+
+      if action == 'delete'
+        action = "#{action}_#{target_controller.sub('cloud_', '').pluralize}"
+      end
+
+      if action == 'detach'
+        volume = find_by_id_filtered(CloudVolume, from_cid(params[:miq_grid_checks]))
+
+        if volume.attachments.empty?
+          render_flash(_("%{volume} \"%{volume_name}\" is not attached to any %{instances}") % {
+            :volume      => ui_lookup(:table => 'cloud_volume'),
+            :volume_name => volume.name,
+            :instances   => ui_lookup(:tables => 'vm_cloud')
+          }, :error)
+
+          return
+        end
+      end
+
+      javascript_redirect :controller      => target_controller,
+                          :miq_grid_checks => params[:miq_grid_checks],
+                          :action          => action
+    end
+  end
+
   menu_section :clo
   has_custom_buttons
 end

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -256,11 +256,11 @@ class CloudTenantController < ApplicationController
   end
 
   def handle_cloud_tenant_new
-    javascript_redirect :action => "new"
+    js_redirect_to_new
   end
 
   def handle_cloud_tenant_edit
-    javascript_redirect :action => "edit", :id => checked_item_id
+    js_redirect_to_edit_for_checked_id
   end
 
   def handled_buttons

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -756,7 +756,7 @@ class CloudVolumeController < ApplicationController
   end
 
   def handle_cloud_volume_edit
-    javascript_redirect :action => "edit", :id => checked_item_id
+    js_redirect_to_edit_for_checked_id
   end
 
   def handle_cloud_volume_snapshot_create
@@ -764,7 +764,7 @@ class CloudVolumeController < ApplicationController
   end
 
   def handle_cloud_volume_new
-    javascript_redirect :action => "new"
+    js_redirect_to_new
   end
 
   def handle_cloud_volume_backup_restore

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -10,14 +10,9 @@ class CloudVolumeController < ApplicationController
   include Mixins::GenericButtonMixin
   include Mixins::GenericSessionMixin
 
-  # handle buttons pressed on the button bar
+  # FIXME: This may follow the GenericButtonMixin method
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    save_current_page_for_refresh
-    set_default_refresh_div
-
-    handle_tag_presses(params[:pressed])
+    generic_button_setup
     handle_button_pressed(params[:pressed])
 
     handle_sub_item_presses(params[:pressed]) do |pfx|
@@ -724,14 +719,15 @@ class CloudVolumeController < ApplicationController
 
   def handled_buttons
     %w(
-      cloud_volume_backup_create
-      cloud_volume_delete
       cloud_volume_attach
+      cloud_volume_backup_create
+      cloud_volume_backup_restore
+      cloud_volume_delete
       cloud_volume_detach
       cloud_volume_edit
-      cloud_volume_snapshot_create
       cloud_volume_new
-      cloud_volume_backup_restore
+      cloud_volume_snapshot_create
+      cloud_volume_tag
     )
   end
 

--- a/app/controllers/cloud_volume_snapshot_controller.rb
+++ b/app/controllers/cloud_volume_snapshot_controller.rb
@@ -16,13 +16,8 @@ class CloudVolumeSnapshotController < ApplicationController
   end
   helper_method :textual_group_list
 
-  # handle buttons pressed on the button bar
-  def specific_buttons(pressed)
-    if pressed == 'cloud_volume_snapshot_delete'
-      delete_cloud_volume_snapshots
-      return true
-    end
-    false
+  def handled_buttons
+    %w(cloud_volume_snapshot_delete)
   end
 
   def self.display_methods
@@ -33,7 +28,7 @@ class CloudVolumeSnapshotController < ApplicationController
     nested_list('based_volumes', CloudVolume)
   end
 
-  def delete_cloud_volume_snapshots
+  def handle_cloud_volume_snapshot_delete
     assert_privileges("cloud_volume_snapshot_delete")
 
     snapshots = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "cloud_volume_snapshot")

--- a/app/controllers/cloud_volume_snapshot_controller.rb
+++ b/app/controllers/cloud_volume_snapshot_controller.rb
@@ -17,7 +17,7 @@ class CloudVolumeSnapshotController < ApplicationController
   helper_method :textual_group_list
 
   def handled_buttons
-    %w(cloud_volume_snapshot_delete)
+    %w(cloud_volume_snapshot_delete cloud_volume_snapshot_tag)
   end
 
   def self.display_methods

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -33,19 +33,12 @@ class ConfigurationController < ApplicationController
   # handle buttons pressed on the button bar
   def button
     set_default_refresh_div
+    handle_button_pressed(params[:pressed])
 
-    case params[:pressed]
-    when "tp_delete" then timeprofile_delete
-    when "tp_copy"   then copy_record
-    when "tp_edit"   then edit_record
-    end
-
-    if button_not_handled?
-      set_refresh_and_alert_not_implemented
-    end
+    check_if_button_is_implemented
 
     if button_has_redirect_suffix?
-      javascript_redirect :action => @refresh_partial, :id => @redirect_id
+      js_redirect_with_partial_and_id
     else
       configuration_render_update
     end
@@ -285,7 +278,7 @@ class ConfigurationController < ApplicationController
   end
 
   # Delete all selected or single displayed VM(s)
-  def timeprofile_delete
+  def handle_tp_delete
     assert_privileges("tp_delete")
     timeprofiles = []
     unless params[:id] # showing a list, scan all selected timeprofiles
@@ -464,14 +457,14 @@ class ConfigurationController < ApplicationController
   private ############################
 
   # copy single selected Object
-  def edit_record
+  def handle_tp_edit
     obj = find_checked_items
     @refresh_partial = "timeprofile_edit"
     @redirect_id = obj[0]
   end
 
   # copy single selected Object
-  def copy_record
+  def handle_tp_copy
     obj = find_checked_items
     @refresh_partial = "timeprofile_copy"
     @redirect_id = obj[0]
@@ -638,6 +631,14 @@ class ConfigurationController < ApplicationController
     s[:views].delete(:dashboards)           # :dashboards is obsolete now
 
     s
+  end
+
+  def handled_buttons
+    %w(
+      tp_delete
+      tp_edit
+      tp_copy
+    )
   end
 
   menu_section :set

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -13,6 +13,15 @@ class ConfigurationController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  def self.model
+    nil # there is no Configuration constant
+  end
+
+  # button looks for something here
+  def self.table_name
+    "configuration"
+  end
+
   def index
     @breadcrumbs = []
     active_tab = nil
@@ -33,7 +42,6 @@ class ConfigurationController < ApplicationController
   # handle buttons pressed on the button bar
   def button
     set_default_refresh_div
-
     handle_button_pressed(params[:pressed])
 
     check_if_button_is_implemented

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -33,6 +33,7 @@ class ConfigurationController < ApplicationController
   # handle buttons pressed on the button bar
   def button
     set_default_refresh_div
+
     handle_button_pressed(params[:pressed])
 
     check_if_button_is_implemented
@@ -40,7 +41,13 @@ class ConfigurationController < ApplicationController
     if button_has_redirect_suffix?
       js_redirect_with_partial_and_id
     else
-      configuration_render_update
+      c_tb = build_toolbar(center_toolbar_filename)
+
+      render_update_with_prologue do |page|
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page.replace_html("main_div", :partial => "ui_4") # Replace the main div area contents
+        page << javascript_pf_toolbar_reload('center_tb', c_tb)
+      end
     end
   end
 

--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -48,36 +48,20 @@ class ConfigurationJobController < ApplicationController
   end
 
   # handle buttons pressed on the button bar
-  # handle buttons pressed on the button bar
   def button
     restore_edit_for_search
     save_current_page_for_refresh
     set_default_refresh_div
 
-    case params[:pressed]
-    when "configuration_job_delete"
-      configuration_job_delete
-    when "configuration_job_tag"
-      tag(ManageIQ::Providers::AnsibleTower::AutomationManager::Job)
-
+    handle_button_pressed(params[:pressed])
+    handle_tag_presses(params[:pressed]) do
       return if @flash_array.nil? # Tag screen showing, so return
     end
 
-    if button_not_handled?
-      set_refresh_and_alert_not_implemented
-    elsif @flash_array && @lastaction == "show"
-      @configuration_job = @record = identify_record(params[:id])
-      @refresh_partial = "layouts/flash_msg"
-      @refresh_div = "flash_msg_div"
-    end
+    check_if_button_is_implemented
+    @configuration_job = @record
 
-    if !@flash_array.nil? && params[:pressed] == "configurations_job_delete" && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message]
-    elsif button_replace_gtl_main?
-      replace_gtl_main_div
-    else
-      render_flash
-    end
+    button_render_fallback
   end
 
   def title
@@ -90,6 +74,15 @@ class ConfigurationJobController < ApplicationController
     [%i(properties relationships), %i(tags)]
   end
   helper_method :textual_group_list
+
+  def handled_buttons
+    %w(configuration_job_delete)
+  end
+
+  def handle_configuration_job_delete
+    configuration_job_delete
+    redirect_to_retire_screen_if_single_delete
+  end
 
   menu_section :conf
 end

--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -47,19 +47,15 @@ class ConfigurationJobController < ApplicationController
     show_association('parameters', _('Parameters'), 'parameter', :parameters, OrchestrationStackParameter)
   end
 
-  # handle buttons pressed on the button bar
   def button
-    restore_edit_for_search
-    save_current_page_for_refresh
-    set_default_refresh_div
+    generic_button_setup
 
-    handle_button_pressed(params[:pressed])
-    handle_tag_presses(params[:pressed]) do
-      return if @flash_array.nil? # Tag screen showing, so return
+    handle_button_pressed(params[:pressed]) do |pressed|
+      return if @flash_array.nil? && pressed.ends_with?("tag")
     end
 
     check_if_button_is_implemented
-    @configuration_job = @record
+    @configuration_job = @record # is this necessary?
 
     button_render_fallback
   end
@@ -76,7 +72,10 @@ class ConfigurationJobController < ApplicationController
   helper_method :textual_group_list
 
   def handled_buttons
-    %w(configuration_job_delete)
+    %w(
+      configuration_job_delete
+      configuration_job_tag
+    )
   end
 
   def handle_configuration_job_delete

--- a/app/controllers/container_build_controller.rb
+++ b/app/controllers/container_build_controller.rb
@@ -17,5 +17,9 @@ class ContainerBuildController < ApplicationController
     "Builds"
   end
 
+  def handled_buttons
+    %w(container_build_tag)
+  end
+
   menu_section :cnt
 end

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -303,5 +303,9 @@ class ContainerController < ApplicationController
     @explorer
   end
 
+  def handled_buttons
+    %w(container_tag)
+  end
+
   menu_section :cnt
 end

--- a/app/controllers/container_group_controller.rb
+++ b/app/controllers/container_group_controller.rb
@@ -26,6 +26,7 @@ class ContainerGroupController < ApplicationController
 
   def handled_buttons
     %(
+      container_group_tag
       container_group_protect
       container_group_check_compliance
     )

--- a/app/controllers/container_group_controller.rb
+++ b/app/controllers/container_group_controller.rb
@@ -24,5 +24,20 @@ class ContainerGroupController < ApplicationController
     "Pods"
   end
 
+  def handled_buttons
+    %(
+      container_group_protect
+      container_group_check_compliance
+    )
+  end
+
+  def handle_container_group_protect
+    assign_policies(ContainerGroup)
+  end
+
+  def handle_container_group_check_compliance
+    check_compliance(ContainerGroup)
+  end
+
   menu_section :cnt
 end

--- a/app/controllers/container_image_controller.rb
+++ b/app/controllers/container_image_controller.rb
@@ -36,6 +36,7 @@ class ContainerImageController < ApplicationController
 
   def handled_buttons
     %(
+      container_image_tag
       container_image_scan
       container_image_protect
       container_image_check_compliance

--- a/app/controllers/container_image_controller.rb
+++ b/app/controllers/container_image_controller.rb
@@ -34,5 +34,44 @@ class ContainerImageController < ApplicationController
     send_data(@record.openscap_result.html, :filename => "openscap_result.html")
   end
 
+  def handled_buttons
+    %(
+      container_image_scan
+      container_image_protect
+      container_image_check_compliance
+    )
+  end
+
+  def handle_container_image_protect
+    assign_policies(ContainerImage)
+  end
+
+  def handle_container_image_check_compliance
+    check_compliance(ContainerImage)
+  end
+
+  # Scan all selected or single displayed image(s)
+  def handle_container_image_scan
+    assert_privileges("image_scan")
+    showlist = @lastaction == "show_list"
+    ids = showlist ? find_checked_items : find_current_item(ContainerImage)
+
+    if ids.empty?
+      add_flash(_("No %{model} were selected for Analysis") % {:model => ui_lookup(:tables => "container_image")},
+                :error)
+    else
+      process_scan_images(ids)
+    end
+
+    showlist ? show_list : show
+    ids.count
+
+    if @lastaction == "show"
+      javascript_flash
+    else
+      replace_main_div :partial => "layouts/gtl"
+    end
+  end
+
   menu_section :cnt
 end

--- a/app/controllers/container_image_registry_controller.rb
+++ b/app/controllers/container_image_registry_controller.rb
@@ -10,6 +10,10 @@ class ContainerImageRegistryController < ApplicationController
 
   private
 
+  def handled_buttons
+    %w(container_image_registry_tag)
+  end
+
   def textual_group_list
     [%i(properties), %i(relationships smart_management)]
   end

--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -25,5 +25,20 @@ class ContainerNodeController < ApplicationController
     end
   end
 
+  def handled_buttons
+    %(
+      container_node_protect
+      container_node_check_compliance
+    )
+  end
+
+  def handle_container_node_protect
+    assign_policies(ContainerNode)
+  end
+
+  def handle_container_node_check_compliance
+    check_compliance(ContainerNode)
+  end
+
   menu_section :cnt
 end

--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -27,6 +27,7 @@ class ContainerNodeController < ApplicationController
 
   def handled_buttons
     %(
+      container_node_tag
       container_node_protect
       container_node_check_compliance
     )

--- a/app/controllers/container_project_controller.rb
+++ b/app/controllers/container_project_controller.rb
@@ -17,5 +17,9 @@ class ContainerProjectController < ApplicationController
   end
   helper_method :textual_group_list
 
+  def handled_buttons
+    %w(container_project_tag)
+  end
+
   menu_section :cnt
 end

--- a/app/controllers/container_replicator_controller.rb
+++ b/app/controllers/container_replicator_controller.rb
@@ -17,6 +17,7 @@ class ContainerReplicatorController < ApplicationController
 
   def handled_buttons
     %(
+      container_replicator_tag
       container_replicator_protect
       container_replicator_check_compliance
     )

--- a/app/controllers/container_replicator_controller.rb
+++ b/app/controllers/container_replicator_controller.rb
@@ -14,4 +14,19 @@ class ContainerReplicatorController < ApplicationController
     [%i(properties container_labels container_selectors compliance), %i(relationships smart_management)]
   end
   helper_method :textual_group_list
+
+  def handled_buttons
+    %(
+      container_replicator_protect
+      container_replicator_check_compliance
+    )
+  end
+
+  def handle_container_replicator_protect
+    assign_policies(ContainerReplicator)
+  end
+
+  def handle_container_replicator_check_compliance
+    check_compliance(ContainerReplicator)
+  end
 end

--- a/app/controllers/container_route_controller.rb
+++ b/app/controllers/container_route_controller.rb
@@ -13,5 +13,9 @@ class ContainerRouteController < ApplicationController
   end
   helper_method :textual_group_list
 
+  def handled_buttons
+    %w(container_route_tag)
+  end
+
   menu_section :cnt
 end

--- a/app/controllers/container_service_controller.rb
+++ b/app/controllers/container_service_controller.rb
@@ -10,6 +10,10 @@ class ContainerServiceController < ApplicationController
 
   private
 
+  def handled_buttons
+    %w(container_service_tag)
+  end
+
   def textual_group_list
     [%i(properties port_configs container_labels container_selectors), %i(relationships smart_management)]
   end

--- a/app/controllers/container_template_controller.rb
+++ b/app/controllers/container_template_controller.rb
@@ -13,5 +13,9 @@ class ContainerTemplateController < ApplicationController
   end
   helper_method :textual_group_list
 
+  def handled_buttons
+    %w(container_template_tag)
+  end
+
   menu_section :cnt
 end

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -6,6 +6,7 @@ class EmsClusterController < ApplicationController
 
   include Mixins::GenericListMixin
   include Mixins::MoreShowActions
+  include Mixins::GenericButtonMixin
 
   def drift_history
     @display = "drift_history"
@@ -93,75 +94,73 @@ class EmsClusterController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    @edit = session[:edit]                                  # Restore @edit for adv search box
-    params[:display] = @display if ["all_vms", "vms", "hosts", "resource_pools"].include?(@display)  # Were we displaying sub-items
+    restore_edit_for_search
+    copy_sub_item_display_value_to_params
 
-    if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
-                                     "miq_template_",
-                                     "guest_",
-                                     "host_",
-                                     "rp_")
+    # Handle buttons from sub-items screen
+    handle_sub_item_presses(params[:pressed]) do |pfx|
+      case params[:pressed]
+      when "host_analyze_check_compliance" then analyze_check_compliance_hosts
+      when "host_check_compliance"         then check_compliance_hosts
+      when "host_compare"                  then comparemiq
+      when "host_delete"                   then deletehosts
+      when "host_edit"                     then edit_record
+      when "host_protect"                  then assign_policies(Host)
+      when "host_refresh"                  then refreshhosts
+      when "host_scan"                     then scanhosts
+      when "host_tag"                      then tag(Host)
+      when "rp_tag"                        then tag(ResourcePool)
+      end
 
-      scanhosts if params[:pressed] == "host_scan"
-      analyze_check_compliance_hosts if params[:pressed] == "host_analyze_check_compliance"
-      check_compliance_hosts if params[:pressed] == "host_check_compliance"
-      refreshhosts if params[:pressed] == "host_refresh"
-      tag(Host) if params[:pressed] == "host_tag"
-      assign_policies(Host) if params[:pressed] == "host_protect"
-      comparemiq  if params[:pressed] == "host_compare"
-      edit_record  if params[:pressed] == "host_edit"
-      deletehosts if params[:pressed] == "host_delete"
-
-      tag(ResourcePool) if params[:pressed] == "rp_tag"
-
-      pfx = pfx_for_vm_button_pressed(params[:pressed])
       # Handle Host power buttons
-      if ["host_shutdown", "host_reboot", "host_standby", "host_enter_maint_mode", "host_exit_maint_mode",
-          "host_start", "host_stop", "host_reset"].include?(params[:pressed])
-        powerbutton_hosts(params[:pressed].split("_")[1..-1].join("_")) # Handle specific power button
+      if button_power_press?(params[:pressed])
+        handle_host_power_press(params[:pressed])
       else
         process_vm_buttons(pfx)
-        return if ["host_tag", "#{pfx}_policy_sim", "host_scan", "host_refresh", "host_protect",
-                   "host_compare", "#{pfx}_compare", "#{pfx}_drift", "#{pfx}_tag", "#{pfx}_retire",
-                   "#{pfx}_protect", "#{pfx}_ownership", "#{pfx}_right_size",
-                   "#{pfx}_reconfigure", "rp_tag"].include?(params[:pressed]) &&
-                  @flash_array.nil?   # Some other screen is showing, so return
+        return if button_control_transferred?(params[:pressed])
 
-        unless ["host_edit", "#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone", "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-          @refresh_div = "main_div"
-          @refresh_partial = "layouts/gtl"
-          show
+        unless button_has_redirect_suffix?(params[:pressed])
+          set_refresh_and_show
         end
       end
-    else
-      @refresh_div = "main_div" # Default div for button.rjs to refresh
-      drift_analysis if params[:pressed] == "common_drift"
-      tag(EmsCluster) if params[:pressed] == "ems_cluster_tag"
-      scanclusters if params[:pressed] == "ems_cluster_scan"
-      comparemiq if params[:pressed] == "ems_cluster_compare"
-      deleteclusters if params[:pressed] == "ems_cluster_delete"
-      assign_policies(EmsCluster) if params[:pressed] == "ems_cluster_protect"
-      custom_buttons if params[:pressed] == "custom_button"
     end
 
-    return if ["custom_button"].include?(params[:pressed])    # custom button screen, so return, let custom_buttons method handle everything
-    return if ["ems_cluster_tag", "ems_cluster_compare", "common_drift", "ems_cluster_protect"].include?(params[:pressed]) && @flash_array.nil?   # Tag screen showing, so return
+    unless params[:pressed].starts_with?(*button_sub_item_prefixes)
+      set_default_refresh_div
 
-    if !@flash_array && !@refresh_partial # if no button handler ran, show not implemented msg
+      case params[:pressed]
+      when "common_drift"        then drift_analysis
+      when "ems_cluster_compare" then comparemiq
+      when "ems_cluster_protect" then assign_policies(EmsCluster)
+      when "ems_cluster_scan"    then scanclusters
+      when "ems_cluster_tag"     then tag(EmsCluster)
+      when "custom_button"
+        custom_buttons
+        return # let custom_buttons method handle everything
+      when "ems_cluster_delete"
+        deleteclusters
+
+        if @flash_array.present? && @single_delete
+          javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message]
+        end
+      when "ems_cluster_tag", "ems_cluster_compare", "common_drift", "ems_cluster_protect"
+        if @flash_array.nil?
+          return # Tag screen showing, so return
+        end
+      end
+    end
+
+    if button_not_handled?
       add_flash(_("Button not yet implemented"), :error)
-      @refresh_partial = "layouts/flash_msg"
-      @refresh_div = "flash_msg_div"
-    elsif @flash_array && @lastaction == "show"
+    elsif lastaction_is_show_and_flash_present?
       @ems_cluster = @record = identify_record(params[:id])
-      @refresh_partial = "layouts/flash_msg"
-      @refresh_div = "flash_msg_div"
     end
 
-    if !@flash_array.nil? && params[:pressed] == "ems_cluster_delete" && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
-    elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
-                                                   "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-      render_or_redirect_partial(pfx)
+    @refresh_partial = "layouts/flash_msg"
+    @refresh_div = "flash_msg_div"
+
+    if button_has_redirect_suffix?(params[:pressed])
+      render_or_redirect_partial(button_prefix(params[:pressed]))
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div
@@ -241,6 +240,15 @@ class EmsClusterController < ApplicationController
     session[:ems_cluster_display]    = @display unless @display.nil?
     session[:ems_cluster_filters]    = @filters
     session[:ems_cluster_catinfo]    = @catinfo
+  end
+
+  # Overrides generic button value
+  def button_sub_item_display_values
+    ["all_vms", "vms", "hosts", "resource_pools"]
+  end
+
+  def button_sub_item_prefixes
+    ["vm_", "miq_template_", "guest_", "host_", "rp_"]
   end
 
   menu_section :inf

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -92,17 +92,16 @@ class EmsClusterController < ApplicationController
     replace_gtl_main_div if pagination_request?
   end
 
-  # handle buttons pressed on the button bar
+  # FIXME: This method may follow the pattern in GenericButtonMixin
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    set_default_refresh_div
+    generic_button_setup
 
-    handle_tag_presses(params[:pressed]) { return if @flash_array.nil? }
-    handle_host_power_press(params[:pressed])
-    handle_button_pressed(params[:pressed])
+    # handle_host_power_press(params[:pressed])
 
-    # Handle buttons from sub-items screen
+    handle_button_pressed(params[:pressed]) do |pressed|
+      return if @flash_array.nil? && pressed.ends_with?("tag")
+    end
+
     handle_sub_item_presses(params[:pressed]) do |pfx|
       process_vm_buttons(pfx)
       return if button_control_transferred?(params[:pressed])
@@ -118,12 +117,10 @@ class EmsClusterController < ApplicationController
 
     if button_has_redirect_suffix?(params[:pressed])
       render_or_redirect_partial(button_prefix(params[:pressed]))
+    elsif button_replace_gtl_main?
+      replace_gtl_main_div
     else
-      if button_replace_gtl_main?
-        replace_gtl_main_div
-      else
-        render_flash
-      end
+      render_flash
     end
   end
 
@@ -201,12 +198,12 @@ class EmsClusterController < ApplicationController
 
   # Overrides generic button value
   def button_sub_item_display_values
-    ["all_vms", "vms", "hosts", "resource_pools"]
+    %w(all_vms vms hosts resource_pools)
   end
 
   # Overrides generic button value
   def button_sub_item_prefixes
-    ["vm_", "miq_template_", "guest_", "host_", "rp_"]
+    %w(vm_ miq_template_ guest_ host_ rp_)
   end
 
   def handled_buttons
@@ -217,6 +214,7 @@ class EmsClusterController < ApplicationController
       "ems_cluster_protect",
       "ems_cluster_scan",
       "ems_cluster_delete",
+      "ems_cluster_tag",
       handled_host_buttons
     ].flatten
   end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -1,18 +1,19 @@
 module EmsCommon
   extend ActiveSupport::Concern
+  include Mixins::GenericButtonMixin
 
   included do
     include Mixins::GenericSessionMixin
     include Mixins::MoreShowActions
+
+    helper_method :textual_group_list
+    private :textual_group_list
 
     # This is a temporary hack ensuring that @ems will be set.
     # Once we use @record in place of @ems, this can be removed
     # together with init_show_ems
     alias_method :init_show_generic, :init_show
     alias_method :init_show, :init_show_ems
-
-    helper_method :textual_group_list
-    private :textual_group_list
   end
 
   def init_show_ems
@@ -23,7 +24,7 @@ module EmsCommon
 
   def textual_group_list
     [
-      %i(properties status),
+      %i(properties status) + (@record.respond_to?(:arbitration_profiles) ? %i(configuration_relationships) : []),
       %i(relationships topology smart_management)
     ]
   end
@@ -314,33 +315,16 @@ module EmsCommon
 
   # handle buttons pressed on the button bar
   def button
-    @edit = session[:edit]                                  # Restore @edit for adv search box
+    restore_edit_for_search
+    copy_sub_item_display_value_to_params
+    save_current_page_for_refresh
 
-    params[:display] = @display if ["vms", "hosts", "storages", "instances", "images", "orchestration_stacks"].include?(@display)  # Were we displaying vms/hosts/storages
-    params[:page] = @current_page unless @current_page.nil?   # Save current page for list refresh
+    if params[:pressed].starts_with?("cloud_object_store_")
+      process_cloud_object_storage_buttons(params[:pressed])
+    end
 
     # Handle buttons from sub-items screen
-    if params[:pressed].starts_with?("availability_zone_",
-                                     "cloud_network_",
-                                     "cloud_subnet_",
-                                     "cloud_tenant_",
-                                     "cloud_volume_",
-                                     "ems_cluster_",
-                                     "flavor_",
-                                     "floating_ip_",
-                                     "guest_",
-                                     "host_",
-                                     "image_",
-                                     "instance_",
-                                     "load_balancer_",
-                                     "miq_template_",
-                                     "network_port_",
-                                     "network_router_",
-                                     "orchestration_stack_",
-                                     "security_group_",
-                                     "storage_",
-                                     "vm_")
-
+    handle_sub_item_presses(params[:pressed]) do |pfx|
       case params[:pressed]
       # Clusters
       when "ems_cluster_compare"              then comparemiq
@@ -369,6 +353,7 @@ module EmsCommon
       # Edit Tags for Network Manager Relationship pages
       when "availability_zone_tag"            then tag(AvailabilityZone)
       when "cloud_network_tag"                then tag(CloudNetwork)
+      when "cloud_object_store_container_tag" then tag(CloudObjectStoreContainer)
       when "cloud_subnet_tag"                 then tag(CloudSubnet)
       when "cloud_tenant_tag"                 then tag(CloudTenant)
       when "cloud_volume_tag"                 then tag(CloudVolume)
@@ -381,46 +366,34 @@ module EmsCommon
       when "security_group_tag"               then tag(SecurityGroup)
       end
 
-      pfx = pfx_for_vm_button_pressed(params[:pressed])
-      # Handle Host power buttons
-      if ["host_shutdown", "host_reboot", "host_standby", "host_enter_maint_mode", "host_exit_maint_mode",
-          "host_start", "host_stop", "host_reset"].include?(params[:pressed])
-        powerbutton_hosts(params[:pressed].split("_")[1..-1].join("_")) # Handle specific power button
+      if button_power_press?(params[:pressed])
+        handle_host_power_press(params[:pressed])
       else
         process_vm_buttons(pfx)
-        # Control transferred to another screen, so return
-        return if ["host_tag", "#{pfx}_policy_sim", "host_scan", "host_refresh", "host_protect",
-                   "host_compare", "#{pfx}_compare", "#{pfx}_tag", "#{pfx}_retire",
-                   "#{pfx}_protect", "#{pfx}_ownership", "#{pfx}_refresh", "#{pfx}_right_size",
-                   "#{pfx}_reconfigure", "storage_tag", "ems_cluster_compare",
-                   "ems_cluster_protect", "ems_cluster_tag", "#{pfx}_resize", "#{pfx}_live_migrate",
-                   "#{pfx}_evacuate"].include?(params[:pressed]) &&
-                  @flash_array.nil?
 
-        unless ["host_edit", "#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
-                "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-          @refresh_div = "main_div"
-          @refresh_partial = "layouts/gtl"
-          show                                                        # Handle EMS buttons
+        return if button_control_transferred?(params[:pressed])
+
+        unless button_has_redirect_suffix?(params[:pressed])
+          set_refresh_and_show
         end
       end
-    elsif params[:pressed].starts_with?("cloud_object_store_")
-      process_cloud_object_storage_buttons(params[:pressed])
-    else
-      @refresh_div = "main_div" # Default div for button.rjs to refresh
-      redirect_to :action => "new" if params[:pressed] == "new"
-      deleteemss if params[:pressed] == "#{@table_name}_delete"
-      refreshemss if params[:pressed] == "#{@table_name}_refresh"
-      #     scanemss if params[:pressed] == "scan"
-      tag(model) if params[:pressed] == "#{@table_name}_tag"
+    end
 
-      # Edit Tags for Middleware Manager Relationship pages
-      tag(@display.camelize.singularize) if @display && @display != 'main' &&
-                                            params[:pressed] == "#{@display.singularize}_tag"
-      assign_policies(model) if params[:pressed] == "#{@table_name}_protect"
-      check_compliance(model) if params[:pressed] == "#{@table_name}_check_compliance"
-      edit_record if params[:pressed] == "#{@table_name}_edit"
-      if params[:pressed] == "#{@table_name}_timeline"
+    unless params[:pressed].starts_with?(*button_sub_item_prefixes)
+      set_default_refresh_div
+
+      case params[:pressed]
+      when "#{@table_name}_refresh"          then refreshemss
+      when "#{@table_name}_edit"             then edit_record
+      when "#{@table_name}_check_compliance" then check_compliance(model)
+      when "new"                             then redirect_to :action => "new"
+      when "#{@table_name}_protect"
+        assign_policies(model)
+        return if @flash_array.nil?
+      when "#{@table_name}_tag"
+        tag(model)
+        return if @flash_array.nil?
+      when "#{@table_name}_timeline"
         @showtype = "timeline"
         @record = find_by_id_filtered(model, params[:id])
         @timeline = @timeline_filter = true
@@ -430,8 +403,7 @@ module EmsCommon
         session[:tl_record_id] = @record.id
         javascript_redirect polymorphic_path(@record, :display => 'timeline')
         return
-      end
-      if params[:pressed] == "#{@table_name}_perf"
+      when "#{@table_name}_perf"
         @showtype = "performance"
         @record = find_by_id_filtered(model, params[:id])
         drop_breadcrumb(:name => _("%{name} Capacity & Utilization") % {:name => @record.name},
@@ -439,28 +411,38 @@ module EmsCommon
         perf_gen_init_options # Intialize options, charts are generated async
         javascript_redirect polymorphic_path(@record, :display => "performance")
         return
-      end
-      if params[:pressed] == "#{@table_name}_ad_hoc_metrics"
+      when "#{@table_name}_ad_hoc_metrics"
         @showtype = "ad_hoc_metrics"
         @record = find_by_id_filtered(model, params[:id])
         drop_breadcrumb(:name => @record.name + _(" (Ad hoc Metrics)"), :url => show_link(@record))
         javascript_redirect polymorphic_path(@record, :display => "ad_hoc_metrics")
         return
-      end
-      if params[:pressed] == "refresh_server_summary"
+      when "#{@table_name}_delete"
+        deleteemss
+
+        # redirect to build the retire screen
+        if !@flash_array.nil? && @single_delete
+          javascript_redirect :action      => 'show_list',
+                              :flash_msg   => @flash_array[0][:message],
+                              :flash_error => @flash_array[0][:level] == :error
+
+          return
+        end
+      when "#{@display.singularize}_tag"
+        if @display && @display != 'main'
+          tag(@display.camelize.singularize)
+        end
+      when "refresh_server_summary"
         javascript_redirect :back
         return
-      end
-      if params[:pressed] == "ems_cloud_recheck_auth_status"          ||
-         params[:pressed] == "ems_infra_recheck_auth_status"          ||
-         params[:pressed] == "ems_physical_infra_recheck_auth_status" ||
-         params[:pressed] == "ems_middleware_recheck_auth_status"     ||
-         params[:pressed] == "ems_container_recheck_auth_status"
+      when "ems_cloud_recheck_auth_status", "ems_infra_recheck_auth_status",
+           "ems_middleware_recheck_auth_status", "ems_container_recheck_auth_status",
+           "ems_physical_infra_recheck_auth_status"
         if params[:id]
           table_key = :table
           _result, details = recheck_authentication
           add_flash(_("Re-checking Authentication status for this %{controller_name} was not successful: %{details}") %
-                        {:controller_name => ui_lookup(:table => controller_name), :details => details}, :error) if details
+                      {:controller_name => ui_lookup(:table => controller_name), :details => details}, :error) if details
         else
           table_key = :tables
           ems_ids = find_checked_items
@@ -473,34 +455,32 @@ module EmsCommon
           end
         end
         add_flash(_("Authentication status will be saved and workers will be restarted for the selected %{controller_name}") %
-                      {:controller_name => ui_lookup(table_key => controller_name)})
+                     {:controller_name => ui_lookup(table_key => controller_name)})
         render_flash
+        return
+      when "host_aggregate_edit"
+        javascript_redirect :controller => "host_aggregate", :action => "edit", :id => find_checked_items[0]
+        return
+      when "cloud_tenant_edit"
+        javascript_redirect :controller => "cloud_tenant", :action => "edit", :id => find_checked_items[0]
+        return
+      when "cloud_volume_edit"
+        javascript_redirect :controller => "cloud_volume", :action => "edit", :id => find_checked_items[0]
+        return
+      when "custom_button"
+        custom_buttons
         return
       end
 
-      custom_buttons if params[:pressed] == "custom_button"
-
-      return if ["custom_button"].include?(params[:pressed])    # custom button screen, so return, let custom_buttons method handle everything
-      return if ["#{@table_name}_tag", "#{@table_name}_protect", "#{@table_name}_timeline"].include?(params[:pressed]) &&
-                @flash_array.nil? # Tag screen showing, so return
       check_if_button_is_implemented
     end
 
-    if !@flash_array.nil? && params[:pressed] == "#{@table_name}_delete" && @single_delete
-      javascript_redirect :action      => 'show_list',
-                          :flash_msg   => @flash_array[0][:message],
-                          :flash_error => @flash_array[0][:level] == :error
-    elsif params[:pressed] == "host_aggregate_edit"
-      javascript_redirect :controller => "host_aggregate", :action => "edit", :id => find_checked_items[0]
-    elsif params[:pressed] == "cloud_tenant_edit"
-      javascript_redirect :controller => "cloud_tenant", :action => "edit", :id => find_checked_items[0]
-    elsif params[:pressed] == "cloud_volume_edit"
-      javascript_redirect :controller => "cloud_volume", :action => "edit", :id => find_checked_items[0]
-    elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
-                                                   "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-      render_or_redirect_partial(pfx)
+    return if performed?
+
+    if button_has_redirect_suffix?(params[:pressed])
+      render_or_redirect_partial(button_prefix(params[:pressed]))
     else
-      if @refresh_div == "main_div" && @lastaction == "show_list"
+      if button_replace_gtl_main?
         replace_gtl_main_div
       else
         render_flash unless performed?
@@ -1081,5 +1061,35 @@ module EmsCommon
     if params[:bearer_token]
       @edit[:new][:bearer_token] = @edit[:new][:bearer_verify] = @ems.authentication_token(:bearer)
     end
+  end
+
+  def button_sub_item_display_values
+    ["vms", "hosts", "storages", "instances", "images", "orchestration_stacks"]
+  end
+
+  def button_sub_item_prefixes
+    [
+      "availability_zone_",
+      "cloud_network_",
+      "cloud_object_store_container_",
+      "cloud_subnet_",
+      "cloud_tenant_",
+      "cloud_volume_",
+      "ems_cluster_",
+      "flavor_",
+      "floating_ip_",
+      "guest_",
+      "host_",
+      "image_",
+      "instance_",
+      "load_balancer_",
+      "miq_template_",
+      "network_port_",
+      "network_router_",
+      "orchestration_stack_",
+      "security_group_",
+      "storage_",
+      "vm_"
+    ]
   end
 end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -315,19 +315,16 @@ module EmsCommon
 
   # handle buttons pressed on the button bar
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    save_current_page_for_refresh
+    generic_button_setup
 
     if params[:pressed].starts_with?("cloud_object_store_")
       process_cloud_object_storage_buttons(params[:pressed])
     end
 
-    handle_tag_presses(params[:pressed]) { return if @flash_array.nil? }
-    handle_host_power_press(params[:pressed])
-    handle_button_pressed(params[:pressed])
+    handle_button_pressed(params[:pressed]) do |pressed|
+      return if pressed.ends_with?("tag") && @flash_array.nil?
+    end
 
-    # Handle buttons from sub-items screen
     handle_sub_item_presses(params[:pressed]) do |pfx|
       process_vm_buttons(pfx)
 
@@ -1022,6 +1019,7 @@ module EmsCommon
 
   def handled_buttons
     [
+      "ems_cluster_tag",
       "host_aggregate_edit",
       "cloud_tenant_edit",
       "cloud_volume_edit",
@@ -1042,6 +1040,10 @@ module EmsCommon
 
   def handle_cloud_volume_edit
     javascript_redirect :controller => "cloud_volume", :action => "edit", :id => find_checked_items[0]
+  end
+
+  def handle_ems_cluster_tag
+    tag(EmsCluster)
   end
 
   def recheck_auth_status

--- a/app/controllers/ems_datawarehouse_controller.rb
+++ b/app/controllers/ems_datawarehouse_controller.rb
@@ -47,5 +47,9 @@ class EmsDatawarehouseController < ApplicationController
     ems_form_fields
   end
 
+  def handled_buttons
+    middleware_handled_buttons
+  end
+
   menu_section :dwh
 end

--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -38,11 +38,15 @@ class EmsMiddlewareController < ApplicationController
     true
   end
 
+  public :restful?
+
   def ems_middleware_form_fields
     ems_form_fields
   end
 
-  public :restful?
+  def handled_buttons
+    middleware_handled_buttons
+  end
 
   menu_section :mdl
 end

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -267,10 +267,10 @@ class FloatingIpController < ApplicationController
   end
 
   def handle_floating_ip_new
-    javascript_redirect :action => "new"
+    js_redirect_to_new
   end
 
   def handle_floating_ip_edit
-    javascript_redirect :action => "edit", :id => checked_item_id(params)
+    js_redirect_to_edit_for_checked_id
   end
 end

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -17,12 +17,7 @@ class FloatingIpController < ApplicationController
   menu_section :net
 
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    save_current_page_for_refresh
-    set_default_refresh_div
-
-    handle_tag_presses(params[:pressed])
+    generic_button_setup
     handle_button_pressed(params[:pressed])
 
     button_render_fallback unless performed?
@@ -263,6 +258,7 @@ class FloatingIpController < ApplicationController
       floating_ip_new
       floating_ip_edit
       floating_ip_delete
+      floating_ip_tag
     )
   end
 

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -22,22 +22,10 @@ class FloatingIpController < ApplicationController
     save_current_page_for_refresh
     set_default_refresh_div
 
-    case params[:pressed]
-    when "floating_ip_tag"
-      tag("FloatingIp")
-    when 'floating_ip_delete'
-      delete_floating_ips
-    when "floating_ip_edit"
-      javascript_redirect :action => "edit", :id => checked_item_id(params)
-    when "floating_ip_new"
-      javascript_redirect :action => "new"
-    else
-      if !flash_errors? && button_replace_gtl_main?
-        replace_gtl_main_div
-      else
-        render_flash
-      end
-    end
+    handle_tag_presses(params[:pressed])
+    handle_button_pressed(params[:pressed])
+
+    button_render_fallback unless performed?
   end
 
   def cancel_action(message)
@@ -92,7 +80,7 @@ class FloatingIpController < ApplicationController
     javascript_redirect :action => "show_list"
   end
 
-  def delete_floating_ips
+  def handle_floating_ip_delete
     assert_privileges("floating_ip_delete")
 
     floating_ips = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "floating_ip")
@@ -268,5 +256,21 @@ class FloatingIpController < ApplicationController
                    "Delete initiated for %{number} Floating IPs.",
                    floating_ips.length) % {:number => floating_ips.length})
     end
+  end
+
+  def handled_buttons
+    %w(
+      floating_ip_new
+      floating_ip_edit
+      floating_ip_delete
+    )
+  end
+
+  def handle_floating_ip_new
+    javascript_redirect :action => "new"
+  end
+
+  def handle_floating_ip_edit
+    javascript_redirect :action => "edit", :id => checked_item_id(params)
   end
 end

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -17,11 +17,10 @@ class FloatingIpController < ApplicationController
   menu_section :net
 
   def button
-    @edit = session[:edit] # Restore @edit for adv search box
-    params[:display] = @display if %w(vms instances images).include?(@display)
-    params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
-
-    @refresh_div = "main_div"
+    restore_edit_for_search
+    copy_sub_item_display_value_to_params
+    save_current_page_for_refresh
+    set_default_refresh_div
 
     case params[:pressed]
     when "floating_ip_tag"
@@ -33,7 +32,7 @@ class FloatingIpController < ApplicationController
     when "floating_ip_new"
       javascript_redirect :action => "new"
     else
-      if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
+      if !flash_errors? && button_replace_gtl_main?
         replace_gtl_main_div
       else
         render_flash

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -571,11 +571,11 @@ class HostAggregateController < ApplicationController
   end
 
   def handle_host_aggregate_new
-    javascript_redirect :action => "new"
+    js_redirect_to_new
   end
 
   def handle_host_aggregate_edit
-    javascript_redirect :action => "edit", :id => checked_item_id
+    js_redirect_to_edit_for_checked_id
   end
 
   def handle_host_aggregate_delete

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -591,5 +591,22 @@ class HostAggregateController < ApplicationController
     javascript_redirect :action => "remove_host_select", :id => checked_item_id
   end
 
+  def host_aggregate_javascript_redirect
+    render_update_with_prologue do |page|
+      unless @refresh_partial.nil?
+        if refreshing_flash_msg?
+          replace_refresh_div_with_partial(page)
+        elsif %w(images instances).include?(@display) # If displaying vms, action_url s/b show
+          button_center_toolbar(page)
+          page.replace_html("main_div",
+                            :partial => "layouts/gtl",
+                            :locals  => {:action_url => "show/#{@host_aggregate.id}"})
+        else
+          replace_refresh_div_contents_with_partial(page)
+        end
+      end
+    end
+  end
+
   menu_section :clo
 end

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -74,17 +74,12 @@ class HostAggregateController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    save_current_page_for_refresh
+    generic_button_setup
 
-    handle_tag_presses(params[:pressed]) do
-      return if @flash_array.nil?
+    handle_button_pressed(params[:pressed]) do |pressed|
+      return if pressed.ends_with?("tag") && @flash_array.nil?
+      return if performed?
     end
-
-    handle_button_pressed(params[:pressed])
-
-    return if performed?
 
     handle_sub_item_presses(params[:pressed]) do |pfx|
       process_vm_buttons(pfx)
@@ -562,6 +557,7 @@ class HostAggregateController < ApplicationController
 
   def handled_buttons
     %(
+      host_aggregate_tag
       host_aggregate_new
       host_aggregate_edit
       host_aggregate_delete

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -407,10 +407,7 @@ class HostController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    save_current_page_for_refresh
-    set_default_refresh_div
+    generic_button_setup
 
     handle_tag_presses(params[:pressed])
     handle_host_power_press(params[:pressed])
@@ -607,7 +604,7 @@ class HostController < ApplicationController
       perf_refresh
       custom_button
     )
-    ctrlr_buttons += handled_host_buttons
+    ctrlr_buttons + handled_host_buttons
   end
 
   def handle_common_drift
@@ -624,6 +621,21 @@ class HostController < ApplicationController
 
   def handle_perf_refresh
     perf_refresh_data
+  end
+
+  def host_javascript_redirect
+    if @flash_array
+      show_list
+      replace_gtl_main_div
+    elsif @redirect_controller
+      if flash_errors?
+        javascript_flash # render called
+      else
+        js_redirect_with_controller
+      end
+    else
+      js_redirect_with_partial_and_id
+    end
   end
 
   menu_section :inf

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -76,7 +76,7 @@ class InfraNetworkingController < ApplicationController
     save_current_page_for_refresh
     set_default_refresh_div
 
-    handle_tag_presses(params[:pressed]) do
+    handle_button_pressed(params[:pressed]) do
       return if @flash_array.nil?
     end
 
@@ -742,6 +742,14 @@ class InfraNetworkingController < ApplicationController
 
   def title
     _("Networking")
+  end
+
+  def handled_buttons
+    %w(infra_networking_tag)
+  end
+
+  def handle_infra_networking_tag
+    tag(Switch)
   end
 
   menu_section :inf

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -5,6 +5,7 @@ class InfraNetworkingController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  include Mixins::GenericButtonMixin
   include Mixins::GenericSessionMixin
 
   def self.model
@@ -71,28 +72,18 @@ class InfraNetworkingController < ApplicationController
   end
 
   def button
-    @edit = session[:edit] # Restore @edit for adv search box
-    params[:page] = @current_page if @current_page.nil? # Save current page for list refresh
+    restore_edit_for_search
+    save_current_page_for_refresh
+    set_default_refresh_div
 
-    params[:page] = @current_page if @current_page.nil? # Save current page for list refresh
-    @refresh_div = "main_div" # Default div for button.rjs to refresh
-    case params[:pressed]
-    when "infra_networking_tag"
+    if params[:pressed] == "infra_networking_tag"
       tag(Switch)
-    end
-    return if %w(infra_networking_tag).include?(params[:pressed]) && @flash_array.nil? # Tag screen showing, so return
-
-    if @flash_array.nil? && !@refresh_partial # if no button handler ran, show not implemented msg
-      add_flash(_("Button not yet implemented"), :error)
-      @refresh_partial = "layouts/flash_msg"
-      @refresh_div = "flash_msg_div"
-    elsif @flash_array && @lastaction == "show"
-      @configuration_job = @record = identify_record(params[:id])
-      @refresh_partial = "layouts/flash_msg"
-      @refresh_div = "flash_msg_div"
+      return if @flash_array.nil? # Tag screen showing, so return
     end
 
-    if @refresh_div == "main_div" && @lastaction == "show_list"
+    check_if_button_is_implemented
+
+    if button_replace_gtl_main?
       replace_gtl_main_div
     else
       render_flash

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -76,9 +76,8 @@ class InfraNetworkingController < ApplicationController
     save_current_page_for_refresh
     set_default_refresh_div
 
-    if params[:pressed] == "infra_networking_tag"
-      tag(Switch)
-      return if @flash_array.nil? # Tag screen showing, so return
+    handle_tag_presses(params[:pressed]) do
+      return if @flash_array.nil?
     end
 
     check_if_button_is_implemented

--- a/app/controllers/middleware_datasource_controller.rb
+++ b/app/controllers/middleware_datasource_controller.rb
@@ -30,5 +30,9 @@ class MiddlewareDatasourceController < ApplicationController
   end
   helper_method :textual_group_list
 
+  def handled_buttons
+    middleware_handled_buttons
+  end
+
   menu_section :mdl
 end

--- a/app/controllers/middleware_deployment_controller.rb
+++ b/app/controllers/middleware_deployment_controller.rb
@@ -55,5 +55,9 @@ class MiddlewareDeploymentController < ApplicationController
     op.call(mw_deployment.ems_ref, mw_deployment.name)
   end
 
+  def handled_buttons
+    middleware_handled_buttons
+  end
+
   menu_section :mdl
 end

--- a/app/controllers/middleware_domain_controller.rb
+++ b/app/controllers/middleware_domain_controller.rb
@@ -25,4 +25,8 @@ class MiddlewareDomainController < ApplicationController
     [%i(properties), %i(relationships smart_management)]
   end
   helper_method :textual_group_list
+
+  def handled_buttons
+    middleware_handled_buttons
+  end
 end

--- a/app/controllers/middleware_messaging_controller.rb
+++ b/app/controllers/middleware_messaging_controller.rb
@@ -17,4 +17,8 @@ class MiddlewareMessagingController < ApplicationController
     [%i(properties), %i(relationships smart_management)]
   end
   helper_method :textual_group_list
+
+  def handled_buttons
+    middleware_handled_buttons
+  end
 end

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -292,5 +292,9 @@ class MiddlewareServerController < ApplicationController
     end
   end
 
+  def handled_buttons
+    middleware_handled_buttons
+  end
+
   menu_section :mdl
 end

--- a/app/controllers/middleware_server_group_controller.rb
+++ b/app/controllers/middleware_server_group_controller.rb
@@ -75,4 +75,8 @@ class MiddlewareServerGroupController < ApplicationController
       render :json => {:status => :error, :msg => fail_msg}
     end
   end
+
+  def handled_buttons
+    middleware_handled_buttons
+  end
 end

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -4,6 +4,8 @@ class MiqAeToolsController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  include Mixins::GenericButtonMixin
+
   def index
     resolve
   end
@@ -14,18 +16,15 @@ class MiqAeToolsController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    @edit = session[:edit]                                  # Restore @edit for adv search box
-    @refresh_div = "main_div" # Default div for button.rjs to refresh
+    restore_edit_for_search
+    set_default_refresh_div
+
     if params[:pressed] == "refresh_log"
       refresh_log
       return
     end
 
-    unless @refresh_partial # if no button handler ran, show not implemented msg
-      add_flash(_("Button not yet implemented"), :error)
-      @refresh_partial = "layouts/flash_msg"
-      @refresh_div = "flash_msg_div"
-    end
+    check_if_button_is_implemented
   end
 
   def log

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -6,6 +6,15 @@ class MiqAeToolsController < ApplicationController
 
   include Mixins::GenericButtonMixin
 
+  def self.model
+    nil # there is no MiqAeTools constant
+  end
+
+  # button looks for something here
+  def self.table_name
+    "miq_ae_tools"
+  end
+
   def index
     resolve
   end
@@ -14,11 +23,8 @@ class MiqAeToolsController < ApplicationController
     @lastaction = "resolve"
   end
 
-  # handle buttons pressed on the button bar
   def button
-    restore_edit_for_search
-    set_default_refresh_div
-
+    generic_button_setup
     handle_button_pressed(params[:pressed]) { return }
 
     check_if_button_is_implemented

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -19,10 +19,7 @@ class MiqAeToolsController < ApplicationController
     restore_edit_for_search
     set_default_refresh_div
 
-    if params[:pressed] == "refresh_log"
-      refresh_log
-      return
-    end
+    handle_button_pressed(params[:pressed]) { return }
 
     check_if_button_is_implemented
   end
@@ -39,7 +36,7 @@ class MiqAeToolsController < ApplicationController
     render :action => "show"
   end
 
-  def refresh_log
+  def handle_refresh_log
     assert_privileges("refresh_log")
     @log = $miq_ae_logger.contents if $miq_ae_logger
     add_flash(_("Logs for this %{product} Server are not available for viewing") % {:product => I18n.t('product.name')}, :warning) if @log.blank?
@@ -457,6 +454,10 @@ Methods updated/added: %{method_stats}") % stat_options)
 
   def set_session_data
     session[:resolve_tools] = @resolve if @resolve
+  end
+
+  def handled_buttons
+    %w(refresh_log)
   end
 
   menu_section :automate

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -78,10 +78,11 @@ class MiqPolicyController < ApplicationController
     restore_edit_for_search
     set_default_refresh_div
 
-    if params[:pressed] == "refresh_log"
-      refresh_log
-      return
-    end
+    # if params[:pressed] == "refresh_log"
+    #   refresh_log
+    #   return
+    # end
+    handle_button_pressed(params[:pressed]) { return }
 
     check_if_button_is_implemented
   end
@@ -1111,6 +1112,10 @@ class MiqPolicyController < ApplicationController
     ].map do |hsh|
       ApplicationController::Feature.new_with_hash(hsh)
     end
+  end
+
+  def handled_buttons
+    %w(refresh_log)
   end
 
   menu_section :con

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -8,6 +8,8 @@ class MiqPolicyController < ApplicationController
   include_concern 'PolicyProfiles'
   include_concern 'Rsop'
 
+  include Mixins::GenericButtonMixin
+
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -73,18 +75,15 @@ class MiqPolicyController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    @edit = session[:edit]                                  # Restore @edit for adv search box
-    @refresh_div = "main_div" # Default div for button.rjs to refresh
+    restore_edit_for_search
+    set_default_refresh_div
+
     if params[:pressed] == "refresh_log"
       refresh_log
       return
     end
 
-    unless @refresh_partial # if no button handler ran, show not implemented msg
-      add_flash(_("Button not yet implemented"), :error)
-      @refresh_partial = "layouts/flash_msg"
-      @refresh_div = "flash_msg_div"
-    end
+    check_if_button_is_implemented
   end
 
   POLICY_X_BUTTON_ALLOWED_ACTIONS = {

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -620,4 +620,18 @@ class MiqRequestController < ApplicationController
       end
     end
   end
+
+  def miq_request_render_update
+    render_update_with_prologue do |page|
+      unless @refresh_partial.nil?
+        if refreshing_flash_msg?
+          replace_refresh_div_with_partial(page)
+        else
+          replace_refresh_div_contents_with_partial(page)
+        end
+      end
+
+      page.replace_html(@refresh_div, :action => @render_action) unless @render_action.nil?
+    end
+  end
 end

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -18,9 +18,7 @@ class MiqRequestController < ApplicationController
     save_current_page_for_refresh
     set_default_refresh_div
 
-    if handled_buttons.include?(params[:pressed])
-      self.send("handle_#{params[:pressed]}".to_sym)
-    end
+    handle_button_pressed(params[:pressed])
 
     return if @refresh_partial == "reconfigure" || performed?
 
@@ -38,26 +36,6 @@ class MiqRequestController < ApplicationController
       miq_request_render_update
     end
   end
-
-  # def request_edit
-  #   assert_privileges("miq_request_edit")
-  #   provision_request = MiqRequest.find_by_id(params[:id])
-  #   if provision_request.workflow_class || provision_request.kind_of?(MiqProvisionConfiguredSystemRequest)
-  #     request_edit_settings(provision_request)
-  #   else
-  #     session[:checked_items] = provision_request.options[:src_ids]
-  #     @refresh_partial = "reconfigure"
-  #     @_params[:controller] = "vm"
-  #     reconfigurevms
-  #   end
-  # end
-
-  # def request_copy
-  #   assert_privileges("miq_request_copy")
-  #   provision_request = MiqRequest.find_by_id(params[:id])
-  #   @refresh_partial = "prov_copy"
-  #   request_settings_for_edit_or_copy(provision_request)
-  # end
 
   # Show the main Requests list view
   def show_list
@@ -467,33 +445,6 @@ class MiqRequestController < ApplicationController
     # TODO: this should be current_user
     User.current_user.role_allows?(:identifier => 'miq_request_approval')
   end
-
-  # Delete all selected or single displayed action(s)
-  # def deleterequests
-  #   assert_privileges("miq_request_delete")
-  #   miq_requests = []
-  #   if @lastaction == "show_list" # showing a list
-  #     miq_requests = find_checked_items
-  #     if miq_requests.empty?
-  #       add_flash(_("No %{model} were selected for deletion") % {:model => ui_lookup(:tables => "miq_request")}, :error)
-  #     end
-  #     process_requests(miq_requests, "destroy") unless miq_requests.empty?
-  #     add_flash(_("The selected %{tables} were deleted") %
-  #       {:tables => ui_lookup(:tables => "miq_request")}) unless flash_errors?
-  #   else # showing 1 request, delete it
-  #     if params[:id].nil? || MiqRequest.find_by_id(params[:id]).nil?
-  #       add_flash(_("%{table} no longer exists") % {:table => ui_lookup(:table => "miq_request")}, :error)
-  #     else
-  #       miq_requests.push(params[:id])
-  #     end
-  #     @single_delete = true
-  #     process_requests(miq_requests, "destroy") unless miq_requests.empty?
-  #     add_flash(_("The selected %{table} was deleted") %
-  #       {:table => ui_lookup(:table => "miq_request")}) unless flash_errors?
-  #   end
-  #   show_list
-  #   @refresh_partial = "layouts/gtl"
-  # end
 
   # Common Request button handler routines
   def process_requests(miq_requests, task)

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -4,6 +4,8 @@ class MiqTaskController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  include Mixins::GenericButtonMixin
+
   def index
     @tabform = nil
     @tabform ||= "tasks_1" if role_allows?(:feature => "job_my_smartproxy")
@@ -215,27 +217,9 @@ class MiqTaskController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    @edit = session[:edit] # Restore @edit for adv search box
-
+    restore_edit_for_search
     generic_x_button(TASK_X_BUTTON_ALLOWED_ACTIONS)
-
-    render :update do |page|
-      page << javascript_prologue
-      unless @refresh_partial.nil?
-        if @refresh_div == "flash_msg_div"
-          page << "miqSetButtons(0, 'center_tb');"
-          page.replace(@refresh_div, :partial => @refresh_partial)
-        else
-          page << "miqSetButtons(0, 'center_tb');"
-          page.replace_html("main_div", :partial => @refresh_partial)
-          page.replace_html("paging_div", :partial => 'layouts/pagingcontrols',
-                                          :locals  => {:pages      => @pages,
-                                                       :action_url => @lastaction,
-                                                       :db         => @view.db,
-                                                       :headers    => @view.headers})
-        end
-      end
-    end
+    miq_task_render_update
   end
 
   # Gather any changed options

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -219,7 +219,23 @@ class MiqTaskController < ApplicationController
   def button
     restore_edit_for_search
     generic_x_button(TASK_X_BUTTON_ALLOWED_ACTIONS)
-    miq_task_render_update
+
+    render_update_with_prologue do |page|
+      return if @refresh_partial.nil?
+
+      button_center_toolbar(page)
+
+      if refreshing_flash_msg?
+        replace_refresh_div_with_partial(page)
+      else
+        page.replace_html("main_div", :partial => @refresh_partial)
+        page.replace_html("paging_div", :partial => 'layouts/pagingcontrols',
+                                        :locals  => {:pages      => @pages,
+                                                     :action_url => @lastaction,
+                                                     :db         => @view.db,
+                                                     :headers    => @view.headers})
+      end
+    end
   end
 
   # Gather any changed options

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -17,11 +17,6 @@ module ContainersCommonMixin
 
   def button
     generic_button_setup
-
-    handle_tag_presses(params[:pressed]) do
-      return if @flash_array.nil?
-    end
-
     handle_button_pressed(params[:pressed])
   end
 

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -1,20 +1,39 @@
 module ContainersCommonMixin
   extend ActiveSupport::Concern
 
+  include Mixins::GenericButtonMixin
+
+  def show
+    # fix breadcrumbs - remove displaying 'topology' when navigating to any container related entity summary page
+    if @breadcrumbs.present? && (@breadcrumbs.last[:name].eql? 'Topology')
+      @breadcrumbs.clear
+    end
+    @display = params[:display] || "main" unless pagination_or_gtl_request?
+    @lastaction = "show"
+    @showtype = "main"
+    @record = identify_record(params[:id])
+    show_container(@record, controller_name, display_name)
+  end
+
   def button
-    @edit = session[:edit]                          # Restore @edit for adv search box
-    params[:display] = @display if ["#{params[:controller]}s"].include?(@display)  # displaying container_*
-    params[:page] = @current_page if @current_page.nil?   # Save current page for list refresh
+    restore_edit_for_search
+    copy_sub_item_display_value_to_params
+    save_current_page_for_refresh
+    set_default_refresh_div
 
     # Handle Toolbar Policy Tag Button
-    @refresh_div = "main_div" # Default div for button.rjs to refresh
+
     model = self.class.model
-    tag(model) if params[:pressed] == "#{params[:controller]}_tag"
+    if params[:pressed] == "#{params[:controller]}_tag"
+      tag(model)
+
+      return if @flash_array.nil? # Tag screen showing
+    end
+
     if [ContainerReplicator, ContainerGroup, ContainerNode, ContainerImage].include?(model)
       assign_policies(model) if params[:pressed] == "#{model.name.underscore}_protect"
       check_compliance(model) if params[:pressed] == "#{model.name.underscore}_check_compliance"
     end
-    return if ["#{params[:controller]}_tag"].include?(params[:pressed]) && @flash_array.nil? # Tag screen showing
 
     # Handle scan
     if params[:pressed] == "container_image_scan"
@@ -103,6 +122,10 @@ module ContainersCommonMixin
         add_flash(_("\"%{record}\": Compliance check successfully initiated") % {:record => entity.name})
       end
     end
+  end
+
+  def button_sub_item_display_values
+    ["#{params[:controller]}s"]
   end
 
   included do

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -16,55 +16,16 @@ module ContainersCommonMixin
   end
 
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    save_current_page_for_refresh
-    set_default_refresh_div
+    generic_button_setup
 
-    # Handle Toolbar Policy Tag Button
-
-    model = self.class.model
-    if params[:pressed] == "#{params[:controller]}_tag"
-      tag(model)
-
-      return if @flash_array.nil? # Tag screen showing
+    handle_tag_presses(params[:pressed]) do
+      return if @flash_array.nil?
     end
 
-    if [ContainerReplicator, ContainerGroup, ContainerNode, ContainerImage].include?(model)
-      assign_policies(model) if params[:pressed] == "#{model.name.underscore}_protect"
-      check_compliance(model) if params[:pressed] == "#{model.name.underscore}_check_compliance"
-    end
-
-    # Handle scan
-    if params[:pressed] == "container_image_scan"
-      scan_images
-
-      if @lastaction == "show"
-        javascript_flash
-      else
-        replace_main_div :partial => "layouts/gtl"
-      end
-    end
+    handle_button_pressed(params[:pressed])
   end
 
   private
-
-  # Scan all selected or single displayed image(s)
-  def scan_images
-    assert_privileges("image_scan")
-    showlist = @lastaction == "show_list"
-    ids = showlist ? find_checked_items : find_current_item(ContainerImage)
-
-    if ids.empty?
-      add_flash(_("No %{model} were selected for Analysis") % {:model => ui_lookup(:tables => "container_image")},
-                :error)
-    else
-      process_scan_images(ids)
-    end
-
-    showlist ? show_list : show
-    ids.count
-  end
 
   def check_compliance(model)
     assert_privileges("#{model.name.underscore}_check_compliance")

--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -1,8 +1,6 @@
 
 module Mixins
   module GenericButtonMixin
-    # handle buttons pressed on the button bar
-    #
     def button
       generic_button_setup
 
@@ -491,7 +489,6 @@ module Mixins
     # redirect to build the retire screen
     def redirect_to_retire_screen_if_single_delete
       if !@flash_array.nil? && @single_delete
-        # javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message]
         javascript_redirect :action      => 'show_list',
                             :flash_msg   => @flash_array[0][:message],
                             :flash_error => @flash_array[0][:level] == :error

--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -6,6 +6,14 @@ module Mixins
     def button
       generic_button_setup
 
+      handle_tag_presses(params[:pressed]) do
+        return if @flash_array.nil?
+      end
+
+      handle_button_pressed(params[:pressed]) do
+        return if performed? # did something build a response?
+      end
+
       handle_sub_item_presses(params[:pressed]) do |pfx|
         process_vm_buttons(pfx)
         return if button_control_transferred?(params[:pressed])
@@ -13,14 +21,6 @@ module Mixins
         unless button_has_redirect_suffix?(params[:pressed])
           set_refresh_and_show
         end
-      end
-
-      handle_tag_presses(params[:pressed]) do
-        return if @flash_array.nil?
-      end
-
-      handle_button_pressed(params[:pressed]) do
-        return if performed? # did something build a response?
       end
 
       check_if_button_is_implemented

--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -699,49 +699,6 @@ module Mixins
     #   end
     # end
 
-    # Moved, legacy
-
-    def process_vm_buttons(pfx)
-      case params[:pressed]
-      when "#{pfx}_policy_sim"                then polsimvms
-      when "#{pfx}_compare"                   then comparemiq
-      when "#{pfx}_scan"                      then scanvms
-      when "#{pfx}_collect_running_processes" then getprocessesvms
-      when "#{pfx}_sync"                      then syncvms
-      # when "#{pfx}_tag"                       then tag(VmOrTemplate)
-      when "#{pfx}_delete"                    then deletevms
-      when "#{pfx}_protect"                   then assign_policies(VmOrTemplate)
-      when "#{pfx}_edit"                      then edit_record
-      when "#{pfx}_refresh"                   then refreshvms
-      when "#{pfx}_start"                     then startvms
-      when "#{pfx}_stop"                      then stopvms
-      when "#{pfx}_suspend"                   then suspendvms
-      when "#{pfx}_pause"                     then pausevms
-      when "#{pfx}_shelve"                    then shelvevms
-      when "#{pfx}_shelveoffloadvms"          then shelveoffloadvms
-      when "#{pfx}_reset"                     then resetvms
-      when "#{pfx}_check_compliance"          then check_compliance_vms
-      when "#{pfx}_reconfigure"               then reconfigurevms
-      when "#{pfx}_resize"                    then resizevms
-      when "#{pfx}_evacuate"                  then evacuatevms
-      when "#{pfx}_live_migrate"              then livemigratevms
-      when "#{pfx}_associate_floating_ip"     then associate_floating_ip_vms
-      when "#{pfx}_disassociate_floating_ip"  then disassociate_floating_ip_vms
-      when "#{pfx}_retire"                    then retirevms
-      when "#{pfx}_retire_now"                then retirevms_now
-      when "#{pfx}_right_size"                then vm_right_size
-      when "#{pfx}_ownership"                 then set_ownership
-      when "#{pfx}_guest_shutdown"            then guestshutdown
-      when "#{pfx}_guest_standby"             then gueststandby
-      when "#{pfx}_guest_restart"             then guestreboot
-      when "#{pfx}_miq_request_new"           then prov_redirect
-      when "#{pfx}_clone"                     then prov_redirect("clone")
-      when "#{pfx}_migrate"                   then prov_redirect("migrate")
-      when "#{pfx}_publish"                   then prov_redirect("publish")
-      when "#{pfx}_terminate"                 then terminatevms
-      end
-    end
-
     # /GenericButtonMixin
   end
 end

--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -1,50 +1,87 @@
 module Mixins
+  # NOTE: ivars and estimated purpose
+  # @current_page
+  # @display
+  # @edit
+  # @flash_array
+  # @lastaction
+  # @redirect_id
+  # @refresh_div
+  # @refresh_partial
+
+  # TODO: consider moving related methods here
+  # ==== ApplicationController
+  # render_or_redirect_partial
+  #
+  # === ApplicationController::Buttons
+  # custom_buttons
+  #
+  # ==== ApplicationHelper
+  # check_if_button_is_implemented
+  #
+  # ==== CiProcessing
+  # process_vm_buttons
+  # pfx_for_vm_button_pressed
+  # POWER_BUTTON_NAMES
+  # powerbutton_hosts
+  # host_button_operation
+
+  # NOTE: Methods that eventually call render
+  # javascript_redirect
+  # javascript_flash
+
+
+  # NOTE: Press values encountered
+  # auth_key_pair_cloud_tag
+  # auth_key_pair_cloud_delete
+  # auth_key_pair_cloud_new
+  # availability_zone_tag
+  # cloud_network_tag
+  # cloud_network_delete
+  # cloud_network_edit
+  # cloud_network_new
+  # cloud_object_store_container_tag
+  # cloud_object_store_object_tag
+  # cloud_subnet_tag
+  # cloud_subnet_delete
+  # cloud_subnet_edit
+  # cloud_subnet_new
+  # cloud_tenant_new
+  # cloud_tenant_edit
+  # cloud_tenant_delete
+  # custom_button
+  # cloud_volume_tag
+  # cloud_volume_delete
+  # cloud_volume_attach
+  # cloud_volume_detach
+  # cloud_volume_edit
+  # cloud_volume_snapshot_create
+  # cloud_volume_new
+  # cloud_volume_backup_create
+  # cloud_volume_backup_restore
+  #
+  #
+  #
   module GenericButtonMixin
+
     # handle buttons pressed on the button bar
+    # TODO: break this up and include only relevant methods in controllers
+    #
     def button
-      @edit = session[:edit] # Restore @edit for adv search box
-      params[:display] = @display if %w(vms images instances).include?(@display)
-      params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
+      restore_edit_for_search
+      copy_sub_item_display_value_to_params
+      save_current_page_for_refresh
 
-      # Handle buttons from sub-items screen
-      if params[:pressed].starts_with?("image_",
-                                       "instance_",
-                                       "vm_",
-                                       "miq_template_",
-                                       "guest_")
-
-        pfx = pfx_for_vm_button_pressed(params[:pressed])
+      handle_sub_item_presses(params[:pressed]) do |pfx|
         process_vm_buttons(pfx)
+        return if button_control_transferred?(params[:pressed])
 
-        # Control transferred to another screen, so return
-        return if ["#{pfx}_policy_sim", "#{pfx}_compare", "#{pfx}_tag",
-                   "#{pfx}_retire", "#{pfx}_protect", "#{pfx}_ownership",
-                   "#{pfx}_refresh", "#{pfx}_right_size",
-                   "#{pfx}_reconfigure"].include?(params[:pressed]) &&
-                  @flash_array.nil?
-
-        unless ["#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
-                "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-          @refresh_div = "main_div"
-          @refresh_partial = "layouts/gtl"
-          show # Handle VMs buttons
+        unless button_has_redirect_suffix?(params[:pressed])
+          set_refresh_and_show
         end
-      elsif params[:pressed].ends_with?("_tag")
-        case params[:pressed]
-        when "#{self.class.table_name}_tag"  then tag(self.class.model)
-        when 'cloud_network_tag'             then tag(CloudNetwork)
-        when 'cloud_object_store_object_tag' then tag(CloudObjectStoreObject)
-        when 'cloud_subnet_tag'              then tag(CloudSubnet)
-        when 'cloud_tenant_tag'              then tag(CloudTenant)
-        when 'cloud_volume_snapshot_tag'     then tag(CloudVolumeSnapshot)
-        when 'cloud_volume_tag'              then tag(CloudVolume)
-        when 'floating_ip_tag'               then tag(FloatingIp)
-        when 'load_balancer_tag'             then tag(LoadBalancer)
-        when 'network_port_tag'              then tag(NetworkPort)
-        when 'network_router_tag'            then tag(NetworkRouter)
-        when 'security_group_tag'            then tag(SecurityGroup)
-        end
+      end
 
+      handle_tag_presses(params[:pressed]) do
         return if @flash_array.nil?
       end
 
@@ -55,14 +92,488 @@ module Mixins
 
       check_if_button_is_implemented
 
-      if params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
-                                                  "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-        render_or_redirect_partial(pfx)
-      elsif @refresh_div == "main_div" && @lastaction == "show_list"
+      if button_has_redirect_suffix?(params[:pressed])
+        render_or_redirect_partial_for(params[:pressed])
+      elsif button_replace_gtl_main?
         replace_gtl_main_div
       else
         render_flash
       end
     end
+
+    private
+
+    def restore_edit_for_search
+      @edit = session[:edit]
+    end
+
+    def save_current_page_for_refresh
+      params[:page] = @current_page unless @current_page.nil?
+    end
+
+    def set_display_param
+      params[:display] = @display
+    end
+
+    # Default div for button.rjs to refresh
+    def set_default_refresh_div
+      @refresh_div = "main_div"
+    end
+
+    # Displaying sub-items
+    def copy_sub_item_display_value_to_params
+      if button_sub_item_display_values.include?(@display)
+        set_display_param
+      end
+    end
+
+    # Handle buttons from sub-item (unrelated to this controller) screens
+    def handle_sub_item_presses(pressed, &block)
+      if pressed.starts_with?(*button_sub_item_prefixes)
+        pfx = button_prefix(params[:pressed])
+
+        yield(pfx)
+      end
+    end
+
+    def handle_tag_presses(pressed, &block)
+      if pressed.ends_with?("_tag")
+        tag_for_pressed(pressed)
+
+        yield if block_given?
+      end
+    end
+
+    def button_set_refresh
+      @refresh_div = "main_div"
+      @refresh_partial = "layouts/gtl"
+
+      # Also seen
+      # @refresh_partial = "layouts/flash_msg"
+      # @refresh_div = "flash_msg_div"
+    end
+
+    def set_refresh_and_show
+      button_set_refresh
+      show # Handle VMs buttons
+    end
+
+    def set_refresh_and_alert_not_implemented
+      add_flash(_("Button not yet implemented"), :error)
+      button_set_refresh
+    end
+
+    def tag_for_pressed(pressed)
+      case pressed
+      when "#{self.class.table_name}_tag"  then tag(self.class.model)
+      when 'cloud_network_tag'             then tag(CloudNetwork)
+      when 'cloud_object_store_object_tag' then tag(CloudObjectStoreObject)
+      when 'cloud_subnet_tag'              then tag(CloudSubnet)
+      when 'cloud_tenant_tag'              then tag(CloudTenant)
+      when 'cloud_volume_snapshot_tag'     then tag(CloudVolumeSnapshot)
+      when 'cloud_volume_tag'              then tag(CloudVolume)
+      when 'floating_ip_tag'               then tag(FloatingIp)
+      when 'load_balancer_tag'             then tag(LoadBalancer)
+      when 'network_port_tag'              then tag(NetworkPort)
+      when 'network_router_tag'            then tag(NetworkRouter)
+      when 'security_group_tag'            then tag(SecurityGroup)
+      end
+    end
+
+    def render_or_redirect_partial_for(pressed)
+      pfx = button_prefix(pressed)
+      render_or_redirect_partial(pfx)
+    end
+
+    def button_render_fallback
+      if !flash_errors? && button_replace_gtl_main?
+        replace_gtl_main_div
+      else
+        render_flash # javascript_flash, renders json
+      end
+    end
+
+    def handle_host_power_press(pressed)
+      powerbutton_hosts(button_remove_prefix(pressed))
+    end
+
+    ### Predicates
+    ############################################################################
+
+    def button_power_press?(pressed)
+      pressed.ends_with?(*button_power_suffixes)
+    end
+
+    def button_skip_show_render?(pressed)
+      # pfx = button_prefix(pressed)
+      suffixes = %w(
+        _edit
+        _miq_request_new
+        _clone
+        _migrate
+        _publish
+      )
+
+      pressed.ends_with?(*suffixes)
+    end
+
+    def button_has_redirect_suffix?(pressed)
+      pressed.ends_with?(*button_redirect_suffixes)
+    end
+
+    def button_replace_gtl_main?
+      @refresh_div == "main_div" && @lastaction == "show_list"
+    end
+
+    # if no button handler ran, show not implemented msg
+    def button_not_handled?
+      !@refresh_partial && @flash_array.nil?
+    end
+
+    def lastaction_is_show_and_flash_present?
+      @flash_array && @lastaction == "show"
+    end
+
+    # Control transferred to another screen
+    # (Also) # Some other screen is showing, so return
+    def button_control_transferred?(pressed)
+      pressed.ends_with?(*button_control_transfer_suffixes) && @flash_array.nil?
+    end
+
+    def refreshing_flash_msg?
+      @refresh_div == "flash_msg_div"
+    end
+
+    ### Prefixes
+    ############################################################################
+
+    def button_sub_item_prefixes
+      %w(
+        guest_
+        host_
+        image_
+        instance_
+        miq_template_
+        rp_
+        vm_
+      )
+    end
+
+    def button_prefix(pressed)
+      @button_pfx ||= pfx_for_vm_button_pressed(pressed)
+    end
+
+    def button_remove_prefix(pressed)
+      pressed.split("_")[1..-1].join("_")
+    end
+
+    ### Suffixes
+    ############################################################################
+
+    def button_redirect_suffixes
+      %w(
+        _edit
+        _copy
+        _miq_request_new
+        _clone
+        _migrate
+        _publish
+      )
+    end
+
+    def button_control_transfer_suffixes
+      %w(
+        _compare
+        _drift
+        _evacuate
+        _live_migrate
+        _ownership
+        _policy_sim
+        _protect
+        _reconfigure
+        _refresh
+        _reload
+        _resize
+        _retire
+        _right_size
+        _scan
+        _tag
+      )
+    end
+
+    def button_power_suffixes
+      %w(
+        _shutdown
+        _reboot
+        _standby
+        _enter_maint_mode
+        _exit_maint_mode
+        _start
+        _stop
+        _reset
+      )
+    end
+
+    ### Other magic strings
+    ############################################################################
+
+    def button_sub_item_display_values
+      %w(all_vms vms images instances)
+    end
+
+    ### Complex code moved for comparison
+    ############################################################################
+
+    # Helpers to break up the complex bits
+
+    def refresh_flash_msg_or_block(page)
+      if refreshing_flash_msg?
+        replace_refresh_div_with_partial(page)
+      elsif block_given?
+        yield(page)
+      end
+    end
+
+    def render_update_with_prologue
+      render :update do |page|
+        page << javascript_prologue
+        yield(page) if block_given?
+      end
+    end
+
+    def js_redirect_with_partial_and_id
+      javascript_redirect :action => @refresh_partial, :id => @redirect_id
+    end
+
+    # In render :update, page is an instance of
+    # ActionView::Helpers::JqueryHelper::JavascriptGenerator
+
+    def button_center_toolbar(page)
+      page << "miqSetButtons(0, 'center_tb');"
+    end
+
+    # JavascriptGenerator#replace_html replaces the contents (inside) of a div
+    def replace_refresh_div_contents_with_partial(page)
+      page.replace_html(@refresh_div, :partial => @refresh_partial)
+    end
+
+    # JavascriptGenerator#replace replaces an entire div itself
+    def replace_refresh_div_with_partial(page)
+      page.replace(@refresh_div, :partial => @refresh_partial)
+    end
+
+    def js_redirect_with_controller(options = {})
+      args = {
+        :controller     => @redirect_controller,
+        :action         => @refresh_partial,
+        :id             => @redirect_id,
+        :prov_type      => @prov_type,
+        :prov_id        => @prov_id,
+        :org_controller => @org_controller,
+        :escape         => false
+      }.merge(options)
+
+      javascript_redirect(args)
+    end
+
+    # These seem to be last resorts, and seem to do similar things in different ways
+
+    # Original
+    # render :update do |page|
+    #   page << javascript_prologue
+    #
+    #   unless @refresh_partial.nil?
+    #     refresh_flash_msg_or_block(page) do |page|
+    #       if ["images", "instances"].include?(@display) # If displaying vms, action_url s/b show
+    #         page << "miqSetButtons(0, 'center_tb');"
+    #         page.replace_html("main_div", :partial => "layouts/gtl", :locals => {:action_url => "show/#{@availability_zone.id}"})
+    #       else
+    #         page.replace_html(@refresh_div, :partial => @refresh_partial)
+    #       end
+    #     end
+    #   end
+    # end
+    #
+    # Context:
+    # !button_replace_gtl_main?
+    #
+    def availability_zone_render_update
+      render_update_with_prologue do |page|
+        return if @refresh_partial.nil?
+
+        refresh_flash_msg_or_block(page) do |page|
+          if button_sub_item_display_values.include?(@display) # If displaying vms, action_url s/b show
+            button_center_toolbar(page)
+            page.replace_html("main_div", :partial => "layouts/gtl", :locals => {:action_url => "show/#{@availability_zone.id}"})
+          else
+            replace_refresh_div_contents_with_partial(page)
+          end
+        end
+      end
+    end
+
+    # Original:
+    # c_tb = build_toolbar(center_toolbar_filename)
+    # render :update do |page|
+    #   page << javascript_prologue
+    #   page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+    #   page.replace_html("main_div", :partial => "ui_4") # Replace the main div area contents
+    #   page << javascript_pf_toolbar_reload('center_tb', c_tb)
+    # end
+    #
+    # Context:
+    # !button_has_redirect_suffix?
+    def configuration_render_update
+      c_tb = build_toolbar(center_toolbar_filename)
+
+      render_update_with_prologue do |page|
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page.replace_html("main_div", :partial => "ui_4") # Replace the main div area contents
+        page << javascript_pf_toolbar_reload('center_tb', c_tb)
+      end
+    end
+
+    # button_has_redirect_suffix?
+    def host_javascript_redirect
+      if @flash_array
+        show_list
+        replace_gtl_main_div
+      else
+        if @redirect_controller
+          if flash_errors?
+            javascript_flash # render called
+          else
+            js_redirect_with_controller
+          end
+        else
+          js_redirect_with_partial_and_id
+        end
+      end
+    end
+
+    # Original:
+    # render :update do |page|
+    #   page << javascript_prologue
+    #   unless @refresh_partial.nil?
+    #     if refreshing_flash_msg?
+    #       page.replace(@refresh_div, :partial => @refresh_partial)
+    #     else
+    #       page.replace_html(@refresh_div, :partial => @refresh_partial)
+    #     end
+    #   end
+    #   page.replace_html(@refresh_div, :action => @render_action) unless @render_action.nil?
+    # end
+    #
+    # Context:
+    # !params[:pressed].ends_with?("_edit")
+    def miq_request_render_update
+      render_update_with_prologue do |page|
+        unless @refresh_partial.nil?
+          if refreshing_flash_msg?
+            replace_refresh_div_with_partial(page)
+          else
+            replace_refresh_div_contents_with_partial(page)
+          end
+        end
+
+        page.replace_html(@refresh_div, :action => @render_action) unless @render_action.nil?
+      end
+    end
+
+    # Original:
+    # render :update do |page|
+    #   page << javascript_prologue
+    #   unless @refresh_partial.nil?
+    #     page << "miqSetButtons(0, 'center_tb');"
+    #     if refreshing_flash_msg?
+    #       replace_refresh_div_with_partial(page)
+    #     else
+    #       page.replace_html("main_div", :partial => @refresh_partial)
+    #       page.replace_html("paging_div", :partial => 'layouts/pagingcontrols',
+    #                                       :locals  => {:pages      => @pages,
+    #                                                    :action_url => @lastaction,
+    #                                                    :db         => @view.db,
+    #                                                    :headers    => @view.headers})
+    #     end
+    #   end
+    # end
+    #
+    def miq_task_render_update
+      render_update_with_prologue do |page|
+        return if @refresh_partial.nil?
+
+        page << "miqSetButtons(0, 'center_tb');"
+
+        if refreshing_flash_msg?
+          replace_refresh_div_with_partial(page)
+        else
+          page.replace_html("main_div", :partial => @refresh_partial)
+          page.replace_html("paging_div", :partial => 'layouts/pagingcontrols',
+                                          :locals  => {:pages      => @pages,
+                                                       :action_url => @lastaction,
+                                                       :db         => @view.db,
+                                                       :headers    => @view.headers})
+        end
+      end
+    end
+
+    # Original:
+    # if !@flash_array.nil? && @single_delete
+    #   javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
+    # elsif params[:pressed].ends_with?("_edit")
+    #   if @redirect_controller
+    #     javascript_redirect :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id, :org_controller => @org_controller
+    #   else
+    #     javascript_redirect :action => @refresh_partial, :id => @redirect_id
+    #   end
+    # else
+    #   if @refresh_div == "main_div" && @lastaction == "show_list"
+    #     replace_gtl_main_div
+    #   else
+    #     if @refresh_div == "flash_msg_div"
+    #       javascript_flash(:spinner_off => true)
+    #     else
+    #       options
+    #       partial_replace(@refresh_div, "vm_common/#{@refresh_partial}")
+    #     end
+    #   end
+    # end
+    #
+    def vm_common_javascript_redirect
+      if !@flash_array.nil? && @single_delete
+        javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
+        return
+      end
+
+      if params[:pressed].ends_with?("_edit")
+        if @redirect_controller
+          js_redirect_with_controller
+        else
+          js_redirect_with_partial_and_id
+        end
+
+        return
+      end
+
+      if button_replace_gtl_main?
+        replace_gtl_main_div
+      else
+        if refreshing_flash_msg?
+          javascript_flash(:spinner_off => true)
+        else
+          options
+          partial_replace(@refresh_div, "vm_common/#{@refresh_partial}")
+        end
+      end
+    end
+
+    # def javascript_redirect(args)
+    #   render :update do |page|
+    #     page << javascript_prologue
+    #     page.redirect_to args
+    #   end
+    # end
+
+    # /GenericButtonMixin
   end
 end

--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -447,6 +447,14 @@ module Mixins
       javascript_redirect :action => @refresh_partial, :id => @redirect_id
     end
 
+    def js_redirect_to_edit_for_checked_id
+      javascript_redirect :action => "edit", :id => checked_item_id
+    end
+
+    def js_redirect_to_new
+      javascript_redirect :action => "new"
+    end
+
     # In render :update, page is an instance of
     # ActionView::Helpers::JqueryHelper::JavascriptGenerator
 

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -16,26 +16,24 @@ class NetworkRouterController < ApplicationController
   end
 
   def button
-    @edit = session[:edit] # Restore @edit for adv search box
-    params[:display] = @display if %w(vms instances images).include?(@display)
-    params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
+    restore_edit_for_search
+    copy_sub_item_display_value_to_params
+    save_current_page_for_refresh
+    set_default_refresh_div
 
-    @refresh_div = "main_div"
-    return tag("NetworkRouter") if params[:pressed] == "network_router_tag"
-    delete_network_routers if params[:pressed] == 'network_router_delete'
-
-    if params[:pressed] == "network_router_edit"
+    case params[:pressed]
+    when "network_router_tag" then return tag("NetworkRouter")
+    when "network_router_delete" then delete_network_routers
+    when "network_router_edit"
       javascript_redirect :action => "edit", :id => checked_item_id
-    elsif params[:pressed] == "network_router_new"
+    when "network_router_new"
       javascript_redirect :action => "new"
-    elsif params[:pressed] == "network_router_add_interface"
+    when "network_router_add_interface"
       javascript_redirect :action => "add_interface_select", :id => checked_item_id
-    elsif params[:pressed] == "network_router_remove_interface"
+    when "network_router_remove_interface"
       javascript_redirect :action => "remove_interface_select", :id => checked_item_id
-    elsif !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
-      replace_gtl_main_div
     else
-      render_flash
+      button_render_fallback
     end
   end
 

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -21,20 +21,10 @@ class NetworkRouterController < ApplicationController
     save_current_page_for_refresh
     set_default_refresh_div
 
-    case params[:pressed]
-    when "network_router_tag" then return tag("NetworkRouter")
-    when "network_router_delete" then delete_network_routers
-    when "network_router_edit"
-      javascript_redirect :action => "edit", :id => checked_item_id
-    when "network_router_new"
-      javascript_redirect :action => "new"
-    when "network_router_add_interface"
-      javascript_redirect :action => "add_interface_select", :id => checked_item_id
-    when "network_router_remove_interface"
-      javascript_redirect :action => "remove_interface_select", :id => checked_item_id
-    else
-      button_render_fallback
-    end
+    handle_tag_presses(params[:pressed]) { return }
+    handle_button_pressed(params[:pressed])
+
+    button_render_fallback unless performed?
   end
 
   def network_router_form_fields
@@ -120,7 +110,7 @@ class NetworkRouterController < ApplicationController
     javascript_redirect :action => "show_list"
   end
 
-  def delete_network_routers
+  def handle_network_router_delete
     assert_privileges("network_router_delete")
 
     routers = if @lastaction == "show_list" ||
@@ -448,6 +438,32 @@ class NetworkRouterController < ApplicationController
                    "Delete initiated for %{number} Network Routers.",
                    routers.length) % {:number => routers.length})
     end
+  end
+
+  def handled_buttons
+    %w(
+      network_router_delete
+      network_router_edit
+      network_router_new
+      network_router_add_interface
+      network_router_remove_interface
+    )
+  end
+
+  def handle_network_router_edit
+    javascript_redirect :action => "edit", :id => checked_item_id
+  end
+
+  def handle_network_router_new
+    javascript_redirect :action => "new"
+  end
+
+  def handle_network_router_add_interface
+    javascript_redirect :action => "add_interface_select", :id => checked_item_id
+  end
+
+  def handle_network_router_remove_interface
+    javascript_redirect :action => "remove_interface_select", :id => checked_item_id
   end
 
   menu_section :net

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -16,13 +16,11 @@ class NetworkRouterController < ApplicationController
   end
 
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    save_current_page_for_refresh
-    set_default_refresh_div
+    generic_button_setup
 
-    handle_tag_presses(params[:pressed]) { return }
-    handle_button_pressed(params[:pressed])
+    handle_button_pressed(params[:pressed]) do |pressed|
+      return if pressed.ends_with?("tag")
+    end
 
     button_render_fallback unless performed?
   end
@@ -445,9 +443,14 @@ class NetworkRouterController < ApplicationController
       network_router_delete
       network_router_edit
       network_router_new
+      network_router_tag
       network_router_add_interface
       network_router_remove_interface
     )
+  end
+
+  def handle_network_router_tag
+    handle_model_tag
   end
 
   def handle_network_router_edit

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -451,11 +451,11 @@ class NetworkRouterController < ApplicationController
   end
 
   def handle_network_router_edit
-    javascript_redirect :action => "edit", :id => checked_item_id
+    js_redirect_to_edit_for_checked_id
   end
 
   def handle_network_router_new
-    javascript_redirect :action => "new"
+    js_redirect_to_new
   end
 
   def handle_network_router_add_interface

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -83,15 +83,13 @@ class OrchestrationStackController < ApplicationController
     show_association('resources', _('Resources'), 'resource', :resources, OrchestrationStackResource)
   end
 
-  # handle buttons pressed on the button bar
+  # FIXME: This may be similar enough to replace with GenericButtonMixin#button
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    save_current_page_for_refresh
-    set_default_refresh_div
+    generic_button_setup
 
-    handle_tag_presses(params[:pressed])
-    handle_button_pressed(params[:pressed])
+    handle_button_pressed(params[:pressed]) do
+      return if performed?
+    end
 
     handle_sub_item_presses(params[:pressed]) do |pfx|
       process_vm_buttons(pfx)
@@ -102,8 +100,6 @@ class OrchestrationStackController < ApplicationController
         set_refresh_and_show
       end
     end
-
-    return if performed?
 
     check_if_button_is_implemented
 
@@ -245,7 +241,12 @@ class OrchestrationStackController < ApplicationController
       orchestration_stack_delete
       orchestration_stack_retire
       orchestration_stack_retire_now
+      orchestration_stack_tag
     )
+  end
+
+  def handle_orchestration_stack_tag
+    handle_model_tag
   end
 
   def handle_orchestration_stack_delete

--- a/app/controllers/persistent_volume_controller.rb
+++ b/app/controllers/persistent_volume_controller.rb
@@ -17,5 +17,9 @@ class PersistentVolumeController < ApplicationController
     _("Volumes")
   end
 
+  def handled_buttons
+    %w(persistent_volume_tag)
+  end
+
   menu_section :cnt
 end

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -25,7 +25,7 @@ class ResourcePoolController < ApplicationController
   end
 
   def handled_buttons
-    %w(resource_pool_delete resource_pool_protect)
+    %w(resource_pool_delete resource_pool_protect resource_pool_tag)
   end
 
   def handle_resource_pool_delete
@@ -35,6 +35,10 @@ class ResourcePoolController < ApplicationController
 
   def handle_resource_pool_protect
     assign_policies(ResourcePool)
+  end
+
+  def handle_resource_pool_tag
+    handle_model_tag
   end
 
   menu_section :inf

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -15,15 +15,13 @@ class ResourcePoolController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    set_default_refresh_div
+    generic_button_setup
 
     handle_tag_presses(params[:pressed])
     handle_button_pressed(params[:pressed])
 
     handle_sub_item_presses(params[:pressed]) do |pfx|
-      process_vm_buttons(pfx)
+      process_vm_buttons(pfx) unless params[:pressed].ends_with?("_tag")
 
       return if button_control_transferred?(params[:pressed])
 

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -13,37 +13,16 @@ class ResourcePoolController < ApplicationController
     %w(vms descendant_vms all_vms resource_pools)
   end
 
-  # handle buttons pressed on the button bar
-  def button
-    generic_button_setup
-
-    handle_tag_presses(params[:pressed])
-    handle_button_pressed(params[:pressed])
-
-    handle_sub_item_presses(params[:pressed]) do |pfx|
-      process_vm_buttons(pfx) unless params[:pressed].ends_with?("_tag")
-
-      return if button_control_transferred?(params[:pressed])
-
-      unless button_has_redirect_suffix?(params[:pressed])
-        set_refresh_and_show
-      end
-    end
-
-    return if response && performed?
-
-    check_if_button_is_implemented
-
-    if button_has_redirect_suffix?(params[:pressed])
-      render_or_redirect_partial_for(params[:pressed])
-    elsif button_replace_gtl_main?
-      replace_gtl_main_div
-    else
-      render_flash
-    end
-  end
-
   private
+
+  def textual_group_list
+    [%i(properties relationships), %i(configuration smart_management)]
+  end
+  helper_method :textual_group_list
+
+  def button_sub_item_display_values
+    %w(all_vms vms resource_pools)
+  end
 
   def handled_buttons
     %w(resource_pool_delete resource_pool_protect)
@@ -56,15 +35,6 @@ class ResourcePoolController < ApplicationController
 
   def handle_resource_pool_protect
     assign_policies(ResourcePool)
-  end
-
-  def textual_group_list
-    [%i(properties relationships), %i(configuration smart_management)]
-  end
-  helper_method :textual_group_list
-
-  def button_sub_item_display_values
-    %w(all_vms vms resource_pools)
   end
 
   menu_section :inf

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -17,34 +17,22 @@ class ResourcePoolController < ApplicationController
   def button
     restore_edit_for_search
     copy_sub_item_display_value_to_params
+    set_default_refresh_div
 
-    if button_sub_item_display_values.include?(@display) # Need to check, since RPs contain RPs
-      handle_sub_item_presses(params[:pressed]) do |pfx|
-        process_vm_buttons(pfx)
+    handle_tag_presses(params[:pressed])
+    handle_button_pressed(params[:pressed])
 
-        return if button_control_transferred?(params[:pressed])
+    handle_sub_item_presses(params[:pressed]) do |pfx|
+      process_vm_buttons(pfx)
 
-        unless button_has_redirect_suffix?(params[:pressed])
-          set_refresh_and_show
-        end
-      end
-    else
-      set_default_refresh_div
+      return if button_control_transferred?(params[:pressed])
 
-      case params[:pressed]
-      when "resource_pool_delete"
-        deleteresourcepools
-        if !@flash_array.nil? && @single_delete
-          javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
-        end
-      when "resource_pool_tag"
-        tag(ResourcePool)
-        return if @flash_array.nil?
-      when "resource_pool_protect"
-        assign_policies(ResourcePool)
-        return if @flash_array.nil?
+      unless button_has_redirect_suffix?(params[:pressed])
+        set_refresh_and_show
       end
     end
+
+    return if response && performed?
 
     check_if_button_is_implemented
 
@@ -58,6 +46,19 @@ class ResourcePoolController < ApplicationController
   end
 
   private
+
+  def handled_buttons
+    %w(resource_pool_delete resource_pool_protect)
+  end
+
+  def handle_resource_pool_delete
+    deleteresourcepools
+    redirect_to_retire_screen_if_single_delete
+  end
+
+  def handle_resource_pool_protect
+    assign_policies(ResourcePool)
+  end
 
   def textual_group_list
     [%i(properties relationships), %i(configuration smart_management)]

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -263,10 +263,10 @@ class SecurityGroupController < ApplicationController
   end
 
   def handle_security_group_edit
-    javascript_redirect :action => "edit", :id => checked_item_id(params)
+    js_redirect_to_edit_for_checked_id
   end
 
   def handle_security_group_new
-    javascript_redirect :action => "new"
+    js_redirect_to_new
   end
 end

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -17,12 +17,7 @@ class SecurityGroupController < ApplicationController
   menu_section :net
 
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    save_current_page_for_refresh
-    set_default_refresh_div
-
-    handle_tag_presses(params[:pressed])
+    generic_button_setup
     handle_button_pressed(params[:pressed])
 
     button_render_fallback unless performed?
@@ -259,6 +254,7 @@ class SecurityGroupController < ApplicationController
       security_group_delete
       security_group_edit
       security_group_new
+      security_group_tag
     )
   end
 

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -22,21 +22,10 @@ class SecurityGroupController < ApplicationController
     save_current_page_for_refresh
     set_default_refresh_div
 
-    case params[:pressed]
-    when "security_group_tag"
-      return tag("SecurityGroup")
-    when 'security_group_delete'
-      delete_security_groups
-    when "security_group_edit"
-      javascript_redirect :action => "edit", :id => checked_item_id(params)
-    else
-      if params[:pressed] == "security_group_new"
-        javascript_redirect :action => "new"
-        return
-      end
+    handle_tag_presses(params[:pressed])
+    handle_button_pressed(params[:pressed])
 
-      button_render_fallback
-    end
+    button_render_fallback unless performed?
   end
 
   def cancel_action(message)
@@ -109,7 +98,7 @@ class SecurityGroupController < ApplicationController
     javascript_redirect :action => "show_list"
   end
 
-  def delete_security_groups
+  def handle_security_group_delete
     assert_privileges("security_group_delete")
 
     security_groups = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "security_group")
@@ -263,5 +252,21 @@ class SecurityGroupController < ApplicationController
                    "Delete initiated for %{number} Security Groups.",
                    security_groups.length) % {:number => security_groups.length})
     end
+  end
+
+  def handled_buttons
+    %w(
+      security_group_delete
+      security_group_edit
+      security_group_new
+    )
+  end
+
+  def handle_security_group_edit
+    javascript_redirect :action => "edit", :id => checked_item_id(params)
+  end
+
+  def handle_security_group_new
+    javascript_redirect :action => "new"
   end
 end

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -17,11 +17,10 @@ class SecurityGroupController < ApplicationController
   menu_section :net
 
   def button
-    @edit = session[:edit] # Restore @edit for adv search box
-    params[:display] = @display if %w(vms instances images).include?(@display)
-    params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
-
-    @refresh_div = "main_div"
+    restore_edit_for_search
+    copy_sub_item_display_value_to_params
+    save_current_page_for_refresh
+    set_default_refresh_div
 
     case params[:pressed]
     when "security_group_tag"
@@ -33,11 +32,10 @@ class SecurityGroupController < ApplicationController
     else
       if params[:pressed] == "security_group_new"
         javascript_redirect :action => "new"
-      elsif !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
-        replace_gtl_main_div
-      else
-        render_flash
+        return
       end
+
+      button_render_fallback
     end
   end
 

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -16,7 +16,6 @@ class ServiceController < ApplicationController
 
   def button
     custom_buttons if params[:pressed] == "custom_button"
-    return if ["custom_button"].include?(params[:pressed])    # custom button screen, so return, let custom_buttons method handle everything
   end
 
   def x_button

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -94,15 +94,9 @@ class StorageController < ApplicationController
     @lastaction = "show"
   end
 
-
-  # handle buttons pressed on the button bar
+  # FIXME: Might be similar enough to GenericButtonMixin#button
   def button
-    restore_edit_for_search
-    copy_sub_item_display_value_to_params
-    set_default_refresh_div
-
-    handle_tag_presses(params[:pressed]) { return if @flash_array.nil? }
-    handle_host_power_press(params[:pressed])
+    generic_button_setup
 
     handle_button_pressed(params[:pressed]) do |pressed|
       return unless pressed == "host_check_compliance"

--- a/app/controllers/storage_manager_controller.rb
+++ b/app/controllers/storage_manager_controller.rb
@@ -10,9 +10,7 @@ class StorageManagerController < ApplicationController
 
   # handle buttons pressed on the button bar
   def button
-    restore_edit_for_search
-    save_current_page_for_refresh
-    set_default_refresh_div
+    generic_button_setup
 
     handle_button_pressed(params[:pressed])
 
@@ -488,6 +486,23 @@ class StorageManagerController < ApplicationController
   def handle_storage_manager_delete
     deletesms
     redirect_to_retire_screen_if_single_delete
+  end
+
+  def storage_manager_javascript_redirect
+    if button_has_redirect_suffix?(params[:pressed])
+      js_redirect_with_redirect_controller_or_partial
+      return
+    end
+
+    if button_replace_gtl_main?
+      replace_gtl_main_div
+    elsif refreshing_flash_msg?
+      javascript_flash
+    else
+      render_update_with_prologue do |page|
+        replace_refresh_div_contents_with_partial(page)
+      end
+    end
   end
 
   menu_section :nap

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -15,11 +15,13 @@ module VmCommon
     helper_method :textual_group_list
   end
 
+  include Mixins::GenericButtonMixin
+
   # handle buttons pressed on the button bar
   def button
-    @edit = session[:edit]                                  # Restore @edit for adv search box
-    params[:page] = @current_page unless @current_page.nil?   # Save current page for list refresh
-    @refresh_div = "main_div" # Default div for button.rjs to refresh
+    restore_edit_for_search
+    save_current_page_for_refresh
+    set_default_refresh_div
 
     case params[:pressed]
     when 'custom_button'
@@ -35,44 +37,8 @@ module VmCommon
       remove_service
     end
 
-    if @flash_array.nil? # if no button handler ran, show not implemented msg
-      add_flash(_("Button not yet implemented"), :error)
-      @refresh_partial = "layouts/flash_msg"
-      @refresh_div = "flash_msg_div"
-    else    # Figure out what was showing to refresh it
-      if @lastaction == "show" && ["vmtree"].include?(@showtype)
-        @refresh_partial = @showtype
-      elsif @lastaction == "show" && ["config"].include?(@showtype)
-        @refresh_partial = @showtype
-      elsif @lastaction == "show_list"
-        # default to the gtl_type already set
-      else
-        @refresh_partial = "layouts/flash_msg"
-        @refresh_div = "flash_msg_div"
-      end
-    end
-    @vm = @record = identify_record(params[:id], VmOrTemplate) unless @lastaction == "show_list"
-
-    if !@flash_array.nil? && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
-    elsif params[:pressed].ends_with?("_edit")
-      if @redirect_controller
-        javascript_redirect :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id, :org_controller => @org_controller
-      else
-        javascript_redirect :action => @refresh_partial, :id => @redirect_id
-      end
-    else
-      if @refresh_div == "main_div" && @lastaction == "show_list"
-        replace_gtl_main_div
-      else
-        if @refresh_div == "flash_msg_div"
-          javascript_flash(:spinner_off => true)
-        else
-          options
-          partial_replace(@refresh_div, "vm_common/#{@refresh_partial}")
-        end
-      end
-    end
+    check_if_button_is_implemented
+    vm_common_javascript_redirect
   end
 
   # to reload currently displayed summary screen in explorer

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -23,19 +23,9 @@ module VmCommon
     save_current_page_for_refresh
     set_default_refresh_div
 
-    case params[:pressed]
-    when 'custom_button'
-      custom_buttons
-      return
-    when 'perf_reload'
-      perf_chart_chooser
-      # VM sub-screen is showing, so return
-      return if @flash_array.nil?
-    when 'perf_refresh'
-      perf_refresh_data
-    when 'remove_service'
-      remove_service
-    end
+    handle_button_pressed(params[:pressed])
+
+    return if performed?
 
     check_if_button_is_implemented
     vm_common_javascript_redirect
@@ -1755,5 +1745,26 @@ module VmCommon
 
   def breadcrumb_prohibited_for_action?
     !%w(accordion_select explorer tree_select).include?(action_name)
+  end
+
+  def handled_buttons
+    %w(
+      custom_button
+      perf_reload
+      perf_refresh
+      remove_service
+    )
+  end
+
+  def handle_perf_reload
+    perf_chart_chooser
+  end
+
+  def handle_perf_refresh
+    perf_refresh_data
+  end
+
+  def handle_remove_service
+    remove_service
   end
 end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1767,4 +1767,23 @@ module VmCommon
   def handle_remove_service
     remove_service
   end
+
+  def vm_common_javascript_redirect
+    redirect_to_retire_screen_if_single_delete
+
+    if params[:pressed].ends_with?("_edit")
+      js_redirect_with_redirect_controller_or_partial
+
+      return
+    end
+
+    if button_replace_gtl_main?
+      replace_gtl_main_div
+    elsif refreshing_flash_msg?
+      javascript_flash(:spinner_off => true)
+    else
+      options
+      partial_replace(@refresh_div, "vm_common/#{@refresh_partial}")
+    end
+  end
 end

--- a/spec/controllers/auth_key_pair_cloud_controller_spec.rb
+++ b/spec/controllers/auth_key_pair_cloud_controller_spec.rb
@@ -1,13 +1,33 @@
 describe AuthKeyPairCloudController do
-  context "#button" do
-    before(:each) do
-      stub_user(:features => :all)
+  let(:user) { stub_user(:features => :all) }
+
+  describe "#button" do
+    let(:pair) { FactoryGirl.create(:auth_key_pair_cloud, :name => "auth-key-pair-cloud-00") }
+
+    before do
       EvmSpecHelper.create_guid_miq_server_zone
+      allow(pair).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+    end
+
+    it "builds tagging screen" do
+      expect(controller).to receive(:tag)
+      post :button, :params => { :pressed => "auth_key_pair_cloud_tag", :format => :js, :id => pair.id }
+      expect(assigns(:flash_array)).to be_nil
+      expect(response.status).to eq(200)
+    end
+
+    it 'handles auth_key_pair_cloud_delete' do
+      expect(controller).to receive(:handle_auth_key_pair_cloud_delete)
+      post :button, :params => { :pressed => "auth_key_pair_cloud_delete", :format => :js, :id => pair.id }
+    end
+
+    it 'handles auth_key_pair_cloud_new' do
+      expect(controller).to receive(:handle_auth_key_pair_cloud_new)
+      post :button, :params => { :pressed => "auth_key_pair_cloud_new", :format => :js, :id => pair.id }
     end
   end
 
   context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       @kp = FactoryGirl.create(:auth_key_pair_cloud, :name => "auth-key-pair-cloud-01")
@@ -33,11 +53,6 @@ describe AuthKeyPairCloudController do
 
     after(:each) do
       expect(response.status).to eq(200)
-    end
-
-    it "builds tagging screen" do
-      post :button, :params => { :pressed => "auth_key_pair_cloud_tag", :format => :js, :id => @kp.id }
-      expect(assigns(:flash_array)).to be_nil
     end
 
     it "cancels tags edit" do

--- a/spec/controllers/availability_zone_controller_spec.rb
+++ b/spec/controllers/availability_zone_controller_spec.rb
@@ -1,24 +1,49 @@
 describe AvailabilityZoneController do
+  let(:zone) { FactoryGirl.create(:availability_zone) }
+  let(:user) { stub_user(:features => :all) }
+
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @zone = FactoryGirl.create(:availability_zone)
-      login_as FactoryGirl.create(:user_admin)
+      login_as user
     end
 
     subject do
-      get :show, :params => {:id => @zone.id}
+      get :show, :params => {:id => zone.id}
     end
 
     context "render listnav partial" do
       render_views
 
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_availability_zone")
-      end
+      it { is_expected.to have_http_status 200 }
+      it { is_expected.to render_template(:partial => "layouts/listnav/_availability_zone") }
     end
   end
 
   include_examples '#download_summary_pdf', :availability_zone
+
+  describe "#button" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as user
+    end
+
+    context "when tag button is pressed" do
+      let(:pressed) { "availability_zone_tag" }
+
+      subject do
+        post :button, :params => { :id => zone.id, :pressed => pressed, :format => :js }
+      end
+
+      it { is_expected.to have_http_status 200 }
+    end
+
+    context 'when control of sub item is transferred' do
+      it 'processes the sub item and returns nothing' do
+        expect(controller).to receive(:process_vm_buttons)
+        post :button, :params => { :id => zone.id, :pressed => "vm_protect", :format => :js }
+        expect(response).to have_http_status 204
+      end
+    end
+  end
 end

--- a/spec/controllers/availability_zone_controller_spec.rb
+++ b/spec/controllers/availability_zone_controller_spec.rb
@@ -29,18 +29,15 @@ describe AvailabilityZoneController do
     end
 
     context "when tag button is pressed" do
-      let(:pressed) { "availability_zone_tag" }
-
-      subject do
-        post :button, :params => { :id => zone.id, :pressed => pressed, :format => :js }
+      it 'handles tag press' do
+        expect(controller).to receive(:tag)
+        post :button, :params => { :id => zone.id, :pressed => "availability_zone_tag", :format => :js }
       end
-
-      it { is_expected.to have_http_status 200 }
     end
 
     context 'when control of sub item is transferred' do
       it 'processes the sub item and returns nothing' do
-        expect(controller).to receive(:process_vm_buttons)
+        expect(controller).to receive(:process_vm_buttons).with('vm') { true }
         post :button, :params => { :id => zone.id, :pressed => "vm_protect", :format => :js }
         expect(response).to have_http_status 204
       end

--- a/spec/controllers/cloud_object_store_container_controller_spec.rb
+++ b/spec/controllers/cloud_object_store_container_controller_spec.rb
@@ -1,27 +1,39 @@
 describe CloudObjectStoreContainerController do
+  let!(:user) { stub_user(:features => :all) }
+  let(:container) { FactoryGirl.create(:cloud_object_store_container, :name => "cloud-object-store-container-01") }
+
   before do
     EvmSpecHelper.create_guid_miq_server_zone
-    @container = FactoryGirl.create(:cloud_object_store_container, :name => "cloud-object-store-container-01")
+    # FIXME: kill allow_any_instance_of
     allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(true)
   end
 
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
+  describe "#button" do
+    it "handles the cloud_object_store_container_tag pressed" do
+      expect(controller).to receive(:tag).with(CloudObjectStoreContainer)
+      post :button, :pressed => "cloud_object_store_container_tag", :format => :js, :id => container.id
+      expect(assigns(:flash_array)).to be_nil
+    end
+  end
+
+  describe "#tagging_edit" do
     before(:each) do
-      allow(@container).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
+      EvmSpecHelper.create_guid_miq_server_zone
+      allow(container).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
+
       @tag1 = FactoryGirl.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
       @tag2 = FactoryGirl.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@container).and_return([@tag1, @tag2])
+      allow(Classification).to receive(:find_assigned_entries).with(container).and_return([@tag1, @tag2])
       session[:tag_db] = "CloudObjectStoreContainer"
       edit = {
-        :key        => "CloudObjectStoreContainer_edit_tags__#{@container.id}",
+        :key        => "CloudObjectStoreContainer_edit_tags__#{container.id}",
         :tagging    => "CloudObjectStoreContainer",
-        :object_ids => [@container.id],
+        :object_ids => [container.id],
         :current    => {:assignments => []},
         :new        => {:assignments => [@tag1.id, @tag2.id]}
       }
@@ -32,21 +44,16 @@ describe CloudObjectStoreContainerController do
       expect(response.status).to eq(200)
     end
 
-    it "builds tagging screen" do
-      post :button, :pressed => "cloud_object_store_container_tag", :format => :js, :id => @container.id
-      expect(assigns(:flash_array)).to be_nil
-    end
-
     it "cancels tags edit" do
-      session[:breadcrumbs] = [{:url => "cloud_object_store_container/show/#{@container.id}"}, 'placeholder']
-      post :tagging_edit, :button => "cancel", :format => :js, :id => @container.id
+      session[:breadcrumbs] = [{:url => "cloud_object_store_container/show/#{container.id}"}, 'placeholder']
+      post :tagging_edit, :button => "cancel", :format => :js, :id => container.id
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
       expect(assigns(:edit)).to be_nil
     end
 
     it "save tags" do
-      session[:breadcrumbs] = [{:url => "cloud_object_store_container/show/#{@container.id}"}, 'placeholder']
-      post :tagging_edit, :button => "save", :format => :js, :id => @container.id
+      session[:breadcrumbs] = [{:url => "cloud_object_store_container/show/#{container.id}"}, 'placeholder']
+      post :tagging_edit, :button => "save", :format => :js, :id => container.id
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
     end
@@ -62,7 +69,7 @@ describe CloudObjectStoreContainerController do
     it "delete invokes process_cloud_object_storage_buttons" do
       expect(controller).to receive(:process_cloud_object_storage_buttons)
       post :button, :params => {
-        :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
+        :pressed => "cloud_object_store_container_delete", :format => :js, :id => container.id
       }
     end
 
@@ -72,7 +79,7 @@ describe CloudObjectStoreContainerController do
         'delete'
       )
       post :button, :params => {
-        :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
+        :pressed => "cloud_object_store_container_delete", :format => :js, :id => container.id
       }
     end
 
@@ -83,13 +90,13 @@ describe CloudObjectStoreContainerController do
         :flash_error => false
       )
       post :button, :params => {
-        :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
+        :pressed => "cloud_object_store_container_delete", :format => :js, :id => container.id
       }
     end
 
     it "delete shows expected flash" do
       post :button, :params => {
-        :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
+        :pressed => "cloud_object_store_container_delete", :format => :js, :id => container.id
       }
 
       expect(assigns(:flash_array).first[:message]).to include(
@@ -99,10 +106,10 @@ describe CloudObjectStoreContainerController do
     end
 
     it "delete shows expected flash (non-existing container)" do
-      @container.destroy
+      container.destroy
 
       post :button, :params => {
-        :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
+        :pressed => "cloud_object_store_container_delete", :format => :js, :id => container.id
       }
 
       expect(assigns(:flash_array).first[:message]).to include(

--- a/spec/controllers/cloud_object_store_object_controller_spec.rb
+++ b/spec/controllers/cloud_object_store_object_controller_spec.rb
@@ -8,11 +8,20 @@ describe CloudObjectStoreObjectController do
     FactoryGirl.create(:cloud_object_store_object)
   end
 
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
+  let!(:user) { stub_user(:features => :all) }
+
+  describe "#button" do
+    it "handles the cloud_object_store_object_tag pressed" do
+      expect(controller).to receive(:tag).with(CloudObjectStoreObject)
+      post :button, :pressed => "cloud_object_store_object_tag", :format => :js, :id => object.id
+      expect(assigns(:flash_array)).to be_nil
+    end
+  end
+
+  describe "#tagging_edit" do
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
-      @object = FactoryGirl.create(:cloud_object_store_object, :name => "cloud-object-store-container-01")
+      @object = FactoryGirl.create(:cloud_object_store_object, :name => "cloud-object-store-object-01")
       allow(@object).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
       @tag1 = FactoryGirl.create(:classification_tag,
@@ -21,7 +30,7 @@ describe CloudObjectStoreObjectController do
       @tag2 = FactoryGirl.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@container).and_return([@tag1, @tag2])
+      allow(Classification).to receive(:find_assigned_entries).with(@object).and_return([@tag1, @tag2])
       session[:tag_db] = "CloudObjectStoreObject"
       edit = {
         :key        => "CloudObjectStoreObject_edit_tags__#{@object.id}",
@@ -35,11 +44,6 @@ describe CloudObjectStoreObjectController do
 
     after(:each) do
       expect(response.status).to eq(200)
-    end
-
-    it "builds tagging screen" do
-      post :button, :pressed => "cloud_object_store_object_tag", :format => :js, :id => @object.id
-      expect(assigns(:flash_array)).to be_nil
     end
 
     it "cancels tags edit" do

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -1,31 +1,49 @@
 describe CloudTenantController do
-  context "#button" do
-    before(:each) do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
+  let(:user)   { stub_user(:features => :all) }
+  let(:tenant) { FactoryGirl.create(:cloud_tenant, :name => "cloud-tenant-01") }
+  let(:ems)    { FactoryGirl.create(:ems_openstack) }
 
-      ApplicationController.handle_exceptions = true
-    end
+  before do
+    login_as user
+    EvmSpecHelper.create_guid_miq_server_zone
+  end
 
-    it "when Instance Retire button is pressed" do
+  describe "#button" do
+    it "handles instance_retire" do
       expect(controller).to receive(:retirevms).once
       post :button, :params => { :pressed => "instance_retire", :format => :js }
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
-    it "when Instance Tag is pressed" do
+    it "handles instance_tag pressed" do
       expect(controller).to receive(:tag).with(VmOrTemplate)
       post :button, :params => { :pressed => "instance_tag", :format => :js }
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
+
+    it "handles cloud_tenant_tag" do
+      expect(controller).to receive(:tag).with(CloudTenant)
+      post :button, :params => { :pressed => "cloud_tenant_tag", :format => :js, :id => tenant.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    it "handles cloud_tenant_edit" do
+      expect(controller).to receive(:handle_cloud_tenant_edit)
+      post :button, :params => { :pressed => "cloud_tenant_edit", :format => :js, :id => tenant.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    it "handles cloud_tenant_new" do
+      expect(controller).to receive(:handle_cloud_tenant_new)
+      post :button, :params => { :pressed => "cloud_tenant_new", :format => :js }
+      expect(assigns(:flash_array)).to be_nil
+    end
   end
 
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
-    before(:each) do
+  describe "#tagging_edit" do
+    before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @ct = FactoryGirl.create(:cloud_tenant, :name => "cloud-tenant-01")
-      allow(@ct).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+      allow(tenant).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
       @tag1 = FactoryGirl.create(:classification_tag,
                                  :name   => "tag1",
@@ -33,51 +51,40 @@ describe CloudTenantController do
       @tag2 = FactoryGirl.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@ct).and_return([@tag1, @tag2])
+      allow(Classification).to receive(:find_assigned_entries).with(tenant).and_return([@tag1, @tag2])
       session[:tag_db] = "CloudTenant"
       edit = {
-        :key        => "CloudTenant_edit_tags__#{@ct.id}",
+        :key        => "CloudTenant_edit_tags__#{tenant.id}",
         :tagging    => "CloudTenant",
-        :object_ids => [@ct.id],
+        :object_ids => [tenant.id],
         :current    => {:assignments => []},
         :new        => {:assignments => [@tag1.id, @tag2.id]}
       }
       session[:edit] = edit
     end
 
-    after(:each) do
+    after do
       expect(response.status).to eq(200)
     end
 
-    it "builds tagging screen" do
-      post :button, :params => { :pressed => "cloud_tenant_tag", :format => :js, :id => @ct.id }
-      expect(assigns(:flash_array)).to be_nil
-    end
-
     it "cancels tags edit" do
-      session[:breadcrumbs] = [{:url => "cloud_tenant/show/#{@ct.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @ct.id }
+      session[:breadcrumbs] = [{:url => "cloud_tenant/show/#{tenant.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => tenant.id }
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
       expect(assigns(:edit)).to be_nil
     end
 
     it "save tags" do
-      session[:breadcrumbs] = [{:url => "cloud_tenant/show/#{@ct.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @ct.id }
+      session[:breadcrumbs] = [{:url => "cloud_tenant/show/#{tenant.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => tenant.id }
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
     end
   end
 
   describe "#show" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @tenant = FactoryGirl.create(:cloud_tenant)
-      login_as FactoryGirl.create(:user)
-    end
-
     subject do
-      get :show, :params => {:id => @tenant.id}
+      get :show, :params => {:id => tenant.id}
     end
 
     context "render listnav partial" do
@@ -90,115 +97,89 @@ describe CloudTenantController do
   end
 
   describe "#create" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @tenant = FactoryGirl.create(:cloud_tenant_openstack)
+    let(:tenant) { FactoryGirl.create(:cloud_tenant_openstack) }
+
+    let(:task_options) do
+      {
+        :action => "creating Cloud Tenant for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#create" do
-      let(:task_options) do
-        {
-          :action => "creating Cloud Tenant for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => CloudTenant.class_by_ems(@ems),
-          :method_name => "create_cloud_tenant",
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@ems.id, {:name => "foo" }]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => CloudTenant.class_by_ems(ems),
+        :method_name => "create_cloud_tenant",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [ems.id, {:name => "foo" }]
+      }
+    end
 
-      it "builds create screen" do
-        post :button, :params => { :pressed => "cloud_tenant_new", :format => :js }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the create action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => @ems.id }
-      end
+    it "queues the create action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => ems.id }
     end
   end
 
-  describe "#edit" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @tenant = FactoryGirl.create(:cloud_tenant_openstack,
-                                   :ext_management_system => @ems)
+  describe "#update" do
+    let(:task_options) do
+      {
+        :action => "updating Cloud Tenant for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#edit" do
-      let(:task_options) do
-        {
-          :action => "updating Cloud Tenant for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @tenant.class.name,
-          :method_name => "update_cloud_tenant",
-          :instance_id => @tenant.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [{:name => "foo"}]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => tenant.class.name,
+        :method_name => "update_cloud_tenant",
+        :instance_id => tenant.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [{:name => "foo"}]
+      }
+    end
 
-      it "builds edit screen" do
-        post :button, :params => { :pressed => "cloud_tenant_edit", :format => :js, :id => @tenant.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
+    let(:tenant) do
+      FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems)
+    end
 
-      it "queues the update action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :update, :params => { :button => "save", :format => :js, :id => @tenant.id, :name => "foo" }
-      end
+    it "queues the update action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :update, :params => { :button => "save", :format => :js, :id => tenant.id, :name => "foo" }
     end
   end
 
-  describe "#delete" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @tenant = FactoryGirl.create(:cloud_tenant_openstack,
-                                   :ext_management_system => @ems)
+  describe "deleting" do
+    let(:tenant) do
+      FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems)
     end
 
-    context "#edit" do
-      let(:task_options) do
-        {
-          :action => "deleting Cloud Tenant for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @tenant.class.name,
-          :method_name => "delete_cloud_tenant",
-          :instance_id => @tenant.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => []
-        }
-      end
+    let(:task_options) do
+      {
+        :action => "deleting Cloud Tenant for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
 
-      it "queues the delete action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :button, :params => { :id => @tenant.id, :pressed => "cloud_tenant_delete", :format => :js }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => tenant.class.name,
+        :method_name => "delete_cloud_tenant",
+        :instance_id => tenant.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => []
+      }
+    end
+
+    it "queues the delete action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :button, :params => { :id => tenant.id, :pressed => "cloud_tenant_delete", :format => :js }
     end
   end
 

--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -1,177 +1,174 @@
 describe CloudVolumeController do
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
-    before(:each) do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @volume = FactoryGirl.create(:cloud_volume, :name => "cloud-volume-01")
-      allow(@volume).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag1",
-                                 :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag2",
-                                 :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@volume).and_return([@tag1, @tag2])
+  let!(:user)  { stub_user(:features => :all) }
+
+  let(:volume) do
+    FactoryGirl.create(:cloud_volume_openstack, :name => "cloud-volume-01", :ext_management_system => ems)
+  end
+
+  let(:ems)    { FactoryGirl.create(:ems_openstack) }
+  let(:backup) { FactoryGirl.create(:cloud_volume_backup) }
+
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
+  end
+
+  describe "#button" do
+    %w(
+      cloud_volume_backup_create
+      cloud_volume_delete
+      cloud_volume_attach
+      cloud_volume_detach
+      cloud_volume_edit
+      cloud_volume_snapshot_create
+      cloud_volume_new
+      cloud_volume_backup_restore
+    ).each do |pressed|
+      it "handles #{pressed}" do
+        expect(controller).to receive("handle_#{pressed}".to_sym)
+        post :button, :params => { :pressed => pressed, :format => :js, :id => volume.id }
+        expect(assigns(:flash_array)).to be_nil
+      end
+    end
+
+    it "handles cloud_volume_tag" do
+      expect(controller).to receive(:tag)
+      post :button, :params => {:pressed => "cloud_volume_tag", :format => :js, :id => volume.id}
+      expect(assigns(:flash_array)).to be_nil
+    end
+  end
+
+  describe "#tagging_edit" do
+    let(:classification) do
+      FactoryGirl.create(:classification, :name => "department", :description => "Department")
+    end
+
+    let(:tag1) do
+      FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification)
+    end
+
+    let(:tag2) do
+      FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification)
+    end
+
+    before do
+      allow(volume).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+      allow(Classification).to receive(:find_assigned_entries).with(volume).and_return([tag1, tag2])
       session[:tag_db] = "CloudVolume"
       edit = {
-        :key        => "CloudVolume_edit_tags__#{@volume.id}",
+        :key        => "CloudVolume_edit_tags__#{volume.id}",
         :tagging    => "CloudVolume",
-        :object_ids => [@volume.id],
+        :object_ids => [volume.id],
         :current    => {:assignments => []},
-        :new        => {:assignments => [@tag1.id, @tag2.id]}
+        :new        => {:assignments => [tag1.id, tag2.id]}
       }
       session[:edit] = edit
     end
 
-    after(:each) do
+    after do
       expect(response.status).to eq(200)
     end
 
-    it "builds tagging screen" do
-      post :button, :params => {:pressed => "cloud_volume_tag", :format => :js, :id => @volume.id}
-      expect(assigns(:flash_array)).to be_nil
-    end
-
     it "cancels tags edit" do
-      session[:breadcrumbs] = [{:url => "cloud_volume/show/#{@volume.id}"}, 'placeholder']
-      post :tagging_edit, :params => {:button => "cancel", :format => :js, :id => @volume.id}
+      session[:breadcrumbs] = [{:url => "cloud_volume/show/#{volume.id}"}, 'placeholder']
+      post :tagging_edit, :params => {:button => "cancel", :format => :js, :id => volume.id}
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
       expect(assigns(:edit)).to be_nil
     end
 
     it "save tags" do
-      session[:breadcrumbs] = [{:url => "cloud_volume/show/#{@volume.id}"}, 'placeholder']
-      post :tagging_edit, :params => {:button => "save", :format => :js, :id => @volume.id}
+      session[:breadcrumbs] = [{:url => "cloud_volume/show/#{volume.id}"}, 'placeholder']
+      post :tagging_edit, :params => {:button => "save", :format => :js, :id => volume.id}
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
     end
   end
 
   describe "#create_backup" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @volume = FactoryGirl.create(:cloud_volume_openstack,
-                                   :name                  => "cloud-volume-01",
-                                   :ext_management_system => @ems)
-      @backup = FactoryGirl.create(:cloud_volume_backup)
+    let(:task_options) do
+      {
+        :action => "creating Cloud Volume Backup for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#create_backup" do
-      let(:task_options) do
-        {
-          :action => "creating Cloud Volume Backup for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @volume.class.name,
-          :method_name => "backup_create",
-          :instance_id => @volume.id,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [{:name => "backup_name"}]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => volume.class.name,
+        :method_name => "backup_create",
+        :instance_id => volume.id,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [{:name => "backup_name"}]
+      }
+    end
 
-      it "builds create backup screen" do
-        post :button, :params => { :pressed => "cloud_volume_backup_create", :format => :js, :id => @volume.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the create cloud backup action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :backup_create, :params => { :button => "create",
-          :format => :js, :id => @volume.id, :backup_name => 'backup_name' }
-      end
+    it "queues the create cloud backup action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :backup_create, :params => { :button => "create",
+        :format => :js, :id => volume.id, :backup_name => 'backup_name' }
     end
   end
 
   describe "#restore_backup" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @volume = FactoryGirl.create(:cloud_volume_openstack,
-                                   :name                  => "cloud-volume-01",
-                                   :ext_management_system => @ems)
-      @backup = FactoryGirl.create(:cloud_volume_backup)
+    let(:task_options) do
+      {
+        :action => "restoring Cloud Volume from Backup for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#restore_backup" do
-      let(:task_options) do
-        {
-          :action => "restoring Cloud Volume from Backup for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @volume.class.name,
-          :method_name => "backup_restore",
-          :instance_id => @volume.id,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@backup.ems_ref]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => volume.class.name,
+        :method_name => "backup_restore",
+        :instance_id => volume.id,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [backup.ems_ref]
+      }
+    end
 
-      it "builds restore backup screen" do
-        post :button, :params => { :pressed => "cloud_volume_backup_restore", :format => :js, :id => @volume.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
+    it "builds restore backup screen" do
+      post :button, :params => { :pressed => "cloud_volume_backup_restore", :format => :js, :id => volume.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      it "queues restore from a cloud backup action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :backup_restore, :params => { :button => "restore",
-          :format => :js, :id => @volume.id, :backup_id => @backup.id }
-      end
+    it "queues restore from a cloud backup action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :backup_restore, :params => { :button => "restore",
+        :format => :js, :id => volume.id, :backup_id => backup.id }
     end
   end
 
   describe "#create_snapshot" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @volume = FactoryGirl.create(:cloud_volume_openstack,
-                                   :name                  => "cloud-volume-01",
-                                   :ext_management_system => @ems)
-      @snapshot = FactoryGirl.create(:cloud_volume_snapshot)
+    let(:task_options) do
+      {
+        :action => "creating volume snapshot in #{ems.inspect} for #{volume.inspect} with #{{:name => "snapshot_name"}.inspect}",
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#create_snapshot" do
-      let(:task_options) do
-        {
-          :action => "creating volume snapshot in #{@ems.inspect} for #{@volume.inspect} with #{{:name => "snapshot_name"}.inspect}",
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @volume.class.name,
-          :instance_id => @volume.id,
-          :method_name => 'create_volume_snapshot',
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => [{:name => "snapshot_name"}]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => volume.class.name,
+        :instance_id => volume.id,
+        :method_name => 'create_volume_snapshot',
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => [{:name => "snapshot_name"}]
+      }
+    end
 
-      it "builds create snapshot screen" do
-        post :button, :params => { :pressed => "cloud_volume_snapshot_create", :format => :js, :id => @volume.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
+    it "builds create snapshot screen" do
+      post :button, :params => { :pressed => "cloud_volume_snapshot_create", :format => :js, :id => volume.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      it "queues the create cloud snapshot action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :snapshot_create, :params => { :button => "create",
-          :format => :js, :id => @volume.id, :snapshot_name => 'snapshot_name' }
-      end
+    it "queues the create cloud snapshot action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :snapshot_create, :params => { :button => "create",
+        :format => :js, :id => volume.id, :snapshot_name => 'snapshot_name' }
     end
   end
 

--- a/spec/controllers/cloud_volume_snapshot_controller_spec.rb
+++ b/spec/controllers/cloud_volume_snapshot_controller_spec.rb
@@ -1,6 +1,7 @@
 describe CloudVolumeSnapshotController do
+  let!(:user) { stub_user(:features => :all) }
+
   context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       @snapshot = FactoryGirl.create(:cloud_volume_snapshot, :name => "cloud-volume-snapshot-01")
@@ -49,37 +50,38 @@ describe CloudVolumeSnapshotController do
   end
 
   describe "#delete" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @snapshot = FactoryGirl.create(:cloud_volume_snapshot_openstack,
-                                     :ext_management_system => @ems)
+    let(:ems) { FactoryGirl.create(:ems_openstack) }
+
+    let(:snapshot) do
+      FactoryGirl.create(:cloud_volume_snapshot_openstack, :ext_management_system => ems)
     end
 
-    context "#delete" do
-      let(:task_options) do
-        {
-          :action => "deleting volume snapshot #{@snapshot.inspect} in #{@ems.inspect}",
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @snapshot.class.name,
-          :instance_id => @snapshot.id,
-          :method_name => 'delete_snapshot',
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => []
-        }
-      end
+    let(:task_options) do
+      {
+        :action => "deleting volume snapshot #{snapshot.inspect} in #{ems.inspect}",
+        :userid => controller.current_user.userid
+      }
+    end
 
-      it "queues the delete action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :button, :params => { :id => @snapshot.id, :pressed => "cloud_volume_snapshot_delete", :format => :js }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => snapshot.class.name,
+        :instance_id => snapshot.id,
+        :method_name => 'delete_snapshot',
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => []
+      }
+    end
+
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
+
+    it "queues the delete action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :button, :params => { :id => snapshot.id, :pressed => "cloud_volume_snapshot_delete", :format => :js }
     end
   end
 end

--- a/spec/controllers/configuration_controller_spec.rb
+++ b/spec/controllers/configuration_controller_spec.rb
@@ -35,4 +35,42 @@ describe ConfigurationController do
                                    ])
     end
   end
+
+  describe "#button" do
+    let(:time_profile) { FactoryGirl.create(:time_profile) }
+
+    before do
+      stub_user(:features => :all)
+    end
+
+    it 'handles tp_delete' do
+      expect(controller).to receive(:handle_tp_delete).and_call_original
+      post :button, :params => {
+        :pressed => "tp_delete",
+        :format => :js,
+        "check_#{time_profile.id}".to_sym => 1
+      }
+      expect(assigns(:flash_array).first[:message]).to match(/Delete successful/)
+    end
+
+    it 'handles tp_edit' do
+      expect(controller).to receive(:handle_tp_edit).and_call_original
+      post :button, :params => {
+        :pressed => "tp_edit",
+        :format => :js,
+        "check_#{time_profile.id}".to_sym => 1
+      }
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    it 'handles tp_copy' do
+      expect(controller).to receive(:handle_tp_copy).and_call_original
+      post :button, :params => {
+        :pressed => "tp_copy",
+        :format => :js,
+        "check_#{time_profile.id}".to_sym => 1
+      }
+      expect(assigns(:flash_array)).to be_nil
+    end
+  end
 end

--- a/spec/controllers/configuration_job_controller_spec.rb
+++ b/spec/controllers/configuration_job_controller_spec.rb
@@ -2,8 +2,9 @@ describe ConfigurationJobController do
   include CompressedIds
 
   let!(:user) { stub_user(:features => :all) }
+  let(:job)   { FactoryGirl.create(:ansible_tower_job, :name => "testJob") }
 
-  before(:each) do
+  before do
     EvmSpecHelper.create_guid_miq_server_zone
   end
 
@@ -11,12 +12,9 @@ describe ConfigurationJobController do
 
   describe '#show' do
     context "instances" do
-      let(:record) { FactoryGirl.create(:ansible_tower_job) }
-
       before do
-        session[:settings] = {
-        }
-        get :show, :params => {:id => record.id}
+        session[:settings] = {}
+        get :show, :params => {:id => job.id}
       end
 
       it "renders the listnav" do
@@ -31,59 +29,70 @@ describe ConfigurationJobController do
           opt
         end
 
-        url_for_options = url_for_db(quadicon_model_name(record), "show", record)
+        url_for_options = url_for_db(quadicon_model_name(job), "show", job)
 
         expect(url_for_options[:controller]).to eq("configuration_job")
       end
     end
   end
 
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
-    before(:each) do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @cj = FactoryGirl.create(:ansible_tower_job, :name => "testJob")
-      allow(@cj).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag1",
-                                 :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag2",
-                                 :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@cj).and_return([@tag1, @tag2])
-      session[:tag_db] = "ManageIQ::Providers::AnsibleTower::AutomationManager::Job"
-      edit = {
-        :key        => "ManageIQ::Providers::AnsibleTower::AutomationManager::Job_edit_tags__#{@cj.id}",
+  describe "#button" do
+    it "handles configuration_job_tag" do
+      expect(controller).to receive(:tag).and_call_original
+      post :button, :params => { :pressed => "configuration_job_tag", :format => :js, :id => job.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    it "handles configuration_job_delete" do
+      expect(controller).to receive(:handle_configuration_job_delete)
+      post :button, :params => { :pressed => "configuration_job_delete", :format => :js, :id => job.id }
+    end
+  end
+
+  describe "#tagging_edit" do
+    let(:classification) do
+      FactoryGirl.create(:classification, :name => "department", :description => "Department")
+    end
+
+    let(:tag1) do
+      FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification)
+    end
+
+    let(:tag2) do
+      FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification)
+    end
+
+    let(:edit) do
+      {
+        :key        => "ManageIQ::Providers::AnsibleTower::AutomationManager::Job_edit_tags__#{job.id}",
         :tagging    => "ManageIQ::Providers::AnsibleTower::AutomationManager::Job",
-        :object_ids => [@cj.id],
+        :object_ids => [job.id],
         :current    => {:assignments => []},
-        :new        => {:assignments => [@tag1.id, @tag2.id]}
+        :new        => {:assignments => [tag1.id, tag2.id]}
       }
+    end
+
+    before do
+      allow(job).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+      allow(Classification).to receive(:find_assigned_entries).with(job).and_return([tag1, tag2])
+      session[:tag_db] = "ManageIQ::Providers::AnsibleTower::AutomationManager::Job"
       session[:edit] = edit
+      session[:breadcrumbs] = [{:url => "configuration_job/show/#{job.id}"}, 'placeholder']
     end
 
     after(:each) do
       expect(response.status).to eq(200)
-    end
-
-    it "builds tagging screen" do
-      post :button, :params => { :pressed => "configuration_job_tag", :format => :js, :id => @cj.id }
-      expect(assigns(:flash_array)).to be_nil
+      expect(assigns(:edit)).to be_nil
     end
 
     it "cancels tags edit" do
-      session[:breadcrumbs] = [{:url => "configuration_job/show/#{@cj.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @cj.id }
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => job.id }
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
-      expect(assigns(:edit)).to be_nil
     end
 
     it "save tags" do
-      session[:breadcrumbs] = [{:url => "configuration_job/show/#{@cj.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @cj.id }
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => job.id }
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
-      expect(assigns(:edit)).to be_nil
     end
   end
 

--- a/spec/controllers/container_build_controller_spec.rb
+++ b/spec/controllers/container_build_controller_spec.rb
@@ -57,4 +57,8 @@ describe ContainerBuildController do
     end
     controller.send(:get_view, "ContainerBuild", :gtl_dbname => :containerbuild)
   end
+
+  describe "#button" do
+    include_examples :container_button_examples, "container_build"
+  end
 end

--- a/spec/controllers/container_controller_spec.rb
+++ b/spec/controllers/container_controller_spec.rb
@@ -136,4 +136,8 @@ describe ContainerController do
       expect(response.status).to eq(200)
     end
   end
+
+  describe "#button" do
+    include_examples :container_button_examples, "container"
+  end
 end

--- a/spec/controllers/container_group_controller_spec.rb
+++ b/spec/controllers/container_group_controller_spec.rb
@@ -38,13 +38,13 @@ describe ContainerGroupController do
   end
 
   describe "#show" do
+    let(:group) { FactoryGirl.create(:container_group_with_assoc) }
+
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @container_group = FactoryGirl.create(:container_group_with_assoc)
-      login_as FactoryGirl.create(:user)
     end
 
-    subject { get :show, :id => @container_group.id }
+    subject { get :show, :params => { :id => group.id } }
 
     context "render" do
       render_views
@@ -57,4 +57,9 @@ describe ContainerGroupController do
   end
 
   include_examples '#download_summary_pdf', :container_group_with_assoc
+
+  describe "#button" do
+    render_views false
+    include_examples :container_button_examples, "container_group"
+  end
 end

--- a/spec/controllers/container_image_controller_spec.rb
+++ b/spec/controllers/container_image_controller_spec.rb
@@ -1,82 +1,76 @@
 describe ContainerImageController do
-  render_views
-  before(:each) do
-    stub_user(:features => :all)
+  let!(:user) { stub_user(:features => :all) }
+
+  describe '#index' do
+    render_views
+
+    it "renders index" do
+      get :index
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to(:action => 'show_list')
+    end
   end
 
-  it "when Smart Analysis is pressed" do
-    ApplicationController.handle_exceptions = true
+  describe "#button" do
+    include_examples :container_button_examples, "container_image"
 
-    expect(controller).to receive(:scan_images)
-    post :button, :params => { :pressed => 'container_image_scan', :format => :js }
-    expect(controller.send(:flash_errors?)).not_to be_truthy
-  end
+    it "when Smart Analysis is pressed" do
+      expect(controller).to receive(:handle_container_image_scan)
+      post :button, :params => { :pressed => "container_image_scan", :format => :js }
+      expect(controller.send(:flash_errors?)).not_to be_truthy
+    end
 
-  it "when Check Compliance is pressed with no images" do
-    ApplicationController.handle_exceptions = true
-
-    expect(controller).to receive(:check_compliance).and_call_original
-    expect(controller).to receive(:add_flash).with("Container Image no longer exists", :error)
-    expect(controller).to receive(:add_flash).with("No Container Images were selected for Compliance Check", :error)
-    post :button, :params => { :pressed => 'container_image_check_compliance', :format => :js }
-  end
-
-  it 'renders edit container image tags' do
-    ApplicationController.handle_exceptions = true
-
-    post :button, :params => {:pressed => "container_image_protect", :format => :js}
-    expect(response.status).to eq(200)
-    expect(response.body).to_not be_empty
-  end
-
-  it "renders index" do
-    get :index
-    expect(response.status).to eq(302)
-    expect(response).to redirect_to(:action => 'show_list')
-  end
-
-  it "renders show screen" do
-    EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_kubernetes)
-    container_image = ContainerImage.create(:ext_management_system => ems, :name => "Test Image")
-    get :show, :params => { :id => container_image.id }
-    expect(response.status).to eq(200)
-    expect(response.body).to_not be_empty
-    expect(assigns(:breadcrumbs)).to eq([{:name => "Container Images",
-                                          :url  => "/container_image/show_list?page=&refresh=y"},
-                                         {:name => "Test Image (Summary)",
-                                          :url  => "/container_image/show/#{container_image.id}"}])
+    it "when Check Compliance is pressed with no images" do
+      expect(controller).to receive(:check_compliance).and_call_original
+      expect(controller).to receive(:add_flash).with("Container Image no longer exists", :error)
+      expect(controller).to receive(:add_flash).with("No Container Images were selected for Compliance Check", :error)
+      post :button, :params => { :pressed => "container_image_check_compliance", :format => :js }
+    end
   end
 
   describe "#show" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      @image = FactoryGirl.create(:container_image)
+    render_views
+
+    let(:ems) { FactoryGirl.create(:ems_kubernetes) }
+
+    let(:image) do
+      FactoryGirl.create(:container_image, :name => "Test Image", :ext_management_system => ems)
     end
 
-    subject { get :show, :id => @image.id }
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
 
-    context "render" do
-      render_views
+    subject { get :show, :params => { :id => image.id } }
 
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_container_image")
-      end
+    it "renders the show screen" do
+      is_expected.to have_http_status 200
+      is_expected.to render_template(:partial => "layouts/listnav/_container_image")
+    end
+
+    it "shows the proper breadcrumbs" do
+      get :show, :params => { :id => image.id }
+      expect(assigns(:breadcrumbs)).to eq([{:name => "Container Images",
+                                            :url  => "/container_image/show_list?page=&refresh=y"},
+                                           {:name => "Test Image (Summary)",
+                                            :url  => "/container_image/show/#{image.id}"}])
     end
   end
 
-  it "renders show_list" do
-    session[:settings] = {:default_search => 'foo',
-                          :views          => {:containerimage => 'list'},
-                          :perpage        => {:list => 10}}
+  describe '#show_list' do
+    render_views
 
-    EvmSpecHelper.create_guid_miq_server_zone
+    it "renders show_list" do
+      session[:settings] = {:default_search => 'foo',
+                            :views          => {:containerimage => 'list'},
+                            :perpage        => {:list => 10}}
 
-    get :show_list
-    expect(response.status).to eq(200)
-    expect(response.body).to_not be_empty
+      EvmSpecHelper.create_guid_miq_server_zone
+
+      get :show_list
+      expect(response.status).to eq(200)
+      expect(response.body).to_not be_empty
+    end
   end
 
   include_examples '#download_summary_pdf', :container_image

--- a/spec/controllers/container_image_registry_controller_spec.rb
+++ b/spec/controllers/container_image_registry_controller_spec.rb
@@ -56,4 +56,8 @@ describe ContainerImageRegistryController do
   end
 
   include_examples '#download_summary_pdf', :container_image_registry
+
+  describe "#button" do
+    include_examples :container_button_examples, "container_image_registry"
+  end
 end

--- a/spec/controllers/container_node_controller_spec.rb
+++ b/spec/controllers/container_node_controller_spec.rb
@@ -30,7 +30,7 @@ describe ContainerNodeController do
       @node = FactoryGirl.create(:container_node)
     end
 
-    subject { get :show, :id => @node.id }
+    subject { get :show, :params => { :id => @node.id } }
 
     context "render" do
       render_views
@@ -54,4 +54,9 @@ describe ContainerNodeController do
   end
 
   include_examples '#download_summary_pdf', :container_node
+
+  describe "#button" do
+    render_views false
+    include_examples :container_button_examples, "container_node"
+  end
 end

--- a/spec/controllers/container_project_controller_spec.rb
+++ b/spec/controllers/container_project_controller_spec.rb
@@ -53,4 +53,8 @@ describe ContainerProjectController do
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
   end
+
+  describe "#button" do
+    include_examples :container_button_examples, "container_project"
+  end
 end

--- a/spec/controllers/container_replicator_controller_spec.rb
+++ b/spec/controllers/container_replicator_controller_spec.rb
@@ -34,7 +34,7 @@ describe ContainerReplicatorController do
       @replicator = FactoryGirl.create(:replicator_with_assoc)
     end
 
-    subject { get :show, :id => @replicator.id }
+    subject { get :show, :params => { :id => @replicator.id } }
 
     context "render" do
       render_views
@@ -56,5 +56,10 @@ describe ContainerReplicatorController do
     get :show_list
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
+  end
+
+  describe "#button" do
+    render_views false
+    include_examples :container_button_examples, "container_replicator"
   end
 end

--- a/spec/controllers/container_route_controller_spec.rb
+++ b/spec/controllers/container_route_controller_spec.rb
@@ -52,4 +52,8 @@ describe ContainerRouteController do
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
   end
+
+  describe "#button" do
+    include_examples :container_button_examples, "container_route"
+  end
 end

--- a/spec/controllers/container_service_controller_spec.rb
+++ b/spec/controllers/container_service_controller_spec.rb
@@ -53,4 +53,8 @@ describe ContainerServiceController do
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
   end
+
+  describe "#button" do
+    include_examples :container_button_examples, "container_service"
+  end
 end

--- a/spec/controllers/container_template_controller_spec.rb
+++ b/spec/controllers/container_template_controller_spec.rb
@@ -57,4 +57,8 @@ describe ContainerTemplateController do
     end
     controller.send(:get_view, "ContainerTemplate", :gtl_dbname => :containertemplate)
   end
+
+  describe "#button" do
+    include_examples :container_button_examples, "container_template"
+  end
 end

--- a/spec/controllers/ems_block_storage_controller_spec.rb
+++ b/spec/controllers/ems_block_storage_controller_spec.rb
@@ -1,3 +1,7 @@
 describe EmsBlockStorageController do
   include_examples :shared_examples_for_ems_block_storage_controller, %w(openstack)
+
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
 end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -3,6 +3,11 @@ describe EmsCloudController do
 
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
   let(:zone) { FactoryGirl.build(:zone) }
+
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
+
   describe "#create" do
     before do
       allow(controller).to receive(:check_privileges).and_return(true)

--- a/spec/controllers/ems_cluster_controller_spec.rb
+++ b/spec/controllers/ems_cluster_controller_spec.rb
@@ -2,12 +2,11 @@ describe EmsClusterController do
   let(:vm) { FactoryGirl.create(:vm_vmware) }
   let!(:user) { stub_user(:features => :all) }
 
-  describe 'Shared Button Examples' do
+  describe "#button" do
+    # FIXME: Test power buttons
     include_examples :host_vm_button_examples
     include_examples :ems_cluster_button_examples
-  end
 
-  describe "#button" do
     it 'handles custom_buttons' do
       expect(controller).to receive(:custom_buttons).and_call_original
       post :button, :params => { :pressed => "custom_button" }

--- a/spec/controllers/ems_cluster_controller_spec.rb
+++ b/spec/controllers/ems_cluster_controller_spec.rb
@@ -1,83 +1,42 @@
 describe EmsClusterController do
-  context "#button" do
-    it "when VM Right Size Recommendations is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_right_size")
-      expect(controller).to receive(:vm_right_size)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
+  let(:vm) { FactoryGirl.create(:vm_vmware) }
+  let!(:user) { stub_user(:features => :all) }
+
+  describe 'Shared Button Examples' do
+    include_examples :host_vm_button_examples
+    include_examples :ems_cluster_button_examples
+  end
+
+  describe "#button" do
+    it 'handles custom_buttons' do
+      expect(controller).to receive(:custom_buttons).and_call_original
+      post :button, :params => { :pressed => "custom_button" }
+      expect(assigns(:flash_array)).to be_nil
     end
 
-    it "when VM Migrate button is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_migrate")
-      controller.instance_variable_set(:@refresh_partial, "layouts/gtl")
-      expect(controller).to receive(:prov_redirect).with("migrate")
-      expect(controller).to receive(:render)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "when VM Retire button is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_retire")
-      expect(controller).to receive(:retirevms).once
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "when VM Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_protect")
-      expect(controller).to receive(:assign_policies).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "when MiqTemplate Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_protect")
-      expect(controller).to receive(:assign_policies).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "when VM Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_tag")
-      expect(controller).to receive(:tag).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "when MiqTemplate Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_tag")
-      expect(controller).to receive(:tag).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "when Host Analyze then Check Compliance is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "host_analyze_check_compliance")
-      allow(controller).to receive(:show)
-      expect(controller).to receive(:analyze_check_compliance_hosts)
-      expect(controller).to receive(:render)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
+    it 'handles common_drift' do
+      expect(controller).to receive(:drift_analysis).and_call_original
+      post :button, :params => { :pressed => "common_drift" }
+      expect(assigns(:flash_array)).to be_nil
     end
   end
 
   describe "#show" do
+    let(:cluster) { FactoryGirl.create(:ems_cluster) }
+
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @cluster = FactoryGirl.create(:ems_cluster)
-      login_as FactoryGirl.create(:user)
     end
 
     subject do
-      get :show, :params => {:id => @cluster.id}
+      get :show, :params => {:id => cluster.id}
     end
 
-    context "render" do
-      render_views
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_ems_cluster")
-      end
+    render_views
+
+    it "renders show" do
+      is_expected.to have_http_status 200
+      is_expected.to render_template(:partial => "layouts/listnav/_ems_cluster")
     end
   end
 

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'kubeclient'
 
+# Button examples moved to shared_ems_common_mixin_examples.rb
+
 describe EmsCloudController do
   context "::EmsCommon" do
     context "#get_form_vars" do
@@ -124,39 +126,6 @@ describe EmsCloudController do
           expect(controller).to receive(:render_flash)
           controller.send(:update_button_validate)
         end
-      end
-    end
-
-    context "#button" do
-      before(:each) do
-        stub_user(:features => :all)
-        EvmSpecHelper.create_guid_miq_server_zone
-      end
-
-      it "when Retire Button is pressed for a Cloud provider Instance" do
-        allow(controller).to receive(:role_allows?).and_return(true)
-        ems = FactoryGirl.create("ems_vmware")
-        vm = FactoryGirl.create(:vm_vmware,
-                                :ext_management_system => ems,
-                                :storage               => FactoryGirl.create(:storage)
-                               )
-        post :button, :params => { :pressed => "instance_retire", "check_#{vm.id}" => "1", :format => :js, :id => ems.id, :display => 'instances' }
-        expect(response.status).to eq 200
-        expect(response.body).to include('vm/retire')
-      end
-
-      it "when Retire Button is pressed for an Orchestration Stack" do
-        allow(controller).to receive(:role_allows?).and_return(true)
-        ems = FactoryGirl.create("ems_amazon")
-        ost = FactoryGirl.create(:orchestration_stack_cloud, :ext_management_system => ems)
-        post :button, :params => { :pressed => "orchestration_stack_retire", "check_#{ost.id}" => "1", :format => :js, :id => ems.id, :display => 'orchestration_stacks' }
-        expect(response.status).to eq 200
-        expect(response.body).to include('orchestration_stack/retire')
-      end
-
-      it "when Delete Button is pressed for CloudObjectStoreContainer" do
-        expect(controller).to receive(:process_cloud_object_storage_buttons)
-        post :button, :params => { :pressed => "cloud_object_store_container_delete" }
       end
     end
   end
@@ -297,38 +266,6 @@ describe EmsContainerController do
           test_setting_few_fields
           expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq('myhawkularroute.com')
         end
-      end
-    end
-
-    context "#button" do
-      before(:each) do
-        stub_user(:features => :all)
-        EvmSpecHelper.create_guid_miq_server_zone
-      end
-
-      it "when VM Migrate is pressed for unsupported type" do
-        allow(controller).to receive(:role_allows?).and_return(true)
-        vm = FactoryGirl.create(:vm_microsoft)
-        post :button, :params => { :pressed => "vm_migrate", :format => :js, "check_#{vm.id}" => "1" }
-        expect(controller.send(:flash_errors?)).to be_truthy
-        expect(assigns(:flash_array).first[:message]).to include('does not apply')
-      end
-
-      let(:ems)     { FactoryGirl.create(:ext_management_system) }
-      let(:storage) { FactoryGirl.create(:storage) }
-
-      it "when VM Migrate is pressed for supported type" do
-        allow(controller).to receive(:role_allows?).and_return(true)
-        vm = FactoryGirl.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
-        post :button, :params => { :pressed => "vm_migrate", :format => :js, "check_#{vm.id}" => "1" }
-        expect(controller.send(:flash_errors?)).not_to be_truthy
-      end
-
-      it "when VM Migrate is pressed for supported type" do
-        allow(controller).to receive(:role_allows?).and_return(true)
-        vm = FactoryGirl.create(:vm_vmware)
-        post :button, :params => { :pressed => "vm_edit", :format => :js, "check_#{vm.id}" => "1" }
-        expect(controller.send(:flash_errors?)).not_to be_truthy
       end
     end
 

--- a/spec/controllers/ems_common_spec.rb
+++ b/spec/controllers/ems_common_spec.rb
@@ -1,0 +1,49 @@
+def solo_run?
+  RSpec.configuration.files_to_run == __FILE__ || RSpec.configuration.files_to_run == [__FILE__]
+end
+
+mixin_controllers = %w(
+  ems_block_storage_controller
+  ems_cloud_controller
+  ems_container_controller
+  ems_datawarehouse_controller
+  ems_infra_controller
+  ems_middleware_controller
+  ems_network_controller
+  ems_object_storage_controller
+  ems_physical_infra_controller
+  ems_storage_controller
+  middleware_datasource_controller
+  middleware_deployment_controller
+  middleware_domain_controller
+  middleware_messaging_controller
+  middleware_server_controller
+  middleware_server_group_controller
+)
+
+# if solo_run?
+#   puts "Running shared button examples for #{mixin_controllers.count} controllers that include EmsCommon"
+# end
+#
+# mixin_controllers.map{|c| c.camelize.constantize }.each do |ctrlr|
+#   describe ctrlr do
+#     describe '#button' do
+#       include_examples :ems_common_button_examples
+#     end
+#   end
+# end
+
+# Only run these specs if it ems_common is run by itself,
+# for instance, from the command line or Guard.
+
+if solo_run?
+  explicit_run_specs = mixin_controllers.map do |s|
+    ManageIQ::UI::Classic::Engine.root.join('spec', 'controllers', "#{s}_spec.rb").to_s
+  end
+
+  explicit_run_specs << ManageIQ::UI::Classic::Engine.root.join("spec/controllers/ems_common_controller_spec.rb").to_s
+
+  puts "Running all examples for #{explicit_run_specs.count} specs that include EmsCommon"
+
+  RSpec::Core::Runner.run(explicit_run_specs)
+end

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -3,11 +3,17 @@ describe EmsContainerController do
     stub_user(:features => :all)
   end
 
-  it "#new" do
-    controller.instance_variable_set(:@breadcrumbs, [])
-    get :new
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
 
-    expect(response.status).to eq(200)
+  describe "#new" do
+    it 'responds with ok' do
+      controller.instance_variable_set(:@breadcrumbs, [])
+      get :new
+
+      expect(response.status).to eq(200)
+    end
   end
 
   describe "#show" do

--- a/spec/controllers/ems_datawarehouse_controller_spec.rb
+++ b/spec/controllers/ems_datawarehouse_controller_spec.rb
@@ -5,11 +5,17 @@ describe EmsDatawarehouseController do
     stub_user(:features => :all)
   end
 
-  it "#new" do
-    controller.instance_variable_set(:@breadcrumbs, [])
-    get :new
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
 
-    expect(response.status).to eq(200)
+  describe "#new" do
+    it 'responds with ok' do
+      controller.instance_variable_set(:@breadcrumbs, [])
+      get :new
+
+      expect(response.status).to eq(200)
+    end
   end
 
   describe "#show" do

--- a/spec/controllers/ems_middleware_controller_spec.rb
+++ b/spec/controllers/ems_middleware_controller_spec.rb
@@ -5,11 +5,17 @@ describe EmsMiddlewareController do
     stub_user(:features => :all)
   end
 
-  it "#new" do
-    controller.instance_variable_set(:@breadcrumbs, [])
-    get :new
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
 
-    expect(response.status).to eq(200)
+  describe "#new" do
+    it 'responds with ok' do
+      controller.instance_variable_set(:@breadcrumbs, [])
+      get :new
+
+      expect(response.status).to eq(200)
+    end
   end
 
   describe "#show" do

--- a/spec/controllers/ems_network_controller_spec.rb
+++ b/spec/controllers/ems_network_controller_spec.rb
@@ -2,4 +2,8 @@ describe EmsNetworkController do
   include_examples :shared_examples_for_ems_network_controller, %w(openstack azure google amazon)
 
   it_behaves_like "controller with custom buttons"
+
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
 end

--- a/spec/controllers/ems_object_storage_controller_spec.rb
+++ b/spec/controllers/ems_object_storage_controller_spec.rb
@@ -1,3 +1,7 @@
 describe EmsObjectStorageController do
   include_examples :shared_examples_for_ems_object_storage_controller, %w(openstack)
+
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
 end

--- a/spec/controllers/ems_physical_infra_controller_spec.rb
+++ b/spec/controllers/ems_physical_infra_controller_spec.rb
@@ -4,14 +4,15 @@ describe EmsPhysicalInfraController do
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
   let(:zone) { FactoryGirl.build(:zone) }
 
-  describe "#create" do
-    before do
-      user = FactoryGirl.create(:user, :features => "ems_physical_infra_new")
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
 
+  describe "#new" do
+    let!(:user) { stub_user(:features => :all) }
+
+    before do
       allow(user).to receive(:server_timezone).and_return("UTC")
-      allow_any_instance_of(described_class).to receive(:set_user_time_zone)
-      allow(controller).to receive(:check_privileges).and_return(true)
-      login_as user
     end
 
     it "adds a new provider" do

--- a/spec/controllers/ems_storage_controller_spec.rb
+++ b/spec/controllers/ems_storage_controller_spec.rb
@@ -2,4 +2,8 @@ describe EmsStorageController do
   include_examples :shared_examples_for_ems_storage_controller, %w(openstack)
 
   it_behaves_like "controller with custom buttons"
+
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
 end

--- a/spec/controllers/floating_ip_controller_spec.rb
+++ b/spec/controllers/floating_ip_controller_spec.rb
@@ -11,7 +11,7 @@ describe FloatingIpController do
 
   describe "#button" do
     it "handles floating_ip_tag" do
-      expect(controller).to receive(:tag)
+      expect(controller).to receive(:tag).with(FloatingIp)
       post :button, :params => { :pressed => "floating_ip_tag", :format => :js, :id => flip.id }
       expect(assigns(:flash_array)).to be_nil
     end

--- a/spec/controllers/floating_ip_controller_spec.rb
+++ b/spec/controllers/floating_ip_controller_spec.rb
@@ -1,98 +1,101 @@
 describe FloatingIpController do
   include_examples :shared_examples_for_floating_ip_controller, %w(openstack azure google amazon)
 
-  context "#button" do
-    before(:each) do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      ApplicationController.handle_exceptions = true
-    end
+  let!(:user) { stub_user(:features => :all) }
+  let(:ems)   { FactoryGirl.create(:ems_openstack).network_manager }
+  let(:flip)  { FactoryGirl.create(:floating_ip) }
 
-    it "when Edit Tag is pressed" do
-      skip "Not ready yet"
-      expect(controller).to receive(:tag)
-      post :button, :params => { :pressed => "edit_tag", :format => :js }
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
   end
 
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
-    before(:each) do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ct = FactoryGirl.create(:floating_ip)
-      allow(@ct).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag1",
-                                 :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag2",
-                                 :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@ct).and_return([@tag1, @tag2])
-      session[:tag_db] = "FloatingIp"
-      edit = {
-        :key        => "FloatingIp_edit_tags__#{@ct.id}",
-        :tagging    => "FloatingIp",
-        :object_ids => [@ct.id],
-        :current    => {:assignments => []},
-        :new        => {:assignments => [@tag1.id, @tag2.id]}
-      }
-      session[:edit] = edit
-    end
-
-    after(:each) do
-      expect(response.status).to eq(200)
-    end
-
-    it "builds tagging screen" do
-      post :button, :params => { :pressed => "floating_ip_tag", :format => :js, :id => @ct.id }
+  describe "#button" do
+    it "handles floating_ip_tag" do
+      expect(controller).to receive(:tag)
+      post :button, :params => { :pressed => "floating_ip_tag", :format => :js, :id => flip.id }
       expect(assigns(:flash_array)).to be_nil
     end
 
-    it "cancels tags edit" do
-      session[:breadcrumbs] = [{:url => "floating_ip/show/#{@ct.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @ct.id }
-      expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
+    it "handles floating_ip_new" do
+      expect(controller).to receive(:handle_floating_ip_new)
+      post :button, :params => { :pressed => "floating_ip_new", :format => :js }
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    it "handles floating_ip_edit" do
+      expect(controller).to receive(:handle_floating_ip_edit)
+      post :button, :params => { :pressed => "floating_ip_edit", :format => :js, :id => flip.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+  end
+
+  describe "#tagging_edit" do
+    let(:classification) do
+      FactoryGirl.create(:classification, :name => "department", :description => "Department")
+    end
+
+    let(:tag1) do
+      FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification)
+    end
+
+    let(:tag2) do
+      FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification)
+    end
+
+    let(:edit) do
+      {
+        :key        => "FloatingIp_edit_tags__#{flip.id}",
+        :tagging    => "FloatingIp",
+        :object_ids => [flip.id],
+        :current    => {:assignments => []},
+        :new        => {:assignments => [tag1.id, tag2.id]}
+      }
+    end
+
+    before do
+      allow(flip).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+      allow(Classification).to receive(:find_assigned_entries).with(flip).and_return([tag1, tag2])
+      session[:tag_db] = "FloatingIp"
+      session[:edit] = edit
+      session[:breadcrumbs] = [{:url => "floating_ip/show/#{flip.id}"}, 'placeholder']
+    end
+
+    after do
       expect(assigns(:edit)).to be_nil
+      expect(response.status).to eq(200)
+    end
+
+    it "cancels tags edit" do
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => flip.id }
+      expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
     end
 
     it "save tags" do
-      session[:breadcrumbs] = [{:url => "floating_ip/show/#{@ct.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @ct.id }
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => flip.id }
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
-      expect(assigns(:edit)).to be_nil
     end
   end
 
   describe "#show" do
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @floating_ip = FactoryGirl.create(:floating_ip)
+      flip = FactoryGirl.create(:floating_ip)
       login_as FactoryGirl.create(:user)
     end
 
     subject do
-      get :show, :params => {:id => @floating_ip.id}
+      get :show, :params => {:id => flip.id}
     end
 
-    context "render listnav partial" do
-      render_views
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_floating_ip")
-      end
+    render_views
+
+    it "renders the listnav partial" do
+      is_expected.to have_http_status 200
+      is_expected.to render_template(:partial => "layouts/listnav/_floating_ip")
     end
   end
 
   describe "#create" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @floating_ip = FactoryGirl.create(:floating_ip_openstack)
-      stub_user(:features => :all)
-    end
+    let(:flip) { FactoryGirl.create(:floating_ip_openstack) }
 
     context "#create" do
       let(:task_options) do
@@ -103,36 +106,26 @@ describe FloatingIpController do
       end
       let(:queue_options) do
         {
-          :class_name  => @ems.class.name,
+          :class_name  => ems.class.name,
           :method_name => 'create_floating_ip',
-          :instance_id => @ems.id,
+          :instance_id => ems.id,
           :priority    => MiqQueue::HIGH_PRIORITY,
           :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
+          :zone        => ems.my_zone,
           :args        => [{}]
         }
-      end
-
-      it "builds create screen" do
-        post :button, :params => { :pressed => "floating_ip_new", :format => :js }
-        expect(assigns(:flash_array)).to be_nil
       end
 
       it "queues the create action" do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
         post :create, :params => { :button => "add", :format => :js, :name => 'test',
-                                   :tenant_id => 'id', :ems_id => @ems.id }
+                                   :tenant_id => 'id', :ems_id => ems.id }
       end
     end
   end
 
   describe "#edit" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @floating_ip = FactoryGirl.create(:floating_ip_openstack, :ext_management_system => @ems)
-    end
+    let(:flip) { FactoryGirl.create(:floating_ip_openstack, :ext_management_system => ems) }
 
     context "#edit" do
       let(:task_options) do
@@ -141,62 +134,52 @@ describe FloatingIpController do
           :userid => controller.current_user.userid
         }
       end
+
       let(:queue_options) do
         {
-          :class_name  => @floating_ip.class.name,
+          :class_name  => flip.class.name,
           :method_name => 'raw_update_floating_ip',
-          :instance_id => @floating_ip.id,
+          :instance_id => flip.id,
           :priority    => MiqQueue::HIGH_PRIORITY,
           :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
+          :zone        => ems.my_zone,
           :args        => [{:network_port_ems_ref => ""}]
         }
       end
 
-      it "builds edit screen" do
-        post :button, :params => { :pressed => "floating_ip_edit", :format => :js, :id => @floating_ip.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
       it "queues the update action" do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :update, :params => { :button => "save", :format => :js, :id => @floating_ip.id,
+        post :update, :params => { :button => "save", :format => :js, :id => flip.id,
                                    :network_port_ems_ref => "" }
       end
     end
   end
 
-  describe "#delete" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @floating_ip = FactoryGirl.create(:floating_ip_openstack, :ext_management_system => @ems)
+  describe "deleting" do
+    let(:flip) { FactoryGirl.create(:floating_ip_openstack, :ext_management_system => ems) }
+
+    let(:task_options) do
+      {
+        :action => "deleting Floating IP for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:queue_options) do
+      {
+        :class_name  => flip.class.name,
+        :method_name => 'raw_delete_floating_ip',
+        :instance_id => flip.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => []
+      }
     end
 
-    context "#delete" do
-      let(:task_options) do
-        {
-          :action => "deleting Floating IP for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @floating_ip.class.name,
-          :method_name => 'raw_delete_floating_ip',
-          :instance_id => @floating_ip.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => []
-        }
-      end
-
-      it "queues the delete action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :button, :params => { :id => @floating_ip.id, :pressed => "floating_ip_delete", :format => :js }
-      end
+    it "queues the delete action" do
+      expect(controller).to receive(:handle_floating_ip_delete).and_call_original
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :button, :params => { :id => flip.id, :pressed => "floating_ip_delete", :format => :js }
     end
   end
 end

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -1,224 +1,203 @@
 describe HostAggregateController do
-  describe "#show" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @aggregate = FactoryGirl.create(:host_aggregate)
-      login_as FactoryGirl.create(:user_admin)
+  let!(:user) { stub_user(:features => :all) }
+  let(:ems) { FactoryGirl.create(:ems_openstack) }
+
+  let(:aggregate) do
+    FactoryGirl.create(:host_aggregate_openstack, :ext_management_system => ems)
+  end
+
+  let(:host) do
+    FactoryGirl.create(:host_openstack_infra, :ext_management_system => ems)
+  end
+
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
+  end
+
+  describe "#button" do
+    let(:aggregate) { FactoryGirl.create(:host_aggregate) }
+
+    after do
+      expect(assigns(:flash_array)).to be_nil
     end
+
+    it "handles host_aggregate_tag" do
+      expect(controller).to receive(:tag).with(HostAggregate).and_call_original
+      post :button, :params => { :pressed => "host_aggregate_tag", :format => :js, :id => aggregate.id }
+    end
+
+    it "handles host_aggregate_new" do
+      expect(controller).to receive(:handle_host_aggregate_new).and_call_original
+      post :button, :params => { :pressed => "host_aggregate_new", :format => :js }
+    end
+
+    it "handles host_aggregate_edit" do
+      expect(controller).to receive(:handle_host_aggregate_edit).and_call_original
+      post :button, :params => { :pressed => "host_aggregate_edit", :format => :js, :id => aggregate.id }
+    end
+
+    it "handles host_aggregate_add_host" do
+      expect(controller).to receive(:handle_host_aggregate_add_host).and_call_original
+      post :button, :params => { :pressed => "host_aggregate_add_host", :format => :js, :id => aggregate.id }
+    end
+
+    it "builds remove host screen" do
+      expect(controller).to receive(:handle_host_aggregate_remove_host).and_call_original
+      post :button, :params => { :pressed => "host_aggregate_remove_host", :format => :js, :id => aggregate.id }
+    end
+  end
+
+  describe "#show" do
+    let(:aggregate) { FactoryGirl.create(:host_aggregate) }
 
     subject do
-      get :show, :params => {:id => @aggregate.id}
+      get :show, :params => {:id => aggregate.id}
     end
 
-    context "render listnav partial" do
-      render_views
+    render_views
 
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_host_aggregate")
-      end
+    it "renders listnav partial" do
+      is_expected.to have_http_status 200
+      is_expected.to render_template(:partial => "layouts/listnav/_host_aggregate")
     end
   end
 
   include_examples '#download_summary_pdf', :host_aggregate_openstack
 
   describe "#create" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @aggregate = FactoryGirl.create(:host_aggregate_openstack)
+    let(:aggregate) { FactoryGirl.create(:host_aggregate_openstack) }
+
+    let(:task_options) do
+      {
+        :action => "creating Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#create" do
-      let(:task_options) do
-        {
-          :action => "creating Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @aggregate.class.name,
-          :method_name => "create_aggregate",
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@ems.id, {:name => "foo", :ems_id => @ems.id.to_s }]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => aggregate.class.name,
+        :method_name => "create_aggregate",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [ems.id, {:name => "foo", :ems_id => ems.id.to_s }]
+      }
+    end
 
-      it "builds create screen" do
-        post :button, :params => { :pressed => "host_aggregate_new", :format => :js }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the create action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => @ems.id }
-      end
+    it "queues the create action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => ems.id }
     end
   end
 
   describe "#edit" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @aggregate = FactoryGirl.create(:host_aggregate_openstack,
-                                      :ext_management_system => @ems)
+    let(:task_options) do
+      {
+        :action => "updating Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#edit" do
-      let(:task_options) do
-        {
-          :action => "updating Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @aggregate.class.name,
-          :method_name => "update_aggregate",
-          :instance_id => @aggregate.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [{:name => "foo"}]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => aggregate.class.name,
+        :method_name => "update_aggregate",
+        :instance_id => aggregate.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [{:name => "foo"}]
+      }
+    end
 
-      it "builds edit screen" do
-        post :button, :params => { :pressed => "host_aggregate_edit", :format => :js, :id => @aggregate.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the update action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :update, :params => { :button => "save", :format => :js, :id => @aggregate.id, :name => "foo" }
-      end
+    it "queues the update action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :update, :params => { :button => "save", :format => :js, :id => aggregate.id, :name => "foo" }
     end
   end
 
-  describe "#delete" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @aggregate = FactoryGirl.create(:host_aggregate_openstack,
-                                      :ext_management_system => @ems)
+  describe "deleting" do
+    let(:task_options) do
+      {
+        :action => "deleting Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#edit" do
-      let(:task_options) do
-        {
-          :action => "deleting Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @aggregate.class.name,
-          :method_name => "delete_aggregate",
-          :instance_id => @aggregate.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => []
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => aggregate.class.name,
+        :method_name => "delete_aggregate",
+        :instance_id => aggregate.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => []
+      }
+    end
 
-      it "queues the delete action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :button, :params => { :id => @aggregate.id, :pressed => "host_aggregate_delete", :format => :js }
-      end
+    it "queues the delete action" do
+      expect(controller).to receive(:handle_host_aggregate_delete).and_call_original
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :button, :params => { :id => aggregate.id, :pressed => "host_aggregate_delete", :format => :js }
     end
   end
 
   describe "#add_host" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @aggregate = FactoryGirl.create(:host_aggregate_openstack,
-                                      :ext_management_system => @ems)
-      @host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems)
+    let(:task_options) do
+      {
+        :action => "Adding Host to Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#add_host" do
-      let(:task_options) do
-        {
-          :action => "Adding Host to Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @aggregate.class.name,
-          :method_name => "add_host",
-          :instance_id => @aggregate.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@host.id]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => aggregate.class.name,
+        :method_name => "add_host",
+        :instance_id => aggregate.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [host.id]
+      }
+    end
 
-      it "builds add host screen" do
-        post :button, :params => { :pressed => "host_aggregate_add_host", :format => :js, :id => @aggregate.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the add host action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :add_host, :params => { :button => "addHost", :format => :js, :id => @aggregate.id, :host_id => @host.id }
-      end
+    it "queues the add host action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :add_host, :params => { :button => "addHost", :format => :js, :id => aggregate.id, :host_id => host.id }
     end
   end
 
   describe "#remove_host" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @aggregate = FactoryGirl.create(:host_aggregate_openstack,
-                                      :ext_management_system => @ems)
-      @host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems)
+    let(:task_options) do
+      {
+        :action => "Removing Host from Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#remove_host" do
-      let(:task_options) do
-        {
-          :action => "Removing Host from Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @aggregate.class.name,
-          :method_name => "remove_host",
-          :instance_id => @aggregate.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@host.id]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => aggregate.class.name,
+        :method_name => "remove_host",
+        :instance_id => aggregate.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [host.id]
+      }
+    end
 
-      it "builds remove host screen" do
-        post :button, :params => { :pressed => "host_aggregate_remove_host", :format => :js, :id => @aggregate.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the remove host action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :remove_host, :params => {
-          :button  => "removeHost",
-          :format  => :js,
-          :id      => @aggregate.id,
-          :host_id => @host.id
-        }
-      end
+    it "queues the remove host action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :remove_host, :params => {
+        :button  => "removeHost",
+        :format  => :js,
+        :id      => aggregate.id,
+        :host_id => host.id
+      }
     end
   end
 end

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -4,42 +4,15 @@ describe HostController do
   let(:host2) { FactoryGirl.create(:host) }
   let(:hardware) { FactoryGirl.create(:hardware, :provision_state => "manageable") }
 
-  describe "Shared button examples" do
-
-  end
-
   describe "#button" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
     end
 
-    # Button presses covered by shared examples:
-    # host_scan
-    # host_check_compliance
-    # host_refresh
-    # host_protect
-    # host_edit
-    # host_delete
-    # host_cloud_service_scheduling_toggle
-    # host_compare
-    # host_introspect
-    # host_manageable
-    # host_miq_request_new
-    # host_provide
-    # host_toggle_maintenance
-    # host_analyze_check_compliance
-    # host_tag
-    # vm_right_size
-    # vm_migrate
-    # vm_retire
-    # vm_protect
-    # miq_template_protect
-    # vm_tag
-    # miq_template_tag
-
     include_examples :host_vm_button_examples
     include_examples :common_host_button_examples
     include_examples :special_host_button_examples
+    include_examples :host_power_button_examples
 
     %w(
       common_drift

--- a/spec/controllers/infra_network_controller_spec.rb
+++ b/spec/controllers/infra_network_controller_spec.rb
@@ -1,114 +1,109 @@
 describe InfraNetworkingController do
   include CompressedIds
 
+  let!(:user) { stub_user(:features => :all) }
+
   let(:switch) { FactoryGirl.create(:switch, :name => 'test_switch1', :shared => 'true') }
   let(:host) { FactoryGirl.create(:host, :name => 'test_host1') }
   let(:ems_vmware) { FactoryGirl.create(:ems_vmware, :name => 'test_vmware') }
   let(:cluster) { FactoryGirl.create(:cluster, :name => 'test_cluster') }
-  before { stub_user(:features => :all) }
 
-  context 'render_views' do
+  before { EvmSpecHelper.create_guid_miq_server_zone }
+
+  describe "button" do
+    it "builds tagging screen" do
+      expect(controller).to receive(:tag).and_call_original
+      post :button, :params => { :pressed => "infra_networking_tag", :format => :js, :id => switch.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+  end
+
+  describe '#explorer' do
     render_views
 
-    context '#explorer' do
-      before do
-        session[:settings] = {:views => {}, :perpage => {:list => 5}}
-        EvmSpecHelper.create_guid_miq_server_zone
-      end
-
-      it 'can render the explorer' do
-        session[:sb] = {:active_accord => :infra_networking_accord}
-        seed_session_trees('switch', :infra_networking_tree, 'root')
-        get :explorer
-        expect(response.status).to eq(200)
-        expect(response.body).to_not be_empty
-      end
-
-      it 'shows a switch in the list' do
-        switch
-        session[:sb] = {:active_accord => :infra_networking_accord}
-        seed_session_trees('switch', :infra_networking_tree, 'root')
-
-        get :explorer
-        expect(response.body).to match(/{"text":\s*"test_switch1"}/)
-      end
-
-      it 'can render the second page of switches' do
-        7.times do |i|
-          FactoryGirl.create(:switch, :name => 'test_switch' % i, :shared => true)
-        end
-        session[:sb] = {:active_accord => :infra_networking_accord}
-        seed_session_trees('switch', :infra_networking_tree, 'root')
-        allow(controller).to receive(:current_page).and_return(2)
-        get :explorer, :params => {:page => '2'}
-        expect(response.status).to eq(200)
-        expect(response.body).to include("<li>\n<span>\n6-7 of 7\n<input name='limitstart' type='hidden' value='0'>\n</span>\n</li>")
-      end
+    before do
+      session[:settings] = {:views => {}, :perpage => {:list => 5}}
     end
 
-    context "#tree_select" do
-      before do
-        switch
+    it 'can render the explorer' do
+      session[:sb] = {:active_accord => :infra_networking_accord}
+      seed_session_trees('switch', :infra_networking_tree, 'root')
+      get :explorer
+      expect(response.status).to eq(200)
+      expect(response.body).to_not be_empty
+    end
+
+    it 'shows a switch in the list' do
+      switch
+      session[:sb] = {:active_accord => :infra_networking_accord}
+      seed_session_trees('switch', :infra_networking_tree, 'root')
+
+      get :explorer
+      expect(response.body).to match(/{"text":\s*"test_switch1"}/)
+    end
+
+    it 'can render the second page of switches' do
+      7.times do |i|
+        FactoryGirl.create(:switch, :name => 'test_switch' % i, :shared => true)
       end
+      session[:sb] = {:active_accord => :infra_networking_accord}
+      seed_session_trees('switch', :infra_networking_tree, 'root')
+      allow(controller).to receive(:current_page).and_return(2)
+      get :explorer, :params => {:page => '2'}
+      expect(response.status).to eq(200)
+      expect(response.body).to include("<li>\n<span>\n6-7 of 7\n<input name='limitstart' type='hidden' value='0'>\n</span>\n</li>")
+    end
+  end
 
-      [
-        ['All Distributed Switches', 'infra_networking_tree'],
-      ].each do |elements, tree|
-        it "renders list of #{elements} for #{tree} root node" do
-          session[:settings] = {}
-          seed_session_trees('infra_networking', tree.to_sym)
+  describe "#tree_select" do
+    [['All Distributed Switches', 'infra_networking_tree']].each do |elements, tree|
+      it "renders list of #{elements} for #{tree} root node" do
+        session[:settings] = {}
+        seed_session_trees('infra_networking', tree.to_sym)
 
-          post :tree_select, :params => { :id => 'root', :format => :js }
-          expect(response.status).to eq(200)
-        end
+        post :tree_select, :params => { :id => 'root', :format => :js }
+        expect(response.status).to eq(200)
       end
     end
   end
 
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
-    before(:each) do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ds = FactoryGirl.create(:switch, :name => "testSwitch")
-      allow(@ds).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag1",
-                                 :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag2",
-                                 :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@ds).and_return([@tag1, @tag2])
+  describe "#tags_edit" do
+    let(:switch) { FactoryGirl.create(:switch, :name => "testSwitch") }
+    let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
+    let(:tag1) { FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification) }
+    let(:tag2) { FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification) }
+
+    before do
+      allow(switch).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+      allow(Classification).to receive(:find_assigned_entries).with(switch).and_return([tag1, tag2])
+
       session[:tag_db] = "Switch"
+
       edit = {
-        :key        => "Switch_edit_tags__#{@ds.id}",
+        :key        => "Switch_edit_tags__#{switch.id}",
         :tagging    => "Switch",
-        :object_ids => [@ds.id],
+        :object_ids => [switch.id],
         :current    => {:assignments => []},
-        :new        => {:assignments => [@tag1.id, @tag2.id]}
+        :new        => {:assignments => [tag1.id, tag2.id]}
       }
+
       session[:edit] = edit
     end
 
-    after(:each) do
+    after do
       expect(response.status).to eq(200)
     end
 
-    it "builds tagging screen" do
-      post :button, :params => { :pressed => "infra_networking_tag", :format => :js, :id => @ds.id }
-      expect(assigns(:flash_array)).to be_nil
-    end
-
     it "cancels tags edit" do
-      session[:breadcrumbs] = [{:url => "infra_networking/show/#{@ds.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @ds.id }
+      session[:breadcrumbs] = [{:url => "infra_networking/show/#{switch.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => switch.id }
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
       expect(assigns(:edit)).to be_nil
     end
 
     it "save tags" do
-      session[:breadcrumbs] = [{:url => "infra_networking/show/#{@ds.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @ds.id }
+      session[:breadcrumbs] = [{:url => "infra_networking/show/#{switch.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => switch.id }
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
     end

--- a/spec/controllers/middleware_datasource_controller_spec.rb
+++ b/spec/controllers/middleware_datasource_controller_spec.rb
@@ -4,6 +4,10 @@ describe MiddlewareDatasourceController do
     stub_user(:features => :all)
   end
 
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
+
   it 'renders index' do
     get :index
     expect(response.status).to eq(302)

--- a/spec/controllers/middleware_deployment_controller_spec.rb
+++ b/spec/controllers/middleware_deployment_controller_spec.rb
@@ -4,6 +4,10 @@ describe MiddlewareDeploymentController do
     stub_user(:features => :all)
   end
 
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
+
   it 'renders index' do
     get :index
     expect(response.status).to eq(302)

--- a/spec/controllers/middleware_domain_controller_spec.rb
+++ b/spec/controllers/middleware_domain_controller_spec.rb
@@ -4,6 +4,10 @@ describe MiddlewareDomainController do
     stub_user(:features => :all)
   end
 
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
+
   it 'renders index' do
     get :index
     expect(response.status).to eq(302)

--- a/spec/controllers/middleware_messaging_controller_spec.rb
+++ b/spec/controllers/middleware_messaging_controller_spec.rb
@@ -4,6 +4,10 @@ describe MiddlewareMessagingController do
     stub_user(:features => :all)
   end
 
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
+
   it 'renders index' do
     get :index
     expect(response.status).to eq(302)

--- a/spec/controllers/middleware_server_controller_spec.rb
+++ b/spec/controllers/middleware_server_controller_spec.rb
@@ -4,6 +4,10 @@ describe MiddlewareServerController do
     stub_user(:features => :all)
   end
 
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
+
   it 'renders index' do
     get :index
     expect(response.status).to eq(302)

--- a/spec/controllers/middleware_server_group_controller_spec.rb
+++ b/spec/controllers/middleware_server_group_controller_spec.rb
@@ -4,6 +4,10 @@ describe MiddlewareServerGroupController do
     stub_user(:features => :all)
   end
 
+  describe '#button' do
+    include_examples :ems_common_button_examples
+  end
+
   it 'renders index' do
     get :index
     expect(response.status).to eq(302)

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -1,9 +1,15 @@
 describe MiqAeToolsController do
-  before(:each) do
-    stub_user(:features => :all)
+  let!(:user) { stub_user(:features => :all) }
+
+  describe "#button" do
+    it 'handles refresh_log' do
+      expect(controller).to receive(:handle_refresh_log)
+      post :button, :params => { :pressed => "refresh_log" }
+      expect(assigns(:flash_array)).to be_nil
+    end
   end
 
-  context "#form_field_changed" do
+  describe "#form_field_changed" do
     it "resets target id to nil, when target class is <none>" do
       new = {
         :target_class => "EmsCluster",

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -1,6 +1,12 @@
 describe MiqPolicyController do
-  before(:each) do
-    stub_user(:features => :all)
+  let!(:user) { stub_user(:features => :all) }
+
+  describe "#button" do
+    it 'handles refresh_log' do
+      expect(controller).to receive(:handle_refresh_log)
+      post :button, :params => { :pressed => "refresh_log" }
+      expect(assigns(:flash_array)).to be_nil
+    end
   end
 
   describe "#import" do

--- a/spec/controllers/mixins/containers_common_mixin_spec.rb
+++ b/spec/controllers/mixins/containers_common_mixin_spec.rb
@@ -1,0 +1,31 @@
+def solo_run?
+  RSpec.configuration.files_to_run == __FILE__ || RSpec.configuration.files_to_run == [__FILE__]
+end
+
+mixin_controllers = %w(
+  container_build_controller
+  container_controller
+  container_group_controller
+  container_image_controller
+  container_image_registry_controller
+  container_node_controller
+  container_project_controller
+  container_replicator_controller
+  container_route_controller
+  container_service_controller
+  container_template_controller
+  persistent_volume_controller
+)
+
+# Only run these specs if it ems_common is run by itself,
+# for instance, from the command line or Guard.
+
+if solo_run?
+  explicit_run_specs = mixin_controllers.map do |s|
+    ManageIQ::UI::Classic::Engine.root.join('spec', 'controllers', "#{s}_spec.rb").to_s
+  end
+
+  puts "Running all examples for #{explicit_run_specs.count} specs that include ContainersCommonMixin"
+
+  RSpec::Core::Runner.run(explicit_run_specs)
+end

--- a/spec/controllers/mixins/generic_button_mixin_spec.rb
+++ b/spec/controllers/mixins/generic_button_mixin_spec.rb
@@ -1,0 +1,36 @@
+# Only run this spec file if it is run by itself,
+# for instance, from the command line or Guard.
+
+if RSpec.configuration.files_to_run == __FILE__ || RSpec.configuration.files_to_run == [__FILE__]
+  mixin_controllers = %w(
+    auth_key_pair_cloud_controller_spec.rb
+    availability_zone_controller_spec.rb
+    cloud_network_controller_spec.rb
+    cloud_object_store_container_controller_spec.rb
+    cloud_object_store_object_controller_spec.rb
+    cloud_subnet_controller_spec.rb
+    cloud_tenant_controller_spec.rb
+    cloud_volume_controller_spec.rb
+    configuration_controller_spec.rb
+    configuration_job_controller_spec.rb
+    floating_ip_controller_spec.rb
+    host_aggregate_controller_spec.rb
+    host_controller_spec.rb
+    infra_network_controller_spec.rb
+    miq_ae_tools_controller_spec.rb
+    miq_policy_controller_spec.rb
+    miq_request_controller_spec.rb
+    network_router_controller_spec.rb
+    orchestration_stack_controller_spec.rb
+    resource_pool_controller_spec.rb
+    security_group_controller_spec.rb
+    storage_controller_spec.rb
+    storage_manager_controller_spec.rb
+    vm_common_spec.rb
+    ems_common_controller_spec.rb
+    ems_cluster_controller_spec.rb
+    ems_infra_controller_spec.rb
+  ).map! { |s| ManageIQ::UI::Classic::Engine.root.join('spec', 'controllers', s).to_s }
+
+  RSpec::Core::Runner.run(mixin_controllers)
+end

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -1,297 +1,270 @@
 describe NetworkRouterController do
   include_examples :shared_examples_for_network_router_controller, %w(openstack azure google amazon)
 
-  context "#button" do
-    before(:each) do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
+  let!(:user) { stub_user(:features => :all) }
+  let(:ems)   { FactoryGirl.create(:ems_openstack).network_manager }
 
-      ApplicationController.handle_exceptions = true
-    end
-
-    it "when Edit Tag is pressed" do
-      # TODO: Fix
-      skip "Not ready yet"
-      expect(controller).to receive(:tag)
-      post :button, :params => { :pressed => "edit_tag", :format => :js }
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
+  let(:router) do
+    FactoryGirl.create(:network_router_openstack, :ext_management_system => ems)
   end
 
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
-    before(:each) do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ct = FactoryGirl.create(:network_router, :name => "router-01")
-      allow(@ct).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag1",
-                                 :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag2",
-                                 :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@ct).and_return([@tag1, @tag2])
-      session[:tag_db] = "NetworkRouter"
-      edit = {
-        :key        => "NetworkRouter_edit_tags__#{@ct.id}",
-        :tagging    => "NetworkRouter",
-        :object_ids => [@ct.id],
-        :current    => {:assignments => []},
-        :new        => {:assignments => [@tag1.id, @tag2.id]}
-      }
-      session[:edit] = edit
-    end
+  let(:subnet) do
+    FactoryGirl.create(:cloud_subnet, :ext_management_system => ems)
+  end
 
-    after(:each) do
-      expect(response.status).to eq(200)
-    end
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
+  end
 
-    it "builds tagging screen" do
-      post :button, :params => { :pressed => "network_router_tag", :format => :js, :id => @ct.id }
+  describe "#button" do
+    # let(:router) { FactoryGirl.create(:network_router, :name => "router-01") }
+
+    it "handles network_router_tag" do
+      expect(controller).to receive(:tag)
+      post :button, :params => { :pressed => "network_router_tag", :format => :js, :id => router.id }
       expect(assigns(:flash_array)).to be_nil
     end
 
+    it "handles network_router_new" do
+      expect(controller).to receive(:handle_network_router_new)
+      post :button, :params => { :pressed => "network_router_new", :format => :js }
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    %w(
+      network_router_edit
+      network_router_remove_interface
+      network_router_add_interface
+    ).each do |pressed|
+      it "handles #{pressed}" do
+        expect(controller).to receive("handle_#{pressed}".to_sym)
+        post :button, :params => { :pressed => pressed, :format => :js, :id => router.id }
+        expect(assigns(:flash_array)).to be_nil
+      end
+    end
+
+    # it "builds edit screen" do
+    #   post :button, :params => { :pressed => "network_router_edit", :format => :js, :id => router.id }
+    #   expect(assigns(:flash_array)).to be_nil
+    # end
+    #
+    # it "builds remove interface screen" do
+    #   post :button, :params => { :pressed => "network_router_remove_interface", :format => :js, :id => router.id }
+    #   expect(assigns(:flash_array)).to be_nil
+    # end
+    #
+    # it "builds add interface screen" do
+    #   post :button, :params => { :pressed => "network_router_add_interface", :format => :js, :id => router.id }
+    #   expect(assigns(:flash_array)).to be_nil
+    # end
+  end
+
+  describe "#tagging_edit" do
+    let(:classification) do
+      FactoryGirl.create(:classification, :name => "department", :description => "Department")
+    end
+
+    let(:tag1) do
+      FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification)
+    end
+
+    let(:tag2) do
+      FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification)
+    end
+
+    before do
+      allow(router).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+      allow(Classification).to receive(:find_assigned_entries).with(router).and_return([tag1, tag2])
+
+      session[:tag_db] = "NetworkRouter"
+
+      edit = {
+        :key        => "NetworkRouter_edit_tags__#{router.id}",
+        :tagging    => "NetworkRouter",
+        :object_ids => [router.id],
+        :current    => {:assignments => []},
+        :new        => {:assignments => [tag1.id, tag2.id]}
+      }
+
+      session[:edit] = edit
+    end
+
+    after do
+      expect(response.status).to eq(200)
+    end
+
     it "cancels tags edit" do
-      session[:breadcrumbs] = [{:url => "network_router/show/#{@ct.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @ct.id }
+      session[:breadcrumbs] = [{:url => "network_router/show/#{router.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => router.id }
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
       expect(assigns(:edit)).to be_nil
     end
 
     it "save tags" do
-      session[:breadcrumbs] = [{:url => "network_router/show/#{@ct.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @ct.id }
+      session[:breadcrumbs] = [{:url => "network_router/show/#{router.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => router.id }
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
     end
   end
 
   describe "#show" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @router = FactoryGirl.create(:network_router)
-      login_as FactoryGirl.create(:user)
-    end
-
     subject do
-      get :show, :params => {:id => @router.id}
+      get :show, :params => {:id => router.id}
     end
 
-    context "render listnav partial" do
-      render_views
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_network_router")
-      end
+    render_views
+
+    it "renders listnav partial" do
+      is_expected.to have_http_status 200
+      is_expected.to render_template(:partial => "layouts/listnav/_network_router")
     end
   end
 
   describe "#create" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @router = FactoryGirl.create(:network_router_openstack)
+    let(:task_options) do
+      {
+        :action => "creating Network Router for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#create" do
-      let(:task_options) do
-        {
-          :action => "creating Network Router for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @ems.class.name,
-          :method_name => 'create_network_router',
-          :instance_id => @ems.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => [{:name => "test"}]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => ems.class.name,
+        :method_name => 'create_network_router',
+        :instance_id => ems.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => [{:name => "test"}]
+      }
+    end
 
-      it "builds create screen" do
-        post :button, :params => { :pressed => "network_router_new", :format => :js }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the create action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :create, :params => { :button => "add", :format => :js, :name => 'test',
-                                   :tenant_id => 'id', :ems_id => @ems.id }
-      end
+    it "queues the create action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :create, :params => { :button => "add", :format => :js, :name => 'test',
+                                 :tenant_id => 'id', :ems_id => ems.id }
     end
   end
 
-  describe "#edit" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @router = FactoryGirl.create(:network_router_openstack,
-                                   :ext_management_system => @ems)
+  describe "#update" do
+    let(:task_options) do
+      {
+        :action => "updating Network Router for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#edit" do
-      let(:task_options) do
-        {
-          :action => "updating Network Router for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @router.class.name,
-          :method_name => 'raw_update_network_router',
-          :instance_id => @router.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => [{:name => "foo2"}]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => router.class.name,
+        :method_name => 'raw_update_network_router',
+        :instance_id => router.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => [{:name => "foo2"}]
+      }
+    end
 
-      it "builds edit screen" do
-        post :button, :params => { :pressed => "network_router_edit", :format => :js, :id => @router.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the update action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :update, :params => { :button => "save", :format => :js, :id => @router.id, :name => "foo2" }
-      end
+    it "queues the update action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :update, :params => { :button => "save", :format => :js, :id => router.id, :name => "foo2" }
     end
   end
 
-  describe "#delete" do
+  describe "deleting" do
+    let(:task_options) do
+      {
+        :action => "deleting Network Router for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+
+    let(:queue_options) do
+      {
+        :class_name  => router.class.name,
+        :method_name => 'raw_delete_network_router',
+        :instance_id => router.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => []
+      }
+    end
+
     before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @router = FactoryGirl.create(:network_router_openstack,
-                                   :ext_management_system => @ems)
       session[:network_router_lastaction] = 'show'
     end
 
-    context "#delete" do
-      let(:task_options) do
-        {
-          :action => "deleting Network Router for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @router.class.name,
-          :method_name => 'raw_delete_network_router',
-          :instance_id => @router.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => []
-        }
-      end
-
-      it "queues the delete action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :button, :params => { :id => @router.id, :pressed => "network_router_delete", :format => :js }
-      end
+    it "queues the delete action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :button, :params => { :id => router.id, :pressed => "network_router_delete", :format => :js }
     end
   end
 
   describe "#add_interface" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @router = FactoryGirl.create(:network_router_openstack,
-                                   :ext_management_system => @ems)
-      @subnet = FactoryGirl.create(:cloud_subnet, :ext_management_system => @ems)
+    let(:task_options) do
+      {
+        :action => "Adding Interface to Network Router for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#add_interface" do
-      let(:task_options) do
-        {
-          :action => "Adding Interface to Network Router for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @router.class.name,
-          :method_name => "raw_add_interface",
-          :instance_id => @router.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@subnet.id]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => router.class.name,
+        :method_name => "raw_add_interface",
+        :instance_id => router.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [subnet.id]
+      }
+    end
 
-      it "builds add interface screen" do
-        post :button, :params => { :pressed => "network_router_add_interface", :format => :js, :id => @router.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the add interface action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :add_interface, :params => {
-          :button          => "add",
-          :format          => :js,
-          :id              => @router.id,
-          :cloud_subnet_id => @subnet.id
-        }
-      end
+    it "queues the add interface action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :add_interface, :params => {
+        :button          => "add",
+        :format          => :js,
+        :id              => router.id,
+        :cloud_subnet_id => subnet.id
+      }
     end
   end
 
   describe "#remove_interface" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @router = FactoryGirl.create(:network_router_openstack,
-                                   :ext_management_system => @ems)
-      @subnet = FactoryGirl.create(:cloud_subnet, :ext_management_system => @ems)
+    let(:subnet) { FactoryGirl.create(:cloud_subnet, :ext_management_system => ems) }
+
+    let(:task_options) do
+      {
+        :action => "Removing Interface from Network Router for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#remove_interface" do
-      let(:task_options) do
-        {
-          :action => "Removing Interface from Network Router for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @router.class.name,
-          :method_name => "raw_remove_interface",
-          :instance_id => @router.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@subnet.id]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => router.class.name,
+        :method_name => "raw_remove_interface",
+        :instance_id => router.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [subnet.id]
+      }
+    end
 
-      it "builds remove interface screen" do
-        post :button, :params => { :pressed => "network_router_remove_interface", :format => :js, :id => @router.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the remove interface action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :remove_interface, :params => {
-          :button          => "remove",
-          :format          => :js,
-          :id              => @router.id,
-          :cloud_subnet_id => @subnet.id
-        }
-      end
+    it "queues the remove interface action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :remove_interface, :params => {
+        :button          => "remove",
+        :format          => :js,
+        :id              => router.id,
+        :cloud_subnet_id => subnet.id
+      }
     end
   end
 end

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -142,9 +142,22 @@ describe OrchestrationStackController do
   end
 
   describe "#button" do
+    let(:record) { FactoryGirl.create(:orchestration_stack_cloud_with_template) }
+
+    it 'handles orchestration_stack_delete' do
+      expect(controller).to receive(:handle_orchestration_stack_delete).and_call_original
+      post :button, :params => {:id => record.id, :pressed => "orchestration_stack_delete"}
+      expect(assigns(:flash_array).first[:message]).to include('deleted')
+    end
+
+    it 'handles orchestration_stack_tag' do
+      expect(controller).to receive(:tag).with(OrchestrationStack).and_call_original
+      post :button, :params => {:id => record.id, :pressed => "orchestration_stack_tag"}
+      expect(assigns(:flash_array)).to be_nil
+    end
+
     context "make stack's orchestration template orderable" do
       it "won't allow making stack's orchestration template orderable when already orderable" do
-        record = FactoryGirl.create(:orchestration_stack_cloud_with_template)
         post :button, :params => {:id => record.id, :pressed => "make_ot_orderable"}
         expect(record.orchestration_template.orderable?).to be_truthy
         expect(response.status).to eq(200)
@@ -164,7 +177,6 @@ describe OrchestrationStackController do
 
     context "copy stack's orchestration template as orderable" do
       it "won't allow copying stack's orchestration template orderable when already orderable" do
-        record = FactoryGirl.create(:orchestration_stack_cloud_with_template)
         post :button, :params => {:id => record.id, :pressed => "orchestration_template_copy"}
         expect(record.orchestration_template.orderable?).to be_truthy
         expect(response.status).to eq(200)
@@ -183,7 +195,6 @@ describe OrchestrationStackController do
 
     context "view stack's orchestration template in catalog" do
       it "redirects to catalog controller" do
-        record = FactoryGirl.create(:orchestration_stack_cloud_with_template)
         post :button, :params => {:id => record.id, :pressed => "orchestration_templates_view"}
         expect(response.status).to eq(200)
         expect(response.body).to include("window.location.href")

--- a/spec/controllers/persistent_volume_controller_spec.rb
+++ b/spec/controllers/persistent_volume_controller_spec.rb
@@ -64,4 +64,8 @@ describe PersistentVolumeController do
       end
     end
   end
+
+  describe "#button" do
+    include_examples :container_button_examples, "persistent_volume"
+  end
 end

--- a/spec/controllers/resource_pool_controller_spec.rb
+++ b/spec/controllers/resource_pool_controller_spec.rb
@@ -17,56 +17,16 @@ describe ResourcePoolController do
       post :button, :params => {:pressed => "resource_pool_delete", :id => pool.id}
     end
 
-    it "handles when VM Right Size Recommendations is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_right_size")
-      expect(controller).to receive(:vm_right_size)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
+    # Presses handled:
+    # vm_right_size
+    # vm_migrate
+    # vm_retire
+    # vm_protect
+    # vm_tag
+    # miq_template_protect
+    # miq_template_tag
 
-    it "handles when VM Migrate is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_migrate")
-      controller.instance_variable_set(:@refresh_partial, "layouts/gtl")
-      expect(controller).to receive(:prov_redirect).with("migrate")
-      expect(controller).to receive(:render)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "handles when VM Retire is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_retire")
-      expect(controller).to receive(:retirevms).once
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "handles when VM Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_protect")
-      expect(controller).to receive(:assign_policies).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "handles when MiqTemplate Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_protect")
-      expect(controller).to receive(:assign_policies).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "handles when VM Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_tag")
-      expect(controller).to receive(:tag).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "handles when MiqTemplate Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_tag")
-      expect(controller).to receive(:tag).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
+    include_examples :host_vm_button_examples
   end
 
   describe "#show" do

--- a/spec/controllers/resource_pool_controller_spec.rb
+++ b/spec/controllers/resource_pool_controller_spec.rb
@@ -1,17 +1,30 @@
 describe ResourcePoolController do
-  context "#button" do
-    before do
-      controller.instance_variable_set(:@display, "vms")
+  describe "#button" do
+    # TODO: Test RPs contained in RPs
+
+    let!(:user) { stub_user(:features => :all) }
+
+    let(:pool) { FactoryGirl.create(:resource_pool) }
+
+    it "handles when resource_pool_tag" do
+      expect(controller).to receive(:tag).with(ResourcePool).and_call_original
+      post :button, :params => {:pressed => "resource_pool_tag", :id => pool.id}
+      expect(assigns(:flash_array)).to be_nil
     end
 
-    it "when VM Right Size Recommendations is pressed" do
+    it 'handles when resource_pool_delete' do
+      expect(controller).to receive(:handle_resource_pool_delete)
+      post :button, :params => {:pressed => "resource_pool_delete", :id => pool.id}
+    end
+
+    it "handles when VM Right Size Recommendations is pressed" do
       controller.instance_variable_set(:@_params, :pressed => "vm_right_size")
       expect(controller).to receive(:vm_right_size)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
-    it "when VM Migrate is pressed" do
+    it "handles when VM Migrate is pressed" do
       controller.instance_variable_set(:@_params, :pressed => "vm_migrate")
       controller.instance_variable_set(:@refresh_partial, "layouts/gtl")
       expect(controller).to receive(:prov_redirect).with("migrate")
@@ -20,35 +33,35 @@ describe ResourcePoolController do
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
-    it "when VM Retire is pressed" do
+    it "handles when VM Retire is pressed" do
       controller.instance_variable_set(:@_params, :pressed => "vm_retire")
       expect(controller).to receive(:retirevms).once
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
-    it "when VM Manage Policies is pressed" do
+    it "handles when VM Manage Policies is pressed" do
       controller.instance_variable_set(:@_params, :pressed => "vm_protect")
       expect(controller).to receive(:assign_policies).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
-    it "when MiqTemplate Manage Policies is pressed" do
+    it "handles when MiqTemplate Manage Policies is pressed" do
       controller.instance_variable_set(:@_params, :pressed => "miq_template_protect")
       expect(controller).to receive(:assign_policies).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
-    it "when VM Tag is pressed" do
+    it "handles when VM Tag is pressed" do
       controller.instance_variable_set(:@_params, :pressed => "vm_tag")
       expect(controller).to receive(:tag).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
-    it "when MiqTemplate Tag is pressed" do
+    it "handles when MiqTemplate Tag is pressed" do
       controller.instance_variable_set(:@_params, :pressed => "miq_template_tag")
       expect(controller).to receive(:tag).with(VmOrTemplate)
       controller.button

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -1,201 +1,178 @@
 describe SecurityGroupController do
   include_examples :shared_examples_for_security_group_controller, %w(openstack azure google amazon)
 
-  context "#button" do
-    before(:each) do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      ApplicationController.handle_exceptions = true
+  let!(:user) { stub_user(:features => :all) }
+  let(:group) { FactoryGirl.create(:security_group, :name => "security-group-01") }
+  let(:ems)   { FactoryGirl.create(:ems_openstack).network_manager }
+
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
+  end
+
+  describe "#button" do
+    it "handles security_group_tag" do
+      expect(controller).to receive(:tag).and_call_original
+      post :button, :params => { :pressed => "security_group_tag", :format => :js, :id => group.id }
+      expect(assigns(:flash_array)).to be_nil
     end
 
-    it "when Edit Tag is pressed" do
-      skip "Not ready yet"
-      expect(controller).to receive(:tag)
-      post :button, :params => { :pressed => "edit_tag", :format => :js }
-      expect(controller.send(:flash_errors?)).not_to be_truthy
+    it "handles handle_security_group_edit" do
+      expect(controller).to receive(:handle_security_group_edit).and_call_original
+      post :button, :params => { :pressed => "security_group_edit", :format => :js, :id => group.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    it "handles handle_security_group_new" do
+      expect(controller).to receive(:handle_security_group_new).and_call_original
+      post :button, :params => { :pressed => "security_group_new", :format => :js, :id => group.id }
+      expect(assigns(:flash_array)).to be_nil
     end
   end
 
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
-    before(:each) do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ct = FactoryGirl.create(:security_group, :name => "security-group-01")
-      allow(@ct).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag1",
-                                 :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag2",
-                                 :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@ct).and_return([@tag1, @tag2])
+  describe "#tagging_edit" do
+    let(:classification) do
+      FactoryGirl.create(:classification, :name => "department", :description => "Department")
+    end
+
+    let(:tag1) do
+      FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification)
+    end
+
+    let(:tag2) do
+      FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification)
+    end
+
+    before do
+      allow(group).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+      allow(Classification).to receive(:find_assigned_entries).with(group).and_return([tag1, tag2])
       session[:tag_db] = "SecurityGroup"
       edit = {
-        :key        => "SecurityGroup_edit_tags__#{@ct.id}",
+        :key        => "SecurityGroup_edit_tags__#{group.id}",
         :tagging    => "SecurityGroup",
-        :object_ids => [@ct.id],
+        :object_ids => [group.id],
         :current    => {:assignments => []},
-        :new        => {:assignments => [@tag1.id, @tag2.id]}
+        :new        => {:assignments => [tag1.id, tag2.id]}
       }
       session[:edit] = edit
     end
 
-    after(:each) do
+    after do
       expect(response.status).to eq(200)
     end
 
-    it "builds tagging screen" do
-      post :button, :params => { :pressed => "security_group_tag", :format => :js, :id => @ct.id }
-      expect(assigns(:flash_array)).to be_nil
-    end
-
     it "cancels tags edit" do
-      session[:breadcrumbs] = [{:url => "security_group/show/#{@ct.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @ct.id }
+      session[:breadcrumbs] = [{:url => "security_group/show/#{group.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => group.id }
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
       expect(assigns(:edit)).to be_nil
     end
 
     it "save tags" do
-      session[:breadcrumbs] = [{:url => "security_group/show/#{@ct.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @ct.id }
+      session[:breadcrumbs] = [{:url => "security_group/show/#{group.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => group.id }
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
     end
   end
 
   describe "#show" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @security_group = FactoryGirl.create(:security_group_with_firewall_rules)
-      login_as FactoryGirl.create(:user)
-    end
+    let(:group) { FactoryGirl.create(:security_group_with_firewall_rules) }
 
     subject do
-      get :show, :params => {:id => @security_group.id}
+      get :show, :params => {:id => group.id}
     end
 
-    context "render" do
-      render_views
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => 'layouts/_textual_groups_generic')
-        is_expected.to render_template(:partial => "layouts/listnav/_security_group")
-      end
+    render_views
+
+    it "renders textual_groups_generic and security_group" do
+      is_expected.to have_http_status 200
+      is_expected.to render_template(:partial => 'layouts/_textual_groups_generic')
+      is_expected.to render_template(:partial => "layouts/listnav/_security_group")
     end
   end
 
   describe "#create" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @security_group = FactoryGirl.create(:security_group_openstack)
+    let(:group) { FactoryGirl.create(:security_group_openstack, :ext_management_system => ems) }
+
+    let(:task_options) do
+      {
+        :action => "creating Security Group for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#create" do
-      let(:task_options) do
-        {
-          :action => "creating Security Group for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @ems.class.name,
-          :method_name => 'create_security_group',
-          :instance_id => @ems.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => [{:name => "test"}]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => ems.class.name,
+        :method_name => 'create_security_group',
+        :instance_id => ems.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => [{:name => "test"}]
+      }
+    end
 
-      it "builds create screen" do
-        post :button, :params => { :pressed => "security_group_new", :format => :js }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the create action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :create, :params => { :button => "add", :format => :js, :name => 'test',
-                                   :tenant_id => 'id', :ems_id => @ems.id }
-      end
+    it "queues the create action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :create, :params => { :button => "add", :format => :js, :name => 'test',
+                                 :tenant_id => 'id', :ems_id => ems.id }
     end
   end
 
-  describe "#edit" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @security_group = FactoryGirl.create(:security_group_openstack, :ext_management_system => @ems)
+  describe "#update" do
+    let(:group) { FactoryGirl.create(:security_group_openstack, :ext_management_system => ems) }
+
+    let(:task_options) do
+      {
+        :action => "updating Security Group for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#edit" do
-      let(:task_options) do
-        {
-          :action => "updating Security Group for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @security_group.class.name,
-          :method_name => 'raw_update_security_group',
-          :instance_id => @security_group.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => [{:name => "foo2"}]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => group.class.name,
+        :method_name => 'raw_update_security_group',
+        :instance_id => group.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => [{:name => "foo2"}]
+      }
+    end
 
-      it "builds edit screen" do
-        post :button, :params => { :pressed => "security_group_edit", :format => :js, :id => @security_group.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the update action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :update, :params => { :button => "save", :format => :js, :id => @security_group.id, :name => "foo2" }
-      end
+    it "queues the update action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :update, :params => { :button => "save", :format => :js, :id => group.id, :name => "foo2" }
     end
   end
 
-  describe "#delete" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @security_group = FactoryGirl.create(:security_group_openstack, :ext_management_system => @ems)
+  describe "deleting" do
+    let(:group) { FactoryGirl.create(:security_group_openstack, :ext_management_system => ems) }
+
+    let(:task_options) do
+      {
+        :action => "deleting Security Group for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
     end
 
-    context "#delete" do
-      let(:task_options) do
-        {
-          :action => "deleting Security Group for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @security_group.class.name,
-          :method_name => 'raw_delete_security_group',
-          :instance_id => @security_group.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => []
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => group.class.name,
+        :method_name => 'raw_delete_security_group',
+        :instance_id => group.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => []
+      }
+    end
 
-      it "queues the delete action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :button, :params => { :id => @security_group.id, :pressed => "security_group_delete", :format => :js }
-      end
+    it "queues the delete action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :button, :params => { :id => group.id, :pressed => "security_group_delete", :format => :js }
     end
   end
 end

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -3,92 +3,42 @@ describe StorageController do
 
   let(:storage) { FactoryGirl.create(:storage, :name => 'test_storage1') }
   let(:storage_cluster) { FactoryGirl.create(:storage_cluster, :name => 'test_storage_cluster1') }
-  before { stub_user(:features => :all) }
 
-  context "#button" do
-    it "when VM Right Size Recommendations is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_right_size")
-      expect(controller).to receive(:vm_right_size)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
+  let!(:user) { stub_user(:features => :all) }
+
+  let(:host) { FactoryGirl.create(:host) }
+
+  describe "#button" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
     end
 
-    it "when VM Migrate is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_migrate")
-      controller.instance_variable_set(:@refresh_partial, "layouts/gtl")
-      expect(controller).to receive(:prov_redirect).with("migrate")
-      expect(controller).to receive(:render)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
+    # Button presses covered by shared examples:
+    # vm_right_size
+    # vm_migrate
+    # vm_retire
+    # vm_protect
+    # miq_template_protect
+    # vm_tag
+    # miq_template_tag
+    # host_scan
+    # host_check_compliance
+    # host_refresh
+    # host_protect
+    # host_edit
+    # host_delete
+    # storage_refresh
+    # storage_scan
+    # storage_delete
 
-    it "when VM Retire is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_retire")
-      expect(controller).to receive(:retirevms).once
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
+    include_examples :host_vm_button_examples
+    include_examples :host_power_button_examples
+    include_examples :common_host_button_examples
+    include_examples :storage_button_examples
 
-    it "when VM Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_protect")
-      expect(controller).to receive(:assign_policies).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "when MiqTemplate Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_protect")
-      expect(controller).to receive(:assign_policies).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "when VM Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_tag")
-      expect(controller).to receive(:tag).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "when MiqTemplate Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_tag")
-      expect(controller).to receive(:tag).with(VmOrTemplate)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    it "when Host Analyze then Check Compliance is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "host_analyze_check_compliance")
-      allow(controller).to receive(:show)
-      expect(controller).to receive(:analyze_check_compliance_hosts)
-      expect(controller).to receive(:render)
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
-    {"host_standby"  => "Enter Standby Mode",
-     "host_shutdown" => "Shut Down",
-     "host_reboot"   => "Restart",
-     "host_start"    => "Power On",
-     "host_stop"     => "Power Off",
-     "host_reset"    => "Reset"
-    }.each do |button, description|
-      it "when Host #{description} button is pressed" do
-        login_as FactoryGirl.create(:user, :features => button)
-
-        host = FactoryGirl.create(:host)
-        command = button.split('_', 2)[1]
-        allow_any_instance_of(Host).to receive(:is_available?).with(command).and_return(true)
-
-        controller.instance_variable_set(:@_params, :pressed => button, :miq_grid_checks => host.id.to_s)
-        controller.instance_variable_set(:@lastaction, "show_list")
-        allow(controller).to receive(:show_list)
-        expect(controller).to receive(:render)
-        controller.button
-        flash_messages = assigns(:flash_array)
-        expect(flash_messages.first[:message]).to include("successfully initiated")
-        expect(flash_messages.first[:level]).to eq(:success)
-      end
+    it 'handles custom_button' do
+      expect(controller).to receive(:handle_custom_button)
+      post :button, :params => {:pressed => "custom_button", :id => host.id}
     end
   end
 

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -13,26 +13,8 @@ describe StorageController do
       EvmSpecHelper.create_guid_miq_server_zone
     end
 
-    # Button presses covered by shared examples:
-    # vm_right_size
-    # vm_migrate
-    # vm_retire
-    # vm_protect
-    # miq_template_protect
-    # vm_tag
-    # miq_template_tag
-    # host_scan
-    # host_check_compliance
-    # host_refresh
-    # host_protect
-    # host_edit
-    # host_delete
-    # storage_refresh
-    # storage_scan
-    # storage_delete
-
     include_examples :host_vm_button_examples
-    include_examples :host_power_button_examples
+    include_examples :host_power_button_examples, :miq_grid_checks
     include_examples :common_host_button_examples
     include_examples :storage_button_examples
 

--- a/spec/controllers/storage_manager_controller_spec.rb
+++ b/spec/controllers/storage_manager_controller_spec.rb
@@ -1,23 +1,68 @@
 describe StorageManagerController do
-  render_views
-  before(:each) do
-    @zone = EvmSpecHelper.local_miq_server.zone
-    stub_user(:features => :all)
+  let!(:user) { stub_user(:features => :all) }
+  let(:manager) { FactoryGirl.create(:storage_manager, :name => "foo") }
+
+  before do
+    EvmSpecHelper.local_miq_server.zone
   end
 
-  it "renders index" do
-    get :index
-    expect(response.status).to eq(302)
-    expect(response).to redirect_to(:action => 'show_list')
+  describe '#button' do
+    it 'handles storage_manager_new' do
+      expect(controller).to receive(:handle_storage_manager_new).and_call_original
+      post :button, :params => { :pressed => "storage_manager_new", :format => :js }
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to(:action => 'new')
+    end
+
+    it 'handles storage_manager_edit' do
+      expect(controller).to receive(:handle_storage_manager_edit).and_call_original
+      post :button, :params => { :pressed => "storage_manager_edit", :format => :js, :id => manager.id }
+      expect(response.status).to eq(200)
+    end
+
+    it 'handles storage_manager_refresh_inventory' do
+      expect(controller).to receive(:handle_storage_manager_refresh_inventory).and_call_original
+      post :button, :params => { :pressed => "storage_manager_refresh_inventory", :format => :js, :id => manager.id }
+      expect(response.status).to eq(200)
+    end
+
+    it 'handles storage_manager_refresh_status' do
+      expect(controller).to receive(:handle_storage_manager_refresh_status).and_call_original
+      post :button, :params => { :pressed => "storage_manager_refresh_status", :format => :js, :id => manager.id }
+      expect(response.status).to eq(200)
+    end
+
+    it 'handles storage_manager_delete' do
+      expect(controller).to receive(:handle_storage_manager_delete).and_call_original
+      post :button, :params => { :pressed => "storage_manager_delete", :format => :js, :id => manager.id }
+      expect(response.status).to eq(200)
+    end
   end
 
-  it "renders a new page" do
-    set_view_10_per_page
-    post :new, :format => :js
-    expect(response.status).to eq(200)
+  describe '#index' do
+    render_views
+
+    it "renders index" do
+      get :index
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to(:action => 'show_list')
+    end
   end
 
-  context "@edit password fields" do
+  describe '#new' do
+    render_views
+
+    before do
+      set_view_10_per_page
+    end
+
+    it "renders a new page" do
+      post :new, :format => :js
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe "@edit password fields" do
     it "sets @edit password fields to blank when change password is clicked" do
       sm = StorageManager.create(:name => "foo")
       auth = Authentication.create(:userid        => "userid",
@@ -47,7 +92,7 @@ describe StorageManagerController do
     end
   end
 
-  context "Validate" do
+  describe "Validate" do
     let(:mocked_sm) { double(StorageManager) }
 
     it "uses @edit password value for validation" do

--- a/spec/shared/controllers/shared_containers_common_examples.rb
+++ b/spec/shared/controllers/shared_containers_common_examples.rb
@@ -1,0 +1,22 @@
+shared_examples :container_button_examples do |prefix|
+  it "handles #{prefix}_tag" do
+    expect(controller).to receive(:tag).with(controller.class.model)
+    post :button, :params => { :pressed => "#{prefix}_tag" }
+  end
+
+  [ContainerReplicator, ContainerGroup, ContainerNode, ContainerImage].each do |model|
+    it "handles #{model.name.underscore}_protect" do
+      if controller.class.model == model
+        expect(controller).to receive(:assign_policies)
+        post :button, :params => { :pressed => "#{model.name.underscore}_protect" }
+      end
+    end
+
+    it "handles #{model.name.underscore}_check_compliance" do
+      if controller.class.model == model
+        expect(controller).to receive(:check_compliance)
+        post :button, :params => { :pressed => "#{model.name.underscore}_check_compliance" }
+      end
+    end
+  end
+end

--- a/spec/shared/controllers/shared_ems_cluster_examples.rb
+++ b/spec/shared/controllers/shared_ems_cluster_examples.rb
@@ -1,0 +1,40 @@
+shared_examples :ems_cluster_button_examples do
+  let(:ems_cluster_1) { FactoryGirl.create(:ems_cluster) }
+  let(:ems_cluster_2) { FactoryGirl.create(:ems_cluster) }
+
+  let(:checked_clusters) do
+    [ems_cluster_1.id, ems_cluster_2.id].map{ |id| ApplicationRecord.compress_id(id) }.join(",")
+  end
+
+  it "handles ems_cluster_compare" do
+    expect(controller).to receive(:comparemiq).and_call_original
+    post :button, :params => { :pressed => "ems_cluster_compare", :miq_grid_checks => checked_clusters }
+    expect(assigns(:flash_array)).to be_nil
+  end
+
+  it "handles ems_cluster_delete" do
+    expect(controller).to receive(:deleteclusters)
+    post :button, :params => { :pressed => "ems_cluster_delete", :id => ems_cluster_1.id }
+  end
+
+  it 'handles ems_cluster_scan' do
+    expect(controller).to receive(:scanclusters)
+    post :button, :params => { :pressed => "ems_cluster_scan", :id => ems_cluster_1.id }
+  end
+
+  it 'handles ems_cluster_tag' do
+    expect(controller).to receive(:tag).with(EmsCluster).and_call_original
+    post :button, :params => { :pressed => "ems_cluster_tag" }
+    expect(assigns(:flash_array)).to be_nil
+    expect(response.status).to eq(200)
+  end
+
+  it "handles ems_cluster_protect" do
+    if controller.send(:handled_buttons).include?("ems_cluster_protect")
+      expect(controller).to receive(:assign_policies).with(EmsCluster).and_call_original
+      post :button, :params => { :pressed => "ems_cluster_protect", :id => ems_cluster_1.id }
+      expect(assigns(:flash_array)).to be_nil
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/shared/controllers/shared_ems_common_mixin_examples.rb
+++ b/spec/shared/controllers/shared_ems_common_mixin_examples.rb
@@ -1,0 +1,100 @@
+shared_examples :ems_common_button_examples do
+  let!(:user) { stub_user(:features => :all) }
+
+  let(:ems)     { FactoryGirl.create(:ext_management_system) }
+  let(:ems_v)   { FactoryGirl.create(:ems_vmware) }
+  let(:ems_a)   { FactoryGirl.create(:ems_amazon) }
+  let(:storage) { FactoryGirl.create(:storage) }
+
+  let(:vm) do
+    FactoryGirl.create(:vm_vmware, :ext_management_system => ems_v, :storage => storage)
+  end
+
+  let(:ost) do
+    FactoryGirl.create(:orchestration_stack_cloud, :ext_management_system => ems_a)
+  end
+
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone unless defined?(server)
+  end
+
+  include_examples :ems_cluster_button_examples
+  include_examples :host_button_method_call_examples
+  include_examples :storage_button_examples
+
+  %w(
+    host_aggregate_edit
+    cloud_tenant_edit
+    cloud_volume_edit
+    custom_button
+  ).each do |pressed|
+    it "handles #{pressed}" do
+      expect(controller).to receive("handle_#{pressed}".to_sym)
+      post :button, { :pressed => pressed, :format => :js }
+    end
+  end
+
+  %w(
+    ems_cloud_recheck_auth_status
+    ems_infra_recheck_auth_status
+    ems_middleware_recheck_auth_status
+    ems_container_recheck_auth_status
+    ems_physical_infra_recheck_auth_status
+  ).each do |pressed|
+    it "handles #{pressed}" do
+      expect(controller).to receive(:recheck_auth_status)
+      post :button, { :pressed => pressed, :format => :js }
+    end
+  end
+
+  it "handles when Retire Button is pressed for a Cloud provider Instance" do
+    allow(controller).to receive(:role_allows?).and_return(true)
+
+    post :button, :params => { :pressed => "instance_retire", "check_#{vm.id}" => "1", :format => :js, :id => ems_v.id, :display => 'instances' }
+    expect(response.status).to eq 200
+    expect(response.body).to include('vm/retire')
+  end
+
+  it "handles when Retire Button is pressed for an Orchestration Stack" do
+    allow(controller).to receive(:role_allows?).and_return(true)
+
+    post_params = {
+      :pressed          => "orchestration_stack_retire",
+      :display          => 'orchestration_stacks',
+      :id               => ems_a.id,
+      :format           => :js,
+      "check_#{ost.id}" => "1"
+    }
+
+    post :button, :params => post_params
+    expect(response.status).to eq 200
+    expect(response.body).to include('orchestration_stack/retire')
+  end
+
+  it "handles when Delete Button is pressed for CloudObjectStoreContainer" do
+    expect(controller).to receive(:process_cloud_object_storage_buttons)
+    post :button, :params => { :pressed => "cloud_object_store_container_delete" }
+  end
+
+  it "handles when VM Migrate is pressed for unsupported type" do
+    allow(controller).to receive(:role_allows?).and_return(true)
+    vm = FactoryGirl.create(:vm_microsoft)
+    post :button, :params => { :pressed => "vm_migrate", :format => :js, "check_#{vm.id}" => "1" }
+    expect(controller.send(:flash_errors?)).to be_truthy
+    expect(assigns(:flash_array).first[:message]).to include('does not apply')
+  end
+
+  it "handles when VM Migrate is pressed for supported type" do
+    allow(controller).to receive(:role_allows?).and_return(true)
+    vm = FactoryGirl.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
+    post :button, :params => { :pressed => "vm_migrate", :format => :js, "check_#{vm.id}" => "1" }
+    expect(controller.send(:flash_errors?)).not_to be_truthy
+  end
+
+  it "handles when VM Migrate is pressed for supported type" do
+    allow(controller).to receive(:role_allows?).and_return(true)
+    vm = FactoryGirl.create(:vm_vmware)
+    post :button, :params => { :pressed => "vm_edit", :format => :js, "check_#{vm.id}" => "1" }
+    expect(controller.send(:flash_errors?)).not_to be_truthy
+  end
+end

--- a/spec/shared/controllers/shared_host_button_examples.rb
+++ b/spec/shared/controllers/shared_host_button_examples.rb
@@ -1,0 +1,289 @@
+
+shared_examples :common_host_button_examples do
+  # host_scan
+  # host_check_compliance
+  # host_refresh
+  # host_protect
+  # host_edit
+  # host_delete
+
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone unless defined?(server)
+  end
+
+  let(:host)  { FactoryGirl.create(:host) }
+  let(:host2) { FactoryGirl.create(:host) }
+
+  let(:checked_hosts) do
+    [host.id, host2.id].map{ |id| ApplicationRecord.compress_id(id) }.join(",")
+  end
+
+  %w(host_protect host_edit).each do |pressed|
+    it "handles #{pressed}" do
+      expect(controller).to receive("handle_#{pressed}".to_sym).and_call_original
+      post :button, :params => { :pressed => pressed, :format => :js, :id => host.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+  end
+
+  it 'handles host_delete' do
+    expect(controller).to receive(:deletehosts).and_call_original
+    post :button, :params => { :pressed => "host_delete", :format => :js, :id => host.id }
+    expect(assigns(:flash_array).first[:message]).to match(/deleted/)
+    expect(assigns(:flash_array).first[:level]).to eq(:success)
+  end
+
+  it 'handles host_scan' do
+    expect(controller).to receive(:scanhosts).and_call_original
+    post :button, :params => { :pressed => "host_scan", :format => :js, :id => host2.id, :miq_grid_checks => checked_hosts }
+    expect(assigns(:flash_array).first[:message]).to match(/initiated/)
+    expect(assigns(:flash_array).first[:level]).to eq(:success)
+  end
+
+  it 'handles host_refresh' do
+    expect(controller).to receive(:refreshhosts).and_call_original
+    post :button, :params => { :pressed => "host_refresh", :format => :js, :id => host.id, :miq_grid_checks => checked_hosts }
+    expect(assigns(:flash_array).first[:message]).to match(/initiated/)
+    expect(assigns(:flash_array).first[:level]).to eq(:success)
+  end
+
+  it "handles host_check_compliance" do
+    expect(controller).to receive(:check_compliance_hosts).and_call_original
+    expect(controller).to receive(:show)
+
+    post :button, :params => { :pressed => "host_check_compliance", :format => :js, :id => host.id, :miq_grid_checks => checked_hosts}
+
+    flash_array = assigns(:flash_array)
+    expect(flash_array.first[:message]).to match(/successfully initiated/)
+    expect(flash_array.first[:level]).to eq(:success)
+  end
+end
+
+shared_examples :special_host_button_examples do
+  # host_cloud_service_scheduling_toggle
+  # host_compare
+  # host_introspect
+  # host_manageable
+  # host_miq_request_new
+  # host_provide
+  # host_toggle_maintenance
+  # host_analyze_check_compliance
+  # host_tag
+
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone unless defined?(server)
+  end
+
+  let(:host)  { FactoryGirl.create(:host) }
+  let(:host2) { FactoryGirl.create(:host) }
+
+  %w(
+    host_delete
+    host_edit
+    host_introspect
+    host_manageable
+    host_provide
+    new
+  ).each do |pressed|
+    it "handles #{pressed}" do
+      expect(controller).to receive("handle_#{pressed}".to_sym)
+      post :button, :params => { :pressed => pressed, :format => :js, :id => host.id }
+    end
+  end
+
+  it "handles host_toggle_maintenance" do
+    expect(controller).to receive(:maintenancehosts)
+    post :button, :params => { :pressed => "host_toggle_maintenance", :format => :js, :id => host.id }
+  end
+
+  it "handles host_cloud_service_scheduling_toggle" do
+    expect(controller).to receive(:toggleservicescheduling)
+    post :button, :params => { :pressed => "host_cloud_service_scheduling_toggle", :format => :js, :id => host.id }
+  end
+
+  %w(
+    host_compare
+    host_miq_request_new
+    host_protect
+    host_refresh
+    host_scan
+  ).each do |pressed|
+    it "handles #{pressed}" do
+      expect(controller).to receive("handle_#{pressed}".to_sym)
+      post :button, :params => { :pressed => pressed, :format => :js, :id => host.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+  end
+
+  it "handles host_tag" do
+    expect(controller).to receive(:tag).with(Host).and_call_original
+    post :button, :params => { :pressed => "host_tag", :id => host.id}
+    expect(assigns(:flash_array)).to be_nil
+  end
+
+  it "handles host_analyze_check_compliance" do
+    expect(controller).to receive(:analyze_check_compliance_hosts).and_call_original
+    expect(controller).to receive(:show)
+
+    post :button, :params => { :pressed => "host_analyze_check_compliance", :format => :js, :id => host.id}
+
+    flash_array = assigns(:flash_array)
+    expect(flash_array.first[:message]).to match(/successfully initiated/)
+    expect(flash_array.first[:level]).to eq(:success)
+  end
+end
+
+shared_examples :host_vm_button_examples do
+  # vm_right_size
+  # vm_migrate
+  # vm_retire
+  # vm_protect
+  # miq_template_protect
+  # vm_tag
+  # miq_template_tag
+
+  let(:host) { FactoryGirl.create(:host, :name => "Shared Example FooHost") }
+
+  it "handles when VM Right Size Recommendations is pressed" do
+    expect(controller).to receive(:vm_right_size)
+    post :button, :params => { :pressed => "vm_right_size", :id => host.id}
+    expect(assigns(:flash_array)).to be_nil
+  end
+
+  it "handles when VM Migrate is pressed" do
+    expect(controller).to receive(:prov_redirect).with("migrate").and_call_original
+    post :button, :params => { :pressed => "vm_migrate", :id => host.id}
+    expect(assigns(:flash_array)).to be_nil
+  end
+
+  it "handles when VM Retire is pressed" do
+    expect(controller).to receive(:retirevms).and_call_original
+    post :button, :params => { :pressed => "vm_retire", :id => host.id}
+    expect(assigns(:flash_array)).to be_nil
+  end
+
+  it "handles when VM Manage Policies is pressed" do
+    expect(controller).to receive(:assign_policies).with(VmOrTemplate).and_call_original
+    post :button, :params => { :pressed => "vm_protect", :id => host.id}
+    expect(assigns(:flash_array)).to be_nil
+  end
+
+  it "handles when MiqTemplate Manage Policies is pressed" do
+    expect(controller).to receive(:assign_policies).with(VmOrTemplate).and_call_original
+    post :button, :params => { :pressed => "miq_template_protect", :id => host.id}
+    expect(assigns(:flash_array)).to be_nil
+  end
+
+  it "handles when VM Tag is pressed" do
+    expect(controller).to receive(:tag).with(VmOrTemplate).and_call_original
+    post :button, :params => { :pressed => "vm_tag", :id => host.id}
+    expect(assigns(:flash_array)).to be_nil
+  end
+
+  it "handles when MiqTemplate Tag is pressed" do
+    expect(controller).to receive(:tag).with(VmOrTemplate).and_call_original
+    post :button, :params => { :pressed => "miq_template_tag", :id => host.id}
+    expect(assigns(:flash_array)).to be_nil
+  end
+end
+
+shared_examples :host_power_button_examples do
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone unless defined?(server)
+  end
+
+  let(:host)  { FactoryGirl.create(:host) }
+
+  {
+    "host_standby"  => "Enter Standby Mode",
+    "host_shutdown" => "Shut Down",
+    "host_reboot"   => "Restart",
+    "host_start"    => "Power On",
+    "host_stop"     => "Power Off",
+    "host_reset"    => "Reset"
+  }.each do |button, description|
+    it "handles when Host #{description} button is pressed" do
+      command = button.split('_', 2)[1]
+      allow_any_instance_of(Host).to receive(:is_available?).with(command).and_return(true)
+      controller.instance_variable_set(:@lastaction, "show_list")
+      allow(controller).to receive(:show_list)
+
+      post :button, :params => { :pressed => button, :miq_grid_checks => host.id.to_s}
+
+      flash_messages = assigns(:flash_array)
+      expect(flash_messages.first[:message]).to include("successfully initiated")
+      expect(flash_messages.first[:level]).to eq(:success)
+    end
+  end
+end
+
+# Quick tests that only check if the method is called
+shared_examples :host_button_method_call_examples do
+  # Used in ems_common:
+  # host_analyze_check_compliance
+  # host_check_compliance
+  # host_compare
+  # host_delete
+  # host_edit
+  # host_protect
+  # host_refresh
+  # host_scan
+  # host_manageable
+  # host_introspect
+  # host_provide
+
+  it 'handles host_analyze_check_compliance' do
+    expect(controller).to receive(:analyze_check_compliance_hosts)
+    post :button, :params => { :pressed => "host_analyze_check_compliance", :format => :js }
+  end
+
+  it "handles host_check_compliance" do
+    expect(controller).to receive(:check_compliance_hosts)
+    post :button, :params => { :pressed => "host_check_compliance", :format => :js }
+  end
+
+  it "handles host_compare" do
+    expect(controller).to receive(:comparemiq)
+    post :button, :params => { :pressed => "host_compare", :format => :js }
+  end
+
+  it 'handles host_delete' do
+    expect(controller).to receive(:deletehosts)
+    post :button, :params => { :pressed => "host_delete", :format => :js }
+  end
+
+  it 'handles host_edit' do
+    expect(controller).to receive(:edit_record)
+    post :button, :params => { :pressed => "host_edit", :format => :js }
+  end
+
+  it 'handles host_protect' do
+    expect(controller).to receive(:assign_policies).with(Host)
+    post :button, :params => { :pressed => "host_protect", :format => :js }
+  end
+
+  it 'handles host_refresh' do
+    expect(controller).to receive(:refreshhosts)
+    post :button, :params => { :pressed => "host_refresh", :format => :js }
+  end
+
+  it "handles host_scan" do
+    expect(controller).to receive(:scanhosts)
+    post :button, :params => { :pressed => "host_scan", :format => :js }
+  end
+
+  it "handles host_manageable" do
+    expect(controller).to receive(:sethoststomanageable)
+    post :button, :params => { :pressed => "host_manageable", :format => :js }
+  end
+
+  it "handles host_introspect" do
+    expect(controller).to receive(:introspecthosts)
+    post :button, :params => { :pressed => "host_introspect", :format => :js }
+  end
+
+  it "handles host_provide" do
+    expect(controller).to receive(:providehosts)
+    post :button, :params => { :pressed => "host_provide", :format => :js }
+  end
+end

--- a/spec/shared/controllers/shared_host_button_examples.rb
+++ b/spec/shared/controllers/shared_host_button_examples.rb
@@ -187,12 +187,20 @@ shared_examples :host_vm_button_examples do
   end
 end
 
-shared_examples :host_power_button_examples do
+shared_examples :host_power_button_examples do |param_mode|
   before do
     EvmSpecHelper.create_guid_miq_server_zone unless defined?(server)
   end
 
   let(:host)  { FactoryGirl.create(:host) }
+
+  let(:id_param) do
+    if param_mode == :miq_grid_checks
+      { :miq_grid_checks => host.id.to_s }
+    else
+      { :id => host.id }
+    end
+  end
 
   {
     "host_standby"  => "Enter Standby Mode",
@@ -208,7 +216,8 @@ shared_examples :host_power_button_examples do
       controller.instance_variable_set(:@lastaction, "show_list")
       allow(controller).to receive(:show_list)
 
-      post :button, :params => { :pressed => button, :miq_grid_checks => host.id.to_s}
+      # post :button, :params => { :pressed => button, :miq_grid_checks => host.id }
+      post :button, :params => { :pressed => button }.merge(id_param)
 
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include("successfully initiated")

--- a/spec/shared/controllers/shared_storage_button_examples.rb
+++ b/spec/shared/controllers/shared_storage_button_examples.rb
@@ -1,0 +1,20 @@
+# storage_refresh
+# storage_scan
+# storage_delete
+
+shared_examples :storage_button_examples do
+  it "handles storage_refresh" do
+    expect(controller).to receive(:refreshstorage)
+    post :button, :params => { :pressed => "storage_refresh", :format => :js }
+  end
+
+  it "handles storage_scan" do
+    expect(controller).to receive(:scanstorage)
+    post :button, :params => { :pressed => "storage_scan", :format => :js }
+  end
+
+  it "handles storage_delete" do
+    expect(controller).to receive(:deletestorages)
+    post :button, :params => { :pressed => "storage_delete", :format => :js }
+  end
+end


### PR DESCRIPTION
This is a proof of concept to demonstrate refactoring controller button methods by [extracting small, composable methods](https://refactoring.com/catalog/extractMethod.html), rather than combine everything into one big method to rule them all.

**Benefits:**
- Move generic code to the mixin, specific code back closer to the action
- Find exactly what is generic and what is specific
- Small composable methods 

**Why do it all at once?** Because I want to find the real common abstractions between all controllers rather than guess up front and squeeze everything into a pattern after. Also, the plan is to break this PR up with one for the generic mixin and separate ones for each controller. If I have one branch with all the changes, I can better test changes to the mixin if they are necessary later.

**Progress**

- [x] First pass of controllers with button methods
- [x] Extract button handlers
- [ ] ~~Attempt to refactor JS redirects~~
- [ ] Split and further refactor by controller

**Bonus:** I've implemented several pending specs so far.