### PR TITLE
[WIP] application_controller assuring settings paths

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1524,6 +1524,8 @@ class ApplicationController < ActionController::Base
 
     # Set up the list view type (grid/tile/list)
     @settings ||= {:views => {}, :perpage => {}}
+    @settings[:views] ||= {}
+    @settings[:perpage] ||= {}
     @settings[:views][db_sym] = params[:type] if params[:type]  # Change the list view type, if it's sent in
 
     @gtl_type = get_view_calculate_gtl_type(db_sym)


### PR DESCRIPTION
This is an attempt to fix a bug that I encountered:
Sometimes @settings already contains fields (in my case it was `default_search`) and so the previous line `@settings ||= {:views => {}, :perpage => {}}` wouldn't add the `view` and `perpage` paths, this will cause a crush when trying to set a value in the next line.
My change will make sure to add those paths to settings if they are not existing.