### PR TITLE
Add class decorator support

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -960,7 +960,7 @@ class ApplicationController < ActionController::Base
   # Return the icon classname for the list view icon of a db,id pair
   # this always supersedes listicon_image if not nil
   def listicon_icon(item)
-    item.decorate.try(:fonticon) if item.decorator_class?
+    item.decorate.try(:fonticon)
   end
 
   # Return the image name for the list view icon of a db,id pair
@@ -977,7 +977,7 @@ class ApplicationController < ActionController::Base
             when ManageIQ::Providers::CloudManager::AuthKeyPair
               "100/auth_key_pair.png"
             else
-              item.decorate.try(:listicon_image) if item.decorator_class?
+              item.decorate.try(:listicon_image)
             end
 
     image || default

--- a/app/decorators/auth_private_key_decorator.rb
+++ b/app/decorators/auth_private_key_decorator.rb
@@ -1,6 +1,4 @@
-class AuthPrivateKeyDecorator < Draper::Decorator
-  delegate_all
-
+class AuthPrivateKeyDecorator < MiqDecorator
   def fonticon
     nil
   end

--- a/app/decorators/configuration_profile_decorator.rb
+++ b/app/decorators/configuration_profile_decorator.rb
@@ -1,6 +1,4 @@
-class ConfigurationProfileDecorator < Draper::Decorator
-  delegate_all
-
+class ConfigurationProfileDecorator < MiqDecorator
   def fonticon
     nil
   end

--- a/app/decorators/configuration_script_source_decorator.rb
+++ b/app/decorators/configuration_script_source_decorator.rb
@@ -1,6 +1,4 @@
-class ConfigurationScriptSourceDecorator < Draper::Decorator
-  delegate_all
-
+class ConfigurationScriptSourceDecorator < MiqDecorator
   def fonticon
     "pficon pficon-repository"
   end

--- a/app/decorators/configured_system_decorator.rb
+++ b/app/decorators/configured_system_decorator.rb
@@ -1,6 +1,4 @@
-class ConfiguredSystemDecorator < Draper::Decorator
-  delegate_all
-
+class ConfiguredSystemDecorator < MiqDecorator
   def fonticon
     nil
   end

--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -1,6 +1,4 @@
-class ExtManagementSystemDecorator < Draper::Decorator
-  delegate_all
-
+class ExtManagementSystemDecorator < MiqDecorator
   def fonticon
     nil
   end

--- a/app/decorators/filesystem_decorator.rb
+++ b/app/decorators/filesystem_decorator.rb
@@ -1,6 +1,4 @@
-class FilesystemDecorator < Draper::Decorator
-  delegate_all
-
+class FilesystemDecorator < MiqDecorator
   def fonticon
     convert = {
       "dll"      => "fa fa-cogs",
@@ -15,5 +13,4 @@ class FilesystemDecorator < Draper::Decorator
     }
     convert[name.downcase] || "fa fa-file-o"
   end
-
 end

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -1,6 +1,4 @@
-class HostDecorator < Draper::Decorator
-  delegate_all
-
+class HostDecorator < MiqDecorator
   def fonticon
     nil
   end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
@@ -1,11 +1,11 @@
-class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptDecorator < Draper::Decorator
-  delegate_all
+module ManageIQ::Providers::AnsibleTower::AutomationManager
+  class ConfigurationScriptDecorator < MiqDecorator
+    def fonticon
+      'product product-template'
+    end
 
-  def fonticon
-    'product product-template'.freeze
-  end
-
-  def listicon_image
-    '100/configuration_script.png'
+    def listicon_image
+      '100/configuration_script.png'
+    end
   end
 end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
@@ -1,5 +1,5 @@
-module ManageIQ::Providers::AnsibleTower::AutomationManager
-  class ConfigurationScriptDecorator < MiqDecorator
+module ManageIQ::Providers::AnsibleTower
+  class AutomationManager::ConfigurationScriptDecorator < MiqDecorator
     def fonticon
       'product product-template'
     end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
@@ -1,11 +1,11 @@
-class ManageIQ::Providers::AnsibleTower::AutomationManager::JobDecorator < Draper::Decorator
-  delegate_all
+module ManageIQ::Providers::AnsibleTower::AutomationManager
+  class JobDecorator < MiqDecorator
+    def fonticon
+      'product product-orchestration_stack'
+    end
 
-  def fonticon
-    'product product-orchestration_stack'.freeze
-  end
-
-  def listicon_image
-    '100/orchestration_stack.png'
+    def listicon_image
+      '100/orchestration_stack.png'
+    end
   end
 end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
@@ -1,5 +1,5 @@
-module ManageIQ::Providers::AnsibleTower::AutomationManager
-  class JobDecorator < MiqDecorator
+module ManageIQ::Providers::AnsibleTower
+  class AutomationManager::JobDecorator < MiqDecorator
     def fonticon
       'product product-orchestration_stack'
     end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
@@ -1,11 +1,11 @@
-class ManageIQ::Providers::AnsibleTower::AutomationManager::PlaybookDecorator < Draper::Decorator
-  delegate_all
+module ManageIQ::Providers::AnsibleTower::AutomationManager
+  class PlaybookDecorator < MiqDecorator
+    def fonticon
+      nil
+    end
 
-  def fonticon
-    nil
-  end
-
-  def listicon_image
-    'svg/vendor-ansible_tower_automation.svg'
+    def listicon_image
+      'svg/vendor-ansible_tower_automation.svg'
+    end
   end
 end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
@@ -1,5 +1,5 @@
-module ManageIQ::Providers::AnsibleTower::AutomationManager
-  class PlaybookDecorator < MiqDecorator
+module ManageIQ::Providers::AnsibleTower
+  class AutomationManager::PlaybookDecorator < MiqDecorator
     def fonticon
       nil
     end

--- a/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
@@ -1,11 +1,11 @@
-class ManageIQ::Providers::AutomationManager::InventoryGroupDecorator < Draper::Decorator
-  delegate_all
+module ManageIQ::Providers::AutomationManager
+  class InventoryGroupDecorator < MiqDecorator
+    def fonticon
+      'pficon pficon-folder-close'
+    end
 
-  def fonticon
-    'pficon pficon-folder-close'.freeze
-  end
-
-  def listicon_image
-    '100/inventory_group.png'
+    def listicon_image
+      '100/inventory_group.png'
+    end
   end
 end

--- a/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
@@ -1,11 +1,11 @@
-class ManageIQ::Providers::AutomationManager::InventoryRootGroupDecorator < Draper::Decorator
-  delegate_all
+module ManageIQ::Providers::AutomationManager
+  class InventoryRootGroupDecorator < MiqDecorator
+    def fonticon
+      'pficon pficon-folder-close'
+    end
 
-  def fonticon
-    'pficon pficon-folder-close'.freeze
-  end
-
-  def listicon_image
-    '100/inventory_group.png'
+    def listicon_image
+      '100/inventory_group.png'
+    end
   end
 end

--- a/app/decorators/manageiq/providers/automation_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager_decorator.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers
-  class AutomationManagerDecorator < Draper::Decorator
-    delegate_all
-
+  class AutomationManagerDecorator < MiqDecorator
     def fonticon
       nil
     end

--- a/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
@@ -1,5 +1,5 @@
-module ManageIQ::Providers::CloudManager
-  class OrchestrationStackDecorator < MiqDecorator
+module ManageIQ::Providers
+  class CloudManager::OrchestrationStackDecorator < MiqDecorator
     def fonticon
       'product product-orchestration_stack'
     end

--- a/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
@@ -1,9 +1,11 @@
-class ManageIQ::Providers::CloudManager::OrchestrationStackDecorator < Draper::Decorator
-  def fonticon
-    'product product-orchestration_stack'.freeze
-  end
+module ManageIQ::Providers::CloudManager
+  class OrchestrationStackDecorator < MiqDecorator
+    def fonticon
+      'product product-orchestration_stack'
+    end
 
-  def listicon_image
-    "100/orchestration_stack.png"
+    def listicon_image
+      "100/orchestration_stack.png"
+    end
   end
 end

--- a/app/decorators/manageiq/providers/configuration_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/configuration_manager_decorator.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers
-  class ConfigurationManagerDecorator < Draper::Decorator
-    delegate_all
-
+  class ConfigurationManagerDecorator < MiqDecorator
     def fonticon
       nil
     end

--- a/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
@@ -1,5 +1,5 @@
 module ManageIQ::Providers::Hawkular
-  class MiddlewareManagerDecorator < Draper::Decorator
+  class MiddlewareManagerDecorator < MiqDecorator
     def fonticon
       nil
     end

--- a/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
@@ -1,7 +1,7 @@
-class ManageIQ::Providers::Kubernetes::ContainerManagerDecorator < Draper::Decorator
-  delegate_all
-
-  def listicon_image
-    "svg/vendor-kubernetes.svg"
+module ManageIQ::Providers::Kubernetes
+  class ContainerManagerDecorator < MiqDecorator
+    def listicon_image
+      "svg/vendor-kubernetes.svg"
+    end
   end
 end

--- a/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
@@ -1,7 +1,7 @@
-class ManageIQ::Providers::Openshift::ContainerManagerDecorator < Draper::Decorator
-  delegate_all
-
-  def listicon_image
-    "svg/vendor-openshift.svg"
+module ManageIQ::Providers::Openshift
+  class ContainerManagerDecorator < MiqDecorator
+    def listicon_image
+      "svg/vendor-openshift.svg"
+    end
   end
 end

--- a/app/decorators/manageiq/providers/openshift_enterprise/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift_enterprise/container_manager_decorator.rb
@@ -1,7 +1,7 @@
-class ManageIQ::Providers::OpenshiftEnterprise::ContainerManagerDecorator < Draper::Decorator
-  delegate_all
-
-  def listicon_image
-    "svg/vendor-openshift_enterprise.svg"
+module ManageIQ::Providers::OpenshiftEnterprise
+  class ContainerManagerDecorator < MiqDecorator
+    def listicon_image
+      "svg/vendor-openshift_enterprise.svg"
+    end
   end
 end

--- a/app/decorators/manageiq/providers/storage_manager/cinder_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager/cinder_manager_decorator.rb
@@ -1,7 +1,7 @@
-class ManageIQ::Providers::StorageManager::CinderManagerDecorator < Draper::Decorator
-  delegate_all
-
-  def listicon_image
-    "svg/vendor-openstack.svg"
+module ManageIQ::Providers::StorageManager
+  class CinderManagerDecorator < MiqDecorator
+    def listicon_image
+      "svg/vendor-openstack.svg"
+    end
   end
 end

--- a/app/decorators/manageiq/providers/storage_manager/cinder_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager/cinder_manager_decorator.rb
@@ -1,5 +1,5 @@
-module ManageIQ::Providers::StorageManager
-  class CinderManagerDecorator < MiqDecorator
+module ManageIQ::Providers
+  class StorageManager::CinderManagerDecorator < MiqDecorator
     def listicon_image
       "svg/vendor-openstack.svg"
     end

--- a/app/decorators/manageiq/providers/storage_manager/swift_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager/swift_manager_decorator.rb
@@ -1,5 +1,5 @@
-module ManageIQ::Providers::StorageManager
-  class SwiftManagerDecorator < MiqDecorator
+module ManageIQ::Providers
+  class StorageManager::SwiftManagerDecorator < MiqDecorator
     def listicon_image
       "svg/vendor-openstack.svg"
     end

--- a/app/decorators/manageiq/providers/storage_manager/swift_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager/swift_manager_decorator.rb
@@ -1,7 +1,7 @@
-class ManageIQ::Providers::StorageManager::SwiftManagerDecorator < Draper::Decorator
-  delegate_all
-
-  def listicon_image
-    "svg/vendor-openstack.svg"
+module ManageIQ::Providers::StorageManager
+  class SwiftManagerDecorator < MiqDecorator
+    def listicon_image
+      "svg/vendor-openstack.svg"
+    end
   end
 end

--- a/app/decorators/middleware_datasource_decorator.rb
+++ b/app/decorators/middleware_datasource_decorator.rb
@@ -1,8 +1,6 @@
-class MiddlewareDatasourceDecorator < Draper::Decorator
-  delegate_all
-
+class MiddlewareDatasourceDecorator < MiqDecorator
   def fonticon
-    'fa fa-database'.freeze
+    'fa fa-database'
   end
 
   def listicon_image

--- a/app/decorators/middleware_deployment_decorator.rb
+++ b/app/decorators/middleware_deployment_decorator.rb
@@ -1,6 +1,4 @@
-class MiddlewareDeploymentDecorator < Draper::Decorator
-  delegate_all
-
+class MiddlewareDeploymentDecorator < MiqDecorator
   def fonticon
     if name.end_with? '.ear'
       'product product-file-ear-o'

--- a/app/decorators/middleware_domain_decorator.rb
+++ b/app/decorators/middleware_domain_decorator.rb
@@ -1,8 +1,6 @@
-class MiddlewareDomainDecorator < Draper::Decorator
-  delegate_all
-
+class MiddlewareDomainDecorator < MiqDecorator
   def fonticon
-    'pficon-domain'.freeze
+    'pficon-domain'
   end
 
   def listicon_image

--- a/app/decorators/middleware_messaging_decorator.rb
+++ b/app/decorators/middleware_messaging_decorator.rb
@@ -1,8 +1,6 @@
-class MiddlewareMessagingDecorator < Draper::Decorator
-  delegate_all
-
+class MiddlewareMessagingDecorator < MiqDecorator
   def fonticon
-    'fa fa-exchange'.freeze
+    'fa fa-exchange'
   end
 
   def listicon_image

--- a/app/decorators/middleware_server_decorator.rb
+++ b/app/decorators/middleware_server_decorator.rb
@@ -1,6 +1,4 @@
-class MiddlewareServerDecorator < Draper::Decorator
-  delegate_all
-
+class MiddlewareServerDecorator < MiqDecorator
   def fonticon
     nil
   end

--- a/app/decorators/middleware_server_group_decorator.rb
+++ b/app/decorators/middleware_server_group_decorator.rb
@@ -1,8 +1,6 @@
-class MiddlewareServerGroupDecorator < Draper::Decorator
-  delegate_all
-
+class MiddlewareServerGroupDecorator < MiqDecorator
   def fonticon
-    'pficon-server-group'.freeze
+    'pficon-server-group'
   end
 
   def listicon_image

--- a/app/decorators/miq_action_decorator.rb
+++ b/app/decorators/miq_action_decorator.rb
@@ -1,6 +1,4 @@
-class MiqActionDecorator < Draper::Decorator
-  delegate_all
-
+class MiqActionDecorator < MiqDecorator
   def fonticon
     case action_type
     when 'assign_scan_profile'

--- a/app/decorators/miq_ae_class_decorator.rb
+++ b/app/decorators/miq_ae_class_decorator.rb
@@ -1,6 +1,4 @@
-class MiqAeClassDecorator < Draper::Decorator
-  delegate_all
-
+class MiqAeClassDecorator < MiqDecorator
   def fonticon
     'product product-ae_class'
   end

--- a/app/decorators/miq_ae_instance_decorator.rb
+++ b/app/decorators/miq_ae_instance_decorator.rb
@@ -1,6 +1,4 @@
-class MiqAeInstanceDecorator < Draper::Decorator
-  delegate_all
-
+class MiqAeInstanceDecorator < MiqDecorator
   def fonticon
     'fa fa-file-text-o'
   end

--- a/app/decorators/miq_ae_method_decorator.rb
+++ b/app/decorators/miq_ae_method_decorator.rb
@@ -1,6 +1,4 @@
-class MiqAeMethodDecorator < Draper::Decorator
-  delegate_all
-
+class MiqAeMethodDecorator < MiqDecorator
   def fonticon
     'product product-method'
   end

--- a/app/decorators/miq_ae_namespace_decorator.rb
+++ b/app/decorators/miq_ae_namespace_decorator.rb
@@ -1,6 +1,4 @@
-class MiqAeNamespaceDecorator < Draper::Decorator
-  delegate_all
-
+class MiqAeNamespaceDecorator < MiqDecorator
   def fonticon
     'pficon pficon-folder-close'
   end

--- a/app/decorators/miq_event_definition_decorator.rb
+++ b/app/decorators/miq_event_definition_decorator.rb
@@ -1,6 +1,4 @@
-class MiqEventDefinitionDecorator < Draper::Decorator
-  delegate_all
-
+class MiqEventDefinitionDecorator < MiqDecorator
   def fonticon
     convert = {
       "after_assigned_company_tag"                  => "fa fa-tag",

--- a/app/decorators/miq_policy_decorator.rb
+++ b/app/decorators/miq_policy_decorator.rb
@@ -1,6 +1,4 @@
-class MiqPolicyDecorator < Draper::Decorator
-  delegate_all
-
+class MiqPolicyDecorator < MiqDecorator
   def fonticon
     icon = case towhat
            when 'Host'

--- a/app/decorators/miq_request_decorator.rb
+++ b/app/decorators/miq_request_decorator.rb
@@ -1,6 +1,4 @@
-class MiqRequestDecorator < Draper::Decorator
-  delegate_all
-
+class MiqRequestDecorator < MiqDecorator
   def fonticon
     case request_status.to_s.downcase
     when "ok"

--- a/app/decorators/registry_item_decorator.rb
+++ b/app/decorators/registry_item_decorator.rb
@@ -1,6 +1,4 @@
-class RegistryItemDecorator < Draper::Decorator
-  delegate_all
-
+class RegistryItemDecorator < MiqDecorator
   def fonticon
     nil
   end

--- a/app/decorators/resource_pool_decorator.rb
+++ b/app/decorators/resource_pool_decorator.rb
@@ -1,6 +1,4 @@
-class ResourcePoolDecorator < Draper::Decorator
-  delegate_all
-
+class ResourcePoolDecorator < MiqDecorator
   def fonticon
     "pficon pficon-resource-pool"
   end

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -1,6 +1,4 @@
-class ServiceDecorator < Draper::Decorator
-  delegate_all
-
+class ServiceDecorator < MiqDecorator
   def fonticon
     nil
   end

--- a/app/decorators/service_resource_decorator.rb
+++ b/app/decorators/service_resource_decorator.rb
@@ -1,6 +1,4 @@
-class ServiceResourceDecorator < Draper::Decorator
-  delegate_all
-
+class ServiceResourceDecorator < MiqDecorator
   def fonticon
     resource_type.to_s == 'VmOrTemplate' ? 'pficon pficon-virtual-machine' : 'product product-template'
   end

--- a/app/decorators/service_template_ansible_tower_decorator.rb
+++ b/app/decorators/service_template_ansible_tower_decorator.rb
@@ -1,6 +1,4 @@
-class ServiceTemplateAnsibleTowerDecorator < Draper::Decorator
-  delegate_all
-
+class ServiceTemplateAnsibleTowerDecorator < MiqDecorator
   def fonticon
     nil
   end

--- a/app/decorators/service_template_decorator.rb
+++ b/app/decorators/service_template_decorator.rb
@@ -1,6 +1,4 @@
-class ServiceTemplateDecorator < Draper::Decorator
-  delegate_all
-
+class ServiceTemplateDecorator < MiqDecorator
   def fonticon
     nil
   end

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -1,6 +1,4 @@
-class VmOrTemplateDecorator < Draper::Decorator
-  delegate_all
-
+class VmOrTemplateDecorator < MiqDecorator
   def fonticon
     nil
   end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -550,7 +550,7 @@ module QuadiconHelper
   def render_non_listicon_single_quadicon(item, options)
     output = []
 
-    img_path = if item.respond_to?(:decorator_class?) && item.decorator_class?
+    img_path = if item.decorate
                  item.decorate.try(:listicon_image)
                else
                  "100/#{item.class.base_class.to_s.underscore}.png"

--- a/config/initializers/class_decorator.rb
+++ b/config/initializers/class_decorator.rb
@@ -1,22 +1,11 @@
 class ApplicationRecord < ActiveRecord::Base
   class << self
     def decorate
-      @_decorator ||= decorator_for(self)
-    end
-
-    def decorator_for(klass)
-      decorator = nil
-
-      while decorator.nil? && klass != ApplicationRecord
-        decorator = "#{klass.name}Decorator".safe_constantize
-        klass = klass.superclass
-      end
-
-      decorator
+      @_decorator ||= MiqDecorator.for(self)
     end
   end
 
   def decorate
-    self.class.decorator_for(self.class).new(self)
+    @_decorator ||= MiqDecorator.for(self.class).new(self)
   end
 end

--- a/config/initializers/class_decorator.rb
+++ b/config/initializers/class_decorator.rb
@@ -6,6 +6,6 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def decorate
-    @_decorator ||= MiqDecorator.for(self.class).new(self)
+    @_decorator ||= MiqDecorator.for(self.class).try(:new, self)
   end
 end

--- a/config/initializers/class_decorator.rb
+++ b/config/initializers/class_decorator.rb
@@ -4,8 +4,6 @@ class ApplicationRecord < ActiveRecord::Base
       @_decorator ||= decorator_for(self)
     end
 
-    private
-
     def decorator_for(klass)
       decorator = nil
 
@@ -16,5 +14,9 @@ class ApplicationRecord < ActiveRecord::Base
 
       decorator
     end
+  end
+
+  def decorate
+    self.class.decorator_for(self.class).new(self)
   end
 end

--- a/config/initializers/class_decorator.rb
+++ b/config/initializers/class_decorator.rb
@@ -1,0 +1,20 @@
+class ApplicationRecord < ActiveRecord::Base
+  class << self
+    def decorate
+      @_decorator ||= decorator_for(self)
+    end
+
+    private
+
+    def decorator_for(klass)
+      decorator = nil
+
+      while decorator.nil? && klass != ApplicationRecord
+        decorator = "#{klass.name}Decorator".safe_constantize
+        klass = klass.superclass
+      end
+
+      decorator
+    end
+  end
+end

--- a/config/initializers/decorate.rb
+++ b/config/initializers/decorate.rb
@@ -1,12 +1,3 @@
 # extending all model instances and classes to have a `decorate` method
-class ApplicationRecord < ActiveRecord::Base
-  class << self
-    def decorate
-      @_decorator ||= MiqDecorator.for(self)
-    end
-  end
-
-  def decorate
-    @_decorator ||= MiqDecorator.for(self.class).try(:new, self)
-  end
-end
+ApplicationRecord.send(:extend, MiqDecorator::Klass)
+ApplicationRecord.send(:include, MiqDecorator::Instance)

--- a/config/initializers/decorate.rb
+++ b/config/initializers/decorate.rb
@@ -1,3 +1,4 @@
+# extending all model instances and classes to have a `decorate` method
 class ApplicationRecord < ActiveRecord::Base
   class << self
     def decorate

--- a/lib/miq_decorator.rb
+++ b/lib/miq_decorator.rb
@@ -1,0 +1,2 @@
+class MiqDecorator < SimpleDelegator
+end

--- a/lib/miq_decorator.rb
+++ b/lib/miq_decorator.rb
@@ -12,3 +12,15 @@ class MiqDecorator < SimpleDelegator
     end
   end
 end
+
+module MiqDecorator::Instance
+  def decorate
+    @_decorator ||= MiqDecorator.for(self.class).try(:new, self)
+  end
+end
+
+module MiqDecorator::Klass
+  def decorate
+    @_decorator ||= MiqDecorator.for(self)
+  end
+end

--- a/lib/miq_decorator.rb
+++ b/lib/miq_decorator.rb
@@ -1,2 +1,14 @@
 class MiqDecorator < SimpleDelegator
+  class << self
+    def for(klass)
+      decorator = nil
+
+      while decorator.nil? && klass != ApplicationRecord && !klass.nil?
+        decorator = "#{klass.name}Decorator".safe_constantize
+        klass = klass.superclass
+      end
+
+      decorator
+    end
+  end
 end

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -890,7 +890,7 @@ describe QuadiconHelper do
 
       context "when item is not CIM or decorated" do
         before(:each) do
-          allow(item).to receive(:decorator_class?) { false }
+          allow(item).to receive(:decorate).and_return(nil)
         end
 
         it "includes an image with the item's base class name" do

--- a/spec/lib/miq_decorator_spec.rb
+++ b/spec/lib/miq_decorator_spec.rb
@@ -1,0 +1,81 @@
+describe MiqDecorator do
+  context ".for" do
+    it "returns nil when a class doesn't have a decorator" do
+      class TestClassWithout1
+      end
+
+      expect(MiqDecorator.for(TestClassWithout1)).to eq(nil)
+    end
+
+    it "correctly decorates a class when a decorator exists" do
+      class TestClass2
+      end
+
+      class TestClass2Decorator < MiqDecorator
+      end
+
+      expect(MiqDecorator.for(TestClass2)).to eq(TestClass2Decorator)
+    end
+
+    it "correctly decorates a namespaced class" do
+      module TestModule3
+        class TestClass3
+        end
+
+        class TestClass3Decorator < MiqDecorator
+        end
+      end
+
+      expect(MiqDecorator.for(TestModule3::TestClass3)).to eq(TestModule3::TestClass3Decorator)
+    end
+
+    it "correctly doesn't decorate a namespaced class" do
+      module TestModule4
+        class TestClass4
+        end
+      end
+
+      class TestClass4Decorator < MiqDecorator
+      end
+
+      expect(MiqDecorator.for(TestModule4::TestClass4)).not_to eq(TestClass4Decorator)
+      expect(MiqDecorator.for(TestModule4::TestClass4)).to eq(nil)
+    end
+
+    it "correctly decorates a class when only a decorator for the superclass" do
+      class TestParent5
+      end
+
+      class TestClass5 < TestParent5
+      end
+
+      class TestParent5Decorator < MiqDecorator
+      end
+
+      expect(MiqDecorator.for(TestClass5)).to eq(TestParent5Decorator)
+    end
+
+    it "correctly decorates an instance" do
+      class TestClass6
+        extend MiqDecorator::Klass
+        include MiqDecorator::Instance
+
+        attr_reader :x
+
+        def initialize(x)
+          @x = x
+        end
+      end
+
+      class TestClass6Decorator < MiqDecorator
+        def foo
+          x + 1
+        end
+      end
+
+      instance = TestClass6.new(123)
+
+      expect(instance.decorate.foo).to eq(124)
+    end
+  end
+end


### PR DESCRIPTION
This makes it possible to run `decorate` not only on model instances, but also directly on the classes.

It also replaces Draper with a simpler solution.

Differences from Drapper:
  * there is only that `decorate` method, no attempt at implementing `decorator_class?` or any other Draper methods was made
  * that `decorate` method is also available on classes now
  * `delegate_all` is done automatically, but only for decorated instances, not much sense in using it for the decorated class
  * `decorate` returns `nil` when no decorator is found, instead of throwing

Usage:

`VmServer.decorate` will return `VmOrTemplateDecorator`
`vm_instance.decorate` will return an instance of `VmOrTemplateDecorator` which delegates to the original `vm_instance` object

adding

```
def self.fonticon
  "foobar"
end
```

to that decorator (note the `self`) will cause `VmServer.decorate.fonticon` to return `"foobar"`.

Closes ManageIQ/manageiq#10313

Done in preparation for https://github.com/ManageIQ/manageiq/issues/13199, cc @epwinchell 

~~TODO:~~:

   * [x] specs
   * [x] miq PR removing the draper dependency - https://github.com/ManageIQ/manageiq/pull/14044
   * [x] replace API ?decorators with supports - removing the last `.decorate` use from manageiq - https://github.com/ManageIQ/manageiq/pull/14040 (and https://github.com/ManageIQ/manageiq-ui-classic/pull/458)

---

Note that this *does* monkeypatch `ApplicationRecord` - adding a class and instance `decorate` method (and a `@_decorator` field to cache it once resolved).

To be able to decorate non-AR models, we'll need to `extend` and `include` the relevant mixin manually.