### PR TITLE
Don't show error message after deleting Report

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -250,8 +250,10 @@ module ApplicationController::Explorer
     unless kls.where(:id => from_cid(rec_id)).exists?
       @replace_trees = [@sb[:active_accord]] # refresh trees
       self.x_node = "root"
-      add_flash(_("Last selected %{record_name} no longer exists") %
-        {:record_name => ui_lookup(:model => kls.to_s)}, :error)
+      unless @report_deleted
+        add_flash(_("Last selected %{record_name} no longer exists") %
+                    {:record_name => ui_lookup(:model => kls.to_s)}, :error)
+      end
     end
     x_node
   end

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -101,6 +101,7 @@ module ReportController::SavedReports
       @sb[:miq_report_id] = r.miq_report_id
       process_saved_reports(savedreports, "destroy")  unless savedreports.empty?
       add_flash(_("The selected Saved Report was deleted")) if @flash_array.nil?
+      @report_deleted = true
     end
     self.x_node = "xx-#{to_cid(@sb[:miq_report_id])}" if x_active_tree == :savedreports_tree &&
                                                          x_node.split('-').first == "rr"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1393294

Cloud Intel -> Reports -> Saved Reports -> choose one report in a tree -> Configuration -> Delete this Saved Report from the Database

Before:
<img width="1192" alt="screen shot 2017-01-25 at 3 06 12 pm" src="https://cloud.githubusercontent.com/assets/9210860/22293461/e34685ac-e30f-11e6-8921-7ad8ea10da29.png">

After:
<img width="1199" alt="screen shot 2017-01-25 at 2 58 29 pm" src="https://cloud.githubusercontent.com/assets/9210860/22293152/ca5c7c28-e30e-11e6-8771-4f61acdbc2a4.png">

@miq-bot add_label bug, wip