### PR TITLE
Merge jobs and tasks layouts (leave only 'My Tasks' and 'All Tasks' tabs)

### DIFF
--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -8,10 +8,11 @@ class MiqTaskController < ApplicationController
 
   def index
     @tabform = nil
-    @tabform ||= "tasks_1" if role_allows?(:feature => "job_my_smartproxy")
-    @tabform ||= "tasks_2" if role_allows?(:feature => "miq_task_my_ui")
-    @tabform ||= "tasks_3" if role_allows?(:feature => "job_all_smartproxy")
-    @tabform ||= "tasks_4" if role_allows?(:feature => "miq_task_all_ui")
+    # TODO: remove :feature => "job_my_smartproxy" and  :feature => "job_all_smartproxy" from miq_user_roles.yml
+    # above features assigned to the same roles as corresponding :feature => "miq_task_my_ui"
+    # and :feature => "miq_task_all_ui"
+    @tabform ||= "tasks_1" if role_allows?(:feature => "miq_task_my_ui")
+    @tabform ||= "tasks_2" if role_allows?(:feature => "miq_task_all_ui")
     jobs
     render :action => "jobs"
   end
@@ -32,17 +33,11 @@ class MiqTaskController < ApplicationController
 
     @tabs ||= []
 
-    if role_allows?(:feature => "job_my_smartproxy")
-      @tabs.push(["1", _("My VM and Container Analysis Tasks")])
-    end
     if role_allows?(:feature => "miq_task_my_ui")
-      @tabs.push(["2", _("My Other UI Tasks")])
-    end
-    if role_allows?(:feature => "job_all_smartproxy")
-      @tabs.push(["3", _("All VM and Container Analysis Tasks")])
+      @tabs.push(["1", _("My Tasks")])
     end
     if role_allows?(:feature => "miq_task_all_ui")
-      @tabs.push(["4", _("All Other Tasks")])
+      @tabs.push(["2", _("All Tasks")])
     end
   end
 
@@ -77,142 +72,79 @@ class MiqTaskController < ApplicationController
 
     case @tabform
     when "tasks_1" then @layout = "my_tasks"
-    when "tasks_2" then @layout = "my_ui_tasks"
-    when "tasks_3", "alltasks_1" then @layout = "all_tasks"
-    when "tasks_4", "alltasks_2" then @layout = "all_ui_tasks"
+    when "tasks_2", "alltasks_2" then @layout = "all_tasks"
     end
 
-    @user_names = db_class.distinct.pluck("userid").delete_if(&:blank?) if @active_tab.to_i > 2
-    @view, @pages = get_view(db_class, :conditions => tasks_condition(@tasks_options[@tabform]))
+    @view, @pages = get_view(MiqTask, :conditions => tasks_condition(@tasks_options[@tabform]))
+    @user_names = MiqTask.distinct.pluck("userid").delete_if(&:blank?) if @active_tab.to_i == 2
   end
 
   # Cancel a single selected job
-  def canceljobs
+  def cancel_task
     assert_privileges("miq_task_canceljob")
-    job_id = find_checked_items
-    if job_id.empty?
-      add_flash(_("No %{model} were selected for cancellation") % {:model => ui_lookup(:tables => "miq_task")}, :error)
-    end
-    job = db_class.find_by_id(job_id)
-    if job["state"].downcase == "finished"
-      add_flash(_("Finished Task cannot be cancelled"), :error)
-    else
-      process_jobs(job_id, "cancel")  unless job_id.empty?
-      add_flash(_("The selected Task was cancelled"), :error) if @flash_array.nil?
-    end
+    task_id = find_checked_items
+    task = MiqTask.find_by(:id => task_id)
+    message = if task.nil?
+                task_id.empty? ? _("No task were selected to cancel") : _("Task %{id} not found") % {:id => task_id}
+              elsif task.state.downcase == "finished"
+                _("Finished Task cannot be cancelled")
+              else
+                task.process_cancel
+              end
+    add_flash(message, :error)
     jobs
     @refresh_partial = "layouts/tasks"
   end
 
-  # Delete all selected or single displayed job(s)
-  def deletejobs
+  # Delete selected tasks
+  def delete_tasks
     assert_privileges("miq_task_delete")
-    job_ids = find_checked_items
-    if job_ids.empty?
-      add_flash(_("No %{model} were selected for deletion") % {:model => ui_lookup(:tables => "miq_task")}, :error)
-    else
-      db_class.delete_by_id(job_ids)
-      AuditEvent.success(:userid       => session[:userid],
-                         :event        => "Delete selected tasks",
-                         :message      => _("Delete started for record ids: %{id}") % {:id => job_ids.inspect},
-                         :target_class => db_class.base_class.name)
-      if @flash_array.nil?
-        add_flash(n_("Delete initiated for %{count} Task from the %{product} Database",
-                     "Delete initiated for %{count} Tasks from the %{product} Database",
-                     job_ids.length) % {:count => job_ids.length, :product => I18n.t('product.name')})
-      end
-    end
+    delete_tasks_from_table(find_checked_items, "Delete selected tasks")
     jobs
     @refresh_partial = "layouts/tasks"
   end
 
   # Delete all finished job(s)
-  def deletealljobs
+  def delete_all_tasks
     assert_privileges("miq_task_deleteall")
-    job_ids = []
+    task_ids = []
     session[:view].table.data.each do |rec|
-      job_ids.push(rec["id"])
+      task_ids.push(rec["id"])
     end
-    if job_ids.empty?
-      add_flash(_("No %{model} were selected for deletion") % {:model => ui_lookup(:tables => "miq_task")}, :error)
-    else
-      db_class.delete_by_id(job_ids)
-      AuditEvent.success(:userid       => session[:userid],
-                         :event        => "Delete all finished tasks",
-                         :message      => _("Delete started for record ids: %{id}") % {:id => job_ids.inspect},
-                         :target_class => db_class.base_class.name)
-      if @flash_array.nil?
-        add_flash(n_("Delete initiated for %{count} Task from the %{product} Database",
-                     "Delete initiated for %{count} Tasks from the %{product} Database",
-                     job_ids.length) % {:count => job_ids.length, :product => I18n.t('product.name')})
-      end
-    end
+    delete_tasks_from_table(task_ids, "Delete all finished tasks")
     jobs
     @refresh_partial = "layouts/tasks"
   end
 
-  # Delete all job(s) older than selected job(s)
-  def deleteolderjobs
+  # Delete all task(s) older than selected task(s)
+  def delete_older_tasks
     assert_privileges("miq_task_deleteolder")
-    jobid = find_checked_items
-    # fetching job record for the selected job
-    job = db_class.find_by_id(jobid)
-    if job
-      db_class.delete_older(job.updated_on, tasks_condition(@tasks_options[@tabform], false))
+    taskid = find_checked_items
+    task = MiqTask.find_by(:id => taskid)
+    if task
+      MiqTask.delete_older(task.updated_on, tasks_condition(@tasks_options[@tabform], false))
       message = _("Delete started for records older than %{date}, conditions: %{conditions}") %
-        {:date       => job.updated_on,
-         :conditions => @tasks_options[@tabform].inspect}
+                {:date => task.updated_on, :conditions => @tasks_options[@tabform].inspect}
       AuditEvent.success(:userid       => session[:userid],
                          :event        => "Delete older tasks",
                          :message      => message,
-                         :target_class => db_class.base_class.name)
-      add_flash(n_("Delete all older Tasks initiated for %{count} Task from the %{product} Database",
-                   "Delete all older Tasks initiated for %{count} Tasks from the %{product} Database",
-                   jobid.length) % {:count => jobid.length, :product => I18n.t('product.name')})
+                         :target_class => "MiqTask")
+      add_flash(_("Deleting all Tasks older than %{date} from the %{product} Database initiated") %
+                 {:date => task.updated_on, :product => I18n.t('product.name')})
     else
-      add_flash(_("The selected job no longer exists, Delete all older Tasks was not completed"), :warning)
+      add_flash(_("The selected task no longer exists, Delete all older Tasks was not completed"), :warning)
     end
     jobs
     @refresh_partial = "layouts/tasks"
   end
 
-  def process_jobs(jobs, task)
-    db_class.where(:id => jobs).order("lower(name)").each do |job|
-      id = job.id
-      job_name = job.name
-      if task == "destroy"
-        audit = {:event        => "jobs_record_delete",
-                 :message      => _("[%{name}] Record deleted") % {:name => job_name},
-                 :target_id    => id,
-                 :target_class => db_class.base_class.name,
-                 :userid       => session[:userid]}
-      end
-      begin
-        job.send(task.to_sym) if job.respond_to?(task)    # Run the task
-      rescue => bang
-        add_flash(_("%{model} \"%{name}\": Error during '%{task}': %{message}") %
-                    {:model   => ui_lookup(:model => "MiqTask"),
-                     :name    => job_name,
-                     :task    => task,
-                     :message => bang.message}, :error)
-      else
-        if task == "destroy"
-          AuditEvent.success(audit)
-          add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:tables => "miq_task"),
-                                                                    :name  => job_name}, :error)
-        else
-          add_flash(_("\"%{record}\": %{task} successfully initiated") % {:record => job_name, :task => task})
-        end
-      end
-    end
-  end
 
   TASK_X_BUTTON_ALLOWED_ACTIONS =  {
-    "miq_task_delete"      => :deletejobs,
-    "miq_task_deleteall"   => :deletealljobs,
-    "miq_task_deleteolder" => :deleteolderjobs,
-    "miq_task_canceljob"   => :canceljobs,
-    "miq_task_reload"      => :reloadjobs,
+    "miq_task_delete"      => :delete_tasks,
+    "miq_task_deleteall"   => :delete_all_tasks,
+    "miq_task_deleteolder" => :delete_older_tasks,
+    "miq_task_canceljob"   => :cancel_task,
+    "miq_task_reload"      => :reload_tasks,
   }
 
   # handle buttons pressed on the button bar
@@ -290,17 +222,18 @@ class MiqTaskController < ApplicationController
 
   private ############################
 
-  def db_class
-    case @tabform
-    when 'tasks_1', 'tasks_3' then Job
-    when 'tasks_2', 'tasks_4' then MiqTask
-    end
-  end
-
-  def db_table
-    case @tabform
-    when 'tasks_1', 'tasks_3' then "jobs."
-    when 'tasks_2', 'tasks_4' then "miq_tasks."
+  def delete_tasks_from_table(task_ids, event_message)
+    if task_ids.empty?
+      add_flash(_("No task were selected to delete"), :error)
+    else
+      MiqTask.delete_by_id(task_ids)
+      AuditEvent.success(:userid       => session[:userid],
+                         :event        => event_message,
+                         :message      => _("Delete started for record ids: %{id}") % {:id => task_ids.inspect},
+                         :target_class => "MiqTask")
+      add_flash(n_("Delete initiated for %{count} Task from the %{product} Database",
+                   "Delete initiated for %{count} Tasks from the %{product} Database",
+                   task_ids.length) % {:count => task_ids.length, :product => I18n.t('product.name')})
     end
   end
 
@@ -312,21 +245,18 @@ class MiqTaskController < ApplicationController
       :error        => true,
       :warn         => true,
       :running      => true,
-      :states       => %w(tasks_1 tasks_3).include?(@tabform) ? SP_STATES : UI_STATES,
+      :states       => UiConstants::TASK_STATES,
       :state_choice => "all",
       :time_period  => 0,
     }
 
-    @tasks_options[@tabform][:zone]        = "<all>" if %w(tasks_1 tasks_3).include?(@tabform)
-    @tasks_options[@tabform][:user_choice] = "all"   if %w(tasks_1 tasks_4).include?(@tabform)
+    @tasks_options[@tabform][:zone]        = "<all>"
+    @tasks_options[@tabform][:user_choice] = "all" if "tasks_2" == @tabform
   end
 
   # Create a condition from the passed in options
   def tasks_condition(opts, use_times = true)
     cond = [[]]
-
-    cond = add_to_condition(cond, "jobs.guid IS NULL", nil) unless vm_analysis_task?
-
     cond = add_to_condition(cond, *build_query_for_userid(opts))
 
     if !opts[:ok] && !opts[:queued] && !opts[:error] && !opts[:warn] && !opts[:running]
@@ -340,7 +270,7 @@ class MiqTaskController < ApplicationController
     cond = add_to_condition(cond, *build_query_for_time_period(opts)) if use_times
 
     # Add zone condition
-    cond = add_to_condition(cond, *build_query_for_zone(opts)) if vm_analysis_task? && opts[:zone] != "<all>"
+    cond = add_to_condition(cond, *build_query_for_zone(opts)) if opts[:zone] && opts[:zone] != "<all>"
 
     cond = add_to_condition(cond, *build_query_for_state(opts)) if opts[:state_choice] != "all"
 
@@ -355,8 +285,8 @@ class MiqTaskController < ApplicationController
   end
 
   def build_query_for_userid(opts)
-    sql = "#{db_table}userid=?"
-    if %w(tasks_1 tasks_2).include?(@tabform)
+    sql = "miq_tasks.userid=?"
+    if "tasks_1" == @tabform
       [sql, session[:userid]]
     elsif opts[:user_choice] && opts[:user_choice] != "all"
       [sql, opts[:user_choice]]
@@ -376,7 +306,7 @@ class MiqTaskController < ApplicationController
   end
 
   def build_query_for_queued
-    ["(#{db_table}state=? OR #{db_table}state=?)", %w(waiting_to_start Queued)]
+    ["(miq_tasks.state=? OR miq_tasks.state=?)", %w(Waiting_to_start Queued)]
   end
 
   def build_query_for_ok
@@ -392,58 +322,42 @@ class MiqTaskController < ApplicationController
   end
 
   def build_query_for_status_completed(status)
-    sql = "(#{db_table}state=? AND #{db_table}status=?)"
-    if vm_analysis_task?
-      [sql, ["finished", status]]
-    else
-      [sql, ["Finished", status.capitalize]]
-    end
+    sql = "(miq_tasks.state=? AND miq_tasks.status=?)"
+    [sql, ["Finished", status.try(:capitalize)]]
   end
 
   def build_query_for_running
-    sql = "(#{db_table}state!=? AND #{db_table}state!=? AND #{db_table}state!=?)"
-    if vm_analysis_task?
-      [sql, %w(finished waiting_to_start queued)]
-    else
-      [sql, %w(Finished waiting_to_start Queued)]
-    end
+    sql = "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)"
+    [sql, %w(Finished Waiting_to_start Queued)]
   end
 
   def build_query_for_status_none_selected
-    sql = "(#{db_table}status!=? AND #{db_table}status!=? AND #{db_table}status!=? AND "\
-          "#{db_table}state!=? AND #{db_table}state!=?)"
-    if vm_analysis_task?
-      [sql, %w(ok error warn finished waiting_to_start)]
-    else
-      [sql, %w(Ok Error Warn Finished Queued)]
-    end
+    sql = "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND "\
+          "miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)"
+    [sql, %w(Ok Error Warn Finished Queued Waiting_to_start)]
   end
 
   def build_query_for_time_period(opts)
     t = format_timezone(opts[:time_period].to_i != 0 ? opts[:time_period].days.ago : Time.now, Time.zone, "raw")
-    ["#{db_table}updated_on>=? AND #{db_table}updated_on<=?", [t.beginning_of_day, t.end_of_day]]
+    ["miq_tasks.updated_on>=? AND miq_tasks.updated_on<=?", [t.beginning_of_day, t.end_of_day]]
   end
 
   def build_query_for_zone(opts)
-    ["#{db_table}zone=?", opts[:zone]]
+    ["miq_tasks.zone=?", opts[:zone]]
   end
 
   def build_query_for_state(opts)
-    ["#{db_table}state=?", opts[:state_choice]]
+    ["miq_tasks.state=?", opts[:state_choice]]
   end
 
-  def vm_analysis_task?
-    %w(tasks_1 tasks_3).include?(@tabform)
-  end
-
-  def reloadjobs
+  def reload_tasks
     assert_privileges("miq_task_reload")
     jobs
     @refresh_partial = "layouts/tasks"
   end
 
   def get_layout
-    %w(my_tasks my_ui_tasks all_tasks all_ui_tasks).include?(session[:layout]) ? session[:layout] : "my_tasks"
+    %w(my_tasks all_tasks).include?(session[:layout]) ? session[:layout] : "my_tasks"
   end
 
   def get_session_data

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1004,7 +1004,7 @@ module ApplicationHelper
     if section.parent.nil?
       # first-level, fallback to old logic for now
       # FIXME: exception behavior to remove
-      active = 'my_tasks' if %w(my_tasks my_ui_tasks all_tasks all_ui_tasks).include?(@layout)
+      active = 'my_tasks' if %w(my_tasks all_tasks).include?(@layout)
       active = 'cloud_volume' if @layout == 'cloud_volume_snapshot' || @layout == 'cloud_volume_backup'
       active = 'cloud_object_store_container' if @layout == 'cloud_object_store_object'
       active = active.to_sym

--- a/app/helpers/application_helper/button/miq_task_canceljob.rb
+++ b/app/helpers/application_helper/button/miq_task_canceljob.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::MiqTaskCanceljob < ApplicationHelper::Button::Basic
   def visible?
-    !%w(all_tasks all_ui_tasks).include?(@layout)
+    !%w(all_tasks my_tasks).include?(@layout)
   end
 end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -4,7 +4,6 @@ module ApplicationHelper::PageLayouts
     return false if %w(
       about
       all_tasks
-      all_ui_tasks
       chargeback
       configuration
       container_dashboard
@@ -28,7 +27,6 @@ module ApplicationHelper::PageLayouts
       monitor_alerts_list
       monitor_alerts_most_recent
       my_tasks
-      my_ui_tasks
       ops
       physical_infra_topology
       pxe
@@ -60,12 +58,10 @@ module ApplicationHelper::PageLayouts
     # listnav always implies paging, this only handles the non-listnav case
     %w(
       all_tasks
-      all_ui_tasks
       miq_request_ae
       miq_request_host
       miq_request_vm
       my_tasks
-      my_ui_tasks
     ).include? @layout
   end
 
@@ -94,11 +90,7 @@ module ApplicationHelper::PageLayouts
       "exception",
       "support",
       "configuration",
-      "rss",
-      "my_tasks",
-      "my_ui_tasks",
-      "all_tasks",
-      "all_ui_tasks"].include?(@layout)
+      "rss"].include?(@layout)
   end
 
   def dashboard_no_listnav?

--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -42,10 +42,6 @@ module ApplicationHelper
                 _(": Analysis Profiles")
               when "miq_policy_rsop"
                 _(": Policy Simulation")
-              when "all_ui_tasks"
-                _(": All UI Tasks")
-              when "my_ui_tasks"
-                _(": My UI Tasks")
               when "rss"
                 _(": RSS")
               when "storage_manager"

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -45,7 +45,7 @@ class ApplicationHelper::ToolbarChooser
       'dashboard_summary_toggle_view_tb'
     elsif %w(container_project).include?(@layout)
       'container_project_view_tb'
-    elsif !%w(all_tasks all_ui_tasks timeline diagnostics my_tasks my_ui_tasks miq_server usage).include?(@layout) &&
+    elsif !%w(all_tasks timeline diagnostics my_tasks miq_server usage).include?(@layout) &&
           (!@layout.starts_with?("miq_request")) && !@treesize_buttons &&
           @display == "main" && @showtype == "main" && !@in_a_form
       controller_restful? ? "summary_view_restful_tb" : "summary_view_tb"
@@ -551,7 +551,7 @@ class ApplicationHelper::ToolbarChooser
           else
             return "miq_request_center_tb"
           end
-        elsif ["my_tasks", "my_ui_tasks", "all_tasks", "all_ui_tasks"].include?(@layout)
+        elsif %w(my_tasks all_tasks).include?(@layout)
           return "tasks_center_tb"
         end
       end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -407,13 +407,12 @@ module UiConstants
     5 => N_("5 Days Ago"),
     6 => N_("6 Days Ago")
   }
-  SP_STATES = [[N_("Initializing"), "initializing"], [N_("Waiting to Start"), "waiting_to_start"],
-               [N_("Cancelling"), "cancelling"], [N_("Aborting"), "aborting"], [N_("Finished"), "finished"],
-               [N_("Snapshot Create"), "snapshot_create"], [N_("Scanning"), "scanning"],
-               [N_("Snapshot Delete"), "snapshot_delete"], [N_("Synchronizing"), "synchronizing"],
-               [N_("Deploy Smartproxy"), "deploy_smartproxy"]].freeze
-  UI_STATES = [[N_("Initialized"), "Initialized"], [N_("Queued"), "Queued"], [N_("Active"), "Active"],
-               [N_("Finished"), "Finished"]].freeze
+  TASK_STATES = [[N_("Initializing"), "initializing"], [N_("Waiting to Start"), "Waiting_to_start"],
+                 [N_("Cancelling"), "Cancelling"], [N_("Aborting"), "Aborting"], [N_("Finished"), "Finished"],
+                 [N_("Snapshot Create"), "Snapshot_create"], [N_("Scanning"), "Scanning"],
+                 [N_("Snapshot Delete"), "Snapshot_delete"], [N_("Synchronizing"), "Synchronizing"],
+                 [N_("Deploy Smartproxy"), "Deploy_smartproxy"],
+                 [N_("Initialized"), "Initialized"], [N_("Queued"), "Queued"], [N_("Active"), "Active"]].freeze
 
   PROV_STATES = {
     "pending_approval" => N_("Pending Approval"),

--- a/app/views/miq_task/_tasks_options.html.haml
+++ b/app/views/miq_task/_tasks_options.html.haml
@@ -16,7 +16,7 @@
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent("chosen_zone", "#{url}");
-    - if @tabform == "tasks_3" || @tabform == "tasks_4"
+    - if @tabform == "tasks_2"
       .form-group
         %label.control-label.col-md-2
           = _("User")

--- a/spec/controllers/miq_task_controller_spec.rb
+++ b/spec/controllers/miq_task_controller_spec.rb
@@ -1,3 +1,5 @@
+require "spec_helper"
+
 describe MiqTaskController do
   context "#tasks_condition" do
     let(:user) { FactoryGirl.create(:user) }
@@ -6,7 +8,7 @@ describe MiqTaskController do
       allow(controller).to receive_messages(:session => user)
     end
 
-    describe "My VM and Container Analysis Tasks" do
+    describe "My Tasks (used to be 'VM and Container Analysis Tasks' - specific to Jobs)" do
       before do
         controller.instance_variable_set(:@tabform, "tasks_1")
         @opts = {:ok           => true,
@@ -15,37 +17,26 @@ describe MiqTaskController do
                  :warn         => true,
                  :running      => true,
                  :state_choice => "all",
-                 :zone         => "<all>",
                  :time_period  => 0,
-                 :states       => [%w(Initializing initializing),
-                                   %w(Waiting to Start waiting_to_start),
-                                   %w(Cancelling cancelling),
-                                   %w(Aborting aborting),
-                                   %w(Finished finished),
-                                   %w(Snapshot\ Create snapshot_create),
-                                   %w(Scanning scanning),
-                                   %w(Snapshot\ Delete snapshot_delete),
-                                   %w(Synchronizing synchronizing),
-                                   %w(Deploy\ Smartproxy deploy_smartproxy)]
-        }
+                 :states       => UiConstants::TASK_STATES}
       end
 
       it "all defaults" do
-        query = "jobs.userid=? AND "\
-                "((jobs.state=? OR jobs.state=?) OR "\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state!=? AND jobs.state!=? AND jobs.state!=?)) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=?"
+        query = "miq_tasks.userid=? AND "\
+                "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=?"
         expected = [query,
                     user.userid,
-                    "waiting_to_start", "Queued",
-                    "finished", "ok",
-                    "finished", "error",
-                    "finished", "warn",
-                    "finished", "waiting_to_start", "queued"]
+                    "Waiting_to_start", "Queued",
+                    "Finished", "Ok",
+                    "Finished", "Error",
+                    "Finished", "Warn",
+                    "Finished", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period])
         expect(subject).to eq(expected)
       end
@@ -55,20 +46,20 @@ describe MiqTaskController do
                  :error        => nil,
                  :warn         => nil,
                  :running      => nil,
-                 :state_choice => "finished",
+                 :state_choice => "Finished",
                  :zone         => "default",
                  :time_period  => 1)
 
-        query = "jobs.userid=? AND "\
-                "((jobs.state=? AND jobs.status=?)) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.zone=? AND "\
-                "jobs.state=?"
+        query = "miq_tasks.userid=? AND "\
+                "((miq_tasks.state=? AND miq_tasks.status=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.zone=? AND "\
+                "miq_tasks.state=?"
         expected = [query,
                     user.userid,
-                    "finished", "ok"]
-        expected += get_time_period(@opts[:time_period]) << "default" << "finished"
+                    "Finished", "Ok"]
+        expected += get_time_period(@opts[:time_period]) << "default" << "Finished"
         expect(subject).to eq(expected)
       end
 
@@ -81,41 +72,41 @@ describe MiqTaskController do
                  :zone        => "default",
                  :time_period => 6)
 
-        query = "jobs.userid=? AND ("\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state=? AND jobs.status=?)) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.zone=?"
+        query = "miq_tasks.userid=? AND ("\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.zone=?"
         expected = [query,
                     user.userid,
-                    "finished", "error",
-                    "finished", "warn"]
+                    "Finished", "Error",
+                    "Finished", "Warn"]
         expected += get_time_period(@opts[:time_period]) << "default"
         expect(subject).to eq(expected)
       end
 
       it "zone: <All Zones>, Time period: Last 24, Status: Queued, Running, Ok, Error and Warn, State: Aborting" do
-        set_opts(:state_choice => "aborting")
+        set_opts(:state_choice => "Aborting")
 
-        query = "jobs.userid=? AND "\
-                "((jobs.state=? OR jobs.state=?) OR "\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state!=? AND jobs.state!=? AND jobs.state!=?)) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.state=?"
+        query = "miq_tasks.userid=? AND "\
+                "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query,
                     user.userid,
-                    "waiting_to_start", "Queued",
-                    "finished", "ok",
-                    "finished", "error",
-                    "finished", "warn",
-                    "finished", "waiting_to_start", "queued"]
+                    "Waiting_to_start", "Queued",
+                    "Finished", "Ok",
+                    "Finished", "Error",
+                    "Finished", "Warn",
+                    "Finished", "Waiting_to_start", "Queued"]
 
-        expected += get_time_period(@opts[:time_period]) << "aborting"
+        expected += get_time_period(@opts[:time_period]) << "Aborting"
         expect(subject).to eq(expected)
       end
 
@@ -126,14 +117,14 @@ describe MiqTaskController do
                  :warn    => nil,
                  :running => nil)
 
-        query = "jobs.userid=? AND "\
-                "(jobs.status!=? AND jobs.status!=? AND jobs.status!=? AND jobs.state!=? AND jobs.state!=?) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=?"
+        query = "miq_tasks.userid=? AND "\
+                "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=?"
 
         expected = [query,
                     user.userid,
-                    "ok", "error", "warn", "finished", "waiting_to_start"]
+                    "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
 
         expected += get_time_period(@opts[:time_period])
         expect(subject).to eq(expected)
@@ -145,16 +136,16 @@ describe MiqTaskController do
                  :error        => nil,
                  :warn         => nil,
                  :running      => nil,
-                 :state_choice => "aborting")
+                 :state_choice => "Aborting")
 
-        query = "jobs.userid=? AND "\
-                "(jobs.status!=? AND jobs.status!=? AND jobs.status!=? AND jobs.state!=? AND jobs.state!=?) "\
-                "AND jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.state=?"
+        query = "miq_tasks.userid=? AND "\
+                "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) "\
+                "AND miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
 
-        expected = [query, user.userid, "ok", "error", "warn", "finished", "waiting_to_start"]
-        expected += get_time_period(@opts[:time_period]) << "aborting"
+        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
+        expected += get_time_period(@opts[:time_period]) << "Aborting"
         expect(subject).to eq(expected)
       end
 
@@ -164,18 +155,18 @@ describe MiqTaskController do
                  :error        => nil,
                  :warn         => nil,
                  :running      => nil,
-                 :state_choice => "waiting_to_start",
+                 :state_choice => "Waiting_to_start",
                  :zone         => "default",
                  :time_period  => 1)
 
-        query = "jobs.userid=? AND "\
-                "(jobs.status!=? AND jobs.status!=? AND jobs.status!=? AND jobs.state!=? AND jobs.state!=?) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.zone=? AND "\
-                "jobs.state=?"
-        expected = [query, user.userid, "ok", "error", "warn", "finished", "waiting_to_start"]
-        expected += get_time_period(@opts[:time_period]) << "default" << "waiting_to_start"
+        query = "miq_tasks.userid=? AND "\
+                "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.zone=? AND "\
+                "miq_tasks.state=?"
+        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
+        expected += get_time_period(@opts[:time_period]) << "default" << "Waiting_to_start"
         expect(subject).to eq(expected)
       end
 
@@ -185,19 +176,19 @@ describe MiqTaskController do
                  :error        => nil,
                  :warn         => nil,
                  :running      => "1",
-                 :state_choice => "synchronizing",
+                 :state_choice => "Synchronizing",
                  :zone         => "default",
                  :time_period  => 4)
 
-        query = "jobs.userid=? AND "\
-                "((jobs.state=? OR jobs.state=?) OR "\
-                "(jobs.state!=? AND jobs.state!=? AND jobs.state!=?)) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.zone=? AND "\
-                "jobs.state=?"
-        expected = [query, user.userid, "waiting_to_start", "Queued", "finished", "waiting_to_start", "queued"]
-        expected += get_time_period(@opts[:time_period]) << "default" << "synchronizing"
+        query = "miq_tasks.userid=? AND "\
+                "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.zone=? AND "\
+                "miq_tasks.state=?"
+        expected = [query, user.userid, "Waiting_to_start", "Queued", "Finished", "Waiting_to_start", "Queued"]
+        expected += get_time_period(@opts[:time_period]) << "default" << "Synchronizing"
         expect(subject).to eq(expected)
       end
 
@@ -207,26 +198,26 @@ describe MiqTaskController do
                  :error        => nil,
                  :warn         => nil,
                  :running      => "1",
-                 :state_choice => "snapshot_delete",
+                 :state_choice => "Snapshot_delete",
                  :zone         => "default",
                  :time_period  => 4)
 
-        query = "jobs.userid=? AND "\
-                "((jobs.state=? OR jobs.state=?) OR "\
-                "(jobs.state!=? AND jobs.state!=? AND jobs.state!=?)) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.zone=? AND "\
-                "jobs.state=?"
-        expected = [query, user.userid, "waiting_to_start", "Queued", "finished", "waiting_to_start", "queued"]
-        expected += get_time_period(@opts[:time_period]) << "default" << "snapshot_delete"
+        query = "miq_tasks.userid=? AND "\
+                "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.zone=? AND "\
+                "miq_tasks.state=?"
+        expected = [query, user.userid, "Waiting_to_start", "Queued", "Finished", "Waiting_to_start", "Queued"]
+        expected += get_time_period(@opts[:time_period]) << "default" << "Snapshot_delete"
         expect(subject).to eq(expected)
       end
     end
 
     describe "My Other UI Tasks" do
       before do
-        controller.instance_variable_set(:@tabform, "tasks_2")
+        controller.instance_variable_set(:@tabform, "tasks_1")
         @opts = {:ok           => true,
                  :queued       => true,
                  :error        => true,
@@ -234,15 +225,11 @@ describe MiqTaskController do
                  :running      => true,
                  :state_choice => "all",
                  :time_period  => 0,
-                 :states       => [%w(Initialized Initialized),
-                                   %w(Queued Queued),
-                                   %w(Active Active),
-                                   %w(Finished Finished)]
-        }
+                 :states       => UiConstants::TASK_STATES}
       end
 
       it "all defaults" do
-        query = 'jobs.guid IS NULL AND miq_tasks.userid=? AND ('\
+        query = 'miq_tasks.userid=? AND ('\
                 '(miq_tasks.state=? OR miq_tasks.state=?) OR '\
                 '(miq_tasks.state=? AND miq_tasks.status=?) OR '\
                 '(miq_tasks.state=? AND miq_tasks.status=?) OR '\
@@ -250,8 +237,8 @@ describe MiqTaskController do
                 '(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND '\
                 'miq_tasks.updated_on>=? AND '\
                 'miq_tasks.updated_on<=?'
-        expected = [query, user.userid, "waiting_to_start", "Queued", "Finished", "Ok",
-                    "Finished", "Error", "Finished", "Warn", "Finished", "waiting_to_start", "Queued"
+        expected = [query, user.userid, "Waiting_to_start", "Queued", "Finished", "Ok",
+                    "Finished", "Error", "Finished", "Warn", "Finished", "Waiting_to_start", "Queued"
                    ]
         expected += get_time_period(@opts[:time_period])
         expect(subject).to eq(expected)
@@ -264,13 +251,13 @@ describe MiqTaskController do
                  :state_choice => "Initialized",
                  :time_period  => 6)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND ("\
+        query = "miq_tasks.userid=? AND ("\
                 "(miq_tasks.state=? OR miq_tasks.state=?) OR "\
                 "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, user.userid, "waiting_to_start", "Queued", "Finished", "waiting_to_start", "Queued"]
+        expected = [query, user.userid, "Waiting_to_start", "Queued", "Finished", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Initialized"
         expect(subject).to eq(expected)
       end
@@ -282,13 +269,13 @@ describe MiqTaskController do
                  :state_choice => "Active",
                  :time_period  => 6)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
                 "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, user.userid, "waiting_to_start", "Queued", "Finished", "waiting_to_start", "Queued"]
+        expected = [query, user.userid, "Waiting_to_start", "Queued", "Finished", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Active"
         expect(subject).to eq(expected)
       end
@@ -296,13 +283,13 @@ describe MiqTaskController do
       it "Time period: 6 Days Ago, status: queued and running, state: finished" do
         set_opts(:ok => nil, :error => nil, :warn => nil, :state_choice => "Finished", :time_period => 6)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
                 "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, user.userid, "waiting_to_start", "Queued", "Finished", "waiting_to_start", "Queued"]
+        expected = [query, user.userid, "Waiting_to_start", "Queued", "Finished", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Finished"
         expect(subject).to eq(expected)
       end
@@ -316,7 +303,7 @@ describe MiqTaskController do
                  :state_choice => "Queued",
                  :time_period  => 6)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "((miq_tasks.state=? AND miq_tasks.status=?)) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
@@ -336,7 +323,7 @@ describe MiqTaskController do
                  :state_choice => "Queued",
                  :time_period  => 6)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "((miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?)) AND "\
                 "miq_tasks.updated_on>=? AND "\
@@ -356,7 +343,7 @@ describe MiqTaskController do
                  :state_choice => "Queued",
                  :time_period  => 6)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "((miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?)) AND "\
@@ -371,12 +358,12 @@ describe MiqTaskController do
       it "Time Period: Last 24, Status: none checked, State: All" do
         set_opts(:ok => nil, :queued => nil, :error => nil, :warn => nil, :running => nil)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND "\
-                "miq_tasks.state!=?) AND "\
+                "miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=?"
-        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued"]
+        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
         expected += get_time_period(@opts[:time_period])
         expect(subject).to eq(expected)
       end
@@ -384,13 +371,13 @@ describe MiqTaskController do
       it "Time Period: Last 24, Status: none checked, State: Active" do
         set_opts(:ok => nil, :queued => nil, :error => nil, :warn => nil, :running => nil, :state_choice => "Active")
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND "\
-                "miq_tasks.state!=?) AND "\
+                "miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued"]
+        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
         expected += get_time_period(@opts[:time_period]) << "Active"
         expect(subject).to eq(expected)
       end
@@ -404,13 +391,13 @@ describe MiqTaskController do
                  :state_choice => "Finished",
                  :time_period  => 1)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND "\
-                "miq_tasks.state!=?) AND "\
+                "miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued"]
+        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
         expected += get_time_period(@opts[:time_period]) << "Finished"
         expect(subject).to eq(expected)
       end
@@ -424,13 +411,13 @@ describe MiqTaskController do
                  :state_choice => "Initialized",
                  :time_period  => 2)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND "\
-                "miq_tasks.state!=?) AND "\
+                "miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued"]
+        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
         expected += get_time_period(@opts[:time_period]) << "Initialized"
         expect(subject).to eq(expected)
       end
@@ -444,21 +431,21 @@ describe MiqTaskController do
                  :state_choice => "Queued",
                  :time_period  => 3)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND "\
-                "miq_tasks.state!=?) AND "\
+                "miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued"]
+        expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
         expected += get_time_period(@opts[:time_period]) << "Queued"
         expect(subject).to eq(expected)
       end
     end
 
-    describe "All VM and Container Analysis Tasks" do
+    describe "All Tasks (used to be 'All VM and Container Analysis Tasks' - specific to Jobs)" do
       before do
-        controller.instance_variable_set(:@tabform, "tasks_3")
+        controller.instance_variable_set(:@tabform, "tasks_2")
         @opts = {:ok           => true,
                  :queued       => true,
                  :error        => true,
@@ -468,29 +455,19 @@ describe MiqTaskController do
                  :zone         => "<all>",
                  :user_choice  => "all",
                  :time_period  => 0,
-                 :states       => [%w(Initializing initializing),
-                                   %w(Waiting to Start waiting_to_start),
-                                   %w(Cancelling cancelling),
-                                   %w(Aborting aborting),
-                                   %w(Finished finished),
-                                   %w(Snapshot\ Create snapshot_create),
-                                   %w(Scanning scanning),
-                                   %w(Snapshot\ Delete snapshot_delete),
-                                   %w(Synchronizing synchronizing),
-                                   %w(Deploy\ Smartproxy deploy_smartproxy)]
-                }
+                 :states       => UiConstants::TASK_STATES}
       end
 
       it "all defaults" do
-        query = "((jobs.state=? OR jobs.state=?) OR "\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state!=? AND jobs.state!=? AND jobs.state!=?)) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=?"
-        expected = [query, "waiting_to_start", "Queued", "finished", "ok", "finished", "error",
-                    "finished", "warn", "finished", "waiting_to_start", "queued"
+        query = "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=?"
+        expected = [query, "Waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
+                    "Finished", "Warn", "Finished", "Waiting_to_start", "Queued"
                    ]
         expected += get_time_period(@opts[:time_period])
         expect(subject).to eq(expected)
@@ -499,12 +476,12 @@ describe MiqTaskController do
       it "zone: default, user: all, Time  period: 6 Days Ago, status: queued and running, state: all" do
         set_opts(:ok => nil, :queued => "1", :error => nil, :warn => nil, :zone => "default", :time_period => 6)
 
-        query = "((jobs.state=? OR jobs.state=?) OR "\
-                "(jobs.state!=? AND jobs.state!=? AND jobs.state!=?)) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.zone=?"
-        expected = [query, "waiting_to_start", "Queued", "finished", "waiting_to_start", "queued"]
+        query = "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.zone=?"
+        expected = [query, "Waiting_to_start", "Queued", "Finished", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "default"
         expect(subject).to eq(expected)
       end
@@ -514,18 +491,18 @@ describe MiqTaskController do
                  :queued       => "1",
                  :error        => nil,
                  :warn         => nil,
-                 :state_choice => "snapshot_create",
+                 :state_choice => "Snapshot_create",
                  :zone         => "default",
                  :time_period  => 6)
 
-        query = "((jobs.state=? OR jobs.state=?) OR "\
-                "(jobs.state!=? AND jobs.state!=? AND jobs.state!=?)) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.zone=? AND "\
-                "jobs.state=?"
-        expected = [query, "waiting_to_start", "Queued", "finished", "waiting_to_start", "queued"]
-        expected += get_time_period(@opts[:time_period]) << "default" << "snapshot_create"
+        query = "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.zone=? AND "\
+                "miq_tasks.state=?"
+        expected = [query, "Waiting_to_start", "Queued", "Finished", "Waiting_to_start", "Queued"]
+        expected += get_time_period(@opts[:time_period]) << "default" << "Snapshot_create"
         expect(subject).to eq(expected)
       end
 
@@ -534,20 +511,20 @@ describe MiqTaskController do
                  :queued       => "1",
                  :error        => nil,
                  :warn         => nil,
-                 :state_choice => "snapshot_create",
+                 :state_choice => "Snapshot_create",
                  :zone         => "default",
                  :time_period  => 6)
 
-        query = "((jobs.state=? OR jobs.state=?) OR "\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state!=? AND jobs.state!=? AND jobs.state!=?)) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.zone=? AND "\
-                "jobs.state=?"
-        expected = [query, "waiting_to_start", "Queued", "finished", "ok",
-                    "finished", "waiting_to_start", "queued"]
-        expected += get_time_period(@opts[:time_period]) << "default" << "snapshot_create"
+        query = "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.zone=? AND "\
+                "miq_tasks.state=?"
+        expected = [query, "Waiting_to_start", "Queued", "Finished", "Ok",
+                    "Finished", "Waiting_to_start", "Queued"]
+        expected += get_time_period(@opts[:time_period]) << "default" << "Snapshot_create"
         expect(subject).to eq(expected)
       end
 
@@ -557,14 +534,14 @@ describe MiqTaskController do
                  :error        => nil,
                  :warn         => nil,
                  :running      => nil,
-                 :state_choice => "snapshot_create")
+                 :state_choice => "Snapshot_create")
 
-        query = "(jobs.status!=? AND jobs.status!=? AND jobs.status!=? AND jobs.state!=? AND jobs.state!=?) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.state=?"
-        expected = [query, "ok", "error", "warn", "finished", "waiting_to_start"]
-        expected += get_time_period(@opts[:time_period]) << "snapshot_create"
+        query = "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
+        expected = [query, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
+        expected += get_time_period(@opts[:time_period]) << "Snapshot_create"
         expect(subject).to eq(expected)
       end
 
@@ -574,15 +551,15 @@ describe MiqTaskController do
                  :error        => nil,
                  :warn         => nil,
                  :running      => nil,
-                 :state_choice => "scanning",
+                 :state_choice => "Scanning",
                  :time_period  => 2)
 
-        query = "(jobs.status!=? AND jobs.status!=? AND jobs.status!=? AND jobs.state!=? AND jobs.state!=?) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.state=?"
-        expected = [query, "ok", "error", "warn", "finished", "waiting_to_start"]
-        expected += get_time_period(@opts[:time_period]) << "scanning"
+        query = "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
+        expected = [query, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
+        expected += get_time_period(@opts[:time_period]) << "Scanning"
         expect(subject).to eq(expected)
       end
 
@@ -592,15 +569,15 @@ describe MiqTaskController do
                  :error        => nil,
                  :warn         => nil,
                  :running      => nil,
-                 :state_choice => "initializing",
+                 :state_choice => "Initializing",
                  :time_period  => 3)
 
-        query = "(jobs.status!=? AND jobs.status!=? AND jobs.status!=? AND jobs.state!=? AND jobs.state!=?) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.state=?"
-        expected = [query, "ok", "error", "warn", "finished", "waiting_to_start"]
-        expected += get_time_period(@opts[:time_period]) << "initializing"
+        query = "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
+        expected = [query, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
+        expected += get_time_period(@opts[:time_period]) << "Initializing"
         expect(subject).to eq(expected)
       end
 
@@ -610,15 +587,15 @@ describe MiqTaskController do
                  :error        => nil,
                  :warn         => nil,
                  :running      => nil,
-                 :state_choice => "finished",
+                 :state_choice => "Finished",
                  :time_period  => 4)
 
-        query = "(jobs.status!=? AND jobs.status!=? AND jobs.status!=? AND jobs.state!=? AND jobs.state!=?) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.state=?"
-        expected = [query, "ok", "error", "warn", "finished", "waiting_to_start"]
-        expected += get_time_period(@opts[:time_period]) << "finished"
+        query = "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
+        expected = [query, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
+        expected += get_time_period(@opts[:time_period]) << "Finished"
         expect(subject).to eq(expected)
       end
 
@@ -628,15 +605,15 @@ describe MiqTaskController do
                  :error        => nil,
                  :warn         => nil,
                  :running      => nil,
-                 :state_choice => "deploy_smartproxy",
+                 :state_choice => "Deploy_smartproxy",
                  :time_period  => 5)
 
-        query = "(jobs.status!=? AND jobs.status!=? AND jobs.status!=? AND jobs.state!=? AND jobs.state!=?) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.state=?"
-        expected = [query, "ok", "error", "warn", "finished", "waiting_to_start"]
-        expected += get_time_period(@opts[:time_period]) << "deploy_smartproxy"
+        query = "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
+        expected = [query, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
+        expected += get_time_period(@opts[:time_period]) << "Deploy_smartproxy"
         expect(subject).to eq(expected)
       end
 
@@ -646,25 +623,24 @@ describe MiqTaskController do
                  :error        => "1",
                  :warn         => "1",
                  :running      => nil,
-                 :state_choice => "cancelling",
+                 :state_choice => "Cancelling",
                  :time_period  => 6)
 
-        query = "((jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state=? AND jobs.status=?) OR "\
-                "(jobs.state=? AND jobs.status=?)) AND "\
-                "jobs.updated_on>=? AND "\
-                "jobs.updated_on<=? AND "\
-                "jobs.state=?"
-        expected = [query, "finished", "ok", "finished", "error", "finished", "warn"]
-        expected += get_time_period(@opts[:time_period]) << "cancelling"
+        query = "((miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
+        expected = [query, "Finished", "Ok", "Finished", "Error", "Finished", "Warn"]
+        expected += get_time_period(@opts[:time_period]) << "Cancelling"
         expect(subject).to eq(expected)
       end
     end
 
-    describe "All Other Tasks" do
+    describe "All Tasks (used to be 'All Other Tasks' - specific to Tasks)" do
       before do
-        controller.instance_variable_set(:@tabform, "tasks_4")
-
+        controller.instance_variable_set(:@tabform, "tasks_2")
         @opts = {:ok           => true,
                  :queued       => true,
                  :error        => true,
@@ -673,24 +649,19 @@ describe MiqTaskController do
                  :state_choice => "all",
                  :user_choice  => "all",
                  :time_period  => 0,
-                 :states       => [%w(Initialized Initialized),
-                                   %w(Queued Queued),
-                                   %w(Active Active),
-                                   %w(Finished Finished)]
-
-        }
+                 :states       => UiConstants::TASK_STATES}
       end
 
       it "all defaults" do
-        query = "jobs.guid IS NULL AND ((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+        query = "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=?"
-        expected = [query, "waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
-                    "Finished", "Warn", "Finished", "waiting_to_start", "Queued"]
+        expected = [query, "Waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
+                    "Finished", "Warn", "Finished", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period])
         expect(subject).to eq(expected)
       end
@@ -698,7 +669,7 @@ describe MiqTaskController do
       it "user: all, Time period: 1 Day Ago, status: queued, running, ok, error and warn, state: active" do
         set_opts(:state_choice => "Active", :time_period => 1)
 
-        query = "jobs.guid IS NULL AND ((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+        query = "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
@@ -706,8 +677,8 @@ describe MiqTaskController do
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, "waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
-                    "Finished", "Warn", "Finished", "waiting_to_start", "Queued"]
+        expected = [query, "Waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
+                    "Finished", "Warn", "Finished", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Active"
         expect(subject).to eq(expected)
       end
@@ -715,7 +686,7 @@ describe MiqTaskController do
       it "user: all, Time period: 1 Day Ago, status: queued, running, ok, error and warn, state: finished" do
         set_opts(:state_choice => "Finished", :time_period => 1)
 
-        query = "jobs.guid IS NULL AND ((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+        query = "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
@@ -723,8 +694,8 @@ describe MiqTaskController do
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, "waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
-                    "Finished", "Warn", "Finished", "waiting_to_start", "Queued"]
+        expected = [query, "Waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
+                    "Finished", "Warn", "Finished", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Finished"
         expect(subject).to eq(expected)
       end
@@ -732,15 +703,15 @@ describe MiqTaskController do
       it "user: all, Time period: 1 Day Ago, status: queued, running, ok, error and warn, state: initialized" do
         set_opts(:state_choice => "Initialized", :time_period => 1)
 
-        query = "jobs.guid IS NULL AND ((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+        query = "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND miq_tasks.state=?"
-        expected = [query, "waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
-                    "Finished", "Warn", "Finished", "waiting_to_start", "Queued"]
+        expected = [query, "Waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
+                    "Finished", "Warn", "Finished", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Initialized"
         expect(subject).to eq(expected)
       end
@@ -748,7 +719,7 @@ describe MiqTaskController do
       it "user: all, Time period: 1 Day Ago, status: queued, running, ok, error and warn, state: queued" do
         set_opts(:state_choice => "Queued", :time_period => 1)
 
-        query = "jobs.guid IS NULL AND ((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+        query = "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
                 "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
@@ -756,8 +727,8 @@ describe MiqTaskController do
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, "waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
-                    "Finished", "Warn", "Finished", "waiting_to_start", "Queued"]
+        expected = [query, "Waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
+                    "Finished", "Warn", "Finished", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Queued"
         expect(subject).to eq(expected)
       end
@@ -765,11 +736,11 @@ describe MiqTaskController do
       it "User: All Users, Time Period: Last 24, Status: none checked, State: All" do
         set_opts(:ok => nil, :queued => nil, :error => nil, :warn => nil, :running => nil)
 
-        query = "jobs.guid IS NULL AND (miq_tasks.status!=? AND miq_tasks.status!=? AND "\
-                "miq_tasks.status!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
+        query = "(miq_tasks.status!=? AND miq_tasks.status!=? AND "\
+                "miq_tasks.status!=? AND miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=?"
-        expected = [query, "Ok", "Error", "Warn", "Finished", "Queued"]
+        expected = [query, "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
         expected += get_time_period(@opts[:time_period])
         expect(subject).to eq(expected)
       end
@@ -784,13 +755,13 @@ describe MiqTaskController do
                  :user_choice  => "system",
                  :time_period  => 1)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND "\
-                "miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
+                "miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, "system", "Ok", "Error", "Warn", "Finished", "Queued"]
+        expected = [query, "system", "Ok", "Error", "Warn", "Finished", "Queued", "Waiting_to_start"]
         expected += get_time_period(@opts[:time_period]) << "Active"
         expect(subject).to eq(expected)
       end
@@ -805,12 +776,12 @@ describe MiqTaskController do
                  :user_choice  => "system",
                  :time_period  => 2)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "((miq_tasks.state=? OR miq_tasks.state=?)) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, "system", "waiting_to_start", "Queued"]
+        expected = [query, "system", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Finished"
         expect(subject).to eq(expected)
       end
@@ -825,12 +796,12 @@ describe MiqTaskController do
                  :user_choice  => "system",
                  :time_period  => 3)
 
-        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+        query = "miq_tasks.userid=? AND "\
                 "((miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
                 "miq_tasks.updated_on>=? AND "\
                 "miq_tasks.updated_on<=? AND "\
                 "miq_tasks.state=?"
-        expected = [query, "system", "Finished", "waiting_to_start", "Queued"]
+        expected = [query, "system", "Finished", "Waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Initialized"
         expect(subject).to eq(expected)
       end
@@ -846,10 +817,8 @@ describe MiqTaskController do
       it 'sets the available tabs' do
         controller.build_jobs_tab
         expect(assigns(:tabs)).to eq([
-                                       ["1", _("My VM and Container Analysis Tasks")],
-                                       ["2", _("My Other UI Tasks")],
-                                       ["3", _("All VM and Container Analysis Tasks")],
-                                       ["4", _("All Other Tasks")]
+                                       ["1", _("My Tasks")],
+                                       ["2", _("All Tasks")],
                                      ])
       end
     end

--- a/spec/helpers/application_helper/buttons/miq_task_canceljob_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_task_canceljob_spec.rb
@@ -3,13 +3,13 @@ describe ApplicationHelper::Button::MiqTaskCanceljob do
 
   describe '#visible?' do
     subject { button.visible? }
-    %w(all_tasks all_ui_tasks).each do |layout|
+    %w(all_tasks my_tasks).each do |layout|
       context "when layout == #{layout}" do
         let(:layout) { layout }
         it { is_expected.to be_falsey }
       end
     end
-    context 'when !layout.in(%w(all_tasks all_ui_tasks))' do
+    context 'when !layout.in(%w(all_tasks my_tasks))' do
       let(:layout) { 'something' }
       it { is_expected.to be_truthy }
     end

--- a/spec/helpers/application_helper/title_spec.rb
+++ b/spec/helpers/application_helper/title_spec.rb
@@ -28,9 +28,9 @@ describe ApplicationHelper::Title do
       expect(subject).to eq(title + ": Policy Simulation")
     end
 
-    it "when layout = 'all_ui_tasks'" do
-      @layout = "all_ui_tasks"
-      expect(subject).to eq(title + ": All UI Tasks")
+    it "when layout = 'all_tasks'" do
+      @layout = "all_tasks"
+      expect(subject).to eq(title + ": All Tasks")
     end
 
     it "when layout = 'rss'" do


### PR DESCRIPTION
There is a request to provide combined view of jobs and tasks: https://www.pivotaltracker.com/story/show/125186471

This PR depends on https://github.com/ManageIQ/manageiq/pull/13452, which implements changes on ```Job``` and ```MiqTask``` models, changes to ```product/views/MiqTask.yamls``` and data migrations.

In this PR:
- merging Jobs specific and Tasks specific layouts: instead of four tabs there would be two -    ```My Tasks``` and ```All Tasks``` with  access based on ```:feature => "miq_task_my_ui"``` and ```:feature => "miq_task_all_ui"``` respectively.
  - Both tabs using the same report to provide view -```MiqTask.yaml```.
  - Dropdown filter (to filter search result by state) has combined set of Tasks and Jobs states

BEFORE:
<img width="1149" alt="before - take 1" src="https://cloud.githubusercontent.com/assets/6556758/22312023/38433762-e324-11e6-84ab-92ad41b461f5.png">


AFTER:
![after](https://cloud.githubusercontent.com/assets/6556758/22311301/dfebe1de-e320-11e6-8ee4-aee0bf0b700d.png)


\cc @Fryguy @gtanzillo @dclarizio 
