### PR TITLE
Handle Menu classes in TreeNode spec

### DIFF
--- a/spec/presenters/tree_node_spec.rb
+++ b/spec/presenters/tree_node_spec.rb
@@ -23,7 +23,7 @@ describe TreeNode do
 
     TreeNode.constants.each do |type|
       # We never instantiate MiqAeNode and Node in our codebase
-      next if [:MiqAeNode, :Node].include?(type)
+      next if [:MiqAeNode, :Node, :Menu].include?(type)
 
       describe(type) do
         let(:klass) { type.to_s.constantize }


### PR DESCRIPTION
Menu module does not have `new` or `descendants` methods, so skip it.

@skateman this issue is blocking #137 