### PR TITLE
Use task queue for set/unset node maintenance

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -2346,7 +2346,7 @@ module ApplicationController::CiProcessing
       each_host(hosts, task_name) do |host|
         if host.maintenance
           if host.respond_to?(:unset_node_maintenance)
-            host.send(:unset_node_maintenance)
+            host.send(:unset_node_maintenance_queue, session[:userid])
             add_flash(_("\"%{record}\": %{task} successfully initiated") %
                       {:record => host.name, :task => (display_name || task)})
           else
@@ -2354,7 +2354,7 @@ module ApplicationController::CiProcessing
                       {:hostname => host.name, :task => (task_name || task)}, :error)
           end
         elsif host.respond_to?(:set_node_maintenance)
-          host.send(:set_node_maintenance)
+          host.send(:set_node_maintenance_queue, session[:userid])
           add_flash(_("\"%{record}\": %{task} successfully initiated") %
                     {:record => host.name, :task => (display_name || task)})
         else


### PR DESCRIPTION
Uses task queue instead of making direct provider API calls from the UI. This PR contains the necessary UI changes.

Depends on model changes in https://github.com/ManageIQ/manageiq/pull/13657