### PR TITLE
Reduce default container topology object limit

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -262,7 +262,7 @@ module UiConstants
       :reports => 20
     },
     :topology  => {
-      :containers_max_items => 0
+      :containers_max_items => 100
     },
     :display   => {
       :startpage     => "/dashboard/show",


### PR DESCRIPTION
Small fix to https://github.com/ManageIQ/manageiq-ui-classic/pull/95
Reduced to `100` objects in the view by default. 

@simon3z 