### PR TITLE
Fixed node id for policy after coming from an event

### DIFF
--- a/app/views/miq_policy/_condition_list.html.haml
+++ b/app/views/miq_policy/_condition_list.html.haml
@@ -14,7 +14,7 @@
         %tbody
           - @conditions.each do |c|
             %tr{:title => _("View this Condition"),
-              :onclick => "miqTreeActivateNode('condition_tree', 'xx-#{c.towhat.downcase}_co-#{to_cid(c.id)}');"}
+              :onclick => "miqTreeActivateNode('condition_tree', 'xx-#{c.towhat.camelize(:lower)}_co-#{to_cid(c.id)}');"}
               %td.narrow
                 %i.product.product-miq_condition
               %td

--- a/app/views/miq_policy/_event_details.html.haml
+++ b/app/views/miq_policy/_event_details.html.haml
@@ -23,7 +23,7 @@
           %table.table.table-striped.table-bordered.table-hover
             %tbody
               - @event_policies.each do |p|
-                - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.downcase}_p-#{to_cid(p.id)}"
+                - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.camelize(:lower)}_p-#{to_cid(p.id)}"
                 %tr{:title => _("Click to view Policy"),
                   :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
                   %td.narrow


### PR DESCRIPTION
Fixed the node_id in the evet_details.haml & _condition_list.haml - 'downcase' causes a number of bugs since the id given is NOT correct and should camelize lower instead.

Scenarios fixed: 
- When you click on an event link [In the Events accord in the Control page] and the select a policy  and in that policy click on Events you will not be transferred back to the Events page.
- When clicking on a condition in the conditions list [i.e. Container Image Condition etc..] and then clicking on one of the conditions it did not take you back to the relevant condition page.
cc: @simon3z @cben 

BZ: 
- https://bugzilla.redhat.com/show_bug.cgi?id=1416408
- https://bugzilla.redhat.com/show_bug.cgi?id=1404469
- https://bugzilla.redhat.com/show_bug.cgi?id=1404463