### PR TITLE
Fix buttons AND, OR, NOT, REMOVE in exp editor

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -95,7 +95,7 @@ module ApplicationController::Filter
       exp = exp_find_by_token(@edit[@expkey][:expression], token)
       @edit[:edit_exp] = copy_hash(exp)
       begin
-        @edit[@expkey].update_from_exp_tree(exp)
+        @edit[@expkey].update_from_exp_tree(@edit[:edit_exp])
       rescue => bang
         @exp_atom_errors = [_("There is an error in the selected expression element, perhaps it was imported or edited manually."),
                             _("This element should be removed and recreated or you can report the error to your %{product} administrator.") % {:product => I18n.t('product.name')},

--- a/app/views/layouts/_exp_editor.html.haml
+++ b/app/views/layouts/_exp_editor.html.haml
@@ -11,72 +11,77 @@
     .toolbar-pf-actions
       .form-group
         - if @edit[@expkey].history.idx > 0
-          %button.btn.btn-default
-            = link_to(image_tag(image_path('toolbars/undo.png'),
-                                :alt => _('Undo the last change')),
-                      {:action  => 'exp_button',
-                       :pressed => 'undo'},
-                      "data-miq_sparkle_on"  => true,
-                      "data-miq_sparkle_off" => true,
-                      :remote                => true,
-                      "data-method"          => :post,
-                      :title                 => _('Undo the last change'))
+          - t = _('Undo the last change')
+          %button.btn.btn-default{"data-miq_sparkle_on" => true,
+          "data-method" => :post,
+          :onclick      => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'undo')}');",
+          :remote       => true,
+          :title        => t}
+            %i.fa.fa-reply
         - else
           %button.btn.btn-default.disabled
-            = image_tag(image_path('toolbars/undo.png'))
+            %i.fa.fa-reply
 
         - if @edit[@expkey].history.idx < @edit[@expkey].history.array.length - 1
-          %button
-            = link_to(image_tag(image_path('toolbars/redo.png'),
-                                :alt => _('Re-apply the previous change')),
-                      {:action  => 'exp_button',
-                       :pressed => 'redo'},
-                      "data-miq_sparkle_on"  => true,
-                      "data-miq_sparkle_off" => true,
-                      :remote                => true,
-                      "data-method"          => :post,
-                      :title                 => _('Re-apply the previous change'))
+          - t = _('Re-apply the previous change')
+          %button.btn.btn-default{"data-miq_sparkle_on" => true,
+          :onclick      => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'redo')}');",
+          :remote       => true,
+          "data-method" => :post,
+          :title        => t}
+            %i.fa.fa-share
         - else
           %button.btn.btn-default.disabled
-            = image_tag(image_path('toolbars/redo.png'))
+            %i.fa.fa-share
 
         %span#exp_buttons_off
-          - %w(and or not discard).each do |image|
-            %button.btn.btn-default.disabled
+          - %w(and or not).each do |image|
+            .btn.btn-default.disabled
               = image_tag(image_path("toolbars/#{image}.png"))
+          %button.btn.btn-default.disabled
+            %i.fa-lg.pficon.pficon-close
 
         %span#exp_buttons_not{:style => "display: none"}
-          - [[_("AND with a new expression element"), 'and',     'and'],
-             [_("OR with a new expression element"),  'or',      'or'],
-             ["",                                     'not',     ''],
-             [_("Remove this expression element"),    'discard', 'remove']].each do |title, image, pressed|
+          - [[_("AND with a new expression element"), 'and', 'and'],
+             [_("OR with a new expression element"),  'or',  'or'],
+             ["",                                     'not', '']].each do |title, image, pressed|
             - if title.empty?
-              %button.btn.btn-default.disabled
+              .btn.btn-default.disabled
                 = link_to(image_tag(image_path("toolbars/#{image}.png")))
             - else
-              %button.btn.btn-default
+              .btn.btn-default
                 = link_to(image_tag(image_path("toolbars/#{image}.png"),
                                     :alt => title),
                           {:action  => "exp_button",
                            :pressed => pressed},
                           "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
                           :remote                => true,
                           "data-method"          => :post,
                           :title                 => title)
 
+          %button.btn.btn-default{"data-method" => :post,
+          "data-miq_sparkle_on" => true,
+          :onclick              => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'remove')}');",
+          :remote               => true,
+          :title                => _("Remove this expression element")}
+            %i.fa-lg.pficon.pficon-close
+
         %span#exp_buttons_on{:style => "display: none"}
           - [[_("AND with a new expression element"),       'and',     'and'],
              [_("OR with a new expression element"),        'or',      'or'],
-             [_("Wrap this expression element with a NOT"), 'not',     'not'],
-             [_("Remove this expression element"),          'discard', 'remove']].each do |title, image, pressed|
-            %button.btn.btn-default
+             [_("Wrap this expression element with a NOT"), 'not',     'not']].each do |title, image, pressed|
+            .btn.btn-default
               = link_to(image_tag(image_path("toolbars/#{image}.png"), :alt => title), {:action => 'exp_button', :pressed => pressed},
                         "data-miq_sparkle_on"  => true,
-                        "data-miq_sparkle_off" => true,
                         :remote                => true,
                         "data-method"          => :post,
                         :title                 => title)
+          %button.btn.btn-default{"data-method" => :post,
+          "data-miq_sparkle_on" => true,
+          :onclick              => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'remove')}');",
+          :remote               => true,
+          :title                => _("Remove this expression element")}
+            %i.fa-lg.pficon.pficon-close
 
     - @edit[@expkey][:exp_table].each do |token|
       - if ! %w(AND OR ( ) ???).include?([token].flatten.first)
@@ -85,7 +90,6 @@
                    :token  => token.last},
                   :style                 => "color: black",
                   "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
                   :remote                => true,
                   "data-method"          => :post,
                   :id                    => "exp_#{token.last}")
@@ -95,7 +99,6 @@
                    :token  => token.last},
                   :style                 => "color: black; background-color: yellow",
                   "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
                   :remote                => true,
                   "data-method"          => :post,
                   :id                    => "exp_#{token.last}")


### PR DESCRIPTION
fixing https://github.com/ManageIQ/manageiq/issues/13262

Change _exp_editor.html.haml to make buttons and, or, not, remove
clickable in expression editor and use patternfly icons for buttons
where it is possible instead of using png images and reach
styling of buttons we need.
Fix bug in exp_token_pressed method to make the buttons work properly.

The buttons were broken by https://github.com/ManageIQ/manageiq/pull/12975