### PR TITLE
Remove task priority from queue in specs

### DIFF
--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -114,7 +114,6 @@ describe CloudVolumeController do
           :class_name  => @volume.class.name,
           :method_name => "backup_restore",
           :instance_id => @volume.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
           :role        => "ems_operations",
           :zone        => @ems.my_zone,
           :args        => [@backup.ems_ref]


### PR DESCRIPTION
The priority has been removed from the task queue in the cloud_volume_controller. 
Removing from the specs as well to match the functionality.