### PR TITLE
Remove priority from task queue for cloud volume backup

### DIFF
--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -71,7 +71,6 @@ describe CloudVolumeController do
           :class_name  => @volume.class.name,
           :method_name => "backup_create",
           :instance_id => @volume.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
           :role        => "ems_operations",
           :zone        => @ems.my_zone,
           :args        => [{:name => "backup_name"}]


### PR DESCRIPTION
Remove priority from task queue for cloud volume backup