### PR TITLE
Cascading Auto Refresh for dialog fields

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -27,7 +27,7 @@ var dialogFieldRefresh = {
     }});
   },
 
-  refreshCheckbox: function(fieldName, fieldId) {
+  refreshCheckbox: function(fieldName, fieldId, callback) {
     miqSparkleOn();
 
     var data = {name: fieldName};
@@ -36,12 +36,13 @@ var dialogFieldRefresh = {
       $('.dynamic-checkbox-' + fieldId).prop('checked', responseData.values.checked);
       dialogFieldRefresh.setReadOnly($('.dynamic-checkbox-' + fieldId), responseData.values.read_only);
       dialogFieldRefresh.setVisible($('#field_' +fieldId + '_tr'), responseData.values.visible);
+      callback.call();
     };
 
     dialogFieldRefresh.sendRefreshRequest('dynamic_checkbox_refresh', data, doneFunction);
   },
 
-  refreshDateTime: function(fieldName, fieldId) {
+  refreshDateTime: function(fieldName, fieldId, callback) {
     miqSparkleOn();
 
     var data = {name: fieldName};

--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -75,6 +75,7 @@ var dialogFieldRefresh = {
 
       dialogFieldRefresh.setReadOnly($('.dynamic-date-' + fieldId), responseData.values.read_only);
       dialogFieldRefresh.setVisible($('#field_' +fieldId + '_tr'), responseData.values.visible);
+      callback.call();
     };
 
     dialogFieldRefresh.sendRefreshRequest('dynamic_date_refresh', data, doneFunction);

--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -171,38 +171,20 @@ var dialogFieldRefresh = {
 
   triggerAutoRefresh: function(autoRefreshOptions) {
     if (Boolean(autoRefreshOptions.trigger) === true) {
-      var groupIndex = autoRefreshOptions.group_index;
-      var fieldIndex = autoRefreshOptions.field_index;
       var autoRefreshableIndicies = autoRefreshOptions.auto_refreshable_field_indicies;
-      var nextAvailableAutoRefreshFieldIndex;
-      var nextAvailableAutoRefreshGroupIndex;
-      var foundNextAvailable = false;
+      var currentIndex = autoRefreshOptions.current_index;
 
-      $.each(autoRefreshableIndicies, function(refreshableGroupIndex, refreshableGroup) {
-        if (foundNextAvailable === false && refreshableGroup[0] !== undefined) {
-          if (groupIndex < refreshableGroupIndex) {
-            $.each(refreshableGroup, function(refreshableFieldIndex, refreshableField) {
-              nextAvailableAutoRefreshFieldIndex = autoRefreshableIndicies[refreshableGroupIndex][refreshableFieldIndex];
-              nextAvailableAutoRefreshGroupIndex = refreshableGroupIndex;
-              foundNextAvailable = true;
-            });
-          } else if (groupIndex === refreshableGroupIndex) {
-            $.each(refreshableGroup, function(refreshableFieldIndex, refreshableField) {
-              if (fieldIndex < refreshableField && foundNextAvailable === false) {
-                nextAvailableAutoRefreshFieldIndex = autoRefreshableIndicies[refreshableGroupIndex][refreshableFieldIndex];
-                nextAvailableAutoRefreshGroupIndex = refreshableGroupIndex;
-                foundNextAvailable = true;
-              }
-            });
-          }
-        }
+      var nextAvailable = $.grep(autoRefreshableIndicies, function(potential, potentialsIndex) {
+        return (potential.auto_refresh === true && potentialsIndex > currentIndex);
       });
 
-      if (nextAvailableAutoRefreshFieldIndex !== undefined) {
+      nextAvailable = nextAvailable[0];
+
+      if (nextAvailable !== undefined) {
         parent.postMessage({
-          tabIndex: autoRefreshOptions.tab_index,
-          groupIndex: nextAvailableAutoRefreshGroupIndex,
-          fieldIndex: nextAvailableAutoRefreshFieldIndex,
+          tabIndex: nextAvailable.tab_index,
+          groupIndex: nextAvailable.group_index,
+          fieldIndex: nextAvailable.field_index,
         }, '*');
       }
     }

--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -3,9 +3,9 @@
 var dialogFieldRefresh = {
   listenForAutoRefreshMessages: function(autoRefreshOptions, callbackFunction) {
     var thisIsTheFieldToUpdate = function(event) {
-      tabIndex = event.data.tabIndex;
-      groupIndex = event.data.groupIndex;
-      fieldIndex = event.data.fieldIndex;
+      var tabIndex = event.data.tabIndex;
+      var groupIndex = event.data.groupIndex;
+      var fieldIndex = event.data.fieldIndex;
       return tabIndex === autoRefreshOptions.tab_index && groupIndex === autoRefreshOptions.group_index && fieldIndex === autoRefreshOptions.field_index;
     };
 
@@ -113,33 +113,33 @@ var dialogFieldRefresh = {
     dialogFieldRefresh.sendRefreshRequest('dynamic_radio_button_refresh', data, doneFunction);
   },
 
+  updateTextContainerDoneFunction: function(containerSelector, fieldId, data, callback) {
+    var responseData = JSON.parse(data.responseText);
+    $(containerSelector + fieldId).val(responseData.values.text);
+    dialogFieldRefresh.setReadOnly($(containerSelector + fieldId), responseData.values.read_only);
+    dialogFieldRefresh.setVisible($('#field_' + fieldId + '_tr'), responseData.values.visible);
+    callback.call();
+  },
+
   refreshTextAreaBox: function(fieldName, fieldId, callback) {
     miqSparkleOn();
 
-    var data = {name: fieldName};
     var doneFunction = function(data) {
-      var responseData = JSON.parse(data.responseText);
-      $('.dynamic-text-area-' + fieldId).val(responseData.values.text);
-      dialogFieldRefresh.setReadOnly($('.dynamic-text-area-' + fieldId), responseData.values.read_only);
-      dialogFieldRefresh.setVisible($('#field_' +fieldId + '_tr'), responseData.values.visible);
-      callback.call();
+      dialogFieldRefresh.updateTextContainerDoneFunction('.dynamic-text-area-', fieldId, data, callback);
     };
 
+    var data = {name: fieldName};
     dialogFieldRefresh.sendRefreshRequest('dynamic_text_box_refresh', data, doneFunction);
   },
 
   refreshTextBox: function(fieldName, fieldId, callback) {
     miqSparkleOn();
 
-    var data = {name: fieldName};
     var doneFunction = function(data) {
-      var responseData = JSON.parse(data.responseText);
-      $('.dynamic-text-box-' + fieldId).val(responseData.values.text);
-      dialogFieldRefresh.setReadOnly($('.dynamic-text-box-' + fieldId), responseData.values.read_only);
-      dialogFieldRefresh.setVisible($('#field_' +fieldId + '_tr'), responseData.values.visible);
-      callback.call();
+      dialogFieldRefresh.updateTextContainerDoneFunction('.dynamic-text-box-', fieldId, data, callback);
     };
 
+    var data = {name: fieldName};
     dialogFieldRefresh.sendRefreshRequest('dynamic_text_box_refresh', data, doneFunction);
   },
 

--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -16,13 +16,14 @@ var dialogFieldRefresh = {
     });
   },
 
-  initializeDialogSelectPicker: function(fieldName, fieldId, selectedValue, url, triggerAutoRefresh) {
+  initializeDialogSelectPicker: function(fieldName, selectedValue, url, autoRefreshOptions) {
     miqInitSelectPicker();
     if (selectedValue !== undefined) {
       $('#' + fieldName).selectpicker('val', selectedValue);
     }
+
     miqSelectPickerEvent(fieldName, url, {callback: function() {
-      dialogFieldRefresh.triggerAutoRefresh(fieldId, triggerAutoRefresh);
+      dialogFieldRefresh.triggerAutoRefresh(autoRefreshOptions);
       return true;
     }});
   },
@@ -81,7 +82,7 @@ var dialogFieldRefresh = {
     dialogFieldRefresh.sendRefreshRequest('dynamic_date_refresh', data, doneFunction);
   },
 
-  refreshDropDownList: function(fieldName, fieldId, selectedValue) {
+  refreshDropDownList: function(fieldName, fieldId, selectedValue, callback) {
     miqSparkleOn();
 
     var data = {name: fieldName, checked_value: selectedValue};
@@ -92,6 +93,7 @@ var dialogFieldRefresh = {
       dialogFieldRefresh.setVisible($('#field_' +fieldId + '_tr'), responseData.values.visible);
       $('#' + fieldName).selectpicker('refresh');
       $('#' + fieldName).selectpicker('val', responseData.values.checked_value);
+      callback.call();
     };
 
     dialogFieldRefresh.sendRefreshRequest('dynamic_radio_button_refresh', data, doneFunction);

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1016,7 +1016,7 @@ function miqSendDateRequest(el) {
 
   var attemptAutoRefreshTrigger = function() {
     if (parms.auto_refresh === true) {
-      dialogFieldRefresh.triggerAutoRefresh(parms.field_id, parms.trigger);
+      dialogFieldRefresh.triggerAutoRefresh(parms);
     }
   };
 

--- a/app/assets/javascripts/miq_ujs_bindings.js
+++ b/app/assets/javascripts/miq_ujs_bindings.js
@@ -58,7 +58,7 @@ $(document).ready(function () {
   var attemptAutoRefreshTrigger = function(parms) {
     return function() {
       if (parms.auto_refresh === true) {
-        dialogFieldRefresh.triggerAutoRefresh(parms.field_id, parms.trigger);
+        dialogFieldRefresh.triggerAutoRefresh(parms);
       }
     };
   };

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -53,12 +53,15 @@ module ApplicationHelper::Dialogs
     add_options_unless_read_only(extra_options, tag_options, field)
   end
 
-  def checkbox_tag_options(field, url)
+  def checkbox_tag_options(field, url, auto_refresh_options_hash)
     tag_options = {:class => "dynamic-checkbox-#{field.id}"}
+    miq_observe_options = {
+      :url => url
+    }.merge(auto_refresh_options(field, auto_refresh_options_hash)).to_json
     extra_options = {
       "data-miq_sparkle_on"       => true,
       "data-miq_sparkle_off"      => true,
-      "data-miq_observe_checkbox" => {:url => url}.merge(auto_refresh_options(field)).to_json
+      "data-miq_observe_checkbox" => miq_observe_options
     }
 
     add_options_unless_read_only(extra_options, tag_options, field)

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -96,25 +96,13 @@ module ApplicationHelper::Dialogs
   def radio_options(field, url, value, selected_value)
     tag_options = {
       :type    => 'radio',
-      :id      => field.id,
+      :class   => field.id,
       :value   => value,
       :name    => field.name,
       :checked => selected_value.to_s == value.to_s ? '' : nil
     }
 
-    auto_refresh_string = field.trigger_auto_refresh ? "dialogFieldRefresh.triggerAutoRefresh('#{field.id}', '#{field.trigger_auto_refresh}');" : ""
-
-    extra_options = {
-      # FIXME: when removing remote_function, note that onclick should really be onchange instead
-      :onclick  => auto_refresh_string + remote_function(
-        :with     => "miqSerializeForm('dynamic-radio-#{field.id}')",
-        :url      => url,
-        :loading  => "miqSparkle(true);",
-        :complete => "miqSparkle(false);"
-      )
-    }
-
-    add_options_unless_read_only(extra_options, tag_options, field)
+    add_options_unless_read_only({}, tag_options, field)
   end
 
   private

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -27,28 +27,28 @@ module ApplicationHelper::Dialogs
     options_for_select(Array.new(59) { |i| i.to_s.rjust(2, '0') }, value)
   end
 
-  def textbox_tag_options(field, url)
+  def textbox_tag_options(field, url, auto_refresh_options_hash)
     tag_options = {
       :maxlength => 50,
       :class     => "dynamic-text-box-#{field.id} form-control"
     }
 
     extra_options = {"data-miq_observe" => {
-      :url      => url,
-    }.merge(auto_refresh_options(field)).to_json}
+      :url => url,
+    }.merge(auto_refresh_options(field, auto_refresh_options_hash)).to_json}
 
     add_options_unless_read_only(extra_options, tag_options, field)
   end
 
-  def textarea_tag_options(field, url)
+  def textarea_tag_options(field, url, auto_refresh_options_hash)
     tag_options = {
       :class     => "dynamic-text-area-#{field.id} form-control",
       :size      => "50x6"
     }
 
     extra_options = {"data-miq_observe" => {
-      :url      => url,
-    }.merge(auto_refresh_options(field)).to_json}
+      :url => url,
+    }.merge(auto_refresh_options(field, auto_refresh_options_hash)).to_json}
 
     add_options_unless_read_only(extra_options, tag_options, field)
   end
@@ -116,12 +116,15 @@ module ApplicationHelper::Dialogs
 
   private
 
-  def auto_refresh_options(field)
+  def auto_refresh_options(field, auto_refresh_options_hash)
     if field.trigger_auto_refresh
       {
-        :auto_refresh => true,
-        :field_id     => field.id.to_s,
-        :trigger      => field.trigger_auto_refresh.to_s
+        :auto_refresh                    => true,
+        :tab_index                       => auto_refresh_options_hash[:tab_index],
+        :group_index                     => auto_refresh_options_hash[:group_index],
+        :field_index                     => auto_refresh_options_hash[:field_index],
+        :auto_refreshable_field_indicies => auto_refresh_options_hash[:auto_refreshable_field_indicies],
+        :trigger                         => auto_refresh_options_hash[:trigger]
       }
     else
       {}

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -110,6 +110,27 @@ module ApplicationHelper::Dialogs
     add_options_unless_read_only({}, tag_options, field)
   end
 
+  def build_auto_refreshable_field_indicies(workflow)
+    auto_refreshable_field_indicies = []
+
+    workflow.dialog.dialog_tabs.each_with_index do |tab, tab_index|
+      tab.dialog_groups.each_with_index do |group, group_index|
+        group.dialog_fields.each_with_index do |field, field_index|
+          if field.auto_refresh || field.trigger_auto_refresh
+            auto_refreshable_field_indicies << {
+              :tab_index        => tab_index,
+              :group_index      => group_index,
+              :field_index      => field_index,
+              :auto_refresh     => !!field.auto_refresh
+            }
+          end
+        end
+      end
+    end
+
+    auto_refreshable_field_indicies
+  end
+
   private
 
   def auto_refresh_options(field, auto_refresh_options_hash)

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -116,14 +116,14 @@ module ApplicationHelper::Dialogs
     workflow.dialog.dialog_tabs.each_with_index do |tab, tab_index|
       tab.dialog_groups.each_with_index do |group, group_index|
         group.dialog_fields.each_with_index do |field, field_index|
-          if field.auto_refresh || field.trigger_auto_refresh
-            auto_refreshable_field_indicies << {
-              :tab_index        => tab_index,
-              :group_index      => group_index,
-              :field_index      => field_index,
-              :auto_refresh     => !!field.auto_refresh
-            }
-          end
+          next unless field.auto_refresh || field.trigger_auto_refresh
+
+          auto_refreshable_field_indicies << {
+            :tab_index    => tab_index,
+            :group_index  => group_index,
+            :field_index  => field_index,
+            :auto_refresh => !!field.auto_refresh
+          }
         end
       end
     end

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -141,6 +141,7 @@ module ApplicationHelper::Dialogs
         :group_index                     => auto_refresh_options_hash[:group_index],
         :field_index                     => auto_refresh_options_hash[:field_index],
         :auto_refreshable_field_indicies => auto_refresh_options_hash[:auto_refreshable_field_indicies],
+        :current_index                   => auto_refresh_options_hash[:current_index],
         :trigger                         => auto_refresh_options_hash[:trigger]
       }
     else

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -67,16 +67,21 @@ module ApplicationHelper::Dialogs
     add_options_unless_read_only(extra_options, tag_options, field)
   end
 
-  def date_tag_options(field, url)
+  def date_tag_options(field, url, auto_refresh_options_hash)
     tag_options = {:class => "css1 dynamic-date-#{field.id}", :readonly => "true"}
-    extra_options = {"data-miq_observe_date" => {:url => url}.merge(auto_refresh_options(field)).to_json}
+    miq_observe_options = {
+      :url => url
+    }.merge(auto_refresh_options(field, auto_refresh_options_hash)).to_json
+    extra_options = {"data-miq_observe_date" => miq_observe_options}
 
     add_options_unless_read_only(extra_options, tag_options, field)
   end
 
-  def time_tag_options(field, url, hour_or_min)
+  def time_tag_options(field, url, hour_or_min, auto_refresh_options_hash)
     tag_options = {:class => "dynamic-date-#{hour_or_min}-#{field.id}"}
-    extra_options = {"data-miq_observe" => {:url => url}.merge(auto_refresh_options(field)).to_json}
+    extra_options = {"data-miq_observe" => {
+      :url => url
+    }.merge(auto_refresh_options(field, auto_refresh_options_hash)).to_json}
 
     add_options_unless_read_only(extra_options, tag_options, field)
   end

--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -13,7 +13,8 @@
   %label.control-label.col-md-2{:title => field.description}
     = field.label
   .col-md-8{:title => field.description}
-    - locals = {:edit => edit, :field => field, :url => url, :wf => wf}
+    - auto_refresh_options = {:tab_index => tab_index, :group_index => group_index, :field_index => field_index, :auto_refreshable_field_indicies => auto_refreshable_field_indicies, :trigger => field.trigger_auto_refresh}
+    - locals = {:edit => edit, :field => field, :url => url, :wf => wf, :auto_refresh_options => auto_refresh_options}
     - case field.type
     - when 'DialogFieldTextBox'
       = render(:partial => "shared/dialogs/dialog_field_text_box", :locals => locals)

--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -13,10 +13,10 @@
   %label.control-label.col-md-2{:title => field.description}
     = field.label
   .col-md-8{:title => field.description}
-    - current_index = auto_refreshable_field_indicies.find_index({:tab_index    => tab_index,
-                                                                  :group_index  => group_index,
-                                                                  :field_index  => field_index,
-                                                                  :auto_refresh => !!field.auto_refresh})
+    - current_index = auto_refreshable_field_indicies.find_index(:tab_index    => tab_index,
+                                                                 :group_index  => group_index,
+                                                                 :field_index  => field_index,
+                                                                 :auto_refresh => !!field.auto_refresh)
     - auto_refresh_options = {:tab_index                       => tab_index,
                               :group_index                     => group_index,
                               :field_index                     => field_index,

--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -13,7 +13,16 @@
   %label.control-label.col-md-2{:title => field.description}
     = field.label
   .col-md-8{:title => field.description}
-    - auto_refresh_options = {:tab_index => tab_index, :group_index => group_index, :field_index => field_index, :auto_refreshable_field_indicies => auto_refreshable_field_indicies, :trigger => field.trigger_auto_refresh}
+    - current_index = auto_refreshable_field_indicies.find_index({:tab_index    => tab_index,
+                                                                  :group_index  => group_index,
+                                                                  :field_index  => field_index,
+                                                                  :auto_refresh => !!field.auto_refresh})
+    - auto_refresh_options = {:tab_index                       => tab_index,
+                              :group_index                     => group_index,
+                              :field_index                     => field_index,
+                              :auto_refreshable_field_indicies => auto_refreshable_field_indicies,
+                              :trigger                         => field.trigger_auto_refresh,
+                              :current_index                   => current_index}
     - locals = {:edit => edit, :field => field, :url => url, :wf => wf, :auto_refresh_options => auto_refresh_options}
     - case field.type
     - when 'DialogFieldTextBox'

--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -51,7 +51,7 @@
                        drop_down_options(field, url).merge(:multiple => true))
 
         :javascript
-          dialogFieldRefresh.initializeDialogSelectPicker('#{field.name}', '#{field.id}', undefined, '#{url}', '#{field.trigger_auto_refresh}');
+          dialogFieldRefresh.initializeDialogSelectPicker('#{field.name}', undefined, '#{url}', JSON.parse('#{j(auto_refresh_options.to_json)}'));
 
       - else
         - value = wf.value(field.name) || ''

--- a/app/views/shared/dialogs/_dialog_field_check_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_check_box.html.haml
@@ -1,10 +1,12 @@
-= check_box_tag(field.name, "1", field.checked?, {:disabled => !edit}.merge(checkbox_tag_options(field, url)))
+= check_box_tag(field.name, "1", field.checked?, {:disabled => !edit}.merge(checkbox_tag_options(field, url, auto_refresh_options)))
 
 - if field.dynamic
   - if field.auto_refresh
     :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages("#{field.id}", function() {
-        dialogFieldRefresh.refreshCheckbox("#{field.name}", "#{field.id}");
+      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
+        dialogFieldRefresh.refreshCheckbox("#{field.name}", "#{field.id}", function() {
+          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+        });
       });
 
   - if field.show_refresh_button?
@@ -12,6 +14,7 @@
 
   :javascript
     $('#refresh-dynamic-checkbox-#{field.id}').click(function() {
-      dialogFieldRefresh.refreshCheckbox("#{field.name}", "#{field.id}");
-      dialogFieldRefresh.triggerAutoRefresh("#{field.id}", "#{field.trigger_auto_refresh}");
+      dialogFieldRefresh.refreshCheckbox("#{field.name}", "#{field.id}", function() {
+        dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+      });
     });

--- a/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
@@ -1,32 +1,34 @@
 - if field.type == "DialogFieldDateControl"
   - if edit
-    = datepicker_input_tag("miq_date__#{field.name}", field.value, date_tag_options(field, url))
+    = datepicker_input_tag("miq_date__#{field.name}", field.value, date_tag_options(field, url, auto_refresh_options))
   - else
     = field.value
 
 - if field.type == "DialogFieldDateTimeControl"
   - date_val = field.refresh_json_value
   - if edit
-    = datepicker_input_tag("miq_date__#{field.name}", date_val[:date], date_tag_options(field, url))
+    = datepicker_input_tag("miq_date__#{field.name}", date_val[:date], date_tag_options(field, url, auto_refresh_options))
   - else
     = date_val[:date]
 
   &nbsp;at&nbsp;
   - if edit
-    = select_tag("start_hour", hour_select_options(date_val[:hour]), time_tag_options(field, url, "hour"))
+    = select_tag("start_hour", hour_select_options(date_val[:hour]), time_tag_options(field, url, "hour", auto_refresh_options))
     = ':'
-    = select_tag("start_min", minute_select_options(date_val[:min]), time_tag_options(field, url, "min"))
+    = select_tag("start_min", minute_select_options(date_val[:min]), time_tag_options(field, url, "min", auto_refresh_options))
 
   - else
     = "#{date_val[:hour].rjust(2, '0')}:#{date_val[:min].rjust(2, '0')}"
   &nbsp;
   = session[:user_tz]
 
-- if field.dynamic && field.show_refresh_button?
+- if field.dynamic
   - if field.auto_refresh
     :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages("#{field.id}", function() {
-        dialogFieldRefresh.refreshDateTime("#{field.name}", "#{field.id}");
+      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
+        dialogFieldRefresh.refreshDateTime("#{field.name}", "#{field.id}", function() {
+          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+        });
       });
 
   - if field.show_refresh_button?
@@ -34,6 +36,7 @@
 
   :javascript
     $('#refresh-dynamic-date-#{field.id}').click(function() {
-      dialogFieldRefresh.refreshDateTime("#{field.name}", "#{field.id}");
-      dialogFieldRefresh.triggerAutoRefresh("#{field.id}", "#{field.trigger_auto_refresh}");
+      dialogFieldRefresh.refreshDateTime("#{field.name}", "#{field.id}", function() {
+        dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+      });
     });

--- a/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
@@ -6,29 +6,31 @@
   :javascript
     dialogFieldRefresh.initializeDialogSelectPicker(
       '#{field.name}',
-      '#{field.id}',
       '#{selected}',
       '#{url}',
-      '#{field.trigger_auto_refresh}'
+      JSON.parse('#{j(auto_refresh_options.to_json)}')
     );
+
+  - if field.dynamic
+    - if field.auto_refresh
+      :javascript
+        dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
+          var selectedValue = $('select[name="#{field.name}"]').val();
+          dialogFieldRefresh.refreshDropDownList("#{field.name}", "#{field.id}", selectedValue, function() {
+            dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+          });
+        });
+
+    - if field.show_refresh_button?
+      = button_tag(_('Refresh'), :id => "refresh-dynamic-field-#{field.id}", :class => "btn btn-default")
+
+    :javascript
+      $('#refresh-dynamic-field-#{field.id}').click(function() {
+        var selectedValue = $('select[name="#{field.name}"]').val();
+        dialogFieldRefresh.refreshDropDownList("#{field.name}", "#{field.id}", selectedValue, function() {
+          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+        });
+      });
 
 - else
   = h(field.values.detect { |k, _v| [k, k.to_s].include?(wf.value(field.name)) }.try(:last) || wf.value(field.name))
-
-- if field.dynamic
-  - if field.auto_refresh
-    :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages("#{field.id}", function() {
-        var selectedValue = $('select[name="#{field.name}"]').val();
-        dialogFieldRefresh.refreshDropDownList("#{field.name}", "#{field.id}", selectedValue);
-      });
-
-  - if field.show_refresh_button?
-    = button_tag(_('Refresh'), :id => "refresh-dynamic-field-#{field.id}", :class => "btn btn-default")
-
-  :javascript
-    $('#refresh-dynamic-field-#{field.id}').click(function() {
-      var selectedValue = $('select[name="#{field.name}"]').val();
-      dialogFieldRefresh.refreshDropDownList("#{field.name}", "#{field.id}", selectedValue);
-      dialogFieldRefresh.triggerAutoRefresh("#{field.id}", "#{field.trigger_auto_refresh}");
-    });

--- a/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
@@ -27,7 +27,11 @@
       dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
         var checkedValue = $('input:radio[name="#{field.name}"]:checked').val();
 
-        dialogFieldRefresh.refreshRadioList("#{field.name}", "#{field.id}", checkedValue, "#{url}", JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
+        dialogFieldRefresh.refreshRadioList("#{field.name}",
+                                            "#{field.id}",
+                                            checkedValue,
+                                            "#{url}",
+                                            JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
           dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
         });
       });
@@ -39,7 +43,11 @@
     $('#refresh-dynamic-field-#{field.id}').click(function() {
       var checkedValue = $('input:radio[name="#{field.name}"]:checked').val();
 
-      dialogFieldRefresh.refreshRadioList("#{field.name}", "#{field.id}", checkedValue, "#{url}", JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
+      dialogFieldRefresh.refreshRadioList("#{field.name}",
+                                          "#{field.id}",
+                                          checkedValue,
+                                          "#{url}",
+                                          JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
         dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
       });
     });

--- a/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
@@ -8,6 +8,13 @@
         %input{radio_options(field, url, rb[0], wf.value(field.name))}
         %label.dynamic-radio-label= rb[1]
 
+    :javascript
+      dialogFieldRefresh.initializeRadioButtonOnClick(
+        '#{field.id}',
+        '#{url}',
+        JSON.parse('#{j(auto_refresh_options.to_json)}')
+      );
+
   - else
     = h(field.values[0].last) unless field.values.empty?
 
@@ -17,33 +24,22 @@
 - if field.dynamic
   - if field.auto_refresh
     :javascript
-      var onClickString = 'dialogFieldRefresh.triggerAutoRefresh(\'#{field.id}\', \'#{field.trigger_auto_refresh}\');' + "#{j(remote_function(
-        :with     => 'miqSerializeForm(\"dynamic-radio-#{field.id}\")',
-        :url      => {:action => 'dialog_field_changed', :id => (@edit && @edit[:rec_id]) || 'new'},
-        :loading  => 'miqSparkle(true);',
-        :complete => 'miqSparkle(false);'
-      ))}";
-
-      dialogFieldRefresh.listenForAutoRefreshMessages("#{field.id}", function() {
+      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
         var checkedValue = $('input:radio[name="#{field.name}"]:checked').val();
 
-        dialogFieldRefresh.refreshRadioList("#{field.name}", "#{field.id}", checkedValue, onClickString);
+        dialogFieldRefresh.refreshRadioList("#{field.name}", "#{field.id}", checkedValue, "#{url}", JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
+          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+        });
       });
 
   - if field.show_refresh_button?
     = button_tag(_('Refresh'), :id => "refresh-dynamic-field-#{field.id}", :class => "btn btn-default")
 
   :javascript
-    var onClickString = 'dialogFieldRefresh.triggerAutoRefresh(\'#{field.id}\', \'#{field.trigger_auto_refresh}\');' + "#{j(remote_function(
-      :with     => 'miqSerializeForm(\"dynamic-radio-#{field.id}\")',
-      :url      => {:action => 'dialog_field_changed', :id => (@edit && @edit[:rec_id]) || 'new'},
-      :loading  => 'miqSparkle(true);',
-      :complete => 'miqSparkle(false);'
-    ))}";
-
     $('#refresh-dynamic-field-#{field.id}').click(function() {
       var checkedValue = $('input:radio[name="#{field.name}"]:checked').val();
 
-      dialogFieldRefresh.refreshRadioList("#{field.name}", "#{field.id}", checkedValue, onClickString);
-      dialogFieldRefresh.triggerAutoRefresh("#{field.id}", "#{field.trigger_auto_refresh}");
+      dialogFieldRefresh.refreshRadioList("#{field.name}", "#{field.id}", checkedValue, "#{url}", JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
+        dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+      });
     });

--- a/app/views/shared/dialogs/_dialog_field_text_area_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_text_area_box.html.haml
@@ -1,13 +1,15 @@
 - if edit
-  = text_area_tag(field.name, field.value, textarea_tag_options(field, url))
+  = text_area_tag(field.name, field.value, textarea_tag_options(field, url, auto_refresh_options))
 - else
   = h(field.value)
 
 - if field.dynamic
   - if field.auto_refresh
     :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages("#{field.id}", function() {
-        dialogFieldRefresh.refreshTextAreaBox("#{field.name}", "#{field.id}");
+      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
+        dialogFieldRefresh.refreshTextAreaBox("#{field.name}", "#{field.id}", function() {
+          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+        });
       });
 
   - if field.show_refresh_button?
@@ -15,6 +17,7 @@
 
     :javascript
       $('#refresh-dynamic-text-field-#{field.id}').click(function() {
-        dialogFieldRefresh.refreshTextAreaBox("#{field.name}", "#{field.id}");
-        dialogFieldRefresh.triggerAutoRefresh("#{field.id}", "#{field.trigger_auto_refresh}");
+        dialogFieldRefresh.refreshTextAreaBox("#{field.name}", "#{field.id}", function() {
+          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+        });
       });

--- a/app/views/shared/dialogs/_dialog_field_text_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_text_box.html.haml
@@ -1,14 +1,16 @@
 - if edit
   - if field.protected?
-    = password_field_tag(field.name + "__protected", field.value, textbox_tag_options(field, url))
+    = password_field_tag(field.name + "__protected", field.value, textbox_tag_options(field, url, auto_refresh_options))
   - else
-    = text_field_tag(field.name, field.value, textbox_tag_options(field, url))
+    = text_field_tag(field.name, field.value, textbox_tag_options(field, url, auto_refresh_options))
 
   - if field.dynamic
     - if field.auto_refresh
       :javascript
-        dialogFieldRefresh.listenForAutoRefreshMessages("#{field.id}", function() {
-          dialogFieldRefresh.refreshTextBox("#{field.name}", "#{field.id}");
+        dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
+          dialogFieldRefresh.refreshTextBox("#{field.name}", "#{field.id}", function() {
+            dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+          });
         });
 
     - if field.show_refresh_button?
@@ -16,8 +18,9 @@
 
       :javascript
         $('#refresh-dynamic-text-field-#{field.id}').click(function() {
-          dialogFieldRefresh.refreshTextBox("#{field.name}", "#{field.id}");
-          dialogFieldRefresh.triggerAutoRefresh("#{field.id}", "#{field.trigger_auto_refresh}");
+          dialogFieldRefresh.refreshTextBox("#{field.name}", "#{field.id}", function() {
+            dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+          });
         });
 
 - else

--- a/app/views/shared/dialogs/_dialog_group.html.haml
+++ b/app/views/shared/dialogs/_dialog_group.html.haml
@@ -5,5 +5,10 @@
     .form-horizontal
       - group.dialog_fields.each_with_index do |field, field_index|
         = render :partial => "shared/dialogs/dialog_field",
-                 :locals  => {:wf => wf, :field => field, :field_index => field_index, :group_index => group_index, :tab_index => tab_index, :auto_refreshable_field_indicies => auto_refreshable_field_indicies}
+                 :locals  => {:wf                              => wf,
+                              :field                           => field,
+                              :field_index                     => field_index,
+                              :group_index                     => group_index,
+                              :tab_index                       => tab_index,
+                              :auto_refreshable_field_indicies => auto_refreshable_field_indicies}
   %hr

--- a/app/views/shared/dialogs/_dialog_group.html.haml
+++ b/app/views/shared/dialogs/_dialog_group.html.haml
@@ -3,7 +3,7 @@
     = group.label
   - unless group.dialog_fields.empty?
     .form-horizontal
-      - group.dialog_fields.each do |field|
+      - group.dialog_fields.each_with_index do |field, field_index|
         = render :partial => "shared/dialogs/dialog_field",
-                 :locals  => {:wf => wf, :field => field}
+                 :locals  => {:wf => wf, :field => field, :field_index => field_index, :group_index => group_index, :tab_index => tab_index, :auto_refreshable_field_indicies => auto_refreshable_field_indicies}
   %hr

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -3,6 +3,8 @@
 .row
   .col-md-12.col-lg-12
     #dialog_tabs
+      - auto_refreshable_field_indicies = build_auto_refreshable_field_indicies(wf)
+
       %ul.nav.nav-tabs
         - wf.dialog.dialog_tabs.each do |tab|
           = miq_tab_header(tab.id) do
@@ -10,7 +12,11 @@
       .tab-content
         - wf.dialog.dialog_tabs.each_with_index do |tab, tab_index|
           = miq_tab_content(tab.id) do
-            = render :partial => "shared/dialogs/dialog_tab", :locals => {:wf => wf, :tab => tab, :tab_index => tab_index}
+            - locals = {:wf                              => wf,
+                        :tab                             => tab,
+                        :tab_index                       => tab_index,
+                        :auto_refreshable_field_indicies => auto_refreshable_field_indicies}
+            = render :partial => "shared/dialogs/dialog_tab", :locals => locals
   - if @edit && !@edit[:explorer] && @record.respond_to?(:buttons)
     = render :partial => "layouts/x_dialog_buttons",
              :locals  => {:action_url => 'dialog_form_button_pressed',

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -8,9 +8,9 @@
           = miq_tab_header(tab.id) do
             = tab.label
       .tab-content
-        - wf.dialog.dialog_tabs.each do |tab|
+        - wf.dialog.dialog_tabs.each_with_index do |tab, tab_index|
           = miq_tab_content(tab.id) do
-            = render :partial => "shared/dialogs/dialog_tab", :locals => {:wf => wf, :tab => tab}
+            = render :partial => "shared/dialogs/dialog_tab", :locals => {:wf => wf, :tab => tab, :tab_index => tab_index}
   - if @edit && !@edit[:explorer] && @record.respond_to?(:buttons)
     = render :partial => "layouts/x_dialog_buttons",
              :locals  => {:action_url => 'dialog_form_button_pressed',

--- a/app/views/shared/dialogs/_dialog_tab.html.haml
+++ b/app/views/shared/dialogs/_dialog_tab.html.haml
@@ -1,3 +1,7 @@
 - tab.dialog_groups.each_with_index do |group, group_index|
   = render :partial => "shared/dialogs/dialog_group",
-           :locals  => {:wf => wf, :group => group, :group_index => group_index, :tab_index => tab_index, :auto_refreshable_field_indicies => auto_refreshable_field_indicies}
+           :locals  => {:wf                              => wf,
+                        :group                           => group,
+                        :group_index                     => group_index,
+                        :tab_index                       => tab_index,
+                        :auto_refreshable_field_indicies => auto_refreshable_field_indicies}

--- a/app/views/shared/dialogs/_dialog_tab.html.haml
+++ b/app/views/shared/dialogs/_dialog_tab.html.haml
@@ -1,3 +1,12 @@
-- tab.dialog_groups.each do |group|
+- auto_refreshable_field_indicies = []
+- tab.dialog_groups.each_with_index do |group, group_index|
+  - auto_refreshable_field_indicies[group_index] = []
+  - group.dialog_fields.each_with_index do |field, field_index|
+    - if field.auto_refresh
+      - auto_refreshable_field_indicies[group_index] << field_index
+
+-# Replace any nils with an empty array for JSON parsing
+- auto_refreshable_field_indicies = auto_refreshable_field_indicies.map(&:to_a)
+- tab.dialog_groups.each_with_index do |group, group_index|
   = render :partial => "shared/dialogs/dialog_group",
-           :locals  => {:wf => wf, :group => group}
+           :locals  => {:wf => wf, :group => group, :group_index => group_index, :tab_index => tab_index, :auto_refreshable_field_indicies => auto_refreshable_field_indicies}

--- a/app/views/shared/dialogs/_dialog_tab.html.haml
+++ b/app/views/shared/dialogs/_dialog_tab.html.haml
@@ -1,12 +1,3 @@
-- auto_refreshable_field_indicies = []
-- tab.dialog_groups.each_with_index do |group, group_index|
-  - auto_refreshable_field_indicies[group_index] = []
-  - group.dialog_fields.each_with_index do |field, field_index|
-    - if field.auto_refresh
-      - auto_refreshable_field_indicies[group_index] << field_index
-
--# Replace any nils with an empty array for JSON parsing
-- auto_refreshable_field_indicies = auto_refreshable_field_indicies.map(&:to_a)
 - tab.dialog_groups.each_with_index do |group, group_index|
   = render :partial => "shared/dialogs/dialog_group",
            :locals  => {:wf => wf, :group => group, :group_index => group_index, :tab_index => tab_index, :auto_refreshable_field_indicies => auto_refreshable_field_indicies}

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -217,11 +217,21 @@ describe ApplicationHelper::Dialogs do
   end
 
   describe "#date_tag_options" do
+    let(:auto_refresh_options_hash) do
+      {
+        :tab_index                       => "100",
+        :group_index                     => "200",
+        :field_index                     => "300",
+        :auto_refreshable_field_indicies => [1, 2, 3],
+        :trigger                         => "true"
+      }
+    end
+
     context "when the field is read_only" do
       let(:read_only) { true }
 
       it "returns the tag options with a disabled true" do
-        expect(helper.date_tag_options(dialog_field, "url")).to eq(
+        expect(helper.date_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
           :class    => "css1 dynamic-date-100",
           :readonly => "true",
           :disabled => true,
@@ -237,10 +247,18 @@ describe ApplicationHelper::Dialogs do
         let(:trigger_auto_refresh) { true }
 
         it "returns the tag options with a few data-miq attributes" do
-          expect(helper.date_tag_options(dialog_field, "url")).to eq(
+          expect(helper.date_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
             :class                  => "css1 dynamic-date-100",
             :readonly               => "true",
-            "data-miq_observe_date" => '{"url":"url","auto_refresh":true,"field_id":"100","trigger":"true"}'
+            "data-miq_observe_date" => {
+              :url                             => "url",
+              :auto_refresh                    => true,
+              :tab_index                       => "100",
+              :group_index                     => "200",
+              :field_index                     => "300",
+              :auto_refreshable_field_indicies => [1, 2, 3],
+              :trigger                         => "true"
+            }.to_json
           )
         end
       end
@@ -249,7 +267,7 @@ describe ApplicationHelper::Dialogs do
         let(:trigger_auto_refresh) { false }
 
         it "returns the tag options with a few data-miq attributes" do
-          expect(helper.date_tag_options(dialog_field, "url")).to eq(
+          expect(helper.date_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
             :class                  => "css1 dynamic-date-100",
             :readonly               => "true",
             "data-miq_observe_date" => '{"url":"url"}'
@@ -260,11 +278,21 @@ describe ApplicationHelper::Dialogs do
   end
 
   describe "#time_tag_options" do
+    let(:auto_refresh_options_hash) do
+      {
+        :tab_index                       => "100",
+        :group_index                     => "200",
+        :field_index                     => "300",
+        :auto_refreshable_field_indicies => [1, 2, 3],
+        :trigger                         => "true"
+      }
+    end
+
     context "when the field is read_only" do
       let(:read_only) { true }
 
       it "returns the tag options with a disabled true" do
-        expect(helper.time_tag_options(dialog_field, "url", "hour_or_min")).to eq(
+        expect(helper.time_tag_options(dialog_field, "url", "hour_or_min", auto_refresh_options_hash)).to eq(
           :class    => "dynamic-date-hour_or_min-100",
           :disabled => true,
           :title    => "This element is disabled because it is read only"
@@ -279,9 +307,17 @@ describe ApplicationHelper::Dialogs do
         let(:trigger_auto_refresh) { true }
 
         it "returns the tag options with a few data-miq attributes" do
-          expect(helper.time_tag_options(dialog_field, "url", "hour_or_min")).to eq(
+          expect(helper.time_tag_options(dialog_field, "url", "hour_or_min", auto_refresh_options_hash)).to eq(
             :class             => "dynamic-date-hour_or_min-100",
-            "data-miq_observe" => '{"url":"url","auto_refresh":true,"field_id":"100","trigger":"true"}'
+            "data-miq_observe" => {
+              :url                             => "url",
+              :auto_refresh                    => true,
+              :tab_index                       => "100",
+              :group_index                     => "200",
+              :field_index                     => "300",
+              :auto_refreshable_field_indicies => [1, 2, 3],
+              :trigger                         => "true"
+            }.to_json
           )
         end
       end
@@ -290,7 +326,7 @@ describe ApplicationHelper::Dialogs do
         let(:trigger_auto_refresh) { false }
 
         it "returns the tag options with a few data-miq attributes" do
-          expect(helper.time_tag_options(dialog_field, "url", "hour_or_min")).to eq(
+          expect(helper.time_tag_options(dialog_field, "url", "hour_or_min", auto_refresh_options_hash)).to eq(
             :class             => "dynamic-date-hour_or_min-100",
             "data-miq_observe" => '{"url":"url"}'
           )

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -155,11 +155,21 @@ describe ApplicationHelper::Dialogs do
   end
 
   describe "#checkbox_tag_options" do
+    let(:auto_refresh_options_hash) do
+      {
+        :tab_index                       => "100",
+        :group_index                     => "200",
+        :field_index                     => "300",
+        :auto_refreshable_field_indicies => [1, 2, 3],
+        :trigger                         => "true"
+      }
+    end
+
     context "when the field is read_only" do
       let(:read_only) { true }
 
       it "returns the tag options with a disabled true" do
-        expect(helper.checkbox_tag_options(dialog_field, "url")).to eq(
+        expect(helper.checkbox_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
           :class    => "dynamic-checkbox-100",
           :disabled => true,
           :title    => "This element is disabled because it is read only"
@@ -174,11 +184,19 @@ describe ApplicationHelper::Dialogs do
         let(:trigger_auto_refresh) { true }
 
         it "returns the tag options with a few data-miq attributes" do
-          expect(helper.checkbox_tag_options(dialog_field, "url")).to eq(
+          expect(helper.checkbox_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
             :class                      => "dynamic-checkbox-100",
             "data-miq_sparkle_on"       => true,
             "data-miq_sparkle_off"      => true,
-            "data-miq_observe_checkbox" => '{"url":"url","auto_refresh":true,"field_id":"100","trigger":"true"}'
+            "data-miq_observe_checkbox" => {
+              :url                             => "url",
+              :auto_refresh                    => true,
+              :tab_index                       => "100",
+              :group_index                     => "200",
+              :field_index                     => "300",
+              :auto_refreshable_field_indicies => [1, 2, 3],
+              :trigger                         => "true"
+            }.to_json
           )
         end
       end
@@ -187,7 +205,7 @@ describe ApplicationHelper::Dialogs do
         let(:trigger_auto_refresh) { false }
 
         it "returns the tag options with a few data-miq attributes" do
-          expect(helper.checkbox_tag_options(dialog_field, "url")).to eq(
+          expect(helper.checkbox_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
             :class                      => "dynamic-checkbox-100",
             "data-miq_sparkle_on"       => true,
             "data-miq_sparkle_off"      => true,

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -33,11 +33,21 @@ describe ApplicationHelper::Dialogs do
   end
 
   describe "#textbox_tag_options" do
+    let(:auto_refresh_options_hash) do
+      {
+        :tab_index                       => "100",
+        :group_index                     => "200",
+        :field_index                     => "300",
+        :auto_refreshable_field_indicies => [1, 2, 3],
+        :trigger                         => "true"
+      }
+    end
+
     context "when the field is read_only" do
       let(:read_only) { true }
 
       it "returns the tag options with a disabled true" do
-        expect(helper.textbox_tag_options(dialog_field, "url")).to eq(
+        expect(helper.textbox_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
           :maxlength => 50,
           :class     => "dynamic-text-box-100 form-control",
           :disabled  => true,
@@ -53,7 +63,7 @@ describe ApplicationHelper::Dialogs do
         let(:trigger_auto_refresh) { false }
 
         it "returns the tag options with a data-miq-observe" do
-          expect(helper.textbox_tag_options(dialog_field, "url")).to eq(
+          expect(helper.textbox_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
             :maxlength         => 50,
             :class             => "dynamic-text-box-100 form-control",
             "data-miq_observe" => '{"url":"url"}'
@@ -65,14 +75,17 @@ describe ApplicationHelper::Dialogs do
         let(:trigger_auto_refresh) { true }
 
         it "returns the tag options with a data-miq-observe" do
-          expect(helper.textbox_tag_options(dialog_field, "url")).to eq(
+          expect(helper.textbox_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
             :maxlength         => 50,
             :class             => "dynamic-text-box-100 form-control",
             "data-miq_observe" => {
-              :url          => "url",
-              :auto_refresh => true,
-              :field_id     => "100",
-              :trigger      => "true"
+              :url                             => "url",
+              :auto_refresh                    => true,
+              :tab_index                       => "100",
+              :group_index                     => "200",
+              :field_index                     => "300",
+              :auto_refreshable_field_indicies => [1, 2, 3],
+              :trigger                         => "true"
             }.to_json
           )
         end
@@ -81,11 +94,21 @@ describe ApplicationHelper::Dialogs do
   end
 
   describe "#textarea_tag_options" do
+    let(:auto_refresh_options_hash) do
+      {
+        :tab_index                       => "100",
+        :group_index                     => "200",
+        :field_index                     => "300",
+        :auto_refreshable_field_indicies => [1, 2, 3],
+        :trigger                         => "true"
+      }
+    end
+
     context "when the field is read_only" do
       let(:read_only) { true }
 
       it "returns the tag options with a disabled true" do
-        expect(helper.textarea_tag_options(dialog_field, "url")).to eq(
+        expect(helper.textarea_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
           :class    => "dynamic-text-area-100 form-control",
           :size     => "50x6",
           :disabled => true,
@@ -101,14 +124,17 @@ describe ApplicationHelper::Dialogs do
         let(:trigger_auto_refresh) { true }
 
         it "returns the tag options with a data-miq-observe" do
-          expect(helper.textarea_tag_options(dialog_field, "url")).to eq(
+          expect(helper.textarea_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
             :class             => "dynamic-text-area-100 form-control",
             :size              => "50x6",
             "data-miq_observe" => {
-              :url          => "url",
-              :auto_refresh => true,
-              :field_id     => "100",
-              :trigger      => "true"
+              :url                             => "url",
+              :auto_refresh                    => true,
+              :tab_index                       => "100",
+              :group_index                     => "200",
+              :field_index                     => "300",
+              :auto_refreshable_field_indicies => [1, 2, 3],
+              :trigger                         => "true"
             }.to_json
           )
         end
@@ -118,7 +144,7 @@ describe ApplicationHelper::Dialogs do
         let(:trigger_auto_refresh) { false }
 
         it "returns the tag options with a data-miq-observe" do
-          expect(helper.textarea_tag_options(dialog_field, "url")).to eq(
+          expect(helper.textarea_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
             :class             => "dynamic-text-area-100 form-control",
             :size              => "50x6",
             "data-miq_observe" => '{"url":"url"}'

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -359,13 +359,14 @@ describe ApplicationHelper::Dialogs do
     context "when the field is read_only" do
       let(:read_only) { true }
       let(:selected_value) { "some_value" }
+
       context "when the current value is equal to the default value" do
         let(:value) { "some_value" }
 
         it "returns the tag options with a disabled true and checked" do
           expect(helper.radio_options(dialog_field, "url", value, selected_value)).to eq(
             :type     => "radio",
-            :id       => "100",
+            :class    => "100",
             :value    => "some_value",
             :name     => "field_name",
             :checked  => '',
@@ -381,7 +382,7 @@ describe ApplicationHelper::Dialogs do
         it "returns the tag options with a disabled true and checked" do
           expect(helper.radio_options(dialog_field, "url", value, selected_value)).to eq(
             :type     => "radio",
-            :id       => "100",
+            :class    => "100",
             :value    => "bogus",
             :name     => "field_name",
             :checked  => nil,
@@ -395,82 +396,32 @@ describe ApplicationHelper::Dialogs do
     context "when the dialog field is not read only" do
       let(:read_only) { false }
       let(:selected_value) { "some_value" }
-      let(:onclick_string) do
-        "$.ajax(" \
-          "{beforeSend:function(request){miqSparkle(true);}, " \
-          "complete:function(request){miqSparkle(false);}, " \
-          "data:miqSerializeForm('dynamic-radio-100'), " \
-          "dataType:'script', " \
-          "type:'post', " \
-          "url:'url'}" \
-        ")"
-      end
 
       context "when the current value is equal to the default value" do
         let(:value) { "some_value" }
 
-        context "when the dialog field triggers auto refresh" do
-          let(:trigger_auto_refresh) { true }
-
-          it "returns the tag options with a disabled true and checked" do
-            expect(helper.radio_options(dialog_field, "url", value, selected_value)).to eq(
-              :type    => "radio",
-              :id      => "100",
-              :value   => "some_value",
-              :name    => "field_name",
-              :checked => '',
-              :onclick => "dialogFieldRefresh.triggerAutoRefresh('100', 'true');" + onclick_string
-            )
-          end
-        end
-
-        context "when the dialog field does not trigger auto refresh" do
-          let(:trigger_auto_refresh) { false }
-
-          it "returns the tag options with a disabled true and checked" do
-            expect(helper.radio_options(dialog_field, "url", value, selected_value)).to eq(
-              :type    => "radio",
-              :id      => "100",
-              :value   => "some_value",
-              :name    => "field_name",
-              :checked => '',
-              :onclick => onclick_string
-            )
-          end
+        it "returns the tag options with a disabled true and checked" do
+          expect(helper.radio_options(dialog_field, "url", value, selected_value)).to eq(
+            :type    => "radio",
+            :class   => "100",
+            :value   => "some_value",
+            :name    => "field_name",
+            :checked => '',
+          )
         end
       end
 
       context "when the current value is not equal to the default value" do
         let(:value) { "bogus" }
 
-        context "when the dialog field triggers auto refresh" do
-          let(:trigger_auto_refresh) { true }
-
-          it "returns the tag options with a disabled true and checked" do
-            expect(helper.radio_options(dialog_field, "url", value, selected_value)).to eq(
-              :type    => "radio",
-              :id      => "100",
-              :value   => "bogus",
-              :name    => "field_name",
-              :checked => nil,
-              :onclick => "dialogFieldRefresh.triggerAutoRefresh('100', 'true');" + onclick_string
-            )
-          end
-        end
-
-        context "when the dialog field does not trigger auto refresh" do
-          let(:trigger_auto_refresh) { false }
-
-          it "returns the tag options with a disabled true and checked" do
-            expect(helper.radio_options(dialog_field, "url", value, selected_value)).to eq(
-              :type    => "radio",
-              :id      => "100",
-              :value   => "bogus",
-              :name    => "field_name",
-              :checked => nil,
-              :onclick => onclick_string
-            )
-          end
+        it "returns the tag options with a disabled true and checked" do
+          expect(helper.radio_options(dialog_field, "url", value, selected_value)).to eq(
+            :type    => "radio",
+            :class   => "100",
+            :value   => "bogus",
+            :name    => "field_name",
+            :checked => nil,
+          )
         end
       end
     end

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -478,14 +478,13 @@ describe ApplicationHelper::Dialogs do
     let(:dialog_field_2) { instance_double("DialogField", :auto_refresh => true, :trigger_auto_refresh => false) }
     let(:dialog_field_3) { instance_double("DialogField", :auto_refresh => false, :trigger_auto_refresh => true) }
 
-
     it "builds a list of auto refreshable fields and trigger fields with their indicies" do
       expect(helper.build_auto_refreshable_field_indicies(workflow)).to eq([
-        {tab_index: 0, group_index: 0, field_index: 2, auto_refresh: true},
-        {tab_index: 0, group_index: 1, field_index: 0, auto_refresh: false},
-        {tab_index: 0, group_index: 1, field_index: 1, auto_refresh: true},
-        {tab_index: 1, group_index: 0, field_index: 0, auto_refresh: false},
-        {tab_index: 1, group_index: 0, field_index: 1, auto_refresh: true}
+        {:tab_index => 0, :group_index => 0, :field_index => 2, :auto_refresh => true},
+        {:tab_index => 0, :group_index => 1, :field_index => 0, :auto_refresh => false},
+        {:tab_index => 0, :group_index => 1, :field_index => 1, :auto_refresh => true},
+        {:tab_index => 1, :group_index => 0, :field_index => 0, :auto_refresh => false},
+        {:tab_index => 1, :group_index => 0, :field_index => 1, :auto_refresh => true}
       ])
     end
   end

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -462,4 +462,31 @@ describe ApplicationHelper::Dialogs do
       end
     end
   end
+
+  describe "#build_auto_refreshable_field_indicies" do
+    let(:workflow) { instance_double("ResourceActionWorkflow", :dialog => dialog) }
+    let(:dialog) { instance_double("Dialog", :dialog_tabs => [dialog_tab_1, dialog_tab_2]) }
+    let(:dialog_tab_1) { instance_double("DialogTab", :dialog_groups => [dialog_group_1, dialog_group_2]) }
+    let(:dialog_tab_2) { instance_double("DialogTab", :dialog_groups => [dialog_group_2]) }
+    let(:dialog_group_1) do
+      instance_double("DialogGroup", :dialog_fields => [dialog_field_1, dialog_field_1, dialog_field_2])
+    end
+    let(:dialog_group_2) do
+      instance_double("DialogGroup", :dialog_fields => [dialog_field_3, dialog_field_2, dialog_field_1])
+    end
+    let(:dialog_field_1) { instance_double("DialogField", :auto_refresh => nil, :trigger_auto_refresh => false) }
+    let(:dialog_field_2) { instance_double("DialogField", :auto_refresh => true, :trigger_auto_refresh => false) }
+    let(:dialog_field_3) { instance_double("DialogField", :auto_refresh => false, :trigger_auto_refresh => true) }
+
+
+    it "builds a list of auto refreshable fields and trigger fields with their indicies" do
+      expect(helper.build_auto_refreshable_field_indicies(workflow)).to eq([
+        {tab_index: 0, group_index: 0, field_index: 2, auto_refresh: true},
+        {tab_index: 0, group_index: 1, field_index: 0, auto_refresh: false},
+        {tab_index: 0, group_index: 1, field_index: 1, auto_refresh: true},
+        {tab_index: 1, group_index: 0, field_index: 0, auto_refresh: false},
+        {tab_index: 1, group_index: 0, field_index: 1, auto_refresh: true}
+      ])
+    end
+  end
 end

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -39,6 +39,7 @@ describe ApplicationHelper::Dialogs do
         :group_index                     => "200",
         :field_index                     => "300",
         :auto_refreshable_field_indicies => [1, 2, 3],
+        :current_index                   => 123,
         :trigger                         => "true"
       }
     end
@@ -85,6 +86,7 @@ describe ApplicationHelper::Dialogs do
               :group_index                     => "200",
               :field_index                     => "300",
               :auto_refreshable_field_indicies => [1, 2, 3],
+              :current_index                   => 123,
               :trigger                         => "true"
             }.to_json
           )
@@ -100,6 +102,7 @@ describe ApplicationHelper::Dialogs do
         :group_index                     => "200",
         :field_index                     => "300",
         :auto_refreshable_field_indicies => [1, 2, 3],
+        :current_index                   => 123,
         :trigger                         => "true"
       }
     end
@@ -134,6 +137,7 @@ describe ApplicationHelper::Dialogs do
               :group_index                     => "200",
               :field_index                     => "300",
               :auto_refreshable_field_indicies => [1, 2, 3],
+              :current_index                   => 123,
               :trigger                         => "true"
             }.to_json
           )
@@ -161,6 +165,7 @@ describe ApplicationHelper::Dialogs do
         :group_index                     => "200",
         :field_index                     => "300",
         :auto_refreshable_field_indicies => [1, 2, 3],
+        :current_index                   => 123,
         :trigger                         => "true"
       }
     end
@@ -195,6 +200,7 @@ describe ApplicationHelper::Dialogs do
               :group_index                     => "200",
               :field_index                     => "300",
               :auto_refreshable_field_indicies => [1, 2, 3],
+              :current_index                   => 123,
               :trigger                         => "true"
             }.to_json
           )
@@ -223,6 +229,7 @@ describe ApplicationHelper::Dialogs do
         :group_index                     => "200",
         :field_index                     => "300",
         :auto_refreshable_field_indicies => [1, 2, 3],
+        :current_index                   => 123,
         :trigger                         => "true"
       }
     end
@@ -257,6 +264,7 @@ describe ApplicationHelper::Dialogs do
               :group_index                     => "200",
               :field_index                     => "300",
               :auto_refreshable_field_indicies => [1, 2, 3],
+              :current_index                   => 123,
               :trigger                         => "true"
             }.to_json
           )
@@ -284,6 +292,7 @@ describe ApplicationHelper::Dialogs do
         :group_index                     => "200",
         :field_index                     => "300",
         :auto_refreshable_field_indicies => [1, 2, 3],
+        :current_index                   => 123,
         :trigger                         => "true"
       }
     end
@@ -316,6 +325,7 @@ describe ApplicationHelper::Dialogs do
               :group_index                     => "200",
               :field_index                     => "300",
               :auto_refreshable_field_indicies => [1, 2, 3],
+              :current_index                   => 123,
               :trigger                         => "true"
             }.to_json
           )

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -170,7 +170,7 @@ describe('dialogFieldRefresh', function() {
     });
 
     it('calls sendRefreshRequest', function() {
-      dialogFieldRefresh.refreshDateTime('abc', 123);
+      dialogFieldRefresh.refreshDateTime('abc', 123, refreshCallback);
       expect(dialogFieldRefresh.sendRefreshRequest).toHaveBeenCalledWith(
         'dynamic_date_refresh',
         {name: 'abc'},
@@ -180,6 +180,7 @@ describe('dialogFieldRefresh', function() {
 
     describe('#refreshDateTime doneFunction', function() {
       beforeEach(function() {
+        dialogFieldRefresh.refreshDateTime('abc', 123, refreshCallback);
         var data = {responseText: JSON.stringify({values: {date: 'today', hour: '12', min: '34', read_only: true, visible: false}})};
         loadedDoneFunction(data);
       });
@@ -214,11 +215,16 @@ describe('dialogFieldRefresh', function() {
           true
         );
       });
+
       it('sets the visible property', function() {
         expect(dialogFieldRefresh.setVisible).toHaveBeenCalledWith(
           jasmine.objectContaining({selector: '#field_123_tr'}),
           false
         );
+      });
+
+      it('calls the callback', function() {
+        expect(refreshCallback.call).toHaveBeenCalled();
       });
     });
   });

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -592,165 +592,67 @@ describe('dialogFieldRefresh', function() {
     });
 
     context('when the trigger passed in is the string "true"', function() {
-      context('when the next auto refreshable field is in the same group and ahead', function() {
+      context('when the next auto refreshable field does not exist', function() {
         beforeEach(function() {
           dialogFieldRefresh.triggerAutoRefresh({
-            tab_index: 0,
-            group_index: 0,
-            field_index: 0,
-            auto_refreshable_field_indicies: [[0, 1, 2], [0, 2]],
-            trigger: "true"
-          });
-        });
-
-        it('posts a message', function() {
-          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 0, groupIndex: 0, fieldIndex: 1}, '*');
-        });
-      });
-
-      context('when the next auto refreshable field is in the same group and behind', function() {
-        beforeEach(function() {
-          dialogFieldRefresh.triggerAutoRefresh({
-            tab_index: 0,
-            group_index: 0,
-            field_index: 1,
-            auto_refreshable_field_indicies: [[0, 1, 2], [0, 2]],
-            trigger: "true"
-          });
-        });
-
-        it('posts a message', function() {
-          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 0, groupIndex: 0, fieldIndex: 2}, '*');
-        });
-      });
-
-      context('when the next auto refreshable field is in the next group', function() {
-        beforeEach(function() {
-          dialogFieldRefresh.triggerAutoRefresh({
-            tab_index: 0,
-            group_index: 0,
-            field_index: 0,
-            auto_refreshable_field_indicies: [[], [2]],
-            trigger: "true"
-          });
-        });
-
-        it('posts a message', function() {
-          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 0, groupIndex: 1, fieldIndex: 2}, '*');
-        });
-      });
-
-      context('when the next auto refreshable field is in the second group and current is ahead', function() {
-        beforeEach(function() {
-          dialogFieldRefresh.triggerAutoRefresh({
-            tab_index: 0,
-            group_index: 1,
-            field_index: 2,
-            auto_refreshable_field_indicies: [[0, 1, 2], [0, 2, 3, 4, 5]],
-            trigger: "true"
-          });
-        });
-
-        it('posts a message', function() {
-          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 0, groupIndex: 1, fieldIndex: 3}, '*');
-        });
-      });
-
-      context('when there are no auto refreshable fields', function() {
-        beforeEach(function() {
-          dialogFieldRefresh.triggerAutoRefresh({
-            tab_index: 0,
-            group_index: 1,
-            field_index: 1,
-            auto_refreshable_field_indicies: [[], []],
+            current_index: 0,
+            auto_refreshable_field_indicies: [{tab_index: 1, group_index: 1, field_index: 1}],
             trigger: "true"
           });
         });
 
         it('does not post a message', function() {
           expect(parent.postMessage).not.toHaveBeenCalled();
+        });
+      });
+
+      context('when the next auto refreshable field exists', function() {
+        beforeEach(function() {
+          dialogFieldRefresh.triggerAutoRefresh({
+            current_index: 0,
+            auto_refreshable_field_indicies: [
+              {tab_index: 1, group_index: 1, field_index: 1},
+              {tab_index: 1, group_index: 1, field_index: 2, auto_refresh: true}
+            ],
+            trigger: "true"
+          });
+        });
+
+        it('posts a message', function() {
+          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 1, groupIndex: 1, fieldIndex: 2}, '*');
         });
       });
     });
 
     context('when the trigger passed in is true', function() {
-      context('when the next auto refreshable field is in the same group and ahead', function() {
+      context('when the next auto refreshable field does not exist', function() {
         beforeEach(function() {
           dialogFieldRefresh.triggerAutoRefresh({
-            tab_index: 0,
-            group_index: 0,
-            field_index: 0,
-            auto_refreshable_field_indicies: [[0, 1, 2], [0, 2]],
-            trigger: true
-          });
-        });
-
-        it('posts a message', function() {
-          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 0, groupIndex: 0, fieldIndex: 1}, '*');
-        });
-      });
-
-      context('when the next auto refreshable field is in the same group and behind', function() {
-        beforeEach(function() {
-          dialogFieldRefresh.triggerAutoRefresh({
-            tab_index: 0,
-            group_index: 0,
-            field_index: 1,
-            auto_refreshable_field_indicies: [[0, 1, 2], [0, 2]],
-            trigger: true
-          });
-        });
-
-        it('posts a message', function() {
-          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 0, groupIndex: 0, fieldIndex: 2}, '*');
-        });
-      });
-
-      context('when the next auto refreshable field is in the next group', function() {
-        beforeEach(function() {
-          dialogFieldRefresh.triggerAutoRefresh({
-            tab_index: 0,
-            group_index: 0,
-            field_index: 0,
-            auto_refreshable_field_indicies: [[], [2]],
-            trigger: true
-          });
-        });
-
-        it('posts a message', function() {
-          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 0, groupIndex: 1, fieldIndex: 2}, '*');
-        });
-      });
-
-      context('when the next auto refreshable field is in the second group and current is ahead', function() {
-        beforeEach(function() {
-          dialogFieldRefresh.triggerAutoRefresh({
-            tab_index: 0,
-            group_index: 1,
-            field_index: 2,
-            auto_refreshable_field_indicies: [[0, 1, 2], [0, 2, 3, 4, 5]],
-            trigger: true
-          });
-        });
-
-        it('posts a message', function() {
-          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 0, groupIndex: 1, fieldIndex: 3}, '*');
-        });
-      });
-
-      context('when there are no auto refreshable fields', function() {
-        beforeEach(function() {
-          dialogFieldRefresh.triggerAutoRefresh({
-            tab_index: 0,
-            group_index: 1,
-            field_index: 1,
-            auto_refreshable_field_indicies: [[], []],
+            current_index: 0,
+            auto_refreshable_field_indicies: [{tab_index: 1, group_index: 1, field_index: 1}],
             trigger: true
           });
         });
 
         it('does not post a message', function() {
           expect(parent.postMessage).not.toHaveBeenCalled();
+        });
+      });
+
+      context('when the next auto refreshable field exists', function() {
+        beforeEach(function() {
+          dialogFieldRefresh.triggerAutoRefresh({
+            current_index: 0,
+            auto_refreshable_field_indicies: [
+              {tab_index: 1, group_index: 1, field_index: 1},
+              {tab_index: 1, group_index: 1, field_index: 2, auto_refresh: true}
+            ],
+            trigger: true
+          });
+        });
+
+        it('posts a message', function() {
+          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 1, groupIndex: 1, fieldIndex: 2}, '*');
         });
       });
     });

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -97,11 +97,13 @@ describe('dialogFieldRefresh', function() {
 
   describe('#refreshCheckbox', function() {
     var loadedDoneFunction;
+    var refreshCallback;
 
     beforeEach(function() {
       spyOn(dialogFieldRefresh, 'setReadOnly');
       spyOn(dialogFieldRefresh, 'setVisible');
       spyOn($.fn, 'prop');
+      refreshCallback = jasmine.createSpyObj('refreshCallback', ['call']);
 
       spyOn(dialogFieldRefresh, 'sendRefreshRequest').and.callFake(function(_url, _data, doneFunction) {
         loadedDoneFunction = doneFunction;
@@ -109,7 +111,7 @@ describe('dialogFieldRefresh', function() {
     });
 
     it('calls sendRefreshRequest', function() {
-      dialogFieldRefresh.refreshCheckbox('abc', 123);
+      dialogFieldRefresh.refreshCheckbox('abc', 123, refreshCallback);
       expect(dialogFieldRefresh.sendRefreshRequest).toHaveBeenCalledWith(
         'dynamic_checkbox_refresh',
         {name: 'abc'},
@@ -119,6 +121,7 @@ describe('dialogFieldRefresh', function() {
 
     describe('#refreshCheckbox doneFunction', function() {
       beforeEach(function() {
+        dialogFieldRefresh.refreshCheckbox('abc', 123, refreshCallback);
         var data = {responseText: JSON.stringify({values: {checked: true, read_only: true, visible: false}})};
         loadedDoneFunction(data);
       });
@@ -137,22 +140,29 @@ describe('dialogFieldRefresh', function() {
           true
         );
       });
+
       it('sets the visible property', function() {
         expect(dialogFieldRefresh.setVisible).toHaveBeenCalledWith(
           jasmine.objectContaining({selector: '#field_123_tr'}),
           false
         );
       });
+
+      it('calls the callback', function() {
+        expect(refreshCallback.call).toHaveBeenCalled();
+      });
     });
   });
 
   describe('#refreshDateTime', function() {
     var loadedDoneFunction;
+    var refreshCallback;
 
     beforeEach(function() {
       spyOn(dialogFieldRefresh, 'setReadOnly');
       spyOn(dialogFieldRefresh, 'setVisible');
       spyOn($.fn, 'val');
+      refreshCallback = jasmine.createSpyObj('refreshCallback', ['call']);
 
       spyOn(dialogFieldRefresh, 'sendRefreshRequest').and.callFake(function(_url, _data, doneFunction) {
         loadedDoneFunction = doneFunction;

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -349,12 +349,14 @@ describe('dialogFieldRefresh', function() {
 
   describe('#refreshDropDownList', function() {
     var loadedDoneFunction;
+    var refreshCallback;
 
     beforeEach(function() {
       spyOn(dialogFieldRefresh, 'addOptionsToDropDownList');
       spyOn(dialogFieldRefresh, 'setReadOnly');
       spyOn(dialogFieldRefresh, 'setVisible');
       spyOn($.fn, 'selectpicker');
+      refreshCallback = jasmine.createSpyObj('refreshCallback', ['call']);
 
       spyOn(dialogFieldRefresh, 'sendRefreshRequest').and.callFake(function(_url, _data, doneFunction) {
         loadedDoneFunction = doneFunction;
@@ -362,7 +364,7 @@ describe('dialogFieldRefresh', function() {
     });
 
     it('calls sendRefreshRequest', function() {
-      dialogFieldRefresh.refreshDropDownList('abc', 123, 'test');
+      dialogFieldRefresh.refreshDropDownList('abc', 123, 'test', refreshCallback);
       expect(dialogFieldRefresh.sendRefreshRequest).toHaveBeenCalledWith(
         'dynamic_radio_button_refresh',
         {name: 'abc', checked_value: 'test'},
@@ -372,6 +374,7 @@ describe('dialogFieldRefresh', function() {
 
     describe('#refreshDropDownList doneFunction', function() {
       beforeEach(function() {
+        dialogFieldRefresh.refreshDropDownList('abc', 123, 'test', refreshCallback);
         var data = {responseText: JSON.stringify({values: {checked_value: 'selectedTest', read_only: true, visible: false}})};
         loadedDoneFunction(data);
       });
@@ -389,7 +392,8 @@ describe('dialogFieldRefresh', function() {
           true
         );
       });
-     it('sets the visible property', function() {
+
+      it('sets the visible property', function() {
         expect(dialogFieldRefresh.setVisible).toHaveBeenCalledWith(
           jasmine.objectContaining({selector: '#field_' + 123 + "_tr"}),
           false
@@ -404,9 +408,12 @@ describe('dialogFieldRefresh', function() {
         expect($.fn.selectpicker).toHaveBeenCalledWith('val', 'selectedTest');
       });
 
-
       it('uses the correct selector', function() {
         expect($.fn.selectpicker.calls.mostRecent().object.selector).toEqual('#abc');
+      });
+
+      it('calls the callback', function() {
+        expect(refreshCallback.call).toHaveBeenCalled();
       });
     });
   });
@@ -468,7 +475,7 @@ describe('dialogFieldRefresh', function() {
   });
 
   describe('#initializeDialogSelectPicker', function() {
-    var fieldName, selectedValue, url;
+    var fieldName, selectedValue, url, autoRefreshOptions;
 
     beforeEach(function() {
       spyOn(dialogFieldRefresh, 'triggerAutoRefresh');
@@ -478,9 +485,9 @@ describe('dialogFieldRefresh', function() {
       });
       spyOn($.fn, 'selectpicker');
       fieldName = 'fieldName';
-      fieldId = 'fieldId';
       selectedValue = 'selectedValue';
       url = 'url';
+      autoRefreshOptions = 'autoRefreshOptions';
 
       var html = "";
       html += '<select id=fieldName class="dynamic-drop-down-193 selectpicker">';
@@ -492,28 +499,28 @@ describe('dialogFieldRefresh', function() {
     });
 
     it('initializes the select picker', function() {
-      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url);
+      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, selectedValue, url, autoRefreshOptions);
       expect(window.miqInitSelectPicker).toHaveBeenCalled();
     });
 
     it('sets the value of the select picker', function() {
-      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url);
+      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, selectedValue, url, autoRefreshOptions);
       expect($.fn.selectpicker).toHaveBeenCalledWith('val', 'selectedValue');
     });
 
     it('uses the correct selector', function() {
-      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url);
+      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, selectedValue, url, autoRefreshOptions);
       expect($.fn.selectpicker.calls.mostRecent().object.selector).toEqual('#fieldName');
     });
 
     it('sets up the select picker event', function() {
-      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url);
+      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, selectedValue, url, autoRefreshOptions);
       expect(window.miqSelectPickerEvent).toHaveBeenCalledWith('fieldName', 'url', {callback: jasmine.any(Function)});
     });
 
     it('triggers autorefresh with true only when triggerAutoRefresh arg is true', function() {
-      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url, 'true');
-      expect(dialogFieldRefresh.triggerAutoRefresh).toHaveBeenCalledWith(fieldId, 'true');
+      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, selectedValue, url, autoRefreshOptions);
+      expect(dialogFieldRefresh.triggerAutoRefresh).toHaveBeenCalledWith('autoRefreshOptions');
     });
   });
 


### PR DESCRIPTION
This changes the functionality of auto-refreshing dialog fields a little bit. Here's how they worked before:
If multiple fields were set to 'auto-refresh', any time another field that was set to 'trigger auto-refresh', all of those fields would refresh at the same time, and that would be the end of the chain. Sometimes, people were relying on one field being refreshed before the next, and this approach wouldn't work.

After this change, the triggers are processed from top to bottom, and any field that is set to 'auto-refresh' will auto-refresh, and then trigger the next field (if it's set to trigger) and so-on, until the end.  ~of the tab. Tabs will no longer trigger auto-refreshes between each other like they used to.~

https://www.pivotaltracker.com/story/show/138457551

/cc @gmcculloug 

You can use this 
[dialog_export_20170126.yml.zip](https://github.com/ManageIQ/manageiq-ui-classic/files/734114/dialog_export_20170126.yml.zip) (I had to zip it up cause github won't allow yml files) for a sample dialog I was testing around with that includes all of the different types of dialog fields we have and some that depend on others.

You can use this [datastore_2017_01_26.zip](https://github.com/ManageIQ/manageiq-ui-classic/files/734107/datastore_2017_01_26.zip) to get the automate methods that I used in the above dialog. The only relevant methods are in the "CascadingAutoRefresh" domain. Ignore the other domains, they're just what I had in my db.