### PR TITLE
Use correct route to derive unfilled hawkular hostname

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -434,7 +434,7 @@ module Mixins
 
     def get_hostname_from_routes(ems, hostname, port, token)
       client = ems.class.raw_connect(hostname, port, :bearer => token)
-      client.get_routes(:name=>'hawkular-metrics').first.try(:spec).try(:host)
+      client.get_route('hawkular-metrics', 'openshift-infra').try(:spec).try(:host)
     end
 
     def build_connection(ems, endpoints, mode)


### PR DESCRIPTION
Plural `get_routes` ignores `:name`, was querying `/oapi/v1/routes` and returning all routes in all namespaces, and we were picking a random one.
`get_route` queries `/oapi/v1/namespaces/openshift-infra/routes/hawkular-metrics` giving the right route or nil.

@miq-bot add-label bug, providers/containers

@yaacov, @simon3z please review.

BTW, when is this supposed to kick in?  I saw this request being done on both [Validate] and [Add] buttons, but after [Validate] the Hawkular form still had empty hostname; [Add] did set the hostname on the hawkular endpoint.  Is this the desired behaviour?  If yes, can this request be skipped on [Validate]?