### PR TITLE
Dont allow to edit the name of Default rate for container images

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -110,6 +110,9 @@ class ChargebackController < ApplicationController
       if @edit[:new][:description].nil? || @edit[:new][:description] == ""
         render_flash(_("Description is required"), :error)
         return
+      elsif @rate.description == "Default Container Image Rate" && @edit[:new][:description] != @rate.description
+        render_flash(_("Can not change description of 'Default Container Image Rate'"), :error)
+        return
       end
       @rate.description = @edit[:new][:description]
       @rate.rate_type   = @edit[:new][:rate_type] if @edit[:new][:rate_type]


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1410012
We want to let the user edit the rates but not the name of this chargeback rate.

@lpichler @isimluk I know this solution is bad. I believe what we should do in general is make some sort of split of chargeback for VM's and chargeback for containers and have different default rates for them.
That is a much more extensive change we would need to discuss and allocate time for.

cc @simon3z @loicavenel

@miq-bot add_label providers/containers, chargeback


