### PR TITLE
Introduce Vm/Chargeback tab [ui-part]

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -42,7 +42,7 @@ module ApplicationController::Explorer
     'guest_restart'    => :s1, 'retire_now'                => :s1, 'snapshot_revert'     => :s1,
     'start'            => :s1, 'stop'                      => :s1, 'suspend'             => :s1,
     'reset'            => :s1, 'terminate'                 => :s1, 'pause'               => :s1,
-    'shelve'           => :s1, 'shelve_offload'            => :s1,
+    'shelve'           => :s1, 'shelve_offload'            => :s1, 'chargeback'          => :s1,
 
     # group 2
     'clone'        => :s2, 'compare'          => :s2, 'drift'           => :s2,

--- a/app/controllers/mixins/chargeback_preview.rb
+++ b/app/controllers/mixins/chargeback_preview.rb
@@ -1,0 +1,26 @@
+module ChargebackPreview
+  extend ActiveSupport::Concern
+
+  def vm_chargeback
+    @sb[:action] ||= 'chargeback'
+    @vm = @record = identify_record(params[:id], VmOrTemplate)
+
+    if params[:task_id]
+      miq_task = MiqTask.find(params[:task_id])
+      if !miq_task.results_ready?
+        add_flash(_("Report preview generation returned: Status [%{status}] Message [%{message}]") %
+                  {:status => miq_task.status, :message => miq_task.message}, :error)
+      else
+        rr = miq_task.miq_report_result
+        @html = report_build_html_table(rr.report_results, rr.html_rows.join)
+        @refresh_partial = 'vm_common/chargeback'
+        miq_task.destroy
+      end
+    else
+      rpt = perf_get_chart_rpt('vm_chargeback')
+      rpt.db_options[:options][:entity_id] = @vm.id
+      # TODO: Use user's timezone
+      initiate_wait_for_task(:task_id => rpt.async_generate_table(:userid => session[:userid]))
+    end
+  end
+end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1,6 +1,7 @@
 module VmCommon
   extend ActiveSupport::Concern
   include ActionView::Helpers::JavaScriptHelper
+  include ChargebackPreview
 
   # handle buttons pressed on the button bar
   def button
@@ -1662,6 +1663,10 @@ module VmCommon
       header = _("Editing %{vm_or_template} \"%{name}\"") %
         {:name => name, :vm_or_template => ui_lookup(:table => table)}
       action = "edit_vm"
+    when 'chargeback'
+      partial = @refresh_partial
+      header = _('Chargeback preview for "%{vm_name}"') % { :vm_name => name }
+      action = 'vm_chargeback'
     when "evm_relationship"
       partial = "vm_common/evm_relationship"
       header = _("Edit %{product} Server Relationship for %{vm_or_template} \"%{name}\"") %

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -164,6 +164,12 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           N_('Timelines'),
           :url_parms => "?display=timeline",
           :klass     => ApplicationHelper::Button::VmTimeline),
+        button(
+          :vm_chargeback,
+          'product product-report fa-lg',
+          N_('Show Chargeback preview'),
+          N_('Chargeback Preview')
+        ),
       ]
     ),
   ])

--- a/app/views/vm_common/_chargeback.html.haml
+++ b/app/views/vm_common/_chargeback.html.haml
@@ -1,0 +1,2 @@
+= render :partial => 'layouts/flash_msg'
+= render :partial => 'layouts/report_html'


### PR DESCRIPTION
For the ability to quickly view chargeback of a single VM. That is useful to get a quick notion of costs associated with the given VM.

This depends on backed https://github.com/ManageIQ/manageiq/pull/13687.

## Button here
![button](https://cloud.githubusercontent.com/assets/6666052/22405833/cb0c161e-e648-11e6-9d59-f8e9a59ab601.jpg)

## Chargeback Preview
![cb](https://cloud.githubusercontent.com/assets/6666052/22405843/f2a9c554-e648-11e6-9433-ba8ee07d6513.jpg)

This is proof of concept. I plan to put there a chart and more information later.