### PR TITLE
Add list of roles to rbac

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1031,6 +1031,10 @@ module OpsController::OpsRbac
     Rbac.filtered(Tenant.in_my_region.where(:id => tenant_id)).present?
   end
 
+  def valid_role?(group_id)
+    Rbac::Filterer.filtered(group_id, :class => MiqUserRole).present?
+  end
+
   # Get variables from group edit form
   def rbac_group_get_form_vars
     if %w(up down).include?(params[:button])
@@ -1039,7 +1043,14 @@ module OpsController::OpsRbac
     else
       @edit[:new][:ldap_groups_user] = params[:ldap_groups_user]  if params[:ldap_groups_user]
       @edit[:new][:description]      = params[:description]       if params[:description]
-      @edit[:new][:role]             = params[:group_role]        if params[:group_role]
+
+      if params[:group_role]
+        if valid_role?(new_role_id = params[:group_role].to_i)
+          @edit[:new][:role] = new_role_id
+        else
+          raise "Invalid group selected."
+        end
+      end
 
       if params[:group_tenant]
         if valid_tenant?(new_tenant_id = params[:group_tenant].to_i)

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1111,7 +1111,8 @@ module OpsController::OpsRbac
 
     # Build roles hash
     @edit[:roles]["<Choose a Role>"] = nil if @record.id.nil?
-    MiqUserRole.all.each do |r|
+
+    Rbac::Filterer.filtered(MiqUserRole).each do |r|
       @edit[:roles][r.name] = r.id
     end
     if @group.miq_user_role.nil? # If adding, set to first role

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -51,7 +51,7 @@ class TreeBuilderOpsRbac < TreeBuilder
       case object_hash[:id]
       when "u"  then Rbac.filtered(User.in_my_region)
       when "g"  then Rbac.filtered(MiqGroup.non_tenant_groups_in_my_region)
-      when "ur" then MiqUserRole.all
+      when "ur" then Rbac.filtered(MiqUserRole)
       when "tn" then Tenant.with_current_tenant
       end
     count_only_or_objects(count_only, objects, "name")


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/135
backend PR required https://github.com/ManageIQ/manageiq/pull/13689

add list of role to rbac:
- in group form
- check role when form of group is stored
- in list of role in tree

cc @gtanzillo 

@miq-bot assign @martinpovolny 