### PR TITLE
ServiceTemplate - html-sanitize long_description

### DIFF
--- a/app/assets/javascripts/angular_modules/module_helpers.js
+++ b/app/assets/javascripts/angular_modules/module_helpers.js
@@ -1,0 +1,1 @@
+miqHttpInject(angular.module('miq.helpers', ['ngSanitize']));

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,6 +25,7 @@
 //= require_tree ./angular_modules/
 //= require_tree ./controllers/
 //= require_tree ./directives/
+//= require_tree ./components/
 //= require_tree ./services/
 //= require d3
 //= require c3

--- a/app/assets/javascripts/components/sanitize.js
+++ b/app/assets/javascripts/components/sanitize.js
@@ -1,0 +1,7 @@
+angular.module('miq.helpers')
+  .component('miqSanitize', {
+    bindings: {
+      value: '@',
+    },
+    template: '<span ng-bind-html="$ctrl.value"></span>',
+  });

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -118,8 +118,8 @@
           .form-group
             %label.col-md-2.control-label
               = _('Long Description')
-            .col-md-8
-              = @record.long_description.to_s.html_safe
+            .col-md-8#long_description
+              %miq-sanitize{:value => @record.long_description}
 
     - if @record.composite?
       = miq_tab_content('resources') do
@@ -175,5 +175,7 @@
                                     :show => true}
           - else
             %span{:style => "color:red"}= @no_wf_msg
+
 :javascript
   miq_tabs_init("#st_tabs");
+  miq_bootstrap('#long_description', 'miq.helpers');

--- a/app/views/catalog/_svccat_tree_show.html.haml
+++ b/app/views/catalog/_svccat_tree_show.html.haml
@@ -1,4 +1,4 @@
-.maincontent{:xmlns => "http://www.w3.org/1999/html"}
+.maincontent
   = render :partial => "layouts/flash_msg"
   .form-horizontal.static
     .form-group
@@ -26,8 +26,9 @@
           %label.col-md-2.control-label
             = _('Long Description')
           .col-md-8
-            %p.form-control-static
-              = @record.long_description.to_s.html_safe
+            %p.form-control-static#long_description
+              %miq-sanitize{:value => @record.long_description}
+
     .form-group
       .col-md-1{:align => "center"}
         #buttons
@@ -38,3 +39,6 @@
                        :onclick => "miqAjaxButton('#{url_for(:action => "svc_catalog_provision",
                                                              :id     => @record.id,
                                                            :button => "order")}');")
+
+:javascript
+  miq_bootstrap('#long_description', 'miq.helpers');


### PR DESCRIPTION
Go to Services > Catalogs > Catalog Items.
Edit a catalog item's long description to include a `<script>` or `<style>` elements.
(Visible in the catalog item's Details tab, or in the Service Catalogs accordion.)

Before: any script will get run, any style will affect the whole page
After: script and style elements will be ignored, `onclick` and `href="javascript:..."` are also removed.

https://bugzilla.redhat.com/show_bug.cgi?id=1415235