### PR TITLE
Refactor - Replace .success calls with .then/.catch (Round 4)

### DIFF
--- a/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
@@ -93,12 +93,12 @@
             $scope.isSingleProvider = false;
             $scope.objectStatus.providers.count = 0;
             $scope.objectStatus.providers.notifications = [];
-            providers.forEach(function (item) {
+            providers.forEach(function(item) {
               $scope.objectStatus.providers.count += item.count;
               $scope.objectStatus.providers.notifications.push({
                 iconImage: item.iconImage,
-                count: item.count
-              })
+                count: item.count,
+              });
             });
           }
 
@@ -118,10 +118,10 @@
 
         // Node utilization donut
         $scope.cpuUsageData = chartsMixin.processUtilizationData(data.ems_utilization.cpu,
-                                                                 "dates",
+                                                                 'dates',
                                                                  $scope.cpuUsageConfig.units);
         $scope.memoryUsageData = chartsMixin.processUtilizationData(data.ems_utilization.mem,
-                                                                    "dates",
+                                                                    'dates',
                                                                     $scope.memoryUsageConfig.units);
 
         // Heatmaps
@@ -137,7 +137,7 @@
 
         $scope.dailyNetworkUtilization =
           chartsMixin.processUtilizationData(data.daily_network_metrics,
-                                             "dates",
+                                             'dates',
                                              $scope.networkUtilizationDailyConfig.units);
 
         // Pod metrics
@@ -145,7 +145,7 @@
 
         $scope.dailyPodEntityTrend =
             chartsMixin.processPodUtilizationData(data.daily_pod_metrics,
-                "dates",
+                'dates',
                 $scope.podEntityTrendDailyConfig.createdLabel,
                 $scope.podEntityTrendDailyConfig.deletedLabel);
 
@@ -154,7 +154,7 @@
 
         $scope.dailyImageEntityTrend =
             chartsMixin.processUtilizationData(data.daily_image_metrics,
-                "dates",
+                'dates',
                 $scope.imageEntityTrendDailyConfig.createdLabel);
 
         // Trend lines data

--- a/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
@@ -1,8 +1,7 @@
 /* global miqHttpInject */
 
-miqHttpInject(angular.module('containerDashboard', ['ui.bootstrap', 'patternfly', 'patternfly.charts', 'miq.card', 'miq.util']))
-  .controller('containerDashboardController', ['$scope', 'dashboardUtilsFactory', 'chartsMixin', '$http', '$interval', '$window',
-    function($scope, dashboardUtilsFactory, chartsMixin, $http, $interval, $window) {
+  ManageIQ.angular.app.controller('containerDashboardController', ['$scope', 'dashboardUtilsFactory', 'chartsMixin', '$http', '$interval', '$window', 'miqService',
+    function($scope, dashboardUtilsFactory, chartsMixin, $http, $interval, $window, miqService) {
       document.getElementById("center_div").className += " miq-body";
 
       // Obj-status cards init
@@ -58,99 +57,19 @@ miqHttpInject(angular.module('containerDashboard', ['ui.bootstrap', 'patternfly'
       };
 
       $scope.refresh = function() {
-        var id;
         // get the pathname and remove trailing / if exist
         var pathname = $window.location.pathname.replace(/\/$/, '');
         if (pathname.match(/show$/)) {
-          id = '';
+          $scope.id = '';
         } else {
           // search for pattern ^/<controler>/<id>$ in the pathname
-          id = '/' + (/^\/[^\/]+\/(\d+)$/.exec(pathname)[1]);
+          $scope.id = '/' + (/^\/[^\/]+\/(\d+)$/.exec(pathname)[1]);
         }
 
-        var url = '/container_dashboard/data' + id;
-        $http.get(url).success(function(response) {
-          'use strict';
-
-          var data = response.data;
-
-          // Obj-status (entity count row)
-          var providers = data.providers;
-          if (providers) {
-            if (id) {
-              $scope.providerTypeIconImage = data.providers[0].iconImage;
-              $scope.isSingleProvider = true;
-            } else {
-              $scope.isSingleProvider = false;
-              $scope.objectStatus.providers.count = 0;
-              $scope.objectStatus.providers.notifications = [];
-              providers.forEach(function (item) {
-                $scope.objectStatus.providers.count += item.count;
-                $scope.objectStatus.providers.notifications.push({
-                  iconImage: item.iconImage,
-                  count: item.count
-                })
-              });
-            }
-
-            if ($scope.objectStatus.providers.count > 0) {
-              $scope.objectStatus.providers.href = data.providers_link;
-            }
-          }
-
-          dashboardUtilsFactory.updateStatus($scope.objectStatus.nodes, data.status.nodes);
-          dashboardUtilsFactory.updateStatus($scope.objectStatus.containers, data.status.containers);
-          dashboardUtilsFactory.updateStatus($scope.objectStatus.registries, data.status.registries);
-          dashboardUtilsFactory.updateStatus($scope.objectStatus.projects, data.status.projects);
-          dashboardUtilsFactory.updateStatus($scope.objectStatus.pods, data.status.pods);
-          dashboardUtilsFactory.updateStatus($scope.objectStatus.services, data.status.services);
-          dashboardUtilsFactory.updateStatus($scope.objectStatus.images, data.status.images);
-          dashboardUtilsFactory.updateStatus($scope.objectStatus.routes, data.status.routes);
-
-          // Node utilization donut
-          $scope.cpuUsageData = chartsMixin.processUtilizationData(data.ems_utilization.cpu,
-                                                                   "dates",
-                                                                   $scope.cpuUsageConfig.units);
-          $scope.memoryUsageData = chartsMixin.processUtilizationData(data.ems_utilization.mem,
-                                                                      "dates",
-                                                                      $scope.memoryUsageConfig.units);
-
-          // Heatmaps
-          $scope.nodeCpuUsage = chartsMixin.processHeatmapData($scope.nodeCpuUsage, data.heatmaps.nodeCpuUsage);
-          $scope.nodeCpuUsage.loadingDone = true;
-
-          $scope.nodeMemoryUsage =
-            chartsMixin.processHeatmapData($scope.nodeMemoryUsage, data.heatmaps.nodeMemoryUsage);
-          $scope.nodeMemoryUsage.loadingDone = true;
-
-          // Network metrics
-          $scope.networkUtilizationDailyConfig = chartsMixin.chartConfig.dailyNetworkUsageConfig;
-
-          $scope.dailyNetworkUtilization =
-            chartsMixin.processUtilizationData(data.daily_network_metrics,
-                                               "dates",
-                                               $scope.networkUtilizationDailyConfig.units);
-
-          // Pod metrics
-          $scope.podEntityTrendDailyConfig = chartsMixin.chartConfig.dailyPodUsageConfig;
-
-          $scope.dailyPodEntityTrend =
-              chartsMixin.processPodUtilizationData(data.daily_pod_metrics,
-                  "dates",
-                  $scope.podEntityTrendDailyConfig.createdLabel,
-                  $scope.podEntityTrendDailyConfig.deletedLabel);
-
-          // Image metrics
-          $scope.imageEntityTrendDailyConfig = chartsMixin.chartConfig.dailyImageUsageConfig;
-
-          $scope.dailyImageEntityTrend =
-              chartsMixin.processUtilizationData(data.daily_image_metrics,
-                  "dates",
-                  $scope.imageEntityTrendDailyConfig.createdLabel);
-
-          // Trend lines data
-          $scope.loadingDone = true;
-        });
+        var url = '/container_dashboard/data' + $scope.id;
+        $http.get(url)
+          .then(getContainerDashboardData)
+          .catch(miqService.handleFailure);
       };
       $scope.refresh();
       var promise = $interval($scope.refresh, 1000 * 60 * 3);
@@ -158,4 +77,87 @@ miqHttpInject(angular.module('containerDashboard', ['ui.bootstrap', 'patternfly'
       $scope.$on('$destroy', function() {
         $interval.cancel(promise);
       });
+
+      function getContainerDashboardData(response) {
+        'use strict';
+
+        var data = response.data.data;
+
+        // Obj-status (entity count row)
+        var providers = data.providers;
+        if (providers) {
+          if ($scope.id) {
+            $scope.providerTypeIconImage = data.providers[0].iconImage;
+            $scope.isSingleProvider = true;
+          } else {
+            $scope.isSingleProvider = false;
+            $scope.objectStatus.providers.count = 0;
+            $scope.objectStatus.providers.notifications = [];
+            providers.forEach(function (item) {
+              $scope.objectStatus.providers.count += item.count;
+              $scope.objectStatus.providers.notifications.push({
+                iconImage: item.iconImage,
+                count: item.count
+              })
+            });
+          }
+
+          if ($scope.objectStatus.providers.count > 0) {
+            $scope.objectStatus.providers.href = data.providers_link;
+          }
+        }
+
+        dashboardUtilsFactory.updateStatus($scope.objectStatus.nodes, data.status.nodes);
+        dashboardUtilsFactory.updateStatus($scope.objectStatus.containers, data.status.containers);
+        dashboardUtilsFactory.updateStatus($scope.objectStatus.registries, data.status.registries);
+        dashboardUtilsFactory.updateStatus($scope.objectStatus.projects, data.status.projects);
+        dashboardUtilsFactory.updateStatus($scope.objectStatus.pods, data.status.pods);
+        dashboardUtilsFactory.updateStatus($scope.objectStatus.services, data.status.services);
+        dashboardUtilsFactory.updateStatus($scope.objectStatus.images, data.status.images);
+        dashboardUtilsFactory.updateStatus($scope.objectStatus.routes, data.status.routes);
+
+        // Node utilization donut
+        $scope.cpuUsageData = chartsMixin.processUtilizationData(data.ems_utilization.cpu,
+                                                                 "dates",
+                                                                 $scope.cpuUsageConfig.units);
+        $scope.memoryUsageData = chartsMixin.processUtilizationData(data.ems_utilization.mem,
+                                                                    "dates",
+                                                                    $scope.memoryUsageConfig.units);
+
+        // Heatmaps
+        $scope.nodeCpuUsage = chartsMixin.processHeatmapData($scope.nodeCpuUsage, data.heatmaps.nodeCpuUsage);
+        $scope.nodeCpuUsage.loadingDone = true;
+
+        $scope.nodeMemoryUsage =
+          chartsMixin.processHeatmapData($scope.nodeMemoryUsage, data.heatmaps.nodeMemoryUsage);
+        $scope.nodeMemoryUsage.loadingDone = true;
+
+        // Network metrics
+        $scope.networkUtilizationDailyConfig = chartsMixin.chartConfig.dailyNetworkUsageConfig;
+
+        $scope.dailyNetworkUtilization =
+          chartsMixin.processUtilizationData(data.daily_network_metrics,
+                                             "dates",
+                                             $scope.networkUtilizationDailyConfig.units);
+
+        // Pod metrics
+        $scope.podEntityTrendDailyConfig = chartsMixin.chartConfig.dailyPodUsageConfig;
+
+        $scope.dailyPodEntityTrend =
+            chartsMixin.processPodUtilizationData(data.daily_pod_metrics,
+                "dates",
+                $scope.podEntityTrendDailyConfig.createdLabel,
+                $scope.podEntityTrendDailyConfig.deletedLabel);
+
+        // Image metrics
+        $scope.imageEntityTrendDailyConfig = chartsMixin.chartConfig.dailyImageUsageConfig;
+
+        $scope.dailyImageEntityTrend =
+            chartsMixin.processUtilizationData(data.daily_image_metrics,
+                "dates",
+                $scope.imageEntityTrendDailyConfig.createdLabel);
+
+        // Trend lines data
+        $scope.loadingDone = true;
+      }
     }]);

--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -93,19 +93,21 @@
 
     dash.refresh = function() {
       dash.loadingMetrics = true;
-      var _tags = dash.tags != {} ? '&tags=' + JSON.stringify(dash.tags) : '';
+      var _tags = dash.tags !== {} ? '&tags=' + JSON.stringify(dash.tags) : '';
       $http.get(dash.url + '&query=metric_definitions' + _tags)
         .then(getMetricDefinitionsData)
         .catch(miqService.handleFailure);
     };
 
-    dash.refresh_graph = function(metric_id, metric_type, n) {
+    dash.refresh_graph = function(metricId, metricType, currentItem) {
       // TODO: replace with a datetimepicker, until then add 24 hours to the date
+      dash.metricId = metricId;
+      dash.currentItem = currentItem;
       var ends = dash.timeFilter.date.valueOf() + 24 * 60 * 60;
       var diff = dash.timeFilter.time_range * dash.timeFilter.range_count * 60 * 60 * 1000; // time_range is in hours
       var starts = ends - diff;
       var bucket_duration = parseInt(diff / 1000 / 200); // bucket duration is in seconds
-      var params = '&query=get_data&type=' + metric_type + '&metric_id=' + metric_id + '&ends=' + ends +
+      var params = '&query=get_data&type=' + metricType + '&metric_id=' + dash.metricId + '&ends=' + ends +
                    '&starts=' + starts+ '&bucket_duration=' + bucket_duration + 's';
 
       $http.get(dash.url + params)
@@ -216,9 +218,9 @@
           dash.filterConfig.fields.push(
             {
               id: data.metric_tags[i],
-              title:  data.metric_tags[i],
-              placeholder: sprintf(__("Filter by %s..."), data.metric_tags[i]),
-              filterType: 'alpha'
+              title: data.metric_tags[i],
+              placeholder: sprintf(__('Filter by %s...'), data.metric_tags[i]),
+              filterType: 'alpha',
             });
         }
       } else {
@@ -260,7 +262,7 @@
             } else {
               change = 0;
             }
-            dash.item.percent_change = "(" + numeral(change).format('0,0.00%') + ")";
+            dash.item.percent_change = '(' + numeral(change).format('0,0.00%') + ')';
           }
         }
       }
@@ -299,11 +301,11 @@
       var yData = data.map(function(d) { return d.avg || null; });
 
       xData.unshift('time');
-      yData.unshift(metric_id);
+      yData.unshift(dash.metricId);
 
       // TODO: Use time buckets
       dash.chartData.xData = xData;
-      dash.chartData['yData'+n] = yData;
+      dash.chartData['yData'+ dash.currentItem] = yData;
 
       dash.chartDataInit = true;
       dash.loadCount++;

--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -1,8 +1,7 @@
 /* global miqHttpInject */
 
-miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'patternfly', 'patternfly.charts']))
-  .controller('containerLiveDashboardController', ['$http', '$window',
-  function ($http, $window) {
+  ManageIQ.angular.app.controller('containerLiveDashboardController', ['$http', '$window', 'miqService',
+    function($http, $window, miqService) {
     var dash = this;
     dash.tenant = '_ops';
 
@@ -77,89 +76,26 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
     };
 
     var getMetricTags = function() {
-      $http.get(dash.url + '&query=metric_tags&limit=250').success(function(response) {
-        dash.tagsLoaded = true;
-        if (response && angular.isArray(response.metric_tags)) {
-          response.metric_tags.sort();
-          for (var i = 0; i < response.metric_tags.length; i++) {
-            dash.filterConfig.fields.push(
-              {
-                id: response.metric_tags[i],
-                title:  response.metric_tags[i],
-                placeholder: sprintf(__("Filter by %s..."), response.metric_tags[i]),
-                filterType: 'alpha'
-              });
-          }
-        } else {
-          // No filters available, apply without filtering
-          dash.toolbarConfig.filterConfig = undefined;
-          dash.doApply();
-        }
-      });
+      $http.get(dash.url + '&query=metric_tags&limit=250')
+        .then(getMetricTagsData)
+        .catch(miqService.handleFailure);
     };
 
     var getLatestData = function(item) {
       var params = '&query=get_data&type=' + item.type + '&metric_id=' + item.id +
         '&limit=5&order=DESC';
 
-      $http.get(dash.url + params).success(function (response) {
-        'use strict';
-        if (response.error) {
-          add_flash(response.error, 'error');
-        } else {
-          var data = response.data;
-
-          item.lastValues = {};
-          angular.forEach(data, function(d) {
-            item.lastValues[d.timestamp] = numeral(d.value).format('0,0.00a');
-          });
-
-          if (data.length > 0) {
-            var lastValue = data[0].value;
-            item.last_value = numeral(lastValue).format('0,0.00a');
-            item.last_timestamp = data[0].timestamp;
-          } else {
-            item.last_value = '-';
-            item.last_timestamp = '-';
-          }
-
-          if (data.length > 1) {
-            var prevValue = data[1].value;
-            if (angular.isNumber(lastValue) && angular.isNumber(prevValue)) {
-              var change;
-              if (prevValue !== 0 && lastValue !== 0) {
-                change = Math.round((lastValue - prevValue) / lastValue);
-              } else if (lastValue !== 0) {
-                change = 1;
-              } else {
-                change = 0;
-              }
-              item.percent_change = "(" + numeral(change).format('0,0.00%') + ")";
-            }
-          }
-        }
-      });
+      $http.get(dash.url + params)
+        .then(getContainerDashboardData)
+        .catch(miqService.handleFailure);
     };
 
     dash.refresh = function() {
       dash.loadingMetrics = true;
       var _tags = dash.tags != {} ? '&tags=' + JSON.stringify(dash.tags) : '';
-      $http.get(dash.url + '&query=metric_definitions' + _tags).success(function (response) {
-        'use strict';
-        dash.loadingMetrics = false;
-        if (response.error) {
-          add_flash(response.error, 'error');
-          return;
-        }
-
-        dash.items = response.metric_definitions.filter(function(item) {
-          return item.id && item.type;
-        });
-
-        angular.forEach(dash.items, getLatestData);
-
-        dash.filterConfig.resultsCount = dash.items.length;
-      });
+      $http.get(dash.url + '&query=metric_definitions' + _tags)
+        .then(getMetricDefinitionsData)
+        .catch(miqService.handleFailure);
     };
 
     dash.refresh_graph = function(metric_id, metric_type, n) {
@@ -171,30 +107,9 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       var params = '&query=get_data&type=' + metric_type + '&metric_id=' + metric_id + '&ends=' + ends +
                    '&starts=' + starts+ '&bucket_duration=' + bucket_duration + 's';
 
-      $http.get(dash.url + params).success(function(response) {
-        'use strict';
-        if (response.error) {
-          add_flash(response.error, 'error');
-          return;
-        }
-
-        var data  = response.data;
-        var xData = data.map(function(d) { return d.start; });
-        var yData = data.map(function(d) { return d.avg || null; });
-
-        xData.unshift('time');
-        yData.unshift(metric_id);
-
-        // TODO: Use time buckets
-        dash.chartData.xData = xData;
-        dash.chartData['yData'+n] = yData;
-
-        dash.chartDataInit = true;
-        dash.loadCount++;
-        if (dash.loadCount >= dash.selectedItems.length) {
-          dash.loadingData = false;
-        }
-      });
+      $http.get(dash.url + params)
+        .then(getContainerParamsData)
+        .catch(miqService.handleFailure);
     };
 
     dash.refresh_graph_data = function() {
@@ -289,5 +204,110 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
 
     initialization();
     getMetricTags();
-  }
-]);
+
+    function getMetricTagsData(response) {
+      var data = response.data;
+
+      dash.tagsLoaded = true;
+      if (data && angular.isArray(data.metric_tags)) {
+        data.metric_tags.sort();
+        for (var i = 0; i < data.metric_tags.length; i++) {
+          dash.filterConfig.fields.push(
+            {
+              id: data.metric_tags[i],
+              title:  data.metric_tags[i],
+              placeholder: sprintf(__("Filter by %s..."), data.metric_tags[i]),
+              filterType: 'alpha'
+            });
+        }
+      } else {
+        // No filters available, apply without filtering
+        dash.toolbarConfig.filterConfig = undefined;
+        dash.doApply();
+      }
+    }
+
+    function getContainerDashboardData(response) {
+      'use strict';
+      if (response.data.error) {
+        add_flash(response.data.error, 'error');
+      } else {
+        var data = response.data.data;
+
+        item.lastValues = {};
+        angular.forEach(data, function(d) {
+          item.lastValues[d.timestamp] = numeral(d.value).format('0,0.00a');
+        });
+
+        if (data.length > 0) {
+          var lastValue = data[0].value;
+          item.last_value = numeral(lastValue).format('0,0.00a');
+          item.last_timestamp = data[0].timestamp;
+        } else {
+          item.last_value = '-';
+          item.last_timestamp = '-';
+        }
+
+        if (data.length > 1) {
+          var prevValue = data[1].value;
+          if (angular.isNumber(lastValue) && angular.isNumber(prevValue)) {
+            var change;
+            if (prevValue !== 0 && lastValue !== 0) {
+              change = Math.round((lastValue - prevValue) / lastValue);
+            } else if (lastValue !== 0) {
+              change = 1;
+            } else {
+              change = 0;
+            }
+            item.percent_change = "(" + numeral(change).format('0,0.00%') + ")";
+          }
+        }
+      }
+    }
+
+    function getMetricDefinitionsData(response) {
+      'use strict';
+
+      var data = response.data;
+
+      dash.loadingMetrics = false;
+      if (response.data.error) {
+        add_flash(response.data.error, 'error');
+        return;
+      }
+
+      dash.items = data.metric_definitions.filter(function(item) {
+        return item.id && item.type;
+      });
+
+      angular.forEach(dash.items, getLatestData);
+
+      dash.filterConfig.resultsCount = dash.items.length;
+    }
+
+    function getContainerParamsData(response) {
+      'use strict';
+
+      if (response.data.error) {
+        add_flash(response.data.error, 'error');
+        return;
+      }
+
+      var data  = response.data.data;
+      var xData = data.map(function(d) { return d.start; });
+      var yData = data.map(function(d) { return d.avg || null; });
+
+      xData.unshift('time');
+      yData.unshift(metric_id);
+
+      // TODO: Use time buckets
+      dash.chartData.xData = xData;
+      dash.chartData['yData'+n] = yData;
+
+      dash.chartDataInit = true;
+      dash.loadCount++;
+      if (dash.loadCount >= dash.selectedItems.length) {
+        dash.loadingData = false;
+      }
+    }
+    }]);

--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -82,7 +82,8 @@
     };
 
     var getLatestData = function(item) {
-      var params = '&query=get_data&type=' + item.type + '&metric_id=' + item.id +
+      dash.item = item;
+      var params = '&query=get_data&type=' + dash.item.type + '&metric_id=' + dash.item.id +
         '&limit=5&order=DESC';
 
       $http.get(dash.url + params)
@@ -234,18 +235,18 @@
       } else {
         var data = response.data.data;
 
-        item.lastValues = {};
+        dash.item.lastValues = {};
         angular.forEach(data, function(d) {
-          item.lastValues[d.timestamp] = numeral(d.value).format('0,0.00a');
+          dash.item.lastValues[d.timestamp] = numeral(d.value).format('0,0.00a');
         });
 
         if (data.length > 0) {
           var lastValue = data[0].value;
-          item.last_value = numeral(lastValue).format('0,0.00a');
-          item.last_timestamp = data[0].timestamp;
+          dash.item.last_value = numeral(lastValue).format('0,0.00a');
+          dash.item.last_timestamp = data[0].timestamp;
         } else {
-          item.last_value = '-';
-          item.last_timestamp = '-';
+          dash.item.last_value = '-';
+          dash.item.last_timestamp = '-';
         }
 
         if (data.length > 1) {
@@ -259,7 +260,7 @@
             } else {
               change = 0;
             }
-            item.percent_change = "(" + numeral(change).format('0,0.00%') + ")";
+            dash.item.percent_change = "(" + numeral(change).format('0,0.00%') + ")";
           }
         }
       }

--- a/app/assets/javascripts/controllers/ems_infra_dashboard/ems_infra_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/ems_infra_dashboard/ems_infra_dashboard_controller.js
@@ -1,8 +1,7 @@
 /* global miqHttpInject */
 
-miqHttpInject(angular.module('emsInfraDashboard', ['ui.bootstrap', 'patternfly', 'patternfly.charts', 'miq.card', 'miq.util']))
-  .controller('emsInfraDashboardController', ['$scope', 'infraDashboardUtilsFactory', 'infraChartsMixin', '$http', '$interval', '$window',
-    function($scope, infraDashboardUtilsFactory, infraChartsMixin, $http, $interval, $window) {
+  ManageIQ.angular.app.controller('emsInfraDashboardController', ['$scope', 'infraDashboardUtilsFactory', 'infraChartsMixin', '$http', '$interval', '$window', 'miqService',
+    function($scope, infraDashboardUtilsFactory, infraChartsMixin, $http, $interval, $window, miqService) {
       document.getElementById("center_div").className += " miq-body";
 
       // Obj-status cards init

--- a/app/assets/javascripts/controllers/ems_infra_dashboard/ems_infra_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/ems_infra_dashboard/ems_infra_dashboard_controller.js
@@ -90,12 +90,12 @@
             $scope.isSingleProvider = false;
             $scope.objectStatus.providers.count = 0;
             $scope.objectStatus.providers.notifications = [];
-            providers.forEach(function (item) {
+            providers.forEach(function(item) {
               $scope.objectStatus.providers.count += item.count;
               $scope.objectStatus.providers.notifications.push({
                 iconImage: item.iconImage,
-                count: item.count
-              })
+                count: item.count,
+              });
             });
           }
 
@@ -112,10 +112,10 @@
 
         // cluster utilization donut
         $scope.cpuUsageData = infraChartsMixin.processUtilizationData(data.ems_utilization.cpu,
-          "dates",
+          'dates',
           $scope.cpuUsageConfig.units);
         $scope.memoryUsageData = infraChartsMixin.processUtilizationData(data.ems_utilization.mem,
-          "dates",
+          'dates',
           $scope.memoryUsageConfig.units);
 
         // Heatmaps
@@ -131,7 +131,7 @@
 
         // recent Hosts chart
         $scope.recentHostsData = infraChartsMixin.processRecentHostsData(data.recentHosts,
-          "dates",
+          'dates',
           $scope.recentHostsConfig.label);
 
         // Recent VMs
@@ -139,7 +139,7 @@
 
         // recent VMS chart
         $scope.recentVmsData = infraChartsMixin.processRecentVmsData(data.recentVms,
-          "dates",
+          'dates',
           $scope.recentVmsConfig.label);
 
         // Trend lines data

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -7,7 +7,7 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'angular.validators',
   'miq.api',
   'miq.card',
-  'miq.util'
+  'miq.util',
 ]);
 miqHttpInject(ManageIQ.angular.app);
 

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -2,9 +2,12 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'ui.bootstrap',
   'ui.codemirror',
   'patternfly',
+  'patternfly.charts',
   'frapontillo.bootstrap-switch',
   'angular.validators',
-  'miq.api'
+  'miq.api',
+  'miq.card',
+  'miq.util'
 ]);
 miqHttpInject(ManageIQ.angular.app);
 

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -127,4 +127,4 @@
                              "show-y-axis" => true}
 
 :javascript
-  miq_bootstrap('.containers-live-dashboard', 'containerLiveDashboard');
+  miq_bootstrap('.containers-live-dashboard');

--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -145,4 +145,4 @@
               = _("Last 30 Days")
 
 :javascript
-  miq_bootstrap('.containers-dashboard', 'containerDashboard');
+  miq_bootstrap('.containers-dashboard');

--- a/app/views/ems_infra/_show_dashboard.html.haml
+++ b/app/views/ems_infra/_show_dashboard.html.haml
@@ -103,4 +103,4 @@
           = _("Last 30 Days")
 
 :javascript
-  miq_bootstrap('.ems-infra-dashboard', 'emsInfraDashboard');
+  miq_bootstrap('.ems-infra-dashboard');

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -5,7 +5,7 @@ describe('containerLiveDashboardController', function() {
   var mock_data1_data = getJSONFixture('container_live_dashboard_data1_response.json');
   var mock_data2_data = getJSONFixture('container_live_dashboard_data2_response.json');
 
-  beforeEach(module('containerLiveDashboard'));
+  beforeEach(module('ManageIQ'));
 
   beforeEach(function() {
     var $window = {location: { pathname: '/ems_container/42' }};
@@ -57,9 +57,9 @@ describe('containerLiveDashboardController', function() {
 
   describe('check numeric formater', function() {
     it('should fomrat numbers correctly', function() {
-      expect($controller.items[0].lastValues[1480424640000]).toBe("10.00");
-      expect($controller.items[0].lastValues[1480424630000]).toBe("1.01k");
-      expect($controller.items[0].lastValues[1480424620000]).toBe("20.00t");
+      expect($controller.items[1].lastValues[1480424640000]).toBe("10.00");
+      expect($controller.items[1].lastValues[1480424630000]).toBe("1.01k");
+      expect($controller.items[1].lastValues[1480424620000]).toBe("20.00t");
     });
   });
 });

--- a/spec/javascripts/controllers/containers/container_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/containers/container_dashboard_controller_spec.js
@@ -2,7 +2,7 @@ describe('containerDashboardController gets data and', function() {
   var $scope, $controller, $httpBackend, dashboardUtilsFactory;
   var mock_data = getJSONFixture('container_dashboard_response.json');
 
-  beforeEach(module('containerDashboard'));
+  beforeEach(module('ManageIQ'));
 
   beforeEach(function() {
     var $window = {location: { pathname: '/container_dashboard/show' }};
@@ -60,7 +60,7 @@ describe('containerDashboardController gets no data and', function() {
   var $scope, $controller, $httpBackend, dashboardUtilsFactory;
   var mock_data = getJSONFixture('container_dashboard_no_data_response.json');
 
-  beforeEach(module('containerDashboard'));
+  beforeEach(module('ManageIQ'));
 
   beforeEach(function() {
     var $window = {location: { pathname: '/container_dashboard/show' }};
@@ -118,7 +118,7 @@ describe('containerDashboardController gets data for one provider and', function
   var $scope, $controller, $httpBackend, dashboardUtilsFactory;
   var mock_data = getJSONFixture('container_dashboard_response.json');
 
-  beforeEach(module('containerDashboard'));
+  beforeEach(module('ManageIQ'));
 
   beforeEach(function() {
     var $window = {location: { pathname: '/ems_container/42' }};

--- a/spec/javascripts/controllers/ems_infra/ems_infra_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/ems_infra/ems_infra_dashboard_controller_spec.js
@@ -2,7 +2,7 @@ describe('emsInfraDashboardController gets data and', function() {
   var $scope, $controller, $httpBackend, infraDashboardUtilsFactory;
   var mock_data = getJSONFixture('ems_infra_dashboard_response.json');
 
-  beforeEach(module('emsInfraDashboard'));
+  beforeEach(module('ManageIQ'));
 
   beforeEach(function() {
     var $window = {location: { pathname: '/ems_infra_dashboard/show' }};
@@ -53,7 +53,7 @@ describe('emsInfraDashboardController gets no data and', function() {
   var $scope, $controller, $httpBackend, infraDashboardUtilsFactory;
   var mock_data = getJSONFixture('ems_infra_dashboard_no_data_response.json');
 
-  beforeEach(module('emsInfraDashboard'));
+  beforeEach(module('ManageIQ'));
 
   beforeEach(function() {
     var $window = {location: { pathname: '/ems_infra_dashboard/show' }};
@@ -103,7 +103,7 @@ describe('emsInfraDashboardController gets data for one provider and', function(
   var $scope, $controller, $httpBackend, infraDashboardUtilsFactory;
   var mock_data = getJSONFixture('ems_infra_dashboard_response.json');
 
-  beforeEach(module('emsInfraDashboard'));
+  beforeEach(module('ManageIQ'));
 
   beforeEach(function() {
     var $window = {location: { pathname: '/ems_infra/42' }};


### PR DESCRIPTION
Replace `.success` calls in angular controllers with `.then` `.catch`
This is Round 4 of refactoring, and probably the last but one round.

@himdel The controllers here are bit of an "oddball" compared to the other plain vanilla controllers, hence I would recommend some UI testing if possible.
I have tested the `Ems Infra Dashboard` controller, but could not test the `Container` ones.

The following controllers have been covered here --

- container_dashboard_controller.js
- container_live_dashboard_controller.js
- ems_infra_dashboard_controller.js

(Round 1 done here -- #13,
 Round 2 done here -- #179,
 Round 3 done here -- https://github.com/ManageIQ/manageiq-ui-classic/pull/232 )

EDIT: I have tested `Ems Infra Dashboard` and `Container Dashboard`, but could not test `Container Live` 
