### PR TITLE
Refactor - Replace .success calls with .then/.catch (Round 5, final round)

### DIFF
--- a/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
+++ b/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
@@ -30,28 +30,9 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
     ManageIQ.angular.scope = $scope;
 
     miqService.sparkleOn();
-    $http.get('/configuration/time_profile_form_fields/' + timeProfileFormId).success(function(data) {
-      $scope.timeProfileModel.description = data.description;
-      $scope.timeProfileModel.admin_user = data.admin_user;
-      $scope.timeProfileModel.restricted_time_profile = data.restricted_time_profile;
-      $scope.timeProfileModel.profile_type = data.profile_type;
-      $scope.timeProfileModel.profile_tz = data.profile_tz;
-      $scope.timeProfileModel.rollup_daily = data.rollup_daily;
-      $scope.timeProfileModel.miq_reports_count = data.miq_reports_count;
-      $scope.timeProfileModel.all_days = data.all_days;
-      $scope.timeProfileModel.days = data.days;
-      $scope.timeProfileModel.all_hours = data.all_hours;
-      $scope.timeProfileModel.hours = data.hours;
-      $scope.getDaysValues();
-      $scope.getHoursValues();
-
-      $scope.note = sprintf(__("In use by %s reports, cannot be disabled"), $scope.timeProfileModel.miq_reports_count);
-
-      $scope.afterGet = true;
-      $scope.modelCopy                    = angular.copy( $scope.timeProfileModel );
-
-      miqService.sparkleOff();
-    });
+    $http.get('/configuration/time_profile_form_fields/' + timeProfileFormId)
+      .then(getTimeProfileFormData)
+      .catch(miqService.handleFailure);
 
     if (timeProfileFormId == 'new') {
       $scope.newRecord = true;
@@ -210,6 +191,31 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
   $scope.addClicked = function() {
     $scope.saveClicked();
   };
+
+  function getTimeProfileFormData(response) {
+    var data = response.data;
+
+    $scope.timeProfileModel.description = data.description;
+    $scope.timeProfileModel.admin_user = data.admin_user;
+    $scope.timeProfileModel.restricted_time_profile = data.restricted_time_profile;
+    $scope.timeProfileModel.profile_type = data.profile_type;
+    $scope.timeProfileModel.profile_tz = data.profile_tz;
+    $scope.timeProfileModel.rollup_daily = data.rollup_daily;
+    $scope.timeProfileModel.miq_reports_count = data.miq_reports_count;
+    $scope.timeProfileModel.all_days = data.all_days;
+    $scope.timeProfileModel.days = data.days;
+    $scope.timeProfileModel.all_hours = data.all_hours;
+    $scope.timeProfileModel.hours = data.hours;
+    $scope.getDaysValues();
+    $scope.getHoursValues();
+
+    $scope.note = sprintf(__("In use by %s reports, cannot be disabled"), $scope.timeProfileModel.miq_reports_count);
+
+    $scope.afterGet = true;
+    $scope.modelCopy                    = angular.copy( $scope.timeProfileModel );
+
+    miqService.sparkleOff();
+  }
 
   init();
 }]);

--- a/app/assets/javascripts/controllers/floating_ip/floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/floating_ip/floating_ip_form_controller.js
@@ -14,12 +14,9 @@ ManageIQ.angular.app.controller('floatingIpFormController', ['$http', '$scope', 
   } else {
     miqService.sparkleOn();
 
-    $http.get('/floating_ip/floating_ip_form_fields/' + floatingIpFormId).success(function(data) {
-      $scope.afterGet = true;
-      $scope.floatingIpModel.network_port_ems_ref = data.network_port_ems_ref;
-      $scope.modelCopy = angular.copy( $scope.floatingIpModel );
-      miqService.sparkleOff();
-    });
+    $http.get('/floating_ip/floating_ip_form_fields/' + floatingIpFormId)
+      .then(getFloatingIpFormData)
+      .catch(miqService.handleFailure);
   }
 
   $scope.addClicked = function() {
@@ -49,9 +46,24 @@ ManageIQ.angular.app.controller('floatingIpFormController', ['$http', '$scope', 
 
   $scope.filterNetworkManagerChanged = function(id) {
     miqService.sparkleOn();
-    $http.get('/floating_ip/networks_by_ems/' + id).success(function(data) {
-      $scope.available_networks = data.available_networks;
-      miqService.sparkleOff();
-    });
+    $http.get('/floating_ip/networks_by_ems/' + id)
+      .then(getNetworkByEmsFormData)
+      .catch(miqService.handleFailure);
   };
+
+  function getFloatingIpFormData(response) {
+    var data = response.data;
+
+    $scope.afterGet = true;
+    $scope.floatingIpModel.network_port_ems_ref = data.network_port_ems_ref;
+    $scope.modelCopy = angular.copy( $scope.floatingIpModel );
+    miqService.sparkleOff();
+  }
+
+  function getNetworkByEmsFormData(response) {
+    var data = response.data;
+
+    $scope.available_networks = data.available_networks;
+    miqService.sparkleOff();
+  }
 }]);

--- a/app/assets/javascripts/controllers/host_aggregate/host_aggregate_form_controller.js
+++ b/app/assets/javascripts/controllers/host_aggregate/host_aggregate_form_controller.js
@@ -85,7 +85,7 @@ ManageIQ.angular.app.controller('hostAggregateFormController', ['$http', '$scope
     $scope.afterGet = true;
     $scope.hostAggregateModel.name = data.name;
     $scope.hostAggregateModel.ems_id = data.ems_id;
-    $scope.hostAggregateModel.host_id = "";
+    $scope.hostAggregateModel.host_id = '';
 
     $scope.modelCopy = angular.copy( $scope.hostAggregateModel );
     miqService.sparkleOff();

--- a/app/assets/javascripts/controllers/host_aggregate/host_aggregate_form_controller.js
+++ b/app/assets/javascripts/controllers/host_aggregate/host_aggregate_form_controller.js
@@ -22,15 +22,9 @@ ManageIQ.angular.app.controller('hostAggregateFormController', ['$http', '$scope
   } else {
     miqService.sparkleOn();
 
-    $http.get('/host_aggregate/host_aggregate_form_fields/' + hostAggregateFormId).success(function(data) {
-      $scope.afterGet = true;
-      $scope.hostAggregateModel.name = data.name;
-      $scope.hostAggregateModel.ems_id = data.ems_id;
-      $scope.hostAggregateModel.host_id = "";
-
-      $scope.modelCopy = angular.copy( $scope.hostAggregateModel );
-      miqService.sparkleOff();
-    });
+    $http.get('/host_aggregate/host_aggregate_form_fields/' + hostAggregateFormId)
+      .then(getHostAggregateFormData)
+      .catch(miqService.handleFailure);
   }
 
   $scope.addClicked = function() {
@@ -84,4 +78,16 @@ ManageIQ.angular.app.controller('hostAggregateFormController', ['$http', '$scope
     $scope.angularForm.$setPristine(true);
     miqService.miqFlash("warn", "All changes have been reset");
   };
+
+  function getHostAggregateFormData(response) {
+    var data = response.data;
+
+    $scope.afterGet = true;
+    $scope.hostAggregateModel.name = data.name;
+    $scope.hostAggregateModel.ems_id = data.ems_id;
+    $scope.hostAggregateModel.host_id = "";
+
+    $scope.modelCopy = angular.copy( $scope.hostAggregateModel );
+    miqService.sparkleOff();
+  }
 }]);

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -17,14 +17,9 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
   } else {
     miqService.sparkleOn();
 
-    $http.get('/network_router/network_router_form_fields/' + networkRouterFormId).success(function(data) {
-      $scope.afterGet = true;
-      $scope.networkRouterModel.name = data.name;
-      $scope.networkRouterModel.cloud_subnet_id = "";
-
-      $scope.modelCopy = angular.copy( $scope.networkRouterModel );
-      miqService.sparkleOff();
-    });
+    $http.get('/network_router/network_router_form_fields/' + networkRouterFormId)
+      .then(getNetworkRouterFormData)
+      .catch(miqService.handleFailure);
   }
 
   $scope.addClicked = function() {
@@ -66,9 +61,26 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
 
   $scope.filterNetworkManagerChanged = function(id) {
     miqService.sparkleOn();
-    $http.get('/network_router/network_router_networks_by_ems/' + id).success(function(data) {
-      $scope.available_networks = data.available_networks;
-      miqService.sparkleOff();
-    });
+    $http.get('/network_router/network_router_networks_by_ems/' + id)
+      .then(getNetworkRouterFormByEmsData)
+      .catch(miqService.handleFailure);
   };
+
+  function getNetworkRouterFormData(response) {
+    var data = response.data;
+
+    $scope.afterGet = true;
+    $scope.networkRouterModel.name = data.name;
+    $scope.networkRouterModel.cloud_subnet_id = "";
+
+    $scope.modelCopy = angular.copy( $scope.networkRouterModel );
+    miqService.sparkleOff();
+  }
+
+  function getNetworkRouterFormByEmsData(response) {
+    var data = response.data;
+
+    $scope.available_networks = data.available_networks;
+    miqService.sparkleOff();
+  }
 }]);

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -71,7 +71,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
 
     $scope.afterGet = true;
     $scope.networkRouterModel.name = data.name;
-    $scope.networkRouterModel.cloud_subnet_id = "";
+    $scope.networkRouterModel.cloud_subnet_id = '';
 
     $scope.modelCopy = angular.copy( $scope.networkRouterModel );
     miqService.sparkleOff();

--- a/app/assets/javascripts/controllers/orchestration_template/orchestration_template_copy_controller.js
+++ b/app/assets/javascripts/controllers/orchestration_template/orchestration_template_copy_controller.js
@@ -41,7 +41,7 @@ ManageIQ.angular.app.controller('orchestrationTemplateCopyController', ['$http',
     var data = response.data;
 
     $scope.templateInfo.templateId = data.template_id;
-    $scope.templateInfo.templateName = "Copy of " + data.template_name;
+    $scope.templateInfo.templateName = 'Copy of ' + data.template_name;
     $scope.templateInfo.templateDescription = data.template_description;
     $scope.templateInfo.templateDraft = data.template_draft;
     $scope.templateInfo.templateContent = data.template_content;

--- a/app/assets/javascripts/controllers/orchestration_template/orchestration_template_copy_controller.js
+++ b/app/assets/javascripts/controllers/orchestration_template/orchestration_template_copy_controller.js
@@ -15,14 +15,9 @@ ManageIQ.angular.app.controller('orchestrationTemplateCopyController', ['$http',
   var otinfoUrl = '/orchestration_stack/stacks_ot_info';
   var submitUrl = '/orchestration_stack/stacks_ot_copy';
 
-  $http.get(otinfoUrl + '/' + stackId).success(function(response) {
-    $scope.templateInfo.templateId = response.template_id;
-    $scope.templateInfo.templateName = "Copy of " + response.template_name;
-    $scope.templateInfo.templateDescription = response.template_description;
-    $scope.templateInfo.templateDraft = response.template_draft;
-    $scope.templateInfo.templateContent = response.template_content;
-    $scope.modelCopy = _.extend({}, $scope.templateInfo);
-  });
+  $http.get(otinfoUrl + '/' + stackId)
+    .then(getOrchestrationInfoFormData)
+    .catch(miqService.handleFailure);
 
   $scope.$watch('templateInfo.templateContent', function() {
     if ($scope.templateInfo.templateContent != null) {
@@ -41,4 +36,15 @@ ManageIQ.angular.app.controller('orchestrationTemplateCopyController', ['$http',
     miqService.sparkleOn();
     miqService.miqAjaxButton(submitUrl + '?button=add', $scope.templateInfo);
   };
+
+  function getOrchestrationInfoFormData(response) {
+    var data = response.data;
+
+    $scope.templateInfo.templateId = data.template_id;
+    $scope.templateInfo.templateName = "Copy of " + data.template_name;
+    $scope.templateInfo.templateDescription = data.template_description;
+    $scope.templateInfo.templateDraft = data.template_draft;
+    $scope.templateInfo.templateContent = data.template_content;
+    $scope.modelCopy = _.extend({}, $scope.templateInfo);
+  }
 }]);

--- a/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
+++ b/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
@@ -14,13 +14,9 @@ ManageIQ.angular.app.controller('ownershipFormController', ['$http', '$scope', '
     ManageIQ.angular.scope = $scope;
 
     miqService.sparkleOn();
-    $http.get('ownership_form_fields/' + objectIds.join(',')).success(function(data) {
-      $scope.ownershipModel.user = data.user;
-      $scope.ownershipModel.group = data.group;
-      $scope.afterGet = true;
-      $scope.modelCopy = angular.copy( $scope.ownershipModel );
-      miqService.sparkleOff();
-    });
+    $http.get('ownership_form_fields/' + objectIds.join(','))
+      .then(getOwnershipFormData)
+      .catch(miqService.handleFailure);
   };
 
   $scope.canValidateBasicInfo = function () {
@@ -66,6 +62,16 @@ ManageIQ.angular.app.controller('ownershipFormController', ['$http', '$scope', '
   $scope.addClicked = function() {
     $scope.saveClicked();
   };
+
+  function getOwnershipFormData(response) {
+    var data = response.data;
+
+    $scope.ownershipModel.user = data.user;
+    $scope.ownershipModel.group = data.group;
+    $scope.afterGet = true;
+    $scope.modelCopy = angular.copy( $scope.ownershipModel );
+    miqService.sparkleOff();
+  }
 
   init();
 }]);

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -37,31 +37,9 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         $scope.newRecord = false;
 
       miqService.sparkleOn();
-      $http.get('reconfigure_form_fields/' + reconfigureFormId + ',' + $scope.objectIds).success(function(data) {
-        $scope.reconfigureModel.memory                 = data.memory;
-        $scope.reconfigureModel.memory_type            = data.memory_type;
-        $scope.reconfigureModel.socket_count           = data.socket_count;
-        $scope.reconfigureModel.cores_per_socket_count = data.cores_per_socket_count;
-        $scope.mem_type_prev = $scope.reconfigureModel.memory_type;
-        $scope.cb_memory = data.cb_memory;
-        $scope.cb_cpu = data.cb_cpu;
-        $scope.reconfigureModel.vmdisks = angular.copy(data.disks);
-
-        $scope.updateDisksAddRemove();
-
-        for (var disk in $scope.reconfigureModel.vmdisks)
-          if($scope.reconfigureModel.vmdisks[disk]['add_remove'] == '' )
-            $scope.reconfigureModel.vmdisks[disk]['delete_backing'] = false;
-
-        if(data.socket_count && data.cores_per_socket_count)
-          $scope.reconfigureModel.total_cpus = (parseInt($scope.reconfigureModel.socket_count, 10) * parseInt($scope.reconfigureModel.cores_per_socket_count, 10)).toString();
-        $scope.afterGet = true;
-        $scope.modelCopy = angular.copy( $scope.reconfigureModel );
-        $scope.cb_memoryCopy = $scope.cb_memory;
-        $scope.cb_cpuCopy = $scope.cb_cpu;
-
-        miqService.sparkleOff();
-      });
+      $http.get('reconfigure_form_fields/' + reconfigureFormId + ',' + $scope.objectIds)
+        .then(getReconfigureFormData)
+        .catch(miqService.handleFailure);
     };
 
     $scope.canValidateBasicInfo = function () {
@@ -284,6 +262,34 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     $scope.addClicked = function() {
       $scope.submitClicked();
     };
+
+    function getReconfigureFormData(response) {
+      var data = response.data;
+
+      $scope.reconfigureModel.memory                 = data.memory;
+      $scope.reconfigureModel.memory_type            = data.memory_type;
+      $scope.reconfigureModel.socket_count           = data.socket_count;
+      $scope.reconfigureModel.cores_per_socket_count = data.cores_per_socket_count;
+      $scope.mem_type_prev = $scope.reconfigureModel.memory_type;
+      $scope.cb_memory = data.cb_memory;
+      $scope.cb_cpu = data.cb_cpu;
+      $scope.reconfigureModel.vmdisks = angular.copy(data.disks);
+
+      $scope.updateDisksAddRemove();
+
+      for (var disk in $scope.reconfigureModel.vmdisks)
+        if($scope.reconfigureModel.vmdisks[disk]['add_remove'] == '' )
+          $scope.reconfigureModel.vmdisks[disk]['delete_backing'] = false;
+
+      if(data.socket_count && data.cores_per_socket_count)
+        $scope.reconfigureModel.total_cpus = (parseInt($scope.reconfigureModel.socket_count, 10) * parseInt($scope.reconfigureModel.cores_per_socket_count, 10)).toString();
+      $scope.afterGet = true;
+      $scope.modelCopy = angular.copy( $scope.reconfigureModel );
+      $scope.cb_memoryCopy = $scope.cb_memory;
+      $scope.cb_cpuCopy = $scope.cb_cpu;
+
+      miqService.sparkleOff();
+    }
 
     init();
 }]);

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -277,12 +277,15 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
 
       $scope.updateDisksAddRemove();
 
-      for (var disk in $scope.reconfigureModel.vmdisks)
-        if($scope.reconfigureModel.vmdisks[disk]['add_remove'] == '' )
-          $scope.reconfigureModel.vmdisks[disk]['delete_backing'] = false;
+      angular.forEach($scope.reconfigureModel.vmdisks, function(disk) {
+        if ($scope.reconfigureModel.vmdisks[disk].add_remove === '' ) {
+          $scope.reconfigureModel.vmdisks[disk].delete_backing = false;
+        }
+      });
 
-      if(data.socket_count && data.cores_per_socket_count)
+      if (data.socket_count && data.cores_per_socket_count) {
         $scope.reconfigureModel.total_cpus = (parseInt($scope.reconfigureModel.socket_count, 10) * parseInt($scope.reconfigureModel.cores_per_socket_count, 10)).toString();
+      }
       $scope.afterGet = true;
       $scope.modelCopy = angular.copy( $scope.reconfigureModel );
       $scope.cb_memoryCopy = $scope.cb_memory;

--- a/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
+++ b/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
@@ -9,13 +9,9 @@ ManageIQ.angular.app.controller('retirementFormController', ['$http', '$scope', 
   $scope.model = 'retirementInfo';
 
   if (objectIds.length == 1) {
-    $http.get('retirement_info/' + objectIds[0]).success(function(response) {
-      if (response.retirement_date != null) {
-        $scope.retirementInfo.retirementDate = moment.utc(response.retirement_date, 'MM-DD-YYYY').toDate();
-      }
-      $scope.retirementInfo.retirementWarning = response.retirement_warning || "";
-      $scope.modelCopy = _.extend({}, $scope.retirementInfo);
-    });
+    $http.get('retirement_info/' + objectIds[0])
+      .then(getRetirementInfoFormData)
+      .catch(miqService.handleFailure);
   }
 
   $scope.cancelClicked = function() {
@@ -29,4 +25,14 @@ ManageIQ.angular.app.controller('retirementFormController', ['$http', '$scope', 
                              {'retire_date': $scope.retirementInfo.retirementDate,
                               'retire_warn': $scope.retirementInfo.retirementWarning});
   };
+
+  function getRetirementInfoFormData(response) {
+    var data = response.data;
+
+    if (data.retirement_date != null) {
+      $scope.retirementInfo.retirementDate = moment.utc(data.retirement_date, 'MM-DD-YYYY').toDate();
+    }
+    $scope.retirementInfo.retirementWarning = data.retirement_warning || "";
+    $scope.modelCopy = _.extend({}, $scope.retirementInfo);
+  }
 }]);

--- a/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
+++ b/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
@@ -32,7 +32,7 @@ ManageIQ.angular.app.controller('retirementFormController', ['$http', '$scope', 
     if (data.retirement_date != null) {
       $scope.retirementInfo.retirementDate = moment.utc(data.retirement_date, 'MM-DD-YYYY').toDate();
     }
-    $scope.retirementInfo.retirementWarning = data.retirement_warning || "";
+    $scope.retirementInfo.retirementWarning = data.retirement_warning || '';
     $scope.modelCopy = _.extend({}, $scope.retirementInfo);
   }
 }]);

--- a/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
+++ b/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
@@ -14,14 +14,9 @@ ManageIQ.angular.app.controller('securityGroupFormController', ['$http', '$scope
   } else {
     miqService.sparkleOn();
 
-    $http.get('/security_group/security_group_form_fields/' + securityGroupFormId).success(function(data) {
-      $scope.afterGet = true;
-      $scope.securityGroupModel.name = data.name;
-      $scope.securityGroupModel.description = data.description;
-      $scope.securityGroupModel.cloud_tenant_name = data.cloud_tenant_name;
-      $scope.modelCopy = angular.copy( $scope.securityGroupModel );
-      miqService.sparkleOff();
-    });
+    $http.get('/security_group/security_group_form_fields/' + securityGroupFormId)
+      .then(getSecurityGroupFormData)
+      .catch(miqService.handleFailure);
   }
 
   $scope.addClicked = function() {
@@ -48,4 +43,15 @@ ManageIQ.angular.app.controller('securityGroupFormController', ['$http', '$scope
     $scope.angularForm.$setPristine(true);
     miqService.miqFlash("warn", "All changes have been reset");
   };
+
+  function getSecurityGroupFormData(response) {
+    var data = response.data;
+
+    $scope.afterGet = true;
+    $scope.securityGroupModel.name = data.name;
+    $scope.securityGroupModel.description = data.description;
+    $scope.securityGroupModel.cloud_tenant_name = data.cloud_tenant_name;
+    $scope.modelCopy = angular.copy( $scope.securityGroupModel );
+    miqService.sparkleOff();
+  }
 }]);

--- a/app/assets/javascripts/controllers/service/service_form_controller.js
+++ b/app/assets/javascripts/controllers/service/service_form_controller.js
@@ -12,14 +12,9 @@ ManageIQ.angular.app.controller('serviceFormController', ['$http', '$scope', 'se
       ManageIQ.angular.scope = $scope;
 
       miqService.sparkleOn();
-      $http.get('/service/service_form_fields/' + serviceFormId).success(function(data) {
-        $scope.serviceModel.name        = data.name;
-        $scope.serviceModel.description = data.description;
-
-        $scope.afterGet = true;
-        $scope.modelCopy = angular.copy( $scope.serviceModel );
-        miqService.sparkleOff();
-      });
+      $http.get('/service/service_form_fields/' + serviceFormId)
+        .then(getServiceFormData)
+        .catch(miqService.handleFailure);
     };
 
     var serviceEditButtonClicked = function(buttonName, serializeFields) {
@@ -45,6 +40,17 @@ ManageIQ.angular.app.controller('serviceFormController', ['$http', '$scope', 'se
       serviceEditButtonClicked('save', true);
       $scope.angularForm.$setPristine(true);
     };
+
+    function getServiceFormData(response) {
+      var data = response.data;
+
+      $scope.serviceModel.name        = data.name;
+      $scope.serviceModel.description = data.description;
+
+      $scope.afterGet = true;
+      $scope.modelCopy = angular.copy( $scope.serviceModel );
+      miqService.sparkleOff();
+    }
 
     init();
 }]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_associate_floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_associate_floating_ip_form_controller.js
@@ -8,11 +8,9 @@ ManageIQ.angular.app.controller('vmCloudAssociateFloatingIpFormController', ['$h
 
   ManageIQ.angular.scope = $scope;
 
-  $http.get('/vm_cloud/associate_floating_ip_form_fields/' + vmCloudAssociateFloatingIpFormId).success(function(data) {
-    $scope.floating_ips = data.floating_ips;
-    $scope.modelCopy = angular.copy( $scope.vmCloudModel );
-    miqService.sparkleOff();
-  });
+  $http.get('/vm_cloud/associate_floating_ip_form_fields/' + vmCloudAssociateFloatingIpFormId)
+    .then(getAssociateFloatingIpFormData)
+    .catch(miqService.handleFailure);
 
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
@@ -25,4 +23,12 @@ ManageIQ.angular.app.controller('vmCloudAssociateFloatingIpFormController', ['$h
     var url = '/vm_cloud/associate_floating_ip_vm/' + vmCloudAssociateFloatingIpFormId + '?button=submit';
     miqService.miqAjaxButton(url, true);
   };
+
+  function getAssociateFloatingIpFormData(response) {
+    var data = response.data;
+
+    $scope.floating_ips = data.floating_ips;
+    $scope.modelCopy = angular.copy( $scope.vmCloudModel );
+    miqService.sparkleOff();
+  }
 }]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_disassociate_floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_disassociate_floating_ip_form_controller.js
@@ -8,11 +8,9 @@ ManageIQ.angular.app.controller('vmCloudDisassociateFloatingIpFormController', [
 
   ManageIQ.angular.scope = $scope;
 
-  $http.get('/vm_cloud/disassociate_floating_ip_form_fields/' + vmCloudDisassociateFloatingIpFormId).success(function(data) {
-    $scope.floating_ips = data.floating_ips;
-    $scope.modelCopy = angular.copy( $scope.vmCloudModel );
-    miqService.sparkleOff();
-  });
+  $http.get('/vm_cloud/disassociate_floating_ip_form_fields/' + vmCloudDisassociateFloatingIpFormId)
+    .then(getDisassociateFloatingIpFormData)
+    .catch(miqService.handleFailure);
 
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
@@ -25,4 +23,12 @@ ManageIQ.angular.app.controller('vmCloudDisassociateFloatingIpFormController', [
     var url = '/vm_cloud/disassociate_floating_ip_vm/' + vmCloudDisassociateFloatingIpFormId + '?button=submit';
     miqService.miqAjaxButton(url, true);
   };
+
+  function getDisassociateFloatingIpFormData(response) {
+    var data = response.data;
+
+    $scope.floating_ips = data.floating_ips;
+    $scope.modelCopy = angular.copy( $scope.vmCloudModel );
+    miqService.sparkleOff();
+  }
 }]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_evacuate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_evacuate_form_controller.js
@@ -11,11 +11,9 @@ ManageIQ.angular.app.controller('vmCloudEvacuateFormController', ['$http', '$sco
 
   ManageIQ.angular.scope = $scope;
 
-  $http.get('/vm_cloud/evacuate_form_fields/' + vmCloudEvacuateFormId).success(function(data) {
-    $scope.hosts = data.hosts;
-    $scope.modelCopy = angular.copy( $scope.vmCloudModel );
-    miqService.sparkleOff();
-  });
+  $http.get('/vm_cloud/evacuate_form_fields/' + vmCloudEvacuateFormId)
+    .then(getEvacuateFormData)
+    .catch(miqService.handleFailure);
 
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
@@ -28,4 +26,12 @@ ManageIQ.angular.app.controller('vmCloudEvacuateFormController', ['$http', '$sco
     var url = '/vm_cloud/evacuate_vm/' + vmCloudEvacuateFormId + '?button=submit';
     miqService.miqAjaxButton(url, true);
   };
+
+  function getEvacuateFormData(response) {
+    var data = response.data;
+
+    $scope.hosts = data.hosts;
+    $scope.modelCopy = angular.copy( $scope.vmCloudModel );
+    miqService.sparkleOff();
+  }
 }]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
@@ -14,12 +14,9 @@ ManageIQ.angular.app.controller('vmCloudLiveMigrateFormController', ['$http', '$
 
   ManageIQ.angular.scope = $scope;
 
-  $http.get('/vm_cloud/live_migrate_form_fields/' + vmCloudLiveMigrateFormId).success(function(data) {
-    $scope.clusters = data.clusters;
-    $scope.hosts = data.hosts;
-    $scope.modelCopy = angular.copy( $scope.vmCloudModel );
-    miqService.sparkleOff();
-  });
+  $http.get('/vm_cloud/live_migrate_form_fields/' + vmCloudLiveMigrateFormId)
+    .then(getLiveMigrateFormData)
+    .catch(miqService.handleFailure);
 
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
@@ -32,4 +29,13 @@ ManageIQ.angular.app.controller('vmCloudLiveMigrateFormController', ['$http', '$
     var url = '/vm_cloud/live_migrate_vm/' + vmCloudLiveMigrateFormId + '?button=submit';
     miqService.miqAjaxButton(url, true);
   };
+
+  function getLiveMigrateFormData(response) {
+    var data = response.data;
+
+    $scope.clusters = data.clusters;
+    $scope.hosts = data.hosts;
+    $scope.modelCopy = angular.copy( $scope.vmCloudModel );
+    miqService.sparkleOff();
+  }
 }]);


### PR DESCRIPTION
Replace `.success` calls in angular controllers with `.then`  `.catch`
This is the final stretch of this refactoring effort (Phew!)

The following controllers have been covered here --

- time_profile_form_controller.js
- floating_ip_form_controller.js
- host_aggregate_form_controller.js
- network_router_form_controller.js
- orchestration_template_copy_controller.js
- ownership_form_controller.js
- reconfigure_form_controller.js
- retirement_form_controller.js
- security_group_form_controller.js
- service_form_controller.js
- vm_cloud_associate_floating_ip_form_controller.js
- vm_cloud_disassociate_floating_ip_form_controller.js
- vm_cloud_evacuate_form_controller.js
- vm_cloud_live_migrate_form_controller.js


(Round 1  -- #13
Round 2 -- https://github.com/ManageIQ/manageiq-ui-classic/pull/179
Round 3 -- https://github.com/ManageIQ/manageiq-ui-classic/pull/232
Round 4 -- https://github.com/ManageIQ/manageiq-ui-classic/pull/281)


