### PR TITLE
[WIP] Address an error scenario in Event Notifications when a `data.error` object exists

### DIFF
--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -70,21 +70,35 @@ function eventNotifications($timeout) {
     if (seed) {
       API.get('/api/notifications?expand=resources&attributes=details')
       .then(function (data) {
-        data.resources.forEach(function(resource) {
-          var msg = miqFormatNotification(resource.details.text, resource.details.bindings);
+        if (angular.isDefined(data.error)) {
+          var msg = miqFormatNotification(data.error.message);
           events.notifications.splice(0, 0, {
-            id: resource.id,
+            // id: null,
             notificationType: _this.EVENT_NOTIFICATION,
-            unread: !resource.seen,
-            type: resource.details.level,
+            unread: true,
+            type: 'error',
             message: msg,
-            data: {
-              message: msg
-            },
-            href: resource.href,
-            timeStamp: resource.details.created_at
+            data: {},
+            href: null,
+            timeStamp: null
           });
-        });
+        } else {
+          data.resources.forEach(function (resource) {
+            var msg = miqFormatNotification(resource.details.text, resource.details.bindings);
+            events.notifications.splice(0, 0, {
+              id: resource.id,
+              notificationType: _this.EVENT_NOTIFICATION,
+              unread: !resource.seen,
+              type: resource.details.level,
+              message: msg,
+              data: {
+                message: msg
+              },
+              href: resource.href,
+              timeStamp: resource.details.created_at
+            });
+          });
+        }
 
         updateUnreadCount(events);
         notifyObservers();


### PR DESCRIPTION
On occasion, I've seen the `Api:AuthenticationError` error when a page is loaded :

<img width="593" alt="screen shot 2017-02-02 at 8 32 28 am" src="https://cloud.githubusercontent.com/assets/1538216/22558486/b9debbda-e922-11e6-902d-c90be0438cc5.png">

So we are dealing with a `data.error` object that has not been handled or processed.
It would be nice to send an event notification about the error message in the `data.error` object.


