### PR TITLE
Fix ui-components to 0.0.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "jquery-ujs": "~1.2.2",
     "jquery.observe_field": "himdel/jquery.observe_field#~0.1.0",
     "kubernetes-topology-graph": "~0.0.23",
-    "manageiq-ui-components": "~0.0.9",
+    "manageiq-ui-components": "0.0.11",
     "moment-strftime": "~0.2.0",
     "moment-timezone": "~0.4.1",
     "numeral": "~1.5.5",


### PR DESCRIPTION
since manageiq-ui-components is not quite semver yet, removing the `~` from the version contstraint and updating to 0.0.11 which was the version used before today.

(Updating to 0.0.12 in a separate PR - https://github.com/ManageIQ/manageiq-ui-classic/pull/288, since that brings in more dependencies.)