### PR TITLE
Containers: Only display CustomAttributes from allowed sections

### DIFF
--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -39,7 +39,7 @@ class EmsContainerController < ApplicationController
   private
 
   def textual_group_list
-    [%i(properties endpoints status miq_custom_attributes), %i(relationships topology smart_management)]
+    [%i(properties endpoints status miq_displayable_custom_attributes), %i(relationships topology smart_management)]
   end
   helper_method :textual_group_list
 

--- a/app/decorators/manageiq/providers/container_manager_decorator_mixin.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator_mixin.rb
@@ -1,0 +1,7 @@
+module ManageIQ::Providers
+  module ContainerManagerDecoratorMixin
+    def displayable_custom_attribute_sections
+      ['metadata']
+    end
+  end
+end

--- a/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers::Kubernetes
   class ContainerManagerDecorator < MiqDecorator
+    include ManageIQ::Providers::ContainerManagerDecoratorMixin
+
     def self.fileicon
       "svg/vendor-kubernetes.svg"
     end

--- a/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers::Openshift
   class ContainerManagerDecorator < MiqDecorator
+    include ManageIQ::Providers::ContainerManagerDecoratorMixin
+
     def self.fileicon
       "svg/vendor-openshift.svg"
     end

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -120,13 +120,17 @@ module EmsContainerHelper::TextualSummary
     )
   end
 
-  def textual_group_miq_custom_attributes
-    TextualGroup.new(_("Custom Attributes"), textual_miq_custom_attributes)
+  def textual_group_miq_displayable_custom_attributes
+    TextualGroup.new(_("Custom Attributes"), textual_miq_displayable_custom_attributes)
   end
 
-  def textual_miq_custom_attributes
-    attrs = @record.custom_attributes
+  def textual_miq_displayable_custom_attributes
+    attrs = @record.custom_attributes.where(
+      :section => @record.decorate.try(:displayable_custom_attribute_sections)
+    )
     return nil if attrs.blank?
-    attrs.sort_by(&:name).collect { |a| {:label => a.name.tr("_", " "), :value => a.value} }
+    attrs.sort_by(&:name).collect do |a|
+      {:label => a.name.tr("_", " "), :value => a.value}
+    end
   end
 end

--- a/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
@@ -7,18 +7,31 @@ describe EmsContainerHelper::TextualSummary do
       allow(controller).to receive(:controller_name).and_return("ems_container")
     end
 
+    it "should only display custom attributes from allowed sections" do
+      @record.save
+      @record.custom_attributes.create(:section => "metadata",
+                                       :name    => "Example_custom_attribute",
+                                       :value   => 4)
+      @record.custom_attributes.create(:section => "no_allowed",
+                                       :name    => "Example_custom_attribute_2",
+                                       :value   => 5)
+
+      expect(textual_miq_displayable_custom_attributes.count).to eq(1)
+    end
+
     it "should parse custom attributes to labels and values" do
-      @record.custom_attributes << FactoryGirl.build(:custom_attribute,
-                                                     :name  => "Example_custom_attribute",
-                                                     :value => 4)
+      @record.save
+      @record.custom_attributes.create(:section => "metadata",
+                                       :name    => "Example_custom_attribute",
+                                       :value   => 4)
 
-      expect(textual_miq_custom_attributes.first[:label]).to eq("Example custom attribute")
+      expect(textual_miq_displayable_custom_attributes.first[:label]).to eq("Example custom attribute")
 
-      expect(textual_miq_custom_attributes.first[:value]).to eq("4")
+      expect(textual_miq_displayable_custom_attributes.first[:value]).to eq("4")
     end
 
     it "should return nil if no custom attributes" do
-      expect(textual_miq_custom_attributes).to eq(nil)
+      expect(textual_miq_displayable_custom_attributes).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
We will only want to display custom attributes from the allowed sections in the Container Provider page.

BZ https://bugzilla.redhat.com/show_bug.cgi?id=1418791