### PR TITLE
Fix search box display for Configuration management providers

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -924,8 +924,7 @@ class ProviderForemanController < ApplicationController
   def replace_search_box(presenter, r)
     # Replace the searchbox
     presenter.replace(:adv_searchbox_div,
-                      r[:partial => 'layouts/x_adv_searchbox',
-                        :locals  => {:nameonly => x_active_tree == :configuration_manager_providers_tree}])
+                      r[:partial => 'layouts/x_adv_searchbox'])
 
     presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1600,7 +1600,7 @@ module ApplicationHelper
        containers_filter
        cs_filter
        configuration_scripts
-       foreman_providers
+       configuration_manager_providers
        images
        images_filter
        instances

--- a/app/views/provider_foreman/explorer.html.haml
+++ b/app/views/provider_foreman/explorer.html.haml
@@ -1,5 +1,5 @@
 - content_for :search do
-  = render(:partial => "layouts/x_adv_searchbox", :locals => {:nameonly => x_active_tree == :configuration_manager_providers_tree})
+  = render(:partial => "layouts/x_adv_searchbox")
   = render(:partial => 'layouts/quick_search')
 
 -# These are the initial divs that will go inside center_cell_div

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1351,6 +1351,19 @@ describe ApplicationHelper do
       expect(result).to be_truthy
     end
 
+    it 'should return true for the configuration providers tree' do
+      controller.instance_variable_set(:@sb,
+                                       :active_tree => :configuration_manager_providers_tree,
+                                       :trees       => {
+                                         :configuration_manager_providers_tree => {
+                                           :tree => :configuration_manager_providers_tree,
+                                           :type => :configuration_manager_providers
+                                         }
+                                       })
+      result = helper.tree_with_advanced_search?
+      expect(result).to be_truthy
+    end
+
     it 'should return false for tree w/o advanced search' do
       controller.instance_variable_set(:@sb,
                                        :active_tree => :reports_tree,


### PR DESCRIPTION
Fix search box display for Configuration management providers

EUWE PR : - https://github.com/ManageIQ/manageiq/pull/13763

Links
--------------------------

https://bugzilla.redhat.com/show_bug.cgi?id=1411372


Steps for Testing/QA
-------------------------------
Steps to Reproduce:
1. Add Tower provider
2. Navigate to Compute -> Cloud -> Providers
3. Navigate back to Confi. Management 
