### PR TITLE
Fix assigning roles in group form

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1031,8 +1031,8 @@ module OpsController::OpsRbac
     Rbac.filtered(Tenant.in_my_region.where(:id => tenant_id)).present?
   end
 
-  def valid_role?(group_id)
-    Rbac::Filterer.filtered_object(group_id, :class => MiqUserRole).present?
+  def valid_role?(user_role_id)
+    Rbac::Filterer.filtered_object(user_role_id, :class => MiqUserRole).present?
   end
 
   # Get variables from group edit form

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1032,7 +1032,7 @@ module OpsController::OpsRbac
   end
 
   def valid_role?(group_id)
-    Rbac::Filterer.filtered(group_id, :class => MiqUserRole).present?
+    Rbac::Filterer.filtered_object(group_id, :class => MiqUserRole).present?
   end
 
   # Get variables from group edit form


### PR DESCRIPTION
Rbac.filtered doesn't accept integer there is Rbac.filtered_object for this purposes.

**Reproducer**
edit any Group in access control
change role and
it is causing error:
```
[----] F, [2017-02-03T09:17:17.212149 #74779:3fd82712598c] FATAL -- : Error caught: [NoMethodError] undefined method `all' for 1000000000009:Fixnum
/Users/liborpichler/manageiq/manageiq/lib/rbac/filterer.rb:209:in `search'
/Users/liborpichler/manageiq/manageiq/lib/rbac/filterer.rb:112:in `search'
/Users/liborpichler/manageiq/manageiq/lib/rbac.rb:3:in `search'
/Users/liborpichler/manageiq/manageiq/lib/rbac/filterer.rb:280:in `filtered'
/Users/liborpichler/manageiq/manageiq/lib/rbac/filterer.rb:116:in `filtered'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/ops_controller/ops_rbac.rb:1035:in `valid_role?'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/ops_controller/ops_rbac.rb:1048:in `rbac_group_get_form_vars'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/ops_controller/ops_rbac.rb:796:in `rbac_field_changed'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/ops_controller/ops_rbac.rb:254:in `rbac_group_field_changed'
```


cc @mzazrivec 
@miq-bot add_label ui, bug

@miq-bot assign @martinpovolny 