### PR TITLE
Enable 'Provision VMs' button in Datastores and Clusters

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -410,7 +410,7 @@ class ApplicationHelper::ToolbarBuilder
   def hide_button?(id)
     # need to hide add buttons when on sub-list view screen of a CI.
     return true if id.ends_with?("_new", "_discover") &&
-                   @lastaction == "show" && !%w(main vms instances).include?(@display)
+                   @lastaction == "show" && !%w(main vms instances all_vms).include?(@display)
 
     # user can see the buttons if they can get to Policy RSOP/Automate Simulate screen
     return false if ["miq_ae_tools"].include?(@layout)

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -302,14 +302,16 @@ describe ApplicationHelper, "::ToolbarBuilder" do
 
     context 'last action set to show' do
       let(:lastaction) { 'show' }
-      context 'requested to display instances' do
-        let(:display) { 'instances' }
-        it 'returns with false' do
-          @lastaction = lastaction
-          @display = display
-          @id = 'vm_miq_request_new'
-          stub_user(:features => :all)
-          expect(subject).to be_falsey
+
+      %w(main vms instances all_vms).each do | display |
+        context "requested to display #{display}" do
+          it 'returns with false' do
+            stub_user(:features => :all)
+            @lastaction = lastaction
+            @display = display
+            @id = 'vm_miq_request_new'
+            expect(subject).to be_falsey
+          end
         end
       end
     end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -303,7 +303,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
     context 'last action set to show' do
       let(:lastaction) { 'show' }
 
-      %w(main vms instances all_vms).each do | display |
+      %w(main vms instances all_vms).each do |display|
         context "requested to display #{display}" do
           it 'returns with false' do
             stub_user(:features => :all)


### PR DESCRIPTION
Also added specs for additional instances of the 'Provision VMs' button.

https://bugzilla.redhat.com/show_bug.cgi?id=1373850
