### PR TITLE
Storage_tree is rendered after adding new filter instead of listnav

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -420,7 +420,7 @@ module ApplicationController::Filter
     end
 
     if ["delete", "saveit"].include?(params[:button])
-      if @edit[:in_explorer]
+      if @edit[:in_explorer] || x_active_tree == :storage_tree
         if "cs_filter_tree" == x_active_tree.to_s
           build_configuration_manager_tree(:cs_filter, x_active_tree)
         else
@@ -449,7 +449,7 @@ module ApplicationController::Filter
       end
 
       if ["delete", "saveit"].include?(params[:button])
-        if @edit[:in_explorer]
+        if @edit[:in_explorer] || x_active_tree == :storage_tree
           tree_name = x_active_tree.to_s
           if "cs_filter_tree" == tree_name
             page.replace_html("#{tree_name}_div", :partial => "provider_foreman/#{tree_name}")


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1402823

Compute -> Infrastructure -> Datastores -> select one Global filter -> Advanced Search -> save it under new name

Before:
<img width="1217" alt="screen shot 2017-02-06 at 3 07 28 pm" src="https://cloud.githubusercontent.com/assets/9210860/22650120/0985bbc6-ec7e-11e6-8511-495cb4a94f4b.png">
After:
<img width="1207" alt="screen shot 2017-02-06 at 3 06 00 pm" src="https://cloud.githubusercontent.com/assets/9210860/22650134/19efe8ce-ec7e-11e6-8e06-bf61111d49b2.png">

Some controllers use listnav for filters like Compute -> Containers -> Containers Build. 

@miq-bot add_label bug