### PR TITLE
Unified fonticon selection logic for TreeNode::MiqPolicy and MiqPolicy listicons

### DIFF
--- a/app/decorators/miq_policy_decorator.rb
+++ b/app/decorators/miq_policy_decorator.rb
@@ -1,0 +1,23 @@
+class MiqPolicyDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    icon = case towhat
+           when 'Host'
+             'pficon pficon-screen'
+           when 'Vm'
+             'pficon pficon-virtual-machine'
+           when 'ContainerReplicator'
+             'pficon pficon-replicator'
+           when 'ContainerGroup'
+             'fa fa-cubes'
+           when 'ContainerNode'
+             'pficon pficon-container-node'
+           when 'ContainerImage'
+             'pficon pficon-image'
+           when 'ExtManagementSystem'
+             'pficon pficon-server'
+           end
+    "#{icon}#{active ? '' : ' fa-inactive'}"
+  end
+end

--- a/app/presenters/tree_node/miq_policy.rb
+++ b/app/presenters/tree_node/miq_policy.rb
@@ -1,24 +1,6 @@
 module TreeNode
   class MiqPolicy < Node
-    set_attribute(:icon) do
-      icon = case @object.towhat
-             when 'Host'
-               'pficon pficon-screen'
-             when 'Vm'
-               'pficon pficon-virtual-machine'
-             when 'ContainerReplicator'
-               'pficon pficon-replicator'
-             when 'ContainerGroup'
-               'fa fa-cubes'
-             when 'ContainerNode'
-               'pficon pficon-container-node'
-             when 'ContainerImage'
-               'pficon pficon-image'
-             when 'ExtManagementSystem'
-               'pficon pficon-server'
-             end
-      "#{icon}#{@object.active ? '' : ' fa-inactive'}"
-    end
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:title) do
       if @options[:tree] == :policy_profile_tree
         ViewHelper.capture do

--- a/app/views/miq_policy/_action_details.html.haml
+++ b/app/views/miq_policy/_action_details.html.haml
@@ -259,8 +259,7 @@
                   %tr{:title => _("Click to view Policy"),
                     :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
                     %td.narrow
-                      - src = "#{p.towhat.downcase}#{p.active ? '' : '_inactive'}"
-                      %img{:src => image_path("100/miq_policy_#{src}.png")}
+                      %i{:class => p.decorate.fonticon}
                     %td
                       = p.description
           %hr

--- a/app/views/miq_policy/_condition_details.html.haml
+++ b/app/views/miq_policy/_condition_details.html.haml
@@ -89,6 +89,6 @@
                 %tr{:title => _("Click to view Policy"),
                   :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
                   %td.narrow
-                    %img{:src => image_path("100/miq_policy_#{p.towhat.downcase}#{p.active ? '' : '_inactive'}.png")}
+                    %i{:class => p.decorate.fonticon}
                   %td
                     = p.description

--- a/app/views/miq_policy/_event_details.html.haml
+++ b/app/views/miq_policy/_event_details.html.haml
@@ -27,7 +27,7 @@
                 %tr{:title => _("Click to view Policy"),
                   :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
                   %td.narrow
-                    %img{:src => image_path("100/miq_policy_#{p.towhat.downcase}#{p.active ? '' : '_inactive'}.png")}
+                    %i{:class => p.decorate.fonticon}
                   %td
                     = p.description
           %hr

--- a/app/views/miq_policy/_profile_details.html.haml
+++ b/app/views/miq_policy/_profile_details.html.haml
@@ -88,7 +88,7 @@
               %tr{:title => _("View this %{model} Policy") % {:model => ui_lookup(:model => p.towhat)},
                 :onclick => "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_p-#{to_cid(p.id)}');"}
                 %td.narrow
-                  %img{:src => image_path("100/miq_policy_#{p.towhat.downcase + (p.active ? '' : '_inactive')}.png")}
+                  %i{:class => p.decorate.fonticon}
                 %td
                   %b
                     #{ui_lookup(:model => p.towhat)} #{p.mode.capitalize}:


### PR DESCRIPTION
Moved the fonticon selection `case` into a decorator and applied wherever was possible.