### PR TITLE
Use task queue for VM actions

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -391,7 +391,7 @@ module ApplicationController::CiProcessing
       if @record.supports_resize?
         begin
           old_flavor = @record.flavor
-          @record.resize(flavor)
+          @record.resize_queue(session[:userid], flavor)
           add_flash(_("Reconfiguring %{instance} \"%{name}\" from %{old_flavor} to %{new_flavor}") % {
             :instance   => ui_lookup(:table => 'vm_cloud'),
             :name       => @record.name,
@@ -616,7 +616,8 @@ module ApplicationController::CiProcessing
         on_shared_storage = params[:on_shared_storage] == 'on'
         admin_password = on_shared_storage ? nil : params[:admin_password]
         begin
-          @record.evacuate(
+          @record.evacuate_queue(
+            session[:userid],
             :hostname          => hostname,
             :on_shared_storage => on_shared_storage,
             :admin_password    => admin_password
@@ -732,7 +733,7 @@ module ApplicationController::CiProcessing
       if @record.supports_associate_floating_ip?
         floating_ip = params[:floating_ip]
         begin
-          @record.associate_floating_ip(floating_ip)
+          @record.associate_floating_ip_queue(session[:userid], floating_ip)
           add_flash(_("Associating Floating IP %{address} with Instance \"%{name}\"") % {
             :address => floating_ip,
             :name    => @record.name})
@@ -826,7 +827,7 @@ module ApplicationController::CiProcessing
       if @record.supports_disassociate_floating_ip?
         floating_ip = params[:floating_ip]
         begin
-          @record.disassociate_floating_ip(floating_ip)
+          @record.disassociate_floating_ip_queue(session[:userid], floating_ip)
           add_flash(_("Disassociating Floating IP %{address} from Instance \"%{name}\"") % {
             :address => floating_ip,
             :name    => @record.name})

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -81,7 +81,7 @@ describe VmCloudController do
       controller.instance_variable_set(:@edit,
                                        :new      => {:flavor => flavor.id},
                                        :explorer => false)
-      expect_any_instance_of(VmCloud).to receive(:resize).with(flavor)
+      expect_any_instance_of(VmCloud).to receive(:resize_queue).with(controller.current_user.userid, flavor)
       post :resize_vm, :params => {
         :button => 'submit',
         :id     => vm_openstack.id
@@ -129,7 +129,7 @@ describe VmCloudController do
       controller.instance_variable_set(:@edit,
                                        :new      => {},
                                        :explorer => false)
-      expect_any_instance_of(VmCloud).to receive(:evacuate)
+      expect_any_instance_of(VmCloud).to receive(:evacuate_queue)
       post :evacuate_vm, :params => {
         :button => 'submit',
         :id     => vm_openstack.id


### PR DESCRIPTION
Uses task queue instead of making direct provider API calls from the UI.
The following model actions are affected:
  resize
  evacuate
  associate_floating_ip
  disassociate_floating_ip

This commit contains the necessary UI changes.
Depends on model PR: https://github.com/ManageIQ/manageiq/pull/13782