### PR TITLE
Add eager loading in service catalog tree

### DIFF
--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -21,7 +21,7 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
   end
 
   def x_get_tree_roots(count_only, _options)
-    objects = Rbac.filtered(ServiceTemplateCatalog.all).sort_by { |o| o.name.downcase }
+    objects = Rbac.filtered(ServiceTemplateCatalog).sort_by { |o| o.name.downcase }
     filtered_objects = []
     # only show catalogs nodes that have any servicetemplate records under them
     objects.each do |object|

--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -21,7 +21,8 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
   end
 
   def x_get_tree_roots(count_only, _options)
-    objects = Rbac.filtered(ServiceTemplateCatalog).sort_by { |o| o.name.downcase }
+    includes = {:tenant => {}}
+    objects = Rbac.filtered(ServiceTemplateCatalog, :include_for_find => includes).sort_by { |o| o.name.downcase }
     filtered_objects = []
     # only show catalogs nodes that have any servicetemplate records under them
     objects.each do |object|

--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -21,7 +21,7 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
   end
 
   def x_get_tree_roots(count_only, _options)
-    includes = {:tenant => {}}
+    includes = {:tenant => {}, :service_templates => {}}
     objects = Rbac.filtered(ServiceTemplateCatalog, :include_for_find => includes).sort_by { |o| o.name.downcase }
     filtered_objects = []
     # only show catalogs nodes that have any servicetemplate records under them


### PR DESCRIPTION
Services -> Catalog

- Include `:tenant` to remove N+1 query
`tenant` is touched here:
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/presenters/tree_node/service_template_catalog.rb#L5
-  Include `:service_templates` to remove N+1 query 
service_templates are touched here:
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/presenters/tree_builder_service_catalog.rb#L35