### PR TITLE
Image to fonticon conversion for MiqAeField datatypes

### DIFF
--- a/app/helpers/miq_ae_class_helper.rb
+++ b/app/helpers/miq_ae_class_helper.rb
@@ -69,4 +69,57 @@ module MiqAeClassHelper
   def nonblank(*items)
     items.detect { |item| !item.blank? }
   end
+
+  def ae_field_fonticon(field)
+    case field
+    when 'string'
+      'product product-string'
+    when 'symbol'
+      'product product-symbol'
+    when 'integer'
+      'product product-integer'
+    when 'float'
+      'product product-float'
+    when 'boolean'
+      'product product-boolean'
+    when 'time'
+      'fa fa-clock-o'
+    when 'array'
+      'product product-array'
+    when 'password'
+      'product product-password'
+    when 'null coalescing'
+      'fa fa-question'
+    when 'host'
+      'pficon pficon-screen'
+    when 'vm'
+      'pficon pficon-virtual-machine'
+    when 'storage'
+      'fa fa-database'
+    when 'ems'
+      'pficon pficon-server'
+    when 'policy'
+      'fa fa-shield'
+    when 'server'
+      'pficon pficon-server'
+    when 'request'
+      'fa fa-question'
+    when 'provision'
+      'pficon pficon-settings'
+    when 'user'
+      'pficon pficon-user'
+    when 'assertion'
+      'product product-assertion'
+    when 'attribute'
+      'product product-attribute'
+    when 'method'
+      'product product-method'
+    when 'relationship'
+      'product product-relationship'
+    when 'state'
+      'product product-state'
+    else
+      raise NotImplementedError, "Missing fonticon for MiqAeField type #{field}"
+    end
+  end
 end

--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -1,4 +1,6 @@
 class TreeBuilderAutomateSimulationResults < TreeBuilder
+  include ApplicationHelper
+
   has_kids_for Hash, [:x_get_tree_hash_kids]
   def initialize(name, type, sandbox, build = true, root = nil)
     @root = root
@@ -49,9 +51,9 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
       }
     elsif !el.text.blank?
       {
-        :text  => el.text,
-        :tip   => el.text,
-        :image => "100/#{el.name.underscore}.png"
+        :text => el.text,
+        :tip  => el.text,
+        :icon => ae_field_fonticon(el.name.underscore)
       }
     else
       {

--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -1,5 +1,5 @@
 class TreeBuilderAutomateSimulationResults < TreeBuilder
-  include ApplicationHelper
+  include MiqAeClassHelper
 
   has_kids_for Hash, [:x_get_tree_hash_kids]
   def initialize(name, type, sandbox, build = true, root = nil)

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -20,11 +20,11 @@
                 %td.text-nowrap
                   / Name is special processed
                   - if fname == 'name'
-                    %i.product.fa-lg{:class => "product-ae_#{ae_field.aetype}",
+                    %i.product.fa-lg{:class  => ae_field_fonticon(ae_field.aetype),
                                       :alt   => (t = "#{_('Type:')} #{ae_field.aetype}"),
                                       :title => t}
                     - if !ae_field.datatype.blank? && ae_field.datatype != "string"
-                      %i.product.fa-lg{:class => "product-#{ae_field.datatype}",
+                      %i.product.fa-lg{:class  => ae_field_fonticon(ae_field.datatype),
                                         :alt   => (t = "#{_('Data Type:')} #{ae_field.datatype}"), :title => t}
 
                     %i.fa-lg{:class => "#{image}",

--- a/spec/helpers/miq_ae_class_helper_spec.rb
+++ b/spec/helpers/miq_ae_class_helper_spec.rb
@@ -34,4 +34,14 @@ describe MiqAeClassHelper do
       end
     end
   end
+
+  describe '#ae_field_fonticon' do
+    (MiqAeField::AVAILABLE_DATATYPES | MiqAeField::AVAILABLE_AETYPES).each do |field|
+      context "field is #{field}" do
+        it 'returns with not nil' do
+          expect(ae_field_fonticon(field)).not_to be_nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
* When displaying a class schema
![screenshot from 2017-02-07 14-04-33](https://cloud.githubusercontent.com/assets/649130/22692252/5f416464-ed3e-11e6-8960-3b32d0f96440.png)

* When editing a class schema
![screenshot from 2017-02-07 14-05-20](https://cloud.githubusercontent.com/assets/649130/22692285/7c7f51b2-ed3e-11e6-96e2-00ff51dc6da7.png)

* When displaying automate simulation results
![screenshot from 2017-02-07 14-06-18](https://cloud.githubusercontent.com/assets/649130/22692312/9d716b76-ed3e-11e6-8e78-f4843c717486.png)
