### PR TITLE
Topology: Fix second search

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -20,6 +20,7 @@ ManageIQ.angular.app.service('topologyService', function() {
 
   this.searchNode = function(svg, query) {
     var nodes = svg.selectAll("g");
+    nodes.style("opacity", "1");
     if (query != "") {
       var selected = nodes.filter(function (d) {
         return d.item.name.indexOf(query) == -1;


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1415472

Topology nodes opacity has to be reset before performing next search so that new results won't be a subset of previous results. 