### PR TITLE
Fix adding Kubernetes provider

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -433,8 +433,12 @@ module Mixins
     end
 
     def get_hostname_from_routes(ems, hostname, port, token)
-      client = ems.class.raw_connect(hostname, port, :bearer => token)
+      return nil unless ems.class.respond_to?(:openshift_connect)
+      client = ems.class.openshift_connect(hostname, port, :bearer => token)
       client.get_route('hawkular-metrics', 'openshift-infra').try(:spec).try(:host)
+    rescue KubeException => e
+      $log.warn("MIQ(#{controller_name}_controller-#{action_name}): get_hostname_from_routes error: #{e}")
+      nil
     end
 
     def build_connection(ems, endpoints, mode)


### PR DESCRIPTION
Reported by @evertmulder yesterday, also encountered by @AparnaKarve and by me today.
If `get_hostname_from_routes` causes exception, you can't [Validate] nor [Add]/[Save] the provider.
This was especially a problem for Kubernetes, apparently made it impossible to create Kubernetes provider via UI.
(Not sure if recent #265 made it more exception-prone?  I can confirm the guessing does work on Openshift.)

- Skipping the guessing entirely for Kubernetes because Routes are an Openshift concept.

IIUC this functionality should be best-effort, failure to guess the hawkular route should not stop block user (if they can make validation happy otherwise).

(The error also doesn't get to UI, the 500 JS page is not the JSON the UI was looking for.  That could be improved but in this case I believe errors are not interesting to user anyway.)

@simon3z Please review.

@miq-bot add-label providers/containers, bug
