### PR TITLE
use settings for custom logo

### DIFF
--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -1,7 +1,7 @@
 - auth_mode = ::Settings.authentication.mode
 
 %span#badge
-  %img{:src => "#{current_tenant.logo? ? '/upload/custom_logo.png' : image_path("login-screen-logo.png")}"}
+  %img{:src => "#{::Settings.server.custom_logo ? '/upload/custom_logo.png' : image_path("login-screen-logo.png")}"}
 
 .container
   .row

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -11,7 +11,7 @@
       %img.navbar-brand-name{:src => image_path("brand.svg"), :alt => "ManageIQ"}
   %nav.collapse.navbar-collapse
     %ul.nav.navbar-nav.navbar-right.navbar-iconic
-      %li{:class => "dropdown brand-white-label #{current_tenant.logo? ? "whitelabeled" : ""}"}
+      %li{:class => "dropdown brand-white-label #{::Settings.server.custom_logo ? "whitelabeled" : ""}"}
       %li
         %a{:class => "nav-item-iconic drawer-pf-trigger-icon", :title => "{{vm.notificationsIndicatorTooltip}}", "ng-click" => "vm.toggleNotificationsList()"}
           %span.fa{"ng-class" => "{'fa-bell': vm.newNotifications, 'fa-bell-o': !vm.newNotifications}"}

--- a/app/views/layouts/_x_adv_searchbox.html.haml
+++ b/app/views/layouts/_x_adv_searchbox.html.haml
@@ -7,7 +7,7 @@
       = render :partial => 'layouts/adv_search'
 
   -# Name based search box
-  #searchbox.search-pf.has-button.form-group.pull-right{:class => current_tenant.logo? ? "whitelabeled" : ""}
+  #searchbox.search-pf.has-button.form-group.pull-right{:class => ::Settings.server.custom_logo ? "whitelabeled" : ""}
     .form-group.has-clear
       .search-pf-input-group
         %label{"for"  => "search_text",


### PR DESCRIPTION
We currently use `Settings` and `tenant.logo` to select a custom logo
logo for users.

This makes it consistently use `Settings`

This change is required for https://github.com/ManageIQ/manageiq/pull/13796

/cc @Fryguy 