### PR TITLE
Replace $scope with vm in timeprofile_form

### DIFF
--- a/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
+++ b/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
@@ -168,31 +168,24 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
     var url = '/configuration/timeprofile_update/' + timeProfileFormId + '?button=' + buttonName;
     var timeProfileModelObj = angular.copy(vm.timeProfileModel);
     delete timeProfileModelObj.profile_tz;
-    var moreUrlParams = $.param(miqService.serializeModel(timeProfileModelObj));
-    if(moreUrlParams)
-      url += '&' + decodeURIComponent(moreUrlParams);
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, timeProfileModelObj);
   };
 
   $scope.cancelClicked = function() {
     timeProfileEditButtonClicked('cancel');
-    vm.angularForm.$setPristine(true);
   };
 
   $scope.resetClicked = function() {
     vm.timeProfileModel = angular.copy( vm.modelCopy );
-    vm.angularForm.$setPristine(true);
+    $scope.angularForm.$setPristine(true);
     miqService.miqFlash("warn", __("All changes have been reset"));
   };
 
   $scope.saveClicked = function() {
     timeProfileEditButtonClicked('save', true);
-    vm.angularForm.$setPristine(true);
   };
 
-  $scope.addClicked = function() {
-    $scope.saveClicked();
-  };
+  $scope.addClicked = $scope.saveClicked;
 
   function getTimeProfileFormData(response) {
     var data = response.data;

--- a/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
+++ b/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
@@ -1,6 +1,8 @@
 ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope', 'timeProfileFormId', 'miqService', function($http, $scope, timeProfileFormId, miqService) {
+  var vm = this;
+
   var init = function() {
-    $scope.timeProfileModel = {
+    vm.timeProfileModel = {
       description: '',
       admin_user: false,
       restricted_time_profile: false,
@@ -19,15 +21,15 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
       some_days_checked: true,
       some_hours_checked: true,
     };
-    $scope.dayNames = [__("Sunday"), __("Monday"), __("Tuesday"), __("Wednesday"), __("Thursday"), __("Friday"), __("Saturday")];
-    $scope.hourNamesFirstHalf = [__("12-1"), __("1-2"), __("2-3"), __("3-4"), __("4-5"), __("5-6")];
-    $scope.hourNamesSecondHalf = [__("6-7"), __("7-8"), __("8-9"), __("9-10"), __("10-11"), __("11-12")];
-    $scope.formId = timeProfileFormId;
-    $scope.afterGet = false;
-    $scope.modelCopy = angular.copy( $scope.timeProfileModel );
-    $scope.model = 'timeProfileModel';
+    vm.dayNames = [__("Sunday"), __("Monday"), __("Tuesday"), __("Wednesday"), __("Thursday"), __("Friday"), __("Saturday")];
+    vm.hourNamesFirstHalf = [__("12-1"), __("1-2"), __("2-3"), __("3-4"), __("4-5"), __("5-6")];
+    vm.hourNamesSecondHalf = [__("6-7"), __("7-8"), __("8-9"), __("9-10"), __("10-11"), __("11-12")];
+    vm.formId = timeProfileFormId;
+    vm.afterGet = false;
+    vm.modelCopy = angular.copy( vm.timeProfileModel );
+    vm.model = 'timeProfileModel';
 
-    ManageIQ.angular.scope = $scope;
+    ManageIQ.angular.scope = vm;
 
     miqService.sparkleOn();
     $http.get('/configuration/time_profile_form_fields/' + timeProfileFormId)
@@ -35,136 +37,136 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
       .catch(miqService.handleFailure);
 
     if (timeProfileFormId == 'new') {
-      $scope.newRecord = true;
+      vm.newRecord = true;
     } else {
-      $scope.newRecord = false;
+      vm.newRecord = false;
     }
   };
 
-  $scope.getDaysValues = function() {
+  vm.getDaysValues = function() {
     for(i = 0; i < 7; i++) {
-      if ($scope.timeProfileModel.days.indexOf(i) > -1) {
-        $scope.timeProfileModel.dayValues.push(true);
+      if (vm.timeProfileModel.days.indexOf(i) > -1) {
+        vm.timeProfileModel.dayValues.push(true);
       } else {
-        $scope.timeProfileModel.dayValues.push(false);
+        vm.timeProfileModel.dayValues.push(false);
       }
     }
   };
 
-  $scope.dayValuesChanged = function() {
+  vm.dayValuesChanged = function() {
     var tempDays = [];
 
     for(var i = 0; i < 7; i++) {
-      if ($scope.timeProfileModel.dayValues[i] === true) {
+      if (vm.timeProfileModel.dayValues[i] === true) {
         tempDays.push(i);
       }
     }
-    $scope.timeProfileModel.days = tempDays;
+    vm.timeProfileModel.days = tempDays;
   };
 
-  $scope.getHoursValues = function() {
+  vm.getHoursValues = function() {
     for(i = 0; i < 6; i++) {
-      if ($scope.timeProfileModel.hours.indexOf(i) > -1) {
-        $scope.timeProfileModel.hourValuesAMFirstHalf.push(true);
+      if (vm.timeProfileModel.hours.indexOf(i) > -1) {
+        vm.timeProfileModel.hourValuesAMFirstHalf.push(true);
       } else {
-        $scope.timeProfileModel.hourValuesAMFirstHalf.push(false);
+        vm.timeProfileModel.hourValuesAMFirstHalf.push(false);
       }
     }
     for(i = 6; i < 12; i++) {
-      if ($scope.timeProfileModel.hours.indexOf(i) > -1) {
-        $scope.timeProfileModel.hourValuesAMSecondHalf.push(true);
+      if (vm.timeProfileModel.hours.indexOf(i) > -1) {
+        vm.timeProfileModel.hourValuesAMSecondHalf.push(true);
       } else {
-        $scope.timeProfileModel.hourValuesAMSecondHalf.push(false);
+        vm.timeProfileModel.hourValuesAMSecondHalf.push(false);
       }
     }
     for(i = 12; i < 18; i++) {
-      if ($scope.timeProfileModel.hours.indexOf(i) > -1) {
-        $scope.timeProfileModel.hourValuesPMFirstHalf.push(true);
+      if (vm.timeProfileModel.hours.indexOf(i) > -1) {
+        vm.timeProfileModel.hourValuesPMFirstHalf.push(true);
       } else {
-        $scope.timeProfileModel.hourValuesPMFirstHalf.push(false);
+        vm.timeProfileModel.hourValuesPMFirstHalf.push(false);
       }
     }
     for(i = 18; i < 24; i++) {
-      if ($scope.timeProfileModel.hours.indexOf(i) > -1) {
-        $scope.timeProfileModel.hourValuesPMSecondHalf.push(true);
+      if (vm.timeProfileModel.hours.indexOf(i) > -1) {
+        vm.timeProfileModel.hourValuesPMSecondHalf.push(true);
       } else {
-        $scope.timeProfileModel.hourValuesPMSecondHalf.push(false);
+        vm.timeProfileModel.hourValuesPMSecondHalf.push(false);
       }
     }
-    $scope.calculateTimeProfileHourValues();
+    vm.calculateTimeProfileHourValues();
   };
 
-  $scope.hourValuesChanged = function() {
+  vm.hourValuesChanged = function() {
     var tempHours = [];
 
     for(var i = 0; i < 6; i++) {
-      if ($scope.timeProfileModel.hourValuesAMFirstHalf[i] === true) {
+      if (vm.timeProfileModel.hourValuesAMFirstHalf[i] === true) {
         tempHours.push(i);
       }
     }
     for(var i = 0, j = 6; i < 6, j < 12; i++, j++) {
-      if ($scope.timeProfileModel.hourValuesAMSecondHalf[i] === true) {
+      if (vm.timeProfileModel.hourValuesAMSecondHalf[i] === true) {
         tempHours.push(j);
       }
     }
     for(var i = 0, j = 12; i < 6, j < 18; i++, j++) {
-      if ($scope.timeProfileModel.hourValuesPMFirstHalf[i] === true) {
+      if (vm.timeProfileModel.hourValuesPMFirstHalf[i] === true) {
         tempHours.push(j);
       }
     }
     for(var i = 0, j = 18; i < 6, j < 24; i++, j++) {
-      if ($scope.timeProfileModel.hourValuesPMSecondHalf[i] === true) {
+      if (vm.timeProfileModel.hourValuesPMSecondHalf[i] === true) {
         tempHours.push(j);
       }
     }
-    $scope.timeProfileModel.hours = tempHours;
-    $scope.calculateTimeProfileHourValues();
+    vm.timeProfileModel.hours = tempHours;
+    vm.calculateTimeProfileHourValues();
   };
 
-  $scope.calculateTimeProfileHourValues = function() {
-    $scope.timeProfileModel.hourValues = [];
-    $scope.timeProfileModel.hourValues.push($scope.timeProfileModel.hourValuesAMFirstHalf);
-    $scope.timeProfileModel.hourValues.push($scope.timeProfileModel.hourValuesAMSecondHalf);
-    $scope.timeProfileModel.hourValues.push($scope.timeProfileModel.hourValuesPMFirstHalf);
-    $scope.timeProfileModel.hourValues.push($scope.timeProfileModel.hourValuesPMSecondHalf);
-    $scope.timeProfileModel.hourValues = _.flattenDeep($scope.timeProfileModel.hourValues);
+  vm.calculateTimeProfileHourValues = function() {
+    vm.timeProfileModel.hourValues = [];
+    vm.timeProfileModel.hourValues.push(vm.timeProfileModel.hourValuesAMFirstHalf);
+    vm.timeProfileModel.hourValues.push(vm.timeProfileModel.hourValuesAMSecondHalf);
+    vm.timeProfileModel.hourValues.push(vm.timeProfileModel.hourValuesPMFirstHalf);
+    vm.timeProfileModel.hourValues.push(vm.timeProfileModel.hourValuesPMSecondHalf);
+    vm.timeProfileModel.hourValues = _.flattenDeep(vm.timeProfileModel.hourValues);
   };
 
-  $scope.allDaysClicked = function() {
-    if ($scope.timeProfileModel.all_days) {
-      $scope.timeProfileModel.dayValues = _.times(7, _.constant(true));
-      $scope.timeProfileModel.days = _.times(7, i);
-      $scope.timeProfileModel.some_days_checked = true;
+  vm.allDaysClicked = function() {
+    if (vm.timeProfileModel.all_days) {
+      vm.timeProfileModel.dayValues = _.times(7, _.constant(true));
+      vm.timeProfileModel.days = _.times(7, i);
+      vm.timeProfileModel.some_days_checked = true;
     } else {
-      $scope.timeProfileModel.dayValues = _.times(7, _.constant(false));
-      $scope.timeProfileModel.days = [];
-      $scope.timeProfileModel.some_days_checked = false;
+      vm.timeProfileModel.dayValues = _.times(7, _.constant(false));
+      vm.timeProfileModel.days = [];
+      vm.timeProfileModel.some_days_checked = false;
     }
   };
 
-  $scope.allHoursClicked = function() {
-    if ($scope.timeProfileModel.all_hours) {
-      $scope.timeProfileModel.hourValuesAMFirstHalf = _.times(6, _.constant(true));
-      $scope.timeProfileModel.hourValuesAMSecondHalf = _.times(6, _.constant(true));
-      $scope.timeProfileModel.hourValuesPMFirstHalf = _.times(6, _.constant(true));
-      $scope.timeProfileModel.hourValuesPMSecondHalf = _.times(6, _.constant(true));
-      $scope.timeProfileModel.hours = _.times(24, i);
-      $scope.timeProfileModel.some_hours_checked = true;
+  vm.allHoursClicked = function() {
+    if (vm.timeProfileModel.all_hours) {
+      vm.timeProfileModel.hourValuesAMFirstHalf = _.times(6, _.constant(true));
+      vm.timeProfileModel.hourValuesAMSecondHalf = _.times(6, _.constant(true));
+      vm.timeProfileModel.hourValuesPMFirstHalf = _.times(6, _.constant(true));
+      vm.timeProfileModel.hourValuesPMSecondHalf = _.times(6, _.constant(true));
+      vm.timeProfileModel.hours = _.times(24, i);
+      vm.timeProfileModel.some_hours_checked = true;
     } else {
-      $scope.timeProfileModel.hourValuesAMFirstHalf = _.times(6, _.constant(false));
-      $scope.timeProfileModel.hourValuesAMSecondHalf = _.times(6, _.constant(false));
-      $scope.timeProfileModel.hourValuesPMFirstHalf = _.times(6, _.constant(false));
-      $scope.timeProfileModel.hourValuesPMSecondHalf = _.times(6, _.constant(false));
-      $scope.timeProfileModel.some_hours_checked = false;
-      $scope.timeProfileModel.hours = [];
+      vm.timeProfileModel.hourValuesAMFirstHalf = _.times(6, _.constant(false));
+      vm.timeProfileModel.hourValuesAMSecondHalf = _.times(6, _.constant(false));
+      vm.timeProfileModel.hourValuesPMFirstHalf = _.times(6, _.constant(false));
+      vm.timeProfileModel.hourValuesPMSecondHalf = _.times(6, _.constant(false));
+      vm.timeProfileModel.some_hours_checked = false;
+      vm.timeProfileModel.hours = [];
     }
-    $scope.calculateTimeProfileHourValues();
+    vm.calculateTimeProfileHourValues();
   };
 
   var timeProfileEditButtonClicked = function(buttonName, serializeFields) {
     miqService.sparkleOn();
     var url = '/configuration/timeprofile_update/' + timeProfileFormId + '?button=' + buttonName;
-    var timeProfileModelObj = angular.copy($scope.timeProfileModel);
+    var timeProfileModelObj = angular.copy(vm.timeProfileModel);
     delete timeProfileModelObj.profile_tz;
     var moreUrlParams = $.param(miqService.serializeModel(timeProfileModelObj));
     if(moreUrlParams)
@@ -174,18 +176,18 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
 
   $scope.cancelClicked = function() {
     timeProfileEditButtonClicked('cancel');
-    $scope.angularForm.$setPristine(true);
+    vm.angularForm.$setPristine(true);
   };
 
   $scope.resetClicked = function() {
-    $scope.timeProfileModel = angular.copy( $scope.modelCopy );
-    $scope.angularForm.$setPristine(true);
+    vm.timeProfileModel = angular.copy( vm.modelCopy );
+    vm.angularForm.$setPristine(true);
     miqService.miqFlash("warn", __("All changes have been reset"));
   };
 
   $scope.saveClicked = function() {
     timeProfileEditButtonClicked('save', true);
-    $scope.angularForm.$setPristine(true);
+    vm.angularForm.$setPristine(true);
   };
 
   $scope.addClicked = function() {
@@ -195,24 +197,24 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
   function getTimeProfileFormData(response) {
     var data = response.data;
 
-    $scope.timeProfileModel.description = data.description;
-    $scope.timeProfileModel.admin_user = data.admin_user;
-    $scope.timeProfileModel.restricted_time_profile = data.restricted_time_profile;
-    $scope.timeProfileModel.profile_type = data.profile_type;
-    $scope.timeProfileModel.profile_tz = data.profile_tz;
-    $scope.timeProfileModel.rollup_daily = data.rollup_daily;
-    $scope.timeProfileModel.miq_reports_count = data.miq_reports_count;
-    $scope.timeProfileModel.all_days = data.all_days;
-    $scope.timeProfileModel.days = data.days;
-    $scope.timeProfileModel.all_hours = data.all_hours;
-    $scope.timeProfileModel.hours = data.hours;
-    $scope.getDaysValues();
-    $scope.getHoursValues();
+    vm.timeProfileModel.description = data.description;
+    vm.timeProfileModel.admin_user = data.admin_user;
+    vm.timeProfileModel.restricted_time_profile = data.restricted_time_profile;
+    vm.timeProfileModel.profile_type = data.profile_type;
+    vm.timeProfileModel.profile_tz = data.profile_tz;
+    vm.timeProfileModel.rollup_daily = data.rollup_daily;
+    vm.timeProfileModel.miq_reports_count = data.miq_reports_count;
+    vm.timeProfileModel.all_days = data.all_days;
+    vm.timeProfileModel.days = data.days;
+    vm.timeProfileModel.all_hours = data.all_hours;
+    vm.timeProfileModel.hours = data.hours;
+    vm.getDaysValues();
+    vm.getHoursValues();
 
-    $scope.note = sprintf(__("In use by %s reports, cannot be disabled"), $scope.timeProfileModel.miq_reports_count);
+    vm.note = sprintf(__("In use by %s reports, cannot be disabled"), vm.timeProfileModel.miq_reports_count);
 
-    $scope.afterGet = true;
-    $scope.modelCopy                    = angular.copy( $scope.timeProfileModel );
+    vm.afterGet = true;
+    vm.modelCopy                    = angular.copy( vm.timeProfileModel );
 
     miqService.sparkleOff();
   }

--- a/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
+++ b/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
@@ -28,7 +28,7 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
     vm.afterGet = false;
     vm.modelCopy = angular.copy( vm.timeProfileModel );
     vm.model = 'timeProfileModel';
-
+    
     ManageIQ.angular.scope = vm;
 
     miqService.sparkleOn();

--- a/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
+++ b/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
@@ -167,10 +167,9 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
     miqService.sparkleOn();
     var url = '/configuration/timeprofile_update/' + timeProfileFormId + '?button=' + buttonName;
     var timeProfileModelObj = angular.copy(vm.timeProfileModel);
-    delete timeProfileModelObj.profile_tz;
     miqService.miqAjaxButton(url, timeProfileModelObj);
   };
-
+  // $scope preserved because it's used by x_edit_buttons_angular
   $scope.cancelClicked = function() {
     timeProfileEditButtonClicked('cancel');
   };

--- a/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
+++ b/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
@@ -28,7 +28,7 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
     vm.afterGet = false;
     vm.modelCopy = angular.copy( vm.timeProfileModel );
     vm.model = 'timeProfileModel';
-    
+
     ManageIQ.angular.scope = vm;
 
     miqService.sparkleOn();
@@ -197,17 +197,8 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
   function getTimeProfileFormData(response) {
     var data = response.data;
 
-    vm.timeProfileModel.description = data.description;
-    vm.timeProfileModel.admin_user = data.admin_user;
-    vm.timeProfileModel.restricted_time_profile = data.restricted_time_profile;
-    vm.timeProfileModel.profile_type = data.profile_type;
-    vm.timeProfileModel.profile_tz = data.profile_tz;
-    vm.timeProfileModel.rollup_daily = data.rollup_daily;
-    vm.timeProfileModel.miq_reports_count = data.miq_reports_count;
-    vm.timeProfileModel.all_days = data.all_days;
-    vm.timeProfileModel.days = data.days;
-    vm.timeProfileModel.all_hours = data.all_hours;
-    vm.timeProfileModel.hours = data.hours;
+    Object.assign(vm.timeProfileModel, data);
+
     vm.getDaysValues();
     vm.getHoursValues();
 

--- a/app/assets/javascripts/directives/checkchange.js
+++ b/app/assets/javascripts/directives/checkchange.js
@@ -5,7 +5,14 @@ ManageIQ.angular.app.directive('checkchange', ['miqService', function(miqService
       scope['formchange_' + ctrl.$name] = elem[0].name
       scope['elemType_' + ctrl.$name] = attr.type;
 
-      if (angular.isDefined(scope.modelCopy)) {
+      var model = function() {
+        return scope.$eval(scope.angularForm.model || scope.model);
+      };
+      var modelCopy = function() {
+        return scope.$eval(scope.angularForm.modelCopy || "modelCopy");
+      };
+
+      if (modelCopy()) {
         scope.$watch(attr.ngModel, function () {
           if (scope['elemType_' + ctrl.$name] == "date" || _.isDate(ctrl.$modelValue)) {
             viewModelDateComparison(scope, ctrl);
@@ -20,7 +27,7 @@ ManageIQ.angular.app.directive('checkchange', ['miqService', function(miqService
       ctrl.$parsers.push(function(value) {
         miqService.miqFlashClear();
 
-        if (value == scope.modelCopy[ctrl.$name]) {
+        if (value == modelCopy()[ctrl.$name]) {
           scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
         }
         if (scope.angularForm[scope['formchange_' + ctrl.$name]].$pristine) {
@@ -30,52 +37,53 @@ ManageIQ.angular.app.directive('checkchange', ['miqService', function(miqService
         return value;
       });
 
-      if(scope.angularForm.$pristine)
+      if (scope.angularForm.$pristine)
         scope.angularForm.$setPristine();
+
+      var viewModelComparison = function(scope, ctrl) {
+        if ((Array.isArray(modelCopy()[ctrl.$name]) &&
+          angular.equals(model()[ctrl.$name], modelCopy()[ctrl.$name])) ||
+          ctrl.$viewValue == modelCopy()[ctrl.$name]) {
+          scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
+          scope.angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
+          scope.angularForm.$pristine = true;
+        } else {
+          scope.angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
+          scope.angularForm.$pristine = false;
+        }
+      };
+
+      var viewModelDateComparison = function(scope, ctrl) {
+        var modelDate = (ctrl.$modelValue != undefined) ? moment(ctrl.$modelValue) : null;
+        var copyDate = (modelCopy()[ctrl.$name] != undefined) ? moment(modelCopy()[ctrl.$name]) : null;
+
+        if((modelDate && copyDate && (modelDate.diff(copyDate, 'days') == 0)) || (!modelDate && !copyDate)){
+          scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
+          scope.angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
+          scope.angularForm.$pristine = true;
+        } else {
+          scope.angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
+          scope.angularForm.$pristine = false;
+        }
+      };
+
+      var checkForOverallFormPristinity = function(scope, ctrl) {
+        // don't do anything before the model and modelCopy are actually initialized
+        if (! (modelCopy() in scope) || ! modelCopy() || ! model() || ! (model() in scope))
+          return;
+
+        var modelCopyObject = _.cloneDeep(modelCopy());
+        delete modelCopyObject[ctrl.$name];
+
+        var modelObject = _.cloneDeep(scope[model()]);
+        delete modelObject[ctrl.$name];
+
+        scope.angularForm.$pristine = angular.equals(modelCopyObject, modelObject);
+
+        if (scope.angularForm.$pristine)
+          scope.angularForm.$setPristine();
+      };
     }
   }
 }]);
 
-var viewModelComparison = function(scope, ctrl) {
-  if ((Array.isArray(scope.modelCopy[ctrl.$name]) &&
-       angular.equals(scope[scope.model][ctrl.$name], scope.modelCopy[ctrl.$name])) ||
-       ctrl.$viewValue == scope.modelCopy[ctrl.$name]) {
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
-    scope.angularForm.$pristine = true;
-  } else {
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
-    scope.angularForm.$pristine = false;
-  }
-};
-
-var viewModelDateComparison = function(scope, ctrl) {
-  var modelDate = (ctrl.$modelValue != undefined) ? moment(ctrl.$modelValue) : null;
-  var copyDate = (scope.modelCopy[ctrl.$name] != undefined) ? moment(scope.modelCopy[ctrl.$name]) : null;
-
-  if((modelDate && copyDate && (modelDate.diff(copyDate, 'days') == 0)) || (!modelDate && !copyDate)){
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
-    scope.angularForm.$pristine = true;
-  } else {
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
-    scope.angularForm.$pristine = false;
-  }
-};
-
-var checkForOverallFormPristinity = function(scope, ctrl) {
-  // don't do anything before the model and modelCopy are actually initialized
-  if (! ('modelCopy' in scope) || ! scope.modelCopy || ! scope.model || ! (scope.model in scope))
-    return;
-
-  var modelCopyObject = _.cloneDeep(scope.modelCopy);
-  delete modelCopyObject[ctrl.$name];
-
-  var modelObject = _.cloneDeep(scope[scope.model]);
-  delete modelObject[ctrl.$name];
-
-  scope.angularForm.$pristine = angular.equals(modelCopyObject, modelObject);
-
-  if (scope.angularForm.$pristine)
-    scope.angularForm.$setPristine();
-};

--- a/app/assets/javascripts/directives/checkchange.js
+++ b/app/assets/javascripts/directives/checkchange.js
@@ -69,13 +69,13 @@ ManageIQ.angular.app.directive('checkchange', ['miqService', function(miqService
 
       var checkForOverallFormPristinity = function(scope, ctrl) {
         // don't do anything before the model and modelCopy are actually initialized
-        if (! (modelCopy() in scope) || ! modelCopy() || ! model() || ! (model() in scope))
+        if (!model() || !modelCopy())
           return;
 
         var modelCopyObject = _.cloneDeep(modelCopy());
         delete modelCopyObject[ctrl.$name];
 
-        var modelObject = _.cloneDeep(scope[model()]);
+        var modelObject = _.cloneDeep(model());
         delete modelObject[ctrl.$name];
 
         scope.angularForm.$pristine = angular.equals(modelCopyObject, modelObject);

--- a/app/assets/javascripts/directives/configuration/all_time_check.js
+++ b/app/assets/javascripts/directives/configuration/all_time_check.js
@@ -12,10 +12,10 @@ ManageIQ.angular.app.directive('allTimeCheck', function() {
       });
 
       var setAllDaysChecked = function(i, value) {
-        var dayValues = scope.timeProfileModel.dayValues;
+        var dayValues = scope.vm.timeProfileModel.dayValues;
         dayValues[i] = value;
         if (angular.equals(_.times(7, _.constant(true)), dayValues)) {
-          scope.timeProfileModel.all_days = true;
+          scope.vm.timeProfileModel.all_days = true;
         }
       };
 
@@ -29,19 +29,19 @@ ManageIQ.angular.app.directive('allTimeCheck', function() {
           if (hoursArr[j] === name) {
             updatedHourArr = allQuarterArrHoursChecked(name, i, value);
           } else {
-            if (!angular.equals(_.times(6, _.constant(true)), scope[scope.model][hoursArr[j]])) {
+            if (!angular.equals(_.times(6, _.constant(true)), scope.vm[scope.vm.model][hoursArr[j]])) {
               otherHourArrs = false;
               break;
             }
           }
         }
         if (updatedHourArr && otherHourArrs) {
-          scope.timeProfileModel.all_hours = true;
+          scope.vm.timeProfileModel.all_hours = true;
         }
       };
 
       var allQuarterArrHoursChecked = function(name, i, value) {
-        var quarterArrHours = scope[scope.model][name];
+        var quarterArrHours = scope.vm[scope.vm.model][name];
         quarterArrHours[i] = value;
         return angular.equals(_.times(6, _.constant(true)), quarterArrHours);
       };

--- a/app/assets/javascripts/directives/configuration/all_time_check.js
+++ b/app/assets/javascripts/directives/configuration/all_time_check.js
@@ -29,7 +29,7 @@ ManageIQ.angular.app.directive('allTimeCheck', function() {
           if (hoursArr[j] === name) {
             updatedHourArr = allQuarterArrHoursChecked(name, i, value);
           } else {
-            if (!angular.equals(_.times(6, _.constant(true)), scope.vm[scope.vm.model][hoursArr[j]])) {
+            if (!angular.equals(_.times(6, _.constant(true)), scope.vm.timeProfileModel[hoursArr[j]])) {
               otherHourArrs = false;
               break;
             }
@@ -41,7 +41,7 @@ ManageIQ.angular.app.directive('allTimeCheck', function() {
       };
 
       var allQuarterArrHoursChecked = function(name, i, value) {
-        var quarterArrHours = scope.vm[scope.vm.model][name];
+        var quarterArrHours = scope.vm.timeProfileModel[name];
         quarterArrHours[i] = value;
         return angular.equals(_.times(6, _.constant(true)), quarterArrHours);
       };

--- a/app/assets/javascripts/directives/configuration/min_time_check.js
+++ b/app/assets/javascripts/directives/configuration/min_time_check.js
@@ -15,17 +15,17 @@ ManageIQ.angular.app.directive('minTimeCheck', function() {
       var setSomePeriodCheckedValidity = function(ctrl, attrs) {
         if (attrs.timeType === "day") {
           if (allDaysUnchecked(attrs.minTimeCheck)) {
-            scope.timeProfileModel.some_days_checked = false;
+            scope.vm.timeProfileModel.some_days_checked = false;
           } else {
-            scope.timeProfileModel.some_days_checked = true;
-            scope.timeProfileModel.all_days = false;
+            scope.vm.timeProfileModel.some_days_checked = true;
+            scope.vm.timeProfileModel.all_days = false;
           }
         } else if (attrs.timeType === "hour") {
           if (allHoursUnchecked(attrs.minTimeCheck)) {
-            scope.timeProfileModel.some_hours_checked = false;
+            scope.vm.timeProfileModel.some_hours_checked = false;
           } else {
-            scope.timeProfileModel.some_hours_checked = true;
-            scope.timeProfileModel.all_hours = false;
+            scope.vm.timeProfileModel.some_hours_checked = true;
+            scope.vm.timeProfileModel.all_hours = false;
           }
         }
       };
@@ -33,7 +33,7 @@ ManageIQ.angular.app.directive('minTimeCheck', function() {
       var allDaysUnchecked = function(i) {
         var dayValues = _.times(7, _.constant(false));
         dayValues[i] = true;
-        return angular.equals(scope.timeProfileModel.dayValues, dayValues);
+        return angular.equals(scope.vm.timeProfileModel.dayValues, dayValues);
       };
 
       var allHoursUnchecked = function(i) {
@@ -46,25 +46,25 @@ ManageIQ.angular.app.directive('minTimeCheck', function() {
       var allFirstHalfAMHoursUnchecked = function(i) {
         var hourFirstHalfAMValues = _.times(6, _.constant(false));
         hourFirstHalfAMValues[i] = true;
-        return angular.equals(scope.timeProfileModel.hourValuesAMFirstHalf, hourFirstHalfAMValues);
+        return angular.equals(scope.vm.timeProfileModel.hourValuesAMFirstHalf, hourFirstHalfAMValues);
       };
 
       var allSecondHalfAMHoursUnchecked = function(i) {
         var hourSecondHalfAMValues = _.times(6, _.constant(false));
         hourSecondHalfAMValues[i] = true;
-        return angular.equals(scope.timeProfileModel.hourValuesAMSecondHalf, hourSecondHalfAMValues);
+        return angular.equals(scope.vm.timeProfileModel.hourValuesAMSecondHalf, hourSecondHalfAMValues);
       };
 
       var allFirstHalfPMHoursUnchecked = function(i) {
         var hourFirstHalfPMValues = _.times(6, _.constant(false));
         hourFirstHalfPMValues[i] = true;
-        return angular.equals(scope.timeProfileModel.hourValuesPMFirstHalf, hourFirstHalfPMValues);
+        return angular.equals(scope.vm.timeProfileModel.hourValuesPMFirstHalf, hourFirstHalfPMValues);
       };
 
       var allSecondHalfPMHoursUnchecked = function(i) {
         var hourSecondHalfPMValues = _.times(6, _.constant(false));
         hourSecondHalfPMValues[i] = true;
-        return angular.equals(scope.timeProfileModel.hourValuesPMSecondHalf, hourSecondHalfPMValues);
+        return angular.equals(scope.vm.timeProfileModel.hourValuesPMSecondHalf, hourSecondHalfPMValues);
       };
     }
   }

--- a/app/assets/javascripts/directives/configuration/some_time_check.js
+++ b/app/assets/javascripts/directives/configuration/some_time_check.js
@@ -12,12 +12,12 @@ ManageIQ.angular.app.directive('someTimeCheck', function() {
 
       var allDaysUnchecked = function(scope) {
         var dayValues = _.times(7, _.constant(false));
-        return angular.equals(scope.timeProfileModel.dayValues, dayValues);
+        return angular.equals(scope.vm.timeProfileModel.dayValues, dayValues);
       };
 
       var allHoursUnchecked = function(scope) {
         var hourValues = _.times(24, _.constant(false));
-        return angular.equals(scope.timeProfileModel.hourValues, hourValues);
+        return angular.equals(scope.vm.timeProfileModel.hourValues, hourValues);
       };
     }
   }

--- a/app/assets/javascripts/directives/miq_form.js
+++ b/app/assets/javascripts/directives/miq_form.js
@@ -1,0 +1,9 @@
+ManageIQ.angular.app.directive('miqForm', function() {
+  return {
+    require: "form",
+    link: function(scope, elem, attr, ctrl) {
+      ctrl.model = attr.model;
+      ctrl.modelCopy = attr.modelCopy;
+    },
+  }
+});

--- a/app/assets/javascripts/directives/start_form_div.js
+++ b/app/assets/javascripts/directives/start_form_div.js
@@ -1,10 +1,8 @@
 ManageIQ.angular.app.directive('startFormDiv', ['$timeout', function($timeout) {
   return {
     link: function(scope, _elem, attr) {
-      scope.$watch(scope['afterGet'], function() {
-        $timeout(function () {
-          angular.element('#' + attr.startFormDiv).show();
-        });
+      $timeout(function () {
+        angular.element('#' + attr.startFormDiv).show();
       });
     },
   };

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -383,8 +383,17 @@ class ConfigurationController < ApplicationController
       session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
       javascript_redirect :action => 'change_tab', :typ => "timeprofiles", :tab => 4, :id => @timeprofile.id.to_s
     elsif params[:button] == "save"
-      params[:all_days] ? days = (0..6).to_a : days = params[:days] ? params[:days].collect{|i| i.to_i} : []
-      params[:all_hours] ? hours = (0..23).to_a : hours = params[:hours] ? params[:hours].collect{|i| i.to_i} : []
+      if params[:all_days] == 'true'
+        days = (0..6).to_a
+      else
+        days = params[:dayValues].each_with_index.map { |item, index| item == 'true' ? index : nil }.compact
+      end
+      if params[:all_hours] == 'true'
+        hours = (0..23).to_a
+      else
+        all_hours = params[:hourValuesAMFirstHalf] + params[:hourValuesAMSecondHalf] + params[:hourValuesPMFirstHalf] + params[:hourValuesPMSecondHalf]
+        hours = all_hours.each_with_index.map { |item, index| item == 'true' ? index : nil }.compact
+      end
       @timeprofile.description = params[:description]
       @timeprofile.profile_key = params[:profile_type] == "user" ? session[:userid] : nil
       @timeprofile.profile_type = params[:profile_type]

--- a/app/views/configuration/_timeprofile_form.html.haml
+++ b/app/views/configuration/_timeprofile_form.html.haml
@@ -3,35 +3,36 @@
   %br
   %br
 
-.form-horizontal{:id => "start_form_div"}
-  %form#form_div{:name           => "angularForm",
-                 'ng-controller' => "timeProfileFormController as vm",
-                 "miq-form"       => true,
-                 "model"          => "vm.timeProfileModel",
-                 "model-copy"     => 'vm.modelCopy',
-                 :novalidate     => true}
-    = render :partial => "layouts/flash_msg"
-    .form-group{"ng-class" => "{'has-error': angularForm.description.$invalid}"}
-      %label.col-md-2.control-label{"for" => "description"}
-        = _('Description')
-      .col-md-8
-        %input.form-control{:type              => "text",
-                              :name            => "description",
-                              "id"             => "description",
-                              'ng-model'       => "vm.timeProfileModel.description",
-                              'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
-                              :maxlength       => MAX_NAME_LEN,
-                              :required        => "",
-                              :checkchange     => true,
-                              "auto-focus"     => "",
-                              "start-form-div" => "start_form_div"}
-        %span.help-block{"ng-show" => "angularForm.description.$error.required"}
-          = _("Required")
-    .form-group{"ng-if" => "vm.timeProfileModel.admin_user"}
-      %label.col-md-2.control-label
-        = _('Scope')
-      .col-md-8
-        = select_tag('profile_type',
+%form.form-horizontal#form_div{:name            => "angularForm",
+                               'ng-controller'  => "timeProfileFormController as vm",
+                               "miq-form"       => true,
+                               'ng-show'        => "vm.afterGet",
+                               "model"          => "vm.timeProfileModel",
+                               "model-copy"     => 'vm.modelCopy',
+                               :novalidate      => true,
+                               :style           => 'display: none',
+                               "start-form-div" => "form_div"}
+  = render :partial => "layouts/flash_msg"
+  .form-group{"ng-class" => "{'has-error': angularForm.description.$invalid}"}
+    %label.col-md-2.control-label{"for" => "description"}
+      = _('Description')
+    .col-md-8
+      %input.form-control{:type         => "text",
+                          :name         => "description",
+                          "id"          => "description",
+                          'ng-model'    => "vm.timeProfileModel.description",
+                          'ng-disabled' => "vm.timeProfileModel.restricted_time_profile",
+                          :maxlength    => MAX_NAME_LEN,
+                          :required     => "",
+                          :checkchange  => true,
+                          "auto-focus"  => ""}
+      %span.help-block{"ng-show" => "angularForm.description.$error.required"}
+        = _("Required")
+  .form-group{"ng-if" => "vm.timeProfileModel.admin_user"}
+    %label.col-md-2.control-label
+      = _('Scope')
+    .col-md-8
+      = select_tag('profile_type',
                    options_for_select([["<#{_('Choose')}>", nil]] + [["#{_('All Users')}", "global"], ["#{_('Current User')}", "user"]], disabled: ["<#{_('Choose')}>", nil]),
                    "ng-model"                    => "vm.timeProfileModel.profile_type",
                    'ng-disabled'                 => "vm.timeProfileModel.restricted_time_profile",
@@ -40,156 +41,150 @@
                    "selectpicker-for-select-tag" => "",
                    "data-live-search"            => "true")
 
-    #timeprofile_days_hours_div
-      .form-horizontal
-        .form-group
-          %label.col-md-2.control-label
-            = _('Days')
-          .col-md-8
-            = _('All')
+  #timeprofile_days_hours_div
+    .form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _('Days')
+        .col-md-8
+          = _('All')
+          %div
+            %input.form-control{:type         => "checkbox",
+                                :name         => "all_days",
+                                "id"          => "all_days",
+                                'ng-model'    => "vm.timeProfileModel.all_days",
+                                'ng-disabled' => "vm.timeProfileModel.restricted_time_profile",
+                                "ng-change"   => "vm.allDaysClicked()",
+                                "bs-switch"   => "",
+                                :checkchange  => ""}
+      .form-group{"ng-class" => "{'has-error': angularForm.some_days_checked.$error.someDaysCheck}"}
+        %label.col-md-2.control-label
+        %div
+          %span.col-sm-1{"ng-repeat" => "day in vm.timeProfileModel.dayValues track by $index"}
+            {{vm.dayNames[$index]}}
             %div
-              %input.form-control{:type         => "checkbox",
-                                  :name         => "all_days",
-                                  "id"          => "all_days",
-                                  'ng-model'    => "vm.timeProfileModel.all_days",
-                                  'ng-disabled' => "vm.timeProfileModel.restricted_time_profile",
-                                  "ng-change"   => "vm.allDaysClicked()",
-                                  "bs-switch"   => "",
-                                  :checkchange  => "",
-                                }
-        .form-group{"ng-class" => "{'has-error': angularForm.some_days_checked.$error.someDaysCheck}"}
-          %label.col-md-2.control-label
+              %input.form-control{:type            => "checkbox",
+                                  :name            => "dayValues",
+                                  'ng-model'       => "vm.timeProfileModel.dayValues[$index]",
+                                  'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
+                                  'ng-change'      => "vm.dayValuesChanged()",
+                                  "bs-switch"      => "",
+                                  :checkchange     => "",
+                                  'time-type'      => "day",
+                                  'all-time-check' => "{{$index}}",
+                                  "min-time-check" => "{{$index}}",
+                                 }
+      .form-group{"ng-class" => "{'has-error': angularForm.some_days_checked.$error.someTimeCheck}"}
+        %label.col-md-2.control-label
+        .col-md-8
           %div
-            %span.col-sm-1{"ng-repeat" => "day in vm.timeProfileModel.dayValues track by $index"}
-              {{vm.dayNames[$index]}}
-              %div
-                %input.form-control{:type            => "checkbox",
-                                    :name            => "dayValues",
-                                    'ng-model'       => "vm.timeProfileModel.dayValues[$index]",
-                                    'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
-                                    'ng-change'      => "vm.dayValuesChanged()",
-                                    "bs-switch"      => "",
-                                    :checkchange     => "",
-                                    'time-type'      => "day",
-                                    'all-time-check' => "{{$index}}",
-                                    "min-time-check" => "{{$index}}",
-                                   }
-        .form-group{"ng-class" => "{'has-error': angularForm.some_days_checked.$error.someTimeCheck}"}
-          %label.col-md-2.control-label
-          .col-md-8
+            %input.form-control{:type             => "checkbox",
+                                :name             => "some_days_checked",
+                                "id"              => "some_days_checked",
+                                'ng-model'        => "vm.timeProfileModel.some_days_checked",
+                                'ng-hide'         => true,
+                                'time-type'       => "day",
+                                "some-time-check" => ""}
+            %span.help-block{"ng-show" => "angularForm.some_days_checked.$error.someTimeCheck"}
+              = _("At least one day needs to be selected")
+      .form-group
+        %label.col-md-2.control-label
+          = _('Hours')
+        .col-md-8
+          = _('All')
+          %div
+            %input.form-control{:type         => "checkbox",
+                                :name         => "all_hours",
+                                "id"          => "all_hours",
+                                'ng-model'    => "vm.timeProfileModel.all_hours",
+                                'ng-disabled' => "vm.timeProfileModel.restricted_time_profile",
+                                "ng-change"   => "vm.allHoursClicked()",
+                                "bs-switch"   => "",
+                                :checkchange  => ""}
+      .form-group
+        %label.col-md-2.control-label
+          = _('AM')
+        %div
+          %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesAMFirstHalf track by $index"}
+            {{vm.hourNamesFirstHalf[$index]}}
             %div
-              %input.form-control{:type             => "checkbox",
-                                  :name             => "some_days_checked",
-                                  "id"              => "some_days_checked",
-                                  'ng-model'        => "vm.timeProfileModel.some_days_checked",
-                                  'ng-hide'         => true,
-                                  'time-type'       => "day",
-                                  "some-time-check" => ""}
-              %span.help-block{"ng-show" => "angularForm.some_days_checked.$error.someTimeCheck"}
-                = _("At least one day needs to be selected")
-        .form-group
-          %label.col-md-2.control-label
-            = _('Hours')
-          .col-md-8
-            = _('All')
+              %input.form-control{:type            => "checkbox",
+                                  :name            => "hourValuesAMFirstHalf",
+                                  'ng-model'       => "vm.timeProfileModel.hourValuesAMFirstHalf[$index]",
+                                  'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
+                                  'ng-change'      => "vm.hourValuesChanged()",
+                                  "bs-switch"      => "",
+                                  :checkchange     => "",
+                                  'time-type'      => "hour",
+                                  'all-time-check' => "{{$index}}",
+                                  'min-time-check' => "{{$index}}"}
+      .form-group
+        %label.col-md-2.control-label
+        %div
+          %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesAMSecondHalf track by $index"}
+            {{vm.hourNamesSecondHalf[$index]}}
             %div
-              %input.form-control{:type         => "checkbox",
-                                  :name         => "all_hours",
-                                  "id"          => "all_hours",
-                                  'ng-model'    => "vm.timeProfileModel.all_hours",
-                                  'ng-disabled' => "vm.timeProfileModel.restricted_time_profile",
-                                  "ng-change"   => "vm.allHoursClicked()",
-                                  "bs-switch"   => "",
-                                  :checkchange  => "",
-                                }
-        .form-group
-          %label.col-md-2.control-label
-            = _('AM')
-          %div
-            %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesAMFirstHalf track by $index"}
-              {{vm.hourNamesFirstHalf[$index]}}
-              %div
-                %input.form-control{:type            => "checkbox",
-                                    :name            => "hourValuesAMFirstHalf",
-                                    'ng-model'       => "vm.timeProfileModel.hourValuesAMFirstHalf[$index]",
-                                    'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
-                                    'ng-change'      => "vm.hourValuesChanged()",
-                                    "bs-switch"      => "",
-                                    :checkchange     => "",
-                                    'time-type'      => "hour",
-                                    'all-time-check' => "{{$index}}",
-                                    'min-time-check' => "{{$index}}",
-                                   }
-        .form-group
-          %label.col-md-2.control-label
-          %div
-            %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesAMSecondHalf track by $index"}
-              {{vm.hourNamesSecondHalf[$index]}}
-              %div
-                %input.form-control{:type            => "checkbox",
-                                    :name            => "hourValuesAMSecondHalf",
-                                    'ng-model'       => "vm.timeProfileModel.hourValuesAMSecondHalf[$index]",
-                                    'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
-                                    'ng-change'      => "vm.hourValuesChanged()",
-                                    "bs-switch"      => "",
-                                    :checkchange     => "",
-                                    'time-type'      => "hour",
-                                    'all-time-check' => "{{$index}}",
-                                    'min-time-check' => "{{$index}}",
-                                   }
-        .form-group
-          %label.col-md-2.control-label
-            = _('PM')
-          %div
-            %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesPMFirstHalf track by $index"}
-              {{vm.hourNamesFirstHalf[$index]}}
-              %div
-                %input.form-control{:type            => "checkbox",
-                                    :name            => "hourValuesPMFirstHalf",
-                                    'ng-model'       => "vm.timeProfileModel.hourValuesPMFirstHalf[$index]",
-                                    'ng-change'      => "vm.hourValuesChanged()",
-                                    'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
-                                    "bs-switch"      => "",
-                                    :checkchange     => "",
-                                    'time-type'      => "hour",
-                                    'all-time-check' => "{{$index}}",
-                                    'min-time-check' => "{{$index}}",
-                                   }
-        .form-group
-          %label.col-md-2.control-label
-          %div
-            %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesPMSecondHalf track by $index"}
-              {{vm.hourNamesSecondHalf[$index]}}
-              %div
-                %input.form-control{:type            => "checkbox",
-                                    :name            => "hourValuesPMSecondHalf",
-                                    'ng-model'       => "vm.timeProfileModel.hourValuesPMSecondHalf[$index]",
-                                    'ng-change'      => "vm.hourValuesChanged()",
-                                    'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
-                                    "bs-switch"      => "",
-                                    :checkchange     => "",
-                                    'time-type'      => "hour",
-                                    'all-time-check' => "{{$index}}",
-                                    'min-time-check' => "{{$index}}",
-                                   }
-        .form-group{"ng-class" => "{'has-error': angularForm.some_hours_checked.$error.someTimeCheck}"}
-          %label.col-md-2.control-label
-          .col-md-8
+              %input.form-control{:type            => "checkbox",
+                                  :name            => "hourValuesAMSecondHalf",
+                                  'ng-model'       => "vm.timeProfileModel.hourValuesAMSecondHalf[$index]",
+                                  'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
+                                  'ng-change'      => "vm.hourValuesChanged()",
+                                  "bs-switch"      => "",
+                                  :checkchange     => "",
+                                  'time-type'      => "hour",
+                                  'all-time-check' => "{{$index}}",
+                                  'min-time-check' => "{{$index}}"}
+      .form-group
+        %label.col-md-2.control-label
+          = _('PM')
+        %div
+          %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesPMFirstHalf track by $index"}
+            {{vm.hourNamesFirstHalf[$index]}}
             %div
-              %input.form-control{:type             => "checkbox",
-                                  :name             => "some_hours_checked",
-                                  "id"              => "some_hours_checked",
-                                  'ng-model'        => "vm.timeProfileModel.some_hours_checked",
-                                  'ng-hide'         => true,
-                                  'time-type'       => "hour",
-                                  "some-time-check" => ""}
-              %span.help-block{"ng-show" => "angularForm.some_hours_checked.$error.someTimeCheck"}
-                = _("At least one hour needs to be selected")
-        .form-group
-          %label.col-md-2.control-label
-            = _('Timezone')
-          .col-md-8
-            = select_tag('profile_tz',
+              %input.form-control{:type            => "checkbox",
+                                  :name            => "hourValuesPMFirstHalf",
+                                  'ng-model'       => "vm.timeProfileModel.hourValuesPMFirstHalf[$index]",
+                                  'ng-change'      => "vm.hourValuesChanged()",
+                                  'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
+                                  "bs-switch"      => "",
+                                  :checkchange     => "",
+                                  'time-type'      => "hour",
+                                  'all-time-check' => "{{$index}}",
+                                  'min-time-check' => "{{$index}}"}
+      .form-group
+        %label.col-md-2.control-label
+        %div
+          %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesPMSecondHalf track by $index"}
+            {{vm.hourNamesSecondHalf[$index]}}
+            %div
+              %input.form-control{:type            => "checkbox",
+                                  :name            => "hourValuesPMSecondHalf",
+                                  'ng-model'       => "vm.timeProfileModel.hourValuesPMSecondHalf[$index]",
+                                  'ng-change'      => "vm.hourValuesChanged()",
+                                  'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
+                                  "bs-switch"      => "",
+                                  :checkchange     => "",
+                                  'time-type'      => "hour",
+                                  'all-time-check' => "{{$index}}",
+                                  'min-time-check' => "{{$index}}"}
+      .form-group{"ng-class" => "{'has-error': angularForm.some_hours_checked.$error.someTimeCheck}"}
+        %label.col-md-2.control-label
+        .col-md-8
+          %div
+            %input.form-control{:type             => "checkbox",
+                                :name             => "some_hours_checked",
+                                "id"              => "some_hours_checked",
+                                'ng-model'        => "vm.timeProfileModel.some_hours_checked",
+                                'ng-hide'         => true,
+                                'time-type'       => "hour",
+                                "some-time-check" => ""}
+            %span.help-block{"ng-show" => "angularForm.some_hours_checked.$error.someTimeCheck"}
+              = _("At least one hour needs to be selected")
+      .form-group
+        %label.col-md-2.control-label
+          = _('Timezone')
+        .col-md-8
+          = select_tag('profile_tz',
                        options_for_select([["<#{_('Determine at Run Time')}>", nil]] + ALL_TIMEZONES),
                        "ng-model"                    => "vm.timeProfileModel.profile_tz",
                        'ng-disabled'                 => "vm.timeProfileModel.restricted_time_profile",
@@ -197,38 +192,37 @@
                        "selectpicker-for-select-tag" => "",
                        "data-live-search"            => "true")
 
-      .form-group{"ng-if" => "vm.timeProfileModel.admin_user && vm.timeProfileModel.profile_tz != ''"}
-        %label.col-md-2.control-label
-          = _('Roll Up Daily Performance')
-        .col-md-8
-          %input.form-control{:type             => "checkbox",
-                              :name             => "rollup_daily",
-                              'ng-model'        => "vm.timeProfileModel.rollup_daily",
-                              "bs-switch"       => "",
-                              "switch-readonly" => "vm.timeProfileModel.restricted_time_profile || vm.timeProfileModel.miq_reports_count > 0",
-                              :checkchange      => "",
-                             }
-          %div{"ng-if" => "vm.timeProfileModel.miq_reports_count > 0"}
-            {{note}}
-    = render :partial => "layouts/angular/x_edit_buttons_angular"
-    %br
-    %br
-    %div{"ng-if" => "vm.timeProfileModel.miq_reports_count > 0"}
-      %hr
-      %h3= _('Reports Currently Using This Time Profile')
-      %table.table.table-striped.table-bordered
-        %thead
+    .form-group{"ng-if" => "vm.timeProfileModel.admin_user && vm.timeProfileModel.profile_tz != ''"}
+      %label.col-md-2.control-label
+        = _('Roll Up Daily Performance')
+      .col-md-8
+        %input.form-control{:type             => "checkbox",
+                            :name             => "rollup_daily",
+                            'ng-model'        => "vm.timeProfileModel.rollup_daily",
+                            "bs-switch"       => "",
+                            "switch-readonly" => "vm.timeProfileModel.restricted_time_profile || vm.timeProfileModel.miq_reports_count > 0",
+                            :checkchange      => ""}
+        %div{"ng-if" => "vm.timeProfileModel.miq_reports_count > 0"}
+          {{note}}
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
+  %br
+  %br
+  %div{"ng-if" => "vm.timeProfileModel.miq_reports_count > 0"}
+    %hr
+    %h3= _('Reports Currently Using This Time Profile')
+    %table.table.table-striped.table-bordered
+      %thead
+        %tr
+          %th.narrow
+          %th= _('Name')
+          %th= _('Title')
+      %tbody
+        - @timeprofile.miq_reports.sort_by { |a| a.name.downcase }.each do |r|
           %tr
-            %th.narrow
-            %th= _('Name')
-            %th= _('Title')
-        %tbody
-          - @timeprofile.miq_reports.sort_by { |a| a.name.downcase }.each do |r|
-            %tr
-              %td.narrow
-                %i.fa.fa-file-text-o
-              %td= r.name
-              %td= r.title
+            %td.narrow
+              %i.fa.fa-file-text-o
+            %td= r.name
+            %td= r.title
 
 :javascript
   ManageIQ.angular.app.value('timeProfileFormId', '#{@timeprofile.id || "new"}');

--- a/app/views/configuration/_timeprofile_form.html.haml
+++ b/app/views/configuration/_timeprofile_form.html.haml
@@ -6,6 +6,9 @@
 .form-horizontal{:id => "start_form_div"}
   %form#form_div{:name           => "angularForm",
                  'ng-controller' => "timeProfileFormController as vm",
+                 "miq-form"       => true,
+                 "model"          => "vm.timeProfileModel",
+                 "model-copy"     => 'vm.modelCopy',
                  :novalidate     => true}
     = render :partial => "layouts/flash_msg"
     .form-group{"ng-class" => "{'has-error': angularForm.description.$invalid}"}

--- a/app/views/configuration/_timeprofile_form.html.haml
+++ b/app/views/configuration/_timeprofile_form.html.haml
@@ -3,10 +3,9 @@
   %br
   %br
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
+.form-horizontal{:id => "start_form_div"}
   %form#form_div{:name           => "angularForm",
-                 'ng-controller' => "timeProfileFormController",
-                 'ng-show'       => "afterGet",
+                 'ng-controller' => "timeProfileFormController as vm",
                  :novalidate     => true}
     = render :partial => "layouts/flash_msg"
     .form-group{"ng-class" => "{'has-error': angularForm.description.$invalid}"}
@@ -16,8 +15,8 @@
         %input.form-control{:type              => "text",
                               :name            => "description",
                               "id"             => "description",
-                              'ng-model'       => "timeProfileModel.description",
-                              'ng-disabled'    => "timeProfileModel.restricted_time_profile",
+                              'ng-model'       => "vm.timeProfileModel.description",
+                              'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
                               :maxlength       => MAX_NAME_LEN,
                               :required        => "",
                               :checkchange     => true,
@@ -25,14 +24,14 @@
                               "start-form-div" => "start_form_div"}
         %span.help-block{"ng-show" => "angularForm.description.$error.required"}
           = _("Required")
-    .form-group{"ng-if" => "timeProfileModel.admin_user"}
+    .form-group{"ng-if" => "vm.timeProfileModel.admin_user"}
       %label.col-md-2.control-label
         = _('Scope')
       .col-md-8
         = select_tag('profile_type',
                    options_for_select([["<#{_('Choose')}>", nil]] + [["#{_('All Users')}", "global"], ["#{_('Current User')}", "user"]], disabled: ["<#{_('Choose')}>", nil]),
-                   "ng-model"                    => "timeProfileModel.profile_type",
-                   'ng-disabled'                 => "timeProfileModel.restricted_time_profile",
+                   "ng-model"                    => "vm.timeProfileModel.profile_type",
+                   'ng-disabled'                 => "vm.timeProfileModel.restricted_time_profile",
                    "required"                    => "",
                    "checkchange"                 => "",
                    "selectpicker-for-select-tag" => "",
@@ -49,23 +48,23 @@
               %input.form-control{:type         => "checkbox",
                                   :name         => "all_days",
                                   "id"          => "all_days",
-                                  'ng-model'    => "timeProfileModel.all_days",
-                                  'ng-disabled' => "timeProfileModel.restricted_time_profile",
-                                  "ng-change"   => "allDaysClicked()",
+                                  'ng-model'    => "vm.timeProfileModel.all_days",
+                                  'ng-disabled' => "vm.timeProfileModel.restricted_time_profile",
+                                  "ng-change"   => "vm.allDaysClicked()",
                                   "bs-switch"   => "",
                                   :checkchange  => "",
                                 }
         .form-group{"ng-class" => "{'has-error': angularForm.some_days_checked.$error.someDaysCheck}"}
           %label.col-md-2.control-label
           %div
-            %span.col-sm-1{"ng-repeat" => "day in timeProfileModel.dayValues track by $index"}
-              {{dayNames[$index]}}
+            %span.col-sm-1{"ng-repeat" => "day in vm.timeProfileModel.dayValues track by $index"}
+              {{vm.dayNames[$index]}}
               %div
                 %input.form-control{:type            => "checkbox",
                                     :name            => "dayValues",
-                                    'ng-model'       => "timeProfileModel.dayValues[$index]",
-                                    'ng-disabled'    => "timeProfileModel.restricted_time_profile",
-                                    'ng-change'      => "dayValuesChanged()",
+                                    'ng-model'       => "vm.timeProfileModel.dayValues[$index]",
+                                    'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
+                                    'ng-change'      => "vm.dayValuesChanged()",
                                     "bs-switch"      => "",
                                     :checkchange     => "",
                                     'time-type'      => "day",
@@ -79,7 +78,7 @@
               %input.form-control{:type             => "checkbox",
                                   :name             => "some_days_checked",
                                   "id"              => "some_days_checked",
-                                  'ng-model'        => "timeProfileModel.some_days_checked",
+                                  'ng-model'        => "vm.timeProfileModel.some_days_checked",
                                   'ng-hide'         => true,
                                   'time-type'       => "day",
                                   "some-time-check" => ""}
@@ -94,9 +93,9 @@
               %input.form-control{:type         => "checkbox",
                                   :name         => "all_hours",
                                   "id"          => "all_hours",
-                                  'ng-model'    => "timeProfileModel.all_hours",
-                                  'ng-disabled' => "timeProfileModel.restricted_time_profile",
-                                  "ng-change"   => "allHoursClicked()",
+                                  'ng-model'    => "vm.timeProfileModel.all_hours",
+                                  'ng-disabled' => "vm.timeProfileModel.restricted_time_profile",
+                                  "ng-change"   => "vm.allHoursClicked()",
                                   "bs-switch"   => "",
                                   :checkchange  => "",
                                 }
@@ -104,14 +103,14 @@
           %label.col-md-2.control-label
             = _('AM')
           %div
-            %span.col-sm-1{"ng-repeat" => "hour in timeProfileModel.hourValuesAMFirstHalf track by $index"}
-              {{hourNamesFirstHalf[$index]}}
+            %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesAMFirstHalf track by $index"}
+              {{vm.hourNamesFirstHalf[$index]}}
               %div
                 %input.form-control{:type            => "checkbox",
                                     :name            => "hourValuesAMFirstHalf",
-                                    'ng-model'       => "timeProfileModel.hourValuesAMFirstHalf[$index]",
-                                    'ng-disabled'    => "timeProfileModel.restricted_time_profile",
-                                    'ng-change'      => "hourValuesChanged()",
+                                    'ng-model'       => "vm.timeProfileModel.hourValuesAMFirstHalf[$index]",
+                                    'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
+                                    'ng-change'      => "vm.hourValuesChanged()",
                                     "bs-switch"      => "",
                                     :checkchange     => "",
                                     'time-type'      => "hour",
@@ -121,14 +120,14 @@
         .form-group
           %label.col-md-2.control-label
           %div
-            %span.col-sm-1{"ng-repeat" => "hour in timeProfileModel.hourValuesAMSecondHalf track by $index"}
-              {{hourNamesSecondHalf[$index]}}
+            %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesAMSecondHalf track by $index"}
+              {{vm.hourNamesSecondHalf[$index]}}
               %div
                 %input.form-control{:type            => "checkbox",
                                     :name            => "hourValuesAMSecondHalf",
-                                    'ng-model'       => "timeProfileModel.hourValuesAMSecondHalf[$index]",
-                                    'ng-disabled'    => "timeProfileModel.restricted_time_profile",
-                                    'ng-change'      => "hourValuesChanged()",
+                                    'ng-model'       => "vm.timeProfileModel.hourValuesAMSecondHalf[$index]",
+                                    'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
+                                    'ng-change'      => "vm.hourValuesChanged()",
                                     "bs-switch"      => "",
                                     :checkchange     => "",
                                     'time-type'      => "hour",
@@ -139,14 +138,14 @@
           %label.col-md-2.control-label
             = _('PM')
           %div
-            %span.col-sm-1{"ng-repeat" => "hour in timeProfileModel.hourValuesPMFirstHalf track by $index"}
-              {{hourNamesFirstHalf[$index]}}
+            %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesPMFirstHalf track by $index"}
+              {{vm.hourNamesFirstHalf[$index]}}
               %div
                 %input.form-control{:type            => "checkbox",
                                     :name            => "hourValuesPMFirstHalf",
-                                    'ng-model'       => "timeProfileModel.hourValuesPMFirstHalf[$index]",
-                                    'ng-change'      => "hourValuesChanged()",
-                                    'ng-disabled'    => "timeProfileModel.restricted_time_profile",
+                                    'ng-model'       => "vm.timeProfileModel.hourValuesPMFirstHalf[$index]",
+                                    'ng-change'      => "vm.hourValuesChanged()",
+                                    'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
                                     "bs-switch"      => "",
                                     :checkchange     => "",
                                     'time-type'      => "hour",
@@ -156,14 +155,14 @@
         .form-group
           %label.col-md-2.control-label
           %div
-            %span.col-sm-1{"ng-repeat" => "hour in timeProfileModel.hourValuesPMSecondHalf track by $index"}
-              {{hourNamesSecondHalf[$index]}}
+            %span.col-sm-1{"ng-repeat" => "hour in vm.timeProfileModel.hourValuesPMSecondHalf track by $index"}
+              {{vm.hourNamesSecondHalf[$index]}}
               %div
                 %input.form-control{:type            => "checkbox",
                                     :name            => "hourValuesPMSecondHalf",
-                                    'ng-model'       => "timeProfileModel.hourValuesPMSecondHalf[$index]",
-                                    'ng-change'      => "hourValuesChanged()",
-                                    'ng-disabled'    => "timeProfileModel.restricted_time_profile",
+                                    'ng-model'       => "vm.timeProfileModel.hourValuesPMSecondHalf[$index]",
+                                    'ng-change'      => "vm.hourValuesChanged()",
+                                    'ng-disabled'    => "vm.timeProfileModel.restricted_time_profile",
                                     "bs-switch"      => "",
                                     :checkchange     => "",
                                     'time-type'      => "hour",
@@ -177,7 +176,7 @@
               %input.form-control{:type             => "checkbox",
                                   :name             => "some_hours_checked",
                                   "id"              => "some_hours_checked",
-                                  'ng-model'        => "timeProfileModel.some_hours_checked",
+                                  'ng-model'        => "vm.timeProfileModel.some_hours_checked",
                                   'ng-hide'         => true,
                                   'time-type'       => "hour",
                                   "some-time-check" => ""}
@@ -189,29 +188,29 @@
           .col-md-8
             = select_tag('profile_tz',
                        options_for_select([["<#{_('Determine at Run Time')}>", nil]] + ALL_TIMEZONES),
-                       "ng-model"                    => "timeProfileModel.profile_tz",
-                       'ng-disabled'                 => "timeProfileModel.restricted_time_profile",
+                       "ng-model"                    => "vm.timeProfileModel.profile_tz",
+                       'ng-disabled'                 => "vm.timeProfileModel.restricted_time_profile",
                        "checkchange"                 => "",
                        "selectpicker-for-select-tag" => "",
                        "data-live-search"            => "true")
 
-      .form-group{"ng-if" => "timeProfileModel.admin_user && timeProfileModel.profile_tz != ''"}
+      .form-group{"ng-if" => "vm.timeProfileModel.admin_user && vm.timeProfileModel.profile_tz != ''"}
         %label.col-md-2.control-label
           = _('Roll Up Daily Performance')
         .col-md-8
           %input.form-control{:type             => "checkbox",
                               :name             => "rollup_daily",
-                              'ng-model'        => "timeProfileModel.rollup_daily",
+                              'ng-model'        => "vm.timeProfileModel.rollup_daily",
                               "bs-switch"       => "",
-                              "switch-readonly" => "timeProfileModel.restricted_time_profile || timeProfileModel.miq_reports_count > 0",
+                              "switch-readonly" => "vm.timeProfileModel.restricted_time_profile || vm.timeProfileModel.miq_reports_count > 0",
                               :checkchange      => "",
                              }
-          %div{"ng-if" => "timeProfileModel.miq_reports_count > 0"}
+          %div{"ng-if" => "vm.timeProfileModel.miq_reports_count > 0"}
             {{note}}
     = render :partial => "layouts/angular/x_edit_buttons_angular"
     %br
     %br
-    %div{"ng-if" => "timeProfileModel.miq_reports_count > 0"}
+    %div{"ng-if" => "vm.timeProfileModel.miq_reports_count > 0"}
       %hr
       %h3= _('Reports Currently Using This Time Profile')
       %table.table.table-striped.table-bordered

--- a/spec/javascripts/controllers/configuration/time_profile_form_controller_spec.js
+++ b/spec/javascripts/controllers/configuration/time_profile_form_controller_spec.js
@@ -13,7 +13,8 @@ describe('timeProfileFormController', function() {
     spyOn(miqService, 'sparkleOff');
     $scope = $rootScope.$new();
 
-    $scope.timeProfileModel = {
+    $scope.vm = {};
+    $scope.vm.timeProfileModel = {
       description: '',
       admin_user: false,
       restricted_time_profile: false,
@@ -39,7 +40,7 @@ describe('timeProfileFormController', function() {
     };
 
     $httpBackend.whenGET('/configuration/time_profile_form_fields/new').respond(timeProfileResponse);
-    $controller = _$controller_('timeProfileFormController', {
+    $controller = _$controller_('timeProfileFormController as vm', {
       $scope: $scope,
       timeProfileFormId: 'new',
       miqService: miqService
@@ -57,25 +58,25 @@ describe('timeProfileFormController', function() {
     });
     describe('when the timeProfileFormId is new', function() {
       it('sets the name to blank', function () {
-        expect($scope.timeProfileModel.description).toEqual('');
+        expect($scope.vm.timeProfileModel.description).toEqual('');
       });
       it('sets the admin_user to false', function () {
-        expect($scope.timeProfileModel.admin_user).toBeFalsy();
+        expect($scope.vm.timeProfileModel.admin_user).toBeFalsy();
       });
       it('sets the restricted_time_profile to false', function () {
-        expect($scope.timeProfileModel.restricted_time_profile).toBeFalsy();
+        expect($scope.vm.timeProfileModel.restricted_time_profile).toBeFalsy();
       });
       it('sets the profile_type to blank', function () {
-        expect($scope.timeProfileModel.profile_type).toEqual('');
+        expect($scope.vm.timeProfileModel.profile_type).toEqual('');
       });
       it('sets the profile_tz to blank', function () {
-        expect($scope.timeProfileModel.profile_tz).toEqual('');
+        expect($scope.vm.timeProfileModel.profile_tz).toEqual('');
       });
       it('sets the all_days to false', function () {
-        expect($scope.timeProfileModel.all_days).toBeFalsy();
+        expect($scope.vm.timeProfileModel.all_days).toBeFalsy();
       });
       it('sets the all_hours to blank', function () {
-        expect($scope.timeProfileModel.all_hours).toBeFalsy();
+        expect($scope.vm.timeProfileModel.all_hours).toBeFalsy();
       });
     });
   });
@@ -96,7 +97,7 @@ describe('timeProfileFormController', function() {
 
     beforeEach(inject(function(_$controller_) {
       $httpBackend.whenGET('/configuration/time_profile_form_fields/12345').respond(timeProfileFormResponse);
-      $controller = _$controller_('timeProfileFormController',
+      $controller = _$controller_('timeProfileFormController as vm',
         {
           $scope: $scope,
           timeProfileFormId: '12345',
@@ -106,25 +107,25 @@ describe('timeProfileFormController', function() {
     }));
 
     it('sets the name to blank', function () {
-      expect($scope.timeProfileModel.description).toEqual('TimeProfileTest');
+      expect($scope.vm.timeProfileModel.description).toEqual('TimeProfileTest');
     });
     it('sets the admin_user to false', function () {
-      expect($scope.timeProfileModel.admin_user).toBeTruthy();
+      expect($scope.vm.timeProfileModel.admin_user).toBeTruthy();
     });
     it('sets the restricted_time_profile to false', function () {
-      expect($scope.timeProfileModel.restricted_time_profile).toBeFalsy();
+      expect($scope.vm.timeProfileModel.restricted_time_profile).toBeFalsy();
     });
     it('sets the profile_type to blank', function () {
-      expect($scope.timeProfileModel.profile_type).toEqual('user');
+      expect($scope.vm.timeProfileModel.profile_type).toEqual('user');
     });
     it('sets the profile_tz to blank', function () {
-      expect($scope.timeProfileModel.profile_tz).toEqual('Alaska');
+      expect($scope.vm.timeProfileModel.profile_tz).toEqual('Alaska');
     });
     it('sets the all_days to false', function () {
-      expect($scope.timeProfileModel.all_days).toBeTruthy();
+      expect($scope.vm.timeProfileModel.all_days).toBeTruthy();
     });
     it('sets the all_hours to blank', function () {
-      expect($scope.timeProfileModel.all_hours).toBeTruthy();
+      expect($scope.vm.timeProfileModel.all_hours).toBeTruthy();
     });
   });
 

--- a/spec/javascripts/directives/configuration/all_time_check_spec.js
+++ b/spec/javascripts/directives/configuration/all_time_check_spec.js
@@ -1,13 +1,14 @@
 describe('allTimeCheck initialization', function() {
-  var $scope, form;
+  var $scope, form, angularForm;
   beforeEach(module('ManageIQ'));
   beforeEach(inject(function($compile, $rootScope) {
     $scope = $rootScope;
-    $scope.timeProfileModel = {};
-    $scope.timeProfileModel.dayValues = _.times(7, _.constant(false));
+    $scope.vm = {};
+    $scope.vm.timeProfileModel = {};
+    $scope.vm.timeProfileModel.dayValues = _.times(7, _.constant(false));
     var element = angular.element(
       '<form name="angularForm">' +
-      '<input type="checkbox" name="dayValue" ng-model="timeProfileModel.dayValues[0]" time-type="day" all-time-check="0"/>' +
+      '<input type="checkbox" name="dayValue" ng-model="vm.timeProfileModel.dayValues[0]" time-type="day" all-time-check="0"/>' +
       '</form>'
     );
     $compile(element)($scope);
@@ -17,21 +18,21 @@ describe('allTimeCheck initialization', function() {
 
   describe('allTimeCheck', function() {
     it('sets timeProfileModel.all_days to false if the selected day checkbox is false', function() {
-      $scope.timeProfileModel.dayValues = _.times(7, _.constant(true));
+      $scope.vm.timeProfileModel.dayValues = _.times(7, _.constant(true));
       angularForm.dayValue.$setViewValue(false);
-      expect($scope.timeProfileModel.all_days).toBeFalsy();
+      expect($scope.vm.timeProfileModel.all_days).toBeFalsy();
     });
 
     it('sets timeProfileModel.all_days to true if the selected day checkbox is true', function() {
-      $scope.timeProfileModel.dayValues = [false, true, true, true, true, true, true];
+      $scope.vm.timeProfileModel.dayValues = [false, true, true, true, true, true, true];
       angularForm.dayValue.$setViewValue(true);
-      expect($scope.timeProfileModel.all_days).toBeTruthy();
+      expect($scope.vm.timeProfileModel.all_days).toBeTruthy();
     });
 
     it('sets timeProfileModel.all_days to undefined if the selected day checkbox is true, but one other day is false', function() {
-      $scope.timeProfileModel.dayValues = [false, false, true, true, true, true, true];
+      $scope.vm.timeProfileModel.dayValues = [false, false, true, true, true, true, true];
       angularForm.dayValue.$setViewValue(true);
-      expect($scope.timeProfileModel.all_days).toBeUndefined();
+      expect($scope.vm.timeProfileModel.all_days).toBeUndefined();
     });
   });
 });

--- a/spec/javascripts/directives/configuration/min_time_check_spec.js
+++ b/spec/javascripts/directives/configuration/min_time_check_spec.js
@@ -1,13 +1,14 @@
 describe('minTimeCheck initialization', function() {
-  var $scope, form;
+  var $scope, form, angularForm;
   beforeEach(module('ManageIQ'));
   beforeEach(inject(function($compile, $rootScope) {
     $scope = $rootScope;
-    $scope.timeProfileModel = {};
-    $scope.timeProfileModel.dayValues = _.times(7, _.constant(false));
+    $scope.vm = {};
+    $scope.vm.timeProfileModel = {};
+    $scope.vm.timeProfileModel.dayValues = _.times(7, _.constant(false));
     var element = angular.element(
       '<form name="angularForm">' +
-      '<input type="checkbox" name="dayValue" ng-model="timeProfileModel.dayValues[0]" time-type="day" min-time-check="0"/>' +
+      '<input type="checkbox" name="dayValue" ng-model="vm.timeProfileModel.dayValues[0]" time-type="day" min-time-check="0"/>' +
       '</form>'
     );
     $compile(element)($scope);
@@ -18,12 +19,12 @@ describe('minTimeCheck initialization', function() {
   describe('minTimeCheck', function() {
     it('sets timeProfileModel.some_days_checked to false if a given day in a week checkbox is false', function() {
       angularForm.dayValue.$setViewValue(false);
-      expect($scope.timeProfileModel.some_days_checked).toBeFalsy();
+      expect($scope.vm.timeProfileModel.some_days_checked).toBeFalsy();
     });
 
     it('sets timeProfileModel.some_days_checked to true if a given day in a week checkbox is true', function() {
       angularForm.dayValue.$setViewValue(true);
-      expect($scope.timeProfileModel.some_days_checked).toBeTruthy();
+      expect($scope.vm.timeProfileModel.some_days_checked).toBeTruthy();
     });
   });
 });

--- a/spec/javascripts/directives/configuration/some_time_check_spec.js
+++ b/spec/javascripts/directives/configuration/some_time_check_spec.js
@@ -1,12 +1,13 @@
 describe('someTimeCheck initialization', function() {
-  var $scope, form;
+  var $scope, form, angularForm;
   beforeEach(module('ManageIQ'));
   beforeEach(inject(function($compile, $rootScope) {
     $scope = $rootScope;
-    $scope.timeProfileModel = {};
+    $scope.vm = {};
+    $scope.vm.timeProfileModel = {};
     var element = angular.element(
       '<form name="angularForm">' +
-      '<input type="checkbox" name="some_days_checked" ng-model="timeProfileModel.some_days_checked" time-type="day" some-time-check/>' +
+      '<input type="checkbox" name="some_days_checked" ng-model="vm.timeProfileModel.some_days_checked" time-type="day" some-time-check/>' +
       '</form>'
     );
     $compile(element)($scope);
@@ -16,7 +17,7 @@ describe('someTimeCheck initialization', function() {
 
   describe('someTimeCheck', function() {
     it('sets someTimeCheck error if none of the days are checked', function() {
-      $scope.timeProfileModel.dayValues = _.times(7, _.constant(false));
+      $scope.vm.timeProfileModel.dayValues = _.times(7, _.constant(false));
       angularForm.some_days_checked.$setViewValue('');
       expect(angularForm.some_days_checked.$error.someTimeCheck).toBeDefined();
       expect(angularForm.some_days_checked.$valid).toBeFalsy();
@@ -24,7 +25,7 @@ describe('someTimeCheck initialization', function() {
     });
 
     it('does not set someTimeCheck error if all of the days are checked', function() {
-      $scope.timeProfileModel.dayValues = _.times(7, _.constant(true));
+      $scope.vm.timeProfileModel.dayValues = _.times(7, _.constant(true));
       angularForm.some_days_checked.$setViewValue('');
       expect(angularForm.some_days_checked.$error.someTimeCheck).toBeUndefined();
       expect(angularForm.some_days_checked.$valid).toBeTruthy();
@@ -32,7 +33,7 @@ describe('someTimeCheck initialization', function() {
     });
 
     it('does not set someTimeCheck error if some of the days are checked', function() {
-      $scope.timeProfileModel.dayValues =[false, false, false, false, false, true, false];
+      $scope.vm.timeProfileModel.dayValues = [false, false, false, false, false, true, false];
       angularForm.some_days_checked.$setViewValue('');
       expect(angularForm.some_days_checked.$error.someTimeCheck).toBeUndefined();
       expect(angularForm.some_days_checked.$valid).toBeTruthy();


### PR DESCRIPTION
Replace `$scope` with `vm`. `$scope` is left only when needed to make edit buttons work.
Refactor `checkchange` directive to work with/without `$scope`.
Replace code that copies data with a function.

@AparnaKarve @himdel please have a look :)  

@miq-bot add_label wip