### PR TITLE
Fixed DOM element names for Utilization & Bottleneck tree select

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -147,9 +147,9 @@ function miqOnClickIncludeDomainPrefix() {
 
 function miqOnClickSelectOptimizeTreeNode(id) {
   var tree;
-  if (miqDomElementExists('miq_capacity_utilization')) {
+  if (miqDomElementExists('utilization_accord')) {
     tree = "utilization_tree";
-  } else if (miqDomElementExists('miq_capacity_bottlenecks')) {
+  } else if (miqDomElementExists('bottlenecks_accord')) {
     tree = "bottlenecks_tree";
   }
   if (id.split('-')[1].split('_')[0] == 'folder' ) {


### PR DESCRIPTION
Could not find any declarations of `#miq_capacity_utilization` and `#miq_capacity_bottlenecks` in our views so my guess is that they were dynamically created probably by dynatree or by some code that was removed during the `TreeBuilder` conversions. Anyway these elements are no longer there so I'm binding the conditional stuff to the accordion IDs.

https://bugzilla.redhat.com/show_bug.cgi?id=1417772
https://bugzilla.redhat.com/show_bug.cgi?id=1417774