### PR TITLE
x_dialog_buttons - call miqAjaxButton with complete:false

### DIFF
--- a/app/views/layouts/_x_dialog_buttons.html.haml
+++ b/app/views/layouts/_x_dialog_buttons.html.haml
@@ -15,31 +15,31 @@
               :class   => "btn btn-primary",
               :alt     => t = _("Save Changes"),
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "save")}');")
+              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "save")}', false, { complete: false });")
           - when "submit"
             = button_tag(t = _('Submit'),
               :class   => "btn btn-primary",
               :alt     => t,
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "submit")}');")
+              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "submit")}', false, { complete: false });")
           - when "continue"
             = button_tag(t = _('Continue'),
               :class   => "btn btn-default",
               :alt     => t,
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "continue")}');")
+              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "continue")}', false, { complete: false });")
           - when "reset"
             = button_tag(_('Reset'),
               :class   => "btn btn-default",
               :alt     => t = _("Reset Changes"),
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "reset")}');")
+              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "reset")}', false, { complete: false });")
           - when "cancel"
             = button_tag(t = _('Cancel'),
               :class   => "btn btn-default",
               :alt     => t,
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "cancel")}');")
+              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "cancel")}', false, { complete: false });")
 
       #buttons_off{:style => session[:changed] ? "display: none;" : ""}
         - buttons.each do |b|
@@ -57,4 +57,4 @@
              :class   => "btn btn-default",
              :alt     => t,
              :title   => t,
-             :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "cancel")}');")
+             :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "cancel")}', false, { complete: false });")


### PR DESCRIPTION
..to prevent the spinner from disappearing right before a redirect.

Go to Services > Catalogs (`/catalog/explorer`) (Services Catalog accordion)
Order a service
Fill out the needed info
Click Submit

before this, the spinner would disappear when the server responded (even though the response was a redirect), now, the spinner never disappears.

https://bugzilla.redhat.com/show_bug.cgi?id=1420314

---

Note that this assumes every single transition from that template is a redirect, otherwise we may get a few screens where the spinner never disappears. However, I haven't been able to find any such screens yet.