### PR TITLE
[WIP] Fix checkbox when saving global filters

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -154,8 +154,10 @@ module ApplicationController::Filter
   def adv_search_toggle
     @edit = session[:edit]
 
-    # Rebuild the pulldowns if opening the search box
-    @edit[@expkey].prefill_val_types unless @edit[:adv_search_open]
+    unless @edit[:adv_search_open]
+      @edit[@expkey].prefill_val_types # Rebuild the pulldowns if opening the search box
+      @edit[:search_type] = 'global' if @edit.fetch_path(:expression, :selected, :typ).present? && @edit[:expression][:selected][:typ] == 'global'
+    end
 
     render :update do |page|
       page << javascript_prologue

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -79,7 +79,7 @@
             %label.control-label.col-md-5
               = _("Global search:")
             .col-md-6
-              - checked = @edit && @edit[:expression] && @edit[:expression][:selected] && @edit[:expression][:selected][:typ] == "global"
+              - checked = @edit && @edit[:search_type] == "global"
               = check_box_tag("search_type", "1", checked,
                 :style                      => "width: 20px",
                 "data-miq_observe_checkbox" => {:url => url2}.to_json)


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1381622

If you select some of `'default' `filters under Global Filters
(I mean search_type) and open expression editor
and save a new filter with the same name but **not** global
(checkbox  _Global search_ unchecked),
it saves the filter with search_type `'global'`
which is wrong because the checkbox is not displayed properly.
You think that you are about to save a filter under My Filters
but this is not true because checkbox displays search_type
of selected filter which can be different to search_type
of filter which you want to save and if you don't change anything
in the window when saving a filter, displayed info doesn't update.
So sometimes it can work right, sometimes not, especially 
when you try to save filter more times (for example,
if error occurs and you try to save filter once again,
or if you want filters with the same name and different search_type,
just like in the BZ above).

This PR just fixes the checkbox.
The BZ will be completely fixed by merging this
and another PR in manageiq repo:
https://github.com/ManageIQ/manageiq/pull/13816