### PR TITLE
Allow enroll state to transition to manageable

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -2399,11 +2399,11 @@ module ApplicationController::CiProcessing
       end
     when "manageable"
       each_host(hosts, task_name) do |host|
-        if ["available", "adoptfail", "inspectfail", "cleanfail"].include?(host.hardware.provision_state)
+        if %w(enroll available adoptfail inspectfail cleanfail).include?(host.hardware.provision_state)
           host.manageable_queue(session[:userid])
           add_flash(_("\"%{record}\": %{task} successfully initiated") % {:record => host.name, :task => (display_name || task)})
         else
-          add_flash(_("\"%{task}\": not available for %{hostname}. %{hostname}'s provision state must be in \"available\", \"adoptfail\", \"cleanfail\", or \"inspectfail\"") % {:hostname => host.name, :task => (display_name || task)}, :error)
+          add_flash(_("\"%{task}\": not available for %{hostname}. %{hostname}'s provision state must be in \"available\", \"adoptfail\", \"cleanfail\", \"enroll\", or \"inspectfail\"") % {:hostname => host.name, :task => (display_name || task)}, :error)
         end
       end
     when "introspect"


### PR DESCRIPTION
Starting with OSP10 registered nodes can start at the 'enroll'
state if --initial-state=enroll is passed into "openstack
baremetal import".

http://tripleo.org/advanced_deployment/node_states.html

Previously, registered nodes defaulted to available.

This patch allows nodes in 'enroll' state to transition to
'manageable' state. Previously, the transition was not possible.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1413371