### PR TITLE
Moved out methods related to VM remote access to a separate mixin

### DIFF
--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -1,5 +1,6 @@
 class VmCloudController < ApplicationController
   include VmCommon # common methods for vm controllers
+  include VmRemote # methods for VM remote access
   include VmShowMixin
 
   before_action :check_privileges

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -95,86 +95,12 @@ module VmCommon
   alias_method :vm_timeline, :show_timeline
   alias_method :miq_template_timeline, :show_timeline
 
-  # Launch a VM console
-  def console
-    console_type = ::Settings.server.remote_console_type.downcase
-    params[:task_id] ? console_after_task(console_type) : console_before_task(console_type)
-  end
-  alias_method :vmrc_console, :console  # VMRC needs its own URL for RBAC checking
-
-  def launch_cockpit
-    vm = identify_record(params[:id], VmOrTemplate)
-
-    if vm.supports_launch_cockpit?
-      javascript_open_window(vm.cockpit_url)
-    else
-      javascript_flash(:text => vm.unsupported_reason(:launch_cockpit), :severity => :error, :spinner_off => true)
-    end
-  end
-
-  def html5_console
-    params[:task_id] ? console_after_task('html5') : console_before_task('html5')
-  end
-
-  def launch_vmware_console
-    console_type = ::Settings.server.remote_console_type.downcase
-    @vm = @record = identify_record(params[:id], VmOrTemplate)
-    options = case console_type
-              when "mks"
-                @sb[:mks].update(
-                  :version     => ::Settings.server.mks_version,
-                  :mks_classid => ::Settings.server.mks_classid
-                )
-              when "vmrc"
-                host = @record.ext_management_system.ipaddress || @record.ext_management_system.hostname
-                vmid = @record.ems_ref
-                {
-                  :host        => host,
-                  :vmid        => @record.ems_ref,
-                  :ticket      => j(params[:ticket]),
-                  :api_version => @record.ext_management_system.api_version.to_s,
-                  :os          => browser_info(:os),
-                  :name        => @record.name,
-                  :vmrc_uri    => URI::Generic.build(:scheme   => "vmrc",
-                                                     :userinfo => "clone:#{params[:ticket]}",
-                                                     :host     => host,
-                                                     :port     => 443,
-                                                     :path     => "/",
-                                                     :query    => "moid=#{vmid}")
-                }
-              end
-    render :template => "vm_common/console_#{console_type}",
-           :layout   => false,
-           :locals   => options
-  end
-
   def hide_vms
     !User.current_user.settings.fetch_path(:display, :display_vms) # default value is false
   end
 
   def vm_selected
     @vm.present?
-  end
-
-  def launch_html5_console
-    scheme = request.ssl? ? 'wss' : 'ws'
-    override_content_security_policy_directives(
-      :connect_src => ["'self'", "#{scheme}://#{request.env['HTTP_HOST']}"],
-      :img_src     => %w(data: 'self')
-    )
-    %i(secret url proto).each { |p| params.require(p) }
-
-    proto = j(params[:proto])
-    if %w(vnc spice).include?(proto) # VMWare, RHEV
-      @console = {
-        :url    => j(params[:url]),
-        :secret => j(params[:secret]),
-        :type   => proto
-      }
-      render(:template => 'layouts/remote_console', :layout => false)
-    else
-      raise 'Unsupported protocol'
-    end
   end
 
   def x_show
@@ -1066,53 +992,6 @@ module VmCommon
   end
 
   private
-
-  # First time thru, kick off the acquire ticket task
-  def console_before_task(console_type)
-    ticket_type = console_type.to_sym
-
-    record = identify_record(params[:id], VmOrTemplate)
-    ems = record.ext_management_system
-    if ems.class.ems_type == 'vmwarews'
-      ticket_type = :vnc if console_type == 'html5'
-      begin
-        ems.validate_remote_console_vmrc_support
-      rescue MiqException::RemoteConsoleNotSupportedError => e
-        add_flash(_("Console access failed: %{message}") % {:message => e.message}, :error)
-        javascript_flash(:spinner_off => true)
-        return
-      end
-    end
-
-    task_id = record.remote_console_acquire_ticket_queue(ticket_type, session[:userid])
-    add_flash(_("Console access failed: Task start failed: ID [%{id}]") %
-                {:id => task_id.to_s}, :error) unless task_id.kind_of?(Integer)
-
-    if @flash_array
-      javascript_flash(:spinner_off => true)
-    else
-      initiate_wait_for_task(:task_id => task_id)
-    end
-  end
-
-  # Task complete, show error or launch console using VNC/MKS/VMRC task info
-  def console_after_task(console_type)
-    miq_task = MiqTask.find(params[:task_id])
-    unless miq_task.results_ready?
-      add_flash(_("Console access failed: %{message}") % {:message => miq_task.message}, :error)
-    end
-    if @flash_array
-      javascript_flash(:spinner_off => true)
-    else # open a window to show a VNC or VMWare console
-      url = if miq_task.task_results[:remote_url]
-              miq_task.task_results[:remote_url]
-            else
-              console_action = console_type == 'html5' ? 'launch_html5_console' : 'launch_vmware_console'
-              url_for(miq_task.task_results.merge(:controller => controller_name, :action => console_action, :id => j(params[:id])))
-            end
-      javascript_open_window(url)
-    end
-  end
 
   # Check for parent nodes missing from vandt tree and return them if any
   def open_parent_nodes(record)

--- a/app/controllers/vm_controller.rb
+++ b/app/controllers/vm_controller.rb
@@ -3,7 +3,8 @@ class VmController < ApplicationController
   before_action :get_session_data
   after_action :cleanup_action
   after_action :set_session_data
-  include VmCommon        # common methods for vm controllers
+  include VmCommon # common methods for vm controllers
+  include VmRemote # methods for VM remote access
 
   def index
     session[:vm_type] = nil             # Reset VM type if coming in from All tab

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -1,5 +1,6 @@
 class VmInfraController < ApplicationController
-  include VmCommon        # common methods for vm controllers
+  include VmCommon # common methods for vm controllers
+  include VmRemote # methods for VM remote access
   include VmShowMixin
 
   before_action :check_privileges

--- a/app/controllers/vm_or_template_controller.rb
+++ b/app/controllers/vm_or_template_controller.rb
@@ -1,5 +1,6 @@
 class VmOrTemplateController < ApplicationController
-  include VmCommon        # common methods for vm controllers
+  include VmCommon # common methods for vm controllers
+  include VmRemote # methods for VM remote access
   include VmShowMixin
 
   before_action :check_privileges

--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -1,0 +1,126 @@
+module VmRemote
+  extend ActiveSupport::Concern
+
+  # Launch a VM console
+  def console
+    console_type = ::Settings.server.remote_console_type.downcase
+    params[:task_id] ? console_after_task(console_type) : console_before_task(console_type)
+  end
+  alias_method :vmrc_console, :console # VMRC needs its own URL for RBAC checking
+
+  def launch_cockpit
+    vm = identify_record(params[:id], VmOrTemplate)
+
+    if vm.supports_launch_cockpit?
+      javascript_open_window(vm.cockpit_url)
+    else
+      javascript_flash(:text => vm.unsupported_reason(:launch_cockpit), :severity => :error, :spinner_off => true)
+    end
+  end
+
+  def html5_console
+    params[:task_id] ? console_after_task('html5') : console_before_task('html5')
+  end
+
+  def launch_vmware_console
+    console_type = ::Settings.server.remote_console_type.downcase
+    @vm = @record = identify_record(params[:id], VmOrTemplate)
+    options = case console_type
+              when "mks"
+                @sb[:mks].update(
+                  :version     => ::Settings.server.mks_version,
+                  :mks_classid => ::Settings.server.mks_classid
+                )
+              when "vmrc"
+                host = @record.ext_management_system.ipaddress || @record.ext_management_system.hostname
+                vmid = @record.ems_ref
+                {
+                  :host        => host,
+                  :vmid        => @record.ems_ref,
+                  :ticket      => j(params[:ticket]),
+                  :api_version => @record.ext_management_system.api_version.to_s,
+                  :os          => browser_info(:os),
+                  :name        => @record.name,
+                  :vmrc_uri    => URI::Generic.build(:scheme   => "vmrc",
+                                                     :userinfo => "clone:#{params[:ticket]}",
+                                                     :host     => host,
+                                                     :port     => 443,
+                                                     :path     => "/",
+                                                     :query    => "moid=#{vmid}")
+                }
+              end
+    render :template => "vm_common/console_#{console_type}",
+           :layout   => false,
+           :locals   => options
+  end
+
+  def launch_html5_console
+    scheme = request.ssl? ? 'wss' : 'ws'
+    override_content_security_policy_directives(
+      :connect_src => ["'self'", "#{scheme}://#{request.env['HTTP_HOST']}"],
+      :img_src     => %w(data: 'self')
+    )
+    %i(secret url proto).each { |p| params.require(p) }
+
+    proto = j(params[:proto])
+    if %w(vnc spice).include?(proto) # VMWare, RHEV
+      @console = {
+        :url    => j(params[:url]),
+        :secret => j(params[:secret]),
+        :type   => proto
+      }
+      render(:template => 'layouts/remote_console', :layout => false)
+    else
+      raise 'Unsupported protocol'
+    end
+  end
+
+  private
+
+  # First time thru, kick off the acquire ticket task
+  def console_before_task(console_type)
+    ticket_type = console_type.to_sym
+
+    record = identify_record(params[:id], VmOrTemplate)
+    ems = record.ext_management_system
+    if ems.class.ems_type == 'vmwarews'
+      ticket_type = :vnc if console_type == 'html5'
+      begin
+        ems.validate_remote_console_vmrc_support
+      rescue MiqException::RemoteConsoleNotSupportedError => e
+        add_flash(_("Console access failed: %{message}") % {:message => e.message}, :error)
+        javascript_flash(:spinner_off => true)
+        return
+      end
+    end
+
+    task_id = record.remote_console_acquire_ticket_queue(ticket_type, session[:userid])
+    add_flash(_("Console access failed: Task start failed: ID [%{id}]") %
+                {:id => task_id.to_s}, :error) unless task_id.kind_of?(Integer)
+
+    if @flash_array
+      javascript_flash(:spinner_off => true)
+    else
+      initiate_wait_for_task(:task_id => task_id)
+    end
+  end
+
+  # Task complete, show error or launch console using VNC/MKS/VMRC task info
+  def console_after_task(console_type)
+    miq_task = MiqTask.find(params[:task_id])
+    unless miq_task.results_ready?
+      add_flash(_("Console access failed: %{message}") % {:message => miq_task.message}, :error)
+    end
+    if @flash_array
+      javascript_flash(:spinner_off => true)
+    else # open a window to show a VNC or VMWare console
+      url = if miq_task.task_results[:remote_url]
+              miq_task.task_results[:remote_url]
+            else
+              console_action = console_type == 'html5' ? 'launch_html5_console' : 'launch_vmware_console'
+              url_for(miq_task.task_results.merge(:controller => controller_name, :action => console_action, :id => j(params[:id])))
+            end
+      javascript_open_window(url)
+    end
+  end
+end


### PR DESCRIPTION
I think these things deserve to live in a separate file. As it was in `VmCommon`, it got included even in `MiqTemplateController` where it has nothing to do. Also fixed some rubocop issues by calling `rubocop -a` on the new file.

@miq-bot add_label refactoring, euwe/no
@anyMartin could you please take a look at this?