### PR TITLE
Remove VNC proxy from the UI as it is not used anywhere in the code

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -607,17 +607,6 @@ module OpsController::Settings::Common
         (@edit[:new][:server][:custom_support_url_description].nil? || @edit[:new][:server][:custom_support_url_description].strip == "") && (!@edit[:new][:server][:custom_support_url].nil? && @edit[:new][:server][:custom_support_url].strip != ""))
       add_flash(_("Custom Support URL and Description both must be entered."), :error)
     end
-    if @sb[:active_tab] == "settings_server" && @edit[:new].fetch_path(:server, :remote_console_type) == "VNC"
-      unless @edit[:new][:server][:vnc_proxy_port] =~ /^\d+$/ || @edit[:new][:server][:vnc_proxy_port].blank?
-        add_flash(_("VNC Proxy Port must be numeric"), :error)
-      end
-      unless (@edit[:new][:server][:vnc_proxy_address].blank? &&
-          @edit[:new][:server][:vnc_proxy_port].blank?) ||
-             (!@edit[:new][:server][:vnc_proxy_address].blank? &&
-                 !@edit[:new][:server][:vnc_proxy_port].blank?)
-        add_flash(_("When configuring a VNC Proxy, both Address and Port are required"), :error)
-      end
-    end
   end
 
   def smartproxy_affinity_get_form_vars(id, checked)
@@ -968,8 +957,6 @@ module OpsController::Settings::Common
       @edit[:current].config[:server][:timezone] = "UTC" if @edit[:current].config[:server][:timezone].blank?
       @edit[:current].config[:server][:locale] = "default" if @edit[:current].config[:server][:locale].blank?
       @edit[:current].config[:server][:remote_console_type] ||= "MKS"
-      @edit[:current].config[:server][:vnc_proxy_address] ||= nil
-      @edit[:current].config[:server][:vnc_proxy_port] ||= nil
       @edit[:current].config[:smtp][:enable_starttls_auto] = GenericMailer.default_for_enable_starttls_auto if @edit[:current].config[:smtp][:enable_starttls_auto].nil?
       @edit[:current].config[:smtp][:openssl_verify_mode] ||= nil
       @edit[:current].config[:ntp] ||= {}

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -144,26 +144,6 @@
                         :class    => "selectpicker")
       :javascript
         miqSelectPickerEvent('server_mks_version', "#{url}")
-
-    - elsif @edit[:new][:server][:remote_console_type] == "VNC"
-      .form-group
-        %label.col-md-2.control-label
-          = _("VNC Proxy Address")
-        .col-md-8
-          = text_field_tag("server_vnc_proxy_address",
-                            @edit[:new][:server][:vnc_proxy_address],
-                            :maxlength => MAX_NAME_LEN,
-                            :class => "form-control",
-                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-      .form-group
-        %label.col-md-2.control-label
-          = _("VNC Proxy Port")
-        .col-md-8
-          = text_field_tag("server_vnc_proxy_port",
-                          @edit[:new][:server][:vnc_proxy_port],
-                          :maxlength => 6, :size => 6,
-                          :class => "form-control",
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %hr
   %h3
     = _("NTP Servers")


### PR DESCRIPTION
I haven't found any use of the `vnc_proxy_address` and `vnc_proxy_port` parameters and as we're using our own [`WebsocketProxy`](https://github.com/ManageIQ/manageiq/blob/daae7ae3f709c2f04c1e34343b6ba6cbf6512159/lib/websocket_proxy.rb), it would be even obsolete to have such feature. :scissors: :scissors: :scissors: :toilet: :toilet: :toilet: 

**Before:**
![screenshot from 2017-02-09 12-45-06](https://cloud.githubusercontent.com/assets/649130/22782092/ceafb836-eec5-11e6-8cb4-24ca8074c8cb.png)

**After:**
![screenshot from 2017-02-09 12-46-52](https://cloud.githubusercontent.com/assets/649130/22782108/d9b93e96-eec5-11e6-8712-5cbca39b1888.png)

@miq-bot add_label euwe/no, technical debt

/cc @bmclaughlin @anyMartin @dclarizio 