### PR TITLE
Fix grouping in CU charts

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -859,7 +859,7 @@ module ApplicationController::Performance
     # Grab the first (and should be only) chart column
     col = chart[:columns].first
     # Create the new chart columns for each tag
-    chart[:columns] ||= rpt.extras[:group_by_tags].collect { |t| col + "_" + t }
+    chart[:columns] = rpt.extras[:group_by_tags].collect { |t| col + "_" + t }
   end
 
   def gen_perf_chart(chart, rpt, idx, zoom_action)


### PR DESCRIPTION
Fix broken grouping for C&U charts. Reintroduced bug with missing bad formatting for these charts. Will fix in following PR.

https://bugzilla.redhat.com/show_bug.cgi?id=1417794

Screenshots
-----------

Before:
![screencapture-localhost-3000-host-show-10000000000017-1487063395008](https://cloud.githubusercontent.com/assets/9535558/22922364/c39115cc-f29d-11e6-955b-639b6934e8a6.png)


After:
![screencapture-localhost-3000-host-show-10000000000017-1487063016635](https://cloud.githubusercontent.com/assets/9535558/22922362/c1c33216-f29d-11e6-8896-f1719beefd99.png)

How to test
--------
1. Have some provider with C&U
2. Refresh Provider
3. Find VM cu-24x7 and tag it.
4. Find its cluster.
5. Go to Configuration -> Server, turn on C&U
6. Go to Configuration -> Region -> C&U Collection turn on for cluster.
7. Go to Configuration -> Region -> Red Hat Categories turn on Capture C&U for category you use to tag VM.
8. Find host Monitoring -> Utilization -> Select Group by category which you set

You may need to wait some time to collect some C&U data
