### PR TITLE
Use table name when generating SQL to filter tasks on `Tasks` screen 

### DIFF
--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -74,8 +74,7 @@ class MiqTaskController < ApplicationController
 
   def get_jobs
     @lastaction = "jobs"
-
-    # Do we use @layout outside of this class, can it be removed ?
+    
     if @tabform == "tasks_1"
       @layout = "my_tasks"
       drop_breadcrumb(:name => _("My VM and Container Analysis Tasks"), :url => "/miq_task/index?jobs_tab=tasks")
@@ -406,16 +405,22 @@ class MiqTaskController < ApplicationController
   end
 
   def build_query_for_running
-    return ["(#{db_table}state!=? AND #{db_table}state!=? AND #{db_table}state!=?)", %w(finished waiting_to_start queued)] if vm_analysis_task?
-    ["(#{db_table}state!=? AND #{db_table}state!=? AND #{db_table}state!=?)", %w(Finished waiting_to_start Queued)]
+    sql = "(#{db_table}state!=? AND #{db_table}state!=? AND #{db_table}state!=?)"
+    if vm_analysis_task?
+      [sql, %w(finished waiting_to_start queued)]
+    else
+      [sql, %w(Finished waiting_to_start Queued)]
+    end
   end
 
   def build_query_for_status_none_selected
+    sql = "(#{db_table}status!=? AND #{db_table}status!=? AND #{db_table}status!=? AND " +
+          "#{db_table}state!=? AND #{db_table}state!=?)"
     if vm_analysis_task?
-      return ["(#{db_table}status!=? AND #{db_table}status!=? AND #{db_table}status!=? AND #{db_table}state!=? AND #{db_table}state!=?)",
-              %w(ok error warn finished waiting_to_start)]
+      [sql , %w(ok error warn finished waiting_to_start)]
+    else
+      [sql, %w(Ok Error Warn Finished Queued)]
     end
-    ["(#{db_table}status!=? AND #{db_table}status!=? AND #{db_table}status!=? AND #{db_table}state!=? AND #{db_table}state!=?)", %w(Ok Error Warn Finished Queued)]
   end
 
   def build_query_for_time_period(opts)

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -77,22 +77,19 @@ class MiqTaskController < ApplicationController
     
     if @tabform == "tasks_1"
       @layout = "my_tasks"
-      drop_breadcrumb(:name => _("My VM and Container Analysis Tasks"), :url => "/miq_task/index?jobs_tab=tasks")
 
     elsif @tabform == "tasks_2"
       # My UI Tasks
       @layout = "my_ui_tasks"
-      drop_breadcrumb(:name => _("My Other UI Tasks"), :url => "/miq_task/index?jobs_tab=tasks")
+
 
     elsif @tabform == "tasks_3" || @tabform == "alltasks_1"
       @layout = "all_tasks"
-      drop_breadcrumb(:name => _("All VM and Container Analysis Tasks"), :url => "/miq_task/index?jobs_tab=alltasks")
       @user_names = Job.distinct("userid").pluck("userid").delete_if(&:blank?)
 
     elsif @tabform == "tasks_4" || @tabform == "alltasks_2"
       # All UI Tasks
       @layout = "all_ui_tasks"
-      drop_breadcrumb(:name => _("All Other Tasks"), :url => "/miq_task/index?jobs_tab=alltasks")
       @user_names = MiqTask.distinct("userid").pluck("userid").delete_if(&:blank?)
     end
 

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -57,8 +57,8 @@ class MiqTaskController < ApplicationController
     @edit[:opts] = {}
     @edit[:opts] = copy_hash(@tasks_options[@tabform])   # Backup current settings
 
+    get_jobs
     if pagination_request?
-      get_jobs(tasks_condition(@tasks_options[@tabform]))
       render :update do |page|
         page << javascript_prologue
         page.replace_html("gtl_div", :partial => "layouts/gtl", :locals => {:action_url => @lastaction})
@@ -69,38 +69,34 @@ class MiqTaskController < ApplicationController
                                                      :headers    => @view.headers})
         page << "miqSparkle(false);"  # Need to turn off sparkle in case original ajax element gets replaced
       end
-    else                      # Came in from non-ajax, just get the jobs
-      get_jobs(tasks_condition(@tasks_options[@tabform]))
     end
   end
 
-  def get_jobs(conditions)
+  def get_jobs
     @lastaction = "jobs"
 
     if @tabform == "tasks_1"
       @layout = "my_tasks"
-      @view, @pages = get_view(Job, :conditions => conditions)  # Get the records (into a view) and the paginator
       drop_breadcrumb(:name => _("My VM and Container Analysis Tasks"), :url => "/miq_task/index?jobs_tab=tasks")
 
     elsif @tabform == "tasks_2"
       # My UI Tasks
       @layout = "my_ui_tasks"
-      @view, @pages = get_view(MiqTask, :conditions => conditions)  # Get the records (into a view) and the paginator
       drop_breadcrumb(:name => _("My Other UI Tasks"), :url => "/miq_task/index?jobs_tab=tasks")
 
     elsif @tabform == "tasks_3" || @tabform == "alltasks_1"
       @layout = "all_tasks"
-      @view, @pages = get_view(Job, :conditions => conditions)  # Get the records (into a view) and the paginator
       drop_breadcrumb(:name => _("All VM and Container Analysis Tasks"), :url => "/miq_task/index?jobs_tab=alltasks")
       @user_names = Job.distinct("userid").pluck("userid").delete_if(&:blank?)
 
     elsif @tabform == "tasks_4" || @tabform == "alltasks_2"
       # All UI Tasks
       @layout = "all_ui_tasks"
-      @view, @pages = get_view(MiqTask, :conditions => conditions)  # Get the records (into a view) and the paginator
       drop_breadcrumb(:name => _("All Other Tasks"), :url => "/miq_task/index?jobs_tab=alltasks")
       @user_names = MiqTask.distinct("userid").pluck("userid").delete_if(&:blank?)
     end
+    
+    @view, @pages = get_view(db_class, :conditions => tasks_condition(@tasks_options[@tabform]))
   end
 
   # Cancel a single selected job
@@ -288,7 +284,7 @@ class MiqTaskController < ApplicationController
       @edit[:opts] = copy_hash(@tasks_options[@tabform]) # Backup current settings
     end
 
-    get_jobs(tasks_condition(@tasks_options[@tabform]))  # Get the jobs based on the latest options
+    get_jobs  # Get the jobs based on the latest options
     @pp_choices = PPCHOICES2                             # Get special pp choices for jobs/tasks lists
 
     render :update do |page|
@@ -314,6 +310,13 @@ class MiqTaskController < ApplicationController
     end
   end
 
+  def db_table
+    case @layout
+      when 'my_tasks', 'all_tasks'       then %Q["jobs"]
+      when 'my_ui_tasks', 'all_ui_tasks' then %Q["miq_tasks"]
+    end
+  end
+  
   # Set all task options to default
   def tasks_set_default_options
     @tasks_options[@tabform] = {
@@ -334,6 +337,9 @@ class MiqTaskController < ApplicationController
   # Create a condition from the passed in options
   def tasks_condition(opts, use_times = true)
     cond = [[]]
+    
+    cond = add_to_condition(cond, "\"jobs\".\"guid\" IS NULL", nil) unless vm_analysis_task?
+    
     cond = add_to_condition(cond, *build_query_for_userid(opts))
 
     if !opts[:ok] && !opts[:queued] && !opts[:error] && !opts[:warn] && !opts[:running]
@@ -362,8 +368,8 @@ class MiqTaskController < ApplicationController
   end
 
   def build_query_for_userid(opts)
-    return ["userid=?", session[:userid]] if %w(tasks_1 tasks_2).include?(@tabform)
-    return ["userid=?", opts[:user_choice]] if opts[:user_choice] && opts[:user_choice] != "all"
+    return ["#{db_table}.\"userid\"=?", session[:userid]] if %w(tasks_1 tasks_2).include?(@tabform)
+    return ["#{db_table}.\"userid\"=?", opts[:user_choice]] if opts[:user_choice] && opts[:user_choice] != "all"
     return nil, nil
   end
 
@@ -378,7 +384,7 @@ class MiqTaskController < ApplicationController
   end
 
   def build_query_for_queued
-    ["(state=? OR state=?)", %w(waiting_to_start Queued)]
+    ["(#{db_table}.\"state\"=? OR #{db_table}.\"state\"=?)", %w(waiting_to_start Queued)]
   end
 
   def build_query_for_ok
@@ -394,32 +400,32 @@ class MiqTaskController < ApplicationController
   end
 
   def build_query_for_status_completed(status)
-    return ["(state=? AND status=?)", ["finished", status]] if vm_analysis_task?
-    ["(state=? AND status=?)", ["Finished", status.capitalize]]
+    return ["(#{db_table}.\"state\"=? AND #{db_table}.\"status\"=?)", ["finished", status]] if vm_analysis_task?
+    ["(#{db_table}.\"state\"=? AND #{db_table}.\"status\"=?)", ["Finished", status.capitalize]]
   end
 
   def build_query_for_running
-    return ["(state!=? AND state!=? AND state!=?)", %w(finished waiting_to_start queued)] if vm_analysis_task?
-    ["(state!=? AND state!=? AND state!=?)", %w(Finished waiting_to_start Queued)]
+    return ["(#{db_table}.\"state\"!=? AND #{db_table}.\"state\"!=? AND #{db_table}.\"state\"!=?)", %w(finished waiting_to_start queued)] if vm_analysis_task?
+    ["(#{db_table}.\"state\"!=? AND #{db_table}.\"state\"!=? AND #{db_table}.\"state\"!=?)", %w(Finished waiting_to_start Queued)]
   end
 
   def build_query_for_status_none_selected
-    return ["(status!=? AND status!=? AND status!=? AND state!=? AND state!=?)",
+    return ["(#{db_table}.\"status\"!=? AND #{db_table}.\"status\"!=? AND #{db_table}.\"status\"!=? AND #{db_table}\"state\"!=? AND #{db_table}.\"state\"!=?)",
             %w(ok error warn finished waiting_to_start)] if vm_analysis_task?
-    ["(status!=? AND status!=? AND status!=? AND state!=? AND state!=?)", %w(Ok Error Warn Finished Queued)]
+    ["(#{db_table}.\"status\"!=? AND #{db_table}.\"status\"!=? AND #{db_table}.\"status\"!=? AND #{db_table}.\"state\"!=? AND #{db_table}.\"state\"!=?)", %w(Ok Error Warn Finished Queued)]
   end
 
   def build_query_for_time_period(opts)
     t = format_timezone(opts[:time_period].to_i != 0 ? opts[:time_period].days.ago : Time.now, Time.zone, "raw")
-    ["updated_on>=? AND updated_on<=?", [t.beginning_of_day, t.end_of_day]]
+    ["#{db_table}.\"updated_on\">=? AND #{db_table}.\"updated_on\"<=?", [t.beginning_of_day, t.end_of_day]]
   end
 
   def build_query_for_zone(opts)
-    ["zone=?", opts[:zone]]
+    ["#{db_table}.\"zone\"=?", opts[:zone]]
   end
 
   def build_query_for_state(opts)
-    ["state=?", opts[:state_choice]]
+    ["#{db_table}.\"state\"=?", opts[:state_choice]]
   end
 
   def vm_analysis_task?

--- a/spec/controllers/miq_task_controller_spec.rb
+++ b/spec/controllers/miq_task_controller_spec.rb
@@ -242,14 +242,14 @@ describe MiqTaskController do
       end
 
       it "all defaults" do
-        query = 'userid=? AND ('\
-                '(state=? OR state=?) OR '\
-                '(state=? AND status=?) OR '\
-                '(state=? AND status=?) OR '\
-                '(state=? AND status=?) OR '\
-                '(state!=? AND state!=? AND state!=?)) AND '\
-                'updated_on>=? AND '\
-                'updated_on<=?'
+        query = 'jobs.guid IS NULL AND miq_tasks.userid=? AND ('\
+                '(miq_tasks.state=? OR miq_tasks.state=?) OR '\
+                '(miq_tasks.state=? AND miq_tasks.status=?) OR '\
+                '(miq_tasks.state=? AND miq_tasks.status=?) OR '\
+                '(miq_tasks.state=? AND miq_tasks.status=?) OR '\
+                '(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND '\
+                'miq_tasks.updated_on>=? AND '\
+                'miq_tasks.updated_on<=?'
         expected = [query, user.userid, "waiting_to_start", "Queued", "Finished", "Ok",
                     "Finished", "Error", "Finished", "Warn", "Finished", "waiting_to_start", "Queued"
                    ]
@@ -264,12 +264,12 @@ describe MiqTaskController do
                  :state_choice => "Initialized",
                  :time_period  => 6)
 
-        query = "userid=? AND ("\
-                "(state=? OR state=?) OR "\
-                "(state!=? AND state!=? AND state!=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND ("\
+                "(miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, user.userid, "waiting_to_start", "Queued", "Finished", "waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Initialized"
         expect(subject).to eq(expected)
@@ -282,12 +282,12 @@ describe MiqTaskController do
                  :state_choice => "Active",
                  :time_period  => 6)
 
-        query = "userid=? AND "\
-                "((state=? OR state=?) OR "\
-                "(state!=? AND state!=? AND state!=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, user.userid, "waiting_to_start", "Queued", "Finished", "waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Active"
         expect(subject).to eq(expected)
@@ -296,12 +296,12 @@ describe MiqTaskController do
       it "Time period: 6 Days Ago, status: queued and running, state: finished" do
         set_opts(:ok => nil, :error => nil, :warn => nil, :state_choice => "Finished", :time_period => 6)
 
-        query = "userid=? AND "\
-                "((state=? OR state=?) OR "\
-                "(state!=? AND state!=? AND state!=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, user.userid, "waiting_to_start", "Queued", "Finished", "waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Finished"
         expect(subject).to eq(expected)
@@ -316,11 +316,11 @@ describe MiqTaskController do
                  :state_choice => "Queued",
                  :time_period  => 6)
 
-        query = "userid=? AND "\
-                "((state=? AND status=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "((miq_tasks.state=? AND miq_tasks.status=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
 
         expected = [query, user.userid, "Finished", "Ok"]
         expected += get_time_period(@opts[:time_period]) << "Queued"
@@ -336,12 +336,12 @@ describe MiqTaskController do
                  :state_choice => "Queued",
                  :time_period  => 6)
 
-        query = "userid=? AND "\
-                "((state=? AND status=?) OR "\
-                "(state=? AND status=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "((miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, user.userid, "Finished", "Ok", "Finished", "Warn"]
         expected += get_time_period(@opts[:time_period]) << "Queued"
         expect(subject).to eq(expected)
@@ -356,13 +356,13 @@ describe MiqTaskController do
                  :state_choice => "Queued",
                  :time_period  => 6)
 
-        query = "userid=? AND "\
-                "((state=? AND status=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state=? AND status=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "((miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, user.userid, "Finished", "Ok", "Finished", "Error", "Finished", "Warn"]
         expected += get_time_period(@opts[:time_period]) << "Queued"
         expect(subject).to eq(expected)
@@ -371,10 +371,11 @@ describe MiqTaskController do
       it "Time Period: Last 24, Status: none checked, State: All" do
         set_opts(:ok => nil, :queued => nil, :error => nil, :warn => nil, :running => nil)
 
-        query = "userid=? AND "\
-                "(status!=? AND status!=? AND status!=? AND state!=? AND state!=?) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND "\
+                "miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=?"
         expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued"]
         expected += get_time_period(@opts[:time_period])
         expect(subject).to eq(expected)
@@ -383,11 +384,12 @@ describe MiqTaskController do
       it "Time Period: Last 24, Status: none checked, State: Active" do
         set_opts(:ok => nil, :queued => nil, :error => nil, :warn => nil, :running => nil, :state_choice => "Active")
 
-        query = "userid=? AND "\
-                "(status!=? AND status!=? AND status!=? AND state!=? AND state!=?) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND "\
+                "miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Active"
         expect(subject).to eq(expected)
@@ -402,11 +404,12 @@ describe MiqTaskController do
                  :state_choice => "Finished",
                  :time_period  => 1)
 
-        query = "userid=? AND "\
-                "(status!=? AND status!=? AND status!=? AND state!=? AND state!=?) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND "\
+                "miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Finished"
         expect(subject).to eq(expected)
@@ -421,11 +424,12 @@ describe MiqTaskController do
                  :state_choice => "Initialized",
                  :time_period  => 2)
 
-        query = "userid=? AND "\
-                "(status!=? AND status!=? AND status!=? AND state!=? AND state!=?) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND "\
+                "miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Initialized"
         expect(subject).to eq(expected)
@@ -440,11 +444,12 @@ describe MiqTaskController do
                  :state_choice => "Queued",
                  :time_period  => 3)
 
-        query = "userid=? AND "\
-                "(status!=? AND status!=? AND status!=? AND state!=? AND state!=?) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.state!=? AND "\
+                "miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, user.userid, "Ok", "Error", "Warn", "Finished", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Queued"
         expect(subject).to eq(expected)
@@ -677,13 +682,13 @@ describe MiqTaskController do
       end
 
       it "all defaults" do
-        query = "((state=? OR state=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state!=? AND state!=? AND state!=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=?"
+        query = "jobs.guid IS NULL AND ((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=?"
         expected = [query, "waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
                     "Finished", "Warn", "Finished", "waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period])
@@ -693,14 +698,14 @@ describe MiqTaskController do
       it "user: all, Time period: 1 Day Ago, status: queued, running, ok, error and warn, state: active" do
         set_opts(:state_choice => "Active", :time_period => 1)
 
-        query = "((state=? OR state=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state!=? AND state!=? AND state!=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND ((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, "waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
                     "Finished", "Warn", "Finished", "waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Active"
@@ -710,14 +715,14 @@ describe MiqTaskController do
       it "user: all, Time period: 1 Day Ago, status: queued, running, ok, error and warn, state: finished" do
         set_opts(:state_choice => "Finished", :time_period => 1)
 
-        query = "((state=? OR state=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state!=? AND state!=? AND state!=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND ((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, "waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
                     "Finished", "Warn", "Finished", "waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Finished"
@@ -727,13 +732,13 @@ describe MiqTaskController do
       it "user: all, Time period: 1 Day Ago, status: queued, running, ok, error and warn, state: initialized" do
         set_opts(:state_choice => "Initialized", :time_period => 1)
 
-        query = "((state=? OR state=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state!=? AND state!=? AND state!=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND state=?"
+        query = "jobs.guid IS NULL AND ((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND miq_tasks.state=?"
         expected = [query, "waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
                     "Finished", "Warn", "Finished", "waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Initialized"
@@ -743,14 +748,14 @@ describe MiqTaskController do
       it "user: all, Time period: 1 Day Ago, status: queued, running, ok, error and warn, state: queued" do
         set_opts(:state_choice => "Queued", :time_period => 1)
 
-        query = "((state=? OR state=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state=? AND status=?) OR "\
-                "(state!=? AND state!=? AND state!=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND ((miq_tasks.state=? OR miq_tasks.state=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state=? AND miq_tasks.status=?) OR "\
+                "(miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, "waiting_to_start", "Queued", "Finished", "Ok", "Finished", "Error",
                     "Finished", "Warn", "Finished", "waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Queued"
@@ -760,9 +765,10 @@ describe MiqTaskController do
       it "User: All Users, Time Period: Last 24, Status: none checked, State: All" do
         set_opts(:ok => nil, :queued => nil, :error => nil, :warn => nil, :running => nil)
 
-        query = "(status!=? AND status!=? AND status!=? AND state!=? AND state!=?) AND " \
-                "updated_on>=? AND " \
-                "updated_on<=?"
+        query = "jobs.guid IS NULL AND (miq_tasks.status!=? AND miq_tasks.status!=? AND "\
+                "miq_tasks.status!=? AND miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=?"
         expected = [query, "Ok", "Error", "Warn", "Finished", "Queued"]
         expected += get_time_period(@opts[:time_period])
         expect(subject).to eq(expected)
@@ -778,11 +784,12 @@ describe MiqTaskController do
                  :user_choice  => "system",
                  :time_period  => 1)
 
-        query = "userid=? AND "\
-                "(status!=? AND status!=? AND status!=? AND state!=? AND state!=?) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "(miq_tasks.status!=? AND miq_tasks.status!=? AND miq_tasks.status!=? AND "\
+                "miq_tasks.state!=? AND miq_tasks.state!=?) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, "system", "Ok", "Error", "Warn", "Finished", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Active"
         expect(subject).to eq(expected)
@@ -798,11 +805,11 @@ describe MiqTaskController do
                  :user_choice  => "system",
                  :time_period  => 2)
 
-        query = "userid=? AND "\
-                "((state=? OR state=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "((miq_tasks.state=? OR miq_tasks.state=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, "system", "waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Finished"
         expect(subject).to eq(expected)
@@ -818,11 +825,11 @@ describe MiqTaskController do
                  :user_choice  => "system",
                  :time_period  => 3)
 
-        query = "userid=? AND "\
-                "((state!=? AND state!=? AND state!=?)) AND "\
-                "updated_on>=? AND "\
-                "updated_on<=? AND "\
-                "state=?"
+        query = "jobs.guid IS NULL AND miq_tasks.userid=? AND "\
+                "((miq_tasks.state!=? AND miq_tasks.state!=? AND miq_tasks.state!=?)) AND "\
+                "miq_tasks.updated_on>=? AND "\
+                "miq_tasks.updated_on<=? AND "\
+                "miq_tasks.state=?"
         expected = [query, "system", "Finished", "waiting_to_start", "Queued"]
         expected += get_time_period(@opts[:time_period]) << "Initialized"
         expect(subject).to eq(expected)

--- a/spec/controllers/miq_task_controller_spec.rb
+++ b/spec/controllers/miq_task_controller_spec.rb
@@ -842,10 +842,6 @@ describe MiqTaskController do
         controller.instance_variable_set(:@settings, :perpage => {})
         allow(controller).to receive(:role_allows?).and_return(true)
       end
-      it 'sets the active tab' do
-        controller.build_jobs_tab
-        expect(assigns(:active_tab)).to eq("2")
-      end
 
       it 'sets the available tabs' do
         controller.build_jobs_tab
@@ -855,6 +851,17 @@ describe MiqTaskController do
                                        ["3", _("All VM and Container Analysis Tasks")],
                                        ["4", _("All Other Tasks")]
                                      ])
+      end
+    end
+
+    describe "#list_jobs" do
+      it 'sets the active tab' do
+        controller.instance_variable_set(:@tabform, "ui_2")
+        controller.instance_variable_set(:@tasks_options, {})
+        allow(controller).to receive(:tasks_condition)
+        allow(controller).to receive(:get_view)
+        controller.list_jobs
+        expect(assigns(:active_tab)).to eq("2")
       end
     end
 


### PR DESCRIPTION
This PR depends and should be merged together with ManageIQ/manageiq#13452

There would be task created for each job after changes in ManageIQ/manageiq#13452 and those new tasks associated with jobs should be filtered out on `UI Tasks` screen.
Since there are columns in ```jobs``` and ```miq_tasks``` tables with same name (like ```state```, ```status```,...) we need to use table name when generating SQL on joined tables.

@miq-bot add-label enhancement

local AFTER  UI and model changes:
<img width="1044" alt="after" src="https://cloud.githubusercontent.com/assets/6556758/22808629/0495a430-eefb-11e6-81c0-8627bf50fc50.png">


\cc @Fryguy @gtanzillo @dclarizio   