### PR TITLE
MiqAlertDelete toolbar button - fix needs @record - missing colon

### DIFF
--- a/app/helpers/application_helper/button/miq_alert_delete.rb
+++ b/app/helpers/application_helper/button/miq_alert_delete.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::MiqAlertDelete < ApplicationHelper::Button::Basic
-  needs @record
+  needs :@record
 
   def disabled?
     @error_message = N_("Alerts referenced by Actions can not be deleted") unless @record.owning_miq_actions.empty?


### PR DESCRIPTION
Fixes a typo introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/279 .. `needs @record` means `instance_variables_required` will be `[nil]`.

Adding that missing colon :).

Testing:
Go to Control > Explorer (`/miq_policy/explorer`)
Select the Alerts accordion
Click on an alert

Before: 
```
Error caught: [NameError] `' is not allowed as an instance variable name
/home/himdel/manageiq-ui-classic/app/helpers/application_helper/button/basic.rb:54:in `instance_variable_get'
/home/himdel/manageiq-ui-classic/app/helpers/application_helper/button/basic.rb:54:in `block in all_instance_variables_set'
/home/himdel/manageiq-ui-classic/app/helpers/application_helper/button/basic.rb:53:in `each'
/home/himdel/manageiq-ui-classic/app/helpers/application_helper/button/basic.rb:53:in `all?'
/home/himdel/manageiq-ui-classic/app/helpers/application_helper/button/basic.rb:53:in `all_instance_variables_set'
/home/himdel/manageiq-ui-classic/app/helpers/application_helper/button/basic.rb:61:in `skipped?'
```

After: the alert detail is shown

Cc: @PanSpagetka - can you please add a test that checks clicking on an alert renders a page and doesn't die horribly? ;)