### PR TITLE
Don't invoke get_tagdata() for non-taggable objects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -155,7 +155,7 @@ class ApplicationController < ActionController::Base
     @record = identify_record(params[:id])
     yield if block_given?
     return if record_no_longer_exists?(@record)
-    get_tagdata(@record)
+    get_tagdata(@record) if @record.try(:taggings)
     @display = "download_pdf"
     set_summary_pdf_data
   end

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -18,7 +18,7 @@ module Mixins
     end
 
     def show_main
-      get_tagdata(@record)
+      get_tagdata(@record) if @record.try(:taggings)
       drop_breadcrumb({:name => ui_lookup(:models => self.class.model.to_s),
                        :url  => "/#{controller_name}/show_list?page=#{@current_page}&refresh=y"},
                       true)


### PR DESCRIPTION
Incidentally, all controllers that use `GenericShowMixin` also work with taggable objects, but
that won't necessarily be true in the future. For example Ansible Repositories won't be taggable,
yet we want to use `GenericShowMixin` in the ansible repo controller.

Same thing applies to `download_summary_pdf()`