### PR TITLE
AutomationManagerController & ProviderForemanController - unify model_to_type_name, fixing toolbars

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -26,18 +26,8 @@ class AutomationManagerController < ApplicationController
     end
   end
 
-  def self.model_to_type_name(provmodel)
-    if provmodel.include?("ManageIQ::Providers::AnsibleTower")
-      'ansible_tower'
-    end
-  end
-
   def model_to_name(provmodel)
     AutomationManagerController.model_to_name(provmodel)
-  end
-
-  def model_to_type_name(provmodel)
-    AutomationManagerController.model_to_type_name(provmodel)
   end
 
   def managed_group_kls

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -194,6 +194,16 @@ module Mixins
       replace_right_cell(:replace_trees => [x_active_accord])
     end
 
+    def model_to_type_name(provmodel)
+      if provmodel.include?("ManageIQ::Providers::AnsibleTower")
+        'ansible_tower'
+      elsif provmodel.include?("ManageIQ::Providers::Foreman")
+        'foreman'
+      else
+        raise "Unknown provmodel value: #{provmodel}"
+      end
+    end
+
     private ###########
 
     def replace_right_cell(options = {})

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -22,22 +22,12 @@ class ProviderForemanController < ApplicationController
     end
   end
 
-  def self.model_to_type_name(provmodel)
-    if provmodel.include?("ManageIQ::Providers::Foreman")
-      'foreman'
-    end
-  end
-
   def manager_prefix
     'configuration_manager'
   end
 
   def model_to_name(provmodel)
     ProviderForemanController.model_to_name(provmodel)
-  end
-
-  def model_to_type_name(provmodel)
-    ProviderForemanController.model_to_type_name(provmodel)
   end
 
   def new


### PR DESCRIPTION
Both controllers are insanely similar, but both use a ManagerControllerMixin.

Foreman controller shows configured systems of all kinds, not just Foreman.

But trying to show a detail of any such non-foreman system fails with an exception trying to load the right toolbar.

Moved the relevant functionality to the mixin and merged so that both can find the right toolbar for either kind of system.

Testing:

Go to Configuration > Management - Configured Systems tab
Click on a system of type Ansible Tower

Before:

```
Error caught: [NameError] uninitialized constant ApplicationHelper::Toolbar::XConfiguredSystemCenter
/home/himdel/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/inflector/methods.rb:270:in `const_get'
/home/himdel/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/inflector/methods.rb:270:in `block in constantize'
/home/himdel/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/inflector/methods.rb:266:in `each'
/home/himdel/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/inflector/methods.rb:266:in `inject'
/home/himdel/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/inflector/methods.rb:266:in `constantize'
/home/himdel/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/core_ext/string/inflections.rb:66:in `constantize'
/home/himdel/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:54:in `predefined_toolbar_class'
/home/himdel/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:63:in `toolbar_class'
/home/himdel/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:17:in `build_toolbar'
/home/himdel/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:6:in `call'
/home/himdel/manageiq-ui-classic/app/helpers/application_helper.rb:381:in `build_toolbar'
/home/himdel/manageiq-ui-classic/app/controllers/mixins/manager_controller_mixin.rb:395:in `rebuild_toolbars'
/home/himdel/manageiq-ui-classic/app/controllers/mixins/manager_controller_mixin.rb:213:in `replace_right_cell'
/home/himdel/manageiq-ui-classic/app/controllers/mixins/manager_controller_mixin.rb:178:in `tree_select'
/home/himdel/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:193:in `block (2 levels) in generic_x_show'
/home/himdel/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.1/lib/action_controller/metal/mime_responds.rb:201:in `respond_to'
/home/himdel/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:186:in `generic_x_show'
/home/himdel/manageiq-ui-classic/app/controllers/provider_foreman_controller.rb:194:in `x_show'
```

After:
it works :)