### PR TITLE
Displays a more informative message on single datasource deletion.

### DIFF
--- a/app/helpers/application_helper/toolbar/middleware_datasource_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_datasource_center.rb
@@ -45,7 +45,8 @@ class ApplicationHelper::Toolbar::MiddlewareDatasourceCenter < ApplicationHelper
             'pficon pficon-delete fa-lg',
             N_('Remove Middleware Datasource'),
             N_('Remove'),
-            :confirm => N_('Do you want to remove this datasource?'),
+            :confirm => N_('Do you want to remove this Datasource? Some Applications could be using this '\
+ +                             'Datasource and may malfunction if it is deleted.'),
             :klass   => ApplicationHelper::Button::MiddlewareStandaloneServerAction)
         ]
       ),


### PR DESCRIPTION

![screenshot from 2017-02-10 12-11-03](https://cloud.githubusercontent.com/assets/3845764/22838419/b0dd023a-ef8a-11e6-9934-88df460f5528.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1390283