### PR TITLE
Disable VNC Console for VMs hosted on ESXi 6.5 or greater

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -455,6 +455,10 @@ class ApplicationHelper::ToolbarBuilder
     return true if @gtl_type && id.starts_with?("view_") && id.ends_with?(@gtl_type)  # GTL view buttons
     return true if id == "view_dashboard" && (@showtype == "dashboard")
     return true if id == "view_summary" && (@showtype != "dashboard")
+    if id == 'vm_vnc_console' && @record.vendor == 'vmware' &&
+       ExtManagementSystem.find_by(:id => @record.ems_id).api_version.to_f >= 6.5
+      return N_("VNC consoles are unsupported on VMware ESXi 6.5 and later.")
+    end
 
     # need to add this here, since this button is on list view screen
     if disable_new_iso_datastore?(id)

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -651,6 +651,27 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           expect(subject).to include('cannot be performed on selected')
         end
       end
+
+      context "and id = vm_vnc_console" do
+        before :each do
+          @id = 'vm_vnc_console'
+          @record = FactoryGirl.create(:vm_vmware)
+        end
+
+        it "should not be available for vmware hosts with an api version greater or equal to 6.5" do
+          @ems = FactoryGirl.create(:ems_vmware, :api_version => '6.5')
+          allow(@record).to receive(:ems_id).and_return(@ems.id)
+          expect(subject).to include('VNC consoles are unsupported on VMware ESXi 6.5 and later.')
+        end
+
+        %w(5.1 5.5 6.0).each do |version|
+          it "should be available for vmware hosts with an api version #{version}" do
+            @ems = FactoryGirl.create(:ems_vmware, :api_version => version)
+            allow(@record).to receive(:ems_id).and_return(@ems.id)
+            expect(subject).to be(false)
+          end
+        end
+      end
     end # end of Vm class
 
   end # end of disable button


### PR DESCRIPTION
It appears per https://github.com/ManageIQ/manageiq/issues/13798 VMware disabled VNC consoles in 6.5.  Testing resulted in a "WebSocket connection to <server> failed: Connection closed before receiving a handshake response". 