### PR TITLE
[WIP] Use `controllerAs vm` syntax for the Provider Foreman Angular controller

### DIFF
--- a/app/assets/javascripts/controllers/buttons/button_group_controller.js
+++ b/app/assets/javascripts/controllers/buttons/button_group_controller.js
@@ -1,11 +1,10 @@
-ManageIQ.angular.app.controller('buttonGroupController', ['$scope', 'miqService', function($scope, miqService) {
-  var init = function() {
-    $scope.saveable = miqService.saveable;
-    $scope.disabledClick = miqService.disabledClick;
-    $scope.addText = __("Add");
-    $scope.saveText = __("Save");
-    $scope.resetText = __("Reset");
-    $scope.cancelText = __("Cancel");
-  };
-  init();
+ManageIQ.angular.app.controller('buttonGroupController', ['miqService', function(miqService) {
+  var vm = this;
+
+  vm.saveable = miqService.saveable;
+  vm.disabledClick = miqService.disabledClick;
+  vm.addText = __("Add");
+  vm.saveText = __("Save");
+  vm.resetText = __("Reset");
+  vm.cancelText = __("Cancel");
 }]);

--- a/app/assets/javascripts/controllers/credentials/credentials_controller.js
+++ b/app/assets/javascripts/controllers/credentials/credentials_controller.js
@@ -43,7 +43,15 @@ ManageIQ.angular.app.controller('CredentialsController', ['$scope', function($sc
   };
 
   vm.showChangePasswordLinks = function(userid) {
-    return !vm.newRecord && $scope.modelCopy[userid] != '';
+    var userid;
+
+    if ($scope.$parent.vm) {
+      userid = $scope.$parent.vm.modelCopy[userid];
+    } else {
+      userid = $scope.modelCopy[userid];
+    }
+
+    return !vm.newRecord && userid !== '';
   };
 
   vm.resetClicked = function() {

--- a/app/assets/javascripts/controllers/credentials/credentials_controller.js
+++ b/app/assets/javascripts/controllers/credentials/credentials_controller.js
@@ -1,55 +1,53 @@
 ManageIQ.angular.app.controller('CredentialsController', ['$scope', function($scope) {
-  var init = function() {
-    $scope.bChangeStoredPassword = undefined;
-    $scope.bCancelPasswordChange = undefined;
+  var vm = this;
 
-    $scope.$on('resetClicked', function(_e) {
-      $scope.resetClicked();
-    });
+  vm.bChangeStoredPassword = undefined;
+  vm.bCancelPasswordChange = undefined;
 
-    $scope.$on('setNewRecord', function(_event, args) {
-      $scope.newRecord = args ? args.newRecord : true;
-    });
+  $scope.$on('resetClicked', function(_e) {
+    vm.resetClicked();
+  });
 
-    $scope.$on('setUserId', function(_event, args) {
-      if (args) {
-        $scope.modelCopy[args.userIdName] = args.userIdValue;
-      }
-    });
+  $scope.$on('setNewRecord', function(_event, args) {
+    vm.newRecord = args ? args.newRecord : true;
+  });
 
-    if ($scope.formId == 'new') {
-      $scope.newRecord = true;
-    } else {
-      $scope.newRecord = false;
-      $scope.bChangeStoredPassword = false;
-      $scope.bCancelPasswordChange = false;
+  $scope.$on('setUserId', function(_event, args) {
+    if (args) {
+      vm.modelCopy[args.userIdName] = args.userIdValue;
+    }
+  });
+
+  if (vm.formId == 'new') {
+    vm.newRecord = true;
+  } else {
+    vm.newRecord = false;
+    vm.bChangeStoredPassword = false;
+    vm.bCancelPasswordChange = false;
+  }
+
+  vm.changeStoredPassword = function() {
+    vm.bChangeStoredPassword = true;
+    vm.bCancelPasswordChange = false;
+  };
+
+  vm.cancelPasswordChange = function() {
+    if (vm.bChangeStoredPassword) {
+      vm.bCancelPasswordChange = true;
+      vm.bChangeStoredPassword = false;
     }
   };
 
-  $scope.changeStoredPassword = function() {
-    $scope.bChangeStoredPassword = true;
-    $scope.bCancelPasswordChange = false;
+  vm.showVerify = function(userid) {
+    return vm.newRecord || (!vm.showChangePasswordLinks(userid)) || vm.bChangeStoredPassword;
   };
 
-  $scope.cancelPasswordChange = function() {
-    if ($scope.bChangeStoredPassword) {
-      $scope.bCancelPasswordChange = true;
-      $scope.bChangeStoredPassword = false;
-    }
+  vm.showChangePasswordLinks = function(userid) {
+    return !vm.newRecord && $scope.modelCopy[userid] != '';
   };
 
-  $scope.showVerify = function(userid) {
-    return $scope.newRecord || (!$scope.showChangePasswordLinks(userid)) || $scope.bChangeStoredPassword;
+  vm.resetClicked = function() {
+    vm.newRecord = false;
+    vm.cancelPasswordChange();
   };
-
-  $scope.showChangePasswordLinks = function(userid) {
-    return !$scope.newRecord && $scope.modelCopy[userid] != '';
-  };
-
-  $scope.resetClicked = function() {
-    $scope.newRecord = false;
-    $scope.cancelPasswordChange();
-  };
-
-  init();
 }]);

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -1,6 +1,8 @@
 ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$scope', 'providerForemanFormId', 'miqService', function($http, $scope, providerForemanFormId, miqService) {
-    var init = function() {
-      $scope.providerForemanModel = {
+    var vm = this;
+
+    // var init = function() {
+      vm.providerForemanModel = {
         provtype: '',
         name: '',
         url: '',
@@ -10,22 +12,22 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
         log_password: '',
         log_verify: ''
       };
-      $scope.formId = providerForemanFormId;
-      $scope.afterGet = false;
-      $scope.validateClicked = miqService.validateWithAjax;
-      $scope.modelCopy = angular.copy( $scope.providerForemanModel );
-      $scope.model = 'providerForemanModel';
+      vm.formId = providerForemanFormId;
+      vm.afterGet = false;
+      vm.validateClicked = miqService.validateWithAjax;
+      vm.modelCopy = angular.copy( vm.providerForemanModel );
+      vm.model = 'providerForemanModel';
 
-      ManageIQ.angular.scope = $scope;
+      ManageIQ.angular.scope = vm;
 
       if (providerForemanFormId == 'new') {
-        $scope.newRecord = true;
+        vm.newRecord = true;
 
         $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId)
           .then(getProviderForemanFormData)
           .catch(miqService.handleFailure);
       } else {
-        $scope.newRecord = false;
+        vm.newRecord = false;
 
         miqService.sparkleOn();
 
@@ -33,20 +35,20 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
           .then(getProviderForemanFormData)
           .catch(miqService.handleFailure);
       }
-    };
+    // };
 
-    $scope.canValidateBasicInfo = function () {
-      if ($scope.isBasicInfoValid())
+    vm.canValidateBasicInfo = function () {
+      if (vm.isBasicInfoValid())
         return true;
       else
         return false;
     }
 
-    $scope.isBasicInfoValid = function() {
-      if($scope.angularForm.url.$valid &&
-         $scope.angularForm.log_userid.$valid &&
-         $scope.angularForm.log_password.$valid &&
-         $scope.angularForm.log_verify.$valid)
+    vm.isBasicInfoValid = function() {
+      if(vm.angularForm.url.$valid &&
+         vm.angularForm.log_userid.$valid &&
+         vm.angularForm.log_password.$valid &&
+         vm.angularForm.log_verify.$valid)
         return true;
       else
         return false;
@@ -62,49 +64,49 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
       }
     };
 
-    $scope.cancelClicked = function() {
+    vm.cancelClicked = function() {
       providerForemanEditButtonClicked('cancel');
-      $scope.angularForm.$setPristine(true);
+      vm.angularForm.$setPristine(true);
     };
 
-    $scope.resetClicked = function() {
+    vm.resetClicked = function() {
       $scope.$broadcast ('resetClicked');
-      $scope.providerForemanModel = angular.copy( $scope.modelCopy );
-      $scope.angularForm.$setPristine(true);
+      vm.providerForemanModel = angular.copy( vm.modelCopy );
+      vm.angularForm.$setPristine(true);
       miqService.miqFlash("warn", __("All changes have been reset"));
     };
 
-    $scope.saveClicked = function() {
+    vm.saveClicked = function() {
       providerForemanEditButtonClicked('save', true);
-      $scope.angularForm.$setPristine(true);
+      vm.angularForm.$setPristine(true);
     };
 
-    $scope.addClicked = function() {
-      $scope.saveClicked();
+    vm.addClicked = function() {
+      vm.saveClicked();
     };
 
     function getProviderForemanFormData(response) {
       var data = response.data;
 
-      if (! $scope.newRecord) {
-        $scope.providerForemanModel.provtype = data.provtype;
-        $scope.providerForemanModel.name = data.name;
-        $scope.providerForemanModel.url = data.url;
-        $scope.providerForemanModel.verify_ssl = data.verify_ssl === 1;
+      if (! vm.newRecord) {
+        vm.providerForemanModel.provtype = data.provtype;
+        vm.providerForemanModel.name = data.name;
+        vm.providerForemanModel.url = data.url;
+        vm.providerForemanModel.verify_ssl = data.verify_ssl === 1;
 
-        $scope.providerForemanModel.log_userid = data.log_userid;
+        vm.providerForemanModel.log_userid = data.log_userid;
 
-        if ($scope.providerForemanModel.log_userid !== '') {
-          $scope.providerForemanModel.log_password = $scope.providerForemanModel.log_verify = miqService.storedPasswordPlaceholder;
+        if (vm.providerForemanModel.log_userid !== '') {
+          vm.providerForemanModel.log_password = vm.providerForemanModel.log_verify = miqService.storedPasswordPlaceholder;
         }
       }
 
-      $scope.providerForemanModel.zone = data.zone;
-      $scope.afterGet = true;
-      $scope.modelCopy = angular.copy( $scope.providerForemanModel );
+      vm.providerForemanModel.zone = data.zone;
+      vm.afterGet = true;
+      vm.modelCopy = angular.copy( vm.providerForemanModel );
 
       miqService.sparkleOff();
     }
 
-    init();
+    // init();
 }]);

--- a/app/assets/javascripts/directives/checkchange.js
+++ b/app/assets/javascripts/directives/checkchange.js
@@ -5,77 +5,113 @@ ManageIQ.angular.app.directive('checkchange', ['miqService', function(miqService
       scope['formchange_' + ctrl.$name] = elem[0].name
       scope['elemType_' + ctrl.$name] = attr.type;
 
-      if (angular.isDefined(scope.modelCopy)) {
+      var angularForm = function() {
+        if (scope.$parent.vm && scope.$parent.vm.angularForm) {
+          return scope.$parent.vm.angularForm;
+        } else if (scope.vm && scope.vm.angularForm) {
+          return scope.vm.angularForm;
+        } else if (scope.$parent.$parent && scope.$parent.$parent.angularForm) {
+          return scope.$parent.$parent.angularForm;
+        } else {
+          return scope.angularForm;
+        }
+      };
+
+      var modelCopy = function() {
+        if (scope.$parent.vm && scope.$parent.vm.modelCopy) {
+          return scope.$parent.vm.modelCopy;
+        } else if (scope.vm && scope.vm.modelCopy) {
+          return scope.vm.modelCopy;
+        } else if (scope.$parent.$parent && scope.$parent.$parent.modelCopy) {
+          return scope.$parent.$parent.modelCopy;
+        } else {
+          return scope.modelCopy;
+        }
+      };
+
+      var model = function() {
+        if (scope.$parent.vm && scope.$parent.vm.model) {
+          return scope.$parent.vm[scope.$parent.vm.model];
+        } else if (scope.vm && scope.vm.model) {
+          return scope.vm[scope.vm.model];
+        } else if (scope.$parent.$parent && scope.$parent.$parent.model) {
+          return scope.$parent.$parent[scope.$parent.$parent.model];
+        } else {
+          return scope[scope.model];
+        }
+      };
+
+      if (angular.isDefined(modelCopy())) {
         scope.$watch(attr.ngModel, function () {
           if (scope['elemType_' + ctrl.$name] == "date" || _.isDate(ctrl.$modelValue)) {
-            viewModelDateComparison(scope, ctrl);
+            viewModelDateComparison(scope, ctrl, modelCopy(), angularForm());
           } else {
-            viewModelComparison(scope, ctrl);
+            viewModelComparison(scope, ctrl, modelCopy(), model(), angularForm());
           }
-          if (scope.angularForm.$pristine)
-            checkForOverallFormPristinity(scope, ctrl);
+          if (angularForm().$pristine)
+            checkForOverallFormPristinity(scope, ctrl, modelCopy(), model(), angularForm());
         });
       }
 
       ctrl.$parsers.push(function(value) {
         miqService.miqFlashClear();
 
-        if (value == scope.modelCopy[ctrl.$name]) {
-          scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
+        if (value == modelCopy()[ctrl.$name]) {
+          angularForm()[scope['formchange_' + ctrl.$name]].$setPristine();
         }
-        if (scope.angularForm[scope['formchange_' + ctrl.$name]].$pristine) {
-          checkForOverallFormPristinity(scope, ctrl);
+        if (angularForm()[scope['formchange_' + ctrl.$name]].$pristine) {
+          checkForOverallFormPristinity(scope, ctrl, modelCopy(), model(), angularForm());
         }
-        scope.angularForm[scope['formchange_' + ctrl.$name]].$setTouched();
+        angularForm()[scope['formchange_' + ctrl.$name]].$setTouched();
         return value;
       });
 
-      if(scope.angularForm.$pristine)
-        scope.angularForm.$setPristine();
+      if(angularForm().$pristine)
+        angularForm().$setPristine();
     }
   }
 }]);
 
-var viewModelComparison = function(scope, ctrl) {
-  if ((Array.isArray(scope.modelCopy[ctrl.$name]) &&
-       angular.equals(scope[scope.model][ctrl.$name], scope.modelCopy[ctrl.$name])) ||
-       ctrl.$viewValue == scope.modelCopy[ctrl.$name]) {
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
-    scope.angularForm.$pristine = true;
+var viewModelComparison = function(scope, ctrl, modelCopy, model, angularForm) {
+  if ((Array.isArray(modelCopy[ctrl.$name]) &&
+       angular.equals(model[ctrl.$name], modelCopy[ctrl.$name])) ||
+       ctrl.$viewValue == modelCopy[ctrl.$name]) {
+    angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
+    angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
+    angularForm.$pristine = true;
   } else {
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
-    scope.angularForm.$pristine = false;
+    angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
+    angularForm.$pristine = false;
   }
 };
 
-var viewModelDateComparison = function(scope, ctrl) {
+var viewModelDateComparison = function(scope, ctrl, modelCopy, angularForm) {
   var modelDate = (ctrl.$modelValue != undefined) ? moment(ctrl.$modelValue) : null;
-  var copyDate = (scope.modelCopy[ctrl.$name] != undefined) ? moment(scope.modelCopy[ctrl.$name]) : null;
+  var copyDate = (modelCopy[ctrl.$name] != undefined) ? moment(modelCopy[ctrl.$name]) : null;
 
   if((modelDate && copyDate && (modelDate.diff(copyDate, 'days') == 0)) || (!modelDate && !copyDate)){
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
-    scope.angularForm.$pristine = true;
+    angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
+    angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
+    angularForm.$pristine = true;
   } else {
-    scope.angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
-    scope.angularForm.$pristine = false;
+    angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
+    angularForm.$pristine = false;
   }
 };
 
-var checkForOverallFormPristinity = function(scope, ctrl) {
+var checkForOverallFormPristinity = function(scope, ctrl, modelCopy, model, angularForm) {
   // don't do anything before the model and modelCopy are actually initialized
-  if (! ('modelCopy' in scope) || ! scope.modelCopy || ! scope.model || ! (scope.model in scope))
+  if (! modelCopy || ! model)
     return;
 
-  var modelCopyObject = _.cloneDeep(scope.modelCopy);
+  var modelCopyObject = _.cloneDeep(modelCopy);
   delete modelCopyObject[ctrl.$name];
 
-  var modelObject = _.cloneDeep(scope[scope.model]);
+  var modelObject = _.cloneDeep(model);
   delete modelObject[ctrl.$name];
 
-  scope.angularForm.$pristine = angular.equals(modelCopyObject, modelObject);
+  angularForm.$pristine = angular.equals(modelCopyObject, modelObject);
 
-  if (scope.angularForm.$pristine)
-    scope.angularForm.$setPristine();
+  if (angularForm.$pristine)
+    angularForm.$setPristine();
 };

--- a/app/assets/javascripts/directives/checkchange.js
+++ b/app/assets/javascripts/directives/checkchange.js
@@ -5,14 +5,7 @@ ManageIQ.angular.app.directive('checkchange', ['miqService', function(miqService
       scope['formchange_' + ctrl.$name] = elem[0].name
       scope['elemType_' + ctrl.$name] = attr.type;
 
-      var model = function() {
-        return scope.$eval(scope.angularForm.model || scope.model);
-      };
-      var modelCopy = function() {
-        return scope.$eval(scope.angularForm.modelCopy || "modelCopy");
-      };
-
-      if (modelCopy()) {
+      if (angular.isDefined(scope.modelCopy)) {
         scope.$watch(attr.ngModel, function () {
           if (scope['elemType_' + ctrl.$name] == "date" || _.isDate(ctrl.$modelValue)) {
             viewModelDateComparison(scope, ctrl);
@@ -27,7 +20,7 @@ ManageIQ.angular.app.directive('checkchange', ['miqService', function(miqService
       ctrl.$parsers.push(function(value) {
         miqService.miqFlashClear();
 
-        if (value == modelCopy()[ctrl.$name]) {
+        if (value == scope.modelCopy[ctrl.$name]) {
           scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
         }
         if (scope.angularForm[scope['formchange_' + ctrl.$name]].$pristine) {
@@ -37,53 +30,52 @@ ManageIQ.angular.app.directive('checkchange', ['miqService', function(miqService
         return value;
       });
 
-      if (scope.angularForm.$pristine)
+      if(scope.angularForm.$pristine)
         scope.angularForm.$setPristine();
-
-      var viewModelComparison = function(scope, ctrl) {
-        if ((Array.isArray(modelCopy()[ctrl.$name]) &&
-          angular.equals(model()[ctrl.$name], modelCopy()[ctrl.$name])) ||
-          ctrl.$viewValue == modelCopy()[ctrl.$name]) {
-          scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
-          scope.angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
-          scope.angularForm.$pristine = true;
-        } else {
-          scope.angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
-          scope.angularForm.$pristine = false;
-        }
-      };
-
-      var viewModelDateComparison = function(scope, ctrl) {
-        var modelDate = (ctrl.$modelValue != undefined) ? moment(ctrl.$modelValue) : null;
-        var copyDate = (modelCopy()[ctrl.$name] != undefined) ? moment(modelCopy()[ctrl.$name]) : null;
-
-        if((modelDate && copyDate && (modelDate.diff(copyDate, 'days') == 0)) || (!modelDate && !copyDate)){
-          scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
-          scope.angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
-          scope.angularForm.$pristine = true;
-        } else {
-          scope.angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
-          scope.angularForm.$pristine = false;
-        }
-      };
-
-      var checkForOverallFormPristinity = function(scope, ctrl) {
-        // don't do anything before the model and modelCopy are actually initialized
-        if (!model() || !modelCopy())
-          return;
-
-        var modelCopyObject = _.cloneDeep(modelCopy());
-        delete modelCopyObject[ctrl.$name];
-
-        var modelObject = _.cloneDeep(model());
-        delete modelObject[ctrl.$name];
-
-        scope.angularForm.$pristine = angular.equals(modelCopyObject, modelObject);
-
-        if (scope.angularForm.$pristine)
-          scope.angularForm.$setPristine();
-      };
     }
   }
 }]);
 
+var viewModelComparison = function(scope, ctrl) {
+  if ((Array.isArray(scope.modelCopy[ctrl.$name]) &&
+       angular.equals(scope[scope.model][ctrl.$name], scope.modelCopy[ctrl.$name])) ||
+       ctrl.$viewValue == scope.modelCopy[ctrl.$name]) {
+    scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
+    scope.angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
+    scope.angularForm.$pristine = true;
+  } else {
+    scope.angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
+    scope.angularForm.$pristine = false;
+  }
+};
+
+var viewModelDateComparison = function(scope, ctrl) {
+  var modelDate = (ctrl.$modelValue != undefined) ? moment(ctrl.$modelValue) : null;
+  var copyDate = (scope.modelCopy[ctrl.$name] != undefined) ? moment(scope.modelCopy[ctrl.$name]) : null;
+
+  if((modelDate && copyDate && (modelDate.diff(copyDate, 'days') == 0)) || (!modelDate && !copyDate)){
+    scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
+    scope.angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
+    scope.angularForm.$pristine = true;
+  } else {
+    scope.angularForm[scope['formchange_' + ctrl.$name]].$setDirty();
+    scope.angularForm.$pristine = false;
+  }
+};
+
+var checkForOverallFormPristinity = function(scope, ctrl) {
+  // don't do anything before the model and modelCopy are actually initialized
+  if (! ('modelCopy' in scope) || ! scope.modelCopy || ! scope.model || ! (scope.model in scope))
+    return;
+
+  var modelCopyObject = _.cloneDeep(scope.modelCopy);
+  delete modelCopyObject[ctrl.$name];
+
+  var modelObject = _.cloneDeep(scope[scope.model]);
+  delete modelObject[ctrl.$name];
+
+  scope.angularForm.$pristine = angular.equals(modelCopyObject, modelObject);
+
+  if (scope.angularForm.$pristine)
+    scope.angularForm.$setPristine();
+};

--- a/app/assets/javascripts/directives/clear_field_set_focus.js
+++ b/app/assets/javascripts/directives/clear_field_set_focus.js
@@ -9,7 +9,11 @@ ManageIQ.angular.app.directive('clearFieldSetFocus', ['$timeout', 'miqService', 
       scope.$watch('vm.bChangeStoredPassword', function(value) {
         if (value) {
           $timeout(function () {
-            scope[scope.model][ctrl.$name] = '';
+            if (scope.$parent.vm) {
+              scope.$parent.vm[scope.$parent.vm.model][ctrl.$name] = '';
+            } else {
+              scope[scope.model][ctrl.$name] = '';
+            }
             if(option != "no-focus")
               angular.element(scope['form_passwordfocus_' + ctrl.$name]).focus();
           }, 0);
@@ -19,7 +23,11 @@ ManageIQ.angular.app.directive('clearFieldSetFocus', ['$timeout', 'miqService', 
       scope.$watch('vm.bCancelPasswordChange', function(value) {
         if (value) {
           $timeout(function () {
-            scope[scope.model][ctrl.$name] = miqService.storedPasswordPlaceholder;
+            if (scope.$parent.vm) {
+              scope.$parent.vm[scope.$parent.vm.model][ctrl.$name] = miqService.storedPasswordPlaceholder;
+            } else {
+              scope[scope.model][ctrl.$name] = miqService.storedPasswordPlaceholder;
+            }
           }, 0);
         }
       });

--- a/app/assets/javascripts/directives/clear_field_set_focus.js
+++ b/app/assets/javascripts/directives/clear_field_set_focus.js
@@ -6,7 +6,7 @@ ManageIQ.angular.app.directive('clearFieldSetFocus', ['$timeout', 'miqService', 
 
       var option = attr.clearFieldSetFocus;
 
-      scope.$watch('bChangeStoredPassword', function(value) {
+      scope.$watch('vm.bChangeStoredPassword', function(value) {
         if (value) {
           $timeout(function () {
             scope[scope.model][ctrl.$name] = '';
@@ -16,7 +16,7 @@ ManageIQ.angular.app.directive('clearFieldSetFocus', ['$timeout', 'miqService', 
         }
       });
 
-      scope.$watch('bCancelPasswordChange', function(value) {
+      scope.$watch('vm.bCancelPasswordChange', function(value) {
         if (value) {
           $timeout(function () {
             scope[scope.model][ctrl.$name] = miqService.storedPasswordPlaceholder;

--- a/app/assets/javascripts/directives/verifypasswd.js
+++ b/app/assets/javascripts/directives/verifypasswd.js
@@ -6,23 +6,33 @@ ManageIQ.angular.app.directive('verifypasswd', function() {
       var log_verify = attr.prefix + "_verify";
       var logVerifyCtrl = attr.prefix + "_VerifyCtrl";
 
-      scope.$watch(attr.ngModel, function() {
-        if((ctrl.$modelValue != undefined && scope.afterGet) || scope.formId == "new") {
-          if(ctrl.$name == log_verify) {
-            scope[logVerifyCtrl] = ctrl;
+      var scopeModel;
+      var scopeVm;
+      if (angular.isDefined(scope.$parent.vm)) {
+        scopeModel = scope.$parent.vm[scope.$parent.vm.model];
+        scopeVm = scope.$parent.vm;
+      } else {
+        scopeModel = scope[scope.model];
+        scopeVm = scope;
+      }
 
-            setValidity(scope, ctrl, ctrl.$viewValue, scope[scope.model][log_password]);
-          }else if(ctrl.$name == log_password && scope[logVerifyCtrl] != undefined) {
-            setValidity(scope, scope[logVerifyCtrl], ctrl.$viewValue, scope[scope.model][log_verify]);
+      scope.$watch(attr.ngModel, function() {
+        if((ctrl.$modelValue != undefined && scopeVm.afterGet) || scopeVm.formId == "new") {
+          if(ctrl.$name == log_verify) {
+            scopeVm[logVerifyCtrl] = ctrl;
+
+            setValidity(scope, ctrl, ctrl.$viewValue, scopeModel[log_password]);
+          }else if(ctrl.$name == log_password && scopeVm[logVerifyCtrl] != undefined) {
+            setValidity(scope, scopeVm[logVerifyCtrl], ctrl.$viewValue, scopeModel[log_verify]);
           }
         }
       });
 
       ctrl.$parsers.push(function(value) {
         if (ctrl.$name == log_verify) {
-          setValidity(scope, ctrl, ctrl.$viewValue, scope[scope.model][log_password]);
-        }else if(ctrl.$name == log_password && scope[logVerifyCtrl] != undefined) {
-          setValidity(scope, scope[logVerifyCtrl], ctrl.$viewValue, scope[scope.model][log_verify]);
+          setValidity(scope, ctrl, ctrl.$viewValue, scopeModel[log_password]);
+        }else if(ctrl.$name == log_password && scopeVm[logVerifyCtrl] != undefined) {
+          setValidity(scope, scopeVm[logVerifyCtrl], ctrl.$viewValue, scopeModel[log_verify]);
         }
         return value;
       });

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -16,10 +16,13 @@
 - verify_title_off       ||= _("Server information, Username and matching password fields are needed to perform verification of credentials")
 - ng_show_userid         ||= true
 - guid_regex             ||= false
+- vm_scope               ||= false
 
 %div{"ng-controller" => "CredentialsController as vm"}
   %div{"ng-show" => "#{ng_show} && #{ng_show_userid}"}
-    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_userid.$invalid}"}
+    - form_group = {"ng-class" => "{'has-error': angularForm.#{prefix}_userid.$invalid}"}
+    - form_group['ng-class'] = "{'has-error': $parent.vm.angularForm.#{prefix}_userid.$invalid}" if vm_scope
+    .form-group{form_group}
       %label.col-md-2.control-label{"for" => "#{prefix}_userid"}
         = userid_label
       .col-md-4
@@ -35,36 +38,49 @@
                              "prefix"                  => "#{prefix}",
                              "reset-validation-status" => "#{prefix}_auth_status"}
         - hash_for_userid['is-uuid'] = 4 if guid_regex
+        - hash_for_userid['ng-model'] = "$parent.vm.#{ng_model}.#{prefix}_userid" if vm_scope
         %input.form-control{hash_for_userid}
-        %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.required"}
+        - span_required = {"ng-show" => "angularForm.#{prefix}_userid.$error.required"}
+        - span_required['ng-show'] = "$parent.vm.angularForm.#{prefix}_userid.$error.required" if vm_scope
+        %span.help-block{span_required}
           = _("Required")
-        %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.detectedSpaces"}
+        - span_spaces = {"ng-show" => "angularForm.#{prefix}_userid.$error.detectedSpaces"}
+        - span_spaces['ng-show'] = "$parent.vm.angularForm.#{prefix}_userid.$error.detectedSpaces" if vm_scope
+        %span.help-block{span_spaces}
           = _("Spaces are prohibited")
-        %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.isUuid"}
+        - span_guid = {"ng-show" => "angularForm.#{prefix}_userid.$error.isUuid"}
+        - span_guid['ng-show'] = "$parent.vm.angularForm.#{prefix}_userid.$error.isUuid" if vm_scope
+        %span.help-block{span_guid}
           = _("Invalid input format, please enter a GUID")
         .note
           {{note}}
 
   %div{"ng-show" => "#{ng_show}"}
-    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_password.$error.required}"}
+    - form_group = {"ng-class" => "{'has-error': angularForm.#{prefix}_password.$invalid}"}
+    - form_group['ng-class'] = "{'has-error': $parent.vm.angularForm.#{prefix}_password.$invalid}" if vm_scope
+    .form-group{form_group}
       %label.col-md-2.control-label{"for" => "#{prefix}_password"}
         %div{"ng-show" => "vm.bChangeStoredPassword != true"}
           = password_label
         %div{"ng-show" => "vm.bChangeStoredPassword"}
           = new_password_label
       .col-md-4
-        %input.form-control{"type"                    => "password",
-                            "id"                      => "#{prefix}_password",
-                            "ng-required"             => "#{ng_reqd_password}",
-                            "ng-disabled"             => "!vm.showVerify('#{prefix}_userid')" || password_disabled,
-                            "name"                    => "#{prefix}_password",
-                            "ng-model"                => "#{ng_model}.#{prefix}_password",
-                            "prefix"                  => "#{prefix}",
-                            "clear-field-set-focus"   => "",
-                            "verifypasswd"            => "",
-                            "checkchange"             => "",
-                            "reset-validation-status" => "#{prefix}_auth_status"}
-        %span.help-block{"ng-show" => "angularForm.#{prefix}_password.$error.required"}
+        - hash_for_password = {"type"                    => "password",
+                               "id"                      => "#{prefix}_password",
+                               "ng-required"             => "#{ng_reqd_password}",
+                               "ng-disabled"             => "!vm.showVerify('#{prefix}_userid')" || password_disabled,
+                               "name"                    => "#{prefix}_password",
+                               "ng-model"                => "#{ng_model}.#{prefix}_password",
+                               "prefix"                  => "#{prefix}",
+                               "clear-field-set-focus"   => "",
+                               "verifypasswd"            => "",
+                               "checkchange"             => "",
+                               "reset-validation-status" => "#{prefix}_auth_status"}
+        - hash_for_password['ng-model'] = "$parent.vm.#{ng_model}.#{prefix}_password" if vm_scope
+        %input.form-control{hash_for_password}
+        - span_required = {"ng-show" => "angularForm.#{prefix}_password.$error.required"}
+        - span_required['ng-show'] = "$parent.vm.angularForm.#{prefix}_password.$error.required" if vm_scope
+        %span.help-block{span_required}
           = _("Required")
       %div{"ng-if" => "vm.showChangePasswordLinks('#{prefix}_userid')"}
         %a{:href => "", "ng-hide" => "vm.bChangeStoredPassword", "ng-click" => "vm.changeStoredPassword()"}
@@ -72,11 +88,13 @@
         %a{:href => "", "ng-show" => "vm.bChangeStoredPassword", "ng-click" => "vm.cancelPasswordChange()"}
           = cancel_password_change
     %div{"ng-show" => "#{ng_show}"}
-    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_verify.$error.required || (#{prefix}_VerifyCtrl != undefined && #{prefix}_VerifyCtrl.$error.verifypasswd)}"}
+    - form_group = {"ng-class" => "{'has-error': angularForm.#{prefix}_verify.$invalid}"}
+    - form_group['ng-class'] = "{'has-error': $parent.vm.angularForm.#{prefix}_verify.$invalid}" if vm_scope
+    .form-group{form_group}
       %label.col-md-2.control-label{"ng-show" => "vm.showVerify('#{prefix}_userid')", "for" => "#{prefix}_verify"}
         = verify_label
       .col-md-4
-        %input.form-control{"type"                    => "password",
+        - hash_for_verify = {"type"                    => "password",
                             "id"                      => "#{prefix}_verify",
                             "ng-required"             => "#{ng_reqd_verify}",
                             "ng-disabled"             => "!vm.showVerify('#{prefix}_userid')" || password_disabled,
@@ -88,10 +106,18 @@
                             "verifypasswd"            => "",
                             "checkchange"             => "",
                             "reset-validation-status" => "#{prefix}_auth_status"}
+        - hash_for_verify['ng-model'] = "$parent.vm.#{ng_model}.#{prefix}_verify" if vm_scope
+        %input.form-control{hash_for_verify}
         %div{"ng-show" => "vm.showVerify('#{prefix}_userid')"}
-          %span.help-block{"ng-show" => "angularForm.#{prefix}_verify.$error.required"}
+          - span_required = {"ng-show" => "angularForm.#{prefix}_verify.$error.required"}
+          - span_required['ng-show'] = "$parent.vm.angularForm.#{prefix}_verify.$error.required" if vm_scope
+          %span.help-block{span_required}
             = _("Required")
-          %span.help-block{"ng-show" => "!angularForm.#{prefix}_verify.$error.required && #{prefix}_VerifyCtrl != undefined && #{prefix}_VerifyCtrl.$error.verifypasswd"}
+          - if vm_scope
+            - passwd_mismatch_hash = {"ng-show" => "!$parent.vm.angularForm.#{prefix}_verify.$error.required && $parent.vm.#{prefix}_VerifyCtrl != undefined && $parent.vm.#{prefix}_VerifyCtrl.$error.verifypasswd"}
+          - else
+            - passwd_mismatch_hash = {"ng-show" => "!angularForm.#{prefix}_verify.$error.required && #{prefix}_VerifyCtrl != undefined && #{prefix}_VerifyCtrl.$error.verifypasswd"}
+          %span.help-block{passwd_mismatch_hash}
             = passwd_mismatch
     %div{"ng-show" => "#{ng_show}"}
       .form-group
@@ -104,4 +130,5 @@
                                                     :ng_model         => "#{ng_model}",
                                                     :valtype          => "#{prefix}",
                                                     :verify_title_off => verify_title_off,
+                                                    :vm_scope         => vm_scope,
                                                     :basic_info_needed => defined?(basic_info_needed) ? basic_info_needed : nil}

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -17,7 +17,7 @@
 - ng_show_userid         ||= true
 - guid_regex             ||= false
 
-%div{"ng-controller" => "CredentialsController"}
+%div{"ng-controller" => "CredentialsController as vm"}
   %div{"ng-show" => "#{ng_show} && #{ng_show_userid}"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_userid.$invalid}"}
       %label.col-md-2.control-label{"for" => "#{prefix}_userid"}
@@ -48,15 +48,15 @@
   %div{"ng-show" => "#{ng_show}"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_password.$error.required}"}
       %label.col-md-2.control-label{"for" => "#{prefix}_password"}
-        %div{"ng-show" => "bChangeStoredPassword != true"}
+        %div{"ng-show" => "vm.bChangeStoredPassword != true"}
           = password_label
-        %div{"ng-show" => "bChangeStoredPassword"}
+        %div{"ng-show" => "vm.bChangeStoredPassword"}
           = new_password_label
       .col-md-4
         %input.form-control{"type"                    => "password",
                             "id"                      => "#{prefix}_password",
                             "ng-required"             => "#{ng_reqd_password}",
-                            "ng-disabled"             => "!showVerify('#{prefix}_userid')" || password_disabled,
+                            "ng-disabled"             => "!vm.showVerify('#{prefix}_userid')" || password_disabled,
                             "name"                    => "#{prefix}_password",
                             "ng-model"                => "#{ng_model}.#{prefix}_password",
                             "prefix"                  => "#{prefix}",
@@ -66,29 +66,29 @@
                             "reset-validation-status" => "#{prefix}_auth_status"}
         %span.help-block{"ng-show" => "angularForm.#{prefix}_password.$error.required"}
           = _("Required")
-      %div{"ng-if" => "showChangePasswordLinks('#{prefix}_userid')"}
-        %a{:href => "", "ng-hide" => "bChangeStoredPassword", "ng-click" => "changeStoredPassword()"}
+      %div{"ng-if" => "vm.showChangePasswordLinks('#{prefix}_userid')"}
+        %a{:href => "", "ng-hide" => "vm.bChangeStoredPassword", "ng-click" => "vm.changeStoredPassword()"}
           = change_stored_password
-        %a{:href => "", "ng-show" => "bChangeStoredPassword", "ng-click" => "cancelPasswordChange()"}
+        %a{:href => "", "ng-show" => "vm.bChangeStoredPassword", "ng-click" => "vm.cancelPasswordChange()"}
           = cancel_password_change
     %div{"ng-show" => "#{ng_show}"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_verify.$error.required || (#{prefix}_VerifyCtrl != undefined && #{prefix}_VerifyCtrl.$error.verifypasswd)}"}
-      %label.col-md-2.control-label{"ng-show" => "showVerify('#{prefix}_userid')", "for" => "#{prefix}_verify"}
+      %label.col-md-2.control-label{"ng-show" => "vm.showVerify('#{prefix}_userid')", "for" => "#{prefix}_verify"}
         = verify_label
       .col-md-4
         %input.form-control{"type"                    => "password",
                             "id"                      => "#{prefix}_verify",
                             "ng-required"             => "#{ng_reqd_verify}",
-                            "ng-disabled"             => "!showVerify('#{prefix}_userid')" || password_disabled,
+                            "ng-disabled"             => "!vm.showVerify('#{prefix}_userid')" || password_disabled,
                             "name"                    => "#{prefix}_verify",
                             "ng-model"                => "#{ng_model}.#{prefix}_verify",
-                            "ng-show"                 => "showVerify('#{prefix}_userid')",
+                            "ng-show"                 => "vm.showVerify('#{prefix}_userid')",
                             "prefix"                  => "#{prefix}",
                             "clear-field-set-focus"   => "no-focus",
                             "verifypasswd"            => "",
                             "checkchange"             => "",
                             "reset-validation-status" => "#{prefix}_auth_status"}
-        %div{"ng-show" => "showVerify('#{prefix}_userid')"}
+        %div{"ng-show" => "vm.showVerify('#{prefix}_userid')"}
           %span.help-block{"ng-show" => "angularForm.#{prefix}_verify.$error.required"}
             = _("Required")
           %span.help-block{"ng-show" => "!angularForm.#{prefix}_verify.$error.required && #{prefix}_VerifyCtrl != undefined && #{prefix}_VerifyCtrl.$error.verifypasswd"}

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -8,13 +8,12 @@
   - validate = "validateClicked($event, '#{valtype}', true)"
 - else
   - validate = "validateClicked('#{url_for(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
-%div{"ng-show" => ng_show, "ng-controller" => "buttonGroupController"}
+%div{"ng-show" => ng_show}
   = button_tag(_("Validate"),
                  :class     => "btn btn-primary btn-xs disabled",
                  :alt       => verify_title_off,
                  :title     => verify_title_off,
-                 "ng-show"  => basic_info_needed ? "!canValidateBasicInfo()" : "!canValidate()",
-                 "ng-click" => "disabledClick($event)")
+                 "ng-show"  => basic_info_needed ? "!canValidateBasicInfo()" : "!canValidate()")
   = button_tag(_("Validate"),
                  :class     => "btn btn-primary btn-xs",
                  :alt       => verify_title_on,

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -1,3 +1,5 @@
+- vm_scope ||= false
+
 - if !session[:host_items].nil?
   - verify_title_on ||= _("Validate the credentials by logging into the selected %{title_for_host}") % {:title_for_host => title_for_host}
   - verify_title_off ||= _("%{host} to validate against, Username and matching password fields are needed to perform verification of credentials") % {:host => title_for_host}
@@ -5,21 +7,32 @@
   - verify_title_on = _("Validate the credentials by logging into the Server")
   - verify_title_off ||= _("Server information, Username and matching password fields are needed to perform verification of credentials")
 - if controller.send(:restful?)
-  - validate = "validateClicked($event, '#{valtype}', true)"
+  - if vm_scope
+    - validate = "$parent.vm.validateClicked($event, '#{valtype}', true)"
+  - else
+    - validate = "validateClicked($event, '#{valtype}', true)"
 - else
-  - validate = "validateClicked('#{url_for(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
+  - if vm_scope
+    - validate = "$parent.vm.validateClicked('#{url_for(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
+  - else
+    - validate = "validateClicked('#{url_for(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
+
 %div{"ng-show" => ng_show}
-  = button_tag(_("Validate"),
-                 :class     => "btn btn-primary btn-xs disabled",
-                 :alt       => verify_title_off,
-                 :title     => verify_title_off,
-                 "ng-show"  => basic_info_needed ? "!canValidateBasicInfo()" : "!canValidate()")
-  = button_tag(_("Validate"),
-                 :class     => "btn btn-primary btn-xs",
-                 :alt       => verify_title_on,
-                 :title     => verify_title_on,
-                 "ng-show"  => basic_info_needed ? "canValidateBasicInfo()" : "canValidate()",
-                 "ng-click" => validate)
+  - validate_button_disabled = {:class     => "btn btn-primary btn-xs disabled",
+                                :alt       => verify_title_off,
+                                :title     => verify_title_off,
+                                "ng-show"  => basic_info_needed ? "!canValidateBasicInfo()" : "!canValidate()"}
+  - validate_button_disabled['ng-show'] = basic_info_needed ? "!$parent.vm.canValidateBasicInfo()" : "!$parent.vm.canValidate()" if vm_scope
+  = button_tag(_("Validate"), validate_button_disabled)
+
+  - validate_button = {:class     => "btn btn-primary btn-xs",
+                       :alt       => verify_title_on,
+                       :title     => verify_title_on,
+                       "ng-show"  => basic_info_needed ? "canValidateBasicInfo()" : "canValidate()",
+                       "ng-click" => validate}
+  - validate_button['ng-show'] = basic_info_needed ? "$parent.vm.canValidateBasicInfo()" : "$parent.vm.canValidate()" if vm_scope
+  = button_tag(_("Validate"), validate_button)
+
   %div{"ng-if" => "checkAuthentication"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{valtype}_auth_status.$error.validationRequired}"}
       .col-md-8
@@ -33,4 +46,3 @@
                             "ng-show"             => false}
         %span.help-block{"ng-if" => "angularForm.#{valtype}_auth_status.$error.validationRequired"}
           = _("Validation Required")
-

--- a/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
+++ b/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
@@ -1,49 +1,63 @@
+- vm_scope ||= false
+
 .clearfix
-.pull-right.button-group{"ng-controller" => "buttonGroupController"}
-  = button_tag(_("Add"),
-               "class"       => "btn btn-primary disabled",
-               :alt          => _("Add"),
-               :title        => _("Add"),
-               "ng-click"    => "disabledClick($event)",
-               "ng-show"     => "newRecord && !saveable(angularForm)")
+.pull-right.button-group{"ng-controller" => "buttonGroupController as vm"}
+  - add_button_disabled = {"class"       => "btn btn-primary disabled",
+                           :alt          => _("Add"),
+                           :title        => _("Add"),
+                           "ng-show"     => "newRecord && !vm.saveable(angularForm)"}
+  - add_button_disabled['ng-show'] = "vm.newRecord && !vm.saveable($parent.vm.angularForm)" if vm_scope
+  = button_tag(_("Add"), add_button_disabled)
 
-  = button_tag(_("Add"),
-               :class        => "btn btn-primary",
-               :alt          => _("Add"),
-               :title        => _("Add"),
-               "ng-click"    => "addClicked($event, true)",
-               "ng-show"     => "newRecord && saveable(angularForm)")
+  - add_button = {"class"       => "btn btn-primary disabled",
+                  :alt          => _("Add"),
+                  :title        => _("Add"),
+                  "ng-show"     => "newRecord && vm.saveable(angularForm)"}
+  - add_button['ng-show'] = "vm.newRecord && vm.saveable($parent.vm.angularForm)" if vm_scope
+  = button_tag(_("Add"), add_button)
 
-  = button_tag(_("Save"),
-               :class        => "btn btn-primary disabled",
-               :alt          => _("Save changes"),
-               :title        => _("Save changes"),
-               "ng-click"    => "disabledClick($event)",
-               "ng-show"     => "!newRecord && !saveable(angularForm)")
 
-  = button_tag(_("Save"),
-               :class        => "btn btn-primary",
-               :alt          => _("Save changes"),
-               :title        => _("Save changes"),
-               "ng-click"    => "saveClicked($event, true)",
-               "ng-show"     => "!newRecord && saveable(angularForm)")
+  - save_button_disabled = {:class        => "btn btn-primary disabled",
+                            :alt          => _("Save changes"),
+                            :title        => _("Save changes"),
+                            "ng-show"     => "!newRecord && !vm.saveable(angularForm)"}
+  - save_button_disabled['ng-show'] = "!vm.newRecord && !vm.saveable($parent.vm.angularForm)" if vm_scope
+  = button_tag(_("Save"), save_button_disabled)
 
-  = button_tag(_("Reset"),
-               :class        => "btn btn-default disabled",
-               :alt          => _("Reset changes"),
-               :title        => _("Reset changes"),
-               "ng-click"    => "disabledClick($event)",
-               "ng-show"     => "!newRecord && angularForm.$pristine")
+  - save_button = {:class        => "btn btn-primary",
+                   :alt          => _("Save changes"),
+                   :title        => _("Save changes"),
+                   "ng-click"    => "saveClicked($event, true)",
+                   "ng-show"     => "!newRecord && vm.saveable(angularForm)"}
+  - if vm_scope
+    - save_button['ng-click'] = "$parent.vm.saveClicked($event, true)"
+    - save_button['ng-show'] = "!vm.newRecord && vm.saveable($parent.vm.angularForm)"
+  = button_tag(_("Save"), save_button)
 
-  = button_tag(_("Reset"),
-               :class        => "btn btn-default",
-               :alt          => _("Reset changes"),
-               :title        => _("Reset changes"),
-               "ng-click"    => "resetClicked()",
-               "ng-show"     => "!newRecord && !angularForm.$pristine")
 
-  = button_tag(_("Cancel"),
-               :class => "btn btn-default",
-               :alt   => _("Cancel"),
-               :title => _("Cancel"),
-               "ng-click" => "cancelClicked($event)")
+  - reset_button_disabled = {:class        => "btn btn-default disabled",
+                             :alt          => _("Reset changes"),
+                             :title        => _("Reset changes"),
+                             "ng-show"     => "!newRecord && angularForm.$pristine"}
+  - reset_button_disabled['ng-show'] = "!vm.newRecord && $parent.vm.angularForm.$pristine" if vm_scope
+  = button_tag(_("Reset"), reset_button_disabled)
+
+
+  - reset_button = {:class        => "btn btn-default",
+                    :alt          => _("Reset changes"),
+                    :title        => _("Reset changes"),
+                    "ng-click"    => "resetClicked()",
+                    "ng-show"     => "!newRecord && !angularForm.$pristine"}
+  - if vm_scope
+    - reset_button['ng-click'] = "$parent.vm.resetClicked($event, true)"
+    - reset_button['ng-show'] = "!vm.newRecord && !$parent.vm.angularForm.$pristine"
+  = button_tag(_("Reset"), reset_button)
+
+
+  - cancel_button = {:class => "btn btn-default",
+                     :alt   => _("Cancel"),
+                     :title => _("Cancel"),
+                     "ng-click" => "cancelClicked($event)"}
+  - cancel_button['ng-click'] = "$parent.vm.cancelClicked($event)" if vm_scope
+
+  = button_tag(_("Cancel"), cancel_button)

--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -1,50 +1,50 @@
 - @angular_form = true
 
 .form-horizontal{:id => "start_form_div", :style => "display:none"}
-  %form#form_div{:name           => "angularForm",
-                 'ng-controller' => "providerForemanFormController",
-                 'ng-show'       => "afterGet",
+  %form#form_div{:name           => "vm.angularForm",
+                 'ng-controller' => "providerForemanFormController as vm",
+                 'ng-show'       => "vm.afterGet",
                  :novalidate     => true}
     = render :partial => "layouts/flash_msg"
     %br
-    .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
+    .form-group{"ng-class" => "{'has-error': vm.angularForm.name.$invalid}"}
       %label.col-md-2.control-label
         = _("Name")
       .col-md-8
         %input.form-control{:type            => "text",
                             :name            => "name",
-                            'ng-model'       => "providerForemanModel.name",
+                            'ng-model'       => "vm.providerForemanModel.name",
                             :maxlength       => MAX_NAME_LEN,
                             :required        => "",
                             :checkchange     => true,
                             "auto-focus"     => "",
                             "start-form-div" => "start_form_div"}
-        %span.help-block{"ng-show" => "angularForm.name.$error.required"}
+        %span.help-block{"ng-show" => "vm.angularForm.name.$error.required"}
           = _("Required")
 
-    .form-group{"ng-class" => "{'has-error': angularForm.type.$invalid}"}
+    .form-group{"ng-class" => "{'has-error': vm.angularForm.type.$invalid}"}
       %label.col-md-2.control-label{"for" => "provider_type"}
         = _('Type')
       .col-md-8
         = select_tag('provtype',
                      options_for_select([["<#{_('Choose')}>", nil]] + @provider_types, disabled: ["<#{_('Choose')}>", nil]),
-                     "ng-if"                       => "newRecord",
-                     "ng-model"                    => "providerForemanModel.provtype",
-                     "ng-change"                   => "providerTypeChanged()",
+                     "ng-if"                       => "vm.newRecord",
+                     "ng-model"                    => "vm.providerForemanModel.provtype",
+                     "ng-change"                   => "vm.providerTypeChanged()",
                      "id"                          => "provider_type",
                      "required"                    => "",
                      "checkchange"                 => "",
                      "selectpicker-for-select-tag" => "")
-        %div{"ng-if" => "!newRecord"}
+        %div{"ng-if" => "!vm.newRecord"}
           %input.form-control{:type      => "text",
                               :name      => "provtype",
-                              "ng-model" => "providerForemanModel.provtype",
-                              "ng-if"    => "!newRecord",
+                              "ng-model" => "vm.providerForemanModel.provtype",
+                              "ng-if"    => "!vm.newRecord",
                               "id"       => "provider_type",
                               "readonly" => true,
                               "style"    => "color: black; font-weight: normal;"}
 
-    .form-group{"ng-class" => "{'has-error': angularForm.zone.$invalid}"}
+    .form-group{"ng-class" => "{'has-error': vm.angularForm.zone.$invalid}"}
       %label.col-md-2.control-label{"for" => "prov_zone"}
         = _("Zone")
       .col-md-8
@@ -52,7 +52,7 @@
           %input.form-control{"type"        => "text",
                               "id"          => "prov_zone",
                               "name"        => "zone",
-                              "ng-model"    => "providerForemanModel.zone",
+                              "ng-model"    => "vm.providerForemanModel.zone",
                               "maxlength"   => 15,
                               "required"    => "",
                               "checkchange" => "",
@@ -61,27 +61,27 @@
         - else
           = select_tag('zone',
                        options_for_select(@server_zones.sort_by { |name, _name| name }),
-                       "ng-model"                    => "providerForemanModel.zone",
+                       "ng-model"                    => "vm.providerForemanModel.zone",
                        "checkchange"                 => "",
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
 
-    .form-group{"ng-class" => "{'has-error': angularForm.url.$invalid}"}
+    .form-group{"ng-class" => "{'has-error': vm.angularForm.url.$invalid}"}
       %label.col-md-2.control-label{"for" => "provider_url"}
         = _("Url")
       .col-md-8
         %input.form-control{:type           => "text",
                             :name           => "url",
-                            'ng-model'      => "providerForemanModel.url",
+                            'ng-model'      => "vm.providerForemanModel.url",
                             :maxlength      => MAX_DESC_LEN,
                             "id"            => "url",
                             :required       => "",
                             "ng-trim"       => false,
                             "detect_spaces" => "",
                             :checkchange    => true}
-        %span.help-block{"ng-show" => "angularForm.url.$error.required"}
+        %span.help-block{"ng-show" => "vm.angularForm.url.$error.required"}
           = _("Required")
-        %span.help-block{"ng-show" => "angularForm.url.$error.detectedSpaces"}
+        %span.help-block{"ng-show" => "vm.angularForm.url.$error.detectedSpaces"}
           = _("Spaces are prohibited")
     .form-group
       %label.col-md-2.control-label
@@ -105,9 +105,11 @@
                           :validate_url      => "authentication_validate",
                           :id                => @provider_manager.id || "new",
                           :valtype           => nil,
+                          :vm_scope          => true,
                           :basic_info_needed => true}
 
-    = render :partial => "layouts/angular/x_edit_buttons_angular"
+    = render :partial => "layouts/angular/x_edit_buttons_angular",
+             :locals  => {:vm_scope => true}
     %span{:style => "color:black"}= _("Required. Should have privileged access, such as root or administrator.")
 
 :javascript


### PR DESCRIPTION
The complexity of applying the preferred `controllerAs vm` syntax in Angular controllers depends on the type of the controller. Forms with `nested controllers` pose many challenges since the `scope` object gets nested too, in turn, requiring many changes to the code in the directives and controllers that deal with the `scope` object.

The `Provider Foreman` form is one such form that contains a good combination of 3 to 4 partials which include `nested controllers` like the `CredentialsController`, and has been used as an example in this PR.
