### PR TITLE
Add proper model class for AutomationManagerController

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -9,7 +9,7 @@ class AutomationManagerController < ApplicationController
   include Mixins::ManagerControllerMixin
 
   def self.model
-    ManageIQ::Providers::AnsibleTower
+    ManageIQ::Providers::AutomationManager
   end
 
   def self.table_name


### PR DESCRIPTION
`ManageIQ::Providers::AnsibleTower` is not model, in addition once we have pluggable providers
`AnsibleTower` should not occur  anywhere.

(rake build_request_file  task from https://github.com/ManageIQ/manageiq-performance was throwing error, because it is using self.model for each controller )
cc @lgalis 

@miq-bot assign @martinpovolny 
