### PR TITLE
Replace "100/#{local_var_or_condition}.png"

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -1936,13 +1936,13 @@ module ApplicationController::Compare
       else
         if base_val == val
           img_bkg = "cell-stripe"
-          img = "compare-same"
+          img = "100/compare-same.png"
         else
           img_bkg = ""
-          img = "compare-diff"
+          img = "100/compare-diff.png"
           unset_same_flag
         end
-        row.merge!(drift_add_image_col(idx, "100/#{img}.png", img_bkg, val))
+        row.merge!(drift_add_image_col(idx, img, img_bkg, val))
       end
     end
     row

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -1798,13 +1798,11 @@ module ApplicationController::Compare
 
   def comp_add_record_field_missing_compressed(idx, val, base_rec)
     if @exists_mode
-      passed_img = "passed"
-      failed_img = "failed"
-      img_path = "16"
+      passed_img = "16/passed.png"
+      failed_img = "16/failed.png"
     else
-      passed_img = "compare-same"
-      failed_img = "compare-diff"
-      img_path = "100"
+      passed_img = "100/compare-same.png"
+      failed_img = "100/compare-diff.png"
     end
     row = {}
 
@@ -1814,7 +1812,7 @@ module ApplicationController::Compare
       row.merge!(drift_add_same_image(idx, val))
     else              # Not on base object
       row.merge!(drift_add_image_col(idx,
-                                     "#{img_path}/#{base_rec_found == val ? passed_img : failed_img}.png",
+                                     base_rec_found == val ? passed_img : failed_img,
                                      "",
                                      val))
     end
@@ -1823,13 +1821,11 @@ module ApplicationController::Compare
 
   def comp_add_record_field_exists_compressed(idx, val, base_rec, field)
     if @exists_mode
-      passed_img = "passed"
-      failed_img = "failed"
-      img_path = "16"
+      passed_img = "16/passed.png"
+      failed_img = "16/failed.png"
     else
-      passed_img = "compare-same"
-      failed_img = "compare-diff"
-      img_path = "100"
+      passed_img = "100/compare-same.png"
+      failed_img = "100/compare-diff.png"
     end
     row = {}
 
@@ -1839,7 +1835,10 @@ module ApplicationController::Compare
     if idx == 0   # On base object
       row.merge!(drift_add_same_image(idx, val))
     else          # Not on base object
-      row.merge!(drift_add_image_col(idx, "#{img_path}/#{base_val == val ? passed_img : failed_img}.png", "", val))
+      row.merge!(drift_add_image_col(idx,
+                                     base_val == val ? passed_img : failed_img,
+                                     "",
+                                     val))
     end
     row
   end

--- a/app/decorators/resource_pool_decorator.rb
+++ b/app/decorators/resource_pool_decorator.rb
@@ -6,6 +6,6 @@ class ResourcePoolDecorator < Draper::Decorator
   end
 
   def listicon_image
-    "100/#{vapp ? 'vapp' : 'resource_pool'}.png"
+    vapp ? '100/vapp.png' : '100/resource_pool.png'
   end
 end

--- a/app/decorators/service_resource_decorator.rb
+++ b/app/decorators/service_resource_decorator.rb
@@ -6,6 +6,6 @@ class ServiceResourceDecorator < Draper::Decorator
   end
 
   def listicon_image
-    "100/#{resource_type.to_s == 'VmOrTemplate' ? 'vm' : 'service_template'}.png"
+    resource_type.to_s == 'VmOrTemplate' ? '100/vm.png' : '100/service_template.png'
   end
 end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -198,13 +198,12 @@ module QuadiconHelper
   end
 
   def img_for_auth_status(item)
-    img = case item.authentication_status
-          when "Invalid" then "x"
-          when "Valid"   then "checkmark"
-          when "None"    then "unknown"
-          else "exclamationpoint"
-          end
-    "100/#{h(img)}.png"
+    case item.authentication_status
+    when "Invalid" then "100/x.png"
+    when "Valid"   then "100/checkmark.png"
+    when "None"    then "100/unknown.png"
+    else                "100/exclamationpoint.png"
+    end
   end
 
   def render_quadicon_text(item, row)
@@ -436,13 +435,13 @@ module QuadiconHelper
   # Renders a quadicon for resource_pools
   #
   def render_resource_pool_quadicon(item, options)
-    img = item.vapp ? "vapp.png" : "resource_pool.png"
+    img = item.vapp ? "100/vapp.png" : "100/resource_pool.png"
     size = options[:size]
     width = options[:size] == 150 ? 54 : 35
     output = []
 
     output << flobj_img_simple(options[:size])
-    output << flobj_img_simple(width * 1.8, "100/#{img}", "e#{size}")
+    output << flobj_img_simple(width * 1.8, img, "e#{size}")
     output << flobj_img_simple(size, '100/shield.png', "g#{size}") unless item.get_policies.empty?
 
     unless options[:typ] == :listnav


### PR DESCRIPTION
We always want keep the whole image path together whenever possible.

`100/foo.png` is always easier to find than `foo`.

This should take care of all the cases where the actual image name is a constant in the same function anyway.

Cc @epwinchell 