### PR TITLE
Fix typo in miq_policy_controller/policies.rb

### DIFF
--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -108,7 +108,7 @@ module MiqPolicyController::Policies
       add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqPolicy"), :name => new_desc})
       @new_policy_node = policy_node(policy)
       get_node_info(@new_policy_node)
-      replace_right_cell(:nodetype => "p", :replace_tres => [:policy])
+      replace_right_cell(:nodetype => "p", :replace_trees => [:policy])
     end
   end
 
@@ -128,7 +128,7 @@ module MiqPolicyController::Policies
     add_flash(_("The selected %{models} was deleted") %
       {:models => ui_lookup(:models => "MiqPolicy")}) if @flash_array.nil?
     get_node_info(@new_policy_node)
-    replace_right_cell(:nodetype => "xx", :replace_tres => [:policy, :policy_profile])
+    replace_right_cell(:nodetype => "xx", :replace_trees => [:policy, :policy_profile])
   end
 
   def policy_field_changed


### PR DESCRIPTION
Minor fix related to BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1402454

Fixes typo `replace_tres` to `replace_trees`. Because of that Policy tree didn't update after delete.
Introduced by https://github.com/ManageIQ/manageiq/pull/12329 which is euwe/no.

Control -> Explorer -> Policies -> choose any 4th level node -> Configuration -> Delete

Before:
<img width="1207" alt="screen shot 2017-02-13 at 12 40 55 pm" src="https://cloud.githubusercontent.com/assets/9210860/22882073/b4168690-f1e9-11e6-9d3f-5771a1551bec.png">

After:
<img width="1204" alt="screen shot 2017-02-13 at 12 39 51 pm" src="https://cloud.githubusercontent.com/assets/9210860/22882068/b183d734-f1e9-11e6-8c5e-0c3e340a8821.png">
@miq-bot add_label bug, euwe/no