### PR TITLE
Fix VM quadicon links in Services

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -28,7 +28,7 @@ module QuadiconHelper
   end
 
   def quadicon_vm_attributes(item)
-    @quad_vm_attrs ||= vm_quad_link_attributes(item)
+    vm_quad_link_attributes(item)
   end
 
   def quadicon_vm_attributes_present?(item)


### PR DESCRIPTION
A cached hash led to different Quadicons rendering with the same url info. It was discovered at the bottom of the Services > My Services screen, but could possibly happen elsewhere.

**Steps to reproduce**
- Go to Services > My Services
- Find a service with multiple vms
- Observe urls for quadicons at the bottom

**Addresses**
https://bugzilla.redhat.com/show_bug.cgi?id=1406833