### PR TITLE
use task queue for update stack operation

### DIFF
--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -199,9 +199,9 @@ class EmsInfraController < ApplicationController
     elsif !stack_parameters.empty?
       # A value was changed
       begin
-        stack.raw_update_stack(nil, stack_parameters)
+        task_id = stack.update_stack_queue(session[:userid], nil, stack_parameters)
         if operation == 'scaledown'
-          @stack.queue_post_scaledown_task(additional_args[:services])
+          @stack.queue_post_scaledown_task(additional_args[:services], task_id)
         end
         redirect_to ems_infra_path(provider_id, :flash_msg => return_message)
       rescue => ex

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -150,7 +150,7 @@ describe EmsInfraController do
 
     it "when patch operation fails, an error message should be displayed" do
       allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .to receive(:raw_update_stack) { raise _("my error") }
+        .to receive(:update_stack_queue) { raise _("my error") }
       post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @ems.orchestration_stacks.first.id,
            @orchestration_stack_parameter_compute.name => 2 }
       expect(controller.send(:flash_errors?)).to be_truthy
@@ -219,7 +219,7 @@ describe EmsInfraController do
 
     it "when patch operation fails, an error message should be displayed" do
       allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .to receive(:raw_update_stack) { raise _("my error") }
+        .to receive(:update_stack_queue) { raise _("my error") }
       post :scaledown, :params => {:id => @ems.id, :scaledown => "",
            :orchestration_stack_id => @ems.orchestration_stacks.first.id, :host_ids => [@ems.hosts[1].id]}
       expect(controller.send(:flash_errors?)).to be_truthy


### PR DESCRIPTION
Update stack should use the task queue for direct operation on the
provider (used by scaling/scaledown UI in ems infra)

This commit includes the necessary UI changes.

Depends on model PR: https://github.com/ManageIQ/manageiq/pull/13897