### PR TITLE
Do not initialize asynchronous notifications if they are disabled

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -37,7 +37,10 @@
         ManageIQ.browser = "#{j browser_info(:name_ui)}";
         ManageIQ.controller = "#{j controller_name}";
         API.autorenew();
-        miqInitNotifications(); // ActionCable causes live reload crashes
+
+      - if ::Settings.server.asynchronous_notifications
+        :javascript
+          miqInitNotifications();
 
     %body{:onload => is_browser_ie? ? '' : 'miqOnLoad();', 'data-controller' => controller_name}
       = render :partial => "layouts/header"


### PR DESCRIPTION
As I [added an option to disable the asynchronous notifications](https://github.com/ManageIQ/manageiq/pull/13898), ActionCable would cause continuous polling for an inaccessible URL if the initialisation is not wrapped by the same option.

https://www.pivotaltracker.com/story/show/140478617