### PR TITLE
Fix creation of trees for new group

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -349,9 +349,8 @@ class OpsController < ApplicationController
       end
     when :rbac_tree
       @sb[:active_tab] = "rbac_details"
-
       # default to the first tab in group detail
-      @sb[:active_rbac_group_tab] ||= "rbac_customer_tags" if node[0] == 'g'
+      @sb[:active_rbac_group_tab] ||= "rbac_customer_tags" if node.last == 'g'
     when :diagnostics_tree
       case node[0]
       when "root"

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -908,18 +908,20 @@ module OpsController::OpsRbac
 
   def rbac_group_get_details(id)
     @record = @group = MiqGroup.find_by_id(from_cid(id))
-    get_tagdata(@group)
-    # Build the belongsto filters hash
     @belongsto = {}
-    @group.get_belongsto_filters.each do |b|            # Go thru the belongsto tags
-      bobj = MiqFilter.belongsto2object(b)            # Convert to an object
-      next unless bobj
-      @belongsto[bobj.class.to_s + "_" + bobj.id.to_s] = b # Store in hash as <class>_<id> string
-    end
     @filters = {}
-    # Build the managed filters hash
-    [@group.get_managed_filters].flatten.each do |f|
-      @filters[f.split("/")[-2] + "-" + f.split("/")[-1]] = f
+    if @record.present?
+      get_tagdata(@group)
+      # Build the belongsto filters hash
+      @group.get_belongsto_filters.each do |b| # Go thru the belongsto tags
+        bobj = MiqFilter.belongsto2object(b) # Convert to an object
+        next unless bobj
+        @belongsto[bobj.class.to_s + "_" + bobj.id.to_s] = b # Store in hash as <class>_<id> string
+      end
+      # Build the managed filters hash
+      [@group.get_managed_filters].flatten.each do |f|
+        @filters[f.split("/")[-2] + "-" + f.split("/")[-1]] = f
+      end
     end
 
     rbac_group_right_tree(@belongsto.keys)

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -36,7 +36,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
   def set_locals_for_render
     locals = super
     locals.merge!(:id_prefix         => 'hac_',
-                  :check_url         => "/ops/rbac_group_field_changed/#{@group.id || "new"}___",
+                  :check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
                   :oncheck           => @edit ? "miqOnCheckUserFilters" : nil,
                   :checkboxes        => true,
                   :highlight_changes => true,

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -35,7 +35,7 @@ class TreeBuilderTags < TreeBuilder
   def set_locals_for_render
     locals = super
     locals.merge!(:id_prefix         => 'tags_',
-                  :check_url         => "/ops/rbac_group_field_changed/#{@group.id || "new"}___",
+                  :check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
                   :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
                   :checkboxes        => true,
                   :highlight_changes => true,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1421196

Configuration -> Access Control -> Groups -> Configuration -> Add new group -> try tabs Red Hat Tags, Hosts/Nodes & Clusters/Deployment Roles, VMs &Templates

One tree maybe rendered but others won't.

Before:
<img width="908" alt="screen shot 2017-02-14 at 11 40 27 am" src="https://cloud.githubusercontent.com/assets/9210860/22925817/67b40310-f2aa-11e6-9021-52b2bd5cd419.png">

After:
<img width="880" alt="screen shot 2017-02-14 at 11 36 29 am" src="https://cloud.githubusercontent.com/assets/9210860/22925684/f40e85d4-f2a9-11e6-9d6e-2564b8540054.png">

@miq-bot add_label bug