### PR TITLE
Enable container start pages

### DIFF
--- a/app/controllers/mixins/start_url.rb
+++ b/app/controllers/mixins/start_url.rb
@@ -2,11 +2,6 @@ module StartUrl
   extend ActiveSupport::Concern
 
   STORAGE_START_PAGES = %w(storage_manager_show_list).to_set.freeze
-  CONTAINERS_START_PAGES = %w(ems_container_show_list
-                              container_node_show_list
-                              container_group_show_list
-                              container_service_show_list
-                              container_view).to_set.freeze
 
   included do
     helper_method :start_page_options
@@ -41,7 +36,6 @@ module StartUrl
 
   def start_page_allowed?(start_page)
     return false if STORAGE_START_PAGES.include?(start_page)
-    return false if CONTAINERS_START_PAGES.include?(start_page) && !::Settings.product.containers
     role_allows?(:feature => start_page, :any => true)
   end
 end

--- a/spec/controllers/dashboard_controller/start_url_spec.rb
+++ b/spec/controllers/dashboard_controller/start_url_spec.rb
@@ -7,19 +7,6 @@ describe DashboardController do
       stub_user(:features => :all)
     end
 
-    context 'ems_container_show_list' do
-      subject { subj.call('ems_container_show_list') }
-
-      it 'should return true for containers start pages when product flag is set' do
-        stub_settings(:product => {:containers => true})
-        is_expected.to be_truthy
-      end
-
-      it 'should return false for containers start pages when product flag is not set' do
-        is_expected.to be_falsey
-      end
-    end
-
     it 'should return true for host start page' do
       expect(subj.call('host_show_list')).to be_truthy
     end


### PR DESCRIPTION
This enables the container pages to be used as start pages.
