### PR TITLE
Fix units formating for grouped charts

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -824,7 +824,7 @@ module ApplicationController::Performance
     # Grab the first (and should be only) chart column
     col = chart[:columns].first
     # Create the new chart columns for each tag
-    chart[:columns] ||= rpt.extras[:group_by_tags].collect { |t| col + "_" + t }
+    chart[:columns] = rpt.extras[:group_by_tags].collect { |t| col + "_" + t }
   end
 
   def gen_perf_chart(chart, rpt, idx, zoom_action)

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -91,7 +91,9 @@ module ReportFormatter
         unless mri.graph[:type] == 'Donut' || mri.graph[:type] == 'Pie'
           mri.chart[:legend] = {:position => 'bottom'}
         end
-        format, options = javascript_format(mri.graph[:columns][0], nil)
+
+        column = grouped_by_tag_category? ? mri.graph[:columns][0].split(/_+/)[0..-2].join('_') : mri.graph[:columns][0]
+        format, options = javascript_format(column, nil)
         return unless format
 
         axis_formatter = {:function => format, :options => options}
@@ -173,6 +175,10 @@ module ReportFormatter
     def build_performance_chart_pie(_maxcols, _divider)
       mri.chart[:miq][:expand_tooltip] = true
       super
+    end
+
+    def grouped_by_tag_category?
+      !!(mri.performance && mri.performance.fetch_path(:group_by_category))
     end
   end
 end

--- a/lib/report_formatter/chart_common.rb
+++ b/lib/report_formatter/chart_common.rb
@@ -353,7 +353,6 @@ module ReportFormatter
       #  'Vm-num_cpu:total'        gives 'num_cpu' and 'num_cpu__total'
       #  "Vm::Providers::InfraManager::Vm-num_cpu:total"
       #                            gives 'Vm::Providers::InfraManager::Vm' and 'num_cpu__total'
-
       stage1, aggreg = mri.graph[:column].split(/(?<!:):(?!:)/) # split by ':', NOT by '::'
       model1, column = stage1.split('-', 2)
       _model, sub_model = model1.split('.', 2)

--- a/spec/lib/report_formater/c3_formatter_spec.rb
+++ b/spec/lib/report_formater/c3_formatter_spec.rb
@@ -92,4 +92,58 @@ describe ReportFormatter::C3Formatter do
       render_report(report)
     end
   end
+
+  context '#C&U charts without grouping' do
+    let(:report) { cu_chart_without_grouping }
+    before(:each) do
+      render_report(report, &proc { |e| e.options.graph_options = { :chart_type => :performance } })
+    end
+
+    it "has right data" do
+      expect(report.chart[:data][:columns][0].count).to eq(report.table.data.count + 1)
+      expect(report.chart[:data][:columns][0]).to eq(["x", "8/19", "8/20"])
+      expect(report.chart[:data][:columns][1]).to eq(["1", 19_986.0, 205_632.0])
+      expect(report.chart[:data][:columns][2]).to eq(["2", 41_584.0, 41_584.0])
+    end
+
+    it "has right type" do
+      expect(report.chart[:axis][:x][:type]).to eq("timeseries")
+    end
+
+    it 'has right formatting functions' do
+      expect(report.chart[:axis][:y][:tick][:format][:function]).to eq("mhz_to_human_size")
+      expect(report.chart[:miq][:format][:function]).to eq("mhz_to_human_size")
+    end
+    it 'has right tabels' do
+      expect(report.chart[:miq][:name_table]).to eq("1" => "Avg Used", "2" => "Max Available")
+      expect(report.chart[:miq][:category_table]).to eq(["8/19", "8/20"])
+    end
+  end
+
+  context '#C&U charts with grouping' do
+    let(:report) { cu_chart_with_grouping }
+    before(:each) do
+      render_report(report, &proc { |e| e.options.graph_options = { :chart_type => :performance } })
+    end
+
+    it "has right data" do
+      expect(report.chart[:data][:columns][0].count).to eq(report.table.data.count + 1)
+      expect(report.chart[:data][:columns][0]).to eq(["x", "8/19", "8/20"])
+      expect(report.chart[:data][:columns][1]).to eq(["1", 19_986.0, 205_632.0])
+      expect(report.chart[:data][:columns][2]).to eq(["2", 41_584.0, 41_584.0])
+    end
+
+    it "has right type" do
+      expect(report.chart[:axis][:x][:type]).to eq("timeseries")
+    end
+
+    it 'has right formatting functions' do
+      expect(report.chart[:axis][:y][:tick][:format][:function]).to eq("mhz_to_human_size")
+      expect(report.chart[:miq][:format][:function]).to eq("mhz_to_human_size")
+    end
+    it 'has right tabels' do
+      expect(report.chart[:miq][:name_table]).to eq("1" => "Avg Used", "2" => "Max Available")
+      expect(report.chart[:miq][:category_table]).to eq(["8/19", "8/20"])
+    end
+  end
 end


### PR DESCRIPTION
Following PR for #335. Formatting function was not added to charts because of name of columns.
Specs depend on https://github.com/ManageIQ/manageiq/pull/13998

Screenshots
---------
Before:
![screencapture-localhost-3000-host-show-10000000000017-1487063016635](https://cloud.githubusercontent.com/assets/9535558/22927935/1578c89c-f2b4-11e6-95d8-8eed60e2b0fb.png)

After:
![screencapture-localhost-3000-host-show-10000000000017-1487072812137](https://cloud.githubusercontent.com/assets/9535558/22927936/17e5148c-f2b4-11e6-924b-b6b4e0c1d64a.png)

Links
-------
https://bugzilla.redhat.com/show_bug.cgi?id=1367560