### PR TITLE
Make sure bucket duration is not less the 20 minutes

### DIFF
--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -6,8 +6,8 @@
     dash.tenant = '_ops';
     dash.minBucketDurationInSecondes = 20 * 60;
 
-    var NUMBER_OF_MILISEC_IN_HOUR = 60 * 60 * 1000;
-    var NUMBER_OF_MILISEC_IN_SEC = 1000;
+    var NUMBER_OF_MILLISEC_IN_HOUR = 60 * 60 * 1000;
+    var NUMBER_OF_MILLISEC_IN_SEC = 1000;
 
     // get the pathname and remove trailing / if exist
     var pathname = $window.location.pathname.replace(/\/$/, '');
@@ -108,11 +108,11 @@
       dash.metricId = metricId;
       dash.currentItem = currentItem;
       var ends = dash.timeFilter.date.valueOf(); // javascript time is in milisec
-      var diff = dash.timeFilter.time_range * dash.timeFilter.range_count * NUMBER_OF_MILISEC_IN_HOUR; // time_range is in hours
+      var diff = dash.timeFilter.time_range * dash.timeFilter.range_count * NUMBER_OF_MILLISEC_IN_HOUR; // time_range is in hours
       var starts = ends - diff;
-      var bucket_duration = parseInt(diff / NUMBER_OF_MILISEC_IN_SEC / numberOfBucketsInChart); // bucket duration is in seconds
+      var bucket_duration = parseInt(diff / NUMBER_OF_MILLISEC_IN_SEC / numberOfBucketsInChart); // bucket duration is in seconds
 
-      // make sure backet duration is not smaller then minBucketDurationInSecondes seconds
+      // make sure bucket duration is not smaller then minBucketDurationInSecondes seconds
       if (bucket_duration < dash.minBucketDurationInSecondes) {
         bucket_duration = dash.minBucketDurationInSecondes;
       }


### PR DESCRIPTION
**Description**

When reviewing the ad-hoc graphs we saw gaps in the graph, this gaps happen when data is collected in a slow rate (more then 5minutes per sample).
This PR makes it impossible for the user to chose a time bucket less then N minutes (N equels 20 for this PR)
We assume that if data is not collected for more then N minutes this is something user need to know about.

**Secnd stage**
Out of scope for this PR, get the N minutes value automatically from the ops team.

**Screenshot**
_Interval between points is 20 minutes ( 03:29 -> 03:49 -> 04:09 ... )._
![gifrecord_2017-02-15_160918](https://cloud.githubusercontent.com/assets/2181522/22977969/72d8c2e0-f399-11e6-90cd-cf93e43b6587.gif)
