### PR TITLE
Create Provider when user creates CloudManager

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -764,6 +764,19 @@ module EmsCommon
     @edit[:new][:api_version] = @ems.api_version
     @edit[:new][:provider_id] = @ems.provider_id
 
+    # when ems has Provider parent, we should show its name
+    if @ems.respond_to? :provider_class
+      provider = @ems.provider
+
+      @edit[:new][:name] = provider.name if provider
+
+      if @ems.kind_of?(ManageIQ::Providers::Amazon::CloudManager)
+        # TODO: when GUI is able to diplay region checkbox, return all regions
+        @edit[:new][:provider_region] = provider.provider_regions.first if provider
+      end
+
+    end
+
     if @ems.kind_of?(ManageIQ::Providers::Openstack::CloudManager) ||
        @ems.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
       # Special behaviour for OpenStack while keeping it backwards compatible for the rest


### PR DESCRIPTION
When user POSTs to CloudManager's create form, we now
create Provider instead of CloudManager. Provider then
creates CloudManager(s) accordingly.

This PR supports usage of Provider concept provided in these PRs:

* https://github.com/ManageIQ/manageiq/pull/13915
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/137