### PR TITLE
MiqReport.to_html minor cleanup

### DIFF
--- a/lib/report_formatter/html.rb
+++ b/lib/report_formatter/html.rb
@@ -26,7 +26,6 @@ module ReportFormatter
 
     def build_document_body
       mri = options.mri
-      tz = mri.get_time_zone(Time.zone.name)
       output << "<table class='table table-striped table-bordered'>"
       output << "<thead>"
       output << "<tr>"
@@ -41,6 +40,14 @@ module ReportFormatter
       end
       output << '<tbody>'
 
+      build_html_rows(mri, output)
+
+      output << '</tbody>'
+    end
+
+    def build_html_rows(mri, output)
+      # This is similar to MiqReport.build_html_rows, needs to be unified
+      tz = mri.get_time_zone(Time.zone.name)
       row = 0
       unless mri.table.nil?
         row_limit = mri.rpt_options && mri.rpt_options[:row_limit] ? mri.rpt_options[:row_limit] : 0
@@ -95,9 +102,8 @@ module ReportFormatter
         output << group_rows(save_val, mri.col_order.length, group_text)
         output << group_rows(:_total_, mri.col_order.length)
       end
-
-      output << '</tbody>'
     end
+    private :build_html_rows
 
     # Generate grouping rows for the passed in grouping value
     def group_rows(group, col_count, group_text = nil)

--- a/lib/report_formatter/html.rb
+++ b/lib/report_formatter/html.rb
@@ -43,7 +43,6 @@ module ReportFormatter
 
       # table data
       #     save_val = nil
-      counter = 0
       row = 0
       unless mri.table.nil?
         row_limit = mri.rpt_options && mri.rpt_options[:row_limit] ? mri.rpt_options[:row_limit] : 0

--- a/lib/report_formatter/html.rb
+++ b/lib/report_formatter/html.rb
@@ -41,8 +41,6 @@ module ReportFormatter
       end
       output << '<tbody>'
 
-      # table data
-      #     save_val = nil
       row = 0
       unless mri.table.nil?
         row_limit = mri.rpt_options && mri.rpt_options[:row_limit] ? mri.rpt_options[:row_limit] : 0

--- a/lib/report_formatter/html.rb
+++ b/lib/report_formatter/html.rb
@@ -46,10 +46,6 @@ module ReportFormatter
       counter = 0
       row = 0
       unless mri.table.nil?
-
-        # Following line commented for now - for not showing repeating column values
-        #       prev_data = String.new                # Initialize the prev_data variable
-
         row_limit = mri.rpt_options && mri.rpt_options[:row_limit] ? mri.rpt_options[:row_limit] : 0
         save_val = :_undefined_                                 # Hang on to the current group value
         group_text = nil                                        # Optionally override what gets displayed for the group (i.e. Chargeback)


### PR DESCRIPTION
This pr
 * removes some useless ancient snippets

and

 * structures `ReportFormatter.build_html_rows` so it reminds `MiqReport.build_html_rows`.

I will need more test & play before I am brave enough to cut one of the `build_html_rows` method.

@miq-bot add_label technical debt
@miq-bot assign @mzazrivec 