### PR TITLE
@ght_type is never equal 'chart'

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -321,8 +321,8 @@ class ApplicationController < ActionController::Base
     @title    = @report.title
 
     @zgraph = case @ght_type
-              when 'tabular'         then nil
-              when 'graph', 'hybrid' then true
+              when 'tabular' then nil
+              when 'hybrid'  then true
               end
 
     render controller_name == 'report' ? 'show' : 'shared/show_report'


### PR DESCRIPTION
The @ght_type can be either params[:type] or 'tabular' or 'hybrid'.

The params[:type] can be either 'tabular' or 'hybrid'.

See `WidgetPresenter.button_fullscreen` for more info.

Cleaning up MiqRererport presentation will take many small steps.

@miq-bot add_label technical debt
@miq-bot assign @mzazrivec 