### PR TITLE
Make buttons visible only in list of chargeback saved reports

### DIFF
--- a/app/helpers/application_helper/button/chargeback_download_choice.rb
+++ b/app/helpers/application_helper/button/chargeback_download_choice.rb
@@ -4,4 +4,8 @@ class ApplicationHelper::Button::ChargebackDownloadChoice < ApplicationHelper::B
                                                               @report && !@report.contains_records?
     @error_message.present?
   end
+
+  def visible?
+    @view_context.x_active_tree == :cb_reports_tree
+  end
 end

--- a/app/helpers/application_helper/button/chargeback_report_only.rb
+++ b/app/helpers/application_helper/button/chargeback_report_only.rb
@@ -4,4 +4,8 @@ class ApplicationHelper::Button::ChargebackReportOnly < ApplicationHelper::Butto
                                                               @report && !@report.contains_records?
     @error_message.present?
   end
+
+  def visible?
+    @view_context.x_active_tree == :cb_reports_tree
+  end
 end


### PR DESCRIPTION
buttons `ChargebackReportOnly` and `ChargebackDownloadChoice` should be ? only in saved chargeback reports.

before
![screen shot 2017-02-15 at 14 15 55](https://cloud.githubusercontent.com/assets/14937244/22976024/47ba92e2-f389-11e6-8fec-706dab006656.png)

after
![screen shot 2017-02-15 at 14 14 50](https://cloud.githubusercontent.com/assets/14937244/22975987/220faeba-f389-11e6-85f7-cc33e27fa50e.png)



@miq-bot assign @mzazrivec 
