### PR TITLE
Quadicon size is always 72, simplify to reflect

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -134,16 +134,8 @@ module QuadiconHelper
     ].join("; ")
   end
 
-  def quadicon_default_options
-    {
-      :size => 72
-    }
-  end
-
   def render_quadicon(item, options = {})
     return unless item
-
-    options = quadicon_default_options.merge!(options)
 
     tag_options = {
       :id => "quadicon_#{item.id}"
@@ -326,13 +318,12 @@ module QuadiconHelper
   # Build a reflection img with common options
   #
   def quadicon_reflection_img(options = {})
-    size = options.delete(:size) || 72
     path = options.delete(:path) || "layout/reflection.png"
 
     options = {
       :border => 0,
-      :width  => size,
-      :height => size
+      :width  => 72,
+      :height => 72,
     }.merge(options)
 
     image_tag(image_path(path), options)
@@ -418,7 +409,6 @@ module QuadiconHelper
   # Renders a quadicon for service classes
   #
   def render_service_quadicon(item, options)
-    size = options[:size]
     output = []
     output << flobj_img_simple
 
@@ -432,7 +422,7 @@ module QuadiconHelper
 
     output << content_tag(:div, :class => "flobj e72") do
       quadicon_link_to(url, **link_opts) do
-        quadicon_reflection_img(:path => item.decorate.listicon_image, :size => size)
+        quadicon_reflection_img(:path => item.decorate.listicon_image)
       end
     end
 
@@ -443,7 +433,6 @@ module QuadiconHelper
   #
   def render_resource_pool_quadicon(item, options)
     img = item.vapp ? "100/vapp.png" : "100/resource_pool.png"
-    size = options[:size]
     output = []
 
     output << flobj_img_simple
@@ -456,7 +445,7 @@ module QuadiconHelper
         url = quadicon_show_links? ? url_for_record(item) : ""
 
         link_to(url, :title => h(item.name)) do
-          quadicon_reflection_img(:path => "layout/clearpix.gif", :size => size)
+          quadicon_reflection_img(:path => "layout/clearpix.gif")
         end
       end
     end
@@ -466,7 +455,6 @@ module QuadiconHelper
   # Renders a quadicon for hosts
   #
   def render_host_quadicon(item, options)
-    size = options[:size]
     output = []
 
     if settings(:quadicons, :host)
@@ -496,7 +484,7 @@ module QuadiconHelper
         title = _("Name: %{name} | Hostname: %{hostname}") % {:name => h(item.name), :hostname => h(item.hostname)}
 
         link_to(href, :title => title) do
-          quadicon_reflection_img(:size => size)
+          quadicon_reflection_img
         end
       end
     end
@@ -506,7 +494,6 @@ module QuadiconHelper
   # Renders a quadicon for ext_management_systems
   #
   def render_ext_management_system_quadicon(item, options)
-    size = options[:size]
     output = []
 
     if settings(:quadicons, db_for_quadicon)
@@ -531,7 +518,7 @@ module QuadiconHelper
            :status   => h(item.last_refresh_status.titleize)}
 
         link_to(url_for_record(item), :title => title) do
-          quadicon_reflection_img(:size => size)
+          quadicon_reflection_img
         end
       end
     end
@@ -541,7 +528,6 @@ module QuadiconHelper
   # Renders quadicon for ems_clusters
   #
   def render_ems_cluster_quadicon(item, options)
-    size = options[:size]
     output = []
 
     output << flobj_img_simple("layout/base-single.png")
@@ -554,7 +540,7 @@ module QuadiconHelper
 
       output << content_tag(:div, :class => 'flobj') do
         link_to(url, :title => h(item.v_qualified_desc)) do
-          quadicon_reflection_img(:size => size)
+          quadicon_reflection_img
         end
       end
     end
@@ -562,7 +548,6 @@ module QuadiconHelper
   end
 
   def render_non_listicon_single_quadicon(item, options)
-    size = options[:size]
     output = []
 
     img_path = if item.respond_to?(:decorator_class?) && item.decorator_class?
@@ -578,7 +563,6 @@ module QuadiconHelper
       name = item.name
 
       img_opts = {
-        :size  => size,
         :title => h(name),
         :path  => "layout/clearpix.gif"
       }
@@ -608,7 +592,6 @@ module QuadiconHelper
   end
 
   def render_listicon_single_quadicon(item, options)
-    size = options[:size]
     output = []
 
     output << flobj_img_simple("layout/base-single.png")
@@ -655,7 +638,6 @@ module QuadiconHelper
   # Renders a storage quadicon
   #
   def render_storage_quadicon(item, options)
-    size = options[:size]
     output = []
 
     if settings(:quadicons, :storage)
@@ -712,10 +694,8 @@ module QuadiconHelper
     opts
   end
 
-  def quadicon_storage_img_options(item, size: 72)
+  def quadicon_storage_img_options(item)
     opts = {
-      :width  => size,
-      :height => size,
       :title  => _("Name: %{name} | Datastore Type: %{storage_type}") % {:name => h(item.name), :storage_type => h(item.store_type)}
     }
 
@@ -725,7 +705,6 @@ module QuadiconHelper
   # Renders a vm quadicon
   #
   def render_vm_or_template_quadicon(item, options)
-    size = options[:size]
     output = []
 
     if settings(:quadicons, item.class.base_model.name.underscore.to_sym)
@@ -795,10 +774,8 @@ module QuadiconHelper
     url
   end
 
-  def quadicon_vt_img_options(item, size: 72)
+  def quadicon_vt_img_options(item)
     options = {
-      :width  => size,
-      :height => size,
       :title  => item.name
     }
 

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -426,7 +426,7 @@ module QuadiconHelper
       link_opts = {:sparkle => true, :remote => true}
     end
 
-    output << content_tag(:div, :class => "flobj e#{size}") do
+    output << content_tag(:div, :class => "flobj e72") do
       quadicon_link_to(url, **link_opts) do
         quadicon_reflection_img(:path => item.decorate.listicon_image, :size => size)
       end
@@ -444,8 +444,8 @@ module QuadiconHelper
     output = []
 
     output << flobj_img_simple(options[:size])
-    output << flobj_img_simple(width * 1.8, img, "e#{size}")
-    output << flobj_img_simple(size, '100/shield.png', "g#{size}") unless item.get_policies.empty?
+    output << flobj_img_simple(width * 1.8, img, "e72")
+    output << flobj_img_simple(size, '100/shield.png', "g72") unless item.get_policies.empty?
 
     unless options[:typ] == :listnav
       # listnav, no clear image needed
@@ -470,14 +470,14 @@ module QuadiconHelper
     if settings(:quadicons, :host)
       output << flobj_img_simple(size, "layout/base.png")
 
-      output << flobj_p_simple("a#{size}", item.vms.size)
-      output << flobj_img_simple(size, "svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b#{size}")
-      output << flobj_img_simple(size, img_for_host_vendor(item), "c#{size}")
-      output << flobj_img_simple(size, img_for_auth_status(item), "d#{size}")
-      output << flobj_img_simple(size, '100/shield.png', "g#{size}") unless item.get_policies.empty?
+      output << flobj_p_simple("a72", item.vms.size)
+      output << flobj_img_simple(size, "svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b72")
+      output << flobj_img_simple(size, img_for_host_vendor(item), "c72")
+      output << flobj_img_simple(size, img_for_auth_status(item), "d72")
+      output << flobj_img_simple(size, '100/shield.png', "g72") unless item.get_policies.empty?
     else
       output << flobj_img_simple(size)
-      output << flobj_img_simple(width * 1.8, img_for_host_vendor(item), "e#{size}")
+      output << flobj_img_simple(width * 1.8, img_for_host_vendor(item), "e72")
     end
 
     if options[:typ] == :listnav
@@ -510,14 +510,14 @@ module QuadiconHelper
 
     if settings(:quadicons, db_for_quadicon)
       output << flobj_img_simple(size, "layout/base.png")
-      output << flobj_p_simple("a#{size}", item.kind_of?(EmsCloud) ? item.total_vms : item.hosts.size)
-      output << flobj_p_simple("b#{size}", item.total_miq_templates) if item.kind_of?(EmsCloud)
-      output << flobj_img_simple(size, "svg/vendor-#{h(item.image_name)}.svg", "c#{size}")
-      output << flobj_img_simple(size, img_for_auth_status(item), "d#{size}")
-      output << flobj_img_simple(size, '100/shield.png', "g#{size}") unless item.get_policies.empty?
+      output << flobj_p_simple("a72", item.kind_of?(EmsCloud) ? item.total_vms : item.hosts.size)
+      output << flobj_p_simple("b72", item.total_miq_templates) if item.kind_of?(EmsCloud)
+      output << flobj_img_simple(size, "svg/vendor-#{h(item.image_name)}.svg", "c72")
+      output << flobj_img_simple(size, img_for_auth_status(item), "d72")
+      output << flobj_img_simple(size, '100/shield.png', "g72") unless item.get_policies.empty?
     else
       output << flobj_img_simple(size, "layout/base-single.png")
-      output << flobj_img_simple(width * 1.8, "svg/vendor-#{h(item.image_name)}.svg", "e#{size}")
+      output << flobj_img_simple(width * 1.8, "svg/vendor-#{h(item.image_name)}.svg", "e72")
     end
 
     if options[:typ] == :listnav
@@ -544,8 +544,8 @@ module QuadiconHelper
     output = []
 
     output << flobj_img_simple(size, "layout/base-single.png")
-    output << flobj_img_simple(size * 1.8, "100/emscluster.png", "e#{size}")
-    output << flobj_img_simple(size, "100/shield.png", "g#{size}") unless item.get_policies.empty?
+    output << flobj_img_simple(size * 1.8, "100/emscluster.png", "e72")
+    output << flobj_img_simple(size, "100/shield.png", "g72") unless item.get_policies.empty?
 
     unless options[:typ] == :listnav
       # Listnav, no clear image needed
@@ -571,7 +571,7 @@ module QuadiconHelper
                end
 
     output << flobj_img_simple(size, "layout/base-single.png")
-    output << flobj_img_simple(size, img_path, "e#{size}")
+    output << flobj_img_simple(size, img_path, "e72")
 
     unless options[:typ] == :listnav
       name = item.name
@@ -611,7 +611,7 @@ module QuadiconHelper
     output = []
 
     output << flobj_img_simple(size, "layout/base-single.png")
-    output << flobj_img_simple(size * 1.8, "100/#{@listicon}.png", "e#{size}")
+    output << flobj_img_simple(size * 1.8, "100/#{@listicon}.png", "e72")
 
     unless options[:typ] == :listnav
       title = case @listicon
@@ -659,16 +659,16 @@ module QuadiconHelper
 
     if settings(:quadicons, :storage)
       output << flobj_img_simple(size, "layout/base.png")
-      output << flobj_img_simple(size, "100/storagetype-#{item.store_type.nil? ? "unknown" : h(item.store_type.to_s.downcase)}.png", "a#{size}")
-      output << flobj_p_simple("b#{size}", item.v_total_vms)
-      output << flobj_p_simple("c#{size}", item.v_total_hosts)
+      output << flobj_img_simple(size, "100/storagetype-#{item.store_type.nil? ? "unknown" : h(item.store_type.to_s.downcase)}.png", "a72")
+      output << flobj_p_simple("b72", item.v_total_vms)
+      output << flobj_p_simple("c72", item.v_total_hosts)
 
       space_percent = item.free_space_percent_of_total == 100 ? 20 : ((item.free_space_percent_of_total.to_i + 2) / 5.25).round
-      output << flobj_img_simple(size, "100/piecharts/datastore/#{h(space_percent)}.png", "d#{size}")
+      output << flobj_img_simple(size, "100/piecharts/datastore/#{h(space_percent)}.png", "d72")
     else
       space_percent = (item.used_space_percent_of_total.to_i + 9) / 10
       output << flobj_img_simple(size, "layout/base-single.png")
-      output << flobj_img_simple(size, "100/datastore-#{h(space_percent)}.png", "e#{size}")
+      output << flobj_img_simple(size, "100/datastore-#{h(space_percent)}.png", "e72")
     end
 
     if options[:typ] == :listnav
@@ -729,32 +729,31 @@ module QuadiconHelper
 
     if settings(:quadicons, item.class.base_model.name.underscore.to_sym)
       output << flobj_img_simple(size, "layout/base.png")
-      output << flobj_img_simple(size, "svg/os-#{h(item.os_image_name.downcase)}.svg", "a#{size}")
-      output << flobj_img_simple(size, "svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b#{size}")
-      output << flobj_img_simple(size, "svg/vendor-#{h(item.vendor.downcase)}.svg", "c#{size}")
+      output << flobj_img_simple(size, "svg/os-#{h(item.os_image_name.downcase)}.svg", "a72")
+      output << flobj_img_simple(size, "svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b72")
+      output << flobj_img_simple(size, "svg/vendor-#{h(item.vendor.downcase)}.svg", "c72")
 
       unless item.get_policies.empty?
-        output << flobj_img_simple(size, "100/shield.png", "g#{size}")
+        output << flobj_img_simple(size, "100/shield.png", "g72")
       end
 
       if quadicon_policy_sim? && !session[:policies].empty? && quadicon_lastaction_is_policy_sim?
-        output << flobj_img_simple(size, img_for_compliance(item), "d#{size}")
+        output << flobj_img_simple(size, img_for_compliance(item), "d72")
       end
 
       unless quadicon_lastaction_is_policy_sim?
-        output << flobj_p_simple("d#{size}", h(item.v_total_snapshots))
+        output << flobj_p_simple("d72", h(item.v_total_snapshots))
       end
     else
       width = options[:size] == 150 ? 54 : 35
       adjusted_width = width * 1.8
-
       output << flobj_img_simple(size, "layout/base-single.png")
 
       if quadicon_policy_sim? && !session[:policies].empty?
-        output << flobj_img_simple(adjusted_width, img_for_compliance(item), "e#{size}")
+        output << flobj_img_simple(adjusted_width, img_for_compliance(item), "e72")
       end
 
-      output << flobj_img_simple(adjusted_width, img_for_vendor(item), "e#{size}")
+      output << flobj_img_simple(adjusted_width, img_for_vendor(item), "e72")
     end
 
     unless options[:typ] == :listnav

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -440,11 +440,10 @@ module QuadiconHelper
   def render_resource_pool_quadicon(item, options)
     img = item.vapp ? "100/vapp.png" : "100/resource_pool.png"
     size = options[:size]
-    width = options[:size] == 150 ? 54 : 35
     output = []
 
     output << flobj_img_simple(options[:size])
-    output << flobj_img_simple(width * 1.8, img, "e72")
+    output << flobj_img_simple(adjusted_quad_size, img, "e72")
     output << flobj_img_simple(size, '100/shield.png', "g72") unless item.get_policies.empty?
 
     unless options[:typ] == :listnav
@@ -464,7 +463,6 @@ module QuadiconHelper
   #
   def render_host_quadicon(item, options)
     size = options[:size]
-    width = options[:size] == 150 ? 54 : 35
     output = []
 
     if settings(:quadicons, :host)
@@ -477,7 +475,7 @@ module QuadiconHelper
       output << flobj_img_simple(size, '100/shield.png', "g72") unless item.get_policies.empty?
     else
       output << flobj_img_simple(size)
-      output << flobj_img_simple(width * 1.8, img_for_host_vendor(item), "e72")
+      output << flobj_img_simple(adjusted_quad_size, img_for_host_vendor(item), "e72")
     end
 
     if options[:typ] == :listnav
@@ -505,7 +503,6 @@ module QuadiconHelper
   #
   def render_ext_management_system_quadicon(item, options)
     size = options[:size]
-    width = options[:size] == 150 ? 54 : 35
     output = []
 
     if settings(:quadicons, db_for_quadicon)
@@ -517,7 +514,7 @@ module QuadiconHelper
       output << flobj_img_simple(size, '100/shield.png', "g72") unless item.get_policies.empty?
     else
       output << flobj_img_simple(size, "layout/base-single.png")
-      output << flobj_img_simple(width * 1.8, "svg/vendor-#{h(item.image_name)}.svg", "e72")
+      output << flobj_img_simple(adjusted_quad_size, "svg/vendor-#{h(item.image_name)}.svg", "e72")
     end
 
     if options[:typ] == :listnav
@@ -544,7 +541,7 @@ module QuadiconHelper
     output = []
 
     output << flobj_img_simple(size, "layout/base-single.png")
-    output << flobj_img_simple(size * 1.8, "100/emscluster.png", "e72")
+    output << flobj_img_simple(adjusted_quad_size, "100/emscluster.png", "e72")
     output << flobj_img_simple(size, "100/shield.png", "g72") unless item.get_policies.empty?
 
     unless options[:typ] == :listnav
@@ -611,7 +608,7 @@ module QuadiconHelper
     output = []
 
     output << flobj_img_simple(size, "layout/base-single.png")
-    output << flobj_img_simple(size * 1.8, "100/#{@listicon}.png", "e72")
+    output << flobj_img_simple(adjusted_quad_size, "100/#{@listicon}.png", "e72")
 
     unless options[:typ] == :listnav
       title = case @listicon
@@ -745,15 +742,13 @@ module QuadiconHelper
         output << flobj_p_simple("d72", h(item.v_total_snapshots))
       end
     else
-      width = options[:size] == 150 ? 54 : 35
-      adjusted_width = width * 1.8
       output << flobj_img_simple(size, "layout/base-single.png")
 
       if quadicon_policy_sim? && !session[:policies].empty?
-        output << flobj_img_simple(adjusted_width, img_for_compliance(item), "e72")
+        output << flobj_img_simple(adjusted_quad_size, img_for_compliance(item), "e72")
       end
 
-      output << flobj_img_simple(adjusted_width, img_for_vendor(item), "e72")
+      output << flobj_img_simple(adjusted_quad_size, img_for_vendor(item), "e72")
     end
 
     unless options[:typ] == :listnav
@@ -882,5 +877,10 @@ module QuadiconHelper
       attributes[:id] = "v-#{record.id}"
     end
     attributes
+  end
+
+  # single quadicon width and height in pixels; also used from _compare_sections
+  def self.adjusted_quad_size
+    64
   end
 end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -397,7 +397,7 @@ module QuadiconHelper
   end
 
   def flobj_img_small(image = nil, cls = '')
-    flobj_img_simple(image, cls, adjusted_quad_size)
+    flobj_img_simple(image, cls, 64)
   end
 
   def flobj_p_simple(cls, text)
@@ -858,10 +858,5 @@ module QuadiconHelper
       attributes[:id] = "v-#{record.id}"
     end
     attributes
-  end
-
-  # single quadicon width and height in pixels; also used from _compare_sections
-  def self.adjusted_quad_size
-    64
   end
 end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -396,13 +396,17 @@ module QuadiconHelper
     value.first(trunc_to / 2) + "..." + value.last(trunc_to / 2)
   end
 
-  def flobj_img_simple(size = 72, image = nil, cls = '')
+  def flobj_img_simple(image = nil, cls = '', size = 72)
     image ||= "layout/base-single.png"
 
     content_tag(:div, :class => "flobj #{cls}") do
       tag(:img, :border => 0, :src => ActionController::Base.helpers.image_path(image),
           :width => size, :height => size)
     end
+  end
+
+  def flobj_img_small(image = nil, cls = '')
+    flobj_img_simple(image, cls, adjusted_quad_size)
   end
 
   def flobj_p_simple(cls, text)
@@ -416,7 +420,7 @@ module QuadiconHelper
   def render_service_quadicon(item, options)
     size = options[:size]
     output = []
-    output << flobj_img_simple(size)
+    output << flobj_img_simple
 
     url = ""
     link_opts = {}
@@ -442,9 +446,9 @@ module QuadiconHelper
     size = options[:size]
     output = []
 
-    output << flobj_img_simple(size)
-    output << flobj_img_simple(adjusted_quad_size, img, "e72")
-    output << flobj_img_simple(size, '100/shield.png', "g72") unless item.get_policies.empty?
+    output << flobj_img_simple
+    output << flobj_img_small(img, "e72")
+    output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
 
     unless options[:typ] == :listnav
       # listnav, no clear image needed
@@ -466,16 +470,16 @@ module QuadiconHelper
     output = []
 
     if settings(:quadicons, :host)
-      output << flobj_img_simple(size, "layout/base.png")
+      output << flobj_img_simple("layout/base.png")
 
       output << flobj_p_simple("a72", item.vms.size)
-      output << flobj_img_simple(size, "svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b72")
-      output << flobj_img_simple(size, img_for_host_vendor(item), "c72")
-      output << flobj_img_simple(size, img_for_auth_status(item), "d72")
-      output << flobj_img_simple(size, '100/shield.png', "g72") unless item.get_policies.empty?
+      output << flobj_img_simple("svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b72")
+      output << flobj_img_simple(img_for_host_vendor(item), "c72")
+      output << flobj_img_simple(img_for_auth_status(item), "d72")
+      output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
     else
-      output << flobj_img_simple(size)
-      output << flobj_img_simple(adjusted_quad_size, img_for_host_vendor(item), "e72")
+      output << flobj_img_simple
+      output << flobj_img_small(img_for_host_vendor(item), "e72")
     end
 
     if options[:typ] == :listnav
@@ -506,19 +510,19 @@ module QuadiconHelper
     output = []
 
     if settings(:quadicons, db_for_quadicon)
-      output << flobj_img_simple(size, "layout/base.png")
+      output << flobj_img_simple("layout/base.png")
       output << flobj_p_simple("a72", item.kind_of?(EmsCloud) ? item.total_vms : item.hosts.size)
       output << flobj_p_simple("b72", item.total_miq_templates) if item.kind_of?(EmsCloud)
-      output << flobj_img_simple(size, "svg/vendor-#{h(item.image_name)}.svg", "c72")
-      output << flobj_img_simple(size, img_for_auth_status(item), "d72")
-      output << flobj_img_simple(size, '100/shield.png', "g72") unless item.get_policies.empty?
+      output << flobj_img_simple("svg/vendor-#{h(item.image_name)}.svg", "c72")
+      output << flobj_img_simple(img_for_auth_status(item), "d72")
+      output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
     else
-      output << flobj_img_simple(size, "layout/base-single.png")
-      output << flobj_img_simple(adjusted_quad_size, "svg/vendor-#{h(item.image_name)}.svg", "e72")
+      output << flobj_img_simple("layout/base-single.png")
+      output << flobj_img_small("svg/vendor-#{h(item.image_name)}.svg", "e72")
     end
 
     if options[:typ] == :listnav
-      output << flobj_img_simple(size, "layout/reflection.png")
+      output << flobj_img_simple("layout/reflection.png")
     else
       output << content_tag(:div, :class => 'flobj') do
         title = _("Name: %{name} | Hostname: %{hostname} | Refresh Status: %{status}") %
@@ -540,9 +544,9 @@ module QuadiconHelper
     size = options[:size]
     output = []
 
-    output << flobj_img_simple(size, "layout/base-single.png")
-    output << flobj_img_simple(adjusted_quad_size, "100/emscluster.png", "e72")
-    output << flobj_img_simple(size, "100/shield.png", "g72") unless item.get_policies.empty?
+    output << flobj_img_simple("layout/base-single.png")
+    output << flobj_img_small("100/emscluster.png", "e72")
+    output << flobj_img_simple("100/shield.png", "g72") unless item.get_policies.empty?
 
     unless options[:typ] == :listnav
       # Listnav, no clear image needed
@@ -567,8 +571,8 @@ module QuadiconHelper
                  "100/#{item.class.base_class.to_s.underscore}.png"
                end
 
-    output << flobj_img_simple(size, "layout/base-single.png")
-    output << flobj_img_simple(size, img_path, "e72")
+    output << flobj_img_simple("layout/base-single.png")
+    output << flobj_img_simple(img_path, "e72")
 
     unless options[:typ] == :listnav
       name = item.name
@@ -607,8 +611,8 @@ module QuadiconHelper
     size = options[:size]
     output = []
 
-    output << flobj_img_simple(size, "layout/base-single.png")
-    output << flobj_img_simple(adjusted_quad_size, "100/#{@listicon}.png", "e72")
+    output << flobj_img_simple("layout/base-single.png")
+    output << flobj_img_small("100/#{@listicon}.png", "e72")
 
     unless options[:typ] == :listnav
       title = case @listicon
@@ -655,21 +659,21 @@ module QuadiconHelper
     output = []
 
     if settings(:quadicons, :storage)
-      output << flobj_img_simple(size, "layout/base.png")
-      output << flobj_img_simple(size, "100/storagetype-#{item.store_type.nil? ? "unknown" : h(item.store_type.to_s.downcase)}.png", "a72")
+      output << flobj_img_simple("layout/base.png")
+      output << flobj_img_simple("100/storagetype-#{item.store_type.nil? ? "unknown" : h(item.store_type.to_s.downcase)}.png", "a72")
       output << flobj_p_simple("b72", item.v_total_vms)
       output << flobj_p_simple("c72", item.v_total_hosts)
 
       space_percent = item.free_space_percent_of_total == 100 ? 20 : ((item.free_space_percent_of_total.to_i + 2) / 5.25).round
-      output << flobj_img_simple(size, "100/piecharts/datastore/#{h(space_percent)}.png", "d72")
+      output << flobj_img_simple("100/piecharts/datastore/#{h(space_percent)}.png", "d72")
     else
       space_percent = (item.used_space_percent_of_total.to_i + 9) / 10
-      output << flobj_img_simple(size, "layout/base-single.png")
-      output << flobj_img_simple(size, "100/datastore-#{h(space_percent)}.png", "e72")
+      output << flobj_img_simple("layout/base-single.png")
+      output << flobj_img_simple("100/datastore-#{h(space_percent)}.png", "e72")
     end
 
     if options[:typ] == :listnav
-      output << flobj_img_simple(size, "layout/reflection.png")
+      output << flobj_img_simple("layout/reflection.png")
     else
       output << content_tag(:div, :class => 'flobj') do
         quadicon_link_to(quadicon_storage_url(item), **quadicon_storage_link_options) do
@@ -725,30 +729,30 @@ module QuadiconHelper
     output = []
 
     if settings(:quadicons, item.class.base_model.name.underscore.to_sym)
-      output << flobj_img_simple(size, "layout/base.png")
-      output << flobj_img_simple(size, "svg/os-#{h(item.os_image_name.downcase)}.svg", "a72")
-      output << flobj_img_simple(size, "svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b72")
-      output << flobj_img_simple(size, "svg/vendor-#{h(item.vendor.downcase)}.svg", "c72")
+      output << flobj_img_simple("layout/base.png")
+      output << flobj_img_simple("svg/os-#{h(item.os_image_name.downcase)}.svg", "a72")
+      output << flobj_img_simple("svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b72")
+      output << flobj_img_simple("svg/vendor-#{h(item.vendor.downcase)}.svg", "c72")
 
       unless item.get_policies.empty?
-        output << flobj_img_simple(size, "100/shield.png", "g72")
+        output << flobj_img_simple("100/shield.png", "g72")
       end
 
       if quadicon_policy_sim? && !session[:policies].empty? && quadicon_lastaction_is_policy_sim?
-        output << flobj_img_simple(size, img_for_compliance(item), "d72")
+        output << flobj_img_simple(img_for_compliance(item), "d72")
       end
 
       unless quadicon_lastaction_is_policy_sim?
         output << flobj_p_simple("d72", h(item.v_total_snapshots))
       end
     else
-      output << flobj_img_simple(size, "layout/base-single.png")
+      output << flobj_img_simple("layout/base-single.png")
 
       if quadicon_policy_sim? && !session[:policies].empty?
-        output << flobj_img_simple(adjusted_quad_size, img_for_compliance(item), "e72")
+        output << flobj_img_small(img_for_compliance(item), "e72")
       end
 
-      output << flobj_img_simple(adjusted_quad_size, img_for_vendor(item), "e72")
+      output << flobj_img_small(img_for_vendor(item), "e72")
     end
 
     unless options[:typ] == :listnav

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -172,7 +172,7 @@ module QuadiconHelper
     when 'storage'               then render_storage_quadicon(item, options)
     when 'vm_or_template'        then render_vm_or_template_quadicon(item, options)
     else
-      flobj_img_simple(options[:size], "#{options[:size]}/#{partial_name}.png")
+      raise "unknown quadicon kind - #{quadicon_builder_name_from(item)}"
     end
   end
 

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -396,7 +396,7 @@ module QuadiconHelper
     value.first(trunc_to / 2) + "..." + value.last(trunc_to / 2)
   end
 
-  def flobj_img_simple(size, image = nil, cls = '')
+  def flobj_img_simple(size = 72, image = nil, cls = '')
     image ||= "layout/base-single.png"
 
     content_tag(:div, :class => "flobj #{cls}") do
@@ -442,7 +442,7 @@ module QuadiconHelper
     size = options[:size]
     output = []
 
-    output << flobj_img_simple(options[:size])
+    output << flobj_img_simple(size)
     output << flobj_img_simple(adjusted_quad_size, img, "e72")
     output << flobj_img_simple(size, '100/shield.png', "g72") unless item.get_policies.empty?
 

--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -21,28 +21,28 @@
               %img{:src => image_path("layout/base.png")}
             - if @drift_obj.template?
               - if @drift_obj.host
-                %div{:class => "flobj b#{size}"}
+                %div{:class => "flobj b72"}
                   %img{:src => image_path('100/template.png')}
               - else
-                %div{:class => "flobj b#{size}"}
+                %div{:class => "flobj b72"}
                   %img{:src => image_path('100/template-no-host.png')}
             - else
-              %div{:class => "flobj b#{size}"}
+              %div{:class => "flobj b72"}
                 %img{:src => image_path("svg/currentstate-#{h(@drift_obj.current_state.downcase)}.svg")}
-            %div{:class => "flobj c#{size}"}
+            %div{:class => "flobj c72"}
               %img{:src => image_path("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg")}
-            %div{:class => "flobj a#{size}"}
+            %div{:class => "flobj a72"}
               %img{:src => image_path("svg/os-#{h(@drift_obj.os_image_name.downcase)}.svg")}
-            %div{:class => "flobj d#{size}"}
+            %div{:class => "flobj d72"}
               %p
                 = @drift_obj.number_of(:snapshots)
           - else
             .flobj
               %img{:src => image_path("layout/base-single.png")}
-            %div{:class => "flobj e#{size}"}
+            %div{:class => "flobj e72"}
               %img{:src => image_path("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg"), :width => "#{width * 1.8}", :height => "#{height * 1.8}"}
           - if @drift_obj.get_policies.length > 0
-            %div{:class => "flobj g#{size}"}
+            %div{:class => "flobj g72"}
               %img{:src => image_path('100/shield.png')}
           .flobj
             %img{:src => image_path("layout/reflection.png")}
@@ -52,21 +52,21 @@
           - if settings(:quadicons, :host)
             .flobj
               %img{:src => image_path("layout/base.png")}
-            %div{:class => "flobj c#{size}"}
+            %div{:class => "flobj c72"}
               %img{:src => image_path("svg/vendor-#{h(@drift_obj.vmm_vendor_display.downcase)}.svg")}
             - unless @drift_obj.power_state.blank?
-              %div{:class => "flobj b#{size}"}
+              %div{:class => "flobj b72"}
                 %img{:src => image_path("svg/currentstate-#{h(@drift_obj.power_state.downcase)}.svg")}
-            %div{:class => "flobj a#{size}"}
+            %div{:class => "flobj a72"}
               %p
                 = @drift_obj.vms.count
           - else
             .flobj
               %img{:src => image_path("layout/base-single.png")}
-            %div{:class => "flobj e#{size}"}
+            %div{:class => "flobj e72"}
               %img{:src => image_path("svg/vendor-#{h(@host.vmm_vendor_display.downcase)}.svg"), :width => "#{width * 1.8}", :height => "#{height * 1.8}"}
           - if @host.number_of(:get_policies) > 0
-            %div{:class => "flobj g#{size}"}
+            %div{:class => "flobj g72"}
               %img{:src => image_path('100/shield.png')}
           .flobj
             %img{:src => image_path("layout/reflection.png")}

--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -17,15 +17,13 @@
           - if settings(:quadicons, :vm)
             .flobj
               %img{:src => image_path("layout/base.png")}
-            - if @drift_obj.template?
-              - if @drift_obj.host
-                %div{:class => "flobj b72"}
+            %div{:class => "flobj b72"}
+              - if @drift_obj.template?
+                - if @drift_obj.host
                   %img{:src => image_path('100/template.png')}
-              - else
-                %div{:class => "flobj b72"}
+                - else
                   %img{:src => image_path('100/template-no-host.png')}
-            - else
-              %div{:class => "flobj b72"}
+              - else
                 %img{:src => image_path("svg/currentstate-#{h(@drift_obj.current_state.downcase)}.svg")}
             %div{:class => "flobj c72"}
               %img{:src => image_path("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg")}

--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -65,7 +65,7 @@
           .flobj
             %img{:src => image_path("layout/reflection.png")}
         - elsif @sb[:compare_db] == "EmsCluster"
-          = render_quadicon(@drift_obj, :mode => :icon, :size => size, :typ => :listnav)
+          = render_quadicon(@drift_obj, :mode => :icon, :typ => :listnav)
       - if @sb[:compare_db] != "EmsCluster"
         %div{:style => "margin-top: -25px;"}
           %center{:style => "color:#000;"}

--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -35,8 +35,7 @@
           - else
             .flobj
               %img{:src => image_path("layout/base-single.png")}
-            %div{:class => "flobj e72"}
-              %img{:src => image_path("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg"), :width => QuadiconHelper.adjusted_quad_size, :height => QuadiconHelper.adjusted_quad_size}
+            = flobj_img_small("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg", "e72")
           - if @drift_obj.get_policies.length > 0
             %div{:class => "flobj g72"}
               %img{:src => image_path('100/shield.png')}
@@ -57,8 +56,7 @@
           - else
             .flobj
               %img{:src => image_path("layout/base-single.png")}
-            %div{:class => "flobj e72"}
-              %img{:src => image_path("svg/vendor-#{h(@host.vmm_vendor_display.downcase)}.svg"), :width => QuadiconHelper.adjusted_quad_size, :height => QuadiconHelper.adjusted_quad_size}
+            = flobj_img_small("svg/vendor-#{h(@host.vmm_vendor_display.downcase)}.svg", "e72")
           - if @host.number_of(:get_policies) > 0
             %div{:class => "flobj g72"}
               %img{:src => image_path('100/shield.png')}

--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -14,8 +14,6 @@
         - height = "100px"
       %div{:style => "position: relative; width: 152px; height: #{height}; z-index: 0; margin: 0px auto;"}
         - if %w(MiqTemplate VmOrTemplate Vm).include?(@sb[:compare_db])
-          - width = size == 150 ? 54 : 35
-          - height = width
           - if settings(:quadicons, :vm)
             .flobj
               %img{:src => image_path("layout/base.png")}
@@ -40,15 +38,13 @@
             .flobj
               %img{:src => image_path("layout/base-single.png")}
             %div{:class => "flobj e72"}
-              %img{:src => image_path("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg"), :width => "#{width * 1.8}", :height => "#{height * 1.8}"}
+              %img{:src => image_path("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg"), :width => QuadiconHelper.adjusted_quad_size, :height => QuadiconHelper.adjusted_quad_size}
           - if @drift_obj.get_policies.length > 0
             %div{:class => "flobj g72"}
               %img{:src => image_path('100/shield.png')}
           .flobj
             %img{:src => image_path("layout/reflection.png")}
         - elsif @sb[:compare_db] == "Host"
-          - width = size == 150 ? 54 : 35
-          - height = width
           - if settings(:quadicons, :host)
             .flobj
               %img{:src => image_path("layout/base.png")}
@@ -64,7 +60,7 @@
             .flobj
               %img{:src => image_path("layout/base-single.png")}
             %div{:class => "flobj e72"}
-              %img{:src => image_path("svg/vendor-#{h(@host.vmm_vendor_display.downcase)}.svg"), :width => "#{width * 1.8}", :height => "#{height * 1.8}"}
+              %img{:src => image_path("svg/vendor-#{h(@host.vmm_vendor_display.downcase)}.svg"), :width => QuadiconHelper.adjusted_quad_size, :height => QuadiconHelper.adjusted_quad_size}
           - if @host.number_of(:get_policies) > 0
             %div{:class => "flobj g72"}
               %img{:src => image_path('100/shield.png')}

--- a/app/views/layouts/listnav/_x_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_x_compare_sections.html.haml
@@ -1,1 +1,1 @@
-= render :partial => "layouts/listnav/compare_sections", :locals => {:size => 72, :truncate_length => truncate_length}
+= render :partial => "layouts/listnav/compare_sections", :locals => {:truncate_length => truncate_length}


### PR DESCRIPTION
`_compare_sections` is never called with size other than 72, we can inline it, making the image urls cleaner.

Similarly, `flobj_img_simple` is only ever called with size 72 and 64, splitting the 64 version into `flobj_img_small`, and hardcoding the sizes.

Also, the `e72`, `g72`, etc. classes don't exist for any other number, no point in dynamically generating the class name.

(If you're wondering where that `64` came from, it's `width = options[:size] == 150 ? 54 : 35`, `width * 1.8` :).)