### PR TITLE
Extract miqAsyncAjax call from timeline and performance partial calls.

### DIFF
--- a/app/views/availability_zone/show.html.haml
+++ b/app/views/availability_zone/show.html.haml
@@ -1,8 +1,6 @@
 #main_div
   - if @showtype == "performance"
-    = render :partial => "layouts/performance"
-    :javascript
-      ManageIQ.afterOnload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
+    = render :partial => "layouts/performance_async"
   - else
     - if %w(instances cloud_volumes).include?(@display) && @showtype != "compare"
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@availability_zone.id}"}
@@ -10,9 +8,7 @@
       = raise 'compare or drift partial called through "show"' if %w(compare drift).include?(@showtype)
       = render :partial => "layouts/#{@showtype}"
     - elsif @showtype == "timeline"
-      = render :partial => "layouts/tl_show"
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
+      = render :partial => "layouts/tl_show_async"
     - elsif @showtype == "main"
       = render :partial => "layouts/textual_groups_generic"
     - else

--- a/app/views/cloud_tenant/show.html.haml
+++ b/app/views/cloud_tenant/show.html.haml
@@ -1,8 +1,6 @@
 #main_div
   - if @showtype == "performance"
-    = render :partial => "layouts/performance"
-    :javascript
-      ManageIQ.afterOnload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
+    = render :partial => "layouts/performance_async"
   - else
     - arr = %w(floating_ips network_ports cloud_tenants cloud_networks cloud_subnets network_routers instances images)
     - arr.concat(%w(security_groups cloud_object_store_containers cloud_volumes cloud_volume_snapshots))
@@ -19,8 +17,6 @@
     - elsif @showtype == "item"
       = render :partial => "layouts/item"
     - elsif @showtype == "timeline"
-      = render :partial => "layouts/tl_show"
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
+      = render :partial => "layouts/tl_show_async"
     - elsif @showtype == 'main'
       = render :partial => "layouts/textual_groups_generic"

--- a/app/views/container/explorer.html.haml
+++ b/app/views/container/explorer.html.haml
@@ -3,13 +3,9 @@
   = render(:partial => 'layouts/quick_search')
 #main_div
   - if @showtype == "timeline"
-    = render(:partial => "layouts/tl_show")
-    :javascript
-      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    = render(:partial => "layouts/tl_show_async")
   - elsif @showtype == "performance"
-    = render(:partial => "layouts/performance")
-    :javascript
-      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    = render(:partial => "layouts/performance_async")
   - elsif TreeBuilder.get_model_for_prefix(@nodetype) == "Container"
     -# Showing a specific Service
     = render :partial => "container_show", :locals => {:controller => "container"}

--- a/app/views/container_group/show.html.haml
+++ b/app/views/container_group/show.html.haml
@@ -5,13 +5,9 @@
     - when "main"
         = render :partial => "layouts/textual_groups_generic"
     - when "timeline"
-        = render :partial => "layouts/tl_show"
-        :javascript
-            ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        = render :partial => "layouts/tl_show_async"
     - when "performance"
-        = render :partial => "layouts/performance"
-        :javascript
-            ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        = render :partial => "layouts/performance_async"
     - when "compliance_history"
         = render :partial => "shared/views/#{@showtype}"
     - else

--- a/app/views/container_node/show.html.haml
+++ b/app/views/container_node/show.html.haml
@@ -1,13 +1,9 @@
 - if %w(container_routes container_services container_replicators container_groups containers container_images).include?(@display) && @showtype != "compare"
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == "timeline"
-  = render(:partial => "layouts/tl_show")
-  :javascript
-    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+  = render(:partial => "layouts/tl_show_async")
 - elsif @showtype == "performance"
-  = render(:partial => "layouts/performance")
-  :javascript
-    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+  = render(:partial => "layouts/performance_async")
 - elsif @showtype == "compliance_history"
   = render :partial => "shared/views/#{@showtype}"
 - elsif @showtype == "main"

--- a/app/views/container_project/show.html.haml
+++ b/app/views/container_project/show.html.haml
@@ -1,13 +1,9 @@
 - if %w(container_routes container_services container_replicators container_groups container_nodes container_images container_templates).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == "timeline"
-  = render(:partial => "layouts/tl_show")
-  :javascript
-    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+  = render(:partial => "layouts/tl_show_async")
 - elsif @showtype == "performance"
-  = render(:partial => "layouts/performance")
-  :javascript
-    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+  = render(:partial => "layouts/performance_async")
 - elsif @showtype == "main"
   = render :partial => "layouts/textual_groups_generic"
 - else

--- a/app/views/container_replicator/show.html.haml
+++ b/app/views/container_replicator/show.html.haml
@@ -1,13 +1,9 @@
 - if %w(container_groups container_nodes).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == "timeline"
-    = render(:partial => "layouts/tl_show")
-    :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    = render(:partial => "layouts/tl_show_async")
 - elsif @showtype == "performance"
-    = render(:partial => "layouts/performance")
-    :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    = render(:partial => "layouts/performance_async")
 - elsif @showtype == "compliance_history"
     = render :partial => "shared/views/#{@showtype}"
 - elsif @showtype == "main"

--- a/app/views/container_service/show.html.haml
+++ b/app/views/container_service/show.html.haml
@@ -3,9 +3,7 @@
 - elsif @showtype == "main"
   = render :partial => "layouts/textual_groups_generic"
 - elsif @showtype == "performance"
-  = render(:partial => "layouts/performance")
-  :javascript
-    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+  = render(:partial => "layouts/performance_async")
 - else
   = render :partial => @showtype
 

--- a/app/views/ems_cluster/show.html.haml
+++ b/app/views/ems_cluster/show.html.haml
@@ -5,9 +5,7 @@
   - else
     - case @showtype
     - when "performance"
-      = render(:partial => "layouts/performance")
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render(:partial => "layouts/performance_async")
     - when "details"
       = render(:partial => "layouts/gtl", :locals => {:action_url => @lastaction})
     - when "compare", "drift"
@@ -15,9 +13,7 @@
     - when "drift_history", "item"
       = render(:partial => "layouts/#{@showtype}")
     - when "timeline"
-      = render(:partial => "layouts/tl_show")
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render(:partial => "layouts/tl_show_async")
     - when "dialog_provision"
       = render(:partial => "shared/dialogs/dialog_provision")
     - when "main"

--- a/app/views/host/show.html.haml
+++ b/app/views/host/show.html.haml
@@ -11,15 +11,11 @@
     - when "drift_history", "item"
       = render :partial => "layouts/#{@showtype}"
     - when "performance"
-      = render :partial => "layouts/performance"
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render :partial => "layouts/performance_async"
     - when "performance_summary"
       = render :partial => "layouts/performance_summary"
     - when "timeline"
-      = render :partial => "layouts/tl_show"
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render :partial => "layouts/tl_show_async"
     - when "dialog_provision"
       = render :partial => "shared/dialogs/dialog_provision"
     - when "compliance_history"

--- a/app/views/host_aggregate/show.html.haml
+++ b/app/views/host_aggregate/show.html.haml
@@ -1,8 +1,6 @@
 #main_div
   - if @showtype == "performance"
-    = render :partial => "layouts/performance"
-    :javascript
-      var miq_after_onload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
+    = render :partial => "layouts/performance_async"
   - else
     - if %w(instances hosts).include?(@display)
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@host_aggregate.id}"}

--- a/app/views/layouts/_performance_async.html.haml
+++ b/app/views/layouts/_performance_async.html.haml
@@ -1,0 +1,4 @@
+= render(:partial => "layouts/performance")
+
+:javascript
+  ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record.id)}');"

--- a/app/views/layouts/_tl_show_async.html.haml
+++ b/app/views/layouts/_tl_show_async.html.haml
@@ -1,0 +1,4 @@
+= render(:partial => "layouts/tl_show")
+
+:javascript
+  ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record.id)}');"

--- a/app/views/middleware_datasource/show.html.haml
+++ b/app/views/middleware_datasource/show.html.haml
@@ -1,7 +1,5 @@
 - if @showtype == "performance"
-  = render(:partial => "layouts/performance")
-  :javascript
-    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+  = render(:partial => "layouts/performance_async")
 - elsif @showtype == 'main'
   = render :partial => "layouts/textual_groups_generic"
 - else

--- a/app/views/middleware_domain/show.html.haml
+++ b/app/views/middleware_domain/show.html.haml
@@ -1,9 +1,7 @@
 - if @display == 'middleware_server_groups'
   = render :partial => 'layouts/gtl', :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == 'performance'
-  = render(:partial => 'layouts/performance')
-  :javascript
-    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+  = render(:partial => 'layouts/performance_async')
 - elsif @showtype == 'main'
   = render :partial => "layouts/textual_groups_generic"
 - else

--- a/app/views/middleware_messaging/show.html.haml
+++ b/app/views/middleware_messaging/show.html.haml
@@ -1,7 +1,5 @@
 - if @showtype == "performance"
-  = render(:partial => "layouts/performance")
-  :javascript
-    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+  = render(:partial => "layouts/performance_async")
 - elsif @showtype == 'main'
   = render :partial => "layouts/textual_groups_generic"
 - else

--- a/app/views/middleware_server/show.html.haml
+++ b/app/views/middleware_server/show.html.haml
@@ -1,9 +1,7 @@
 - if %w(middleware_datasources middleware_messagings middleware_deployments).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == "performance"
-  = render(:partial => "layouts/performance")
-  :javascript
-    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+  = render(:partial => "layouts/performance_async")
 - elsif @showtype == 'main'
   = render :partial => "layouts/textual_groups_generic"
 - else

--- a/app/views/middleware_server_group/show.html.haml
+++ b/app/views/middleware_server_group/show.html.haml
@@ -1,9 +1,7 @@
 - if @display == 'middleware_servers'
   = render :partial => 'layouts/gtl', :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == 'performance'
-  = render(:partial => 'layouts/performance')
-  :javascript
-    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+  = render(:partial => 'layouts/performance_async')
 - elsif @showtype == 'main'
   = render :partial => "layouts/textual_groups_generic"
 - else

--- a/app/views/miq_template/show.html.haml
+++ b/app/views/miq_template/show.html.haml
@@ -16,9 +16,7 @@
     - when "compare", "drift_history", "drift", "item"
       = render :partial => "layouts/#{@showtype}"
     - when "performance"
-      = render :partial => "layouts/performance"
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render :partial => "layouts/performance_async"
     - when "performance_summary"
       = render :partial => "layouts/performance_summary"
     - when "timeline"

--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -16,13 +16,9 @@
     = raise 'compare partial called through "show"'
     = render :partial => "layouts/compare"
   - elsif @showtype == "timeline"
-    = render :partial => "layouts/tl_show"
-    :javascript
-      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    = render :partial => "layouts/tl_show_async"
   - elsif @showtype == "performance"
-    = render(:partial => "layouts/performance")
-    :javascript
-      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    = render(:partial => "layouts/performance_async")
   - elsif @showtype == "dialog_provision"
     = render :partial => "shared/dialogs/dialog_provision"
   - elsif @showtype == "config"

--- a/app/views/storage/show.html.haml
+++ b/app/views/storage/show.html.haml
@@ -11,9 +11,7 @@
       = raise 'compare partial called through "show"' if @showtype == 'compare'
       = render :partial => "layouts/#{@showtype}"
     - when "performance"
-      = render :partial => "layouts/performance"
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render :partial => "layouts/performance_async"
     - when "dialog_provision"
       = render :partial => "shared/dialogs/dialog_provision"
     - when "main"

--- a/app/views/vm_cloud/explorer.html.haml
+++ b/app/views/vm_cloud/explorer.html.haml
@@ -7,13 +7,9 @@
   -# Showing a specific VM or Template record
   #main_div
     - if @showtype == "performance"
-      = render(:partial => "layouts/performance")
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render(:partial => "layouts/performance_async")
     - elsif @showtype == "timeline"
-      = render(:partial => "layouts/tl_show")
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render(:partial => "layouts/tl_show_async")
     - else
       = render :partial => "layouts/textual_groups_generic"
 - else

--- a/app/views/vm_infra/explorer.html.haml
+++ b/app/views/vm_infra/explorer.html.haml
@@ -7,13 +7,9 @@
   -# Showing a specific VM or Template record
   #main_div
     - if @showtype == "performance"
-      = render(:partial => "layouts/performance")
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render(:partial => "layouts/performance_async")
     - elsif @showtype == "timeline"
-      = render(:partial => "layouts/tl_show")
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render(:partial => "layouts/tl_show_async")
     - else
       = render :partial => "layouts/textual_groups_generic"
 - elsif @upload_sysprep_file

--- a/app/views/vm_or_template/explorer.html.haml
+++ b/app/views/vm_or_template/explorer.html.haml
@@ -7,13 +7,9 @@
   -# Showing a specific VM or Template record
   #main_div
     - if @showtype == "performance"
-      = render(:partial => "layouts/performance")
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render(:partial => "layouts/performance_async")
     - elsif @showtype == "timeline"
-      = render(:partial => "layouts/tl_show")
-      :javascript
-        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      = render(:partial => "layouts/tl_show_async")
     - else
       = render :partial => "layouts/textual_groups_generic"
 - elsif @upload_sysprep_file


### PR DESCRIPTION
This is c-n-ped everywhere. So moving it to one place.

Next step would be removing it from controllers and `ExplorerPresenter`.

This relates to #176 allowing more `show.html.haml` partial to be removed and replaced by code in the `GenericShowMixin`.