### PR TITLE
UI and spec changes before we remove cols on ChargebackRateDetail

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -929,7 +929,7 @@ class ChargebackController < ApplicationController
   end
 
   def display_detail_errors(detail, errors)
-    errors.each { |field, msg| add_flash("'#{detail.description}' #{field.to_s.humanize.downcase} #{msg}", :error) }
+    errors.each { |field, msg| add_flash("'#{detail.chargeable_field.description}' #{field.to_s.humanize.downcase} #{msg}", :error) }
   end
 
   def add_row(i, pos, code_currency)

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -508,6 +508,7 @@ class ChargebackController < ApplicationController
 
     rate_details.each_with_index do |detail, detail_index|
       temp = detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES)
+      temp[:group] = detail.chargeable_field.group
       temp[:per_time] ||= "hourly"
 
       temp[:currency] = detail.detail_currency.id

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -459,6 +459,7 @@ describe ChargebackController do
       rate.chargeback_rate_details.each do |rate_detail|
         rate_detail_hash = rate_detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES)
         rate_detail_hash = Hash[rate_detail_hash.map { |(k, v)| [k.to_sym, v] }]
+        rate_detail_hash[:group] = rate_detail.chargeable_field.group
         rate_detail_hash[:tiers] = []
         rate_detail.chargeback_tiers.each do |tier|
           tier_hash = tier.slice(*ChargebackTier::FORM_ATTRIBUTES)

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -374,11 +374,7 @@ describe ChargebackController do
       end
 
       before do
-        [ChargebackRateDetailCurrency, ChargebackRate].each do |k|
-          # This is unfortunate try and I am sorry. After repo split, some design clean-ups are more difficult
-          # than before. I'll remove the `try` asap (after other prs are merged, no eta obviously).
-          k.try(:seed)
-        end
+        [ChargebackRateDetailCurrency, ChargebackRate].each(&:seed)
       end
 
       it "adds new chargeback rate using default values" do

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -528,7 +528,7 @@ describe ChargebackController do
       flash_messages = assigns(:flash_array)
 
       expect(flash_messages.count).to eq(1)
-      expected_message = "'Allocated Memory in MB' chargeback tiers must start at zero and "
+      expected_message = "'Allocated Memory' chargeback tiers must start at zero and "
       expected_message += "not contain any gaps between start and prior end value."
       expect(flash_messages[0][:message]).to eq(expected_message)
     end
@@ -543,7 +543,7 @@ describe ChargebackController do
       flash_messages = assigns(:flash_array)
 
       expect(flash_messages.count).to eq(1)
-      expect(flash_messages[0][:message]).to eq("'Allocated Memory in MB' start is not a number")
+      expect(flash_messages[0][:message]).to eq("'Allocated Memory' start is not a number")
     end
 
     it "doesn't store rate and displays validation message with invalid input of tiers(ambiguous tiers)" do
@@ -559,7 +559,7 @@ describe ChargebackController do
       flash_messages = assigns(:flash_array)
 
       expect(flash_messages.count).to eq(1)
-      expected_message = "'Allocated Memory in MB' finish value must be greater than start value."
+      expected_message = "'Allocated Memory' finish value must be greater than start value."
       expect(flash_messages[0][:message]).to eq(expected_message)
     end
   end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -353,9 +353,9 @@ describe ChargebackController do
         expect(rate_detail.detail_currency.name).to eq(rate_detail_hash[:type_currency])
 
         if rate_detail_hash[:measure].nil?
-          expect(rate_detail.detail_measure).to be_nil
+          expect(rate_detail.chargeable_field.detail_measure).to be_nil
         else
-          expect(rate_detail.detail_measure.name).to eq(rate_detail_hash[:measure])
+          expect(rate_detail.chargeable_field.detail_measure.name).to eq(rate_detail_hash[:measure])
         end
 
         rate_detail.chargeback_tiers.each_with_index do |tier, tier_index|
@@ -466,7 +466,7 @@ describe ChargebackController do
           rate_detail_hash[:tiers].push(tier_hash)
         end
 
-        rate_detail_hash[:measure] = rate_detail.detail_measure.name
+        rate_detail_hash[:measure] = rate_detail.chargeable_field.detail_measure.name
         rate_detail_hash[:type_currency] = rate_detail.detail_currency.name
         origin_chargeback_rate_hash[:rates].push(rate_detail_hash)
       end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -197,6 +197,7 @@ describe ChargebackController do
       EvmSpecHelper.local_miq_server
       allow_any_instance_of(described_class).to receive(:center_toolbar_filename).and_return("chargeback_center_tb")
       seed_session_trees('chargeback', :cb_rates_tree, "xx-Compute")
+      [ChargebackRateDetailMeasure, ChargeableField].each(&:seed)
     end
 
     def expect_input(body, selector, value)
@@ -373,7 +374,7 @@ describe ChargebackController do
       end
 
       before do
-        [ChargebackRateDetailMeasure, ChargebackRateDetailCurrency, ChargeableField, ChargebackRate].each do |k|
+        [ChargebackRateDetailCurrency, ChargebackRate].each do |k|
           # This is unfortunate try and I am sorry. After repo split, some design clean-ups are more difficult
           # than before. I'll remove the `try` asap (after other prs are merged, no eta obviously).
           k.try(:seed)


### PR DESCRIPTION
## What
Bunch of commits with the same story.

## Story
Some time ago I started extracting one model from the other. That is ChargeableField from ChargebackRateDetail. More infor at https://github.com/ManageIQ/manageiq/issues/13375

This work affects UI in Chargeback Rate Editor. In the long run it will enable simplification of that editor.

This effort is getting close to be done. We are soon to remove db cols from ChargebackRateDetail. This pr needs to be merged before https://github.com/ManageIQ/manageiq/pull/13661

@miq-bot add_label euwe/no
@miq-bot assign @mzazrivec 

