### PR TITLE
clean up custom font styling

### DIFF
--- a/app/assets/stylesheets/icon_customizations.scss
+++ b/app/assets/stylesheets/icon_customizations.scss
@@ -9,25 +9,11 @@
 .fa-1xplus { //custom resize for fa-tachometer on dashboard summary toggle
   font-size: 1.18em;
 }
-.fa-bar-chart-o:before, .fa-chart:before {
-  content: "\f080";
-}
-.fa-file-text-o:before, .fa-report:before {
-  content: "\f0f6";
-}
-.fa-warning:before,
-.fa-exclamation-triangle:before{
-  color: #c90813;
-}
 .fa-play:before {
   color: #57a81c;
 }
 .fa-pause:before {
   color: #eb7720;
-}
-.pficon-ok:before, .pficon-complete:before {
-  color: $color-success;
-  content: "\e602";
 }
 .pficon-close:before {
   // color: $color-critical;
@@ -290,47 +276,32 @@ span[class^="product-"], span[class*=" product-"], // i & span tags prevent conf
 }
 
 /* define  colors */
-.product-custom-1:before {
-  color: #2d7623;
+
+.product-custom-1:before,
+.product-custom-4:before,
+.product-custom-14:before {
+  color: #2d7623; //pf-green-500
 }
 .product-custom-3:before {
-  color: #f5c12e
+  color: #f5c12e; //pf-gold-300
 }
-.product-custom-4:before {
-  color: #2d7623;
-}
-.product-custom-8:before {
-  color: #cc0000;
-}
-.product-custom-9:before {
-  color: #00659c;
-}
-.product-custom-10:before {
-  color: #00659c;
-}
-.product-custom-11:before {
-  color: #00659c;
-}
-.product-custom-12:before {
-  color: #00659c;
-}
-.product-custom-13:before {
-  color: #00659c;
-}
-.product-custom-14:before {
-  color: #2d7623;
-}
+.product-custom-8:before,
 .product-custom-15:before {
-  color: #cc0000;
+  color: #cc0000; //pf-red-100
 }
-.product-custom-2:before {
-  color: #00659c;
+.product-custom-2:before,
+.product-custom-9:before,
+.product-custom-10:before,
+.product-custom-11:before,
+.product-custom-12:before,
+.product-custom-13:before {
+  color: #00659c; //pf-blue-500
 }
 .product-custom-5:before {
-  color: orange;
+  color: #ec7a08; //pf-orange-400
 }
 .product-miq_condition:before {
-  color: #0099cc;
+  color: #39a5dc; //pf-blue-300
 }
 
 /*end icon customizations*/

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1640,7 +1640,7 @@ module ApplicationHelper
     when 'complete' then 'pficon pficon-ok'
     when 'queued'   then 'fa fa-pause'
     when 'running'  then 'pficon pficon-running'
-    when 'error'    then 'fa fa-warning'
+    when 'error'    then 'pficon pficon-warning-triangle-o'
     end
   end
 
@@ -1652,7 +1652,7 @@ module ApplicationHelper
     when "MiqReportResult"
       case row['status'].downcase
       when "error"
-        glyphicon = "fa fa-warning"
+        glyphicon = "pficon pficon-warning-triangle-o"
       when "finished"
         glyphicon = "pficon pficon-ok"
       when "running"


### PR DESCRIPTION
Reorganize "product" font color styling. Added PF color references. Replaced outdated font references (fa-warning => pficon-warning-triangle-o).