### PR TITLE
Revert fix for BZ 1396068 as it breaks VMware

### DIFF
--- a/app/helpers/application_helper/button/vm_snapshot_revert.rb
+++ b/app/helpers/application_helper/button/vm_snapshot_revert.rb
@@ -7,9 +7,7 @@ class ApplicationHelper::Button::VmSnapshotRevert < ApplicationHelper::Button::B
   end
 
   def disabled?
-    @error_message = if @active
-                       _('Select a snapshot that is not the active one')
-                     elsif !@record.is_available?(:revert_to_snapshot)
+    @error_message = unless @record.is_available?(:revert_to_snapshot)
                        @record.is_available_now_error_message(:revert_to_snapshot)
                      end
     @error_message.present?

--- a/spec/helpers/application_helper/buttons/vm_snapshot_revert_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_revert_spec.rb
@@ -29,18 +29,13 @@ describe ApplicationHelper::Button::VmSnapshotRevert do
 
   describe '#calculate_properties' do
     before { button.calculate_properties }
-    context 'when snapshot is active' do
-      it_behaves_like 'a disabled button', 'Select a snapshot that is not the active one'
+
+    context 'when reverting to a snapshot is available' do
+      it_behaves_like 'an enabled button'
     end
-    context 'when snapshot is not active' do
-      let(:active) { false }
-      context 'and reverting to a snapshot is available' do
-        it_behaves_like 'an enabled button'
-      end
-      context 'and reverting to a snapshot is not available' do
-        let(:record) { FactoryGirl.create(:vm_amazon) }
-        it_behaves_like 'a disabled button', 'Revert Snapshot operation not supported for Amazon VM'
-      end
+    context 'when reverting to a snapshot is not available' do
+      let(:record) { FactoryGirl.create(:vm_amazon) }
+      it_behaves_like 'a disabled button', 'Revert Snapshot operation not supported for Amazon VM'
     end
   end
 end


### PR DESCRIPTION
The change to not allow revert for an active snapshot breaks VMware
snapshot handling when you have a single snapshot.

Original PR was https://github.com/ManageIQ/manageiq/pull/12768

https://bugzilla.redhat.com/show_bug.cgi?id=1396068