### PR TITLE
Fix Snapshot revert

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -214,6 +214,7 @@ module VmCommon
       @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, :root => @record)
       @active = if @snapshot_tree.selected_node
                   snap_selected = Snapshot.find_by_id(from_cid(@snapshot_tree.selected_node.split('-').last))
+                  session[:snap_selected] = snap_selected.id
                   snap_selected.current?
                 else
                   false

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -123,24 +123,38 @@ describe VmOrTemplateController do
       expect(response).to redirect_to(:controller => "dashboard", :action => 'show')
     end
 
-    it 'set session[:snap_selected] to nil if Snapshot does not exist' do
-      tree_hash = {
-        :trees         => {
-          :vandt_tree => {
-            :active_node => "v-#{@vm.id}"
-          }
-        },
-        :active_tree   => :vandt_tree,
-        :active_accord => :vandt
-      }
-      session[:sandboxes] = {'vm_or_template' => tree_hash}
-      @lastaction = 'show'
-      @display = 'snapshot_info'
-      @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
+    context 'set session[:snap_selected]' do
+      before :each do
+        tree_hash = {
+          :trees         => {
+            :vandt_tree => {
+              :active_node => "v-#{@vm.id}"
+            }
+          },
+          :active_tree   => :vandt_tree,
+          :active_accord => :vandt
+        }
+        session[:sandboxes] = {'vm_or_template' => tree_hash}
+        @lastaction = 'show'
+        @display = 'snapshot_info'
+        @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
+      end
 
-      session[:snap_selected] = '21'
-      get :show, :params => {:id => @vm.id, :display => 'snapshot_info'}
-      expect(session[:snap_selected]).to be(nil)
+      it 'to snap_selected.id if a Snapshot exists' do
+        @snapshot = FactoryGirl.create(:snapshot,
+                                       :vm_or_template_id => @vm.id,
+                                       :name              => 'EvmSnapshot',
+                                       :description       => 'Some Description')
+        @vm.snapshots = [@snapshot]
+        post :show, :params => {:id => @vm.id, :display => 'snapshot_info'}
+        expect(session[:snap_selected]).to eq(@snapshot.id)
+      end
+
+      it 'to nil if Snapshot does not exist' do
+        session[:snap_selected] = '21'
+        get :show, :params => {:id => @vm.id, :display => 'snapshot_info'}
+        expect(session[:snap_selected]).to be(nil)
+      end
     end
   end
 


### PR DESCRIPTION
Ensure that session[:snap_selected] is set to the first Snapshot if only one exists and remains unchanged if set to an existing Snapshot.

https://bugzilla.redhat.com/show_bug.cgi?id=1421951