### PR TITLE
Remove unnecesary condition in report editor

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -56,17 +56,11 @@ module ApplicationController::Filter
       if exp_model == '_display_filter_'
         exp_available_tags
       else
-        available_tags
+        self.available_tags ||= MiqExpression.model_details(exp_model, :typ             => "tag",
+                                                                       :include_model   => true,
+                                                                       :include_my_tags => use_mytags,
+                                                                       :userid          => User.current_user.userid)
       end
-    end
-
-    # Get the dynamic list of tags for the expression atom editor
-    def available_tags
-      # Generate tag list unless already generated during this transaction
-      self.available_tags ||= MiqExpression.model_details(exp_model, :typ             => "tag",
-                                                                     :include_model   => true,
-                                                                     :include_my_tags => use_mytags,
-                                                                     :userid          => User.current_user.userid)
     end
 
     def available_adv_searches

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -53,12 +53,12 @@ module ApplicationController::Filter
     end
 
     # Get the dynamic list of tags for the expression atom editor
-    def exp_available_tags
+    def available_tags
       # Generate tag list unless already generated during this transaction
-      self.exp_available_tags ||= MiqExpression.model_details(exp_model, :typ             => "tag",
-                                                                         :include_model   => true,
-                                                                         :include_my_tags => use_mytags,
-                                                                         :userid          => User.current_user.userid)
+      self.available_tags ||= MiqExpression.model_details(exp_model, :typ             => "tag",
+                                                                     :include_model   => true,
+                                                                     :include_my_tags => use_mytags,
+                                                                     :userid          => User.current_user.userid)
     end
 
     def available_adv_searches

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -52,6 +52,14 @@ module ApplicationController::Filter
       end
     end
 
+    def tags_for_display_filters
+      if exp_model == '_display_filter_'
+        exp_available_tags
+      else
+        available_tags
+      end
+    end
+
     # Get the dynamic list of tags for the expression atom editor
     def available_tags
       # Generate tag list unless already generated during this transaction

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -52,6 +52,15 @@ module ApplicationController::Filter
       end
     end
 
+    # Get the dynamic list of tags for the expression atom editor
+    def exp_available_tags
+      # Generate tag list unless already generated during this transaction
+      self.exp_available_tags ||= MiqExpression.model_details(exp_model, :typ             => "tag",
+                                                                         :include_model   => true,
+                                                                         :include_my_tags => use_mytags,
+                                                                         :userid          => User.current_user.userid)
+    end
+
     def available_adv_searches
       @available_adv_searches ||=
         begin

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -410,15 +410,6 @@ module ApplicationHelper
     (dbs.include?(".") ? "#{dbs.split(".").last}.#{fld}" : fld)
   end
 
-  # Get the dynamic list of tags for the expression atom editor
-  def exp_available_tags(model, use_mytags = false)
-    # Generate tag list unless already generated during this transaction
-    @exp_available_tags ||= MiqExpression.model_details(model, :typ             => "tag",
-                                                               :include_model   => true,
-                                                               :include_my_tags => use_mytags,
-                                                               :userid          => session[:userid])
-  end
-
   # Derive the browser title text based on the layout value
   def title_from_layout(layout)
     # TODO: leave I18n until we have productization capability in gettext

--- a/app/views/layouts/exp_atom/_edit_tag.html.haml
+++ b/app/views/layouts/exp_atom/_edit_tag.html.haml
@@ -5,11 +5,7 @@
     exp_model       Model in use for this expression
 
 - opts = ["<#{_('Choose')}>"]
-- if exp_model == '_display_filter_'
-  -# Use list in @edit for reporting display filter
-  - opts += @edit[@expkey][:exp_available_tags]
-- else
-  - opts += @edit[@expkey].exp_available_tags
+- opts += @edit[@expkey].tags_for_display_filters
 
 %br
 

--- a/app/views/layouts/exp_atom/_edit_tag.html.haml
+++ b/app/views/layouts/exp_atom/_edit_tag.html.haml
@@ -9,7 +9,7 @@
   -# Use list in @edit for reporting display filter
   - opts += @edit[@expkey][:exp_available_tags]
 - else
-  - opts += exp_available_tags(exp_model, @edit[@expkey][:use_mytags])
+  - opts += @edit[@expkey].exp_available_tags
 
 %br
 

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -51,7 +51,7 @@
         - when '_display_filter_'
           - unless @edit[@expkey][:exp_available_fields].empty?
             - opts.push([_('Field'), 'field'])
-          - unless @edit[@expkey][:exp_available_tags] && @edit[@expkey][:exp_available_tags].empty? || exp_available_tags(exp_model, @edit[@expkey][:use_mytags]).empty?
+          - unless @edit[@expkey][:exp_available_tags] && @edit[@expkey][:exp_available_tags].empty?
             - opts.push([_('Tag'), 'tag'])
         - else
           - opts += exptypes

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -51,7 +51,7 @@
         - when '_display_filter_'
           - unless @edit[@expkey][:exp_available_fields].empty?
             - opts.push([_('Field'), 'field'])
-          - unless @edit[@expkey][:exp_available_tags] && @edit[@expkey][:exp_available_tags].empty?
+          - unless @edit[@expkey].tags_for_display_filters.empty?
             - opts.push([_('Tag'), 'tag'])
         - else
           - opts += exptypes


### PR DESCRIPTION
This is causing error in report editor for display filters
I also did some refactoring.

@miq-bot add_label ui, refactoring, bug

Reproducer
Add new report, based on VMs
Add column `Service.user.miq_templates.managed.clientes`
Go tab filter and pres on Edit icon 📝  for displaying report filters then it was causing error.

@miq-bot assign @mzazrivec 
cc @gtanzillo @kbrock 

thanks @isimluk !


This PR is blocking:
https://github.com/ManageIQ/manageiq/pull/13702
