### PR TITLE
Allow to remove super administrator user

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -579,7 +579,7 @@ class ApplicationHelper::ToolbarBuilder
       when "rbac_user_copy"
         return N_("User [Administrator] can not be copied") if @record.super_admin_user?
       when "rbac_user_delete"
-        return N_("User [Administrator] can not be deleted") if @record.super_admin_user?
+        return N_("User [Administrator] can not be deleted") if @record.userid == 'admin'
       end
     when "UserRole"
       case id


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1408478

Disable the toolbar button to remove user only if the administrator is only OOTB 'admin', in other case, the button should be enabled

(taking back changes done in https://github.com/ManageIQ/manageiq-ui-classic/commit/81fabce73104f18153b4304a0d159537514ccac6)