### PR TITLE
[WIP] Clean up Quadicon class names

### DIFF
--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -68,18 +68,18 @@ img.tiny { margin: 0; padding: 0;width:20px;height:20px; border: 0; vertical-ali
 
 .flobj { position: absolute;z-index: auto;width: 72px;}
 .flobj p { margin: 5px 0 0 0;padding: 0;color: #e3e4e4;vertical-align: middle;text-align:center;text-transform: none;text-shadow: 0 0 3px #000;font: normal 16px OpenSansSemibold,Arial,Helvetica,sans-serif !important;}
-.a72 { padding: 3px  0 0 5px; width: 28px; height: 28px;font-size: 1.3em;line-height: 1.8em;}
-.b72 { padding: 3px 0 0 37px; font-size: 1.3em;line-height: 1.8em;}
-.c72 { padding: 38px 0 0 5px; width: 31px; height: 31px;font-size: 1.3em;line-height: 1.7em;}
-.d72 { padding: 38px 0 0 39px; font-size: 1.3em;line-height: 1.7em;}
-.e72 { padding: 6px  0 0 6px; width: 35px; height: 35px;font-size: 1.3em;line-height: 2em;}
-.f72 { padding: 22px 0 0 24px; width: 24px; height: 24px;}
-.g72 { padding: 16px 0 0 19px; width: 24px; height: 24px;}
-.b72 img {margin-top: -3px; width: 34px; height: 34px;}
-.a72 img,.c72 img,.d72 img{ width: 28px; height: 28px;}
-.f72 img,.f72 img { width: 24px; height: 24px;}
-.g72 img,.g72 img { width: 36px; height: 36px;}
-.e72 img { width: 60px; height: 60px;}
+.a { padding: 3px  0 0 5px; width: 28px; height: 28px;font-size: 1.3em;line-height: 1.8em;}
+.b { padding: 3px 0 0 37px; font-size: 1.3em;line-height: 1.8em;}
+.c { padding: 38px 0 0 5px; width: 31px; height: 31px;font-size: 1.3em;line-height: 1.7em;}
+.d { padding: 38px 0 0 39px; font-size: 1.3em;line-height: 1.7em;}
+.e { padding: 6px  0 0 6px; width: 35px; height: 35px;font-size: 1.3em;line-height: 2em;}
+.f { padding: 22px 0 0 24px; width: 24px; height: 24px;}
+.g { padding: 16px 0 0 19px; width: 24px; height: 24px;}
+.b img {margin-top: -3px; width: 34px; height: 34px;}
+.a img,.c img,.d img{ width: 28px; height: 28px;}
+.f img,.f img { width: 24px; height: 24px;}
+.g img,.g img { width: 36px; height: 36px;}
+.e img { width: 60px; height: 60px;}
 
 /************ Misc ************/
 /*select boxes*/

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -420,7 +420,7 @@ module QuadiconHelper
       link_opts = {:sparkle => true, :remote => true}
     end
 
-    output << content_tag(:div, :class => "flobj e72") do
+    output << content_tag(:div, :class => "flobj e") do
       quadicon_link_to(url, **link_opts) do
         quadicon_reflection_img(:path => item.decorate.listicon_image)
       end
@@ -436,8 +436,8 @@ module QuadiconHelper
     output = []
 
     output << flobj_img_simple
-    output << flobj_img_small(img, "e72")
-    output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
+    output << flobj_img_small(img, "e")
+    output << flobj_img_simple('100/shield.png', "g") unless item.get_policies.empty?
 
     unless options[:typ] == :listnav
       # listnav, no clear image needed
@@ -460,14 +460,14 @@ module QuadiconHelper
     if settings(:quadicons, :host)
       output << flobj_img_simple("layout/base.png")
 
-      output << flobj_p_simple("a72", item.vms.size)
-      output << flobj_img_simple("svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b72")
-      output << flobj_img_simple(img_for_host_vendor(item), "c72")
-      output << flobj_img_simple(img_for_auth_status(item), "d72")
-      output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
+      output << flobj_p_simple("a", item.vms.size)
+      output << flobj_img_simple("svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b")
+      output << flobj_img_simple(img_for_host_vendor(item), "c")
+      output << flobj_img_simple(img_for_auth_status(item), "d")
+      output << flobj_img_simple('100/shield.png', "g") unless item.get_policies.empty?
     else
       output << flobj_img_simple
-      output << flobj_img_small(img_for_host_vendor(item), "e72")
+      output << flobj_img_small(img_for_host_vendor(item), "e")
     end
 
     if options[:typ] == :listnav
@@ -498,14 +498,14 @@ module QuadiconHelper
 
     if settings(:quadicons, db_for_quadicon)
       output << flobj_img_simple("layout/base.png")
-      output << flobj_p_simple("a72", item.kind_of?(EmsCloud) ? item.total_vms : item.hosts.size)
-      output << flobj_p_simple("b72", item.total_miq_templates) if item.kind_of?(EmsCloud)
-      output << flobj_img_simple("svg/vendor-#{h(item.image_name)}.svg", "c72")
-      output << flobj_img_simple(img_for_auth_status(item), "d72")
-      output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
+      output << flobj_p_simple("a", item.kind_of?(EmsCloud) ? item.total_vms : item.hosts.size)
+      output << flobj_p_simple("b", item.total_miq_templates) if item.kind_of?(EmsCloud)
+      output << flobj_img_simple("svg/vendor-#{h(item.image_name)}.svg", "c")
+      output << flobj_img_simple(img_for_auth_status(item), "d")
+      output << flobj_img_simple('100/shield.png', "g") unless item.get_policies.empty?
     else
       output << flobj_img_simple("layout/base-single.png")
-      output << flobj_img_small("svg/vendor-#{h(item.image_name)}.svg", "e72")
+      output << flobj_img_small("svg/vendor-#{h(item.image_name)}.svg", "e")
     end
 
     if options[:typ] == :listnav
@@ -531,8 +531,8 @@ module QuadiconHelper
     output = []
 
     output << flobj_img_simple("layout/base-single.png")
-    output << flobj_img_small("100/emscluster.png", "e72")
-    output << flobj_img_simple("100/shield.png", "g72") unless item.get_policies.empty?
+    output << flobj_img_small("100/emscluster.png", "e")
+    output << flobj_img_simple("100/shield.png", "g") unless item.get_policies.empty?
 
     unless options[:typ] == :listnav
       # Listnav, no clear image needed
@@ -557,7 +557,7 @@ module QuadiconHelper
                end
 
     output << flobj_img_simple("layout/base-single.png")
-    output << flobj_img_simple(img_path, "e72")
+    output << flobj_img_simple(img_path, "e")
 
     unless options[:typ] == :listnav
       name = item.name
@@ -595,7 +595,7 @@ module QuadiconHelper
     output = []
 
     output << flobj_img_simple("layout/base-single.png")
-    output << flobj_img_small("100/#{@listicon}.png", "e72")
+    output << flobj_img_small("100/#{@listicon}.png", "e")
 
     unless options[:typ] == :listnav
       title = case @listicon
@@ -642,16 +642,16 @@ module QuadiconHelper
 
     if settings(:quadicons, :storage)
       output << flobj_img_simple("layout/base.png")
-      output << flobj_img_simple("100/storagetype-#{item.store_type.nil? ? "unknown" : h(item.store_type.to_s.downcase)}.png", "a72")
-      output << flobj_p_simple("b72", item.v_total_vms)
-      output << flobj_p_simple("c72", item.v_total_hosts)
+      output << flobj_img_simple("100/storagetype-#{item.store_type.nil? ? "unknown" : h(item.store_type.to_s.downcase)}.png", "a")
+      output << flobj_p_simple("b", item.v_total_vms)
+      output << flobj_p_simple("c", item.v_total_hosts)
 
       space_percent = item.free_space_percent_of_total == 100 ? 20 : ((item.free_space_percent_of_total.to_i + 2) / 5.25).round
-      output << flobj_img_simple("100/piecharts/datastore/#{h(space_percent)}.png", "d72")
+      output << flobj_img_simple("100/piecharts/datastore/#{h(space_percent)}.png", "d")
     else
       space_percent = (item.used_space_percent_of_total.to_i + 9) / 10
       output << flobj_img_simple("layout/base-single.png")
-      output << flobj_img_simple("100/datastore-#{h(space_percent)}.png", "e72")
+      output << flobj_img_simple("100/datastore-#{h(space_percent)}.png", "e")
     end
 
     if options[:typ] == :listnav
@@ -709,29 +709,29 @@ module QuadiconHelper
 
     if settings(:quadicons, item.class.base_model.name.underscore.to_sym)
       output << flobj_img_simple("layout/base.png")
-      output << flobj_img_simple("svg/os-#{h(item.os_image_name.downcase)}.svg", "a72")
-      output << flobj_img_simple("svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b72")
-      output << flobj_img_simple("svg/vendor-#{h(item.vendor.downcase)}.svg", "c72")
+      output << flobj_img_simple("svg/os-#{h(item.os_image_name.downcase)}.svg", "a")
+      output << flobj_img_simple("svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b")
+      output << flobj_img_simple("svg/vendor-#{h(item.vendor.downcase)}.svg", "c")
 
       unless item.get_policies.empty?
-        output << flobj_img_simple("100/shield.png", "g72")
+        output << flobj_img_simple("100/shield.png", "g")
       end
 
       if quadicon_policy_sim? && !session[:policies].empty? && quadicon_lastaction_is_policy_sim?
-        output << flobj_img_simple(img_for_compliance(item), "d72")
+        output << flobj_img_simple(img_for_compliance(item), "d")
       end
 
       unless quadicon_lastaction_is_policy_sim?
-        output << flobj_p_simple("d72", h(item.v_total_snapshots))
+        output << flobj_p_simple("d", h(item.v_total_snapshots))
       end
     else
       output << flobj_img_simple("layout/base-single.png")
 
       if quadicon_policy_sim? && !session[:policies].empty?
-        output << flobj_img_small(img_for_compliance(item), "e72")
+        output << flobj_img_small(img_for_compliance(item), "e")
       end
 
-      output << flobj_img_small(img_for_vendor(item), "e72")
+      output << flobj_img_small(img_for_vendor(item), "e")
     end
 
     unless options[:typ] == :listnav

--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -17,7 +17,7 @@
           - if settings(:quadicons, :vm)
             .flobj
               %img{:src => image_path("layout/base.png")}
-            %div{:class => "flobj b72"}
+            %div{:class => "flobj b"}
               - if @drift_obj.template?
                 - if @drift_obj.host
                   %img{:src => image_path('100/template.png')}
@@ -25,19 +25,19 @@
                   %img{:src => image_path('100/template-no-host.png')}
               - else
                 %img{:src => image_path("svg/currentstate-#{h(@drift_obj.current_state.downcase)}.svg")}
-            %div{:class => "flobj c72"}
+            %div{:class => "flobj c"}
               %img{:src => image_path("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg")}
-            %div{:class => "flobj a72"}
+            %div{:class => "flobj a"}
               %img{:src => image_path("svg/os-#{h(@drift_obj.os_image_name.downcase)}.svg")}
-            %div{:class => "flobj d72"}
+            %div{:class => "flobj d"}
               %p
                 = @drift_obj.number_of(:snapshots)
           - else
             .flobj
               %img{:src => image_path("layout/base-single.png")}
-            = flobj_img_small("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg", "e72")
+            = flobj_img_small("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg", "e")
           - if @drift_obj.get_policies.length > 0
-            %div{:class => "flobj g72"}
+            %div{:class => "flobj g"}
               %img{:src => image_path('100/shield.png')}
           .flobj
             %img{:src => image_path("layout/reflection.png")}
@@ -45,20 +45,20 @@
           - if settings(:quadicons, :host)
             .flobj
               %img{:src => image_path("layout/base.png")}
-            %div{:class => "flobj c72"}
+            %div{:class => "flobj c"}
               %img{:src => image_path("svg/vendor-#{h(@drift_obj.vmm_vendor_display.downcase)}.svg")}
             - unless @drift_obj.power_state.blank?
-              %div{:class => "flobj b72"}
+              %div{:class => "flobj b"}
                 %img{:src => image_path("svg/currentstate-#{h(@drift_obj.power_state.downcase)}.svg")}
-            %div{:class => "flobj a72"}
+            %div{:class => "flobj a"}
               %p
                 = @drift_obj.vms.count
           - else
             .flobj
               %img{:src => image_path("layout/base-single.png")}
-            = flobj_img_small("svg/vendor-#{h(@host.vmm_vendor_display.downcase)}.svg", "e72")
+            = flobj_img_small("svg/vendor-#{h(@host.vmm_vendor_display.downcase)}.svg", "e")
           - if @host.number_of(:get_policies) > 0
-            %div{:class => "flobj g72"}
+            %div{:class => "flobj g"}
               %img{:src => image_path('100/shield.png')}
           .flobj
             %img{:src => image_path("layout/reflection.png")}


### PR DESCRIPTION
This PR removes the "72" suffix from Quadicon class names. This is a follow-up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/395