### PR TITLE
Add new method display_filter_details_for 

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -154,6 +154,10 @@ module ReportController::Reports::Editor
     end
   end
 
+  def display_filter_details_for(target_class, cols)
+    cols ? cols.select { |_, column| target_class.parse(column).try(:plural?) } : []
+  end
+
   private
 
   def build_edit_screen
@@ -211,10 +215,11 @@ module ReportController::Reports::Editor
       @edit[:display_filter][:exp_table] = exp_build_table(@edit[:display_filter][:expression])
 
       cols = @edit[:new][:field_order]
-      @edit[:display_filter][:exp_available_fields] = MiqReport.display_filter_details(cols, :field)
+      @edit[:display_filter][:exp_available_fields] = display_filter_details_for(MiqExpression::Field, cols)
 
       cols = @edit[:new][:fields]
-      @edit[:display_filter][:exp_available_tags] = MiqReport.display_filter_details(cols, :tag)
+      @edit[:display_filter][:exp_available_tags] = display_filter_details_for(MiqExpression::Tag, cols)
+
       @edit[:display_filter][:exp_model] = "_display_filter_" # Set model for display filter
 
       @expkey = :record_filter # Start with Record Filter showing

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -1,4 +1,33 @@
 describe ReportController do
+  describe '.display_filter_details_for' do
+    let(:has_many_tag_col) do
+      ['Vm.Service.Users.MiqTemplates : My Company Tag clientes', 'Vm.service.user.miq_templates.managed-clientes']
+    end
+
+    let(:has_many_field_col) do
+      ['Vm.Storage.Storage Volumes.Disks : Storage Volume Class Hier', 'Vm.storage_volumes-class_hier']
+    end
+
+    let(:cols) do
+      [
+        has_many_tag_col,
+        has_many_field_col,
+        ['Vm.Storage.Disks : My Company Tag Quota - Max  Storage', 'Vm.storage.managed-quota_max_storage'],
+        ['Vm.Hardware : Hardware Guest OS', 'Vm.hardware-guest_os']
+      ]
+    end
+
+    it 'is filtering tags with has many relations' do
+      filtered_cols = controller.display_filter_details_for(MiqExpression::Tag, cols)
+      expect(filtered_cols).to match_array([has_many_tag_col])
+    end
+
+    it 'is filtering fields with has many relations' do
+      filtered_cols = controller.display_filter_details_for(MiqExpression::Field, cols)
+      expect(filtered_cols).to match_array([has_many_field_col])
+    end
+  end
+
   context "::Reports::Editor" do
     context "#set_form_vars" do
       let(:user) { stub_user(:features => :all) }


### PR DESCRIPTION
Taken from ManageIQ/manageiq#13702

this method is replacing MiqReport#display_filter_details,
which will be removed.

cc @kbrock @gtanzillo 
@miq-bot assign @mzazrivec 
