### PR TITLE
update/replacePartials - carp when element doesn't exist

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -92,6 +92,10 @@ ManageIQ.explorer.processFlash = function(data) {
 ManageIQ.explorer.replacePartials = function(data) {
   if (_.isObject(data.replacePartials)) {
     _.forEach(data.replacePartials, function (content, element) {
+      if (! miqDomElementExists(element)) {
+        console.error('replacePartials: #' + element + ' does not exist in the DOM');
+      }
+
       $('#' + element).replaceWith(content);
     });
   }
@@ -100,6 +104,10 @@ ManageIQ.explorer.replacePartials = function(data) {
 ManageIQ.explorer.updatePartials = function(data) {
   if (_.isObject(data.updatePartials)) {
     _.forEach(data.updatePartials, function (content, element) {
+      if (! miqDomElementExists(element)) {
+        console.error('updatePartials: #' + element + ' does not exist in the DOM');
+      }
+
       $('#' + element).html(content);
     });
   }


### PR DESCRIPTION
When trying to `updatePartials` or `replacePartials` an element that doesn't exist, warn about it.

Useful when debugging issues like https://github.com/ManageIQ/manageiq-ui-classic/issues/415 :).

![update](https://cloud.githubusercontent.com/assets/289743/23077638/591a3582-f53d-11e6-9d2b-cb0a0e26a850.png)

@martinpovolny WDYT?