### PR TITLE
Use `controllerAs vm` syntax for the Provider Foreman Angular controller (cleaner approach)

### DIFF
--- a/app/assets/javascripts/components/miq-button.js
+++ b/app/assets/javascripts/components/miq-button.js
@@ -5,6 +5,7 @@ ManageIQ.angular.app.component('miqButton', {
     enabledTitle: '@?',
     disabledTitle: '@?',
     primary: '<?',
+    xs: '<?',
     onClick: '&',
   },
   controllerAs: 'vm',
@@ -33,7 +34,7 @@ ManageIQ.angular.app.component('miqButton', {
   template: [
     '<button',
     'controllerAs="vm"',
-    'ng-class="{btn: true, \'btn-primary\': vm.primary, \'btn-default\': !vm.primary, disabled: !vm.enabled}"',
+    'ng-class="{btn: true, \'btn-primary\': vm.primary, \'btn-xs\': vm.xs, \'btn-default\': !vm.primary, disabled: !vm.enabled}"',
     'ng-click="vm.buttonClicked($event)"',
     'ng-attr-title="{{vm.title}}"',
     'ng-attr-alt="{{vm.title}}">',

--- a/app/assets/javascripts/components/miq-button.js
+++ b/app/assets/javascripts/components/miq-button.js
@@ -15,6 +15,7 @@ ManageIQ.angular.app.component('miqButton', {
         this.onClick();
       }
       event.preventDefault();
+      event.target.blur();
     };
     this.setTitle = function() {
       if (this.enabledTitle || this.disabledTitle) {

--- a/app/assets/javascripts/controllers/credentials/credentials_controller.js
+++ b/app/assets/javascripts/controllers/credentials/credentials_controller.js
@@ -1,55 +1,58 @@
-ManageIQ.angular.app.controller('CredentialsController', ['$scope', function($scope) {
-  var init = function() {
-    $scope.bChangeStoredPassword = undefined;
-    $scope.bCancelPasswordChange = undefined;
+ManageIQ.angular.app.controller('CredentialsController', ['$scope', '$attrs', function($scope, $attrs) {
+  var vm = this;
+
+  vm.vmScope = function() {
+    return $scope.$eval($attrs.vmScope);
+  };
+
+
+    vm.bChangeStoredPassword = undefined;
+    vm.bCancelPasswordChange = undefined;
 
     $scope.$on('resetClicked', function(_e) {
-      $scope.resetClicked();
+      vm.resetClicked();
     });
 
     $scope.$on('setNewRecord', function(_event, args) {
-      $scope.newRecord = args ? args.newRecord : true;
+      vm.vmScope().newRecord = args ? args.newRecord : true;
     });
 
     $scope.$on('setUserId', function(_event, args) {
       if (args) {
-        $scope.modelCopy[args.userIdName] = args.userIdValue;
+        vm.vmScope().modelCopy[args.userIdName] = args.userIdValue;
       }
     });
 
-    if ($scope.formId == 'new') {
-      $scope.newRecord = true;
+    if (vm.vmScope().formId == 'new') {
+      vm.newRecord = true;
     } else {
-      $scope.newRecord = false;
-      $scope.bChangeStoredPassword = false;
-      $scope.bCancelPasswordChange = false;
+      vm.newRecord = false;
+      vm.bChangeStoredPassword = false;
+      vm.bCancelPasswordChange = false;
+    }
+
+  vm.changeStoredPassword = function() {
+    vm.bChangeStoredPassword = true;
+    vm.bCancelPasswordChange = false;
+  };
+
+  vm.cancelPasswordChange = function() {
+    if (vm.bChangeStoredPassword) {
+      vm.bCancelPasswordChange = true;
+      vm.bChangeStoredPassword = false;
     }
   };
 
-  $scope.changeStoredPassword = function() {
-    $scope.bChangeStoredPassword = true;
-    $scope.bCancelPasswordChange = false;
+  vm.showVerify = function(userid) {
+    return vm.vmScope().newRecord || (!vm.showChangePasswordLinks(userid)) || vm.bChangeStoredPassword;
   };
 
-  $scope.cancelPasswordChange = function() {
-    if ($scope.bChangeStoredPassword) {
-      $scope.bCancelPasswordChange = true;
-      $scope.bChangeStoredPassword = false;
-    }
+  vm.showChangePasswordLinks = function(userid) {
+    return !vm.vmScope().newRecord && vm.vmScope().modelCopy[userid] != '';
   };
 
-  $scope.showVerify = function(userid) {
-    return $scope.newRecord || (!$scope.showChangePasswordLinks(userid)) || $scope.bChangeStoredPassword;
+  vm.resetClicked = function() {
+    vm.newRecord = false;
+    vm.cancelPasswordChange();
   };
-
-  $scope.showChangePasswordLinks = function(userid) {
-    return !$scope.newRecord && $scope.modelCopy[userid] != '';
-  };
-
-  $scope.resetClicked = function() {
-    $scope.newRecord = false;
-    $scope.cancelPasswordChange();
-  };
-
-  init();
 }]);

--- a/app/assets/javascripts/controllers/credentials/credentials_controller.js
+++ b/app/assets/javascripts/controllers/credentials/credentials_controller.js
@@ -4,32 +4,31 @@ ManageIQ.angular.app.controller('CredentialsController', ['$scope', '$attrs', fu
   vm.vmScope = function() {
     return $scope.$eval($attrs.vmScope);
   };
+  
+  vm.bChangeStoredPassword = undefined;
+  vm.bCancelPasswordChange = undefined;
 
+  $scope.$on('resetClicked', function(_e) {
+    vm.resetClicked();
+  });
 
-    vm.bChangeStoredPassword = undefined;
-    vm.bCancelPasswordChange = undefined;
+  $scope.$on('setNewRecord', function(_event, args) {
+    vm.vmScope().newRecord = args ? args.newRecord : true;
+  });
 
-    $scope.$on('resetClicked', function(_e) {
-      vm.resetClicked();
-    });
-
-    $scope.$on('setNewRecord', function(_event, args) {
-      vm.vmScope().newRecord = args ? args.newRecord : true;
-    });
-
-    $scope.$on('setUserId', function(_event, args) {
-      if (args) {
-        vm.vmScope().modelCopy[args.userIdName] = args.userIdValue;
-      }
-    });
-
-    if (vm.vmScope().formId == 'new') {
-      vm.newRecord = true;
-    } else {
-      vm.newRecord = false;
-      vm.bChangeStoredPassword = false;
-      vm.bCancelPasswordChange = false;
+  $scope.$on('setUserId', function(_event, args) {
+    if (args) {
+      vm.vmScope().modelCopy[args.userIdName] = args.userIdValue;
     }
+  });
+
+  if (vm.vmScope().formId == 'new') {
+    vm.newRecord = true;
+  } else {
+    vm.newRecord = false;
+    vm.bChangeStoredPassword = false;
+    vm.bCancelPasswordChange = false;
+  }
 
   vm.changeStoredPassword = function() {
     vm.bChangeStoredPassword = true;

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -1,109 +1,110 @@
 ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$scope', 'providerForemanFormId', 'miqService', function($http, $scope, providerForemanFormId, miqService) {
-    var vm = this;
-      vm.providerForemanModel = {
-        provtype: '',
-        name: '',
-        url: '',
-        zone: '',
-        verify_ssl: '',
-        log_userid: '',
-        log_password: '',
-        log_verify: ''
-      };
-      vm.formId = providerForemanFormId;
-      vm.afterGet = false;
-      vm.validateClicked = miqService.validateWithAjax;
-      vm.modelCopy = angular.copy( vm.providerForemanModel );
-      vm.model = 'providerForemanModel';
+  var vm = this;
 
-      ManageIQ.angular.scope = vm;
+  vm.providerForemanModel = {
+    provtype: '',
+    name: '',
+    url: '',
+    zone: '',
+    verify_ssl: '',
+    log_userid: '',
+    log_password: '',
+    log_verify: ''
+  };
+
+  vm.formId = providerForemanFormId;
+  vm.afterGet = false;
+  vm.validateClicked = miqService.validateWithAjax;
+  vm.modelCopy = angular.copy( vm.providerForemanModel );
+  vm.model = 'providerForemanModel';
+
+  ManageIQ.angular.scope = vm;
 
 
   if (providerForemanFormId == 'new') {
-        vm.newRecord = true;
+    vm.newRecord = true;
 
-        $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId)
-          .then(getProviderForemanFormData)
-          .catch(miqService.handleFailure);
-      } else {
-        vm.newRecord = false;
+    $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId)
+      .then(getProviderForemanFormData)
+      .catch(miqService.handleFailure);
+  } else {
+    vm.newRecord = false;
 
-        miqService.sparkleOn();
+    miqService.sparkleOn();
 
-        $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId)
-          .then(getProviderForemanFormData)
-          .catch(miqService.handleFailure);
+    $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId)
+      .then(getProviderForemanFormData)
+      .catch(miqService.handleFailure);
+  }
+
+  vm.canValidateBasicInfo = function () {
+    if (vm.isBasicInfoValid())
+      return true;
+    else
+      return false;
+  }
+
+  vm.isBasicInfoValid = function() {
+    if(angularForm.url.$valid &&
+      angularForm.log_userid.$valid &&
+      angularForm.log_password.$valid &&
+      angularForm.log_verify.$valid)
+      return true;
+    else
+      return false;
+  };
+
+  var providerForemanEditButtonClicked = function(buttonName, serializeFields) {
+    miqService.sparkleOn();
+    var url = '/provider_foreman/edit/' + providerForemanFormId + '?button=' + buttonName;
+    if (serializeFields === undefined) {
+      miqService.miqAjaxButton(url);
+    } else {
+      miqService.miqAjaxButton(url, serializeFields);
+    }
+  };
+
+  vm.cancelClicked = function() {
+    providerForemanEditButtonClicked('cancel');
+    angularForm.$setPristine(true);
+  };
+
+  vm.resetClicked = function() {
+    $scope.$broadcast ('resetClicked');
+    vm.providerForemanModel = angular.copy( vm.modelCopy );
+    angularForm.$setPristine(true);
+    miqService.miqFlash("warn", __("All changes have been reset"));
+  };
+
+  vm.saveClicked = function() {
+    providerForemanEditButtonClicked('save', true);
+    angularForm.$setPristine(true);
+  };
+
+  vm.addClicked = function() {
+    vm.saveClicked();
+  };
+
+  function getProviderForemanFormData(response) {
+    var data = response.data;
+
+    if (! vm.newRecord) {
+      vm.providerForemanModel.provtype = data.provtype;
+      vm.providerForemanModel.name = data.name;
+      vm.providerForemanModel.url = data.url;
+      vm.providerForemanModel.verify_ssl = data.verify_ssl === 1;
+
+      vm.providerForemanModel.log_userid = data.log_userid;
+
+      if (vm.providerForemanModel.log_userid !== '') {
+        vm.providerForemanModel.log_password = vm.providerForemanModel.log_verify = miqService.storedPasswordPlaceholder;
       }
-
-    vm.canValidateBasicInfo = function () {
-      if (vm.isBasicInfoValid())
-        return true;
-      else
-        return false;
     }
 
-    vm.isBasicInfoValid = function() {
-      if(angularForm.url.$valid &&
-        angularForm.log_userid.$valid &&
-        angularForm.log_password.$valid &&
-        angularForm.log_verify.$valid)
-        return true;
-      else
-        return false;
-    };
+    vm.providerForemanModel.zone = data.zone;
+    vm.afterGet = true;
+    vm.modelCopy = angular.copy( vm.providerForemanModel );
 
-    var providerForemanEditButtonClicked = function(buttonName, serializeFields) {
-      miqService.sparkleOn();
-      var url = '/provider_foreman/edit/' + providerForemanFormId + '?button=' + buttonName;
-      if (serializeFields === undefined) {
-        miqService.miqAjaxButton(url);
-      } else {
-        miqService.miqAjaxButton(url, serializeFields);
-      }
-    };
-
-    vm.cancelClicked = function() {
-      providerForemanEditButtonClicked('cancel');
-      angularForm.$setPristine(true);
-    };
-
-    vm.resetClicked = function() {
-      $scope.$broadcast ('resetClicked');
-      vm.providerForemanModel = angular.copy( vm.modelCopy );
-      angularForm.$setPristine(true);
-      miqService.miqFlash("warn", __("All changes have been reset"));
-    };
-
-    vm.saveClicked = function() {
-      providerForemanEditButtonClicked('save', true);
-      angularForm.$setPristine(true);
-    };
-
-    vm.addClicked = function() {
-      vm.saveClicked();
-    };
-
-    function getProviderForemanFormData(response) {
-      var data = response.data;
-
-      if (! vm.newRecord) {
-        vm.providerForemanModel.provtype = data.provtype;
-        vm.providerForemanModel.name = data.name;
-        vm.providerForemanModel.url = data.url;
-        vm.providerForemanModel.verify_ssl = data.verify_ssl === 1;
-
-        vm.providerForemanModel.log_userid = data.log_userid;
-
-        if (vm.providerForemanModel.log_userid !== '') {
-          vm.providerForemanModel.log_password = vm.providerForemanModel.log_verify = miqService.storedPasswordPlaceholder;
-        }
-      }
-
-      vm.providerForemanModel.zone = data.zone;
-      vm.afterGet = true;
-      vm.modelCopy = angular.copy( vm.providerForemanModel );
-
-      miqService.sparkleOff();
-    }
-
+    miqService.sparkleOff();
+  }
 }]);

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -1,6 +1,6 @@
 ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$scope', 'providerForemanFormId', 'miqService', function($http, $scope, providerForemanFormId, miqService) {
-    var init = function() {
-      $scope.providerForemanModel = {
+    var vm = this;
+      vm.providerForemanModel = {
         provtype: '',
         name: '',
         url: '',
@@ -10,22 +10,23 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
         log_password: '',
         log_verify: ''
       };
-      $scope.formId = providerForemanFormId;
-      $scope.afterGet = false;
-      $scope.validateClicked = miqService.validateWithAjax;
-      $scope.modelCopy = angular.copy( $scope.providerForemanModel );
-      $scope.model = 'providerForemanModel';
+      vm.formId = providerForemanFormId;
+      vm.afterGet = false;
+      vm.validateClicked = miqService.validateWithAjax;
+      vm.modelCopy = angular.copy( vm.providerForemanModel );
+      vm.model = 'providerForemanModel';
 
-      ManageIQ.angular.scope = $scope;
+      ManageIQ.angular.scope = vm;
 
-      if (providerForemanFormId == 'new') {
-        $scope.newRecord = true;
+
+  if (providerForemanFormId == 'new') {
+        vm.newRecord = true;
 
         $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId)
           .then(getProviderForemanFormData)
           .catch(miqService.handleFailure);
       } else {
-        $scope.newRecord = false;
+        vm.newRecord = false;
 
         miqService.sparkleOn();
 
@@ -33,20 +34,19 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
           .then(getProviderForemanFormData)
           .catch(miqService.handleFailure);
       }
-    };
 
-    $scope.canValidateBasicInfo = function () {
-      if ($scope.isBasicInfoValid())
+    vm.canValidateBasicInfo = function () {
+      if (vm.isBasicInfoValid())
         return true;
       else
         return false;
     }
 
-    $scope.isBasicInfoValid = function() {
-      if($scope.angularForm.url.$valid &&
-         $scope.angularForm.log_userid.$valid &&
-         $scope.angularForm.log_password.$valid &&
-         $scope.angularForm.log_verify.$valid)
+    vm.isBasicInfoValid = function() {
+      if(angularForm.url.$valid &&
+        angularForm.log_userid.$valid &&
+        angularForm.log_password.$valid &&
+        angularForm.log_verify.$valid)
         return true;
       else
         return false;
@@ -62,49 +62,48 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
       }
     };
 
-    $scope.cancelClicked = function() {
+    vm.cancelClicked = function() {
       providerForemanEditButtonClicked('cancel');
-      $scope.angularForm.$setPristine(true);
+      angularForm.$setPristine(true);
     };
 
-    $scope.resetClicked = function() {
+    vm.resetClicked = function() {
       $scope.$broadcast ('resetClicked');
-      $scope.providerForemanModel = angular.copy( $scope.modelCopy );
-      $scope.angularForm.$setPristine(true);
+      vm.providerForemanModel = angular.copy( vm.modelCopy );
+      angularForm.$setPristine(true);
       miqService.miqFlash("warn", __("All changes have been reset"));
     };
 
-    $scope.saveClicked = function() {
+    vm.saveClicked = function() {
       providerForemanEditButtonClicked('save', true);
-      $scope.angularForm.$setPristine(true);
+      angularForm.$setPristine(true);
     };
 
-    $scope.addClicked = function() {
-      $scope.saveClicked();
+    vm.addClicked = function() {
+      vm.saveClicked();
     };
 
     function getProviderForemanFormData(response) {
       var data = response.data;
 
-      if (! $scope.newRecord) {
-        $scope.providerForemanModel.provtype = data.provtype;
-        $scope.providerForemanModel.name = data.name;
-        $scope.providerForemanModel.url = data.url;
-        $scope.providerForemanModel.verify_ssl = data.verify_ssl === 1;
+      if (! vm.newRecord) {
+        vm.providerForemanModel.provtype = data.provtype;
+        vm.providerForemanModel.name = data.name;
+        vm.providerForemanModel.url = data.url;
+        vm.providerForemanModel.verify_ssl = data.verify_ssl === 1;
 
-        $scope.providerForemanModel.log_userid = data.log_userid;
+        vm.providerForemanModel.log_userid = data.log_userid;
 
-        if ($scope.providerForemanModel.log_userid !== '') {
-          $scope.providerForemanModel.log_password = $scope.providerForemanModel.log_verify = miqService.storedPasswordPlaceholder;
+        if (vm.providerForemanModel.log_userid !== '') {
+          vm.providerForemanModel.log_password = vm.providerForemanModel.log_verify = miqService.storedPasswordPlaceholder;
         }
       }
 
-      $scope.providerForemanModel.zone = data.zone;
-      $scope.afterGet = true;
-      $scope.modelCopy = angular.copy( $scope.providerForemanModel );
+      vm.providerForemanModel.zone = data.zone;
+      vm.afterGet = true;
+      vm.modelCopy = angular.copy( vm.providerForemanModel );
 
       miqService.sparkleOff();
     }
 
-    init();
 }]);

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -62,7 +62,7 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
     if (serializeFields === undefined) {
       miqService.miqAjaxButton(url);
     } else {
-      miqService.miqAjaxButton(url, serializeFields);
+      miqService.miqAjaxButton(url, vm.providerForemanModel);
     }
   };
 

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -39,14 +39,14 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
       .catch(miqService.handleFailure);
   }
 
-  vm.canValidateBasicInfo = function () {
-    if (vm.isBasicInfoValid())
+  vm.canValidateBasicInfo = function (angularForm) {
+    if (vm.isBasicInfoValid(angularForm))
       return true;
     else
       return false;
   }
 
-  vm.isBasicInfoValid = function() {
+  vm.isBasicInfoValid = function(angularForm) {
     if(angularForm.url.$valid &&
       angularForm.log_userid.$valid &&
       angularForm.log_password.$valid &&

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -18,6 +18,8 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
   vm.modelCopy = angular.copy( vm.providerForemanModel );
   vm.model = 'providerForemanModel';
 
+  vm.saveable = miqService.saveable;
+
   ManageIQ.angular.scope = vm;
 
 
@@ -64,25 +66,25 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
     }
   };
 
-  vm.cancelClicked = function() {
+  vm.cancelClicked = function(angularForm) {
     providerForemanEditButtonClicked('cancel');
     angularForm.$setPristine(true);
   };
 
-  vm.resetClicked = function() {
+  vm.resetClicked = function(angularForm) {
     $scope.$broadcast ('resetClicked');
     vm.providerForemanModel = angular.copy( vm.modelCopy );
     angularForm.$setPristine(true);
     miqService.miqFlash("warn", __("All changes have been reset"));
   };
 
-  vm.saveClicked = function() {
+  vm.saveClicked = function(angularForm) {
     providerForemanEditButtonClicked('save', true);
     angularForm.$setPristine(true);
   };
 
-  vm.addClicked = function() {
-    vm.saveClicked();
+  vm.addClicked = function(angularForm) {
+    vm.saveClicked(angularForm);
   };
 
   function getProviderForemanFormData(response) {

--- a/app/assets/javascripts/directives/checkchange.js
+++ b/app/assets/javascripts/directives/checkchange.js
@@ -6,10 +6,18 @@ ManageIQ.angular.app.directive('checkchange', ['miqService', function(miqService
       scope['elemType_' + ctrl.$name] = attr.type;
 
       var model = function() {
-        return scope.$eval(scope.angularForm.model || scope.model);
+        if (scope.$parent.angularForm) {
+          return scope.$parent.$eval(scope.$parent.angularForm.model || scope.$parent.model);
+        } else {
+          return scope.$eval(scope.angularForm.model || scope.model);
+        }
       };
       var modelCopy = function() {
-        return scope.$eval(scope.angularForm.modelCopy || "modelCopy");
+        if (scope.$parent.angularForm) {
+          return scope.$parent.$eval(scope.$parent.angularForm.modelCopy || "modelCopy");
+        } else {
+          return scope.$eval(scope.angularForm.modelCopy || "modelCopy");
+        }
       };
 
       if (modelCopy()) {

--- a/app/assets/javascripts/directives/clear_field_set_focus.js
+++ b/app/assets/javascripts/directives/clear_field_set_focus.js
@@ -2,24 +2,31 @@ ManageIQ.angular.app.directive('clearFieldSetFocus', ['$timeout', 'miqService', 
   return {
     require: 'ngModel',
     link: function (scope, elem, attr, ctrl) {
+      var model = function() {
+        if (scope.$parent.angularForm) {
+          return scope.$parent.$eval(scope.$parent.angularForm.model || scope.$parent.model);
+        } else {
+          return scope.$eval(scope.angularForm.model || scope.model);
+        }
+      };
       scope['form_passwordfocus_' + ctrl.$name] = elem[0];
 
       var option = attr.clearFieldSetFocus;
 
-      scope.$watch('bChangeStoredPassword', function(value) {
+      scope.$watch('vm.bChangeStoredPassword', function(value) {
         if (value) {
           $timeout(function () {
-            scope[scope.model][ctrl.$name] = '';
+            model()[ctrl.$name] = '';
             if(option != "no-focus")
               angular.element(scope['form_passwordfocus_' + ctrl.$name]).focus();
           }, 0);
         }
       });
 
-      scope.$watch('bCancelPasswordChange', function(value) {
+      scope.$watch('vm.bCancelPasswordChange', function(value) {
         if (value) {
           $timeout(function () {
-            scope[scope.model][ctrl.$name] = miqService.storedPasswordPlaceholder;
+            model()[ctrl.$name] = miqService.storedPasswordPlaceholder;
           }, 0);
         }
       });

--- a/app/assets/javascripts/directives/verifypasswd.js
+++ b/app/assets/javascripts/directives/verifypasswd.js
@@ -2,27 +2,43 @@ ManageIQ.angular.app.directive('verifypasswd', function() {
   return {
     require: 'ngModel',
     link: function (scope, _elem, attr, ctrl) {
+      var model = function() {
+        if (scope.$parent.angularForm) {
+          return scope.$parent.$eval(scope.$parent.angularForm.model || scope.$parent.model);
+        } else {
+          return scope.$eval(scope.angularForm.model || scope.model);
+        }
+      };
+
+      var vmScope = function() {
+        if (scope.$parent.angularForm) {
+          return scope.$parent;
+        } else {
+          return scope;
+        }
+      };
+
       var log_password = attr.prefix + "_password";
       var log_verify = attr.prefix + "_verify";
       var logVerifyCtrl = attr.prefix + "_VerifyCtrl";
 
       scope.$watch(attr.ngModel, function() {
-        if((ctrl.$modelValue != undefined && scope.afterGet) || scope.formId == "new") {
+        if((ctrl.$modelValue != undefined && vmScope().afterGet) || vmScope().formId == "new") {
           if(ctrl.$name == log_verify) {
             scope[logVerifyCtrl] = ctrl;
 
-            setValidity(scope, ctrl, ctrl.$viewValue, scope[scope.model][log_password]);
+            setValidity(vmScope(), ctrl, ctrl.$viewValue, model()[log_password]);
           }else if(ctrl.$name == log_password && scope[logVerifyCtrl] != undefined) {
-            setValidity(scope, scope[logVerifyCtrl], ctrl.$viewValue, scope[scope.model][log_verify]);
+            setValidity(vmScope(), scope[logVerifyCtrl], ctrl.$viewValue, model()[log_verify]);
           }
         }
       });
 
       ctrl.$parsers.push(function(value) {
         if (ctrl.$name == log_verify) {
-          setValidity(scope, ctrl, ctrl.$viewValue, scope[scope.model][log_password]);
+          setValidity(vmScope(), ctrl, ctrl.$viewValue, model()[log_password]);
         }else if(ctrl.$name == log_password && scope[logVerifyCtrl] != undefined) {
-          setValidity(scope, scope[logVerifyCtrl], ctrl.$viewValue, scope[scope.model][log_verify]);
+          setValidity(vmScope(), scope[logVerifyCtrl], ctrl.$viewValue, model()[log_verify]);
         }
         return value;
       });
@@ -37,3 +53,4 @@ ManageIQ.angular.app.directive('verifypasswd', function() {
     }
   }
 });
+

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -16,8 +16,10 @@
 - verify_title_off       ||= _("Server information, Username and matching password fields are needed to perform verification of credentials")
 - ng_show_userid         ||= true
 - guid_regex             ||= false
+- vm_scope               ||= false
+- main_scope            = vm_scope ? "$parent.vm" : "$parent"
 
-%div{"ng-controller" => "CredentialsController"}
+%div{"ng-controller" => "CredentialsController as vm", "vm-scope" => "$parent.vm.model ? $parent.vm : $parent"}
   %div{"ng-show" => "#{ng_show} && #{ng_show_userid}"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_userid.$invalid}"}
       %label.col-md-2.control-label{"for" => "#{prefix}_userid"}
@@ -28,7 +30,7 @@
                              "ng-required"             => "#{ng_reqd_userid}",
                              "ng-disabled"             => userid_disabled,
                              "name"                    => "#{prefix}_userid",
-                             "ng-model"                => "#{ng_model}.#{prefix}_userid",
+                             "ng-model"                => "#{main_scope}.#{ng_model}.#{prefix}_userid",
                              "checkchange"             => "",
                              "ng-trim"                 => false,
                              "detect_spaces"           => "",
@@ -48,17 +50,17 @@
   %div{"ng-show" => "#{ng_show}"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_password.$error.required}"}
       %label.col-md-2.control-label{"for" => "#{prefix}_password"}
-        %div{"ng-show" => "bChangeStoredPassword != true"}
+        %div{"ng-show" => "vm.bChangeStoredPassword != true"}
           = password_label
-        %div{"ng-show" => "bChangeStoredPassword"}
+        %div{"ng-show" => "vm.bChangeStoredPassword"}
           = new_password_label
       .col-md-4
         %input.form-control{"type"                    => "password",
                             "id"                      => "#{prefix}_password",
                             "ng-required"             => "#{ng_reqd_password}",
-                            "ng-disabled"             => "!showVerify('#{prefix}_userid')" || password_disabled,
+                            "ng-disabled"             => "!vm.showVerify('#{prefix}_userid')" || password_disabled,
                             "name"                    => "#{prefix}_password",
-                            "ng-model"                => "#{ng_model}.#{prefix}_password",
+                            "ng-model"                => "#{main_scope}.#{ng_model}.#{prefix}_password",
                             "prefix"                  => "#{prefix}",
                             "clear-field-set-focus"   => "",
                             "verifypasswd"            => "",
@@ -66,32 +68,32 @@
                             "reset-validation-status" => "#{prefix}_auth_status"}
         %span.help-block{"ng-show" => "angularForm.#{prefix}_password.$error.required"}
           = _("Required")
-      %div{"ng-if" => "showChangePasswordLinks('#{prefix}_userid')"}
-        %a{:href => "", "ng-hide" => "bChangeStoredPassword", "ng-click" => "changeStoredPassword()"}
+      %div{"ng-if" => "vm.showChangePasswordLinks('#{prefix}_userid')"}
+        %a{:href => "", "ng-hide" => "vm.bChangeStoredPassword", "ng-click" => "vm.changeStoredPassword()"}
           = change_stored_password
-        %a{:href => "", "ng-show" => "bChangeStoredPassword", "ng-click" => "cancelPasswordChange()"}
+        %a{:href => "", "ng-show" => "vm.bChangeStoredPassword", "ng-click" => "vm.cancelPasswordChange()"}
           = cancel_password_change
     %div{"ng-show" => "#{ng_show}"}
-    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_verify.$error.required || (#{prefix}_VerifyCtrl != undefined && #{prefix}_VerifyCtrl.$error.verifypasswd)}"}
-      %label.col-md-2.control-label{"ng-show" => "showVerify('#{prefix}_userid')", "for" => "#{prefix}_verify"}
+    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_verify.$error.required || angularForm.#{prefix}_verify.$error.verifypasswd}"}
+      %label.col-md-2.control-label{"ng-show" => "vm.showVerify('#{prefix}_userid')", "for" => "#{prefix}_verify"}
         = verify_label
       .col-md-4
         %input.form-control{"type"                    => "password",
                             "id"                      => "#{prefix}_verify",
                             "ng-required"             => "#{ng_reqd_verify}",
-                            "ng-disabled"             => "!showVerify('#{prefix}_userid')" || password_disabled,
+                            "ng-disabled"             => "!vm.showVerify('#{prefix}_userid')" || password_disabled,
                             "name"                    => "#{prefix}_verify",
-                            "ng-model"                => "#{ng_model}.#{prefix}_verify",
-                            "ng-show"                 => "showVerify('#{prefix}_userid')",
+                            "ng-model"                => "#{main_scope}.#{ng_model}.#{prefix}_verify",
+                            "ng-show"                 => "vm.showVerify('#{prefix}_userid')",
                             "prefix"                  => "#{prefix}",
                             "clear-field-set-focus"   => "no-focus",
                             "verifypasswd"            => "",
                             "checkchange"             => "",
                             "reset-validation-status" => "#{prefix}_auth_status"}
-        %div{"ng-show" => "showVerify('#{prefix}_userid')"}
+        %div{"ng-show" => "vm.showVerify('#{prefix}_userid')"}
           %span.help-block{"ng-show" => "angularForm.#{prefix}_verify.$error.required"}
             = _("Required")
-          %span.help-block{"ng-show" => "!angularForm.#{prefix}_verify.$error.required && #{prefix}_VerifyCtrl != undefined && #{prefix}_VerifyCtrl.$error.verifypasswd"}
+          %span.help-block{"ng-show" => "!angularForm.#{prefix}_verify.$error.required && angularForm.#{prefix}_verify.$error.verifypasswd"}
             = passwd_mismatch
     %div{"ng-show" => "#{ng_show}"}
       .form-group

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -104,6 +104,7 @@
                                                     :validate_url     => validate_url,
                                                     :id               => id,
                                                     :ng_model         => "#{ng_model}",
+                                                    :main_scope       => main_scope,
                                                     :valtype          => "#{prefix}",
                                                     :verify_title_off => verify_title_off,
                                                     :basic_info_needed => defined?(basic_info_needed) ? basic_info_needed : nil}

--- a/app/views/layouts/angular-bootstrap/_auth_keypair_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_keypair_angular_bootstrap.html.haml
@@ -11,6 +11,9 @@
 - change_stored_private_key ||= _("Change stored private key")
 - cancel_private_key_change ||= _("Cancel private key change")
 - verify_title_off          ||= _("Server information, username and private key fields are needed to perform verification of credentials")
+- vm_scope                  ||= false
+- main_scope                  = vm_scope ? "$parent.vm" : "$parent"
+
 
 %div{"ng-controller" => "emsKeypairController as vm", "ng-init" => "vm.initialize(#{ng_model}, formId)"}
   %div{"ng-show" => "#{ng_show}"}
@@ -82,5 +85,6 @@
                                                     :id                => id,
                                                     :valtype           => prefix,
                                                     :ng_model          => "#{ng_model}",
+                                                    :main_scope        => main_scope,
                                                     :verify_title_off  => verify_title_off,
                                                     :basic_info_needed => defined?(basic_info_needed) ? basic_info_needed : nil}

--- a/app/views/layouts/angular/_auth_service_account_angular.html.haml
+++ b/app/views/layouts/angular/_auth_service_account_angular.html.haml
@@ -1,6 +1,8 @@
 - ng_show ||= true
 - validate_url ||= 'log_depot_edit'
 - prefix ||= 'log'
+- vm_scope ||= false
+- main_scope = vm_scope ? "$parent.vm" : "$parent"
 
 %div{"ng-controller" => "CredentialsController"}
   %div{"ng-show" => ng_show}
@@ -28,4 +30,5 @@
                                                   :id                => id,
                                                   :valtype           => prefix,
                                                   :ng_model          => "#{ng_model}",
+                                                  :main_scope        => main_scope,
                                                   :basic_info_needed => defined?(basic_info_needed) ? basic_info_needed : nil}

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -16,6 +16,7 @@
               "enabled-title"  => verify_title_on,
               :enabled         => basic_info_needed ? "#{main_scope}.canValidateBasicInfo(angularForm)" : "#{main_scope}.canValidate(angularForm)",
               'on-click'       => validate,
+              :xs              => 'true',
               :primary         => 'true'}
   %div{"ng-if" => "checkAuthentication"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{valtype}_auth_status.$error.validationRequired}"}

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -6,15 +6,15 @@
   - verify_title_off ||= _("Server information, Username and matching password fields are needed to perform verification of credentials")
 - if controller.send(:restful?)
   -# TODO: replace first argument with a sane way of submitting the form
-  - validate = "validateClicked({target: '.validate_button:visible'}, '#{valtype}', true)"
+  - validate = "#{main_scope}.validateClicked({target: '.validate_button:visible'}, '#{valtype}', true)"
 - else
-  - validate = "validateClicked('#{url_for_only_path(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
+  - validate = "#{main_scope}.validateClicked('#{url_for_only_path(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
 %div{"ng-show" => ng_show}
   %miq-button{:class           => 'validate_button',
               :name            => _("Validate"),
               "disabled-title" => verify_title_off,
               "enabled-title"  => verify_title_on,
-              :enabled         => basic_info_needed ? "canValidateBasicInfo()" : "canValidate()",
+              :enabled         => basic_info_needed ? "#{main_scope}.canValidateBasicInfo(angularForm)" : "#{main_scope}.canValidate(angularForm)",
               'on-click'       => validate,
               :primary         => 'true'}
   %div{"ng-if" => "checkAuthentication"}

--- a/app/views/layouts/angular/_generic_form_buttons.html.haml
+++ b/app/views/layouts/angular/_generic_form_buttons.html.haml
@@ -1,0 +1,27 @@
+.clearfix
+.pull-right.button-group.edit_buttons
+  %miq-button{:name      => t = _("Add"),
+              :title     => t,
+              :alt       => t,
+              'ng-show'  => 'vm.newRecord',
+              :enabled   => "vm.saveable(angularForm)",
+              'on-click' => "vm.addClicked(angularForm)",
+              :primary   => 'true'}
+  %miq-button{:name      => t = _("Save"),
+              :title     => t,
+              :alt       => t,
+              'ng-show'  => '!vm.newRecord',
+              :enabled   => "vm.saveable(angularForm)",
+              'on-click' => "vm.saveClicked(angularForm)",
+              :primary   => 'true'}
+  %miq-button{:name      => t = _("Reset"),
+              :title     => t,
+              :alt       => t,
+              'ng-show'  => '!vm.newRecord',
+              :enabled   => "!angularForm.$pristine",
+              'on-click' => "vm.resetClicked(angularForm)"}
+  %miq-button{:name      => t = _("Cancel"),
+              :title     => t,
+              :alt       => t,
+              :enabled   => "true",
+              'on-click' => "vm.cancelClicked(angularForm)"}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -1,5 +1,7 @@
 - validate_url ||= (record.id || @selected_hosts) ? "update" : "create"
 - legendtext ||= _("Endpoints")
+- vm_scope   ||= false
+- main_scope  = vm_scope ? "$parent.vm" : "$parent"
 
 #auth_tabs
   %h3
@@ -272,6 +274,7 @@
                      :locals  => {:ng_show           => true,
                                   :validate_url      => validate_url,
                                   :id                => record.id,
+                                  :main_scope        => main_scope,
                                   :ng_model          => "#{ng_model}",
                                   :valtype           => "hawkular",
                                   :verify_title_off  => _("hawkular URL and API port fields are needed to perform validation."),

--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -111,7 +111,7 @@
                           :vm_scope          => true,
                           :basic_info_needed => true}
 
-    = render :partial => "layouts/angular/x_edit_buttons_angular"
+    = render :partial => "layouts/angular/generic_form_buttons"
     %span{:style => "color:black"}= _("Required. Should have privileged access, such as root or administrator.")
 
 :javascript

--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -108,6 +108,7 @@
                           :validate_url      => "authentication_validate",
                           :id                => @provider_manager.id || "new",
                           :valtype           => nil,
+                          :vm_scope          => true,
                           :basic_info_needed => true}
 
     = render :partial => "layouts/angular/x_edit_buttons_angular"

--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -2,8 +2,11 @@
 
 .form-horizontal{:id => "start_form_div", :style => "display:none"}
   %form#form_div{:name           => "angularForm",
-                 'ng-controller' => "providerForemanFormController",
-                 'ng-show'       => "afterGet",
+                 'ng-controller' => "providerForemanFormController as vm",
+                 'ng-show'       => "vm.afterGet",
+                 "miq-form"      => true,
+                 "model"         => "vm.providerForemanModel",
+                 "model-copy"    => 'vm.modelCopy',
                  :novalidate     => true}
     = render :partial => "layouts/flash_msg"
     %br
@@ -13,7 +16,7 @@
       .col-md-8
         %input.form-control{:type            => "text",
                             :name            => "name",
-                            'ng-model'       => "providerForemanModel.name",
+                            'ng-model'       => "vm.providerForemanModel.name",
                             :maxlength       => MAX_NAME_LEN,
                             :required        => "",
                             :checkchange     => true,
@@ -28,18 +31,18 @@
       .col-md-8
         = select_tag('provtype',
                      options_for_select([["<#{_('Choose')}>", nil]] + @provider_types, disabled: ["<#{_('Choose')}>", nil]),
-                     "ng-if"                       => "newRecord",
-                     "ng-model"                    => "providerForemanModel.provtype",
+                     "ng-if"                       => "vm.newRecord",
+                     "ng-model"                    => "vm.providerForemanModel.provtype",
                      "ng-change"                   => "providerTypeChanged()",
                      "id"                          => "provider_type",
                      "required"                    => "",
                      "checkchange"                 => "",
                      "selectpicker-for-select-tag" => "")
-        %div{"ng-if" => "!newRecord"}
+        %div{"ng-if" => "!vm.newRecord"}
           %input.form-control{:type      => "text",
                               :name      => "provtype",
-                              "ng-model" => "providerForemanModel.provtype",
-                              "ng-if"    => "!newRecord",
+                              "ng-model" => "vm.providerForemanModel.provtype",
+                              "ng-if"    => "!vm.newRecord",
                               "id"       => "provider_type",
                               "readonly" => true,
                               "style"    => "color: black; font-weight: normal;"}
@@ -52,7 +55,7 @@
           %input.form-control{"type"        => "text",
                               "id"          => "prov_zone",
                               "name"        => "zone",
-                              "ng-model"    => "providerForemanModel.zone",
+                              "ng-model"    => "vm.providerForemanModel.zone",
                               "maxlength"   => 15,
                               "required"    => "",
                               "checkchange" => "",
@@ -61,7 +64,7 @@
         - else
           = select_tag('zone',
                        options_for_select(@server_zones.sort_by { |name, _name| name }),
-                       "ng-model"                    => "providerForemanModel.zone",
+                       "ng-model"                    => "vm.providerForemanModel.zone",
                        "checkchange"                 => "",
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
@@ -72,7 +75,7 @@
       .col-md-8
         %input.form-control{:type           => "text",
                             :name           => "url",
-                            'ng-model'      => "providerForemanModel.url",
+                            'ng-model'      => "vm.providerForemanModel.url",
                             :maxlength      => MAX_DESC_LEN,
                             "id"            => "url",
                             :required       => "",
@@ -89,7 +92,7 @@
       .col-md-8
         %input{:type            => "checkbox",
                :name            => "verify_ssl",
-               'ng-model'       => "providerForemanModel.verify_ssl",
+               'ng-model'       => "vm.providerForemanModel.verify_ssl",
                :checkchange     => true}
 
 

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -273,7 +273,7 @@ describe HostController do
     it "renders a new page with ng-required condition set to false for password" do
       get :new
       expect(response.status).to eq(200)
-      expect(response.body).to include("name='default_password' ng-disabled='!showVerify(&#39;default_userid&#39;)' ng-model='hostModel.default_password' ng-required='false'")
+      expect(response.body).to include("name='default_password' ng-disabled='!vm.showVerify(&#39;default_userid&#39;)' ng-model='$parent.hostModel.default_password' ng-required='false'")
     end
   end
 end

--- a/spec/javascripts/controllers/credentials/credentials_controller_spec.js
+++ b/spec/javascripts/controllers/credentials/credentials_controller_spec.js
@@ -1,15 +1,16 @@
 describe('CredentialsController', function() {
-  var $scope, $controller, $httpBackend, miqService;
+  var $scope, vm, $httpBackend;
 
   beforeEach(module('ManageIQ'));
 
-  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _miqService_) {
-    miqService = _miqService_;
+  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_) {
     $scope = $rootScope.$new();
     $httpBackend = _$httpBackend_;
     $scope.model = "hostModel";
-    $controller = _$controller_('CredentialsController',
-      {$http: $httpBackend, $scope: $scope, miqService: miqService});
+    vm = _$controller_('CredentialsController',
+      {$http: $httpBackend,
+       $scope: $scope,
+       $attrs: {'vmScope': '$parent'}});
   }));
 
   afterEach(function() {
@@ -19,95 +20,99 @@ describe('CredentialsController', function() {
 
   describe('when formId is new', function() {
     beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_) {
-      $scope.formId = 'new';
-      $controller = _$controller_('CredentialsController',
-        {$http: $httpBackend, $scope: $scope, miqService: miqService});
+      $scope.$parent.formId = 'new';
+      vm = _$controller_('CredentialsController',
+        {$http: $httpBackend,
+         $scope: $scope,
+         $attrs: {'vmScope': '$parent'}});
     }));
     it('initializes stored password state flags for new records', function() {
-      expect($scope.newRecord).toBeTruthy();
-      expect($scope.bChangeStoredPassword).toBeUndefined();
-      expect($scope.bCancelPasswordChange).toBeUndefined();
+      expect(vm.newRecord).toBeTruthy();
+      expect(vm.bChangeStoredPassword).toBeUndefined();
+      expect(vm.bCancelPasswordChange).toBeUndefined();
     });
   });
 
   describe('when formId is not new', function() {
     beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_) {
-      $scope.formId = '12345';
-      $controller = _$controller_('CredentialsController',
-        {$http: $httpBackend, $scope: $scope, miqService: miqService});
+      $scope.$parent.formId = '12345';
+      vm = _$controller_('CredentialsController',
+        {$http: $httpBackend, $scope: $scope, $attrs: {'vmScope': '$parent'}});
     }));
     it('initializes stored password state flags for existing records', function() {
-      expect($scope.newRecord).toBeFalsy();
-      expect($scope.bChangeStoredPassword).toBeFalsy();
-      expect($scope.bCancelPasswordChange).toBeFalsy();
+      expect(vm.newRecord).toBeFalsy();
+      expect(vm.bChangeStoredPassword).toBeFalsy();
+      expect(vm.bCancelPasswordChange).toBeFalsy();
     });
   });
 
   it('sets proper values when Change Stored Password is clicked', function() {
-    $scope.changeStoredPassword();
-    expect($scope.bChangeStoredPassword).toBeTruthy();
-    expect($scope.bCancelPasswordChange).toBeFalsy();
+    vm.changeStoredPassword();
+    expect(vm.bChangeStoredPassword).toBeTruthy();
+    expect(vm.bCancelPasswordChange).toBeFalsy();
   });
 
   it('sets proper values when Cancel Password change is clicked', function() {
-    $scope.changeStoredPassword();
-    $scope.cancelPasswordChange();
-    expect($scope.bChangeStoredPassword).toBeFalsy();
-    expect($scope.bCancelPasswordChange).toBeTruthy();
+    vm.changeStoredPassword();
+    vm.cancelPasswordChange();
+    expect(vm.bChangeStoredPassword).toBeFalsy();
+    expect(vm.bCancelPasswordChange).toBeTruthy();
   });
 
   it('shows Verify Password field when record is new', function() {
-    $scope.newRecord = true;
-    expect($scope.showVerify('default_userid')).toBeTruthy();
+    vm.newRecord = true;
+    $scope.$parent.hostModel = {'default_userid': '', 'default_password': '', 'default_verify': ''};
+    $scope.$parent.modelCopy = angular.copy( $scope.$parent.hostModel );
+    expect(vm.showVerify('default_userid')).toBeTruthy();
   });
 
   it('shows Verify Password field only after Change Stored Password is clicked', function() {
-    $scope.hostModel = {'default_userid': 'abc', 'default_password': '********', 'default_verify': '********'};
-    $scope.modelCopy = angular.copy( $scope.hostModel );
-    expect($scope.showVerify('default_userid')).toBeFalsy();
-    $scope.changeStoredPassword();
-    expect($scope.showVerify('default_userid')).toBeTruthy();
+    $scope.$parent.hostModel = {'default_userid': 'abc', 'default_password': '********', 'default_verify': '********'};
+    $scope.$parent.modelCopy = angular.copy( $scope.$parent.hostModel );
+    expect(vm.showVerify('default_userid')).toBeFalsy();
+    vm.changeStoredPassword();
+    expect(vm.showVerify('default_userid')).toBeTruthy();
   });
 
   it('shows Verify Password field when record is not new, userid does not exist', function() {
-    $scope.newRecord = false;
-    $scope.hostModel = {'default_userid': '', 'default_password': '', 'default_verify': ''};
-    $scope.modelCopy = angular.copy( $scope.hostModel );
-    expect($scope.showVerify('default_userid')).toBeTruthy();
+    vm.newRecord = false;
+    $scope.$parent.hostModel = {'default_userid': '', 'default_password': '', 'default_verify': ''};
+    $scope.$parent.modelCopy = angular.copy( $scope.$parent.hostModel );
+    expect(vm.showVerify('default_userid')).toBeTruthy();
   });
 
   it('shows password change links when record is not new and userid exists', function() {
-    $scope.newRecord = false;
-    $scope.hostModel = {'default_userid': 'abc', 'default_password': '********', 'default_verify': '********'};
-    $scope.modelCopy = angular.copy( $scope.hostModel );
-    expect($scope.showChangePasswordLinks('default_userid')).toBeTruthy();
+    vm.newRecord = false;
+    $scope.$parent.hostModel = {'default_userid': 'abc', 'default_password': '********', 'default_verify': '********'};
+    $scope.$parent.modelCopy = angular.copy( $scope.$parent.hostModel );
+    expect(vm.showChangePasswordLinks('default_userid')).toBeTruthy();
   });
 
   it('does not show password change links when record is not new and userid does not exist', function() {
-    $scope.newRecord = false;
-    $scope.hostModel = {'default_userid': '', 'default_password': '', 'default_verify': ''};
-    $scope.modelCopy = angular.copy( $scope.hostModel );
-    expect($scope.showChangePasswordLinks('default_userid')).toBeFalsy();
+    vm.newRecord = false;
+    $scope.$parent.hostModel = {'default_userid': '', 'default_password': '', 'default_verify': ''};
+    $scope.$parent.modelCopy = angular.copy( $scope.$parent.hostModel );
+    expect(vm.showChangePasswordLinks('default_userid')).toBeFalsy();
   });
 
   it('does not show password change links when record is not new, userid did not exist before but is now filled in by the user', function() {
-    $scope.newRecord = false;
-    $scope.hostModel = {'default_userid': '', 'default_password': '', 'default_verify': ''};
-    $scope.modelCopy = angular.copy( $scope.hostModel );
-    $scope.hostModel.default_userid = 'xyz';
-    expect($scope.showChangePasswordLinks('default_userid')).toBeFalsy();
+    vm.newRecord = false;
+    $scope.$parent.hostModel = {'default_userid': '', 'default_password': '', 'default_verify': ''};
+    $scope.$parent.modelCopy = angular.copy( $scope.$parent.hostModel );
+    $scope.$parent.hostModel.default_userid = 'xyz';
+    expect(vm.showChangePasswordLinks('default_userid')).toBeFalsy();
   });
 
   it('restores the flag values to original state when reset is clicked after Change stored password link was clicked', function() {
-    $scope.changeStoredPassword();
-    $scope.resetClicked();
-    expect($scope.bCancelPasswordChange).toBeTruthy();
-    expect($scope.bChangeStoredPassword).toBeFalsy();
+    vm.changeStoredPassword();
+    vm.resetClicked();
+    expect(vm.bCancelPasswordChange).toBeTruthy();
+    expect(vm.bChangeStoredPassword).toBeFalsy();
   });
 
   it('restores the flag values to original state when reset is clicked before Change stored password link was clicked', function() {
-    $scope.resetClicked();
-    expect($scope.bCancelPasswordChange).toBeFalsy();
-    expect($scope.bChangeStoredPassword).toBeFalsy();
+    vm.resetClicked();
+    expect(vm.bCancelPasswordChange).toBeFalsy();
+    expect(vm.bChangeStoredPassword).toBeFalsy();
   });
 });

--- a/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
+++ b/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
@@ -1,5 +1,5 @@
 describe('providerForemanFormController', function() {
-  var $scope, $controller, $httpBackend, miqService;
+  var $scope, vm, $httpBackend, miqService;
 
   beforeEach(module('ManageIQ'));
 
@@ -22,7 +22,7 @@ describe('providerForemanFormController', function() {
 
     $httpBackend = _$httpBackend_;
     $httpBackend.whenGET('/provider_foreman/provider_foreman_form_fields/new').respond(providerForemanFormResponse);
-    $controller = _$controller_('providerForemanFormController', {
+    vm = _$controller_('providerForemanFormController', {
       $scope: $scope,
       providerForemanFormId: 'new',
       miqService: miqService
@@ -38,25 +38,25 @@ describe('providerForemanFormController', function() {
   describe('initialization', function() {
     describe('when the providerForemanFormId is new', function() {
       it('sets the name to blank', function () {
-        expect($scope.providerForemanModel.name).toEqual('');
+        expect(vm.providerForemanModel.name).toEqual('');
       });
       it('sets the zone to blank', function () {
-        expect($scope.providerForemanModel.zone).toEqual('foo_zone');
+        expect(vm.providerForemanModel.zone).toEqual('foo_zone');
       });
       it('sets the url to blank', function () {
-        expect($scope.providerForemanModel.url).toEqual('');
+        expect(vm.providerForemanModel.url).toEqual('');
       });
       it('sets the verify_ssl to blank', function () {
-        expect($scope.providerForemanModel.verify_ssl).toBeFalsy();
+        expect(vm.providerForemanModel.verify_ssl).toBeFalsy();
       });
       it('sets the log_userid to blank', function () {
-        expect($scope.providerForemanModel.log_userid).toEqual('');
+        expect(vm.providerForemanModel.log_userid).toEqual('');
       });
       it('sets the log_password to blank', function () {
-        expect($scope.providerForemanModel.log_password).toEqual('');
+        expect(vm.providerForemanModel.log_password).toEqual('');
       });
       it('sets the log_verify to blank', function () {
-        expect($scope.providerForemanModel.log_verify).toEqual('');
+        expect(vm.providerForemanModel.log_verify).toEqual('');
       });
     });
 
@@ -71,7 +71,7 @@ describe('providerForemanFormController', function() {
 
       beforeEach(inject(function(_$controller_) {
         $httpBackend.whenGET('/provider_foreman/provider_foreman_form_fields/12345').respond(providerForemanFormResponse);
-        $controller = _$controller_('providerForemanFormController',
+        vm = _$controller_('providerForemanFormController',
           {
             $scope: $scope,
             providerForemanFormId: '12345',
@@ -81,36 +81,36 @@ describe('providerForemanFormController', function() {
       }));
 
       it('sets the name to the value returned from http request', function () {
-        expect($scope.providerForemanModel.name).toEqual('Foreman');
+        expect(vm.providerForemanModel.name).toEqual('Foreman');
       });
       it('sets the zone to the value returned from the http request', function () {
-        expect($scope.providerForemanModel.zone).toEqual('My Test Zone');
+        expect(vm.providerForemanModel.zone).toEqual('My Test Zone');
       });
       it('sets the url to the value returned from http request', function () {
-        expect($scope.providerForemanModel.url).toEqual('10.10.10.10');
+        expect(vm.providerForemanModel.url).toEqual('10.10.10.10');
       });
       it('sets the verify_ssl to the value returned from http request', function () {
-        expect($scope.providerForemanModel.verify_ssl).toBeTruthy();
+        expect(vm.providerForemanModel.verify_ssl).toBeTruthy();
       });
       it('sets the log_userid to the value returned from http request', function () {
-        expect($scope.providerForemanModel.log_userid).toEqual('admin');
+        expect(vm.providerForemanModel.log_userid).toEqual('admin');
       });
       it('sets the log_password to the value returned from http request', function () {
-        expect($scope.providerForemanModel.log_password).toEqual(miqService.storedPasswordPlaceholder);
+        expect(vm.providerForemanModel.log_password).toEqual(miqService.storedPasswordPlaceholder);
       });
       it('sets the log_verify to the value returned from http request', function () {
-        expect($scope.providerForemanModel.log_verify).toEqual(miqService.storedPasswordPlaceholder);
+        expect(vm.providerForemanModel.log_verify).toEqual(miqService.storedPasswordPlaceholder);
       });
     });
   });
 
   describe('#resetClicked', function() {
     beforeEach(function() {
-      $scope.angularForm = {
+      var angularForm = {
         $setPristine: function (value){},
         $setUntouched: function (value){},
       };
-      $scope.resetClicked();
+      vm.resetClicked(angularForm);
     });
 
     it('does not turn the spinner on', function() {
@@ -120,10 +120,10 @@ describe('providerForemanFormController', function() {
 
   describe('#saveClicked', function() {
     beforeEach(function() {
-      $scope.angularForm = {
+      var angularForm = {
         $setPristine: function (value){}
       };
-      $scope.saveClicked();
+      vm.saveClicked(angularForm);
     });
 
     it('turns the spinner on via the miqService', function() {
@@ -141,10 +141,10 @@ describe('providerForemanFormController', function() {
 
   describe('#addClicked', function() {
     beforeEach(function() {
-      $scope.angularForm = {
+      var angularForm = {
         $setPristine: function (value){}
       };
-      $scope.addClicked();
+      vm.addClicked(angularForm);
     });
 
     it('turns the spinner on via the miqService', function() {
@@ -158,19 +158,17 @@ describe('providerForemanFormController', function() {
 
   describe('Validates credential fields', function() {
     beforeEach(inject(function($compile, miqService) {
-      var angularForm;
       var element = angular.element(
         '<form name="angularForm">' +
-        '<input ng-model="providerForemanModel.url" name="url" required text />' +
-        '<input ng-model="providerForemanModel.log_userid" name="log_userid" required text />' +
-        '<input ng-model="providerForemanModel.log_password" name="log_password" required text />' +
-        '<input ng-model="providerForemanModel.log_verify" name="log_verify" required text />' +
+        '<input ng-model="vm.providerForemanModel.url" name="url" required text />' +
+        '<input ng-model="vm.providerForemanModel.log_userid" name="log_userid" required text />' +
+        '<input ng-model="vm.providerForemanModel.log_password" name="log_password" required text />' +
+        '<input ng-model="vm.providerForemanModel.log_verify" name="log_verify" required text />' +
         '</form>'
       );
 
       $compile(element)($scope);
       $scope.$digest();
-      angularForm = $scope.angularForm;
 
       $scope.angularForm.url.$setViewValue('foreman-url');
       $scope.angularForm.log_userid.$setViewValue('admin');
@@ -179,13 +177,13 @@ describe('providerForemanFormController', function() {
     }));
 
     it('returns true if all the Validation fields are filled in', function() {
-      expect($scope.canValidateBasicInfo()).toBe(true);
+      expect(vm.isBasicInfoValid($scope.angularForm)).toBe(true);
     });
   });
 
   describe('Checks for validateClicked in the scope', function() {
     it('contains validateClicked in the scope', function() {
-      expect($scope.validateClicked).toBeDefined();
+      expect(vm.validateClicked).toBeDefined();
     });
   });
 });

--- a/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
+++ b/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
@@ -135,7 +135,8 @@ describe('providerForemanFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/provider_foreman/edit/new?button=save', true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/provider_foreman/edit/new?button=save',
+        vm.providerForemanModel);
     });
   });
 
@@ -152,7 +153,8 @@ describe('providerForemanFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/provider_foreman/edit/new?button=save', true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/provider_foreman/edit/new?button=save',
+        vm.providerForemanModel);
     });
   });
 

--- a/spec/javascripts/directives/checkchange_spec.js
+++ b/spec/javascripts/directives/checkchange_spec.js
@@ -2,7 +2,7 @@ describe('checkchange initialization', function() {
   var $scope, form;
   beforeEach(module('ManageIQ'));
   beforeEach(inject(function($compile, $rootScope, miqService) {
-    $scope = $rootScope;
+    $scope = $rootScope.$new();
     var element = angular.element(
       '<form name="angularForm">' +
       '<input checkchange type="text" ng-model="repo.path" name="repo_path"/>' +

--- a/spec/javascripts/directives/clear_field_set_focus_spec.js
+++ b/spec/javascripts/directives/clear_field_set_focus_spec.js
@@ -1,48 +1,54 @@
 describe('clearFieldSetFocus initialization', function() {
-  var $scope, form;
+  var $scope, form, ctrl, hostScope, credScope;
   beforeEach(module('ManageIQ'));
-  beforeEach(inject(function($compile, $rootScope, _miqService_) {
-    $scope = $rootScope;
+  beforeEach(inject(function($compile, $rootScope, _miqService_, _$controller_) {
+    hostScope = $rootScope.$new();
+    credScope = hostScope.$new();
+    $scope = credScope.$new();
     miqService = _miqService_;
+
+    $scope.$parent.formId = '12345';
+    ctrl = _$controller_('CredentialsController',
+      {$scope: credScope, $attrs: {'vmScope': '$parent'}});
 
     var element = angular.element(
       '<form name="angularForm">' +
-      '<input clear-field-set-focus type="text" ng-model="hostModel.password" name="password"/>' +
-      '<input clear-field-set-focus="no-focus" type="text" ng-model="hostModel.password_verify" name="password_verify"/>' +
+      '<ng-controller="CredentialsController as vm">' +
+      '<input clear-field-set-focus type="text" ng-model="$parent.hostModel.password" name="password"/>' +
+      '<input clear-field-set-focus="no-focus" type="text" ng-model="$parent.hostModel.password_verify" name="password_verify"/>' +
       '</form>'
     );
-    elem = $compile(element)($rootScope);
+    elem = $compile(element)(credScope);
     form = $scope.angularForm;
-    $scope.model = "hostModel";
-    $scope.bChangeStoredPassword = false;
-    $scope.bCancelPasswordChange = false;
-    $scope.hostModel = {'password': '', 'password_verify': ''};
-    $scope.hostModel.password = miqService.storedPasswordPlaceholder;
-    $scope.hostModel.password_verify = miqService.storedPasswordPlaceholder;
+    $scope.$parent.model = "hostModel";
+    $scope.$parent.hostModel = {'password': '', 'password_verify': ''};
+    $scope.$parent.hostModel.password = miqService.storedPasswordPlaceholder;
+    $scope.$parent.hostModel.password_verify = miqService.storedPasswordPlaceholder;
+    $scope.$parent.vm = ctrl;
   }));
 
   describe('clear-field-set-focus specs', function() {
     it('sets focus on the password field and clears out the placeholder', inject(function($timeout) {
       spyOn(elem[0][0], 'focus');
-      $scope.bChangeStoredPassword = true;
+      ctrl.changeStoredPassword();
       $timeout.flush();
-      expect($scope.hostModel.password).toBe('');
+      expect($scope.$parent.hostModel.password).toBe('');
       expect((elem[0][0]).focus).toHaveBeenCalled();
     }));
 
     it('clears out the placeholder in the password verify field', inject(function($timeout) {
       spyOn(elem[0][1], 'focus');
-      $scope.bChangeStoredPassword = true;
+      ctrl.bChangeStoredPassword = true;
       $timeout.flush();
-      expect($scope.hostModel.password_verify).toBe('');
+      expect($scope.$parent.hostModel.password_verify).toBe('');
       expect((elem[0][1]).focus).not.toHaveBeenCalled();
     }));
 
     it('puts back the placeholder when cancel password change is selected', inject(function($timeout) {
-      $scope.bCancelPasswordChange = true;
+      ctrl.bCancelPasswordChange = true;
       $timeout.flush();
-      expect($scope.hostModel.password).toBe(miqService.storedPasswordPlaceholder);
-      expect($scope.hostModel.password_verify).toBe(miqService.storedPasswordPlaceholder);
+      expect($scope.$parent.hostModel.password).toBe(miqService.storedPasswordPlaceholder);
+      expect($scope.$parent.hostModel.password_verify).toBe(miqService.storedPasswordPlaceholder);
     }));
   });
 });


### PR DESCRIPTION
Changes in this PR demonstrate how to apply the `controller as` changes to an angular controller like Foreman that contains a `nested controller` -- `CredentialsController` and uses many directives running in different scopes.

The buttons have been converted to `components` in order to better manage the `scope` related logic.

The logic here is much crisper than https://github.com/ManageIQ/manageiq-ui-classic/pull/360.

Closes #360