### PR TITLE
Change method name that gets metrics default db name

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -312,7 +312,7 @@ module Mixins
 
     def metrics_default_database_name
       if @ems.class.name == 'ManageIQ::Providers::Redhat::InfraManager'
-        ManageIQ::Providers::Redhat::InfraManager.history_database_name_for('4.0')
+        ManageIQ::Providers::Redhat::InfraManager.default_history_database_name
       end
     end
 


### PR DESCRIPTION
The name of the method to get the default metrics db name in RHV
has changed.

this is dependent on: https://github.com/ManageIQ/manageiq/pull/13981