### PR TITLE
Make cascading auto-refresh behavior more consistent with how it was previously

### DIFF
--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -131,6 +131,10 @@ module ApplicationHelper::Dialogs
     auto_refreshable_field_indicies
   end
 
+  def auto_refresh_listening_options(options, trigger_override)
+    options.merge(:trigger => trigger_override)
+  end
+
   private
 
   def auto_refresh_options(field, auto_refresh_options_hash)

--- a/app/views/shared/dialogs/_dialog_field_check_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_check_box.html.haml
@@ -5,7 +5,9 @@
     :javascript
       dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
         dialogFieldRefresh.refreshCheckbox("#{field.name}", "#{field.id}", function() {
-          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+          dialogFieldRefresh.triggerAutoRefresh(
+            JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
+          );
         });
       });
 

--- a/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
@@ -27,7 +27,9 @@
     :javascript
       dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
         dialogFieldRefresh.refreshDateTime("#{field.name}", "#{field.id}", function() {
-          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+          dialogFieldRefresh.triggerAutoRefresh(
+            JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
+          );
         });
       });
 

--- a/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
@@ -17,7 +17,9 @@
         dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
           var selectedValue = $('select[name="#{field.name}"]').val();
           dialogFieldRefresh.refreshDropDownList("#{field.name}", "#{field.id}", selectedValue, function() {
-            dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+            dialogFieldRefresh.triggerAutoRefresh(
+              JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
+            );
           });
         });
 

--- a/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
@@ -32,7 +32,9 @@
                                             checkedValue,
                                             "#{url}",
                                             JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
-          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+          dialogFieldRefresh.triggerAutoRefresh(
+            JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
+          );
         });
       });
 

--- a/app/views/shared/dialogs/_dialog_field_text_area_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_text_area_box.html.haml
@@ -8,7 +8,9 @@
     :javascript
       dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
         dialogFieldRefresh.refreshTextAreaBox("#{field.name}", "#{field.id}", function() {
-          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+          dialogFieldRefresh.triggerAutoRefresh(
+            JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
+          );
         });
       });
 

--- a/app/views/shared/dialogs/_dialog_field_text_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_text_box.html.haml
@@ -9,7 +9,9 @@
       :javascript
         dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
           dialogFieldRefresh.refreshTextBox("#{field.name}", "#{field.id}", function() {
-            dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+            dialogFieldRefresh.triggerAutoRefresh(
+              JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
+            );
           });
         });
 

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -498,4 +498,12 @@ describe ApplicationHelper::Dialogs do
       ])
     end
   end
+
+  describe "#auto_refresh_listening_options" do
+    let(:options) { {:trigger => false} }
+
+    it "overrides the trigger attribute" do
+      expect(helper.auto_refresh_listening_options(options, true)).to eq(:trigger => true)
+    end
+  end
 end


### PR DESCRIPTION
This forces triggering of fields set to auto-refresh in order to stay consistent with the behavior prior to the cascading change.

The reasoning is that previously, if we had 1 field set to trigger and 4 set to listen, all 4 would get updated, but with the new cascading changes, the 4 set to listen would need to be set to also trigger. This fix will ensure that all 4 will update even if they are not set to trigger.

@miq-bot add_label darga/yes euwe/yes
@miq-bot assign @gmcculloug 

@gmcculloug Please re-assign as necessary and/or tag people for review.