### PR TITLE
Show filter with list of users on All Jobs and All UI Task screens

### DIFF
--- a/app/views/miq_task/_tasks_options.html.haml
+++ b/app/views/miq_task/_tasks_options.html.haml
@@ -16,7 +16,7 @@
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent("chosen_zone", "#{url}");
-    - if @lastaction == "all_jobs" || @lastaction == "all_ui_jobs"
+    - if @tabform == "tasks_3" || @tabform == "tasks_4"
       .form-group
         %label.control-label.col-md-2
           = _("User")


### PR DESCRIPTION
Filter with list of users was not visible on ```All VM and Container Analysis Tasks``` and ```All Other Tasks``` tabs.


BEFORE:
<img width="1228" alt="before" src="https://cloud.githubusercontent.com/assets/6556758/23140595/7fac10cc-f780-11e6-85fa-1e2304973983.png">



AFTER adding ```User``` filter
![after](https://cloud.githubusercontent.com/assets/6556758/23140608/8fe4402c-f780-11e6-88c0-c491a7bf7f62.png)


@miq-bot add-label bug
