### PR TITLE
Fix to render pagination and listnav on list view.

### DIFF
--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -41,7 +41,7 @@ module ApplicationHelper::PageLayouts
 
     return false if @showtype == "dialog_provision"
 
-    return false if @showtype == "dashboard"
+    return false if @showtype == "dashboard" && @lastaction.ends_with?("_dashboard")
 
     return false if @showtype == "consumption"
 
@@ -73,7 +73,7 @@ module ApplicationHelper::PageLayouts
        (@layout == "report" && ["new", "create", "edit", "copy", "update", "explorer"].include?(controller.action_name))
       return false
     elsif %w(container_dashboard dashboard ems_infra_dashboard).include?(@layout) ||
-          %w(dashboard topology).include?(@showtype)
+          (%w(dashboard topology).include?(@showtype) && @lastaction.ends_with?("_dashboard"))
       # Dashboard tabs are located in taskbar because they are otherwise hidden behind the taskbar regardless of z-index
       return false
     end


### PR DESCRIPTION
Fixed a condition to make sure listnav & paginator are rendered on list view.

https://bugzilla.redhat.com/show_bug.cgi?id=1422449

to recreate to Infrastructure Provider list view, then go to a PRovider summary screen, switch view to Dashboard view of selected provider then using breadcrumb link go back to List of providers. Paginator, Title & listnav are missing. This PR fixes to render paginator & listnav on list view.

before
![before](https://cloud.githubusercontent.com/assets/3450808/23141239/d7afb49c-f783-11e6-8c52-64381376f006.png)

after
![after](https://cloud.githubusercontent.com/assets/3450808/23141831/a973e4d8-f786-11e6-8297-ce4c3e365cd7.png)

@dclarizio please review.