### PR TITLE
Listnav Quad power state styling fix

### DIFF
--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -55,12 +55,12 @@ img.tiny { margin: 0; padding: 0;width:20px;height:20px; border: 0; vertical-ali
 .quadicon:hover{ padding: 1px 0 0 1px;}
 
 // adjust power state images for use in quad icon //
-.quadicon img[src*="currentstate"] {
+.b72 img[src*="currentstate"] {
   clip-path: inset(0 0 2px 0 round 0 12px 0 0);
   -webkit-clip-path: inset(0 0 2px 0 round 0 12px 0 0);
 }
 
-.quadicon img[src*="archived"], .quadicon img[src*="template"], .quadicon img[src*="disconnected"], .quadicon img[src*="orphaned"], .quadicon img[src*="never"], img[src*="retired"], .quadicon img[src*="unknown"] {
+.b72 img[src*="archived"], .b72 img[src*="template"], .b72 img[src*="disconnected"], .b72 img[src*="orphaned"], .b72 img[src*="never"], img[src*="retired"], .b72 img[src*="unknown"] {
   width: 24px; 
   height: 24px;
   margin-left: 4px;


### PR DESCRIPTION
This PR corrects a styling issue introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/386 because listnav quad icons do not contain a "quad icon" class.

https://www.pivotaltracker.com/n/projects/1613907/stories/123185361

Old
![screen shot 2017-02-21 at 9 30 30 am](https://cloud.githubusercontent.com/assets/1287144/23169084/6d3a000a-f818-11e6-99a3-cfa4729c24a3.png)

New
![screen shot 2017-02-21 at 9 30 10 am](https://cloud.githubusercontent.com/assets/1287144/23169085/6d422fb4-f818-11e6-84e2-b6fd247fb7e8.png)