### PR TITLE
Add subscription backlog to replication tab

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -277,7 +277,8 @@ module OpsController::Settings::Common
         :user            => sub.user,
         :password        => '●●●●●●●●',
         :port            => sub.port,
-        :provider_region => sub.provider_region
+        :provider_region => sub.provider_region,
+        :backlog         => number_to_human_size(sub.backlog)
       }
     end
   end

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -36,6 +36,7 @@
           %th= _('Username')
           %th= _('Password')
           %th= _('Port')
+          %th= _('Backlog')
           %th{:colspan => 2}=_('Actions')
         %tbody
           %tr{"ng-if" => "pglogicalReplicationModel.addEnabled"}
@@ -73,6 +74,7 @@
                                   "id"          => "port",
                                   "name"        => "port",
                                   "ng-model"    => "pglogicalReplicationModel.port"}
+            %td
             %td{:class => "action-cell"}
               %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-disabled" => "!subscriptionValid()",  "ng-click" => "addSubscription()"}= _('Accept')
 
@@ -142,6 +144,8 @@
                                   "name"        => "port",
                                   "ng-model"    => "pglogicalReplicationModel.port"}
 
+            %td
+              {{subscription.backlog}}
             %td{:class => "action-cell", "ng-show" => "showCancelDelete($index)"}
               %button.btn.btn-default.btn-sm{:type => "button", "ng-click" => "cancelDelete($index)"}= _('Cancel Delete')
 


### PR DESCRIPTION
This is the UI for the new value exposed for the subscription in https://github.com/ManageIQ/manageiq/pull/14010

Marking this as WIP until all dependent PRs are merged.

@lgalis please review