### PR TITLE
Catalog Items - show all items, regardless of display=true

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1695,7 +1695,12 @@ class CatalogController < ApplicationController
                                    {:typ   => ui_lookup(:models => "Service"),
                                     :model => ui_lookup(:model => "ServiceTemplateCatalog")}
               else
-                condition = ["display=? and service_template_catalog_id=? and service_template_catalog_id IS NOT NULL", true, from_cid(id)]
+                if x_active_tree == :sandt_tree
+                  # catalog items accordion also shows the non-"Display in Catalog" items
+                  condition = ["service_template_catalog_id=? and service_template_catalog_id IS NOT NULL", from_cid(id)]
+                else
+                  condition = ["display=? and service_template_catalog_id=? and service_template_catalog_id IS NOT NULL", true, from_cid(id)]
+                end
                 service_template_list(condition, :model => model, :no_order_button => true)
                 stc = ServiceTemplateCatalog.find_by_id(from_cid(id))
                 @right_cell_text = _("%{typ} in %{model} \"%{name}\"") % {:name => stc.name, :typ => ui_lookup(:models => "Service"), :model => ui_lookup(:model => "ServiceTemplateCatalog")}


### PR DESCRIPTION
Go to Services > Catalogs...

in Service Catalogs, we correctly display only catalog items with `display=true` ("Display in Catalog")

in Catalog Items, we should show all of them, regardless of `display`, but previously, those with `display=false` would only be visible in the tree, not the right side

This makes the right side consistent with the tree.

Fixes #440