### PR TITLE
Make URLs path only

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1567,7 +1567,7 @@ module ApplicationController::CiProcessing
     @view, @pages = get_view(model || self.class.model, options)  # Get the records (into a view) and the paginator
     if session[:bc] && session[:menu_click]               # See if we came from a perf chart menu click
       drop_breadcrumb(:name => session[:bc],
-                      :url  => url_for(:controller    => self.class.table_name,
+                      :url  => url_for_only_path(:controller    => self.class.table_name,
                                        :action        => "show_list",
                                        :bc            => session[:bc],
                                        :sb_controller => params[:sb_controller],

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -139,7 +139,7 @@ module ApplicationController::Performance
       end
     else
       drop_breadcrumb(:name => params[:bc],
-                      :url  => url_for(:id     => @perf_record.id,
+                      :url  => url_for_only_path(:id     => @perf_record.id,
                                        :action => "perf_top_chart",
                                        :bc     => params[:bc],
                                        :escape => false))
@@ -595,10 +595,10 @@ module ApplicationController::Performance
     if @perf_options[:cat]
       drop_breadcrumb(:name => _("%{name} Capacity & Utilization (by %{option}:%{model})") %
         {:name => name, :option => @perf_options[:cats][@perf_options[:cat_model]], :model => @perf_options[:cat]},
-                      :url  => url_for(:action => "show", :id => @perf_record, :display => "performance", :refresh => "n"))
+                      :url  => url_for_only_path(:action => "show", :id => @perf_record, :display => "performance", :refresh => "n"))
     else
       drop_breadcrumb(:name => _("%{name} Capacity & Utilization") % {:name => name},
-                      :url  => url_for(:action => "show", :id => @perf_record, :display => "performance", :refresh => "n"))
+                      :url  => url_for_only_path(:action => "show", :id => @perf_record, :display => "performance", :refresh => "n"))
     end
     @ajax_action = "perf_chart_chooser"
   end
@@ -610,10 +610,10 @@ module ApplicationController::Performance
         {:name   => @perf_record.name,
          :option => @perf_options[:cats][@perf_options[:cat_model]],
          :model  => @perf_options[:cat]},
-                      :url  => url_for(:action => "show", :id => @perf_record, :display => "performance", :refresh => "n"))
+                      :url  => url_for_only_path(:action => "show", :id => @perf_record, :display => "performance", :refresh => "n"))
     else
       drop_breadcrumb(:name => _("%{name} Capacity & Utilization") % {:name => @perf_record.name},
-                      :url  => url_for(:action => "show", :id => @perf_record, :display => "performance", :refresh => "n"))
+                      :url  => url_for_only_path(:action => "show", :id => @perf_record, :display => "performance", :refresh => "n"))
     end
 
     unless @perf_options[:typ] == "realtime"
@@ -1428,7 +1428,7 @@ module ApplicationController::Performance
   # Build the chart zoom url
   def perf_zoom_url(action, idx)
     url = "javascript:miqAsyncAjax('" +
-          url_for(:only_path => true,
+          url_for_only_path(:only_path => true,
                   :action    => action,
                   :id        => @perf_record.id,
                   :chart_idx => idx) +

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -1428,10 +1428,9 @@ module ApplicationController::Performance
   # Build the chart zoom url
   def perf_zoom_url(action, idx)
     url = "javascript:miqAsyncAjax('" +
-          url_for_only_path(:only_path => true,
-                  :action    => action,
-                  :id        => @perf_record.id,
-                  :chart_idx => idx) +
+          url_for_only_path(:action    => action,
+                            :id        => @perf_record.id,
+                            :chart_idx => idx) +
           "')"
     url
   end

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -68,7 +68,7 @@ module ApplicationController::ReportDownloads
       render :update do |page|
         page << javascript_prologue
         page << "miqSparkle(false);"
-        page << "DoNav('#{url_for(:action => "send_report_data")}');"
+        page << "DoNav('#{url_for_only_path(:action => "send_report_data")}');"
       end
     end
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -513,7 +513,7 @@ class DashboardController < ApplicationController
       render :update do |page|
         page << javascript_prologue
         if @ajax_action
-          page << "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+          page << "miqAsyncAjax('#{url_for_only_path(:action => @ajax_action, :id => @record)}');"
         end
       end
     else
@@ -590,7 +590,7 @@ class DashboardController < ApplicationController
     session_reset
     session_init(db_user)
     session[:group_changed] = true
-    url = start_url_for_user(nil) || url_for(:controller => params[:controller], :action => 'show')
+    url = start_url_for_user(nil) || url_for_only_path(:controller => params[:controller], :action => 'show')
     javascript_redirect url
   end
 

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -1065,7 +1065,7 @@ module EmsCommon
   end
 
   def show_list_link(ems, options = {})
-    url_for(options.merge(:controller => @table_name,
+    url_for_only_path(options.merge(:controller => @table_name,
                           :action     => "show_list",
                           :id         => ems.id,
                           :only_path  => true))

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -1067,8 +1067,7 @@ module EmsCommon
   def show_list_link(ems, options = {})
     url_for_only_path(options.merge(:controller => @table_name,
                           :action     => "show_list",
-                          :id         => ems.id,
-                          :only_path  => true))
+                          :id         => ems.id))
   end
 
   def restore_password

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -362,7 +362,7 @@ class HostController < ApplicationController
       rescue Net::SSH::HostKeyMismatch => e   # Capture the Host key mismatch from the verify
         render :update do |page|
           page << javascript_prologue
-          new_url = url_for(:action => "update", :button => "validate", :type => params[:type], :remember_host => "true", :escape => false)
+          new_url = url_for_only_path(:action => "update", :button => "validate", :type => params[:type], :remember_host => "true", :escape => false)
           page << "if (confirm('The Host SSH key has changed, do you want to accept the new key?')) miqAjax('#{new_url}');"
         end
         return

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -506,7 +506,7 @@ module MiqAeCustomizationController::Dialogs
       page << javascript_for_miq_button_visibility(changed)
 
       # replace select tag of default values
-      url = url_for(:action => 'dialog_form_field_changed', :id => (@record.id || "new").to_s)
+      url = url_for_only_path(:action => 'dialog_form_field_changed', :id => (@record.id || "new").to_s)
       none =  [['<None>', nil]]
       values = key[:values].empty? ? none : none + key[:values].collect(&:reverse)
       selected = @edit[:field_default_value]
@@ -546,7 +546,7 @@ module MiqAeCustomizationController::Dialogs
       page << javascript_for_miq_button_visibility(changed)
 
       # replace select tag of default values
-      url = url_for(:action => 'dialog_form_field_changed', :id => (@record.id || "new").to_s)
+      url = url_for_only_path(:action => 'dialog_form_field_changed', :id => (@record.id || "new").to_s)
       none =  [['<None>', nil]]
       values = key[:values].empty? ? none : none + key[:values].collect(&:reverse)
       selected = @edit[:field_default_value]

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -55,7 +55,7 @@ module Mixins
           :action     => :show,
           :only_path  => true,
         )
-        url_for(opts)
+        url_for_only_path(opts)
       end
     end
 

--- a/app/controllers/mixins/start_url.rb
+++ b/app/controllers/mixins/start_url.rb
@@ -8,8 +8,8 @@ module StartUrl
   end
 
   def start_url_for_user(start_url)
-    return url_for(start_url) unless start_url.nil?
-    return url_for(:controller => 'dashboard', :action => 'show') unless helpers.settings(:display, :startpage)
+    return url_for_only_path(start_url) unless start_url.nil?
+    return url_for_only_path(:controller => 'dashboard', :action => 'show') unless helpers.settings(:display, :startpage)
 
     first_allowed_url = nil
     startpage_already_set = nil

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -468,7 +468,7 @@ module ReportController::Schedules
     schedule.enabled = @edit[:new][:enabled]
     schedule.towhat = "MiqReport"                           # Default schedules apply to MiqReport model for now
 
-    email_url_prefix = url_for(:controller => "report", :action => "show_saved") + "/"
+    email_url_prefix = url_for_only_path(:controller => "report", :action => "show_saved") + "/"
     schedule_options = {
       :send_email       => @edit[:new][:send_email],
       :email_url_prefix => email_url_prefix,

--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -120,7 +120,7 @@ module VmRemote
               miq_task.task_results[:remote_url]
             else
               console_action = console_type == 'html5' ? 'launch_html5_console' : 'launch_vmware_console'
-              url_for(miq_task.task_results.merge(:controller => controller_name,
+              url_for_only_path(miq_task.task_results.merge(:controller => controller_name,
                                                   :action     => console_action,
                                                   :id         => j(params[:id])))
             end

--- a/app/helpers/ansible_credential_helper/textual_summary.rb
+++ b/app/helpers/ansible_credential_helper/textual_summary.rb
@@ -29,7 +29,7 @@ module AnsibleCredentialHelper::TextualSummary
     num = @record.number_of(:configuration_script_sources)
     h = {:label => _("Repositories"), :value => num}
     if role_allows?(:feature => "embedded_configuration_script_source_view") && num > 0
-      h.update(:link  => url_for(:action => 'show', :id => @record, :display => 'repositories'),
+      h.update(:link  => url_for_only_path(:action => 'show', :id => @record, :display => 'repositories'),
                :title => _('Show all Repositories'))
     end
     h

--- a/app/helpers/ansible_playbook_helper/textual_summary.rb
+++ b/app/helpers/ansible_playbook_helper/textual_summary.rb
@@ -28,7 +28,7 @@ module AnsiblePlaybookHelper::TextualSummary
     if role_allows?(:feature => "embedded_configuration_script_source_view") && @record.configuration_script_source.try(:name)
       h.update(:value => @record.configuration_script_source.name,
                :icon  => "pficon pficon-repository",
-               :link  => url_for(:controller => 'ansible_repository', :action => 'show', :id => @record.configuration_script_source),
+               :link  => url_for_only_path(:controller => 'ansible_repository', :action => 'show', :id => @record.configuration_script_source),
                :title => _("Show Repository"))
     end
     h

--- a/app/helpers/ansible_repository_helper/textual_summary.rb
+++ b/app/helpers/ansible_repository_helper/textual_summary.rb
@@ -25,7 +25,7 @@ module AnsibleRepositoryHelper::TextualSummary
   def textual_playbooks
     h = {:label => _('Playbooks'), :value => @record.total_payloads}
     if @record.total_payloads > 0 && role_allows?(:feature => 'embedded_configuration_script_payload_view')
-      h.update(:link  => url_for(:action => 'show', :id => @record, :display => 'playbooks'),
+      h.update(:link  => url_for_only_path(:action => 'show', :id => @record, :display => 'playbooks'),
                :title => _('Show all Playbooks'))
     end
     h

--- a/app/helpers/ansible_repository_helper/textual_summary.rb
+++ b/app/helpers/ansible_repository_helper/textual_summary.rb
@@ -34,7 +34,7 @@ module AnsibleRepositoryHelper::TextualSummary
   def textual_credential
     h = {:label => _('Credential')}
     if @record.try(:authentication) && role_allows?(:feature => 'embedded_automation_manager_credentials_view')
-      h.update(:link  => url_for(:controller => 'ansible_credential',
+      h.update(:link  => url_for_only_path(:controller => 'ansible_credential',
                                  :action     => 'show',
                                  :id         => @record.authentication),
                :title => _('Show Credential'),

--- a/app/helpers/auth_key_pair_cloud_helper/textual_summary.rb
+++ b/app/helpers/auth_key_pair_cloud_helper/textual_summary.rb
@@ -24,7 +24,7 @@ module AuthKeyPairCloudHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/availability_zone_helper/textual_summary.rb
+++ b/app/helpers/availability_zone_helper/textual_summary.rb
@@ -22,7 +22,7 @@ module AvailabilityZoneHelper::TextualSummary
     num   = @record.number_of(:cloud_volumes)
     h     = {:label => label, :icon => "pficon pficon-volume", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_volume_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'cloud_volumes')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'cloud_volumes')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -33,7 +33,7 @@ module AvailabilityZoneHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/charting_helper.rb
+++ b/app/helpers/charting_helper.rb
@@ -2,7 +2,7 @@ module ChartingHelper
   def chart_remote(a_controller, options)
     case Charting.backend
     when :c3
-      c3chart_remote(url_for(:controller => a_controller,
+      c3chart_remote(url_for_only_path(:controller => a_controller,
                              :action     => options[:action] || 'render_chart'),
                      options.slice(:id, :zoomed))
     end

--- a/app/helpers/cloud_network_helper/textual_summary.rb
+++ b/app/helpers/cloud_network_helper/textual_summary.rb
@@ -37,7 +37,7 @@ module CloudNetworkHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/cloud_object_store_container_helper/textual_summary.rb
+++ b/app/helpers/cloud_object_store_container_helper/textual_summary.rb
@@ -32,7 +32,7 @@ module CloudObjectStoreContainerHelper::TextualSummary
     h = {:label => label, :icon => "pficon pficon-cloud-tenant", :value => (cloud_tenant.nil? ? "None" : cloud_tenant.name)}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this Cloud Object Store's parent %{parent}") % {:parent => label}
-      h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
+      h[:link]  = url_for_only_path(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
     end
     h
   end
@@ -43,7 +43,7 @@ module CloudObjectStoreContainerHelper::TextualSummary
     h = {:label => label, :icon => "product product-cloud_object_store", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_object_store_object_show_list")
       h[:title] = _("Show this Cloud Object Store's child %{children}") % {:children => label}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'cloud_object_store_objects')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'cloud_object_store_objects')
     end
     h
   end

--- a/app/helpers/cloud_object_store_object_helper/textual_summary.rb
+++ b/app/helpers/cloud_object_store_object_helper/textual_summary.rb
@@ -39,7 +39,7 @@ module CloudObjectStoreObjectHelper::TextualSummary
     h = {:label => label, :icon => "pficon pficon-cloud-tenant", :value => (cloud_tenant.nil? ? "None" : cloud_tenant.name)}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this Cloud Object's parent %{parent}") % {:parent => label}
-      h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
+      h[:link]  = url_for_only_path(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
     end
     h
   end
@@ -54,7 +54,7 @@ module CloudObjectStoreObjectHelper::TextualSummary
     }
     if object_store_container && role_allows?(:feature => "cloud_object_store_container_show")
       h[:title] = _("Show this Cloud Object's parent %{parent}") % {:parent => label}
-      h[:link]  = url_for(:controller => 'cloud_object_store_container',
+      h[:link]  = url_for_only_path(:controller => 'cloud_object_store_container',
                           :action     => 'show',
                           :id         => object_store_container)
     end

--- a/app/helpers/cloud_subnet_helper/textual_summary.rb
+++ b/app/helpers/cloud_subnet_helper/textual_summary.rb
@@ -71,7 +71,7 @@ module CloudSubnetHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -98,7 +98,7 @@ module CloudSubnetHelper::TextualSummary
     num   = @record.number_of(:cloud_subnets)
     h     = {:label => label, :icon => "product product-cloud_network", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_subnet_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'cloud_subnets')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'cloud_subnets')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/cloud_tenant_helper/textual_summary.rb
+++ b/app/helpers/cloud_tenant_helper/textual_summary.rb
@@ -29,7 +29,7 @@ module CloudTenantHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -40,7 +40,7 @@ module CloudTenantHelper::TextualSummary
     num   = @record.number_of(:miq_templates)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "miq_template_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'images')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'images')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -64,7 +64,7 @@ module CloudTenantHelper::TextualSummary
     h     = {:label => label, :icon => "pficon pficon-volume", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_volume_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => "cloud_volumes")
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => "cloud_volumes")
     end
     h
   end
@@ -75,7 +75,7 @@ module CloudTenantHelper::TextualSummary
     h     = {:label => label, :icon => "fa fa-camera", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_volume_snapshot_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => "cloud_volume_snapshots")
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => "cloud_volume_snapshots")
     end
     h
   end
@@ -85,7 +85,7 @@ module CloudTenantHelper::TextualSummary
     num   = @record.number_of(:cloud_object_store_containers)
     h     = {:label => label, :icon => "product product-cloud_object_store", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_object_store_container_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'cloud_object_store_containers')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'cloud_object_store_containers')
       h[:title] = _("Show all %{models}") % {:models => label}
     end
     h

--- a/app/helpers/cloud_volume_backup_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_backup_helper/textual_summary.rb
@@ -37,7 +37,7 @@ module CloudVolumeBackupHelper::TextualSummary
     h = {:label => label, :icon => "pficon pficon-cloud-tenant", :value => (cloud_tenant.try(:name) || _("None"))}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this Backup's %{parent}") % {:parent => label}
-      h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
+      h[:link]  = url_for_only_path(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
     end
     h
   end

--- a/app/helpers/cloud_volume_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_helper/textual_summary.rb
@@ -43,7 +43,7 @@ module CloudVolumeHelper::TextualSummary
     }
     if availability_zone && role_allows?(:feature => "availability_zone_show")
       h[:title] = _("Show this Volume's %{availability_zone}") % {:availability_zone => label}
-      h[:link]  = url_for(:controller => 'availability_zone', :action => 'show', :id => availability_zone)
+      h[:link]  = url_for_only_path(:controller => 'availability_zone', :action => 'show', :id => availability_zone)
     end
     h
   end
@@ -58,7 +58,7 @@ module CloudVolumeHelper::TextualSummary
     }
     if base_snapshot && role_allows?(:feature => "cloud_volume_snapshot_show")
       h[:title] = _("Show this Volume's %{parent}") % {:parent => label}
-      h[:link]  = url_for(:controller => 'cloud_volume_snapshot', :action => 'show', :id => base_snapshot)
+      h[:link]  = url_for_only_path(:controller => 'cloud_volume_snapshot', :action => 'show', :id => base_snapshot)
     end
     h
   end
@@ -69,7 +69,7 @@ module CloudVolumeHelper::TextualSummary
     h = {:label => label, :icon => "pficon pficon-cloud-tenant", :value => (cloud_tenant.nil? ? _("None") : cloud_tenant.name)}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this Volume's %{cloud_tenant}") % {:cloud_tenant => label}
-      h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
+      h[:link]  = url_for_only_path(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
     end
     h
   end
@@ -81,7 +81,7 @@ module CloudVolumeHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "cloud_volume_snapshot_show_list")
       label = ui_lookup(:tables => "cloud_volume_snapshots")
       h[:title] = _("Show all %{models}") % {:models => label}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'cloud_volume_snapshots')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'cloud_volume_snapshots')
     end
     h
   end
@@ -93,7 +93,7 @@ module CloudVolumeHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "cloud_volume_backup_show_list")
       label = ui_lookup(:tables => "cloud_volume_backups")
       h[:title] = _("Show all %{models}") % {:models => label}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'cloud_volume_backups')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'cloud_volume_backups')
     end
     h
   end
@@ -104,7 +104,7 @@ module CloudVolumeHelper::TextualSummary
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show all attached %{models}") % {:models => label}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
     end
     h
   end

--- a/app/helpers/cloud_volume_snapshot_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_snapshot_helper/textual_summary.rb
@@ -22,7 +22,7 @@ module CloudVolumeSnapshotHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "cloud_volume_show_list")
       label = ui_lookup(:table => "cloud_volumes")
       h[:title] = _("Show all %{volumes} based on this Snapshot.") % {:volumes => label}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'based_volumes')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'based_volumes')
     end
     h
   end
@@ -45,7 +45,7 @@ module CloudVolumeSnapshotHelper::TextualSummary
     h = {:label => label, :icon => "pficon pficon-cloud-tenant", :value => (cloud_tenant.nil? ? _("None") : cloud_tenant.name)}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this Snapshot's %{parent}") % {:parent => label}
-      h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
+      h[:link]  = url_for_only_path(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
     end
     h
   end

--- a/app/helpers/compliance_summary_helper.rb
+++ b/app/helpers/compliance_summary_helper.rb
@@ -20,7 +20,7 @@ module ComplianceSummaryHelper
                   end
       h[:title] = _("Show Details of Compliance Check on %{date}") % {:date => format_timezone(date)}
       h[:explorer] = true if @explorer
-      h[:link] = url_for(
+      h[:link] = url_for_only_path(
         :controller => controller.controller_name,
         :action     => 'show',
         :id         => @record,
@@ -40,7 +40,7 @@ module ComplianceSummaryHelper
       h[:title] = _("Show Compliance History of this %{model} (Last 10 Checks)") %
                   {:model => ui_lookup(:model => controller.class.model.name)}
       h[:explorer] = true if @explorer
-      h[:link] = url_for(
+      h[:link] = url_for_only_path(
         :controller => controller.controller_name,
         :action     => 'show',
         :id         => @record,

--- a/app/helpers/configuration_job_helper/textual_summary.rb
+++ b/app/helpers/configuration_job_helper/textual_summary.rb
@@ -37,7 +37,7 @@ module ConfigurationJobHelper::TextualSummary
     else
       h[:value] = service.name
       h[:title] = _("Show this Service")
-      h[:link]  = url_for(:controller => 'service', :action => 'show', :id => to_cid(service.id))
+      h[:link]  = url_for_only_path(:controller => 'service', :action => 'show', :id => to_cid(service.id))
     end
     h
   end
@@ -50,7 +50,7 @@ module ConfigurationJobHelper::TextualSummary
     else
       h[:value] = provider.name
       h[:title] = _("Show this Parent Provider")
-      h[:link]  = url_for(:controller => 'provider_foreman', :action => 'explorer', :id => "at-#{to_cid(provider.id)}")
+      h[:link]  = url_for_only_path(:controller => 'provider_foreman', :action => 'explorer', :id => "at-#{to_cid(provider.id)}")
     end
     h
   end
@@ -59,7 +59,7 @@ module ConfigurationJobHelper::TextualSummary
     num   = @record.number_of(:parameters)
     h     = {:label => _("Parameters"), :icon => "product product-parameter", :value => num}
     if num > 0
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'parameters', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'parameters', :id => @record)
       h[:title] = _("Show all parameters")
     end
     h

--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -113,7 +113,7 @@ module ContainerGroupHelper::TextualSummary
       :label => _("Underlying %{name}") % {:name => lives_on_entity_name},
       :image => "svg/vendor-#{lives_on_ems.image_name}.svg",
       :value => @record.container_node.lives_on.name.to_s,
-      :link  => url_for(
+      :link  => url_for_only_path(
         :action     => 'show',
         :controller => 'vm_or_template',
         :id         => @record.container_node.lives_on.id

--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -91,7 +91,7 @@ module ContainerNodeHelper::TextualSummary
       :label => _("Underlying %{name}") % {:name => lives_on_entity_name},
       :image => "svg/vendor-#{lives_on_ems.image_name}.svg",
       :value => @record.lives_on.name.to_s,
-      :link  => url_for(
+      :link  => url_for_only_path(
         :action     => 'show',
         :controller => 'vm_or_template',
         :id         => @record.lives_on.id

--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -110,7 +110,7 @@ module ContainerSummaryHelper
   def textual_guest_applications
     textual_link(@record.guest_applications, :feature => "container_image_show",
                                              :label   => _("Packages"),
-                                             :link    => url_for(:controller => controller.controller_name,
+                                             :link    => url_for_only_path(:controller => controller.controller_name,
                                                                  :action     => 'guest_applications',
                                                                  :id         => @record,
                                                                  :db         => controller.controller_name))
@@ -121,7 +121,7 @@ module ContainerSummaryHelper
       @record.openscap_rule_results,
       :feature => "container_image_show",
       :label   => _("OpenSCAP Results"),
-      :link    => url_for(
+      :link    => url_for_only_path(
         :controller => controller.controller_name,
         :action     => 'openscap_rule_results',
         :id         => @record,
@@ -138,7 +138,7 @@ module ContainerSummaryHelper
     h = {:label => _("OpenSCAP HTML")}
     if @record.openscap_result
       h[:value] = _('Available')
-      h[:link] = url_for(
+      h[:link] = url_for_only_path(
         :id         => @record,
         :controller => controller.controller_name,
         :action     => 'openscap_html'

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -156,7 +156,7 @@ module EmsCloudHelper::TextualSummary
   def textual_topology
     {:label => _('Topology'),
      :icon  => "pficon pficon-topology",
-     :link  => url_for(:controller => 'cloud_topology', :action => 'show', :id => @record.id),
+     :link  => url_for_only_path(:controller => 'cloud_topology', :action => 'show', :id => @record.id),
      :title => _("Show topology")}
   end
 end

--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -58,7 +58,7 @@ module EmsClusterHelper::TextualSummary
                  :value => _("Running (%{number})") % {:number => running_count},
                  :icon  => failed_count == 0 && running_count > 0 ? 'pficon pficon-ok' : nil,
                  :link  => if running_count > 0
-                             url_for(:controller              => controller.controller_name,
+                             url_for_only_path(:controller              => controller.controller_name,
                                      :action                  => 'show',
                                      :id                      => @record,
                                      :display                 => 'hosts',
@@ -70,7 +70,7 @@ module EmsClusterHelper::TextualSummary
                 :value => _("Failed (%{number})") % {:number => failed_count},
                 :icon  => failed_count > 0 ? 'pficon pficon-error-circle-o' : nil,
                 :link  => if failed_count > 0
-                            url_for(:controller              => controller.controller_name,
+                            url_for_only_path(:controller              => controller.controller_name,
                                     :action                  => 'show',
                                     :id                      => @record,
                                     :display                 => 'hosts',
@@ -82,7 +82,7 @@ module EmsClusterHelper::TextualSummary
              :value => _("All (%{number})") % {:number => all_count},
              :icon  => 'pficon pficon-screen',
              :link  => if all_count > 0
-                         url_for(:controller              => controller.controller_name,
+                         url_for_only_path(:controller              => controller.controller_name,
                                  :action                  => 'show',
                                  :display                 => 'hosts',
                                  :id                      => @record,
@@ -140,7 +140,7 @@ module EmsClusterHelper::TextualSummary
     h = {:label => title_for_hosts, :icon => "pficon pficon-screen", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
       h[:title] = _("Show all %{title}") % {:title => title_for_hosts}
-      h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'hosts')
+      h[:link]  = url_for_only_path(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'hosts')
     end
     h
   end
@@ -150,7 +150,7 @@ module EmsClusterHelper::TextualSummary
     h = {:label => _("Direct VMs"), :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show VMs in this %{title}, but not in Resource Pools below") % {:title => cluster_title}
-      h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'vms')
+      h[:link]  = url_for_only_path(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'vms')
     end
     h
   end
@@ -160,7 +160,7 @@ module EmsClusterHelper::TextualSummary
     h = {:label => _("All VMs"), :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show all VMs in this %{title}") % {:title => cluster_title}
-      h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'all_vms')
+      h[:link]  = url_for_only_path(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'all_vms')
     end
     h
   end
@@ -172,7 +172,7 @@ module EmsClusterHelper::TextualSummary
     h = {:label => _("All Templates"), :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "miq_template_show_list")
       h[:title] = _("Show all Templates in this %{title}") % {:title => cluster_title}
-      h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'miq_templates')
+      h[:link]  = url_for_only_path(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'miq_templates')
     end
     h
   end
@@ -182,7 +182,7 @@ module EmsClusterHelper::TextualSummary
     h = {:label => _("All VMs (Tree View)"), :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show tree of all VMs by Resource Pool in this %{title}") % {:title => cluster_title}
-      h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'descendant_vms')
+      h[:link]  = url_for_only_path(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'descendant_vms')
     end
     h
   end
@@ -192,7 +192,7 @@ module EmsClusterHelper::TextualSummary
 
     textual_link(@record.resource_pools,
                  :as   => EmsCluster,
-                 :link => url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'resource_pools'))
+                 :link => url_for_only_path(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'resource_pools'))
   end
 
   def textual_states_size
@@ -201,7 +201,7 @@ module EmsClusterHelper::TextualSummary
     h = {:label => _("Drift History"), :icon => "product product-drift", :value => (num == 0 ? _("None") : num)}
     if num > 0
       h[:title] = _("Show %{title} drift history") % {:title => cluster_title}
-      h[:link]  = url_for(:controller => 'ems_cluster', :action => 'drift_history', :id => @record)
+      h[:link]  = url_for_only_path(:controller => 'ems_cluster', :action => 'drift_history', :id => @record)
     end
     h
   end

--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -192,7 +192,7 @@ module EmsInfraHelper::TextualSummary
   def textual_topology
     {:label => _('Topology'),
      :icon  => "pficon pficon-topology",
-     :link  => url_for(:controller => '/infra_topology', :action => 'show', :id => @record.id),
+     :link  => url_for_only_path(:controller => '/infra_topology', :action => 'show', :id => @record.id),
      :title => _("Show topology")}
   end
 end

--- a/app/helpers/ems_middleware_helper/textual_summary.rb
+++ b/app/helpers/ems_middleware_helper/textual_summary.rb
@@ -53,7 +53,7 @@ module EmsMiddlewareHelper::TextualSummary
   def textual_topology
     {:label => _('Topology'),
      :icon  => "pficon pficon-topology",
-     :link  => url_for(:controller => 'middleware_topology', :action => 'show', :id => @record.id),
+     :link  => url_for_only_path(:controller => 'middleware_topology', :action => 'show', :id => @record.id),
      :title => _('Show topology')}
   end
 end

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -97,7 +97,7 @@ module EmsNetworkHelper::TextualSummary
   def textual_topology
     {:label => _('Topology'),
      :icon  => "pficon pficon-topology",
-     :link  => url_for(:controller => 'network_topology', :action => 'show', :id => @record.id),
+     :link  => url_for_only_path(:controller => 'network_topology', :action => 'show', :id => @record.id),
      :title => _("Show topology")}
   end
 

--- a/app/helpers/flavor_helper/textual_summary.rb
+++ b/app/helpers/flavor_helper/textual_summary.rb
@@ -69,7 +69,7 @@ module FlavorHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/floating_ip_helper/textual_summary.rb
+++ b/app/helpers/floating_ip_helper/textual_summary.rb
@@ -43,7 +43,7 @@ module FloatingIpHelper::TextualSummary
     h        = {:label => label, :icon => "pficon pficon-virtual-machine"}
     if instance && role_allows?(:feature => "vm_show")
       h[:value] = instance.name
-      h[:link]  = url_for(:controller => 'vm_cloud', :action => 'show', :id => instance.id)
+      h[:link]  = url_for_only_path(:controller => 'vm_cloud', :action => 'show', :id => instance.id)
       h[:title] = _("Show %{label}") % {:label => label}
     end
     h

--- a/app/helpers/host_aggregate_helper/textual_summary.rb
+++ b/app/helpers/host_aggregate_helper/textual_summary.rb
@@ -18,7 +18,7 @@ module HostAggregateHelper::TextualSummary
     num   = @record.number_of(:hosts)
     h     = {:label => label, :icon => "pficon pficon-screen", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hosts')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'hosts')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -29,7 +29,7 @@ module HostAggregateHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -84,7 +84,7 @@ module HostHelper::TextualSummary
       running = {:title => _("Show list of running %{name}") % {:name => x.name},
                  :value => _("Running (%{number})") % {:number => running_count},
                  :icon  => failed_count == 0 && running_count > 0 ? 'pficon pficon-ok' : nil,
-                 :link  => running_count > 0 ? url_for(:controller => controller.controller_name,
+                 :link  => running_count > 0 ? url_for_only_path(:controller => controller.controller_name,
                                                       :action => 'host_services', :id => @record,
                                                       :db => controller.controller_name, :host_service_group => x.id,
                                                       :status => :running) : nil}
@@ -92,7 +92,7 @@ module HostHelper::TextualSummary
       failed = {:title => _("Show list of failed %{name}") % {:name => x.name},
                 :value => _("Failed (%{number})") % {:number => failed_count},
                 :icon  => failed_count > 0 ? 'pficon pficon-error-circle-o' : nil,
-                :link  => failed_count > 0 ? url_for(:controller => controller.controller_name,
+                :link  => failed_count > 0 ? url_for_only_path(:controller => controller.controller_name,
                                                     :action => 'host_services', :id => @record,
                                                     :db => controller.controller_name, :host_service_group => x.id,
                                                     :status => :failed) : nil}
@@ -100,14 +100,14 @@ module HostHelper::TextualSummary
       all = {:title => _("Show list of all %{name}") % {:name => x.name},
              :value => _("All (%{number})") % {:number => all_count},
              :icon  => 'pficon pficon-service',
-             :link  => all_count > 0 ? url_for(:controller => controller.controller_name, :action => 'host_services',
+             :link  => all_count > 0 ? url_for_only_path(:controller => controller.controller_name, :action => 'host_services',
                                               :id => @record, :db => controller.controller_name,
                                               :host_service_group => x.id, :status => :all) : nil}
 
       configuration = {:title => _("Show list of configuration files of %{name}") % {:name => x.name},
                        :icon  => 'fa fa-file-o',
                        :value => _("Configuration (%{number})") % {:number => configuration_count},
-                       :link  => configuration_count > 0 ? url_for(:controller => controller.controller_name,
+                       :link  => configuration_count > 0 ? url_for_only_path(:controller => controller.controller_name,
                                                                   :action => 'filesystems', :id => @record,
                                                                   :db => controller.controller_name,
                                                                   :host_service_group => x.id) : nil}
@@ -146,7 +146,7 @@ module HostHelper::TextualSummary
       h[:image] = "svg/vendor-#{@vmminfo[0][:description].downcase}.svg"
       h[:value] = @vmminfo[0][:description]
       h[:title] = _("Show VMM container information")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hv_info')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'hv_info')
     end
     h
   end
@@ -185,7 +185,7 @@ module HostHelper::TextualSummary
       end
 
       h[:title] = _("Show OS container information")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'os_info')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'os_info')
     end
     h
   end
@@ -210,7 +210,7 @@ module HostHelper::TextualSummary
     h = {:label => _("Storage Adapters"), :icon => "product product-network_card", :value => num}
     if num > 0
       h[:title] = _("Show %{title} Storage Adapters") % {:title => host_title}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'storage_adapters')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'storage_adapters')
     end
     h
   end
@@ -221,7 +221,7 @@ module HostHelper::TextualSummary
     h = {:label => _("Network"), :icon => "pficon pficon-network", :value => (num == 0 ? _("N/A") : _("Available"))}
     if num > 0
       h[:title] = _("Show %{title} Network") % {:title => host_title}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'network')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'network')
     end
     h
   end
@@ -232,7 +232,7 @@ module HostHelper::TextualSummary
          :value => (@devices.nil? || @devices.empty? ? _("None") : @devices.length)}
     if @devices.length > 0
       h[:title] = _("Show %{title} devices") % {:title => host_title}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'devices')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'devices')
     end
     h
   end
@@ -273,7 +273,7 @@ module HostHelper::TextualSummary
     if cluster && role_allows?(:feature => "ems_cluster_show")
       h[:title] = _("Show this %{host_title}'s %{cluster_title}") %
                   {:host_title => host_title, :cluster_title => title_for_cluster}
-      h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => cluster)
+      h[:link]  = url_for_only_path(:controller => 'ems_cluster', :action => 'show', :id => cluster)
     end
     h
   end
@@ -287,7 +287,7 @@ module HostHelper::TextualSummary
     return nil if @record.openstack_host?
     textual_link(@record.resource_pools,
                  :as   => ResourcePool,
-                 :link => url_for(:action => 'show', :id => @record, :display => 'resource_pools'))
+                 :link => url_for_only_path(:action => 'show', :id => @record, :display => 'resource_pools'))
   end
 
   def textual_drift_history
@@ -297,7 +297,7 @@ module HostHelper::TextualSummary
     h     = {:label => label, :icon => "product product-drift", :value => num}
     if num > 0
       h[:title] = _("Show all %{label}") % {:label => label}
-      h[:link]  = url_for(:action => 'drift_history', :id => @record)
+      h[:link]  = url_for_only_path(:action => 'drift_history', :id => @record)
     end
     h
   end
@@ -311,7 +311,7 @@ module HostHelper::TextualSummary
          :value => (availability_zone.nil? ? _("None") : availability_zone.name)}
     if availability_zone && role_allows?(:feature => "availability_zone_show")
       h[:title] = _("Show this %{title}'s %{label}") % {:title => host_title, :label => label}
-      h[:link]  = url_for(:controller => 'availability_zone', :action => 'show', :id => availability_zone)
+      h[:link]  = url_for_only_path(:controller => 'availability_zone', :action => 'show', :id => availability_zone)
     end
     h
   end
@@ -320,7 +320,7 @@ module HostHelper::TextualSummary
     return nil unless @record.openstack_host?
     textual_link(@record.cloud_tenants,
                  :as   => CloudTenant,
-                 :link => url_for(:action => 'show', :id => @record, :display => 'cloud_tenants'))
+                 :link => url_for_only_path(:action => 'show', :id => @record, :display => 'cloud_tenants'))
   end
 
   def textual_vms
@@ -329,7 +329,7 @@ module HostHelper::TextualSummary
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'vms')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'vms')
     end
     h
   end
@@ -349,7 +349,7 @@ module HostHelper::TextualSummary
     h = {:label => _("Users"), :icon => "pficon pficon-user", :value => num}
     if num > 0
       h[:title] = n_("Show the User defined on this VM", "Show the Users defined on this VM", num)
-      h[:link]  = url_for(:action => 'users', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:action => 'users', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -361,7 +361,7 @@ module HostHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Group defined on this %{title}", "Show the Groups defined on this %{title}", num) %
         {:title => host_title}
-      h[:link]  = url_for(:action => 'groups', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:action => 'groups', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -373,7 +373,7 @@ module HostHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Firewall Rule defined on this %{title}",
                     "Show the Firewall Rules defined on this %{title}", num) % {:title => host_title}
-      h[:link]  = url_for(:action => 'firewall_rules', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:action => 'firewall_rules', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -390,7 +390,7 @@ module HostHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Patch defined on this %{title}", "Show the Patches defined on this %{title}", num) %
         {:title => host_title}
-      h[:link]  = url_for(:action => 'patches', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:action => 'patches', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -401,7 +401,7 @@ module HostHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Package installed on this %{title}",
                      "Show the Packages installed on this %{title}", num) % {:title => host_title}
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'guest_applications', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'guest_applications', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -412,7 +412,7 @@ module HostHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Service installed on this %{title}",
                      "Show the Services installed on this %{title}", num) % {:title => host_title}
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'host_services', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'host_services', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -423,7 +423,7 @@ module HostHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the File installed on this %{title}", "Show the Files installed on this %{title}", num) %
         {:title => host_title}
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'filesystems', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'filesystems', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -434,7 +434,7 @@ module HostHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Advanced Setting installed on this %{title}",
                      "Show the Advanced Settings installed on this %{title}", num) % {:title => host_title}
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'advanced_settings', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'advanced_settings', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -444,7 +444,7 @@ module HostHelper::TextualSummary
     h = {:label => _("ESX Logs"), :icon => "fa fa-file-text-o", :value => (num == 0 ? _("Not Available") : _("Available"))}
     if num > 0
       h[:title] = _("Show %{title} Network") % {:title => host_title}
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'event_logs')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'event_logs')
     end
     h
   end
@@ -463,7 +463,7 @@ module HostHelper::TextualSummary
 
   def textual_openstack_nova_scheduler
     {:label => _("Openstack Nova Scheduler"), :value => openstack_nova_scheduler_value,
-     :link => url_for(:controller => controller.controller_name, :action => 'host_cloud_services', :id => @record)}
+     :link => url_for_only_path(:controller => controller.controller_name, :action => 'host_cloud_services', :id => @record)}
   end
 
   def openstack_nova_scheduler_value

--- a/app/helpers/infra_networking_helper/textual_summary.rb
+++ b/app/helpers/infra_networking_helper/textual_summary.rb
@@ -24,7 +24,7 @@ module InfraNetworkingHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "host_show_list")
       h = {:label => title_for_hosts, :icon => "pficon pficon-screen", :value => num}
       h[:explorer] = true
-      h[:link] = url_for(:action => 'hosts', :id => @record, :db => 'switch')
+      h[:link] = url_for_only_path(:action => 'hosts', :id => @record, :db => 'switch')
     end
     h
   end

--- a/app/helpers/load_balancer_helper/textual_summary.rb
+++ b/app/helpers/load_balancer_helper/textual_summary.rb
@@ -54,7 +54,7 @@ module LoadBalancerHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/middleware_server_helper/textual_summary.rb
+++ b/app/helpers/middleware_server_helper/textual_summary.rb
@@ -69,7 +69,7 @@ module MiddlewareServerHelper::TextualSummary
       :label => "Underlying #{lives_on_entity_name}",
       :image => "svg/vendor-#{lives_on_ems.image_name}.svg",
       :value => @record.lives_on.name.to_s,
-      :link  => url_for(
+      :link  => url_for_only_path(
         :action     => 'show',
         :controller => 'vm_or_template',
         :id         => @record.lives_on.id

--- a/app/helpers/network_port_helper/textual_summary.rb
+++ b/app/helpers/network_port_helper/textual_summary.rb
@@ -54,7 +54,7 @@ module NetworkPortHelper::TextualSummary
     if instance && role_allows?(:feature => "vm_show")
       h = {:label => label, :icon => "pficon pficon-virtual-machine"}
       h[:value] = instance.name
-      h[:link]  = url_for(:controller => 'vm_cloud', :action => 'show', :id => instance.id)
+      h[:link]  = url_for_only_path(:controller => 'vm_cloud', :action => 'show', :id => instance.id)
       h[:title] = _("Show %{label}") % {:label => label}
     end
     h
@@ -77,7 +77,7 @@ module NetworkPortHelper::TextualSummary
     {
       :icon  => "pficon pficon-screen",
       :value => @record.device,
-      :link  => url_for(
+      :link  => url_for_only_path(
         :controller => "host",
         :action     => "show",
         :id         => @record.device.id

--- a/app/helpers/network_router_helper/textual_summary.rb
+++ b/app/helpers/network_router_helper/textual_summary.rb
@@ -37,7 +37,7 @@ module NetworkRouterHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -54,7 +54,7 @@ module OrchestrationStackHelper::TextualSummary
     else
       h[:value] = service.name
       h[:title] = _("Show this Service")
-      h[:link]  = url_for(:controller => 'service', :action => 'show', :id => service)
+      h[:link]  = url_for_only_path(:controller => 'service', :action => 'show', :id => service)
     end
     h
   end
@@ -70,7 +70,7 @@ module OrchestrationStackHelper::TextualSummary
     elsif num > 1 && role_allows(:feature => "orchestration_stack_show_list")
       label     = _("Child Orchestration Stacks")
       h         = {:label => label, :icon => "product product-orchestration_stack", :value => num}
-      h[:link]  = url_for(:action => 'show', :id => @record.id, :display => 'children')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record.id, :display => 'children')
       h[:title] = _("Show all %{label}") % {:label => label}
       h
     end
@@ -83,7 +83,7 @@ module OrchestrationStackHelper::TextualSummary
     h = {:label => label, :icon => "product product-template", :value => template.name}
     if role_allows?(:feature => "orchestration_templates_view")
       h[:title] = _("Show this Orchestration Template")
-      h[:link] = url_for(:action => 'show', :id => @record, :display => 'stack_orchestration_template')
+      h[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'stack_orchestration_template')
     end
     h
   end
@@ -93,7 +93,7 @@ module OrchestrationStackHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -113,7 +113,7 @@ module OrchestrationStackHelper::TextualSummary
     num   = @record.number_of(:parameters)
     h     = {:label => _("Parameters"), :icon => "product product-parameter", :value => num}
     if num > 0
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'parameters', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'parameters', :id => @record)
       h[:title] = _("Show all parameters")
     end
     h
@@ -123,7 +123,7 @@ module OrchestrationStackHelper::TextualSummary
     num   = @record.number_of(:outputs)
     h     = {:label => _("Outputs"), :icon => "product product-output", :value => num}
     if num > 0
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'outputs', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'outputs', :id => @record)
       h[:title] = _("Show all outputs")
     end
     h
@@ -133,7 +133,7 @@ module OrchestrationStackHelper::TextualSummary
     num   = @record.number_of(:resources)
     h     = {:label => _("Resources"), :icon => "product product-resource", :value => num}
     if num > 0
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'resources', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'resources', :id => @record)
       h[:title] = _("Show all resources")
     end
     h

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -114,7 +114,7 @@ module QuadiconHelper
   # Currently only used once
   #
   def quadicon_url_with_parent_and_lastaction(item)
-    url_for(
+    url_for_only_path(
       :controller => @parent.class.base_class.to_s.underscore,
       :action     => @lastaction,
       :id         => @parent.id,
@@ -257,7 +257,7 @@ module QuadiconHelper
       attrs[:id]      = to_cid(row['id']) || row['x_show_id']
     end
 
-    url_for(attrs)
+    url_for_only_path(attrs)
   end
 
   def quadicon_build_label_options(item, row)

--- a/app/helpers/resource_pool_helper/textual_summary.rb
+++ b/app/helpers/resource_pool_helper/textual_summary.rb
@@ -82,7 +82,7 @@ module ResourcePoolHelper::TextualSummary
          :value => (cluster.nil? ? _("None") : cluster.name)}
     if cluster && role_allows?(:feature => "ems_cluster_show")
       h[:title] = _("Show Parent %{title} %{name}") % {:title => title_for_cluster, :name => cluster.name}
-      h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => cluster)
+      h[:link]  = url_for_only_path(:controller => 'ems_cluster', :action => 'show', :id => cluster)
     end
     h
   end
@@ -94,7 +94,7 @@ module ResourcePoolHelper::TextualSummary
          :value => (host.nil? ? _("None") : host.name)}
     if host && role_allows?(:feature => "host_show")
       h[:title] = _("Show Parent %{title} '%{name}'") % {:title => title_for_host, :name => host.name}
-      h[:link]  = url_for(:controller => 'host', :action => 'show', :id => host)
+      h[:link]  = url_for_only_path(:controller => 'host', :action => 'show', :id => host)
     end
     h
   end
@@ -104,7 +104,7 @@ module ResourcePoolHelper::TextualSummary
     h = {:label => _("Direct VMs"), :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show VMs in this Resource Pool, but not in Resource Pools below")
-      h[:link]  = url_for(:controller => 'resource_pool', :action => 'show', :id => @record, :display => 'vms')
+      h[:link]  = url_for_only_path(:controller => 'resource_pool', :action => 'show', :id => @record, :display => 'vms')
     end
     h
   end
@@ -114,7 +114,7 @@ module ResourcePoolHelper::TextualSummary
     h = {:label => _("All VMs"), :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show all VMs in this Resource Pool")
-      h[:link]  = url_for(:controller => 'resource_pool', :action => 'show', :id => @record, :display => 'all_vms')
+      h[:link]  = url_for_only_path(:controller => 'resource_pool', :action => 'show', :id => @record, :display => 'all_vms')
     end
     h
   end
@@ -125,7 +125,7 @@ module ResourcePoolHelper::TextualSummary
     # TODO: Why is this role_allows? resource_pool_show_list but the previous 2 methods are for vm_show_list
     if num > 0 && role_allows?(:feature => "resource_pool_show_list")
       h[:title] = _("Show tree of all VMs in this Resource Pool")
-      h[:link]  = url_for(:controller => 'resource_pool', :action => 'show', :id => @record, :display => 'descendant_vms')
+      h[:link]  = url_for_only_path(:controller => 'resource_pool', :action => 'show', :id => @record, :display => 'descendant_vms')
     end
     h
   end
@@ -135,7 +135,7 @@ module ResourcePoolHelper::TextualSummary
     h = {:label => _("Resource Pools"), :icon => "pficon pficon-resource-pool", :value => num}
     if num > 0 && role_allows?(:feature => "resource_pool_show_list")
       h[:title] = _("Show all Resource Pools")
-      h[:link]  = url_for(:controller => "resource_pool", :action => 'show', :id => @record, :display => 'resource_pools')
+      h[:link]  = url_for_only_path(:controller => "resource_pool", :action => 'show', :id => @record, :display => 'resource_pools')
     end
     h
   end

--- a/app/helpers/security_group_helper/textual_summary.rb
+++ b/app/helpers/security_group_helper/textual_summary.rb
@@ -54,7 +54,7 @@ module SecurityGroupHelper::TextualSummary
     num   = @record.number_of(:vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -82,7 +82,7 @@ module ServiceHelper::TextualSummary
     s = {:label => _("Parent Catalog Item"), :icon => "product product-template", :value => (st.nil? ? _("None") : st.name)}
     if st && role_allows?(:feature => "catalog_items_accord")
       s[:title] = _("Show this Service's Parent Service Catalog")
-      s[:link]  = url_for(:controller => 'catalog', :action => 'show', :id => st)
+      s[:link]  = url_for_only_path(:controller => 'catalog', :action => 'show', :id => st)
     end
     s
   end
@@ -95,7 +95,7 @@ module ServiceHelper::TextualSummary
       :icon  => parent.picture ? nil : "pficon pficon-service",
       :value => parent.name,
       :title => _("Show this Service's Parent Service"),
-      :link  => url_for(:controller => 'service', :action => 'show', :id => parent)
+      :link  => url_for_only_path(:controller => 'service', :action => 'show', :id => parent)
     } if parent
   end
 
@@ -120,7 +120,7 @@ module ServiceHelper::TextualSummary
       :icon  => "product product-orchestration_stack",
       :value => job.name,
       :title => _("Show this Service's Job"),
-      :link  => url_for(:controller => 'configuration_job', :action => 'show', :id => job.id)
+      :link  => url_for_only_path(:controller => 'configuration_job', :action => 'show', :id => job.id)
     } if job
   end
 

--- a/app/helpers/storage_helper/textual_summary.rb
+++ b/app/helpers/storage_helper/textual_summary.rb
@@ -75,7 +75,7 @@ module StorageHelper::TextualSummary
     num   = @record.number_of(:hosts)
     h     = {:label => label, :icon => "pficon pficon-screen", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hosts')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'hosts')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -86,7 +86,7 @@ module StorageHelper::TextualSummary
     num   = @record.number_of(:all_vms)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'all_vms')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'all_vms')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -97,7 +97,7 @@ module StorageHelper::TextualSummary
     num   = @record.number_of(:all_miq_templates)
     h     = {:label => label, :icon => "pficon pficon-virtual-machine", :value => num}
     if num > 0 && role_allows?(:feature => "miq_template_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'all_miq_templates')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'all_miq_templates')
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
@@ -120,7 +120,7 @@ module StorageHelper::TextualSummary
     h     = {:label => _("All Files"), :icon => "fa fa-file-o", :value => num}
     if num > 0
       h[:title] = _("Show all files installed on this %{table}") % {:table => ui_lookup(:table => "storages")}
-      h[:link]  = url_for(:action => 'files', :id => @record)
+      h[:link]  = url_for_only_path(:action => 'files', :id => @record)
     end
     h
   end
@@ -139,7 +139,7 @@ module StorageHelper::TextualSummary
     if num > 0
       h[:title] = _("Show VM Provisioned Disk Files installed on this %{table}") %
                   {:table => ui_lookup(:table => "storages")}
-      h[:link]  = url_for(:action => 'disk_files', :id => @record)
+      h[:link]  = url_for_only_path(:action => 'disk_files', :id => @record)
     end
     h
   end
@@ -157,7 +157,7 @@ module StorageHelper::TextualSummary
     if num > 0
       h[:title] = _("Show VM Snapshot Files installed on this %{storage}") %
                   {:storage => ui_lookup(:table => "storages")}
-      h[:link]  = url_for(:action => 'snapshot_files', :id => @record)
+      h[:link]  = url_for_only_path(:action => 'snapshot_files', :id => @record)
     end
     h
   end
@@ -174,7 +174,7 @@ module StorageHelper::TextualSummary
     h     = {:label => _("VM Memory Files"), :icon => "fa fa-file-o", :value => value}
     if num > 0
       h[:title] = _("Show VM Memory Files installed on this %{storage}") % {:storage => ui_lookup(:table => "storages")}
-      h[:link]  = url_for(:action => 'vm_ram_files', :id => @record)
+      h[:link]  = url_for_only_path(:action => 'vm_ram_files', :id => @record)
     end
     h
   end
@@ -191,7 +191,7 @@ module StorageHelper::TextualSummary
     h     = {:label => _("Other VM Files"), :icon => "fa fa-file-o", :value => value}
     if num > 0
       h[:title] = _("Show Other VM Files installed on this %{storage}") % {:storage => ui_lookup(:table => "storages")}
-      h[:link]  = url_for(:action => 'vm_misc_files', :id => @record)
+      h[:link]  = url_for_only_path(:action => 'vm_misc_files', :id => @record)
     end
     h
   end
@@ -208,7 +208,7 @@ module StorageHelper::TextualSummary
     h     = {:label => _("Non-VM Files"), :icon => "fa fa-file-o", :value => value}
     if num > 0
       h[:title] = _("Show Non-VM Files installed on this %{storage}") % {:storage => ui_lookup(:table => "storages")}
-      h[:link]  = url_for(:action => 'debris_files', :id => @record)
+      h[:link]  = url_for_only_path(:action => 'debris_files', :id => @record)
     end
     h
   end

--- a/app/helpers/textual_mixins/textual_advanced_settings.rb
+++ b/app/helpers/textual_mixins/textual_advanced_settings.rb
@@ -5,7 +5,7 @@ module TextualMixins::TextualAdvancedSettings
     if num > 0
       h[:title] = _("Show the advanced settings on this VM")
       h[:explorer] = true
-      h[:link] = url_for(:action => 'advanced_settings', :id => @record, :db => controller.controller_name)
+      h[:link] = url_for_only_path(:action => 'advanced_settings', :id => @record, :db => controller.controller_name)
     end
     h
   end

--- a/app/helpers/textual_mixins/textual_drift.rb
+++ b/app/helpers/textual_mixins/textual_drift.rb
@@ -9,7 +9,7 @@ module TextualMixins::TextualDrift
       h[:value] = num
       h[:title] = _("Show virtual machine drift history")
       h[:explorer] = true
-      h[:link] = url_for(:controller => controller.controller_name, :action => 'drift_history', :id => @record)
+      h[:link] = url_for_only_path(:controller => controller.controller_name, :action => 'drift_history', :id => @record)
     end
     h
   end

--- a/app/helpers/textual_mixins/textual_filesystems.rb
+++ b/app/helpers/textual_mixins/textual_filesystems.rb
@@ -5,7 +5,7 @@ module TextualMixins::TextualFilesystems
     if num > 0
       h[:title] = n_("Show the File installed on this VM", "Show the Files installed on this VM", num)
       h[:explorer] = true
-      h[:link] = url_for(:controller => controller.controller_name, :action => 'filesystems', :id => @record)
+      h[:link] = url_for_only_path(:controller => controller.controller_name, :action => 'filesystems', :id => @record)
     end
     h
   end

--- a/app/helpers/textual_mixins/textual_init_processes.rb
+++ b/app/helpers/textual_mixins/textual_init_processes.rb
@@ -8,7 +8,7 @@ module TextualMixins::TextualInitProcesses
     if num > 0
       h[:title] = n_("Show the Init Process installed on this VM", "Show the Init Processes installed on this VM", num)
       h[:explorer] = true
-      h[:link] = url_for(:controller => controller.controller_name, :action => 'linux_initprocesses', :id => @record)
+      h[:link] = url_for_only_path(:controller => controller.controller_name, :action => 'linux_initprocesses', :id => @record)
     end
     h
   end

--- a/app/helpers/textual_mixins/textual_os_info.rb
+++ b/app/helpers/textual_mixins/textual_os_info.rb
@@ -15,7 +15,7 @@ module TextualMixins::TextualOsInfo
       h[:value] = product_name
       h[:title] = _("Show OS container information")
       h[:explorer] = true
-      h[:link] = url_for(:action => 'show', :id => @record, :display => 'os_info')
+      h[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'os_info')
     end
     h
   end

--- a/app/helpers/textual_mixins/textual_patches.rb
+++ b/app/helpers/textual_mixins/textual_patches.rb
@@ -7,7 +7,7 @@ module TextualMixins::TextualPatches
     if num > 0
       h[:title] = n_("Show the Patch defined on this VM", "Show the Patches defined on this VM", num)
       h[:explorer] = true
-      h[:link] = url_for(:action => 'patches', :id => @record, :db => controller.controller_name)
+      h[:link] = url_for_only_path(:action => 'patches', :id => @record, :db => controller.controller_name)
     end
     h
   end

--- a/app/helpers/textual_mixins/textual_region.rb
+++ b/app/helpers/textual_mixins/textual_region.rb
@@ -6,7 +6,7 @@ module TextualMixins::TextualRegion
     url = reg.remote_ui_url
     h[:value] = if url
                   # TODO: Why is this link different than the others?
-                  link_to(reg.description, url_for(:host   => url,
+                  link_to(reg.description, url_for_only_path(:host   => url,
                                                    :action => 'show',
                                                    :id     => @record),
                           :title   => _("Connect to this VM in its Region"),

--- a/app/helpers/textual_mixins/textual_scan_history.rb
+++ b/app/helpers/textual_mixins/textual_scan_history.rb
@@ -8,7 +8,7 @@ module TextualMixins::TextualScanHistory
       h[:value] = num
       h[:title] = _("Show virtual machine analysis history")
       h[:explorer] = true
-      h[:link] = url_for(:controller => controller.controller_name, :action => 'scan_histories', :id => @record)
+      h[:link] = url_for_only_path(:controller => controller.controller_name, :action => 'scan_histories', :id => @record)
     end
     h
   end

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -90,7 +90,7 @@ module TextualSummaryHelper
       if restful_routed?(object)
         h[:link] = polymorphic_path(object)
       else
-        h[:link] = url_for(:controller => controller,
+        h[:link] = url_for_only_path(:controller => controller,
                            :action     => 'show',
                            :id         => object)
       end
@@ -129,13 +129,13 @@ module TextualSummaryHelper
         if restful_routed?(owner)
           h[:link] = polymorphic_path(owner, :display => display)
         else
-          h[:link] = url_for(:controller => controller_for_model(owner.class),
+          h[:link] = url_for_only_path(:controller => controller_for_model(owner.class),
                              :action     => 'show',
                              :id         => owner,
                              :display    => display)
         end
       else
-        h[:link] = url_for(:controller => controller_collection,
+        h[:link] = url_for_only_path(:controller => controller_collection,
                            :action     => 'list')
       end
       h[:title] = _("Show all %{label}") % {:label => label}

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -112,7 +112,7 @@ module VmCloudHelper::TextualSummary
     if role_allows?(:feature => "vm_snapshot_show_list") && @record.supports_snapshots?
       h[:title] = _("Show the snapshot info for this VM")
       h[:explorer] = true
-      h[:link] = url_for(:action => 'show', :id => @record, :display => 'snapshot_info')
+      h[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'snapshot_info')
     end
     h
   end
@@ -120,7 +120,7 @@ module VmCloudHelper::TextualSummary
   def textual_resources
     return nil if @record.template?
     {:label => _("Resources"), :value => _("Available"), :title => _("Show resources of this VM"), :explorer => true,
-      :link => url_for(:action => 'show', :id => @record, :display => 'resources_info')}
+      :link => url_for_only_path(:action => 'show', :id => @record, :display => 'resources_info')}
   end
 
   def textual_guid
@@ -133,7 +133,7 @@ module VmCloudHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the User defined on this VM", "Show the Users defined on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'users', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:action => 'users', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -144,7 +144,7 @@ module VmCloudHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Group defined on this VM", "Show the Groups defined on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'groups', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:action => 'groups', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -166,7 +166,7 @@ module VmCloudHelper::TextualSummary
     if num > 0
       h[:title] = ("Show the %{label} installed on this VM") % {:label => label}
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'guest_applications', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'guest_applications', :id => @record)
     end
     h
   end
@@ -180,7 +180,7 @@ module VmCloudHelper::TextualSummary
       h[:title] = n_("Show the Win32 Service installed on this VM",
                      "Show the Win32 Services installed on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'win32_services', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'win32_services', :id => @record)
     end
     h
   end
@@ -195,7 +195,7 @@ module VmCloudHelper::TextualSummary
       h[:title] = n_("Show the Kernel Driver installed on this VM",
                      "Show the Kernel Drivers installed on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'kernel_drivers', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'kernel_drivers', :id => @record)
     end
     h
   end
@@ -210,7 +210,7 @@ module VmCloudHelper::TextualSummary
       h[:title] = n_("Show the File System Driver installed on this VM",
                     "Show the File System Drivers installed on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'filesystem_drivers', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'filesystem_drivers', :id => @record)
     end
     h
   end
@@ -224,7 +224,7 @@ module VmCloudHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Registry Item installed on this VM", "Show the Registry Items installed on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'registry_items', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'registry_items', :id => @record)
     end
     h
   end
@@ -240,7 +240,7 @@ module VmCloudHelper::TextualSummary
       h[:value] = _("From %{time} Ago") % {:time => time_ago_in_words(date.in_time_zone(Time.zone)).titleize}
       h[:title] = _("Show Running Processes on this VM")
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'processes', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'processes', :id => @record)
     end
     h
   end
@@ -252,7 +252,7 @@ module VmCloudHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show Event Log on this VM", "Show Event Logs on this VM", num)
       h[:explorer] = true
-      h[:link] = url_for(:controller => controller.controller_name, :action => 'event_logs', :id => @record)
+      h[:link] = url_for_only_path(:controller => controller.controller_name, :action => 'event_logs', :id => @record)
     end
     h
   end

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -137,7 +137,7 @@ module VmHelper::TextualSummary
          :value    => ips.join(", "),
          :explorer => true}
     if @record.hardware.try(:networks) && @record.hardware.networks.present?
-      h[:link] = url_for(:action => 'show', :id => @record, :display => 'networks')
+      h[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'networks')
     end
     h
   end
@@ -165,7 +165,7 @@ module VmHelper::TextualSummary
       h[:image] = "svg/vendor-#{vendor}.svg"
       h[:title] = _("Show VMM container information")
       h[:explorer] = true
-      h[:link] = url_for(:action => 'show', :id => @record, :display => 'hv_info')
+      h[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'hv_info')
 
       cpu_details =
         if @record.num_cpu && @record.cpu_cores_per_socket
@@ -197,14 +197,14 @@ module VmHelper::TextualSummary
     if role_allows?(:feature => "vm_snapshot_show_list") && @record.supports_snapshots?
       h[:title] = _("Show the snapshot info for this VM")
       h[:explorer] = true
-      h[:link] = url_for(:action => 'show', :id => @record, :display => 'snapshot_info')
+      h[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'snapshot_info')
     end
     h
   end
 
   def textual_resources
     {:label => _("Resources"), :value => _("Available"), :title => _("Show resources of this VM"), :explorer => true,
-      :link => url_for(:action => 'show', :id => @record, :display => 'resources_info')}
+      :link => url_for_only_path(:action => 'show', :id => @record, :display => 'resources_info')}
   end
 
   def textual_guid
@@ -257,7 +257,7 @@ module VmHelper::TextualSummary
     h = {:label => title_for_cluster, :icon => "pficon pficon-cluster", :value => (cluster.nil? ? _("None") : cluster.name)}
     if cluster && role_allows?(:feature => "ems_cluster_show")
       h[:title] = _("Show this VM's %{title}") % {:title => title_for_cluster}
-      h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => cluster)
+      h[:link]  = url_for_only_path(:controller => 'ems_cluster', :action => 'show', :id => cluster)
     end
     h
   end
@@ -268,7 +268,7 @@ module VmHelper::TextualSummary
     h = {:label => title_for_host, :icon => "pficon pficon-cluster", :value => (host.nil? ? _("None") : host.name)}
     if host && role_allows?(:feature => "host_show")
       h[:title] = _("Show this VM's %{title}") % {:title => title_for_host}
-      h[:link]  = url_for(:controller => 'host', :action => 'show', :id => host)
+      h[:link]  = url_for_only_path(:controller => 'host', :action => 'show', :id => host)
     end
     h
   end
@@ -278,7 +278,7 @@ module VmHelper::TextualSummary
     h = {:label => _("Resource Pool"), :icon => "pficon pficon-resource-pool", :value => (rp.nil? ? _("None") : rp.name)}
     if rp && role_allows?(:feature => "resource_pool_show")
       h[:title] = _("Show this VM's Resource Pool")
-      h[:link]  = url_for(:controller => 'resource_pool', :action => 'show', :id => rp)
+      h[:link]  = url_for_only_path(:controller => 'resource_pool', :action => 'show', :id => rp)
     end
     h
   end
@@ -293,7 +293,7 @@ module VmHelper::TextualSummary
       storage = storages.first
       h[:value] = storage.name
       h[:title] = _("Show this VM's %{label}") % {:label => label}
-      h[:link]  = url_for(:controller => 'storage', :action => 'show', :id => storage)
+      h[:link]  = url_for_only_path(:controller => 'storage', :action => 'show', :id => storage)
     else
       h.delete(:image) # Image will be part of each line item, instead
       main = @record.storage
@@ -301,7 +301,7 @@ module VmHelper::TextualSummary
         {:icon  => "fa fa-database",
          :value => "#{s.name}#{" (main)" if s == main}",
          :title => _("Show this VM's %{label}") % {:label => label},
-         :link  => url_for(:controller => 'storage', :action => 'show', :id => s)}
+         :link  => url_for_only_path(:controller => 'storage', :action => 'show', :id => s)}
       end
     end
     h
@@ -323,7 +323,7 @@ module VmHelper::TextualSummary
          :value => (availability_zone.nil? ? _("None") : availability_zone.name)}
     if availability_zone && role_allows?(:feature => "availability_zone_show")
       h[:title] = _("Show this VM's %{label}") % {:label => label}
-      h[:link]  = url_for(:controller => 'availability_zone', :action => 'show', :id => availability_zone)
+      h[:link]  = url_for_only_path(:controller => 'availability_zone', :action => 'show', :id => availability_zone)
     end
     h
   end
@@ -334,7 +334,7 @@ module VmHelper::TextualSummary
     h = {:label => label, :icon => "pficon-flavor", :value => (flavor.nil? ? _("None") : flavor.name)}
     if flavor && role_allows?(:feature => "flavor_show")
       h[:title] = _("Show this VM's %{label}") % {:label => label}
-      h[:link]  = url_for(:controller => 'flavor', :action => 'show', :id => flavor)
+      h[:link]  = url_for_only_path(:controller => 'flavor', :action => 'show', :id => flavor)
     end
     h
   end
@@ -345,7 +345,7 @@ module VmHelper::TextualSummary
     h = {:label => label, :icon => "product product-template", :value => (vm_template.nil? ? _("None") : vm_template.name)}
     if vm_template && role_allows?(:feature => "miq_template_show")
       h[:title] = _("Show this VM's %{label}") % {:label => label}
-      h[:link]  = url_for(:controller => 'miq_template', :action => 'show', :id => vm_template)
+      h[:link]  = url_for_only_path(:controller => 'miq_template', :action => 'show', :id => vm_template)
     end
     h
   end
@@ -361,7 +361,7 @@ module VmHelper::TextualSummary
       h[:title] = _("Show this Image's parent")
       h[:explorer] = true
       url, action = set_controller_action
-      h[:link]  = url_for(:controller => url, :action => action, :id => parent_vm)
+      h[:link]  = url_for_only_path(:controller => url, :action => action, :id => parent_vm)
     end
     h
   end
@@ -372,7 +372,7 @@ module VmHelper::TextualSummary
     h = {:label => label, :icon => "product-orchestration_stack", :value => (stack.nil? ? _("None") : stack.name)}
     if stack && role_allows?(:feature => "orchestration_stack_show")
       h[:title] = _("Show this VM's %{label} '%{name}'") % {:label => label, :name => stack.name}
-      h[:link]  = url_for(:controller => 'orchestration_stack', :action => 'show', :id => stack)
+      h[:link]  = url_for_only_path(:controller => 'orchestration_stack', :action => 'show', :id => stack)
     end
     h
   end
@@ -385,7 +385,7 @@ module VmHelper::TextualSummary
     else
       h[:value] = service.name
       h[:title] = _("Show this Service")
-      h[:link]  = url_for(:controller => 'service', :action => 'show', :id => service)
+      h[:link]  = url_for_only_path(:controller => 'service', :action => 'show', :id => service)
     end
     h
   end
@@ -397,7 +397,7 @@ module VmHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "security_group_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'security_groups', :id => @record, :display => "security_groups")
+      h[:link]  = url_for_only_path(:action => 'security_groups', :id => @record, :display => "security_groups")
     end
     h
   end
@@ -409,7 +409,7 @@ module VmHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "floating_ip_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'floating_ips', :id => @record, :display => "floating_ips")
+      h[:link]  = url_for_only_path(:action => 'floating_ips', :id => @record, :display => "floating_ips")
     end
     h
   end
@@ -421,7 +421,7 @@ module VmHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "network_router_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'network_routers', :id => @record, :display => "network_routers")
+      h[:link]  = url_for_only_path(:action => 'network_routers', :id => @record, :display => "network_routers")
     end
     h
   end
@@ -433,7 +433,7 @@ module VmHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "cloud_subnet_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'cloud_subnets', :id => @record, :display => "cloud_subnets")
+      h[:link]  = url_for_only_path(:action => 'cloud_subnets', :id => @record, :display => "cloud_subnets")
     end
     h
   end
@@ -445,7 +445,7 @@ module VmHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "network_port_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'network_ports', :id => @record, :display => "network_ports")
+      h[:link]  = url_for_only_path(:action => 'network_ports', :id => @record, :display => "network_ports")
     end
     h
   end
@@ -459,7 +459,7 @@ module VmHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "load_balancer_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'load_balancers', :id => @record, :display => "load_balancers")
+      h[:link]  = url_for_only_path(:action => 'load_balancers', :id => @record, :display => "load_balancers")
     end
     h
   end
@@ -471,7 +471,7 @@ module VmHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "cloud_network_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'cloud_networks', :id => @record, :display => "cloud_networks")
+      h[:link]  = url_for_only_path(:action => 'cloud_networks', :id => @record, :display => "cloud_networks")
     end
     h
   end
@@ -482,7 +482,7 @@ module VmHelper::TextualSummary
     h = {:label => label, :icon => "pficon pficon-cloud-tenant", :value => (cloud_tenant.nil? ? _("None") : cloud_tenant.name)}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this VM's %{label}") % {:label => label}
-      h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
+      h[:link]  = url_for_only_path(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
     end
     h
   end
@@ -494,7 +494,7 @@ module VmHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "cloud_volume_show_list")
       h[:title]    = _("Show all Cloud Volumes attached to this VM.")
       h[:explorer] = true
-      h[:link]     = url_for(:action => 'cloud_volumes', :id => @record, :display => "cloud_volumes")
+      h[:link]     = url_for_only_path(:action => 'cloud_volumes', :id => @record, :display => "cloud_volumes")
     end
     h
   end
@@ -507,7 +507,7 @@ module VmHelper::TextualSummary
       :title    => _("Show virtual machine genealogy"),
       :explorer => true,
       :spinner  => true,
-      :link     => url_for(
+      :link     => url_for_only_path(
         :controller => controller.controller_name,
         :action     => 'show',
         :id         => @record,
@@ -522,7 +522,7 @@ module VmHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the User defined on this VM", "Show the Users defined on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'users', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:action => 'users', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -533,7 +533,7 @@ module VmHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Group defined on this VM", "Show the Groups defined on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'groups', :id => @record, :db => controller.controller_name)
+      h[:link]  = url_for_only_path(:action => 'groups', :id => @record, :db => controller.controller_name)
     end
     h
   end
@@ -548,7 +548,7 @@ module VmHelper::TextualSummary
     if num > 0
       h[:title] = _("Show the %{label} installed on this VM") % {:label => label}
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'guest_applications', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'guest_applications', :id => @record)
     end
     h
   end
@@ -561,7 +561,7 @@ module VmHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Win32 Service installed on this VM", "Show the Win32 Services installed on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'win32_services', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'win32_services', :id => @record)
     end
     h
   end
@@ -575,7 +575,7 @@ module VmHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Kernel Driver installed on this VM", "Show the Kernel Drivers installed on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'kernel_drivers', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'kernel_drivers', :id => @record)
     end
     h
   end
@@ -590,7 +590,7 @@ module VmHelper::TextualSummary
       h[:title] = n_("Show the File System Driver installed on this VM",
                      "Show the File System Drivers installed on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'filesystem_drivers', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'filesystem_drivers', :id => @record)
     end
     h
   end
@@ -604,7 +604,7 @@ module VmHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show the Registry Item installed on this VM", "Show the Registry Items installed on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'registry_items', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'registry_items', :id => @record)
     end
     h
   end
@@ -615,7 +615,7 @@ module VmHelper::TextualSummary
     if num > 0
       h[:title] = n_("Show disk on this VM", "Show disks on this VM", num)
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'show', :id => @record, :display => "disks")
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'show', :id => @record, :display => "disks")
     end
     h
   end
@@ -698,7 +698,7 @@ module VmHelper::TextualSummary
       h[:value] = _("From %{time} Ago") % {:time => time_ago_in_words(date.in_time_zone(Time.zone)).titleize}
       h[:title] = _("Show Running Processes on this VM")
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'processes', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'processes', :id => @record)
     end
     h
   end
@@ -709,7 +709,7 @@ module VmHelper::TextualSummary
     if num > 0
       h[:title] = _("Show Event Logs on this VM")
       h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'event_logs', :id => @record)
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'event_logs', :id => @record)
     end
     h
   end
@@ -818,7 +818,7 @@ module VmHelper::TextualSummary
          :value    => (@devices.nil? || @devices.empty? ? _("None") : @devices.length)}
     if @devices.length > 0
       h[:title] = _("Show VMs devices")
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'devices')
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'devices')
     end
     h
   end

--- a/app/presenters/widget_presenter.rb
+++ b/app/presenters/widget_presenter.rb
@@ -10,7 +10,7 @@ class WidgetPresenter
   end
 
   extend Forwardable
-  def_delegators(:@controller, :current_user, :url_for, :initiate_wait_for_task,
+  def_delegators(:@controller, :current_user, :url_for_only_path, :initiate_wait_for_task,
                  :session_init, :session_reset, :start_url_for_user)
 
   attr_reader :widget

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -107,7 +107,7 @@ class ContainerDashboardService
     if @ems.present?
       @controller.polymorphic_url(@ems, :display => entity.to_s.pluralize)
     else
-      @controller.url_for(:action     => 'show_list',
+      @controller.url_for_only_path(:action     => 'show_list',
                           :controller => entity)
     end
   end

--- a/app/services/ems_infra_dashboard_service.rb
+++ b/app/services/ems_infra_dashboard_service.rb
@@ -82,7 +82,7 @@ class EmsInfraDashboardService
     if @ems.present?
       @controller.polymorphic_url(@ems, :display => entity.to_s.pluralize)
     else
-      @controller.url_for(:action     => 'show_list',
+      @controller.url_for_only_path(:action     => 'show_list',
                           :controller => entity)
     end
   end

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -4,7 +4,7 @@ class UserValidationService
   end
 
   extend Forwardable
-  delegate [:session, :url_for, :initiate_wait_for_task, :session_init, :clear_current_user,
+  delegate [:session, :initiate_wait_for_task, :session_init, :clear_current_user,
             :session_reset, :start_url_for_user, :url_for_only_path] => :@controller
 
   ValidateResult = Struct.new(:result, :flash_msg, :url)

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -5,7 +5,7 @@ class UserValidationService
 
   extend Forwardable
   delegate [:session, :url_for, :initiate_wait_for_task, :session_init, :clear_current_user,
-            :session_reset, :start_url_for_user] => :@controller
+            :session_reset, :start_url_for_user, :url_for_only_path] => :@controller
 
   ValidateResult = Struct.new(:result, :flash_msg, :url)
 

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -71,14 +71,14 @@ class UserValidationService
   private
 
   def validate_user_handle_no_records
-    ValidateResult.new(:pass, nil, url_for(
+    ValidateResult.new(:pass, nil, url_for_only_path(
                                      :controller    => "ems_infra",
                                      :action        => 'show_list'))
   end
 
   def validate_user_handle_not_ready(db_user)
     if db_user.super_admin_user?
-      ValidateResult.new(:pass, nil, url_for(
+      ValidateResult.new(:pass, nil, url_for_only_path(
                                        :controller    => "ops",
                                        :action        => 'explorer',
                                        :flash_warning => true,

--- a/app/views/_ldap_domain_form.html.haml
+++ b/app/views/_ldap_domain_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'ldap_domain_form_field_changed', :id => @edit[:ldap_domain_id] || "new")
+- url = url_for_only_path(:action => 'ldap_domain_form_field_changed', :id => @edit[:ldap_domain_id] || "new")
 #form_div
   = form_tag({:action => 'ldap_domain_edit',
               :id     => @edit[:ldap_domain_id] || "new"},

--- a/app/views/alert/_rss_list.html.haml
+++ b/app/views/alert/_rss_list.html.haml
@@ -14,7 +14,7 @@
             = select_tag('role',
                          options_for_select(@rss_roles, @rss_role),
                          :multiple => false,
-                         "data-miq_observe" => {:url => url_for(:action => 'role_selected')}.to_json)
+                         "data-miq_observe" => {:url => url_for_only_path(:action => 'role_selected')}.to_json)
             = javascript_tag(javascript_focus('role'))
         %tr
           %th.narrow

--- a/app/views/automation_manager/_configscript_service_dialog.html.haml
+++ b/app/views/automation_manager/_configscript_service_dialog.html.haml
@@ -1,7 +1,7 @@
 #form_div
   #basic_info_div
     = render :partial => "layouts/flash_msg"
-    - url = url_for(:action => "cs_form_field_changed", :id => @edit[:rec_id])
+    - url = url_for_only_path(:action => "cs_form_field_changed", :id => @edit[:rec_id])
     .form-horizontal
       .form-group
         %label.col-md-2.control-label

--- a/app/views/catalog/_column_lists.html.haml
+++ b/app/views/catalog/_column_lists.html.haml
@@ -1,5 +1,5 @@
 #column_lists
-  - url = url_for_only_path(:action => 'st_catalog_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
+  - url = url_for_only_path(:action => 'st_catalog_form_field_changed', :id => (@edit[:rec_id] || "new"))
   %table.form#formtest{:width => "100%"}
     %tr
       %td.widthed{:align => "left"}= _('Unassigned:')

--- a/app/views/catalog/_column_lists.html.haml
+++ b/app/views/catalog/_column_lists.html.haml
@@ -1,5 +1,5 @@
 #column_lists
-  - url = url_for(:action => 'st_catalog_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
+  - url = url_for_only_path(:action => 'st_catalog_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
   %table.form#formtest{:width => "100%"}
     %tr
       %td.widthed{:align => "left"}= _('Unassigned:')

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:id => "#{@edit[:rec_id] || "new"}",
+- url = url_for_only_path(:id => "#{@edit[:rec_id] || "new"}",
   :action => @edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed")
 
 #basic_info_div

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:id => "#{@edit[:rec_id] || "new"}",
+- url = url_for_only_path(:id => (@edit[:rec_id] || "new"),
   :action => @edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed")
 
 #basic_info_div

--- a/app/views/catalog/_form_details_info.html.haml
+++ b/app/views/catalog/_form_details_info.html.haml
@@ -1,5 +1,5 @@
 - action = @edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed"
-- url_one_trans = url_for_only_path(:action => action, :id => "#{@edit[:rec_id] || "new"}", :transOne => '1')
+- url_one_trans = url_for_only_path(:action => action, :id => (@edit[:rec_id] || "new"), :transOne => '1')
 
 %h3= _('Long Description')
 = text_area_tag("long_description", @edit[:new][:long_description],

--- a/app/views/catalog/_form_details_info.html.haml
+++ b/app/views/catalog/_form_details_info.html.haml
@@ -1,5 +1,5 @@
 - action = @edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed"
-- url_one_trans = url_for(:action => action, :id => "#{@edit[:rec_id] || "new"}", :transOne => '1')
+- url_one_trans = url_for_only_path(:action => action, :id => "#{@edit[:rec_id] || "new"}", :transOne => '1')
 
 %h3= _('Long Description')
 = text_area_tag("long_description", @edit[:new][:long_description],

--- a/app/views/catalog/_form_resources_info.html.haml
+++ b/app/views/catalog/_form_resources_info.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:id => "#{@edit[:rec_id] || "new"}",
+- url = url_for_only_path(:id => "#{@edit[:rec_id] || "new"}",
   :action => @edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed")
 
 #resources_info_div

--- a/app/views/catalog/_form_resources_info.html.haml
+++ b/app/views/catalog/_form_resources_info.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:id => "#{@edit[:rec_id] || "new"}",
+- url = url_for_only_path(:id => (@edit[:rec_id] || "new").to_s,
   :action => @edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed")
 
 #resources_info_div

--- a/app/views/catalog/_ot_add.html.haml
+++ b/app/views/catalog/_ot_add.html.haml
@@ -1,7 +1,7 @@
 #form_div
   #basic_info_div
     = render :partial => "layouts/flash_msg"
-    - url = url_for(:action => "ot_add_form_field_changed", :id => "new")
+    - url = url_for_only_path(:action => "ot_add_form_field_changed", :id => "new")
     .form-horizontal
       .form-group
         %label.col-md-2.control-label

--- a/app/views/catalog/_ot_copy.html.haml
+++ b/app/views/catalog/_ot_copy.html.haml
@@ -1,7 +1,7 @@
 #form_div
   #basic_info_div
     = render :partial => "layouts/flash_msg"
-    - url = url_for(:action => "ot_form_field_changed", :id => @edit[:rec_id])
+    - url = url_for_only_path(:action => "ot_form_field_changed", :id => @edit[:rec_id])
     %h3
       = _("New Orchestration Template Information")
     %input{:type => "hidden", :name => "original_ot_id", :value => @edit[:rec_id]}

--- a/app/views/catalog/_ot_edit.html.haml
+++ b/app/views/catalog/_ot_edit.html.haml
@@ -1,7 +1,7 @@
 #form_div
   #basic_info_div
     = render :partial => "layouts/flash_msg"
-    - url = url_for(:action => "ot_form_field_changed", :id => @edit[:rec_id])
+    - url = url_for_only_path(:action => "ot_form_field_changed", :id => @edit[:rec_id])
     .form-horizontal
       .form-group
         %label.col-md-2.control-label

--- a/app/views/catalog/_service_dialog_from_ot.html.haml
+++ b/app/views/catalog/_service_dialog_from_ot.html.haml
@@ -1,7 +1,7 @@
 #form_div
   #basic_info_div
     = render :partial => "layouts/flash_msg"
-    - url = url_for(:action => "ot_form_field_changed", :id => @edit[:rec_id])
+    - url = url_for_only_path(:action => "ot_form_field_changed", :id => @edit[:rec_id])
     .form-horizontal
       .form-group
         %label.col-md-2.control-label

--- a/app/views/catalog/_st_form.html.haml
+++ b/app/views/catalog/_st_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:id => "#{@edit[:rec_id] || "new"}",
+- url = url_for_only_path(:id => "#{@edit[:rec_id] || "new"}",
   :action => @edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed")
 #form_div
   = render :partial => "layouts/flash_msg"

--- a/app/views/catalog/_st_form.html.haml
+++ b/app/views/catalog/_st_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:id => "#{@edit[:rec_id] || "new"}",
+- url = url_for_only_path(:id => (@edit[:rec_id] || "new"),
   :action => @edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed")
 #form_div
   = render :partial => "layouts/flash_msg"

--- a/app/views/catalog/_stcat_form.html.haml
+++ b/app/views/catalog/_stcat_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => "st_catalog_form_field_changed",
+- url = url_for_only_path(:action => "st_catalog_form_field_changed",
                 :id     => "#{@edit[:rec_id] || "new"}")
 
 #form_div

--- a/app/views/catalog/_stcat_form.html.haml
+++ b/app/views/catalog/_stcat_form.html.haml
@@ -1,5 +1,4 @@
-- url = url_for_only_path(:action => "st_catalog_form_field_changed",
-                :id     => "#{@edit[:rec_id] || "new"}")
+- url = url_for_only_path(:action => "st_catalog_form_field_changed", :id => (@edit[:rec_id] || "new"))
 
 #form_div
   = render :partial => "layouts/flash_msg"

--- a/app/views/catalog/_svccat_tree_show.html.haml
+++ b/app/views/catalog/_svccat_tree_show.html.haml
@@ -36,7 +36,7 @@
                        :class   => "btn btn-default",
                        :alt     => t = _("Order this Service"),
                        :title   => t,
-                       :onclick => "miqAjaxButton('#{url_for(:action => "svc_catalog_provision",
+                       :onclick => "miqAjaxButton('#{url_for_only_path(:action => "svc_catalog_provision",
                                                              :id     => @record.id,
                                                            :button => "order")}');")
 

--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -1,5 +1,5 @@
 - nothing = "<#{_('Nothing')}>"
-- url = url_for_only_path(:action => 'cb_assign_field_changed', :id => "#{x_node}")
+- url = url_for_only_path(:action => 'cb_assign_field_changed', :id => x_node.to_s)
 #cb_assignment_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -1,5 +1,5 @@
 - nothing = "<#{_('Nothing')}>"
-- url = url_for(:action => 'cb_assign_field_changed', :id => "#{x_node}")
+- url = url_for_only_path(:action => 'cb_assign_field_changed', :id => "#{x_node}")
 #cb_assignment_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'cb_rate_form_field_changed', :id => @edit[:rec_id] || "new")
+- url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => @edit[:rec_id] || "new")
 - currency = ChargebackRateDetailCurrency.currencies_for_select
 #form_div
   %h3

--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'cb_rate_form_field_changed', :id => @edit[:rec_id] || "new")
+- url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => @edit[:rec_id] || "new")
 %table.table.table-bordered{:id => "chargeback_rate_edit_form"}
   %thead
     %tr
@@ -44,7 +44,7 @@
         = render :partial => 'cb_tier_edit_values', :locals => {:detail_index => detail_index, :url => url, :row_within_rate => 0}
         %td.action
           = button_tag(_("Add"), :class => "btn btn-default", :alt => t = _("Add a new tier"), :title => t,
-                                 :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_add",
+                                 :onclick => "miqAjaxButton('#{url_for_only_path(:action => "cb_tier_add",
                                                                        :detail_index => detail_index,
                                                                        :button => "add")}');")
       - (1..num_tiers.to_i - 1).each do |tier_index|
@@ -53,7 +53,7 @@
           = render :partial => 'cb_tier_edit_values', :locals => {:detail_index => detail_index, :url => url, :row_within_rate => tier_index}
           %td.action
             = button_tag(_("Delete"), :class => "btn btn-default", :alt => t = _("Remove the tier"), :title => t,
-                                      :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_remove",
+                                      :onclick => "miqAjaxButton('#{url_for_only_path(:action => "cb_tier_remove",
                                                                             :index => "#{detail_index}-#{tier_index}",
                                                                             :button => "remove")}');")
 

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -1,6 +1,6 @@
 - i = params[:detail_index]
 - r = @edit[:new][:details][i.to_i]
-- url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
+- url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => (@edit[:rec_id] || "new"))
 - n = @edit[:new][:num_tiers][i.to_i]
 
 %tr.rdetail{:id => "rate_detail_row_#{i}_0"}

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -1,6 +1,6 @@
 - i = params[:detail_index]
 - r = @edit[:new][:details][i.to_i]
-- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
+- url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
 - n = @edit[:new][:num_tiers][i.to_i]
 
 %tr.rdetail{:id => "rate_detail_row_#{i}_0"}
@@ -27,6 +27,6 @@
                  :class   => "btn btn-default",
                  :alt     => t = _("Add a new tier"),
                  :title   => t,
-                 :onclick => "miqAjaxButton('#{url_for(:action       => "cb_tier_add",
+                 :onclick => "miqAjaxButton('#{url_for_only_path(:action       => "cb_tier_add",
                                                        :detail_index => i,
                                                        :button       => "add")}');")

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -1,5 +1,5 @@
 - i = params[:detail_index]
-- url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
+- url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => (@edit[:rec_id] || "new"))
 - n = @edit[:new][:num_tiers][i.to_i]
 - n = params[:tier_row] if params[:tier_row]
 

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -1,5 +1,5 @@
 - i = params[:detail_index]
-- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
+- url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
 - n = @edit[:new][:num_tiers][i.to_i]
 - n = params[:tier_row] if params[:tier_row]
 
@@ -10,7 +10,7 @@
                  :class   => "btn btn-default",
                  :alt     => t = _("Remove the tier"),
                  :title   => t,
-                 :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_remove",
+                 :onclick => "miqAjaxButton('#{url_for_only_path(:action => "cb_tier_remove",
                                                        :index  => i + "-#{n - 1}",
                                                        :button => "remove")}');")
   :javascript

--- a/app/views/configuration/_timeprofile_days_hours.html.haml
+++ b/app/views/configuration/_timeprofile_days_hours.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => "timeprofile_field_changed")
+- url = url_for_only_path(:action => "timeprofile_field_changed")
 - url_json = {:url => url}.to_json
 #timeprofile_days_hours_div
   .form-horizontal

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -1,5 +1,4 @@
 - url = url_for_only_path(:action => "form_field_changed")
-- url_json = {:url => url_for_only_path(:action => "form_field_changed")}.to_json
 = render :partial => "layouts/flash_msg"
 
 #tab_div

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -1,5 +1,5 @@
-- url = url_for(:action => "form_field_changed")
-- url_json = {:url => url_for(:action => "form_field_changed")}.to_json
+- url = url_for_only_path(:action => "form_field_changed")
+- url_json = {:url => url_for_only_path(:action => "form_field_changed")}.to_json
 = render :partial => "layouts/flash_msg"
 
 #tab_div

--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => "view_selected")
+- url = url_for_only_path(:action => "view_selected")
 = render :partial => "layouts/flash_msg"
 
 #tab_div

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -88,9 +88,9 @@
                           :title        => _("Update Password"))
 
           .col-xs-4.col-md-3.submit
-            - login_url = url_for(:action => "authenticate",
+            - login_url = url_for_only_path(:action => "authenticate",
                                   :button => "login")
-            - sso_url = url_for(:action => "kerberos_authenticate",
+            - sso_url = url_for_only_path(:action => "kerberos_authenticate",
                                 :button => "sso_login")
 
             = link_to(_("Login"), '',

--- a/app/views/ems_block_storage/edit.html.haml
+++ b/app/views/ems_block_storage/edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:controller => 'ems_block_storage', :action => 'update', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_block_storage', :action => 'update', :id => "#{@ems.id || 'new'}")
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_block_storage/edit.html.haml
+++ b/app/views/ems_block_storage/edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:controller => 'ems_block_storage', :action => 'update', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_block_storage', :action => 'update', :id => (@ems.id || 'new'))
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_block_storage/new.html.haml
+++ b/app/views/ems_block_storage/new.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:controller => 'ems_block_storage', :action => 'create', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_block_storage', :action => 'create', :id => (@ems.id || 'new'))
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_block_storage/new.html.haml
+++ b/app/views/ems_block_storage/new.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:controller => 'ems_block_storage', :action => 'create', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_block_storage', :action => 'create', :id => "#{@ems.id || 'new'}")
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_cloud/discover.html.haml
+++ b/app/views/ems_cloud/discover.html.haml
@@ -1,4 +1,4 @@
-- url = url_for :action => 'discover_field_changed'
+- url = url_for_only_path :action => 'discover_field_changed'
 = render :partial => "layouts/flash_msg"
 = form_tag({:action => "discover"},
            :id     => 'discover_cloud_form',

--- a/app/views/ems_network/edit.html.haml
+++ b/app/views/ems_network/edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:controller => 'ems_network', :action => 'update', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_network', :action => 'update', :id => (@ems.id || 'new'))
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_network/edit.html.haml
+++ b/app/views/ems_network/edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:controller => 'ems_network', :action => 'update', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_network', :action => 'update', :id => "#{@ems.id || 'new'}")
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_network/new.html.haml
+++ b/app/views/ems_network/new.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:controller => 'ems_network', :action => 'create', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_network', :action => 'create', :id => (@ems.id || 'new'))
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_network/new.html.haml
+++ b/app/views/ems_network/new.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:controller => 'ems_network', :action => 'create', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_network', :action => 'create', :id => "#{@ems.id || 'new'}")
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_object_storage/edit.html.haml
+++ b/app/views/ems_object_storage/edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:controller => 'ems_object_storage', :action => 'update', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_object_storage', :action => 'update', :id => (@ems.id || 'new'))
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_object_storage/edit.html.haml
+++ b/app/views/ems_object_storage/edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:controller => 'ems_object_storage', :action => 'update', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_object_storage', :action => 'update', :id => "#{@ems.id || 'new'}")
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_object_storage/new.html.haml
+++ b/app/views/ems_object_storage/new.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:controller => 'ems_object_storage', :action => 'create', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_object_storage', :action => 'create', :id => (@ems.id || 'new'))
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_object_storage/new.html.haml
+++ b/app/views/ems_object_storage/new.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:controller => 'ems_object_storage', :action => 'create', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_object_storage', :action => 'create', :id => "#{@ems.id || 'new'}")
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_storage/edit.html.haml
+++ b/app/views/ems_storage/edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:controller => 'ems_storage', :action => 'update', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_storage', :action => 'update', :id => "#{@ems.id || 'new'}")
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_storage/edit.html.haml
+++ b/app/views/ems_storage/edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:controller => 'ems_storage', :action => 'update', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_storage', :action => 'update', :id => (@ems.id || 'new'))
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_storage/new.html.haml
+++ b/app/views/ems_storage/new.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:controller => 'ems_storage', :action => 'create', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_storage', :action => 'create', :id => "#{@ems.id || 'new'}")
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/ems_storage/new.html.haml
+++ b/app/views/ems_storage/new.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:controller => 'ems_storage', :action => 'create', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:controller => 'ems_storage', :action => 'create', :id => (@ems.id || 'new'))
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -1,5 +1,5 @@
-- url = url_for(:action => 'adv_search_load_choice')
-- url2 = url_for(:action => 'adv_search_name_typed')
+- url = url_for_only_path(:action => 'adv_search_load_choice')
+- url2 = url_for_only_path(:action => 'adv_search_name_typed')
 - report_expressions = MiqReport.get_expressions_by_model(@edit[@expkey][:exp_model])
 - mode ||= "search"
 #adv_search_body

--- a/app/views/layouts/_adv_search_footer.html.haml
+++ b/app/views/layouts/_adv_search_footer.html.haml
@@ -1,5 +1,3 @@
-- url = url_for_only_path(:action =>'adv_search_load_choice')
-- url2 = url_for_only_path(:action =>'adv_search_name_typed')
 - report_expressions = MiqReport.get_expressions_by_model(@edit[@expkey][:exp_model])
 - mode ||= "search"
 

--- a/app/views/layouts/_adv_search_footer.html.haml
+++ b/app/views/layouts/_adv_search_footer.html.haml
@@ -1,5 +1,5 @@
-- url = url_for(:action =>'adv_search_load_choice')
-- url2 = url_for(:action =>'adv_search_name_typed')
+- url = url_for_only_path(:action =>'adv_search_load_choice')
+- url2 = url_for_only_path(:action =>'adv_search_name_typed')
 - report_expressions = MiqReport.get_expressions_by_model(@edit[@expkey][:exp_model])
 - mode ||= "search"
 
@@ -15,7 +15,7 @@
                    :class   => "btn btn-primary pull-left",
                    :alt     => t = _("Load a filter"),
                    :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for(:action => 'adv_search_button', :button => "load")}');")
+                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "load")}');")
     - if @edit[@expkey][:exp_table].flatten.first == "???"
       = button_tag(_("Apply"),
                    :class => "btn btn-primary disabled",
@@ -26,7 +26,7 @@
                    :class   => "btn btn-primary",
                    :alt     => t = _("Apply the current filter"),
                    :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for(:action => 'adv_search_button', :button => "apply")}');")
+                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "apply")}');")
     - if @edit[@expkey][:selected] && @edit[@expkey][:selected][:typ] != "default" && @edit[@expkey][:selected][:id] != 0
       - if admin_user? || @edit[@expkey][:selected][:typ] == "user"
         - confirm_msg = _("Delete the %{model} filter named %{filter}?") % {:model  => ui_lookup(:model => @edit[@expkey][:exp_mode]),
@@ -37,7 +37,7 @@
                    'data-confirm' => confirm_msg,
                    :alt     => t = _("Delete the filter named %{filter_name}") % {:filter_name => @edit[@expkey][:selected][:description]},
                    :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for(:action => 'adv_search_button', :button => "delete")}');")
+                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "delete")}');")
     - if @edit[@expkey][:exp_table].flatten.first == "???"
       = button_tag(_("Save"),
                    :class => "btn btn-primary disabled",
@@ -48,7 +48,7 @@
                    :class   => "btn btn-primary",
                    :alt     => t = _("Save the current filter"),
                    :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for(:action => 'adv_search_button', :button => "save")}');")
+                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "save")}');")
     - if @edit[@expkey][:exp_table].flatten.first == "???"
       = button_tag(_("Reset"),
                    :class => "btn btn-default disabled",
@@ -59,7 +59,7 @@
                    :class   => "btn btn-default",
                    :alt     => t = _("Reset the filter"),
                    :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for(:action => 'adv_search_button', :button => "reset")}');")
+                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "reset")}');")
   - elsif mode == "load"
     - if @edit[@expkey][:exp_chosen_report].nil? && @edit[@expkey][:exp_chosen_search].nil?
       = button_tag(_("Load"),
@@ -71,20 +71,20 @@
                    :class   => "btn btn-primary pull-left",
                    :alt     => t = _("Load the filter shown above"),
                    :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for(:action => 'adv_search_button', :button => "loadit")}');")
+                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "loadit")}');")
     = button_tag(_('Cancel'),
                    :class   => "btn btn-primary",
                    :alt     => t = _("Cancel the load"),
                    :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for(:action => 'adv_search_button', :button => "cancel")}');")
+                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "cancel")}');")
   - elsif mode == "save"
     = button_tag(_('Save'),
                    :class   => "btn btn-primary",
                    :alt     => t = _("Save the current search"),
                    :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for(:action => 'adv_search_button', :button => "saveit")}');")
+                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "saveit")}');")
     = button_tag(_('Cancel'),
                    :class   => "btn btn-default",
                    :alt     => t = _("Cancel the save"),
                    :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for(:action => 'adv_search_button', :button => "cancel")}');")
+                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "cancel")}');")

--- a/app/views/layouts/_ae_resolve_options.html.haml
+++ b/app/views/layouts/_ae_resolve_options.html.haml
@@ -2,7 +2,7 @@
 - ae_sim_form       ||= false
 - ae_custom_button  ||= false
 - rec_id = @edit && @edit[:action_id].present? ? @edit[:action_id] : "new"
-- url    = url_for(:action => field_changed_url, :id => rec_id)
+- url    = url_for_only_path(:action => field_changed_url, :id => rec_id)
 .form-horizontal
   - if form_action == "ae_resolve"
     %hr

--- a/app/views/layouts/_auth_bearer_token.html.haml
+++ b/app/views/layouts/_auth_bearer_token.html.haml
@@ -3,7 +3,7 @@
 - pfx ||= ""
 - record ||= nil
 - rec_id   = record && record.id ? "#{record.id}" : "new"
-- url      = url_for(:action => change_url, :id => "#{rec_id}")
+- url      = url_for_only_path(:action => change_url, :id => "#{rec_id}")
 - url_json = {:interval => '.5', :url => url}.to_json
 - token_label ||= _("Token")
 

--- a/app/views/layouts/_auth_bearer_token.html.haml
+++ b/app/views/layouts/_auth_bearer_token.html.haml
@@ -2,8 +2,8 @@
 - change_url ||= "form_field_changed"
 - pfx ||= ""
 - record ||= nil
-- rec_id   = record && record.id ? "#{record.id}" : "new"
-- url      = url_for_only_path(:action => change_url, :id => "#{rec_id}")
+- rec_id   = record && record.id ? record.id : "new"
+- url      = url_for_only_path(:action => change_url, :id => rec_id)
 - url_json = {:interval => '.5', :url => url}.to_json
 - token_label ||= _("Token")
 

--- a/app/views/layouts/_auth_credentials.html.haml
+++ b/app/views/layouts/_auth_credentials.html.haml
@@ -3,7 +3,7 @@
 - pfx          ||= ""
 - record       ||= nil
 - rec_id   = record && record.id ? "#{record.id}" : "new"
-- url      = url_for(:action => change_url, :id => "#{rec_id}")
+- url      = url_for_only_path(:action => change_url, :id => "#{rec_id}")
 - url_json = {:interval => '.5', :url => url}.to_json
 - ujs_button   ||= nil
 - uid_label    ||= _("Username")

--- a/app/views/layouts/_auth_credentials.html.haml
+++ b/app/views/layouts/_auth_credentials.html.haml
@@ -2,8 +2,8 @@
 - change_url   ||= "form_field_changed"
 - pfx          ||= ""
 - record       ||= nil
-- rec_id   = record && record.id ? "#{record.id}" : "new"
-- url      = url_for_only_path(:action => change_url, :id => "#{rec_id}")
+- rec_id   = record && record.id ? record.id : "new"
+- url      = url_for_only_path(:action => change_url, :id => rec_id)
 - url_json = {:interval => '.5', :url => url}.to_json
 - ujs_button   ||= nil
 - uid_label    ||= _("Username")

--- a/app/views/layouts/_auth_credentials_keypair.html.haml
+++ b/app/views/layouts/_auth_credentials_keypair.html.haml
@@ -2,7 +2,7 @@
 - pfx        ||= ""
 - record     ||= nil
 - rec_id   = record && record.id ? "#{record.id}" : "new"
-- url      = url_for(:action => change_url, :id => "#{rec_id}")
+- url      = url_for_only_path(:action => change_url, :id => "#{rec_id}")
 - url_json = {:interval => '.5', :url => url}.to_json
 - uid_label ||= _("Username")
 - pwd_label ||= _("Private Key")

--- a/app/views/layouts/_auth_credentials_keypair.html.haml
+++ b/app/views/layouts/_auth_credentials_keypair.html.haml
@@ -1,8 +1,8 @@
 - change_url ||= "form_field_changed"
 - pfx        ||= ""
 - record     ||= nil
-- rec_id   = record && record.id ? "#{record.id}" : "new"
-- url      = url_for_only_path(:action => change_url, :id => "#{rec_id}")
+- rec_id   = record && record.id ? record.id : "new"
+- url      = url_for_only_path(:action => change_url, :id => rec_id)
 - url_json = {:interval => '.5', :url => url}.to_json
 - uid_label ||= _("Username")
 - pwd_label ||= _("Private Key")

--- a/app/views/layouts/_discover.html.haml
+++ b/app/views/layouts/_discover.html.haml
@@ -1,4 +1,4 @@
-- url = url_for :action => 'discover_field_changed'
+- url = url_for_only_path :action => 'discover_field_changed'
 = render :partial => 'layouts/flash_msg'
 = form_tag({:action => 'discover'},
            :id     => 'discover_form',

--- a/app/views/layouts/_discover_azure_credentials.html.haml
+++ b/app/views/layouts/_discover_azure_credentials.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'discover_field_changed')
+- url = url_for_only_path(:action => 'discover_field_changed')
 %h3
   = label
 .form-horizontal

--- a/app/views/layouts/_discover_credentials.html.haml
+++ b/app/views/layouts/_discover_credentials.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'discover_field_changed')
+- url = url_for_only_path(:action => 'discover_field_changed')
 %h3
   = label
 .form-horizontal

--- a/app/views/layouts/_edit_buttons.html.haml
+++ b/app/views/layouts/_edit_buttons.html.haml
@@ -12,14 +12,14 @@
                        :class   => 'btn btn-primary',
                        :alt     => t = _("Add"),
                        :title   => t,
-                       :onclick => "miqAjaxButton('#{url_for(:action => action_url,
+                       :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url,
                                                              :button => "add")}');")
         - else
           = button_tag(_("Save"),
                        :class   => 'btn btn-primary',
                        :alt     => t = _("Save Changes"),
                        :title   => t,
-                       :onclick => "miqAjaxButton('#{url_for(:action => action_url,
+                       :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url,
                                                              :id     => record_id,
                                                              :button => "save")}');")
           - unless noreset
@@ -27,14 +27,14 @@
                          :class   => 'btn btn-default',
                          :alt     => t = _("Reset Changes"),
                          :title   => t,
-                         :onclick => "miqAjaxButton('#{url_for(:action => action_url,
+                         :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url,
                                                                :id     => record_id,
                                                                :button => "reset")}');")
         = button_tag(_("Cancel"),
                      :class   => 'btn btn-default',
                      :alt     => t = _("Cancel"),
                      :title   => t,
-                     :onclick => "miqAjaxButton('#{url_for(:action => action_url,
+                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url,
                                                            :id     => record_id,
                                                            :button => "cancel")}');")
       #buttons_off{:style => "display:#{@changed ? "none" : "display"};"}
@@ -51,6 +51,6 @@
                      :class   => 'btn btn-default',
                      :alt     => t = _("Cancel"),
                      :title   => t,
-                     :onclick => "miqAjaxButton('#{url_for(:action => action_url,
+                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url,
                                                            :id     => record_id,
                                                            :button => "cancel")}');")

--- a/app/views/layouts/_edit_email.html.haml
+++ b/app/views/layouts/_edit_email.html.haml
@@ -1,7 +1,7 @@
 - box_title ||= _("E-mail")
 - action_url ||= "form_field_changed"
 - if @edit
-  - url = url_for_only_path(:action => action_url, :id => "#{record.id || "new"}")
+  - url = url_for_only_path(:action => action_url, :id => (record.id || "new"))
 #edit_email_div
   %h3
     = box_title

--- a/app/views/layouts/_edit_email.html.haml
+++ b/app/views/layouts/_edit_email.html.haml
@@ -1,7 +1,7 @@
 - box_title ||= _("E-mail")
 - action_url ||= "form_field_changed"
 - if @edit
-  - url = url_for(:action => action_url, :id => "#{record.id || "new"}")
+  - url = url_for_only_path(:action => action_url, :id => "#{record.id || "new"}")
 #edit_email_div
   %h3
     = box_title

--- a/app/views/layouts/_edit_form_buttons.html.haml
+++ b/app/views/layouts/_edit_form_buttons.html.haml
@@ -21,7 +21,7 @@
                          :class   => 'btn btn-primary',
                          :alt     => save_text,
                          :title   => save_text,
-                         :onclick => "miqAjaxButton('#{url_for(:action => action_url,
+                         :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url,
                                                                :id     => record_id,
                                                                :button => "save")}', true);")
           - else
@@ -31,7 +31,7 @@
                              :class   => 'btn btn-primary',
                              :alt     => t = _("Continue"),
                              :title   => t,
-                             :onclick => "miqAjaxButton('#{url_for(:action => action_url,
+                             :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url,
                                                                    :id     => record_id,
                                                                    :button => "continue")}');")
               - else
@@ -41,7 +41,7 @@
                              :class   => 'btn btn-primary',
                              :alt     => save_text,
                              :title   => save_text,
-                             :onclick => "#{function}('#{url_for(:action => action_url,
+                             :onclick => "#{function}('#{url_for_only_path(:action => action_url,
                                                                    :id     => record_id,
                                                                    :button => "save")}'#{extra});")
             - else
@@ -49,7 +49,7 @@
                            :class   => 'btn btn-primary',
                            :alt     => save_text,
                            :title   => save_text,
-                           :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for(:action => action_url,
+                           :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for_only_path(:action => action_url,
                                                                                                       :id     => record_id,
                                                                                                       :button => "save")}');")
         - else
@@ -77,13 +77,13 @@
                            :class   => 'btn btn-default',
                            :alt     => t = _("Reset Changes"),
                            :title   => t,
-                           :onclick => "miqAjaxButton('#{url_for(:action => "menu_update",
+                           :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update",
                                                                  :button => "reset")}');")
             = button_tag(_("Default"),
                          :class   => 'btn btn-primary',
                          :alt     => t = _("Reset All menus to defaults"),
                          :title   => t,
-                         :onclick => "miqAjaxButton('#{url_for(:action => "menu_update",
+                         :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update",
                                                                :button => "default")}');")
           - else
             - if @layout == "miq_ae_class" || (ajax_buttons && params[:action] != "tagging_edit")
@@ -91,7 +91,7 @@
                            :class   => 'btn btn-default',
                            :alt     => t = _("Reset Changes"),
                            :title   => t,
-                           :onclick => "miqAjaxButton('#{url_for(:action  => action_url,
+                           :onclick => "miqAjaxButton('#{url_for_only_path(:action  => action_url,
                                                                  :id      => record_id,
                                                                  :button  => "reset")}');")
             - else
@@ -109,7 +109,7 @@
                            :class   => 'btn btn-default',
                            :alt     => t = _("Cancel Changes"),
                            :title   => t,
-                           :onclick => "miqAjaxButton('#{url_for(:action => action_url,
+                           :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url,
                                                                  :id     => record_id,
                                                                  :button => "cancel")}');")
           - else
@@ -133,7 +133,7 @@
                          :class   => 'btn btn-primary',
                          :alt     => t = _("Reset All menus to defaults"),
                          :title   => t,
-                         :onclick => "miqAjaxButton('#{url_for(:action => "menu_update",
+                         :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update",
                                                                :button => "default")}');")
         - unless ((@layout == "ops" && !force_cancel_button) || (@layout == "configuration" && !show_cancel_button.include?(controller.action_name)) || (@layout == "report" && !@sb[:menu_buttons] && !%w(edit update schedule_edit schedule_update widget_edit widget_update db_seq_edit db_form_field_changed db_edit db_update db_widget_remove).include?(controller.action_name) && "edit" != @lastaction))
           - if @layout == "miq_ae_class" || ajax_buttons
@@ -141,7 +141,7 @@
                          :class   => 'btn btn-default',
                          :alt     => t,
                          :title   => t,
-                         :onclick => "miqAjaxButton('#{url_for(:action => action_url,
+                         :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url,
                                                                :id     => record_id,
                                                                :button => "cancel")}');")
           - else

--- a/app/views/layouts/_edit_log_depot_settings.html.haml
+++ b/app/views/layouts/_edit_log_depot_settings.html.haml
@@ -1,6 +1,6 @@
 - action ||= "log_depot_field_changed"
 - record    = @schedule || @record
-- url       = url_for(:action => action, :id => (record.try(:id) || "new"))
+- url       = url_for_only_path(:action => action, :id => (record.try(:id) || "new"))
 
 #form_filter_div
   = render :partial => "layouts/flash_msg"

--- a/app/views/layouts/_edit_to_email.html.haml
+++ b/app/views/layouts/_edit_to_email.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => action_url, :id => "#{record.id || "new"}")
+- url = url_for_only_path(:action => action_url, :id => "#{record.id || "new"}")
 #edit_to_email_div
   %br
     .form-horizontal
@@ -55,6 +55,6 @@
                              :class             => "form-control",
                              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %span.input-group-btn
-              .btn.btn-default{:alt => t = _("Add"), :title => t, :onclick => "miqAjaxButton('#{url_for(:action => action_url, :button => "add_email", :id => "#{record.id || "new"}")}');"}
+              .btn.btn-default{:alt => t = _("Add"), :title => t, :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => "add_email", :id => "#{record.id || "new"}")}');"}
                 %i.fa.fa-plus
 

--- a/app/views/layouts/_edit_to_email.html.haml
+++ b/app/views/layouts/_edit_to_email.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => action_url, :id => "#{record.id || "new"}")
+- url = url_for_only_path(:action => action_url, :id => (record.id || "new"))
 #edit_to_email_div
   %br
     .form-horizontal
@@ -55,6 +55,6 @@
                              :class             => "form-control",
                              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %span.input-group-btn
-              .btn.btn-default{:alt => t = _("Add"), :title => t, :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => "add_email", :id => "#{record.id || "new"}")}');"}
+              .btn.btn-default{:alt => t = _("Add"), :title => t, :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => 'add_email', :id => (record.id || 'new'))}');"}
                 %i.fa.fa-plus
 

--- a/app/views/layouts/_exp_editor.html.haml
+++ b/app/views/layouts/_exp_editor.html.haml
@@ -14,7 +14,7 @@
           - t = _('Undo the last change')
           %button.btn.btn-default{"data-miq_sparkle_on" => true,
           "data-method" => :post,
-          :onclick      => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'undo')}');",
+          :onclick      => "miqAjaxButton('#{url_for_only_path(:action => 'exp_button', :pressed => 'undo')}');",
           :remote       => true,
           :title        => t}
             %i.fa.fa-reply
@@ -25,7 +25,7 @@
         - if @edit[@expkey].history.idx < @edit[@expkey].history.array.length - 1
           - t = _('Re-apply the previous change')
           %button.btn.btn-default{"data-miq_sparkle_on" => true,
-          :onclick      => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'redo')}');",
+          :onclick      => "miqAjaxButton('#{url_for_only_path(:action => 'exp_button', :pressed => 'redo')}');",
           :remote       => true,
           "data-method" => :post,
           :title        => t}
@@ -61,7 +61,7 @@
 
           %button.btn.btn-default{"data-method" => :post,
           "data-miq_sparkle_on" => true,
-          :onclick              => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'remove')}');",
+          :onclick              => "miqAjaxButton('#{url_for_only_path(:action => 'exp_button', :pressed => 'remove')}');",
           :remote               => true,
           :title                => _("Remove this expression element")}
             %i.fa-lg.pficon.pficon-close
@@ -78,7 +78,7 @@
                         :title                 => title)
           %button.btn.btn-default{"data-method" => :post,
           "data-miq_sparkle_on" => true,
-          :onclick              => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'remove')}');",
+          :onclick              => "miqAjaxButton('#{url_for_only_path(:action => 'exp_button', :pressed => 'remove')}');",
           :remote               => true,
           :title                => _("Remove this expression element")}
             %i.fa-lg.pficon.pficon-close

--- a/app/views/layouts/_form_buttons.html.haml
+++ b/app/views/layouts/_form_buttons.html.haml
@@ -12,13 +12,13 @@
             :class   => 'btn btn-primary',
             :alt     => save_text,
             :title   => save_text,
-            :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => 'save')}', true);")
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => 'save')}', true);")
         - else
           = button_tag(_('Save'),
             :class   => 'btn btn-primary',
             :alt     => save_text,
             :title   => save_text,
-            :onclick => "miqAjaxButton('#{url_for(:action => action_url, :button => 'save')}');")
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => 'save')}');")
       - else
         - if save_confirm_text
           = button_tag(_("Save"),
@@ -43,7 +43,7 @@
           :class   => 'btn btn-default',
           :alt     => t = _("Reset Changes"),
           :title   => t,
-          :onclick => "miqAjaxButton('#{url_for(:action => action_url, :button => 'reset')}');")
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => 'reset')}');")
       - else
         = button_tag(_('Reset'),
           :id      => "reset",

--- a/app/views/layouts/_form_buttons_verify.html.haml
+++ b/app/views/layouts/_form_buttons_verify.html.haml
@@ -19,7 +19,7 @@
                  :class   => "btn btn-primary btn-xs pull-right",
                  :alt     => verify_title_on,
                  :title   => verify_title_on,
-                 :onclick => "miqAjaxButton('#{url_for(:action => validate_url,
+                 :onclick => "miqAjaxButton('#{url_for_only_path(:action => validate_url,
                                                        :id     => id,
                                                        :button => "validate")}', true);")
   - else

--- a/app/views/layouts/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/_multi_auth_credentials.html.haml
@@ -119,7 +119,7 @@
             = select_tag('validate_id',
                          options_for_select(@edit[:selected_hosts].invert.sort,
                                             @edit[:validate_against].to_i),
-                         "data-miq_observe" => {:url => url_for(:action => 'form_field_changed',
+                         "data-miq_observe" => {:url => url_for_only_path(:action => 'form_field_changed',
                                                                 :id     => "#{record.id || "new"}")}.to_json)
   %hr
 

--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'perf_chart_chooser',
+- url = url_for_only_path(:action => 'perf_chart_chooser',
                 :id     => @record.id)
 #perf_options_div{:onclick => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
   - if @charts || @perf_options[:chart_type] != :performance

--- a/app/views/layouts/_performance_async.html.haml
+++ b/app/views/layouts/_performance_async.html.haml
@@ -1,4 +1,4 @@
 = render(:partial => "layouts/performance")
 
 :javascript
-  ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record.id)}');"
+  ManageIQ.afterOnload = "miqAsyncAjax('#{url_for_only_path(:action => @ajax_action, :id => @record.id)}');"

--- a/app/views/layouts/_policy_sim.html.haml
+++ b/app/views/layouts/_policy_sim.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'policy_sim_add')
+- url = url_for_only_path(:action => 'policy_sim_add')
 #main_div
 
   #flash_msg_div

--- a/app/views/layouts/_role_visibility.html.haml
+++ b/app/views/layouts/_role_visibility.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => action, :id => rec_id)
+- url = url_for_only_path(:action => action, :id => rec_id)
 #form_role_visibility
   %hr
   %h3

--- a/app/views/layouts/_saved_report_paging_bar.html.haml
+++ b/app/views/layouts/_saved_report_paging_bar.html.haml
@@ -1,7 +1,7 @@
 .col-md-12
   .toolbar-pf-actions
     - action_url = "saved_report_paging"
-    - url = url_for(:action => action_url)
+    - url = url_for_only_path(:action => action_url)
     - @pb_occ ||= 0
     - @pb_occ += 1
     - pages ||= {:perpage => @settings[:perpage][:reports],

--- a/app/views/layouts/_tag_edit.html.haml
+++ b/app/views/layouts/_tag_edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'tag_edit_form_field_changed', :id => @sb[:rec_id] || @edit[:object_ids][0])
+- url = url_for_only_path(:action => 'tag_edit_form_field_changed', :id => @sb[:rec_id] || @edit[:object_ids][0])
 #tab_div
   %h3
     - if @tagitems.length > 1

--- a/app/views/layouts/_tag_edit_cat_tags.html.haml
+++ b/app/views/layouts/_tag_edit_cat_tags.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'tag_edit_form_field_changed', :id => @sb[:rec_id] || @edit[:object_ids][0])
+- url = url_for_only_path(:action => 'tag_edit_form_field_changed', :id => @sb[:rec_id] || @edit[:object_ids][0])
 #cat_tags_div
   - tags = @entries.sort_by { |key, _| key.downcase }
   - options = @entries.empty? ? [[_("<All values are assigned>"), "select"]] : [[_("<Select a value to assign>"), "select"]] + tags

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'tl_chooser', :id => @record.id)
+- url = url_for_only_path(:action => 'tl_chooser', :id => @record.id)
 
 #tl_options_div
   %form#form_div{:name           => 'angularForm',

--- a/app/views/layouts/_tl_show_async.html.haml
+++ b/app/views/layouts/_tl_show_async.html.haml
@@ -1,4 +1,4 @@
 = render(:partial => "layouts/tl_show")
 
 :javascript
-  ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record.id)}');"
+  ManageIQ.afterOnload = "miqAsyncAjax('#{url_for_only_path(:action => @ajax_action, :id => @record.id)}');"

--- a/app/views/layouts/_user_input_filter.html.haml
+++ b/app/views/layouts/_user_input_filter.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'quick_search')
+- url = url_for_only_path(:action => 'quick_search')
 #user_input_filter
   - if @edit
     .modal-dialog.modal-lg

--- a/app/views/layouts/_x_dialog_buttons.html.haml
+++ b/app/views/layouts/_x_dialog_buttons.html.haml
@@ -15,31 +15,31 @@
               :class   => "btn btn-primary",
               :alt     => t = _("Save Changes"),
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "save")}', false, { complete: false });")
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', false, { complete: false });")
           - when "submit"
             = button_tag(t = _('Submit'),
               :class   => "btn btn-primary",
               :alt     => t,
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "submit")}', false, { complete: false });")
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "submit")}', false, { complete: false });")
           - when "continue"
             = button_tag(t = _('Continue'),
               :class   => "btn btn-default",
               :alt     => t,
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "continue")}', false, { complete: false });")
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "continue")}', false, { complete: false });")
           - when "reset"
             = button_tag(_('Reset'),
               :class   => "btn btn-default",
               :alt     => t = _("Reset Changes"),
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "reset")}', false, { complete: false });")
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "reset")}', false, { complete: false });")
           - when "cancel"
             = button_tag(t = _('Cancel'),
               :class   => "btn btn-default",
               :alt     => t,
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "cancel")}', false, { complete: false });")
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}', false, { complete: false });")
 
       #buttons_off{:style => session[:changed] ? "display: none;" : ""}
         - buttons.each do |b|
@@ -57,4 +57,4 @@
              :class   => "btn btn-default",
              :alt     => t,
              :title   => t,
-             :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "cancel")}', false, { complete: false });")
+             :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}', false, { complete: false });")

--- a/app/views/layouts/_x_edit_buttons.html.haml
+++ b/app/views/layouts/_x_edit_buttons.html.haml
@@ -46,7 +46,7 @@
         :class   => "btn btn-primary",
         :alt     => t,
         :title   => t,
-        :onclick => "miqAjaxButton('#{url_for(:action => action_url, :button => "add")}', #{serialize});")
+        :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => "add")}', #{serialize});")
     - else
       - if apply_button
         = link_to(_("Apply"),
@@ -68,25 +68,25 @@
           :class   => "btn btn-primary",
           :alt     => t,
           :title   => t,
-          :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "submit")}');")
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "submit")}');")
       - elsif continue_button
         = button_tag(t = _('Continue'),
           :class   => "btn btn-primary",
           :alt     => t,
           :title   => t,
-          :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "continue")}');")
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "continue")}');")
       - elsif create_button
         = button_tag(t = _('Create'),
           :class   => "btn btn-primary",
           :alt     => t,
           :title   => t,
-          :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "create")}',true);")
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "create")}',true);")
       - elsif copy_button
         = button_tag(t = _('Copy'),
           :class   => "btn btn-primary",
           :alt     => t,
           :title   => t,
-          :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "copy")}',true);")
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "copy")}',true);")
       - else
         - if save_confirm_text
           -# Ask for confirmation before saving
@@ -94,32 +94,32 @@
             :class   => "btn btn-primary",
             :alt     => save_text,
             :title   => save_text,
-            :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
+            :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
         - else
           = button_tag(_('Save'),
             :class   => "btn btn-primary",
             :alt     => t = _("Save Changes"),
             :title   => t,
-            :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
 
       - unless no_reset
         = button_tag(_('Reset'),
           :class   => "btn btn-default",
           :alt     => t = _("Reset Changes"),
           :title   => t,
-          :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "reset")}');")
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "reset")}');")
     - if default_button
       = button_tag(_('Default'),
         :class   => "btn btn-default",
         :alt     => t = _("Reset All menus to %{product} defaults") % {:product => I18n.t('product.name')},
         :title   => t,
-        :onclick => "miqAjaxButton('#{url_for(:action => "menu_update", :button => "default")}');")
+        :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update", :button => "default")}');")
     - unless no_cancel
       = button_tag(t = _('Cancel'),
         :class   => "btn btn-default",
         :alt     => t,
         :title   => t,
-        :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "cancel")}');")
+        :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}');")
 
   #buttons_off{:style => session[:changed] ? "display: none;" : ""}
     - if record_id.blank? && multi_record.nil? && submit_button.nil? && continue_button.nil?
@@ -144,14 +144,14 @@
         :class   => "btn btn-default",
         :alt     => t = _("Reset All menus to %{product} defaults") % {:product => I18n.t('product.name')},
         :title   => t,
-        :onclick => "miqAjaxButton('#{url_for(:action => "menu_update", :button => "default")}');")
+        :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update", :button => "default")}');")
 
     - unless no_cancel
       = button_tag(t = _('Cancel'),
         :class   => "btn btn-default",
         :alt     => t,
         :title   => t,
-        :onclick => "miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "cancel")}');")
+        :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}');")
 - elsif record_id || export_button
   -# show button to go back
   #buttons
@@ -162,14 +162,14 @@
         :class   => "btn btn-default",
         :alt     => t,
         :title   => t,
-        :onclick => "miqAjaxButton('#{url_for(:action => action, :continue => true)}');")
+        :onclick => "miqAjaxButton('#{url_for_only_path(:action => action, :continue => true)}');")
     - elsif %w(drift policy_sim).include?(@sb[:action])
       -# Button to cancel policy simulation/drift and return to latest tree node
       = button_tag(t = _('Cancel'),
         :class   => "btn btn-default",
         :alt     => t,
         :title   => t,
-        :onclick => "miqAjaxButton('#{url_for(:action => "x_history", :item   => 0)}');")
+        :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item   => 0)}');")
     - else
       -# export_button
       = button_tag(_("Export"),
@@ -184,4 +184,4 @@
       :class   => "btn btn-default",
       :alt     => t,
       :title   => t,
-      :onclick => "miqAjaxButton('#{url_for(:action => "x_history", :item => 0)}');")
+      :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item => 0)}');")

--- a/app/views/layouts/_x_pagingcontrols.html.haml
+++ b/app/views/layouts/_x_pagingcontrols.html.haml
@@ -6,7 +6,7 @@
     - if action_url.include?("/")
       - action_method = action_url.split("/").first
       - action_id = action_url.split("/").last
-    - url = action_id ? url_for(:action => action_method, :id => action_id) : url_for(:action => action_url)
+    - url = action_id ? url_for_only_path(:action => action_method, :id => action_id) : url_for_only_path(:action => action_url)
     - @pc_occ ||= 0
     - @pc_occ += 1
 

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -7,7 +7,7 @@
 - if controller.send(:restful?)
   - validate = "validateClicked($event, '#{valtype}', true)"
 - else
-  - validate = "validateClicked('#{url_for(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
+  - validate = "validateClicked('#{url_for_only_path(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
 %div{"ng-show" => ng_show, "ng-controller" => "buttonGroupController"}
   = button_tag(_("Validate"),
                  :class     => "btn btn-primary btn-xs disabled",

--- a/app/views/layouts/exp_atom/_edit_count.html.haml
+++ b/app/views/layouts/exp_atom/_edit_count.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'exp_changed')
+- url = url_for_only_path(:action => 'exp_changed')
 
 -#
   Parameters:

--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'exp_changed')
+- url = url_for_only_path(:action => 'exp_changed')
 
 -# Parameters:
 -# exp_model    Model in use for this expression

--- a/app/views/layouts/exp_atom/_edit_find.html.haml
+++ b/app/views/layouts/exp_atom/_edit_find.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'exp_changed')
+- url = url_for_only_path(:action => 'exp_changed')
 
 -# Parameters:
 -# exp_model      Model in use for this expression

--- a/app/views/layouts/exp_atom/_edit_regkey.html.haml
+++ b/app/views/layouts/exp_atom/_edit_regkey.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'exp_changed')
+- url = url_for_only_path(:action => 'exp_changed')
 - input_attrs = {:maxlength => 500, "data-miq_observe" => {:interval => '.5', :url => url}.to_json}
 
 %span#chosen_regkey_span

--- a/app/views/layouts/exp_atom/_edit_tag.html.haml
+++ b/app/views/layouts/exp_atom/_edit_tag.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'exp_changed')
+- url = url_for_only_path(:action => 'exp_changed')
 
 -#
   Parameters:

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -7,7 +7,7 @@
           = ae
           %br
 - else
-  - url = url_for(:action => 'exp_changed')
+  - url = url_for_only_path(:action => 'exp_changed')
   -# Grab the model for this expression
   - exp_model = @edit[@expkey][:exp_model]
 
@@ -26,14 +26,14 @@
           - t = _('Commit expression element changes')
           %button.btn.btn-default{"data-method" => :post,
           "data-miq_sparkle_on" => true,
-          :onclick              => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'commit')}');",
+          :onclick              => "miqAjaxButton('#{url_for_only_path(:action => 'exp_button', :pressed => 'commit')}');",
           :remote               => true,
           :title                => t}
             %i.fa.fa-lg.fa-check
           - t = _("Discard expression element changes")
           %button.btn.btn-default{"data-method" => :post,
           "data-miq_sparkle_on" => true,
-          :onclick              => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'discard')}');",
+          :onclick              => "miqAjaxButton('#{url_for_only_path(:action => 'exp_button', :pressed => 'discard')}');",
           :remote               => true,
           :title                => t}
             %i.fa-lg.pficon.pficon-close

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -66,7 +66,7 @@
           - view.col_order.each do |col|
             %th
               - if %w(zone.name miq_worker.type address).include?(col)
-                - url = url_for(:action => 'list_view_filter')
+                - url = url_for_only_path(:action => 'list_view_filter')
                 - if col == "zone.name"
                   = select_tag('zone_name',
                     options_for_select([["<#{_('All')}>", "all"]] + @zones, @sb[:zone_name]),

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -43,7 +43,7 @@
                  :locals  => {:message => _("No schema found")}
 
     - else
-      - url = url_for_only_path(:action => 'fields_form_field_changed', :id => "#{@ae_class.id || 'new'}")
+      - url = url_for_only_path(:action => 'fields_form_field_changed', :id => (@ae_class.id || 'new'))
       - obs = {:interval => '.5', :url => url}.to_json
       / Edit Schema
       #form_div

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -43,7 +43,7 @@
                  :locals  => {:message => _("No schema found")}
 
     - else
-      - url = url_for(:action => 'fields_form_field_changed', :id => "#{@ae_class.id || 'new'}")
+      - url = url_for_only_path(:action => 'fields_form_field_changed', :id => "#{@ae_class.id || 'new'}")
       - obs = {:interval => '.5', :url => url}.to_json
       / Edit Schema
       #form_div

--- a/app/views/miq_ae_class/_class_form.html.haml
+++ b/app/views/miq_ae_class/_class_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@ae_class.id || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@ae_class.id || 'new'}")
 - obs = {:interval => '.5', :url => url}.to_json
 %h3
   = _('Properties')

--- a/app/views/miq_ae_class/_class_form.html.haml
+++ b/app/views/miq_ae_class/_class_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@ae_class.id || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@ae_class.id || 'new'))
 - obs = {:interval => '.5', :url => url}.to_json
 %h3
   = _('Properties')

--- a/app/views/miq_ae_class/_copy_objects_form.html.haml
+++ b/app/views/miq_ae_class/_copy_objects_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_copy_objects_field_changed', :id => @edit[:rec_id])
+- url = url_for_only_path(:action => 'form_copy_objects_field_changed', :id => @edit[:rec_id])
 = render :partial => "layouts/flash_msg"
 #form_div
   = hidden_div_if(!@edit[:new][:namespace], :id => "ae_tree_select_div") do

--- a/app/views/miq_ae_class/_inputs.html.haml
+++ b/app/views/miq_ae_class/_inputs.html.haml
@@ -1,5 +1,5 @@
 #inputs_div{:style => @sb[:squash_state] ? "display: none;" : ""}
-  - url = url_for(:action => 'form_method_field_changed', :id => "#{@ae_method.id || 'new'}")
+  - url = url_for_only_path(:action => 'form_method_field_changed', :id => "#{@ae_method.id || 'new'}")
   - obs = {:interval => '.5', :url => url}.to_json
   - prefix = row_selected_in_grid? ? "cls_" : ""
   %table.table.table-striped.table-bordered.table-hover

--- a/app/views/miq_ae_class/_inputs.html.haml
+++ b/app/views/miq_ae_class/_inputs.html.haml
@@ -1,5 +1,5 @@
 #inputs_div{:style => @sb[:squash_state] ? "display: none;" : ""}
-  - url = url_for_only_path(:action => 'form_method_field_changed', :id => "#{@ae_method.id || 'new'}")
+  - url = url_for_only_path(:action => 'form_method_field_changed', :id => (@ae_method.id || 'new'))
   - obs = {:interval => '.5', :url => url}.to_json
   - prefix = row_selected_in_grid? ? "cls_" : ""
   %table.table.table-striped.table-bordered.table-hover

--- a/app/views/miq_ae_class/_instance_form.html.haml
+++ b/app/views/miq_ae_class/_instance_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_instance_field_changed', :id => "#{@ae_inst.id || "new"}")
+- url = url_for_only_path(:action => 'form_instance_field_changed', :id => "#{@ae_inst.id || "new"}")
 - obs = {:interval => '.5', :url => url}.to_json
 %h3
   = _('Main Info')

--- a/app/views/miq_ae_class/_instance_form.html.haml
+++ b/app/views/miq_ae_class/_instance_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_instance_field_changed', :id => "#{@ae_inst.id || "new"}")
+- url = url_for_only_path(:action => 'form_instance_field_changed', :id => (@ae_inst.id || "new"))
 - obs = {:interval => '.5', :url => url}.to_json
 %h3
   = _('Main Info')

--- a/app/views/miq_ae_class/_method_data.html.haml
+++ b/app/views/miq_ae_class/_method_data.html.haml
@@ -1,7 +1,5 @@
-- url = url_for_only_path(:action => 'form_method_field_changed', :id => "#{@ae_method.id || 'new'}")
-- url_one_trans = url_for_only_path(:action => 'form_method_field_changed',
-  :id                             => "#{@ae_method.id || 'new'}",
-  :transOne                       => '1')
+- url = url_for_only_path(:action => 'form_method_field_changed', :id => (@ae_method.id || 'new'))
+- url_one_trans = url_for_only_path(:action => 'form_method_field_changed', :id => (@ae_method.id || 'new'), :transOne => '1')
 #form_div
   - if @edit[:new][:location] == "inline"
     = text_area_tag("#{field_name}_data",

--- a/app/views/miq_ae_class/_method_data.html.haml
+++ b/app/views/miq_ae_class/_method_data.html.haml
@@ -1,5 +1,5 @@
-- url = url_for(:action => 'form_method_field_changed', :id => "#{@ae_method.id || 'new'}")
-- url_one_trans = url_for(:action => 'form_method_field_changed',
+- url = url_for_only_path(:action => 'form_method_field_changed', :id => "#{@ae_method.id || 'new'}")
+- url_one_trans = url_for_only_path(:action => 'form_method_field_changed',
   :id                             => "#{@ae_method.id || 'new'}",
   :transOne                       => '1')
 #form_div

--- a/app/views/miq_ae_class/_method_form.html.haml
+++ b/app/views/miq_ae_class/_method_form.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "methods"
-- url = url_for_only_path(:action => 'form_method_field_changed', :id => "#{@ae_method.id || 'new'}")
+- url = url_for_only_path(:action => 'form_method_field_changed', :id => (@ae_method.id || 'new'))
 - obs = {:interval => '.5', :url => url}.to_json
   %h3
     = _('Main Info')

--- a/app/views/miq_ae_class/_method_form.html.haml
+++ b/app/views/miq_ae_class/_method_form.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "methods"
-- url = url_for(:action => 'form_method_field_changed', :id => "#{@ae_method.id || 'new'}")
+- url = url_for_only_path(:action => 'form_method_field_changed', :id => "#{@ae_method.id || 'new'}")
 - obs = {:interval => '.5', :url => url}.to_json
   %h3
     = _('Main Info')
@@ -56,7 +56,7 @@
       %tr
         %th
           - icon = @sb[:squash_state] ? "down" : "up"
-          - url2 = url_for(:action => 'expand_toggle', :id => "exp_collapse")
+          - url2 = url_for_only_path(:action => 'expand_toggle', :id => "exp_collapse")
           %button.btn.btn-default{:title => (@sb[:squash_state] ? _("Show Input Parameters") : _("Hide Input Parameters")),
                   "data-miq_sparkle_on" => true,
                   :remote               => true,

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -40,7 +40,7 @@
       });
 
   - else
-    - url = url_for_only_path(:action => 'form_ns_field_changed', :id => "#{@ae_ns.id || 'new'}")
+    - url = url_for_only_path(:action => 'form_ns_field_changed', :id => (@ae_ns.id || 'new'))
     = render :partial => "layouts/flash_msg"
     #form_ns_div
       %h3

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -40,7 +40,7 @@
       });
 
   - else
-    - url = url_for(:action => 'form_ns_field_changed', :id => "#{@ae_ns.id || 'new'}")
+    - url = url_for_only_path(:action => 'form_ns_field_changed', :id => "#{@ae_ns.id || 'new'}")
     = render :partial => "layouts/flash_msg"
     #form_ns_div
       %h3

--- a/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
+- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => (@record.id || 'new'))
 #dialog_field_div
   %h3
     = _('Element Information')

--- a/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
+- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
 #dialog_field_div
   %h3
     = _('Element Information')

--- a/app/views/miq_ae_customization/_dialog_group_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_group_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
+- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
 %h3
   = _('Box Information')
 .form-horizontal

--- a/app/views/miq_ae_customization/_dialog_group_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_group_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
+- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => (@record.id || 'new'))
 %h3
   = _('Box Information')
 .form-horizontal

--- a/app/views/miq_ae_customization/_dialog_info_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_info_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
+- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => (@record.id || 'new'))
 -# dialog info form fields
 %h3
   = _('Dialog Information')

--- a/app/views/miq_ae_customization/_dialog_info_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_info_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
+- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
 -# dialog info form fields
 %h3
   = _('Dialog Information')

--- a/app/views/miq_ae_customization/_dialog_tab_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_tab_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
+- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => (@record.id || 'new'))
 %h3
   = _('Tab Information')
 .form-horizontal

--- a/app/views/miq_ae_customization/_dialog_tab_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_tab_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
+- url = url_for_only_path(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
 %h3
   = _('Tab Information')
 .form-horizontal

--- a/app/views/miq_ae_customization/_old_dialogs_form.html.haml
+++ b/app/views/miq_ae_customization/_old_dialogs_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'old_dialogs_form_field_changed', :id => "#{@dialog.id || 'new'}")
+- url = url_for_only_path(:action => 'old_dialogs_form_field_changed', :id => (@dialog.id || 'new'))
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/miq_ae_customization/_old_dialogs_form.html.haml
+++ b/app/views/miq_ae_customization/_old_dialogs_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'old_dialogs_form_field_changed', :id => "#{@dialog.id || 'new'}")
+- url = url_for_only_path(:action => 'old_dialogs_form_field_changed', :id => "#{@dialog.id || 'new'}")
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/miq_capacity/_bottlenecks_options.html.haml
+++ b/app/views/miq_capacity/_bottlenecks_options.html.haml
@@ -1,4 +1,4 @@
-- url = url_for :action => 'bottleneck_tl_chooser'
+- url = url_for_only_path :action => 'bottleneck_tl_chooser'
 #tl_options_div
   %h3
     = _('Options')

--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'planning_option_changed')
+- url = url_for_only_path(:action => 'planning_option_changed')
 -# Div to hold the planning options
 #planning_options_div
   = render :partial => "layouts/flash_msg"

--- a/app/views/miq_capacity/_planning_summary.html.haml
+++ b/app/views/miq_capacity/_planning_summary.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'planning_option_changed')
+- url = url_for_only_path(:action => 'planning_option_changed')
 #planning_summary_div
   = render :partial => "layouts/flash_msg"
   - if @perf_record

--- a/app/views/miq_capacity/_utilization_options.html.haml
+++ b/app/views/miq_capacity/_utilization_options.html.haml
@@ -1,5 +1,5 @@
 - cap_type ||= "details"
-- url = url_for(:action => 'util_chart_chooser', :id => @record.id)
+- url = url_for_only_path(:action => 'util_chart_chooser', :id => @record.id)
 %div{:id => "capacity_#{cap_type}_options_div", :onclick => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
   %h3
     = _('Options')

--- a/app/views/miq_capacity/utilization.html.haml
+++ b/app/views/miq_capacity/utilization.html.haml
@@ -2,4 +2,4 @@
   = render :partial => "utilization_tabs"
 
 :javascript
-  ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action)}');"
+  ManageIQ.afterOnload = "miqAsyncAjax('#{url_for_only_path(:action => @ajax_action)}');"

--- a/app/views/miq_policy/_action_details.html.haml
+++ b/app/views/miq_policy/_action_details.html.haml
@@ -7,7 +7,7 @@
       .form-horizontal
         - if @edit
           -# Don't show description unless in edit mode
-          - url = url_for(:action => 'action_field_changed', :id => "#{@action.id || 'new'}")
+          - url = url_for_only_path(:action => 'action_field_changed', :id => "#{@action.id || 'new'}")
           .form-group
             %label.col-md-2.control-label
               = _('Description')

--- a/app/views/miq_policy/_action_details.html.haml
+++ b/app/views/miq_policy/_action_details.html.haml
@@ -7,7 +7,7 @@
       .form-horizontal
         - if @edit
           -# Don't show description unless in edit mode
-          - url = url_for_only_path(:action => 'action_field_changed', :id => "#{@action.id || 'new'}")
+          - url = url_for_only_path(:action => 'action_field_changed', :id => (@action.id || 'new'))
           .form-group
             %label.col-md-2.control-label
               = _('Description')

--- a/app/views/miq_policy/_action_options.html.haml
+++ b/app/views/miq_policy/_action_options.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'action_field_changed', :id => "#{@action.id || 'new'}")
+- url = url_for_only_path(:action => 'action_field_changed', :id => "#{@action.id || 'new'}")
 - observe_with_interval = {:interval => '.5', :url => url}.to_json
 - observe = {:url => url}.to_json
 #action_options_div

--- a/app/views/miq_policy/_action_options.html.haml
+++ b/app/views/miq_policy/_action_options.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'action_field_changed', :id => "#{@action.id || 'new'}")
+- url = url_for_only_path(:action => 'action_field_changed', :id => (@action.id || 'new'))
 - observe_with_interval = {:interval => '.5', :url => url}.to_json
 - observe = {:url => url}.to_json
 #action_options_div

--- a/app/views/miq_policy/_alert_builtin_exp.html.haml
+++ b/app/views/miq_policy/_alert_builtin_exp.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
+  - url = url_for_only_path(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
 .form-group
   - case option[:name]

--- a/app/views/miq_policy/_alert_builtin_exp.html.haml
+++ b/app/views/miq_policy/_alert_builtin_exp.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for_only_path(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
+  - url = url_for_only_path(:action => 'alert_field_changed', :id => (@alert.id || 'new'))
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
 .form-group
   - case option[:name]

--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
+  - url = url_for_only_path(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
   - observe = {:url => url}.to_json
 #alert_details_div
   - if @assign

--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for_only_path(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
+  - url = url_for_only_path(:action => 'alert_field_changed', :id => (@alert.id || 'new'))
   - observe = {:url => url}.to_json
 #alert_details_div
   - if @assign

--- a/app/views/miq_policy/_alert_evm_event.html.haml
+++ b/app/views/miq_policy/_alert_evm_event.html.haml
@@ -3,7 +3,7 @@
     = _('Timeline Event')
   .form-horizontal
     - if @edit
-      - url = url_for(:action => 'alert_field_changed',  :id => "#{@alert.id || 'new'}")
+      - url = url_for_only_path(:action => 'alert_field_changed',  :id => "#{@alert.id || 'new'}")
       .form-group
         %label.col-md-2.control-label
           = _('Show on Timeline')

--- a/app/views/miq_policy/_alert_evm_event.html.haml
+++ b/app/views/miq_policy/_alert_evm_event.html.haml
@@ -3,7 +3,7 @@
     = _('Timeline Event')
   .form-horizontal
     - if @edit
-      - url = url_for_only_path(:action => 'alert_field_changed',  :id => "#{@alert.id || 'new'}")
+      - url = url_for_only_path(:action => 'alert_field_changed',  :id => (@alert.id || 'new'))
       .form-group
         %label.col-md-2.control-label
           = _('Show on Timeline')

--- a/app/views/miq_policy/_alert_mgmt_event.html.haml
+++ b/app/views/miq_policy/_alert_mgmt_event.html.haml
@@ -3,7 +3,7 @@
     = _('Management Event')
   .form-horizontal
     - if @edit
-      - url = url_for_only_path(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
+      - url = url_for_only_path(:action => 'alert_field_changed', :id => (@alert.id || 'new'))
       .form-group
         %label.control-label.col-md-2
           = _('Send a Management Event')
@@ -14,7 +14,7 @@
             "data-miq_observe_checkbox" => {:url => url}.to_json)
       - if @edit[:new][:send_event]
         .form-group
-          %label.control-label.col-md-2 
+          %label.control-label.col-md-2
             = _('Event Name')
           .col-md-8
             = text_field_tag("event_name", @edit[:new][:event_name],

--- a/app/views/miq_policy/_alert_mgmt_event.html.haml
+++ b/app/views/miq_policy/_alert_mgmt_event.html.haml
@@ -3,7 +3,7 @@
     = _('Management Event')
   .form-horizontal
     - if @edit
-      - url = url_for(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
+      - url = url_for_only_path(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
       .form-group
         %label.control-label.col-md-2
           = _('Send a Management Event')

--- a/app/views/miq_policy/_alert_profile_assign.html.haml
+++ b/app/views/miq_policy/_alert_profile_assign.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'alert_profile_assign_changed')
+- url = url_for_only_path(:action => 'alert_profile_assign_changed')
 #alert_profile_assign_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/miq_policy/_alert_profile_details.html.haml
+++ b/app/views/miq_policy/_alert_profile_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for_only_path(:action => 'alert_profile_field_changed', :id => "#{@alert_profile.id || 'new'}")
+  - url = url_for_only_path(:action => 'alert_profile_field_changed', :id => (@alert_profile.id || 'new'))
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
 #alert_profile_details_div
   - if @assign

--- a/app/views/miq_policy/_alert_profile_details.html.haml
+++ b/app/views/miq_policy/_alert_profile_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for(:action => 'alert_profile_field_changed', :id => "#{@alert_profile.id || 'new'}")
+  - url = url_for_only_path(:action => 'alert_profile_field_changed', :id => "#{@alert_profile.id || 'new'}")
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
 #alert_profile_details_div
   - if @assign

--- a/app/views/miq_policy/_alert_snmp.html.haml
+++ b/app/views/miq_policy/_alert_snmp.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
+  - url = url_for_only_path(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
   - observe = {:url => url}.to_json
 #alert_snmp_div

--- a/app/views/miq_policy/_alert_snmp.html.haml
+++ b/app/views/miq_policy/_alert_snmp.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for_only_path(:action => 'alert_field_changed', :id => "#{@alert.id || 'new'}")
+  - url = url_for_only_path(:action => 'alert_field_changed', :id => (@alert.id || 'new'))
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
   - observe = {:url => url}.to_json
 #alert_snmp_div

--- a/app/views/miq_policy/_condition_details.html.haml
+++ b/app/views/miq_policy/_condition_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for(:action => 'condition_field_changed', :id => "#{@condition.id || 'new'}")
+  - url = url_for_only_path(:action => 'condition_field_changed', :id => "#{@condition.id || 'new'}")
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
 #condition_details_div
   - if @condition

--- a/app/views/miq_policy/_condition_details.html.haml
+++ b/app/views/miq_policy/_condition_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for_only_path(:action => 'condition_field_changed', :id => "#{@condition.id || 'new'}")
+  - url = url_for_only_path(:action => 'condition_field_changed', :id => (@condition.id || 'new'))
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
 #condition_details_div
   - if @condition

--- a/app/views/miq_policy/_export.html.haml
+++ b/app/views/miq_policy/_export.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'export_field_changed')
+- url = url_for_only_path(:action => 'export_field_changed')
 #profile_export_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for(:action => 'policy_field_changed', :id => "#{@policy.id || 'new'}")
+  - url = url_for_only_path(:action => 'policy_field_changed', :id => "#{@policy.id || 'new'}")
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
 #policy_details_div
   - if @policy
@@ -100,7 +100,7 @@
                                             "data-method" => :post,
                                             "data-miq_sparkle_on"  => true,
                                             "data-miq_sparkle_off" => true,
-                                            "data-click_url" => {:url => url_for(:action => 'policy_edit',
+                                            "data-click_url" => {:url => url_for_only_path(:action => 'policy_edit',
                                                                                  :button => action,
                                                                                  :id => @policy)}.to_json}
                       %i.fa{:class => arrow_style}

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for_only_path(:action => 'policy_field_changed', :id => "#{@policy.id || 'new'}")
+  - url = url_for_only_path(:action => 'policy_field_changed', :id => (@policy.id || 'new'))
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
 #policy_details_div
   - if @policy

--- a/app/views/miq_policy/_profile_details.html.haml
+++ b/app/views/miq_policy/_profile_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for_only_path(:action => 'profile_field_changed', :id => "#{@profile.id || 'new'}")
+  - url = url_for_only_path(:action => 'profile_field_changed', :id => (@profile.id || 'new'))
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
 - if @profile
   #profile_info_div

--- a/app/views/miq_policy/_profile_details.html.haml
+++ b/app/views/miq_policy/_profile_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for(:action => 'profile_field_changed', :id => "#{@profile.id || 'new'}")
+  - url = url_for_only_path(:action => 'profile_field_changed', :id => "#{@profile.id || 'new'}")
   - observe_with_interval = {:interval => '.5', :url => url}.to_json
 - if @profile
   #profile_info_div

--- a/app/views/miq_policy/_rsop_form.html.haml
+++ b/app/views/miq_policy/_rsop_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'rsop_option_changed')
+- url = url_for_only_path(:action => 'rsop_option_changed')
 - observe = {:url => url}.to_json
 #rsop_form_div
   %table

--- a/app/views/miq_policy/_rsop_results.html.haml
+++ b/app/views/miq_policy/_rsop_results.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'rsop_show_options')
+- url = url_for_only_path(:action => 'rsop_show_options')
 - observe = {:url => url}.to_json
 #rsop_results_div
   = render :partial => "layouts/flash_msg"

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -6,7 +6,7 @@
   %label
     - id = @edit[:req_id] || "new"
     %input{:type => "checkbox",
-           :onclick => "miqAjax('" + url_for({:action => "vm_pre_prov", :id => id.to_s, :hide_deprecated_templates => !@edit[:hide_deprecated_templates]}) + "')",
+           :onclick => "miqAjax('" + url_for_only_path({:action => "vm_pre_prov", :id => id.to_s, :hide_deprecated_templates => !@edit[:hide_deprecated_templates]}) + "')",
            :checked => @edit[:hide_deprecated_templates]}
       = _('Hide deprecated')
   %table.table.table-bordered.table-hover.table-striped.table-selectable

--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'prov_field_changed', :id => "#{@edit[:req_id] || 'new'}") if @edit
+- url = url_for_only_path(:action => 'prov_field_changed', :id => "#{@edit[:req_id] || 'new'}") if @edit
 - options = @options ? @options : @edit[:new]
 - draw_fields = true
 - counter = 1

--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'prov_field_changed', :id => "#{@edit[:req_id] || 'new'}") if @edit
+- url = url_for_only_path(:action => 'prov_field_changed', :id => (@edit[:req_id] || 'new')) if @edit
 - options = @options ? @options : @edit[:new]
 - draw_fields = true
 - counter = 1

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'prov_field_changed', :id => "#{@edit[:req_id] || 'new'}") if @edit
+- url = url_for_only_path(:action => 'prov_field_changed', :id => (@edit[:req_id] || 'new')) if @edit
 -# wf          The workflow object currently in use
 -# dialog      Dialog name (symbol)
 -# field       Field name (symbol)

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'prov_field_changed', :id => "#{@edit[:req_id] || 'new'}") if @edit
+- url = url_for_only_path(:action => 'prov_field_changed', :id => "#{@edit[:req_id] || 'new'}") if @edit
 -# wf          The workflow object currently in use
 -# dialog      Dialog name (symbol)
 -# field       Field name (symbol)
@@ -133,7 +133,7 @@
                              :class   => "btn btn-primary",
                              :alt     => t = _("LDAP Group Lookup"),
                              :title   => t,
-                             :onclick => "miqAjaxButton('#{url_for(:controller => 'miq_request',
+                             :onclick => "miqAjaxButton('#{url_for_only_path(:controller => 'miq_request',
                                                                    :action     => 'retrieve_email',
                                                                    :field      => fh[:pressed][:method],
                                                                    :button     => 'submit')}');")

--- a/app/views/miq_request/_prov_form_buttons.html.haml
+++ b/app/views/miq_request/_prov_form_buttons.html.haml
@@ -17,7 +17,7 @@
               - text = _("Continue this provisioning request")
             - action       = button == :continue ? 'prov_continue' : 'prov_edit'
             - button_class = button == :cancel ? 'default' : 'primary'
-            - url          = url_for(:action => action, :id => "#{@edit[:req_id] || 'new'}", :button => button)
+            - url          = url_for_only_path(:action => action, :id => "#{@edit[:req_id] || 'new'}", :button => button)
             = button_tag(button_name,
               :class   => "btn btn-#{button_class}",
               :alt     => text,
@@ -32,7 +32,7 @@
             - when :submit
               = button_tag(_("Submit"), :class => "btn btn-primary disabled")
             - when :cancel
-              - url = url_for(:action => 'prov_edit', :id => "#{@edit[:req_id] || 'new'}", :button => button)
+              - url = url_for_only_path(:action => 'prov_edit', :id => "#{@edit[:req_id] || 'new'}", :button => button)
               = button_tag(_("Cancel"),
                 :class   => "btn btn-default",
                 :alt     => (t = _("Cancel this provisioning request")),

--- a/app/views/miq_request/_prov_form_buttons.html.haml
+++ b/app/views/miq_request/_prov_form_buttons.html.haml
@@ -17,7 +17,7 @@
               - text = _("Continue this provisioning request")
             - action       = button == :continue ? 'prov_continue' : 'prov_edit'
             - button_class = button == :cancel ? 'default' : 'primary'
-            - url          = url_for_only_path(:action => action, :id => "#{@edit[:req_id] || 'new'}", :button => button)
+            - url          = url_for_only_path(:action => action, :id => (@edit[:req_id] || 'new'), :button => button)
             = button_tag(button_name,
               :class   => "btn btn-#{button_class}",
               :alt     => text,
@@ -32,7 +32,7 @@
             - when :submit
               = button_tag(_("Submit"), :class => "btn btn-primary disabled")
             - when :cancel
-              - url = url_for_only_path(:action => 'prov_edit', :id => "#{@edit[:req_id] || 'new'}", :button => button)
+              - url = url_for_only_path(:action => 'prov_edit', :id => (@edit[:req_id] || 'new'), :button => button)
               = button_tag(_("Cancel"),
                 :class   => "btn btn-default",
                 :alt     => (t = _("Cancel this provisioning request")),

--- a/app/views/miq_request/_prov_options.html.haml
+++ b/app/views/miq_request/_prov_options.html.haml
@@ -1,5 +1,5 @@
 = render :partial => "layouts/flash_msg"
-- url = url_for(:action => 'prov_change_options')
+- url = url_for_only_path(:action => 'prov_change_options')
 #prov_options_div
   %h3
     = _("Filter By")

--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -1,5 +1,5 @@
 - if @edit && @edit[:stamp_typ]
-  - url = url_for(:action => 'stamp_field_changed', :id => @edit[:request].id)
+  - url = url_for_only_path(:action => 'stamp_field_changed', :id => @edit[:request].id)
 #request_div
   %h3
     = _("Request Details")

--- a/app/views/miq_request/_request_details.html.haml
+++ b/app/views/miq_request/_request_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit && @edit[:stamp_typ]
-  - url = url_for(:action => 'stamp_field_changed')
+  - url = url_for_only_path(:action => 'stamp_field_changed')
 
 %fieldset
   %h3

--- a/app/views/miq_task/_tasks_options.html.haml
+++ b/app/views/miq_task/_tasks_options.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'tasks_change_options')
+- url = url_for_only_path(:action => 'tasks_change_options')
 #tasks_options_div
   %h3
     = _("Filter By")

--- a/app/views/ops/_ap_form.html.haml
+++ b/app/views/ops/_ap_form.html.haml
@@ -1,5 +1,5 @@
 - if x_active_tree == :settings_tree
-  - url = url_for_only_path(:action => 'ap_form_field_changed', :id => "#{@scan.id || "new"}")
+  - url = url_for_only_path(:action => 'ap_form_field_changed', :id => (@scan.id || "new"))
   #ap_form_div
     .form-horizontal
       = render :partial => "layouts/flash_msg"

--- a/app/views/ops/_ap_form.html.haml
+++ b/app/views/ops/_ap_form.html.haml
@@ -1,5 +1,5 @@
 - if x_active_tree == :settings_tree
-  - url = url_for(:action => 'ap_form_field_changed', :id => "#{@scan.id || "new"}")
+  - url = url_for_only_path(:action => 'ap_form_field_changed', :id => "#{@scan.id || "new"}")
   #ap_form_div
     .form-horizontal
       = render :partial => "layouts/flash_msg"

--- a/app/views/ops/_ap_form_file.html.haml
+++ b/app/views/ops/_ap_form_file.html.haml
@@ -1,5 +1,5 @@
 - scan_id = "#{@scan.id || 'new'}"
-- url = url_for(:action => 'ap_edit',
+- url = url_for_only_path(:action => 'ap_edit',
                 :id     => scan_id)
 %h3= _("File Entry")
 %table.table.table-striped.table-bordered.table-hover

--- a/app/views/ops/_ap_form_nteventlog.html.haml
+++ b/app/views/ops/_ap_form_nteventlog.html.haml
@@ -1,5 +1,5 @@
 - scan_id = "#{@scan.id || 'new'}"
-- url = url_for(:action => 'ap_edit',
+- url = url_for_only_path(:action => 'ap_edit',
                 :id     => scan_id)
 %h3= _("Event Log Entry")
 %table.table.table-striped.table-bordered.table-hover
@@ -50,7 +50,7 @@
             "value"    => session[:nteventlog_data][:numdays],
             :style     => "width: 100%;")
         %td.action-cell
-          - url = url_for(:action    => 'ap_edit',
+          - url = url_for_only_path(:action    => 'ap_edit',
                           :id        => scan_id,
                           :accept    => 'accept',
                           :item_type => 'nteventlog')
@@ -93,7 +93,7 @@
                 :style     => "width: 100%;")
 
             %td.action-cell
-              - url = url_for(:action     => 'ap_edit',
+              - url = url_for_only_path(:action     => 'ap_edit',
                               :id         => scan_id,
                               :accept     => 'accept',
                               :edit_entry => 'edit_entry_nteventlog',

--- a/app/views/ops/_ap_form_registry.html.haml
+++ b/app/views/ops/_ap_form_registry.html.haml
@@ -1,5 +1,5 @@
 - scan_id = "#{@scan.id || 'new'}"
-- url = url_for(:action => 'ap_edit',
+- url = url_for_only_path(:action => 'ap_edit',
                 :id     => scan_id)
 %h3= _("Registry Entry")
 %table.table.table-striped.table-bordered.table-hover
@@ -35,7 +35,7 @@
             :style     => "width: 100%;")
 
         %td.action-cell
-          - url = url_for(:action => 'ap_edit',
+          - url = url_for_only_path(:action => 'ap_edit',
                           :id     => scan_id,
                           :accept => 'accept',
                           :item_type => 'registry')
@@ -64,7 +64,7 @@
                 "value"    => session[:reg_data][:value],
                 :style     => "width: 100%;")
             %td.action-cell
-              - url = url_for(:action => 'ap_edit',
+              - url = url_for_only_path(:action => 'ap_edit',
                           :id         => scan_id,
                           :accept     => 'accept',
                           :edit_entry => 'edit_entry',

--- a/app/views/ops/_ap_form_set.html.haml
+++ b/app/views/ops/_ap_form_set.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'ap_form_field_changed', :item_type => "category", :id => "#{@scan.id || "new"}")
+- url = url_for_only_path(:action => 'ap_form_field_changed', :item_type => "category", :id => (@scan.id || "new"))
 #form_div
   %h3
     = _("Category Selection")

--- a/app/views/ops/_ap_form_set.html.haml
+++ b/app/views/ops/_ap_form_set.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'ap_form_field_changed', :item_type => "category", :id => "#{@scan.id || "new"}")
+- url = url_for_only_path(:action => 'ap_form_field_changed', :item_type => "category", :id => "#{@scan.id || "new"}")
 #form_div
   %h3
     = _("Category Selection")

--- a/app/views/ops/_category_form.html.haml
+++ b/app/views/ops/_category_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'category_field_changed', :id => "#{@category && @category.id ? @category.id : "new"}")
+- url = url_for_only_path(:action => 'category_field_changed', :id => (@category && @category.id ? @category.id : "new"))
 #main_div
   %h3= _("Category Information")
   = form_tag({:action => 'category_update'},

--- a/app/views/ops/_category_form.html.haml
+++ b/app/views/ops/_category_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'category_field_changed', :id => "#{@category && @category.id ? @category.id : "new"}")
+- url = url_for_only_path(:action => 'category_field_changed', :id => "#{@category && @category.id ? @category.id : "new"}")
 #main_div
   %h3= _("Category Information")
   = form_tag({:action => 'category_update'},

--- a/app/views/ops/_classification_entry.html.haml
+++ b/app/views/ops/_classification_entry.html.haml
@@ -1,5 +1,5 @@
 - if edit
-  - url = url_for(:action => "ce_accept", :id => "accept")
+  - url = url_for_only_path(:action => "ce_accept", :id => "accept")
   - if entry == "new"
     %tr#new_tr{:class => cycle('row0', 'row1')}
       %td

--- a/app/views/ops/_diagnostics_cu_repair_tab.html.haml
+++ b/app/views/ops/_diagnostics_cu_repair_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "diagnostics_cu_repair"
-  - url = url_for(:action => 'cu_repair_field_changed')
+  - url = url_for_only_path(:action => 'cu_repair_field_changed')
   - url_json = {:url => url}.to_json
   -# Create from/to date JS vars to limit calendar starting from
   :javascript

--- a/app/views/ops/_diagnostics_utilization_tab.html.haml
+++ b/app/views/ops/_diagnostics_utilization_tab.html.haml
@@ -11,4 +11,4 @@
     = render :partial => 'layouts/info_msg', :locals => {:message => msg}
   - if @ajax_action
     :javascript
-      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for :action => @ajax_action, :id => @record}');"
+      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for_only_path :action => @ajax_action, :id => @record}');"

--- a/app/views/ops/_label_tag_mapping_form.html.haml
+++ b/app/views/ops/_label_tag_mapping_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'label_tag_mapping_field_changed', :id => @lt_map && @lt_map.id ? @lt_map.id.to_s : "new")
+- url = url_for_only_path(:action => 'label_tag_mapping_field_changed', :id => @lt_map && @lt_map.id ? @lt_map.id.to_s : "new")
 #main_div
   = render :partial => "layouts/flash_msg"
   = form_tag({:action => 'label_tag_mapping_update'},

--- a/app/views/ops/_ldap_auth_users.html.haml
+++ b/app/views/ops/_ldap_auth_users.html.haml
@@ -5,7 +5,7 @@
         %label.col-md-2.control-label
           = _("LDAP Groups for User")
         .col-md-8
-          - url = url_for(:action => 'rbac_group_field_changed', :id => "#{@edit[:group_id] || "new"}")
+          - url = url_for_only_path(:action => 'rbac_group_field_changed', :id => "#{@edit[:group_id] || "new"}")
           - options = options_for_select(["<Choose>"] + @edit[:ldap_groups_by_user].uniq.sort, @edit[:selected_ldap_groups_by_user])
           - attributes = {"data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker"}
           = select_tag('ldap_groups_user', options, attributes)                                                  |

--- a/app/views/ops/_ldap_auth_users.html.haml
+++ b/app/views/ops/_ldap_auth_users.html.haml
@@ -5,7 +5,7 @@
         %label.col-md-2.control-label
           = _("LDAP Groups for User")
         .col-md-8
-          - url = url_for_only_path(:action => 'rbac_group_field_changed', :id => "#{@edit[:group_id] || "new"}")
+          - url = url_for_only_path(:action => 'rbac_group_field_changed', :id => (@edit[:group_id] || "new"))
           - options = options_for_select(["<Choose>"] + @edit[:ldap_groups_by_user].uniq.sort, @edit[:selected_ldap_groups_by_user])
           - attributes = {"data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker"}
           = select_tag('ldap_groups_user', options, attributes)                                                  |

--- a/app/views/ops/_ldap_domain_form.html.haml
+++ b/app/views/ops/_ldap_domain_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'ldap_domain_form_field_changed', :id => @edit[:ldap_domain_id] || "new")
+- url = url_for_only_path(:action => 'ldap_domain_form_field_changed', :id => @edit[:ldap_domain_id] || "new")
 #form_div
   = form_tag({:action => 'ldap_domain_edit',
               :id     => @edit[:ldap_domain_id] || "new"},

--- a/app/views/ops/_ldap_forest_entries.html.haml
+++ b/app/views/ops/_ldap_forest_entries.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'forest_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
+- url = url_for_only_path(:action => 'forest_form_field_changed', :id => @sb[:active_tab].split('_').last)
 #forest_entries_div
   %h3= _("Trusted Forest Settings")
   = form_tag({:action => 'forest_accept',

--- a/app/views/ops/_ldap_forest_entries.html.haml
+++ b/app/views/ops/_ldap_forest_entries.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'forest_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
+- url = url_for_only_path(:action => 'forest_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
 #forest_entries_div
   %h3= _("Trusted Forest Settings")
   = form_tag({:action => 'forest_accept',

--- a/app/views/ops/_ldap_region_form.html.haml
+++ b/app/views/ops/_ldap_region_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'ldap_region_form_field_changed', :id => @edit[:ldap_region_id] || "new")
+- url = url_for_only_path(:action => 'ldap_region_form_field_changed', :id => @edit[:ldap_region_id] || "new")
 #form_div
   = render :partial => "layouts/flash_msg"
   %fieldset

--- a/app/views/ops/_ldap_server_entry.html.haml
+++ b/app/views/ops/_ldap_server_entry.html.haml
@@ -39,8 +39,7 @@
                      "value"    => entry[:hostname],
                      :style     => "width: 100%;")
       %td
-        - url1 = url_for_only_path(:action => 'ldap_entry_changed',
-                         :id     => "#{@edit[:ldap_domain_id] || "new"}")
+        - url1 = url_for_only_path(:action => 'ldap_entry_changed', :id => (@edit[:ldap_domain_id] || "new"))
         = select_tag('entry_mode',
                      options_for_select([[_("LDAP"), 'ldap'], [_("LDAPS"), 'ldaps']], entry[:mode]),
                      "data-miq_observe" => {:url => url1}.to_json)

--- a/app/views/ops/_ldap_server_entry.html.haml
+++ b/app/views/ops/_ldap_server_entry.html.haml
@@ -12,7 +12,7 @@
       %td
         = text_field("entry", "hostname", :maxlength => MAX_NAME_LEN, :style => "width: 100%;")
       %td
-        - url1 = url_for(:action => 'ldap_entry_changed',
+        - url1 = url_for_only_path(:action => 'ldap_entry_changed',
                          :id     => @edit[:ldap_domain_id] || "new")
         = select_tag('entry_mode',
                      options_for_select([[_("LDAP"), 'ldap'], [_("LDAPS"), 'ldaps']], "ldaps"),
@@ -39,7 +39,7 @@
                      "value"    => entry[:hostname],
                      :style     => "width: 100%;")
       %td
-        - url1 = url_for(:action => 'ldap_entry_changed',
+        - url1 = url_for_only_path(:action => 'ldap_entry_changed',
                          :id     => "#{@edit[:ldap_domain_id] || "new"}")
         = select_tag('entry_mode',
                      options_for_select([[_("LDAP"), 'ldap'], [_("LDAPS"), 'ldaps']], entry[:mode]),

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -1,6 +1,5 @@
 - if @edit
-  - url = url_for_only_path(:action => 'rbac_group_field_changed',
-                  :id     => "#{@edit[:group_id] || "new"}")
+  - url = url_for_only_path(:action => 'rbac_group_field_changed', :id => (@edit[:group_id] || "new"))
   - combo_url = "/ops/rbac_group_field_changed/#{@edit[:group_id] || 'new'}"
 = render :partial => "layouts/flash_msg"
 #main_div

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for(:action => 'rbac_group_field_changed',
+  - url = url_for_only_path(:action => 'rbac_group_field_changed',
                   :id     => "#{@edit[:group_id] || "new"}")
   - combo_url = "/ops/rbac_group_field_changed/#{@edit[:group_id] || 'new'}"
 = render :partial => "layouts/flash_msg"

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -1,6 +1,5 @@
 - if @edit
-  - url = url_for_only_path(:action => 'rbac_role_field_changed',
-                  :id     => "#{@edit[:role_id] || "new"}")
+  - url = url_for_only_path(:action => 'rbac_role_field_changed', :id => (@edit[:role_id] || "new"))
 = render :partial => "layouts/flash_msg"
 #main_div
   .row

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -1,5 +1,5 @@
 - if @edit
-  - url = url_for(:action => 'rbac_role_field_changed',
+  - url = url_for_only_path(:action => 'rbac_role_field_changed',
                   :id     => "#{@edit[:role_id] || "new"}")
 = render :partial => "layouts/flash_msg"
 #main_div

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -4,8 +4,7 @@
 - pfx ||= ""
 
 - if @edit
-  - url = url_for_only_path(:action => 'rbac_user_field_changed',
-                  :id     => "#{@edit[:user_id] || "new"}")
+  - url = url_for_only_path(:action => 'rbac_user_field_changed', :id => (@edit[:user_id] || "new"))
 - observe_url_json = {:interval => '.5', :url => url}.to_json
 = render :partial => "layouts/flash_msg"
 - disabled = @edit && @edit[:new][:userid] == "admin"

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -4,7 +4,7 @@
 - pfx ||= ""
 
 - if @edit
-  - url = url_for(:action => 'rbac_user_field_changed',
+  - url = url_for_only_path(:action => 'rbac_user_field_changed',
                   :id     => "#{@edit[:user_id] || "new"}")
 - observe_url_json = {:interval => '.5', :url => url}.to_json
 = render :partial => "layouts/flash_msg"

--- a/app/views/ops/_settings_advanced_tab.html.haml
+++ b/app/views/ops/_settings_advanced_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_advanced"
-  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
+  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => @sb[:active_tab].split('_').last)
   = render :partial => "layouts/flash_msg"
   #form_div
     .alert.alert-danger

--- a/app/views/ops/_settings_advanced_tab.html.haml
+++ b/app/views/ops/_settings_advanced_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_advanced"
-  - url = url_for(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
+  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
   = render :partial => "layouts/flash_msg"
   #form_div
     .alert.alert-danger

--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_authentication"
-  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
+  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => @sb[:active_tab].split('_').last)
   = render :partial => "layouts/flash_msg"
   %h3
     = _("Authentication")

--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_authentication"
-  - url = url_for(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
+  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
   = render :partial => "layouts/flash_msg"
   %h3
     = _("Authentication")

--- a/app/views/ops/_settings_co_tags_tab.html.haml
+++ b/app/views/ops/_settings_co_tags_tab.html.haml
@@ -1,6 +1,6 @@
 - if @sb[:active_tab] == "settings_co_tags"
   #tab_div
-    - url = url_for(:action => 'ce_new_cat')
+    - url = url_for_only_path(:action => 'ce_new_cat')
     .form-horizontal
       %h3
         = _("Choose a Category")

--- a/app/views/ops/_settings_cu_collection_tab.html.haml
+++ b/app/views/ops/_settings_cu_collection_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_cu_collection"
-  - url = url_for(:action => 'cu_collection_field_changed')
+  - url = url_for_only_path(:action => 'cu_collection_field_changed')
   - clusters_title = title_for_clusters
   = form_tag({:action => 'cu_collection_update'},
              :id     => "config_form",

--- a/app/views/ops/_settings_custom_logos_tab.html.haml
+++ b/app/views/ops/_settings_custom_logos_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_custom_logos"
-  - url = url_for(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_')[1]}_#{@sb[:active_tab].split('_').last}")
+  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_')[1]}_#{@sb[:active_tab].split('_').last}")
   = render :partial => "layouts/flash_msg"
   %h3= _("Custom Logo Image (Shown on top right of all screens)")
   - if File.exist?(@logo_file)

--- a/app/views/ops/_settings_details_tab.html.haml
+++ b/app/views/ops/_settings_details_tab.html.haml
@@ -3,7 +3,7 @@
     = render :partial => "layouts/flash_msg"
     - region = MiqRegion.my_region
     - if @edit
-      - url = url_for_only_path(:action => 'region_form_field_changed', :id => "#{region.id || "new"}")
+      - url = url_for_only_path(:action => 'region_form_field_changed', :id => (region.id || "new"))
       %h3
         = _("Region Information")
       .form-horizontal

--- a/app/views/ops/_settings_details_tab.html.haml
+++ b/app/views/ops/_settings_details_tab.html.haml
@@ -3,7 +3,7 @@
     = render :partial => "layouts/flash_msg"
     - region = MiqRegion.my_region
     - if @edit
-      - url = url_for(:action => 'region_form_field_changed', :id => "#{region.id || "new"}")
+      - url = url_for_only_path(:action => 'region_form_field_changed', :id => "#{region.id || "new"}")
       %h3
         = _("Region Information")
       .form-horizontal

--- a/app/views/ops/_settings_import_tab.html.haml
+++ b/app/views/ops/_settings_import_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_import"
-  - url = url_for(:action => 'upload_form_field_changed', :id => @sb[:active_tab].split('_').last)
+  - url = url_for_only_path(:action => 'upload_form_field_changed', :id => @sb[:active_tab].split('_').last)
   %h3= _("Messages")
   = render(:partial => "layouts/flash_msg")
   %hr

--- a/app/views/ops/_settings_rhn_edit_tab.html.haml
+++ b/app/views/ops/_settings_rhn_edit_tab.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'settings_form_field_changed', :id => 'rhn_edit')
+- url = url_for_only_path(:action => 'settings_form_field_changed', :id => 'rhn_edit')
 - url_jsh = {:url => url}.to_json
 - url_int_jsh = {:interval => '.5', :url => url}.to_json
 
@@ -35,7 +35,7 @@
           = button_tag(_('Default'),
                     :id      => 'rhn_default_button',
                     :class   => 'btn btn-default',
-                    :onclick => "miqAjaxButton('#{url_for(:action => 'rhn_default_server', :id => 'rhn_edit')}');")
+                    :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'rhn_default_server', :id => 'rhn_edit')}');")
 
     .form-group
       - label = _("Repository Name(s):")
@@ -48,7 +48,7 @@
         = button_tag(_('Default'),
                   :id      => 'repo_default_name',
                   :class   => 'btn btn-default',
-                  :onclick => "miqAjaxButton('#{url_for(:action => 'repo_default_name', :id => 'rhn_edit')}');")
+                  :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'repo_default_name', :id => 'rhn_edit')}');")
 
     .form-group
       %label.col-md-2.control-label

--- a/app/views/ops/_settings_rhn_tab.html.haml
+++ b/app/views/ops/_settings_rhn_tab.html.haml
@@ -20,7 +20,7 @@
       = button_tag(_('Edit Registration'),
                   :id      => 'settings_rhn_edit',
                   :class   => 'btn btn-default',
-                  :onclick => "miqAjaxButton('#{url_for(:action => 'edit_rhn')}');")
+                  :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'edit_rhn')}');")
 
 
   - if @customer.registered

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_server"
-  - url = url_for(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
+  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
   = render :partial => "layouts/flash_msg"
   %h3
     = _("Basic Information")

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_server"
-  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
+  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => @sb[:active_tab].split('_').last)
   = render :partial => "layouts/flash_msg"
   %h3
     = _("Basic Information")

--- a/app/views/ops/_settings_workers_tab.html.haml
+++ b/app/views/ops/_settings_workers_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_workers"
-  - url = url_for(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
+  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
   = render :partial => "layouts/flash_msg"
   .row
     .col-md-12.col-lg-6

--- a/app/views/ops/_settings_workers_tab.html.haml
+++ b/app/views/ops/_settings_workers_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_workers"
-  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_').last}")
+  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => @sb[:active_tab].split('_').last)
   = render :partial => "layouts/flash_msg"
   .row
     .col-md-12.col-lg-6

--- a/app/views/ops/_zone_form.html.haml
+++ b/app/views/ops/_zone_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'zone_field_changed', :id => "#{@zone.id || "new"}")
+- url = url_for_only_path(:action => 'zone_field_changed', :id => "#{@zone.id || "new"}")
 = render :partial => "layouts/flash_msg"
 - disabled_name = !@zone.name.nil? && !@edit[:current][:name].nil?
 %h3

--- a/app/views/ops/_zone_form.html.haml
+++ b/app/views/ops/_zone_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'zone_field_changed', :id => "#{@zone.id || "new"}")
+- url = url_for_only_path(:action => 'zone_field_changed', :id => (@zone.id || "new"))
 = render :partial => "layouts/flash_msg"
 - disabled_name = !@zone.name.nil? && !@edit[:current][:name].nil?
 %h3

--- a/app/views/ops/explorer.html.haml
+++ b/app/views/ops/explorer.html.haml
@@ -13,7 +13,7 @@
   = javascript_dim("vmdb_tree_div", false) if role_allows?(:feature => "ops_db")
   = javascript_dim("rbac_tree_div", false) if role_allows?(:feature => "ops_rbac", :any => true)
   - if @sb[:active_tab] == "db_utilization"
-    miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');
+    miqAsyncAjax('#{url_for_only_path(:action => @ajax_action, :id => @record)}');
   - if @sb[:center_tb_filename].nil? || @sb[:center_tb_filename] == "blank_view_tb"
     $('#toolbar').hide();
   };

--- a/app/views/ops/rhn/_server_table.html.haml
+++ b/app/views/ops/rhn/_server_table.html.haml
@@ -14,14 +14,14 @@
         = button_tag(_("Refresh List"),
                   :id      => 'rhn_refresh_button',
                   :class   => 'btn btn-default',
-                  :onclick => "miqAjaxButton('#{url_for(:action => 'rhn_buttons',
+                  :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'rhn_buttons',
                                                         :button => 'refresh')}');")
       %td
         = button_tag(_("Check for Updates"),
                   :id       => 'rhn_check_updates_button_on_1',
                   :class    => 'btn btn-default',
                   :disabled => !@buttons_on,
-                  :onclick  => "miqAjaxButton('#{url_for(:action => 'rhn_buttons',
+                  :onclick  => "miqAjaxButton('#{url_for_only_path(:action => 'rhn_buttons',
                                                          :button => 'check')}',
                                               true);")
       %td
@@ -29,7 +29,7 @@
                   :id       => 'rhn_register_button_on_1',
                   :class    => 'btn btn-default',
                   :disabled => !@buttons_on,
-                  :onclick  => "miqAjaxButton('#{url_for(:action => 'rhn_buttons',
+                  :onclick  => "miqAjaxButton('#{url_for_only_path(:action => 'rhn_buttons',
                                                          :button => 'register')}',
                                               true);")
       %td
@@ -37,7 +37,7 @@
                   :id       => 'rhn_update_button_on_1',
                   :class    => 'btn btn-default',
                   :disabled => !@buttons_on,
-                  :onclick  => "miqAjaxButton('#{url_for(:action => 'rhn_buttons',
+                  :onclick  => "miqAjaxButton('#{url_for_only_path(:action => 'rhn_buttons',
                                                          :button => 'update')}',
                                               true);")
 %br

--- a/app/views/provider_foreman/_configscript_service_dialog.html.haml
+++ b/app/views/provider_foreman/_configscript_service_dialog.html.haml
@@ -1,7 +1,7 @@
 #form_div
   #basic_info_div
     = render :partial => "layouts/flash_msg"
-    - url = url_for(:action => "cs_form_field_changed", :id => @edit[:rec_id])
+    - url = url_for_only_path(:action => "cs_form_field_changed", :id => @edit[:rec_id])
     .form-horizontal
       .form-group
         %label.col-md-2.control-label

--- a/app/views/pxe/_iso_datastore_form.html.haml
+++ b/app/views/pxe/_iso_datastore_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'iso_datastore_form_field_changed', :id => "#{@isd.id || "new"}")
+- url = url_for_only_path(:action => 'iso_datastore_form_field_changed', :id => (@isd.id || "new"))
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_iso_datastore_form.html.haml
+++ b/app/views/pxe/_iso_datastore_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'iso_datastore_form_field_changed', :id => "#{@isd.id || "new"}")
+- url = url_for_only_path(:action => 'iso_datastore_form_field_changed', :id => "#{@isd.id || "new"}")
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_iso_img_form.html.haml
+++ b/app/views/pxe/_iso_img_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'iso_img_form_field_changed', :id => "#{@img.id || "new"}")
+- url = url_for_only_path(:action => 'iso_img_form_field_changed', :id => "#{@img.id || "new"}")
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_iso_img_form.html.haml
+++ b/app/views/pxe/_iso_img_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'iso_img_form_field_changed', :id => "#{@img.id || "new"}")
+- url = url_for_only_path(:action => 'iso_img_form_field_changed', :id => (@img.id || "new"))
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_pxe_form.html.haml
+++ b/app/views/pxe/_pxe_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'pxe_server_form_field_changed', :id => "#{@ps.id || "new"}")
+- url = url_for_only_path(:action => 'pxe_server_form_field_changed', :id => (@ps.id || "new"))
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_pxe_form.html.haml
+++ b/app/views/pxe/_pxe_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'pxe_server_form_field_changed', :id => "#{@ps.id || "new"}")
+- url = url_for_only_path(:action => 'pxe_server_form_field_changed', :id => "#{@ps.id || "new"}")
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_pxe_image_type_form.html.haml
+++ b/app/views/pxe/_pxe_image_type_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'pxe_image_type_form_field_changed', :id => "#{@pxe_image_type.id || "new"}")
+- url = url_for_only_path(:action => 'pxe_image_type_form_field_changed', :id => (@pxe_image_type.id || "new"))
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_pxe_image_type_form.html.haml
+++ b/app/views/pxe/_pxe_image_type_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'pxe_image_type_form_field_changed', :id => "#{@pxe_image_type.id || "new"}")
+- url = url_for_only_path(:action => 'pxe_image_type_form_field_changed', :id => "#{@pxe_image_type.id || "new"}")
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_pxe_img_form.html.haml
+++ b/app/views/pxe/_pxe_img_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'pxe_img_form_field_changed', :id => "#{@img.id || "new"}")
+- url = url_for_only_path(:action => 'pxe_img_form_field_changed', :id => (@img.id || "new"))
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_pxe_img_form.html.haml
+++ b/app/views/pxe/_pxe_img_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'pxe_img_form_field_changed', :id => "#{@img.id || "new"}")
+- url = url_for_only_path(:action => 'pxe_img_form_field_changed', :id => "#{@img.id || "new"}")
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_pxe_wimg_form.html.haml
+++ b/app/views/pxe/_pxe_wimg_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'pxe_wimg_form_field_changed', :id => "#{@wimg.id || "new"}")
+- url = url_for_only_path(:action => 'pxe_wimg_form_field_changed', :id => "#{@wimg.id || "new"}")
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_pxe_wimg_form.html.haml
+++ b/app/views/pxe/_pxe_wimg_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'pxe_wimg_form_field_changed', :id => "#{@wimg.id || "new"}")
+- url = url_for_only_path(:action => 'pxe_wimg_form_field_changed', :id => (@wimg.id || "new"))
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/pxe/_template_form.html.haml
+++ b/app/views/pxe/_template_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'template_form_field_changed', :id => "#{@ct.id || "new"}")
+- url = url_for_only_path(:action => 'template_form_field_changed', :id => (@ct.id || "new"))
 
 #form_div
   = render :partial => "layouts/flash_msg"

--- a/app/views/pxe/_template_form.html.haml
+++ b/app/views/pxe/_template_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'template_form_field_changed', :id => "#{@ct.id || "new"}")
+- url = url_for_only_path(:action => 'template_form_field_changed', :id => "#{@ct.id || "new"}")
 
 #form_div
   = render :partial => "layouts/flash_msg"

--- a/app/views/pxe/_template_script_data.html.haml
+++ b/app/views/pxe/_template_script_data.html.haml
@@ -7,5 +7,5 @@
   :locals => {:text_area_id => "script_data",
     :mode => @edit[:new][:typ] == "CustomizationTemplateKickstart" ? "shell" : "xml",
     :line_numbers => true,
-    :url => url_for(:action => 'template_form_field_changed',
+    :url => url_for_only_path(:action => 'template_form_field_changed',
       :id => "#{@ct.id || "new"}", :transOne => '1')})

--- a/app/views/report/_column_lists.html.haml
+++ b/app/views/report/_column_lists.html.haml
@@ -31,7 +31,7 @@
                                     :remote          => true,
                                     "data-submit"    => 'column_lists',
                                     "data-method"    => :post,
-                                    "data-click_url" => {:url => url_for(:action => 'form_field_changed',
+                                    "data-click_url" => {:url => url_for_only_path(:action => 'form_field_changed',
                                                                          :button => button,
                                                                          :id     => @edit[:rpt_id] || "new")}.to_json}
 
@@ -65,7 +65,7 @@
                                       :remote          => true,
                                       "data-submit"    => 'column_lists',
                                       "data-method"    => :post,
-                                      "data-click_url" => {:url => url_for(:action => 'form_field_changed',
+                                      "data-click_url" => {:url => url_for_only_path(:action => 'form_field_changed',
                                                                            :button => button,
                                                                            :id     => @edit[:rpt_id] || "new")}.to_json}
                 %i.fa.fa-lg{:class => icon}

--- a/app/views/report/_db_form.html.haml
+++ b/app/views/report/_db_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'db_form_field_changed', :id => "#{@db.id || 'new'}")
+- url = url_for_only_path(:action => 'db_form_field_changed', :id => "#{@db.id || 'new'}")
 #form_div
   = render :partial => "layouts/flash_msg"
   - read_only = @edit && @edit[:db_id] && @edit[:db_id] ? true : false

--- a/app/views/report/_db_form.html.haml
+++ b/app/views/report/_db_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'db_form_field_changed', :id => "#{@db.id || 'new'}")
+- url = url_for_only_path(:action => 'db_form_field_changed', :id => (@db.id || 'new'))
 #form_div
   = render :partial => "layouts/flash_msg"
   - read_only = @edit && @edit[:db_id] && @edit[:db_id] ? true : false

--- a/app/views/report/_export_custom_reports.html.haml
+++ b/app/views/report/_export_custom_reports.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'export_field_changed')
+- url = url_for_only_path(:action => 'export_field_changed')
 = render :partial => "layouts/flash_msg"
 
 %h2

--- a/app/views/report/_form.html.haml
+++ b/app/views/report/_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 #form_div
   = render :partial => '/layouts/tabs'
   = render :partial => "layouts/flash_msg"

--- a/app/views/report/_form.html.haml
+++ b/app/views/report/_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 #form_div
   = render :partial => '/layouts/tabs'
   = render :partial => "layouts/flash_msg"

--- a/app/views/report/_form_chart.html.haml
+++ b/app/views/report/_form_chart.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 #chart_div
   %h3
     = _('Chart Settings')

--- a/app/views/report/_form_chart.html.haml
+++ b/app/views/report/_form_chart.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 #chart_div
   %h3
     = _('Chart Settings')

--- a/app/views/report/_form_columns.html.haml
+++ b/app/views/report/_form_columns.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 #columns_div
   = form_tag({:action => 'create',
               :id     => "report_columns_form"},

--- a/app/views/report/_form_columns.html.haml
+++ b/app/views/report/_form_columns.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 #columns_div
   = form_tag({:action => 'create',
               :id     => "report_columns_form"},

--- a/app/views/report/_form_columns_performance.html.haml
+++ b/app/views/report/_form_columns_performance.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 .form-group
   %label.control-label.col-md-2
     = _('* Performance Interval')

--- a/app/views/report/_form_columns_performance.html.haml
+++ b/app/views/report/_form_columns_performance.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 .form-group
   %label.control-label.col-md-2
     = _('* Performance Interval')

--- a/app/views/report/_form_columns_trend.html.haml
+++ b/app/views/report/_form_columns_trend.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 .form-group
   %label.control-label.col-md-2
     = _('Trending for')

--- a/app/views/report/_form_columns_trend.html.haml
+++ b/app/views/report/_form_columns_trend.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 .form-group
   %label.control-label.col-md-2
     = _('Trending for')

--- a/app/views/report/_form_consolidate.html.haml
+++ b/app/views/report/_form_consolidate.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 #consolidate_div
   %h3
     = _('Group Records by up to 3 Columns')

--- a/app/views/report/_form_consolidate.html.haml
+++ b/app/views/report/_form_consolidate.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 #consolidate_div
   %h3
     = _('Group Records by up to 3 Columns')

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 - if @edit[:new][:model] == "ChargebackVm"
   %h3
     = _('Chargeback Resources')

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 - if @edit[:new][:model] == "ChargebackVm"
   %h3
     = _('Chargeback Resources')

--- a/app/views/report/_form_filter_performance.html.haml
+++ b/app/views/report/_form_filter_performance.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 %h3
   = _('Performance Timeframe')
 .form-horizontal

--- a/app/views/report/_form_filter_performance.html.haml
+++ b/app/views/report/_form_filter_performance.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 %h3
   = _('Performance Timeframe')
 .form-horizontal

--- a/app/views/report/_form_formatting.html.haml
+++ b/app/views/report/_form_formatting.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 #formatting_div
   %h3
     = _('PDF Output')

--- a/app/views/report/_form_formatting.html.haml
+++ b/app/views/report/_form_formatting.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 #formatting_div
   %h3
     = _('PDF Output')

--- a/app/views/report/_form_sort.html.haml
+++ b/app/views/report/_form_sort.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 #sort_div
   %h3
     = _('Sort Criteria')

--- a/app/views/report/_form_sort.html.haml
+++ b/app/views/report/_form_sort.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 #sort_div
   %h3
     = _('Sort Criteria')

--- a/app/views/report/_form_styling.html.haml
+++ b/app/views/report/_form_styling.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 -# JSON hash to hold text fields and types for miqValueStylePrefill
 = javascript_tag("ManageIQ.reportEditor.valueStyles = {};")
 

--- a/app/views/report/_form_styling.html.haml
+++ b/app/views/report/_form_styling.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 -# JSON hash to hold text fields and types for miqValueStylePrefill
 = javascript_tag("ManageIQ.reportEditor.valueStyles = {};")
 

--- a/app/views/report/_form_tl_settings.html.haml
+++ b/app/views/report/_form_tl_settings.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 #tl_settings_div
   %h3
     = _('Timeline Settings')

--- a/app/views/report/_form_tl_settings.html.haml
+++ b/app/views/report/_form_tl_settings.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
 #tl_settings_div
   %h3
     = _('Timeline Settings')

--- a/app/views/report/_menu_form1.html.haml
+++ b/app/views/report/_menu_form1.html.haml
@@ -1,5 +1,5 @@
 #menu_div1
-  - url = url_for(:action => 'menu_field_changed')
+  - url = url_for_only_path(:action => 'menu_field_changed')
   .col-sm-7
     %h3
       %span#menu1_legend
@@ -63,7 +63,7 @@
                 = _('Commit')
 
               - t = _("Discard expression element changes")
-              - url = url_for(:action => 'discard_changes')
+              - url = url_for_only_path(:action => 'discard_changes')
               %button.btn.btn-default{:title => t,
                   "data-submit"         => 'column_lists',
                   "data-miq_sparkle_on" => true,

--- a/app/views/report/_menu_form1.html.haml
+++ b/app/views/report/_menu_form1.html.haml
@@ -1,5 +1,4 @@
 #menu_div1
-  - url = url_for_only_path(:action => 'menu_field_changed')
   .col-sm-7
     %h3
       %span#menu1_legend

--- a/app/views/report/_menu_form2.html.haml
+++ b/app/views/report/_menu_form2.html.haml
@@ -1,6 +1,6 @@
 #menu_div2
   - if @selected && @selected[1] && (!@edit[:selected_reports].blank? || !@edit[:available_reports].blank?)
-    - url = url_for(:action => 'menu_field_changed')
+    - url = url_for_only_path(:action => 'menu_field_changed')
     .col-sm-6
       %h3
         = _('Manage Reports')
@@ -120,7 +120,7 @@
                     'data-click_url'      => {:url => "#{url}?pressed=commit"}.to_json}
                   = _('Commit')
                 - t = _("Discard report management changes")
-                - url2 = url_for(:action => 'discard_changes')
+                - url2 = url_for_only_path(:action => 'discard_changes')
                 %button.btn.btn-default{:title => t,
                     "data-submit"         => 'column_lists',
                     "data-miq_sparkle_on" => true,

--- a/app/views/report/_schedule_email_options.html.haml
+++ b/app/views/report/_schedule_email_options.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'schedule_form_field_changed', :id => @schedule.id || "new")
+- url = url_for_only_path(:action => 'schedule_form_field_changed', :id => @schedule.id || "new")
 - url_json = {:url => url}.to_json
 #schedule_email_options_div
   - if @edit[:new][:send_email]

--- a/app/views/report/_schedule_form.html.haml
+++ b/app/views/report/_schedule_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'schedule_form_field_changed', :id => "#{@schedule.id || 'new'}")
+- url = url_for_only_path(:action => 'schedule_form_field_changed', :id => (@schedule.id || 'new'))
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/report/_schedule_form.html.haml
+++ b/app/views/report/_schedule_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'schedule_form_field_changed', :id => "#{@schedule.id || 'new'}")
+- url = url_for_only_path(:action => 'schedule_form_field_changed', :id => "#{@schedule.id || 'new'}")
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/report/_schedule_form_filter.html.haml
+++ b/app/views/report/_schedule_form_filter.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'schedule_form_field_changed',  :id => "#{@schedule.id || 'new'}")
+- url = url_for_only_path(:action => 'schedule_form_field_changed',  :id => "#{@schedule.id || 'new'}")
 #form_filter_div
   %h3
     = _('Report Selection')

--- a/app/views/report/_schedule_form_filter.html.haml
+++ b/app/views/report/_schedule_form_filter.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'schedule_form_field_changed',  :id => "#{@schedule.id || 'new'}")
+- url = url_for_only_path(:action => 'schedule_form_field_changed',  :id => (@schedule.id || 'new'))
 #form_filter_div
   %h3
     = _('Report Selection')

--- a/app/views/report/_schedule_form_timer.html.haml
+++ b/app/views/report/_schedule_form_timer.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => action_url, :id => "#{record.id || 'new'}")
+- url = url_for_only_path(:action => action_url, :id => "#{record.id || 'new'}")
 #form_timer_div
   %h3
     = _('Timer')

--- a/app/views/report/_schedule_form_timer.html.haml
+++ b/app/views/report/_schedule_form_timer.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => action_url, :id => "#{record.id || 'new'}")
+- url = url_for_only_path(:action => action_url, :id => (record.id || 'new'))
 #form_timer_div
   %h3
     = _('Timer')

--- a/app/views/report/_widget_columns.html.haml
+++ b/app/views/report/_widget_columns.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
 .form-group
   %label.control-label.col-md-2
     - if @edit[:read_only]

--- a/app/views/report/_widget_columns.html.haml
+++ b/app/views/report/_widget_columns.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => (@widget.id || "new"))
 .form-group
   %label.control-label.col-md-2
     - if @edit[:read_only]

--- a/app/views/report/_widget_form.html.haml
+++ b/app/views/report/_widget_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => (@widget.id || "new"))
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/report/_widget_form.html.haml
+++ b/app/views/report/_widget_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
 #form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/report/_widget_form_chart.html.haml
+++ b/app/views/report/_widget_form_chart.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
 %h3
   = _('Chart Report')
 .form-horizontal

--- a/app/views/report/_widget_form_chart.html.haml
+++ b/app/views/report/_widget_form_chart.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => (@widget.id || "new)")
 %h3
   = _('Chart Report')
 .form-horizontal

--- a/app/views/report/_widget_form_menu.html.haml
+++ b/app/views/report/_widget_form_menu.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => (@widget.id || "new"))
 %h3
   = _('Menu Shortcuts')
 = select_tag("add_shortcut",

--- a/app/views/report/_widget_form_menu.html.haml
+++ b/app/views/report/_widget_form_menu.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
 %h3
   = _('Menu Shortcuts')
 = select_tag("add_shortcut",

--- a/app/views/report/_widget_form_report.html.haml
+++ b/app/views/report/_widget_form_report.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'widget_form_field_changed', :id => @widget.id || "new")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => @widget.id || "new")
 %h3
   = _("Report Options")
 .form-horizontal

--- a/app/views/report/_widget_form_rss.html.haml
+++ b/app/views/report/_widget_form_rss.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => (@widget.id || "new"))
 %h3
   = _('RSS Feed Options')
 .form-horizontal

--- a/app/views/report/_widget_form_rss.html.haml
+++ b/app/views/report/_widget_form_rss.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => "#{@widget.id || "new"}")
 %h3
   = _('RSS Feed Options')
 .form-horizontal

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'automate_button_field_changed')
+- url = url_for_only_path(:action => 'automate_button_field_changed')
 #ab_form
   #policy_bar
     - if @resolve[:uri] && Hash[*@resolve[:target_classes].flatten].invert[@resolve[:new][:target_class]] == @edit[:new][:target_class]

--- a/app/views/shared/buttons/_column_lists.html.haml
+++ b/app/views/shared/buttons/_column_lists.html.haml
@@ -27,7 +27,7 @@
                                       :remote          => true,
                                       "data-submit"    => 'column_lists',
                                       "data-method"    => :post,
-                                      "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                      "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
                                                                            :button => 'right',
                                                                            :id     => @custom_button_set.id || 'new')}.to_json}
                 %i.fa.fa-angle-right.fa-lg
@@ -40,7 +40,7 @@
                                       :remote          => true,
                                       "data-submit"    => 'column_lists',
                                       "data-method"    => :post,
-                                      "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                      "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
                                                                            :button => 'left',
                                                                            :id     => @custom_button_set.id || 'new')}.to_json}
                 %i.fa.fa-angle-left.fa-lg
@@ -61,7 +61,7 @@
                                   :remote          => true,
                                   "data-submit"    => 'column_lists',
                                   "data-method"    => :post,
-                                  "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                  "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
                                                                        :button => 'top',
                                                                        :id     => @custom_button_set.id || 'new')}.to_json}
             %i.fa.fa-angle-double-up.fa-lg
@@ -74,7 +74,7 @@
                                   :remote          => true,
                                   "data-submit"    => 'column_lists',
                                   "data-method"    => :post,
-                                  "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                  "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
                                                                        :button => 'up',
                                                                        :id     => @custom_button_set.id || 'new')}.to_json}
             %i.fa.fa-angle-up.fa-lg
@@ -87,7 +87,7 @@
                                   :remote          => true,
                                   "data-submit"    => 'column_lists',
                                   "data-method"    => :post,
-                                  "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                  "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
                                                                        :button => 'down',
                                                                        :id     => @custom_button_set.id || 'new')}.to_json}
             %i.fa.fa-angle-down.fa-lg
@@ -100,7 +100,7 @@
                                   :remote          => true,
                                   "data-submit"    => 'column_lists',
                                   "data-method"    => :post,
-                                  "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                  "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
                                                                        :button => 'bottom',
                                                                        :id     => @custom_button_set.id || 'new')}.to_json}
             %i.fa.fa-angle-double-down.fa-lg

--- a/app/views/shared/buttons/_group_form.html.haml
+++ b/app/views/shared/buttons/_group_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'group_form_field_changed', :id => "#{@custom_button_set.id || 'new'}")
+- url = url_for_only_path(:action => 'group_form_field_changed', :id => "#{@custom_button_set.id || 'new'}")
 #group_form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/shared/buttons/_group_form.html.haml
+++ b/app/views/shared/buttons/_group_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'group_form_field_changed', :id => "#{@custom_button_set.id || 'new'}")
+- url = url_for_only_path(:action => 'group_form_field_changed', :id => (@custom_button_set.id || 'new'))
 #group_form_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/shared/buttons/_group_order_form.html.haml
+++ b/app/views/shared/buttons/_group_order_form.html.haml
@@ -26,7 +26,7 @@
                                         :remote          => true,
                                         "data-submit"    => "column_lists",
                                         "data-method"    => :post,
-                                        "data-click_url" => {:url => url_for(:action => 'group_reorder_field_changed',
+                                        "data-click_url" => {:url => url_for_only_path(:action => 'group_reorder_field_changed',
                                                                              :button => 'up',
                                                                              :id     => "seq")}.to_json}
                   %i.fa.fa-angle-up.fa-lg
@@ -39,7 +39,7 @@
                                         :remote          => true,
                                         "data-submit"    => "column_lists",
                                         "data-method"    => :post,
-                                        "data-click_url" => {:url => url_for(:action => 'group_reorder_field_changed',
+                                        "data-click_url" => {:url => url_for_only_path(:action => 'group_reorder_field_changed',
                                                                              :button => 'down',
                                                                              :id     => "seq")}.to_json}
                   %i.fa.fa-angle-down.fa-lg

--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'dialog_field_changed', :id => @edit[:rec_id] || "new") if @edit
+- url = url_for_only_path(:action => 'dialog_field_changed', :id => @edit[:rec_id] || "new") if @edit
 - dialog_mode = @edit[:dialog_mode] if @edit
 
 - case dialog_mode

--- a/app/views/shared/views/ems_common/_form.html.haml
+++ b/app/views/shared/views/ems_common/_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@ems.id || 'new'}")
 
 #form_div
   = render :partial => "layouts/flash_msg"
@@ -106,13 +106,13 @@
               :class   => "btn btn-primary",
               :alt     => t,
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => "create", :id => "new", :button => "add")}');")
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => "create", :id => "new", :button => "add")}');")
             - t = _("Cancel")
             = button_tag(t,
               :class   => "btn btn-default",
               :alt     => t,
               :title   => t,
-              :href    => url_for(:action => "show_list", :flash_msg => _("Add of new %{provider} was cancelled by the user") % {:provider => name}),
+              :href    => url_for_only_path(:action => "show_list", :flash_msg => _("Add of new %{provider} was cancelled by the user") % {:provider => name}),
               :onclick => 'window.location = this.getAttribute("href");')
   - else
     = render :partial => '/layouts/edit_form_buttons', :locals  => {:record_id => @ems.id, :ajax_buttons => true, :restful => true}

--- a/app/views/shared/views/ems_common/_form.html.haml
+++ b/app/views/shared/views/ems_common/_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@ems.id || 'new'}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@ems.id || 'new'))
 
 #form_div
   = render :partial => "layouts/flash_msg"

--- a/app/views/storage_manager/_form.html.haml
+++ b/app/views/storage_manager/_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@sm.id || "new"}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => (@sm.id || "new"))
 - validate_url ||= %w(new create).include?(controller.action_name) ? "create" : "update"
 - change_stored_password ||= _("Change stored password")
 - cancel_password_change ||= _("Cancel password change")

--- a/app/views/storage_manager/_form.html.haml
+++ b/app/views/storage_manager/_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'form_field_changed', :id => "#{@sm.id || "new"}")
+- url = url_for_only_path(:action => 'form_field_changed', :id => "#{@sm.id || "new"}")
 - validate_url ||= %w(new create).include?(controller.action_name) ? "create" : "update"
 - change_stored_password ||= _("Change stored password")
 - cancel_password_change ||= _("Cancel password change")
@@ -132,11 +132,11 @@
               :class => "btn btn-primary",
               :alt => (t = _("Add this Storage Manager")),
               :title => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => "create", :id => "new", :button => "add")}');")
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => "create", :id => "new", :button => "add")}');")
             = button_tag((t = _('Cancel')),
               :class => "btn btn-default",
               :alt => t,
               :title => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => "create", :id => "new", :button => "cancel")}');")
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => "create", :id => "new", :button => "cancel")}');")
   - else
     = render(:partial => '/layouts/edit_form_buttons', :locals => {:record_id => @sm.id, :ajax_buttons => true})

--- a/app/views/vm_common/_evacuate.html.haml
+++ b/app/views/vm_common/_evacuate.html.haml
@@ -57,12 +57,12 @@
             :class   => "btn btn-primary",
             :alt     => t,
             :title   => t,
-            :onclick => "miqAjaxButton('#{url_for(:action => "evacuate_vm", :id => "#{@record.id}", :button => "submit")}');")
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "evacuate_vm", :id => "#{@record.id}", :button => "submit")}');")
           = button_tag(t = _('Cancel'),
             :class   => "btn btn-default",
             :alt     => t,
             :title   => t,
-            :onclick => "miqAjaxButton('#{url_for(:action => "evacuate_vm", :id => "#{@record.id}", :button => "cancel")}');")
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "evacuate_vm", :id => "#{@record.id}", :button => "cancel")}');")
 
 :javascript
   ManageIQ.angular.app.value('vmCloudEvacuateFormId', '#{@record.id}');

--- a/app/views/vm_common/_evm_relationship.html.haml
+++ b/app/views/vm_common/_evm_relationship.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'evm_relationship_field_changed')
+- url = url_for_only_path(:action => 'evm_relationship_field_changed')
 #tab_div
   = render :partial => "layouts/flash_msg"
   %h3

--- a/app/views/vm_common/_form.html.haml
+++ b/app/views/vm_common/_form.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - url = url_for(:action => 'form_field_changed', :id => "#{@record.id || "new"}")
+  - url = url_for_only_path(:action => 'form_field_changed', :id => "#{@record.id || "new"}")
 
   = render :partial => "layouts/flash_msg"
 

--- a/app/views/vm_common/_form.html.haml
+++ b/app/views/vm_common/_form.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - url = url_for_only_path(:action => 'form_field_changed', :id => "#{@record.id || "new"}")
+  - url = url_for_only_path(:action => 'form_field_changed', :id => (@record.id || "new"))
 
   = render :partial => "layouts/flash_msg"
 

--- a/app/views/vm_common/_live_migrate.html.haml
+++ b/app/views/vm_common/_live_migrate.html.haml
@@ -61,12 +61,12 @@
             :class   => "btn btn-primary",
             :alt     => t,
             :title   => t,
-            :onclick => "miqAjaxButton('#{url_for(:action => "live_migrate_vm", :id => "#{@record.id}", :button => "submit")}');")
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "live_migrate_vm", :id => "#{@record.id}", :button => "submit")}');")
           = button_tag(t = _('Cancel'),
             :class   => "btn btn-default",
             :alt     => t,
             :title   => t,
-            :onclick => "miqAjaxButton('#{url_for(:action => "live_migrate_vm", :id => "#{@record.id}", :button => "cancel")}');")
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "live_migrate_vm", :id => "#{@record.id}", :button => "cancel")}');")
 
 
 

--- a/app/views/vm_common/_policy_options.html.haml
+++ b/app/views/vm_common/_policy_options.html.haml
@@ -1,5 +1,5 @@
-- url = {:url => url_for(:action => 'policy_options', :id => @record.id)}.to_json
-- url2 = {:url => url_for(:action => 'policy_show_options', :id => @record.id)}.to_json
+- url = {:url => url_for_only_path(:action => 'policy_options', :id => @record.id)}.to_json
+- url2 = {:url => url_for_only_path(:action => 'policy_show_options', :id => @record.id)}.to_json
 #policy_options_div
   %h3
     = _('Options')

--- a/app/views/vm_common/_resize.html.haml
+++ b/app/views/vm_common/_resize.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - url = url_for(:action => 'resize_field_changed', :id => @record.id.to_s)
+  - url = url_for_only_path(:action => 'resize_field_changed', :id => @record.id.to_s)
 
   = render :partial => "layouts/flash_msg"
 
@@ -34,14 +34,14 @@
                          :class   => 'btn btn-primary',
                          :alt     => 'Submit',
                          :title   => 'Submit',
-                         :onclick => "miqAjaxButton('#{url_for(:action => 'resize_vm',
+                         :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'resize_vm',
                                                                :id     => @edit[:vm_id],
                                                                :button => "submit")}');")
           = button_tag(_("Cancel"),
                            :class   => 'btn btn-default',
                            :alt     => t = _("Cancel Changes"),
                            :title   => t,
-                           :onclick => "miqAjaxButton('#{url_for(:action => 'resize_vm',
+                           :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'resize_vm',
                                                                  :id     => @edit[:vm_id],
                                                                  :button => "cancel")}');")
         #buttons_off{:style => "display:#{@changed ? "none" : "display"};"}
@@ -50,6 +50,6 @@
                            :class   => 'btn btn-default',
                            :alt     => t = _("Cancel Changes"),
                            :title   => t,
-                           :onclick => "miqAjaxButton('#{url_for(:action => 'resize_vm',
+                           :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'resize_vm',
                                                                  :id     => @edit[:vm_id],
                                                                  :button => "cancel")}');")

--- a/app/views/vm_common/_right_size.html.haml
+++ b/app/views/vm_common/_right_size.html.haml
@@ -219,6 +219,6 @@
         :class   => 'btn btn-default',
         :alt     => t,
         :title   => t,
-        :onclick => "miqAjaxButton('#{url_for(:action => "right_size",
+        :onclick => "miqAjaxButton('#{url_for_only_path(:action => "right_size",
                                               :id     => @record_id,
                                               :button => "back")}');")


### PR DESCRIPTION
One of the fixes needed for correct functionality behing a HTTP(S) proxy: make all `url_for` calls return path only.

doing this by replacing all the calls with a new helper function.

Other options/ideas where
  * use `path_for`, but that is not a helper function http://apidock.com/rails/ActionDispatch/Http/URL/path_for/class
  * hack the defaults of http://apidock.com/rails/ActionDispatch/Routing/UrlFor/url_for

