### PR TITLE
TLS verification & custom CA UI for oVirt and Container providers

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -117,6 +117,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.default_tls_verify              = data.default_tls_verify;
       $scope.emsCommonModel.default_tls_ca_certs            = data.default_tls_ca_certs;
       $scope.emsCommonModel.amqp_security_protocol          = data.amqp_security_protocol !== '' ? data.amqp_security_protocol : 'non-ssl';
+      $scope.emsCommonModel.hawkular_security_protocol      = data.hawkular_security_protocol;
+      $scope.emsCommonModel.hawkular_tls_ca_certs           = data.hawkular_tls_ca_certs;
       $scope.emsCommonModel.provider_region                 = data.provider_region;
       $scope.emsCommonModel.default_userid                  = data.default_userid;
       $scope.emsCommonModel.amqp_userid                     = data.amqp_userid;
@@ -346,6 +348,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.metrics_database_name = "ovirt_engine_history";
     } else if ($scope.emsCommonModel.ems_controller === 'ems_container') {
       $scope.emsCommonModel.default_api_port = "8443";
+      $scope.emsCommonModel.default_security_protocol = 'ssl-with-validation';
+      $scope.emsCommonModel.hawkular_security_protocol = 'ssl-with-validation';
     } else if ($scope.emsCommonModel.emstype === 'vmware_cloud') {
       $scope.emsCommonModel.default_api_port = "443";
       $scope.emsCommonModel.event_stream_selection = "none";

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -19,6 +19,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       metrics_api_port: '',
       api_version: '',
       default_security_protocol: '',
+      default_tls_verify: true,
+      default_tls_ca_certs: '',
       realm: '',
       security_protocol: '',
       amqp_security_protocol: '',
@@ -112,6 +114,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.default_security_protocol       = data.default_security_protocol;
       $scope.emsCommonModel.realm                           = data.realm;
       $scope.emsCommonModel.security_protocol               = data.security_protocol;
+      $scope.emsCommonModel.default_tls_verify              = data.default_tls_verify;
+      $scope.emsCommonModel.default_tls_ca_certs            = data.default_tls_ca_certs;
       $scope.emsCommonModel.amqp_security_protocol          = data.amqp_security_protocol !== '' ? data.amqp_security_protocol : 'non-ssl';
       $scope.emsCommonModel.provider_region                 = data.provider_region;
       $scope.emsCommonModel.default_userid                  = data.default_userid;
@@ -322,6 +326,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     $scope.emsCommonModel.default_api_port = "";
     $scope.emsCommonModel.provider_region = "";
     $scope.emsCommonModel.default_security_protocol = "";
+    $scope.emsCommonModel.default_tls_verify = true;
+    $scope.emsCommonModel.default_tls_ca_certs = "";
     $scope.note = "";
     if ($scope.emsCommonModel.emstype === 'openstack' || $scope.emsCommonModel.emstype === 'openstack_infra') {
       $scope.emsCommonModel.default_api_port = $scope.getDefaultApiPort($scope.emsCommonModel.emstype);

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -717,6 +717,7 @@ module EmsCommon
     @openstack_security_protocols = retrieve_openstack_security_protocols
     @amqp_security_protocols = retrieve_amqp_security_protocols
     @nuage_security_protocols = retrieve_nuage_security_protocols
+    @container_security_protocols = retrieve_container_security_protocols
     @scvmm_security_protocols = [[_('Basic (SSL)'), 'ssl'], ['Kerberos', 'kerberos']]
     @openstack_api_versions = retrieve_openstack_api_versions
     @vmware_cloud_api_versions = retrieve_vmware_cloud_api_versions
@@ -766,6 +767,12 @@ module EmsCommon
   def retrieve_amqp_security_protocols
     # OSP8 doesn't support SSL for AMQP
     [[_('Non-SSL'), 'non-ssl']]
+  end
+
+  def retrieve_container_security_protocols
+    [[_('SSL'), 'ssl-with-validation'],
+     [_('SSL trusting custom CA'), 'ssl-with-validation-custom-ca'],
+     [_('SSL without validation'), 'ssl-without-validation']]
   end
 
   # Get variables from edit form

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -139,6 +139,8 @@ module Mixins
       keystone_v3_domain_id = ""
       hawkular_hostname = ""
       hawkular_api_port = ""
+      hawkular_security_protocol = ""
+      hawkular_tls_ca_certs = ""
 
       if @ems.connection_configurations.amqp.try(:endpoint)
         amqp_hostname = @ems.connection_configurations.amqp.endpoint.hostname
@@ -174,6 +176,8 @@ module Mixins
         hawkular_hostname = @ems.connection_configurations.hawkular.endpoint.hostname
         hawkular_api_port = @ems.connection_configurations.hawkular.endpoint.port
         hawkular_auth_status = @ems.authentication_status_ok?(:hawkular)
+        hawkular_security_protocol = @ems.connection_configurations.hawkular.endpoint.security_protocol
+        hawkular_tls_ca_certs = @ems.connection_configurations.hawkular.endpoint.certificate_authority
       end
 
       if @ems.connection_configurations.default.try(:endpoint)
@@ -271,24 +275,27 @@ module Mixins
                         :ssh_keypair_auth_status       => ssh_keypair_auth_status.nil? ? true : ssh_keypair_auth_status
       } if controller_name == "ems_infra"
 
-      render :json => {:name                      => @ems.name,
-                       :emstype                   => @ems.emstype,
-                       :zone                      => zone,
-                       :provider_id               => @ems.provider_id ? @ems.provider_id : "",
-                       :hostname                  => @ems.hostname,
-                       :default_hostname          => @ems.connection_configurations.default.endpoint.hostname,
-                       :hawkular_hostname         => hawkular_hostname,
-                       :default_api_port          => @ems.connection_configurations.default.endpoint.port,
-                       :hawkular_api_port         => hawkular_api_port,
-                       :api_version               => @ems.api_version ? @ems.api_version : "v2",
-                       :default_security_protocol => default_security_protocol,
-                       :provider_region           => @ems.provider_region,
-                       :default_userid            => @ems.authentication_userid ? @ems.authentication_userid : "",
-                       :service_account           => service_account ? service_account : "",
-                       :bearer_token_exists       => @ems.authentication_token(:bearer).nil? ? false : true,
-                       :ems_controller            => controller_name,
-                       :default_auth_status       => default_auth_status,
-                       :hawkular_auth_status      => hawkular_auth_status.nil? ? true : hawkular_auth_status,
+      render :json => {:name                       => @ems.name,
+                       :emstype                    => @ems.emstype,
+                       :zone                       => zone,
+                       :provider_id                => @ems.provider_id ? @ems.provider_id : "",
+                       :hostname                   => @ems.hostname,
+                       :default_hostname           => @ems.connection_configurations.default.endpoint.hostname,
+                       :hawkular_hostname          => hawkular_hostname,
+                       :default_api_port           => @ems.connection_configurations.default.endpoint.port,
+                       :hawkular_api_port          => hawkular_api_port,
+                       :api_version                => @ems.api_version ? @ems.api_version : "v2",
+                       :default_security_protocol  => default_security_protocol,
+                       :hawkular_security_protocol => hawkular_security_protocol,
+                       :default_tls_ca_certs       => default_tls_ca_certs,
+                       :hawkular_tls_ca_certs      => hawkular_tls_ca_certs,
+                       :provider_region            => @ems.provider_region,
+                       :default_userid             => @ems.authentication_userid ? @ems.authentication_userid : "",
+                       :service_account            => service_account ? service_account : "",
+                       :bearer_token_exists        => @ems.authentication_token(:bearer).nil? ? false : true,
+                       :ems_controller             => controller_name,
+                       :default_auth_status        => default_auth_status,
+                       :hawkular_auth_status       => hawkular_auth_status.nil? ? true : hawkular_auth_status,
       } if controller_name == "ems_container"
 
       render :json => {:name                => @ems.name,
@@ -348,6 +355,9 @@ module Mixins
       metrics_database_name = params[:metrics_database_name].strip if params[:metrics_database_name]
       hawkular_hostname = params[:hawkular_hostname].strip if params[:hawkular_hostname]
       hawkular_api_port = params[:hawkular_api_port].strip if params[:hawkular_api_port]
+      hawkular_security_protocol = params[:hawkular_security_protocol].strip if params[:hawkular_security_protocol]
+      default_tls_ca_certs  = params[:default_tls_ca_certs].strip if params[:default_tls_ca_certs]
+      hawkular_tls_ca_certs = params[:hawkular_tls_ca_certs].strip if params[:hawkular_tls_ca_certs]
       default_endpoint = {}
       amqp_endpoint = {}
       ceilometer_endpoint = {}
@@ -411,14 +421,15 @@ module Mixins
 
       if ems.kind_of?(ManageIQ::Providers::ContainerManager)
         params[:cred_type] = ems.default_authentication_type if params[:cred_type] == "default"
-        ems.hostname = hostname
+        default_endpoint = {:role => :default, :hostname => hostname, :port => port}
+        default_endpoint.merge!(container_security_options(ems.security_protocol, default_tls_ca_certs))
+
         if hawkular_hostname.blank?
           default_key = params[:default_password] || ems.authentication_key
-          hawkular_hostname = get_hostname_from_routes(ems, hostname, port, default_key)
+          hawkular_hostname = get_hostname_from_routes(ems, default_endpoint, default_key)
         end
-
-        default_endpoint = {:role => :default, :hostname => hostname, :port => port}
         hawkular_endpoint = {:role => :hawkular, :hostname => hawkular_hostname, :port => hawkular_api_port}
+        hawkular_endpoint.merge!(container_security_options(hawkular_security_protocol, hawkular_tls_ca_certs))
       end
 
       if ems.kind_of?(ManageIQ::Providers::MiddlewareManager)
@@ -444,13 +455,27 @@ module Mixins
       build_connection(ems, endpoints, mode)
     end
 
-    def get_hostname_from_routes(ems, hostname, port, token)
+    def get_hostname_from_routes(ems, endpoint_hash, token)
       return nil unless ems.class.respond_to?(:openshift_connect)
-      client = ems.class.openshift_connect(hostname, port, :bearer => token)
+      endpoint = Endpoint.new(endpoint_hash)
+      ssl_options = {
+        :verify_ssl => ems.verify_ssl_mode(endpoint),
+        :cert_store => ems.ssl_cert_store(endpoint)
+      }
+      client = ems.class.raw_connect(endpoint.hostname, endpoint.port,
+                                     :service => :openshift, :bearer => token, :ssl_options => ssl_options)
       client.get_route('hawkular-metrics', 'openshift-infra').try(:spec).try(:host)
     rescue KubeException => e
       $log.warn("MIQ(#{controller_name}_controller-#{action_name}): get_hostname_from_routes error: #{e}")
       nil
+    end
+
+    def container_security_options(security_protocol, certificate_authority)
+      {
+        :security_protocol     => security_protocol,
+        :verify_ssl            => security_protocol != 'ssl-without-validation',
+        :certificate_authority => security_protocol == 'ssl-with-validation-custom-ca' ? certificate_authority : nil,
+      }
     end
 
     def build_connection(ems, endpoints, mode)

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -114,6 +114,38 @@
                        "selectpicker-for-select-tag" => "",
                        "prefix"                      => "#{prefix}",
                        "reset-validation-status"     => "#{prefix}_auth_status")
+
+%div{"ng-if" => defined?(tls_hide) ? false : true}
+  .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm'"}
+    %label.col-md-2.control-label{"for" => "#{prefix}_tls_verify"}
+      = _('Verify TLS Certificates')
+    .col-md-8
+      %input{"type"            => "checkbox",
+             "id"              => "#{prefix}_tls_verify",
+             "name"            => "#{prefix}_tls_verify",
+             "bs-switch"       => "",
+             "switch-on-text"  => _("Yes"),
+             "switch-off-text" => _("No"),
+             "ng-true-value"   => "true",
+             "ng-false-value"  => "false",
+             "ng-model"        => "#{ng_model}.#{prefix}_tls_verify",
+             "prefix"          => "#{prefix}"}
+
+%div{"ng-if" => defined?(tls_hide) ? false : true}
+  .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm'"}
+    %label.col-md-2.control-label{"for" => "#{prefix}_tls_ca_certs"}
+      = _('Trusted CA Certificates')
+    .col-md-4
+      %textarea.form-control{"id"          => "#{prefix}_tls_ca_certs",
+                             "name"        => "#{prefix}_tls_ca_certs",
+                             "ng-model"    => "#{ng_model}.#{prefix}_tls_ca_certs",
+                             "ng-disabled" => "!#{ng_model}.#{prefix}_tls_verify",
+                             "ng-required" => false,
+                             "ng-trim"     => false,
+                             "prefix"      => "#{prefix}"}
+      %span.help-block
+        = _("Paste here the trusted CA certificates, in PEM format.")
+
 .form-group{"ng-class" => "{'has-error': angularForm.realm.$invalid}",
             "ng-if" => "emsCommonModel.emstype == 'scvmm' && emsCommonModel.default_security_protocol == 'kerberos'"}
   %label.col-md-2.control-label{"for" => "realm"}
@@ -133,3 +165,4 @@
       = _("Required")
     %span.help-block{"ng-show" => "angularForm.realm.$error.detectedSpaces"}
       = _("Spaces are prohibited")
+

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -83,7 +83,8 @@
                             "emsCommonModel.emstype == 'openstack_infra' || " +                        |
                             "emsCommonModel.emstype == 'nuage_network' || " +                          |
                             "(emsCommonModel.emstype == 'vmware_cloud' && '#{prefix}' === 'amqp') || " |
-                            "emsCommonModel.emstype == 'scvmm'"}                                       |
+                            "emsCommonModel.emstype == 'scvmm' || " +                                  |
+                            "emsCommonModel.ems_controller == 'ems_container'"}                        |
     %label.col-md-2.control-label{"for" => "#{prefix}_security_protocol"}
       = _('Security Protocol')
     .col-md-8{"ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra' || emsCommonModel.emstype == 'vmware_cloud'"}
@@ -114,6 +115,15 @@
                        "selectpicker-for-select-tag" => "",
                        "prefix"                      => "#{prefix}",
                        "reset-validation-status"     => "#{prefix}_auth_status")
+    .col-md-8{"ng-if" => "emsCommonModel.ems_controller == 'ems_container'"}
+      = select_tag("#{prefix}_security_protocol",
+                       options_for_select([["<#{_('Choose')}>", nil]] + @container_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
+                       "checkchange"                 => "",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "",
+                       "prefix"                      => "#{prefix}",
+                       "reset-validation-status"     => "#{prefix}_auth_status")
 
 %div{"ng-if" => defined?(tls_verify_hide) ? false : true}
   .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm'"}
@@ -132,14 +142,16 @@
              "prefix"          => "#{prefix}"}
 
 %div{"ng-if" => defined?(tls_ca_certs_hide) ? false : true}
-  .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm'"}
+  .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm' || " +                                          |
+                        "(emsCommonModel.ems_controller == 'ems_container' && " +                          |
+                        " emsCommonModel.#{prefix}_security_protocol == 'ssl-with-validation-custom-ca')"} |
     %label.col-md-2.control-label{"for" => "#{prefix}_tls_ca_certs"}
       = _('Trusted CA Certificates')
     .col-md-4
       %textarea.form-control{"id"          => "#{prefix}_tls_ca_certs",
                              "name"        => "#{prefix}_tls_ca_certs",
                              "ng-model"    => "#{ng_model}.#{prefix}_tls_ca_certs",
-                             "ng-disabled" => "!#{ng_model}.#{prefix}_tls_verify",
+                             "ng-disabled" => "emsCommonModel.emstype == 'rhevm' && !#{ng_model}.#{prefix}_tls_verify",
                              "ng-required" => false,
                              "ng-trim"     => false,
                              "prefix"      => "#{prefix}"}
@@ -165,4 +177,3 @@
       = _("Required")
     %span.help-block{"ng-show" => "angularForm.realm.$error.detectedSpaces"}
       = _("Spaces are prohibited")
-

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -115,7 +115,7 @@
                        "prefix"                      => "#{prefix}",
                        "reset-validation-status"     => "#{prefix}_auth_status")
 
-%div{"ng-if" => defined?(tls_hide) ? false : true}
+%div{"ng-if" => defined?(tls_verify_hide) ? false : true}
   .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm'"}
     %label.col-md-2.control-label{"for" => "#{prefix}_tls_verify"}
       = _('Verify TLS Certificates')
@@ -131,7 +131,7 @@
              "ng-model"        => "#{ng_model}.#{prefix}_tls_verify",
              "prefix"          => "#{prefix}"}
 
-%div{"ng-if" => defined?(tls_hide) ? false : true}
+%div{"ng-if" => defined?(tls_ca_certs_hide) ? false : true}
   .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm'"}
     %label.col-md-2.control-label{"for" => "#{prefix}_tls_ca_certs"}
       = _('Trusted CA Certificates')

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -262,7 +262,6 @@
                                  :locals  => {:ng_show                => true,
                                               :ng_model               => "#{ng_model}",
                                               :id                     => record.id,
-                                              :security_protocol_hide => true,
                                               :ng_reqd_hostname       => "false",
                                               :ng_reqd_api_port       => "false",
                                               :prefix                 => "hawkular"}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -150,7 +150,8 @@
                                               :id                     => record.id,
                                               :database_name_required => true,
                                               :database_name_show     => true,
-                                              :tls_hide               => true,
+                                              :tls_verify_hide        => true,
+                                              :tls_ca_certs_hide      => true,
                                               :prefix                 => "metrics",
                                               :ng_reqd_hostname       => "#{ng_model}.metrics_userid != '' && #{ng_model}.metrics_userid != undefined",
                                               :ng_reqd_api_port       => "false"}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -150,6 +150,7 @@
                                               :id                     => record.id,
                                               :database_name_required => true,
                                               :database_name_show     => true,
+                                              :tls_hide               => true,
                                               :prefix                 => "metrics",
                                               :ng_reqd_hostname       => "#{ng_model}.metrics_userid != '' && #{ng_model}.metrics_userid != undefined",
                                               :ng_reqd_api_port       => "false"}

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -239,16 +239,26 @@ describe EmsContainerController do
                                                       :default_userid    => '_',
                                                       :default_hostname  => '10.10.10.11',
                                                       :default_api_port  => '5000',
+                                                      :default_security_protocol  => 'ssl-with-validation-custom-ca',
+                                                      :default_tls_ca_certs       => '-----BEGIN DUMMY...',
                                                       :default_password  => 'valid-token',
                                                       :hawkular_hostname => '10.10.10.10',
                                                       :hawkular_api_port => '8443',
+                                                      :hawkular_security_protocol => 'ssl-with-validation',
                                                       :emstype           => @type)
           controller.send(:set_ems_record_vars, @ems)
           expect(@flash_array).to be_nil
-          expect(@ems.connection_configurations.default.endpoint.hostname).to eq('10.10.10.11')
-          expect(@ems.connection_configurations.default.endpoint.port).to eq(5000)
-          expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq('10.10.10.10')
-          expect(@ems.connection_configurations.hawkular.endpoint.port).to eq(8443)
+          cc = @ems.connection_configurations
+          expect(cc.default.endpoint.hostname).to eq('10.10.10.11')
+          expect(cc.default.endpoint.port).to eq(5000)
+          expect(cc.default.endpoint.security_protocol).to eq('ssl-with-validation-custom-ca')
+          expect(cc.default.endpoint.verify_ssl?).to eq(true)
+          expect(cc.default.endpoint.certificate_authority).to eq('-----BEGIN DUMMY...')
+          expect(cc.hawkular.endpoint.hostname).to eq('10.10.10.10')
+          expect(cc.hawkular.endpoint.port).to eq(8443)
+          expect(cc.hawkular.endpoint.security_protocol).to eq('ssl-with-validation')
+          expect(cc.hawkular.endpoint.verify_ssl?).to eq(true)
+          expect(cc.hawkular.endpoint.certificate_authority).to eq(nil)
           expect(@ems.authentication_token("bearer")).to eq('valid-token')
           expect(@ems.authentication_type("default")).to be_nil
           expect(@ems.hostname).to eq('10.10.10.11')

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -235,17 +235,17 @@ describe EmsContainerController do
         end
 
         def test_setting_many_fields
-          controller.instance_variable_set(:@_params, :name              => 'EMS 2',
-                                                      :default_userid    => '_',
-                                                      :default_hostname  => '10.10.10.11',
-                                                      :default_api_port  => '5000',
+          controller.instance_variable_set(:@_params, :name                       => 'EMS 2',
+                                                      :default_userid             => '_',
+                                                      :default_hostname           => '10.10.10.11',
+                                                      :default_api_port           => '5000',
                                                       :default_security_protocol  => 'ssl-with-validation-custom-ca',
                                                       :default_tls_ca_certs       => '-----BEGIN DUMMY...',
-                                                      :default_password  => 'valid-token',
-                                                      :hawkular_hostname => '10.10.10.10',
-                                                      :hawkular_api_port => '8443',
+                                                      :default_password           => 'valid-token',
+                                                      :hawkular_hostname          => '10.10.10.10',
+                                                      :hawkular_api_port          => '8443',
                                                       :hawkular_security_protocol => 'ssl-with-validation',
-                                                      :emstype           => @type)
+                                                      :emstype                    => @type)
           controller.send(:set_ems_record_vars, @ems)
           expect(@flash_array).to be_nil
           cc = @ems.connection_configurations


### PR DESCRIPTION
Combined PR with @jhernand — UI side for oVirt's https://github.com/ManageIQ/manageiq/pull/14004 and containers' https://github.com/ManageIQ/manageiq/pull/14019.
Depends on the core PR (at least the containers one), should be merged soon after.

[Travis can't pass until https://github.com/ManageIQ/manageiq/pull/14019 lands, passes locally with it.]

These build on https://github.com/ManageIQ/manageiq/pull/13567 [merged] for storing & parsing the certificate_authority  #field.

## oVirt
(core part: https://github.com/ManageIQ/manageiq/pull/14004)

Currently the oVirt provider doesn't check the validity of the TLS certificates presented by the oVirt server. This patch adds to the form used to add and modify the oVirt provider connection details two new controls. The first is a checkbox to enable or disable checking the TLS certificates of the oVirt server:
```
Verify TLS Certificates [Yes | No]
```
The second will only be enabled when the value of the first is 'Yes', and it is is a text box where the user can optionally paste a set of trusted CA certificates, in PEM format:
```
Trusted CA Certificates ┌────────────────────────────────────────┐
                        │-----BEGIN CERTIFICATE-----             │
                        │MIIDxjCCAq6gAwIBAgICEAAwDQYJKoZIhvc     │
                        │NAQELBQAwSTELMAkGA1UEBhMCVVMxMCVVMx     │
                        │...                                     │
                        │-----END CERTIFICATE-----               │
                        └────────────────────────────────────────┘
                        Paste here the trusted CA certificates, in
                        PEM format.
```
The value of the first control will be stored in the 'verify_ssl' column of the 'endpoints' table.
The value of the second control will be stored in the certificate_authority column of the endpoints table.

**See screenshots [below](#issuecomment-281947044)**

## Containers
(core part: https://github.com/ManageIQ/manageiq/pull/14019)

Container provider: add Security Protocol, Trusted CA Certificates fields

Both on default & hawkular endpoints, added dropdown:
- SSL
- SSL trusting custom CA, which additionally shows CA field.
- SSL without validation

This UI always sets (security_protocol, certificate_authority, verify_ssl) consisently.
Container backend will use security_protocol if set, ignoring verify_ssl.
See core PR for backward-compat details.

> ![with](https://cloud.githubusercontent.com/assets/273688/23213670/7bae26a0-f914-11e6-8885-7897ca582352.png)

-----

> ![custom](https://cloud.githubusercontent.com/assets/273688/23213674/826aa6d0-f914-11e6-848f-1ec72c52d354.png)


-----

> ![without](https://cloud.githubusercontent.com/assets/273688/23213683/889296c6-f914-11e6-93a1-3742f7f650c2.png)

Hawkular endpoint has same dropdown and hiding/appearing CA field:
(independent control is useful because default openshift installs have bad SSL config, trying to address in https://github.com/openshift/openshift-ansible/pull/3226 but no immediate relief)

> ![hawkular-custom](https://cloud.githubusercontent.com/assets/273688/23213703/99121c6a-f914-11e6-989c-0c59a4b51ce3.png)


@miq-bot add-label compute/containers, security, enhancement, pending core

@h-kataria @AparnaKarve @yaacov please review.  cc @jhernand @simon3z
