### PR TITLE
Skip protect_from_forgery for #authenticate

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
     # This secret is reset to a value found in the miq_databases table in
     # MiqWebServerWorkerMixin.configure_secret_token for rails server, UI, and
     # web service worker processes.
-    protect_from_forgery :secret => SecureRandom.hex(64), :except => :csp_report, :with => :exception
+    protect_from_forgery :secret => SecureRandom.hex(64), :except => [:authenticate, :csp_report], :with => :exception
   end
 
   helper ChartingHelper

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -10,7 +10,6 @@
       = javascript_include_tag 'miq_debug'
       = stylesheet_link_tag 'miq_debug'
 
-    = csrf_meta_tag
     = render :partial => 'layouts/i18n_js'
 
   %body{:class => ::Settings.server.custom_login_logo ? 'whitelabel' : ''}


### PR DESCRIPTION
It makes no sense to check the token for the authenticate action.
It only makes the product seem broken when you return to a login screen
after the session has expired.

@mzazrivec, @himdel: review?