### PR TITLE
Remove disabling of 'instance_retire' button

### DIFF
--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -125,8 +125,7 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           :instance_retire,
           'fa fa-clock-o fa-lg',
           N_('Set Retirement Dates for this Instance'),
-          N_('Set Retirement Date'),
-          :klass   => ApplicationHelper::Button::InstanceRetire),
+          N_('Set Retirement Date')),
         button(
           :instance_retire_now,
           'fa fa-clock-o fa-lg',

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -89,8 +89,7 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           :instance_retire,
           'fa fa-clock-o fa-lg',
           N_('Set Retirement Dates for this Instance'),
-          N_('Set Retirement Date'),
-          :klass   => ApplicationHelper::Button::InstanceRetire),
+          N_('Set Retirement Date')),
         button(
           :instance_retire_now,
           'fa fa-clock-o fa-lg',


### PR DESCRIPTION
copy of the PR to Euwe: https://github.com/ManageIQ/manageiq/pull/14016

___

Leaves the button "Set Retirement Date" enabled even for a retired instance

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1306471

Steps for Testing/QA
-------------------------------
1. retire an instance
2. go to that instance details page
3. click `Lifecycle`
4. button `Set Retirement Date` should be enabled
 
**(see BZ ticket for more info)**

/cc @simaishi 

Parent issue: ManageIQ/manageiq#6259
Related issue: ManageIQ/manageiq#6554
