### PR TITLE
Change ordering of Saved Chargeback reports

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -469,7 +469,7 @@ class ChargebackController < ApplicationController
     miq_report = MiqReport.find(@sb[:miq_report_id])
     saved_reports = miq_report.miq_report_results.with_current_user_groups
                               .select("id, miq_report_id, name, last_run_on, report_source")
-                              .order(:last_run_on)
+                              .order(:last_run_on => :desc)
 
     @sb[:tree_typ] = "reports"
     @right_cell_text = _("Report \"%{report_name}\"") % {:report_name => miq_report.name}

--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -43,7 +43,7 @@ class TreeBuilderChargebackReports < TreeBuilder
   def x_get_tree_custom_kids(object, count_only, _options)
     objects = MiqReportResult.with_saved_chargeback_reports(from_cid(object[:id].split('-').first))
                              .select(:id, :miq_report_id, :name, :last_run_on, :miq_task_id)
-                             .order(:last_run_on)
+                             .order(:last_run_on => :desc)
 
     count_only_or_objects(count_only, objects, "name")
   end


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1420133

Change ordering of Saved Chargeback reports
in Cloud Intel -> Chargeback -> Reports
or Cloud Intel -> Reports -> Saved Reports.

Before:
![chargeback_before](https://cloud.githubusercontent.com/assets/13417815/23219979/cf28755e-f920-11e6-82c1-3521b179a83f.png)

After:
![chargeback_after](https://cloud.githubusercontent.com/assets/13417815/23219986/d25178e8-f920-11e6-8ac7-372ae46144e1.png)
