### PR TITLE
Updated summary screen to show details of Playbook type template

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -323,6 +323,11 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     return prefix == "provisioning";
   };
 
+  vm.variablesEmpty = function(prefix) {
+    field = vm.catalogItemModel[prefix + "_variables"];
+    return Object.keys(field).length === 0;
+  };
+
   // watch for all the drop downs on screen
   "catalog provisioning_playbook retirement_playbook provisioning_machine_credential retirement_machine_credential provisioning_network_credential retirement_network_credential provisioning_cloud_credential retirement_cloud_credential provisioning_dialog retirement_dialog".split(" ").forEach(idWatch)
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1756,7 +1756,7 @@ class CatalogController < ApplicationController
                 # saving values of ServiceTemplate catalog id and resource that are needed in view to build the link
                 @sb[:stc_nodes] = {}
                 @record.service_resources.each do |r|
-                  st = ServiceTemplate.find_by_id(r.resource_id)
+                  st = ServiceTemplate.find_by(:id => r.resource_id)
                   @sb[:stc_nodes][r.resource_id] = st.service_template_catalog_id ? st.service_template_catalog_id : "Unassigned" unless st.nil?
                 end
               end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -227,8 +227,10 @@ class CatalogController < ApplicationController
       upload_sysprep_file
       set_form_locals_for_sysprep
     end
+    template_locals = {:locals => {:controller => "catalog"}}
+    template_locals[:locals].merge!(fetch_playbook_details) if TreeBuilder.get_model_for_prefix(@nodetype) == "ServiceTemplate" && !@view && @record.prov_type == "generic_ansible_playbook"
 
-    render :layout => "application", :action => "explorer"
+    render :layout => "application", :action => "explorer", :locals => template_locals
   end
 
   def set_form_locals_for_sysprep
@@ -1734,27 +1736,29 @@ class CatalogController < ApplicationController
                 @miq_request = MiqRequest.find_by_id(@record.service_resources[0].resource_id)
                 prov_set_show_vars
               end
-              @sb[:dialog_label]       = _("No Dialog")
-              @sb[:fqname]             = nil
-              @sb[:reconfigure_fqname] = nil
-              @sb[:retire_fqname]      = nil
-              @record.resource_actions.each do |ra|
-                d = Dialog.where(:id => ra.dialog_id).first
-                @sb[:dialog_label] = d.label if d
-                case ra.action.downcase
-                when 'provision'
-                  @sb[:fqname] = ra.fqname
-                when 'reconfigure'
-                  @sb[:reconfigure_fqname] = ra.fqname
-                when 'retirement'
-                  @sb[:retire_fqname] = ra.fqname
+              unless @record.prov_type == "generic_ansible_playbook"
+                @sb[:dialog_label]       = _("No Dialog")
+                @sb[:fqname]             = nil
+                @sb[:reconfigure_fqname] = nil
+                @sb[:retire_fqname]      = nil
+                @record.resource_actions.each do |ra|
+                  d = Dialog.where(:id => ra.dialog_id).first
+                  @sb[:dialog_label] = d.label if d
+                  case ra.action.downcase
+                  when 'provision'
+                    @sb[:fqname] = ra.fqname
+                  when 'reconfigure'
+                    @sb[:reconfigure_fqname] = ra.fqname
+                  when 'retirement'
+                    @sb[:retire_fqname] = ra.fqname
+                  end
                 end
-              end
-              # saving values of ServiceTemplate catalog id and resource that are needed in view to build the link
-              @sb[:stc_nodes] = {}
-              @record.service_resources.each do |r|
-                st = ServiceTemplate.find_by_id(r.resource_id)
-                @sb[:stc_nodes][r.resource_id] = st.service_template_catalog_id ? st.service_template_catalog_id : "Unassigned" unless st.nil?
+                # saving values of ServiceTemplate catalog id and resource that are needed in view to build the link
+                @sb[:stc_nodes] = {}
+                @record.service_resources.each do |r|
+                  st = ServiceTemplate.find_by_id(r.resource_id)
+                  @sb[:stc_nodes][r.resource_id] = st.service_template_catalog_id ? st.service_template_catalog_id : "Unassigned" unless st.nil?
+                end
               end
               if params[:action] == "x_show"
                 prefix = @record.service_template_catalog_id ? "stc-#{to_cid(@record.service_template_catalog_id)}" : "-Unassigned"
@@ -1768,6 +1772,34 @@ class CatalogController < ApplicationController
       end
     end
     x_history_add_item(:id => treenodeid, :text => @right_cell_text)
+  end
+
+  def fetch_playbook_details
+    playbook_details = {}
+    provision = @record.config_info[:provision]
+    playbook_details[:provisioning] = {}
+    playbook_details[:provisioning][:repository] = ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource.find(provision[:repository_id]).name
+    playbook_details[:provisioning][:playbook] = ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook.find(provision[:playbook_id]).name
+    playbook_details[:provisioning][:machine_credential] = ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential.find(provision[:credential_id]).name
+    playbook_details[:provisioning][:network_credential] = ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential.find(provision[:network_credential_id]).name if provision[:network_credential_id]
+    playbook_details[:provisioning][:cloud_credential] = ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential.find(provision[:cloud_credential_id]).name if provision[:cloud_credential_id]
+    dialog = provision[:dialog_id] ? Dialog.find(provision[:dialog_id]) : Dialog.find_by(:name => provision[:dialog_name])
+    playbook_details[:provisioning][:dialog] = dialog.name
+    playbook_details[:provisioning][:dialog_id] = dialog.id
+
+    if @record.config_info[:retirement]
+      retirement = @record.config_info[:retirement]
+      playbook_details[:retirement] = {}
+      playbook_details[:retirement][:repository] = ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource.find(retirement[:repository_id]).name
+      playbook_details[:retirement][:playbook] = ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook.find(retirement[:playbook_id]).name
+      playbook_details[:retirement][:machine_credential] = ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential.find(retirement[:credential_id]).name
+      playbook_details[:retirement][:network_credential] = ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential.find(retirement[:network_credential_id]).name if retirement[:network_credential_id]
+      playbook_details[:retirement][:cloud_credential] = ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential.find(retirement[:cloud_credential_id]).name if retirement[:cloud_credential_id]
+      dialog = provision[:dialog_id] ? Dialog.find(retirement[:dialog_id]) : Dialog.find_by(:name => retirement[:dialog_name])
+      playbook_details[:retirement][:dialog] = dialog.name
+      playbook_details[:retirement][:dialog_id] = dialog.id
+    end
+    playbook_details
   end
 
   def open_parent_nodes(record)
@@ -1900,7 +1932,9 @@ class CatalogController < ApplicationController
         elsif @sb[:buttons_node]
           r[:partial => "shared/buttons/ab_list"]
         else
-          r[:partial => "catalog/#{x_active_tree}_show", :locals => {:controller => "catalog"}]
+          template_locals = {:controller => "catalog"}
+          template_locals.merge!(fetch_playbook_details) if TreeBuilder.get_model_for_prefix(@nodetype) == "ServiceTemplate" && @record.prov_type == "generic_ansible_playbook"
+          r[:partial => "catalog/#{x_active_tree}_show", :locals => template_locals]
         end
       elsif @sb[:buttons_node]
         r[:partial => "shared/buttons/ab_list"]

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -166,15 +166,14 @@ class MiqAeCustomizationController < ApplicationController
   # Dialog show selected from catalog explorer
   def show
     nodes = params[:id].split("-")
-    record = Dialog.find_by_id(from_cid(nodes.last))
+    record = Dialog.find_by(:id =>from_cid(nodes.last))
     self.x_active_accord = "dialogs"
     self.x_active_tree   = "#{x_active_accord}_tree"
     self.x_node = TreeBuilder.build_node_cid(record)
     get_node_info
     redirect_to :controller => "miq_ae_customization",
                 :action     => "explorer",
-                :id         => self.x_node
-    return
+                :id         => x_node
   end
 
   private

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -163,6 +163,20 @@ class MiqAeCustomizationController < ApplicationController
     tree_select
   end
 
+  # Dialog show selected from catalog explorer
+  def show
+    nodes = params[:id].split("-")
+    record = Dialog.find_by_id(from_cid(nodes.last))
+    self.x_active_accord = "dialogs"
+    self.x_active_tree   = "#{x_active_accord}_tree"
+    self.x_node = TreeBuilder.build_node_cid(record)
+    get_node_info
+    redirect_to :controller => "miq_ae_customization",
+                :action     => "explorer",
+                :id         => self.x_node
+    return
+  end
+
   private
 
   def features

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -19,57 +19,57 @@
         = _('Basic Information')
       .form-horizontal.static
         .form-group
-          %label.col-md-2.control-label
+          %label.col-md-3.control-label
             = _('Name / Description')
-          .col-md-8
+          .col-md-9
             #{@record.name} / #{@record.description}
         .form-group
-          %label.col-md-2.control-label
+          %label.col-md-3.control-label
             = _('Display in Catalog')
-          .col-md-8
+          .col-md-9
             &nbsp;
             = check_box_tag("display", true, @record.display, :disabled => true)
         - if @record.display
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Catalog')
-            .col-md-8
+            .col-md-9
               = h(@record.service_template_catalog ? @record.service_template_catalog.name : "<#{_('Unassigned')}>")
         - unless @record.prov_type == "generic_ansible_playbook"
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Dialog')
-            .col-md-8
+            .col-md-9
               = h(@sb[:dialog_label])
         - if @record.prov_type
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Item Type')
-            .col-md-8
+            .col-md-9
               = h(ServiceTemplate::CATALOG_ITEM_TYPES[@record.prov_type])
         - if @record.prov_type == "generic"
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Subtype')
-            .col-md-8
+            .col-md-9
               = h(ServiceTemplate::GENERIC_ITEM_SUBTYPES[@record[:generic_subtype]])
         - if @record.prov_type == "generic_orchestration"
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Orchestration Template')
-            .col-md-8
+            .col-md-9
               = h(@record.try(:orchestration_template).try(:name))
           - if @record.orchestration_manager
             .form-group
-              %label.col-md-2.control-label
+              %label.col-md-3.control-label
                 = _('Provider')
-              .col-md-8
+              .col-md-9
                 = h(@record.orchestration_manager.name)
         - elsif @record.prov_type == "generic_ansible_tower"
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Ansible Tower Job Template')
-            .col-md-8
+            .col-md-9
               = h(@record.try(:job_template).try(:name))
         - entry_points = [[_("Provisioning"), :fqname]]
         - unless @record.prov_type.try(:start_with?, "generic_")
@@ -77,9 +77,9 @@
              [_("Retirement"),   :retire_fqname])
         - entry_points.each do |entry_points_op|
           .form-group
-            %label.col-md-2.control-label{:title => _("%{entry_point} Entry Point (NameSpace/Class/Instance)") % {:entry_point => entry_points_op[0]}}
+            %label.col-md-3.control-label{:title => _("%{entry_point} Entry Point (NameSpace/Class/Instance)") % {:entry_point => entry_points_op[0]}}
               #{entry_points_op[0]} #{_('Entry Point')}
-            .col-md-8
+            .col-md-9
               = h(@sb[entry_points_op[1]])
       %hr
       %h3
@@ -87,10 +87,10 @@
       .form-horizontal
         - if @record.picture
           .form-group
-            .col-md-8
+            .col-md-9
               = image_tag("#{@record.picture.url_path}?#{rand(99_999_999)}",
                           :style => "width:100px; height:100px;")
-            .col-md-8{:valign => "bottom"}
+            .col-md-9{:valign => "bottom"}
               = link_to(image_tag(image_path('toolbars/remove.png'),
                                   :class => "rollover small",
                                   :alt   => t = _("Remove this Custom Image")),
@@ -123,9 +123,9 @@
           = _('Basic Information')
         .form-horizontal.static
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Long Description')
-            .col-md-8#long_description
+            .col-md-9#long_description
               %miq-sanitize{:value => @record.long_description}
 
     - if @record.composite?
@@ -198,59 +198,58 @@
         .col-md-12.col-lg-6
           .form-horizontal.static
             .form-group
-              %label.col-md-2.control-label
+              %label.col-md-3.control-label
                 = _('Repository')
-              .col-md-8
+              .col-md-9
                 = h(provisioning[:repository])
-          .form-horizontal.static
             .form-group
-              %label.col-md-2.control-label
+              %label.col-md-3.control-label
                 = _('Playbook')
-              .col-md-8
+              .col-md-9
                 = h(provisioning[:playbook])
-          .form-horizontal.static
             .form-group
-              %label.col-md-2.control-label
+              %label.col-md-3.control-label
                 = _('Machine Credential')
-              .col-md-8
+              .col-md-9
                 = h(provisioning[:machine_credential])
-          .form-horizontal.static
             .form-group
-              %label.col-md-2.control-label
+              %label.col-md-3.control-label
                 = _('Network Credential')
-              .col-md-8
+              .col-md-9
                 = h(provisioning[:network_credential])
-          .form-horizontal.static
             .form-group
-              %label.col-md-2.control-label
+              %label.col-md-3.control-label
                 = _('Cloud Credential')
-              .col-md-8
+              .col-md-9
                 = h(provisioning[:cloud_credential])
-          .form-horizontal.static
             .form-group
-              %label.col-md-2.control-label
+              %label.col-md-3.control-label
                 = _('Hosts')
-              .col-md-8
+              .col-md-9
                 = h(@record.config_info[:provision][:hosts])
         .col-md-12.col-lg-6
-          .form-group
-            %table.table.table-striped.table-hover.table-condensed.table-bordered
-              %tbody
-                %thead
-                  %tr
-                    %th{:colspan => "3", :align => "left"}
-                      = _("Variables and Default values")
-                      - @record.config_info[:provision][:extra_vars].each do |key, value|
-                        %tr
-                          %td
-                            = h(key)
-                          %td
-                            = h(value)
-          .form-horizontal.static
+          .form-horizontal
             .form-group
-              %label.col-md-2.control-label
+              %label.col-md-3.control-label
+                = _("Variables & Default Values")
+              .col-md-9
+                %table.table.table-bordered.table-striped   
+                  %thead
+                    %th
+                      = _("Variable")
+                    %th
+                      = _("Default value")
+                  %tbody
+                  - @record.config_info[:provision][:extra_vars].each do |key, value|
+                    %tr
+                      %td
+                        = h(key)
+                      %td
+                        = h(value)
+            .form-group
+              %label.col-md-3.control-label
                 = _('Dialog')
-              .col-md-8
+              .col-md-9
                 - if role_allows?(:feature => "dialog_accord", :any => true)
                   - params = {:controller => 'miq_ae_customization', :action => 'show', :id => "dg-#{to_cid(provisioning[:dialog_id])}"}
                   = link_to(provisioning[:dialog],
@@ -267,57 +266,60 @@
           .col-md-12.col-lg-6
             .form-horizontal.static
               .form-group
-                %label.col-md-2.control-label
+                %label.col-md-3.control-label
                   = _('Repository')
-                .col-md-8
+                .col-md-9
                   = h(retirement[:repository])
             .form-horizontal.static
               .form-group
-                %label.col-md-2.control-label
+                %label.col-md-3.control-label
                   = _('Playbook')
-                .col-md-8
+                .col-md-9
                   = h(retirement[:playbook])
             .form-horizontal.static
               .form-group
-                %label.col-md-2.control-label
+                %label.col-md-3.control-label
                   = _('Machine Credential')
-                .col-md-8
+                .col-md-9
                   = h(retirement[:machine_credential])
             .form-horizontal.static
               .form-group
-                %label.col-md-2.control-label
+                %label.col-md-3.control-label
                   = _('Network Credential')
-                .col-md-8
+                .col-md-9
                   = h(retirement[:network_credential])
             .form-horizontal.static
               .form-group
-                %label.col-md-2.control-label
+                %label.col-md-3.control-label
                   = _('Cloud Credential')
-                .col-md-8
+                .col-md-9
                   = h(retirement[:cloud_credential])
             .form-horizontal.static
               .form-group
-                %label.col-md-2.control-label
+                %label.col-md-3.control-label
                   = _('Hosts')
-                .col-md-8
+                .col-md-9
                   = h(@record.config_info[:retirement][:hosts])
           .col-md-12.col-lg-6
             .form-group
-              %table.table.table-striped.table-hover.table-condensed.table-bordered
-                %tbody
+              %label.col-md-3.control-label
+                = _("Variables & Default Values")
+              .col-md-9
+                %table.table.table-bordered
                   %thead
+                    %th
+                      = _("Variable")
+                    %th
+                      = _("Default value")
+                  %tbody
+                  - @record.config_info[:retirement][:extra_vars].each do |key, value|
                     %tr
-                      %th{:colspan => "3", :align => "left"}
-                        = _("Variables and Default values")
-                      - @record.config_info[:retirement][:extra_vars].each do |key, value|
-                        %tr
-                          %td = h(key)
-                          %td = h(value)
-            .form-horizontal.static
+                      %td = h(key)
+                      %td = h(value)
             .form-group
-              %label.col-md-2.control-label
+              %label.col-md-3.control-label
                 = _('Dialog')
-              .col-md-8
+              .col-md-9
                 - if role_allows?(:feature => "dialog_accord", :any => true)
                   - params = {:controller => 'miq_ae_customization', :action => 'show', :id => "dg-#{to_cid(retirement[:dialog_id])}"}
                   = link_to(retirement[:dialog],

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -228,24 +228,24 @@
               .col-md-9
                 = h(@record.config_info[:provision][:hosts])
         .col-md-12.col-lg-6
-          .form-horizontal
+          .form-horizontal.static
             .form-group
               %label.col-md-3.control-label
                 = _("Variables & Default Values")
               .col-md-9
-                %table.table.table-bordered.table-striped   
+                %table.table.table-bordered.table-striped
                   %thead
                     %th
                       = _("Variable")
                     %th
                       = _("Default value")
                   %tbody
-                  - @record.config_info[:provision][:extra_vars].each do |key, value|
-                    %tr
-                      %td
-                        = h(key)
-                      %td
-                        = h(value)
+                    - @record.config_info[:provision][:extra_vars].each do |key, value|
+                      %tr
+                        %td
+                          = h(key)
+                        %td
+                          = h(value)
             .form-group
               %label.col-md-3.control-label
                 = _('Dialog')
@@ -270,31 +270,26 @@
                   = _('Repository')
                 .col-md-9
                   = h(retirement[:repository])
-            .form-horizontal.static
               .form-group
                 %label.col-md-3.control-label
                   = _('Playbook')
                 .col-md-9
                   = h(retirement[:playbook])
-            .form-horizontal.static
               .form-group
                 %label.col-md-3.control-label
                   = _('Machine Credential')
                 .col-md-9
                   = h(retirement[:machine_credential])
-            .form-horizontal.static
               .form-group
                 %label.col-md-3.control-label
                   = _('Network Credential')
                 .col-md-9
                   = h(retirement[:network_credential])
-            .form-horizontal.static
               .form-group
                 %label.col-md-3.control-label
                   = _('Cloud Credential')
                 .col-md-9
                   = h(retirement[:cloud_credential])
-            .form-horizontal.static
               .form-group
                 %label.col-md-3.control-label
                   = _('Hosts')
@@ -305,17 +300,19 @@
               %label.col-md-3.control-label
                 = _("Variables & Default Values")
               .col-md-9
-                %table.table.table-bordered
+                %table.table.table-bordered.table-striped
                   %thead
                     %th
                       = _("Variable")
                     %th
                       = _("Default value")
                   %tbody
-                  - @record.config_info[:retirement][:extra_vars].each do |key, value|
-                    %tr
-                      %td = h(key)
-                      %td = h(value)
+                    - @record.config_info[:retirement][:extra_vars].each do |key, value|
+                      %tr
+                        %td
+                          = h(key)
+                        %td
+                          = h(value)
             .form-group
               %label.col-md-3.control-label
                 = _('Dialog')

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -35,11 +35,12 @@
               = _('Catalog')
             .col-md-8
               = h(@record.service_template_catalog ? @record.service_template_catalog.name : "<#{_('Unassigned')}>")
-        .form-group
-          %label.col-md-2.control-label
-            = _('Dialog')
-          .col-md-8
-            = h(@sb[:dialog_label])
+        - unless @record.prov_type == "generic_ansible_playbook"
+          .form-group
+            %label.col-md-2.control-label
+              = _('Dialog')
+            .col-md-8
+              = h(@sb[:dialog_label])
         - if @record.prov_type
           .form-group
             %label.col-md-2.control-label
@@ -182,6 +183,152 @@
           - else
             %span{:style => "color:red"}= @no_wf_msg
 
+- if @record.prov_type == "generic_ansible_playbook"
+  #playbook_tabs
+    %ul.nav.nav-tabs
+      = miq_tab_header('provisioning') do
+        = _('Provisioning')
+      - if @record.config_info.fetch_path(:retirement)
+        = miq_tab_header('retirement') do
+          = _('Retirement')
+    .tab-content
+      = miq_tab_content('provisioning') do
+        %h3
+          = _('Provisioning Info')
+        .col-md-12.col-lg-6
+          .form-horizontal.static
+            .form-group
+              %label.col-md-2.control-label
+                = _('Repository')
+              .col-md-8
+                = h(provisioning[:repository])
+          .form-horizontal.static
+            .form-group
+              %label.col-md-2.control-label
+                = _('Playbook')
+              .col-md-8
+                = h(provisioning[:playbook])
+          .form-horizontal.static
+            .form-group
+              %label.col-md-2.control-label
+                = _('Machine Credential')
+              .col-md-8
+                = h(provisioning[:machine_credential])
+          .form-horizontal.static
+            .form-group
+              %label.col-md-2.control-label
+                = _('Network Credential')
+              .col-md-8
+                = h(provisioning[:network_credential])
+          .form-horizontal.static
+            .form-group
+              %label.col-md-2.control-label
+                = _('Cloud Credential')
+              .col-md-8
+                = h(provisioning[:cloud_credential])
+          .form-horizontal.static
+            .form-group
+              %label.col-md-2.control-label
+                = _('Hosts')
+              .col-md-8
+                = h(@record.config_info[:provision][:hosts])
+        .col-md-12.col-lg-6
+          .form-group
+            %table.table.table-striped.table-hover.table-condensed.table-bordered
+              %tbody
+                %thead
+                  %tr
+                    %th{:colspan => "3", :align => "left"}
+                      = _("Variables and Default values")
+                      - @record.config_info[:provision][:extra_vars].each do |key, value|
+                        %tr
+                          %td
+                            = h(key)
+                          %td
+                            = h(value)
+          .form-horizontal.static
+            .form-group
+              %label.col-md-2.control-label
+                = _('Dialog')
+              .col-md-8
+                - if role_allows?(:feature => "dialog_accord", :any => true)
+                  - params = {:controller => 'miq_ae_customization', :action => 'show', :id => "dg-#{to_cid(provisioning[:dialog_id])}"}
+                  = link_to(provisioning[:dialog],
+                          params,
+                          "data-miq_sparkle_on"  => true,
+                          "data-miq_sparkle_off" => true,
+                          :title                 => provisioning[:dialog])
+                - else
+                  = h(provisioning[:dialog])
+      - if @record.config_info.fetch_path(:retirement)
+        = miq_tab_content('retirement') do
+          %h3
+            = _('Retirement Info')
+          .col-md-12.col-lg-6
+            .form-horizontal.static
+              .form-group
+                %label.col-md-2.control-label
+                  = _('Repository')
+                .col-md-8
+                  = h(retirement[:repository])
+            .form-horizontal.static
+              .form-group
+                %label.col-md-2.control-label
+                  = _('Playbook')
+                .col-md-8
+                  = h(retirement[:playbook])
+            .form-horizontal.static
+              .form-group
+                %label.col-md-2.control-label
+                  = _('Machine Credential')
+                .col-md-8
+                  = h(retirement[:machine_credential])
+            .form-horizontal.static
+              .form-group
+                %label.col-md-2.control-label
+                  = _('Network Credential')
+                .col-md-8
+                  = h(retirement[:network_credential])
+            .form-horizontal.static
+              .form-group
+                %label.col-md-2.control-label
+                  = _('Cloud Credential')
+                .col-md-8
+                  = h(retirement[:cloud_credential])
+            .form-horizontal.static
+              .form-group
+                %label.col-md-2.control-label
+                  = _('Hosts')
+                .col-md-8
+                  = h(@record.config_info[:retirement][:hosts])
+          .col-md-12.col-lg-6
+            .form-group
+              %table.table.table-striped.table-hover.table-condensed.table-bordered
+                %tbody
+                  %thead
+                    %tr
+                      %th{:colspan => "3", :align => "left"}
+                        = _("Variables and Default values")
+                      - @record.config_info[:retirement][:extra_vars].each do |key, value|
+                        %tr
+                          %td = h(key)
+                          %td = h(value)
+            .form-horizontal.static
+            .form-group
+              %label.col-md-2.control-label
+                = _('Dialog')
+              .col-md-8
+                - if role_allows?(:feature => "dialog_accord", :any => true)
+                  - params = {:controller => 'miq_ae_customization', :action => 'show', :id => "dg-#{to_cid(retirement[:dialog_id])}"}
+                  = link_to(retirement[:dialog],
+                          params,
+                          "data-miq_sparkle_on"  => true,
+                          "data-miq_sparkle_off" => true,
+                          :title                 => retirement[:dialog])
+                - else
+                  = h(retirement[:dialog])
+
 :javascript
   miq_tabs_init("#st_tabs");
+  miq_tabs_init("#playbook_tabs");
   miq_bootstrap('#long_description', 'miq.helpers');

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -71,16 +71,17 @@
               = _('Ansible Tower Job Template')
             .col-md-9
               = h(@record.try(:job_template).try(:name))
-        - entry_points = [[_("Provisioning"), :fqname]]
-        - unless @record.prov_type.try(:start_with?, "generic_")
-          - entry_points.push([_("Reconfigure"),  :reconfigure_fqname],
-             [_("Retirement"),   :retire_fqname])
-        - entry_points.each do |entry_points_op|
-          .form-group
-            %label.col-md-3.control-label{:title => _("%{entry_point} Entry Point (NameSpace/Class/Instance)") % {:entry_point => entry_points_op[0]}}
-              #{entry_points_op[0]} #{_('Entry Point')}
-            .col-md-9
-              = h(@sb[entry_points_op[1]])
+        - unless @record.prov_type == "generic_ansible_playbook"
+          - entry_points = [[_("Provisioning"), :fqname]]
+          - unless @record.prov_type.try(:start_with?, "generic_")
+            - entry_points.push([_("Reconfigure"),  :reconfigure_fqname],
+               [_("Retirement"),   :retire_fqname])
+          - entry_points.each do |entry_points_op|
+            .form-group
+              %label.col-md-3.control-label{:title => _("%{entry_point} Entry Point (NameSpace/Class/Instance)") % {:entry_point => entry_points_op[0]}}
+                #{entry_points_op[0]} #{_('Entry Point')}
+              .col-md-9
+                = h(@sb[entry_points_op[1]])
       %hr
       %h3
         = _('Custom Image')
@@ -296,36 +297,37 @@
                 .col-md-9
                   = h(@record.config_info[:retirement][:hosts])
           .col-md-12.col-lg-6
-            .form-group
-              %label.col-md-3.control-label
-                = _("Variables & Default Values")
-              .col-md-9
-                %table.table.table-bordered.table-striped
-                  %thead
-                    %th
-                      = _("Variable")
-                    %th
-                      = _("Default value")
-                  %tbody
-                    - @record.config_info[:retirement][:extra_vars].each do |key, value|
-                      %tr
-                        %td
-                          = h(key)
-                        %td
-                          = h(value)
-            .form-group
-              %label.col-md-3.control-label
-                = _('Dialog')
-              .col-md-9
-                - if role_allows?(:feature => "dialog_accord", :any => true)
-                  - params = {:controller => 'miq_ae_customization', :action => 'show', :id => "dg-#{to_cid(retirement[:dialog_id])}"}
-                  = link_to(retirement[:dialog],
-                          params,
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          :title                 => retirement[:dialog])
-                - else
-                  = h(retirement[:dialog])
+            .form-horizontal.static
+              .form-group
+                %label.col-md-3.control-label
+                  = _("Variables & Default Values")
+                .col-md-9
+                  %table.table.table-bordered.table-striped
+                    %thead
+                      %th
+                        = _("Variable")
+                      %th
+                        = _("Default value")
+                    %tbody
+                      - @record.config_info[:retirement][:extra_vars].each do |key, value|
+                        %tr
+                          %td
+                            = h(key)
+                          %td
+                            = h(value)
+              .form-group
+                %label.col-md-3.control-label
+                  = _('Dialog')
+                .col-md-9
+                  - if role_allows?(:feature => "dialog_accord", :any => true)
+                    - params = {:controller => 'miq_ae_customization', :action => 'show', :id => "dg-#{to_cid(retirement[:dialog_id])}"}
+                    = link_to(retirement[:dialog],
+                            params,
+                            "data-miq_sparkle_on"  => true,
+                            "data-miq_sparkle_off" => true,
+                            :title                 => retirement[:dialog])
+                  - else
+                    = h(retirement[:dialog])
 
 :javascript
   miq_tabs_init("#st_tabs");

--- a/app/views/catalog/explorer.html.haml
+++ b/app/views/catalog/explorer.html.haml
@@ -6,7 +6,7 @@
       = render :partial => "layouts/textual_groups_generic"
     - else
       = render(:partial => "#{x_active_tree}_show",
-        :locals  => {:controller => "catalog"})
+        :locals  => locals)
 - else
   #main_div
     - if @sb[:buttons_node]

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -18,14 +18,6 @@
         %label.col-md-3.control-label{"for" => "#{prefix}_playbook_id"}
           = _('Playbook')
         .col-md-9
-          %select{"ng-model"    => "vm._#{prefix}_playbook",
-                  "name"        => "#{prefix}_playbook_id",
-                  'ng-options'  => "playbook as playbook.name for playbook in vm.#{prefix}_playbooks",
-                  "required"    => "",
-                  :miqrequired  => true,
-                  :checkchange  => true,
-                  'pf-select'   => true}
-        .col-md-8
           %select{"ng-model"         => "vm._#{prefix}_playbook",
                   "name"             => "#{prefix}_playbook_id",
                   'ng-options'       => "playbook as playbook.name for playbook in vm.#{prefix}_playbooks",
@@ -41,7 +33,7 @@
         .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_machine_credential_id.$invalid}"}
           %label.col-md-3.control-label{"for" => "#{prefix}_machine_credential_id"}
             = _('Machine Credentials')
-          .col-md-8
+          .col-md-9
             %select{"ng-model"         => "vm._#{prefix}_machine_credential",
                     "name"             => "#{prefix}_machine_credential_id",
                     'ng-options'       => 'machine_credential as machine_credential.name for machine_credential in vm.machine_credentials',
@@ -52,11 +44,10 @@
                     'pf-select'        => true}
               %option{"value" => ""}
                 = "<#{_('Choose')}>"
-
         .form-group
           %label.col-md-3.control-label{"for" => "vm.#{prefix}_network_credential_id"}
             = _('Network Credentials')
-          .col-md-8
+          .col-md-9
             %select{"ng-model"         => "vm._#{prefix}_network_credential",
                     "name"             => "#{prefix}_network_credential_id",
                     'ng-options'       => 'network_credential as network_credential.name for network_credential in vm.network_credentials',
@@ -78,12 +69,11 @@
                     "pf-select"   => true}
               %option{"value" => ""}
                 = "<#{_('Choose')}>"
-
         #cloud_credentials_div{"ng-show" => "#{ng_model}.#{prefix}_cloud_type !== ''"}
           .form-group
             %label.col-md-3.control-label{"for" => "vm.#{prefix}_cloud_credential_id"}
               = _('Cloud Credentials')
-            .col-md-8
+            .col-md-9
               %select{"ng-model"         => "vm._#{prefix}_cloud_credential",
                       "name"             => "#{prefix}_cloud_credential_id",
                       'ng-options'       => 'cloud_credential as cloud_credential.name for cloud_credential in vm.cloud_credentials',
@@ -117,7 +107,6 @@
                "checkchange" => ""}
         %span.help-block{"ng-show" => "(#{ng_model}.#{prefix}_key === '' && #{ng_model}.#{prefix}_value !== '')"}
           = _("Required")
-
         %input{:type         => "text",
                'ng-model'    => "#{ng_model}.#{prefix}_value",
                :name         => "#{prefix}_value",

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -125,55 +125,55 @@
                "checkchange" => ""}
         %span.help-block{"ng-show" => "(#{ng_model}.#{prefix}_key !== '' && #{ng_model}.#{prefix}_value === '')"}
           = _("Required")
-        %button{:class        => "btn btn-link",
-                :type         => "button",
-                "ng-click"    => "vm.addKeyValue('#{prefix}')",
-                "ng-disabled" => "(#{ng_model}.#{prefix}_key == '' || #{ng_model}.#{prefix}_value == '')"}
+        %button{:class     => "btn btn-link",
+                :type      => "button",
+                "ng-click" => "vm.addKeyValue('#{prefix}')",
+                "ng-if"    => "(#{ng_model}.#{prefix}_key != '' && #{ng_model}.#{prefix}_value != '')"}
           %span{:class => "fa fa-plus tag-add"}
 
+    #variables_div{"ng-if" => "!vm.variablesEmpty('#{prefix}')"}
+      .form-group
+        %label.col-md-3.control-label
+        .col-md-7
+          %table.table.table-bordered.table-striped
+            %thead
+              %th
+                = _("Variable")
+              %th
+                = _("Default value")
+              %th
+                = _("Actions")
+            %tbody
+              %tr{"ng-repeat" => "(key, key_value) in #{ng_model}.#{prefix}_variables track by $index", "ng-form" => "rowForm"}
+                %td{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)"}
+                  {{key}}
+                %td{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}
+                  %input.form-control{:type         => "text",
+                                      :name         => "key",
+                                      'ng-model'    => "#{ng_model}.key",
+                                      "ng-change" => "",
+                                      "miqrequired" => ""}
+                %td{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)"}
+                  {{key_value}}
+                %td{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}
+                  %input.form-control{:type         => "text",
+                                      :name         => "key_value",
+                                      'ng-model'    => "#{ng_model}.key_value",
+                                      "ng-change" => "",
+                                      "miqrequired" => ""}
 
-    .form-group
-      %label.col-md-3.control-label
-      .col-md-7
-        %table.table.table-bordered.table-striped
-          %thead
-            %th
-              = _("Variable")
-            %th
-              = _("Default value")
-            %th
-              = _("Actions")
-          %tbody
-            %tr{"ng-repeat" => "(key, key_value) in #{ng_model}.#{prefix}_variables track by $index", "ng-form" => "rowForm"}
-              %td{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)"}
-                {{key}}
-              %td{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}
-                %input.form-control{:type         => "text",
-                                    :name         => "key",
-                                    'ng-model'    => "#{ng_model}.key",
-                                    "ng-change" => "",
-                                    "miqrequired" => ""}
-              %td{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)"}
-                {{key_value}}
-              %td{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}
-                %input.form-control{:type         => "text",
-                                    :name         => "key_value",
-                                    'ng-model'    => "#{ng_model}.key_value",
-                                    "ng-change" => "",
-                                    "miqrequired" => ""}
+                %td.narrow
+                  %div{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}
+                    %button{:class => "btn btn-link", :type => "button", "ng-disabled" => "(#{ng_model}.key === '' || #{ng_model}.key_value === '')", "ng-click" => "vm.saveKeyValue('#{prefix}', $index)"}
+                      %i.pficon.pficon-save
+                    %button{:class => "btn btn-link", :type => "button", "ng-click" => "vm.cancelKeyValue('#{prefix}')"}
+                      %i.pficon.pficon-close
 
-              %td.narrow
-                %div{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}
-                  %button{:class => "btn btn-link", :type => "button", "ng-disabled" => "(#{ng_model}.key === '' || #{ng_model}.key_value === '')", "ng-click" => "vm.saveKeyValue('#{prefix}', $index)"}
-                    %i.pficon.pficon-save
-                  %button{:class => "btn btn-link", :type => "button", "ng-click" => "vm.cancelKeyValue('#{prefix}')"}
-                    %i.pficon.pficon-close
-
-                %div{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)", :class => "btn-container"}
-                  %button{:class => "btn btn-link", :type => "button", "ng-click" => "vm.editKeyValue('#{prefix}', this.key, this.key_value, $index)", "ng-disabled" => "#{ng_model}.#{prefix}_editMode"}
-                    %span{:class => "pficon pficon-edit"}
-                  %button{:class => "btn btn-link", :type => "button", "ng-click" => "vm.removeKeyValue('#{prefix}', this.key, this.key_value, $index)", "ng-disabled" => "#{ng_model}.#{prefix}_editMode"}
-                    %span{:class => "pficon pficon-delete"}
+                  %div{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)", :class => "btn-container"}
+                    %button{:class => "btn btn-link", :type => "button", "ng-click" => "vm.editKeyValue('#{prefix}', this.key, this.key_value, $index)", "ng-disabled" => "#{ng_model}.#{prefix}_editMode"}
+                      %span{:class => "pficon pficon-edit"}
+                    %button{:class => "btn btn-link", :type => "button", "ng-click" => "vm.removeKeyValue('#{prefix}', this.key, this.key_value, $index)", "ng-disabled" => "#{ng_model}.#{prefix}_editMode"}
+                      %span{:class => "pficon pficon-delete"}
 
     .form-group
       %label.col-md-3.control-label

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -2,9 +2,9 @@
 .row
   .col-md-12.col-lg-6
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_repository_id.$invalid}"}
-      %label.col-md-2.control-label{"for" => "vm.#{prefix}_repository_id"}
+      %label.col-md-3.control-label{"for" => "vm.#{prefix}_repository_id"}
         = _('Repository')
-      .col-md-8
+      .col-md-9
         %select{"ng-model"    => "vm._#{prefix}_repository",
                 "name"        => "#{prefix}_repository_id",
                 'ng-options'  => 'repository as repository.name for repository in vm.repositories',
@@ -15,8 +15,16 @@
 
     #playbook_div{"ng-if" => "vm.#{prefix}_repository_selected()"}
       .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_playbook_id.$invalid}"}
-        %label.col-md-2.control-label{"for" => "#{prefix}_playbook_id"}
+        %label.col-md-3.control-label{"for" => "#{prefix}_playbook_id"}
           = _('Playbook')
+        .col-md-9
+          %select{"ng-model"    => "vm._#{prefix}_playbook",
+                  "name"        => "#{prefix}_playbook_id",
+                  'ng-options'  => "playbook as playbook.name for playbook in vm.#{prefix}_playbooks",
+                  "required"    => "",
+                  :miqrequired  => true,
+                  :checkchange  => true,
+                  'pf-select'   => true}
         .col-md-8
           %select{"ng-model"         => "vm._#{prefix}_playbook",
                   "name"             => "#{prefix}_playbook_id",
@@ -31,7 +39,7 @@
 
       #credentials_div{"ng-show" => "vm.#{prefix}_repository_selected()"}
         .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_machine_credential_id.$invalid}"}
-          %label.col-md-2.control-label{"for" => "#{prefix}_machine_credential_id"}
+          %label.col-md-3.control-label{"for" => "#{prefix}_machine_credential_id"}
             = _('Machine Credentials')
           .col-md-8
             %select{"ng-model"         => "vm._#{prefix}_machine_credential",
@@ -46,7 +54,7 @@
                 = "<#{_('Choose')}>"
 
         .form-group
-          %label.col-md-2.control-label{"for" => "vm.#{prefix}_network_credential_id"}
+          %label.col-md-3.control-label{"for" => "vm.#{prefix}_network_credential_id"}
             = _('Network Credentials')
           .col-md-8
             %select{"ng-model"         => "vm._#{prefix}_network_credential",
@@ -59,9 +67,9 @@
                 = "<#{_('Choose')}>"
 
         .form-group
-          %label.col-md-2.control-label{"for" => "vm.#{prefix}_cloud_type"}
+          %label.col-md-3.control-label{"for" => "vm.#{prefix}_cloud_type"}
             = _('Cloud Type')
-          .col-md-8
+          .col-md-9
             %select{"ng-model"    => "#{ng_model}.#{prefix}_cloud_type",
                     "name"        => "#{prefix}_cloud_type",
                     'ng-options'  => "cloud_type for cloud_type in #{ng_model}.cloud_types",
@@ -73,7 +81,7 @@
 
         #cloud_credentials_div{"ng-show" => "#{ng_model}.#{prefix}_cloud_type !== ''"}
           .form-group
-            %label.col-md-2.control-label{"for" => "vm.#{prefix}_cloud_credential_id"}
+            %label.col-md-3.control-label{"for" => "vm.#{prefix}_cloud_credential_id"}
               = _('Cloud Credentials')
             .col-md-8
               %select{"ng-model"         => "vm._#{prefix}_cloud_credential",
@@ -86,9 +94,9 @@
                   = "<#{_('Choose')}>"
 
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_inventory.$invalid}"}
-      %label.col-md-2.control-label
+      %label.col-md-3.control-label
         = _("Hosts")
-      .col-md-8
+      .col-md-9
         %input.form-control{:type         => "text",
                             'ng-model'    => "#{ng_model}.#{prefix}_inventory",
                             :name         => "#{prefix}_inventory",
@@ -99,38 +107,43 @@
             = _("Required")
   .col-md-12.col-lg-6
     .form-group
-      %table.table.table-striped.table-hover.table-condensed.table-bordered
-        %tbody
+      %label.col-md-3.control-label
+        = _("Variables & Default Values")
+      .col-md-9
+        %input{:type         => "text",
+               'ng-model'    => "#{ng_model}.#{prefix}_key",
+               :name         => "#{prefix}_key",
+               "placeholder" => "Variable",
+               "checkchange" => ""}
+        %span.help-block{"ng-show" => "(#{ng_model}.#{prefix}_key === '' && #{ng_model}.#{prefix}_value !== '')"}
+          = _("Required")
+
+        %input{:type         => "text",
+               'ng-model'    => "#{ng_model}.#{prefix}_value",
+               :name         => "#{prefix}_value",
+               "placeholder" => "Default value",
+               "checkchange" => ""}
+        %span.help-block{"ng-show" => "(#{ng_model}.#{prefix}_key !== '' && #{ng_model}.#{prefix}_value === '')"}
+          = _("Required")
+        %button{:class        => "btn btn-link",
+                :type         => "button",
+                "ng-click"    => "vm.addKeyValue('#{prefix}')",
+                "ng-disabled" => "(#{ng_model}.#{prefix}_key == '' || #{ng_model}.#{prefix}_value == '')"}
+          %span{:class => "fa fa-plus tag-add"}
+
+
+    .form-group
+      %label.col-md-3.control-label
+      .col-md-7
+        %table.table.table-bordered.table-striped
           %thead
-            %tr
-              %th{:colspan => "3", :align => "left"}
-                = _("Variables and Default values")
-            %tr
-              %td
-                %input.form-control{:type   => "text",
-                              'ng-model'    => "#{ng_model}.#{prefix}_key",
-                              :name         => "#{prefix}_key",
-                              "placeholder" => "Variable",
-                              "checkchange" => ""}
-                %span.help-block{"ng-show" => "(#{ng_model}.#{prefix}_key === '' && #{ng_model}.#{prefix}_value !== '')"}
-                  = _("Required")
-              %td
-                %input.form-control{:type   => "text",
-                              'ng-model'    => "#{ng_model}.#{prefix}_value",
-                              :name         => "#{prefix}_value",
-                              "placeholder" => "Default value",
-                              "checkchange" => ""}
-                %span.help-block{"ng-show" => "(#{ng_model}.#{prefix}_key !== '' && #{ng_model}.#{prefix}_value === '')"}
-                  = _("Required")
-
-              %td
-                %div{:class => "btn-container"}
-                  %button{:class => "btn btn-link",
-                  :type => "button",
-                  "ng-click" => "vm.addKeyValue('#{prefix}')",
-                  "ng-disabled" => "(#{ng_model}.#{prefix}_key == '' || #{ng_model}.#{prefix}_value == '')"}
-                    %span{:class => "fa fa-plus tag-add"}
-
+            %th
+              = _("Variable")
+            %th
+              = _("Default value")
+            %th
+              = _("Actions")
+          %tbody
             %tr{"ng-repeat" => "(key, key_value) in #{ng_model}.#{prefix}_variables track by $index", "ng-form" => "rowForm"}
               %td{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)"}
                 {{key}}
@@ -149,12 +162,12 @@
                                     "ng-change" => "",
                                     "miqrequired" => ""}
 
-              %td
+              %td.narrow
                 %div{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}
-                  %button{:class => "btn btn-primary", :type => "button", "ng-disabled" => "(#{ng_model}.key === '' || #{ng_model}.key_value === '')", "ng-click" => "vm.saveKeyValue('#{prefix}', $index)"}
-                    =_("Save")
-                  %button{:class => "btn btn-default", :type => "button", "ng-click" => "vm.cancelKeyValue('#{prefix}')"}
-                    =_("Cancel")
+                  %button{:class => "btn btn-link", :type => "button", "ng-disabled" => "(#{ng_model}.key === '' || #{ng_model}.key_value === '')", "ng-click" => "vm.saveKeyValue('#{prefix}', $index)"}
+                    %i.pficon.pficon-save
+                  %button{:class => "btn btn-link", :type => "button", "ng-click" => "vm.cancelKeyValue('#{prefix}')"}
+                    %i.pficon.pficon-close
 
                 %div{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)", :class => "btn-container"}
                   %button{:class => "btn btn-link", :type => "button", "ng-click" => "vm.editKeyValue('#{prefix}', this.key, this.key_value, $index)", "ng-disabled" => "#{ng_model}.#{prefix}_editMode"}
@@ -163,13 +176,13 @@
                     %span{:class => "pficon pficon-delete"}
 
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-3.control-label
         = _("Dialog")
-      .col-md-4
-        %label.radio
+      .col-md-3
+        .radio
           %input{"ng-model" => "vm.#{prefix}_dialog_existing", :type => "radio", :value => "existing", "ng-click" => "vm.toggleDialogSelection('#{prefix}', 'existing')", "ng-checked" => "#{ng_model}.#{prefix}_dialog_existing == 'existing'"}
           = _("Use Existing")
-        %label.radio
+        .radio
           %input{"ng-model" => "vm.#{prefix}_dialog_existing", :type => "radio", :value => "create", "ng-click" => "vm.toggleDialogSelection('#{prefix}', 'create')", "ng-checked" => ("#{ng_model}.#{prefix}_dialog_existing == 'create'")}
           = _("Create New")
       .col-md-4

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2007,6 +2007,7 @@ Rails.application.routes.draw do
         dialog_accordion_json
         explorer
         export_service_dialogs
+        show
       ),
       :post => %w(
         ab_group_reorder


### PR DESCRIPTION
Changed to Catalog Items screen to show Ansible Playbook type service template details that user entered when adding a template. Linked Dialog field to go to selected Dialog in Automate/Customization explorer.

https://www.pivotaltracker.com/story/show/140247021

@epwinchell need some help with formatting of field son screen.

screenshots:
![playbook_catalog_item_summary1](https://cloud.githubusercontent.com/assets/3450808/23273449/0b1ed204-f9cd-11e6-94b7-f89a9e641e31.png)

![playbook_catalog_item_summary2](https://cloud.githubusercontent.com/assets/3450808/23273448/0b1e6134-f9cd-11e6-9afe-7dd0f4b642b9.png)
