### PR TITLE
VmOrTemplateDecorator - remove supports_console and supports_cockpit

### DIFF
--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -8,12 +8,4 @@ class VmOrTemplateDecorator < Draper::Decorator
   def listicon_image
     "svg/vendor-#{vendor.downcase}.svg"
   end
-
-  def supports_console?
-    console_supported?('spice') || console_supported?('vnc')
-  end
-
-  def supports_cockpit?
-    supports_launch_cockpit?
-  end
 end


### PR DESCRIPTION
Depends on: ManageIQ/manageiq#14040

only used by the API, for the Vms collection, removed in ManageIQ/manageiq#14040.

(Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/237.)