### PR TITLE
Hawkular/add ssl support

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -378,7 +378,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     var defaultNonSSLPort = '8080';
     var defaultSSLPort = '8443';
     var defaultPorts = [defaultNonSSLPort, defaultSSLPort];
-    if ($scope.emsCommonModel.default_api_port === undefined ||
+    if (typeof $scope.emsCommonModel.default_api_port === 'undefined' ||
         $scope.emsCommonModel.default_api_port === '' ||
         defaultPorts.indexOf($scope.emsCommonModel.default_api_port) != -1) {
       if ($scope.emsCommonModel.default_security_protocol === 'non-ssl') {

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -374,6 +374,21 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     }
   };
 
+  $scope.hawkularSecurityProtocolChanged = function() {
+    var defaultNonSSLPort = '8080';
+    var defaultSSLPort = '8443';
+    var defaultPorts = [defaultNonSSLPort, defaultSSLPort];
+    if ($scope.emsCommonModel.default_api_port === undefined ||
+        $scope.emsCommonModel.default_api_port === '' ||
+        defaultPorts.indexOf($scope.emsCommonModel.default_api_port) != -1) {
+      if ($scope.emsCommonModel.default_security_protocol === 'non-ssl') {
+        $scope.emsCommonModel.default_api_port = defaultNonSSLPort;
+      } else {
+        $scope.emsCommonModel.default_api_port = defaultSSLPort;
+      }
+    }
+  };
+
   $scope.getDefaultApiPort = function(emstype) {
     if( emstype=='openstack' || emstype === 'openstack_infra') {
       return '5000';

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -716,6 +716,7 @@ module EmsCommon
     @vmware_cloud_api_versions = retrieve_vmware_cloud_api_versions
     @emstype_display = model.supported_types_and_descriptions_hash[@ems.emstype]
     @nuage_api_versions = retrieve_nuage_api_versions
+    @hawkular_security_protocols = retrieve_hawkular_security_protocols
   end
 
   def retrieve_provider_regions
@@ -766,6 +767,13 @@ module EmsCommon
     [[_('SSL'), 'ssl-with-validation'],
      [_('SSL trusting custom CA'), 'ssl-with-validation-custom-ca'],
      [_('SSL without validation'), 'ssl-without-validation']]
+  end
+
+  def retrieve_hawkular_security_protocols
+    [[_('SSL'), 'ssl-with-validation'],
+     [_('SSL trusting custom CA'), 'ssl-with-validation-custom-ca'],
+     [_('SSL without validation'), 'ssl-without-validation'],
+     [_('Non-SSL'), 'non-ssl']]
   end
 
   # Get variables from edit form

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -291,14 +291,16 @@ module Mixins
                        :hawkular_auth_status       => hawkular_auth_status.nil? ? true : hawkular_auth_status,
       } if controller_name == "ems_container"
 
-      render :json => {:name                => @ems.name,
-                       :emstype             => @ems.emstype,
-                       :zone                => zone,
-                       :default_hostname    => @ems.connection_configurations.default.endpoint.hostname,
-                       :default_api_port    => @ems.connection_configurations.default.endpoint.port,
-                       :default_userid      => @ems.authentication_userid ? @ems.authentication_userid : "",
-                       :ems_controller      => controller_name,
-                       :default_auth_status => default_auth_status,
+      render :json => {:name                      => @ems.name,
+                       :emstype                   => @ems.emstype,
+                       :zone                      => zone,
+                       :default_hostname          => @ems.connection_configurations.default.endpoint.hostname,
+                       :default_api_port          => @ems.connection_configurations.default.endpoint.port,
+                       :default_userid            => @ems.authentication_userid ? @ems.authentication_userid : "",
+                       :default_security_protocol => default_security_protocol,
+                       :default_tls_ca_certs      => default_tls_ca_certs,
+                       :ems_controller            => controller_name,
+                       :default_auth_status       => default_auth_status,
       } if controller_name == "ems_middleware"
 
       render :json => {:name                => @ems.name,
@@ -427,6 +429,7 @@ module Mixins
 
       if ems.kind_of?(ManageIQ::Providers::MiddlewareManager)
         default_endpoint = {:role => :default, :hostname => hostname, :port => port}
+        default_endpoint.merge!(container_security_options(ems.security_protocol, default_tls_ca_certs))
       end
 
       if ems.kind_of?(ManageIQ::Providers::Hawkular::DatawarehouseManager)
@@ -470,8 +473,8 @@ module Mixins
     def container_security_options(security_protocol, certificate_authority)
       {
         :security_protocol     => security_protocol,
-        :verify_ssl            => security_protocol != 'ssl-without-validation',
-        :certificate_authority => security_protocol == 'ssl-with-validation-custom-ca' ? certificate_authority : nil,
+        :verify_ssl            => %w(ssl-without-validation non-ssl).exclude?(security_protocol),
+        :certificate_authority => security_protocol == 'ssl-with-validation-custom-ca' ? certificate_authority : nil
       }
     end
 

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -417,19 +417,19 @@ module Mixins
       if ems.kind_of?(ManageIQ::Providers::ContainerManager)
         params[:cred_type] = ems.default_authentication_type if params[:cred_type] == "default"
         default_endpoint = {:role => :default, :hostname => hostname, :port => port}
-        default_endpoint.merge!(container_security_options(ems.security_protocol, default_tls_ca_certs))
+        default_endpoint.merge!(endpoint_security_options(ems.security_protocol, default_tls_ca_certs))
 
         if hawkular_hostname.blank?
           default_key = params[:default_password] || ems.authentication_key
           hawkular_hostname = get_hostname_from_routes(ems, default_endpoint, default_key)
         end
         hawkular_endpoint = {:role => :hawkular, :hostname => hawkular_hostname, :port => hawkular_api_port}
-        hawkular_endpoint.merge!(container_security_options(hawkular_security_protocol, hawkular_tls_ca_certs))
+        hawkular_endpoint.merge!(endpoint_security_options(hawkular_security_protocol, hawkular_tls_ca_certs))
       end
 
       if ems.kind_of?(ManageIQ::Providers::MiddlewareManager)
         default_endpoint = {:role => :default, :hostname => hostname, :port => port}
-        default_endpoint.merge!(container_security_options(ems.security_protocol, default_tls_ca_certs))
+        default_endpoint.merge!(endpoint_security_options(ems.security_protocol, default_tls_ca_certs))
       end
 
       if ems.kind_of?(ManageIQ::Providers::Hawkular::DatawarehouseManager)
@@ -470,7 +470,7 @@ module Mixins
       nil
     end
 
-    def container_security_options(security_protocol, certificate_authority)
+    def endpoint_security_options(security_protocol, certificate_authority)
       {
         :security_protocol     => security_protocol,
         :verify_ssl            => %w(ssl-without-validation non-ssl).exclude?(security_protocol),

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -291,17 +291,18 @@ module Mixins
                        :hawkular_auth_status       => hawkular_auth_status.nil? ? true : hawkular_auth_status,
       } if controller_name == "ems_container"
 
-      render :json => {:name                      => @ems.name,
-                       :emstype                   => @ems.emstype,
-                       :zone                      => zone,
-                       :default_hostname          => @ems.connection_configurations.default.endpoint.hostname,
-                       :default_api_port          => @ems.connection_configurations.default.endpoint.port,
-                       :default_userid            => @ems.authentication_userid ? @ems.authentication_userid : "",
-                       :default_security_protocol => default_security_protocol,
-                       :default_tls_ca_certs      => default_tls_ca_certs,
-                       :ems_controller            => controller_name,
-                       :default_auth_status       => default_auth_status,
-      } if controller_name == "ems_middleware"
+      if controller_name == "ems_middleware"
+        render :json => {:name                      => @ems.name,
+                         :emstype                   => @ems.emstype,
+                         :zone                      => zone,
+                         :default_hostname          => @ems.connection_configurations.default.endpoint.hostname,
+                         :default_api_port          => @ems.connection_configurations.default.endpoint.port,
+                         :default_userid            => @ems.authentication_userid ? @ems.authentication_userid : "",
+                         :default_security_protocol => default_security_protocol,
+                         :default_tls_ca_certs      => default_tls_ca_certs,
+                         :ems_controller            => controller_name,
+                         :default_auth_status       => default_auth_status}
+      end
 
       render :json => {:name                => @ems.name,
                        :emstype             => @ems.emstype,

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -153,10 +153,11 @@
              "prefix"          => "#{prefix}"}
 
 %div{"ng-if" => defined?(tls_ca_certs_hide) ? false : true}
-  .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm' || " +                                          |
-                        "((emsCommonModel.ems_controller == 'ems_container' || " +                         |
-                        "emsCommonModel.emstype == 'hawkular') && " +                               |
-                        " emsCommonModel.#{prefix}_security_protocol == 'ssl-with-validation-custom-ca')"} |
+  .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm' || " +                                             |
+                        "(emsCommonModel.ems_controller == 'ems_container' && " +                             |
+                        " emsCommonModel.#{prefix}_security_protocol == 'ssl-with-validation-custom-ca') || " |
+                        "(emsCommonModel.emstype == 'hawkular' && " +                                         |
+                        " emsCommonModel.#{prefix}_security_protocol == 'ssl-with-validation-custom-ca')"}    |
     %label.col-md-2.control-label{"for" => "#{prefix}_tls_ca_certs"}
       = _('Trusted CA Certificates')
     .col-md-4

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -132,6 +132,7 @@
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "required"                    => "",
+                       "ng-change"                   => "hawkularSecurityProtocolChanged()",
                        "selectpicker-for-select-tag" => "",
                        "prefix"                      => "#{prefix}",
                        "reset-validation-status"     => "#{prefix}_auth_status")

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -128,13 +128,13 @@
                        "reset-validation-status"     => "#{prefix}_auth_status")
     .col-md-8{"ng-if" => "emsCommonModel.emstype == 'hawkular'"}
       = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose')}>", nil]] + @hawkular_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       options_for_select([["<#{_('Choose')}>", nil]] + @hawkular_security_protocols, "disabled" => ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "required"                    => "",
                        "ng-change"                   => "hawkularSecurityProtocolChanged()",
                        "selectpicker-for-select-tag" => "",
-                       "prefix"                      => "#{prefix}",
+                       "prefix"                      => prefix.to_s,
                        "reset-validation-status"     => "#{prefix}_auth_status")
 
 %div{"ng-if" => defined?(tls_verify_hide) ? false : true}

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -85,7 +85,8 @@
                             "emsCommonModel.emstype == 'nuage_network' || " +                          |
                             "(emsCommonModel.emstype == 'vmware_cloud' && '#{prefix}' === 'amqp') || " |
                             "emsCommonModel.emstype == 'scvmm' || " +                                  |
-                            "emsCommonModel.ems_controller == 'ems_container'"}                        |
+                            "emsCommonModel.ems_controller == 'ems_container' || " +                   |
+                            "emsCommonModel.emstype == 'hawkular'"}                                    |
     %label.col-md-2.control-label{"for" => "#{prefix}_security_protocol"}
       = _('Security Protocol')
     .col-md-8{"ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra' || emsCommonModel.emstype == 'vmware_cloud'"}
@@ -125,6 +126,15 @@
                        "selectpicker-for-select-tag" => "",
                        "prefix"                      => "#{prefix}",
                        "reset-validation-status"     => "#{prefix}_auth_status")
+    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'hawkular'"}
+      = select_tag("#{prefix}_security_protocol",
+                       options_for_select([["<#{_('Choose')}>", nil]] + @hawkular_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
+                       "checkchange"                 => "",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "",
+                       "prefix"                      => "#{prefix}",
+                       "reset-validation-status"     => "#{prefix}_auth_status")
 
 %div{"ng-if" => defined?(tls_verify_hide) ? false : true}
   .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm'"}
@@ -144,7 +154,8 @@
 
 %div{"ng-if" => defined?(tls_ca_certs_hide) ? false : true}
   .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm' || " +                                          |
-                        "(emsCommonModel.ems_controller == 'ems_container' && " +                          |
+                        "((emsCommonModel.ems_controller == 'ems_container' || " +                         |
+                        "emsCommonModel.emstype == 'hawkular') && " +                               |
                         " emsCommonModel.#{prefix}_security_protocol == 'ssl-with-validation-custom-ca')"} |
     %label.col-md-2.control-label{"for" => "#{prefix}_tls_ca_certs"}
       = _('Trusted CA Certificates')


### PR DESCRIPTION
Adds support for tls endpoints on Hawkular MW provider

ToDo:
 - [x] Rename `container_security_options` to `endpoint_security_options`

![screenshot from 2017-02-23 11-15-26](https://cloud.githubusercontent.com/assets/3845764/23273321/464563ec-f9c4-11e6-8799-6bac3b0392fe.png)

![screenshot from 2017-02-23 11-26-29](https://cloud.githubusercontent.com/assets/3845764/23273325/4bd04d04-f9c4-11e6-95f0-262340609ba9.png)

![screenshot from 2017-02-23 11-16-02](https://cloud.githubusercontent.com/assets/3845764/23273331/52f39c80-f9c4-11e6-9c6e-21ea13e087f4.png)



This PR ~~depends on PR #450 and~~ supports https://github.com/ManageIQ/manageiq/pull/14054

@miq-bot add-label providers/hawkular

