### PR TITLE
Fix retrieval of `device_path` from the attach form

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -175,7 +175,7 @@ class CloudVolumeController < ApplicationController
       vm = find_by_id_filtered(VmCloud, options[:vm_id])
       if @volume.is_available?(:attach_volume)
         begin
-          @volume.raw_attach_volume(vm.ems_ref, options['device_path'])
+          @volume.raw_attach_volume(vm.ems_ref, options[:device_path])
           add_flash(_("Attaching %{volume} \"%{volume_name}\" to %{vm_name}") % {
             :volume      => ui_lookup(:table => 'cloud_volume'),
             :volume_name => @volume.name,


### PR DESCRIPTION
All other form options are retrieved using symbols, but the
`device_path` was retrieved as a string resulting in `nil` being passed
to the provider's `raw_attach_volume`. This patch fixes this allowing
Amazon EBS manager to attach the volume to an instance at a given device
path.

@miq-bot add_label bug