### PR TITLE
Make chart loading more error resistant.

### DIFF
--- a/lib/charting/c3_charting.rb
+++ b/lib/charting/c3_charting.rb
@@ -34,7 +34,7 @@ class C3Charting < Charting
   def data_ok?(data)
     obj = YAML.load(data)
     !!obj && obj.kind_of?(Hash) && !obj[:options]
-  rescue Psych::SyntaxError
+  rescue Psych::SyntaxError, ArgumentError
     false
   end
 


### PR DESCRIPTION
With recent removal of jqplot stuff you can get:
```
/home/martin/.rvm/gems/ruby-2.3.3/gems/psych-2.0.17/lib/psych/visitors/visitor.rb:15:in `visit'
/home/martin/.rvm/gems/ruby-2.3.3/gems/psych-2.0.17/lib/psych/visitors/visitor.rb:5:in `accept'
/home/martin/.rvm/gems/ruby-2.3.3/gems/psych-2.0.17/lib/psych/visitors/to_ruby.rb:31:in `accept'
/home/martin/.rvm/gems/ruby-2.3.3/gems/psych-2.0.17/lib/psych/visitors/to_ruby.rb:310:in `visit_Psych_Nodes_Document'
/home/martin/.rvm/gems/ruby-2.3.3/gems/psych-2.0.17/lib/psych/visitors/visitor.rb:15:in `visit'
/home/martin/.rvm/gems/ruby-2.3.3/gems/psych-2.0.17/lib/psych/visitors/visitor.rb:5:in `accept'
/home/martin/.rvm/gems/ruby-2.3.3/gems/psych-2.0.17/lib/psych/visitors/to_ruby.rb:31:in `accept'
/home/martin/.rvm/gems/ruby-2.3.3/gems/psych-2.0.17/lib/psych/nodes/node.rb:37:in `to_ruby'
/home/martin/.rvm/gems/ruby-2.3.3/gems/psych-2.0.17/lib/psych.rb:252:in `load'
/home/martin/Projects/manageiq-ui-classic/lib/charting/c3_charting.rb:35:in `data_ok?'
/home/martin/Projects/manageiq-ui-classic/app/views/dashboard/_widget_chart.html.haml:12:in `__home_martin__rojects_manageiq_ui_classic_app_views_dashboard__widget_chart_html_haml___2628784257344300695_23625540'
/home/martin/.rvm/gems/ruby-2.3.3/gems/actionview-5.0.1/lib/action_view/template.rb:159:in `block in render'
/home/martin/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.1/lib/active_support/notifications.rb:166:in `instrument'
/home/martin/.rvm/gems/ruby-2.3.3/gems/actionview-5.0.1/lib/action_view/template.rb:354:in `instrument'
/home/martin/.rvm/gems/ruby-2.3.3/gems/actionview-5.0.1/lib/action_view/template.rb:157:in `render'
/home/martin/.rvm/gems/ruby-2.3.3/gems/actionview-5.0.1/lib/action_view/renderer/partial_renderer.rb:343:in `render_partial'
/home/martin/.rvm/gems/ruby-2.3.3/gems/actionview-5.0.1/lib/action_view/renderer/partial_renderer.rb:311:in `block in render'
/home/martin/.rvm/gems/ruby-2.3.3/gems/actionview-5.0.1/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
/home/martin/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.1/lib/active_support/notifications.rb:164:in `block in instrument'
/home/martin/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.1/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/martin/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.1/lib/active_support/notifications.rb:164:in `instrument'
```

This fixes the problem.