### PR TITLE
Include GenericSessionMixin to miq_ae_customization_controller.rb

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -3,8 +3,12 @@ class MiqAeCustomizationController < ApplicationController
   include_concern 'OldDialogs'
   include_concern 'Dialogs'
 
+
   include AutomateTreeHelper
+
   helper ApplicationHelper::ImportExportHelper
+  include GenericSessionMixin
+
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -9,6 +9,9 @@ class MiqAeCustomizationController < ApplicationController
   helper ApplicationHelper::ImportExportHelper
   include GenericSessionMixin
 
+  include Mixins::GenericSessionMixin
+
+
 
   before_action :check_privileges
   before_action :get_session_data
@@ -107,6 +110,14 @@ class MiqAeCustomizationController < ApplicationController
     self.x_active_tree   = "#{x_active_accord}_tree"
     get_node_info
     replace_right_cell(:nodetype => x_node)
+  end
+
+  def self.session_key_prefix
+    "miq_ae_customization"
+  end
+
+  def title
+    "miq_ae_customization"
   end
 
   def explorer
@@ -362,11 +373,12 @@ class MiqAeCustomizationController < ApplicationController
   end
 
   def get_session_data
-    @layout  = "miq_ae_customization"
+    super
     @resolve = session[:resolve] if session[:resolve]
   end
 
   def set_session_data
+    super
     session[:resolve] = @resolve if @resolve
   end
 

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -117,7 +117,7 @@ class MiqAeCustomizationController < ApplicationController
   end
 
   def title
-    "miq_ae_customization"
+    _("Automate Customization")
   end
 
   def explorer

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -3,15 +3,10 @@ class MiqAeCustomizationController < ApplicationController
   include_concern 'OldDialogs'
   include_concern 'Dialogs'
 
-
   include AutomateTreeHelper
 
   helper ApplicationHelper::ImportExportHelper
-  include GenericSessionMixin
-
   include Mixins::GenericSessionMixin
-
-
 
   before_action :check_privileges
   before_action :get_session_data


### PR DESCRIPTION
- Include GenericSessionMixin to miq_ae_customization_controller.rb 
- removing duplicates in method get_session_data from miq_ae_customization_controller.rb

Because of method def explorer methods for prefix title 
- adding method self.session_key_prefix 
- adding method title 