### PR TITLE
ContainerDashboardController : use session mixin

### DIFF
--- a/app/controllers/container_dashboard_controller.rb
+++ b/app/controllers/container_dashboard_controller.rb
@@ -28,14 +28,14 @@ class ContainerDashboardController < ApplicationController
   end
 
   def title
-    "container_dashboard"
+    _("Container Dashboard")
   end
-
-  private
 
   def self.session_key_prefix
     "container_dashboard"
   end
+
+  private
 
   def get_session_data
     super

--- a/app/controllers/container_dashboard_controller.rb
+++ b/app/controllers/container_dashboard_controller.rb
@@ -1,6 +1,8 @@
 class ContainerDashboardController < ApplicationController
   extend ActiveSupport::Concern
-
+  
+  include GenericSessionMixin
+ 
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action

--- a/app/controllers/container_dashboard_controller.rb
+++ b/app/controllers/container_dashboard_controller.rb
@@ -27,20 +27,18 @@ class ContainerDashboardController < ApplicationController
     render :json => collect_live_data(params[:id], params[:query])
   end
 
+  def title
+    "container_dashboard"
+  end
+
   private
 
   def self.session_key_prefix
     "container_dashboard"
   end
 
-  def self.table_name
-    _('title')
-  end
-
   def get_session_data
     super
-    binding .pry
-    @layout = "container_dashboard"
   end
 
   def collect_data(provider_id)
@@ -52,7 +50,6 @@ class ContainerDashboardController < ApplicationController
   end
 
   def set_session_data
-    binding.pry
     session[:layout] = @layout
   end
 

--- a/app/controllers/container_dashboard_controller.rb
+++ b/app/controllers/container_dashboard_controller.rb
@@ -49,9 +49,5 @@ class ContainerDashboardController < ApplicationController
     HawkularProxyService.new(provider_id, self).data(query)
   end
 
-  def set_session_data
-    session[:layout] = @layout
-  end
-
   menu_section :cnt
 end

--- a/app/controllers/container_dashboard_controller.rb
+++ b/app/controllers/container_dashboard_controller.rb
@@ -1,8 +1,8 @@
 class ContainerDashboardController < ApplicationController
   extend ActiveSupport::Concern
-  
-  include GenericSessionMixin
- 
+
+  include Mixins::GenericSessionMixin
+
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -29,7 +29,17 @@ class ContainerDashboardController < ApplicationController
 
   private
 
+  def self.session_key_prefix
+    "container_dashboard"
+  end
+
+  def self.table_name
+    _('title')
+  end
+
   def get_session_data
+    super
+    binding .pry
     @layout = "container_dashboard"
   end
 
@@ -42,6 +52,7 @@ class ContainerDashboardController < ApplicationController
   end
 
   def set_session_data
+    binding.pry
     session[:layout] = @layout
   end
 


### PR DESCRIPTION
_GenericSessionMixin_ included in _ContainerDashboardController_, controller now implements **get_session_data** method from _GenericSessionMixin_. It was necessary add methods **self.session_key_prefix** and **title** to controller.