### PR TITLE
DashboardController - removed unused current_page parameter and set_session_data method

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class DashboardController < ApplicationController
   include DashboardHelper
   include StartUrl
-  include GenericSessionMixin
+  include Mixins::GenericSessionMixin
 
   menu_section :vi
 
@@ -756,11 +756,13 @@ class DashboardController < ApplicationController
   end
 
   def get_session_data
+    super
     @layout       = "login"
     @current_page = session[:vm_current_page] # current page number
   end
 
   def set_session_data
+    super
     session[:layout]          = @layout
     session[:vm_current_page] = @current_page
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -14,7 +14,6 @@ class DashboardController < ApplicationController
   before_action :get_session_data, :except => [:csp_report, :authenticate,
                                                :external_authenticate, :kerberos_authenticate, :saml_login]
   after_action :cleanup_action,    :except => [:csp_report]
-  after_action :set_session_data,  :except => [:csp_report]
 
   def index
     redirect_to :action => 'show'
@@ -759,11 +758,5 @@ class DashboardController < ApplicationController
     super
     @layout       = "login"
     @current_page = session[:vm_current_page] # current page number
-  end
-
-  def set_session_data
-    super
-    session[:layout]          = @layout
-    session[:vm_current_page] = @current_page
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,7 +1,6 @@
 class DashboardController < ApplicationController
   include DashboardHelper
   include StartUrl
-  include Mixins::GenericSessionMixin
 
   menu_section :vi
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -754,7 +754,6 @@ class DashboardController < ApplicationController
   end
 
   def get_session_data
-    super
     @layout       = "login"
     @current_page = session[:vm_current_page] # current page number
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -635,7 +635,6 @@ class DashboardController < ApplicationController
 
     # Clear instance vars that end up in the session
     @sb = @edit = @view = @settings = @lastaction = @perf_options = @assign = nil
-    @current_page = @search_text = @detail_sortcol = @detail_sortdir = @exp_key = nil
     @server_options = @tl_options = @pp_choices = @panels = @breadcrumbs = nil
   end
 
@@ -755,6 +754,5 @@ class DashboardController < ApplicationController
 
   def get_session_data
     @layout       = "login"
-    @current_page = session[:vm_current_page] # current page number
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,6 +1,7 @@
 class DashboardController < ApplicationController
   include DashboardHelper
   include StartUrl
+  include GenericSessionMixin
 
   menu_section :vi
 


### PR DESCRIPTION
The main reason was to include GenericSessionMixin. After discussion was decided that in this controller it's not necessary.
+ Attribute current_page was not used on Dashboard
+ The whole set_session_data method was not useful after all, so I removed it