### PR TITLE
ConfigurationController: use GenericSessionMixin

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -1,6 +1,7 @@
 require 'miq_bulk_import'
 class ConfigurationController < ApplicationController
   include StartUrl
+  include GenericSessionMixin
 
   logo_dir = File.expand_path(File.join(Rails.root, "public/upload"))
   Dir.mkdir logo_dir unless File.exist?(logo_dir)

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -1,7 +1,7 @@
 require 'miq_bulk_import'
 class ConfigurationController < ApplicationController
   include StartUrl
-  include GenericSessionMixin
+  include Mixins::GenericSessionMixin
 
   logo_dir = File.expand_path(File.join(Rails.root, "public/upload"))
   Dir.mkdir logo_dir unless File.exist?(logo_dir)
@@ -608,7 +608,17 @@ class ConfigurationController < ApplicationController
     end
   end
 
+  def self.model
+   self
+  end
+
+  def self.session_key_prefix
+   "config"
+  end
+
   def get_session_data
+    super
+    binding.pry
     @title        = session[:config_title] ? _("Configuration") : session[:config_title]
     @layout       = "configuration"
     @tabform      = session[:config_tabform]    if session[:config_tabform]
@@ -617,6 +627,8 @@ class ConfigurationController < ApplicationController
   end
 
   def set_session_data
+    super
+    binding.pry
     session[:config_tabform]    = @tabform
     session[:config_schema_ver] = @schema_ver
     session[:vm_filters]        = @filters

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -13,7 +13,7 @@ class ConfigurationController < ApplicationController
   after_action :set_session_data
 
   def title
-    session[:config_title] ? _("configuration") : session[:config_title]
+     _("Configuration")
   end
 
   def index

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -12,6 +12,10 @@ class ConfigurationController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  def title
+    session[:config_title] ? _("configuration") : session[:config_title]
+  end
+
   def index
     @breadcrumbs = []
     active_tab = nil
@@ -608,19 +612,13 @@ class ConfigurationController < ApplicationController
     end
   end
 
-  def self.model
-   self
-  end
 
   def self.session_key_prefix
-   "config"
+    "configuration"
   end
 
   def get_session_data
     super
-    binding.pry
-    @title        = session[:config_title] ? _("Configuration") : session[:config_title]
-    @layout       = "configuration"
     @tabform      = session[:config_tabform]    if session[:config_tabform]
     @schema_ver   = session[:config_schema_ver] if session[:config_schema_ver]
     @zone_options = session[:zone_options]      if session[:zone_options]
@@ -628,7 +626,6 @@ class ConfigurationController < ApplicationController
 
   def set_session_data
     super
-    binding.pry
     session[:config_tabform]    = @tabform
     session[:config_schema_ver] = @schema_ver
     session[:vm_filters]        = @filters

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -13,7 +13,7 @@ class ConfigurationController < ApplicationController
   after_action :set_session_data
 
   def title
-     _("Configuration")
+    _("Configuration")
   end
 
   def index
@@ -611,7 +611,6 @@ class ConfigurationController < ApplicationController
       @edit[:new][:display][:drift] = params[:display][:drift] if !params[:display].nil? && !params[:display][:drift].nil?
     end
   end
-
 
   def self.session_key_prefix
     "configuration"

--- a/app/controllers/mixins/generic_session_mixin.rb
+++ b/app/controllers/mixins/generic_session_mixin.rb
@@ -4,6 +4,7 @@ module Mixins
     private
 
     def get_session_data
+      binding.pry
       prefix      = self.class.session_key_prefix
       @title      = respond_to?(:title) ? title : ui_lookup(:tables => self.class.table_name)
       @layout     = prefix
@@ -16,6 +17,7 @@ module Mixins
     end
 
     def set_session_data
+      binding.pry
       prefix = self.class.session_key_prefix
       session["#{prefix}_lastaction".to_sym] = @lastaction
       session["#{prefix}_display".to_sym]    = @display unless @display.nil?

--- a/app/controllers/mixins/generic_session_mixin.rb
+++ b/app/controllers/mixins/generic_session_mixin.rb
@@ -4,7 +4,6 @@ module Mixins
     private
 
     def get_session_data
-      binding.pry
       prefix      = self.class.session_key_prefix
       @title      = respond_to?(:title) ? title : ui_lookup(:tables => self.class.table_name)
       @layout     = prefix
@@ -17,7 +16,6 @@ module Mixins
     end
 
     def set_session_data
-      binding.pry
       prefix = self.class.session_key_prefix
       session["#{prefix}_lastaction".to_sym] = @lastaction
       session["#{prefix}_display".to_sym]    = @display unless @display.nil?


### PR DESCRIPTION
ConfigurationController now has it's own implementations of **set_session_data** and **get_session_data** methods. These methods duplicate some of the functionality of GenericSessionMixin. This PR aims to fix that by including and using GenericSessionMixin and removing code that can be replaced by GenericSessionMixin.