### PR TITLE
Fix spinner issues in Dialog Runner

### DIFF
--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -32,14 +32,14 @@ module ApplicationController::DialogRunner
         result = @edit[:wf].submit_request
       rescue => bang
         add_flash(_("Error during 'Provisioning': %{error_message}") % {:error_message => bang.message}, :error)
-        javascript_flash
+        javascript_flash(:spinner_off => true)
       else
         unless result[:errors].blank?
           # show validation errors
           result[:errors].each do |err|
             add_flash(err, :error)
           end
-          javascript_flash
+          javascript_flash(:spinner_off => true)
         else
           flash = _("Order Request was Submitted")
           if role_allows?(:feature => "miq_request_show_list", :any => true)
@@ -74,7 +74,7 @@ module ApplicationController::DialogRunner
     else
       return unless load_edit("dialog_edit__#{params[:id]}", "replace_cell__explorer")
       add_flash(_("%{button_name} Button not yet implemented") % {:button_name => params[:button].capitalize}, :error)
-      javascript_flash
+      javascript_flash(:spinner_off => true)
     end
   end
 

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -83,11 +83,7 @@ module ApplicationController::DialogRunner
     return unless load_edit("dialog_edit__#{params[:id]}", "replace_cell__explorer")
     dialog_get_form_vars
 
-    # Use JS to update the display
-    render :update do |page|
-      page << javascript_prologue
-      page << "miqSparkle(false);"
-    end
+    head :ok
   end
 
   # for non-explorer screen

--- a/spec/controllers/application_controller/dialog_runner_spec.rb
+++ b/spec/controllers/application_controller/dialog_runner_spec.rb
@@ -22,9 +22,9 @@ describe CatalogController do
       allow(wf).to receive(:set_value)
     end
 
-    it "includes disabling the sparkle in the response" do
+    it "doesn't include disabling the sparkle in the response" do
       post :dialog_field_changed, :params => params, :session => session, :xhr => true
-      expect(response.body).to include("miqSparkle(false);")
+      expect(response.body).not_to include("miqSparkle")
     end
 
     it "stores the incoming value in the edit variable" do


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/325 ..

The spinner would not disappear when an error occurs - https://bugzilla.redhat.com/show_bug.cgi?id=1426192
Now, a flash message also disables the spinner.

The spinner would disappear prematurely when editing a field right before submitting the form - https://bugzilla.redhat.com/show_bug.cgi?id=1420314#c6
Now, `form_field_changed` does not disable the spinner.

Cc @jkrocil