### PR TITLE
Allow for Rails 5.1 beta

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "rails", "~> 5.0.0", ">= 5.0.0.1"
+  s.add_dependency "rails", ">= 5.0.0.1", "< 5.1"
 
   s.add_dependency "angular-ui-bootstrap-rails", "~>0.13.0"
   s.add_dependency "coffee-rails"


### PR DESCRIPTION
This maintains the locking of the minor version while still allowing for
the core repo to try the Rails 5.1 beta.