### PR TITLE
ReportController: use GenericSessionMixin

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -10,7 +10,7 @@ class ReportController < ApplicationController
 
   helper ApplicationHelper::ImportExportHelper
   include ReportHelper
-  include GenericSessionMixin
+  include Mixins::GenericSessionMixin
 
   before_action :check_privileges
   before_action :get_session_data
@@ -891,7 +891,17 @@ class ReportController < ApplicationController
     render :json => presenter.for_render
   end
 
+ def self.session_key_prefix
+    'report'
+ end
+
+ def self.table_name
+	nil
+ end
+
   def get_session_data
+	super
+	#binding.pry
     @layout           = 'report'
     @lastaction       = session[:report_lastaction]
     @report_tab       = session[:report_tab]
@@ -906,6 +916,8 @@ class ReportController < ApplicationController
   end
 
   def set_session_data
+	#super
+	#binding.pry
     session[:report_lastaction] = @lastaction
     session[:report_tab]        = @report_tab
     session[:panels]            = @panels

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -263,7 +263,7 @@ class ReportController < ApplicationController
   end
 
   def title
-    nil
+    _("Reports")
   end
 
   private ###########################
@@ -901,27 +901,23 @@ class ReportController < ApplicationController
 
   def get_session_data
     super
-    @lastaction       = session[:report_lastaction]
     @report_tab       = session[:report_tab]
     @report_result_id = session[:report_result_id]
     @menu             = session[:report_menu]
     @folders          = session[:report_folders]
     @ght_type         = session[:ght_type] || "tabular"
     @report_groups    = session[:report_groups]
-    @edit             = session[:edit] unless session[:edit].nil?
     @catinfo          = session[:vm_catinfo]
     @grid_folders     = session[:report_grid_folders]
   end
 
   def set_session_data
     super
-    session[:report_lastaction] = @lastaction
     session[:report_tab]        = @report_tab
     session[:panels]            = @panels
     session[:ght_type]          = @ght_type
     session[:report_groups]     = @report_groups
     session[:vm_catinfo]        = @catinfo
-    session[:edit]              = @edit unless @edit.nil?
     session[:report_result_id]  = @report_result_id
     session[:report_menu]       = @menu
     session[:report_folders]    = @folders

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -10,6 +10,7 @@ class ReportController < ApplicationController
 
   helper ApplicationHelper::ImportExportHelper
   include ReportHelper
+  include GenericSessionMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -907,6 +907,7 @@ class ReportController < ApplicationController
     @folders          = session[:report_folders]
     @ght_type         = session[:ght_type] || "tabular"
     @report_groups    = session[:report_groups]
+    @edit             = session[:edit] unless session[:edit].nil?
     @catinfo          = session[:vm_catinfo]
     @grid_folders     = session[:report_grid_folders]
   end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -257,6 +257,10 @@ class ReportController < ApplicationController
 
     replace_right_cell(:partial => 'export_widgets')
   end
+	
+  def title
+	nil
+  end
 
   private ###########################
 
@@ -895,14 +899,8 @@ class ReportController < ApplicationController
     'report'
  end
 
- def self.table_name
-	nil
- end
-
   def get_session_data
 	super
-	#binding.pry
-    @layout           = 'report'
     @lastaction       = session[:report_lastaction]
     @report_tab       = session[:report_tab]
     @report_result_id = session[:report_result_id]
@@ -916,8 +914,7 @@ class ReportController < ApplicationController
   end
 
   def set_session_data
-	#super
-	#binding.pry
+	super
     session[:report_lastaction] = @lastaction
     session[:report_tab]        = @report_tab
     session[:panels]            = @panels

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -263,7 +263,7 @@ class ReportController < ApplicationController
   end
 
   def title
-	nil
+    nil
   end
 
   private ###########################
@@ -900,7 +900,7 @@ class ReportController < ApplicationController
   end
 
   def get_session_data
-	super
+    super
     @lastaction       = session[:report_lastaction]
     @report_tab       = session[:report_tab]
     @report_result_id = session[:report_result_id]
@@ -914,7 +914,7 @@ class ReportController < ApplicationController
   end
 
   def set_session_data
-	super
+    super
     session[:report_lastaction] = @lastaction
     session[:report_tab]        = @report_tab
     session[:panels]            = @panels

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -257,7 +257,11 @@ class ReportController < ApplicationController
 
     replace_right_cell(:partial => 'export_widgets')
   end
-	
+
+  def self.session_key_prefix
+    'report'
+  end
+
   def title
 	nil
   end
@@ -894,10 +898,6 @@ class ReportController < ApplicationController
 
     render :json => presenter.for_render
   end
-
- def self.session_key_prefix
-    'report'
- end
 
   def get_session_data
 	super


### PR DESCRIPTION
I added _ReportController_ to include _GenericSessionMixin_. Due this change **self.session_key_prefix** and **title** methods added. '@layout' from get_session_data deleted. Both get_session_data and set_session_data calling parent method first.