### PR TITLE
Fix #show_link in GenericShowMixin.

### DIFF
--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -50,7 +50,7 @@ module Mixins
         polymorphic_path(record, options)
       else
         opts = options.merge(
-          :controller => self.class.table_name,
+          :controller => controller_name,
           :id         => record.id,
           :action     => :show,
           :only_path  => true,


### PR DESCRIPTION
Fix #show_link broken by https://github.com/ManageIQ/manageiq-ui-classic/pull/427

This obviously needs to be the controller name. I copied the table_name usage from the EmsCommon mixin (there it worked due to a coincidence). That was an oversight.