### PR TITLE
Add condition to select Datacenter in vm_tree with hidden vms

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -930,10 +930,15 @@ module VmCommon
       TreeBuilder.build_node_cid(vm.ems_id, 'ExtManagementSystem')
     elsif vm.cloud
       TreeBuilder.build_node_cid(vm.availability_zone_id, 'AvailabilityZone')
-    elsif (blue_folder = vm.parent_blue_folder)
+    elsif (blue_folder = vm.parent_blue_folder) && !blue_folder.hidden
       TreeBuilder.build_node_cid(blue_folder.id, 'EmsFolder')
     elsif vm.ems_id # has no folder parent but is in the tree
-      TreeBuilder.build_node_cid(vm.ems_id, 'ExtManagementSystem')
+      if vm.parent_datacenter
+        TreeBuilder.build_node_cid(vm.parent_datacenter.id, 'Datacenter')
+      else
+        TreeBuilder.build_node_cid(vm.ems_id, 'ExtManagementSystem')
+      end
+
     else
       nil # no selection if VmOrTemplate has no parent
     end

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -257,6 +257,18 @@ describe VmOrTemplateController do
       expect(controller.parent_folder_id(template_infra)).to eq(TreeBuilder.build_node_cid(template_infra.ext_management_system))
     end
 
+    it 'returns id of Datacenter folder for infra VM/Template without blue folder but with Datacenter parent' do
+      datacenter = FactoryGirl.create(:datacenter, :hidden => true)
+      vm_infra_datacenter = FactoryGirl.create(:vm_infra, :ext_management_system => FactoryGirl.create(:ems_infra))
+      template_infra_datacenter = FactoryGirl.create(:template_infra, :ext_management_system => FactoryGirl.create(:ems_infra))
+      vm_infra_datacenter.with_relationship_type("ems_metadata") { vm_infra_datacenter.parent = datacenter }
+      allow(vm_infra_datacenter).to receive(:parent_datacenter).and_return(datacenter)
+      template_infra_datacenter.with_relationship_type("ems_metadata") { template_infra_datacenter.parent = datacenter }
+      allow(template_infra_datacenter).to receive(:parent_datacenter).and_return(datacenter)
+      expect(controller.parent_folder_id(vm_infra_datacenter)).to eq(TreeBuilder.build_node_cid(datacenter.id, 'Datacenter'))
+      expect(controller.parent_folder_id(template_infra_datacenter)).to eq(TreeBuilder.build_node_cid(datacenter.id, 'Datacenter'))
+    end
+
     it 'returns id of blue folder for VM/Template with one' do
       folder = FactoryGirl.create(:ems_folder)
       vm_infra_folder = FactoryGirl.create(:vm_infra, :ext_management_system => FactoryGirl.create(:ems_infra))


### PR DESCRIPTION
Any Vm that is directly under Datacenter folder didn't have its parent selected correctly.

VM place:
<img width="304" alt="screen shot 2017-02-27 at 12 17 57 pm" src="https://cloud.githubusercontent.com/assets/9210860/23359513/d3af0380-fce6-11e6-8fb3-35a5c9f2deff.png">
Before:
<img width="753" alt="screen shot 2017-02-27 at 12 16 44 pm" src="https://cloud.githubusercontent.com/assets/9210860/23359520/d959c8c4-fce6-11e6-9fe4-52f33854b35b.png">
After:
<img width="735" alt="screen shot 2017-02-27 at 12 17 21 pm" src="https://cloud.githubusercontent.com/assets/9210860/23359525/de1f1bc0-fce6-11e6-90dd-2010a2689a0b.png">



Introduced by https://github.com/ManageIQ/manageiq/pull/11387 => euwe/yes

Closes #311 

@miq-bot add_label euwe/yes, bug