### PR TITLE
Adding External Logging Link for Containers Providers

### DIFF
--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -1,5 +1,6 @@
 class ContainerNodeController < ApplicationController
   include ContainersCommonMixin
+  include ContainersExternalLoggingSupportMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -5,6 +5,7 @@ class EmsContainerController < ApplicationController
   include Mixins::EmsCommonAngular
   include Mixins::GenericSessionMixin
   include Mixins::DashboardViewMixin
+  include ContainersExternalLoggingSupportMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/mixins/containers_external_logging_support_mixin.rb
+++ b/app/controllers/mixins/containers_external_logging_support_mixin.rb
@@ -1,0 +1,18 @@
+module ContainersExternalLoggingSupportMixin
+  def launch_external_logging_support
+    record = self.class.model.find(params[:id])
+    ems = record.ext_management_system
+    route_name = ems.external_logging_route_name
+    logging_route = ContainerRoute.find_by(:name => route_name, :ems_id => ems.id) if route_name
+    if logging_route
+      scheme = URI.parse(logging_route.host_name).scheme || "https"
+      url = "#{scheme}://#{logging_route.host_name}#{record.external_logging_path}"
+      javascript_open_window(url)
+    else
+      javascript_flash(:text        => _("A route named '#{route_name}' is configured to connect to the " \
+                                          "external logging server but it doesn't exist"),
+                       :severity    => :error,
+                       :spinner_off => true)
+    end
+  end
+end

--- a/app/helpers/application_helper/button/ems_container_launch_external_logging_support.rb
+++ b/app/helpers/application_helper/button/ems_container_launch_external_logging_support.rb
@@ -1,0 +1,17 @@
+class ApplicationHelper::Button::EmsContainerLaunchExternalLoggingSupport < ApplicationHelper::Button::GenericFeatureButton
+  def initialize(view_context, view_binding, instance_data, props)
+    props ||= {}
+    props.store_path(:options, :feature, :external_logging_support)
+    super(view_context, view_binding, instance_data, props)
+  end
+
+  def disabled?
+    ems = @record.ext_management_system
+    route_name = ems.external_logging_route_name
+    disabled = !visible? || ContainerRoute.find_by(:name   => route_name,
+                                                   :ems_id => ems.id).blank?
+    @error_message = _("A route named '#{route_name}' is configured to connect to the " \
+                       "external logging server but it doesn't exist") if disabled
+    disabled
+  end
+end

--- a/app/helpers/application_helper/toolbar/container_node_center.rb
+++ b/app/helpers/application_helper/toolbar/container_node_center.rb
@@ -22,6 +22,15 @@ class ApplicationHelper::Toolbar::ContainerNodeCenter < ApplicationHelper::Toolb
           N_('Utilization'),
           :url       => "/show",
           :url_parms => "?display=performance"),
+        button(
+          :ems_container_launch_external_logging_support,
+          'product product-monitoring fa-lg',
+          N_('Open a new browser window with the External Logging Presentation UI. ' \
+             'This requires the External Logging to be deployed on this Proider.'),
+          N_('External Logging'),
+          :klass => ApplicationHelper::Button::EmsContainerLaunchExternalLoggingSupport,
+          :url   => "launch_external_logging_support"
+        ),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -64,6 +64,15 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
           :klass     => ApplicationHelper::Button::GenericFeatureButton,
           :options   => {:feature => :ad_hoc_metrics},
           :url_parms => "?display=ad_hoc_metrics"),
+        button(
+          :ems_container_launch_external_logging_support,
+          'product product-monitoring fa-lg',
+          N_('Open a new browser window with the External Logging Presentation UI. ' \
+             'This requires the External Logging to be deployed on this Proider.'),
+          N_('External Logging'),
+          :klass => ApplicationHelper::Button::EmsContainerLaunchExternalLoggingSupport,
+          :url   => "launch_external_logging_support"
+        ),
       ]
     ),
   ])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -691,6 +691,7 @@ Rails.application.routes.draw do
         protect
         squash_toggle
         launch_cockpit
+        launch_external_logging_support
       ) +
                adv_search_post +
                exp_post +
@@ -1225,6 +1226,7 @@ Rails.application.routes.draw do
         tagging_edit
         tag_edit_form_field_changed
         squash_toggle
+        launch_external_logging_support
       ) +
                adv_search_post +
                compare_post +


### PR DESCRIPTION
This also adds the links for container nodes for when support for this feature will be added to container nodes.

![launch_kibana](https://cloud.githubusercontent.com/assets/3123328/23481740/34f61e68-fed5-11e6-9a15-72325478911f.png)

------------------------------

![no_route_for_external_logging](https://cloud.githubusercontent.com/assets/3123328/23481747/3d3cd3aa-fed5-11e6-8f40-0b3b72cb3c21.png)


--------------------------------

![gifrecord_2017-03-01_231329](https://cloud.githubusercontent.com/assets/3123328/23481755/435041c8-fed5-11e6-9bd6-7d59c3abf7f2.gif)


This is a "resubmission" of https://github.com/ManageIQ/manageiq-ui-classic/pull/36 due to Travis problems with the previous PR.