### PR TITLE
TextualMultilabel is needed for container image env vars

### DIFF
--- a/app/helpers/container_image_helper/textual_summary.rb
+++ b/app/helpers/container_image_helper/textual_summary.rb
@@ -114,7 +114,7 @@ module ContainerImageHelper
   end
 
   def textual_group_env
-    TextualGroup.new(
+    TextualMultilabel.new(
       _("Environment variables"),
       :additional_table_class => "table-fixed",
       :labels                 => [_("Name"), _("Type"), _("Value")],


### PR DESCRIPTION
Container Image environment varialbes need the TextualMultilabel class
to display correctly.