### PR TITLE
Support operation `delete` on CloudObjectStoreObject

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1858,7 +1858,7 @@ module ApplicationController::CiProcessing
     items = []
 
     # Either a list or coming from a different controller
-    if @lastaction == "show_list" || !%w(cloud_object_store_container).include?(request.parameters["controller"])
+    if @lastaction == "show_list" || %w(cloud_object_store_containers cloud_object_store_objects).include?(@display)
       items = find_checked_items
       if items.empty?
         add_flash(_("No %{model} were selected for %{task}") %
@@ -1892,9 +1892,11 @@ module ApplicationController::CiProcessing
     when "service"
       return Service
     when "cloud_object_store_container"
-      CloudObjectStoreContainer
+      params[:pressed].starts_with?("cloud_object_store_object") ? CloudObjectStoreObject : CloudObjectStoreContainer
+    when "cloud_object_store_object"
+      CloudObjectStoreObject
     when "ems_storage"
-      CloudObjectStoreContainer
+      params[:pressed].starts_with?("cloud_object_store_object") ? CloudObjectStoreObject : CloudObjectStoreContainer
     else
       return VmOrTemplate
     end
@@ -1914,6 +1916,9 @@ module ApplicationController::CiProcessing
     when "CloudObjectStoreContainer"
       objs, _objs_out_reg = filter_ids_in_region(objs, "CloudObjectStoreContainer")
       klass = CloudObjectStoreContainer
+    when "CloudObjectStoreObject"
+      objs, _objs_out_reg = filter_ids_in_region(objs, "CloudObjectStoreObject")
+      klass = CloudObjectStoreObject
     end
 
     assert_rbac(current_user, get_rec_cls, objs)

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -14,7 +14,16 @@ class CloudObjectStoreObjectController < ApplicationController
   def button
     @edit = session[:edit]
     params[:page] = @current_page unless @current_page.nil?
-    return tag("CloudObjectStoreObject") if params[:pressed] == 'cloud_object_store_object_tag'
+
+    process_cloud_object_storage_buttons(params[:pressed])
+
+    if !@flash_array.nil? && params[:pressed].ends_with?("delete")
+      javascript_redirect :action      => 'show_list',
+                          :flash_msg   => @flash_array[0][:message],
+                          :flash_error => @flash_array[0][:level] == :error
+    elsif !@flash_array.nil?
+      render_flash unless performed?
+    end
   end
 
   def show

--- a/app/helpers/application_helper/toolbar/cloud_object_store_object_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_object_store_object_center.rb
@@ -1,4 +1,27 @@
 class ApplicationHelper::Toolbar::CloudObjectStoreObjectCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'cloud_object_store_object_vmdb',
+    [
+      select(
+        :cloud_object_store_object_vmdb_choice,
+        'fa fa-cog fa-lg',
+        t = N_('Configuration'),
+        t,
+        :items => [
+          button(
+            :cloud_object_store_object_delete,
+            'pficon pficon-delete fa-lg',
+            N_('Remove Object Storage Object'),
+            N_('Remove Object Storage Object'),
+            :url_parms => "main_div",
+            :confirm   => N_("Warning: The selected Object Storage Object will be permanently removed!"),
+            :klass     => ApplicationHelper::Button::GenericFeatureButtonWithDisable,
+            :options   => {:feature => :delete}
+          ),
+        ]
+      ),
+    ]
+  )
   button_group('cloud_object_store_object_policy', [
     select(
       :cloud_object_store_object_policy_choice,

--- a/app/helpers/application_helper/toolbar/cloud_object_store_objects_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_object_store_objects_center.rb
@@ -1,4 +1,29 @@
 class ApplicationHelper::Toolbar::CloudObjectStoreObjectsCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'cloud_object_store_object_vmdb',
+    [
+      select(
+        :cloud_object_store_object_vmdb_choice,
+        'fa fa-cog fa-lg',
+        t = N_('Configuration'),
+        t,
+        :enabled => false,
+        :onwhen  => "1+",
+        :items   => [
+          button(
+            :cloud_object_store_object_delete,
+            'pficon pficon-delete fa-lg',
+            N_('Remove selected Object Storage Objects'),
+            N_('Remove Object Storage Objects'),
+            :url_parms => "main_div",
+            :confirm   => N_("Warning: The selected Object Storage Object will be permanently removed!"),
+            :enabled   => false,
+            :onwhen    => "1+"
+          ),
+        ]
+      ),
+    ]
+  )
   button_group('cloud_object_store_object_policy', [
     select(
       :cloud_object_store_object_policy_choice,

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -445,7 +445,7 @@ class ApplicationHelper::ToolbarChooser
                     load_balancers network_ports network_routers orchestration_stacks resource_pools
                     security_groups storages middleware_deployments middleware_datasources
                     middleware_messagings middleware_servers)
-    to_display_center = %w(stack_orchestration_template topology)
+    to_display_center = %w(stack_orchestration_template topology cloud_object_store_objects)
     if @lastaction == 'show' && (@view || @display != 'main') && !@layout.starts_with?("miq_request")
       if @display == "vms" || @display == "all_vms"
         return "vm_infras_center_tb"

--- a/spec/controllers/cloud_object_store_object_spec.rb
+++ b/spec/controllers/cloud_object_store_object_spec.rb
@@ -1,4 +1,13 @@
 describe CloudObjectStoreObjectController do
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
+    allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(true)
+  end
+
+  let :object do
+    FactoryGirl.create(:cloud_object_store_object)
+  end
+
   context "#tags_edit" do
     let!(:user) { stub_user(:features => :all) }
     before(:each) do
@@ -45,6 +54,66 @@ describe CloudObjectStoreObjectController do
       post :tagging_edit, :button => "save", :format => :js, :id => @object.id
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
+    end
+  end
+
+  context "delete object store object" do
+    before do
+      login_as FactoryGirl.create(:user, :features => "everything")
+      request.parameters["controller"] = "cloud_object_store_object"
+      allow(controller).to receive(:role_allows?).and_return(true)
+    end
+
+    it "delete invokes process_cloud_object_storage_buttons" do
+      expect(controller).to receive(:process_cloud_object_storage_buttons)
+      post :button, :params => {
+        :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
+      }
+    end
+
+    it "delete triggers delete" do
+      expect(controller).to receive(:cloud_object_store_button_operation).with(
+        CloudObjectStoreObject,
+        'delete'
+      )
+      post :button, :params => {
+        :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
+      }
+    end
+
+    it "delete redirects to show_list" do
+      expect(controller).to receive(:javascript_redirect).with(
+        :action      => 'show_list',
+        :flash_msg   => anything,
+        :flash_error => false
+      )
+      post :button, :params => {
+        :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
+      }
+    end
+
+    it "delete shows expected flash" do
+      post :button, :params => {
+        :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
+      }
+
+      expect(assigns(:flash_array).first[:message]).to include(
+        "Delete initiated for 1 Cloud Object Store Object from the ManageIQ Database"
+      )
+      expect(response.status).to eq(200)
+    end
+
+    it "delete shows expected flash (non-existing object)" do
+      object.destroy
+
+      post :button, :params => {
+        :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
+      }
+
+      expect(assigns(:flash_array).first[:message]).to include(
+        "Cloud Object Store Object no longer exists"
+      )
+      expect(response.status).to eq(200)
     end
   end
 


### PR DESCRIPTION
Until now, only tagging operation was supported for CloudObjectStoreObject. With this commit we introduce a new center menu for operations and already support 'delete' operation. The menu is visible from three views:
   
* details page
![capture](https://cloud.githubusercontent.com/assets/8102426/23703663/67d10cea-0401-11e7-98f4-1776a4cf7935.PNG)

* list (all)
![capture](https://cloud.githubusercontent.com/assets/8102426/23703704/986475e0-0401-11e7-92f1-6cd6eb7a5307.PNG)


* list (per bucket)
![capture](https://cloud.githubusercontent.com/assets/8102426/23703637/3f16ed9c-0401-11e7-8634-63cce0129fbb.PNG)


Depends on (from other repos):
* https://github.com/ManageIQ/manageiq/pull/14080 (merged)
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/152 (merged)