### PR TITLE
Support operation `clear` on CloudObjectStoreContainer

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1852,8 +1852,15 @@ module ApplicationController::CiProcessing
   end
 
   def cloud_object_store_button_operation(klass, task)
-    method = "#{task}_#{klass.name.underscore.to_sym}"
-    display_name = _(task.capitalize)
+    # Map to instance method name
+    case task
+    when "delete"
+      method = "#{task}_#{klass.name.underscore.to_sym}"
+      display_name = _(task.capitalize)
+    else
+      display_name = _(task.capitalize)
+      method = task = "#{klass.name.underscore.to_sym}_#{task}"
+    end
 
     items = []
 

--- a/app/helpers/application_helper/toolbar/cloud_object_store_container_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_object_store_container_center.rb
@@ -9,6 +9,17 @@ class ApplicationHelper::Toolbar::CloudObjectStoreContainerCenter < ApplicationH
         t,
         :items => [
           button(
+            :cloud_object_store_container_clear,
+            'pficon pficon-delete fa-lg',
+            N_('Clear Object Storage Container'),
+            N_('Clear Object Storage Container'),
+            :url_parms => "main_div",
+            :confirm   => N_("Warning: ALL Objects will be permanently removed from the Object Storage Container!"),
+            :klass     => ApplicationHelper::Button::GenericFeatureButtonWithDisable,
+            :options   => {:feature => :cloud_object_store_container_clear}
+          ),
+          separator,
+          button(
             :cloud_object_store_container_delete,
             'pficon pficon-delete fa-lg',
             N_('Remove Object Storage Container'),

--- a/app/helpers/application_helper/toolbar/cloud_object_store_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_object_store_containers_center.rb
@@ -11,6 +11,18 @@ class ApplicationHelper::Toolbar::CloudObjectStoreContainersCenter < Application
         :onwhen  => "1+",
         :items   => [
           button(
+            :cloud_object_store_container_clear,
+            'pficon pficon-delete fa-lg',
+            N_('Clear selected Object Storage Containers'),
+            N_('Clear Object Storage Containers'),
+            :url_parms => "main_div",
+            :confirm   => N_("Warning: ALL Objects will be permanently removed from the selected "\
+                             "Object Storage Containers!"),
+            :enabled   => false,
+            :onwhen    => "1+"
+          ),
+          separator,
+          button(
             :cloud_object_store_container_delete,
             'pficon pficon-delete fa-lg',
             N_('Remove selected Object Storage Containers'),


### PR DESCRIPTION
To `clear` CloudObjectStoreContainer means to remove all CloudObjectStoreObjects from it. This option is available from three views:
1) CloudObjectStoreContainer list
![capture](https://cloud.githubusercontent.com/assets/8102426/24108295/7f4e598c-0d8d-11e7-935a-dabb7dfbba9c.PNG)

2) CloudObjectStoreContainer details
![capture](https://cloud.githubusercontent.com/assets/8102426/24108186/3814f436-0d8d-11e7-8d90-81c5c1279594.PNG)

3) CloudObjectStoreContainer per-storage-manager list
![capture](https://cloud.githubusercontent.com/assets/8102426/24108243/5c9111d2-0d8d-11e7-827d-d4cefda4b649.PNG)


Depends on:
* https://github.com/ManageIQ/manageiq-ui-classic/pull/420 (merged)
* https://github.com/ManageIQ/manageiq/pull/14082 (merged)
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/153 (merged)
