### PR TITLE
Fix an error when cancelling from edit subnet screen

### DIFF
--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -249,7 +249,7 @@ class CloudSubnetController < ApplicationController
 
     # A gateway address is automatically assigned by Openstack when gateway is null
     unless @subnet.gateway == params[:gateway]
-      options[:gateway_ip] = params[:gateway].empty? ? nil : params[:gateway]
+      options[:gateway_ip] = params[:gateway].blank? ? nil : params[:gateway]
     end
     unless @subnet.dhcp_enabled == switch_to_bol(params[:dhcp_enabled])
       options[:enable_dhcp] = switch_to_bol(params[:dhcp_enabled])
@@ -267,7 +267,7 @@ class CloudSubnetController < ApplicationController
     options[:cidr] = params[:cidr] if params[:cidr]
     # An address is automatically assigned by Openstack when gateway is null
     if params[:gateway]
-      options[:gateway] = params[:gateway].empty? ? nil : params[:gateway]
+      options[:gateway] = params[:gateway].blank? ? nil : params[:gateway]
     end
     options[:ip_version] = params[:ip_version]
     options[:cloud_tenant] = find_by_id_filtered(CloudTenant, params[:cloud_tenant_id]) if params[:cloud_tenant_id]


### PR DESCRIPTION
Loading the form to edit an OpenStack Cloud Subnet and then canceling will error with `undefined method empty? for nil::NilClass`. This replaces `empty?` with `blank?` to catch empty strings and nils.

This problem exists in Euwe as well.

**Steps to reproduce**
1. Go to network > cloud subnet 
2. Select an existing OpenStack cloud subnet
3. Click configuration > edit
4. Click cancel

**Addresses**
https://bugzilla.redhat.com/show_bug.cgi?id=1426908

@miq-bot add_label ui, bug, euwe/yes

@dclarizio 