### PR TITLE
Adjust checkbox styling on My Tasks screen

### DIFF
--- a/app/views/miq_task/_tasks_options.html.haml
+++ b/app/views/miq_task/_tasks_options.html.haml
@@ -41,30 +41,31 @@
       %label.control-label.col-md-2
         = _("Task Status")
       .col-md-8
-        = check_box_tag("queued", "1", @tasks_options[@tabform][:queued], "data-miq_observe_checkbox" => {:url => url}.to_json)
-        &nbsp;
-        %i.fa.fa-step-forward
-        = _("Queued")
-        &nbsp;
-        = check_box_tag("running", "1", @tasks_options[@tabform][:running], "data-miq_observe_checkbox" => {:url => url}.to_json)
-        &nbsp;
-        %i.pficon.pficon-running
-        = _("Running")
-        &nbsp;
-        = check_box_tag("ok", "1", @tasks_options[@tabform][:ok], "data-miq_observe_checkbox" => {:url => url}.to_json)
-        &nbsp;
-        %i.pficon.pficon-ok
-        = _("Ok")
-        &nbsp;
-        = check_box_tag("error", "1", @tasks_options[@tabform][:error], "data-miq_observe_checkbox" => {:url => url}.to_json)
-        &nbsp;
-        %i.pficon.pficon-error-circle-o
-        = _("Error")
-        &nbsp;
-        = check_box_tag("warn", "1", @tasks_options[@tabform][:warn], "data-miq_observe_checkbox" => {:url => url}.to_json)
-        &nbsp;
-        %i.pficon.pficon-warning-triangle-o
-        = _("Warn")
+        .checkbox-inline
+          %label
+            = check_box_tag("queued", "1", @tasks_options[@tabform][:queued], :class => "checkbox", "data-miq_observe_checkbox" => {:url => url}.to_json)
+            %i.fa.fa-step-forward.fa-lg
+            = _("Queued")
+        .checkbox-inline
+          %label
+            = check_box_tag("running", "1", @tasks_options[@tabform][:running], :class => "checkbox", "data-miq_observe_checkbox" => {:url => url}.to_json)
+            %i.pficon.pficon-running.fa-lg
+            = _("Running")
+        .checkbox-inline
+          %label
+            = check_box_tag("ok", "1", @tasks_options[@tabform][:ok], :class => "checkbox", "data-miq_observe_checkbox" => {:url => url}.to_json)
+            %i.pficon.pficon-ok.fa-lg
+            = _("Ok")
+        .checkbox-inline
+          %label
+            = check_box_tag("error", "1", @tasks_options[@tabform][:error], :class => "checkbox", "data-miq_observe_checkbox" => {:url => url}.to_json)
+            %i.pficon.pficon-error-circle-o.fa-lg
+            = _("Error")
+        .checkbox-inline
+          %label
+            = check_box_tag("warn", "1", @tasks_options[@tabform][:warn], :class => "checkbox", "data-miq_observe_checkbox" => {:url => url}.to_json)
+            %i.pficon.pficon-warning-triangle-o.fa-lg
+            = _("Warn")
     .form-group
       %label.control-label.col-md-2
         = _("Task State")


### PR DESCRIPTION
This PR adjusts the styling of inline checkboxes on the My Tasks screen, which were misaligned in FireFox for Fedora.

Old
<img width="445" alt="screen shot 2017-02-27 at 5 10 27 pm" src="https://cloud.githubusercontent.com/assets/1287144/23385474/f7d6eb1a-fd1d-11e6-9f85-98af491953f0.png">

New
<img width="436" alt="screen shot 2017-02-27 at 5 11 09 pm" src="https://cloud.githubusercontent.com/assets/1287144/23385451/e90e3278-fd1d-11e6-83ed-762dde95d661.png">



https://bugzilla.redhat.com/show_bug.cgi?id=1396579