### PR TITLE
Moved fonticon/svgimage definitions from `TreeNode`s to decorators

### DIFF
--- a/app/decorators/availability_zone_decorator.rb
+++ b/app/decorators/availability_zone_decorator.rb
@@ -1,0 +1,5 @@
+class AvailabilityZoneDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-zone'
+  end
+end

--- a/app/decorators/chargeback_rate_decorator.rb
+++ b/app/decorators/chargeback_rate_decorator.rb
@@ -1,0 +1,5 @@
+class ChargebackRateDecorator < MiqDecorator
+  def fonticon
+    'fa fa-file-text-o'
+  end
+end

--- a/app/decorators/classification_decorator.rb
+++ b/app/decorators/classification_decorator.rb
@@ -1,0 +1,5 @@
+class ClassificationDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-folder-close'
+  end
+end

--- a/app/decorators/compliance_decorator.rb
+++ b/app/decorators/compliance_decorator.rb
@@ -1,0 +1,5 @@
+class ComplianceDecorator < MiqDecorator
+  def fonticon
+    "pficon #{compliant ? 'pficon-ok' : 'pficon-error-circle-o'}"
+  end
+end

--- a/app/decorators/compliance_detail_decorator.rb
+++ b/app/decorators/compliance_detail_decorator.rb
@@ -1,0 +1,5 @@
+class ComplianceDetailDecorator < MiqDecorator
+  def fonticon
+    "pficon #{miq_policy_result ? 'pficon-ok' : 'pficon-error-circle-o'}"
+  end
+end

--- a/app/decorators/condition_decorator.rb
+++ b/app/decorators/condition_decorator.rb
@@ -1,0 +1,5 @@
+class ConditionDecorator < MiqDecorator
+  def fonticon
+    'product product-miq_condition'
+  end
+end

--- a/app/decorators/configuration_profile_decorator.rb
+++ b/app/decorators/configuration_profile_decorator.rb
@@ -1,6 +1,10 @@
 class ConfigurationProfileDecorator < MiqDecorator
   def fonticon
-    nil
+    if id.nil?
+      'pficon pficon-folder-close'
+    else
+      'fa fa-list-ul'
+    end
   end
 
   def listicon_image

--- a/app/decorators/configured_system_decorator.rb
+++ b/app/decorators/configured_system_decorator.rb
@@ -1,6 +1,6 @@
 class ConfiguredSystemDecorator < MiqDecorator
   def fonticon
-    nil
+    'product product-configured_system'
   end
 
   def listicon_image

--- a/app/decorators/container_decorator.rb
+++ b/app/decorators/container_decorator.rb
@@ -1,0 +1,5 @@
+class ContainerDecorator < MiqDecorator
+  def fonticon
+    'fa fa-cube'
+  end
+end

--- a/app/decorators/custom_button_decorator.rb
+++ b/app/decorators/custom_button_decorator.rb
@@ -1,0 +1,5 @@
+class CustomButtonDecorator < MiqDecorator
+  def fonticon
+    options && options[:button_image] ? "product product-custom-#{options[:button_image]}" : 'fa fa-file-o'
+  end
+end

--- a/app/decorators/custom_button_set_decorator.rb
+++ b/app/decorators/custom_button_set_decorator.rb
@@ -1,0 +1,5 @@
+class CustomButtonSetDecorator < MiqDecorator
+  def fonticon
+    set_data && set_data[:button_image] ? "product product-custom-#{set_data[:button_image]}" : 'pficon pficon-folder-close'
+  end
+end

--- a/app/decorators/customization_template_decorator.rb
+++ b/app/decorators/customization_template_decorator.rb
@@ -1,0 +1,5 @@
+class CustomizationTemplateDecorator < MiqDecorator
+  def fonticon
+    'product product-template'
+  end
+end

--- a/app/decorators/datacenter_decorator.rb
+++ b/app/decorators/datacenter_decorator.rb
@@ -1,0 +1,5 @@
+class DatacenterDecorator < MiqDecorator
+  def fonticon
+    'fa fa-building-o'
+  end
+end

--- a/app/decorators/dialog_decorator.rb
+++ b/app/decorators/dialog_decorator.rb
@@ -1,0 +1,5 @@
+class DialogDecorator < MiqDecorator
+  def fonticon
+    'fa fa-comment-o'
+  end
+end

--- a/app/decorators/dialog_field_decorator.rb
+++ b/app/decorators/dialog_field_decorator.rb
@@ -1,0 +1,5 @@
+class DialogFieldDecorator < MiqDecorator
+  def fonticon
+    'product product-field'
+  end
+end

--- a/app/decorators/dialog_group_decorator.rb
+++ b/app/decorators/dialog_group_decorator.rb
@@ -1,0 +1,5 @@
+class DialogGroupDecorator < MiqDecorator
+  def fonticon
+    'fa fa-comments-o'
+  end
+end

--- a/app/decorators/dialog_tab_decorator.rb
+++ b/app/decorators/dialog_tab_decorator.rb
@@ -1,0 +1,5 @@
+class DialogTabDecorator < MiqDecorator
+  def fonticon
+    'product product-tab'
+  end
+end

--- a/app/decorators/ems_cluster_decorator.rb
+++ b/app/decorators/ems_cluster_decorator.rb
@@ -1,0 +1,5 @@
+class EmsClusterDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-cluster'
+  end
+end

--- a/app/decorators/ems_folder_decorator.rb
+++ b/app/decorators/ems_folder_decorator.rb
@@ -1,0 +1,5 @@
+class EmsFolderDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-folder-close'
+  end
+end

--- a/app/decorators/guest_device_decorator.rb
+++ b/app/decorators/guest_device_decorator.rb
@@ -1,0 +1,5 @@
+class GuestDeviceDecorator < MiqDecorator
+  def fonticon
+    'product product-network_card'
+  end
+end

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -1,6 +1,6 @@
 class HostDecorator < MiqDecorator
   def fonticon
-    nil
+    'pficon pficon-screen'
   end
 
   def listicon_image

--- a/app/decorators/iso_datastore_decorator.rb
+++ b/app/decorators/iso_datastore_decorator.rb
@@ -1,0 +1,5 @@
+class IsoDatastoreDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-server'
+  end
+end

--- a/app/decorators/iso_image_decorator.rb
+++ b/app/decorators/iso_image_decorator.rb
@@ -1,0 +1,5 @@
+class IsoImageDecorator < MiqDecorator
+  def fonticon
+    'product product-network_card'
+  end
+end

--- a/app/decorators/lan_decorator.rb
+++ b/app/decorators/lan_decorator.rb
@@ -1,0 +1,5 @@
+class LanDecorator < MiqDecorator
+  def fonticon
+    'product product-switch'
+  end
+end

--- a/app/decorators/ldap_domain_decorator.rb
+++ b/app/decorators/ldap_domain_decorator.rb
@@ -1,0 +1,5 @@
+class LdapDomainDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-domain'
+  end
+end

--- a/app/decorators/ldap_region_decorator.rb
+++ b/app/decorators/ldap_region_decorator.rb
@@ -1,0 +1,5 @@
+class LdapRegionDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-regions'
+  end
+end

--- a/app/decorators/manageiq/providers/storage_manager/cinder_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager/cinder_manager_decorator.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers
   class StorageManager::CinderManagerDecorator < MiqDecorator
     def listicon_image
-      "svg/vendor-openstack.svg"
+      "svg/vendor-cinder.svg"
     end
   end
 end

--- a/app/decorators/manageiq/providers/storage_manager/swift_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager/swift_manager_decorator.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers
   class StorageManager::SwiftManagerDecorator < MiqDecorator
     def listicon_image
-      "svg/vendor-openstack.svg"
+      "svg/vendor-swift.svg"
     end
   end
 end

--- a/app/decorators/miq_alert_decorator.rb
+++ b/app/decorators/miq_alert_decorator.rb
@@ -1,0 +1,5 @@
+class MiqAlertDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-warning-triangle-o'
+  end
+end

--- a/app/decorators/miq_alert_set_decorator.rb
+++ b/app/decorators/miq_alert_set_decorator.rb
@@ -1,0 +1,5 @@
+class MiqAlertSetDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-warning-triangle-o'
+  end
+end

--- a/app/decorators/miq_dialog_decorator.rb
+++ b/app/decorators/miq_dialog_decorator.rb
@@ -1,0 +1,5 @@
+class MiqDialogDecorator < MiqDecorator
+  def fonticon
+    'fa fa-comment-o'
+  end
+end

--- a/app/decorators/miq_group_decorator.rb
+++ b/app/decorators/miq_group_decorator.rb
@@ -1,0 +1,5 @@
+class MiqGroupDecorator < MiqDecorator
+  def fonticon
+    'product product-group'
+  end
+end

--- a/app/decorators/miq_policy_set_decorator.rb
+++ b/app/decorators/miq_policy_set_decorator.rb
@@ -1,0 +1,5 @@
+class MiqPolicySetDecorator < MiqDecorator
+  def fonticon
+    active? ? 'fa fa-shield' : 'fa fa-inactive fa-shield'
+  end
+end

--- a/app/decorators/miq_region_decorator.rb
+++ b/app/decorators/miq_region_decorator.rb
@@ -1,0 +1,5 @@
+class MiqRegionDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-regions'
+  end
+end

--- a/app/decorators/miq_report_decorator.rb
+++ b/app/decorators/miq_report_decorator.rb
@@ -1,0 +1,5 @@
+class MiqReportDecorator < MiqDecorator
+  def fonticon
+    'fa fa-file-text-o'
+  end
+end

--- a/app/decorators/miq_report_result_decorator.rb
+++ b/app/decorators/miq_report_result_decorator.rb
@@ -1,0 +1,16 @@
+class MiqReportResultDecorator < MiqDecorator
+  def fonticon
+    case status.downcase
+    when 'error'
+      'pficon pficon-error-circle-o'
+    when 'finished'
+      'pficon pficon-ok'
+    when 'running'
+      'pficon pficon-running'
+    when 'queued'
+      'fa fa-play-circle-o'
+    else
+      'fa fa-arrow-right'
+    end
+  end
+end

--- a/app/decorators/miq_schedule_decorator.rb
+++ b/app/decorators/miq_schedule_decorator.rb
@@ -1,0 +1,5 @@
+class MiqScheduleDecorator < MiqDecorator
+  def fonticon
+    'fa fa-clock-o'
+  end
+end

--- a/app/decorators/miq_scsi_lun_decorator.rb
+++ b/app/decorators/miq_scsi_lun_decorator.rb
@@ -1,0 +1,5 @@
+class MiqScsiLunDecorator < MiqDecorator
+  def fonticon
+    'fa fa-database'
+  end
+end

--- a/app/decorators/miq_scsi_target_decorator.rb
+++ b/app/decorators/miq_scsi_target_decorator.rb
@@ -1,0 +1,5 @@
+class MiqScsiTargetDecorator < MiqDecorator
+  def fonticon
+    'product product-network_card'
+  end
+end

--- a/app/decorators/miq_search_decorator.rb
+++ b/app/decorators/miq_search_decorator.rb
@@ -1,0 +1,5 @@
+class MiqSearchDecorator < MiqDecorator
+  def fonticon
+    'fa fa-filter'
+  end
+end

--- a/app/decorators/miq_server_decorator.rb
+++ b/app/decorators/miq_server_decorator.rb
@@ -1,0 +1,5 @@
+class MiqServerDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-server'
+  end
+end

--- a/app/decorators/miq_user_role_decorator.rb
+++ b/app/decorators/miq_user_role_decorator.rb
@@ -1,0 +1,5 @@
+class MiqUserRoleDecorator < MiqDecorator
+  def fonticon
+    'product product-role'
+  end
+end

--- a/app/decorators/miq_widget_decorator.rb
+++ b/app/decorators/miq_widget_decorator.rb
@@ -1,0 +1,14 @@
+class MiqWidgetDecorator < MiqDecorator
+  def fonticon
+    case content_type
+    when 'chart'
+      'fa fa-pie-chart'
+    when 'menu'
+      'fa fa-share-square-o'
+    when 'report'
+      'fa fa-file-text-o'
+    when 'rss'
+      'fa fa-rss'
+    end
+  end
+end

--- a/app/decorators/miq_widget_set_decorator.rb
+++ b/app/decorators/miq_widget_set_decorator.rb
@@ -1,0 +1,5 @@
+class MiqWidgetSetDecorator < MiqDecorator
+  def fonticon
+    'fa fa-tachometer'
+  end
+end

--- a/app/decorators/orchestration_template_decorator.rb
+++ b/app/decorators/orchestration_template_decorator.rb
@@ -1,0 +1,5 @@
+class OrchestrationTemplateDecorator < MiqDecorator
+  def fonticon
+    'product product-template'
+  end
+end

--- a/app/decorators/pxe_image_decorator.rb
+++ b/app/decorators/pxe_image_decorator.rb
@@ -1,0 +1,5 @@
+class PxeImageDecorator < MiqDecorator
+  def fonticon
+    default_for_windows ? 'fa fa-cog' : 'product product-network_card'
+  end
+end

--- a/app/decorators/pxe_image_type_decorator.rb
+++ b/app/decorators/pxe_image_type_decorator.rb
@@ -1,0 +1,5 @@
+class PxeImageTypeDecorator < MiqDecorator
+  def fonticon
+    'product product-network_card'
+  end
+end

--- a/app/decorators/pxe_server_decorator.rb
+++ b/app/decorators/pxe_server_decorator.rb
@@ -1,0 +1,5 @@
+class PxeServerDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-server'
+  end
+end

--- a/app/decorators/resource_pool_decorator.rb
+++ b/app/decorators/resource_pool_decorator.rb
@@ -1,6 +1,6 @@
 class ResourcePoolDecorator < MiqDecorator
   def fonticon
-    "pficon pficon-resource-pool"
+    'pficon pficon-resource-pool'
   end
 
   def listicon_image

--- a/app/decorators/scan_item_set_decorator.rb
+++ b/app/decorators/scan_item_set_decorator.rb
@@ -1,0 +1,5 @@
+class ResourcePoolDecorator < MiqDecorator
+  def fonticon
+    'fa fa-search'
+  end
+end

--- a/app/decorators/server_role_decorator.rb
+++ b/app/decorators/server_role_decorator.rb
@@ -1,0 +1,5 @@
+class ServerRoleDecorator < MiqDecorator
+  def fonticon
+    'product product-role'
+  end
+end

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -1,6 +1,6 @@
 class ServiceDecorator < MiqDecorator
   def fonticon
-    nil
+    'pficon pficon-service'
   end
 
   def listicon_image

--- a/app/decorators/service_template_ansible_tower_decorator.rb
+++ b/app/decorators/service_template_ansible_tower_decorator.rb
@@ -1,6 +1,6 @@
 class ServiceTemplateAnsibleTowerDecorator < MiqDecorator
   def fonticon
-    nil
+    'product product-template'
   end
 
   def listicon_image

--- a/app/decorators/service_template_catalog_decorator.rb
+++ b/app/decorators/service_template_catalog_decorator.rb
@@ -1,0 +1,5 @@
+class ServiceTemplateCatalogDecorator < MiqDecorator
+  def fonticon
+    'product product-template'
+  end
+end

--- a/app/decorators/service_template_decorator.rb
+++ b/app/decorators/service_template_decorator.rb
@@ -1,6 +1,6 @@
 class ServiceTemplateDecorator < MiqDecorator
   def fonticon
-    nil
+    'product product-template'
   end
 
   def listicon_image

--- a/app/decorators/snapshot_decorator.rb
+++ b/app/decorators/snapshot_decorator.rb
@@ -1,0 +1,5 @@
+class SnapshotDecorator < MiqDecorator
+  def fonticon
+    'fa fa-camera'
+  end
+end

--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -1,0 +1,5 @@
+class StorageDecorator < MiqDecorator
+  def fonticon
+    'fa fa-database'
+  end
+end

--- a/app/decorators/switch_decorator.rb
+++ b/app/decorators/switch_decorator.rb
@@ -1,0 +1,5 @@
+class SwitchDecorator < MiqDecorator
+  def fonticon
+    'product product-switch'
+  end
+end

--- a/app/decorators/tenant_decorator.rb
+++ b/app/decorators/tenant_decorator.rb
@@ -1,0 +1,5 @@
+class TenantDecorator < MiqDecorator
+  def fonticon
+    tenant? ? 'pficon pficon-tenant' : 'pficon pficon-project'
+  end
+end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,0 +1,5 @@
+class UserDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-user'
+  end
+end

--- a/app/decorators/vmdb_index_decorator.rb
+++ b/app/decorators/vmdb_index_decorator.rb
@@ -1,0 +1,5 @@
+class VmdbIndexDecorator < MiqDecorator
+  def fonticon
+    'fa fa-table'
+  end
+end

--- a/app/decorators/vmdb_table_decorator.rb
+++ b/app/decorators/vmdb_table_decorator.rb
@@ -1,0 +1,5 @@
+class VmdbTableDecorator < MiqDecorator
+  def fonticon
+    'fa fa-table'
+  end
+end

--- a/app/decorators/windows_image_decorator.rb
+++ b/app/decorators/windows_image_decorator.rb
@@ -1,0 +1,5 @@
+class WindowsImageDecorator < MiqDecorator
+  def listicon_image
+    'svg/os-windows_generic.svg'
+  end
+end

--- a/app/decorators/zone_decorator.rb
+++ b/app/decorators/zone_decorator.rb
@@ -1,0 +1,5 @@
+class ZoneDecorator < MiqDecorator
+  def fonticon
+    'pficon pficon-zone'
+  end
+end

--- a/app/presenters/tree_node/availability_zone.rb
+++ b/app/presenters/tree_node/availability_zone.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class AvailabilityZone < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { |object| _("Availability Zone: %{name}") % {:name => object.name} }
   end
 end

--- a/app/presenters/tree_node/availability_zone.rb
+++ b/app/presenters/tree_node/availability_zone.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class AvailabilityZone < Node
-    set_attribute(:icon, 'pficon pficon-zone')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { |object| _("Availability Zone: %{name}") % {:name => object.name} }
   end
 end

--- a/app/presenters/tree_node/chargeback_rate.rb
+++ b/app/presenters/tree_node/chargeback_rate.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class ChargebackRate < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/chargeback_rate.rb
+++ b/app/presenters/tree_node/chargeback_rate.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class ChargebackRate < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon, 'fa fa-file-text-o')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/classification.rb
+++ b/app/presenters/tree_node/classification.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class Classification < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon, "pficon pficon-folder-close")
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:no_click, true)
     set_attribute(:hide_checkbox, true)
     set_attribute(:tooltip) { _("Category: %{description}") % { :description => @object.description } }

--- a/app/presenters/tree_node/classification.rb
+++ b/app/presenters/tree_node/classification.rb
@@ -1,7 +1,6 @@
 module TreeNode
   class Classification < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:no_click, true)
     set_attribute(:hide_checkbox, true)
     set_attribute(:tooltip) { _("Category: %{description}") % { :description => @object.description } }

--- a/app/presenters/tree_node/compliance.rb
+++ b/app/presenters/tree_node/compliance.rb
@@ -7,6 +7,6 @@ module TreeNode
       end
     end
 
-    set_attribute(:icon) { "pficon #{@object.compliant ? 'pficon-ok' : 'pficon-error-circle-o'}" }
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/compliance.rb
+++ b/app/presenters/tree_node/compliance.rb
@@ -7,6 +7,5 @@ module TreeNode
       end
     end
 
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/compliance_detail.rb
+++ b/app/presenters/tree_node/compliance_detail.rb
@@ -7,6 +7,6 @@ module TreeNode
       end
     end
 
-    set_attribute(:icon) { "pficon #{@object.miq_policy_result ? 'pficon-ok' : 'pficon-error-circle-o'}" }
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/compliance_detail.rb
+++ b/app/presenters/tree_node/compliance_detail.rb
@@ -7,6 +7,5 @@ module TreeNode
       end
     end
 
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/condition.rb
+++ b/app/presenters/tree_node/condition.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class Condition < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon, 'product product-miq_condition')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/condition.rb
+++ b/app/presenters/tree_node/condition.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class Condition < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/configuration_profile.rb
+++ b/app/presenters/tree_node/configuration_profile.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class ConfigurationProfile < Node
     set_attribute(:title) { @object.name.split('|').first }
-    set_attribute(:icon) { @object.id ? 'fa fa-list-ul' : 'pficon pficon-folder-close' }
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Configuration Profile: %{name}") % {:name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/configuration_profile.rb
+++ b/app/presenters/tree_node/configuration_profile.rb
@@ -1,7 +1,6 @@
 module TreeNode
   class ConfigurationProfile < Node
     set_attribute(:title) { @object.name.split('|').first }
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Configuration Profile: %{name}") % {:name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/configured_system.rb
+++ b/app/presenters/tree_node/configured_system.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class ConfiguredSystem < Node
     set_attribute(:title, &:hostname)
-    set_attribute(:icon, 'product product-configured_system')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Configured System: %{hostname}") % {:hostname => @object.hostname} }
   end
 end

--- a/app/presenters/tree_node/configured_system.rb
+++ b/app/presenters/tree_node/configured_system.rb
@@ -1,7 +1,6 @@
 module TreeNode
   class ConfiguredSystem < Node
     set_attribute(:title, &:hostname)
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Configured System: %{hostname}") % {:hostname => @object.hostname} }
   end
 end

--- a/app/presenters/tree_node/container.rb
+++ b/app/presenters/tree_node/container.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class Container < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/container.rb
+++ b/app/presenters/tree_node/container.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class Container < Node
-    set_attribute(:icon, 'fa fa-cube')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/custom_button.rb
+++ b/app/presenters/tree_node/custom_button.rb
@@ -1,9 +1,6 @@
 module TreeNode
   class CustomButton < Node
-    set_attribute(:icon) do
-      @object.options && @object.options[:button_image] ? "product product-custom-#{@object.options[:button_image]}" : 'fa fa-file-o'
-    end
-
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Button: %{button_description}") % {:button_description => @object.description} }
   end
 end

--- a/app/presenters/tree_node/custom_button.rb
+++ b/app/presenters/tree_node/custom_button.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class CustomButton < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Button: %{button_description}") % {:button_description => @object.description} }
   end
 end

--- a/app/presenters/tree_node/custom_button_set.rb
+++ b/app/presenters/tree_node/custom_button_set.rb
@@ -8,7 +8,6 @@ module TreeNode
       end
     end
 
-    set_attribute(:icon) { @object.decorate.fonticon }
 
     set_attribute(:tooltip) do
       if @object.description

--- a/app/presenters/tree_node/custom_button_set.rb
+++ b/app/presenters/tree_node/custom_button_set.rb
@@ -8,9 +8,7 @@ module TreeNode
       end
     end
 
-    set_attribute(:icon) do
-      @object.set_data && @object.set_data[:button_image] ? "product product-custom-#{@object.set_data[:button_image]}" : 'pficon pficon-folder-close'
-    end
+    set_attribute(:icon) { @object.decorate.fonticon }
 
     set_attribute(:tooltip) do
       if @object.description

--- a/app/presenters/tree_node/customization_template.rb
+++ b/app/presenters/tree_node/customization_template.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class CustomizationTemplate < Node
-    set_attribute(:icon, 'product product-template')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/customization_template.rb
+++ b/app/presenters/tree_node/customization_template.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class CustomizationTemplate < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/dialog.rb
+++ b/app/presenters/tree_node/dialog.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class Dialog < Node
     set_attribute(:title, &:label)
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/dialog.rb
+++ b/app/presenters/tree_node/dialog.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class Dialog < Node
     set_attribute(:title, &:label)
-    set_attribute(:icon, 'fa fa-comment-o')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/dialog_field.rb
+++ b/app/presenters/tree_node/dialog_field.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class DialogField < Node
     set_attribute(:title, &:label)
-    set_attribute(:icon, 'product product-field')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/dialog_field.rb
+++ b/app/presenters/tree_node/dialog_field.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class DialogField < Node
     set_attribute(:title, &:label)
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/dialog_group.rb
+++ b/app/presenters/tree_node/dialog_group.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class DialogGroup < Node
     set_attribute(:title, &:label)
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/dialog_group.rb
+++ b/app/presenters/tree_node/dialog_group.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class DialogGroup < Node
     set_attribute(:title, &:label)
-    set_attribute(:icon, 'fa fa-comments-o')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/dialog_tab.rb
+++ b/app/presenters/tree_node/dialog_tab.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class DialogTab < Node
     set_attribute(:title, &:label)
-    set_attribute(:icon, 'product product-tab')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/dialog_tab.rb
+++ b/app/presenters/tree_node/dialog_tab.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class DialogTab < Node
     set_attribute(:title, &:label)
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/ems_cluster.rb
+++ b/app/presenters/tree_node/ems_cluster.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class EmsCluster < Node
-    set_attribute(:icon, 'pficon pficon-cluster')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Cluster / Deployment Role: %{name}") % {:name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/ems_cluster.rb
+++ b/app/presenters/tree_node/ems_cluster.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class EmsCluster < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Cluster / Deployment Role: %{name}") % {:name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/ems_folder.rb
+++ b/app/presenters/tree_node/ems_folder.rb
@@ -2,10 +2,11 @@ module TreeNode
   class EmsFolder < Node
     set_attributes(:icon, :tooltip) do
       if @object.kind_of?(Datacenter)
-        icon = 'fa fa-building-o'
+        icon = @object.decorate.fonticon # calls DatacenterDecorator#fonticon
         tooltip = _("Datacenter: %{datacenter_name}") % {:datacenter_name => @object.name}
       else
-        icon = "pficon #{%i(vandt vat).include?(@options[:type]) ? 'pficon-folder-close-blue' : 'pficon-folder-close'}"
+        # TODO: move this logic into TreeBuilder#override for the specific trees
+        icon = %i(vandt vat).include?(@options[:type]) ? 'pficon pficon-folder-close-blue' : @object.decorate.fonticon
         tooltip = _("Folder: %{folder_name}") % {:folder_name => @object.name}
       end
       [icon, tooltip]

--- a/app/presenters/tree_node/ext_management_system.rb
+++ b/app/presenters/tree_node/ext_management_system.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class ExtManagementSystem < Node
-    set_attribute(:image) { "svg/vendor-#{@object.image_name}.svg" }
+    set_attribute(:image) { @object.decorate.listicon_image }
 
     set_attribute(:tooltip) do
       # # TODO: This should really leverage .base_model on an EMS

--- a/app/presenters/tree_node/guest_device.rb
+++ b/app/presenters/tree_node/guest_device.rb
@@ -2,16 +2,14 @@ module TreeNode
   class GuestDevice < Node
     set_attribute(:title, &:device_name)
 
-    set_attributes(:icon, :tooltip) do
-      if @object.device_type == "ethernet"
-        icon = 'product product-network_card'
-        tooltip = _("Physical NIC: %{name}") % {:name => @object.device_name}
-      else
-        icon = "product product-network_card"
-        tooltip = _("%{type} Storage Adapter: %{name}") % {:type => @object.controller_type, :name => @object.device_name}
-      end
+    set_attribute(:icon) { @object.decorate.fonticon }
 
-      [icon, tooltip]
+    set_attribute(:tooltip) do
+      if @object.device_type == "ethernet"
+        _("Physical NIC: %{name}") % {:name => @object.device_name}
+      else
+        _("%{type} Storage Adapter: %{name}") % {:type => @object.controller_type, :name => @object.device_name}
+      end
     end
   end
 end

--- a/app/presenters/tree_node/guest_device.rb
+++ b/app/presenters/tree_node/guest_device.rb
@@ -2,8 +2,6 @@ module TreeNode
   class GuestDevice < Node
     set_attribute(:title, &:device_name)
 
-    set_attribute(:icon) { @object.decorate.fonticon }
-
     set_attribute(:tooltip) do
       if @object.device_type == "ethernet"
         _("Physical NIC: %{name}") % {:name => @object.device_name}

--- a/app/presenters/tree_node/host.rb
+++ b/app/presenters/tree_node/host.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class Host < Node
-    set_attribute(:icon, 'pficon pficon-screen')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Host / Node: %{name}") % {:name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/host.rb
+++ b/app/presenters/tree_node/host.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class Host < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Host / Node: %{name}") % {:name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/iso_datastore.rb
+++ b/app/presenters/tree_node/iso_datastore.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class IsoDatastore < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/iso_datastore.rb
+++ b/app/presenters/tree_node/iso_datastore.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class IsoDatastore < Node
-    set_attribute(:icon, 'pficon pficon-server')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/iso_image.rb
+++ b/app/presenters/tree_node/iso_image.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class IsoImage < Node
-    set_attribute(:icon, 'product product-network_card')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/iso_image.rb
+++ b/app/presenters/tree_node/iso_image.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class IsoImage < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/lan.rb
+++ b/app/presenters/tree_node/lan.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class Lan < Node
-    set_attribute(:icon, 'product product-switch')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Port Group: %{name}") % {:name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/lan.rb
+++ b/app/presenters/tree_node/lan.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class Lan < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Port Group: %{name}") % {:name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/ldap_domain.rb
+++ b/app/presenters/tree_node/ldap_domain.rb
@@ -1,7 +1,6 @@
 module TreeNode
   class LdapDomain < Node
     set_attribute(:title) { _("Domain: %{domain_name}") % {:domain_name => @object.name} }
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("LDAP Domain: %{ldap_domain_name}") % {:ldap_domain_name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/ldap_domain.rb
+++ b/app/presenters/tree_node/ldap_domain.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class LdapDomain < Node
     set_attribute(:title) { _("Domain: %{domain_name}") % {:domain_name => @object.name} }
-    set_attribute(:icon, 'pficon pficon-domain')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("LDAP Domain: %{ldap_domain_name}") % {:ldap_domain_name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/ldap_region.rb
+++ b/app/presenters/tree_node/ldap_region.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class LdapRegion < Node
     set_attribute(:title) { _("Region: %{region_name}") % {:region_name => @object.name} }
-    set_attribute(:icon, 'pficon pficon-regions')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("LDAP Region: %{ldap_region_name}") % {:ldap_region_name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/ldap_region.rb
+++ b/app/presenters/tree_node/ldap_region.rb
@@ -1,7 +1,6 @@
 module TreeNode
   class LdapRegion < Node
     set_attribute(:title) { _("Region: %{region_name}") % {:region_name => @object.name} }
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("LDAP Region: %{ldap_region_name}") % {:ldap_region_name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/miq_ae_node.rb
+++ b/app/presenters/tree_node/miq_ae_node.rb
@@ -2,7 +2,6 @@ module TreeNode
   class MiqAeNode < Node
     set_attribute(:title) { text }
     set_attribute(:tooltip) { "#{ui_lookup(:model => model)}: #{text}" }
-    set_attribute(:icon) { @object.decorate.fonticon }
 
     private
 

--- a/app/presenters/tree_node/miq_alert.rb
+++ b/app/presenters/tree_node/miq_alert.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class MiqAlert < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_alert.rb
+++ b/app/presenters/tree_node/miq_alert.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class MiqAlert < Node
-    set_attribute(:icon, 'pficon pficon-warning-triangle-o')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_alert_set.rb
+++ b/app/presenters/tree_node/miq_alert_set.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class MiqAlertSet < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_alert_set.rb
+++ b/app/presenters/tree_node/miq_alert_set.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class MiqAlertSet < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon, 'pficon pficon-warning-triangle-o')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_dialog.rb
+++ b/app/presenters/tree_node/miq_dialog.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class MiqDialog < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon, 'fa fa-comment-o')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { @object[0] }
   end
 end

--- a/app/presenters/tree_node/miq_dialog.rb
+++ b/app/presenters/tree_node/miq_dialog.rb
@@ -1,7 +1,6 @@
 module TreeNode
   class MiqDialog < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { @object[0] }
   end
 end

--- a/app/presenters/tree_node/miq_event_definition.rb
+++ b/app/presenters/tree_node/miq_event_definition.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class MiqEventDefinition < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_group.rb
+++ b/app/presenters/tree_node/miq_group.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class MiqGroup < Node
-    set_attribute(:icon, 'product product-group')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_group.rb
+++ b/app/presenters/tree_node/miq_group.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class MiqGroup < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_policy.rb
+++ b/app/presenters/tree_node/miq_policy.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class MiqPolicy < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:title) do
       if @options[:tree] == :policy_profile_tree
         ViewHelper.capture do

--- a/app/presenters/tree_node/miq_policy_set.rb
+++ b/app/presenters/tree_node/miq_policy_set.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class MiqPolicySet < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon) { @object.active? ? 'fa fa-shield' : 'fa fa-inactive fa-shield' }
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_policy_set.rb
+++ b/app/presenters/tree_node/miq_policy_set.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class MiqPolicySet < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_region.rb
+++ b/app/presenters/tree_node/miq_region.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class MiqRegion < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { @object[0] }
     set_attribute(:expand, true)
   end

--- a/app/presenters/tree_node/miq_region.rb
+++ b/app/presenters/tree_node/miq_region.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class MiqRegion < Node
-    set_attribute(:icon, 'pficon pficon-regions')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { @object[0] }
     set_attribute(:expand, true)
   end

--- a/app/presenters/tree_node/miq_report.rb
+++ b/app/presenters/tree_node/miq_report.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class MiqReport < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_report.rb
+++ b/app/presenters/tree_node/miq_report.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class MiqReport < Node
-    set_attribute(:icon, 'fa fa-file-text-o')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_report_result.rb
+++ b/app/presenters/tree_node/miq_report_result.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class MiqReportResult < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
 
     set_attributes(:title, :tooltip, :expand) do
       expand = nil

--- a/app/presenters/tree_node/miq_report_result.rb
+++ b/app/presenters/tree_node/miq_report_result.rb
@@ -1,19 +1,6 @@
 module TreeNode
   class MiqReportResult < Node
-    set_attribute(:icon) do
-      case @object.status.downcase
-      when 'error'
-        'pficon pficon-error-circle-o'
-      when 'finished'
-        'pficon pficon-ok'
-      when 'running'
-        'pficon pficon-running'
-      when 'queued'
-        'fa fa-play-circle-o'
-      else
-        'fa fa-arrow-right'
-      end
-    end
+    set_attribute(:icon) { @object.decorate.fonticon }
 
     set_attributes(:title, :tooltip, :expand) do
       expand = nil

--- a/app/presenters/tree_node/miq_schedule.rb
+++ b/app/presenters/tree_node/miq_schedule.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class MiqSchedule < Node
-    set_attribute(:icon, 'fa fa-clock-o')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_schedule.rb
+++ b/app/presenters/tree_node/miq_schedule.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class MiqSchedule < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_scsi_lun.rb
+++ b/app/presenters/tree_node/miq_scsi_lun.rb
@@ -1,7 +1,6 @@
 module TreeNode
   class MiqScsiLun < Node
     set_attribute(:title, &:canonical_name)
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("LUN: %{name}") % {:name => @object.canonical_name} }
   end
 end

--- a/app/presenters/tree_node/miq_scsi_lun.rb
+++ b/app/presenters/tree_node/miq_scsi_lun.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class MiqScsiLun < Node
     set_attribute(:title, &:canonical_name)
-    set_attribute(:icon, 'fa fa-database')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("LUN: %{name}") % {:name => @object.canonical_name} }
   end
 end

--- a/app/presenters/tree_node/miq_scsi_target.rb
+++ b/app/presenters/tree_node/miq_scsi_target.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class MiqScsiTarget < Node
-    set_attribute(:icon, 'product product-network_card')
+    set_attribute(:icon) { @object.decorate.fonticon }
 
     set_attributes(:title, :tooltip) do
       title = if @object.iscsi_name.blank?

--- a/app/presenters/tree_node/miq_scsi_target.rb
+++ b/app/presenters/tree_node/miq_scsi_target.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class MiqScsiTarget < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
 
     set_attributes(:title, :tooltip) do
       title = if @object.iscsi_name.blank?

--- a/app/presenters/tree_node/miq_search.rb
+++ b/app/presenters/tree_node/miq_search.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class MiqSearch < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon, 'fa fa-filter')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Filter: %{filter_description}") % {:filter_description => @object.description} }
   end
 end

--- a/app/presenters/tree_node/miq_search.rb
+++ b/app/presenters/tree_node/miq_search.rb
@@ -1,7 +1,6 @@
 module TreeNode
   class MiqSearch < Node
     set_attribute(:title, &:description)
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Filter: %{filter_description}") % {:filter_description => @object.description} }
   end
 end

--- a/app/presenters/tree_node/miq_server.rb
+++ b/app/presenters/tree_node/miq_server.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class MiqServer < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:expand, true)
 
     set_attributes(:title, :tooltip) do

--- a/app/presenters/tree_node/miq_server.rb
+++ b/app/presenters/tree_node/miq_server.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class MiqServer < Node
-    set_attribute(:icon, 'pficon pficon-server')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:expand, true)
 
     set_attributes(:title, :tooltip) do

--- a/app/presenters/tree_node/miq_user_role.rb
+++ b/app/presenters/tree_node/miq_user_role.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class MiqUserRole < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_user_role.rb
+++ b/app/presenters/tree_node/miq_user_role.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class MiqUserRole < Node
-    set_attribute(:icon, 'product product-role')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_widget.rb
+++ b/app/presenters/tree_node/miq_widget.rb
@@ -2,6 +2,5 @@ module TreeNode
   class MiqWidget < Node
     set_attribute(:title, &:title)
     set_attribute(:tooltip, &:title)
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_widget.rb
+++ b/app/presenters/tree_node/miq_widget.rb
@@ -2,17 +2,6 @@ module TreeNode
   class MiqWidget < Node
     set_attribute(:title, &:title)
     set_attribute(:tooltip, &:title)
-    set_attribute(:icon) do
-      case @object.content_type
-      when 'chart'
-        'fa fa-pie-chart'
-      when 'menu'
-        'fa fa-share-square-o'
-      when 'report'
-        'fa fa-file-text-o'
-      when 'rss'
-        'fa fa-rss'
-      end
-    end
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_widget_set.rb
+++ b/app/presenters/tree_node/miq_widget_set.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class MiqWidgetSet < Node
     set_attribute(:tooltip, &:name)
-    set_attribute(:icon) { @object.decorate_fonticon }
   end
 end

--- a/app/presenters/tree_node/miq_widget_set.rb
+++ b/app/presenters/tree_node/miq_widget_set.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class MiqWidgetSet < Node
     set_attribute(:tooltip, &:name)
-    set_attribute(:icon, 'fa fa-tachometer')
+    set_attribute(:icon) { @object.decorate_fonticon }
   end
 end

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -67,7 +67,7 @@ module TreeNode
     end
 
     def icon
-      nil
+      @object.try(:decorate).try(:fonticon)
     end
 
     def klass

--- a/app/presenters/tree_node/orchestration_template.rb
+++ b/app/presenters/tree_node/orchestration_template.rb
@@ -1,7 +1,5 @@
 module TreeNode
   class OrchestrationTemplate < Node
-    set_attribute(:icon) do
-      "product product-template"
-    end
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/orchestration_template.rb
+++ b/app/presenters/tree_node/orchestration_template.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class OrchestrationTemplate < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/pxe_image.rb
+++ b/app/presenters/tree_node/pxe_image.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class PxeImage < Node
-    set_attribute(:icon) { @object.default_for_windows ? 'fa fa-cog' : 'product product-network_card' }
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/pxe_image.rb
+++ b/app/presenters/tree_node/pxe_image.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class PxeImage < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/pxe_image_type.rb
+++ b/app/presenters/tree_node/pxe_image_type.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class PxeImageType < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/pxe_image_type.rb
+++ b/app/presenters/tree_node/pxe_image_type.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class PxeImageType < Node
-    set_attribute(:icon, 'product product-network_card')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/pxe_server.rb
+++ b/app/presenters/tree_node/pxe_server.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class PxeServer < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/pxe_server.rb
+++ b/app/presenters/tree_node/pxe_server.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class PxeServer < Node
-    set_attribute(:icon, 'pficon pficon-server')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/resource_pool.rb
+++ b/app/presenters/tree_node/resource_pool.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class ResourcePool < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/resource_pool.rb
+++ b/app/presenters/tree_node/resource_pool.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class ResourcePool < Node
-    set_attribute(:icon) { "pficon pficon-resource-pool" }
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/scan_item_set.rb
+++ b/app/presenters/tree_node/scan_item_set.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class ScanItemSet < Node
-    set_attribute(:icon, 'fa fa-search')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/scan_item_set.rb
+++ b/app/presenters/tree_node/scan_item_set.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class ScanItemSet < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/server_role.rb
+++ b/app/presenters/tree_node/server_role.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class ServerRole < Node
-    set_attribute(:icon) { "product product-role" }
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:expand, true)
 
     set_attributes(:title, :tooltip) do

--- a/app/presenters/tree_node/server_role.rb
+++ b/app/presenters/tree_node/server_role.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class ServerRole < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:expand, true)
 
     set_attributes(:title, :tooltip) do

--- a/app/presenters/tree_node/service.rb
+++ b/app/presenters/tree_node/service.rb
@@ -4,7 +4,7 @@ module TreeNode
       if @object.picture
         image = @object.decorate.listicon_image
       else
-        icon = 'product product-service'
+        icon = @object.decorate.fonticon
       end
       [image, icon]
     end

--- a/app/presenters/tree_node/service_resource.rb
+++ b/app/presenters/tree_node/service_resource.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class ServiceResource < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/service_resource.rb
+++ b/app/presenters/tree_node/service_resource.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class ServiceResource < Node
-    set_attribute(:icon) { @object.resource_type == 'VmOrTemplate' ? 'pficon pficon-virtual-machine' : 'product product-template' }
-
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/service_template.rb
+++ b/app/presenters/tree_node/service_template.rb
@@ -4,7 +4,7 @@ module TreeNode
       if @object.picture
         image = @object.decorate.listicon_image
       else
-        icon = 'product product-template'
+        icon = @object.decorate.fonticon
       end
       [image, icon]
     end

--- a/app/presenters/tree_node/service_template_catalog.rb
+++ b/app/presenters/tree_node/service_template_catalog.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class ServiceTemplateCatalog < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:title) do
       if @object.tenant.present? && @object.tenant.ancestors.present?
         "#{@object.name} (#{@object.tenant.name})"

--- a/app/presenters/tree_node/service_template_catalog.rb
+++ b/app/presenters/tree_node/service_template_catalog.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class ServiceTemplateCatalog < Node
-    set_attribute(:icon, 'product product-template')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:title) do
       if @object.tenant.present? && @object.tenant.ancestors.present?
         "#{@object.name} (#{@object.tenant.name})"

--- a/app/presenters/tree_node/snapshot.rb
+++ b/app/presenters/tree_node/snapshot.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class Snapshot < Node
-    set_attribute(:icon, 'fa fa-camera')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip, &:name)
     set_attribute(:title) do
       if @object.current?

--- a/app/presenters/tree_node/snapshot.rb
+++ b/app/presenters/tree_node/snapshot.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class Snapshot < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip, &:name)
     set_attribute(:title) do
       if @object.current?

--- a/app/presenters/tree_node/storage.rb
+++ b/app/presenters/tree_node/storage.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class Storage < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/storage.rb
+++ b/app/presenters/tree_node/storage.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class Storage < Node
-    set_attribute(:icon, 'fa fa-database')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/switch.rb
+++ b/app/presenters/tree_node/switch.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class Switch < Node
-    set_attribute(:icon, 'product product-switch')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Switch: %{name}") % {:name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/switch.rb
+++ b/app/presenters/tree_node/switch.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class Switch < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attribute(:tooltip) { _("Switch: %{name}") % {:name => @object.name} }
   end
 end

--- a/app/presenters/tree_node/tenant.rb
+++ b/app/presenters/tree_node/tenant.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class Tenant < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/tenant.rb
+++ b/app/presenters/tree_node/tenant.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class Tenant < Node
-    set_attribute(:icon) { @object.tenant? ? "pficon pficon-tenant" : "pficon pficon-project" }
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/user.rb
+++ b/app/presenters/tree_node/user.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class User < Node
-    set_attribute(:icon, 'pficon pficon-user')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/user.rb
+++ b/app/presenters/tree_node/user.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class User < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/vmdb_index.rb
+++ b/app/presenters/tree_node/vmdb_index.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class VmdbIndex < Node
-    set_attribute(:icon, 'fa fa-table')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/vmdb_index.rb
+++ b/app/presenters/tree_node/vmdb_index.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class VmdbIndex < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/vmdb_table.rb
+++ b/app/presenters/tree_node/vmdb_table.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class VmdbTable < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/vmdb_table.rb
+++ b/app/presenters/tree_node/vmdb_table.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class VmdbTable < Node
-    set_attribute(:icon, 'fa fa-table')
+    set_attribute(:icon) { @object.decorate.fonticon }
   end
 end

--- a/app/presenters/tree_node/windows_image.rb
+++ b/app/presenters/tree_node/windows_image.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class WindowsImage < Node
-    set_attribute(:image, 'svg/os-windows_generic.svg')
+    set_attribute(:image) { @object.decorate.listicon_image }
   end
 end

--- a/app/presenters/tree_node/zone.rb
+++ b/app/presenters/tree_node/zone.rb
@@ -1,6 +1,5 @@
 module TreeNode
   class Zone < Node
-    set_attribute(:icon) { @object.decorate.fonticon }
     set_attributes(:title, :tooltip) do
       if @options[:is_current]
         tooltip = "#{ui_lookup(:model => @object.class.to_s)}: #{@object.description} (#{_('current')})"

--- a/app/presenters/tree_node/zone.rb
+++ b/app/presenters/tree_node/zone.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class Zone < Node
-    set_attribute(:icon, 'pficon pficon-zone')
+    set_attribute(:icon) { @object.decorate.fonticon }
     set_attributes(:title, :tooltip) do
       if @options[:is_current]
         tooltip = "#{ui_lookup(:model => @object.class.to_s)}: #{@object.description} (#{_('current')})"

--- a/spec/presenters/tree_node/service_spec.rb
+++ b/spec/presenters/tree_node/service_spec.rb
@@ -5,5 +5,5 @@ describe TreeNode::Service do
   let(:object) { FactoryGirl.create(:service) }
 
   include_examples 'TreeNode::Node#key prefix', 's-'
-  include_examples 'TreeNode::Node#icon', 'product product-service'
+  include_examples 'TreeNode::Node#icon', 'pficon pficon-service'
 end


### PR DESCRIPTION
The `TreeNode::` subclasses contained most of the icon/image definitions for tree nodes. As we're using these icons/images in other places (like listicons), there were some duplications. This PR unifies these icon/image definitions in a single place.

There were some cases where it was not possible or just partially possible to use these decorators, as the tree node icon can be different from a listicon/quadicon and it sometimes depends on parameters that are given for the specific tree only. I was trying to minimise the issues in such cases, but it might need someone else's eye, @himdel or @martinpovolny maybe?

The `#listicon_image` method name became a bit confusing, but I kept using it for SVG node icons. @epwinchell  we should come up with something better in the future.

https://www.pivotaltracker.com/story/show/140762807