### PR TITLE
Move `decorate` to ApplicationRecord

### DIFF
--- a/config/initializers/decorate.rb
+++ b/config/initializers/decorate.rb
@@ -1,3 +1,0 @@
-# extending all model instances and classes to have a `decorate` method
-ApplicationRecord.send(:extend, MiqDecorator::Klass)
-ApplicationRecord.send(:include, MiqDecorator::Instance)


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/237, but this doesn't work with Rails' autoloader (reloading ApplicationRecord won't patch it again).

Thus, moving the code to ApplicationRecord for now, until the second phase of the decorator refactoring.

---

Please merge together with https://github.com/ManageIQ/manageiq/pull/14093 (either breaks without the other).