### PR TITLE
Fix C&U chart precision

### DIFF
--- a/app/assets/javascripts/miq_c3.js
+++ b/app/assets/javascripts/miq_c3.js
@@ -160,7 +160,7 @@ function getChartFormatedValueWithFormat(format, value) {
 function validateMinMax(min, max, minShowed, maxShowed) {
   var invalid = false;
   // if there are no valid values or there is only single values big enough, then not change formating function
-  if (max <= min || maxShowed <= minShowed) {
+  if (max <= min || maxShowed < minShowed) {
     if (max < min || max > 10) {
       invalid = true;
     } else if (max > 0){


### PR DESCRIPTION
Fix little bug introduced in #40 which resulted in bad Y labels for some cases. Now it should be good.

This should be backported to euwe.