### PR TITLE
Show also non vpc vms in network topology

### DIFF
--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -13,26 +13,32 @@ class NetworkTopologyService < TopologyService
 
   def build_topology
     topo_items = {}
-    links = []
+    links      = []
 
     included_relations = [
       :tags,
-      :cloud_subnets => [
-        :parent_cloud_subnet,
-        :tags,
-        :cloud_network  => :tags,
-        :vms            => [
+      :availability_zones => [
+        :vms => [
           :tags,
           :load_balancers  => :tags,
           :floating_ips    => :tags,
           :cloud_tenant    => :tags,
-          :security_groups => :tags],
+          :security_groups => :tags
+        ]
+      ],
+      :cloud_subnets      => [
+        :parent_cloud_subnet,
+        :tags,
+        :vms,
+        :cloud_network  => :tags,
         :network_router => [
           :tags,
           :cloud_network => [
             :floating_ips => :tags
           ]
-        ]]]
+        ]
+      ]
+    ]
 
     entity_relationships = {:NetworkManager => build_entity_relationships(included_relations)}
 
@@ -89,7 +95,7 @@ class NetworkTopologyService < TopologyService
 
   def build_kinds
     kinds = [:NetworkRouter, :CloudSubnet, :Vm, :NetworkManager, :FloatingIp, :CloudNetwork, :NetworkPort, :CloudTenant,
-             :SecurityGroup, :LoadBalancer, :Tag]
+             :SecurityGroup, :LoadBalancer, :Tag, :AvailabilityZone]
     build_legend_kinds(kinds)
   end
 end

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -6,6 +6,14 @@
   .legend
     %label#selected
     %div{'ng-if' => "kinds"}
+      %kubernetes-topology-icon{tooltipOptions, :kind => "AvailabilityZone"}
+        %svg.kube-topology
+          %g.EntityLegend.Cloud.AvailabilityZone
+            %circle{:r => "17"}
+            -# pficon-network
+            %text{:y => "8"} &#xE911;
+        %label
+          = _("Availability Zones")
       %kubernetes-topology-icon{tooltipOptions, :kind => "CloudSubnet"}
         %svg.kube-topology
           %g.EntityLegend.Network.CloudSubnet

--- a/spec/services/network_topology_service_spec.rb
+++ b/spec/services/network_topology_service_spec.rb
@@ -5,7 +5,7 @@ describe NetworkTopologyService do
     it "creates the expected number of entity types" do
       expect(network_topology_service.build_kinds.keys).to match_array([
         :CloudNetwork, :CloudSubnet, :CloudTenant, :FloatingIp, :LoadBalancer, :NetworkManager, :NetworkPort, :NetworkRouter,
-        :SecurityGroup, :Tag, :Vm])
+        :SecurityGroup, :Tag, :Vm, :AvailabilityZone])
     end
   end
 
@@ -26,7 +26,13 @@ describe NetworkTopologyService do
 
     before :each do
       @cloud_tenant = FactoryGirl.create(:cloud_tenant_openstack)
-      @vm = FactoryGirl.create(:vm_openstack, :cloud_tenant => @cloud_tenant, :ext_management_system => ems_cloud)
+      @availability_zone = FactoryGirl.create(:availability_zone_openstack,
+                                              :name                  => "AZ name",
+                                              :ext_management_system => ems_cloud)
+      @vm = FactoryGirl.create(:vm_openstack,
+                               :cloud_tenant          => @cloud_tenant,
+                               :ext_management_system => ems_cloud,
+                               :availability_zone     => @availability_zone)
       @cloud_network = FactoryGirl.create(:cloud_network_openstack)
       @public_network = FactoryGirl.create(:cloud_network_openstack)
       @cloud_subnet = FactoryGirl.create(:cloud_subnet_openstack, :cloud_network         => @cloud_network,
@@ -66,59 +72,88 @@ describe NetworkTopologyService do
       allow(network_topology_service).to receive(:retrieve_providers).and_return([ems])
       network_topology_service.instance_variable_set(:@entity, ems)
 
-      expect(subject[:items]).to eq(
-        "NetworkManager" + ems.compressed_id.to_s            => {:name         => ems.name,
-                                                                 :kind         => "NetworkManager",
-                                                                 :miq_id       => ems.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "Openstack"},
-        "CloudTenant" + @cloud_tenant.compressed_id.to_s     => {:name         => @cloud_tenant.name,
-                                                                 :kind         => "CloudTenant",
-                                                                 :miq_id       => @cloud_tenant.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "CloudTenant"},
-        "CloudNetwork" + @cloud_network.compressed_id.to_s   => {:name         => @cloud_network.name,
-                                                                 :kind         => "CloudNetwork",
-                                                                 :miq_id       => @cloud_network.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "CloudNetwork"},
-        "CloudNetwork" + @public_network.compressed_id.to_s  => {:name         => @public_network.name,
-                                                                 :kind         => "CloudNetwork",
-                                                                 :miq_id       => @public_network.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "CloudNetwork"},
-        "CloudSubnet" + @cloud_subnet.compressed_id.to_s     => {:name         => @cloud_subnet.name,
-                                                                 :kind         => "CloudSubnet",
-                                                                 :miq_id       => @cloud_subnet.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "CloudSubnet"},
-        "FloatingIp" + @floating_ip.compressed_id.to_s       => {:name         => @floating_ip.name,
-                                                                 :kind         => "FloatingIp",
-                                                                 :miq_id       => @floating_ip.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "FloatingIp"},
-        "NetworkRouter" + @network_router.compressed_id.to_s => {:name         => @network_router.name,
-                                                                 :kind         => "NetworkRouter",
-                                                                 :miq_id       => @network_router.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "NetworkRouter"},
+      expect(subject[:items]).to(
+        eq(
+          "NetworkManager" + ems.compressed_id.to_s            => {
+            :name         => ems.name,
+            :kind         => "NetworkManager",
+            :miq_id       => ems.id,
+            :status       => "Unknown",
+            :display_kind => "Openstack"
+          },
+          "AvailabilityZone" + @availability_zone.compressed_id.to_s          => {
+            :name         => "AZ name",
+            :kind         => "AvailabilityZone",
+            :miq_id       => @availability_zone.id,
+            :status       => "Unknown",
+            :display_kind => "AvailabilityZone"
+          },
+          "CloudTenant" + @cloud_tenant.compressed_id.to_s     => {
+            :name         => @cloud_tenant.name,
+            :kind         => "CloudTenant",
+            :miq_id       => @cloud_tenant.id,
+            :status       => "Unknown",
+            :display_kind => "CloudTenant"
+          },
+          "CloudNetwork" + @cloud_network.compressed_id.to_s   => {
+            :name         => @cloud_network.name,
+            :kind         => "CloudNetwork",
+            :miq_id       => @cloud_network.id,
+            :status       => "Unknown",
+            :display_kind => "CloudNetwork"
+          },
+          "CloudNetwork" + @public_network.compressed_id.to_s  => {
+            :name         => @public_network.name,
+            :kind         => "CloudNetwork",
+            :miq_id       => @public_network.id,
+            :status       => "Unknown",
+            :display_kind => "CloudNetwork"
+          },
+          "CloudSubnet" + @cloud_subnet.compressed_id.to_s     => {
+            :name         => @cloud_subnet.name,
+            :kind         => "CloudSubnet",
+            :miq_id       => @cloud_subnet.id,
+            :status       => "Unknown",
+            :display_kind => "CloudSubnet"
+          },
+          "FloatingIp" + @floating_ip.compressed_id.to_s       => {
+            :name         => @floating_ip.name,
+            :kind         => "FloatingIp",
+            :miq_id       => @floating_ip.id,
+            :status       => "Unknown",
+            :display_kind => "FloatingIp"
+          },
+          "NetworkRouter" + @network_router.compressed_id.to_s => {
+            :name         => @network_router.name,
+            :kind         => "NetworkRouter",
+            :miq_id       => @network_router.id,
+            :status       => "Unknown",
+            :display_kind => "NetworkRouter"
+          },
 
-        "SecurityGroup" + @security_group.compressed_id.to_s => {:name         => @security_group.name,
-                                                                 :kind         => "SecurityGroup",
-                                                                 :miq_id       => @security_group.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "SecurityGroup"},
-        "Vm" + @vm.compressed_id.to_s                        => {:name         => @vm.name,
-                                                                 :kind         => "Vm",
-                                                                 :miq_id       => @vm.id,
-                                                                 :status       => "On",
-                                                                 :display_kind => "VM",
-                                                                 :provider     => ems_cloud.name},
+          "SecurityGroup" + @security_group.compressed_id.to_s => {
+            :name         => @security_group.name,
+            :kind         => "SecurityGroup",
+            :miq_id       => @security_group.id,
+            :status       => "Unknown",
+            :display_kind => "SecurityGroup"
+          },
+          "Vm" + @vm.compressed_id.to_s                        => {
+            :name         => @vm.name,
+            :kind         => "Vm",
+            :miq_id       => @vm.id,
+            :status       => "On",
+            :display_kind => "VM",
+            :provider     => ems_cloud.name
+          },
+        )
       )
 
-      expect(subject[:relations].size).to eq(9)
+      expect(subject[:relations].size).to eq(11)
       expect(subject[:relations]).to include(
         {:source => "NetworkManager" + ems.compressed_id.to_s, :target => "CloudSubnet" + @cloud_subnet.compressed_id.to_s},
+        {:source => "NetworkManager" + ems.compressed_id.to_s, :target => "CloudSubnet" + @cloud_subnet.compressed_id.to_s},
+        {:source => "AvailabilityZone" + @availability_zone.compressed_id.to_s, :target => "Vm" + @vm.compressed_id.to_s},
         {:source => "CloudSubnet" + @cloud_subnet.compressed_id.to_s, :target => "CloudNetwork" + @cloud_network.compressed_id.to_s},
         {:source => "CloudSubnet" + @cloud_subnet.compressed_id.to_s, :target => "Vm" + @vm.compressed_id.to_s},
         {:source => "Vm" + @vm.compressed_id.to_s, :target => "FloatingIp" + @floating_ip.compressed_id.to_s},
@@ -136,58 +171,87 @@ describe NetworkTopologyService do
       allow(network_topology_service).to receive(:retrieve_providers).and_return([ems])
       network_topology_service.instance_variable_set(:@entity, ems)
 
-      expect(subject[:items]).to eq(
-        "NetworkManager" + ems.compressed_id.to_s            => {:name         => ems.name,
-                                                                 :kind         => "NetworkManager",
-                                                                 :miq_id       => ems.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "Openstack"},
-        "CloudTenant" + @cloud_tenant.compressed_id.to_s     => {:name         => @cloud_tenant.name,
-                                                                 :kind         => "CloudTenant",
-                                                                 :miq_id       => @cloud_tenant.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "CloudTenant"},
-        "CloudNetwork" + @cloud_network.compressed_id.to_s   => {:name         => @cloud_network.name,
-                                                                 :kind         => "CloudNetwork",
-                                                                 :miq_id       => @cloud_network.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "CloudNetwork"},
-        "CloudNetwork" + @public_network.compressed_id.to_s  => {:name         => @public_network.name,
-                                                                 :kind         => "CloudNetwork",
-                                                                 :miq_id       => @public_network.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "CloudNetwork"},
-        "CloudSubnet" + @cloud_subnet.compressed_id.to_s     => {:name         => @cloud_subnet.name,
-                                                                 :kind         => "CloudSubnet",
-                                                                 :miq_id       => @cloud_subnet.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "CloudSubnet"},
-        "FloatingIp" + @floating_ip.compressed_id.to_s       => {:name         => @floating_ip.name,
-                                                                 :kind         => "FloatingIp",
-                                                                 :miq_id       => @floating_ip.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "FloatingIp"},
-        "NetworkRouter" + @network_router.compressed_id.to_s => {:name         => @network_router.name,
-                                                                 :kind         => "NetworkRouter",
-                                                                 :miq_id       => @network_router.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "NetworkRouter"},
-        "SecurityGroup" + @security_group.compressed_id.to_s => {:name         => @security_group.name,
-                                                                 :kind         => "SecurityGroup",
-                                                                 :miq_id       => @security_group.id,
-                                                                 :status       => "Unknown",
-                                                                 :display_kind => "SecurityGroup"},
-        "Vm" + @vm.compressed_id.to_s                        => {:name         => @vm.name,
-                                                                 :kind         => "Vm",
-                                                                 :miq_id       => @vm.id,
-                                                                 :status       => "Off",
-                                                                 :display_kind => "VM",
-                                                                 :provider     => ems_cloud.name},
+      expect(subject[:items]).to(
+        eq(
+          "NetworkManager" + ems.compressed_id.to_s                  => {
+            :name         => ems.name,
+            :kind         => "NetworkManager",
+            :miq_id       => ems.id,
+            :status       => "Unknown",
+            :display_kind => "Openstack"
+          },
+          "AvailabilityZone" + @availability_zone.compressed_id.to_s => {
+            :name         => "AZ name",
+            :kind         => "AvailabilityZone",
+            :miq_id       => @availability_zone.id,
+            :status       => "Unknown",
+            :display_kind => "AvailabilityZone"
+          },
+          "CloudTenant" + @cloud_tenant.compressed_id.to_s           => {
+            :name         => @cloud_tenant.name,
+            :kind         => "CloudTenant",
+            :miq_id       => @cloud_tenant.id,
+            :status       => "Unknown",
+            :display_kind => "CloudTenant"
+          },
+          "CloudNetwork" + @cloud_network.compressed_id.to_s         => {
+            :name         => @cloud_network.name,
+            :kind         => "CloudNetwork",
+            :miq_id       => @cloud_network.id,
+            :status       => "Unknown",
+            :display_kind => "CloudNetwork"
+          },
+          "CloudNetwork" + @public_network.compressed_id.to_s        => {
+            :name         => @public_network.name,
+            :kind         => "CloudNetwork",
+            :miq_id       => @public_network.id,
+            :status       => "Unknown",
+            :display_kind => "CloudNetwork"
+          },
+          "CloudSubnet" + @cloud_subnet.compressed_id.to_s           => {
+            :name         => @cloud_subnet.name,
+            :kind         => "CloudSubnet",
+            :miq_id       => @cloud_subnet.id,
+            :status       => "Unknown",
+            :display_kind => "CloudSubnet"
+          },
+          "FloatingIp" + @floating_ip.compressed_id.to_s             => {
+            :name         => @floating_ip.name,
+            :kind         => "FloatingIp",
+            :miq_id       => @floating_ip.id,
+            :status       => "Unknown",
+            :display_kind => "FloatingIp"
+          },
+          "NetworkRouter" + @network_router.compressed_id.to_s       => {
+            :name         => @network_router.name,
+            :kind         => "NetworkRouter",
+            :miq_id       => @network_router.id,
+            :status       => "Unknown",
+            :display_kind => "NetworkRouter"
+          },
+          "SecurityGroup" + @security_group.compressed_id.to_s       => {
+            :name         => @security_group.name,
+            :kind         => "SecurityGroup",
+            :miq_id       => @security_group.id,
+            :status       => "Unknown",
+            :display_kind => "SecurityGroup"
+          },
+          "Vm" + @vm.compressed_id.to_s                              => {
+            :name         => @vm.name,
+            :kind         => "Vm",
+            :miq_id       => @vm.id,
+            :status       => "Off",
+            :display_kind => "VM",
+            :provider     => ems_cloud.name
+          },
+        )
       )
 
-      expect(subject[:relations].size).to eq(9)
+      expect(subject[:relations].size).to eq(11)
       expect(subject[:relations]).to include(
+        {:source => "NetworkManager" + ems.compressed_id.to_s, :target => "AvailabilityZone" + @availability_zone.compressed_id.to_s},
         {:source => "NetworkManager" + ems.compressed_id.to_s, :target => "CloudSubnet" + @cloud_subnet.compressed_id.to_s},
+        {:source => "AvailabilityZone" + @availability_zone.compressed_id.to_s, :target => "Vm" + @vm.compressed_id.to_s},
         {:source => "CloudSubnet" + @cloud_subnet.compressed_id.to_s, :target => "CloudNetwork" + @cloud_network.compressed_id.to_s},
         {:source => "CloudSubnet" + @cloud_subnet.compressed_id.to_s, :target => "Vm" + @vm.compressed_id.to_s},
         {:source => "Vm" + @vm.compressed_id.to_s, :target => "FloatingIp" + @floating_ip.compressed_id.to_s},

--- a/spec/services/network_topology_service_spec.rb
+++ b/spec/services/network_topology_service_spec.rb
@@ -4,8 +4,9 @@ describe NetworkTopologyService do
   describe "#build_kinds" do
     it "creates the expected number of entity types" do
       expect(network_topology_service.build_kinds.keys).to match_array([
-        :CloudNetwork, :CloudSubnet, :CloudTenant, :FloatingIp, :LoadBalancer, :NetworkManager, :NetworkPort, :NetworkRouter,
-        :SecurityGroup, :Tag, :Vm, :AvailabilityZone])
+                                                                         :CloudNetwork, :CloudSubnet, :CloudTenant, :FloatingIp, :LoadBalancer, :NetworkManager, :NetworkPort, :NetworkRouter,
+                                                                         :SecurityGroup, :Tag, :Vm, :AvailabilityZone
+                                                                       ])
     end
   end
 
@@ -13,8 +14,9 @@ describe NetworkTopologyService do
     it "creates link between source to target" do
       expect(network_topology_service.build_link(
                "95e49048-3e00-11e5-a0d2-18037327aaeb",
-               "96c35f65-3e00-11e5-a0d2-18037327aaeb")).to eq(:source => "95e49048-3e00-11e5-a0d2-18037327aaeb",
-                                                              :target => "96c35f65-3e00-11e5-a0d2-18037327aaeb")
+               "96c35f65-3e00-11e5-a0d2-18037327aaeb"
+      )).to eq(:source => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+               :target => "96c35f65-3e00-11e5-a0d2-18037327aaeb")
     end
   end
 
@@ -56,7 +58,8 @@ describe NetworkTopologyService do
       ems = FactoryGirl.create(:ems_openstack).network_manager
 
       allow(network_topology_service).to receive(:retrieve_providers).with(
-                                           anything, ManageIQ::Providers::NetworkManager).and_return([ems])
+        anything, ManageIQ::Providers::NetworkManager
+      ).and_return([ems])
       network_topology_service.instance_variable_set(:@providers,
                                                      ManageIQ::Providers::NetworkManager.where(:id => ems.id))
 
@@ -65,7 +68,8 @@ describe NetworkTopologyService do
                                                       :status       => "Unknown",
                                                       :kind         => "NetworkManager",
                                                       :display_kind => "Openstack",
-                                                      :miq_id       => ems.id})
+                                                      :miq_id       => ems.id}
+      )
     end
 
     it "topology contains the expected structure and content" do
@@ -74,56 +78,56 @@ describe NetworkTopologyService do
 
       expect(subject[:items]).to(
         eq(
-          "NetworkManager" + ems.compressed_id.to_s            => {
+          "NetworkManager" + ems.compressed_id.to_s                  => {
             :name         => ems.name,
             :kind         => "NetworkManager",
             :miq_id       => ems.id,
             :status       => "Unknown",
             :display_kind => "Openstack"
           },
-          "AvailabilityZone" + @availability_zone.compressed_id.to_s          => {
+          "AvailabilityZone" + @availability_zone.compressed_id.to_s => {
             :name         => "AZ name",
             :kind         => "AvailabilityZone",
             :miq_id       => @availability_zone.id,
             :status       => "Unknown",
             :display_kind => "AvailabilityZone"
           },
-          "CloudTenant" + @cloud_tenant.compressed_id.to_s     => {
+          "CloudTenant" + @cloud_tenant.compressed_id.to_s           => {
             :name         => @cloud_tenant.name,
             :kind         => "CloudTenant",
             :miq_id       => @cloud_tenant.id,
             :status       => "Unknown",
             :display_kind => "CloudTenant"
           },
-          "CloudNetwork" + @cloud_network.compressed_id.to_s   => {
+          "CloudNetwork" + @cloud_network.compressed_id.to_s         => {
             :name         => @cloud_network.name,
             :kind         => "CloudNetwork",
             :miq_id       => @cloud_network.id,
             :status       => "Unknown",
             :display_kind => "CloudNetwork"
           },
-          "CloudNetwork" + @public_network.compressed_id.to_s  => {
+          "CloudNetwork" + @public_network.compressed_id.to_s        => {
             :name         => @public_network.name,
             :kind         => "CloudNetwork",
             :miq_id       => @public_network.id,
             :status       => "Unknown",
             :display_kind => "CloudNetwork"
           },
-          "CloudSubnet" + @cloud_subnet.compressed_id.to_s     => {
+          "CloudSubnet" + @cloud_subnet.compressed_id.to_s           => {
             :name         => @cloud_subnet.name,
             :kind         => "CloudSubnet",
             :miq_id       => @cloud_subnet.id,
             :status       => "Unknown",
             :display_kind => "CloudSubnet"
           },
-          "FloatingIp" + @floating_ip.compressed_id.to_s       => {
+          "FloatingIp" + @floating_ip.compressed_id.to_s             => {
             :name         => @floating_ip.name,
             :kind         => "FloatingIp",
             :miq_id       => @floating_ip.id,
             :status       => "Unknown",
             :display_kind => "FloatingIp"
           },
-          "NetworkRouter" + @network_router.compressed_id.to_s => {
+          "NetworkRouter" + @network_router.compressed_id.to_s       => {
             :name         => @network_router.name,
             :kind         => "NetworkRouter",
             :miq_id       => @network_router.id,
@@ -131,14 +135,14 @@ describe NetworkTopologyService do
             :display_kind => "NetworkRouter"
           },
 
-          "SecurityGroup" + @security_group.compressed_id.to_s => {
+          "SecurityGroup" + @security_group.compressed_id.to_s       => {
             :name         => @security_group.name,
             :kind         => "SecurityGroup",
             :miq_id       => @security_group.id,
             :status       => "Unknown",
             :display_kind => "SecurityGroup"
           },
-          "Vm" + @vm.compressed_id.to_s                        => {
+          "Vm" + @vm.compressed_id.to_s                              => {
             :name         => @vm.name,
             :kind         => "Vm",
             :miq_id       => @vm.id,


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/14161

In AWS, EC2 classic Vms do not have a subnet associated, so
these would not show in the topology. By allowing the Vms to
be shown also under Availability Zone, we should be showing all
Vms in the system.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1400087