### PR TITLE
Add live search to the service template id dropdown for Run Ansible Playbook action

### DIFF
--- a/app/views/miq_policy/_action_options.html.haml
+++ b/app/views/miq_policy/_action_options.html.haml
@@ -331,8 +331,9 @@
           = select_tag('service_template_id',
           options_for_select([["<#{_('Choose')}>", nil]] + @edit[:ansible_playbooks],
           @edit[:new][:options][:service_template_id]),
-          :style             => "width:150px",
-          :class             => "selectpicker")
+          "style"            => "width:150px",
+          "data-live-search" => "true",
+          "class"            => "selectpicker")
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent('service_template_id', '#{url}')


### PR DESCRIPTION
Add live search to the service template id dropdown for Run Ansible Playbook action

https://www.pivotaltracker.com/story/show/140352501