### PR TITLE
Fix 'show_dashboard' to 'show'

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -17,7 +17,7 @@ module Mixins
       flash_msg = _("Edit of %{model} \"%{name}\" was cancelled by the user") %
                   {:model => ui_lookup(:model => model_name),
                    :name  => update_ems.name}
-      js_args = {:action    => @lastaction,
+      js_args = {:action    => @lastaction == 'show_dashboard' ? 'show' : @lastaction,
                  :id        => update_ems.id,
                  :display   => session[:ems_display],
                  :flash_msg => flash_msg,


### PR DESCRIPTION
Compute -> Infrastructure -> Providers -> click any provider -> set it to Dashboard View (default) -> Configuration -> Edit this Infrastructure Provider -> Click Cancel in edit form

Before:
<img width="1417" alt="screen shot 2017-03-01 at 1 27 22 pm" src="https://cloud.githubusercontent.com/assets/9210860/23459960/f85d73f4-fe82-11e6-8a5a-b0485727a4e2.png">

After:
<img width="1213" alt="screen shot 2017-03-01 at 1 23 05 pm" src="https://cloud.githubusercontent.com/assets/9210860/23459957/f2efed7a-fe82-11e6-9c97-e1c1bf52fe0d.png">


@miq-bot add_label wip, bug