### PR TITLE
Extend form for creating new cloud volumes

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -1,20 +1,33 @@
-ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope', 'cloudVolumeFormId', 'miqService', function($http, $scope, cloudVolumeFormId, miqService) {
-  $scope.cloudVolumeModel = { name: '', cloud_tenant_id: '' };
-  $scope.formId = cloudVolumeFormId;
-  $scope.afterGet = false;
-  $scope.modelCopy = angular.copy( $scope.cloudVolumeModel );
-  $scope.model = "cloudVolumeModel";
+ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope', 'cloudVolumeFormId', 'miqService', 'API', function($http, $scope, cloudVolumeFormId, miqService, API) {
+  var init = function() {
+    $scope.cloudVolumeModel = {
+      aws_encryption: false,
+    };
+    $scope.formId = cloudVolumeFormId;
+    $scope.afterGet = false;
+    $scope.modelCopy = angular.copy( $scope.cloudVolumeModel );
+    $scope.model = "cloudVolumeModel";
 
-  ManageIQ.angular.scope = $scope;
+    // This ia a fixed list of available cloud volume types for AWS.
+    $scope.awsVolumeTypes = [
+      { type: "gp2", name: "General Purpose SSD (GP2)" },
+      { type: "io1", name: "Provisioned IOPS SSD (IO1)" },
+      { type: "st1", name: "Throughput Optimized HDD (ST1)" },
+      { type: "sc1", name: "Cold HDD (SC1)" },
+      { type: "magnetic", name: "Magnetic" },
+    ];
 
-  if (cloudVolumeFormId == 'new') {
-    $scope.cloudVolumeModel.name = "";
-  } else {
-    miqService.sparkleOn();
-    $http.get('/cloud_volume/cloud_volume_form_fields/' + cloudVolumeFormId)
-      .then(getCloudVolumeFormDataComplete)
-      .catch(miqService.handleFailure);
-  }
+    ManageIQ.angular.scope = $scope;
+
+    if (cloudVolumeFormId == 'new') {
+      $scope.cloudVolumeModel.name = "";
+    } else {
+      miqService.sparkleOn();
+      $http.get('/cloud_volume/cloud_volume_form_fields/' + cloudVolumeFormId)
+        .then(getCloudVolumeFormDataComplete)
+        .catch(miqService.handleFailure);
+    }
+  };
 
   function getCloudVolumeFormDataComplete(response) {
     var data = response.data;
@@ -23,6 +36,22 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
     $scope.cloudVolumeModel.name = data.name;
 
     $scope.modelCopy = angular.copy( $scope.cloudVolumeModel );
+    miqService.sparkleOff();
+  }
+
+  $scope.storageManagerChanged = function(id) {
+    miqService.sparkleOn();
+    API.get('/api/providers/' + id + '?attributes=type,parent_manager.availability_zones,parent_manager.cloud_tenants')
+      .then(getStorageManagerFormDataComplete)
+      .catch(miqService.handleFailure);
+  };
+
+  function getStorageManagerFormDataComplete(data) {
+    $scope.afterGet = true;
+    $scope.cloudVolumeModel.emstype = data.type;
+    $scope.cloudTenantChoices = data.parent_manager.cloud_tenants;
+    $scope.availabilityZoneChoices = data.parent_manager.availability_zones;
+
     miqService.sparkleOff();
   }
 
@@ -101,4 +130,46 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
     $scope.angularForm.$setPristine(true);
     miqService.miqFlash("warn", "All changes have been reset");
   };
+
+  $scope.sizeChanged = function(size) {
+    // Dynamically update the AWS IOPS only if GP2 volume type is selected.
+    if ($scope.cloudVolumeModel.aws_volume_type === 'gp2') {
+      var volumeSize = parseInt(size, 10);
+
+      if (isNaN(volumeSize)) {
+        $scope.cloudVolumeModel.aws_iops = null;
+      } else {
+        $scope.cloudVolumeModel.aws_iops = Math.max(100, Math.min(volumeSize * 3, 10000));
+      }
+    }
+  };
+
+  $scope.awsVolumeTypeChanged = function(voltype) {
+    // The requested number of I/O operations per second that the volume can
+    // support. For Provisioned IOPS (SSD) volumes, you can provision up to 50
+    // IOPS per GiB. For General Purpose (SSD) volumes, baseline performance is
+    // 3 IOPS per GiB, with a minimum of 100 IOPS and a maximum of 10000 IOPS.
+    // General Purpose (SSD) volumes under 1000 GiB can burst up to 3000 IOPS
+
+    switch (voltype) {
+      case "gp2":
+      case "io1":
+        var volumeSize = parseInt($scope.cloudVolumeModel.size, 10);
+        if (isNaN(volumeSize)) {
+          $scope.cloudVolumeModel.aws_iops = '';
+        } else if (voltype === 'gp2') {
+          $scope.cloudVolumeModel.aws_iops = Math.max(100, Math.min(volumeSize * 3, 10000));
+        } else {
+          // Default ratio is 50 IOPS per 1 GiB. 20000 IOPS is the max.
+          $scope.cloudVolumeModel.aws_iops = Math.min(volumeSize * 50, 20000);
+        }
+        break;
+
+      default:
+        $scope.cloudVolumeModel.aws_iops = 'Not Applicable';
+        break;
+    }
+  };
+
+  init();
 }]);

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -277,8 +277,8 @@ class CloudVolumeController < ApplicationController
     assert_privileges("cloud_volume_new")
     @volume = CloudVolume.new
     @in_a_form = true
-    @cloud_tenant_choices = {}
-    CloudTenant.all.each { |tenant| @cloud_tenant_choices[tenant.name] = tenant.id }
+    @storage_manager_choices = {}
+    ExtManagementSystem.all.each { |ems| @storage_manager_choices[ems.name] = ems.id if ems.supports_block_storage? }
     drop_breadcrumb(
       :name => _("Add New %{model}") % {:model => ui_lookup(:table => 'cloud_volume')},
       :url  => "/cloud_volume/new"
@@ -294,12 +294,11 @@ class CloudVolumeController < ApplicationController
 
     when "add"
       @volume = CloudVolume.new
-      options = form_params
-      cloud_tenant = find_by_id_filtered(CloudTenant, options[:cloud_tenant_id])
-      options[:cloud_tenant] = cloud_tenant
-      valid_action, action_details = CloudVolume.validate_create_volume(cloud_tenant.ext_management_system)
+      options = form_params_create
+      ext_management_system = options.delete(:ems)
+      valid_action, action_details = CloudVolume.validate_create_volume(ext_management_system)
       if valid_action
-        task_id = CloudVolume.create_volume_queue(session[:userid], cloud_tenant.ext_management_system, options)
+        task_id = CloudVolume.create_volume_queue(session[:userid], ext_management_system, options)
 
         if task_id.kind_of?(Integer)
           initiate_wait_for_task(:task_id => task_id, :action => "create_finished")
@@ -697,6 +696,32 @@ class CloudVolumeController < ApplicationController
     options[:cloud_tenant_id] = params[:cloud_tenant_id] if params[:cloud_tenant_id]
     options[:vm_id] = params[:vm_id] if params[:vm_id]
     options[:device_path] = params[:device_path] if params[:device_path]
+    options
+  end
+
+  def form_params_create
+    options = {}
+    options[:name] = params[:name] if params[:name]
+    options[:size] = params[:size].to_i if params[:size]
+
+    # Depending on the storage manager type, collect required form params.
+    case params[:emstype]
+    when "ManageIQ::Providers::StorageManager::CinderManager"
+      cloud_tenant_id = params[:cloud_tenant_id] if params[:cloud_tenant_id]
+      cloud_tenant = find_by_id_filtered(CloudTenant, cloud_tenant_id)
+      options[:cloud_tenant] = cloud_tenant
+      options[:ems] = cloud_tenant.ext_management_system
+    when "ManageIQ::Providers::Amazon::StorageManager::Ebs"
+      options[:volume_type] = params[:aws_volume_type] if params[:aws_volume_type]
+      # Only set IOPS if io1 (provisioned IOPS) and IOPS available
+      options[:iops] = params[:aws_iops] if options[:volume_type] == 'io1' && params[:aws_iops]
+      options[:availability_zone] = params[:aws_availability_zone_id] if params[:aws_availability_zone_id]
+      options[:encrypted] = params[:aws_encryption]
+
+      # Get the storage manager.
+      storage_manager_id = params[:storage_manager_id] if params[:storage_manager_id]
+      options[:ems] = find_by_id_filtered(ExtManagementSystem, storage_manager_id)
+    end
     options
   end
 

--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -1,9 +1,53 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController"}
+%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => ""}
   = render :partial => "layouts/flash_msg"
-  %h3
-    = _('Basic Information')
   .form-horizontal
-    .form-group
+    .form-group{"ng-class" => "{'has-error': angularForm.storage_manager_id.$invalid}"}
+      %label.col-md-2.control-label
+        = _('Storage Manager')
+      .col-md-8
+        = select_tag("storage_manager_id",
+                     options_for_select([["<#{_('Choose')}>", nil]] + @storage_manager_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
+                     "ng-model"                    => "cloudVolumeModel.storage_manager_id",
+                     "ng-change"                   => "storageManagerChanged(cloudVolumeModel.storage_manager_id)",
+                     "required"                    => "",
+                     :checkchange                  => true,
+                     "selectpicker-for-select-tag" => "")
+        %span.help-block{"ng-show" => "angularForm.storage_manager_id.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.cloud_tenant_id.$invalid}",
+                "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::StorageManager::CinderManager'"}
+      %label.col-md-2.control-label
+        = _('Cloud Tenant')
+      .col-md-8
+        %select{"name"                        => "cloud_tenant_id",
+                "ng-model"                    => "cloudVolumeModel.cloud_tenant_id",
+                "ng-options"                  => "tenant.id as tenant.name for tenant in cloudTenantChoices",
+                "required"                    => "",
+                :checkchange                  => true,
+                "selectpicker-for-select-tag" => ""}
+          %option{"value" => "", "disabled" => ""}
+            = "<#{_('Choose')}>"
+        %span.help-block{"ng-show" => "angularForm.cloud_tenant_id.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.aws_availability_zone_id.$invalid}",
+                "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+      %label.col-md-2.control-label
+        = _('Availability Zone')
+      .col-md-8
+        %select{"name"                        => "aws_availability_zone_id",
+                "ng-model"                    => "cloudVolumeModel.aws_availability_zone_id",
+                "ng-options"                  => "az.ems_ref as az.name for az in availabilityZoneChoices",
+                "required"                    => "",
+                :checkchange                  => true,
+                "selectpicker-for-select-tag" => ""}
+          %option{"value" => "", "disabled" => ""}
+            = "<#{_('Choose')}>"
+        %span.help-block{"ng-show" => "angularForm.aws_availability_zone_id.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label
         = _('Volume Name')
       .col-md-8
@@ -11,9 +55,29 @@
                             :name          => "name",
                             'ng-model'     => "cloudVolumeModel.name",
                             'ng-maxlength' => 128,
-                            :miqrequired   => true,
+                            :required      => "",
                             :checkchange   => true}
-    .form-group
+        %span.help-block{"ng-show" => "angularForm.name.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.aws_volume_type.$invalid}",
+                "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+      %label.col-md-2.control-label
+        = _('Cloud Volume Type')
+      .col-md-8
+        %select{"name"                        => "aws_volume_type",
+                "ng-model"                    => "cloudVolumeModel.aws_volume_type",
+                "ng-options"                  => "voltype.type as voltype.name for voltype in awsVolumeTypes",
+                "ng-change"                   => "awsVolumeTypeChanged(cloudVolumeModel.aws_volume_type)",
+                "required"                    => "",
+                :checkchange                  => true,
+                "selectpicker-for-select-tag" => ""}
+          %option{"value" => "", "disabled" => ""}
+            = "<#{_('Choose')}>"
+        %span.help-block{"ng-show" => "angularForm.aws_volume_type.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.size.$invalid}"}
       %label.col-md-2.control-label
         = _('Size (in gigabytes)')
       .col-md-8
@@ -21,22 +85,37 @@
                             :name          => "size",
                             'ng-model'     => "cloudVolumeModel.size",
                             'ng-maxlength' => 10,
-                            :miqrequired   => true,
+                            'ng-change'    => "sizeChanged(cloudVolumeModel.size)",
+                            :required      => "",
                             :checkchange   => true}
-  %h3
-    = _('Placement')
-  .form-horizontal
-    .form-group{"ng-class" => "{'has-error': angularForm.cloud_tenant_id.$invalid}"}
+        %span.help-block{"ng-show" => "angularForm.size.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.aws_iops.$invalid}",
+                "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
       %label.col-md-2.control-label
-        = _('Cloud Tenant')
+        = _('IOPS')
       .col-md-8
-        = select_tag("cloud_tenant_id",
-          options_for_select([["<#{_('Choose')}>", nil]] + @cloud_tenant_choices.sort),
-                      "ng-model"                    => "cloudVolumeModel.cloud_tenant_id",
-                      "required"                    => "",
-                      :miqrequired                  => true,
-                      :checkchange                  => true,
-                      "selectpicker-for-select-tag" => "")
+        %input.form-control{:type          => "text",
+                            :name          => "aws_iops",
+                            'ng-model'     => "cloudVolumeModel.aws_iops",
+                            'ng-maxlength' => 50,
+                            'ng-disabled'  => "cloudVolumeModel.aws_volume_type != 'io1'",
+                            "required"     => "",
+                            :checkchange   => true}
+        %span.help-block{"ng-show" => "cloudVolumeModel.aws_volume_type == 'io1' && angularForm.aws_iops.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-if" => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+      %label.col-md-2.control-label
+        = _('Encryption')
+      .col-md-8
+        %input.form-control{"bs-switch"  => "",
+                            :data        => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+                            :type        => "checkbox",
+                            :name        => "encryption",
+                            'ng-model'   => "cloudVolumeModel.aws_encryption",
+                            :checkchange => true}
 
   %table{:width => '100%'}
     %tr


### PR DESCRIPTION
Current form for creating a new cloud volume is very specific to OpenStack and allows specification of volume name, size and target tenant. With this change we are planning on adding dynamic support for provisioning of new cloud volumes allowing for different backend providers (OpenStack Cinder and Amazon EBS for the time being).

Current video of the UI: http://x.k00.fr/lqzwd

Current appearance for Amazon:
![screen shot 2017-02-28 at 22 49 57](https://cloud.githubusercontent.com/assets/1437960/23445990/ebcd0cc8-fe3f-11e6-9340-d45bafbd8d61.png)

Current appearance for OpenStack:
![screen shot 2017-02-28 at 22 50 03](https://cloud.githubusercontent.com/assets/1437960/23446002/f7a296da-fe3f-11e6-8f85-e5fce0d66015.png)


@miq-bot add_label wip,storage,question

@AparnaKarve, @dclarizio This is the first attempt to support the Amazon block storage provider along side OpenStack ([ref doc](https://docs.google.com/document/d/1Idt4xqMEmm14jUjQ_IqIgGjVO6oG4YZcKzeQM8y5wcI/edit)). Could you please have a look if this is going in the right direction so that we can add other fields for Amazon provider?

/cc @miha-plesko 