### PR TITLE
Unify and remove #show functionality from middeware controllers.

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -7,18 +7,6 @@ module EmsCommon
 
     helper_method :textual_group_list
     private :textual_group_list
-
-    # This is a temporary hack ensuring that @ems will be set.
-    # Once we use @record in place of @ems, this can be removed
-    # together with init_show_ems
-    alias_method :init_show_generic, :init_show
-    alias_method :init_show, :init_show_ems
-  end
-
-  def init_show_ems
-    result = init_show_generic
-    @ems = @record
-    result
   end
 
   def textual_group_list

--- a/app/controllers/middleware_domain_controller.rb
+++ b/app/controllers/middleware_domain_controller.rb
@@ -9,13 +9,8 @@ class MiddlewareDomainController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
-  def show
-    return unless init_show
-    @display = params[:display] unless params[:display].nil?
-    case @display
-    when 'middleware_server_groups' then show_middleware_entities(MiddlewareServerGroup)
-    else show_middleware
-    end
+  def self.display_methods
+    %i(middleware_server_groups)
   end
 
   menu_section :cnt

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -154,15 +154,8 @@ class MiddlewareServerController < ApplicationController
     end
   end
 
-  def show
-    return unless init_show
-    @display = params[:display] unless params[:display].nil?
-    case @display
-    when 'middleware_datasources' then show_middleware_entities(MiddlewareDatasource)
-    when 'middleware_deployments' then show_middleware_entities(MiddlewareDeployment)
-    when 'middleware_messagings' then show_middleware_entities(MiddlewareMessaging)
-    else show_middleware
-    end
+  def self.display_methods
+    %i(middleware_datasources middleware_deployments middleware_messagings)
   end
 
   def button

--- a/app/controllers/middleware_server_group_controller.rb
+++ b/app/controllers/middleware_server_group_controller.rb
@@ -34,13 +34,8 @@ class MiddlewareServerGroupController < ApplicationController
     OPERATIONS
   end
 
-  def show
-    return unless init_show
-    @display = params[:display] unless params[:display].nil?
-    case @display
-    when 'middleware_servers' then show_middleware_entities(MiddlewareServer)
-    else show_middleware
-    end
+  def self.display_methods
+    %i(middleware_servers)
   end
 
   def textual_group_list

--- a/app/controllers/mixins/middleware_common_mixin.rb
+++ b/app/controllers/mixins/middleware_common_mixin.rb
@@ -2,52 +2,23 @@ module MiddlewareCommonMixin
   extend ActiveSupport::Concern
   include Mixins::MiddlewareOperationsMixin
 
-  def show
-    return unless init_show
-    @ems = @record
-    clear_topology_breadcrumb
+  included do
+    # This is a temporary hack ensuring that @ems will be set.
+    # Once we use @record in place of @ems, this can be removed
+    # together with init_show_ems
+    alias_method :init_show_generic, :init_show
+    alias_method :init_show, :init_show_ems
+  end
 
-    show_middleware
+  def init_show_ems
+    result = init_show_generic
+    @ems = @record
+    result
   end
 
   private
 
-  def display_name(display = nil)
-    if display.blank?
-      ui_lookup(:tables => @record.class.base_class.name)
-    else
-      ui_lookup(:tables => display)
-    end
-  end
-
   def listicon_image(item, _view)
     item.decorate.try(:listicon_image)
-  end
-
-  def clear_topology_breadcrumb
-    # fix breadcrumbs - remove displaying 'topology' in breadcrumb when navigating to a middleware related entity summary page
-    if @breadcrumbs.present? && (@breadcrumbs.last[:name].eql? 'Topology')
-      @breadcrumbs.clear
-    end
-  end
-
-  def show_middleware
-    drop_breadcrumb({:name => display_name,
-                     :url  => show_list_link(@record, :page => @current_page, :refresh => 'y')
-                    }, true)
-    case @display
-    when 'main'                          then show_main
-    when 'summary_only'                  then show_download
-    when 'timeline'                      then show_timeline
-    when 'performance'                   then show_performance
-    end
-  end
-
-  def show_middleware_entities(klass)
-    @showtype = @display = params[:display] unless params[:display].nil?
-    breadcrumb_title = _("%{name} (All %{title})") % {:name  => @record.name,
-                                                      :title => display_name(@display)}
-    drop_breadcrumb(:name => breadcrumb_title, :url => show_link(@record, :display => @display))
-    @view, @pages = get_view(klass, :parent => @record)
   end
 end


### PR DESCRIPTION
Use `GenericShowMixin` for `#show` functionality.

Also removed the removal of Topology breadrumb. Breadcrumbs are not supposed to create a hiareachy but rather history. So it makes no sense to remove the topology link from the breadcumbs.

Besides this unifies the breadcrumb behavior and should we decide that we don't want the topology link in the breadcrumbs we would want that for all the controller not just middleware.