### PR TITLE
Title refactor

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -416,81 +416,6 @@ module ApplicationHelper
     (dbs.include?(".") ? "#{dbs.split(".").last}.#{fld}" : fld)
   end
 
-  def productized_title(title)
-    product_title + title
-  end
-
-  def product_title
-    # TODO: leave I18n until we have productization capability in gettext
-    I18n.t('product.name')
-  end
-
-  # Derive the browser title text based on the layout value
-  def title_from_layout(layout)
-    title = product_title
-
-    if layout.blank?  # no layout, leave title alone
-    elsif ["configuration", "dashboard", "chargeback", "about"].include?(layout)
-      title += ": #{layout.titleize}"
-    elsif @layout == "ems_cluster"
-      title += ": #{title_for_clusters}"
-    elsif @layout == "host"
-      title += ": #{title_for_hosts}"
-    # Specific titles for certain layouts
-    elsif layout == "miq_server"
-      title += _(": Servers")
-    elsif layout == "usage"
-      title += _(": VM Usage")
-    elsif layout == "scan_profile"
-      title += _(": Analysis Profiles")
-    elsif layout == "miq_policy_rsop"
-      title += _(": Policy Simulation")
-    elsif layout == "all_ui_tasks"
-      title += _(": All UI Tasks")
-    elsif layout == "my_ui_tasks"
-      title += _(": My UI Tasks")
-    elsif layout == "rss"
-      title += _(": RSS")
-    elsif layout == "storage_manager"
-      title += _(": Storage - Storage Managers")
-    elsif layout == "ops"
-      title += _(": Configuration")
-    elsif layout == "provider_foreman"
-      title += _(": Configuration Management")
-    elsif layout == "pxe"
-      title += _(": PXE")
-    elsif layout == "explorer"
-      title += ": #{controller_model_name(params[:controller])} Explorer"
-    elsif layout == "vm_cloud"
-      title += _(": Instances")
-    elsif layout == "vm_infra"
-      title += _(": Virtual Machines")
-    elsif layout == "vm_or_template"
-      title += _(": Workloads")
-    # Specific titles for groups of layouts
-    elsif layout.starts_with?("miq_ae_")
-      title += _(": Automation")
-    elsif layout.starts_with?("miq_policy")
-      title += _(": Control")
-    elsif layout.starts_with?("miq_capacity")
-      title += _(": Optimize")
-    elsif layout.starts_with?("miq_request")
-      title += _(": Requests")
-    elsif layout == "login"
-      title += _(": Login")
-    elsif layout == "manageiq/providers/ansible_tower/automation_manager/playbook"
-      title += ": Playbooks (Ansible Tower)"
-    elsif layout == "manageiq/providers/automation_manager/authentication"
-      title += ": Credentials"
-    elsif layout == "configuration_script_source"
-      title += ": Repositories"
-    # Assume layout is a table name and look up the plural version
-    else
-      title += ": #{ui_lookup(:tables => layout)}"
-    end
-    title
-  end
-
   def controller_model_name(controller)
     ui_lookup(:model => (controller.camelize + "Controller").constantize.model.name)
   end
@@ -1498,36 +1423,6 @@ module ApplicationHelper
       :ems_cloud
     else
       :ems_container
-    end
-  end
-
-  def title_for_hosts
-    title_for_host(true)
-  end
-
-  def title_for_host(plural = false)
-    case Host.node_types
-    when :non_openstack
-      plural ? _("Hosts") : _("Host")
-    when :openstack
-      plural ? _("Nodes") : _("Node")
-    else
-      plural ? _("Hosts / Nodes") : _("Host / Node")
-    end
-  end
-
-  def title_for_clusters
-    title_for_cluster(true)
-  end
-
-  def title_for_cluster(plural = false)
-    case EmsCluster.node_types
-    when :non_openstack
-      plural ? _("Clusters") : _("Cluster")
-    when :openstack
-      plural ? _("Deployment Roles") : _("Deployment Role")
-    else
-      plural ? _("Clusters / Deployment Roles") : _("Cluster / Deployment Role")
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,7 @@ module ApplicationHelper
   include ToolbarHelper
   include TextualSummaryHelper
   include NumberHelper
+  include Title
 
   def settings(*path)
     @settings ||= {}
@@ -415,10 +416,19 @@ module ApplicationHelper
     (dbs.include?(".") ? "#{dbs.split(".").last}.#{fld}" : fld)
   end
 
+  def productized_title(title)
+    product_title + title
+  end
+
+  def product_title
+    # TODO: leave I18n until we have productization capability in gettext
+    I18n.t('product.name')
+  end
+
   # Derive the browser title text based on the layout value
   def title_from_layout(layout)
-    # TODO: leave I18n until we have productization capability in gettext
-    title = I18n.t('product.name')
+    title = product_title
+
     if layout.blank?  # no layout, leave title alone
     elsif ["configuration", "dashboard", "chargeback", "about"].include?(layout)
       title += ": #{layout.titleize}"

--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -9,6 +9,10 @@ module ApplicationHelper
       I18n.t('product.name')
     end
 
+    def page_title
+      @page_title.present? ? productized_title(@page_title) : title_from_layout(@layout)
+    end
+
     # Derive the browser title text based on the layout value
     def title_from_layout(layout)
       title = product_title

--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -20,12 +20,19 @@ module ApplicationHelper
       return title if layout.blank?  # no layout, leave title alone
 
       title + case layout
-              when "configuration", "dashboard", "chargeback", "about"
-                ": #{layout.titleize}"
+              when "configuration"
+                _(": Configuration")
+              when "dashboard"
+                _(": Dashboard")
+              when "chargeback"
+                _(": Chargeback")
+              when "about"
+                _(": About")
               when "ems_cluster"
                 ": #{title_for_clusters}"
               when "host"
                 ": #{title_for_hosts}"
+
               # Specific titles for certain layouts
               when "miq_server"
                 _(": Servers")
@@ -68,11 +75,12 @@ module ApplicationHelper
               when /^miq_request/
                 _(": Requests")
               when "manageiq/providers/ansible_tower/automation_manager/playbook"
-                ": Playbooks (Ansible Tower)"
+                _(": Playbooks (Ansible Tower)")
               when "manageiq/providers/automation_manager/authentication"
-                ": Credentials"
+                _(": Credentials")
               when "configuration_script_source"
-                ": Repositories"
+                _(": Repositories")
+
               else
                 # Assume layout is a table name and look up the plural version
                 ": #{ui_lookup(:tables => layout)}"

--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -1,5 +1,9 @@
 module ApplicationHelper
   module Title
+    def productized_title(title)
+      product_title + title
+    end
+
     def product_title
       # TODO: leave I18n until we have productization capability in gettext
       I18n.t('product.name')
@@ -56,8 +60,6 @@ module ApplicationHelper
         title += _(": Optimize")
       elsif layout.starts_with?("miq_request")
         title += _(": Requests")
-      elsif layout == "login"
-        title += _(": Login")
       elsif layout == "manageiq/providers/ansible_tower/automation_manager/playbook"
         title += ": Playbooks (Ansible Tower)"
       elsif layout == "manageiq/providers/automation_manager/authentication"
@@ -70,6 +72,5 @@ module ApplicationHelper
       end
       title
     end
-
   end
 end

--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -86,5 +86,35 @@ module ApplicationHelper
                 ": #{ui_lookup(:tables => layout)}"
               end
     end
+
+    def title_for_hosts
+      title_for_host(true)
+    end
+
+    def title_for_host(plural = false)
+      case Host.node_types
+      when :non_openstack
+        plural ? _("Hosts") : _("Host")
+      when :openstack
+        plural ? _("Nodes") : _("Node")
+      else
+        plural ? _("Hosts / Nodes") : _("Host / Node")
+      end
+    end
+
+    def title_for_clusters
+      title_for_cluster(true)
+    end
+
+    def title_for_cluster(plural = false)
+      case EmsCluster.node_types
+      when :non_openstack
+        plural ? _("Clusters") : _("Cluster")
+      when :openstack
+        plural ? _("Deployment Roles") : _("Deployment Role")
+      else
+        plural ? _("Clusters / Deployment Roles") : _("Cluster / Deployment Role")
+      end
+    end
   end
 end

--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -17,64 +17,66 @@ module ApplicationHelper
     def title_from_layout(layout)
       title = product_title
 
-      if layout.blank?  # no layout, leave title alone
-      elsif ["configuration", "dashboard", "chargeback", "about"].include?(layout)
-        title += ": #{layout.titleize}"
-      elsif @layout == "ems_cluster"
-        title += ": #{title_for_clusters}"
-      elsif @layout == "host"
-        title += ": #{title_for_hosts}"
-      # Specific titles for certain layouts
-      elsif layout == "miq_server"
-        title += _(": Servers")
-      elsif layout == "usage"
-        title += _(": VM Usage")
-      elsif layout == "scan_profile"
-        title += _(": Analysis Profiles")
-      elsif layout == "miq_policy_rsop"
-        title += _(": Policy Simulation")
-      elsif layout == "all_ui_tasks"
-        title += _(": All UI Tasks")
-      elsif layout == "my_ui_tasks"
-        title += _(": My UI Tasks")
-      elsif layout == "rss"
-        title += _(": RSS")
-      elsif layout == "storage_manager"
-        title += _(": Storage - Storage Managers")
-      elsif layout == "ops"
-        title += _(": Configuration")
-      elsif layout == "provider_foreman"
-        title += _(": Configuration Management")
-      elsif layout == "pxe"
-        title += _(": PXE")
-      elsif layout == "explorer"
-        title += ": #{controller_model_name(params[:controller])} Explorer"
-      elsif layout == "vm_cloud"
-        title += _(": Instances")
-      elsif layout == "vm_infra"
-        title += _(": Virtual Machines")
-      elsif layout == "vm_or_template"
-        title += _(": Workloads")
-      # Specific titles for groups of layouts
-      elsif layout.starts_with?("miq_ae_")
-        title += _(": Automation")
-      elsif layout.starts_with?("miq_policy")
-        title += _(": Control")
-      elsif layout.starts_with?("miq_capacity")
-        title += _(": Optimize")
-      elsif layout.starts_with?("miq_request")
-        title += _(": Requests")
-      elsif layout == "manageiq/providers/ansible_tower/automation_manager/playbook"
-        title += ": Playbooks (Ansible Tower)"
-      elsif layout == "manageiq/providers/automation_manager/authentication"
-        title += ": Credentials"
-      elsif layout == "configuration_script_source"
-        title += ": Repositories"
-      # Assume layout is a table name and look up the plural version
-      else
-        title += ": #{ui_lookup(:tables => layout)}"
-      end
-      title
+      return title if layout.blank?  # no layout, leave title alone
+
+      title + case layout
+              when "configuration", "dashboard", "chargeback", "about"
+                ": #{layout.titleize}"
+              when "ems_cluster"
+                ": #{title_for_clusters}"
+              when "host"
+                ": #{title_for_hosts}"
+              # Specific titles for certain layouts
+              when "miq_server"
+                _(": Servers")
+              when "usage"
+                _(": VM Usage")
+              when "scan_profile"
+                _(": Analysis Profiles")
+              when "miq_policy_rsop"
+                _(": Policy Simulation")
+              when "all_ui_tasks"
+                _(": All UI Tasks")
+              when "my_ui_tasks"
+                _(": My UI Tasks")
+              when "rss"
+                _(": RSS")
+              when "storage_manager"
+                _(": Storage - Storage Managers")
+              when "ops"
+                _(": Configuration")
+              when "provider_foreman"
+                _(": Configuration Management")
+              when "pxe"
+                _(": PXE")
+              when "explorer"
+                ": #{controller_model_name(params[:controller])} Explorer"
+              when "vm_cloud"
+                _(": Instances")
+              when "vm_infra"
+                _(": Virtual Machines")
+              when "vm_or_template"
+                _(": Workloads")
+
+              # Specific titles for groups of layouts
+              when /^miq_ae_/
+                _(": Automation")
+              when /^miq_policy/
+                _(": Control")
+              when /^miq_capacity/
+                _(": Optimize")
+              when /^miq_request/
+                _(": Requests")
+              when "manageiq/providers/ansible_tower/automation_manager/playbook"
+                ": Playbooks (Ansible Tower)"
+              when "manageiq/providers/automation_manager/authentication"
+                ": Credentials"
+              when "configuration_script_source"
+                ": Repositories"
+              else
+                # Assume layout is a table name and look up the plural version
+                ": #{ui_lookup(:tables => layout)}"
+              end
     end
   end
 end

--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -1,0 +1,75 @@
+module ApplicationHelper
+  module Title
+    def product_title
+      # TODO: leave I18n until we have productization capability in gettext
+      I18n.t('product.name')
+    end
+
+    # Derive the browser title text based on the layout value
+    def title_from_layout(layout)
+      title = product_title
+
+      if layout.blank?  # no layout, leave title alone
+      elsif ["configuration", "dashboard", "chargeback", "about"].include?(layout)
+        title += ": #{layout.titleize}"
+      elsif @layout == "ems_cluster"
+        title += ": #{title_for_clusters}"
+      elsif @layout == "host"
+        title += ": #{title_for_hosts}"
+      # Specific titles for certain layouts
+      elsif layout == "miq_server"
+        title += _(": Servers")
+      elsif layout == "usage"
+        title += _(": VM Usage")
+      elsif layout == "scan_profile"
+        title += _(": Analysis Profiles")
+      elsif layout == "miq_policy_rsop"
+        title += _(": Policy Simulation")
+      elsif layout == "all_ui_tasks"
+        title += _(": All UI Tasks")
+      elsif layout == "my_ui_tasks"
+        title += _(": My UI Tasks")
+      elsif layout == "rss"
+        title += _(": RSS")
+      elsif layout == "storage_manager"
+        title += _(": Storage - Storage Managers")
+      elsif layout == "ops"
+        title += _(": Configuration")
+      elsif layout == "provider_foreman"
+        title += _(": Configuration Management")
+      elsif layout == "pxe"
+        title += _(": PXE")
+      elsif layout == "explorer"
+        title += ": #{controller_model_name(params[:controller])} Explorer"
+      elsif layout == "vm_cloud"
+        title += _(": Instances")
+      elsif layout == "vm_infra"
+        title += _(": Virtual Machines")
+      elsif layout == "vm_or_template"
+        title += _(": Workloads")
+      # Specific titles for groups of layouts
+      elsif layout.starts_with?("miq_ae_")
+        title += _(": Automation")
+      elsif layout.starts_with?("miq_policy")
+        title += _(": Control")
+      elsif layout.starts_with?("miq_capacity")
+        title += _(": Optimize")
+      elsif layout.starts_with?("miq_request")
+        title += _(": Requests")
+      elsif layout == "login"
+        title += _(": Login")
+      elsif layout == "manageiq/providers/ansible_tower/automation_manager/playbook"
+        title += ": Playbooks (Ansible Tower)"
+      elsif layout == "manageiq/providers/automation_manager/authentication"
+        title += ": Credentials"
+      elsif layout == "configuration_script_source"
+        title += ": Repositories"
+      # Assume layout is a table name and look up the plural version
+      else
+        title += ": #{ui_lookup(:tables => layout)}"
+      end
+      title
+    end
+
+  end
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,7 +15,7 @@
       = yield
   - else
     %head
-      %title= h(title_from_layout(@layout))
+      %title= h page_title
 
       %meta{"http-equiv" => "Pragma", :content => "no-cache"}
       %meta{"http-equiv" => "Pragma", :content => "no-store"}

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -2,7 +2,7 @@
 %html.login-pf{:class => ::Settings.server.custom_login_logo ? '' : 'rcue-login', :lang => I18n.locale.to_s.sub('-', '_')}
   %head
     %title
-      = h(title_from_layout(@layout))
+      = h productized_title(_(": Login"))
     = favicon_link_tag
     = stylesheet_link_tag 'application'
     = javascript_include_tag 'application'

--- a/spec/helpers/application_helper/title_spec.rb
+++ b/spec/helpers/application_helper/title_spec.rb
@@ -1,0 +1,176 @@
+describe ApplicationHelper::Title do
+  context "#title_from_layout" do
+    let(:title) { I18n.t('product.name') }
+    subject { helper.title_from_layout(@layout) }
+
+    it "when layout is blank" do
+      @layout = ""
+      expect(subject).to eq(title)
+    end
+
+    it "when layout = 'miq_server'" do
+      @layout = "miq_server"
+      expect(subject).to eq(title + ": Servers")
+    end
+
+    it "when layout = 'usage'" do
+      @layout = "usage"
+      expect(subject).to eq(title + ": VM Usage")
+    end
+
+    it "when layout = 'scan_profile'" do
+      @layout = "scan_profile"
+      expect(subject).to eq(title + ": Analysis Profiles")
+    end
+
+    it "when layout = 'miq_policy_rsop'" do
+      @layout = "miq_policy_rsop"
+      expect(subject).to eq(title + ": Policy Simulation")
+    end
+
+    it "when layout = 'all_ui_tasks'" do
+      @layout = "all_ui_tasks"
+      expect(subject).to eq(title + ": All UI Tasks")
+    end
+
+    it "when layout = 'rss'" do
+      @layout = "rss"
+      expect(subject).to eq(title + ": RSS")
+    end
+
+    it "when layout = 'management_system'" do
+      @layout = "management_system"
+      expect(subject).to eq(title + ": Management Systems")
+    end
+
+    it "when layout = 'storage_manager'" do
+      @layout = "storage_manager"
+      expect(subject).to eq(title + ": Storage - Storage Managers")
+    end
+
+    it "when layout = 'ops'" do
+      @layout = "ops"
+      expect(subject).to eq(title + ": Configuration")
+    end
+
+    it "when layout = 'pxe'" do
+      @layout = "pxe"
+      expect(subject).to eq(title + ": PXE")
+    end
+
+    it "when layout = 'vm_or_template'" do
+      @layout = "vm_or_template"
+      expect(subject).to eq(title + ": Workloads")
+    end
+
+    it "when layout likes 'miq_ae_*'" do
+      @layout = "miq_ae_some_thing"
+      expect(subject).to eq(title + ": Automation")
+    end
+
+    it "when layout likes 'miq_policy*'" do
+      @layout = "miq_policy_some_thing"
+      expect(subject).to eq(title + ": Control")
+    end
+
+    it "when layout likes 'miq_capacity*'" do
+      @layout = "miq_capacity_some_thing"
+      expect(subject).to eq(title + ": Optimize")
+    end
+
+    it "when layout likes 'miq_request*'" do
+      @layout = "miq_request_some_thing"
+      expect(subject).to eq(title + ": Requests")
+    end
+
+    it "otherwise" do
+      @layout = "xxx"
+      expect(subject).to eq(title + ": #{ui_lookup(:tables => @layout)}")
+    end
+  end
+
+  context "#title_for_hosts" do
+    it "returns 'Hosts / Nodes' when there are both openstack & non-openstack hosts" do
+      FactoryGirl.create(:host_vmware_esx, :ext_management_system => FactoryGirl.create(:ems_vmware))
+      FactoryGirl.create(:host_openstack_infra, :ext_management_system => FactoryGirl.create(:ems_openstack_infra))
+
+      expect(helper.title_for_hosts).to eq("Hosts / Nodes")
+    end
+
+    it "returns 'Hosts' when there are only non-openstack hosts" do
+      FactoryGirl.create(:host_vmware_esx, :ext_management_system => FactoryGirl.create(:ems_vmware))
+
+      expect(helper.title_for_hosts).to eq("Hosts")
+    end
+
+    it "returns 'Nodes' when there are only openstack hosts" do
+      FactoryGirl.create(:host_openstack_infra, :ext_management_system => FactoryGirl.create(:ems_openstack_infra))
+
+      expect(helper.title_for_hosts).to eq("Nodes")
+    end
+  end
+
+  context "#title_for_host" do
+    it "returns 'Host' for non-openstack host" do
+      FactoryGirl.create(:host_vmware, :ext_management_system => FactoryGirl.create(:ems_vmware))
+
+      expect(helper.title_for_host).to eq("Host")
+    end
+
+    it "returns 'Node' for openstack host" do
+      FactoryGirl.create(:host_openstack_infra, :ext_management_system => FactoryGirl.create(:ems_openstack_infra))
+
+      expect(helper.title_for_host).to eq("Node")
+    end
+  end
+
+  context "#title_for_clusters" do
+    before(:each) do
+      @ems1 = FactoryGirl.create(:ems_vmware)
+      @ems2 = FactoryGirl.create(:ems_openstack_infra)
+    end
+
+    it "returns 'Clusters / Deployment Roles' when there are both openstack & non-openstack clusters" do
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
+
+      result = helper.title_for_clusters
+      expect(result).to eq("Clusters / Deployment Roles")
+    end
+
+    it "returns 'Clusters' when there are only non-openstack clusters" do
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
+
+      result = helper.title_for_clusters
+      expect(result).to eq("Clusters")
+    end
+
+    it "returns 'Deployment Roles' when there are only openstack clusters" do
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
+
+      result = helper.title_for_clusters
+      expect(result).to eq("Deployment Roles")
+    end
+  end
+
+  context "#title_for_cluster" do
+    before(:each) do
+      @ems1 = FactoryGirl.create(:ems_vmware)
+      @ems2 = FactoryGirl.create(:ems_openstack_infra)
+    end
+
+    it "returns 'Cluster' for non-openstack cluster" do
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
+
+      result = helper.title_for_cluster
+      expect(result).to eq("Cluster")
+    end
+
+    it "returns 'Deployment Role' for openstack cluster" do
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
+
+      result = helper.title_for_cluster
+      expect(result).to eq("Deployment Role")
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -540,96 +540,6 @@ describe ApplicationHelper do
     end
   end
 
-  context "#title_from_layout" do
-    let(:title) { I18n.t('product.name') }
-    subject { helper.title_from_layout(@layout) }
-
-    it "when layout is blank" do
-      @layout = ""
-      expect(subject).to eq(title)
-    end
-
-    it "when layout = 'miq_server'" do
-      @layout = "miq_server"
-      expect(subject).to eq(title + ": Servers")
-    end
-
-    it "when layout = 'usage'" do
-      @layout = "usage"
-      expect(subject).to eq(title + ": VM Usage")
-    end
-
-    it "when layout = 'scan_profile'" do
-      @layout = "scan_profile"
-      expect(subject).to eq(title + ": Analysis Profiles")
-    end
-
-    it "when layout = 'miq_policy_rsop'" do
-      @layout = "miq_policy_rsop"
-      expect(subject).to eq(title + ": Policy Simulation")
-    end
-
-    it "when layout = 'all_ui_tasks'" do
-      @layout = "all_ui_tasks"
-      expect(subject).to eq(title + ": All UI Tasks")
-    end
-
-    it "when layout = 'rss'" do
-      @layout = "rss"
-      expect(subject).to eq(title + ": RSS")
-    end
-
-    it "when layout = 'management_system'" do
-      @layout = "management_system"
-      expect(subject).to eq(title + ": Management Systems")
-    end
-
-    it "when layout = 'storage_manager'" do
-      @layout = "storage_manager"
-      expect(subject).to eq(title + ": Storage - Storage Managers")
-    end
-
-    it "when layout = 'ops'" do
-      @layout = "ops"
-      expect(subject).to eq(title + ": Configuration")
-    end
-
-    it "when layout = 'pxe'" do
-      @layout = "pxe"
-      expect(subject).to eq(title + ": PXE")
-    end
-
-    it "when layout = 'vm_or_template'" do
-      @layout = "vm_or_template"
-      expect(subject).to eq(title + ": Workloads")
-    end
-
-    it "when layout likes 'miq_ae_*'" do
-      @layout = "miq_ae_some_thing"
-      expect(subject).to eq(title + ": Automation")
-    end
-
-    it "when layout likes 'miq_policy*'" do
-      @layout = "miq_policy_some_thing"
-      expect(subject).to eq(title + ": Control")
-    end
-
-    it "when layout likes 'miq_capacity*'" do
-      @layout = "miq_capacity_some_thing"
-      expect(subject).to eq(title + ": Optimize")
-    end
-
-    it "when layout likes 'miq_request*'" do
-      @layout = "miq_request_some_thing"
-      expect(subject).to eq(title + ": Requests")
-    end
-
-    it "otherwise" do
-      @layout = "xxx"
-      expect(subject).to eq(title + ": #{ui_lookup(:tables => @layout)}")
-    end
-  end
-
   context "#is_browser_ie7?" do
     it "when browser's explorer version 7.x" do
       allow_any_instance_of(ActionController::TestSession)
@@ -1162,56 +1072,6 @@ describe ApplicationHelper do
     end
   end
 
-  context "#title_for_clusters" do
-    before(:each) do
-      @ems1 = FactoryGirl.create(:ems_vmware)
-      @ems2 = FactoryGirl.create(:ems_openstack_infra)
-    end
-
-    it "returns 'Clusters / Deployment Roles' when there are both openstack & non-openstack clusters" do
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
-
-      result = helper.title_for_clusters
-      expect(result).to eq("Clusters / Deployment Roles")
-    end
-
-    it "returns 'Clusters' when there are only non-openstack clusters" do
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
-
-      result = helper.title_for_clusters
-      expect(result).to eq("Clusters")
-    end
-
-    it "returns 'Deployment Roles' when there are only openstack clusters" do
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
-
-      result = helper.title_for_clusters
-      expect(result).to eq("Deployment Roles")
-    end
-  end
-
-  context "#title_for_cluster" do
-    before(:each) do
-      @ems1 = FactoryGirl.create(:ems_vmware)
-      @ems2 = FactoryGirl.create(:ems_openstack_infra)
-    end
-
-    it "returns 'Cluster' for non-openstack cluster" do
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
-
-      result = helper.title_for_cluster
-      expect(result).to eq("Cluster")
-    end
-
-    it "returns 'Deployment Role' for openstack cluster" do
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
-
-      result = helper.title_for_cluster
-      expect(result).to eq("Deployment Role")
-    end
-  end
-
   context "#title_for_cluster_record" do
     before(:each) do
       @ems1 = FactoryGirl.create(:ems_vmware)
@@ -1230,41 +1090,6 @@ describe ApplicationHelper do
 
       result = helper.title_for_cluster_record(cluster)
       expect(result).to eq("Deployment Role")
-    end
-  end
-
-  context "#title_for_hosts" do
-    it "returns 'Hosts / Nodes' when there are both openstack & non-openstack hosts" do
-      FactoryGirl.create(:host_vmware_esx, :ext_management_system => FactoryGirl.create(:ems_vmware))
-      FactoryGirl.create(:host_openstack_infra, :ext_management_system => FactoryGirl.create(:ems_openstack_infra))
-
-      expect(helper.title_for_hosts).to eq("Hosts / Nodes")
-    end
-
-    it "returns 'Hosts' when there are only non-openstack hosts" do
-      FactoryGirl.create(:host_vmware_esx, :ext_management_system => FactoryGirl.create(:ems_vmware))
-
-      expect(helper.title_for_hosts).to eq("Hosts")
-    end
-
-    it "returns 'Nodes' when there are only openstack hosts" do
-      FactoryGirl.create(:host_openstack_infra, :ext_management_system => FactoryGirl.create(:ems_openstack_infra))
-
-      expect(helper.title_for_hosts).to eq("Nodes")
-    end
-  end
-
-  context "#title_for_host" do
-    it "returns 'Host' for non-openstack host" do
-      FactoryGirl.create(:host_vmware, :ext_management_system => FactoryGirl.create(:ems_vmware))
-
-      expect(helper.title_for_host).to eq("Host")
-    end
-
-    it "returns 'Node' for openstack host" do
-      FactoryGirl.create(:host_openstack_infra, :ext_management_system => FactoryGirl.create(:ems_openstack_infra))
-
-      expect(helper.title_for_host).to eq("Node")
     end
   end
 


### PR DESCRIPTION
Extract and refactor title calculation.

Allow setting page title using @page_title.

The goal is to get rid of the ugly case logic for setting page title and moving the decision back to the controllers.

Example of stuff to avoid in the future: https://github.com/ManageIQ/manageiq-ui-classic/pull/452/files#diff-127a850b7d7b20173ad3fba88f8a25e3R473