### PR TITLE
Replace @settings access with helper methods.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1430,7 +1430,7 @@ class ApplicationController < ActionController::Base
   end
 
   def get_view_calculate_gtl_type(db_sym)
-    gtl_type = @settings.fetch_path(:views, db_sym) unless %w(scanitemset miqschedule pxeserver customizationtemplate).include?(db_sym.to_s)
+    gtl_type = settings(:views, db_sym) unless %w(scanitemset miqschedule pxeserver customizationtemplate).include?(db_sym.to_s)
     gtl_type = 'grid' if ['vm'].include?(db_sym.to_s) && request.parameters[:controller] == 'service'
     gtl_type ||= 'list' # return a sane default
     gtl_type
@@ -1523,7 +1523,7 @@ class ApplicationController < ActionController::Base
     sortdir_sym = "#{sort_prefix}_sortdir".to_sym
 
     # Set up the list view type (grid/tile/list)
-    @settings.store_path(:views, db_sym, params[:type]) if params[:type]  # Change the list view type, if it's sent in
+    @settings.store_path(:views, db_sym, params[:type]) if params[:type] # Change the list view type, if it's sent in
 
     @gtl_type = get_view_calculate_gtl_type(db_sym)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -190,7 +190,7 @@ class ApplicationController < ActionController::Base
       response.headers["Cache-Control"] = "cache, must-revalidate"
       response.headers["Pragma"] = "public"
     end
-    rpt.to_chart(@settings[:display][:reporttheme], true, MiqReport.graph_options(params[:width], params[:height]))
+    rpt.to_chart(settings(:display, :reporttheme), true, MiqReport.graph_options(params[:width], params[:height]))
     render Charting.render_format => rpt.chart
   end
 
@@ -274,14 +274,14 @@ class ApplicationController < ActionController::Base
   def saved_report_paging
     # Check new paging parms coming in
     if params[:ppsetting]
-      @settings[:perpage][:reports] = params[:ppsetting].to_i
+      @settings.store_path(:perpage, :reports, params[:ppsetting].to_i)
       @sb[:pages][:current] = 1
-      total = @sb[:pages][:items] / @settings[:perpage][:reports]
-      total += 1 if @sb[:pages][:items] % @settings[:perpage][:reports] != 0
+      total = @sb[:pages][:items] / settings(:perpage, :reports)
+      total += 1 if @sb[:pages][:items] % settings(:perpage, :reports) != 0
       @sb[:pages][:total] = total
     end
     @sb[:pages][:current] = params[:page].to_i if params[:page]
-    @sb[:pages][:perpage] = @settings[:perpage][:reports]
+    @sb[:pages][:perpage] = settings(:perpage, :reports)
 
     rr = MiqReportResult.find(@sb[:pages][:rr_id])
     @html = report_build_html_table(rr.report_results,
@@ -585,7 +585,7 @@ class ApplicationController < ActionController::Base
     @sb[:pages] ||= {}
     @sb[:pages][:rr_id] = rr.id
     @sb[:pages][:items] = @report.extras[:total_html_rows]
-    @sb[:pages][:perpage] = @settings[:perpage][:reports]
+    @sb[:pages][:perpage] = settings(:perpage, :reports)
     @sb[:pages][:current] = 1
     total = @sb[:pages][:items] / @sb[:pages][:perpage]
     total += 1 if @sb[:pages][:items] % @sb[:pages][:perpage] != 0
@@ -1523,8 +1523,7 @@ class ApplicationController < ActionController::Base
     sortdir_sym = "#{sort_prefix}_sortdir".to_sym
 
     # Set up the list view type (grid/tile/list)
-    @settings ||= {:views => {}, :perpage => {}}
-    @settings[:views][db_sym] = params[:type] if params[:type]  # Change the list view type, if it's sent in
+    @settings.store_path(:views, db_sym, params[:type]) if params[:type]  # Change the list view type, if it's sent in
 
     @gtl_type = get_view_calculate_gtl_type(db_sym)
 
@@ -1533,7 +1532,7 @@ class ApplicationController < ActionController::Base
 
     # Check for changed settings in params
     if params[:ppsetting]                             # User selected new per page value
-      @settings[:perpage][perpage_key(dbname)] = params[:ppsetting].to_i
+      @settings.store_path(:perpage, perpage_key(dbname), params[:ppsetting].to_i)
     elsif params[:sortby]                             # New sort order (by = col click, choice = pull down)
       params[:sortby]      = params[:sortby].to_i - 1
       params[:sort_choice] = view.headers[params[:sortby]]
@@ -1634,13 +1633,7 @@ class ApplicationController < ActionController::Base
   end
 
   def get_view_pages_perpage(dbname)
-    perpage = 10 # return a sane default
-    return perpage unless @settings && @settings.key?(:perpage)
-
-    key = perpage_key(dbname)
-    perpage = @settings[:perpage][key] if key && @settings[:perpage].key?(key)
-
-    perpage
+    settings_default(10, :perpage, perpage_key(dbname))
   end
 
   # Create the pages hash and return with the view

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -739,11 +739,11 @@ module ApplicationController::Compare
     @compare = nil                                                            # Clear the compare array to have it rebuilt
     @base = nil                                                                 # Clear the base comparison VM
     if mode == "compare"
-      session[:miq_compressed]  = (@settings[:views][:compare] == "compressed")
-      session[:miq_exists_mode] = (@settings[:views][:compare_mode] == "exists")
+      session[:miq_compressed]  = (settings(:views, :compare) == "compressed")
+      session[:miq_exists_mode] = (settings(:views, :compare_mode) == "exists")
     else
-      session[:miq_compressed]  = (@settings[:views][:drift] == "compressed")
-      session[:miq_exists_mode] = (@settings[:views][:drift_mode] == "exists")
+      session[:miq_compressed]  = (settings(:views, :drift) == "compressed")
+      session[:miq_exists_mode] = (settings(:views, :drift_mode) == "exists")
     end
     @compressed = session[:miq_compressed]
     @exists_mode = session[:miq_exists_mode]

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -529,7 +529,7 @@ module ApplicationController::Filter
         session[:adv_search] ||= {}                   # Create/reuse the adv search hash
         session[:adv_search][@edit[@expkey][:exp_model]] = copy_hash(@edit) # Save by model name in settings
         default_search = settings(:default_search, @view.db.to_s.to_sym)
-        if default_search.present? && default_search != "0"
+        if default_search.present? && default_search.to_i != 0
           s = MiqSearch.find(default_search)
           @edit[@expkey].select_filter(s)
           @edit[:selected] = false
@@ -986,7 +986,7 @@ module ApplicationController::Filter
   def build_listnav_search_list(db)
     @settings[:default_search] = current_user.settings[:default_search]  # Get the user's default search settings again, incase default search was deleted
     default_search_db = settings(:default_search, db.to_sym).to_s
-    if default_search_db.present? && default_search_db != '0' && MiqSearch.exists?(default_search_db)
+    if default_search_db.present? && default_search_db.to_i != 0 && MiqSearch.exists?(default_search_db)
       @default_search = MiqSearch.find(default_search_db)
     end
 

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -1394,7 +1394,7 @@ module ApplicationController::Performance
     report.graph[:legends] = options[:legends]
     report.graph[:max_col_size] = options[:max_value]
     # FIXME: rename xml, xml2 to something like 'chart_data'
-    report.to_chart(@settings[:display][:reporttheme], false,
+    report.to_chart(settings(:display, :reporttheme), false,
                     MiqReport.graph_options(options[:width], options[:height], options))
     chart_xml = {
       :xml      => report.chart,            # Save the graph xml
@@ -1403,7 +1403,7 @@ module ApplicationController::Performance
     if options[:chart2]
       report.graph[:type]    = options[:chart2][:type]
       report.graph[:columns] = options[:chart2][:columns]
-      report.to_chart(@settings[:display][:reporttheme], false,
+      report.to_chart(settings(:display, :reporttheme), false,
                       MiqReport.graph_options(options[:width], options[:height], options.merge(:composite => true)))
       chart_xml[:xml2] = report.chart
     end

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -76,7 +76,7 @@ class ChargebackController < ApplicationController
     @explorer = true
     if params[:ppsetting]                                              # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                        # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page          # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:rates_sortcol].nil? ? 0 : session[:rates_sortcol].to_i
     @sortdir = session[:rates_sortdir].nil? ? "ASC" : session[:rates_sortdir]

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -164,12 +164,12 @@ class ConfigurationController < ApplicationController
 
           # Now copying ALL display settings into the :css hash so we can easily add new settings
           @settings[:css] ||= {}
-          @settings[:css].merge!(@settings[:display])
-          @settings[:css].merge!(THEME_CSS_SETTINGS[@settings[:display][:theme]])
+          @settings[:css].merge!(settings(:display))
+          @settings[:css].merge!(THEME_CSS_SETTINGS[settings(:display, :theme)])
 
           @css ||= {}
-          @css.merge!(@settings[:display])
-          @css.merge!(THEME_CSS_SETTINGS[@settings[:display][:theme]])
+          @css.merge!(settings(:display))
+          @css.merge!(THEME_CSS_SETTINGS[settings(:display, :theme)])
           set_user_time_zone
           add_flash(_("User Interface settings saved for User %{name}") % {:name => current_user.name})
         else

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -342,7 +342,7 @@ class DashboardController < ApplicationController
       @user_name     = params[:user_name]
       @user_password = params[:user_password]
     end
-    css = @settings[:css] if @settings && @settings[:css] # Save prior CSS settings
+    css = settings(:css) # Save prior CSS settings
     @settings = copy_hash(DEFAULT_SETTINGS)               # Need settings, else pages won't display
     @settings[:css] = css if css                          # Restore CSS settings for other tabs previusly logged in
     @more = params[:type] && params[:type] != "less"
@@ -658,12 +658,12 @@ class DashboardController < ApplicationController
     # Copy ALL display settings into the :css hash so we can easily add new settings
     @settings[:css] ||= {}
     @settings[:css].merge!(@settings[:display])
-    @settings[:display][:theme] = THEMES.first.last unless THEMES.collect(&:last).include?(@settings[:display][:theme])
-    @settings[:css].merge!(THEME_CSS_SETTINGS[@settings[:display][:theme]])
+    @settings.store_path(:display, :theme, THEMES.first.last) unless THEMES.collect(&:last).include?(settings(:display, :theme))
+    @settings[:css].merge!(THEME_CSS_SETTINGS[settings(:display, :theme)])
 
     @css ||= {}
     @css.merge!(@settings[:display])
-    @css.merge!(THEME_CSS_SETTINGS[@settings[:display][:theme]])
+    @css.merge!(THEME_CSS_SETTINGS[settings(:display, :theme)])
 
     session[:user_TZO] = params[:user_TZO] ? params[:user_TZO].to_i : nil     # Grab the timezone (future use)
     session[:browser] ||= Hash.new("Unknown")

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -641,7 +641,7 @@ class HostController < ApplicationController
     page = params[:page].nil? ? 1 : params[:page].to_i
     @current_page = page
 
-    @items_per_page = @settings[:perpage][@gtl_type.to_sym]   # Get the per page setting for this gtl type
+    @items_per_page = settings(:perpage, @gtl_type.to_sym) # Get the per page setting for this gtl type
     @host_pages, @hosts = paginate(:hosts, :per_page => @items_per_page, :order => @col_names[get_sort_col] + " " + @sortdir)
   end
 

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -77,7 +77,7 @@ module MiqAeCustomizationController::Dialogs
 
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
 
     @sortcol = session[:dialog_sortcol].nil? ? 0 : session[:dialog_sortcol].to_i

--- a/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -148,7 +148,7 @@ module MiqAeCustomizationController::OldDialogs
     @dialog = nil
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:dialog_sortcol].nil? ? 0 : session[:dialog_sortcol].to_i
     @sortdir = session[:dialog_sortdir].nil? ? "ASC" : session[:dialog_sortdir]

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -368,7 +368,7 @@ class MiqPolicyController < ApplicationController
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page)# Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     sortcol_key = "#{what}_sortcol".to_sym
     sortdir_key = "#{what}_sortdir".to_sym

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -368,7 +368,7 @@ class MiqPolicyController < ApplicationController
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page)# Set the per page setting for this gtl type
     end
     sortcol_key = "#{what}_sortcol".to_sym
     sortdir_key = "#{what}_sortdir".to_sym

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -114,12 +114,12 @@ class MiqRequestController < ApplicationController
     @lastaction = "show_list"
     @gtl_url = "/show_list"
 
-    @settings[:views][:miqrequest] = params[:type] if params[:type]   # new gtl type came in, set it
-    @gtl_type = @settings[:views][:miqrequest]                        # set the var for the UI to use
+    @settings.storage_path(:views, :miqrequest, params[:type]) if params[:type]   # new gtl type came in, set it
+    @gtl_type = settings(:views, :miqrequest)                        # set the var for the UI to use
 
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][PERPAGE_TYPES[@gtl_type]] = @items_per_page # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, PERPAGE_TYPES[@gtl_type], @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:request_sortcol].nil? ? 0 : session[:request_sortcol].to_i
     @sortdir = session[:request_sortdir].nil? ? "ASC" : session[:request_sortdir]

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -114,8 +114,8 @@ class MiqRequestController < ApplicationController
     @lastaction = "show_list"
     @gtl_url = "/show_list"
 
-    @settings.storage_path(:views, :miqrequest, params[:type]) if params[:type]   # new gtl type came in, set it
-    @gtl_type = settings(:views, :miqrequest)                        # set the var for the UI to use
+    @settings.store_path(:views, :miqrequest, params[:type]) if params[:type]
+    @gtl_type = settings(:views, :miqrequest)
 
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value

--- a/app/controllers/mixins/start_url.rb
+++ b/app/controllers/mixins/start_url.rb
@@ -17,13 +17,13 @@ module StartUrl
       allowed = start_page_allowed?(rbac_feature_name)
       first_allowed_url ||= url if allowed
       # if default startpage is set, check if it is allowed
-      startpage_already_set = true if @settings[:display][:startpage] == url && allowed
+      startpage_already_set = true if settings(:display, :startpage) == url && allowed
       break if startpage_already_set
     end
 
     # user first_allowed_url in start_pages to be default page, if default startpage is not allowed
     @settings.store_path(:display, :startpage, first_allowed_url) unless startpage_already_set
-    @settings[:display][:startpage]
+    settings(:display, :startpage)
   end
 
   def start_page_options

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -763,7 +763,7 @@ module OpsController::OpsRbac
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session["rbac_#{rec_type}_sortcol"].nil? ? 0 : @sb["rbac_#{rec_type}_sortcol"].to_i
     @sortdir = session["rbac_#{rec_type}_sortdir"].nil? ? "ASC" : @sb["rbac_#{rec_type}_sortdir"]

--- a/app/controllers/ops_controller/settings/ldap.rb
+++ b/app/controllers/ops_controller/settings/ldap.rb
@@ -336,7 +336,7 @@ module OpsController::Settings::Ldap
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:ldap_region_sortcol].nil? ? 0 : session[:ldap_region_sortcol].to_i
     @sortdir = session[:ldap_region_sortdir].nil? ? "ASC" : session[:ldap_region_sortdir]

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -421,7 +421,7 @@ module OpsController::Settings::Schedules
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:schedule_sortcol].nil? ? 0 : session[:schedule_sortcol].to_i
     @sortdir = session[:schedule_sortdir].nil? ? "ASC" : session[:schedule_sortdir]

--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -143,7 +143,7 @@ module PxeController::IsoDatastores
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:iso_sortcol].nil? ? 0 : session[:iso_sortcol].to_i
     @sortdir = session[:iso_sortdir].nil? ? "ASC" : session[:iso_sortdir]

--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -30,7 +30,7 @@ module PxeController::PxeCustomizationTemplates
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:ct_sortcol].nil? ? 0 : session[:ct_sortcol].to_i
     @sortdir = session[:ct_sortdir].nil? ? "ASC" : session[:ct_sortdir]

--- a/app/controllers/pxe_controller/pxe_image_types.rb
+++ b/app/controllers/pxe_controller/pxe_image_types.rb
@@ -136,7 +136,7 @@ module PxeController::PxeImageTypes
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:pxe_image_type_sortcol].nil? ? 0 : session[:pxe_image_type_sortcol].to_i
     @sortdir = session[:pxe_image_type_sortdir].nil? ? "ASC" : session[:pxe_image_type_sortdir]

--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -163,7 +163,7 @@ module PxeController::PxeServers
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:pxe_sortcol].nil? ? 0 : session[:pxe_sortcol].to_i
     @sortdir = session[:pxe_sortdir].nil? ? "ASC" : session[:pxe_sortdir]

--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -163,7 +163,7 @@ module PxeController::PxeServers
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:pxe_sortcol].nil? ? 0 : session[:pxe_sortcol].to_i
     @sortdir = session[:pxe_sortdir].nil? ? "ASC" : session[:pxe_sortdir]

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -65,7 +65,7 @@ module ReportController::Reports
       end
       unless rpt.graph.nil? || rpt.graph[:type].blank?            # If graph present
         # FIXME: UNTESTED!!!
-        rpt.to_chart(@settings[:display][:reporttheme], false, MiqReport.graph_options(350, 250))  # Generate the chart
+        rpt.to_chart(settings(:display, :reporttheme), false, MiqReport.graph_options(350, 250))  # Generate the chart
         @edit[:zgraph_xml] = rpt.chart                 # Save chart data
       else
         @edit[:zgraph_xml] = nil
@@ -117,7 +117,7 @@ module ReportController::Reports
 
   # Generating sample chart
   def sample_chart
-    render Charting.render_format => Charting.sample_chart(@edit[:new], @settings[:display][:reporttheme])
+    render Charting.render_format => Charting.sample_chart(@edit[:new], settings(:display, :reporttheme))
   end
 
   def sample_timeline
@@ -163,7 +163,7 @@ module ReportController::Reports
 
       if params[:ppsetting]                                             # User selected new per page value
         @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-        @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+        @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
       end
 
       @sortcol = session["#{x_active_tree}_sortcol".to_sym].nil? ? 0 : session["#{x_active_tree}_sortcol".to_sym].to_i

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -65,7 +65,7 @@ module ReportController::Reports
       end
       unless rpt.graph.nil? || rpt.graph[:type].blank?            # If graph present
         # FIXME: UNTESTED!!!
-        rpt.to_chart(settings(:display, :reporttheme), false, MiqReport.graph_options(350, 250))  # Generate the chart
+        rpt.to_chart(settings(:display, :reporttheme), false, MiqReport.graph_options(350, 250)) # Generate the chart
         @edit[:zgraph_xml] = rpt.chart                 # Save chart data
       else
         @edit[:zgraph_xml] = nil

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -116,7 +116,7 @@ module ReportController::SavedReports
     #   @embedded = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
 
     @sortcol = session["#{x_active_tree}_sortcol".to_sym].nil? ? 0 : session["#{x_active_tree}_sortcol".to_sym].to_i

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -33,7 +33,7 @@ module ReportController::Schedules
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:schedule_sortcol].nil? ? 0 : session[:schedule_sortcol].to_i
     @sortdir = session[:schedule_sortdir].nil? ? "ASC" : session[:schedule_sortdir]

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -216,7 +216,7 @@ module ReportController::Widgets
     #   @embedded = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
 
     @sortcol = session["#{x_active_tree}_sortcol".to_sym].nil? ? 0 : session["#{x_active_tree}_sortcol".to_sym].to_i

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -216,7 +216,7 @@ class StorageController < ApplicationController
   def get_storages
     page = params[:page].nil? ? 1 : params[:page].to_i
     @current_page = page
-    @items_per_page = settings(:perpage, @gtl_type.to_sym)   # Get the per page setting for this gtl type
+    @items_per_page = settings(:perpage, @gtl_type.to_sym) # Get the per page setting for this gtl type
     @storage_pages, @storages = paginate(:storages, :per_page => @items_per_page, :order => @col_names[get_sort_col] + " " + @sortdir)
   end
 

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -75,7 +75,7 @@ class StorageController < ApplicationController
 
     when "main", "summary_only"
       get_tagdata(@storage)
-      session[:vm_summary_cool] = (@settings[:views][:vm_summary_cool] == "summary")
+      session[:vm_summary_cool] = (settings(:views, :vm_summary_cool) == "summary")
       @summary_view = session[:vm_summary_cool]
       drop_breadcrumb({:name => ui_lookup(:tables => "storages"), :url => "/storage/show_list?page=#{@current_page}&refresh=y"}, true)
       drop_breadcrumb(:name => "%{name} (Summary)" % {:name => @storage.name},
@@ -216,7 +216,7 @@ class StorageController < ApplicationController
   def get_storages
     page = params[:page].nil? ? 1 : params[:page].to_i
     @current_page = page
-    @items_per_page = @settings[:perpage][@gtl_type.to_sym]   # Get the per page setting for this gtl type
+    @items_per_page = settings(:perpage, @gtl_type.to_sym)   # Get the per page setting for this gtl type
     @storage_pages, @storages = paginate(:storages, :per_page => @items_per_page, :order => @col_names[get_sort_col] + " " + @sortdir)
   end
 

--- a/app/controllers/storage_controller/storage_d.rb
+++ b/app/controllers/storage_controller/storage_d.rb
@@ -15,7 +15,7 @@ module StorageController::StorageD
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings.shore_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:storage_sortcol].nil? ? 0 : session[:storage_sortcol].to_i
     @sortdir = session[:storage_sortdir].nil? ? "ASC" : session[:storage_sortdir]

--- a/app/controllers/storage_controller/storage_d.rb
+++ b/app/controllers/storage_controller/storage_d.rb
@@ -15,7 +15,7 @@ module StorageController::StorageD
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      @settings.shore_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:storage_sortcol].nil? ? 0 : session[:storage_sortcol].to_i
     @sortdir = session[:storage_sortdir].nil? ? "ASC" : session[:storage_sortdir]

--- a/app/controllers/storage_controller/storage_pod.rb
+++ b/app/controllers/storage_controller/storage_pod.rb
@@ -15,7 +15,7 @@ module StorageController::StoragePod
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
+      @settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:dsc_sortcol].nil? ? 0 : session[:dsc_sortcol].to_i
     @sortdir = session[:dsc_sortdir].nil? ? "ASC" : session[:dsc_sortdir]

--- a/app/controllers/storage_controller/storage_pod.rb
+++ b/app/controllers/storage_controller/storage_pod.rb
@@ -15,7 +15,7 @@ module StorageController::StoragePod
     @ajax_paging_buttons = true
     if params[:ppsetting]                                             # User selected new per page value
       @items_per_page = params[:ppsetting].to_i                       # Set the new per page value
-      @settings[:perpage][@gtl_type.to_sym] = @items_per_page         # Set the per page setting for this gtl type
+      settings.store_path(:perpage, @gtl_type.to_sym, @items_per_page) # Set the per page setting for this gtl type
     end
     @sortcol = session[:dsc_sortcol].nil? ? 0 : session[:dsc_sortcol].to_i
     @sortdir = session[:dsc_sortdir].nil? ? "ASC" : session[:dsc_sortdir]

--- a/app/controllers/storage_manager_controller.rb
+++ b/app/controllers/storage_manager_controller.rb
@@ -205,7 +205,7 @@ class StorageManagerController < ApplicationController
   def show
     @display = params[:display] || "main" unless pagination_or_gtl_request?
 
-    session[:sm_summary_cool] = (@settings[:views][:sm_summary_cool] == "summary")
+    session[:sm_summary_cool] = (settings(:views, :sm_summary_cool) == "summary")
     @summary_view = session[:sm_summary_cool]
     @sm = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@sm)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1758,7 +1758,7 @@ module VmCommon
   def get_vms(selected = nil)
     page = params[:page].nil? ? 1 : params[:page].to_i
     @current_page = page
-    @items_per_page = @settings[:perpage][@gtl_type.to_sym]   # Get the per page setting for this gtl type
+    @items_per_page = settings(:perpage, @gtl_type.to_sym) # Get the per page setting for this gtl type
     if selected                             # came in with a list of selected ids (i.e. checked vms)
       @record_pages, @records = paginate(:vms, :per_page => @items_per_page, :order => @col_names[get_sort_col] + " " + @sortdir, :conditions => ["id IN (?)", selected])
     else                                      # getting ALL vms

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,6 +21,10 @@ module ApplicationHelper
     @settings.fetch_path(*path)
   end
 
+  def settings_default(default, *path)
+    settings(*path) || default
+  end
+
   def documentation_link(url = nil, documentation_subject = "")
     if url
       link_to(_("For more information, visit the %{subject} documentation.") % {:subject => documentation_subject},

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -28,7 +28,7 @@ class ApplicationHelper::ToolbarBuilder
   delegate :request, :current_user, :to => :@view_context
   delegate :role_allows?, :model_for_vm, :rbac_common_feature_for_buttons, :to => :@view_context
   delegate :x_tree_history, :x_node, :x_active_tree, :to => :@view_context
-  delegate :is_browser?, :is_browser_os?, :to => :@view_context
+  delegate :settings, :is_browser?, :is_browser_os?, :to => :@view_context
 
   def initialize(view_context, view_binding, instance_data)
     @view_context = view_context
@@ -611,13 +611,13 @@ class ApplicationHelper::ToolbarBuilder
     return true if id.starts_with?("view_") && id.ends_with?("textual")  # Summary view buttons
     return true if @gtl_type && id.starts_with?("view_") && id.ends_with?(@gtl_type)  # GTL view buttons
     return true if @ght_type && id.starts_with?("view_") && id.ends_with?(@ght_type)  # GHT view buttons on report show
-    return true if id.starts_with?("tree_") && id.ends_with?(@settings[:views][:treesize].to_i == 32 ? "large" : "small")
-    return true if id.starts_with?("compare_") && id.ends_with?(@settings[:views][:compare])
-    return true if id.starts_with?("drift_") && id.ends_with?(@settings[:views][:drift])
+    return true if id.starts_with?("tree_") && id.ends_with?(settings(:views, :treesize).to_i == 32 ? "large" : "small")
+    return true if id.starts_with?("compare_") && id.ends_with?(settings(:views, :compare))
+    return true if id.starts_with?("drift_") && id.ends_with?(settings(:views, :drift))
     return true if id == "compare_all"
     return true if id == "drift_all"
-    return true if id.starts_with?("comparemode_") && id.ends_with?(@settings[:views][:compare_mode])
-    return true if id.starts_with?("driftmode_") && id.ends_with?(@settings[:views][:drift_mode])
+    return true if id.starts_with?("comparemode_") && id.ends_with?(settings(:views, :compare_mode))
+    return true if id.starts_with?("driftmode_") && id.ends_with?(settings(:views, :drift_mode))
     return true if id == "view_dashboard" && @showtype == "dashboard"
     return true if id == "view_topology" && @showtype == "topology"
     return true if id == "view_summary" && @showtype == "main"

--- a/app/views/layouts/_saved_report_paging_bar.html.haml
+++ b/app/views/layouts/_saved_report_paging_bar.html.haml
@@ -4,7 +4,7 @@
     - url = url_for_only_path(:action => action_url)
     - @pb_occ ||= 0
     - @pb_occ += 1
-    - pages ||= {:perpage => @settings[:perpage][:reports],
+    - pages ||= {:perpage => settings(:perpage, :reports),
                 :current => 1,
                 :total   => @sb[:pages][:total],
                 :items   => @sb[:pages][:items]}

--- a/app/views/layouts/listnav/_show_list.html.haml
+++ b/app/views/layouts/listnav/_show_list.html.haml
@@ -17,7 +17,7 @@
                 - li_class = "active"
             - elsif @edit && @edit[:expression] && ((@edit[:expression][:selected] && @edit[:expression][:selected][:id] == 0 && search.id.to_i == 0) || (@edit[:expression][:selected] && @edit[:expression][:selected][:name] == search.name && !@edit[:custom_search]))
               - li_class = "active"
-            - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i == 0 && @settings[:default_search] && @settings[:default_search][@edit[@expkey][:exp_model].to_s.to_sym] && @settings[:default_search][@edit[@expkey][:exp_model].to_s.to_sym].to_i == 0)
+            - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i == 0 && settings_default('0', :default_search, @edit[@expkey][:exp_model].to_s.to_sym).to_s == '0')
               - search_name << " (#{_('Default')})"
             %li{:class => li_class}
               = link_to(search_name.html_safe,
@@ -41,7 +41,7 @@
             - elsif @edit && @edit[:expression] && ((@edit[:expression][:selected].nil? && search.id.to_i == 0) || (@edit[:expression][:selected] && @edit[:expression][:selected][:name] == search.name && !@edit[:custom_search]))
               - li_class = "active"
             %li{:class => "#{li_class}"}
-              - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i == 0 && @settings[:default_search] && @settings[:default_search][@edit[@expkey][:exp_model].to_s.to_sym] && @settings[:default_search][@edit[@expkey][:exp_model].to_s.to_sym].to_i == 0)
+              - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i == 0 && settings_default('0', :default_search, @edit[@expkey][:exp_model].to_s.to_sym).to_s == '0')
                 - search_name << " (#{_('Default')})"
               = link_to(search.description.html_safe,
                 {:action => 'listnav_search_selected', :id => search.id, :button => "apply"},
@@ -51,7 +51,7 @@
                 :onclick      => "return miqCheckForChanges()")
 
 
-  - if @edit && @edit[:expression] && @edit[:expression][:selected] && (!@settings[:default_search] || (@settings[:default_search] && @edit[:expression][:selected][:id].to_i != @settings[:default_search][@edit[@expkey][:exp_model].to_s.to_sym].to_i) || (!@settings[:default_search][@edit[@expkey][:exp_model].to_s.to_sym]))
+  - if @edit && @edit[:expression] && @edit[:expression][:selected] && (@settings[:default_search] || (@edit[:expression][:selected][:id].to_i != settings(:default_search, @edit[@expkey][:exp_model].to_s.to_sym).to_i) || (!settings(:default_search, @edit[@expkey][:exp_model].to_s.to_sym)))
     - t = _('Set the current filter as my default')
     = link_to(_("Set Default"),
       {:action => "save_default_search", :id => @edit[:expression][:selected][:id].to_i},

--- a/app/views/layouts/listnav/_show_list.html.haml
+++ b/app/views/layouts/listnav/_show_list.html.haml
@@ -11,13 +11,13 @@
           - @def_searches.each do |search|
             - li_class = ""
             - search_name = search.description
-            - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i == 0)
+            - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i.is_zero?)
               -# highlight if default is selected, or first time in
               - if @edit && @edit[:expression] && ((@edit[:expression][:selected].nil? && @edit[:selected].nil?) || (!@edit[:expression][:selected].nil? && @edit[:expression][:selected][:id] == search.id.to_i && !@edit[:custom_search]))
                 - li_class = "active"
-            - elsif @edit && @edit[:expression] && ((@edit[:expression][:selected] && @edit[:expression][:selected][:id] == 0 && search.id.to_i == 0) || (@edit[:expression][:selected] && @edit[:expression][:selected][:name] == search.name && !@edit[:custom_search]))
+            - elsif @edit && @edit[:expression] && ((@edit[:expression][:selected] && @edit[:expression][:selected][:id].is_zero? && search.id.to_i.is_zero?) || (@edit[:expression][:selected] && @edit[:expression][:selected][:name] == search.name && !@edit[:custom_search]))
               - li_class = "active"
-            - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i == 0 && settings_default('0', :default_search, @edit[@expkey][:exp_model].to_s.to_sym).to_s == '0')
+            - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i.is_zero? && settings_default('0', :default_search, @edit[@expkey][:exp_model].to_s.to_sym).to_s == '0')
               - search_name << " (#{_('Default')})"
             %li{:class => li_class}
               = link_to(search_name.html_safe,
@@ -38,10 +38,10 @@
             - if !@default_search.blank? && @default_search.name == search.name
               - if @edit && @edit[:expression] && ((@edit[:expression][:selected].nil? && @edit[:selected].nil?) || (!@edit[:expression][:selected].nil? && @edit[:expression][:selected][:id] == search.id.to_i && !@edit[:custom_search]))
                 - li_class = "active"
-            - elsif @edit && @edit[:expression] && ((@edit[:expression][:selected].nil? && search.id.to_i == 0) || (@edit[:expression][:selected] && @edit[:expression][:selected][:name] == search.name && !@edit[:custom_search]))
+            - elsif @edit && @edit[:expression] && ((@edit[:expression][:selected].nil? && search.id.to_i.is_zero?) || (@edit[:expression][:selected] && @edit[:expression][:selected][:name] == search.name && !@edit[:custom_search]))
               - li_class = "active"
             %li{:class => "#{li_class}"}
-              - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i == 0 && settings_default('0', :default_search, @edit[@expkey][:exp_model].to_s.to_sym).to_s == '0')
+              - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i.is_zero? && settings_default('0', :default_search, @edit[@expkey][:exp_model].to_s.to_sym).to_s == '0')
                 - search_name << " (#{_('Default')})"
               = link_to(search.description.html_safe,
                 {:action => 'listnav_search_selected', :id => search.id, :button => "apply"},


### PR DESCRIPTION
This is buying us:

  * fixing some bugs that happen from time to time such as what is mentioned here: ManageIQ/manageiq-ui-classic#236
 * the settings don't need to be set when writing specs
 * and this type of access is already present in some places (were people where either fixing bugs or simplifying test setup). So it's also an unification.

Looking forward we can replace hash access with a Struct to enforce structure to the settings