### PR TITLE
add icon for ansible credentials

### DIFF
--- a/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::AutomationManager::AuthenticationDecorator < Draper::
   delegate_all
 
   def fonticon
-    nil
+    'fa fa-lock'
   end
 
   def listicon_image


### PR DESCRIPTION
This is a follow-up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/452