### PR TITLE
Fix for inability to import an automate zip file

### DIFF
--- a/app/services/automate_import_json_serializer_service.rb
+++ b/app/services/automate_import_json_serializer_service.rb
@@ -1,11 +1,12 @@
 class AutomateImportJsonSerializerService
   def serialize(import_file_upload)
-    temp_file = Tempfile.new(['automate_temporary_zip', '.zip'])
-    temp_file.binmode
-    temp_file.write(import_file_upload.binary_blob.binary)
-    ae_import = MiqAeImport.new("*", "zip_file" => temp_file.path)
-
-    temp_file.unlink
+    ae_import = nil
+    Tempfile.open(['automate_temporary_zip', '.zip']) do |temp_file|
+      temp_file.binmode
+      temp_file.write(import_file_upload.binary_blob.binary)
+      temp_file.close
+      ae_import = MiqAeImport.new("*", "zip_file" => temp_file.path)
+    end
 
     domains = ae_import.domain_entries("*")
 


### PR DESCRIPTION
A previous change to the automate import switched using a temporary `File.new` with `Tempfile`, but after writing, the `Tempfile` was never closed. This causes an error when trying to read the contents, and thus automate imports don't work. This fix simply closes the `Tempfile` after writing to it, and automate imports work again 🎉 . 

The spec has also been updated to ensure that we're writing and then closing after setting the binary mode.

https://bugzilla.redhat.com/show_bug.cgi?id=1427531

/cc @gmcculloug 

@martinpovolny You had originally suggested the use of `Tempfile`, so please review and make sure I didn't forget something else :smile: