### PR TITLE
Moved cb_entities_by_provider_id hash out of @edit

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -164,7 +164,7 @@ module ReportController::Reports::Editor
     build_tabs
 
     get_time_profiles # Get time profiles list (global and user specific)
-
+    cb_entities_by_provider if Chargeback.db_is_chargeback?(@edit[:new][:model])
     case @sb[:miq_tab].split("_")[1]
     when "1"  # Select columns
       @edit[:models] ||= reportable_models
@@ -1283,6 +1283,7 @@ module ReportController::Reports::Editor
       @edit[:new][:cb_interval_size] = options[:interval_size]
       @edit[:new][:cb_end_interval_offset] = options[:end_interval_offset]
       @edit[:new][:cb_groupby] = options[:groupby]
+      cb_entities_by_provider
     end
 
     # Only show chargeback users choice if an admin
@@ -1293,20 +1294,6 @@ module ReportController::Reports::Editor
       @edit[:new][:cb_show_typ] = "owner"
       @edit[:new][:cb_owner_id] = session[:userid]
       @edit[:cb_owner_name] = current_user.name
-    end
-
-    @edit[:cb_providers] = { :container_project => {}, :container_image => {} }
-    @edit[:cb_entities_by_provider_id] = { :container_project => {}, :container_image => {} }
-    ManageIQ::Providers::ContainerManager.includes(:container_projects, :container_images).all.each do |provider|
-      @edit[:cb_providers][:container_project][provider.name] = provider.id
-      @edit[:cb_providers][:container_image][provider.name] = provider.id
-      @edit[:cb_entities_by_provider_id][provider.id] = {:container_project => {}, :container_image => {}}
-      provider.container_projects.all.each do |project|
-        @edit[:cb_entities_by_provider_id][provider.id][:container_project][project.id] = project.name
-      end
-      provider.container_images.all.each do |image|
-        @edit[:cb_entities_by_provider_id][provider.id][:container_image][image.id] = image.name
-      end
     end
 
     # Build trend limit cols array
@@ -1412,6 +1399,22 @@ module ReportController::Reports::Editor
          @edit[:new][:perf_trend_db] + "-" + @edit[:new][:perf_trend_col]
        end.first.include?("(%)")
       @edit[:percent_col] = true
+    end
+  end
+
+  def cb_entities_by_provider
+    @edit[:cb_providers] = { :container_project => {}, :container_image => {} }
+    @cb_entities_by_provider_id = { :container_project => {}, :container_image => {} }
+    ManageIQ::Providers::ContainerManager.includes(:container_projects, :container_images).all.each do |provider|
+      @edit[:cb_providers][:container_project][provider.name] = provider.id
+      @edit[:cb_providers][:container_image][provider.name] = provider.id
+      @cb_entities_by_provider_id[provider.id] = {:container_project => {}, :container_image => {}}
+      provider.container_projects.all.each do |project|
+        @cb_entities_by_provider_id[provider.id][:container_project][project.id] = project.name
+      end
+      provider.container_images.all.each do |image|
+        @cb_entities_by_provider_id[provider.id][:container_image][image.id] = image.name
+      end
     end
   end
 

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -105,8 +105,8 @@
           .col-md-8
             - opts = [["<#{_('Choose %{entity}')}>" % {:entity => ui_lookup(:model => @edit[:new][:cb_model])}, nil],
                       [_("All #{ui_lookup(:tables => @edit[:new][:cb_model].to_s)}"), :all]]
-            - if @edit[:cb_entities_by_provider_id][@edit[:new][:cb_provider_id].to_i].present?
-              - opts += Array(@edit[:cb_entities_by_provider_id][@edit[:new][:cb_provider_id].to_i][@edit[:new][:cb_model].underscore.to_sym].invert).sort_by { |a| a.first.downcase }
+            - if @cb_entities_by_provider_id[@edit[:new][:cb_provider_id].to_i].present?
+              - opts += Array(@cb_entities_by_provider_id[@edit[:new][:cb_provider_id].to_i][@edit[:new][:cb_model].underscore.to_sym].invert).sort_by { |a| a.first.downcase }
             = select_tag('cb_entity_id',
               options_for_select(opts, @edit[:new][:cb_entity_id]),
               :class                 => "selectpicker")

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1285,6 +1285,28 @@ describe ReportController do
       expect(MiqReport.last.db).to eq(chosen_model)
     end
 
+    it "cb_entities_by_provider_id is set for chargeback based reports" do
+      post :x_button, :params => {:pressed => "miq_report_new"}
+      post :form_field_changed, :params => {:id => "new", :chosen_model => "ChargebackContainerImage"}
+      post :form_field_changed, :params => {:id => "new", :title => "test"}
+      post :form_field_changed, :params => {:id => "new", :name => "test"}
+      post :form_field_changed, :params => {:button => "right", :available_fields => ["ChargebackContainerImage-archived"]}
+
+      post :miq_report_edit, :params => {:button => "add"}
+      expect(assigns(:cb_entities_by_provider_id)).not_to be_nil
+    end
+
+    it "cb_entities_by_provider_id is not set for not chargeback reports" do
+      post :x_button, :params => {:pressed => "miq_report_new"}
+      post :form_field_changed, :params => {:id => "new", :chosen_model => "Host"}
+      post :form_field_changed, :params => {:id => "new", :title => "test"}
+      post :form_field_changed, :params => {:id => "new", :name => "test"}
+      post :form_field_changed, :params => {:button => "right", :available_fields => ["Host-name"]}
+
+      post :miq_report_edit, :params => {:button => "add"}
+      expect(assigns(:cb_entities_by_provider_id)).to be_nil
+    end
+
     it 'allows user to remove columns while editing' do
       post :x_button, :params => {:pressed => 'miq_report_new'}
       post :form_field_changed, :params => {:id => 'new', :chosen_model => chosen_model}


### PR DESCRIPTION
Changed code to set @cb_entities_by_provider_id only when adding/copying/editing chargeback reports. Having this data in @edit hash with 30k+ items was exceeding session limit and causing issues.

https://bugzilla.redhat.com/show_bug.cgi?id=1427999

@dclarizio please review.