### PR TITLE
Replace custom “narrow” table class with “table-view-pf-select”

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -227,12 +227,7 @@ table.table tbody td img {
   font-weight: normal
 }
 
-table .narrow {
-  width: 1%;
-  white-space: nowrap;
-}
-
-table .narrow i { /* font icon styling in table view (equivalent to fa-lg) */
+table .table-view-pf-select i { /* font icon styling in table view (equivalent to fa-lg) */
   padding-left: 2px;
   font-size: 1.33333333em;
   line-height: 0.75em;

--- a/app/views/alert/_rss_list.html.haml
+++ b/app/views/alert/_rss_list.html.haml
@@ -17,14 +17,14 @@
                          "data-miq_observe" => {:url => url_for_only_path(:action => 'role_selected')}.to_json)
             = javascript_tag(javascript_focus('role'))
         %tr
-          %th.narrow
+          %th.table-view-pf-select
           %th= _('Title')
           %th= _('Description')
           %th= _('Feed URL')
       %tbody
         - @rss_feeds.each do |feed|
           %tr{:title => _("Subscribe to this feed"), :onclick => "DoNav('#{feed.link}');"}
-            %td.narrow
+            %td.table-view-pf-select
               %i.fa.fa-rss
             %td
               = h(feed.title)

--- a/app/views/catalog/_form_resources_info.html.haml
+++ b/app/views/catalog/_form_resources_info.html.haml
@@ -26,7 +26,7 @@
       %table.table.table-bordered.table-striped
         %thead
           %tr
-            %th.narrow
+            %th.table-view-pf-select
             - [_('Name'), _('Action Order'), _('Provision Order'), _('Action'), _('Delay (mins)')].each_with_index do |title, id|
               %th{:colspan => (id >= 3) ? 2 : 1}
                 = title

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -140,7 +140,7 @@
           %table.table.table-bordered.table-hover.table-striped
             %thead
               %tr
-                %th.narrow
+                %th.table-view-pf-select
                 - titles = [_("Name"), _("Description"), _("Action Order"), _("Provision Order"), _("Action"), _("Delay (mins)")]
                 - colspan = [_("Action"), _("Delay (mins)")]
                 - titles.each do |title|
@@ -163,7 +163,7 @@
                     :onclick     => remote_function(:loading  => "miqSparkle(true);",
                                                     :complete => "miqSparkle(false);",
                                                     :url      => "/catalog/x_show/#{to_cid(r.resource_id)}")}
-                  %td.narrow
+                  %td.table-view-pf-select
                     %i.product.product-template
                   - keys = %w(resource_name resource_description group_idx provision_index start_action stop_action start_delay stop_delay)
                   - keys.each do |key|

--- a/app/views/chargeback/_assignments_list.html.haml
+++ b/app/views/chargeback/_assignments_list.html.haml
@@ -2,12 +2,12 @@
 %table.table.table-striped.table-bordered.table-hover
   %tbody
     %tr{:onclick => remote_function(:url => {:action => 'tree_select', :id => 'xx-Compute'})}
-      %td.narrow{:title => _("Edit Compute Rate Assignments")}
+      %td.table-view-pf-select{:title => _("Edit Compute Rate Assignments")}
         %i.pficon.pficon-cpu
       %td{:title => _("Edit Compute Rate Assignments")}
         = _('Compute')
     %tr{:onclick => remote_function(:url => {:action => 'tree_select', :id => "xx-Storage"})}
-      %td.narrow{:title => _("Edit Storage Rate Assignments")}
+      %td.table-view-pf-select{:title => _("Edit Storage Rate Assignments")}
         %i.fa.fa-hdd-o
       %td{:title => _("Edit Storage Rate Assignments")}
         = _('Storage')

--- a/app/views/chargeback/_rates_list.html.haml
+++ b/app/views/chargeback/_rates_list.html.haml
@@ -2,12 +2,12 @@
 %table.table.table-striped.table-bordered.table-hover
   %tbody
     %tr{:onclick => "miqTreeActivateNode('#{x_active_tree}', 'xx-Compute');"}
-      %td.narrow{:title => _("View Compute Rates")}
+      %td.table-view-pf-select{:title => _("View Compute Rates")}
         %i.pficon.pficon-cpu
       %td{:title => _("View Compute Rates")}
         Compute
     %tr{:onclick => "miqTreeActivateNode('#{x_active_tree}', 'xx-Storage');"}
-      %td.narrow{:title => _("View Storage Rates")}
+      %td.table-view-pf-select{:title => _("View Storage Rates")}
         %i.fa.fa-hdd-o
       %td{:title => _("View Storage Rates")}
         Storage

--- a/app/views/chargeback/_reports_list.html.haml
+++ b/app/views/chargeback/_reports_list.html.haml
@@ -14,7 +14,7 @@
         %tbody
         - @parent_reports.each do |r|
           %tr{:title => _("View this Report"), :onclick => "miqTreeActivateNode('#{x_active_tree}', 'xx-#{r[1]}');"}
-            %td.narrow
+            %td.table-view-pf-select
               %i.fa.fa-file-text-o
             %td
               = r[0]
@@ -27,7 +27,7 @@
       %table.table.table-striped.table-bordered.table-hover
         %thead
           %tr
-            %th.narrow
+            %th.table-view-pf-select
             %th= _('Run On')
             %th= _('Name')
             %th= _('Source')
@@ -36,7 +36,7 @@
             - row_id = "#{x_node}_rr-#{to_cid(row['id'])}"
             %tr
               - t = _("Click to view saved report")
-              %td{:title => t, :onclick => remote_function(:loading => "miqSparkle(true);",
+              %td.table-view-pf-select{:title => t, :onclick => remote_function(:loading => "miqSparkle(true);",
                 :complete => "miqSparkle(false);", :url => {:action => 'tree_select', :id => row_id})}
                 %i.fa.fa-clock-o{:title => _("Saved Report: %{report_name}") % {:report_name => row['name']}}
               %td{:title => t, :onclick => remote_function(:loading => "miqSparkle(true);",

--- a/app/views/configuration/_timeprofile_form.html.haml
+++ b/app/views/configuration/_timeprofile_form.html.haml
@@ -213,13 +213,13 @@
     %table.table.table-striped.table-bordered
       %thead
         %tr
-          %th.narrow
+          %th.table-view-pf-select
           %th= _('Name')
           %th= _('Title')
       %tbody
         - @timeprofile.miq_reports.sort_by { |a| a.name.downcase }.each do |r|
           %tr
-            %td.narrow
+            %td.table-view-pf-select
               %i.fa.fa-file-text-o
             %td= r.name
             %td= r.title

--- a/app/views/configuration/_ui_4.html.haml
+++ b/app/views/configuration/_ui_4.html.haml
@@ -15,7 +15,7 @@
         %tbody
           - @timeprofiles.each do |row|
             %tr
-              %td.narrow
+              %td.table-view-pf-select
                 = check_box_tag("check_#{row['id']}", "1", false, :class => "listcheckbox", :onclick => "miqUpdateButtons(this, 'center_tb');")
               - title = row["description"] == "UTC" ? _("Click to view Time Profile") : _("Click to view/edit Time Profile")
               - [row["description"], row["profile_type"], row["profile_key"],

--- a/app/views/layouts/_classify_table.html.haml
+++ b/app/views/layouts/_classify_table.html.haml
@@ -2,13 +2,13 @@
   %table.table.table-bordered.table-striped.table-hover
     %thead
       %tr
-        %th.narrow
+        %th.table-view-pf-select
         %th= _("Category")
         %th= _("Assigned Value")
     %tbody
       - if session[:assignments].length == 0
         %tr
-          %td.narrow
+          %td.table-view-pf-select
           %td
             - if @tagitems.length == 1
               = _("No %{tenant_name} Tags are assigned") % {:tenant_name => current_tenant.name}

--- a/app/views/layouts/_drift_history.html.haml
+++ b/app/views/layouts/_drift_history.html.haml
@@ -10,7 +10,7 @@
   %table.table.table-bordered.table-striped
     %thead
       %tr
-        %th.narrow
+        %th.table-view-pf-select
         %th
           = _("Timestamp")
     %tbody

--- a/app/views/layouts/_list_grid.html.haml
+++ b/app/views/layouts/_list_grid.html.haml
@@ -45,7 +45,7 @@
   %thead
     %tr
       - grid_hash[:head].each do |h|
-        %th{:class => h[:is_narrow] ? 'narrow' : ''}
+        %th{:class => h[:is_narrow] ? 'table-view-pf-select' : ''}
           - text = translate_header_text(h[:text])
           - if h[:sort]
             %a{:href => '#',

--- a/app/views/layouts/_policy_sim.html.haml
+++ b/app/views/layouts/_policy_sim.html.haml
@@ -20,7 +20,7 @@
               miqInitSelectPicker();
               miqSelectPickerEvent("profile_id", "#{url}", {beforeSend: true, complete: true});
         %tr
-          %th.narrow
+          %th.table-view-pf-select
           %th= _("Policy Profiles in Effect")
       %tbody
         - if session[:policies].length == 0

--- a/app/views/layouts/_tag_edit_assignments.html.haml
+++ b/app/views/layouts/_tag_edit_assignments.html.haml
@@ -2,7 +2,7 @@
   %table.table.table-striped.table-bordered
     %thead
       %tr
-        %th.narrow
+        %th.table-view-pf-select
         %th
           = _("Category")
         %th

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -151,7 +151,7 @@
                                       "ng-change" => "",
                                       "miqrequired" => ""}
 
-                %td.narrow
+                %td.table-view-pf-select
                   %div{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}
                     %button{:class => "btn btn-link", :type => "button", "ng-disabled" => "(#{ng_model}.key === '' || #{ng_model}.key_value === '')", "ng-click" => "vm.saveKeyValue('#{prefix}', $index)"}
                       %i.pficon.pficon-save

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -33,8 +33,8 @@
     %thead
       %tr
         - unless @embedded || @no_checkboxes
-          %th.narrow
-        %th.narrow
+          %th.table-view-pf-select
+        %th.table-view-pf-select
         - view.headers.each_with_index do |h, i|
           - if !@embedded && @pages
             -# Replaced to exclude non-view table fields from sorting
@@ -81,7 +81,7 @@
           - classes.append("no-hover")
         %tr{:class => classes.join(' ')}
           - unless @embedded || @no_checkboxes
-            %td.narrow
+            %td.table-view-pf-select
               = check_box_tag("check_#{@id}", 1, false,
                               :class   => "listcheckbox list-grid-checkbox",
                               :onchange => "miqGridOnCheck(this, '#{button_div}', 'gtl_div');")
@@ -160,7 +160,7 @@
               - click = remote_function(:url => {:action => 'diagnostics_worker_selected', :id => "#{row['id']}"})
             - else
               - click = "DoNav('#{url_for_db(view.db)}');"
-          %td.narrow{:title => title, :onclick => click}
+          %td.table-view-pf-select{:title => title, :onclick => click}
             = listicon_tag(view.db, row)
           - view.col_order.each do |col|
             - title = ""

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -52,7 +52,7 @@
         %table.table.table-striped.table-bordered
           %thead
             %tr
-              %th.narrow
+              %th.table-view-pf-select
               - [_('Name'), _('Type'), _('Data Type'), _('Default Value'), _('Display Name'), _('Description'), _('Sub'), _('Collect'),
                 _('Message'), _('On Entry'), _('On Exit'), _('On Error'), _('Max Retries'), _('Max Time')].each do |title|
                 %th

--- a/app/views/miq_ae_class/_class_instances.html.haml
+++ b/app/views/miq_ae_class/_class_instances.html.haml
@@ -5,7 +5,7 @@
     - if @record.ae_instances.present?
       %table#class_instances_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
         %thead
-          %th.narrow
+          %th.table-view-pf-select
             %input.checkall{:type => 'checkbox', :title => _('Check All')}
           %th
           %th
@@ -14,9 +14,9 @@
             - next if record.name == '$'
             - cls_cid = "#{class_prefix(record.class)}-#{ApplicationRecord.compress_id(record.id)}"
             %tr{'data-click-id' => cls_cid}
-              %td.narrow.noclick
+              %td.table-view-pf-select.noclick
                 %input{:type => 'checkbox', :value => cls_cid}
-              %td.narrow
+              %td.table-view-pf-select
                 %i{:class => record.decorate.fonticon}
               %td
                 = record_name(record)

--- a/app/views/miq_ae_class/_class_methods.html.haml
+++ b/app/views/miq_ae_class/_class_methods.html.haml
@@ -5,7 +5,7 @@
     - if @record.ae_methods.present?
       %table#class_methods_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
         %thead
-          %th.narrow
+          %th.table-view-pf-select
             %input.checkall{:type => 'checkbox', :title => _('Check All')}
           %th
           %th
@@ -14,9 +14,9 @@
             - next if record.name == '$'
             - cls_cid = "#{class_prefix(record.class)}-#{ApplicationRecord.compress_id(record.id)}"
             %tr{'data-click-id' => cls_cid}
-              %td.narrow.noclick
+              %td.table-view-pf-select.noclick
                 %input{:type => 'checkbox', :value => cls_cid}
-              %td.narrow
+              %td.table-view-pf-select
                 %i{:class => record.decorate.fonticon}
               %td
                 = record_name(record)

--- a/app/views/miq_ae_class/_inputs.html.haml
+++ b/app/views/miq_ae_class/_inputs.html.haml
@@ -5,7 +5,7 @@
   %table.table.table-striped.table-bordered.table-hover
     %thead
       %tr
-        %th.narrow
+        %th.table-view-pf-select
         %th= _('Name')
         %th= _('Default Value')
         %th= _('Data Type')

--- a/app/views/miq_ae_class/_ns_details.html.haml
+++ b/app/views/miq_ae_class/_ns_details.html.haml
@@ -4,7 +4,7 @@
     = render :partial => "layouts/flash_msg"
     %table#ns_details_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
       %thead
-        %th.narrow
+        %th.table-view-pf-select
           %input.checkall{:type => 'checkbox', :title => _('Check All')}
         %th
         %th
@@ -13,9 +13,9 @@
           - next if record.name == '$'
           - cls_cid = "#{class_prefix(record.class)}-#{ApplicationRecord.compress_id(record.id)}"
           %tr{'data-click-id' => cls_cid}
-            %td.narrow.noclick
+            %td.table-view-pf-select.noclick
               %input{:type => 'checkbox', :value => cls_cid}
-            %td.narrow
+            %td.table-view-pf-select
               %i{:class => record.decorate.fonticon}
             %td
               = record_name(record)

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -6,7 +6,7 @@
     = render :partial => "layouts/flash_msg"
     %table#ns_list_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
       %thead
-        %th.narrow
+        %th.table-view-pf-select
           %input.checkall{:type => 'checkbox', :title => _('Check All')}
         %th
         %th= _('Name')
@@ -17,9 +17,9 @@
           - next if record.name == '$'
           - cls_cid = "#{class_prefix(record.class)}-#{ApplicationRecord.compress_id(record.id)}"
           %tr{'data-click-id' => cls_cid}
-            %td.narrow.noclick
+            %td.table-view-pf-select.noclick
               %input{:type => 'checkbox', :value => cls_cid}
-            %td.narrow
+            %td.table-view-pf-select
               - if record.git_enabled?
                 %img{:src => image_path('svg/ae_git_domain.svg')}
               - elsif record.name == MiqAeDatastore::MANAGEIQ_DOMAIN

--- a/app/views/miq_ae_customization/_dialog_import_export.html.haml
+++ b/app/views/miq_ae_customization/_dialog_import_export.html.haml
@@ -7,7 +7,7 @@
     %table#import-grid.table.table-striped.table-bordered
       %thead
         %tr
-          %th.narrow
+          %th.table-view-pf-select
             %input{:type => 'checkbox', :id => 'check-all'}
           %th
             = _('Dialog name')
@@ -16,7 +16,7 @@
       %tbody
         - @import.each do |item|
           %tr
-            %td.narrow
+            %td.table-view-pf-select
               %input{:type => 'checkbox', :name => 'dialogs_to_import[]', :value => item[:name]}
             %td
               = item[:name]

--- a/app/views/miq_ae_customization/_field_values.html.haml
+++ b/app/views/miq_ae_customization/_field_values.html.haml
@@ -8,7 +8,7 @@
     %table.table.table-striped.table-bordered.table-hover
       %thead
         %tr
-          %th.narrow
+          %th.table-view-pf-select
           %th.title= _('Value')
           %th.title= _('Description')
       %tbody

--- a/app/views/miq_ae_customization/_old_dialogs_folders.html.haml
+++ b/app/views/miq_ae_customization/_old_dialogs_folders.html.haml
@@ -5,7 +5,7 @@
       - @folders.each do |f|
         %tr{:title => (_("View %{name} Folder") % {:name => f[0]}),
           :onclick => "miqTreeActivateNode('old_dialogs_tree', 'xx-MiqDialog_#{f[1]}');"}
-          %td.narrow
+          %td.table-view-pf-select
             %i.pficon.pficon-folder-close
           %td
             = h(f[0])

--- a/app/views/miq_policy/_action_details.html.haml
+++ b/app/views/miq_policy/_action_details.html.haml
@@ -217,7 +217,7 @@
                   - id = "al-#{to_cid(alert.id)}"
                   %tr{:title => _('View This Alert'),
                     :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=alert")}
-                    %td.narrow
+                    %td.table-view-pf-select
                       %i.pficon.pficon-warning-triangle-o
                       = alert.description
           %hr
@@ -258,7 +258,7 @@
                   - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.downcase}_p-#{to_cid(p.id)}"
                   %tr{:title => _("Click to view Policy"),
                     :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
-                    %td.narrow
+                    %td.table-view-pf-select
                       %i{:class => p.decorate.fonticon}
                     %td
                       = p.description

--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -294,8 +294,8 @@
                       - id = "a-#{to_cid(oa.id)}"
                       %tr{:title => _("View this Action"),
                         :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=action")}
-                        %td.narrow
+                        %td.table-view-pf-select
                           %i{:class => oa.decorate.fonticon}
-                        %td.narrow
+                        %td.table-view-pf-select
                           = oa.description
               %hr

--- a/app/views/miq_policy/_alert_profile_details.html.haml
+++ b/app/views/miq_policy/_alert_profile_details.html.haml
@@ -34,7 +34,7 @@
               - @alert_profile_alerts.each do |a|
                 %tr{:title => _("View this Alert"),
                   :onclick => "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_al-#{to_cid(a.id)}');"}
-                  %td.narrow
+                  %td.table-view-pf-select
                     %i.pficon.pficon-warning-triangle-o
                   %td
                     = h(a.description)

--- a/app/views/miq_policy/_alert_profile_folders.html.haml
+++ b/app/views/miq_policy/_alert_profile_folders.html.haml
@@ -6,7 +6,7 @@
         - @ap_folders.each do |f|
           %tr{:title => _("Open Folder"),
             :onclick => "miqTreeActivateNode('alert_profile_tree', 'xx-#{f.last}');"}
-            %td.narrow
+            %td.table-view-pf-select
               %img{:src => image_path("100/#{f.last.underscore.downcase}.png")}
             %td
               = f.first

--- a/app/views/miq_policy/_alert_profile_list.html.haml
+++ b/app/views/miq_policy/_alert_profile_list.html.haml
@@ -13,7 +13,7 @@
           - @alert_profiles.each do |ap|
             %tr{:title => _("View this Alert Profile"),
               :onclick => "miqTreeActivateNode('alert_profile_tree', 'xx-#{ap.mode}_ap-#{to_cid(ap.id)}');"}
-              %td.narrow
+              %td.table-view-pf-select
                 %i.pficon.pficon-warning-triangle-o
                 = ap.description
   %hr

--- a/app/views/miq_policy/_condition_details.html.haml
+++ b/app/views/miq_policy/_condition_details.html.haml
@@ -88,7 +88,7 @@
                 - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.downcase}_p-#{to_cid(p.id)}"
                 %tr{:title => _("Click to view Policy"),
                   :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
-                  %td.narrow
+                  %td.table-view-pf-select
                     %i{:class => p.decorate.fonticon}
                   %td
                     = p.description

--- a/app/views/miq_policy/_condition_folders.html.haml
+++ b/app/views/miq_policy/_condition_folders.html.haml
@@ -6,7 +6,7 @@
         - @folders.each do |f|
           %tr{:title => _("View Condition"),
             :onclick => "miqTreeActivateNode('condition_tree', 'xx-#{f.camelize(:lower)}');"}
-            %td.narrow
+            %td.table-view-pf-select
               %img{:src => image_path("100/#{f.underscore}.png")}
             %td
               = _("%{object} Conditions") % {:object => ui_lookup(:model => f)}

--- a/app/views/miq_policy/_condition_list.html.haml
+++ b/app/views/miq_policy/_condition_list.html.haml
@@ -15,7 +15,7 @@
           - @conditions.each do |c|
             %tr{:title => _("View this Condition"),
               :onclick => "miqTreeActivateNode('condition_tree', 'xx-#{c.towhat.camelize(:lower)}_co-#{to_cid(c.id)}');"}
-              %td.narrow
+              %td.table-view-pf-select
                 %i.product.product-miq_condition
               %td
                 = c.description

--- a/app/views/miq_policy/_event_details.html.haml
+++ b/app/views/miq_policy/_event_details.html.haml
@@ -26,7 +26,7 @@
                 - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.camelize(:lower)}_p-#{to_cid(p.id)}"
                 %tr{:title => _("Click to view Policy"),
                   :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
-                  %td.narrow
+                  %td.table-view-pf-select
                     %i{:class => p.decorate.fonticon}
                   %td
                     = p.description
@@ -129,7 +129,7 @@
             %table.table.table-striped.table-bordered.table-hover
               %thead
                 %tr
-                  %th.narrow
+                  %th.table-view-pf-select
                   %th= _("Description")
                   %th= _("Synchronous")
                   %th= _("Type")
@@ -140,7 +140,7 @@
                   - f = "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_#{id}');"
                   %tr{:title => _("View this Event Action"),
                     :onclick => (x_active_tree == :action_tree) ? t : f}
-                    %td.narrow
+                    %td.table-view-pf-select
                       %i.pficon.pficon-ok
                     %td
                       = a.description
@@ -252,7 +252,7 @@
             %table.table.table-striped.table-bordered.table-hover
               %thead
                 %tr
-                  %th.narrow
+                  %th.table-view-pf-select
                   %th= _('Description')
                   %th= _('Synchronous')
                   %th= _('Type')
@@ -263,7 +263,7 @@
                   - f = "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_#{id}');"
                   %tr{:title => _("View this Event Action"),
                      :onclick => (x_active_tree == :action_tree) ? t : f}
-                    %td.narrow
+                    %td.table-view-pf-select
                       %i.pficon.pficon-error-circle-o
                     %td
                       = a.description

--- a/app/views/miq_policy/_event_list.html.haml
+++ b/app/views/miq_policy/_event_list.html.haml
@@ -12,7 +12,7 @@
           - @events.each do |e|
             %tr{:title => _("View this Event"),
               :onclick => "miqTreeActivateNode('event_tree', 'ev-#{to_cid(e.id)}');"}
-              %td.narrow
+              %td.table-view-pf-select
                 %i{:class => e.decorate.try(:fonticon)}
               %td
                 = e.description

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -122,14 +122,14 @@
           %table.table.table-striped.table-bordered.table-hover
             %thead
               %tr
-                %th.narrow
+                %th.table-view-pf-select
                 %th= _("Description")
                 %th= _("Scopes / Expressions")
             %tbody
               - @policy_conditions.each do |c|
                 %tr{:title => _("View this Condition"),
                   :onclick => "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_co-#{to_cid(c.id)}');"}
-                  %td.narrow
+                  %td.table-view-pf-select
                     %i{:class => "product product-miq_condition"}
                   %td
                     = c.description
@@ -168,13 +168,13 @@
           %table.table.table-striped.table-bordered.table-hover
             %thead
               %tr
-                %th.narrow
+                %th.table-view-pf-select
                 %th= _("Description")
                 %th= _("Actions")
             %tbody
               - @policy_events.each do |e|
                 %tr
-                  %td.narrow{:title => _("View this Policy Event"),
+                  %td.table-view-pf-select{:title => _("View this Policy Event"),
                     :onclick => "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_ev-#{to_cid(e.id)}');"}
                     %i{:class => e.decorate.try(:fonticon)}
                   %td{:title => _("View this Policy Event"),
@@ -240,7 +240,7 @@
                   - id = "pp-#{to_cid(pp.id)}"
                   %tr{:title => _("View this Profile"),
                     :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy_profile")}
-                    %td.narrow
+                    %td.table-view-pf-select
                       %img{:src => image_path("100/policy_profile#{pp.active? ? '' : '_inactive'}.png")}
                     %td
                       = pp.description

--- a/app/views/miq_policy/_policy_folders.html.haml
+++ b/app/views/miq_policy/_policy_folders.html.haml
@@ -28,7 +28,7 @@
           - type = f.split[-1].downcase
           - click = "#{type}_xx-#{type}-#{model_name}"
         %tr{:onclick => "miqTreeActivateNode('policy_tree', 'xx-#{click}');", :title => _("Open Folder")}
-          %td.narrow
+          %td.table-view-pf-select
             %img{:src => image_path("100/#{model_name.underscore}.png")}
           %td
             = folders_i18n[f]

--- a/app/views/miq_policy/_profile_details.html.haml
+++ b/app/views/miq_policy/_profile_details.html.haml
@@ -87,7 +87,7 @@
             - @profile_policies.each do |p|
               %tr{:title => _("View this %{model} Policy") % {:model => ui_lookup(:model => p.towhat)},
                 :onclick => "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_p-#{to_cid(p.id)}');"}
-                %td.narrow
+                %td.table-view-pf-select
                   %i{:class => p.decorate.fonticon}
                 %td
                   %b

--- a/app/views/miq_policy/_profile_list.html.haml
+++ b/app/views/miq_policy/_profile_list.html.haml
@@ -13,7 +13,7 @@
           - @profiles.each do |profile|
             %tr{:title => _("View this Profile"),
               :onclick => "miqTreeActivateNode('policy_profile_tree', 'profile-#{to_cid(profile.id)}');"}
-              %td.narrow
+              %td.table-view-pf-select
                 %img{:src => image_path("100/policy_profile#{profile.active? ? '' : '_inactive'}.png")}
               %td
                 = profile.description

--- a/app/views/ops/_db_info.html.haml
+++ b/app/views/ops/_db_info.html.haml
@@ -85,7 +85,7 @@
   - else
     %table.table.table-striped.table-bordered.table-hover
       %thead
-        %th.narrow
+        %th.table-view-pf-select
         %th= _("Name")
         %th= _("Rows")
         %th= _("Size")
@@ -95,7 +95,7 @@
         - @indexes.each_with_index do |ind, _|
           %tr{:onclick => "#{remote_function(:url => "/ops/x_show/#{ind.id}")}",
             :title => _("Click to view index")}
-            %td.narrow
+            %td.table-view-pf-select
               %i.fa.fa-table
             %td= ind.name
             - metrics = ind.latest_hourly_metric

--- a/app/views/ops/_diagnostics_savedreports.html.haml
+++ b/app/views/ops/_diagnostics_savedreports.html.haml
@@ -7,7 +7,7 @@
   %table.table.table-striped.table-bordered
     %thead
       %tr
-        %th.narrow
+        %th.table-view-pf-select
         %th= _("Username")
         %th= _("Count")
     %tbody
@@ -16,7 +16,7 @@
           - question = _("Are you sure you want to delete orphaned records for user '%{user}'?") % rec[:userid]
           - onclick = remote_function(:url => {:action => 'orphaned_records_delete', :userid => rec[:userid]}, :confirm => question)
 
-          %td.narrow{:onclick => onclick, :title => _("Click to delete Orphaned Records for this user")}
+          %td.table-view-pf-select{:onclick => onclick, :title => _("Click to delete Orphaned Records for this user")}
             = image_tag(image_path('toolbars/delete.png'), :class => "rollover small")
           %td= h(rec[:userid])
           %td= h(rec[:count])

--- a/app/views/ops/_diagnostics_zones_tab.html.haml
+++ b/app/views/ops/_diagnostics_zones_tab.html.haml
@@ -8,7 +8,7 @@
         %tbody
           - @zones.sort_by(&:name).each do |z|
             %tr{:onclick => "miqTreeActivateNode('diagnostics_tree', 'z-#{to_cid(z.id)}')", :title => _("View this Zone")}
-              %td.narrow
+              %td.table-view-pf-select
                 %i.pficon.pficon-zone
               %td
                 - if my_zone_name == z.name

--- a/app/views/ops/_ldap_domain_show.html.haml
+++ b/app/views/ops/_ldap_domain_show.html.haml
@@ -104,14 +104,14 @@
   - else
     %table.table.table-striped.table-bordered.table-hover
       %thead
-        %th.narrow
+        %th.table-view-pf-select
         %th= _("Hostname")
         %th= _("Mode")
         %th= _("Port")
       %tbody
         - @selected_ld.ldap_servers.sort_by { |svr| svr.hostname.to_s }.each do |svr|
           %tr{:class => "no-hover #{cycle('row0', 'row1')}"}
-            %td.narrow
+            %td.table-view-pf-select
               %i.pficon.pficon-server
             %td
               = svr.hostname

--- a/app/views/ops/_ldap_forest_entries.html.haml
+++ b/app/views/ops/_ldap_forest_entries.html.haml
@@ -8,7 +8,7 @@
     %table.table.table-striped.table-bordered.table-hover
       %thead
         %tr
-          %th.narrow
+          %th.table-view-pf-select
           %th= _("LDAP Hostname")
           %th= _("Mode")
           %th= _("LDAP Port")

--- a/app/views/ops/_ldap_region_show.html.haml
+++ b/app/views/ops/_ldap_region_show.html.haml
@@ -27,7 +27,7 @@
   - else
     %table.table.table-striped.table-bordered.table-hover
       %thead
-        %th.narrow
+        %th.table-view-pf-select
         %th= _("Name")
         %th= _("Base DN")
         %th= _("User Type")
@@ -35,7 +35,7 @@
       %tbody
         - @selected_lr.ldap_domains.sort_by { |d| d.name.to_s }.each do |domain|
           %tr{:onclick => "miqTreeActivateNode('settings_tree', 'ld-#{to_cid(domain.id)}');", :title => _("Click to view details")}
-            %td.narrow
+            %td.table-view-pf-select
               %i.product.product-domain
             %td
               = domain.name

--- a/app/views/ops/_ldap_server_entries.html.haml
+++ b/app/views/ops/_ldap_server_entries.html.haml
@@ -5,7 +5,7 @@
     %table.table.table-striped.table-bordered.table-hover
       %thead
         %tr
-          %th.narrow
+          %th.table-view-pf-select
           %th= _("Hostname")
           %th= _("Mode")
           %th= _("Port")

--- a/app/views/ops/_rbac_details_tab.html.haml
+++ b/app/views/ops/_rbac_details_tab.html.haml
@@ -23,25 +23,25 @@
       %tbody
         - if role_allows?(:feature => "rbac_user_view", :any => true)
           %tr
-            %td.narrow{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-u');", :title => _("View Users")}
+            %td.table-view-pf-select{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-u');", :title => _("View Users")}
               %i.pficon.pficon-user
             %td{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-u');", :title => _("View Users")}
               = _("Users (%{users_count})") % {:users_count => @users_count.to_s}
         - if role_allows?(:feature => "rbac_group_view", :any => true)
           %tr
-            %td.narrow{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-g');", :title => _("View Groups")}
+            %td.table-view-pf-select{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-g');", :title => _("View Groups")}
               %i.product.product-group
             %td{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-g');", :title => _("View Groups")}
               = _("Groups (%{groups_count})") % {:groups_count => @groups_count.to_s}
         - if role_allows?(:feature => "rbac_role_view", :any => true)
           %tr
-            %td.narrow{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-ur');", :title => _("View Roles")}
+            %td.table-view-pf-select{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-ur');", :title => _("View Roles")}
               %i.product.product-role
             %td{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-ur');", :title => _("View Roles")}
               = _("Roles (%{roles_count})") % {:roles_count => @roles_count.to_s}
         - if role_allows?(:feature => "rbac_tenant_view", :any => true)
           %tr
-            %td.narrow{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-tn');", :title => _("View Tenants")}
+            %td.table-view-pf-select{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-tn');", :title => _("View Tenants")}
               %i.pficon.pficon-tenant
             %td{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-tn');", :title => _("View Tenants")}
               = _("Tenants (%{tenants_count})") % {:tenants_count => @tenants_count.to_s}

--- a/app/views/ops/_rbac_tenant_details.html.haml
+++ b/app/views/ops/_rbac_tenant_details.html.haml
@@ -43,13 +43,13 @@
     %h3= _("Child Tenants")
     %table.table.table-striped.table-bordered.table-hover
       %thead
-        %th.narrow
+        %th.table-view-pf-select
         %th= _("Name")
         %tbody
           - all_subtenants.each do |tenant|
             %tr{:onclick => "miqTreeActivateNode('rbac_tree', 'tn-#{to_cid(tenant.id)}');",
               :title => _("Click to view child Tenant")}
-              %td.narrow
+              %td.table-view-pf-select
                 %i.pficon.pficon-tenant
               %td= tenant.name
   - all_subprojects = @tenant.all_subprojects
@@ -57,13 +57,13 @@
     %h3= _("Projects")
     %table.table.table-striped.table-bordered.table-hover
       %thead
-        %th.narrow
+        %th.table-view-pf-select
         %th= _("Name")
         %tbody
           - all_subprojects.each do |tenant|
             %tr{:onclick => "miqTreeActivateNode('rbac_tree', 'tn-#{to_cid(tenant.id)}');",
               :title => _("Click to view child TenantProject")}
-              %td.narrow
+              %td.table-view-pf-select
                 %i.pficon.pficon-project
               %td= tenant.name
   .row

--- a/app/views/ops/_settings_details_tab.html.haml
+++ b/app/views/ops/_settings_details_tab.html.haml
@@ -29,32 +29,32 @@
       %tbody
         - unless @edit
           %tr
-            %td.narrow{:onclick => remote_function(:url => {:action => 'region_edit', :id => region.id}), :title => _("Edit this Region")}
+            %td.table-view-pf-select{:onclick => remote_function(:url => {:action => 'region_edit', :id => region.id}), :title => _("Edit this Region")}
               %i.pficon.pficon-regions
             %td{:onclick => remote_function(:url => {:action => 'region_edit', :id => region.id}), :title => _("Edit this Region")}
               = h(region.description)
               [#{h(region.region)}]
         %tr
-          %td.narrow{:onclick => "miqTreeActivateNode('settings_tree', 'xx-sis');", :title => _("View Analysis Profiles")}
+          %td.table-view-pf-select{:onclick => "miqTreeActivateNode('settings_tree', 'xx-sis');", :title => _("View Analysis Profiles")}
             %i.fa.fa-search
           %td{:onclick => "miqTreeActivateNode('settings_tree', 'xx-sis');", :title => _("View Analysis Profiles")}
             = _("Analysis Profiles")
             (#{h(@scan_items.size)})
         %tr
-          %td.narrow{:onclick => "miqTreeActivateNode('settings_tree', 'xx-z');", :title => _("View Zones")}
+          %td.table-view-pf-select{:onclick => "miqTreeActivateNode('settings_tree', 'xx-z');", :title => _("View Zones")}
             %i.pficon.pficon-zone
           %td{:onclick => "miqTreeActivateNode('settings_tree', 'xx-z');", :title => _("View Zones")}
             = _("Zones")
             (#{h(@zones.size)})
         %tr
-          %td.narrow{:onclick => "miqTreeActivateNode('settings_tree', 'xx-msc');", :title => _("View Schedules")}
+          %td.table-view-pf-select{:onclick => "miqTreeActivateNode('settings_tree', 'xx-msc');", :title => _("View Schedules")}
             %i.fa.fa-clock-o
           %td{:onclick => "miqTreeActivateNode('settings_tree', 'xx-msc');", :title => _("View Schedules")}
             = _("Schedules")
             (#{h(@miq_schedules.size)})
         - if ::Settings.product.new_ldap
           %tr
-            %td.narrow{:onclick => "miqTreeActivateNode('settings_tree', 'xx-l');", :title => _("View LDAP Regions")}
+            %td.table-view-pf-select{:onclick => "miqTreeActivateNode('settings_tree', 'xx-l');", :title => _("View LDAP Regions")}
               %i.pficon.pficon-regions
             %td{:onclick => "miqTreeActivateNode('settings_tree', 'xx-l');", :title => _("View LDAP Regions")}
               = _("LDAP Regions")

--- a/app/views/ops/_settings_evm_servers_tab.html.haml
+++ b/app/views/ops/_settings_evm_servers_tab.html.haml
@@ -70,7 +70,7 @@
         %tbody
           - @servers.sort_by(&:id).each do |s|
             %tr{:onclick => "miqTreeActivateNode('settings_tree', 'svr-#{to_cid(s.id)}');", :title => _("View this MiqServer")}
-              %td.narrow
+              %td.table-view-pf-select
                 %i.pficon.pficon-server
               %td
                 - if my_server.id == s.id

--- a/app/views/ops/_settings_list_tab.html.haml
+++ b/app/views/ops/_settings_list_tab.html.haml
@@ -9,7 +9,7 @@
         %tbody
           - @zones.sort_by(&:description).each do |z|
             %tr{:onclick => "miqTreeActivateNode('settings_tree', 'z-#{to_cid(z.id)}');", :title => _("View this Zone's settings")}
-              %td.narrow
+              %td.table-view-pf-select
                 %i.pficon.pficon-zone
               %td
                 - if my_zone_name == z.name

--- a/app/views/ops/_tenant_quota_form.html.haml
+++ b/app/views/ops/_tenant_quota_form.html.haml
@@ -20,7 +20,7 @@
               = _("Units")
         %tbody
           %tr{"ng-repeat" => "(quota_name, quota_obj) in tenantQuotaModel.quotas", "ng-form" => "rowForm", "ng-class" => "{'has-error': rowForm.value.$invalid}"}
-            %td.narrow
+            %td.table-view-pf-select
               %input{"bs-switch"  => "",
                     "id"          => "{{quota_name}}",
                     "type"        => "checkbox",

--- a/app/views/ops/rhn/_server_table.html.haml
+++ b/app/views/ops/rhn/_server_table.html.haml
@@ -58,7 +58,7 @@
     %tbody
       - Array(@updates).each do |update|
         %tr
-          %td.narrow
+          %td.table-view-pf-select
             = check_box_tag("check_server_#{update.id}", 1,
                             update.checked,
                             :class => 'listcheckbox',

--- a/app/views/pxe/_template_folders.html.haml
+++ b/app/views/pxe/_template_folders.html.haml
@@ -5,13 +5,13 @@
       %tbody
         %tr{:title => _("View Examples (read only)' Folder"),
           :onclick => "miqTreeActivateNode('customization_templates_tree', 'xx-xx-system');"}
-          %td.narrow
+          %td.table-view-pf-select
             %i.pficon.pficon-folder-close
           %td Examples (read only)
         - @folders.each do |f|
           %tr{:title => _("View '%{name}' Folder") % {:name => f.name},
             :onclick => "miqTreeActivateNode('customization_templates_tree', 'xx-xx-#{to_cid(f.id)}');"}
-            %td.narrow
+            %td.table-view-pf-select
               %i.pficon.pficon-folder-close
             %td
               = h(f.name)

--- a/app/views/report/_db_list.html.haml
+++ b/app/views/report/_db_list.html.haml
@@ -4,14 +4,14 @@
     %table.table.table-striped.table-bordered.table-hover
       %thead
         %tr
-          %th.narrow
+          %th.table-view-pf-select
           %th
             = _('Type')
       %tbody
         - @db_nodes_order.each do |node|
           %tr{:title => _("Click to view '%{title}'") % {:title => @db_nodes[node][:title]},
             :onclick => "miqTreeActivateNode('#{@sb[:active_tree]}', '#{@db_nodes[node][:id]}');"}
-            %td.narrow{:nowrap => 1}
+            %td.table-view-pf-select{:nowrap => 1}
               %i{:class => @db_nodes[node][:glyph]}
             %td
               = h(@db_nodes[node][:text])
@@ -21,14 +21,14 @@
     %table.table.table-striped.table-bordered.table-hover
       %thead
         %tr
-          %th.narrow
+          %th.table-view-pf-select
           %th
             = _('Description')
       %tbody
         - @miq_groups.sort_by(&:description).each do |g|
           %tr{:onclick => remote_function(:loading => "miqSparkle(true);", :complete => "miqSparkle(false);",
               :url => {:action => 'tree_select', :id => "xx-g_g-#{to_cid(g.id)}"}), :title => _("Click to view %{group} ") % {:group => g.description}, :class => "icon"}
-            %td.narrow
+            %td.table-view-pf-select
               %i.product.product-group
             %td
               = h(g.description)
@@ -40,14 +40,14 @@
       %table.table.table-striped.table-bordered.table-hover
         %thead
           %tr
-            %th.narrow
+            %th.table-view-pf-select
             %th
               = _('Description')
         %tbody
           - @widgetsets.sort_by { |widgetset| widgetset.name.downcase }.each do |ws|
             %tr{:onclick => remote_function(:loading => "miqSparkle(true);", :complete => "miqSparkle(false);", :url => {:action => 'tree_select',
                 :id => "xx-g_g-#{@sb[:nodes][2]}_-#{to_cid(ws.id)}"}), :title => _("Click to view '%{widgetset_description} (%{widgetset_name})'") % {:widgetset_description => ws.description, :widgetset_name => ws.name}, :class => "icon"}
-              %td.narrow
+              %td.table-view-pf-select
                 %i.fa.fa-dashboard{:title => ws.description}
               %td
                 = "#{h(ws.description)} (#{h(ws.name)})"

--- a/app/views/report/_export_widgets.html.haml
+++ b/app/views/report/_export_widgets.html.haml
@@ -7,7 +7,7 @@
     %table.table.table-striped.table-bordered
       %thead
         %tr
-          %th.narrow
+          %th.table-view-pf-select
             %input{:type => 'checkbox', :id => 'check-all'}
           %th
             = _('Widget name')
@@ -16,7 +16,7 @@
       %tbody
         - @import.each do |item|
           %tr
-            %td.narrow
+            %td.table-view-pf-select
               %input{:type => 'checkbox', :name => 'widgets_to_import[]', :value => item[:name]}
             %td.treegrid-node
               = item[:name]

--- a/app/views/report/_report_info.html.haml
+++ b/app/views/report/_report_info.html.haml
@@ -53,7 +53,7 @@
   - else
     %table.table.table-striped.table-bordered.table-hover
       %thead
-        %th.narrow
+        %th.table-view-pf-select
         %th
           = _('Name')
         %th
@@ -79,7 +79,7 @@
           - else
             - params = {}
           %tr{params}
-            %td.narrow
+            %td.table-view-pf-select
               %i.fa.fa-clock-o
             %td
               = s.name
@@ -109,7 +109,7 @@
   - else
     %table.table.table-striped.table-bordered.table-hover
       %thead
-        %th.narrow
+        %th.table-view-pf-select
         %th
           = _('Title')
         %th
@@ -124,7 +124,7 @@
           - else
             - params = {}
           %tr{params}
-            %td.narrow
+            %td.table-view-pf-select
               %i.fa.fa-file-text-o
             %td
               = h(w.title)

--- a/app/views/report/_report_list.html.haml
+++ b/app/views/report/_report_list.html.haml
@@ -33,11 +33,11 @@
             - @sb[:rpt_menu].each_with_index do |folder, i|
               - if i == 0
                 %thead
-                  %th.narrow
+                  %th.table-view-pf-select
                   %th
                     = _("Name")
               %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('reports_tree','xx-#{i}');"}
-                %td.narrow
+                %td.table-view-pf-select
                   - if folder[0] == @sb[:grp_title]
                     - glyphicon = "pficon pficon-folder-close-blue"
                   - else
@@ -52,11 +52,11 @@
             - @sb[:rpt_menu][nodes[1].to_i][1].each_with_index do |folder, i|
               - if i == 0
                 %thead
-                  %th.narrow
+                  %th.table-view-pf-select
                   %th
                     = _('Name')
               %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('reports_tree','xx-#{nodes[1].to_i}_xx-#{nodes[1].to_i}-#{i}');"}
-                %td.narrow
+                %td.table-view-pf-select
                   %i.pficon{:class => "pficon-folder-close#{@sb[:rpt_menu][nodes[1].to_i][0] == @sb[:grp_title] ? '-blue' : ''}"}
                 %td
                   -# removing :::#{@sb[:count]} that was added at the end of report name to make id's unique in the tree
@@ -68,7 +68,7 @@
               - if i == 0
                 %thead
                   -# had to move <th> inside loop to show following columns only when report node is selected in tree
-                  %th.narrow
+                  %th.table-view-pf-select
                   %th
                     = _('Name')
                   %th
@@ -85,7 +85,7 @@
                     = Dictionary.gettext("MiqGroup", :type => :model, :notfound => :titleize)
               - if @sb[:rep_details][rep]
                 %tr{:title => _('Click to view details'), :onclick => "miqTreeActivateNode('reports_tree','xx-#{nodes[1].to_i}_xx-#{nodes[2].to_i}-#{nodes[3].to_i}_rep-#{to_cid(@sb[:rep_details][rep]["id"])}');"}
-                  %td.narrow
+                  %td.table-view-pf-select
                     %i.fa.fa-file-text-o
                   %td
                     -# removing :::#{@sb[:count]} that was added at the end of report name to make id's unique in the tree

--- a/app/views/report/_role_list.html.haml
+++ b/app/views/report/_role_list.html.haml
@@ -18,7 +18,7 @@
           %tbody
             - @sb[:menu].invert.each do |pp|
               %tr{:title => _("View this Profile"), :onclick => "miqTreeActivateNode('#{@sb[:active_tree]}', 'g-#{to_cid(pp[1])}');"}
-                %td.narrow
+                %td.table-view-pf-select
                   %i.product.product-group
                 %td
                   = pp[0]

--- a/app/views/shared/buttons/_ab_list.html.haml
+++ b/app/views/shared/buttons/_ab_list.html.haml
@@ -20,7 +20,7 @@
     = render :partial => "layouts/flash_msg"
     %table.table.table-bordered.table-hover.table-striped
       %thead
-        %th.narrow
+        %th.table-view-pf-select
         %th
           = _('Text')
         - if x_active_tree == :sandt_tree
@@ -32,7 +32,7 @@
         - @sb[:button_groups].each do |obj|
           - if obj.kind_of?(String)
             %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('ab_tree', '-ub-#{@nodetype[1]}')"}
-              %td.narrow
+              %td.table-view-pf-select
                 %i{:class => "pficon pficon-folder-close"}
               %td
                 = obj
@@ -50,7 +50,7 @@
               - img = obj[:button_image]
               - rec_type = "Group"
             %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('#{tree_box}', '#{tree_id}_#{typ}-#{to_cid(obj[:id])}')"}
-              %td.narrow
+              %td.table-view-pf-select
                 %i{:class => "product product-custom-#{img}"}
               %td
                 = obj[:name].split("|").first
@@ -93,7 +93,7 @@
     %hr
     %table.table.table-bordered.table-hover.table-striped
       %thead
-        %th.narrow
+        %th.table-view-pf-select
         %th
           = _('Text')
         %th
@@ -103,7 +103,7 @@
           - tree_box = x_active_tree == :sandt_tree ? 'sandt_tree' : 'ab_tree'
           - id = @nodetype[0].split('-')[1] == "ub" ? "#{@nodetype[0]}_cb-#{to_cid(obj[:id])}" : "#{x_node}_cb-#{to_cid(obj[:id])}"
           %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('#{tree_box}', '#{id}')"}
-            %td.narrow
+            %td.table-view-pf-select
               %i{:class => "product product-custom-#{obj[:button_image]}"}
             %td
               = obj[:name]

--- a/app/views/storage/_storage_pod_folders.html.haml
+++ b/app/views/storage/_storage_pod_folders.html.haml
@@ -6,7 +6,7 @@
         - @folders.each do |f|
           %tr{:title => _("View '%{name}' Cluster") % {:name => f.name},
             :onclick => "miqTreeActivateNode('storage_pod_tree', 'xx-#{f.id}');"}
-            %td.narrow
+            %td.table-view-pf-select
               %i.pficon.pficon-folder-close
             %td
               = h(f.name)

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -126,10 +126,10 @@
           %th= _('Type')
           %th{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Mode')
           %th= _('Size')
-          %th.narrow
-          %th.narrow{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Dependent')
-          %th.narrow= _('Delete Backing')
-          %th.narrow{"ng-if" => @reconfigitems.first.vendor == 'redhat'}= _('Bootable')
+          %th.table-view-pf-select
+          %th.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Dependent')
+          %th.table-view-pf-select= _('Delete Backing')
+          %th.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'redhat'}= _('Bootable')
           %th= _('Actions')
         %tbody
           %tr{"ng-if"       => "reconfigureModel.addEnabled",
@@ -163,7 +163,7 @@
                                   "ng-change"   => "hdChanged()"}
               %span{"style" => "color:red", "ng-show" => "rowForm.dvcSize.$invalid"}
                 = _(" Valid numeric disk size required ")
-            %td.narrow
+            %td.table-view-pf-select
               = select_tag('hdUnit',
                        options_for_select(%w(MB GB)),
                        "ng-model"                    => "reconfigureModel.hdUnit",
@@ -171,14 +171,14 @@
                        "data-width"                  => "auto",
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
-            %td.narrow{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
+            %td.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
               %input{"bs-switch" => "",
                      :data       => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"      => "checkbox",
                      "name"      => "cb_dependent",
                      "ng-model"  => "reconfigureModel.cb_dependent"}
-            %td.narrow
-            %td.narrow{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
+            %td.table-view-pf-select
+            %td.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
               %input{"bs-switch" => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",
@@ -195,9 +195,9 @@
               {{disk.hdMode}}
             %td
               {{disk.hdSize}}
-            %td.narrow
+            %td.table-view-pf-select
               {{disk.hdUnit}}
-            %td.narrow{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
+            %td.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
               %input{"bs-switch"     => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",
@@ -206,7 +206,7 @@
                      "switch-active" => "{{disk.add_remove!='add'}}",
                      "ng-readonly"   => "disk.add_remove=='add'",
                      "ng-if"         => "disk.add_remove=='add'"}
-            %td.narrow
+            %td.table-view-pf-select
               %input{"bs-switch"     => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",
@@ -215,7 +215,7 @@
                      "ng-readonly"   => "disk.add_remove=='remove'",
                      "switch-active" => "{{disk.add_remove!='remove'}}",
                      "ng-if"         => "disk.add_remove!='add'"}
-            %td.narrow{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
+            %td.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
               %input{"bs-switch"     => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",


### PR DESCRIPTION
This PR replaces the custom "narrow" table class with the recently added Patternfly "table-view-pf-select" class, which styles a narrow table cell that can be utilized for checkboxes, icons, etc.

https://www.pivotaltracker.com/n/projects/1613907/stories/129462395

Old
<img width="479" alt="screen shot 2017-03-01 at 4 01 08 pm" src="https://cloud.githubusercontent.com/assets/1287144/23481127/54be5018-fe98-11e6-9088-1cb8dc4487f1.png">

New
<img width="425" alt="screen shot 2017-03-01 at 4 02 47 pm" src="https://cloud.githubusercontent.com/assets/1287144/23481187/8f8f97e2-fe98-11e6-8ea5-b84b448a9d78.png">

