### PR TITLE
Enable Add button when copying an existing report.

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1391,6 +1391,7 @@ module ReportController::Reports::Editor
     end
 
     @edit[:current] = ["copy", "new"].include?(params[:action]) ? {} : copy_hash(@edit[:new])
+    @edit[:new][:name] = "Copy of #{@rpt.name}" if params[:pressed] == "miq_report_copy"
 
     # For trend reports, check for percent field chosen
     if @rpt.db && @rpt.db == TREND_MODEL &&


### PR DESCRIPTION
Prefixed report name with "Copy of" to enable Add button when copying a report

https://bugzilla.redhat.com/show_bug.cgi?id=1428132

before:
![before](https://cloud.githubusercontent.com/assets/3450808/23484851/b45a6d78-fea6-11e6-974e-72d5ccd736b3.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/23484854/b8056ea0-fea6-11e6-8dc9-8be455bea239.png)

@dclarizio please review.