### PR TITLE
Use the proper EAP icon for EAP 6.4 instead of using default icon

### DIFF
--- a/app/decorators/middleware_server_decorator.rb
+++ b/app/decorators/middleware_server_decorator.rb
@@ -7,7 +7,7 @@ class MiddlewareServerDecorator < MiqDecorator
     case product
     when 'Hawkular'
       'svg/vendor-hawkular.svg'
-    when 'JBoss EAP'
+    when /EAP$/
       'svg/vendor-jboss-eap.svg'
     else
       'svg/vendor-wildfly.svg'


### PR DESCRIPTION
We recently added the ability to pull in EAP 6.4 servers (in addition to EAP 7) however, the icon shows as the default Hawkular icon and not a EAP icon. This PR fixes that.

![manageiq__middleware_servers](https://cloud.githubusercontent.com/assets/1312165/23487126/f15a1b5a-fe98-11e6-840a-cc5ae30e62ab.jpg)

![manageiq__middleware_servers](https://cloud.githubusercontent.com/assets/1312165/23487146/0458f47e-fe99-11e6-9acc-6df7748c51b0.jpg)

**Refer to BZ1426313: https://bugzilla.redhat.com/show_bug.cgi?id=1426313**
