### PR TITLE
container node condition displayed with multilabel

### DIFF
--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -25,17 +25,19 @@ module ContainerNodeHelper::TextualSummary
   end
 
   def textual_group_conditions
-    labels = [_("Name"), _("Status"), _("Last Transition Time"), _("Reason")]
-    h = {:labels => labels}
-    h[:values] = @record.container_conditions.collect do |condition|
-      [
-        condition.name,
-        condition.status,
-        (condition.last_transition_time || ""),
-        (condition.reason || "")
-      ]
-    end
-    TextualGroup.new(_("Conditions"), h)
+    TextualMultilabel.new(
+      _("Conditions"),
+      :additional_table_class => "table-fixed",
+      :labels                 => [_("Name"), _("Status"), _("Last Transition Time"), _("Reason")],
+      :values                 => @record.container_conditions.collect do |condition|
+        [
+          condition.name,
+          condition.status,
+          (condition.last_transition_time || ""),
+          (condition.reason || "")
+        ]
+      end
+    )
   end
 
   def textual_group_smart_management


### PR DESCRIPTION
The conditions for container node should be displayed with multilabel.


before:
![container_node_conditions_without_multilabel](https://cloud.githubusercontent.com/assets/3123328/23501067/090204e6-ff3b-11e6-94fb-5defed190514.png)
-------
after:
![container_node_conditions_with_multilabel](https://cloud.githubusercontent.com/assets/3123328/23501088/278e7f52-ff3b-11e6-832b-b42e224a95a4.png)
