### PR TITLE
Ansible Service summary screen

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1070,7 +1070,7 @@ function miq_tabs_init(id, url) {
   $(id + ' > ul.nav-tabs a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
     // Refresh CodeMirror when its tab is toggled
     if ($($(e.target).attr('href')).hasClass('cm-tab') && typeof(ManageIQ.editor) != 'undefined') {
-      ManageIQ.editor.refresh();
+      miq_refresh_code_mirror();
     }
   });
 
@@ -1090,6 +1090,13 @@ function miq_tabs_init(id, url) {
   } else if ($(id + ' > ul.nav-tabs > li:not(.hidden)').length > 1) {
     $(id + ' > ul.nav-tabs').show();
   }
+}
+
+// refresh multiple/single code mirror textboxes on screen
+function miq_refresh_code_mirror() {
+  $('.CodeMirror').each(function(_i, el){
+    el.CodeMirror.refresh();
+  });
 }
 
 function miq_tabs_disable_inactive(id) {

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -141,12 +141,12 @@ class ServiceController < ApplicationController
   helper_method :textual_group_list
 
   def textual_provisioning_group_list
-    [%i(provisioning_results), %i(provisioning_details), %i(provisioning_credentials), %i(provisioning_stdout)]
+    [%i(provisioning_results), %i(provisioning_details), %i(provisioning_credentials), %i(provisioning_plays)]
   end
   helper_method :textual_provisioning_group_list
 
   def textual_retirement_group_list
-    [%i(retirement_results), %i(retirement_details), %i(retirement_credentials), %i(retirement_stdout)]
+    [%i(retirement_results), %i(retirement_details), %i(retirement_credentials), %i(retirement_plays)]
   end
   helper_method :textual_retirement_group_list
 

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -141,12 +141,12 @@ class ServiceController < ApplicationController
   helper_method :textual_group_list
 
   def textual_provisioning_group_list
-    [%i(provisioning_results), %i(provisioning_details), %i(provisioning_credentials), %i(provisioning_plays)]
+    [%i(provisioning_results provisioning_plays), %i(provisioning_details provisioning_credentials)]
   end
   helper_method :textual_provisioning_group_list
 
   def textual_retirement_group_list
-    [%i(retirement_results), %i(retirement_details), %i(retirement_credentials), %i(retirement_plays)]
+    [%i(retirement_results retirement_plays), %i(retirement_details retirement_credentials)]
   end
   helper_method :textual_retirement_group_list
 

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -132,9 +132,23 @@ class ServiceController < ApplicationController
   private
 
   def textual_group_list
-    [%i(properties lifecycle relationships miq_custom_attributes), %i(vm_totals tags)]
+    if @record.type == "ServiceAnsiblePlaybook"
+      [%i(properties)]
+    else
+      [%i(properties lifecycle relationships miq_custom_attributes), %i(vm_totals tags)]
+    end
   end
   helper_method :textual_group_list
+
+  def textual_provisioning_group_list
+    [%i(provisioning_results), %i(provisioning_details), %i(provisioning_credentials), %i(provisioning_stdout)]
+  end
+  helper_method :textual_provisioning_group_list
+
+  def textual_retirement_group_list
+    [%i(retirement_results), %i(retirement_details), %i(retirement_credentials), %i(retirement_stdout)]
+  end
+  helper_method :textual_retirement_group_list
 
   def features
     [ApplicationController::Feature.new_with_hash(:role     => "service",

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -252,6 +252,7 @@ module ServiceHelper::TextualSummary
       [
         play.name,
         format_timezone(play.start_time),
+        format_timezone(play.finish_time),
         play.finish_time && play.start_time ? calculate_elapsed_time(play.start_time, play.finish_time) : '/A'
       ]
     end.sort
@@ -259,7 +260,7 @@ module ServiceHelper::TextualSummary
     TextualTable.new(
       _("Plays"),
       items,
-      [_("Name"), _("Start Time"), _("Elapsed Time")]
+      [_("Name"), _("Started"), _("Finished"),_("Elapsed")]
     )
   end
 

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -27,7 +27,7 @@ module ServiceHelper::TextualSummary
 
   def textual_group_provisioning_plays
     return nil unless provisioning_get_job
-    get_job_plays
+    fetch_job_plays
   end
 
   def textual_group_retirement_results
@@ -47,7 +47,7 @@ module ServiceHelper::TextualSummary
 
   def textual_group_retirement_plays
     return nil unless retirement_get_job
-    get_job_plays
+    fetch_job_plays
   end
 
   def textual_group_vm_totals
@@ -219,35 +219,39 @@ module ServiceHelper::TextualSummary
   def textual_machine_credential
     credential = @job.authentications.find_by(:type => 'ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential')
     return nil unless credential
-    {:label => _("Machine"), :value => credential.name}
+    credential(credential, _("Machine"))
   end
 
   def textual_network_credential
     credential = @job.authentications.find_by(:type => 'ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential')
     return nil unless credential
-    {:label => _("Network"), :value => credential.name}
+    credential(credential, _("Network"))
   end
 
   def textual_cloud_credential
     credential = @job.authentications.find_by(:type => 'ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential')
     return nil unless credential
-    {:label => _("Cloud"), :value => credential.name}
+    credential(credential, _("Cloud"))
+  end
+
+  def credential(credential, label)
+    {:label => label, :value => credential.name}
   end
 
   def provisioning_get_job
-    get_job("Provision")
+    fetch_job("Provision")
   end
 
   def retirement_get_job
-    get_job("Retirement")
+    fetch_job("Retirement")
   end
 
-  def get_job(type)
+  def fetch_job(type)
     @job = @record.try(:job, type)
     @job
   end
 
-  def get_job_plays
+  def fetch_job_plays
     items = @job.job_plays.sort_by(&:start_time).collect do |play|
       [
         play.name,
@@ -260,13 +264,13 @@ module ServiceHelper::TextualSummary
     TextualTable.new(
       _("Plays"),
       items,
-      [_("Name"), _("Started"), _("Finished"),_("Elapsed")]
+      [_("Name"), _("Started"), _("Finished"), _("Elapsed")]
     )
   end
 
   def calculate_elapsed_time(stime, ftime)
     val = (ftime - stime)
-    hours   = val / 3600
+    hours = val / 3600
     mins = val / 60
     secs = val % 60
     ("%02d:%02d:%02d" % [hours, mins, secs])

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -10,6 +10,46 @@ module ServiceHelper::TextualSummary
     TextualGroup.new(_("Properties"), %i(name description guid))
   end
 
+  def textual_group_provisioning_results
+    return nil unless provisioning_get_job
+    TextualGroup.new(_("Results"), %i(status start_time finish_time elapsed_time owner))
+  end
+
+  def textual_group_provisioning_details
+    return nil unless provisioning_get_job
+    TextualGroup.new(_("Details"), %i(playbook repository verbosity hosts))
+  end
+
+  def textual_group_provisioning_credentials
+    return nil unless provisioning_get_job
+    TextualGroup.new(_("Credentials"), %i(machine_credential network_credential cloud_credential))
+  end
+
+  def textual_group_provisioning_stdout
+    return nil unless provisioning_get_job
+    TextualGroup.new(_("Standard Output"), %i(stdout))
+  end
+
+  def textual_group_retirement_results
+    return nil unless retirement_get_job
+    TextualGroup.new(_("Results"), %i(status start_time finish_time elapsed_time owner))
+  end
+
+  def textual_group_retirement_details
+    return nil unless retirement_get_job
+    TextualGroup.new(_("Details"), %i(playbook repository verbosity hosts))
+  end
+
+  def textual_group_retirement_credentials
+    return nil unless retirement_get_job
+    TextualGroup.new(_("Credentials"), %i(machine_credential network_credential cloud_credential))
+  end
+
+  def textual_group_retirement_stdout
+    return nil unless retirement_get_job
+    TextualGroup.new(_("Standard Output"), %i(stdout))
+  end
+
   def textual_group_vm_totals
     TextualGroup.new(
       _("Totals for Service VMs"),
@@ -140,5 +180,72 @@ module ServiceHelper::TextualSummary
     attrs = @record.miq_custom_attributes
     return nil if attrs.blank?
     attrs.sort_by(&:name).collect { |a| {:label => a.name, :value => a.value} }
+  end
+
+  def textual_status
+    {:label => _("Status"), :value => @job.status}
+  end
+
+  def textual_start_time
+    {:label => _("Started"), :value => format_timezone(@job.start_time)}
+  end
+
+  def textual_finish_time
+    {:label => _("Finished"), :value => format_timezone(@job.finish_time)}
+  end
+
+  def textual_elapsed_time
+    {:label => _("Elapsed"), :value => @job.finish_time && @job.start_time ? @job.finish_time - @job.start_time : "N/A"}
+  end
+
+  def textual_playbook
+    {:label => _("Playbook"), :value => @job.playbook.name}
+  end
+
+  def textual_repository
+    {:label => _("Repository"), :value => @job.playbook.configuration_script_source.name}
+  end
+
+  def textual_verbosity
+    {:label => _("Verbosity"), :value => @job.verbosity}
+  end
+
+  def textual_hosts
+    {:label => _("Hosts"), :value => @job.hosts.join(", ")}
+  end
+
+  def textual_machine_credential
+    credential = @job.authentications.find_by(:type => 'ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential')
+    return nil unless credential
+    {:label => _("Machine"), :value => credential.name}
+  end
+
+  def textual_network_credential
+    credential = @job.authentications.find_by(:type => 'ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential')
+    return nil unless credential
+    {:label => _("Network"), :value => credential.name}
+  end
+
+  def textual_cloud_credential
+    credential = @job.authentications.find_by(:type => 'ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential')
+    return nil unless credential
+    {:label => _("Cloud"), :value => credential.name}
+  end
+
+  def textual_stdout
+    {:label => _("Output"), :value => @job.raw_stdout}
+  end
+
+  def provisioning_get_job
+    get_job("Provision")
+  end
+
+  def retirement_get_job
+    get_job("Retirement")
+  end
+
+  def get_job(type)
+    @job = @record.try(:job, type)
+    @job
   end
 end

--- a/app/views/layouts/_textual_code_mirror.haml
+++ b/app/views/layouts/_textual_code_mirror.haml
@@ -1,0 +1,16 @@
+.row
+  .col-md-12.col-lg-6
+    %hr
+      %h3= _("#{label}")
+      = text_area("textual", "data",
+          :value => "#{value}",
+          :size => "90x20",
+          :disabled => true,
+          :style => "display:none;")
+      -# Create a MyCodeMirror editor for the text area
+      = render(:partial => "/layouts/my_code_mirror",
+        :locals => {:text_area_id => "textual_data",
+          :mode => "#{mode}",
+          :line_numbers => true,
+          :read_only => true})
+

--- a/app/views/layouts/_textual_code_mirror.haml
+++ b/app/views/layouts/_textual_code_mirror.haml
@@ -1,5 +1,5 @@
 .row
-  .col-md-12.col-lg-6
+  .col-md-12.col-lg-12
     %hr
       %h3= _("#{label}")
       = text_area("textual", "data",

--- a/app/views/layouts/_textual_code_mirror.haml
+++ b/app/views/layouts/_textual_code_mirror.haml
@@ -2,14 +2,14 @@
   .col-md-12.col-lg-12
     %hr
       %h3= _("#{label}")
-      = text_area("textual", "data",
+      = text_area(text_area_id, "data",
           :value => "#{value}",
           :size => "90x20",
           :disabled => true,
           :style => "display:none;")
       -# Create a MyCodeMirror editor for the text area
       = render(:partial => "/layouts/my_code_mirror",
-        :locals => {:text_area_id => "textual_data",
+        :locals => {:text_area_id => "#{text_area_id}_data",
           :mode => "#{mode}",
           :line_numbers => true,
           :read_only => true})

--- a/app/views/layouts/_textual_groups_tabs.html.haml
+++ b/app/views/layouts/_textual_groups_tabs.html.haml
@@ -1,6 +1,2 @@
-.row
-  - groups.each do |big_group|
-    .col-md-12.col-lg-6
-      - big_group.each do |group|
-        - render_options = textual_group_render_options(group)
-        = render textual_group_render_options(group) if render_options.present?
+-# each tab can have different set of boxes
+= render :partial => "layouts/textual_groups_raw", :locals => {:textual_group_list => textual_group_list}

--- a/app/views/layouts/_textual_groups_tabs.html.haml
+++ b/app/views/layouts/_textual_groups_tabs.html.haml
@@ -1,0 +1,6 @@
+.row
+  - groups.each do |big_group|
+    .col-md-12.col-lg-6
+      - big_group.each do |group|
+        - render_options = textual_group_render_options(group)
+        = render textual_group_render_options(group) if render_options.present?

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -5,6 +5,7 @@
     - unless job
       -# show header when Retirement tab is not visible,
       -# tabs are only displayed when there are are more than 1 tab on screen
+      %hr
       %h3= _("Provisioning")
     %ul.nav.nav-tabs
       = miq_tab_header("provisioning") do
@@ -13,17 +14,17 @@
         = miq_tab_header("retirement") do
           = _("Retirement")
     .tab-content
-      = miq_tab_content("provisioning", 'default') do
+      = miq_tab_content("provisioning", 'default', :class => 'cm-tab') do
         = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_provisioning_group_list}
         - if @job && @job.try(:raw_stdout)
-          = render :partial => "layouts/textual_code_mirror", :locals => {:label => 'Standard Output', :value => @job.raw_stdout, :mode => "htmlmixed"}
+          = render :partial => "layouts/textual_code_mirror", :locals => {:label => 'Standard Output', :value => @job.raw_stdout, :mode => "htmlmixed", :text_area_id => "provision_output"}
       - if job
-        = miq_tab_content("retirement") do
+        = miq_tab_content("retirement", 'default', :class => 'cm-tab') do
           = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_retirement_group_list}
-          = render :partial => "layouts/textual_code_mirror", :locals => {:label => 'Standard Output', :value => job.raw_stdout, :mode => "htmlmixed"}
+          = render :partial => "layouts/textual_code_mirror", :locals => {:label => 'Standard Output', :value => job.raw_stdout, :mode => "htmlmixed", :text_area_id => "retirement_output"}
   :javascript
     miq_tabs_init('#services_tab');
-    ManageIQ.editor.refresh();
+    miq_refresh_code_mirror();
 - else
   .row
     .col-md-12.col-lg-6

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -1,8 +1,12 @@
 = render :partial => "layouts/textual_groups_generic"
 - if @record.type == "ServiceAnsiblePlaybook"
   #services_tab
+    - job = @record.try(:job, "Retirement")
+    - unless job
+      -# show header when Retirement tab is not visible,
+      -# tabs are only displayed when there are are more than 1 tab on screen
+      %h3= _("Provisioning")
     %ul.nav.nav-tabs
-      - job = @record.try(:job, "Retirement")
       = miq_tab_header("provisioning") do
         = _("Provisioning")
       - if job
@@ -11,11 +15,15 @@
     .tab-content
       = miq_tab_content("provisioning", 'default') do
         = render :partial => "layouts/textual_groups_tabs", :locals => {:groups => textual_provisioning_group_list}
+        - if @job && @job.try(:raw_stdout)
+          = render :partial => "layouts/textual_code_mirror", :locals => {:label => 'Standard Output', :value => @job.raw_stdout, :mode => "htmlmixed"}
       - if job
         = miq_tab_content("retirement") do
           = render :partial => "layouts/textual_groups_tabs", :locals => {:groups => textual_retirement_group_list}
+          = render :partial => "layouts/textual_code_mirror", :locals => {:label => 'Standard Output', :value => job.raw_stdout, :mode => "htmlmixed"}
   :javascript
     miq_tabs_init('#services_tab');
+    ManageIQ.editor.refresh();
 - else
   .row
     .col-md-12.col-lg-6

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -14,12 +14,12 @@
           = _("Retirement")
     .tab-content
       = miq_tab_content("provisioning", 'default') do
-        = render :partial => "layouts/textual_groups_tabs", :locals => {:groups => textual_provisioning_group_list}
+        = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_provisioning_group_list}
         - if @job && @job.try(:raw_stdout)
           = render :partial => "layouts/textual_code_mirror", :locals => {:label => 'Standard Output', :value => @job.raw_stdout, :mode => "htmlmixed"}
       - if job
         = miq_tab_content("retirement") do
-          = render :partial => "layouts/textual_groups_tabs", :locals => {:groups => textual_retirement_group_list}
+          = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_retirement_group_list}
           = render :partial => "layouts/textual_code_mirror", :locals => {:label => 'Standard Output', :value => job.raw_stdout, :mode => "htmlmixed"}
   :javascript
     miq_tabs_init('#services_tab');

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -1,8 +1,26 @@
 = render :partial => "layouts/textual_groups_generic"
-.row
-  .col-md-12.col-lg-6
-    %h3
-      = _('VMs')
+- if @record.type == "ServiceAnsiblePlaybook"
+  #services_tab
+    %ul.nav.nav-tabs
+      - job = @record.try(:job, "Retirement")
+      = miq_tab_header("provisioning") do
+        = _("Provisioning")
+      - if job
+        = miq_tab_header("retirement") do
+          = _("Retirement")
+    .tab-content
+      = miq_tab_content("provisioning", 'default') do
+        = render :partial => "layouts/textual_groups_tabs", :locals => {:groups => textual_provisioning_group_list}
+      - if job
+        = miq_tab_content("retirement") do
+          = render :partial => "layouts/textual_groups_tabs", :locals => {:groups => textual_retirement_group_list}
+  :javascript
+    miq_tabs_init('#services_tab');
+- else
+  .row
+    .col-md-12.col-lg-6
+      %h3
+        = _('VMs')
 
-    - if @view
-      = render :partial => "layouts/gtl", :locals => {:view => @view}
+      - if @view
+        = render :partial => "layouts/gtl", :locals => {:view => @view}


### PR DESCRIPTION
Updated existing Service summary screen to show Ansible Service details differently.

https://www.pivotaltracker.com/story/show/139988291
When Retirement tab is not visible
![without_tabs](https://cloud.githubusercontent.com/assets/3450808/23874108/de502c40-080a-11e7-98c0-f8228891e810.png)

When both tabs have data to display:
![provisioning_tab](https://cloud.githubusercontent.com/assets/3450808/23873762/87103ec6-0809-11e7-8a95-8c2dd136510d.png)

![retirement_tab](https://cloud.githubusercontent.com/assets/3450808/23873759/87043dc4-0809-11e7-99f1-63902bc87028.png)