### PR TITLE
Datastore selection flash message fix

### DIFF
--- a/app/controllers/storage_controller/storage_d.rb
+++ b/app/controllers/storage_controller/storage_d.rb
@@ -32,7 +32,7 @@ module StorageController::StorageD
   def miq_search_node
     options = {:model => "Storage"}
     process_show_list(options)
-    @right_cell_text = _("All %{title} Datastores") % {:title => ui_lookup(:ui_title => "datastore")}
+    @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => "Datastore")}
   end
 
   private #######################


### PR DESCRIPTION
Corrected flash message text when selecting datastore filter for display

https://bugzilla.redhat.com/show_bug.cgi?id=1398744

Screen shots before and after attached below:

Before:
![selected datastore flash msg prior to fix](https://cloud.githubusercontent.com/assets/552686/23522665/b21fa9a0-ff38-11e6-9a9a-e6ca1a34adb0.png)
After:
![selected datastore flash msg post fix](https://cloud.githubusercontent.com/assets/552686/23522675/b9753c56-ff38-11e6-9810-987e2865e92a.png)
