### PR TITLE
Add custom logo capability to the ‘About’ modal

### DIFF
--- a/app/assets/stylesheets/about_modal_background.scss
+++ b/app/assets/stylesheets/about_modal_background.scss
@@ -5,3 +5,7 @@
   background-color: $modal-about-pf-bg-color;
   background-image: image-url($modal-about-pf-bg-img);
 }
+.about-modal-pf.whitelabel {
+  background-image: image-url($img-bg-login-whitelabel);
+  background-size: 100% 100%;
+}

--- a/app/views/layouts/_about_modal.html.haml
+++ b/app/views/layouts/_about_modal.html.haml
@@ -1,6 +1,6 @@
 .modal.fade{:id => "aboutModal", "tabindex" => "-1", "role" => "dialog1", "aria-labelledby" => "aboutModalLabel", "aria-hidden" => "true"}
   .modal-dialog
-    .modal-content.about-modal-pf
+    .modal-content.about-modal-pf{:class => ::Settings.server.custom_login_logo ? 'whitelabel' : ''}
       .modal-header
         %button.close{"data-dismiss" => "modal"}
           %span.pficon.pficon-close
@@ -23,7 +23,7 @@
         .trademark-pf
           = I18n.t("product.copyright")
       .modal-footer
-        %img{:src => image_path("layout/login-screen-logo.png"), :alt => "ManageIQ"}
+        %img{:src => ::Settings.server.custom_logo ? '/upload/custom_logo.png' : image_path("layout/login-screen-logo.png")}
 :javascript
   $(function(){
     $("button[data-dismiss='modal']").off('click');

--- a/app/views/ops/_settings_custom_logos_tab.html.haml
+++ b/app/views/ops/_settings_custom_logos_tab.html.haml
@@ -27,7 +27,7 @@
         .col-md-8
           = check_box_tag("server_uselogo", true, @edit[:new][:server][:custom_logo], :data => {:on_text => 'Yes', :off_text => 'No'})
   %hr
-  %h3= _("Custom Login Background Image")
+  %h3= _("Custom Login & 'About' Screen Background Image")
   - if File.exist?(@login_logo_file)
     = image_tag("/upload/custom_login_logo.png?#{rand(99_999_999)}",
                 :height => 400,
@@ -58,7 +58,7 @@
     %form.form-horizontal
       .form-group
         %label.col-md-2.control-label
-          = _("Use Custom Login Background Image")
+          = _("Use Custom Login & 'About' Screen Background Image")
         .col-md-8
           = check_box_tag("server_useloginlogo", true, @edit[:new][:server][:custom_login_logo], :data => {:on_text => 'Yes', :off_text => 'No'})
   %hr


### PR DESCRIPTION
Currently, the 'About' modal displays only the standard product logo and background. This PR updates that screen when custom logos are selected under the "Custom Logos" tab in the Server Settings Area.

https://bugzilla.redhat.com/show_bug.cgi?id=1427163
https://www.pivotaltracker.com/n/projects/1613907/stories/141014527

'About' modal displaying custom logos:
<img width="904" alt="screen shot 2017-03-03 at 9 49 01 am" src="https://cloud.githubusercontent.com/assets/1287144/23555928/b085712c-fff8-11e6-8a2a-d875c7a6f1bf.png">

Updated text on "Custom Logos" screen
<img width="830" alt="screen shot 2017-03-03 at 10 04 14 am" src="https://cloud.githubusercontent.com/assets/1287144/23555964/cd728202-fff8-11e6-88b3-4d4addd62519.png">


