### PR TITLE
Toolbar refactoring #disable_button: AeCopySimulate

### DIFF
--- a/app/helpers/application_helper/button/ae_copy_simulate.rb
+++ b/app/helpers/application_helper/button/ae_copy_simulate.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::AeCopySimulate < ApplicationHelper::Button::ButtonWithoutRbacCheck
+  def disabled?
+    if @resolve[:button_class].blank?
+      @error_message = _('Object attribute must be specified to copy object details for use in a Button')
+    end
+  end
+end

--- a/app/helpers/application_helper/button/ae_copy_simulate.rb
+++ b/app/helpers/application_helper/button/ae_copy_simulate.rb
@@ -2,6 +2,7 @@ class ApplicationHelper::Button::AeCopySimulate < ApplicationHelper::Button::But
   def disabled?
     if @resolve[:button_class].blank?
       @error_message = _('Object attribute must be specified to copy object details for use in a Button')
+      @error_message.present?
     end
   end
 end

--- a/app/helpers/application_helper/toolbar/miq_ae_tools_simulate_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_ae_tools_simulate_center.rb
@@ -7,6 +7,6 @@ class ApplicationHelper::Toolbar::MiqAeToolsSimulateCenter < ApplicationHelper::
       N_('Copy'),
       :url       => "resolve",
       :url_parms => "?button=copy",
-      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck),
+      :klass     => ApplicationHelper::Button::AeCopySimulate),
   ])
 end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -456,10 +456,6 @@ class ApplicationHelper::ToolbarBuilder
       end
     when nil, "NilClass"
       case id
-      when "ae_copy_simulate"
-        if @resolve[:button_class].blank?
-          return N_("Object attribute must be specified to copy object details for use in a Button")
-        end
       when "customization_template_new"
         if @pxe_image_types_count <= 0
           return N_("No System Image Types available, Customization Template cannot be added")

--- a/spec/helpers/application_helper/buttons/ae_copy_simulate_spec.rb
+++ b/spec/helpers/application_helper/buttons/ae_copy_simulate_spec.rb
@@ -1,0 +1,19 @@
+describe ApplicationHelper::Button::AeCopySimulate do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:resolve) { {:button_class => button_class} }
+  let(:button) { described_class.new(view_context, {}, {'resolve' => resolve}, {}) }
+
+  describe '#calculate_properties' do
+    before { button.calculate_properties }
+
+    context 'when object attribute is specified' do
+      let(:button_class) { 'some_button_class' }
+      it_behaves_like 'an enabled button'
+    end
+    context 'when object attribute is not specified' do
+      let(:button_class) { nil }
+      it_behaves_like 'a disabled button',
+                      'Object attribute must be specified to copy object details for use in a Button'
+    end
+  end
+end


### PR DESCRIPTION
| Toolbar button ids | Toolbar button classes created |
| --- | --- |
| ae_copy_simulate | AeCopySimulate < ButtonWithoutRbacCheck |

# Links

Parent issue: https://github.com/ManageIQ/manageiq/issues/6259
Related issue: https://github.com/ManageIQ/manageiq/issues/6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/140769029