### PR TITLE
Don't generate child nodes for node without children in report_reports tree

### DIFF
--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -45,7 +45,7 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
   def x_get_tree_custom_kids(object, count_only, _options)
     objects = []
     nodes = object[:full_id] ? object[:full_id].split('-') : object[:id].to_s.split('-')
-    if nodes.length == 1 # && nodes.last.split('-').length <= 2 #|| nodes.length == 2
+    if nodes.length == 1 && @rpt_menu[nodes.last.to_i][1].kind_of?(Array)
       @rpt_menu[nodes.last.to_i][1].each_with_index do |r, i|
         objects.push(
           :id    => "#{nodes.last.split('-').last}-#{i}",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1424843

Steps to reproduce:

1. Navigate to Edit Report Menus
2. Select a group to edit and remove everything under one of second level nodes (f.e. `Migration Readiness`) and save.
3. The accordion is now empty.
4. Login as a user from the group that was edited in previous steps.
5. Navigate to Cloud Intel => Reports.
6. "Unexpected error encountered" is displayed on the page.

Before:
<img width="1175" alt="screen shot 2017-03-06 at 1 55 56 pm" src="https://cloud.githubusercontent.com/assets/9210860/23610855/a5e71058-0274-11e7-83fc-3dba68e39ed7.png">

After:
<img width="1209" alt="screen shot 2017-03-06 at 1 55 06 pm" src="https://cloud.githubusercontent.com/assets/9210860/23610842/8f01e14c-0274-11e7-93a2-792889f17a0a.png">

@miq-bot add_label bug