### PR TITLE
Fetch the allowed WebSocket origin from the XFH header when possible

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,8 +66,7 @@ class ApplicationController < ActionController::Base
   end
 
   def allow_websocket
-    proto = request.ssl? ? 'wss' : 'ws'
-    override_content_security_policy_directives(:connect_src => ["'self'", "#{proto}://#{request.env['HTTP_HOST']}"])
+    override_content_security_policy_directives(:connect_src => ["'self'", websocket_origin])
   end
   private :allow_websocket
 

--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -55,11 +55,7 @@ module VmRemote
   end
 
   def launch_html5_console
-    scheme = request.ssl? ? 'wss' : 'ws'
-    override_content_security_policy_directives(
-      :connect_src => ["'self'", "#{scheme}://#{request.env['HTTP_HOST']}"],
-      :img_src     => %w(data: self)
-    )
+    override_content_security_policy_directives(:connect_src => ["'self'", websocket_origin], :img_src => %w(data: self))
     %i(secret url proto).each { |p| params.require(p) }
 
     proto = j(params[:proto])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,6 +33,19 @@ module ApplicationHelper
     end
   end
 
+  def websocket_origin
+    proto = request.ssl? ? 'wss' : 'ws'
+    # Retrieve the host that needs to be explicitly allowed for websocket connections
+    host = if request.env['HTTP_X_FORWARDED_HOST']
+             # Use the first proxy (production)
+             request.env['HTTP_X_FORWARDED_HOST'].split(/,\s*/).first
+           else
+             # Use the HOST header (development)
+             request.env['HTTP_HOST']
+           end
+    "#{proto}://#{host}"
+  end
+
   def valid_html_id(id)
     id = id.to_s.gsub("::", "__")
     raise "HTML ID is not valid" if /[^\w_]/.match(id)


### PR DESCRIPTION
This will allow to use WebSocket (notifications, remote consoles) connections to be processed properly when using ~~an additional proxy~~ a chain of proxies between the client and the appliance.

Testing was done on Fedora 25 with httpd pointing to the MiQ [docker container](http://manageiq.org/docs/get-started/docker) with this PR cherry-picked. The following lines were added to the virtual host available in `/etc/httpd/conf.d/ssl.conf`:
```
# Be more permissive with SSL certificates
SSLProxyEngine on
SSLProxyVerify none
SSLProxyCheckPeerCN off
SSLProxyCheckPeerName off
SSLProxyCheckPeerExpire off

# Make sure that X_FORWARDED is set
RequestHeader set X_FORWARDED_PROTO 'https'
RequestHeader set X-Forwarded-Ssl on
AllowEncodedSlashes NoDecode

# Load balancer for HTTP(S) requests
<Proxy balancer://manageiq>
  BalancerMember https://localhost:8443
</Proxy>

# Separate load balancer for WS(S) requests
<Proxy balancer://websocket>
  BalancerMember wss://localhost:8443
</Proxy>

# These two lines should always go BEFORE the rules for /
ProxyPass /ws/ balancer://websocket/ws/
ProxyPassReverse /ws/ balancer://websocket/ws/

ProxyPass / balancer://manageiq/
ProxyPassReverse / balancer://manageiq/
```

Pending core PR: https://github.com/ManageIQ/manageiq/pull/14214