### PR TITLE
Fix expired session redirection.

### DIFF
--- a/app/controllers/mixins/start_url.rb
+++ b/app/controllers/mixins/start_url.rb
@@ -8,7 +8,7 @@ module StartUrl
   end
 
   def start_url_for_user(start_url)
-    return url_for_only_path(start_url) unless start_url.nil?
+    return start_url unless start_url.nil?
     return url_for_only_path(:controller => 'dashboard', :action => 'show') unless helpers.settings(:display, :startpage)
 
     first_allowed_url = nil


### PR DESCRIPTION
A path where a non-null is passed to  `def start_url_for_user(start_url)` comes from `session[:start_url] = request.url if request.method == "GET"` So it's a URL string.

So fixing this.

Failure:
```
[----] F, [2017-03-06T16:34:15.422108 #31900:3895618] FATAL -- : Error caught: [TypeError] no implicit conversion of String into Hash
/home/martin/Projects/manageiq-ui-classic/app/helpers/application_helper.rb:17:in `url_for_only_path'
/home/martin/Projects/manageiq-ui-classic/app/controllers/mixins/start_url.rb:11:in `start_url_for_user'
/home/martin/Projects/manageiq-ui-classic/app/services/user_validation_service.rb:54:in `validate_user'
/home/martin/Projects/manageiq-ui-classic/app/controllers/dashboard_controller.rb:626:in `validate_user'
/home/martin/Projects/manageiq-ui-classic/app/controllers/dashboard_controller.rb:464:in `authenticate'
/home/martin/.rvm/gems/ruby-2.3.3/gems/actionpack-5.0.2/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/home/martin/.rvm/gems/ruby-2.3.3/gems/actionpack-5.0.2/lib/abstract_controller/base.rb:188:in `process_action'
/home/martin/.rvm/gems/ruby-2.3.3/gems/actionpack-5.0.2/lib/action_controller/metal/rendering.rb:30:in `process_action'
/home/martin/.rvm/gems/ruby-2.3.3/gems/actionpack-5.0.2/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
```

broken by: https://github.com/ManageIQ/manageiq-ui-classic/pull/487

ping @mzazrivec 