### PR TITLE
Removed ng-required from catalog drop down

### DIFF
--- a/app/views/catalog/_st_angular_form.html.haml
+++ b/app/views/catalog/_st_angular_form.html.haml
@@ -53,7 +53,6 @@
       .col-md-8
         %select{"ng-model"         => "vm._catalog",
                 "name"             => "catalog_id",
-                "ng-required"      => "vm.catalogItemModel.display",
                 'ng-options'       => 'catalog as catalog.name for catalog in vm.catalogs',
                 "data-live-search" => "true",
                 'pf-select'        => true}


### PR DESCRIPTION
This was still causing catalog drop down to be a required field and not enabling "Add" button on screen. Catalog drop down was changed to be a not required field in https://github.com/ManageIQ/manageiq-ui-classic/pull/514

@mkanoor please test, this should fix the issue you are seeing with disabled Add button.