### PR TITLE
ScanItemSetDecorator - name the class correctly, instead of ResourcePoolDecorator

### DIFF
--- a/app/decorators/scan_item_set_decorator.rb
+++ b/app/decorators/scan_item_set_decorator.rb
@@ -1,4 +1,4 @@
-class ResourcePoolDecorator < MiqDecorator
+class ScanItemSetDecorator < MiqDecorator
   def fonticon
     'fa fa-search'
   end


### PR DESCRIPTION
Introduced by #505, the intent is clear, but the class name was copypasted incorrreclty :).

Cc @skateman 