### PR TITLE
Adding an exception for forgery token for external auth.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
     # This secret is reset to a value found in the miq_databases table in
     # MiqWebServerWorkerMixin.configure_secret_token for rails server, UI, and
     # web service worker processes.
-    protect_from_forgery :secret => SecureRandom.hex(64), :except => [:authenticate, :csp_report], :with => :exception
+    protect_from_forgery :secret => SecureRandom.hex(64), :except => [:authenticate, :external_authenticate, :kerberos_authenticate, :saml_login, :initiate_saml_login, :csp_report], :with => :exception
   end
 
   helper ChartingHelper


### PR DESCRIPTION
should fix https://bugzilla.redhat.com/show_bug.cgi?id=1429011

basically we need to skip the csrf token check for all the methods that the login page can lead to

I hope I listed all, and I hope I have not put in any extra method

@jvlcek : please, test
ping @abellotti 

what about about `:saml_login` and  `:initiate_saml_login` ?

should go to euwe together with https://github.com/ManageIQ/manageiq-ui-classic/pull/451
