### PR TITLE
Add fonticon spec for TreeNode::ScanItemSet

### DIFF
--- a/spec/presenters/tree_node/scan_item_set_spec.rb
+++ b/spec/presenters/tree_node/scan_item_set_spec.rb
@@ -1,5 +1,8 @@
 require 'shared/presenters/tree_node/common'
 
 describe TreeNode::ScanItemSet do
-  pending 'add some tests here (will require a factory too)'
+  subject { described_class.new(object, nil, {}) }
+  let(:object) { FactoryGirl.create(:scan_item_set) }
+
+  include_examples 'TreeNode::Node#icon', 'fa fa-search'
 end


### PR DESCRIPTION
For the issue introduced in #505 and fixed by #594, cc @martinpovolny @himdel 

@miq-bot add_label euwe/no, test