### PR TITLE
Allow any EMS to create cloud volume

### DIFF
--- a/app/helpers/application_helper/button/cloud_volume_new.rb
+++ b/app/helpers/application_helper/button/cloud_volume_new.rb
@@ -8,6 +8,6 @@ class ApplicationHelper::Button::CloudVolumeNew < ApplicationHelper::Button::But
 
   # disable button if no active providers support create action
   def disabled?
-    EmsCloud.all.none? { |ems| CloudVolume.class_by_ems(ems).supports_create? }
+    ExtManagementSystem.all.none? { |ems| CloudVolume.class_by_ems(ems).supports_create? }
   end
 end

--- a/spec/helpers/application_helper/buttons/cloud_volume_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/cloud_volume_new_spec.rb
@@ -12,6 +12,13 @@ describe ApplicationHelper::Button::CloudVolumeNew do
       button = described_class.new(view_context, {}, {}, {})
       expect(button.disabled?).to be true
     end
+
+    it "when only Amazon EBS storage manager is available, the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_amazon_ebs)
+      button = described_class.new(view_context, {}, {}, {})
+      expect(button.disabled?).to be false
+    end
   end
 
   describe '#calculate_properties' do
@@ -25,6 +32,14 @@ describe ApplicationHelper::Button::CloudVolumeNew do
     it "when at least one provider supports volume create, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
       FactoryGirl.create(:ems_openstack)
+      button = described_class.new(view_context, {}, {}, {})
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+
+    it "when only Amazon EBS storage manager is available, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_amazon_ebs)
       button = described_class.new(view_context, {}, {}, {})
       button.calculate_properties
       expect(button[:title]).to be nil


### PR DESCRIPTION
Contrary to OpenStack where `CloudVolume` is part of the OpenStack cloud
manager, Amazon provides a separate EMS for block storage management.
This is not based on `EmsCloud`. Therefore, when only Amazon provider is
available, the button for creating a new cloud volume is disabled.

This patch checks all `CloudVolume`s that are defined by any
`ExtManagementSystem` and enables the button as soon as any of them
supports volume creation.

New requirement has been described in the updated spec that fails with
the current version. Applying this patch all tests pass.

@miq-bot add_label storage,enhancement