### PR TITLE
Allow cloud volume to provide list of supported VMs for attachment

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -134,7 +134,7 @@ class CloudVolumeController < ApplicationController
     assert_privileges("cloud_volume_attach")
     @vm_choices = {}
     @volume = find_by_id_filtered(CloudVolume, params[:id])
-    @volume.cloud_tenant.vms.each { |vm| @vm_choices[vm.name] = vm.id }
+    @volume.available_vms.each { |vm| @vm_choices[vm.name] = vm.id }
 
     @in_a_form = true
     drop_breadcrumb(


### PR DESCRIPTION
With the introduction of Amazon EBS block storage manager, the UI should
no longer on cloud tenant of a cloud volume to provide the list of VMs
that the volume can be attached to. EBS has no notion of tenants. It
does, however, require that the volume resides in the same availability
zone as the instance to which volume is being attached.

This patch therefore asks the cloud volume to provide the list of
instances that it can be attached to.

Depends on: https://github.com/ManageIQ/manageiq/pull/14058

@miq-bot add_label storage,pending core