### PR TITLE
Textual Summaries - textual_*_icon - support for fonticons, decorators

### DIFF
--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -144,9 +144,11 @@ module TextualSummaryHelper
   end
 
   def textual_object_icon(object, klass)
-    case object
-    when ExtManagementSystem
-      {:image => "svg/vendor-#{object.image_name}.svg"}
+    icon = object.decorate.try(:fonticon)
+    image = object.decorate.try(:listicon_image)
+
+    if icon || image
+      {:icon => icon, :image => image}
     else
       textual_class_icon(klass)
     end
@@ -157,7 +159,12 @@ module TextualSummaryHelper
   end
 
   def textual_class_icon(klass)
-    if klass <= AdvancedSetting
+    icon = klass.decorate.try(:fonticon)
+    image = klass.decorate.try(:listicon_image)
+
+    if icon || image
+      {:icon => icon, :image => image}
+    elsif klass <= AdvancedSetting
       {:image => "100/advancedsetting.png"}
     elsif klass <= MiqTemplate
       {:image => "100/vm.png"}

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -77,14 +77,13 @@ module TextualSummaryHelper
     feature ||= "#{controller}_show"
 
     label ||= ui_lookup(:model => klass.name)
-    image = textual_object_icon(object, klass)
     value = if block_given?
               yield object
             else
               object.name
             end
 
-    h = {:label => label, :image => image, :value => value}
+    h = {:label => label, :value => value}.merge(textual_object_icon(object, klass))
 
     if role_allows?(:feature => feature)
       if restful_routed?(object)
@@ -114,10 +113,9 @@ module TextualSummaryHelper
     feature ||= "#{controller_collection}_show_list"
 
     label ||= ui_lookup(:models => klass.name)
-    image = textual_collection_icon(collection, klass)
     count = collection.count
 
-    h = {:label => label, :image => image, :value => count.to_s}
+    h = {:label => label, :value => count.to_s}.merge(textual_collection_icon(collection, klass))
 
     if count > 0 && role_allows?(:feature => feature)
       if link
@@ -148,7 +146,7 @@ module TextualSummaryHelper
   def textual_object_icon(object, klass)
     case object
     when ExtManagementSystem
-      "svg/vendor-#{object.image_name}.svg"
+      {:image => "svg/vendor-#{object.image_name}.svg"}
     else
       textual_class_icon(klass)
     end
@@ -160,11 +158,11 @@ module TextualSummaryHelper
 
   def textual_class_icon(klass)
     if klass <= AdvancedSetting
-      "100/advancedsetting.png"
+      {:image => "100/advancedsetting.png"}
     elsif klass <= MiqTemplate
-      "100/vm.png"
+      {:image => "100/vm.png"}
     else
-      "100/#{klass.name.underscore}.png"
+      {:image => "100/#{klass.name.underscore}.png"}
     end
   end
 

--- a/spec/helpers/container_summary_helper_spec.rb
+++ b/spec/helpers/container_summary_helper_spec.rb
@@ -1,7 +1,7 @@
 describe ContainerSummaryHelper do
   let(:container_project)     { FactoryGirl.create(:container_project) }
-  let(:rel_hash_with_link)    { [:label, :image, :value, :link, :title] }
-  let(:rel_hash_without_link) { [:label, :image, :value] }
+  let(:rel_hash_with_link)    { [:label, :value, :link, :title] }
+  let(:rel_hash_without_link) { [:label, :value] }
 
   before do
     self.class.send(:include, ApplicationHelper)
@@ -14,13 +14,13 @@ describe ContainerSummaryHelper do
 
     it 'show link when role allows' do
       stub_user(:features => :all)
-      expect(subject.keys).to eq(rel_hash_with_link)
+      expect(subject.keys).to include(*rel_hash_with_link)
       expect(subject[:value]).to eq(container_project.name)
     end
 
     it 'hide link when role does not allow' do
       stub_user(:features => :none)
-      expect(subject.keys).to eq(rel_hash_without_link)
+      expect(subject.keys).to include(*rel_hash_without_link)
       expect(subject[:value]).to eq(container_project.name)
     end
   end
@@ -31,13 +31,13 @@ describe ContainerSummaryHelper do
 
     it 'show link when role allows' do
       stub_user(:features => :all)
-      expect(subject.keys).to eq(rel_hash_with_link)
+      expect(subject.keys).to include(*rel_hash_with_link)
       expect(subject[:value]).to eq("2")
     end
 
     it 'hide link when role does not allow' do
       stub_user(:features => :none)
-      expect(subject.keys).to eq(rel_hash_without_link)
+      expect(subject.keys).to include(*rel_hash_without_link)
       expect(subject[:value]).to eq("2")
     end
   end


### PR DESCRIPTION
Right now, textual summaries do use the `icon_or_image` partial, so they do support fonticons and images .. but so far, don't use fonticons.

This changes `textual_object_icon` and `textual_class_icon` to first try the decorator, and to be able to return a fonticon instead of image.

@epwinchell This shouldn't break anything, except possibly show fonticons instead of `vm.png` for MiqTemplate instances, but can you check please? Also, this should make it trivial to add fonticons to summaries :)