### PR TITLE
Removed unnecessary instance variable

### DIFF
--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -50,7 +50,6 @@ class PxeController < ApplicationController
 
     @right_cell_div ||= "pxe_server_list"
     @right_cell_text ||= _("All PXE Servers")
-    @pxe_image_types_count = PxeImageType.count
 
     render :layout => "application"
   end

--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -236,9 +236,6 @@ module PxeController::PxeCustomizationTemplates
 
   def template_get_node_info(treenodeid)
     if treenodeid == "root"
-      @folders = PxeImageType.all.sort
-      # to check if Add customization template button should be enabled
-      @pxe_image_types_count = @folders.count
       @right_cell_text = _("All %{model} - %{group}") % {:model => ui_lookup(:models => "PxeCustomizationTemplate"), :group => ui_lookup(:models => "PxeImageType")}
       @right_cell_div  = "template_list"
     else
@@ -249,7 +246,6 @@ module PxeController::PxeCustomizationTemplates
         @right_cell_text = _("%{model} \"%{name}\"") % {:name => @ct.name, :model => ui_lookup(:model => "PxeCustomizationTemplate")}
       else
         template_list
-        @pxe_image_types_count = PxeImageType.count
         pxe_img_id = x_node.split('-').last
 
         pxe_img_type = PxeImageType.find_by_id(from_cid(pxe_img_id)) if pxe_img_id != "system"

--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -236,6 +236,7 @@ module PxeController::PxeCustomizationTemplates
 
   def template_get_node_info(treenodeid)
     if treenodeid == "root"
+      @folders = PxeImageType.all.sort
       @right_cell_text = _("All %{model} - %{group}") % {:model => ui_lookup(:models => "PxeCustomizationTemplate"), :group => ui_lookup(:models => "PxeImageType")}
       @right_cell_div  = "template_list"
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -409,7 +409,6 @@ module ApplicationHelper
       :msg_title             => @msg_title,
       :perf_options          => @perf_options,
       :policy                => @policy,
-      :pxe_image_types_count => @pxe_image_types_count,
       :record                => @record,
       :report                => @report,
       :report_result_id      => @report_result_id,

--- a/app/helpers/application_helper/button/customization_template_new.rb
+++ b/app/helpers/application_helper/button/customization_template_new.rb
@@ -6,7 +6,7 @@ class ApplicationHelper::Button::CustomizationTemplateNew < ApplicationHelper::B
   end
 
   def disabled?
-    if @pxe_image_types_count <= 0
+    if PxeImageType.count.zero?
       @error_message = _('No System Image Types available, Customization Template cannot be added')
     end
     @error_message.present?

--- a/app/views/pxe/_template_folders.html.haml
+++ b/app/views/pxe/_template_folders.html.haml
@@ -1,5 +1,5 @@
 #template_folders_div
-  - if @folders
+  - if @folders.any?
     = render(:partial => "layouts/flash_msg")
     %table.table.table-bordered.table-striped.table-hover
       %tbody

--- a/spec/helpers/application_helper/buttons/customization_template_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/customization_template_new_spec.rb
@@ -3,8 +3,7 @@ describe ApplicationHelper::Button::CustomizationTemplateNew do
   let(:lastaction) { '' }
   let(:display) { '' }
   let(:x_node) { 'root' }
-  let(:count) { 1 }
-  let(:instance_data) { {'lastaction' => lastaction, 'display' => display, 'pxe_image_types_count' => count} }
+  let(:instance_data) { {'lastaction' => lastaction, 'display' => display} }
   let(:button) { described_class.new(view_context, {}, instance_data, {}) }
 
   before { allow(view_context).to receive(:x_node).and_return(x_node) }
@@ -27,7 +26,10 @@ describe ApplicationHelper::Button::CustomizationTemplateNew do
   end
 
   describe '#calculate_properties' do
-    before { button.calculate_properties }
+    before do
+      allow(PxeImageType).to receive(:count).and_return(count)
+      button.calculate_properties
+    end
 
     context 'when there are no System Image Types available' do
       let(:count) { 0 }
@@ -35,6 +37,7 @@ describe ApplicationHelper::Button::CustomizationTemplateNew do
     end
 
     context 'when there are System Image Types available' do
+      let(:count) { 1 }
       it_behaves_like 'an enabled button'
     end
   end


### PR DESCRIPTION
The only usage of the instance variable `@pxe_image_types_count` was in the toolbar button, and can be substitued with `PxeImageType.count`