### PR TITLE
Change all_instance_variables_set? to return false only when not nil

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -49,16 +49,16 @@ class ApplicationHelper::Button::Basic < Hash
 
   # Check if all instance variables for that button works with are set and
   # are not `nil`
-  def all_instance_variables_set
+  def all_instance_variables_set?
     self.class.instance_variables_required.to_a.all? do |instance_variable|
-      instance_variable_get(instance_variable.to_s).present?
+      !instance_variable_get(instance_variable.to_s).nil?
     end
   end
-  private :all_instance_variables_set
+  private :all_instance_variables_set?
 
   def skipped?
     return true unless role_allows_feature?
-    return true unless all_instance_variables_set
+    return true unless all_instance_variables_set?
     !visible?
   end
 


### PR DESCRIPTION
Change `all_instance_variables_set?` to return false only when not nil. We have some button (DbSeqEdit) where instance variable was set to [], and button was hidden even when it should be shown.