### PR TITLE
More negative flow fixes in ad-hoc metrics page

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
+++ b/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
@@ -1,20 +1,12 @@
 /* global miqHttpInject */
 
   ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', 'miqService',
-    'metricsUtilsFactory', 'metricsHttpFactory', 'metricsConfigFactory',
-    function($http, $window, miqService, metricsUtilsFactory, metricsHttpFactory, metricsConfigFactory) {
+    'metricsUtilsFactory', 'metricsHttpFactory', 'metricsConfigFactory', 'metricsParseUrlFactory',
+    function($http, $window, miqService, metricsUtilsFactory, metricsHttpFactory, metricsConfigFactory, metricsParseUrlFactory) {
 
     var dash = this;
     var utils = metricsUtilsFactory(dash);
     var httpUtils = metricsHttpFactory(dash, $http, utils, miqService);
-
-    // get the pathname and remove trailing / if exist
-    var pathname = $window.location.pathname.replace(/\/$/, '');
-
-    dash.providerId = '/' + (/^\/[^\/]+\/([r\d]+)$/.exec(pathname)[1]);
-    dash.tenant = '_ops';
-    dash.minBucketDurationInSecondes = 20 * 60;
-    dash.max_metrics = 1000;
 
     var initialization = function() {
       dash.tenantChanged = false;
@@ -120,6 +112,11 @@
     dash.refreshList = httpUtils.refreshList;
     dash.refreshGraph = httpUtils.refreshGraph;
 
+    // try to parse config variables from page url
+    // and set page config variables
+    metricsParseUrlFactory(dash, $window);
     metricsConfigFactory(dash);
+
+    // initialize page elemants
     initialization();
   }]);

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
@@ -29,17 +29,6 @@ angular.module('miq.util').factory('metricsConfigFactory', function() {
       dash.timeFilter.range_count++;
     };
 
-    dash.timeRanges = [
-      {title: _("Hours"), value: 1},
-      {title: _("Days"), value: 24},
-      {title: _("Weeks"), value: 168},
-      {title: _("Months"), value: 672}
-    ];
-
-    dash.dateOptions = {
-      format: __('MM/DD/YYYY HH:mm')
-    };
-
     // Graphs
     dash.chartConfig = {
       legend       : { show: false },
@@ -68,6 +57,23 @@ angular.module('miq.util').factory('metricsConfigFactory', function() {
       showSelectBox: true,
       useExpandingRows: true,
       onCheckBoxChange: selectionChange
+    };
+
+    dash.timeRanges = [
+      {title: __("Hours"), value: 1},
+      {title: __("Days"), value: 24},
+      {title: __("Weeks"), value: 168},
+      {title: __("Months"), value: 672}
+    ];
+
+    dash.timeIntervals = [
+      {title: __("Min interval 1 Minute"), value: 1 * 60},
+      {title: __("Min interval 5 Minutes"), value: 5 * 60},
+      {title: __("Min interval 20 Minutes"), value: 20 * 60}
+    ];
+
+    dash.dateOptions = {
+      format: __('MM/DD/YYYY HH:mm')
     };
   }
 });

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
@@ -14,12 +14,10 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
 
     function getMetricDefinitionsData(response) {
       'use strict';
-
       var data = response.data;
-
       dash.loadingMetrics = false;
-      if (response.error || response.data.error) {
-        add_flash(response.error || response.data.error, 'error');
+
+      if (utils.checkResponse(response) === false) {
         return;
       }
 
@@ -75,6 +73,10 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
 
     var getTenants = function(include) {
       return $http.get(dash.url + "&query=get_tenants&limit=7&include=" + include).then(function(response) {
+        if (utils.checkResponse(response) === false) {
+          return [];
+        }
+
         return response.data.tenants;
       });
     }

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-parse-url-factroy.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-parse-url-factroy.js
@@ -1,0 +1,12 @@
+angular.module('miq.util').factory('metricsParseUrlFactory', function() {
+  return function(dash, $window) {
+    // get the pathname and remove trailing / if exist
+    var pathname = $window.location.pathname.replace(/\/$/, '');
+    dash.providerId = '/' + (/^\/[^\/]+\/([r\d]+)$/.exec(pathname)[1]);
+
+    // TODO: get this values from GET/POST values ?
+    dash.tenant = '_system';
+    dash.minBucketDurationInSecondes = 20 * 60;
+    dash.max_metrics = 1000;
+  };
+});

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -33,6 +33,10 @@
   .graph-view {
     overflow-x: hidden;
     overflow-y: hidden;
+
+    .dropdown-kebab-pf .dropdown-menu {
+      left: 0px;
+    }
   }
 
   .line-chart {

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -30,6 +30,11 @@
     padding-top: 10px;
   }
 
+  .graph-view {
+    overflow-x: hidden;
+    overflow-y: hidden;
+  }
+
   .line-chart {
     margin-top: 36px;
     margin-left: 30px;

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -21,62 +21,75 @@ class HawkularProxyService
   end
 
   def data(query)
+    params = {
+      :type           => @params['type'],
+      :metric_id      => @params['metric_id'],
+      :tags           => _tags,
+      :limit          => @params['limit'] || 10_000,
+      :ends           => @params['ends'] || (DateTime.now.to_i * 1000),
+      :starts         => @params['starts'],
+      :bucketDuration => @params['bucket_duration'],
+      :order          => @params['order']
+    }
+
+    params[:starts] = (params[:ends] - 8 * 60 * 60 * 1000) if params[:starts].blank?
+
     case query
     when 'metric_definitions'
-      { :metric_definitions => metric_definitions }
+      {
+        :metric_definitions => metric_definitions(params[:tags], params[:limit].to_i, params[:type])
+      }
     when 'metric_tags'
-      { :metric_tags => metric_tags }
+      {
+        :metric_tags => metric_tags(params[:tags], params[:limit].to_i, params[:type])
+      }
     when 'get_data'
-      { :id   => @params['metric_id'],
-        :data => get_data(@params['metric_id']).compact }
+      {
+        :data => get_data(params[:metric_id], params).compact
+      }
     when 'get_tenants'
-      { :tenants => tenants }
+      {
+        :tenants => tenants(params[:limit].to_i)
+      }
     else
-      {}
+      {
+        :error => "Bad query"
+      }
     end
   rescue StandardError => e
-    { :error => e }
+    {
+      :parameters => params,
+      :error      => e
+    }
   end
 
-  def metric_definitions
-    tags = @params['tags'].blank? ? nil : JSON.parse(@params['tags'])
-    tags = nil if tags == {}
-    limit = @params['limit'] || 2000
+  def metric_definitions(tags, limit, type)
+    list = _metric_definitions(tags, type).map { |m| m.json if m.json }
 
-    list = if @params['type'].blank?
-             @cli.hawkular_client.counters.query(tags).compact +
-               @cli.hawkular_client.gauges.query(tags).compact
-           else
-             client.query(tags).compact
-           end
-
-    list.map { |m| m.json if m.json }.sort { |a, b| a["id"].downcase <=> b["id"].downcase }[0..limit.to_i]
+    list.sort { |a, b| a["id"].downcase <=> b["id"].downcase }[0..limit]
   end
 
-  def metric_tags
-    metric_definitions.map { |x| x["tags"].keys if x["tags"] }.compact.flatten.uniq.sort
+  def metric_tags(tags, limit, type)
+    tags = metric_definitions(tags, limit, type).map do |x|
+      x["tags"].keys if x["tags"]
+    end
+
+    tags.compact.flatten.uniq.sort
   end
 
-  def get_data(id)
-    ends = @params['ends'] || (DateTime.now.to_i * 1000)
-    starts = @params['starts'] || (ends - 8 * 60 * 60 * 1000)
-    bucket_duration = @params['bucket_duration'] || nil
-    order = @params['order'] || 'ASC'
-    limit = @params['limit'] || 360
-
+  def get_data(id, params)
     data = client.get_data(id,
-                           :limit          => limit.to_i,
-                           :starts         => starts.to_i,
-                           :ends           => ends.to_i,
-                           :bucketDuration => bucket_duration,
-                           :order          => order)
+                           :limit          => params[:limit].to_i,
+                           :starts         => params[:starts].to_i,
+                           :ends           => params[:ends].to_i,
+                           :bucketDuration => params[:bucketDuration] || nil,
+                           :order          => params[:order] || 'ASC')
 
-    data[0..limit.to_i]
+    data[0..params[:limit].to_i]
   end
 
-  def tenants
+  def tenants(limit)
     tenants = @cli.hawkular_client.http_get('/tenants')
-    limit = @params['limit'] || 7
 
     if @params['include'].blank?
       tenants.map! { |x| x["id"] }
@@ -84,6 +97,23 @@ class HawkularProxyService
       tenants.map! { |x| x["id"] if x["id"].include?(@params['include']) }
     end
 
-    tenants.compact[0..limit.to_i]
+    tenants.compact[0..limit]
+  end
+
+  private
+
+  def _metric_definitions(tags, type)
+    if type.blank?
+      @cli.hawkular_client.counters.query(tags).compact +
+        @cli.hawkular_client.gauges.query(tags).compact
+    else
+      client.query(tags).compact
+    end
+  end
+
+  def _tags
+    tags = @params['tags'].blank? ? nil : JSON.parse(@params['tags'])
+
+    tags == {} ? nil : tags
   end
 end

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -1,10 +1,10 @@
 = render :partial => "layouts/flash_msg"
 .ad-hoc-metrics.row.miq-dashboard-view.miq-metrics{"ng-controller" => "adHocMetricsController as dash"}
-  .row.toolbar-pf{"ng-show" => "!dash.showGraph"}
+  .row.toolbar-pf.list-view{"ng-show" => "!dash.showGraph"}
     = render :partial => "ems_container/ad_hoc/list_view_form"
     = render :partial => "ems_container/ad_hoc/list_view"
     = render :partial => "ems_container/ad_hoc/list_view_blank"
-  .row.toolbar-pf{"ng-show" => "dash.showGraph"}
+  .row.toolbar-pf.graph-view{"ng-show" => "dash.showGraph"}
     = render :partial => "ems_container/ad_hoc/chart_view_form"
     = render :partial => "ems_container/ad_hoc/chart_view"
 

--- a/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
@@ -31,7 +31,7 @@
                                            "data-toggle"   => "dropdown",
                                            "aria-haspopup" => "true",
                                            "aria-expanded" => "true"}
-        %span.fa.fa-ellipsis-v
+        %span.fa.fa-fw.fa-ellipsis-v
       %ul.dropdown-menu{"aria-labelledby" => "dropdownKebab"}
         %li{"ng-repeat" => "range in dash.timeIntervals"}
           %a{"href"     => "#",

--- a/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
@@ -26,5 +26,17 @@
                                          "options"            => "dash.dateOptions",
                                          "date"               => "dash.timeFilter.date"}
 
+    %dropdown.dropdown-kebab-pf
+      %button.btn.btn-link.dropdown-toggle{"type"          => "button",
+                                           "data-toggle"   => "dropdown",
+                                           "aria-haspopup" => "true",
+                                           "aria-expanded" => "true"}
+        %span.fa.fa-ellipsis-v
+      %ul.dropdown-menu{"aria-labelledby" => "dropdownKebab"}
+        %li{"ng-repeat" => "range in dash.timeIntervals"}
+          %a{"href"     => "#",
+             "ng-click" => "dash.minBucketDurationInSecondes = range.value; dash.refreshGraph()"}
+            {{range.title}}
+
     %button.btn.btn-primary.pull-left{"type" => "button", "ng-click" => "dash.refreshGraph()"}
       = _("Refresh")

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -16,10 +16,10 @@ describe('adHocMetricsController', function() {
 
   beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_) {
     $httpBackend = _$httpBackend_;
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_tags&limit=250').respond(mock_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&limit=1000&query=metric_definitions&tags={}').respond(mock_metrics_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauge&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauge&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_system&query=metric_tags&limit=250').respond(mock_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_system&limit=1000&query=metric_definitions&tags={}').respond(mock_metrics_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauge&tenant=_system&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauge&tenant=_system&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
     $controller = _$controller_('adHocMetricsController');
     $controller.refreshList();
     $httpBackend.flush();


### PR DESCRIPTION
Compute > Containers > Providers - pick a provider - toolbar Monitoring > Ad hoc Metrics

**Description**

**A. Error handling**

More negative flow fixes in ad-hoc metrics page.
Plus an option to set the minimal bucket length.

When page times out, metrics can't be pulled (instead of metrics we get the login screen) we need to inform users they need to re-login.


**Screenshot**
_A. Negative flows_
![screenshot-localhost 3000-2017-03-07-15-18-03](https://cloud.githubusercontent.com/assets/2181522/23657972/5c3b0ce0-0349-11e7-9031-643bc0263691.png)
