### PR TITLE
Add name of filter to Filtered by in the title

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -667,8 +667,8 @@ module ApplicationController::Filter
   # Set advanced search filter text
   def adv_search_set_text
     if @edit[@expkey].history.idx == 0                          # Are we pointing at the first exp
-      if @edit[:adv_search_name]
-        @edit[:adv_search_applied][:text] = _(" - Filtered by \"%{text}\"") % {:text => @edit[:adv_search_name]}
+      if @edit[:new_search_name]
+        @edit[:adv_search_applied][:text] = _(" - Filtered by \"%{text}\"") % {:text => @edit[:new_search_name]}
       else
         @edit[:adv_search_applied][:text] = _(" - Filtered by \"%{text}\" report") %
                                               {:text => @edit[:adv_search_report]}


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1429410

Add name of filter to Filtered by in the title in the page
when creating, saving and then applying a filter
in Advanced search, by fixing adv_search_set_text method.

Before:
![name_before](https://cloud.githubusercontent.com/assets/13417815/23662484/1053c856-0350-11e7-8a80-1721dad5c05b.png)

After:
![name_after](https://cloud.githubusercontent.com/assets/13417815/23662490/1370073e-0350-11e7-87f0-1fefdd48026c.png)
