### PR TITLE
Hide tenant parent name when user cannot see it

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -755,6 +755,11 @@ module OpsController::OpsRbac
     update_gtl_div("rbac_#{rec_type.pluralize}_list") if pagination_or_gtl_request?
   end
 
+  def allowed_tenant_names
+    current_tenant = User.current_user.current_tenant
+    (current_tenant.descendants + [current_tenant]).map(&:name)
+  end
+
   # Create the view and associated vars for the rbac list
   def rbac_build_list(rec_type)
     @lastaction = "rbac_#{rec_type}s_list"
@@ -777,7 +782,14 @@ module OpsController::OpsRbac
                     when "role"
                       get_view(MiqUserRole)
                     when "tenant"
-                      get_view(Tenant, :named_scope => :in_my_region)
+                      view, pages = get_view(Tenant, :named_scope => :in_my_region)
+                      unless User.current_user.super_admin_user?
+                        view.table.data.map! do |x|
+                          x['parent_name'] = '' unless allowed_tenant_names.include?(x['parent_name'])
+                          x
+                        end
+                      end
+                      [view, pages]
                     end
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1417874
 
use of any Tenant cannot see parent tenant name.


Not sure if we can do it without using `post processing` on `@view.table.data`.

@miq-bot assign @mzazrivec 

before
![screen shot 2017-03-07 at 17 22 50](https://cloud.githubusercontent.com/assets/14937244/23666294/e35b8fae-035a-11e7-96a9-a7c73c47e45c.png)

after
![screen shot 2017-03-07 at 17 21 07](https://cloud.githubusercontent.com/assets/14937244/23666344/0a998e72-035b-11e7-9162-19efb7e8390b.png)


