### PR TITLE
Fix for Service requests show none with "refresh" buttons instead of selected values 

### DIFF
--- a/app/views/miq_request/_st_prov_show.html.haml
+++ b/app/views/miq_request/_st_prov_show.html.haml
@@ -3,7 +3,7 @@
   - ra = st.resource_actions.find_by_action('Provision') if st
   - if ra && ra.dialog
     - values = @miq_request.options[:dialog]
-    - opts = {}
+    - opts = {:request_view => true}
     %fieldset
       %h3
         = _("Dialog Options")

--- a/app/views/miq_request/_st_prov_show.html.haml
+++ b/app/views/miq_request/_st_prov_show.html.haml
@@ -3,7 +3,7 @@
   - ra = st.resource_actions.find_by_action('Provision') if st
   - if ra && ra.dialog
     - values = @miq_request.options[:dialog]
-    - opts = {:request_view => true}
+    - opts = {:display_view_only => true}
     %fieldset
       %h3
         = _("Dialog Options")

--- a/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
@@ -37,4 +37,4 @@
       });
 
 - else
-  = h(field.values.detect { |k, _v| [k, k.to_s].include?(wf.value(field.name)) }.try(:last) || wf.value(field.name))
+  = h(field.value.nil? ? "<None>" : field.value)


### PR DESCRIPTION
This change utilizes a new option `:request_view` to force values that are passed in to be shown on the request review screen instead of running through the dialog again when it doesn't need to.

This will need to be combined with [this PR](https://github.com/ManageIQ/manageiq/pull/14219) in the main repo. to fix this specific BZ.

https://bugzilla.redhat.com/show_bug.cgi?id=1428171

~~This is also a related BZ, where instead of seeing "<None>" when nothing was picked, it was showing the first thing in the drop-down list: https://bugzilla.redhat.com/show_bug.cgi?id=1428133~~ This was a misunderstanding on my part, these BZs are not related.

/cc @gmcculloug, not sure who to assign to this one.
@miq-bot add_label euwe/yes, bug