### PR TITLE
Fix for unable to import service dialog from yaml 

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -4,6 +4,7 @@ class MiqAeCustomizationController < ApplicationController
   include_concern 'Dialogs'
 
   include AutomateTreeHelper
+  helper ApplicationHelper::ImportExportHelper
 
   before_action :check_privileges
   before_action :get_session_data


### PR DESCRIPTION
Makes helper methods accessible. 

https://bugzilla.redhat.com/show_bug.cgi?id=1429964