### PR TITLE
Add a type column to the list of images in the pre-prov flow

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -416,6 +416,9 @@ module ApplicationController::MiqRequestMethods
 
     # add tenant column header to cloud workflows only
     headers["cloud_tenant"] = "Tenant" if vms.any? { |vm| vm.respond_to?(:cloud_tenant) }
+    # add snapshot/image column header to cloud workflows only, since they're
+    # currently the only ones that support the field.
+    headers["image?"] = "Type" if vms.any? { |vm| vm.respond_to?(:image?) }
 
     integer_fields = %w(allocated_disk_storage mem_cpu logical_cpus v_total_snapshots)
 

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -415,10 +415,10 @@ module ApplicationController::MiqRequestMethods
     }
 
     # add tenant column header to cloud workflows only
-    headers["cloud_tenant"] = "Tenant" if vms.any? { |vm| vm.respond_to?(:cloud_tenant) }
+    headers["cloud_tenant"] = _("Tenant") if vms.any? { |vm| vm.respond_to?(:cloud_tenant) }
     # add snapshot/image column header to cloud workflows only, since they're
     # currently the only ones that support the field.
-    headers["image?"] = "Type" if vms.any? { |vm| vm.respond_to?(:image?) }
+    headers["image?"] = _("Type") if vms.any? { |vm| vm.respond_to?(:image?) }
 
     integer_fields = %w(allocated_disk_storage mem_cpu logical_cpus v_total_snapshots)
 

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -13,17 +13,20 @@
     %thead
       %tr
         - id = @edit[:req_id] || "new"
-        - @edit[:vm_columns].each_with_index do |h, i|
+        - ["name", "image?", "operating_system.product_name", "platform",
+            "logical_cpus", "mem_cpu", "allocated_disk_storage", "deprecated",
+            "ext_management_system.name", "v_total_snapshots", "cloud_tenant"].each do |column_name|
           %th
-            -# Replaced to exclude non-view table fields from sorting
-            = link_to(h(@edit[:vm_headers][h]),
-              {:action => "vm_pre_prov", :sort_choice => h, :id => id.to_s},
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              "data-method"          => :post,
-              :remote                => true)
-            - if @edit[:vm_columns][i] == @edit[:vm_sortcol]
-              %img{:src => image_path("16/sort_#{@edit[:vm_sortdir] == 'ASC' ? 'up' : 'down'}.png")}
+            - if @edit[:vm_headers].include?(column_name)
+              -# Replaced to exclude non-view table fields from sorting
+              = link_to(h(@edit[:vm_headers][column_name]),
+                {:action => "vm_pre_prov", :sort_choice => column_name, :id => id.to_s},
+                "data-miq_sparkle_on"  => true,
+                "data-miq_sparkle_off" => true,
+                "data-method"          => :post,
+                :remote                => true)
+              - if column_name == @edit[:vm_sortcol]
+                %img{:src => image_path("16/sort_#{@edit[:vm_sortdir] == 'ASC' ? 'up' : 'down'}.png")}
     %tbody
       - @vms.each do |row|
         - @id = row.id
@@ -31,6 +34,10 @@
         %tr{:class => cls, :onclick => "miqAjax('/miq_request/pre_prov/?sel_id=#{@id}');", :id => "row_#{@id}"}
           %td
             = h(row.name)
+          - if @edit[:vm_headers].include?("image?")
+            %td
+              - if row.respond_to?(:image?)
+                = h(row.image? ? _("Image") : _("Snapshot"))
           %td
             = h(row.operating_system.try(:product_name))
           %td
@@ -52,7 +59,3 @@
             %td
               - if row.respond_to?(:cloud_tenant)
                 = h(row.cloud_tenant.try(:name))
-          - if @edit[:vm_headers].include?("image?")
-            %td
-              - if row.respond_to?(:image?)
-                = h(row.image? ? _("Image") : _("Snapshot"))

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -52,3 +52,7 @@
             %td
               - if row.respond_to?(:cloud_tenant)
                 = h(row.cloud_tenant.try(:name))
+          - if @edit[:vm_headers].include?("image?")
+            %td
+              - if row.respond_to?(:image?)
+                = h(row.image? ? _("Image") : _("Snapshot"))


### PR DESCRIPTION
This adds a type column to the pre-provision image-select screen to differentiate images from snapshots.
![screenshot from 2017-03-07 17-16-29](https://cloud.githubusercontent.com/assets/628956/23680719/3b2a8eb6-035a-11e7-81c9-fb70b4013cb7.png)

Depends upon https://github.com/ManageIQ/manageiq/pull/12970