### PR TITLE
Drop build_html_rows method

### DIFF
--- a/lib/report_formatter/html.rb
+++ b/lib/report_formatter/html.rb
@@ -39,57 +39,9 @@ module ReportFormatter
         output << "</thead>"
       end
       output << '<tbody>'
-
-      build_html_rows(mri, output)
-
+      output << mri.build_html_rows.join
       output << '</tbody>'
     end
-
-    def build_html_rows(mri, output)
-      # This is similar to MiqReport.build_html_rows, needs to be unified
-      tz = mri.get_time_zone(Time.zone.name)
-      row = 0
-      in_a_widget = mri.rpt_options[:in_a_widget] || false
-
-      unless mri.table.nil?
-        row_limit = mri.rpt_options && mri.rpt_options[:row_limit] ? mri.rpt_options[:row_limit] : 0
-        save_val = :_undefined_                                 # Hang on to the current group value
-        break_label = mri.col_options.fetch_path(mri.sortby[0], :break_label) unless mri.sortby.nil? || mri.col_options.nil? || in_a_widget
-        group_text = nil                                        # Optionally override what gets displayed for the group (i.e. Chargeback)
-        use_table = mri.sub_table ? mri.sub_table : mri.table
-        use_table.data.each_with_index do |d, d_idx|
-          break if row_limit != 0 && d_idx > row_limit - 1
-          if ["y", "c"].include?(mri.group) && !mri.sortby.nil? && save_val != d.data[mri.sortby[0]].to_s
-            unless d_idx == 0                       # If not the first row, we are at a group break
-              output << build_group_html_rows(save_val, mri.col_order.length, break_label, group_text).join
-            end
-            save_val = d.data[mri.sortby[0]].to_s
-            # Chargeback, sort by date, but show range
-            group_text = d.data["display_range"] if Chargeback.db_is_chargeback?(db) && mri.sortby[0] == "start_date"
-          end
-
-          if row == 0
-            output << '<tr class="row0 no-hover">'
-            row = 1
-          else
-            output << '<tr class="row1 no-hover">'
-            row = 0
-          end
-          mri.col_formats ||= []                 # Backward compat - create empty array for formats
-          mri.col_order.each_with_index do |c, c_idx|
-            mri.build_html_col(output, c, mri.col_formats[c_idx], d.data)
-          end
-
-          output << "</tr>"
-        end
-      end
-
-      if ["y", "c"].include?(mri.group) && !mri.sortby.nil?
-        output << build_group_html_rows(save_val, mri.col_order.length, break_label, group_text).join
-        output << build_group_html_rows(:_total_, mri.col_order.length).join
-      end
-    end
-    private :build_html_rows
 
     def build_document_footer
       mri = options.mri


### PR DESCRIPTION
Drop `build_html_rowsh -> use `MiqReport.build_html_rows` instead.

I audited the differences and I feel confident this can be done.

The drop method was copied from `MiqReport.build_html_rows` long time ago. Since them the latter was many times amended while the former was amended less often.