### PR TITLE
GenericToolbarMixin - set toolbar for current controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,8 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
   include Mixins::TimeHelper
   include Mixins::MenuSection
+  include Mixins::GenericToolbarMixin
+
   helper ToolbarHelper
   helper JsHelper
   helper QuadiconHelper

--- a/app/controllers/mixins/generic_list_mixin.rb
+++ b/app/controllers/mixins/generic_list_mixin.rb
@@ -5,6 +5,7 @@ module Mixins
     end
 
     def show_list
+      @center_toolbar = self.class.toolbar_plural if self.class.toolbar_plural
       process_show_list
     end
   end

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -2,6 +2,7 @@ module Mixins
   module GenericShowMixin
     def show
       return unless init_show
+      @center_toolbar = self.class.toolbar_singular if self.class.toolbar_singular
 
       case @display
       # these methods are defined right in GenericShowMixin

--- a/app/controllers/mixins/generic_toolbar_mixin.rb
+++ b/app/controllers/mixins/generic_toolbar_mixin.rb
@@ -1,0 +1,22 @@
+module Mixins
+  module GenericToolbarMixin
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def toolbar(singular, plural = nil)
+        plural = singular.to_s.pluralize if plural.nil?
+
+        @generic_toolbar_singular = singular.to_sym
+        @generic_toolbar_plural = plural.to_sym
+      end
+
+      def toolbar_singular
+        @generic_toolbar_singular
+      end
+
+      def toolbar_plural
+        @generic_toolbar_plural
+      end
+    end
+  end
+end


### PR DESCRIPTION
This lets us write

```ruby
class FooController < ApplicationController
  toolbar :cloud_network
  ...
end
```

in any controller that uses `GenericListMixin` or `GenericShowMixin` .. which causes `show` to set `@center_toolbar = :cloud_network` while `show_list` will set it to `:cloud_networks`.

(The plural version comes from `singular.to_s.pluralize`, but can be provided explicitly by `toolbar :singular, :plural`.)

Ping @martinpovolny, @mzazrivec, @ZitaNemeckova 