### PR TITLE
Toolbar refactoring: removal of #disable_button method

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -346,22 +346,6 @@ class ApplicationHelper::ToolbarBuilder
     img
   end
 
-  def get_record_cls(record)
-    if record.kind_of?(AvailabilityZone)
-      record.class.base_class.name
-    elsif MiqRequest.descendants.include?(record.class)
-      record.class.base_class.name
-    else
-      klass = case record
-              when ContainerNode, ContainerGroup, Container then record.class.base_class
-              when Host, ExtManagementSystem                then record.class.base_class
-              when VmOrTemplate                             then record.class.base_model
-              else                                               record.class
-              end
-      klass.name
-    end
-  end
-
   # Determine if a button should be selected for buttonTwoState
   def twostate_button_selected(id)
     return true if id.starts_with?("view_") && id.ends_with?("textual")  # Summary view buttons

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -149,13 +149,6 @@ class ApplicationHelper::ToolbarBuilder
       button[:url_parms] = "?show=#{request.parameters[:show]}"
     end
 
-    dis_title = disable_button(button[:child_id] || button[:id])
-    if dis_title
-      button[:enabled] = false
-      if dis_title.kind_of? String
-        button[:title] = button.localized(:title, dis_title)
-      end
-    end
     button.calculate_properties
     button
   end
@@ -351,12 +344,6 @@ class ApplicationHelper::ToolbarBuilder
     # to change summary screen button to green image
     return "summary-green" if b_name == "show_summary" && %w(miq_schedule miq_task scan_profile).include?(@layout)
     img
-  end
-
-  # Determine if a button should be disabled. Returns either boolean or
-  # string message with explanation of reason for disabling
-  def disable_button(_id)
-    false
   end
 
   def get_record_cls(record)

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -166,38 +166,6 @@ describe ApplicationHelper, "::ToolbarBuilder" do
     end
   end # get_image
 
-  describe "#get_record_cls" do
-    subject { toolbar_builder.get_record_cls(record) }
-    context "when record not exist" do
-      let(:record) { nil }
-      it { is_expected.to eq("NilClass") }
-    end
-
-    context "when record is array" do
-      let(:record) { ["some", "thing"] }
-      it { is_expected.to eq(record.class.name) }
-    end
-
-    context "when record is valid" do
-      [ManageIQ::Providers::Redhat::InfraManager::Host].each do |c|
-        it "and with #{c}" do
-          record = c.new
-          expect(toolbar_builder.get_record_cls(record)).to eq(record.class.base_class.to_s)
-        end
-      end
-
-      it "and with 'VmOrTemplate'" do
-        record = ManageIQ::Providers::Vmware::InfraManager::Template.new
-        expect(toolbar_builder.get_record_cls(record)).to eq(record.class.base_model.to_s)
-      end
-
-      it "otherwise" do
-        record = Job.new
-        expect(toolbar_builder.get_record_cls(record)).to eq(record.class.to_s)
-      end
-    end
-  end
-
   describe "#twostate_button_selected" do
     before do
       @gtl_type = 'list'


### PR DESCRIPTION
Removed `#disable_button` and `#get_record_cls` methods from `toolbar_builder.rb`.

# Links

Parent issue: https://github.com/ManageIQ/manageiq/issues/6259
Related issue: https://github.com/ManageIQ/manageiq/issues/6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/141308215