### PR TITLE
Refactor GenericFeatureButton specs

### DIFF
--- a/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
@@ -1,29 +1,9 @@
 describe ApplicationHelper::Button::GenericFeatureButton do
-  describe '#visible?' do
-    it "that supports feature :some_feature will not be skipped" do
-      record = double
-      allow(record).to receive(:supports_some_feature?).and_return(true)
-      view_context = setup_view_context_with_sandbox({})
-      button = described_class.new(
-        view_context,
-        {},
-        {'record' => record},
-        {:options => {:feature => :some_feature}}
-      )
-      expect(button.visible?).to be_truthy
-    end
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:record) { double }
+  let(:feature) { :some_feature }
+  let(:props) { {:options => {:feature => feature}} }
+  let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
 
-    it "that dont support feature :some_feature will be skipped" do
-      record = double
-      allow(record).to receive(:supports_some_feature?).and_return(false)
-      view_context = setup_view_context_with_sandbox({})
-      button = described_class.new(
-        view_context,
-        {},
-        {'record' => record},
-        {:options => {:feature => :some_feature}}
-      )
-      expect(button.visible?).to be_falsey
-    end
-  end
+  it_behaves_like 'a generic feature button'
 end

--- a/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
@@ -1,43 +1,9 @@
 describe ApplicationHelper::Button::GenericFeatureButtonWithDisable do
   let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:record) { FactoryGirl.create(:vm_vmware) }
   let(:feature) { :evacuate }
-  let(:available) { true }
-  let(:record) { FactoryGirl.create(:vm_or_template) }
-  let(:button) { described_class.new(view_context, {}, {'record' => record}, {:options => {:feature => feature}}) }
-  before do
-    allow(record).to receive(:is_available?).with(feature).and_return(available)
-    allow(record).to receive(:is_available_now_error_message).and_return('unavailable')
-  end
+  let(:props) { {:options => {:feature => feature}} }
+  let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
 
-  describe '#disabled?' do
-    subject { button.disabled? }
-
-    context 'when feature exists' do
-      let(:feature) { :evacuate }
-      before do
-        allow(record).to receive(:supports_evacuate?).and_return(support)
-        allow(record).to receive(:unsupported_reason).and_return('feature not supported')
-      end
-
-      context 'when feature is supported' do
-        let(:support) { true }
-        it { expect(subject).to be_falsey }
-      end
-      context 'when feature is not supported' do
-        let(:support) { false }
-        it { expect(subject).to be_truthy }
-      end
-    end
-    context 'when feature is unknown' do
-      let(:feature) { :non_existent_feature }
-
-      context 'and feature is not available' do
-        let(:available) { false }
-        it { expect(subject).to be_truthy }
-      end
-      context 'but feature is available' do
-        it { expect(subject).to be_falsey }
-      end
-    end
-  end
+  it_behaves_like 'a generic feature button with disabled'
 end

--- a/spec/helpers/application_helper/buttons/tenant_add_spec.rb
+++ b/spec/helpers/application_helper/buttons/tenant_add_spec.rb
@@ -1,7 +1,11 @@
 describe ApplicationHelper::Button::TenantAdd do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:options) { {:feature => 'rbac_project_add'} }
+  let(:record) { FactoryGirl.create(:tenant) }
+  let(:feature) { 'rbac_project_add' }
+  let(:options) { {:feature => feature} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {:options => options}) }
+
+  it_behaves_like 'a generic feature button after initialization'
 
   describe '#visible?' do
     subject { button.visible? }
@@ -10,7 +14,6 @@ describe ApplicationHelper::Button::TenantAdd do
       it { expect(subject).to be_falsey }
     end
     context 'when record is not a project' do
-      let(:record) { FactoryGirl.create(:tenant) }
       it { expect(subject).to be_truthy }
     end
   end

--- a/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
@@ -22,3 +22,42 @@ shared_examples_for 'a generic feature button after initialization' do
     it { expect(subject).to eq(feature) }
   end
 end
+
+shared_examples_for 'a generic feature button with disabled' do
+  include_examples 'a generic feature button'
+  include_examples 'GenericFeatureButtonWithDisabled#calculate_properties'
+end
+
+shared_examples_for 'GenericFeatureButtonWithDisabled#calculate_properties' do
+  describe '#calculate_properties' do
+    let(:available) { true }
+    before do
+      allow(record).to receive(:is_available?).with(feature).and_return(available)
+      allow(record).to receive(:is_available_now_error_message).and_return('unavailable')
+      allow(record).to receive(:supports?).with(feature).and_return(support) if defined? support
+      button.calculate_properties
+    end
+
+    context 'when feature exists' do
+      let(:feature) { :evacuate }
+      context 'and feature is supported' do
+        let(:support) { true }
+        it_behaves_like 'an enabled button'
+      end
+      context 'and feature is not supported' do
+        let(:support) { false }
+        it_behaves_like 'a disabled button', 'Feature not available/supported'
+      end
+    end
+    context 'when feature is unknown' do
+      let(:feature) { :non_existent_feature }
+      context 'and feature is not available' do
+        let(:available) { false }
+        it_behaves_like 'a disabled button', 'unavailable'
+      end
+      context 'but feature is available' do
+        it_behaves_like 'an enabled button'
+      end
+    end
+  end
+end

--- a/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
@@ -1,0 +1,24 @@
+shared_examples_for 'a generic feature button' do
+  include_examples 'a generic feature button after initialization'
+
+  describe '#visible?' do
+    subject { button.visible? }
+    before { allow(record).to receive("supports_#{feature}?".to_sym).and_return(supports_feature) }
+
+    context "when record supports #{feature}" do
+      let(:supports_feature) { true }
+      it { expect(subject).to be_truthy }
+    end
+    context "when record does not support #{feature}" do
+      let(:supports_feature) { false }
+      it { expect(subject).to be_falsey }
+    end
+  end
+end
+
+shared_examples_for 'a generic feature button after initialization' do
+  describe '#initialize' do
+    subject { button.instance_variable_get('@feature') }
+    it { expect(subject).to eq(feature) }
+  end
+end


### PR DESCRIPTION
Creates shared examples to test `GenericFeatureButton` and `GenericFeatureButtonWithDisabled` button class behavior. It further applies the shared examples in specs describing button classes inheriting from the above mentioned classes.

| Spec files using the created shared examples |
| --- |
| generic_feature_button_spec.rb |
| generic_feature_button_with_disable_spec.rb |
| host_feature_button_spec.rb |
| storage_scan_spec.rb |
| tenant_add_spec.rb |