### PR TITLE
Fix the displaying of the flash message(s) in policy list

### DIFF
--- a/app/views/miq_policy/_policy_list.html.haml
+++ b/app/views/miq_policy/_policy_list.html.haml
@@ -1,6 +1,7 @@
 #policy_list_div
   - if x_active_tree == :policy_tree && @view
     - if @view.table.data.empty?
+      = render :partial => "layouts/flash_msg"
       - mode, model = @sb[:folder].split('-')
       - mode = _(mode.titleize)
       - model = ui_lookup(:model => model.camelize)

--- a/spec/views/miq_policy/_policy_list.html.haml_spec.rb
+++ b/spec/views/miq_policy/_policy_list.html.haml_spec.rb
@@ -1,0 +1,12 @@
+require "ostruct"
+
+describe "miq_policy/_policy_list.html.haml" do
+  it "renders flash message for cancelled creation of new Policy" do
+    assign(:sb, :active_tree => :policy_tree, :folder => "a-b")
+    assign(:view, OpenStruct.new(:table => OpenStruct.new(:data => [])))
+    assign(:flash_array, [{ :message => "Add of new Policy was cancelled by the user",
+                            :level   => :success }])
+    render :partial => "miq_policy/policy_list"
+    expect(rendered).to match "Add of new Policy was cancelled by the user"
+  end
+end


### PR DESCRIPTION
When the user wants to add new policy (to the parent accordion w/o any record) and cancel the creation, no flash message displays. This PR is fixing that by adding the partial view to support displaying of the flash messages when no records are under the accordion.

https://bugzilla.redhat.com/show_bug.cgi?id=1404473