### PR TITLE
Added remove resources option in the form on Retirement tab

### DIFF
--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -23,6 +23,7 @@
                   'ng-options'       => "playbook as playbook.name for playbook in vm.#{prefix}_playbooks",
                   "required"         => "",
                   :miqrequired       => true,
+                  "ng-change"        => "playbookTypeChanged('#{prefix}')",
                   :checkchange       => true,
                   "data-live-search" => "true",
                   'pf-select'        => true}
@@ -95,6 +96,17 @@
                             "checkchange" => ""}
           %span.help-block{"ng-show" => "angularForm.#{prefix}_inventory.$error.miqrequired"}
             = _("Required")
+
+    - if prefix == "retirement"
+      .form-group
+        %label.col-md-3.control-label{"for" => "catalog_id"}
+          = _('Remove resources?')
+        .col-md-9
+          %select{"ng-model"   => "vm.catalogItemModel.retirement_remove_resources",
+                  "name"       => "vm.catalogItemModel.retirement_remove_resources",
+                  'ng-options' => "v as k for (k, v) in vm.catalogItemModel.remove_resources_types",
+                  :checkchange => true,
+                  "pf-select"  => true}
   .col-md-12.col-lg-6
     .form-group
       %label.col-md-3.control-label

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -35,6 +35,9 @@ describe('catalogItemFormController', function() {
           },
           network_credential_id: undefined,
           cloud_credential_id: undefined
+        },
+        retirement: {
+          remove_resources: 'yes_without_playbook',
         }
       }
     };


### PR DESCRIPTION
#Added an option to ask user if they want to remove associated resources as part of service retirement, default is set to "none" with options none/pre/post.

https://www.pivotaltracker.com/story/show/141238703

@tinaafitz @bzwei @gmcculloug please review/test.

screenshots:
![catalog_item_remove_resources1](https://cloud.githubusercontent.com/assets/3450808/23806006/09bfed0e-058e-11e7-9128-c4b47b0f7061.png)
![catalog_item_remove_resoures2](https://cloud.githubusercontent.com/assets/3450808/23806009/0bbcff98-058e-11e7-9176-7da57e1083ef.png)

