### PR TITLE
Display AWS instance labels in the Summary screen

### DIFF
--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -184,7 +184,7 @@ class VmCloudController < ApplicationController
     [
       %i(properties lifecycle) +
         (@record.kind_of?(VmCloud) ? %i(vm_cloud_relationships) : %i(template_cloud_relationships)) +
-        %i(vmsafe miq_custom_attributes ems_custom_attributes),
+        %i(vmsafe miq_custom_attributes ems_custom_attributes labels),
       %i(compliance power_management security configuration diagnostics tags)
     ]
   end

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -104,6 +104,10 @@ module VmHelper::TextualSummary
     TextualGroup.new(_("VC Custom Attributes"), textual_ems_custom_attributes)
   end
 
+  def textual_group_labels
+    TextualGroup.new(_("Labels"), textual_labels)
+  end
+
   def textual_group_power_management
     TextualGroup.new(_("Power Management"), %i(power_state boot_time state_changed_on))
   end
@@ -752,6 +756,12 @@ module VmHelper::TextualSummary
 
   def textual_ems_custom_attributes
     attrs = @record.ems_custom_attributes
+    return nil if attrs.blank?
+    attrs.sort_by(&:name).collect { |a| {:label => a.name, :value => a.value} }
+  end
+
+  def textual_labels
+    attrs = @record.custom_attributes
     return nil if attrs.blank?
     attrs.sort_by(&:name).collect { |a| {:label => a.name, :value => a.value} }
   end


### PR DESCRIPTION
<img width="476" alt="screen shot 2017-03-08 at 1 50 41 pm" src="https://cloud.githubusercontent.com/assets/1538216/23725663/49334f1e-0406-11e7-92df-5802cf87028b.png">

Depends on 
- https://github.com/ManageIQ/manageiq/pull/14202 -- (Status: Merged)
- https://github.com/ManageIQ/manageiq-providers-amazon/pull/162 -- (Status: Open)

https://www.pivotaltracker.com/n/projects/1644071/stories/139414085

