### PR TITLE
Fix for duplicate "None" default values - Related to BZ1428133

### DIFF
--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -111,6 +111,19 @@ module ApplicationHelper::Dialogs
     add_options_unless_read_only({}, tag_options, field)
   end
 
+  def default_value_form_options(field_type, field_values, field_default_value)
+    no_default_value = [["<#{_('None')}>", nil]]
+    if field_values.empty?
+      values = no_default_value
+    else
+      values = field_values.collect(&:reverse)
+      values = no_default_value + values if field_type == "DialogFieldRadioButton"
+    end
+
+    selected = field_default_value || nil
+    options_for_select(values, selected)
+  end
+
   def build_auto_refreshable_field_indicies(workflow)
     auto_refreshable_field_indicies = []
 

--- a/app/views/miq_ae_customization/_dialog_field_form_non_dynamic_options.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form_non_dynamic_options.html.haml
@@ -114,12 +114,9 @@
     %label.col-md-2.control-label
       = _('Default Value')
     .col-md-8
-      - none = [["<#{_('None')}>", nil]]
-      - values = @edit[:field_values].empty? ? none : none + @edit[:field_values].collect(&:reverse)
-      - selected = @edit[:field_default_value] || nil
       = select_tag("field_default_value",
-                    options_for_select(values, selected),
-                    :class    => "selectpicker")
+                   default_value_form_options(@edit[:field_typ], @edit[:field_values], @edit[:field_default_value]),
+                   :class    => "selectpicker")
       :javascript
         miqSelectPickerEvent("field_default_value", "#{url}")
   .form-group

--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -86,14 +86,13 @@
                                     options_for_select(val.collect(&:reverse), field.default_value))
                                 - else
                                   = select_tag('field.id',
-                                              options_for_select([["<#{_('Choose')}>", nil]] + val.collect(&:reverse),
-                                                                  field.default_value))
+                                              options_for_select(val.collect(&:reverse), field.default_value))
 
                               - else
                                 -# NOT REQUIRED
-                                = select_tag(field.id.to_s, options_for_select([[_('None').to_s, nil]] + val.collect(&:reverse),
-                                              field.default_value),
-                                              drop_down_options(field, "someURL"))
+                                = select_tag(field.id.to_s,
+                                             options_for_select(val.collect(&:reverse), field.default_value),
+                                             drop_down_options(field, "someURL"))
                                 :javascript
                                   dialogFieldRefresh.initializeDialogSelectPicker('#{field.name}',
                                                                                   '#{field.id}',
@@ -102,11 +101,6 @@
 
                             - else
                               - val.each_with_index do |rb, i|
-                                - unless field.required || i != 0
-                                  %input{:type => "radio", :disabled => true, :checked => field.default_value.nil?,
-                                    :id => "None", :value => "nil", :name => "None"}
-                                  &nbsp; None &nbsp;
-
                                 %input{:type => "radio", :disabled => true, :checked => (field.default_value == rb[0]),
                                   :id => rb[0], :value => rb[1], :name => rb[0]}
                                 &nbsp;

--- a/app/views/miq_ae_customization/_field_values.html.haml
+++ b/app/views/miq_ae_customization/_field_values.html.haml
@@ -17,7 +17,8 @@
         - else
           = render :partial => "field_value_entry", :locals => {:entry => "new", :edit => false}
         - @edit[:field_values].each_with_index do |e, i|
-          - if !entry.nil? && entry != "new" && entry.to_i == i
-            = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => true}
-          - else
-            = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => false}
+          - unless e[0].nil?
+            - if !entry.nil? && entry != "new" && entry.to_i == i
+              = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => true}
+            - else
+              = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => false}

--- a/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
@@ -1,9 +1,7 @@
 - if edit
   - if field.values.length > 1
     %span{:id => "dynamic-radio-#{field.id}"}
-      - values = field.values
-      - values = [['', "<#{_('None')}>"]] + values if !field.required && !field.dynamic
-      - values.each do |rb|
+      - field.values.each do |rb|
 
         %input{radio_options(field, url, rb[0], wf.value(field.name))}
         %label.dynamic-radio-label= rb[1]

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -509,4 +509,104 @@ describe ApplicationHelper::Dialogs do
       expect(helper.auto_refresh_listening_options(options, true)).to eq(:trigger => true)
     end
   end
+
+  describe "#default_value_form_options" do
+    let(:subject) { helper.default_value_form_options(field_type, field_values, field_default_value) }
+
+    context "when the field values are empty" do
+      let(:field_values) { [] }
+
+      context "when the field type is a DialogFieldDropDownList" do
+        let(:field_type) { "DialogFieldDropDownList" }
+
+        context "when the field default value is set" do
+          let(:field_default_value) { "some default" }
+
+          it "adds the ability to select no default value" do
+            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
+          end
+        end
+
+        context "when the field default value is not set" do
+          let(:field_default_value) { nil }
+
+          it "adds the ability to select no default value" do
+            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
+          end
+        end
+      end
+
+      context "when the field type is a DialogFieldRadioButton" do
+        let(:field_type) { "DialogFieldRadioButton" }
+
+        context "when the field default value is set" do
+          let(:field_default_value) { "some default" }
+
+          it "adds the ability to select no default value" do
+            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
+          end
+        end
+
+        context "when the field default value is not set" do
+          let(:field_default_value) { nil }
+
+          it "adds the ability to select no default value" do
+            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
+          end
+        end
+      end
+    end
+
+    context "when the field values are not empty" do
+      let(:field_values) { [%w(123 456)] }
+
+      context "when the field type is a DialogFieldDropDownList" do
+        let(:field_type) { "DialogFieldDropDownList" }
+
+        context "when the field default value is set" do
+          let(:field_default_value) { "123" }
+
+          it "selects the default value and does not add any" do
+            expect(subject).to eq("<option selected=\"selected\" value=\"123\">456</option>")
+          end
+        end
+
+        context "when the field default value is not set" do
+          let(:field_default_value) { nil }
+
+          it "does not explicitly select anything" do
+            expect(subject).to eq("<option value=\"123\">456</option>")
+          end
+        end
+      end
+
+      context "when the field type is a DialogFieldRadioButton" do
+        let(:field_type) { "DialogFieldRadioButton" }
+
+        context "when the field default value is set" do
+          let(:field_default_value) { "123" }
+
+          it "adds the ability to select no default value but selects the default" do
+            expected_html = <<-HTML
+<option value=\"\">&lt;None&gt;</option>
+<option selected=\"selected\" value=\"123\">456</option>
+            HTML
+            expect(subject).to eq(expected_html.chomp)
+          end
+        end
+
+        context "when the field default value is not set" do
+          let(:field_default_value) { nil }
+
+          it "adds the ability to select no default value" do
+            expected_html = <<-HTML
+<option value=\"\">&lt;None&gt;</option>
+<option value=\"123\">456</option>
+            HTML
+            expect(subject).to eq(expected_html.chomp)
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This change removes the need to prepend 'none' option to values as it is done in model now. ~~It's not a strictly necessary counterpart for https://github.com/ManageIQ/manageiq/pull/14240, but without it, you would see double "None"/"Choose" values when editing the dialog field.~~

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1428133.

/cc @gmcculloug 

@miq-bot add_label bug, euwe/yes