### PR TITLE
For middleware UI, only allow operations on mutable servers.

### DIFF
--- a/app/helpers/application_helper/button/middleware_server_action.rb
+++ b/app/helpers/application_helper/button/middleware_server_action.rb
@@ -1,7 +1,18 @@
 class ApplicationHelper::Button::MiddlewareServerAction < ApplicationHelper::Button::Basic
 
   def visible?
-    !@record.present? ||
-      (@record.try(:product) != 'Hawkular' && @record.try(:middleware_server).try(:product) != 'Hawkular')
+    @record.present? && !hawkular? && !immutable?
+  end
+
+  private
+
+  def immutable?
+    properties = @record.try(:properties)
+    properties.nil? ? false : properties['Immutable'] == 'true'
+  end
+
+  def hawkular?
+    @record.try(:product) == 'Hawkular' ||
+      @record.try(:middleware_server).try(:product) == 'Hawkular'
   end
 end

--- a/spec/helpers/application_helper/buttons/middleware_standalone_server_action_spec.rb
+++ b/spec/helpers/application_helper/buttons/middleware_standalone_server_action_spec.rb
@@ -14,6 +14,27 @@ describe ApplicationHelper::Button::MiddlewareStandaloneServerAction do
         it { expect(subject.visible?).to be_truthy }
       end
     end
+
+    context 'when record responds to #immutable?' do
+      def create_immutable(value)
+        {'Immutable' => value.to_s }
+      end
+
+      context 'when server.properties.immutable? == true' do
+        let(:immutable_server) { FactoryGirl.create(:middleware_server, :properties => create_immutable(true)) }
+        let(:record) { immutable_server }
+        subject { described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record}, {}) }
+        it { expect(subject).not_to be_visible }
+      end
+
+      context 'when server.properties.immutable? == false' do
+        let(:mutable_server) { FactoryGirl.create(:middleware_server, :properties => create_immutable(false)) }
+        let(:record) { mutable_server }
+        subject { described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record}, {}) }
+        it { expect(subject).to be_visible }
+      end
+    end
+
     context 'when record does not respond to #in_domain?' do
       let(:record) { FactoryGirl.create(:middleware_deployment, :middleware_server => server) }
       context 'when server.in_domain? == true' do


### PR DESCRIPTION
The Hawkular agent now reads the properties from managed servers. These properties can be used to indicate the immutability of the environment (such as an EAP server running in OpenShift). The property being set here is: **-Dhawkular.agent.immutable=true**

An Immutable server:
![immutable_toolbar](https://cloud.githubusercontent.com/assets/1312165/23729207/64b07b7c-0415-11e7-9018-fc2e3221d413.jpg)

A mutable server:
![mutable_toolbar](https://cloud.githubusercontent.com/assets/1312165/23729221/79391a40-0415-11e7-9c6d-fcd779262e5e.jpg)

### Testing
1. Start a hawkular server _(requires Hawkular Services >= 0.32)_
2. Add a Hawkular Provider
3. Add manger EAP 7.0 server (with Hawkular Agent) to Hawkular Provider with parameter: **-Dhawkular.agent.immutable=true** where *machineA* can be any string. For example: 
````
bin/standalone.sh -Djboss.socket.binding.port-offset=100 -Dhawkular.agent.in-container=true -Dhawkular.agent.immutable=true 
````

### Links

- [Prevent MiQ UI from showing mutable operations for servers in container
](https://issues.jboss.org/browse/HAWKULAR-1201)
- [Treat EAP immutable if running in Container
](https://issues.jboss.org/browse/HAWKULAR-1183)

