### PR TITLE
Fix for broken specs in ApplicationHelper::Dialogs

### DIFF
--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -1,11 +1,6 @@
 module ApplicationHelper::Dialogs
-  def dialog_dropdown_select_values(field, selected_value, category_tags = nil)
+  def dialog_dropdown_select_values(field, _selected_value, category_tags = nil)
     values = []
-    if !field.required
-      values.push(["<None>", nil])
-    elsif selected_value.blank?
-      values.push(["<Choose>", nil])
-    end
     if field.type.include?("DropDown")
       values += field.values.collect(&:reverse)
     elsif field.type.include?("TagControl")

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -12,7 +12,7 @@ describe ApplicationHelper::Dialogs do
 
   describe "#dialog_dropdown_select_values" do
     let(:dialog_field) { instance_double("DialogFieldDropDownList", :values => values, :type => type) }
-    let(:values) { [["cat", "Cat"], ["dog", "Dog"]] }
+    let(:values) { [%w(cat Cat), %w(dog Dog)] }
 
     context "when the field type includes drop down" do
       let(:type) { "BananaDropDown" }

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -11,25 +11,23 @@ describe ApplicationHelper::Dialogs do
   let(:trigger_auto_refresh) { nil }
 
   describe "#dialog_dropdown_select_values" do
-    before do
-      val_array = [["cat", "Cat"], ["dog", "Dog"]]
-      @val_array_reversed = val_array.collect(&:reverse)
-      @field = DialogFieldDropDownList.new(:values => val_array)
+    let(:dialog_field) { instance_double("DialogFieldDropDownList", :values => values, :type => type) }
+    let(:values) { [["cat", "Cat"], ["dog", "Dog"]] }
+
+    context "when the field type includes drop down" do
+      let(:type) { "BananaDropDown" }
+
+      it "returns the values collected and reversed" do
+        expect(helper.dialog_dropdown_select_values(dialog_field, nil)).to eq(values.collect(&:reverse))
+      end
     end
 
-    it "not required" do
-      @field.required = false
-      expect(helper.dialog_dropdown_select_values(@field, nil)).to eq([["<None>", nil]] + @val_array_reversed)
-    end
+    context "when the field type includes tag control" do
+      let(:type) { "BananaTagControl" }
 
-    it "required, nil selected" do
-      @field.required = true
-      expect(helper.dialog_dropdown_select_values(@field, nil)).to eq([["<Choose>", nil]] + @val_array_reversed)
-    end
-
-    it "required, non-nil selected" do
-      @field.required = true
-      expect(helper.dialog_dropdown_select_values(@field, "cat")).to eq(@val_array_reversed)
+      it "returns the values with the passed in category tags" do
+        expect(helper.dialog_dropdown_select_values(dialog_field, nil, %w(category tags))).to eq(%w(category tags))
+      end
     end
   end
 

--- a/spec/services/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/services/ansible_tower_job_template_dialog_service_spec.rb
@@ -73,8 +73,8 @@ describe AnsibleTowerJobTemplateDialogService do
     assert_field(fields[1], DialogFieldTextBox,      :name => 'param_param2', :data_type => 'string',    :default_value => "as")
     assert_field(fields[2], DialogFieldTextAreaBox,  :name => 'param_param3', :data_type => 'string',    :default_value => "no\nhello")
     assert_field(fields[3], DialogFieldTextBox,      :name => 'param_param4', :data_type => 'string',    :default_value => "mypassword", :options => {:protected => true})
-    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :default_value => "Peach", :values => [%w(Apple Apple), %w(Banana Banana), %w(Peach Peach)])
-    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :default_value => "opt1",  :values => [%w(222 222), %w(opt1 opt1), %w(opt3 opt3)])
+    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :default_value => "Peach", :values => [[nil, "<Choose>"], %w(Apple Apple), %w(Banana Banana), %w(Peach Peach)])
+    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :default_value => "opt1",  :values => [%w(222 222), [nil, "<Choose>"], %w(opt1 opt1), %w(opt3 opt3)])
     assert_field(fields[6], DialogFieldTextBox,      :name => 'param_param7', :data_type => 'string',    :default_value => "14.5")
   end
 

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -58,7 +58,7 @@ describe OrchestrationTemplateDialogService do
         # Get the dropdown field
         field = dropdown_field(dialog)
         # Ensure the allowed values are properly stored.
-        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [%w(val1 val1), %w(val2 val2)])
+        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [[nil, "<Choose>"], %w(val1 val1), %w(val2 val2)])
       end
     end
 
@@ -73,7 +73,7 @@ describe OrchestrationTemplateDialogService do
         # Get the dropdown field
         field = dropdown_field(dialog)
         # Ensure the allowed values are properly stored.
-        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [%w(key1 val1), %w(key2 val2)])
+        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [[nil, "<Choose>"], %w(key1 val1), %w(key2 val2)])
       end
     end
 
@@ -124,7 +124,7 @@ describe OrchestrationTemplateDialogService do
     expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
     assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
     assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
-    assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [%w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
+    assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [[nil, "<Choose>"], %w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
     assert_field(fields[3], DialogFieldTextBox,      :name => "stack_timeout",   :data_type => 'integer')
   end
 
@@ -143,7 +143,8 @@ describe OrchestrationTemplateDialogService do
     assert_field(fields[2], DialogFieldDropDownList, :name => "resource_group",     :dynamic => true)
     assert_field(fields[3], DialogFieldTextBox,      :name => "new_resource_group", :validator_rule => '^[A-Za-z][A-Za-z0-9\-_]*$')
 
-    mode_values = [["Complete",    "Complete (Delete other resources in the group)"],
+    mode_values = [[nil,           "<Choose>"],
+                   ["Complete",    "Complete (Delete other resources in the group)"],
                    ["Incremental", "Incremental (Default)"]]
     assert_field(fields[4], DialogFieldDropDownList, :name => "deploy_mode", :values => mode_values)
     expect(fields[4].default_value).to eq("Incremental")
@@ -193,7 +194,7 @@ describe OrchestrationTemplateDialogService do
     expect(fields.size).to eq(3)
 
     assert_field(fields[0], DialogFieldTextBox,      :name => "param_flavor",     :default_value => "m1.small")
-    assert_field(fields[1], DialogFieldDropDownList, :name => "param_image_id",   :default_value => "F18-x86_64-cfntools", :values => [%w(F18-i386-cfntools F18-i386-cfntools), %w(F18-x86_64-cfntools F18-x86_64-cfntools)])
+    assert_field(fields[1], DialogFieldDropDownList, :name => "param_image_id",   :default_value => "F18-x86_64-cfntools", :values => [[nil, "<Choose>"], %w(F18-i386-cfntools F18-i386-cfntools), %w(F18-x86_64-cfntools F18-x86_64-cfntools)])
     assert_field(fields[2], DialogFieldTextBox,      :name => "param_cartridges", :default_value => "cron,diy,haproxy,mysql,nodejs,perl,php,postgresql,python,ruby")
   end
 


### PR DESCRIPTION
Some specs started breaking on the [EUWE backport](https://github.com/ManageIQ/manageiq/pull/14259) of https://github.com/ManageIQ/manageiq/pull/14240 and that's because the model logic was changed to include 'none' or 'choose' now instead of the view needing to do it. There was a helper that was missed, and I think the original classic UI PR didn't have the test failure because the model change wasn't merged yet.

This should fix that by relying on the model to provide 'none' values instead of helper trying to do it. It removes some unnecessary logic in the helper and cleans up the tests a little bit as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1428133

Note this does not need to be backported because I found it on the EUWE backport and made the necessary changes there already and am just forwarding it here.

@h-kataria You merged the earlier [related classic UI component PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/633) for the above mentioned PRs, so I'm assigning you here as well, please re-assign if this isn't correct!
/cc @gmcculloug 

@miq-bot assign @h-kataria 