### PR TITLE
Disable ownership screen for provider with tenant mapping

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -99,8 +99,8 @@ module ApplicationController::CiProcessing
     Rbac.filtered(MiqGroup.non_tenant_groups).each { |g| @groups[g.description] = g.id.to_s }
 
     @user = @group = DONT_CHANGE_OWNER if ownership_items.length > 1
-
-    @ownershipitems = klass.find(ownership_items).sort_by(&:name)
+    ownership_scope = klass.where(:id => ownership_items)
+    @ownershipitems = ownership_scope.order(:name)
     @view = get_db_view(klass == VmOrTemplate ? Vm : klass) # Instantiate the MIQ Report view object
     @view.table = MiqFilter.records2table(@ownershipitems, @view.cols + ['id'])
   end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -162,7 +162,8 @@ module ApplicationController::CiProcessing
       end
 
       klass = get_class_from_controller_param(request.parameters[:controller])
-      result = klass.set_ownership(params[:objectIds].map(&:to_i), opts)
+      param_ids = params[:objectIds].map(&:to_i)
+      result = klass.set_ownership(param_ids, opts)
       unless result == true
         result["missing_ids"].each { |msg| add_flash(msg, :error) } if result["missing_ids"]
         result["error_updating"].each { |msg| add_flash(msg, :error) } if result["error_updating"]

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -100,6 +100,7 @@ module ApplicationController::CiProcessing
 
     @user = @group = DONT_CHANGE_OWNER if ownership_items.length > 1
     ownership_scope = klass.where(:id => ownership_items)
+    ownership_scope = ownership_scope.with_ownership if klass.respond_to?(:with_ownership)
     @ownershipitems = ownership_scope.order(:name)
     @view = get_db_view(klass == VmOrTemplate ? Vm : klass) # Instantiate the MIQ Report view object
     @view.table = MiqFilter.records2table(@ownershipitems, @view.cols + ['id'])

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -127,7 +127,8 @@ module ApplicationController::CiProcessing
     @group = group ? group.id.to_s : nil
     Rbac.filtered(MiqGroup).each { |g| @groups[g.description] = g.id.to_s }
     @user = @group = DONT_CHANGE_OWNER if ownership_items.length > 1
-    @ownershipitems = klass.find(ownership_items).sort_by(&:name)
+    @ownershipitems = Rbac.filtered(klass.where(:id => ownership_items).order(:name), :class => klass)
+    raise _('Invalid items passed') unless @ownershipitems.pluck(:id).to_set == ownership_items.map(&:to_i).to_set
     {:user  => @user,
      :group => @group}
   end

--- a/app/helpers/application_helper/button/set_ownership.rb
+++ b/app/helpers/application_helper/button/set_ownership.rb
@@ -1,0 +1,9 @@
+class ApplicationHelper::Button::SetOwnership < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def disabled?
+    @error_message = _('Ownership is controlled by tenant mapping') if
+      @record.ext_management_system.tenant_mapping_enabled?
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -29,7 +29,8 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           :instance_ownership,
           'pficon pficon-user fa-lg',
           N_('Set Ownership for this Instance'),
-          N_('Set Ownership')),
+          N_('Set Ownership'),
+          :klass => ApplicationHelper::Button::SetOwnership),
         button(
           :instance_delete,
           'pficon pficon-delete fa-lg',

--- a/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
@@ -29,7 +29,9 @@ class ApplicationHelper::Toolbar::XTemplateCloudCenter < ApplicationHelper::Tool
                        :image_ownership,
                        'pficon pficon-user fa-lg',
                        N_('Set Ownership for this Image'),
-                       N_('Set Ownership')),
+                       N_('Set Ownership'),
+                       :klass => ApplicationHelper::Button::SetOwnership
+                     ),
                      button(
                        :image_delete,
                        'pficon pficon-delete fa-lg',

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -29,7 +29,9 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           :instance_ownership,
           'pficon pficon-user fa-lg',
           N_('Set Ownership for this Instance'),
-          N_('Set Ownership')),
+          N_('Set Ownership'),
+          :klass => ApplicationHelper::Button::SetOwnership
+        ),
         separator,
         button(
           :instance_delete,

--- a/app/views/shared/views/_ownership.html.haml
+++ b/app/views/shared/views/_ownership.html.haml
@@ -41,6 +41,9 @@
   %hr
   %h3
     = _('Affected Items')
+  - if @origin_ownership_items.count != @ownershipitems.count
+    %strong
+      = _('Note: Some items might be hidden due to the possibility of an ownership change')
   - if @ownershipitems
     - @embedded = true
     - @quadicon_no_url = true

--- a/spec/controllers/vm_cloud_controller/trees_spec.rb
+++ b/spec/controllers/vm_cloud_controller/trees_spec.rb
@@ -33,7 +33,7 @@ describe VmCloudController do
       %w(vm_amazon Amazon)
     ].each do |instance, name|
       it "renders Instance details for #{name} node" do
-        instance = FactoryGirl.create(instance.to_sym)
+        instance = FactoryGirl.create(instance.to_sym, :with_provider)
 
         session[:settings] = {}
         seed_session_trees('vm_cloud', 'instances_tree')

--- a/spec/helpers/application_helper/buttons/set_ownership_spec.rb
+++ b/spec/helpers/application_helper/buttons/set_ownership_spec.rb
@@ -1,0 +1,25 @@
+describe ApplicationHelper::Button::SetOwnership do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+
+  let(:ext_management_system) do
+    FactoryGirl.create(:ext_management_system, :tenant_mapping_enabled => tenant_mapping_enabled)
+  end
+
+  let(:record) { FactoryGirl.create(:vm, :ext_management_system => ext_management_system) }
+
+  let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
+
+  describe '#calculate_properties' do
+    before { button.calculate_properties }
+
+    context 'when provider has tenant mapping enabled' do
+      let(:tenant_mapping_enabled) { true }
+      it_behaves_like 'a disabled button', 'Ownership is controlled by tenant mapping'
+    end
+
+    context 'when provider has tenant mapping disabled' do
+      let(:tenant_mapping_enabled) { false }
+      it_behaves_like 'an enabled button'
+    end
+  end
+end


### PR DESCRIPTION
There are general cases where it shoul be checked from list of Images/Instances or from Image/Instance summary.
There also are some new messages which need to be checked.

a) Trying to select  Images/Instances  and all of them  come from provider with tenant mapping.
Ownership change is not allowed.
![screen shot 2017-03-13 at 13 13 12](https://cloud.githubusercontent.com/assets/14937244/23853872/e803edba-07ee-11e7-9ebf-106356ccb413.png)

b) Trying to select  Images/Instances  and some of them  come from provider with tenant mapping.
Ownership change is not allowed for some item and there is added note about this situation.

![screen shot 2017-03-10 at 14 31 55](https://cloud.githubusercontent.com/assets/14937244/23797102/7d9519b0-059e-11e7-97d8-590e9aa09c01.png)


## Test scenario:
1.Enable tenant mapping on provider
2. Try to change ownership of provider's instances/images - it should not be possible from
a) list
b) summary page

cc @patchez @gtanzillo @martinpovolny 
thanks @himdel 

backend PR is needed  https://github.com/ManageIQ/manageiq/pull/14264
@miq-bot add_label backend_pending, blocker, euwe/yes

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1400671
backend PR https://github.com/ManageIQ/manageiq/pull/14264