### PR TITLE
Stop setting-up remote_proxy for OrchestrationTemplates

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -722,7 +722,6 @@ class CatalogController < ApplicationController
           {:name => ot.name}, :error)
       else
         begin
-          ot.remote_proxy = true
           ot.destroy
         rescue => bang
           add_flash(_("Error during 'Orchestration Template Deletion': %{error_message}") %
@@ -1000,7 +999,6 @@ class CatalogController < ApplicationController
       ot.name = @edit[:new][:name]
       ot.description = @edit[:new][:description]
       ot.ems_id = @edit[:new][:manager_id]
-      ot.remote_proxy = true
       unless ot.in_use?
         ot.content = params[:template_content]
         ot.draft = @edit[:new][:draft]
@@ -1056,8 +1054,8 @@ class CatalogController < ApplicationController
         :type         => old_ot.type,
         :content      => params[:template_content],
         :draft        => @edit[:new][:draft] == true || @edit[:new][:draft] == "true",
-        :ems_id       => @edit[:new][:manager_id],
-        :remote_proxy => true)
+        :ems_id       => @edit[:new][:manager_id]
+      )
       begin
         ot.save_as_orderable!
       rescue => bang
@@ -1102,8 +1100,8 @@ class CatalogController < ApplicationController
         :type         => @edit[:new][:type],
         :content      => params[:content],
         :draft        => @edit[:new][:draft],
-        :ems_id       => @edit[:new][:manager_id],
-        :remote_proxy => true)
+        :ems_id       => @edit[:new][:manager_id]
+      )
       begin
         ot.save_as_orderable!
       rescue => bang


### PR DESCRIPTION
It's been replaced with block_raw_action.

Merge together with core: https://github.com/ManageIQ/manageiq/pull/14266

@miq-bot add_label refactoring, pending_core