### PR TITLE
Support operation `create` on CloudObjectStoreContainer

### DIFF
--- a/app/assets/javascripts/controllers/cloud_object_store_container/cloud_object_store_container_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_object_store_container/cloud_object_store_container_form_controller.js
@@ -1,0 +1,44 @@
+ManageIQ.angular.app.controller('cloudObjectStoreContainerFormController', ['$scope', 'miqService', 'API', function($scope, miqService, API) {
+  var init = function() {
+    $scope.cloudContainerModel = {
+      name: '',
+      emstype: '',
+      parent_emstype: '',
+      storage_manager_id: '',
+      provider_region: '',
+    };
+    $scope.afterGet = false;
+    $scope.modelCopy = angular.copy( $scope.cloudContainerModel );
+    $scope.model = 'cloudContainerModel';
+    $scope.newRecord = true;
+
+    ManageIQ.angular.scope = $scope;
+  };
+
+  $scope.addClicked = function() {
+    var url = 'create' + '?button=add';
+    miqService.miqAjaxButton(url, $scope.cloudContainerModel, { complete: false });
+  };
+
+  $scope.cancelClicked = function() {
+    miqService.miqAjaxButton('/cloud_object_store_container/create?button=cancel');
+  };
+
+  $scope.storageManagerChanged = function(id) {
+    miqService.sparkleOn();
+
+    API.get('/api/providers/' + id + '?attributes=type,parent_manager.type')
+      .then(getStorageManagerFormDataComplete)
+      .catch(miqService.handleFailure);
+  };
+
+  function getStorageManagerFormDataComplete(data) {
+    $scope.afterGet = true;
+    $scope.cloudContainerModel.emstype = data.type;
+    $scope.cloudContainerModel.parent_emstype = data.parent_manager.type;
+
+    miqService.sparkleOff();
+  }
+
+  init();
+}]);

--- a/app/assets/javascripts/controllers/cloud_object_store_container/cloud_object_store_container_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_object_store_container/cloud_object_store_container_form_controller.js
@@ -11,9 +11,7 @@ ManageIQ.angular.app.controller('cloudObjectStoreContainerFormController', ['miq
     };
 
     // fetch StorageManager from querystring
-    if (! isNaN(parseInt(storageManagerId, 10))) {
-      vm.cloudContainerModel.storage_manager_id = parseInt(storageManagerId, 10);
-    }
+    vm.cloudContainerModel.storage_manager_id = storageManagerId;
 
     vm.model = 'cloudContainerModel';
     vm.newRecord = true;

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1826,6 +1826,7 @@ module ApplicationController::CiProcessing
     task = pressed.sub("#{klass.name.underscore.to_sym}_", "")
 
     return tag(klass) if task == "tag"
+    return javascript_redirect(:controller => klass.name.underscore.to_sym, :action => "new") if task == "new"
 
     cloud_object_store_button_operation(klass, task)
   end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1826,7 +1826,6 @@ module ApplicationController::CiProcessing
     task = pressed.sub("#{klass.name.underscore.to_sym}_", "")
 
     return tag(klass) if task == "tag"
-    return javascript_redirect(:controller => klass.name.underscore.to_sym, :action => "new") if task == "new"
 
     cloud_object_store_button_operation(klass, task)
   end

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -17,7 +17,12 @@ class CloudObjectStoreContainerController < ApplicationController
     @edit = session[:edit] # Restore @edit for adv search box
     params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
 
-    process_cloud_object_storage_buttons(params[:pressed])
+    case params[:pressed]
+    when "cloud_object_store_container_new"
+      return javascript_redirect(:action => "new")
+    else
+      process_cloud_object_storage_buttons(params[:pressed])
+    end
 
     if !@flash_array.nil? && params[:pressed].ends_with?("delete")
       javascript_redirect :action      => 'show_list',

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -54,9 +54,7 @@ class CloudObjectStoreContainerController < ApplicationController
     assert_privileges("cloud_object_store_container_new")
     case params[:button]
     when "cancel"
-      javascript_redirect :action    => 'show_list',
-                          :flash_msg => _("Add of new %{model} was cancelled by the user") %
-                                        {:model => ui_lookup(:table => 'cloud_object_store_container')}
+      javascript_redirect previous_breadcrumb_url
     when "add"
       options = form_params_create
       ext_management_system = options.delete(:ems)
@@ -92,10 +90,8 @@ class CloudObjectStoreContainerController < ApplicationController
       }, :error)
     end
 
-    @breadcrumbs.pop if @breadcrumbs
     session[:flash_msgs] = @flash_array.dup if @flash_array
-
-    javascript_redirect :action => "show_list"
+    javascript_redirect previous_breadcrumb_url
   end
 
   def form_params_create

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -40,11 +40,8 @@ class CloudObjectStoreContainerController < ApplicationController
   def new
     assert_privileges("cloud_object_store_container_new")
     @in_a_form = true
-    @storage_manager_choices = {}
-    ExtManagementSystem.all.each do |ems|
-      if ems.supports?(:cloud_object_store_container_create)
-        @storage_manager_choices[ems.name] = ems.id
-      end
+    if params[:storage_manager_id]
+      @storage_manager = find_record_with_rbac(ExtManagementSystem, params[:storage_manager_id])
     end
     @provider_regions = retrieve_provider_regions
     drop_breadcrumb(
@@ -116,7 +113,7 @@ class CloudObjectStoreContainerController < ApplicationController
 
       # Get the storage manager.
       storage_manager_id = params[:storage_manager_id] if params[:storage_manager_id]
-      options[:ems] = find_by_id_filtered(ExtManagementSystem, storage_manager_id)
+      options[:ems] = find_record_with_rbac(ExtManagementSystem, storage_manager_id)
     end
     options
   end

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -32,7 +32,99 @@ class CloudObjectStoreContainerController < ApplicationController
     %w(cloud_object_store_objects)
   end
 
+  def new
+    assert_privileges("cloud_object_store_container_new")
+    @in_a_form = true
+    @storage_manager_choices = {}
+    ExtManagementSystem.all.each do |ems|
+      if ems.supports?(:cloud_object_store_container_create)
+        @storage_manager_choices[ems.name] = ems.id
+      end
+    end
+    @provider_regions = retrieve_provider_regions
+    drop_breadcrumb(
+      :name => _("Add New %{model}") % {:model => ui_lookup(:table => 'cloud_object_store_container')},
+      :url  => "/cloud_object_store_container/new"
+    )
+  end
+
+  def create
+    assert_privileges("cloud_object_store_container_new")
+    case params[:button]
+    when "cancel"
+      javascript_redirect :action    => 'show_list',
+                          :flash_msg => _("Add of new %{model} was cancelled by the user") %
+                                        {:model => ui_lookup(:table => 'cloud_object_store_container')}
+    when "add"
+      options = form_params_create
+      ext_management_system = options.delete(:ems)
+
+      # Queue task
+      task_id = CloudObjectStoreContainer.cloud_object_store_container_create_queue(
+        session[:userid],
+        ext_management_system,
+        options
+      )
+
+      if task_id.kind_of?(Integer)
+        initiate_wait_for_task(:task_id => task_id, :action => "create_finished")
+      else
+        add_flash(_("Cloud Object Store Container creation failed: Task start failed"), :error)
+        javascript_flash(:spinner_off => true)
+      end
+    end
+  end
+
+  def create_finished
+    task_id = session[:async][:params][:task_id]
+    container_name = session[:async][:params][:name]
+    task = MiqTask.find(task_id)
+    if MiqTask.status_ok?(task.status)
+      add_flash(_("Cloud Object Store Container \"%{name}\" created") % {
+        :name => container_name
+      })
+    else
+      add_flash(_("Unable to create Cloud Object Store Container \"%{name}\": %{details}") % {
+        :name    => container_name,
+        :details => task.message
+      }, :error)
+    end
+
+    @breadcrumbs.pop if @breadcrumbs
+    session[:flash_msgs] = @flash_array.dup if @flash_array
+
+    javascript_redirect :action => "show_list"
+  end
+
+  def form_params_create
+    options = {}
+    options[:name] = params[:name] if params[:name]
+
+    # Depending on the storage manager type, collect required form params.
+    case params[:emstype]
+    when "ManageIQ::Providers::Amazon::StorageManager::S3"
+      if params[:provider_region]
+        options[:create_bucket_configuration] = {
+          :location_constraint => params[:provider_region]
+        }
+      end
+
+      # Get the storage manager.
+      storage_manager_id = params[:storage_manager_id] if params[:storage_manager_id]
+      options[:ems] = find_by_id_filtered(ExtManagementSystem, storage_manager_id)
+    end
+    options
+  end
+
   private
+
+  def retrieve_provider_regions
+    managers = ManageIQ::Providers::CloudManager.supported_subclasses.select(&:supports_regions?)
+    managers.each_with_object({}) do |manager, provider_regions|
+      regions = manager.parent::Regions.all.sort_by { |r| r[:description] }
+      provider_regions[manager.name] = regions.map { |region| [region[:description], region[:name]] }
+    end
+  end
 
   def textual_group_list
     [%i(properties relationships), %i(tags)]

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -361,7 +361,13 @@ module EmsCommon
         end
       end
     elsif params[:pressed].starts_with?("cloud_object_store_")
-      process_cloud_object_storage_buttons(params[:pressed])
+      case params[:pressed]
+      when "cloud_object_store_container_new"
+        return javascript_redirect(:controller => "cloud_object_store_container", :action => "new",
+                                   :storage_manager_id => params[:id])
+      else
+        process_cloud_object_storage_buttons(params[:pressed])
+      end
     else
       @refresh_div = "main_div" # Default div for button.rjs to refresh
       redirect_to :action => "new" if params[:pressed] == "new"

--- a/app/helpers/application_helper/button/cloud_object_store_container_new.rb
+++ b/app/helpers/application_helper/button/cloud_object_store_container_new.rb
@@ -1,0 +1,12 @@
+class ApplicationHelper::Button::CloudObjectStoreContainerNew < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if disabled?
+      self[:title] = _("No storage managers support creating cloud object store containers.")
+    end
+  end
+
+  def disabled?
+    !ExtManagementSystem.any? { |ems| ems.supports?(:cloud_object_store_container_create) }
+  end
+end

--- a/app/helpers/application_helper/toolbar/cloud_object_store_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_object_store_containers_center.rb
@@ -7,9 +7,16 @@ class ApplicationHelper::Toolbar::CloudObjectStoreContainersCenter < Application
         'fa fa-cog fa-lg',
         t = N_('Configuration'),
         t,
-        :enabled => false,
-        :onwhen  => "1+",
+        :enabled => true,
         :items   => [
+          button(
+            :cloud_object_store_container_new,
+            'pficon pficon-add-circle-o fa-lg',
+            t = N_('Add a new Cloud Object Store Container'),
+            t,
+            :klass => ApplicationHelper::Button::CloudObjectStoreContainerNew
+          ),
+          separator,
           button(
             :cloud_object_store_container_clear,
             'pficon pficon-delete fa-lg',
@@ -21,7 +28,6 @@ class ApplicationHelper::Toolbar::CloudObjectStoreContainersCenter < Application
             :enabled   => false,
             :onwhen    => "1+"
           ),
-          separator,
           button(
             :cloud_object_store_container_delete,
             'pficon pficon-delete fa-lg',

--- a/app/views/cloud_object_store_container/new.html.haml
+++ b/app/views/cloud_object_store_container/new.html.haml
@@ -1,0 +1,50 @@
+%form#form_div{:name => "angularForm", 'ng-controller' => "cloudObjectStoreContainerFormController", "ng-cloak" => ""}
+  = render :partial => "layouts/flash_msg"
+  %h3
+    = _('Basic Information')
+  .form-horizontal
+    .form-group{"ng-class" => "{'has-error': angularForm.storage_manager_id.$invalid}"}
+      %label.col-md-2.control-label
+        = _('Storage Manager')
+      .col-md-8
+        = select_tag("storage_manager_id",
+          options_for_select([["<#{_('Choose')}>", nil]] + @storage_manager_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
+                      "ng-model"                    => "cloudContainerModel.storage_manager_id",
+                      "ng-change"                   => "storageManagerChanged(cloudContainerModel.storage_manager_id)",
+                      "required"                    => "",
+                      :checkchange                  => true,
+                      "selectpicker-for-select-tag" => "")
+
+    .form-group
+      %label.col-md-2.control-label
+        = _('Container Name')
+      .col-md-8
+        %input.form-control{:type          => "text",
+                            :name          => "name",
+                            'ng-model'     => "cloudContainerModel.name",
+                            'ng-maxlength' => 255,
+                            :miqrequired   => true,
+                            :checkchange   => true}
+  %div{"ng-if" => "cloudContainerModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::S3'"}
+    %h3
+      = _('Placement')
+    .form-horizontal
+      .form-group{"ng-class"  => "{'has-error': angularForm.provider_region.$invalid}",
+                  "ng-if"     => "#{@provider_regions.keys.to_json}.includes(cloudContainerModel.parent_emstype)",
+                  "ng-switch" => "",
+                  "on"        => "cloudContainerModel.parent_emstype"}
+        %label.col-md-2.control-label{"for" => "ems_region"}
+          = _('Region')
+        .col-md-8
+          - @provider_regions.each do |name, regions|
+            = select_tag('provider_region',
+                         options_for_select([["<#{_('Choose')}>", nil]] + regions, disabled: ["<#{_('Choose')}>", nil]),
+                         "ng-model"                    => "cloudContainerModel.provider_region",
+                         "ng-switch-when"              => name,
+                         "required"                    => "",
+                         "checkchange"                 => "",
+                         "selectpicker-for-select-tag" => "")
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
+
+:javascript
+  miq_bootstrap('#form_div');

--- a/app/views/cloud_object_store_container/new.html.haml
+++ b/app/views/cloud_object_store_container/new.html.haml
@@ -1,4 +1,10 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudObjectStoreContainerFormController", "ng-cloak" => ""}
+%form#form_div{:name           => "angularForm",
+               'ng-controller' => "cloudObjectStoreContainerFormController as vm",
+               "ng-show"       => "vm.afterGet",
+               "ng-cloak"      => "",
+               "miq-form"      => true,
+               "model"         => "vm.cloudContainerModel",
+               "model-copy"    => "vm.modelCopy"}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Basic Information')
@@ -7,44 +13,50 @@
       %label.col-md-2.control-label
         = _('Storage Manager')
       .col-md-8
-        = select_tag("storage_manager_id",
-          options_for_select([["<#{_('Choose')}>", nil]] + @storage_manager_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
-                      "ng-model"                    => "cloudContainerModel.storage_manager_id",
-                      "ng-change"                   => "storageManagerChanged(cloudContainerModel.storage_manager_id)",
-                      "required"                    => "",
-                      :checkchange                  => true,
-                      "selectpicker-for-select-tag" => "")
+        %select{"name"        => "storage_manager_id",
+                "ng-model"    => "vm.cloudContainerModel.storage_manager_id",
+                "ng-options"  => "mgr.id as mgr.name for mgr in vm.storageManagers",
+                "ng-change"   => "vm.storageManagerChanged(vm.cloudContainerModel.storage_manager_id)",
+                "required"    => "",
+                "disabled"    => !@storage_manager.nil?,
+                :checkchange  => true,
+                "pf-select"   => true}
+          %option{"value" => "", "disabled" => ""}
+            = "<#{_('Choose')}>"
+        %span.help-block{"ng-show" => "angularForm.storage_manager_id.$error.required"}
+          = _("Required")
 
-    .form-group
+    .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label
         = _('Container Name')
       .col-md-8
         %input.form-control{:type          => "text",
                             :name          => "name",
-                            'ng-model'     => "cloudContainerModel.name",
+                            'ng-model'     => "vm.cloudContainerModel.name",
                             'ng-maxlength' => 255,
                             :miqrequired   => true,
                             :checkchange   => true}
-  %div{"ng-if" => "cloudContainerModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::S3'"}
+  %div{"ng-if" => "vm.cloudContainerModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::S3'"}
     %h3
       = _('Placement')
     .form-horizontal
       .form-group{"ng-class"  => "{'has-error': angularForm.provider_region.$invalid}",
-                  "ng-if"     => "#{@provider_regions.keys.to_json}.includes(cloudContainerModel.parent_emstype)",
+                  "ng-if"     => "#{@provider_regions.keys.to_json}.includes(vm.cloudContainerModel.parent_emstype)",
                   "ng-switch" => "",
-                  "on"        => "cloudContainerModel.parent_emstype"}
+                  "on"        => "vm.cloudContainerModel.parent_emstype"}
         %label.col-md-2.control-label{"for" => "ems_region"}
           = _('Region')
         .col-md-8
           - @provider_regions.each do |name, regions|
             = select_tag('provider_region',
                          options_for_select([["<#{_('Choose')}>", nil]] + regions, disabled: ["<#{_('Choose')}>", nil]),
-                         "ng-model"                    => "cloudContainerModel.provider_region",
+                         "ng-model"                    => "vm.cloudContainerModel.provider_region",
                          "ng-switch-when"              => name,
                          "required"                    => "",
                          "checkchange"                 => "",
                          "selectpicker-for-select-tag" => "")
-  = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/generic_form_buttons"
 
 :javascript
+  ManageIQ.angular.app.value('storageManagerId', '#{@storage_manager.try(:id)}');
   miq_bootstrap('#form_div');

--- a/app/views/cloud_object_store_container/new.html.haml
+++ b/app/views/cloud_object_store_container/new.html.haml
@@ -6,8 +6,6 @@
                "model"         => "vm.cloudContainerModel",
                "model-copy"    => "vm.modelCopy"}
   = render :partial => "layouts/flash_msg"
-  %h3
-    = _('Basic Information')
   .form-horizontal
     .form-group{"ng-class" => "{'has-error': angularForm.storage_manager_id.$invalid}"}
       %label.col-md-2.control-label
@@ -15,7 +13,7 @@
       .col-md-8
         %select{"name"        => "storage_manager_id",
                 "ng-model"    => "vm.cloudContainerModel.storage_manager_id",
-                "ng-options"  => "mgr.id as mgr.name for mgr in vm.storageManagers",
+                "ng-options"  => "mgr.id|number as mgr.name for mgr in vm.storageManagers",
                 "ng-change"   => "vm.storageManagerChanged(vm.cloudContainerModel.storage_manager_id)",
                 "required"    => "",
                 "disabled"    => !@storage_manager.nil?,
@@ -32,13 +30,14 @@
       .col-md-8
         %input.form-control{:type          => "text",
                             :name          => "name",
-                            'ng-model'     => "vm.cloudContainerModel.name",
-                            'ng-maxlength' => 255,
+                            "ng-model"     => "vm.cloudContainerModel.name",
+                            "ng-maxlength" => 255,
+                            "required"     => "",
                             :miqrequired   => true,
                             :checkchange   => true}
+        %span.help-block{"ng-show" => "angularForm.name.$error.required"}
+          = _("Required")
   %div{"ng-if" => "vm.cloudContainerModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::S3'"}
-    %h3
-      = _('Placement')
     .form-horizontal
       .form-group{"ng-class"  => "{'has-error': angularForm.provider_region.$invalid}",
                   "ng-if"     => "#{@provider_regions.keys.to_json}.includes(vm.cloudContainerModel.parent_emstype)",
@@ -55,6 +54,8 @@
                          "required"                    => "",
                          "checkchange"                 => "",
                          "selectpicker-for-select-tag" => "")
+          %span.help-block{"ng-show" => "angularForm.provider_region.$error.required"}
+            = _("Required")
   = render :partial => "layouts/angular/generic_form_buttons"
 
 :javascript

--- a/app/views/cloud_object_store_container/new.html.haml
+++ b/app/views/cloud_object_store_container/new.html.haml
@@ -53,7 +53,9 @@
                          "ng-switch-when"              => name,
                          "required"                    => "",
                          "checkchange"                 => "",
-                         "selectpicker-for-select-tag" => "")
+                         "selectpicker-for-select-tag" => "",
+                         "multiple"                    => false,
+                         "data-live-search"            => true)
           %span.help-block{"ng-show" => "angularForm.provider_region.$error.required"}
             = _("Required")
   = render :partial => "layouts/angular/generic_form_buttons"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -401,6 +401,7 @@ Rails.application.routes.draw do
         show_list
         tagging_edit
         tag_edit_form_field_changed
+        new
       ) + compare_get,
       :post => %w(
         button
@@ -412,6 +413,8 @@ Rails.application.routes.draw do
         show_list
         tagging_edit
         tag_edit_form_field_changed
+        create
+        wait_for_task
       ) + compare_post + adv_search_post + exp_post + save_post
     },
 

--- a/spec/controllers/cloud_object_store_container_spec.rb
+++ b/spec/controllers/cloud_object_store_container_spec.rb
@@ -112,5 +112,72 @@ describe CloudObjectStoreContainerController do
     end
   end
 
+  describe "create object store container" do
+    before do
+      stub_user(:features => :all)
+    end
+
+    shared_examples "queue create container task" do
+      let(:task_options) do
+        {
+          :action => "creating Cloud Object Store Container for user %{user}" %
+            {:user => controller.current_user.userid},
+          :userid => controller.current_user.userid
+        }
+      end
+
+      let(:queue_options) do
+        {
+          :class_name  => "CloudObjectStoreContainer",
+          :method_name => 'cloud_object_store_container_create',
+          :role        => 'ems_operations',
+          :zone        => @ems.my_zone,
+          :args        => [@ems.id, @expected_args]
+        }
+      end
+
+      it "builds add new container screen" do
+        post :button, :params => { :pressed => "cloud_object_store_container_new", :format => :js }
+        expect(assigns(:flash_array)).to be_nil
+      end
+
+      it "queues the create cloud object store container action form" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        post :create, :params => @form_params.merge(:button => "add", :format => :js)
+      end
+    end
+
+    context "in Amazon S3" do
+      before do
+        @cloud_manager = FactoryGirl.create(:ems_amazon)
+        @ems = @cloud_manager.s3_storage_manager
+
+        @form_params = {
+          :name               => "bucket-01",
+          :emstype            => "ManageIQ::Providers::Amazon::StorageManager::S3",
+          :parent_emstype     => "ManageIQ::Providers::Amazon::CloudManager",
+          :storage_manager_id => @ems.id,
+          :provider_region    => "eu-central-1",
+        }
+
+        @expected_args = {
+          :name                        => "bucket-01",
+          :create_bucket_configuration => {:location_constraint => "eu-central-1"}
+        }
+      end
+
+      context "create" do
+        it_behaves_like "queue create container task"
+      end
+
+      it "aws regions" do
+        provider_regions = controller.send(:retrieve_provider_regions)
+
+        expect(provider_regions["ManageIQ::Providers::Amazon::CloudManager"]).not_to be_nil
+        expect(provider_regions["ManageIQ::Providers::Amazon::CloudManager"].count).to be > 0
+      end
+    end
+  end
+
   include_examples '#download_summary_pdf', :cloud_object_store_container
 end


### PR DESCRIPTION
This commit adds a new page /cloud_object_store_container/new where user can create new CloudObjectStoreContainer. Page is fully functional and extendable. Tested on Amazon S3 provider.

Button that redirects to /cloud_object_store_container/new appears in center toolbar:
![capture](https://cloud.githubusercontent.com/assets/8102426/24153560/1918a9fc-0e4f-11e7-82e1-e6c9b6b31fdf.PNG)

And the  /cloud_object_store_container/new page itself:
![capture](https://cloud.githubusercontent.com/assets/8102426/24153618/44e8ceae-0e4f-11e7-9c88-0a2fd5024f4e.PNG)


Depends on:
* https://github.com/ManageIQ/manageiq/pull/14269 (merged)
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/172 (merged)

@miq-bot add_label enhancement
@miq-bot assign @h-kataria 
