### PR TITLE
Break method for handling action in performance charts to smaller methods

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -184,7 +184,8 @@ module ApplicationController::Performance
     ts = (data_row["timestamp"] || data_row["statistic_time"]).in_time_zone(@perf_options[:tz])                 # Grab the timestamp from the row in selected tz
 
     if cmd == "Display" && model == "Current" && typ == "Top"
-      return if display_current_top(data_row)
+      display_current_top(data_row)
+      return
     elsif cmd == "Display" && typ == "bytag"
       return if display_by_tag(data_row, report, ts, bc_model, model, legend_idx)
     elsif cmd == "Display"
@@ -218,12 +219,11 @@ module ApplicationController::Performance
 
   # display the CI selected from a Top chart
   def display_current_top(data_row)
-    return true unless perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"], data_row["resource_name"])
+    return unless perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"], data_row["resource_name"])
     javascript_redirect :controller => data_row["resource_type"].underscore,
                         :action     => "show",
                         :id         => data_row["resource_id"],
                         :escape     => false
-    return true
   end
 
   # display selected resources from a tag chart

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -201,22 +201,8 @@ module ApplicationController::Performance
       return if chart_selected(data_row, typ, ts)
     elsif cmd == "Chart" && typ.starts_with?("top") && @perf_options[:cat]
       return if chart_top_by_tag(data_row, report, legend_idx, model, ts, bc_model)
-    elsif cmd == "Chart" && typ.starts_with?("top")                         # Create top chart for selected timestamp/model
-      @record = identify_tl_or_perf_record
-      @perf_record = @record.kind_of?(MiqServer) ? @record.vm : @record # Use related server vm record
-      top_ids = data_row["assoc_ids"][model.downcase.to_sym][:on]
-      dt = typ == "tophour" ? "on #{ts.to_date} at #{ts.strftime("%H:%M:%S %Z")}" : "on #{ts.to_date}"
-      if top_ids.blank?
-        msg = _("No %{model} were running %{time}") % {:model => model, :time => dt}
-      else
-        javascript_redirect :id          => @perf_record.id,
-                            :action      => "perf_top_chart",
-                            :menu_choice => params[:menu_click],
-                            :bc          => "#{@perf_record.name} top #{bc_model} (#{dt})",
-                            :escape      => false
-        return
-      end
-
+    elsif cmd == "Chart" && typ.starts_with?("top")
+      return if chart_top(data_row, typ, ts, model, bc_model)
     else
       msg = _("Chart menu selection not yet implemented")
     end
@@ -488,6 +474,25 @@ module ApplicationController::Performance
                           :action      => "perf_top_chart",
                           :menu_choice => params[:menu_click],
                           :bc          => "#{@perf_record.name} top #{bc_model} (#{bc_tag} #{dt})",
+                          :escape      => false
+      return true
+    end
+    false
+  end
+
+  # create top chart for selected timestamp/model
+  def chart_top(data_row, typ, ts, model, bc_model)
+    @record = identify_tl_or_perf_record
+    @perf_record = @record.kind_of?(MiqServer) ? @record.vm : @record # Use related server vm record
+    top_ids = data_row["assoc_ids"][model.downcase.to_sym][:on]
+    dt = typ == "tophour" ? "on #{ts.to_date} at #{ts.strftime("%H:%M:%S %Z")}" : "on #{ts.to_date}"
+    if top_ids.blank?
+      msg = _("No %{model} were running %{time}") % {:model => model, :time => dt}
+    else
+      javascript_redirect :id          => @perf_record.id,
+                          :action      => "perf_top_chart",
+                          :menu_choice => params[:menu_click],
+                          :bc          => "#{@perf_record.name} top #{bc_model} (#{dt})",
                           :escape      => false
       return true
     end

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -183,14 +183,8 @@ module ApplicationController::Performance
     # Use timestamp or statistic_time (metrics vs ontap)
     ts = (data_row["timestamp"] || data_row["statistic_time"]).in_time_zone(@perf_options[:tz])                 # Grab the timestamp from the row in selected tz
 
-    if cmd == "Display" && model == "Current" && typ == "Top"                   # Display the CI selected from a Top chart
-      return unless perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"], data_row["resource_name"])
-      javascript_redirect :controller => data_row["resource_type"].underscore,
-                          :action     => "show",
-                          :id         => data_row["resource_id"],
-                          :escape     => false
-      return
-
+    if cmd == "Display" && model == "Current" && typ == "Top"
+      return if display_current_top(data_row)
     elsif cmd == "Display" && typ == "bytag"  # Display selected resources from a tag chart
       dt = @perf_options[:typ] == "Hourly" ? "on #{ts.to_date} at #{ts.strftime("%H:%M:%S %Z")}" : "on #{ts.to_date}"
       top_ids = data_row["assoc_ids_#{report.extras[:group_by_tags][legend_idx]}"][model.downcase.to_sym][:on]
@@ -451,6 +445,16 @@ module ApplicationController::Performance
 
     msg ? add_flash(msg, :warning) : add_flash(_("Unknown error has occurred"), :error)
     javascript_flash(:spinner_off => true)
+  end
+
+  # display the CI selected from a Top chart
+  def display_current_top(data_row)
+    return true unless perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"], data_row["resource_name"])
+    javascript_redirect :controller => data_row["resource_type"].underscore,
+                        :action     => "show",
+                        :id         => data_row["resource_id"],
+                        :escape     => false
+    return true
   end
 
   # Send error message if record is found and authorized, else return the record


### PR DESCRIPTION
Code should work the same, it was only moved to smaller methods.

Code handles clicks in context menu of charts in ManageIQ UI (e.g. in Capacity & Utilization)
![screenshot from 2017-03-13 14-34-40](https://cloud.githubusercontent.com/assets/1187051/23856522/3f154e2c-07fa-11e7-95c8-36eaa1e9be99.png)
