### PR TITLE
MiqDecorator - delegate #fonticon and #listicon_image to self.class

### DIFF
--- a/app/decorators/auth_private_key_decorator.rb
+++ b/app/decorators/auth_private_key_decorator.rb
@@ -1,5 +1,5 @@
 class AuthPrivateKeyDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     nil
   end
 

--- a/app/decorators/auth_private_key_decorator.rb
+++ b/app/decorators/auth_private_key_decorator.rb
@@ -3,7 +3,7 @@ class AuthPrivateKeyDecorator < MiqDecorator
     nil
   end
 
-  def listicon_image
+  def self.listicon_image
     "100/auth_key_pair.png"
   end
 end

--- a/app/decorators/availability_zone_decorator.rb
+++ b/app/decorators/availability_zone_decorator.rb
@@ -3,7 +3,7 @@ class AvailabilityZoneDecorator < MiqDecorator
     'pficon pficon-zone'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/availability_zone.png'
   end
 end

--- a/app/decorators/availability_zone_decorator.rb
+++ b/app/decorators/availability_zone_decorator.rb
@@ -3,10 +3,6 @@ class AvailabilityZoneDecorator < MiqDecorator
     'pficon pficon-zone'
   end
 
-  def fonticon
-    'pficon pficon-zone'
-  end
-
   def listicon_image
     '100/availability_zone.png'
   end

--- a/app/decorators/chargeback_rate_decorator.rb
+++ b/app/decorators/chargeback_rate_decorator.rb
@@ -1,5 +1,5 @@
 class ChargebackRateDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-file-text-o'
   end
 end

--- a/app/decorators/classification_decorator.rb
+++ b/app/decorators/classification_decorator.rb
@@ -1,5 +1,5 @@
 class ClassificationDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-folder-close'
   end
 end

--- a/app/decorators/cloud_network_decorator.rb
+++ b/app/decorators/cloud_network_decorator.rb
@@ -3,7 +3,7 @@ class CloudNetworkDecorator < MiqDecorator
     'product product-cloud_network'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/cloud_network.png'
   end
 end

--- a/app/decorators/cloud_network_decorator.rb
+++ b/app/decorators/cloud_network_decorator.rb
@@ -3,10 +3,6 @@ class CloudNetworkDecorator < MiqDecorator
     'product product-cloud_network'
   end
 
-  def fonticon
-    'product product-cloud_network'
-  end
-
   def listicon_image
     '100/cloud_network.png'
   end

--- a/app/decorators/cloud_object_store_container_decorator.rb
+++ b/app/decorators/cloud_object_store_container_decorator.rb
@@ -3,10 +3,6 @@ class CloudObjectStoreContainerDecorator < MiqDecorator
     'product product-cloud_object_store'
   end
 
-  def fonticon
-    'product product-cloud_object_store'
-  end
-
   def listicon_image
     '100/cloud_object_store_container.png'
   end

--- a/app/decorators/cloud_object_store_container_decorator.rb
+++ b/app/decorators/cloud_object_store_container_decorator.rb
@@ -3,7 +3,7 @@ class CloudObjectStoreContainerDecorator < MiqDecorator
     'product product-cloud_object_store'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/cloud_object_store_container.png'
   end
 end

--- a/app/decorators/cloud_object_store_object_decorator.rb
+++ b/app/decorators/cloud_object_store_object_decorator.rb
@@ -3,10 +3,6 @@ class CloudObjectStoreObjectDecorator < MiqDecorator
     'product product-cloud_object_store'
   end
 
-  def fonticon
-    'product product-cloud_object_store'
-  end
-
   def listicon_image
     '100/cloud_object_store_container.png'
   end

--- a/app/decorators/cloud_object_store_object_decorator.rb
+++ b/app/decorators/cloud_object_store_object_decorator.rb
@@ -3,7 +3,7 @@ class CloudObjectStoreObjectDecorator < MiqDecorator
     'product product-cloud_object_store'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/cloud_object_store_container.png'
   end
 end

--- a/app/decorators/cloud_subnet_decorator.rb
+++ b/app/decorators/cloud_subnet_decorator.rb
@@ -3,7 +3,7 @@ class CloudSubnetDecorator < MiqDecorator
     'pficon pficon-network'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/cloud_subnet.png'
   end
 end

--- a/app/decorators/cloud_subnet_decorator.rb
+++ b/app/decorators/cloud_subnet_decorator.rb
@@ -3,10 +3,6 @@ class CloudSubnetDecorator < MiqDecorator
     'pficon pficon-network'
   end
 
-  def fonticon
-    'pficon pficon-network'
-  end
-
   def listicon_image
     '100/cloud_subnet.png'
   end

--- a/app/decorators/cloud_tenant_decorator.rb
+++ b/app/decorators/cloud_tenant_decorator.rb
@@ -3,10 +3,6 @@ class CloudTenantDecorator < MiqDecorator
     'pficon pficon-cloud-tenant'
   end
 
-  def fonticon
-    'pficon pficon-cloud-tenant'
-  end
-
   def listicon_image
     '100/cloud_tenant.png'
   end

--- a/app/decorators/cloud_tenant_decorator.rb
+++ b/app/decorators/cloud_tenant_decorator.rb
@@ -3,7 +3,7 @@ class CloudTenantDecorator < MiqDecorator
     'pficon pficon-cloud-tenant'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/cloud_tenant.png'
   end
 end

--- a/app/decorators/cloud_volume_backup_decorator.rb
+++ b/app/decorators/cloud_volume_backup_decorator.rb
@@ -3,7 +3,7 @@ class CloudVolumeBackupDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/cloud_volume.png'
   end
 end

--- a/app/decorators/cloud_volume_backup_decorator.rb
+++ b/app/decorators/cloud_volume_backup_decorator.rb
@@ -3,10 +3,6 @@ class CloudVolumeBackupDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def fonticon
-    'pficon pficon-volume'
-  end
-
   def listicon_image
     '100/cloud_volume.png'
   end

--- a/app/decorators/cloud_volume_decorator.rb
+++ b/app/decorators/cloud_volume_decorator.rb
@@ -3,7 +3,7 @@ class CloudVolumeDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/cloud_volume.png'
   end
 end

--- a/app/decorators/cloud_volume_decorator.rb
+++ b/app/decorators/cloud_volume_decorator.rb
@@ -3,10 +3,6 @@ class CloudVolumeDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def fonticon
-    'pficon pficon-volume'
-  end
-
   def listicon_image
     '100/cloud_volume.png'
   end

--- a/app/decorators/cloud_volume_snapshot_decorator.rb
+++ b/app/decorators/cloud_volume_snapshot_decorator.rb
@@ -3,7 +3,7 @@ class CloudVolumeSnapshotDecorator < MiqDecorator
     'fa fa-camera'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/cloud_volume_snapshot.png'
   end
 end

--- a/app/decorators/cloud_volume_snapshot_decorator.rb
+++ b/app/decorators/cloud_volume_snapshot_decorator.rb
@@ -3,10 +3,6 @@ class CloudVolumeSnapshotDecorator < MiqDecorator
     'fa fa-camera'
   end
 
-  def fonticon
-    'fa fa-camera'
-  end
-
   def listicon_image
     '100/cloud_volume_snapshot.png'
   end

--- a/app/decorators/condition_decorator.rb
+++ b/app/decorators/condition_decorator.rb
@@ -1,5 +1,5 @@
 class ConditionDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-miq_condition'
   end
 end

--- a/app/decorators/configuration_script_source_decorator.rb
+++ b/app/decorators/configuration_script_source_decorator.rb
@@ -3,7 +3,7 @@ class ConfigurationScriptSourceDecorator < MiqDecorator
     "pficon pficon-repository"
   end
 
-  def listicon_image
+  def self.listicon_image
     nil
   end
 end

--- a/app/decorators/configuration_script_source_decorator.rb
+++ b/app/decorators/configuration_script_source_decorator.rb
@@ -1,5 +1,5 @@
 class ConfigurationScriptSourceDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     "pficon pficon-repository"
   end
 

--- a/app/decorators/configured_system_decorator.rb
+++ b/app/decorators/configured_system_decorator.rb
@@ -1,5 +1,5 @@
 class ConfiguredSystemDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-configured_system'
   end
 

--- a/app/decorators/container_build_decorator.rb
+++ b/app/decorators/container_build_decorator.rb
@@ -3,7 +3,7 @@ class ContainerBuildDecorator < MiqDecorator
     'pficon pficon-build'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/container_build.png'
   end
 end

--- a/app/decorators/container_build_decorator.rb
+++ b/app/decorators/container_build_decorator.rb
@@ -1,5 +1,5 @@
 class ContainerBuildDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-build'
   end
 

--- a/app/decorators/container_decorator.rb
+++ b/app/decorators/container_decorator.rb
@@ -3,7 +3,7 @@ class ContainerDecorator < MiqDecorator
     'fa fa-cube'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/container.png'
   end
 end

--- a/app/decorators/container_decorator.rb
+++ b/app/decorators/container_decorator.rb
@@ -3,10 +3,6 @@ class ContainerDecorator < MiqDecorator
     'fa fa-cube'
   end
 
-  def fonticon
-    'fa fa-cube'
-  end
-
   def listicon_image
     '100/container.png'
   end

--- a/app/decorators/container_group_decorator.rb
+++ b/app/decorators/container_group_decorator.rb
@@ -3,10 +3,6 @@ class ContainerGroupDecorator < MiqDecorator
     'fa fa-cubes'
   end
 
-  def fonticon
-    'fa fa-cubes'
-  end
-
   def listicon_image
     '100/container_group.png'
   end

--- a/app/decorators/container_group_decorator.rb
+++ b/app/decorators/container_group_decorator.rb
@@ -3,7 +3,7 @@ class ContainerGroupDecorator < MiqDecorator
     'fa fa-cubes'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/container_group.png'
   end
 end

--- a/app/decorators/container_image_decorator.rb
+++ b/app/decorators/container_image_decorator.rb
@@ -3,7 +3,7 @@ class ContainerImageDecorator < MiqDecorator
     'pficon pficon-image'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/container_image.png'
   end
 end

--- a/app/decorators/container_image_decorator.rb
+++ b/app/decorators/container_image_decorator.rb
@@ -3,10 +3,6 @@ class ContainerImageDecorator < MiqDecorator
     'pficon pficon-image'
   end
 
-  def fonticon
-    'pficon pficon-image'
-  end
-
   def listicon_image
     '100/container_image.png'
   end

--- a/app/decorators/container_image_registry_decorator.rb
+++ b/app/decorators/container_image_registry_decorator.rb
@@ -3,7 +3,7 @@ class ContainerImageRegistryDecorator < MiqDecorator
     'pficon pficon-registry'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/container_image_registry.png'
   end
 end

--- a/app/decorators/container_image_registry_decorator.rb
+++ b/app/decorators/container_image_registry_decorator.rb
@@ -3,10 +3,6 @@ class ContainerImageRegistryDecorator < MiqDecorator
     'pficon pficon-registry'
   end
 
-  def fonticon
-    'pficon pficon-registry'
-  end
-
   def listicon_image
     '100/container_image_registry.png'
   end

--- a/app/decorators/container_node_decorator.rb
+++ b/app/decorators/container_node_decorator.rb
@@ -3,15 +3,7 @@ class ContainerNodeDecorator < MiqDecorator
     'pficon pficon-container-node'
   end
 
-  def fonticon
-    'pficon pficon-container-node'
-  end
-
   def self.listicon_image
-    '100/container_node.png'
-  end
-
-  def listicon_image
     '100/container_node.png'
   end
 end

--- a/app/decorators/container_project_decorator.rb
+++ b/app/decorators/container_project_decorator.rb
@@ -3,7 +3,7 @@ class ContainerProjectDecorator < MiqDecorator
     'pficon pficon-project'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/container_project.png'
   end
 end

--- a/app/decorators/container_project_decorator.rb
+++ b/app/decorators/container_project_decorator.rb
@@ -3,10 +3,6 @@ class ContainerProjectDecorator < MiqDecorator
     'pficon pficon-project'
   end
 
-  def fonticon
-    'pficon pficon-project'
-  end
-
   def listicon_image
     '100/container_project.png'
   end

--- a/app/decorators/container_replicator_decorator.rb
+++ b/app/decorators/container_replicator_decorator.rb
@@ -3,7 +3,7 @@ class ContainerReplicatorDecorator < MiqDecorator
     'pficon pficon-replicator'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/container_replicator.png'
   end
 end

--- a/app/decorators/container_replicator_decorator.rb
+++ b/app/decorators/container_replicator_decorator.rb
@@ -3,10 +3,6 @@ class ContainerReplicatorDecorator < MiqDecorator
     'pficon pficon-replicator'
   end
 
-  def fonticon
-    'pficon pficon-replicator'
-  end
-
   def listicon_image
     '100/container_replicator.png'
   end

--- a/app/decorators/container_route_decorator.rb
+++ b/app/decorators/container_route_decorator.rb
@@ -3,10 +3,6 @@ class ContainerRouteDecorator < MiqDecorator
     'pficon pficon-route'
   end
 
-  def fonticon
-    'pficon pficon-route'
-  end
-
   def listicon_image
     '100/container_route.png'
   end

--- a/app/decorators/container_route_decorator.rb
+++ b/app/decorators/container_route_decorator.rb
@@ -3,7 +3,7 @@ class ContainerRouteDecorator < MiqDecorator
     'pficon pficon-route'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/container_route.png'
   end
 end

--- a/app/decorators/container_service_decorator.rb
+++ b/app/decorators/container_service_decorator.rb
@@ -3,10 +3,6 @@ class ContainerServiceDecorator < MiqDecorator
     'pficon pficon-service'
   end
 
-  def fonticon
-    'pficon pficon-service'
-  end
-
   def listicon_image
     '100/container_service.png'
   end

--- a/app/decorators/container_service_decorator.rb
+++ b/app/decorators/container_service_decorator.rb
@@ -3,7 +3,7 @@ class ContainerServiceDecorator < MiqDecorator
     'pficon pficon-service'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/container_service.png'
   end
 end

--- a/app/decorators/container_template_decorator.rb
+++ b/app/decorators/container_template_decorator.rb
@@ -3,7 +3,7 @@ class ContainerTemplateDecorator < MiqDecorator
     'product product-template'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/container_template.png'
   end
 end

--- a/app/decorators/container_template_decorator.rb
+++ b/app/decorators/container_template_decorator.rb
@@ -3,10 +3,6 @@ class ContainerTemplateDecorator < MiqDecorator
     'product product-template'
   end
 
-  def fonticon
-    'product product-template'
-  end
-
   def listicon_image
     '100/container_template.png'
   end

--- a/app/decorators/customization_template_decorator.rb
+++ b/app/decorators/customization_template_decorator.rb
@@ -1,5 +1,5 @@
 class CustomizationTemplateDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-template'
   end
 end

--- a/app/decorators/datacenter_decorator.rb
+++ b/app/decorators/datacenter_decorator.rb
@@ -1,5 +1,5 @@
 class DatacenterDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-building-o'
   end
 end

--- a/app/decorators/dialog_decorator.rb
+++ b/app/decorators/dialog_decorator.rb
@@ -1,5 +1,5 @@
 class DialogDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-comment-o'
   end
 end

--- a/app/decorators/dialog_field_decorator.rb
+++ b/app/decorators/dialog_field_decorator.rb
@@ -1,5 +1,5 @@
 class DialogFieldDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-field'
   end
 end

--- a/app/decorators/dialog_group_decorator.rb
+++ b/app/decorators/dialog_group_decorator.rb
@@ -1,5 +1,5 @@
 class DialogGroupDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-comments-o'
   end
 end

--- a/app/decorators/dialog_tab_decorator.rb
+++ b/app/decorators/dialog_tab_decorator.rb
@@ -1,5 +1,5 @@
 class DialogTabDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-tab'
   end
 end

--- a/app/decorators/ems_cluster_decorator.rb
+++ b/app/decorators/ems_cluster_decorator.rb
@@ -3,7 +3,7 @@ class EmsClusterDecorator < MiqDecorator
     'pficon pficon-cluster'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/ems_cluster.png'
   end
 end

--- a/app/decorators/ems_cluster_decorator.rb
+++ b/app/decorators/ems_cluster_decorator.rb
@@ -1,5 +1,5 @@
 class EmsClusterDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-cluster'
   end
 

--- a/app/decorators/ems_folder_decorator.rb
+++ b/app/decorators/ems_folder_decorator.rb
@@ -1,5 +1,5 @@
 class EmsFolderDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-folder-close'
   end
 end

--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -1,5 +1,5 @@
 class ExtManagementSystemDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     nil
   end
 

--- a/app/decorators/flavor_decorator.rb
+++ b/app/decorators/flavor_decorator.rb
@@ -3,10 +3,6 @@ class FlavorDecorator < MiqDecorator
     'pficon pficon-flavor'
   end
 
-  def fonticon
-    'pficon pficon-flavor'
-  end
-
   def listicon_image
     '100/flavor.png'
   end

--- a/app/decorators/flavor_decorator.rb
+++ b/app/decorators/flavor_decorator.rb
@@ -3,7 +3,7 @@ class FlavorDecorator < MiqDecorator
     'pficon pficon-flavor'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/flavor.png'
   end
 end

--- a/app/decorators/floating_ip_decorator.rb
+++ b/app/decorators/floating_ip_decorator.rb
@@ -3,10 +3,6 @@ class FloatingIpDecorator < MiqDecorator
     'fa fa-map-marker'
   end
 
-  def fonticon
-    'fa fa-map-marker'
-  end
-
   def listicon_image
     '100/floating_ip.png'
   end

--- a/app/decorators/floating_ip_decorator.rb
+++ b/app/decorators/floating_ip_decorator.rb
@@ -3,7 +3,7 @@ class FloatingIpDecorator < MiqDecorator
     'fa fa-map-marker'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/floating_ip.png'
   end
 end

--- a/app/decorators/guest_device_decorator.rb
+++ b/app/decorators/guest_device_decorator.rb
@@ -1,5 +1,5 @@
 class GuestDeviceDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-network_card'
   end
 end

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -1,5 +1,5 @@
 class HostDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-screen'
   end
 

--- a/app/decorators/iso_datastore_decorator.rb
+++ b/app/decorators/iso_datastore_decorator.rb
@@ -1,5 +1,5 @@
 class IsoDatastoreDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-server'
   end
 end

--- a/app/decorators/iso_image_decorator.rb
+++ b/app/decorators/iso_image_decorator.rb
@@ -1,5 +1,5 @@
 class IsoImageDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-network_card'
   end
 end

--- a/app/decorators/lan_decorator.rb
+++ b/app/decorators/lan_decorator.rb
@@ -1,5 +1,5 @@
 class LanDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-network_switch'
   end
 

--- a/app/decorators/lan_decorator.rb
+++ b/app/decorators/lan_decorator.rb
@@ -3,7 +3,7 @@ class LanDecorator < MiqDecorator
     'product product-network_switch'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/network_switch.png'
   end
 end

--- a/app/decorators/ldap_domain_decorator.rb
+++ b/app/decorators/ldap_domain_decorator.rb
@@ -1,5 +1,5 @@
 class LdapDomainDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-domain'
   end
 end

--- a/app/decorators/ldap_region_decorator.rb
+++ b/app/decorators/ldap_region_decorator.rb
@@ -1,5 +1,5 @@
 class LdapRegionDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-regions'
   end
 end

--- a/app/decorators/load_balancer_decorator.rb
+++ b/app/decorators/load_balancer_decorator.rb
@@ -3,7 +3,7 @@ class LoadBalancerDecorator < MiqDecorator
     'product product-load_balancer'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/load_balancer.png'
   end
 end

--- a/app/decorators/load_balancer_decorator.rb
+++ b/app/decorators/load_balancer_decorator.rb
@@ -3,10 +3,6 @@ class LoadBalancerDecorator < MiqDecorator
     'product product-load_balancer'
   end
 
-  def fonticon
-    'product product-load_balancer'
-  end
-
   def listicon_image
     '100/load_balancer.png'
   end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::AnsibleTower
       'product product-template'
     end
 
-    def listicon_image
+    def self.listicon_image
       '100/configuration_script.png'
     end
   end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::AnsibleTower
   class AutomationManager::ConfigurationScriptDecorator < MiqDecorator
-    def fonticon
+    def self.fonticon
       'product product-template'
     end
 

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
@@ -4,10 +4,6 @@ module ManageIQ::Providers::AnsibleTower
       'product product-orchestration_stack'
     end
 
-    def fonticon
-      'product product-orchestration_stack'
-    end
-
     def listicon_image
       '100/orchestration_stack.png'
     end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::AnsibleTower
       'product product-orchestration_stack'
     end
 
-    def listicon_image
+    def self.listicon_image
       '100/orchestration_stack.png'
     end
   end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::AnsibleTower
       nil
     end
 
-    def listicon_image
+    def self.listicon_image
       'svg/vendor-ansible.svg'
     end
   end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::AnsibleTower
   class AutomationManager::PlaybookDecorator < MiqDecorator
-    def fonticon
+    def self.fonticon
       nil
     end
 

--- a/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'fa fa-lock'
     end
 
-    def listicon_image
+    def self.listicon_image
       '100/authentication.png'
     end
   end

--- a/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class AutomationManager::AuthenticationDecorator < MiqDecorator
-    def fonticon
+    def self.fonticon
       'fa fa-lock'
     end
 

--- a/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'pficon pficon-folder-close'
     end
 
-    def listicon_image
+    def self.listicon_image
       '100/inventory_group.png'
     end
   end

--- a/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class AutomationManager::InventoryGroupDecorator < MiqDecorator
-    def fonticon
+    def self.fonticon
       'pficon pficon-folder-close'
     end
 

--- a/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'pficon pficon-folder-close'
     end
 
-    def listicon_image
+    def self.listicon_image
       '100/inventory_group.png'
     end
   end

--- a/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class AutomationManager::InventoryRootGroupDecorator < MiqDecorator
-    def fonticon
+    def self.fonticon
       'pficon pficon-folder-close'
     end
 

--- a/app/decorators/manageiq/providers/automation_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class AutomationManagerDecorator < MiqDecorator
-    def fonticon
+    def self.fonticon
       nil
     end
 

--- a/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'product product-orchestration_stack'
     end
 
-    def listicon_image
+    def self.listicon_image
       "100/orchestration_stack.png"
     end
   end

--- a/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
@@ -4,10 +4,6 @@ module ManageIQ::Providers
       'product product-orchestration_stack'
     end
 
-    def fonticon
-      'product product-orchestration_stack'
-    end
-
     def listicon_image
       "100/orchestration_stack.png"
     end

--- a/app/decorators/manageiq/providers/configuration_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/configuration_manager_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class ConfigurationManagerDecorator < MiqDecorator
-    def fonticon
+    def self.fonticon
       nil
     end
 

--- a/app/decorators/manageiq/providers/embedded_ansible/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_ansible/automation_manager/playbook_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::EmbeddedAnsible
       nil
     end
 
-    def listicon_image
+    def self.listicon_image
       'svg/vendor-ansible.svg'
     end
   end

--- a/app/decorators/manageiq/providers/embedded_ansible/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_ansible/automation_manager/playbook_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::EmbeddedAnsible
   class AutomationManager::PlaybookDecorator < MiqDecorator
-    def fonticon
+    def self.fonticon
       nil
     end
 

--- a/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'fa fa-lock'
     end
 
-    def listicon_image
+    def self.listicon_image
       '100/authentication.png'
     end
   end

--- a/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class EmbeddedAutomationManager::AuthenticationDecorator < MiqDecorator
-    def fonticon
+    def self.fonticon
       'fa fa-lock'
     end
 

--- a/app/decorators/manageiq/providers/embedded_automation_manager/configuration_script_source_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/configuration_script_source_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       "pficon pficon-repository"
     end
 
-    def listicon_image
+    def self.listicon_image
       nil
     end
   end

--- a/app/decorators/manageiq/providers/embedded_automation_manager/configuration_script_source_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/configuration_script_source_decorator.rb
@@ -1,9 +1,9 @@
 module ManageIQ::Providers
   class EmbeddedAutomationManager::ConfigurationScriptSourceDecorator < MiqDecorator
-    def fonticon
+    def self.fonticon
       "pficon pficon-repository"
     end
-  
+
     def listicon_image
       nil
     end

--- a/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::Hawkular
       nil
     end
 
-    def listicon_image
+    def self.listicon_image
       "svg/vendor-hawkular.svg"
     end
   end

--- a/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Hawkular
   class MiddlewareManagerDecorator < MiqDecorator
-    def fonticon
+    def self.fonticon
       nil
     end
 

--- a/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Kubernetes
   class ContainerManagerDecorator < MiqDecorator
-    def listicon_image
+    def self.listicon_image
       "svg/vendor-kubernetes.svg"
     end
   end

--- a/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
@@ -3,9 +3,5 @@ module ManageIQ::Providers::Openshift
     def self.listicon_image
       "svg/vendor-openshift.svg"
     end
-
-    def listicon_image
-      self.class.listicon_image
-    end
   end
 end

--- a/app/decorators/manageiq/providers/storage_manager/cinder_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager/cinder_manager_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class StorageManager::CinderManagerDecorator < MiqDecorator
-    def listicon_image
+    def self.listicon_image
       "svg/vendor-cinder.svg"
     end
   end

--- a/app/decorators/manageiq/providers/storage_manager/swift_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager/swift_manager_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class StorageManager::SwiftManagerDecorator < MiqDecorator
-    def listicon_image
+    def self.listicon_image
       "svg/vendor-swift.svg"
     end
   end

--- a/app/decorators/middleware_datasource_decorator.rb
+++ b/app/decorators/middleware_datasource_decorator.rb
@@ -3,10 +3,6 @@ class MiddlewareDatasourceDecorator < MiqDecorator
     'fa fa-database'
   end
 
-  def fonticon
-    'fa fa-database'
-  end
-
   def listicon_image
     '100/middleware_datasource.png'
   end

--- a/app/decorators/middleware_datasource_decorator.rb
+++ b/app/decorators/middleware_datasource_decorator.rb
@@ -3,7 +3,7 @@ class MiddlewareDatasourceDecorator < MiqDecorator
     'fa fa-database'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/middleware_datasource.png'
   end
 end

--- a/app/decorators/middleware_domain_decorator.rb
+++ b/app/decorators/middleware_domain_decorator.rb
@@ -3,10 +3,6 @@ class MiddlewareDomainDecorator < MiqDecorator
     'pficon-domain'
   end
 
-  def fonticon
-    'pficon-domain'
-  end
-
   def listicon_image
     '100/middleware_domain.png'
   end

--- a/app/decorators/middleware_domain_decorator.rb
+++ b/app/decorators/middleware_domain_decorator.rb
@@ -3,7 +3,7 @@ class MiddlewareDomainDecorator < MiqDecorator
     'pficon-domain'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/middleware_domain.png'
   end
 end

--- a/app/decorators/middleware_messaging_decorator.rb
+++ b/app/decorators/middleware_messaging_decorator.rb
@@ -3,7 +3,7 @@ class MiddlewareMessagingDecorator < MiqDecorator
     'fa fa-exchange'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/middleware_messaging.png'
   end
 end

--- a/app/decorators/middleware_messaging_decorator.rb
+++ b/app/decorators/middleware_messaging_decorator.rb
@@ -3,10 +3,6 @@ class MiddlewareMessagingDecorator < MiqDecorator
     'fa fa-exchange'
   end
 
-  def fonticon
-    'fa fa-exchange'
-  end
-
   def listicon_image
     '100/middleware_messaging.png'
   end

--- a/app/decorators/middleware_server_decorator.rb
+++ b/app/decorators/middleware_server_decorator.rb
@@ -1,5 +1,5 @@
 class MiddlewareServerDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     nil
   end
 

--- a/app/decorators/middleware_server_group_decorator.rb
+++ b/app/decorators/middleware_server_group_decorator.rb
@@ -3,7 +3,7 @@ class MiddlewareServerGroupDecorator < MiqDecorator
     'pficon-server-group'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/middleware_server_group.png'
   end
 end

--- a/app/decorators/middleware_server_group_decorator.rb
+++ b/app/decorators/middleware_server_group_decorator.rb
@@ -3,10 +3,6 @@ class MiddlewareServerGroupDecorator < MiqDecorator
     'pficon-server-group'
   end
 
-  def fonticon
-    'pficon-server-group'
-  end
-
   def listicon_image
     '100/middleware_server_group.png'
   end

--- a/app/decorators/miq_ae_class_decorator.rb
+++ b/app/decorators/miq_ae_class_decorator.rb
@@ -1,5 +1,5 @@
 class MiqAeClassDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-ae_class'
   end
 end

--- a/app/decorators/miq_ae_instance_decorator.rb
+++ b/app/decorators/miq_ae_instance_decorator.rb
@@ -1,5 +1,5 @@
 class MiqAeInstanceDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-file-text-o'
   end
 end

--- a/app/decorators/miq_ae_method_decorator.rb
+++ b/app/decorators/miq_ae_method_decorator.rb
@@ -1,5 +1,5 @@
 class MiqAeMethodDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-method'
   end
 end

--- a/app/decorators/miq_ae_namespace_decorator.rb
+++ b/app/decorators/miq_ae_namespace_decorator.rb
@@ -1,5 +1,5 @@
 class MiqAeNamespaceDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-folder-close'
   end
 end

--- a/app/decorators/miq_alert_decorator.rb
+++ b/app/decorators/miq_alert_decorator.rb
@@ -1,5 +1,5 @@
 class MiqAlertDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-warning-triangle-o'
   end
 end

--- a/app/decorators/miq_alert_set_decorator.rb
+++ b/app/decorators/miq_alert_set_decorator.rb
@@ -1,5 +1,5 @@
 class MiqAlertSetDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-warning-triangle-o'
   end
 end

--- a/app/decorators/miq_dialog_decorator.rb
+++ b/app/decorators/miq_dialog_decorator.rb
@@ -1,5 +1,5 @@
 class MiqDialogDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-comment-o'
   end
 end

--- a/app/decorators/miq_group_decorator.rb
+++ b/app/decorators/miq_group_decorator.rb
@@ -1,5 +1,5 @@
 class MiqGroupDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-group'
   end
 end

--- a/app/decorators/miq_region_decorator.rb
+++ b/app/decorators/miq_region_decorator.rb
@@ -1,5 +1,5 @@
 class MiqRegionDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-regions'
   end
 end

--- a/app/decorators/miq_report_decorator.rb
+++ b/app/decorators/miq_report_decorator.rb
@@ -1,5 +1,5 @@
 class MiqReportDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-file-text-o'
   end
 end

--- a/app/decorators/miq_schedule_decorator.rb
+++ b/app/decorators/miq_schedule_decorator.rb
@@ -1,5 +1,5 @@
 class MiqScheduleDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-clock-o'
   end
 end

--- a/app/decorators/miq_scsi_lun_decorator.rb
+++ b/app/decorators/miq_scsi_lun_decorator.rb
@@ -1,5 +1,5 @@
 class MiqScsiLunDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-database'
   end
 end

--- a/app/decorators/miq_scsi_target_decorator.rb
+++ b/app/decorators/miq_scsi_target_decorator.rb
@@ -1,5 +1,5 @@
 class MiqScsiTargetDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-network_card'
   end
 end

--- a/app/decorators/miq_search_decorator.rb
+++ b/app/decorators/miq_search_decorator.rb
@@ -1,5 +1,5 @@
 class MiqSearchDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-filter'
   end
 end

--- a/app/decorators/miq_server_decorator.rb
+++ b/app/decorators/miq_server_decorator.rb
@@ -1,5 +1,5 @@
 class MiqServerDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-server'
   end
 end

--- a/app/decorators/miq_user_role_decorator.rb
+++ b/app/decorators/miq_user_role_decorator.rb
@@ -1,5 +1,5 @@
 class MiqUserRoleDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-role'
   end
 end

--- a/app/decorators/miq_widget_set_decorator.rb
+++ b/app/decorators/miq_widget_set_decorator.rb
@@ -1,5 +1,5 @@
 class MiqWidgetSetDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-tachometer'
   end
 end

--- a/app/decorators/network_port_decorator.rb
+++ b/app/decorators/network_port_decorator.rb
@@ -3,10 +3,6 @@ class NetworkPortDecorator < MiqDecorator
     'fa product-network_port'
   end
 
-  def fonticon
-    'fa product-network_port'
-  end
-
   def listicon_image
     '100/network_port.png'
   end

--- a/app/decorators/network_port_decorator.rb
+++ b/app/decorators/network_port_decorator.rb
@@ -3,7 +3,7 @@ class NetworkPortDecorator < MiqDecorator
     'fa product-network_port'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/network_port.png'
   end
 end

--- a/app/decorators/network_router_decorator.rb
+++ b/app/decorators/network_router_decorator.rb
@@ -3,10 +3,6 @@ class NetworkRouterDecorator < MiqDecorator
     'pficon pficon-route'
   end
 
-  def fonticon
-    'pficon pficon-route'
-  end
-
   def listicon_image
     '100/network_router.png'
   end

--- a/app/decorators/network_router_decorator.rb
+++ b/app/decorators/network_router_decorator.rb
@@ -3,7 +3,7 @@ class NetworkRouterDecorator < MiqDecorator
     'pficon pficon-route'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/network_router.png'
   end
 end

--- a/app/decorators/orchestration_template_decorator.rb
+++ b/app/decorators/orchestration_template_decorator.rb
@@ -1,5 +1,5 @@
 class OrchestrationTemplateDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-template'
   end
 end

--- a/app/decorators/persistent_volume_decorator.rb
+++ b/app/decorators/persistent_volume_decorator.rb
@@ -3,7 +3,7 @@ class PersistentVolumeDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/persistent_volume.png'
   end
 end

--- a/app/decorators/persistent_volume_decorator.rb
+++ b/app/decorators/persistent_volume_decorator.rb
@@ -3,10 +3,6 @@ class PersistentVolumeDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def fonticon
-    'pficon pficon-volume'
-  end
-
   def listicon_image
     '100/persistent_volume.png'
   end

--- a/app/decorators/pxe_image_type_decorator.rb
+++ b/app/decorators/pxe_image_type_decorator.rb
@@ -1,5 +1,5 @@
 class PxeImageTypeDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-network_card'
   end
 end

--- a/app/decorators/pxe_server_decorator.rb
+++ b/app/decorators/pxe_server_decorator.rb
@@ -1,5 +1,5 @@
 class PxeServerDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-server'
   end
 end

--- a/app/decorators/registry_item_decorator.rb
+++ b/app/decorators/registry_item_decorator.rb
@@ -1,5 +1,5 @@
 class RegistryItemDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     nil
   end
 

--- a/app/decorators/resource_pool_decorator.rb
+++ b/app/decorators/resource_pool_decorator.rb
@@ -3,10 +3,6 @@ class ResourcePoolDecorator < MiqDecorator
     'pficon pficon-resource-pool'
   end
 
-  def fonticon
-    'pficon pficon-resource-pool'
-  end
-
   def listicon_image
     vapp ? '100/vapp.png' : '100/resource_pool.png'
   end

--- a/app/decorators/scan_item_set_decorator.rb
+++ b/app/decorators/scan_item_set_decorator.rb
@@ -1,5 +1,5 @@
 class ScanItemSetDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-search'
   end
 end

--- a/app/decorators/security_group_decorator.rb
+++ b/app/decorators/security_group_decorator.rb
@@ -3,7 +3,7 @@ class SecurityGroupDecorator < MiqDecorator
     'pficon pficon-cloud-security'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/security_group.png'
   end
 end

--- a/app/decorators/security_group_decorator.rb
+++ b/app/decorators/security_group_decorator.rb
@@ -3,10 +3,6 @@ class SecurityGroupDecorator < MiqDecorator
     'pficon pficon-cloud-security'
   end
 
-  def fonticon
-    'pficon pficon-cloud-security'
-  end
-
   def listicon_image
     '100/security_group.png'
   end

--- a/app/decorators/server_role_decorator.rb
+++ b/app/decorators/server_role_decorator.rb
@@ -1,5 +1,5 @@
 class ServerRoleDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-role'
   end
 end

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -1,5 +1,5 @@
 class ServiceDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-service'
   end
 

--- a/app/decorators/service_template_ansible_tower_decorator.rb
+++ b/app/decorators/service_template_ansible_tower_decorator.rb
@@ -1,5 +1,5 @@
 class ServiceTemplateAnsibleTowerDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-template'
   end
 

--- a/app/decorators/service_template_catalog_decorator.rb
+++ b/app/decorators/service_template_catalog_decorator.rb
@@ -1,5 +1,5 @@
 class ServiceTemplateCatalogDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-template'
   end
 end

--- a/app/decorators/service_template_decorator.rb
+++ b/app/decorators/service_template_decorator.rb
@@ -1,5 +1,5 @@
 class ServiceTemplateDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-template'
   end
 

--- a/app/decorators/snapshot_decorator.rb
+++ b/app/decorators/snapshot_decorator.rb
@@ -1,5 +1,5 @@
 class SnapshotDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-camera'
   end
 end

--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -1,5 +1,5 @@
 class StorageDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-database'
   end
 end

--- a/app/decorators/switch_decorator.rb
+++ b/app/decorators/switch_decorator.rb
@@ -1,5 +1,5 @@
 class SwitchDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'product product-network_switch'
   end
 

--- a/app/decorators/switch_decorator.rb
+++ b/app/decorators/switch_decorator.rb
@@ -3,7 +3,7 @@ class SwitchDecorator < MiqDecorator
     'product product-network_switch'
   end
 
-  def listicon_image
+  def self.listicon_image
     '100/network_switch.png'
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,5 +1,5 @@
 class UserDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-user'
   end
 end

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -1,5 +1,5 @@
 class VmOrTemplateDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     nil
   end
 

--- a/app/decorators/vmdb_index_decorator.rb
+++ b/app/decorators/vmdb_index_decorator.rb
@@ -1,5 +1,5 @@
 class VmdbIndexDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-table'
   end
 end

--- a/app/decorators/vmdb_table_decorator.rb
+++ b/app/decorators/vmdb_table_decorator.rb
@@ -1,5 +1,5 @@
 class VmdbTableDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'fa fa-table'
   end
 end

--- a/app/decorators/windows_image_decorator.rb
+++ b/app/decorators/windows_image_decorator.rb
@@ -1,5 +1,5 @@
 class WindowsImageDecorator < MiqDecorator
-  def listicon_image
+  def self.listicon_image
     'svg/os-windows_generic.svg'
   end
 end

--- a/app/decorators/zone_decorator.rb
+++ b/app/decorators/zone_decorator.rb
@@ -1,5 +1,5 @@
 class ZoneDecorator < MiqDecorator
-  def fonticon
+  def self.fonticon
     'pficon pficon-zone'
   end
 end

--- a/lib/miq_decorator.rb
+++ b/lib/miq_decorator.rb
@@ -10,7 +10,14 @@ class MiqDecorator < SimpleDelegator
 
       decorator
     end
+
+    # Initialize these two attributes with default to nil
+    attr_reader :fonticon, :listicon_image
   end
+
+  # Call the class methods with identical names if these are not set
+  delegate :fonticon, :to => :class
+  delegate :listicon_image, :to => :class
 end
 
 module MiqDecorator::Instance


### PR DESCRIPTION
If there is a `fonticon` (`listicon_image`) method defined as a class method in a decorator, it gets delegated to the instance if no method with the same name is defined there. I also removed the duplications and moved the string-only instance methods to be class methods where it was possible.

Before:
```ruby
class MyDecorator < MiqDecorator
  def fonticon
    'my awesome icon' # or self.class.fonticon
  end

  def self.fonticon
    'my awesome icon'
  end
end
```

After:
```ruby
class MyDecorator < MiqDecorator
  def self.fonticon
    'my awesome icon'
  end
end
```

@miq-bot add_label technical debt, euwe/no

Pivotal story: https://www.pivotaltracker.com/story/show/141603375