### PR TITLE
[WIP] Quadicons - use fonticons in single quads

### DIFF
--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -81,6 +81,20 @@ img.tiny { margin: 0; padding: 0;width:20px;height:20px; border: 0; vertical-ali
 .g72 img,.g72 img { width: 36px; height: 36px;}
 .e72 img { width: 60px; height: 60px;}
 
+.quadicon-single-fonticon {
+  line-height: 60px !important;
+
+  &.fa {
+    font-size: 48px;
+  }
+  &.product {
+    font-size: 60px;
+  }
+  &.pficon {
+    font-size: 47px;
+  }
+}
+
 /************ Misc ************/
 /*select boxes*/
 .form .widthed{ width:400px;}

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -415,6 +415,7 @@ module QuadiconHelper
   # Renders a quadicon for service classes
   #
   def render_service_quadicon(item, options)
+    return render_single_quad_quadicon(item, options) #TODO: FIXME
     output = []
     output << flobj_img_simple
 

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -396,6 +396,12 @@ module QuadiconHelper
     end
   end
 
+  def flobj_fonticon_simple(icon = nil, cls = '')
+    content_tag(:div, :class => "flobj #{cls}") do
+      tag(:i, :class => "fa-fw quadicon-single-fonticon #{icon}")
+    end
+  end
+
   def flobj_img_small(image = nil, cls = '')
     flobj_img_simple(image, cls, 64)
   end
@@ -550,6 +556,8 @@ module QuadiconHelper
   # Renders a single_quad uh, quadicon
   #
   def render_single_quad_quadicon(item, options)
+    fonticon = item.try(:picture) ? nil : item.decorate.try(:fonticon)
+
     img_path = if item.decorate.try(:listicon_image)
                  item.decorate.listicon_image
                elsif @listicon
@@ -560,7 +568,8 @@ module QuadiconHelper
 
     output = []
     output << flobj_img_simple("layout/base-single.png")
-    output << flobj_img_simple(img_path, "e72")
+    output << flobj_img_simple(img_path, "e72") unless fonticon
+    output << flobj_fonticon_simple(fonticon, "e72") if fonticon
 
     unless options[:typ] == :listnav
       title = case @listicon


### PR DESCRIPTION
This should enable single quadicons to use fonticons when available (and picture not present).

WIP because some merging and cleanup and validation is still required, not to mention support for fonticons in quads.

Cc @epwinchell 