### PR TITLE
Remove `hide_action` patch to StaticController

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -4,10 +4,5 @@ class StaticController < ActionController::Base
   # Added to satisfy Brakeman, https://github.com/presidentbeef/brakeman/pull/953
   protect_from_forgery :with => :exception
 
-  # hide_action is gone in Rails, but high_voltage is still using it.
-  # https://github.com/thoughtbot/high_voltage/pull/214
-  def self.hide_action(*)
-  end
-
   include HighVoltage::StaticPage
 end


### PR DESCRIPTION
I know... this is the day you all have been dreading... @NickLaMuro is finally making a PR against ManageIQ/manageiq-ui-classic ... but have no fear, it is short and to the point and will hopefully do minimal damage... hopefully...

Purpose
-------
This removes a patch that was added in https://github.com/ManageIQ/manageiq/pull/6318 that was to cover the fact that `HighVoltage` (at the time) was not updated to support Rails5's removal of `hide_action`.

This has now been updated in v3.0.0 of that gem, and is scheduled for an update in https://github.com/ManageIQ/manageiq/pull/14262 , so this patch is now not necessary and can be removed.


Note to Mergers:
----------------
This should be re-tested and merged after https://github.com/ManageIQ/manageiq/pull/14262 has been merged into master.


Links
-----
* https://github.com/ManageIQ/manageiq/pull/6318
* https://github.com/ManageIQ/manageiq/pull/14262
* https://github.com/thoughtbot/high_voltage/compare/v2.4.0...v3.0.0