### PR TITLE
Merging muliple variables in performace controller into one object

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -79,14 +79,13 @@ module ApplicationController::Performance
     @perf_record = @record.kind_of?(MiqServer) ? @record.vm : @record # Use related server vm record
     if params[:menu_choice]
       chart_click_data = parse_chart_click(params[:menu_choice])
-      chart_idx, _cmd, model, typ = [
-        chart_click_data[:chart_index],
+      _cmd, model, typ = [
         [chart_click_data[:cmd],
          chart_click_data[:model],
          chart_click_data[:update_periods]]
       ].flatten
 
-      report = @sb[:chart_reports].kind_of?(Array) ? report = @sb[:chart_reports][chart_idx] : @sb[:chart_reports]
+      report = @sb[:chart_reports].kind_of?(Array) ? report = @sb[:chart_reports][chart_click_data[:chart_index]] : @sb[:chart_reports]
       data_row = report.table.data[chart_click_data[:data_index]]
       if @perf_options[:cat]
         top_ids = data_row["assoc_ids_#{report.extras[:group_by_tags][chart_click_data[:legend_index]]}"][model.downcase.to_sym][:on]
@@ -179,8 +178,7 @@ module ApplicationController::Performance
   def perf_menu_click
     # Parse the clicked item to get indexes and selection variables
     chart_click_data = parse_chart_click(params[:menu_click])
-    chart_idx, cmd, model, typ = [
-      chart_click_data[:chart_index],
+    cmd, model, typ = [
       [chart_click_data[:cmd],
        chart_click_data[:model],
        chart_click_data[:update_periods]]
@@ -189,7 +187,7 @@ module ApplicationController::Performance
     # Swap in 'Instances' for 'VMs' in AZ breadcrumbs (poor man's cloud/infra split hack)
     bc_model = ['availability_zone', 'host_aggregate'].include?(request.parameters['controller']) && model == 'VMs' ? 'Instances' : model
 
-    report = @sb[:chart_reports].kind_of?(Array) ? @sb[:chart_reports][chart_idx] : @sb[:chart_reports]
+    report = @sb[:chart_reports].kind_of?(Array) ? @sb[:chart_reports][chart_click_data[:chart_index]] : @sb[:chart_reports]
     data_row = report.table.data[chart_click_data[:data_index]]
 
     # Use timestamp or statistic_time (metrics vs ontap)

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -420,7 +420,7 @@ module ApplicationController::Performance
       page << Charting.js_load_statement
       page << 'miqSparkle(false);'
     end
-    return true
+    true
   end
 
   # Create daily/hourly chart for selected CI
@@ -459,7 +459,7 @@ module ApplicationController::Performance
                           :refresh    => "n",
                           :escape     => false
     end
-    return true
+    true
   end
 
   # create top chart for selected timestamp/model by tag

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -1530,8 +1530,7 @@ module ApplicationController::Performance
   # get JSON encoded in Base64
   def parse_chart_click(click_params)
     click_parts = JSON.parse(Base64.decode64(click_params))
-    Struct.new('ChartClickData', :legend_index, :data_index, :chart_index, :cmd, :model, :type)
-    Struct::ChartClickData.new(
+    ApplicationController::Performance::ChartClickData.new(
       click_parts['row'].to_i,
       click_parts['column'].to_i,
       click_parts['chart_index'].to_i,

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -289,7 +289,7 @@ module ApplicationController::Performance
                           _("No events available for this %{model}") % {:model => new_opts[:model]}
                         end
     elsif @record.kind_of?(MiqServer) # For server charts in OPS
-      change_tab("diagnostics_timelines")                # Switch to the Timelines tab
+      change_tab("diagnostics_timelines") # Switch to the Timelines tab
       return true
     else
       if @explorer
@@ -328,7 +328,7 @@ module ApplicationController::Performance
                           _("No events available for this %{model}") % {:model => model}
                         end
     elsif @record.kind_of?(MiqServer) # For server charts in OPS
-      change_tab("diagnostics_timelines")                # Switch to the Timelines tab
+      change_tab("diagnostics_timelines") # Switch to the Timelines tab
       return true
     else
       if @explorer
@@ -400,7 +400,7 @@ module ApplicationController::Performance
     @perf_options[:typ] = "Daily"
     perf_set_or_fix_dates(false) unless params[:task_id] # Set dates if first time thru
     perf_gen_data
-    return true unless @charts        # Return if no charts got created (first time thru async rpt gen)
+    return true unless @charts # Return if no charts got created (first time thru async rpt gen)
 
     render :update do |page|
       page << javascript_prologue

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -79,8 +79,7 @@ module ApplicationController::Performance
     @perf_record = @record.kind_of?(MiqServer) ? @record.vm : @record # Use related server vm record
     if params[:menu_choice]
       chart_click_data = parse_chart_click(params[:menu_choice])
-      data_idx, chart_idx, _cmd, model, typ = [
-        chart_click_data[:data_index],
+      chart_idx, _cmd, model, typ = [
         chart_click_data[:chart_index],
         [chart_click_data[:cmd],
          chart_click_data[:model],
@@ -88,7 +87,7 @@ module ApplicationController::Performance
       ].flatten
 
       report = @sb[:chart_reports].kind_of?(Array) ? report = @sb[:chart_reports][chart_idx] : @sb[:chart_reports]
-      data_row = report.table.data[data_idx]
+      data_row = report.table.data[chart_click_data[:data_index]]
       if @perf_options[:cat]
         top_ids = data_row["assoc_ids_#{report.extras[:group_by_tags][chart_click_data[:legend_index]]}"][model.downcase.to_sym][:on]
       else
@@ -180,8 +179,7 @@ module ApplicationController::Performance
   def perf_menu_click
     # Parse the clicked item to get indexes and selection variables
     chart_click_data = parse_chart_click(params[:menu_click])
-    data_idx, chart_idx, cmd, model, typ = [
-      chart_click_data[:data_index],
+    chart_idx, cmd, model, typ = [
       chart_click_data[:chart_index],
       [chart_click_data[:cmd],
        chart_click_data[:model],
@@ -192,7 +190,7 @@ module ApplicationController::Performance
     bc_model = ['availability_zone', 'host_aggregate'].include?(request.parameters['controller']) && model == 'VMs' ? 'Instances' : model
 
     report = @sb[:chart_reports].kind_of?(Array) ? @sb[:chart_reports][chart_idx] : @sb[:chart_reports]
-    data_row = report.table.data[data_idx]
+    data_row = report.table.data[chart_click_data[:data_index]]
 
     # Use timestamp or statistic_time (metrics vs ontap)
     ts = (data_row["timestamp"] || data_row["statistic_time"]).in_time_zone(@perf_options[:tz])                 # Grab the timestamp from the row in selected tz

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -229,7 +229,7 @@ module ApplicationController::Performance
   # display selected resources from a tag chart
   def display_by_tag(data_row, report, ts, bc_model, model, legend_idx)
     top_ids = data_row["assoc_ids_#{report.extras[:group_by_tags][legend_idx]}"][model.downcase.to_sym][:on]
-    bc_tag =  "#{Classification.find_by_name(@perf_options[:cat]).description}:#{report.extras[:group_by_tag_descriptions][legend_idx]}"
+    bc_tag =  "#{Classification.find_by(:name => @perf_options[:cat]).description}:#{report.extras[:group_by_tag_descriptions][legend_idx]}"
     dt = typ == "tophour" ? "on #{ts.to_date} at #{ts.strftime("%H:%M:%S %Z")}" : "on #{ts.to_date}"
     if top_ids.blank?
       @menu_click_msg = _("No %{tag} %{model} were running %{time}") % {:tag => bc_tag, :model => bc_model, :time => dt}
@@ -273,7 +273,7 @@ module ApplicationController::Performance
   def timeline_current(typ, ts)
     @record = identify_tl_or_perf_record
     @perf_record = @record.kind_of?(MiqServer) ? @record.vm : @record # Use related server vm record
-    @perf_record = VmOrTemplate.find_by_id(@perf_options[:compare_vm]) unless @perf_options[:compare_vm].nil?
+    @perf_record = VmOrTemplate.find(@perf_options[:compare_vm]) unless @perf_options[:compare_vm].nil?
     new_opts = tl_session_data(request.parameters["controller"]) || ApplicationController::Timelines::Options.new
     new_opts[:model] = @perf_record.class.base_class.to_s
     new_opts.date.typ = typ

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -228,7 +228,6 @@ module ApplicationController::Performance
 
   # display selected resources from a tag chart
   def display_by_tag(data_row, report, ts, bc_model, model, legend_idx)
-    dt = @perf_options[:typ] == "Hourly" ? "on #{ts.to_date} at #{ts.strftime("%H:%M:%S %Z")}" : "on #{ts.to_date}"
     top_ids = data_row["assoc_ids_#{report.extras[:group_by_tags][legend_idx]}"][model.downcase.to_sym][:on]
     bc_tag =  "#{Classification.find_by_name(@perf_options[:cat]).description}:#{report.extras[:group_by_tag_descriptions][legend_idx]}"
     dt = typ == "tophour" ? "on #{ts.to_date} at #{ts.strftime("%H:%M:%S %Z")}" : "on #{ts.to_date}"
@@ -277,7 +276,6 @@ module ApplicationController::Performance
     @perf_record = VmOrTemplate.find_by_id(@perf_options[:compare_vm]) unless @perf_options[:compare_vm].nil?
     new_opts = tl_session_data(request.parameters["controller"]) || ApplicationController::Timelines::Options.new
     new_opts[:model] = @perf_record.class.base_class.to_s
-    dt = typ == "Hourly" ? "on #{ts.to_date} at #{ts.strftime("%H:%M:%S %Z")}" : "on #{ts.to_date}"
     new_opts.date.typ = typ
     new_opts.date.daily = @perf_options[:daily_date] if typ == "Daily"
     new_opts.date.hourly = [ts.month, ts.day, ts.year].join("/") if typ == "Hourly"
@@ -317,7 +315,6 @@ module ApplicationController::Performance
     controller = data_row["resource_type"].underscore
     new_opts = tl_session_data(controller) || ApplicationController::Timelines::Options.new
     new_opts[:model] = data_row["resource_type"]
-    dt = typ == "Hourly" ? "on #{ts.to_date} at #{ts.strftime("%H:%M:%S %Z")}" : "on #{ts.to_date}"
     new_opts.date.typ = typ
     new_opts.date.daily = @perf_options[:daily_date] if typ == "Daily"
     new_opts.date.hourly = [ts.month, ts.day, ts.year].join("/") if typ == "Hourly"

--- a/app/controllers/application_controller/performance/chart_click_data.rb
+++ b/app/controllers/application_controller/performance/chart_click_data.rb
@@ -1,0 +1,11 @@
+module ApplicationController::Performance
+  ChartClickData = Struct.new(
+    :legend_index,
+    :data_index,
+    :chart_index,
+    :cmd,
+    :model,
+    :type,
+  )
+end
+


### PR DESCRIPTION
- Fixing a few Rubocop issues from PR #652
- Merging muliple variables into one object

**tl;dr:**
```diff
- legend_idx, data_idx, chart_idx, _cmd, model, typ = parse_chart_click(params[:menu_choice])
+ chart_click_data = parse_chart_click(params[:menu_choice])
``` 

this way, it's not necessary to pass too many parameters to methods called by `perf_menu_click` method, splitted in #652.

@martinpovolny please, see if these changes make sense.
/cc @PanSpagetka (related to changes c3bedda3 from PR https://github.com/ManageIQ/manageiq/pull/11400)