### PR TITLE
Remove dead @cats

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -620,7 +620,6 @@ class ConfigurationController < ApplicationController
     session[:config_schema_ver] = @schema_ver
     session[:vm_filters]        = @filters
     session[:vm_catinfo]        = @catinfo
-    session[:vm_cats]           = @cats
     session[:zone_options]      = @zone_options
   end
 

--- a/app/controllers/miq_template_controller.rb
+++ b/app/controllers/miq_template_controller.rb
@@ -1,4 +1,5 @@
 require "rexml/document"
+
 class MiqTemplateController < ApplicationController
   include VmCommon
   include Mixins::GenericListMixin
@@ -24,7 +25,6 @@ class MiqTemplateController < ApplicationController
     @base           = session[:miq_template_compare_base]
     @filters        = session[:miq_template_filters]
     @catinfo        = session[:miq_template_catinfo]
-    @cats           = session[:miq_template_cats]
     @display        = session[:miq_template_display]
     @polArr         = session[:polArr] || "" # current tags in effect
     @policy_options = session[:policy_options] || ""
@@ -38,7 +38,6 @@ class MiqTemplateController < ApplicationController
     session[:miq_template_compare_base] = @base
     session[:miq_template_filters]      = @filters
     session[:miq_template_catinfo]      = @catinfo
-    session[:miq_template_cats]         = @cats
     session[:miq_template_display]      = @display unless @display.nil?
     session[:polArr]                    = @polArr unless @polArr.nil?
     session[:policy_options]            = @policy_options unless @policy_options.nil?

--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -138,7 +138,6 @@ module VmShowMixin
     @base           = session[:vm_compare_base]
     @filters        = get_filters
     @catinfo        = session[:vm_catinfo]
-    @cats           = session[:vm_cats]
     @display        = session[:vm_display]
     @polArr         = session[:polArr] || ""          # current tags in effect
     @policy_options = session[:policy_options] || ""
@@ -152,7 +151,6 @@ module VmShowMixin
     session[:vm_compare_base] = @base
     session[:vm_filters]      = @filters
     session[:vm_catinfo]      = @catinfo
-    session[:vm_cats]         = @cats
     session[:vm_display]      = @display unless @display.nil?
     session[:polArr]          = @polArr unless @polArr.nil?
     session[:policy_options]  = @policy_options unless @policy_options.nil?

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -909,7 +909,6 @@ class ReportController < ApplicationController
     session[:ght_type]          = @ght_type
     session[:report_groups]     = @report_groups
     session[:vm_catinfo]        = @catinfo
-    session[:vm_cats]           = @cats
     session[:edit]              = @edit unless @edit.nil?
     session[:report_result_id]  = @report_result_id
     session[:report_menu]       = @menu

--- a/app/controllers/vm_controller.rb
+++ b/app/controllers/vm_controller.rb
@@ -27,7 +27,6 @@ class VmController < ApplicationController
     @base           = session[:vm_compare_base]
     @filters        = session[:vm_filters]
     @catinfo        = session[:vm_catinfo]
-    @cats           = session[:vm_cats]
     @display        = session[:vm_display]
     @polArr         = session[:polArr] || ""           # current tags in effect
     @policy_options = session[:policy_options] || ""
@@ -41,7 +40,6 @@ class VmController < ApplicationController
     session[:vm_compare_base] = @base
     session[:vm_filters]      = @filters
     session[:vm_catinfo]      = @catinfo
-    session[:vm_cats]         = @cats
     session[:vm_display]      = @display unless @display.nil?
     session[:polArr]          = @polArr unless @polArr.nil?
     session[:policy_options]  = @policy_options unless @policy_options.nil?


### PR DESCRIPTION
`@cats` is dead, for great justice :).

It's never used in application controller, or any shared templates, so the only valid users of `@cats` are OpsController and MiqPolicyController.