### PR TITLE
Compare - remove dead compare_set_base, {compare,drift}_matches, @base

### DIFF
--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -653,7 +653,6 @@ class HostController < ApplicationController
     @display    = session[:host_display]
     @filters    = session[:host_filters]
     @catinfo    = session[:host_catinfo]
-    @base       = session[:vm_compare_base]
   end
 
   def set_session_data
@@ -663,7 +662,6 @@ class HostController < ApplicationController
     session[:host_catinfo]    = @catinfo
     session[:miq_compressed]  = @compressed  unless @compressed.nil?
     session[:miq_exists_mode] = @exists_mode unless @exists_mode.nil?
-    session[:vm_compare_base] = @base
   end
 
   menu_section :inf

--- a/app/controllers/miq_template_controller.rb
+++ b/app/controllers/miq_template_controller.rb
@@ -21,7 +21,6 @@ class MiqTemplateController < ApplicationController
     @layout         = session[:miq_template_type] ? session[:miq_template_type] : "miq_template"
     @lastaction     = session[:miq_template_lastaction]
     @showtype       = session[:miq_template_showtype]
-    @base           = session[:miq_template_compare_base]
     @filters        = session[:miq_template_filters]
     @catinfo        = session[:miq_template_catinfo]
     @cats           = session[:miq_template_cats]
@@ -35,7 +34,6 @@ class MiqTemplateController < ApplicationController
     session[:miq_template_showtype]     = @showtype
     session[:miq_compressed]            = @compressed unless @compressed.nil?
     session[:miq_exists_mode]           = @exists_mode unless @exists_mode.nil?
-    session[:miq_template_compare_base] = @base
     session[:miq_template_filters]      = @filters
     session[:miq_template_catinfo]      = @catinfo
     session[:miq_template_cats]         = @cats

--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -135,7 +135,6 @@ module VmShowMixin
     @layout         = controller_name
     @lastaction     = session[:vm_lastaction]
     @showtype       = session[:vm_showtype]
-    @base           = session[:vm_compare_base]
     @filters        = get_filters
     @catinfo        = session[:vm_catinfo]
     @cats           = session[:vm_cats]
@@ -149,7 +148,6 @@ module VmShowMixin
     session[:vm_showtype]     = @showtype
     session[:miq_compressed]  = @compressed unless @compressed.nil?
     session[:miq_exists_mode] = @exists_mode unless @exists_mode.nil?
-    session[:vm_compare_base] = @base
     session[:vm_filters]      = @filters
     session[:vm_catinfo]      = @catinfo
     session[:vm_cats]         = @cats

--- a/app/controllers/vm_controller.rb
+++ b/app/controllers/vm_controller.rb
@@ -24,7 +24,6 @@ class VmController < ApplicationController
     @layout         = "vm"
     @lastaction     = session[:vm_lastaction]
     @showtype       = session[:vm_showtype]
-    @base           = session[:vm_compare_base]
     @filters        = session[:vm_filters]
     @catinfo        = session[:vm_catinfo]
     @cats           = session[:vm_cats]
@@ -38,7 +37,6 @@ class VmController < ApplicationController
     session[:vm_showtype]     = @showtype
     session[:miq_compressed]  = @compressed unless @compressed.nil?
     session[:miq_exists_mode] = @exists_mode unless @exists_mode.nil?
-    session[:vm_compare_base] = @base
     session[:vm_filters]      = @filters
     session[:vm_catinfo]      = @catinfo
     session[:vm_cats]         = @cats


### PR DESCRIPTION
`compare_matches` is only called from `compare_set_base`.

`compare_set_base` and `drift_matches` are never called.

`@base` is no longer useful, since `compare_set_base` is the only method to save something useful there