### PR TITLE
Modify label_tag_mapping_add to accommodate scoped entity type.

### DIFF
--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -132,15 +132,12 @@ module OpsController::Settings::LabelTagMapping
     prefix = ContainerLabelTagMapping::AUTOTAG_PREFIX
 
     # The entity is a string in the form "Provider::ResourceType".
-    if entity
+    if entity && entity.include?('::')
       prefix, entity = entity.split('::')
-      # Backwards compatibility
-      if prefix && entity
-        prefix.downcase!
-        entity_str = entity.underscore
-      else
-        prefix = ContainerLabelTagMapping::AUTOTAG_PREFIX
-      end
+      prefix.downcase!
+      entity_str = entity.underscore
+    else
+      entity_str = entity.underscore if entity
     end
 
     cat_name = "#{prefix}:#{entity_str}:" + Classification.sanitize_name(label_name.tr("/", ":"))

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -128,8 +128,21 @@ module OpsController::Settings::LabelTagMapping
   end
 
   def label_tag_mapping_add(entity, label_name, cat_description)
+    entity_str = ''
     prefix = ContainerLabelTagMapping::AUTOTAG_PREFIX
-    entity_str = entity.nil? ? "" : entity.underscore
+
+    # The entity is a string in the form "Provider::ResourceType".
+    if entity
+      prefix, entity = entity.split('::')
+      # Backwards compatibility
+      if prefix && entity
+        prefix.downcase!
+        entity_str = entity.underscore
+      else
+        prefix = ContainerLabelTagMapping::AUTOTAG_PREFIX
+      end
+    end
+
     cat_name = "#{prefix}:#{entity_str}:" + Classification.sanitize_name(label_name.tr("/", ":"))
 
     # UI currently can't allow 2 mappings for same (entity, label).

--- a/app/views/ops/_label_tag_mapping_form.html.haml
+++ b/app/views/ops/_label_tag_mapping_form.html.haml
@@ -7,9 +7,9 @@
               :method => :post}) do
     - disabled = !@lt_map.nil?
     - if disabled
-      %h3= _("Container entity and label")
+      %h3= _("Resource entity and label")
     - else
-      %h3= _("Choose a container entity and label")
+      %h3= _("Choose a resource entity and label")
     .form-group
       %label.col-md-2.control-label
         = _("Entity")

--- a/app/views/ops/_settings_label_tag_mapping_tab.html.haml
+++ b/app/views/ops/_settings_label_tag_mapping_tab.html.haml
@@ -3,8 +3,8 @@
   %table.table.table-striped.table-bordered.table-hover
     %thead
       %tr
-        %th= _("Container Entity")
-        %th= _("Container Label")
+        %th= _("Resource Entity")
+        %th= _("Resource Label")
         %th= _("Tag Category")
         %th= _("Actions")
     %tbody

--- a/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
+++ b/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
@@ -15,6 +15,14 @@ describe OpsController do
       post :label_tag_mapping_edit, :button => 'add'
     end
 
+    def use_form_to_create_scoped_mapping
+      post :label_tag_mapping_edit
+      post :label_tag_mapping_field_changed, :id => 'new', :entity => 'Amazon::Vm'
+      post :label_tag_mapping_field_changed, :id => 'new', :label_name => 'some-amazon-label'
+      post :label_tag_mapping_field_changed, :id => 'new', :category => 'Amazon Vms'
+      post :label_tag_mapping_edit, :button => 'add'
+    end
+
     it "creates new mapping on save" do
       use_form_to_create_mapping
       mapping = ContainerLabelTagMapping.last
@@ -25,7 +33,17 @@ describe OpsController do
       expect(mapping.tag.classification.description).to eq('My Cat')
     end
 
-    it "can edit existing mapping" do
+    it "creates new scoped mapping on save" do
+      use_form_to_create_scoped_mapping
+      mapping = ContainerLabelTagMapping.last
+      expect(mapping.labeled_resource_type).to eq('Vm')
+      expect(mapping.label_name).to eq('some-amazon-label')
+      expect(mapping.label_value).to be nil
+      expect(mapping.tag.classification.category?).to be true
+      expect(mapping.tag.classification.description).to eq('Amazon Vms')
+    end
+
+    it "can edit an existing mapping" do
       use_form_to_create_mapping
       mapping = ContainerLabelTagMapping.last
 
@@ -54,6 +72,35 @@ describe OpsController do
       controller.instance_variable_set :@flash_array, nil
       post :label_tag_mapping_edit, :id => mapping.id.to_s, :button => 'save'
       expect(mapping.tag.classification.description).to eq('Edited Again Cat')
+    end
+
+    it "can edit an existing scoped mapping" do
+      use_form_to_create_scoped_mapping
+      mapping = ContainerLabelTagMapping.last
+
+      post :label_tag_mapping_edit, :id => mapping.id.to_s
+      expect(assigns(:edit)[:new]).to include(:entity     => 'Vm',
+                                              :label_name => 'some-amazon-label',
+                                              :category   => 'Amazon Vms')
+
+      post :label_tag_mapping_field_changed, :id => mapping.id.to_s, :category => 'Edited Amazon'
+      expect(assigns(:edit)[:new]).to include(:entity     => 'Vm',
+                                              :label_name => 'some-amazon-label',
+                                              :category   => 'Edited Amazon')
+
+      post :label_tag_mapping_edit, :id => mapping.id.to_s, :button => 'reset'
+      expect(assigns(:edit)[:new]).to include(:entity     => 'Vm',
+                                              :label_name => 'some-amazon-label',
+                                              :category   => 'Amazon Vms')
+
+      post :label_tag_mapping_field_changed, :id => mapping.id.to_s, :category => 'Edited Again Amazon'
+      expect(assigns(:edit)[:new]).to include(:entity     => 'Vm',
+                                              :label_name => 'some-amazon-label',
+                                              :category   => 'Edited Again Amazon')
+
+      controller.instance_variable_set :@flash_array, nil
+      post :label_tag_mapping_edit, :id => mapping.id.to_s, :button => 'save'
+      expect(mapping.tag.classification.description).to eq('Edited Again Amazon')
     end
   end
 end


### PR DESCRIPTION
This PR is based on the changes in https://github.com/ManageIQ/manageiq/pull/14288. In that PR the mappable types are scoped by provider, e.g. "Amazon::Vm" or "Kubernetes::ContainerNode".

Instead of automatically using the hard coded AUTOTAG_PREFIX, it parses the provider name from the selected item if possible. The AUTOTAG_PREFIX is still the default value, which preserves backwards compatibility.