### PR TITLE
Fix breaking VMs page after closing user input dialog

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -608,7 +608,7 @@ module ApplicationController::Filter
     @edit[@expkey][:selected] = @edit[@expkey][:pre_qs_selected]                # Restore previous selected search
     @edit[:adv_search_applied] = @edit[:qs_prev_adv_search_applied]             # Restore previous adv search
     @edit[:adv_search_applied] = nil unless @edit.fetch_path(:adv_search_applied, :exp) # Remove adv search if no prev expression
-    self.x_node = @edit[:qs_prev_x_node] if @edit[:in_explorer]                   # Restore previous exp tree node
+    self.x_node = @edit[:qs_prev_x_node] if @edit[:in_explorer] && @edit[@expkey][:exp_value] != :user_input # Restore previous exp tree node
     session[:adv_search] ||= {}
     session[:adv_search][@edit[@expkey][:exp_model]] = copy_hash(@edit) # Save by model name in settings
 

--- a/spec/controllers/application_controller/filter_spec.rb
+++ b/spec/controllers/application_controller/filter_spec.rb
@@ -77,4 +77,48 @@ describe ApplicationController, "::Filter" do
       expect(user.settings).to eq(:default_search => {:Host => search.id})
     end
   end
+
+  describe "#quick_search_cancel_click" do
+    let(:edit) do
+      {:expression                 => {:selected        => {},
+                                       :pre_qs_selected => {},
+                                       :exp_value       => nil},
+       :qs_prev_adv_search_applied => {},
+       :adv_search_applied         => {},
+       :qs_prev_x_node             => nil}
+    end
+
+    before :each do
+      controller.instance_variable_set(:@expkey, :expression)
+      controller.instance_variable_set(:@edit, edit)
+      allow(controller).to receive(:render)
+    end
+
+    it "is in explorer screen and exp value is :user_input" do
+      edit[:in_explorer] = true
+      edit[:expression][:exp_value] = :user_input
+      controller.x_node = "root"
+
+      controller.send(:quick_search_cancel_click)
+      expect(controller.x_node).to eq("root")
+    end
+
+    it "is in explorer screen and exp value is NOT :user_input" do
+      edit[:in_explorer] = true
+      edit[:expression][:exp_value] = nil
+      controller.x_node = "root"
+
+      controller.send(:quick_search_cancel_click)
+      expect(controller.x_node).to eq(edit[:qs_prev_x_node])
+    end
+
+    it "is in non explorer screen" do
+      edit[:in_explorer] = false
+      edit[:expression][:exp_value] = nil
+      controller.x_node = nil
+
+      controller.send(:quick_search_cancel_click)
+      expect(controller.x_node).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1425840

Fix breaking VMs page after closing user input dialog
and clicking view selector after creating a filter
in Advanced search in Compute->Infrastructure->Virtual Machines,
VMs or Templates accordion.

After this fix:
Virtual Machines page doesn't break anymore.
Search field doesn't disappear anymore.
View Selector control doesn't break in Templates view.
Advanced search button appears after changing view normally.

The problem was:
`x_root` changed value from `"root"` to `nil` in `quick_search_cancel_click` method
when clicked on "Cancel" button in user input dialog.
I think that there is some reason for this, but as I was exploring,
`x_root` had value `"root"` in the method whether any filter was applied or not,
in other working pages. The value affects the proper view
of the page when changing the view.

Before:
![search_field1](https://cloud.githubusercontent.com/assets/13417815/23860917/af507500-0808-11e7-846d-7e4fcd4a7db0.png)

After:
![search_field2](https://cloud.githubusercontent.com/assets/13417815/23860920/b201be26-0808-11e7-8a0c-8a6d1184ecc0.png)

