### PR TITLE
renaming external_logging feature

### DIFF
--- a/app/controllers/mixins/containers_external_logging_support_mixin.rb
+++ b/app/controllers/mixins/containers_external_logging_support_mixin.rb
@@ -1,5 +1,5 @@
 module ContainersExternalLoggingSupportMixin
-  def launch_external_logging_support
+  def launch_external_logging
     record = self.class.model.find(params[:id])
     ems = record.ext_management_system
     route_name = ems.external_logging_route_name

--- a/app/helpers/application_helper/button/ems_container_launch_external_logging_support.rb
+++ b/app/helpers/application_helper/button/ems_container_launch_external_logging_support.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Button::EmsContainerLaunchExternalLoggingSupport < ApplicationHelper::Button::GenericFeatureButton
   def initialize(view_context, view_binding, instance_data, props)
     props ||= {}
-    props.store_path(:options, :feature, :external_logging_support)
+    props.store_path(:options, :feature, :external_logging)
     super(view_context, view_binding, instance_data, props)
   end
 

--- a/app/helpers/application_helper/toolbar/container_node_center.rb
+++ b/app/helpers/application_helper/toolbar/container_node_center.rb
@@ -23,13 +23,13 @@ class ApplicationHelper::Toolbar::ContainerNodeCenter < ApplicationHelper::Toolb
           :url       => "/show",
           :url_parms => "?display=performance"),
         button(
-          :ems_container_launch_external_logging_support,
+          :ems_container_launch_external_logging,
           'product product-monitoring fa-lg',
           N_('Open a new browser window with the External Logging Presentation UI. ' \
              'This requires the External Logging to be deployed on this Proider.'),
           N_('External Logging'),
           :klass => ApplicationHelper::Button::EmsContainerLaunchExternalLoggingSupport,
-          :url   => "launch_external_logging_support"
+          :url   => "launch_external_logging"
         ),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -65,13 +65,13 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
           :options   => {:feature => :ad_hoc_metrics},
           :url_parms => "?display=ad_hoc_metrics"),
         button(
-          :ems_container_launch_external_logging_support,
+          :ems_container_launch_external_logging,
           'product product-monitoring fa-lg',
           N_('Open a new browser window with the External Logging Presentation UI. ' \
              'This requires the External Logging to be deployed on this Proider.'),
           N_('External Logging'),
           :klass => ApplicationHelper::Button::EmsContainerLaunchExternalLoggingSupport,
-          :url   => "launch_external_logging_support"
+          :url   => "launch_external_logging"
         ),
       ]
     ),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -691,7 +691,7 @@ Rails.application.routes.draw do
         protect
         squash_toggle
         launch_cockpit
-        launch_external_logging_support
+        launch_external_logging
       ) +
                adv_search_post +
                exp_post +
@@ -1300,7 +1300,7 @@ Rails.application.routes.draw do
         tagging_edit
         tag_edit_form_field_changed
         squash_toggle
-        launch_external_logging_support
+        launch_external_logging
       ) +
                adv_search_post +
                compare_post +


### PR DESCRIPTION
Omitting the _support due to redundancy

followup on: https://github.com/ManageIQ/manageiq/pull/13704#discussion_r105698081
backend PR : https://github.com/ManageIQ/manageiq/pull/14298