### PR TITLE
Container TLS fixes

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -331,6 +331,11 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.providerTypeChanged = function() {
+    if ($scope.emsCommonModel.ems_controller === 'ems_container') {
+      $scope.emsCommonModel.default_api_port = "8443"; // TODO: correct per-type port
+      // Container types are nearly identical, no point resetting most fields on type change.
+      return;
+    }
     $scope.emsCommonModel.default_api_port = "";
     $scope.emsCommonModel.provider_region = "";
     $scope.emsCommonModel.default_security_protocol = "";
@@ -352,10 +357,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.metrics_api_port = "5432";
       $scope.emsCommonModel.default_api_port = $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
       $scope.emsCommonModel.metrics_database_name = "ovirt_engine_history";
-    } else if ($scope.emsCommonModel.ems_controller === 'ems_container') {
-      $scope.emsCommonModel.default_api_port = "8443";
-      $scope.emsCommonModel.default_security_protocol = 'ssl-with-validation';
-      $scope.emsCommonModel.hawkular_security_protocol = 'ssl-with-validation';
     } else if ($scope.emsCommonModel.emstype === 'vmware_cloud') {
       $scope.emsCommonModel.default_api_port = "443";
       $scope.emsCommonModel.event_stream_selection = "none";

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -187,6 +187,10 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.api_version                     = 'v2';
       $scope.emsCommonModel.ems_controller                  = data.ems_controller;
       $scope.emsCommonModel.ems_controller === 'ems_container' ? $scope.emsCommonModel.default_api_port = '8443' : $scope.emsCommonModel.default_api_port = '';
+      $scope.emsCommonModel.default_security_protocol       = data.default_security_protocol;
+      $scope.emsCommonModel.hawkular_security_protocol      = data.hawkular_security_protocol;
+      $scope.emsCommonModel.default_tls_ca_certs            = data.default_tls_ca_certs;
+      $scope.emsCommonModel.hawkular_tls_ca_certs           = data.hawkular_tls_ca_certs;
       $scope.emsCommonModel.default_auth_status             = data.default_auth_status;
       $scope.emsCommonModel.amqp_auth_status                = data.amqp_auth_status;
       $scope.emsCommonModel.service_account_auth_status     = data.service_account_auth_status;

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -24,6 +24,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       realm: '',
       security_protocol: '',
       amqp_security_protocol: '',
+      hawkular_security_protocol: '',
+      hawkular_tls_ca_certs: '',
       provider_region: '',
       default_userid: '',
       default_password: '',

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -430,6 +430,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         default_hostname:          $scope.emsCommonModel.default_hostname,
         default_api_port:          $scope.emsCommonModel.default_api_port,
         default_security_protocol: $scope.emsCommonModel.default_security_protocol,
+        default_tls_verify:        $scope.emsCommonModel.default_tls_verify,
+        default_tls_ca_certs:      $scope.emsCommonModel.default_tls_ca_certs,
         default_userid:            $scope.emsCommonModel.default_userid,
         default_password:          default_password,
         default_verify:            default_verify,
@@ -486,8 +488,10 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       }
     } else if (prefix === "hawkular") {
       $scope.postValidationModel['hawkular'] = {
-        hawkular_hostname:         $scope.emsCommonModel.hawkular_hostname,
-        hawkular_api_port:         $scope.emsCommonModel.hawkular_api_port,
+        hawkular_hostname:          $scope.emsCommonModel.hawkular_hostname,
+        hawkular_api_port:          $scope.emsCommonModel.hawkular_api_port,
+        hawkular_security_protocol: $scope.emsCommonModel.hawkular_security_protocol,
+        hawkular_tls_ca_certs:      $scope.emsCommonModel.hawkular_tls_ca_certs,
       }
     }
   };

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -215,7 +215,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
        $scope.emsCommonModel.emstype == "openstack_infra" && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "nuage_network"  && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "rhevm" && $scope.emsCommonModel.default_hostname ||
-       $scope.emsCommonModel.emstype == "vmwarews" && $scope.emsCommonModel.default_hostname || 
+       $scope.emsCommonModel.emstype == "vmwarews" && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "vmware_cloud" && $scope.emsCommonModel.default_hostname) &&
       ($scope.emsCommonModel.default_userid != '' && $scope.angularForm.default_userid.$valid &&
        $scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid &&

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -172,6 +172,7 @@ module Mixins
         hawkular_api_port = @ems.connection_configurations.hawkular.endpoint.port
         hawkular_auth_status = @ems.authentication_status_ok?(:hawkular)
         hawkular_security_protocol = @ems.connection_configurations.hawkular.endpoint.security_protocol
+        hawkular_security_protocol ||= security_protocol_default
         hawkular_tls_ca_certs = @ems.connection_configurations.hawkular.endpoint.certificate_authority
       end
 

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -118,9 +118,9 @@ module Mixins
       @ems = model.new if params[:id] == 'new'
       @ems = find_by_id_filtered(model, params[:id]) if params[:id] != 'new'
       default_endpoint = @ems.default_endpoint
-      default_security_protocol = default_endpoint.security_protocol ? default_endpoint.security_protocol : 'ssl'
+      default_security_protocol = default_endpoint.security_protocol || security_protocol_default
       default_tls_verify = default_endpoint.verify_ssl != 0 ? true : false
-      default_tls_ca_certs = default_endpoint.certificate_authority
+      default_tls_ca_certs = default_endpoint.certificate_authority || ""
 
       amqp_userid = ""
       amqp_hostname = ""
@@ -134,7 +134,7 @@ module Mixins
       keystone_v3_domain_id = ""
       hawkular_hostname = ""
       hawkular_api_port = ""
-      hawkular_security_protocol = ""
+      hawkular_security_protocol = security_protocol_default
       hawkular_tls_ca_certs = ""
 
       if @ems.connection_configurations.amqp.try(:endpoint)
@@ -318,6 +318,13 @@ module Mixins
     def metrics_default_database_name
       if @ems.class.name == 'ManageIQ::Providers::Redhat::InfraManager'
         ManageIQ::Providers::Redhat::InfraManager.default_history_database_name
+      end
+    end
+
+    def security_protocol_default
+      case controller_name
+      when "ems_container" then "ssl-with-validation"
+      else "ssl"
       end
     end
 

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -155,7 +155,8 @@
                              "ng-disabled" => "emsCommonModel.emstype == 'rhevm' && !#{ng_model}.#{prefix}_tls_verify",
                              "ng-required" => false,
                              "ng-trim"     => false,
-                             "prefix"      => "#{prefix}"}
+                             "prefix"      => "#{prefix}",
+                             "reset-validation-status" => "#{prefix}_auth_status"}
       %span.help-block
         = _("Paste here the trusted CA certificates, in PEM format.")
 


### PR DESCRIPTION
Followups to #450.  Fix ability to create new containers provider without hawkular, and to edit existing provider without hawkular.
https://bugzilla.redhat.com/show_bug.cgi?id=1430405

- Security protocol on new containers provider, or if editing provider where it was null, now defaults to "SSL".  (default & hawkular endpoints)  This makes Hawkular endpoint valid initially.
- Correctly track changes to protocol & CA fields in computing whether [Validate] is required.
- Not quite bug but improvement: For containers, the specific provider types ( Kubernetes/OpenShift /OpenShift Enterprise) are essentially same and there is no point resetting fields when you change the type.

cc @josejulio @jhernand 
@miq-bot add-label wip, compute/containers, bug