### PR TITLE
Corrected loading record id by selected node

### DIFF
--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -6,7 +6,7 @@ module VmShowMixin
     @lastaction = "explorer"
     @timeline = @timeline_filter = true    # need to set these to load timelines on vm show screen
     if params[:menu_click]              # Came in from a chart context menu click
-      @_params[:id] = parse_nodetype_and_id(x_node).last
+      @_params[:id] = parse_nodetype_and_id(x_node_right_cell).last
       @explorer = true
       perf_menu_click                    # Handle the menu action
       return


### PR DESCRIPTION
Problem here is that `@perf_record` variable is getting `nil`, because controller takes folder selected in the tree as the `@record`.

```ruby
 151   def perf_set_or_fix_dates(allow_interval_override = true)                                                                      
 152     start_date, end_date = @perf_record.first_and_last_capture('hourly')                                                         
 153     start_date, end_date = @perf_record.first_and_last_capture('realtime') if realtime = start_date.nil?
```

After clicking in chart context menu, the id sent in `params` is the id of folder.
There is alternative method `x_node_right_cell`, that returns the id of what's in right cell.

Reproducing bug:

1. Compute -> Infrastructure -> Virtual Machines
2. Select one VM, that has data with C&U
3. Click "Utilization" button
4. In rendered chart, click o anything in contextual menu:

![screencast from 2017-03-13 19-10-46](https://cloud.githubusercontent.com/assets/1187051/23868750/e7286880-0820-11e7-95e6-244af5d242d6.gif)