### PR TITLE
Fixed an error when clicking on items in Service Catalogs accordion

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -228,7 +228,7 @@ class CatalogController < ApplicationController
       set_form_locals_for_sysprep
     end
     template_locals = {:locals => {:controller => "catalog"}}
-    template_locals[:locals].merge!(fetch_playbook_details) if TreeBuilder.get_model_for_prefix(@nodetype) == "ServiceTemplate" && !@view && @record.prov_type == "generic_ansible_playbook"
+    template_locals[:locals].merge!(fetch_playbook_details) if need_ansible_locals?
 
     render :layout => "application", :action => "explorer", :locals => template_locals
   end
@@ -1933,7 +1933,7 @@ class CatalogController < ApplicationController
           r[:partial => "shared/buttons/ab_list"]
         else
           template_locals = {:controller => "catalog"}
-          template_locals.merge!(fetch_playbook_details) if TreeBuilder.get_model_for_prefix(@nodetype) == "ServiceTemplate" && @record.prov_type == "generic_ansible_playbook"
+          template_locals.merge!(fetch_playbook_details) if need_ansible_locals?
           r[:partial => "catalog/#{x_active_tree}_show", :locals => template_locals]
         end
       elsif @sb[:buttons_node]
@@ -2025,6 +2025,12 @@ class CatalogController < ApplicationController
     presenter.reset_one_trans
 
     render :json => presenter.for_render
+  end
+
+  def need_ansible_locals?
+    x_active_tree == :sandt_tree &&
+      TreeBuilder.get_model_for_prefix(@nodetype) == "ServiceTemplate" &&
+      @record.prov_type == "generic_ansible_playbook"
   end
 
   # Build a Catalog Items explorer tree

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -690,4 +690,44 @@ describe CatalogController do
       expect(response).to have_http_status 200
     end
   end
+
+  context "#need_ansible_locals?" do
+    before do
+      controller.instance_variable_set(:@nodetype, 'st')
+      st = FactoryGirl.create(:service_template,
+                              :type      => "ServiceTemplateAnsiblePlaybook",
+                              :prov_type => "generic_ansible_playbook")
+      controller.instance_variable_set(:@record, st)
+    end
+
+    it "returns true for Ansible Playbook Service Template in Catalog Items accordion only" do
+      controller.instance_variable_set(:@sb,
+                                       :trees       => {:sandt_tree => {:open_nodes => []}},
+                                       :active_tree => :sandt_tree)
+      expect(controller.send(:need_ansible_locals?)).to be_truthy
+    end
+
+    it "returns false for Ansible Playbook Service Template in other accordions" do
+      controller.instance_variable_set(:@sb,
+                                       :trees       => {:svccat_tree => {:open_nodes => []}},
+                                       :active_tree => :svccat_tree)
+      expect(controller.send(:need_ansible_locals?)).to be_falsey
+    end
+
+    it "returns false for any other Service Template in Catalog Items accordions" do
+      controller.instance_variable_set(:@record, FactoryGirl.create(:service_template))
+      controller.instance_variable_set(:@sb,
+                                       :trees       => {:svccat_tree => {:open_nodes => []}},
+                                       :active_tree => :svccat_tree)
+      expect(controller.send(:need_ansible_locals?)).to be_falsey
+    end
+
+    it "returns false for any other Service Template in other accordions" do
+      controller.instance_variable_set(:@record, FactoryGirl.create(:service_template))
+      controller.instance_variable_set(:@sb,
+                                       :trees       => {:svccat_tree => {:open_nodes => []}},
+                                       :active_tree => :svccat_tree)
+      expect(controller.send(:need_ansible_locals?)).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Moved check into a new method that determines if we need to set Ansible Playbook related variables or not, We only need to set those when a catalog Item is clicked on in "Catalog Items" accordion.

@dclarizio this issue can be recreated by clicking on an Ansible Playbook type Catalog Item in Service Catalogs accordion in Catalog Explorer