### PR TITLE
Allow advanced modifications of Amazon cloud volumes

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope', 'cloudVolumeFormId', 'miqService', 'API', function($http, $scope, cloudVolumeFormId, miqService, API) {
+ManageIQ.angular.app.controller('cloudVolumeFormController', ['$scope', 'cloudVolumeFormId', 'miqService', 'API', function($scope, cloudVolumeFormId, miqService, API) {
   var init = function() {
     $scope.cloudVolumeModel = {
       aws_encryption: false,
@@ -14,7 +14,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
       { type: "io1", name: "Provisioned IOPS SSD (IO1)" },
       { type: "st1", name: "Throughput Optimized HDD (ST1)" },
       { type: "sc1", name: "Cold HDD (SC1)" },
-      { type: "magnetic", name: "Magnetic" },
+      { type: "standard", name: "Magnetic" },
     ];
 
     ManageIQ.angular.scope = $scope;
@@ -23,17 +23,21 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
       $scope.cloudVolumeModel.name = "";
     } else {
       miqService.sparkleOn();
-      $http.get('/cloud_volume/cloud_volume_form_fields/' + cloudVolumeFormId)
+      API.get('/api/cloud_volumes/' + cloudVolumeFormId + '?attributes=ext_management_system.type')
         .then(getCloudVolumeFormDataComplete)
         .catch(miqService.handleFailure);
     }
   };
 
-  function getCloudVolumeFormDataComplete(response) {
-    var data = response.data;
-
+  function getCloudVolumeFormDataComplete(data) {
     $scope.afterGet = true;
+    $scope.cloudVolumeModel.emstype = data.ext_management_system.type;
     $scope.cloudVolumeModel.name = data.name;
+    // We have to display size in GB.
+    $scope.cloudVolumeModel.size = data.size / 1073741824;
+    // Currently, this is only relevant for AWS volumes so we are prefixing the
+    // model attribute with AWS.
+    $scope.cloudVolumeModel.aws_volume_type = data.volume_type;
 
     $scope.modelCopy = angular.copy( $scope.cloudVolumeModel );
     miqService.sparkleOff();

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -121,14 +121,6 @@ class CloudVolumeController < ApplicationController
     replace_gtl_main_div if pagination_request?
   end
 
-  def cloud_volume_form_fields
-    assert_privileges("cloud_volume_edit")
-    volume = find_by_id_filtered(CloudVolume, params[:id])
-    render :json => {
-      :name => volume.name
-    }
-  end
-
   def attach
     params[:id] = checked_item_id unless params[:id].present?
     assert_privileges("cloud_volume_attach")
@@ -696,6 +688,9 @@ class CloudVolumeController < ApplicationController
     options[:cloud_tenant_id] = params[:cloud_tenant_id] if params[:cloud_tenant_id]
     options[:vm_id] = params[:vm_id] if params[:vm_id]
     options[:device_path] = params[:device_path] if params[:device_path]
+    options[:volume_type] = params[:aws_volume_type] if params[:aws_volume_type]
+    # Only set IOPS if io1 (provisioned IOPS) and IOPS available
+    options[:iops] = params[:aws_iops] if options[:volume_type] == 'io1' && params[:aws_iops]
     options
   end
 

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -1,0 +1,60 @@
+.form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
+  %label.col-md-2.control-label
+    = _('Volume Name')
+  .col-md-8
+    %input.form-control{:type          => "text",
+                        :name          => "name",
+                        'ng-model'     => "cloudVolumeModel.name",
+                        'ng-maxlength' => 128,
+                        :required      => "",
+                        :checkchange   => true}
+    %span.help-block{"ng-show" => "angularForm.name.$error.required"}
+      = _("Required")
+
+.form-group{"ng-class" => "{'has-error': angularForm.aws_volume_type.$invalid}",
+            "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+  %label.col-md-2.control-label
+    = _('Cloud Volume Type')
+  .col-md-8
+    %select{"name"                        => "aws_volume_type",
+            "ng-model"                    => "cloudVolumeModel.aws_volume_type",
+            "ng-options"                  => "voltype.type as voltype.name for voltype in awsVolumeTypes",
+            "ng-change"                   => "awsVolumeTypeChanged(cloudVolumeModel.aws_volume_type)",
+            "ng-disabled" 				  => "formId != 'new' && cloudVolumeModel.aws_volume_type == 'standard'",
+            "required"                    => "",
+            :checkchange                  => true,
+            "selectpicker-for-select-tag" => ""}
+      %option{"value" => "", "disabled" => ""}
+        = "<#{_('Choose')}>"
+    %span.help-block{"ng-show" => "angularForm.aws_volume_type.$error.required"}
+      = _("Required")
+
+.form-group{"ng-class" => "{'has-error': angularForm.size.$invalid}"}
+  %label.col-md-2.control-label
+    = _('Size (in gigabytes)')
+  .col-md-8
+    %input.form-control{:type          => "text",
+                        :name          => "size",
+                        'ng-model'     => "cloudVolumeModel.size",
+                        'ng-maxlength' => 10,
+                        'ng-change'    => "sizeChanged(cloudVolumeModel.size)",
+                        'ng-disabled'  => "formId != 'new' && (cloudVolumeModel.emstype != 'ManageIQ::Providers::Amazon::StorageManager::Ebs' || cloudVolumeModel.aws_volume_type == 'standard')",
+                        :required      => "",
+                        :checkchange   => true}
+    %span.help-block{"ng-show" => "angularForm.size.$error.required"}
+      = _("Required")
+
+.form-group{"ng-class" => "{'has-error': angularForm.aws_iops.$invalid}",
+            "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+  %label.col-md-2.control-label
+    = _('IOPS')
+  .col-md-8
+    %input.form-control{:type          => "text",
+                        :name          => "aws_iops",
+                        'ng-model'     => "cloudVolumeModel.aws_iops",
+                        'ng-maxlength' => 50,
+                        'ng-disabled'  => "cloudVolumeModel.aws_volume_type != 'io1'",
+                        "ng-required"  => "cloudVolumeModel.aws_volume_type == 'io1'",
+                        :checkchange   => true}
+    %span.help-block{"ng-show" => "cloudVolumeModel.aws_volume_type == 'io1' && angularForm.aws_iops.$error.required"}
+      = _("Required")

--- a/app/views/cloud_volume/edit.html.haml
+++ b/app/views/cloud_volume/edit.html.haml
@@ -1,18 +1,9 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController"}
+%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => ""}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Edit Volume')
   .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
-        = _('Volume Name')
-      .col-md-8
-        %input.form-control{:type          => "text",
-                            :name          => "name",
-                            'ng-model'     => "cloudVolumeModel.name",
-                            'ng-maxlength' => 128,
-                            :miqrequired   => false,
-                            :checkchange   => true}
+    = render :partial => "common_new_edit"
 
   %table{:width => '100%'}
     %tr

--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -47,64 +47,7 @@
         %span.help-block{"ng-show" => "angularForm.aws_availability_zone_id.$error.required"}
           = _("Required")
 
-    .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
-      %label.col-md-2.control-label
-        = _('Volume Name')
-      .col-md-8
-        %input.form-control{:type          => "text",
-                            :name          => "name",
-                            'ng-model'     => "cloudVolumeModel.name",
-                            'ng-maxlength' => 128,
-                            :required      => "",
-                            :checkchange   => true}
-        %span.help-block{"ng-show" => "angularForm.name.$error.required"}
-          = _("Required")
-
-    .form-group{"ng-class" => "{'has-error': angularForm.aws_volume_type.$invalid}",
-                "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
-      %label.col-md-2.control-label
-        = _('Cloud Volume Type')
-      .col-md-8
-        %select{"name"                        => "aws_volume_type",
-                "ng-model"                    => "cloudVolumeModel.aws_volume_type",
-                "ng-options"                  => "voltype.type as voltype.name for voltype in awsVolumeTypes",
-                "ng-change"                   => "awsVolumeTypeChanged(cloudVolumeModel.aws_volume_type)",
-                "required"                    => "",
-                :checkchange                  => true,
-                "selectpicker-for-select-tag" => ""}
-          %option{"value" => "", "disabled" => ""}
-            = "<#{_('Choose')}>"
-        %span.help-block{"ng-show" => "angularForm.aws_volume_type.$error.required"}
-          = _("Required")
-
-    .form-group{"ng-class" => "{'has-error': angularForm.size.$invalid}"}
-      %label.col-md-2.control-label
-        = _('Size (in gigabytes)')
-      .col-md-8
-        %input.form-control{:type          => "text",
-                            :name          => "size",
-                            'ng-model'     => "cloudVolumeModel.size",
-                            'ng-maxlength' => 10,
-                            'ng-change'    => "sizeChanged(cloudVolumeModel.size)",
-                            :required      => "",
-                            :checkchange   => true}
-        %span.help-block{"ng-show" => "angularForm.size.$error.required"}
-          = _("Required")
-
-    .form-group{"ng-class" => "{'has-error': angularForm.aws_iops.$invalid}",
-                "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
-      %label.col-md-2.control-label
-        = _('IOPS')
-      .col-md-8
-        %input.form-control{:type          => "text",
-                            :name          => "aws_iops",
-                            'ng-model'     => "cloudVolumeModel.aws_iops",
-                            'ng-maxlength' => 50,
-                            'ng-disabled'  => "cloudVolumeModel.aws_volume_type != 'io1'",
-                            "required"     => "",
-                            :checkchange   => true}
-        %span.help-block{"ng-show" => "cloudVolumeModel.aws_volume_type == 'io1' && angularForm.aws_iops.$error.required"}
-          = _("Required")
+    = render :partial => "common_new_edit"
 
     .form-group{"ng-if" => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
       %label.col-md-2.control-label

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -481,7 +481,6 @@ Rails.application.routes.draw do
         backup_select
         snapshot_new
         edit
-        cloud_volume_form_fields
         cloud_volume_tenants
         index
         new


### PR DESCRIPTION
Amazon EBS has recently introduced ability to modify cloud volume
configuration (type of cloud volume, its size and the IOPS). This patch
reuses the UI from the cloud volume creation dialog to allow users to
modify volumes on the fly.

Depends on
 * https://github.com/ManageIQ/manageiq-providers-amazon/pull/176
 * https://github.com/ManageIQ/manageiq-providers-amazon/pull/177

Video: http://x.k00.fr/7t19f
 * shows how different volume types are created
 * compares OpenStack and Amazon UIs
 * shows UI for editing standard (Magnetic), gp2 and io1 volumes
   * magnetic: only name is enabled, other info just shown
   * gp2: type and size can be changed; IOPS disabled
   * io1: all fields can be changed
 * video shows AWS console to present the results

@miq-bot add_label enhancement, storage