### PR TITLE
Add high_voltage ~> 3.0.0 as a gem dependency

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "lodash-rails", "~>3.10.0"
   s.add_dependency "patternfly-sass", "~> 3.15.0"
   s.add_dependency "sass-rails"
+  s.add_dependency "high_voltage", "~> 3.0.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "guard-rspec", '~> 4.7.3'


### PR DESCRIPTION
An alternative to https://github.com/ManageIQ/manageiq/pull/14262

I expect that tests will fail with this until a complementing PR on the manageiq repo because it has a lock on the '~> 2.4.0' gem.

Possibly, we could merge the two previous PRs for this first, and then add this PR, and finally the PR to remove the gem from the main repo, but that is only if you are concerned about test failures for a small period of time.