### PR TITLE
Default to a 0 evaluation frequency in dwh alerts

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -345,9 +345,14 @@ module MiqPolicyController::Alerts
   end
 
   def alert_default_repeat_time
-    (@edit[:new][:expression][:eval_method] && @edit[:new][:expression][:eval_method] == "hourly_performance") ||
-      @edit[:new][:exp_event] == "_hourly_timer_" ?
-      1.hour.to_i : 10.minutes.to_i
+    if (@edit[:new][:expression][:eval_method] && @edit[:new][:expression][:eval_method] == "hourly_performance") ||
+       @edit[:new][:exp_event] == "_hourly_timer_"
+      1.hour.to_i
+    elsif @edit[:new][:expression][:eval_method] && @edit[:new][:expression][:eval_method] == "dwh_generic"
+      0.minutes.to_i
+    else
+      10.minutes.to_i
+    end
   end
 
   def alert_get_perf_column_unit(val)
@@ -487,6 +492,11 @@ module MiqPolicyController::Alerts
       15.minutes.to_i => _("15 Minutes"), 30.minutes.to_i => _("30 Minutes"), 1.hour.to_i => _("1 Hour"),
       2.hours.to_i => _("2 Hours"), 3.hours.to_i => _("3 Hours"), 4.hours.to_i => _("4 Hours"),
       6.hours.to_i => _("6 Hours"), 12.hours.to_i => _("12 Hours"), 1.day.to_i => _("1 Day")
+    }
+
+    # repeat times for Notify Datawarehouse pull down
+    @sb[:alert][:repeat_times_dwh] ||= {
+      0.minutes.to_i => _("Always Notify")
     }
   end
 

--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -101,13 +101,17 @@
                 %p.form-control-static
                   = h(@event)
         -# Repeat Time
-        .form-group
+        .form-group.notification-frequency
           %label.control-label.col-md-2
             = _("Notification Frequency")
+          - hide = false
           - if @edit
             .col-md-8
               - if @edit[:new][:expression][:eval_method] == "hourly_performance"
                 - repeat = @sb[:alert][:hourly_repeat_times]
+              - elsif @edit[:new][:expression][:eval_method] == "dwh_generic"
+                - repeat = @sb[:alert][:repeat_times_dwh]
+                - hide = true
               - else
                 - repeat = @sb[:alert][:repeat_times]
               = select_tag('repeat_time',
@@ -121,8 +125,13 @@
               %p.form-control-static
                 - if @alert.options[:notifications][:delay_next_evaluation].blank?
                   = _('10 Minutes')
+                - elsif @alert.options[:notifications][:delay_next_evaluation].zero?
+                  - hide = true
                 - else
                   = h(@sb[:alert][:repeat_times][@alert.options[:notifications][:delay_next_evaluation]])
+          - if hide
+            :javascript
+              $(".notification-frequency").hide();
       %hr
       -# Expression
       - if @edit


### PR DESCRIPTION
See https://github.com/ManageIQ/manageiq/pull/14318 for explanation why a 0 notification frequency makes sense here

![manageiq control](https://cloud.githubusercontent.com/assets/3010449/24139830/59538eca-0e26-11e7-86ef-b7d25c5fa5cc.png)
