### PR TITLE
Make SCVMM "name@realm" hint declarative

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -58,7 +58,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       hawkular_auth_status: '',
       vmware_cloud_api_version: ''
     };
-    $scope.realmNote = __("Note: Username must be in the format: name@realm");
     $scope.formId = emsCommonFormId;
     $scope.afterGet = false;
     $scope.modelCopy = angular.copy( $scope.emsCommonModel );
@@ -349,8 +348,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       if ($scope.emsCommonModel.emstype === 'openstack') {
         $scope.emsCommonModel.tenant_mapping_enabled = false;
       }
-    } else if ($scope.emsCommonModel.emstype === 'scvmm' && $scope.emsCommonModel.default_security_protocol === 'kerberos') {
-      $scope.note = $scope.realmNote;
     } else if ($scope.emsCommonModel.emstype === 'scvmm') {
       $scope.emsCommonModel.default_security_protocol = 'ssl';
     } else if ($scope.emsCommonModel.emstype === 'rhevm') {
@@ -371,13 +368,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       } else {
         $scope.emsCommonModel.default_api_port = "13000";
       }
-    }
-  };
-
-  $scope.scvmmSecurityProtocolChanged = function() {
-    $scope.note = "";
-    if ($scope.emsCommonModel.emstype === 'scvmm' && $scope.emsCommonModel.default_security_protocol === 'kerberos') {
-      $scope.note = $scope.realmNote;
     }
   };
 

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -46,8 +46,8 @@
           = _("Spaces are prohibited")
         %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.isUuid"}
           = _("Invalid input format, please enter a GUID")
-        .note
-          {{note}}
+        .note{"ng-if" => "emsCommonModel.emstype == 'scvmm' && emsCommonModel.default_security_protocol == 'kerberos'"}
+          = _("Note: Username must be in the format: name@realm")
 
   %div{"ng-show" => "#{ng_show} && #{ng_show_password}"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_password.$error.required}"}

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -113,7 +113,6 @@
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "required"                    => "",
-                       "ng-change"                   => "scvmmSecurityProtocolChanged()",
                        "selectpicker-for-select-tag" => "",
                        "prefix"                      => "#{prefix}",
                        "reset-validation-status"     => "#{prefix}_auth_status")


### PR DESCRIPTION
The assignment in `providerTypeChanged()` was unreachable
(default_security_protocol is cleared to "" at start of function)
though it worked in practice via `scvmmSecurityProtocolChanged()`.
Anyway declarative is simpler than change callbacks.