### PR TITLE
Add default tab for first selected group after login

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -350,7 +350,7 @@ class OpsController < ApplicationController
     when :rbac_tree
       @sb[:active_tab] = "rbac_details"
       # default to the first tab in group detail
-      @sb[:active_rbac_group_tab] ||= "rbac_customer_tags" if node.last == 'g'
+      @sb[:active_rbac_group_tab] ||= "rbac_customer_tags" if node.last == 'g' || node.first == 'g'
     when :diagnostics_tree
       case node[0]
       when "root"


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/379
https://bugzilla.redhat.com/show_bug.cgi?id=1421196

Log in -> Configuration -> Access control (has to be first time after login) -> choose a group (Do not select Groups node beforehand)

Before:
<img width="793" alt="screen shot 2017-03-14 at 2 09 55 pm" src="https://cloud.githubusercontent.com/assets/9210860/23902057/fcaf8310-08bf-11e7-8745-78a1f09413ee.png">

After:
<img width="813" alt="screen shot 2017-03-14 at 2 08 11 pm" src="https://cloud.githubusercontent.com/assets/9210860/23902063/008a8610-08c0-11e7-8c93-c8d914227b89.png">

@miq-bot assign @himdel 

@miq-bot add_label bug, trees, euwe/yes
(Darga version has it already fixed)