### PR TITLE
Delete unused vendor-ansible_tower_configuration.svg symlink

### DIFF
--- a/app/assets/images/svg/vendor-ansible_tower_configuration.svg
+++ b/app/assets/images/svg/vendor-ansible_tower_configuration.svg
@@ -1,1 +1,0 @@
-vendor-ansible.svg


### PR DESCRIPTION
At one point `vendor-ansible_tower_configuration.svg` was missing and added but later it changed to `vendor-ansible.svg`. So it's no longer needed.

@miq-bot add_label technical debt

@miq-bot assign @skateman 