### PR TITLE
Add UI support for Pod to PV relationship

### DIFF
--- a/app/helpers/persistent_volume_helper/textual_summary.rb
+++ b/app/helpers/persistent_volume_helper/textual_summary.rb
@@ -23,7 +23,7 @@ module PersistentVolumeHelper::TextualSummary
   end
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i(parent))
+    TextualGroup.new(_("Relationships"), %i(parent pods_using_persistent_volume))
   end
 
   def textual_group_smart_management
@@ -40,6 +40,11 @@ module PersistentVolumeHelper::TextualSummary
   #
   # Items
   #
+  def textual_pods_using_persistent_volume
+    link = url_for_only_path(:id => @record.id, :action => "show", :display => "container_groups")
+    textual_link(@record.container_groups, :as => ContainerGroup, :link => link)
+  end
+
   def textual_resource_version
     @record.resource_version
   end

--- a/app/views/layouts/listnav/_persistent_volume.html.haml
+++ b/app/views/layouts/listnav/_persistent_volume.html.haml
@@ -15,3 +15,11 @@
             = link_to("#{ui_lookup(:table => "ems_container")}: #{@record.parent.name}",
                 polymorphic_path(@record.parent),
                 :title => _("Show this persistent volume's parent Containers Provider"))
+        - if @record.number_of(:container_groups).zero?
+          %li.disabled
+            = link_to(_("%{container_groups} (0)") % {:container_groups => ui_lookup(:tables => "container_groups")}, "#")
+        - else
+          %li
+            = link_to(_("%{container_groups} (%{count})") % {:container_groups => ui_lookup(:table => "container_groups"), 
+                                                            :count => @record.number_of(:container_groups)},
+                        url_for_only_path(:id => @record.id, :action => "show", :display => "container_groups"))

--- a/app/views/persistent_volume/show.html.haml
+++ b/app/views/persistent_volume/show.html.haml
@@ -1,4 +1,4 @@
-- if @display == 'containers'
+- if %w(containers container_groups).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == 'main'
   = render :partial => "layouts/textual_groups_generic"


### PR DESCRIPTION
This is part of an effort to support the Pod to PV relationship - Such that one could be able to view which pods are using a given persistent volume(if the are any).
![screenshot from 2017-03-14 18-00-08](https://cloud.githubusercontent.com/assets/8366181/23915439/c484dac6-08f1-11e7-82e4-8153d8b79336.png)
After click:
![screenshot from 2017-03-14 18-00-15](https://cloud.githubusercontent.com/assets/8366181/23909899/a7522ec4-08e0-11e7-9cfd-c058d38de967.png)

cc: @simon3z @zakiva 

related to: https://github.com/ManageIQ/manageiq/pull/14231
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1402329