### PR TITLE
TreeBuilder* - remove dead id_prefix

### DIFF
--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -28,8 +28,7 @@ class TreeBuilderAutomate < TreeBuilderAeClass
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:id_prefix    => "",
-                  :onclick      => "miqOnClickSelectAETreeNode",
+    locals.merge!(:onclick      => "miqOnClickSelectAETreeNode",
                   :exp_tree     => false,
                   :autoload     => true,
                   :base_id      => "root",

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -35,8 +35,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:id_prefix         => 'hac_',
-                  :check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
+    locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
                   :oncheck           => @edit ? "miqOnCheckUserFilters" : nil,
                   :checkboxes        => true,
                   :highlight_changes => true,

--- a/app/presenters/tree_builder_belongs_to_vat.rb
+++ b/app/presenters/tree_builder_belongs_to_vat.rb
@@ -23,11 +23,6 @@ class TreeBuilderBelongsToVat < TreeBuilderBelongsToHac
     end
   end
 
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:id_prefix => 'vat_')
-  end
-
   def x_get_tree_datacenter_kids(parent, count_only)
     kids = []
     parent.folders.each do |child|

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -16,7 +16,8 @@ class TreeBuilderInfraNetworking < TreeBuilder
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:id_prefix => 'nt_', :autoload => true)
+    locals[:autoload] = true
+    locals
   end
 
   def root_options

--- a/app/presenters/tree_builder_miq_action_category.rb
+++ b/app/presenters/tree_builder_miq_action_category.rb
@@ -25,7 +25,6 @@ class TreeBuilderMiqActionCategory < TreeBuilder
   def set_locals_for_render
     locals = super
     locals.merge!(
-      :id_prefix => "cat_tree",
       :click_url => "/miq_policy/action_tag_pressed/",
       :onclick   => "miqOnClickTagCat"
     )

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -34,8 +34,7 @@ class TreeBuilderTags < TreeBuilder
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:id_prefix         => 'tags_',
-                  :check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
+    locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
                   :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
                   :checkboxes        => true,
                   :highlight_changes => true,

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -80,7 +80,6 @@ describe TreeBuilderBelongsToHac do
       expect(subject.send(:set_locals_for_render)).to include(:onclick           => false,
                                                               :tree_state        => true,
                                                               :checkboxes        => true,
-                                                              :id_prefix         => "hac_",
                                                               :check_url         => "/ops/rbac_group_field_changed/#{group.id || "new"}___",
                                                               :oncheck           => nil,
                                                               :highlight_changes => true)

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -49,8 +49,7 @@ describe TreeBuilderBelongsToVat do
   describe '#set_locals_for_render' do
     it 'set locals for render correctly' do
       locals = subject.send(:set_locals_for_render)
-      expect(locals).to include(:id_prefix         => 'vat_',
-                                :checkboxes        => true,
+      expect(locals).to include(:checkboxes        => true,
                                 :check_url         => "/ops/rbac_group_field_changed/#{group.id || "new"}___",
                                 :onclick           => false,
                                 :oncheck           => edit ? "miqOnCheckUserFilters" : nil,

--- a/spec/presenters/tree_builder_miq_action_category_spec.rb
+++ b/spec/presenters/tree_builder_miq_action_category_spec.rb
@@ -33,7 +33,6 @@ describe TreeBuilderMiqActionCategory do
   describe '#set_locals_for_render' do
     it 'set locals for render correctly' do
       locals = subject.send(:set_locals_for_render)
-      expect(locals[:id_prefix]).to eq('cat_tree')
       expect(locals[:click_url]).to eq("/miq_policy/action_tag_pressed/")
       expect(locals[:onclick]).to eq("miqOnClickTagCat")
     end

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -28,7 +28,6 @@ describe TreeBuilderTags do
     end
     it 'set locals for render correctly' do
       locals = @tags_tree.send(:set_locals_for_render)
-      expect(locals[:id_prefix]).to eq('tags_')
       expect(locals[:checkboxes]).to eq(true)
       expect(locals[:check_url]).to eq("/ops/rbac_group_field_changed/#{@group.id || "new"}___")
       expect(locals[:highlight_changes]).to eq(true)


### PR DESCRIPTION
`id_prefix` in treebuilders used to be used before https://github.com/ManageIQ/manageiq/pull/10767, but has been dead since then, removing.

(Removed in https://github.com/ManageIQ/manageiq/pull/10767/files#diff-68c04f575f602a2ea2b246518f9b0acdL6 and https://github.com/ManageIQ/manageiq/pull/10767/files#diff-e4bb0ff2bbc5a334b211e9b8684210e0L231)

Cc @skateman 