### PR TITLE
Fix middleware display methods methods

### DIFF
--- a/app/controllers/middleware_domain_controller.rb
+++ b/app/controllers/middleware_domain_controller.rb
@@ -10,7 +10,7 @@ class MiddlewareDomainController < ApplicationController
   after_action :set_session_data
 
   def self.display_methods
-    %i(middleware_server_groups)
+    %w(middleware_server_groups)
   end
 
   menu_section :cnt

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -159,7 +159,7 @@ class MiddlewareServerController < ApplicationController
   end
 
   def self.display_methods
-    %i(middleware_datasources middleware_deployments middleware_messagings)
+    %w(middleware_datasources middleware_deployments middleware_messagings)
   end
 
   def button

--- a/app/controllers/middleware_server_group_controller.rb
+++ b/app/controllers/middleware_server_group_controller.rb
@@ -35,7 +35,7 @@ class MiddlewareServerGroupController < ApplicationController
   end
 
   def self.display_methods
-    %i(middleware_servers)
+    %w(middleware_servers)
   end
 
   def textual_group_list

--- a/spec/controllers/middleware_server_controller_spec.rb
+++ b/spec/controllers/middleware_server_controller_spec.rb
@@ -30,4 +30,18 @@ describe MiddlewareServerController do
       end
     end
   end
+
+  # FIXME: should test for nested entities: %w(middleware_datasources middleware_deployments middleware_messagings)
+  describe '#show' do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
+
+    let(:server) { FactoryGirl.create(:middleware_server) }
+    let(:deployment) { FactoryGirl.create(:middleware_deployment, :middleware_server => server) }
+
+    it "show associated server groups" do
+      assert_nested_list(server, [deployment], 'middleware_deployments', 'All Middleware Deployments')
+    end
+  end
 end


### PR DESCRIPTION
Broken here: https://github.com/ManageIQ/manageiq-ui-classic/pull/590

Adding a sample nested list spec for one of the controllers.

Of cource it would be very convenient to have at least a single test for each screen (nested list in this case).

Ping @Jiri-Kremser, @karelhala 