### PR TITLE
Tenant options instead of free text

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
@@ -9,6 +9,9 @@ angular.module('miq.util').factory('metricsConfigFactory', function() {
       }
     };
 
+    dash.DEFAULT_TENANT = "_system";
+    dash.tenant = {value: null};
+
     dash.actionsConfig = {
       actionsInclude: true
     };

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
@@ -68,13 +68,28 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
           miqService.handleFailure(error); });
     };
 
-    var getTenants = function(include) {
-      return $http.get(dash.url + "&query=get_tenants&limit=7&include=" + include).then(function(response) {
+    var getTenants = function() {
+      var url = '/container_dashboard/data' + dash.providerId  + '/?live=true&query=get_tenants';
+
+      return $http.get(url).then(function(response) {
         if (utils.checkResponse(response) === false) {
-          return [];
+          dash.tenantList = [];
+          dash.tenant = {value: null};
+          return;
         }
 
-        return response.data.tenants;
+        // get the tenant list, and set the current tenant
+        dash.tenantList = response.data.tenants;
+        dash.tenant = dash.tenantList[0];
+
+        // try to set the current tenant to be the default one
+        dash.tenantList.forEach(function callback(obj, i) {
+          if (obj.value === dash.DEFAULT_TENANT) {
+            dash.tenant = dash.tenantList[i];
+          }
+        });
+
+        getMetricTags();
       });
     }
 

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-parse-url-factroy.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-parse-url-factroy.js
@@ -5,7 +5,7 @@ angular.module('miq.util').factory('metricsParseUrlFactory', function() {
     dash.providerId = '/' + (/^\/[^\/]+\/([r\d]+)$/.exec(pathname)[1]);
 
     // TODO: get this values from GET/POST values ?
-    dash.tenant = '_system';
+    dash.tenantList = [];
     dash.minBucketDurationInSecondes = 20 * 60;
     dash.max_metrics = 1000;
     dash.items_per_page = 10;

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js
@@ -21,6 +21,7 @@ angular.module('miq.util').factory('metricsUtilsFactory', function() {
 
       var data = response.data;
 
+      dash.filterConfig.fields = [];
       if (data && angular.isArray(data.metric_tags)) {
         data.metric_tags.sort();
         for (var i = 0; i < data.metric_tags.length; i++) {
@@ -32,9 +33,6 @@ angular.module('miq.util').factory('metricsUtilsFactory', function() {
               filterType: 'alpha',
             });
         }
-      } else {
-        // No filters available, apply without filtering
-        dash.filterConfig.fields = [];
       }
     }
 

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -2,13 +2,12 @@
   overflow-x:hidden;
 
   .ad-hoc-toolbar {
-      margin-left: 10px;
+    margin-left: 10px;
   }
 
   .ad-hoc-tenant {
     margin-left: 5px;
-
-    input  {
+    input {
       display: inline;
       width: 190px;
     }
@@ -17,22 +16,34 @@
       vertical-align: top;
       margin-bottom: 10px;
     }
+
+    .btn {
+      margin-left: 0;
+    }
   }
 
-  .form-group.toolbar-actions.ng-scope {
-    width: calc(100% - 295px);
+  .form-group {
+    &.toolbar-pf-filter {
+      margin-bottom: 0;
+    }
+
+    &.toolbar-actions.ng-scope {
+      margin-bottom: 0;
+    }
   }
 
-  .toolbar-pf-include-actions.ng-scope {
-    width: 100%;
-  }
-
-  .pagination, .pagination-div, .form-group.pagination-div.ng-scope {
+  .pagination {
     display: flex;
     float: right;
-    margin: 0px;
-    margin-bottom: 0px;
+    margin: 0;
+    margin-bottom: 0;
+  }
 
+  .pagination-div {
+    display: flex;
+    float: right;
+    margin: 0;
+    margin-bottom: 0;
     .page-input {
       width: 40px;
       margin-left: 10px;
@@ -41,40 +52,78 @@
     }
   }
 
-  .form-group.toolbar-pf-filter,
-  .form-group.toolbar-actions.ng-scope,
-  .toolbar-pf-actions.ng-pristine.ng-valid.no-filter-results {
-    margin-bottom: 5px;
-  }
-
-  .list-view-container, .line-chart, .blank-slate-pf {
-    margin-bottom: 0;
-    min-height: calc(100vh - 357px);
-    margin-left: 20px;
-    margin-right: 20px;
-  }
-
-  .list-view-container {
-    padding-top: 10px;
-  }
-
   .graph-view {
     overflow-x: hidden;
     overflow-y: hidden;
+    .form-group.toolbar-actions.ng-scope {
+      margin-bottom: 10px;
+    }
 
     .dropdown-kebab-pf .dropdown-menu {
-      left: 0px;
+      left: 0;
+    }
+
+    .toolbar-pf-actions .dropdown-kebab-pf {
+      float: none;
+      margin-left: 10px;
     }
   }
 
+  .list-view-container {
+    min-height: calc(100vh - 362px);
+    padding-top: 10px;
+    margin-bottom: 0;
+  }
+
   .line-chart {
+    min-height: calc(100vh - 347px);
     margin-top: 36px;
     margin-left: 30px;
     margin-right: 50px;
+    margin-bottom: 0;
+  }
+
+  .blank-slate-pf {
+    min-height: calc(100vh - 362px);
+    margin-bottom: 0;
+  }
+
+  .list-view {
+    overflow-x: hidden;
+    overflow-y: hidden;
+
+    .form-group {
+      &.toolbar-actions.ng-scope {
+        width: calc(100% - 425px);
+      }
+    }
+
+    .dropdown-kebab-pf .dropdown-menu {
+      left: -5px;
+    }
+
+    .toolbar-pf-actions .dropdown-kebab-pf {
+      float: none;
+      margin-left: 10px;
+    }
+
+    .filter-pf.filter-fields .form-group {
+      width: 410px;
+    }
+
+    .toolbar-pf .form-group {
+      .btn-group {
+        margin-left: 0;
+      }
+
+      .btn {
+        margin-left: 0;
+      }
+    }
   }
 
   .timeline-date-input {
-    width: 250px;
+    width: 300px;
   }
 
   .list-group {
@@ -83,5 +132,36 @@
 
   .bootstrap-touchspin {
     text-align: center;
+  }
+
+  .tenant-filter-bar {
+    margin-left: 5px;
+    .dropdown-menu.open {
+      margin-top: -11px;
+    }
+  }
+
+  .timeline-stepper {
+    margin-left: 5px;
+  }
+
+  .toolbar-pf-include-actions.ng-scope {
+    width: 100%;
+  }
+
+  .toolbar-pf-actions.ng-pristine.ng-valid.no-filter-results {
+    margin-bottom: 0;
+  }
+
+  .btn.btn-default.dropdown-toggle.filter-fields {
+    min-width: 100px;
+  }
+
+  .filters-selector .btn {
+    margin-left: 0;
+  }
+
+  .tenants-selector .btn {
+    margin-left: 0;
   }
 }

--- a/app/views/ems_container/ad_hoc/_list_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_list_view_form.html.haml
@@ -5,17 +5,15 @@
                             "ng-click"    => "dash.refreshTenant()"}
       = _("Set Tenant")
 
-    %input.form-control{"id"                  => "ad-hoc-tenant",
-                        "type"                => "text",
-                        "ng-model"            => "dash.tenant",
-                        "placeholder"         => _("Choose Tenants"),
-                        "typeahead"           => "tenenat for tenenat in dash.getTenants($viewValue)",
-                        "typeahead-loading"   => "dash.loadingTenants",
-                        "ng-change"           => "dash.tenantChanged = true",
-                        "typeahead-on-select" => "dash.refreshTenant()",
-                        "typeahead-wait-ms"   => 500}
+    %select.selectpicker.tenants-selector{"pf-select"        => "",
+                                          "id"               => "tenant-slector",
+                                          "ng-options"       => "o.label for o in dash.tenantList",
+                                          "ng-model"         => "dash.tenant",
+                                          "ng-change"        => "dash.tenantChanged = true",
+                                          "data-live-search" => "true",
+                                          "data-actions-box" => "true"}
 
-.ad-hoc-toolbar{"pf-toolbar" => "", "config" => "dash.toolbarConfig"}
+.ad-hoc-toolbar.filters-selector{"pf-toolbar" => "", "config" => "dash.toolbarConfig"}
   %actions
     %button.btn.btn-default{"type"        => "button",
                             "ng-click"    => "dash.doAddFilter()",

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -1,6 +1,7 @@
 describe('adHocMetricsController', function() {
   var $scope, $controller, $httpBackend, pfViewUtils;
   var mock_data = getJSONFixture('container_live_dashboard_response.json');
+  var mock_tenants_data = getJSONFixture('container_live_dashboard_tenant_response.json');
   var mock_metrics_data = getJSONFixture('container_live_dashboard_metrics_response.json');
   var mock_data1_data = getJSONFixture('container_live_dashboard_data1_response.json');
   var mock_data2_data = getJSONFixture('container_live_dashboard_data2_response.json');
@@ -16,6 +17,7 @@ describe('adHocMetricsController', function() {
 
   beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_) {
     $httpBackend = _$httpBackend_;
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&query=get_tenants').respond(mock_tenants_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_system&query=metric_tags&limit=250').respond(mock_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_system&limit=1000&query=metric_definitions&tags={}&page=1&items_per_page=10').respond(mock_metrics_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauge&tenant=_system&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);

--- a/spec/javascripts/fixtures/json/container_live_dashboard_tenant_response.json
+++ b/spec/javascripts/fixtures/json/container_live_dashboard_tenant_response.json
@@ -1,0 +1,8 @@
+{
+  "tenants":
+    [
+      {"label": "System", "value": "_system"},
+      {"label": "Operations", "value": "_ops"},
+      {"label": "Default", "value": "default"}
+    ]
+}


### PR DESCRIPTION
**Description**

Compute > Containers > Providers - pick a provider - toolbar Monitoring > Ad hoc Metrics

Make _system and _ops easier to discover. Make the tenant html input element a select instead of type-ahead free text input.  

(*) maybe using nice labels "System" and "Operators", or anything more descriptive)

**Screenshot**
![gifrecord_2017-03-16_133854](https://cloud.githubusercontent.com/assets/2181522/23994582/3558f55e-0a4e-11e7-9d2c-3046b36c2ed8.gif)

