### PR TITLE
More tests for middleware controllers

### DIFF
--- a/spec/controllers/middleware_domain_controller_spec.rb
+++ b/spec/controllers/middleware_domain_controller_spec.rb
@@ -12,15 +12,17 @@ describe MiddlewareDomainController do
 
   describe '#show' do
     let(:domain) { FactoryGirl.create(:hawkular_middleware_domain, :properties => {}) }
-    let(:server_group) { FactoryGirl.create(:hawkular_middleware_server_group, :properties => {},
-                                            :middleware_domain => domain) }
+    let(:server_group) do
+      FactoryGirl.create(:hawkular_middleware_server_group, :properties        => {},
+                                                            :middleware_domain => domain)
+    end
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)
     end
 
-    subject { get :show, :id => domain.id }
+    subject { get :show, :params => { :id => domain.id } }
 
     context 'render' do
       render_views

--- a/spec/controllers/middleware_domain_controller_spec.rb
+++ b/spec/controllers/middleware_domain_controller_spec.rb
@@ -11,31 +11,31 @@ describe MiddlewareDomainController do
   end
 
   describe '#show' do
+    let(:domain) { FactoryGirl.create(:hawkular_middleware_domain, :properties => {}) }
+    let(:server_group) { FactoryGirl.create(:hawkular_middleware_server_group, :properties => {},
+                                            :middleware_domain => domain) }
+
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)
-      @domain = FactoryGirl.create(:hawkular_middleware_domain,
-                                   :name       => 'master',
-                                   :nativeid   => 'Local~/host=master',
-                                   :properties => {
-                                     'Running Mode'         => 'NORMAL',
-                                     'Version'              => '9.0.2.Final',
-                                     'Product Name'         => 'WildFly Full',
-                                     'Host State'           => 'running',
-                                     'Is Domain Controller' => 'true',
-                                     'Name'                 => 'master',
-                                   })
     end
 
-    subject { get :show, :id => @domain.id }
+    subject { get :show, :id => domain.id }
 
     context 'render' do
       render_views
 
-      it do
+      it 'display textual groups' do
         is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => 'layouts/listnav/_middleware_domain')
         is_expected.to render_template(:partial => 'layouts/_textual_groups_generic')
+      end
+
+      it 'display listnav partial' do
+        is_expected.to render_template(:partial => 'layouts/listnav/_middleware_domain')
+      end
+
+      it 'show associated server_group entities' do
+        assert_nested_list(domain, [server_group], 'middleware_server_groups', 'All Middleware Server Groups')
       end
     end
   end

--- a/spec/controllers/middleware_server_controller_spec.rb
+++ b/spec/controllers/middleware_server_controller_spec.rb
@@ -15,8 +15,10 @@ describe MiddlewareServerController do
   describe '#show' do
     let(:deployment) { FactoryGirl.create(:middleware_deployment, :middleware_server => server) }
     let(:datasource) { FactoryGirl.create(:middleware_datasource, :middleware_server => server) }
-    let(:jms_queue) { FactoryGirl.create(:hawkular_middleware_messaging_initialized_queue,
-                                         :middleware_server => server) }
+    let(:jms_queue) do
+      FactoryGirl.create(:hawkular_middleware_messaging_initialized_queue,
+                         :middleware_server => server)
+    end
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
@@ -55,8 +57,8 @@ describe MiddlewareServerController do
   context '#tags_edit' do
     let!(:user) { stub_user(:features => :all) }
     let(:classification) { FactoryGirl.create(:classification, :name => 'department', :description => 'Department') }
-    let(:tag1) { FactoryGirl.create(:classification_tag, :name   => 'tag1', :parent => classification)}
-    let(:tag2) { FactoryGirl.create(:classification_tag, :name   => 'tag2', :parent => classification)}
+    let(:tag1) { FactoryGirl.create(:classification_tag, :name   => 'tag1', :parent => classification) }
+    let(:tag2) { FactoryGirl.create(:classification_tag, :name   => 'tag2', :parent => classification) }
 
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
@@ -96,5 +98,4 @@ describe MiddlewareServerController do
       expect(assigns(:edit)).to be_nil
     end
   end
-
 end

--- a/spec/controllers/middleware_server_controller_spec.rb
+++ b/spec/controllers/middleware_server_controller_spec.rb
@@ -1,4 +1,6 @@
 describe MiddlewareServerController do
+  let(:server) { FactoryGirl.create(:hawkular_middleware_server, :properties => {}, :middleware_server_group => nil) }
+
   render_views
   before(:each) do
     stub_user(:features => :all)
@@ -11,7 +13,10 @@ describe MiddlewareServerController do
   end
 
   describe '#show' do
-    let(:server) { FactoryGirl.create(:hawkular_middleware_server, :properties => {}, :middleware_server_group => nil) }
+    let(:deployment) { FactoryGirl.create(:middleware_deployment, :middleware_server => server) }
+    let(:datasource) { FactoryGirl.create(:middleware_datasource, :middleware_server => server) }
+    let(:jms_queue) { FactoryGirl.create(:hawkular_middleware_messaging_initialized_queue,
+                                         :middleware_server => server) }
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
@@ -23,25 +28,73 @@ describe MiddlewareServerController do
     context 'render' do
       render_views
 
-      it do
+      it 'display textual groups' do
         is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => 'layouts/listnav/_middleware_server')
         is_expected.to render_template(:partial => 'layouts/_textual_groups_generic')
       end
+
+      it 'display listnav partial' do
+        is_expected.to render_template(:partial => 'layouts/listnav/_middleware_server')
+      end
+
+      it 'display other specific partials' do
+        is_expected.to render_template(:partial => 'middleware_shared/_ops_params')
+        is_expected.to render_template(:partial => 'middleware_server/_deploy')
+        is_expected.to render_template(:partial => 'middleware_server/_add_jdbc_driver')
+        is_expected.to render_template(:partial => 'middleware_server/_add_datasource')
+      end
     end
-  end
 
-  # FIXME: should test for nested entities: %w(middleware_datasources middleware_deployments middleware_messagings)
-  describe '#show' do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
-
-    let(:server) { FactoryGirl.create(:middleware_server) }
-    let(:deployment) { FactoryGirl.create(:middleware_deployment, :middleware_server => server) }
-
-    it "show associated server groups" do
+    it 'show associated server entities' do
       assert_nested_list(server, [deployment], 'middleware_deployments', 'All Middleware Deployments')
+      assert_nested_list(server, [datasource], 'middleware_datasources', 'All Middleware Datasources')
+      assert_nested_list(server, [jms_queue], 'middleware_messagings', 'All Middleware Messagings')
     end
   end
+
+  context '#tags_edit' do
+    let!(:user) { stub_user(:features => :all) }
+    let(:classification) { FactoryGirl.create(:classification, :name => 'department', :description => 'Department') }
+    let(:tag1) { FactoryGirl.create(:classification_tag, :name   => 'tag1', :parent => classification)}
+    let(:tag2) { FactoryGirl.create(:classification_tag, :name   => 'tag2', :parent => classification)}
+
+    before(:each) do
+      EvmSpecHelper.create_guid_miq_server_zone
+      allow(server).to receive(:tagged_with).with(:cat => user.userid).and_return('my tags')
+      allow(Classification).to receive(:find_assigned_entries).with(server).and_return([tag1, tag2])
+      session[:tag_db] = 'MiddlewareServer'
+      edit = {
+        :key        => "MiddlewareServer_edit_tags__#{server.id}",
+        :tagging    => 'MiddlewareServer',
+        :object_ids => [server.id],
+        :current    => {:assignments => []},
+        :new        => {:assignments => [tag1.id, tag2.id]}
+      }
+      session[:edit] = edit
+    end
+
+    after(:each) do
+      expect(response.status).to eq(200)
+    end
+
+    it 'builds tagging screen' do
+      post :button, :params => { :pressed => 'middleware_server_tag', :format => :js, :id => server.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    it 'cancels tags edit' do
+      session[:breadcrumbs] = [{:url => "middleware_server/show/#{server.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => 'cancel', :format => :js, :id => server.id }
+      expect(assigns(:flash_array).first[:message]).to include('was cancelled by the user')
+      expect(assigns(:edit)).to be_nil
+    end
+
+    it 'save tags' do
+      session[:breadcrumbs] = [{:url => "middleware_server/show/#{server.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => 'save', :format => :js, :id => server.id }
+      expect(assigns(:flash_array).first[:message]).to include('Tag edits were successfully saved')
+      expect(assigns(:edit)).to be_nil
+    end
+  end
+
 end

--- a/spec/controllers/middleware_server_group_controller_spec.rb
+++ b/spec/controllers/middleware_server_group_controller_spec.rb
@@ -11,28 +11,37 @@ describe MiddlewareServerGroupController do
   end
 
   describe '#show' do
+    let(:group) { FactoryGirl.create(:hawkular_middleware_server_group, :properties => {}, :middleware_domain => nil) }
+    let(:server) { FactoryGirl.create(:hawkular_middleware_server, :properties => {},
+                                      :middleware_server_group => group) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)
-      @group = FactoryGirl.create(:hawkular_middleware_server_group,
-                                  :name       => 'main-server-group',
-                                  :nativeid   => 'Local~/server-group=main-server-group',
-                                  :profile    => 'full',
-                                  :properties => {
-                                    'Profile' => 'full',
-                                  })
     end
 
-    subject { get :show, :id => @group.id }
+    subject { get :show, :id => group.id }
 
     context 'render' do
       render_views
 
-      it do
+      it 'display textual groups' do
         is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => 'layouts/listnav/_middleware_server_group')
         is_expected.to render_template(:partial => 'layouts/_textual_groups_generic')
       end
+
+      it 'display listnav partial' do
+        is_expected.to render_template(:partial => 'layouts/listnav/_middleware_server_group')
+      end
+
+      it 'display other specific partials' do
+        is_expected.to render_template(:partial => 'middleware_shared/_ops_params')
+        is_expected.to render_template(:partial => 'middleware_server_group/_deploy')
+      end
     end
+
+    it 'show associated servers' do
+      assert_nested_list(group, [server], 'middleware_servers', 'All Middleware Servers')
+    end
+
   end
 end

--- a/spec/controllers/middleware_server_group_controller_spec.rb
+++ b/spec/controllers/middleware_server_group_controller_spec.rb
@@ -12,14 +12,16 @@ describe MiddlewareServerGroupController do
 
   describe '#show' do
     let(:group) { FactoryGirl.create(:hawkular_middleware_server_group, :properties => {}, :middleware_domain => nil) }
-    let(:server) { FactoryGirl.create(:hawkular_middleware_server, :properties => {},
-                                      :middleware_server_group => group) }
+    let(:server) do
+      FactoryGirl.create(:hawkular_middleware_server, :properties              => {},
+                                                      :middleware_server_group => group)
+    end
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)
     end
 
-    subject { get :show, :id => group.id }
+    subject { get :show, :params => { :id => group.id } }
 
     context 'render' do
       render_views
@@ -42,6 +44,5 @@ describe MiddlewareServerGroupController do
     it 'show associated servers' do
       assert_nested_list(group, [server], 'middleware_servers', 'All Middleware Servers')
     end
-
   end
 end


### PR DESCRIPTION
This PR adds more specs for these middleware controllers:
* middleware_domain_controller
* middleware_server_group_controller
* middleware_server_controller

It tests whether the nested entities were correctly rendered and if there are some special partials like angular popups, we test if the partial was rendered.

@miq-bot add_label technical debt, test