### PR TITLE
Fix for TagControl issues after previous BZ1428133 fix

### DIFF
--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -1,12 +1,22 @@
 module ApplicationHelper::Dialogs
-  def dialog_dropdown_select_values(field, _selected_value, category_tags = nil)
-    values = []
+  def dialog_dropdown_select_values(field)
+    values = field.values
     if field.type.include?("DropDown")
-      values += field.values.collect(&:reverse)
+      values.collect!(&:reverse)
     elsif field.type.include?("TagControl")
-      values += category_tags
+      values.map! { |category| [category[:description], category[:id]] }
     end
     values
+  end
+
+  def category_tags(category_id)
+    classification = Classification.find_by(:id => category_id)
+    return [] if classification.nil?
+
+    available_tags = classification.entries.collect do |category|
+      {:name => category.name, :description => category.description}
+    end
+    available_tags
   end
 
   def disable_check_box?

--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -112,12 +112,8 @@
                       - when "DialogFieldButton"
                         = button_tag(_('Save'), :disabled => true)
                       - when "DialogFieldTagControl"
-                        - category_tags = DialogFieldTagControl.category_tags(field.category).map do |cat|
-                          - [cat[:description], cat[:id]]
-                        - if field.single_value?
-                          = select_tag('field.id', options_for_select(category_tags),
-                            :prompt => field.required? ? "<#{_('Choose')}>" : "<#{_('None')}>")
-                        - else
-                          = select_tag('field.id', options_for_select(category_tags), :multiple => true)
+                        - multiple = field.single_value? ? {} : {:multiple => true}
+                        = select_tag('field.id', options_for_select(dialog_dropdown_select_values(field)), multiple)
+
 :javascript
   miq_tabs_init("#dialog_tabs");

--- a/app/views/miq_ae_customization/_tag_field_values.html.haml
+++ b/app/views/miq_ae_customization/_tag_field_values.html.haml
@@ -6,7 +6,7 @@
         %th= _('Value')
         %th= _('Description')
     %tbody
-      - DialogFieldTagControl.category_tags(@edit[:field_category]).each do |cat|
+      - category_tags(@edit[:field_category]).each do |cat|
         %tr
           %td= cat[:name]
           %td= cat[:description]

--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -47,17 +47,11 @@
       = button_tag(_("Save"), :class => edit ? 'btn btn-primary' : 'btn btn-primary disabled')
 
     - when 'DialogFieldTagControl'
-      - category_tags = DialogFieldTagControl.category_tags(field.category).map { |cat| [cat[:description], cat[:id]] }
       - if edit
-        - if field.single_value?
-          - select_values = dialog_dropdown_select_values(field, wf.value(field.name), category_tags)
-          = select_tag(field.name,
-                       options_for_select(select_values, wf.value(field.name)),
-                       drop_down_options(field, url))
-        - else
-          = select_tag(field.name,
-                       options_for_select(category_tags, wf.value(field.name)),
-                       drop_down_options(field, url).merge(:multiple => true))
+        - multiple = field.single_value? ? {} : {:multiple => true}
+        = select_tag(field.name,
+                     options_for_select(dialog_dropdown_select_values(field), wf.value(field.name)),
+                     drop_down_options(field, url).merge(multiple))
 
         :javascript
           dialogFieldRefresh.initializeDialogSelectPicker('#{field.name}', undefined, '#{url}', JSON.parse('#{j(auto_refresh_options.to_json)}'));

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -12,21 +12,50 @@ describe ApplicationHelper::Dialogs do
 
   describe "#dialog_dropdown_select_values" do
     let(:dialog_field) { instance_double("DialogFieldDropDownList", :values => values, :type => type) }
-    let(:values) { [%w(cat Cat), %w(dog Dog)] }
 
     context "when the field type includes drop down" do
       let(:type) { "BananaDropDown" }
+      let(:values) { [%w(cat Cat), %w(dog Dog)] }
 
       it "returns the values collected and reversed" do
-        expect(helper.dialog_dropdown_select_values(dialog_field, nil)).to eq(values.collect(&:reverse))
+        reversed_values = values.collect(&:reverse)
+        expect(helper.dialog_dropdown_select_values(dialog_field)).to eq(reversed_values)
       end
     end
 
     context "when the field type includes tag control" do
       let(:type) { "BananaTagControl" }
+      let(:values) { [{:description => "Cat", :id => 123}, {:description => "Dog", :id => 321}] }
 
-      it "returns the values with the passed in category tags" do
-        expect(helper.dialog_dropdown_select_values(dialog_field, nil, %w(category tags))).to eq(%w(category tags))
+      it "returns the values mapped to a description and id" do
+        expect(helper.dialog_dropdown_select_values(dialog_field)).to eq([["Cat", 123], ["Dog", 321]])
+      end
+    end
+  end
+
+  describe "#category_tags" do
+    before do
+      allow(Classification).to receive(:find_by).with(:id => 123).and_return(classification)
+    end
+
+    context "when the category exists with the given id" do
+      let(:classification) { instance_double("Classification", :entries => [entry1, entry2]) }
+      let(:entry1) { instance_double("Classification", :name => "cat", :description => "Cat") }
+      let(:entry2) { instance_double("Classification", :name => "dog", :description => "Dog") }
+
+      it "returns a list of entries by name and description" do
+        expect(helper.category_tags(123)).to eq([
+          {:name => "cat", :description => "Cat"},
+          {:name => "dog", :description => "Dog"}
+        ])
+      end
+    end
+
+    context "when the category does not exist by the given id" do
+      let(:classification) { nil }
+
+      it "returns an empty array" do
+        expect(helper.category_tags(123)).to eq([])
       end
     end
   end


### PR DESCRIPTION
This leverages the fact that TagControl#values includes nil values now, so all of the UI components that were manually adding the blank values in had to be changed.

Note this is dependent on [this main repo PR](https://github.com/ManageIQ/manageiq/pull/14348)

https://bugzilla.redhat.com/show_bug.cgi?id=1428133

/cc @gmcculloug 