### PR TITLE
Remove HighVoltage dependency... entirely!

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,8 +1,85 @@
 # used to serve static angular templates from under app/views/static/
+#
+# Much of this has been extracted from the `high_voltage` gem, and the LICENSE
+# for that can be found below:
+#
+# Copyright 2010-2015 thoughtbot, inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+class ManageIQ::UI::Classic::InvalidPageIdError < StandardError; end
 
 class StaticController < ActionController::Base
   # Added to satisfy Brakeman, https://github.com/presidentbeef/brakeman/pull/953
   protect_from_forgery :with => :exception
 
-  include HighVoltage::StaticPage
+  VALID_CHARACTERS_REGXP = "^a-zA-Z0-9~!@$%^&*()#`_+-=<>\"{}|[];',?".freeze
+
+  layout ->(_) { nil }
+
+  rescue_from ActionView::MissingTemplate do |exception|
+    if exception.message =~ /Missing template #{page_finder.content_path}/
+      invalid_page
+    else
+      raise exception
+    end
+  end
+
+  rescue_from ManageIQ::UI::Classic::InvalidPageIdError, :with => :invalid_page
+
+  def show
+    render :template => current_page
+  end
+
+  def invalid_page
+    raise ActionController::RoutingError, "No such page: #{params[:id]}"
+  end
+
+  private
+
+  def page_id
+    @page_id ||= params[:id].to_s
+  end
+
+  def current_page
+    "static/#{clean_path}"
+  end
+
+  def clean_path
+    path = Pathname.new("/#{clean_id}")
+    path.cleanpath.to_s[1..-1].tap do |p|
+      if p.blank?
+        raise ManageIQ::UI::Classic::InvalidPageIdError, "Invalid page id: #{params[:id]}"
+      end
+    end
+  end
+
+  def clean_id
+    page_id.tr(VALID_CHARACTERS_REGXP, "").tap do |id|
+      if invalid_page_id?(id)
+        raise ManageIQ::UI::Classic::InvalidPageIdError, "Invalid page id: #{params[:id]}"
+      end
+    end
+  end
+
+  def invalid_page_id?(id)
+    id.blank? || (id.first == ".")
+  end
 end

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_dependency "lodash-rails", "~>3.10.0"
   s.add_dependency "patternfly-sass", "~> 3.15.0"
   s.add_dependency "sass-rails"
-  s.add_dependency "high_voltage", "~> 3.0.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "guard-rspec", '~> 4.7.3'


### PR DESCRIPTION
Why?
----
Well, in the process of trying make https://github.com/ManageIQ/manageiq/pull/14315 function, I found that the `config/initializer/high_voltage.rb` was still within the main repo, but was having load ordering issues.  Also, the functionality that was needed from the `high_voltage` gem was specifically the `app/controllers/concerns/high_voltage/static_page.rb` concern, which isn't very accessible from outside the gem directly, and also had some loading issues.

We are using a small fraction of `HighVoltage` to serve our static pages, and that is it, so instead of deal with how to handle the initializer in this repo , just import the functionality that we need, which really isn't much.

Just don't tell Chris Arcand...


QA
--
To the reviewer:

**PLEASE** check my work with this one and confirm that I got all of the necessary functionality ported over with this one.  I didn't import extra tests from the `high_voltage` gem with this (though, considered it), but did make sure that `/static/test.html` and `/static/test_haml.html.haml` pages worked as expected.