### PR TITLE
Fixes "cannot read property '$apply' of null" when clicking on 'Deployments / Add deployment' #658

### DIFF
--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -97,6 +97,10 @@ class MiddlewareServerController < ApplicationController
     ALL_OPERATIONS
   end
 
+  def self.default_show_template
+    "middleware_server/show"
+  end
+
   def add_jdbc_driver
     selected_server = identify_selected_entities
 

--- a/app/views/middleware_server/show.html.haml
+++ b/app/views/middleware_server/show.html.haml
@@ -1,10 +1,4 @@
-- if %w(middleware_datasources middleware_messagings middleware_deployments).include?(@display)
-  = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
-- elsif @showtype == "performance"
-  = render(:partial => "layouts/performance_async")
-- elsif @showtype == 'main'
-  = render :partial => "layouts/textual_groups_generic"
-
+= render :partial => "shared/views/ems_common/show"
 - @angular_form = true
 %ng-form#mw_server_form{"name"          => "mw_server_form",
                         "ng-controller" => "mwServerController",


### PR DESCRIPTION
Fixes #658 