### PR TITLE
Added missing bracket to widget editing template

### DIFF
--- a/app/views/report/_widget_form_chart.html.haml
+++ b/app/views/report/_widget_form_chart.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'widget_form_field_changed', :id => (@widget.id || "new)")
+- url = url_for_only_path(:action => 'widget_form_field_changed', :id => (@widget.id || "new"))
 %h3
   = _('Chart Report')
 .form-horizontal


### PR DESCRIPTION
Fixed error:
```
[----] F, [2017-03-16T08:31:22.107406 #15277:2b17ce744e2c] FATAL -- : SyntaxError (/home/rblanco/devel/manageiq/plugins/manageiq-ui-classic/app/views/report/_widget_form_chart.html.haml:1: syntax error, unexpected ';', expecting ')'
... :id => (@widget.id || "new)"); 
...                               ^):
```

Reproduce:
Cloud Intel -> Reports -> Dashboard Widgets -> Edit this widget