### PR TITLE
Fixed miq policy profile onclick in the policy profile list

### DIFF
--- a/app/views/miq_policy/_profile_list.html.haml
+++ b/app/views/miq_policy/_profile_list.html.haml
@@ -12,7 +12,7 @@
         %tbody
           - @profiles.each do |profile|
             %tr{:title => _("View this Profile"),
-              :onclick => "miqTreeActivateNode('policy_profile_tree', 'profile-#{to_cid(profile.id)}');"}
+              :onclick => "miqTreeActivateNode('policy_profile_tree', 'pp-#{to_cid(profile.id)}');"}
               %td.table-view-pf-select
                 %img{:src => image_path("100/policy_profile#{profile.active? ? '' : '_inactive'}.png")}
               %td


### PR DESCRIPTION
Policy profiles list items weren't clickable under: `Control -> Explorer -> Policy Profiles`
Regression caused by: https://github.com/ManageIQ/manageiq-ui-classic/commit/e6c24c692481816c40827a92550186ce3eb7da15#diff-b27309c027e5c4dadd975646b8a8189dR15
Following rubocop's suggestions isn't always the *Right Way&trade;* :wink: 