### PR TITLE
Fix failing chart specs

### DIFF
--- a/spec/support/report_helper.rb
+++ b/spec/support/report_helper.rb
@@ -5,7 +5,7 @@ module Spec
         ReportFormatter::ReportRenderer.render(Charting.format) do |e|
           e.options.mri           = report
           e.options.show_title    = true
-          e.options.graph_options = MiqReport.graph_options(600, 400)
+          e.options.graph_options = MiqReport.graph_options
           e.options.theme         = 'miq'
           yield e if block_given?
         end


### PR DESCRIPTION
Failing specs was caused by change of `graph_options` method introduced in https://github.com/ManageIQ/manageiq/pull/13470