### PR TITLE
Call changeAuthTab from more miq_tab_header()s

### DIFF
--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -7,29 +7,29 @@
   %h3
     = legendtext
   %ul.nav.nav-tabs
-    = miq_tab_header('default') do
+    = miq_tab_header('default', nil, {'ng-click' => "changeAuthTab('default')"}) do
       %i{"error-on-tab" => "default", :style => "color:#cc0000"}
       = _("Default")
     - if %w(ems_cloud ems_infra).include?(controller_name)
-      = miq_tab_header('metrics') do
+      = miq_tab_header('metrics', nil, {'ng-click' => "changeAuthTab('metrics')"}) do
         %i{"error-on-tab" => "metrics", :style => "color:#cc0000"}
         = _("C & U Database")
-      = miq_tab_header('amqp') do
+      = miq_tab_header('amqp', nil, {'ng-click' => "changeAuthTab('amqp')"}) do
         %i{"error-on-tab" => "amqp", :style => "color:#cc0000"}
         = _("Events")
-      = miq_tab_header('ssh_keypair') do
+      = miq_tab_header('ssh_keypair', nil, {'ng-click' => "changeAuthTab('ssh_keypair')"}) do
         %i{"error-on-tab" => "ssh_keypair", :style => "color:#cc0000"}
         = _("RSA key pair")
     - elsif controller_name == "ems_container"
-      = miq_tab_header('hawkular') do
+      = miq_tab_header('hawkular', nil, {'ng-click' => "changeAuthTab('hawkular')"}) do
         %i{"error-on-tab" => "hawkular", :style => "color:#cc0000"}
         = _("Hawkular")
     - elsif controller_name == "host"
-      = miq_tab_header('remote') do
+      = miq_tab_header('remote', nil, {'ng-click' => "changeAuthTab('remote')"}) do
         = _("Remote Login")
-      = miq_tab_header('ws') do
+      = miq_tab_header('ws', nil, {'ng-click' => "changeAuthTab('ws')"}) do
         = _("Web Services")
-      = miq_tab_header('ipmi') do
+      = miq_tab_header('ipmi', nil, {'ng-click' => "changeAuthTab('ipmi')"}) do
         = _("IPMI")
 
   .tab-content


### PR DESCRIPTION
miq_tab_header() once did this automatically.
That was disabled by 2b1da75e4d389b1212f3db1b2885016a047846ee in #68 and explicit ng-click
was added to some tab headers but not all.  This adds some more.

*Should* help some tabs in providers add/edit (e.g. containers Hawkular tab) and something dealing with hosts(?), not sure where that is but I see there is changeAuthTab function in host_form_controller.js so added it.

Alas, something still doesn't work and Hawkular tab [Verify] button is broken, there is probably something else going on...
@himdel @AparnaKarve Please review/test.