### PR TITLE
Fix dashboard styling

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -101,10 +101,6 @@ li.brand-white-label.whitelabeled {
 
 /* Dashboard overrides */
 
-body#dashboard .container-cards-pf {
-  margin-top: 0;
-}
-
 body#dashboard table {
   border: 0;
 }

--- a/app/views/layouts/_center_div_dashboard_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_dashboard_no_listnav.html.haml
@@ -1,10 +1,10 @@
 = render :partial => "layouts/vertical_navbar"
-.container-fluid.container-cards-pf.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus{:style => "overflow: hidden; height: 100%;"}
+.container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus{:style => "overflow: hidden; height: 100%;"}
   .row.toolbar-pf#toolbar
     .col-md-12
       - if @widgets_menu
         = render :partial => "layouts/angular/toolbar"
-  .row#main-content
+  .row#main-content.miq-body
     .col-md-12
       .spacer
       = render :partial => 'layouts/tabs'


### PR DESCRIPTION
This PR restores the background color of the main dashboard and corrects the height of the toolbar.

Old
<img width="1610" alt="screen shot 2017-03-16 at 9 27 58 am" src="https://cloud.githubusercontent.com/assets/1287144/23998286/fd7e6772-0a2a-11e7-8f39-b3ecd02d911c.png">

New
<img width="1611" alt="screen shot 2017-03-16 at 9 22 58 am" src="https://cloud.githubusercontent.com/assets/1287144/23998285/fd7621e8-0a2a-11e7-9aab-33fa3f21efde.png">