### PR TITLE
Change graph options calls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -192,7 +192,7 @@ class ApplicationController < ActionController::Base
       response.headers["Cache-Control"] = "cache, must-revalidate"
       response.headers["Pragma"] = "public"
     end
-    rpt.to_chart(settings(:display, :reporttheme), true, MiqReport.graph_options(params[:width], params[:height]))
+    rpt.to_chart(settings(:display, :reporttheme), true, MiqReport.graph_options)
     render Charting.render_format => rpt.chart
   end
 

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -1282,7 +1282,7 @@ module ApplicationController::Performance
     report.graph[:max_col_size] = options[:max_value]
     # FIXME: rename xml, xml2 to something like 'chart_data'
     report.to_chart(settings(:display, :reporttheme), false,
-                    MiqReport.graph_options(options[:width], options[:height], options))
+                    MiqReport.graph_options(options))
     chart_xml = {
       :xml      => report.chart,            # Save the graph xml
       :main_col => options[:columns].first  # And the main (first) column of the chart
@@ -1291,7 +1291,7 @@ module ApplicationController::Performance
       report.graph[:type]    = options[:chart2][:type]
       report.graph[:columns] = options[:chart2][:columns]
       report.to_chart(settings(:display, :reporttheme), false,
-                      MiqReport.graph_options(options[:width], options[:height], options.merge(:composite => true)))
+                      MiqReport.graph_options(options.merge(:composite => true)))
       chart_xml[:xml2] = report.chart
     end
     chart_xml

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -65,7 +65,7 @@ module ReportController::Reports
       end
       unless rpt.graph.nil? || rpt.graph[:type].blank?            # If graph present
         # FIXME: UNTESTED!!!
-        rpt.to_chart(settings(:display, :reporttheme), false, MiqReport.graph_options(350, 250)) # Generate the chart
+        rpt.to_chart(settings(:display, :reporttheme), false, MiqReport.graph_options) # Generate the chart
         @edit[:zgraph_xml] = rpt.chart                 # Save chart data
       else
         @edit[:zgraph_xml] = nil


### PR DESCRIPTION
Fix calls of `graph_options method` introduced according to ManageIQ/manageiq#13470