### PR TITLE
Add Gemfile.dev.rb to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .bundle/
 .yardoc
 Gemfile.lock
+Gemfile.dev.rb
 _yardoc/
 bin/*
 coverage/


### PR DESCRIPTION
This is local configuration that should never be committed to the main repo, so ignore it.