### PR TITLE
Verify button haml should always be called via credentials haml

### DIFF
--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -15,6 +15,8 @@
 - cancel_password_change ||= _("Cancel password change")
 - verify_title_off       ||= _("Server information, Username and matching password fields are needed to perform verification of credentials")
 - ng_show_userid         ||= true
+- ng_show_password       ||= true
+- ng_show_verify         ||= true
 - guid_regex             ||= false
 - vm_scope               ||= false
 - main_scope            = vm_scope ? "$parent.vm" : "$parent"
@@ -47,7 +49,7 @@
         .note
           {{note}}
 
-  %div{"ng-show" => "#{ng_show}"}
+  %div{"ng-show" => "#{ng_show} && #{ng_show_password}"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_password.$error.required}"}
       %label.col-md-2.control-label{"for" => "#{prefix}_password"}
         %div{"ng-show" => "vm.bChangeStoredPassword != true"}
@@ -73,7 +75,7 @@
           = change_stored_password
         %a{:href => "", "ng-show" => "vm.bChangeStoredPassword", "ng-click" => "vm.cancelPasswordChange()"}
           = cancel_password_change
-    %div{"ng-show" => "#{ng_show}"}
+    %div{"ng-show" => "#{ng_show} && #{ng_show_verify}"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_verify.$error.required || angularForm.#{prefix}_verify.$error.verifypasswd}"}
       %label.col-md-2.control-label{"ng-show" => "vm.showVerify('#{prefix}_userid')", "for" => "#{prefix}_verify"}
         = verify_label
@@ -95,16 +97,16 @@
             = _("Required")
           %span.help-block{"ng-show" => "!angularForm.#{prefix}_verify.$error.required && angularForm.#{prefix}_verify.$error.verifypasswd"}
             = passwd_mismatch
-    %div{"ng-show" => "#{ng_show}"}
-      .form-group
-        %label.col-md-2
-        .col-md-4
-          = render :partial => "layouts/angular/form_buttons_verify_angular",
-                                       :locals  => {:ng_show          => "#{ng_show}",
-                                                    :validate_url     => validate_url,
-                                                    :id               => id,
-                                                    :ng_model         => "#{ng_model}",
-                                                    :main_scope       => main_scope,
-                                                    :valtype          => "#{prefix}",
-                                                    :verify_title_off => verify_title_off,
-                                                    :basic_info_needed => defined?(basic_info_needed) ? basic_info_needed : nil}
+  %div{"ng-show" => "#{ng_show}"}
+    .form-group
+      %label.col-md-2
+      .col-md-4
+        = render :partial => "layouts/angular/form_buttons_verify_angular",
+                                     :locals  => {:ng_show          => "#{ng_show}",
+                                                  :validate_url     => validate_url,
+                                                  :id               => id,
+                                                  :ng_model         => "#{ng_model}",
+                                                  :main_scope       => main_scope,
+                                                  :valtype          => "#{prefix}",
+                                                  :verify_title_off => verify_title_off,
+                                                  :basic_info_needed => defined?(basic_info_needed) ? basic_info_needed : nil}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -268,17 +268,18 @@
                                               :ng_reqd_hostname       => "false",
                                               :ng_reqd_api_port       => "false",
                                               :prefix                 => "hawkular"}
-          %label.col-md-2
-          .col-md-4
-            = render :partial => "layouts/angular/form_buttons_verify_angular",
-                     :locals  => {:ng_show           => true,
-                                  :validate_url      => validate_url,
-                                  :id                => record.id,
-                                  :main_scope        => main_scope,
-                                  :ng_model          => "#{ng_model}",
-                                  :valtype           => "hawkular",
-                                  :verify_title_off  => _("hawkular URL and API port fields are needed to perform validation."),
-                                  :basic_info_needed => true}
+            = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                       :locals  => {:ng_show           => true,
+                                    :ng_model          => "#{ng_model}",
+                                    :main_scope        => main_scope,
+                                    :ng_show_userid    => "false",
+                                    :ng_show_password  => "false",
+                                    :ng_show_verify    => "false",
+                                    :validate_url      => validate_url,
+                                    :id                => record.id,
+                                    :prefix            => "hawkular",
+                                    :verify_title_off  => _("hawkular URL and API port fields are needed to perform validation."),
+                                    :basic_info_needed => true}
         .form-group
           .col-md-12
             %span{:style => "color:black"}


### PR DESCRIPTION
No explicit calls should be made to `layouts/angular/form_buttons_verify_angular`, since the existing code pattern is to render the `credentials` haml, which in turn will render the `layouts/angular/form_buttons_verify_angular` haml.

`Hawkular` is the only case not adhering to this existing code pattern due to which the `Validate` button does not seem to function anymore.

Issue discovered in https://github.com/ManageIQ/manageiq-ui-classic/pull/670
and related to --
#430 
#425

This PR fixes the `Hawkular` `Validate` button issue.