### PR TITLE
Enable new cloud volume for provider

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope', 'cloudVolumeFormId', 'miqService', 'API', function($http, $scope, cloudVolumeFormId, miqService, API) {
+ManageIQ.angular.app.controller('cloudVolumeFormController', ['$scope', 'cloudVolumeFormId', 'miqService', 'API', function($scope, cloudVolumeFormId, miqService, API) {
   var init = function() {
     $scope.cloudVolumeModel = {
       aws_encryption: false,
@@ -14,7 +14,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
       { type: "io1", name: "Provisioned IOPS SSD (IO1)" },
       { type: "st1", name: "Throughput Optimized HDD (ST1)" },
       { type: "sc1", name: "Cold HDD (SC1)" },
-      { type: "magnetic", name: "Magnetic" },
+      { type: "standard", name: "Magnetic" },
     ];
 
     ManageIQ.angular.scope = $scope;
@@ -23,17 +23,21 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
       $scope.cloudVolumeModel.name = "";
     } else {
       miqService.sparkleOn();
-      $http.get('/cloud_volume/cloud_volume_form_fields/' + cloudVolumeFormId)
+      API.get('/api/cloud_volumes/' + cloudVolumeFormId + '?attributes=ext_management_system.type')
         .then(getCloudVolumeFormDataComplete)
         .catch(miqService.handleFailure);
     }
   };
 
-  function getCloudVolumeFormDataComplete(response) {
-    var data = response.data;
-
+  function getCloudVolumeFormDataComplete(data) {
     $scope.afterGet = true;
+    $scope.cloudVolumeModel.emstype = data.ext_management_system.type;
     $scope.cloudVolumeModel.name = data.name;
+    // We have to display size in GB.
+    $scope.cloudVolumeModel.size = data.size / 1073741824;
+    // Currently, this is only relevant for AWS volumes so we are prefixing the
+    // model attribute with AWS.
+    $scope.cloudVolumeModel.aws_volume_type = data.volume_type;
 
     $scope.modelCopy = angular.copy( $scope.cloudVolumeModel );
     miqService.sparkleOff();

--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('cloudVolumeFormController', ['$scope', 'cloudVolumeFormId', 'miqService', 'API', function($scope, cloudVolumeFormId, miqService, API) {
+ManageIQ.angular.app.controller('cloudVolumeFormController', ['$scope', 'miqService', 'API', 'cloudVolumeFormId', 'storageManagerId', function($scope, miqService, API, cloudVolumeFormId, storageManagerId) {
   var init = function() {
     $scope.cloudVolumeModel = {
       aws_encryption: false,
@@ -26,6 +26,11 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$scope', 'cloudVo
       API.get('/api/cloud_volumes/' + cloudVolumeFormId + '?attributes=ext_management_system.type')
         .then(getCloudVolumeFormDataComplete)
         .catch(miqService.handleFailure);
+    }
+
+    if (storageManagerId) {
+      $scope.cloudVolumeModel.storage_manager_id = storageManagerId;
+      $scope.storageManagerChanged(storageManagerId);
     }
   };
 

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -121,14 +121,6 @@ class CloudVolumeController < ApplicationController
     replace_gtl_main_div if pagination_request?
   end
 
-  def cloud_volume_form_fields
-    assert_privileges("cloud_volume_edit")
-    volume = find_by_id_filtered(CloudVolume, params[:id])
-    render :json => {
-      :name => volume.name
-    }
-  end
-
   def attach
     params[:id] = checked_item_id unless params[:id].present?
     assert_privileges("cloud_volume_attach")
@@ -696,6 +688,9 @@ class CloudVolumeController < ApplicationController
     options[:cloud_tenant_id] = params[:cloud_tenant_id] if params[:cloud_tenant_id]
     options[:vm_id] = params[:vm_id] if params[:vm_id]
     options[:device_path] = params[:device_path] if params[:device_path]
+    options[:volume_type] = params[:aws_volume_type] if params[:aws_volume_type]
+    # Only set IOPS if io1 (provisioned IOPS) and IOPS available
+    options[:iops] = params[:aws_iops] if options[:volume_type] == 'io1' && params[:aws_iops]
     options
   end
 

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -270,7 +270,13 @@ class CloudVolumeController < ApplicationController
     @volume = CloudVolume.new
     @in_a_form = true
     @storage_manager_choices = {}
-    ExtManagementSystem.all.each { |ems| @storage_manager_choices[ems.name] = ems.id if ems.supports_block_storage? }
+    if params[:storage_manager_id]
+      @storage_manager_id = params[:storage_manager_id]
+      ems = find_by_id_filtered(ExtManagementSystem, @storage_manager_id)
+      @storage_manager_choices[ems.name] = ems.id
+    else
+      ExtManagementSystem.all.each { |ems| @storage_manager_choices[ems.name] = ems.id if ems.supports_block_storage? }
+    end
     drop_breadcrumb(
       :name => _("Add New %{model}") % {:model => ui_lookup(:table => 'cloud_volume')},
       :url  => "/cloud_volume/new"
@@ -281,8 +287,7 @@ class CloudVolumeController < ApplicationController
     assert_privileges("cloud_volume_new")
     case params[:button]
     when "cancel"
-      javascript_redirect :action => 'show_list',
-                          :flash_msg => _("Add of new %{model} was cancelled by the user") % {:model => ui_lookup(:table => 'cloud_volume')}
+      cancel_action(_("Add of new %{model} was cancelled by the user") % {:model => ui_lookup(:table => 'cloud_volume')})
 
     when "add"
       @volume = CloudVolume.new
@@ -337,11 +342,10 @@ class CloudVolumeController < ApplicationController
       }, :error)
     end
 
-    @breadcrumbs.pop if @breadcrumbs
     session[:edit] = nil
     session[:flash_msgs] = @flash_array.dup if @flash_array
 
-    javascript_redirect :action => "show_list"
+    javascript_redirect previous_breadcrumb_url
   end
 
   def edit

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -494,6 +494,8 @@ module EmsCommon
       javascript_redirect :controller => "host_aggregate", :action => "edit", :id => find_checked_items[0]
     elsif params[:pressed] == "cloud_tenant_edit"
       javascript_redirect :controller => "cloud_tenant", :action => "edit", :id => find_checked_items[0]
+    elsif params[:pressed] == "cloud_volume_new"
+      javascript_redirect :controller => "cloud_volume", :action => "new", :storage_manager_id => params[:id]
     elsif params[:pressed] == "cloud_volume_edit"
       javascript_redirect :controller => "cloud_volume", :action => "edit", :id => find_checked_items[0]
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",

--- a/app/helpers/application_helper/button/mixins/sub_list_view_screen_mixin.rb
+++ b/app/helpers/application_helper/button/mixins/sub_list_view_screen_mixin.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper::Button::Mixins::SubListViewScreenMixin
   def sub_list_view_screen?
-    @lastaction == 'show' && !@display.in?(%w(main vms instances all_vms))
+    @lastaction == 'show' && !@display.in?(%w(main vms instances all_vms cloud_volumes))
   end
 end

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -1,0 +1,60 @@
+.form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
+  %label.col-md-2.control-label
+    = _('Volume Name')
+  .col-md-8
+    %input.form-control{:type          => "text",
+                        :name          => "name",
+                        'ng-model'     => "cloudVolumeModel.name",
+                        'ng-maxlength' => 128,
+                        :required      => "",
+                        :checkchange   => true}
+    %span.help-block{"ng-show" => "angularForm.name.$error.required"}
+      = _("Required")
+
+.form-group{"ng-class" => "{'has-error': angularForm.aws_volume_type.$invalid}",
+            "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+  %label.col-md-2.control-label
+    = _('Cloud Volume Type')
+  .col-md-8
+    %select{"name"                        => "aws_volume_type",
+            "ng-model"                    => "cloudVolumeModel.aws_volume_type",
+            "ng-options"                  => "voltype.type as voltype.name for voltype in awsVolumeTypes",
+            "ng-change"                   => "awsVolumeTypeChanged(cloudVolumeModel.aws_volume_type)",
+            "ng-disabled" 				  => "formId != 'new' && cloudVolumeModel.aws_volume_type == 'standard'",
+            "required"                    => "",
+            :checkchange                  => true,
+            "selectpicker-for-select-tag" => ""}
+      %option{"value" => "", "disabled" => ""}
+        = "<#{_('Choose')}>"
+    %span.help-block{"ng-show" => "angularForm.aws_volume_type.$error.required"}
+      = _("Required")
+
+.form-group{"ng-class" => "{'has-error': angularForm.size.$invalid}"}
+  %label.col-md-2.control-label
+    = _('Size (in gigabytes)')
+  .col-md-8
+    %input.form-control{:type          => "text",
+                        :name          => "size",
+                        'ng-model'     => "cloudVolumeModel.size",
+                        'ng-maxlength' => 10,
+                        'ng-change'    => "sizeChanged(cloudVolumeModel.size)",
+                        'ng-disabled'  => "formId != 'new' && (cloudVolumeModel.emstype != 'ManageIQ::Providers::Amazon::StorageManager::Ebs' || cloudVolumeModel.aws_volume_type == 'standard')",
+                        :required      => "",
+                        :checkchange   => true}
+    %span.help-block{"ng-show" => "angularForm.size.$error.required"}
+      = _("Required")
+
+.form-group{"ng-class" => "{'has-error': angularForm.aws_iops.$invalid}",
+            "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+  %label.col-md-2.control-label
+    = _('IOPS')
+  .col-md-8
+    %input.form-control{:type          => "text",
+                        :name          => "aws_iops",
+                        'ng-model'     => "cloudVolumeModel.aws_iops",
+                        'ng-maxlength' => 50,
+                        'ng-disabled'  => "cloudVolumeModel.aws_volume_type != 'io1'",
+                        "ng-required"  => "cloudVolumeModel.aws_volume_type == 'io1'",
+                        :checkchange   => true}
+    %span.help-block{"ng-show" => "cloudVolumeModel.aws_volume_type == 'io1' && angularForm.aws_iops.$error.required"}
+      = _("Required")

--- a/app/views/cloud_volume/edit.html.haml
+++ b/app/views/cloud_volume/edit.html.haml
@@ -1,18 +1,9 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController"}
+%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => ""}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Edit Volume')
   .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
-        = _('Volume Name')
-      .col-md-8
-        %input.form-control{:type          => "text",
-                            :name          => "name",
-                            'ng-model'     => "cloudVolumeModel.name",
-                            'ng-maxlength' => 128,
-                            :miqrequired   => false,
-                            :checkchange   => true}
+    = render :partial => "common_new_edit"
 
   %table{:width => '100%'}
     %tr

--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -6,10 +6,11 @@
         = _('Storage Manager')
       .col-md-8
         = select_tag("storage_manager_id",
-                     options_for_select([["<#{_('Choose')}>", nil]] + @storage_manager_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
+                     options_for_select((@storage_manager_id.nil? ? [["<#{_('Choose')}>", nil]] : []) + @storage_manager_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
                      "ng-model"                    => "cloudVolumeModel.storage_manager_id",
                      "ng-change"                   => "storageManagerChanged(cloudVolumeModel.storage_manager_id)",
                      "required"                    => "",
+                     "disabled"                    => !@storage_manager_id.nil?,
                      :checkchange                  => true,
                      "selectpicker-for-select-tag" => "")
         %span.help-block{"ng-show" => "angularForm.storage_manager_id.$error.required"}
@@ -87,4 +88,5 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id || "new"}');
+  ManageIQ.angular.app.value('storageManagerId', '#{@storage_manager_id}');
   miq_bootstrap('#form_div');

--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -47,64 +47,7 @@
         %span.help-block{"ng-show" => "angularForm.aws_availability_zone_id.$error.required"}
           = _("Required")
 
-    .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
-      %label.col-md-2.control-label
-        = _('Volume Name')
-      .col-md-8
-        %input.form-control{:type          => "text",
-                            :name          => "name",
-                            'ng-model'     => "cloudVolumeModel.name",
-                            'ng-maxlength' => 128,
-                            :required      => "",
-                            :checkchange   => true}
-        %span.help-block{"ng-show" => "angularForm.name.$error.required"}
-          = _("Required")
-
-    .form-group{"ng-class" => "{'has-error': angularForm.aws_volume_type.$invalid}",
-                "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
-      %label.col-md-2.control-label
-        = _('Cloud Volume Type')
-      .col-md-8
-        %select{"name"                        => "aws_volume_type",
-                "ng-model"                    => "cloudVolumeModel.aws_volume_type",
-                "ng-options"                  => "voltype.type as voltype.name for voltype in awsVolumeTypes",
-                "ng-change"                   => "awsVolumeTypeChanged(cloudVolumeModel.aws_volume_type)",
-                "required"                    => "",
-                :checkchange                  => true,
-                "selectpicker-for-select-tag" => ""}
-          %option{"value" => "", "disabled" => ""}
-            = "<#{_('Choose')}>"
-        %span.help-block{"ng-show" => "angularForm.aws_volume_type.$error.required"}
-          = _("Required")
-
-    .form-group{"ng-class" => "{'has-error': angularForm.size.$invalid}"}
-      %label.col-md-2.control-label
-        = _('Size (in gigabytes)')
-      .col-md-8
-        %input.form-control{:type          => "text",
-                            :name          => "size",
-                            'ng-model'     => "cloudVolumeModel.size",
-                            'ng-maxlength' => 10,
-                            'ng-change'    => "sizeChanged(cloudVolumeModel.size)",
-                            :required      => "",
-                            :checkchange   => true}
-        %span.help-block{"ng-show" => "angularForm.size.$error.required"}
-          = _("Required")
-
-    .form-group{"ng-class" => "{'has-error': angularForm.aws_iops.$invalid}",
-                "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
-      %label.col-md-2.control-label
-        = _('IOPS')
-      .col-md-8
-        %input.form-control{:type          => "text",
-                            :name          => "aws_iops",
-                            'ng-model'     => "cloudVolumeModel.aws_iops",
-                            'ng-maxlength' => 50,
-                            'ng-disabled'  => "cloudVolumeModel.aws_volume_type != 'io1'",
-                            "required"     => "",
-                            :checkchange   => true}
-        %span.help-block{"ng-show" => "cloudVolumeModel.aws_volume_type == 'io1' && angularForm.aws_iops.$error.required"}
-          = _("Required")
+    = render :partial => "common_new_edit"
 
     .form-group{"ng-if" => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
       %label.col-md-2.control-label

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -481,7 +481,6 @@ Rails.application.routes.draw do
         backup_select
         snapshot_new
         edit
-        cloud_volume_form_fields
         cloud_volume_tenants
         index
         new


### PR DESCRIPTION
Currently, adding new cloud volumes from the UI is only possible in `Storage > Block Storage > Volumes`, i.e. the list of all cloud volumes. This requires that users choose the target storage manager before specifying volume options.

Each block storage manager also provides the list of its own volumes. However, there is no way to create new cloud volume from this list.

This patch resolves this by enabling the button for adding volumes to this list and extending involved controllers to handle the given storage manager id.

Extends: https://github.com/ManageIQ/manageiq-ui-classic/pull/676 (thus, it also includes that commit for easier testing).

Video: http://x.k00.fr/d7x4y:
 * First, it shows the original form opened from the list of all cloud volumes (target manager needs to be chosen first)
 * Amazon block storage manager
 * OpenStack block storage manager (here we also show the problem related https://github.com/ManageIQ/manageiq-ui-classic/issues/688 - it's even more noticeable here because we only see manager's volumes)

@miq-bot assign @AparnaKarve 
@miq-bot add_label enhancement,storage

Sorry for another PR ;-). 