### PR TITLE
Fixed TreeNode.exists? behavior when using a non-ActiveRecord object

### DIFF
--- a/app/presenters/tree_node.rb
+++ b/app/presenters/tree_node.rb
@@ -16,9 +16,9 @@ module TreeNode
     private
 
     def subclass(object)
-      klass = "#{self}::#{object.class}"
-      node = object.kind_of?(Hash) || Object.const_defined?(klass) ? klass : "#{self}::#{object.class.base_class}"
-      node.safe_constantize
+      klass = "#{self}::#{object.class}".safe_constantize
+      klass ||= "#{self}::#{object.class.base_class}".safe_constantize if object.kind_of?(ApplicationRecord)
+      klass
     end
   end
 end

--- a/spec/presenters/tree_node_spec.rb
+++ b/spec/presenters/tree_node_spec.rb
@@ -51,4 +51,33 @@ describe TreeNode do
       end
     end
   end
+
+  describe '.exists?' do
+    subject { described_class.exists?(object) }
+
+    context 'object has a direct subclass' do
+      let(:object) { User.new }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'object has an indirect subclass' do
+      let(:object) { VmOrTemplate.new }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'object is a hash' do
+      let(:object) { Hash.new }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'object is an array' do
+      let(:object) { [] }
+      it { is_expected.to be_falsey }
+    end
+
+    context 'object is nil' do
+      let(:object) { nil }
+      it { is_expected.to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
Slightly related to #714, but it does not fix the issue described there. `Object.const_defined?` does not play well with Rails' `autoload`. Also if an `Integer` or an `Array` has been passed to the exists? method it was failing on the `base_class`. This PR makes this method more error-proof.