### PR TITLE
Change empty chart layout

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1682,6 +1682,9 @@ function chartData(type, data, data2) {
   }
 
   if (_.isObject(data.miq)) {
+    if (data.miq.empty) {
+      return _.defaultsDeep({}, data, data2);
+    }
     // set maximum count of x axis tick labels for C&U charts
     if (data.miq.performance_chart) {
       data.axis.x.tick.centered = true;

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -57,7 +57,7 @@ module ReportFormatter
       type = c3_convert_type(mri.graph[:type].to_s)
       mri.chart = {
         :miqChart => type,
-        :data     => {:columns => [], :names => {}},
+        :data     => {:columns => [], :names => {}, :empty => {:label => {:text => _('No data available.')}}},
         :axis     => {:x => {:tick => {}}, :y => {:tick => {}, :padding => {:bottom => 0}}},
         :tooltip  => {:format => {}},
         :miq      => {:name_table => {}, :category_table => {}},
@@ -122,11 +122,9 @@ module ReportFormatter
 
     def no_records_found_chart(*)
       mri.chart = {
-        :miqChart => 'Line',
-        :data     => {:columns => [], :names => {}},
-        :axis     => {:x => {:tick => {}}, :y => {:tick => {}}},
-        :tooltip  => {:format => {}},
-        :miq      => {:name_table => {}}
+        :axis => {:y => {:show => false}},
+        :data => {:columns => [], :empty => {:label => {:text => _('No data available.')}}},
+        :miq  => {:empty => true},
       }
     end
 

--- a/spec/lib/report_formater/c3_formatter_spec.rb
+++ b/spec/lib/report_formater/c3_formatter_spec.rb
@@ -146,4 +146,15 @@ describe ReportFormatter::C3Formatter do
       expect(report.chart[:miq][:category_table]).to eq(["8/19", "8/20"])
     end
   end
+
+  context '#C&U charts with no data' do
+    let(:report) { cu_chart_with_grouping }
+    before(:each) do
+      render_report(report, &proc { |e| e.options.graph_options = { :chart_type => :performance } })
+    end
+
+    it "has right empty data description" do
+      expect(report.chart[:data][:empty][:label][:text]).to eq(_("No data available."))
+    end
+  end
 end

--- a/spec/support/report_helper.rb
+++ b/spec/support/report_helper.rb
@@ -262,6 +262,27 @@ module Spec
         report
       end
 
+      def cu_chart_with_no_data
+        report = MiqReport.new(
+          :db        => "VimPerformanceDaily",
+          :cols      => %w(timestamp cpu_usagemhz_rate_average max_derived_cpu_available),
+          :include   => {"resource" => {"columns" => %w(cpu_usagemhz_rate_average_high_over_time_period cpu_usagemhz_rate_average_low_over_time_period)}},
+          :col_order => %w(timestamp cpu_usagemhz_rate_average max_derived_cpu_available),
+          :headers   => ["Date/Time", "Avg Used", "Max Available"],
+          :order     => "Ascending",
+          :sortby    => %w(timestamp),
+          :group     => "n",
+          :graph     => {:type => "Line", :columns => %w(cpu_usagemhz_rate_average max_derived_cpu_available)},
+          :extras    => {:trend => {"trend_max_cpu_usagemhz_rate_average|max_derived_cpu_available"=>"Trending Down"}}
+        )
+
+        report.table = Ruport::Data::Table.new(
+          :column_names => %w(timestamp cpu_usagemhz_rate_average max_derived_cpu_available),
+          :data         => []
+        )
+        report
+      end
+
       def long_category
         'Daenerys Targaryen, the First of Her Name, Queen of Meereen, Queen of the Andals and the Rhoynar and the First Men,\
          Lord of the Seven Kingdoms, Protector of the Realm, Khaleesi of the Great Grass Sea, called Daenerys Stormborn, the Unburnt,\


### PR DESCRIPTION
Change empty chart layout to show `No data available.` message.
Also this message is shown when you hide all series from non-empty chart.

Screenshots:
No data:
![screenshot from 2017-03-17 12-00-08](https://cloud.githubusercontent.com/assets/9535558/24040391/5a6a06a6-0b09-11e7-9ca1-97f78febcab6.png)

Hidden data:
![screenshot from 2017-03-17 11-59-44](https://cloud.githubusercontent.com/assets/9535558/24040394/5c04463e-0b09-11e7-9968-87babf1f9549.png)

