### PR TITLE
Reorganize the logic in lookup_attrs for AutomateSimulationTree

### DIFF
--- a/app/helpers/miq_ae_class_helper.rb
+++ b/app/helpers/miq_ae_class_helper.rb
@@ -114,6 +114,8 @@ module MiqAeClassHelper
       'product product-relationship'
     when 'state'
       'product product-state'
+    when 'element'
+      'product product-element'
     else
       raise NotImplementedError, "Missing fonticon for MiqAeField type #{field}"
     end

--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -49,13 +49,7 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
         :tooltip => el.attributes["name"],
         :icon    => 'product product-attribute'
       }
-    elsif !el.text.blank?
-      {
-        :text => el.text,
-        :tip  => el.text,
-        :icon => ae_field_fonticon(el.name.underscore)
-      }
-    else
+    elsif el.name.starts_with?('MiqAeService')
       key = el.name.sub(/^MiqAeService/, '').gsub('_', '::')
       base_obj = key.safe_constantize.try(:new)
       obj = TreeNode.new(base_obj) if TreeNode.exists?(base_obj)
@@ -65,6 +59,13 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
         :tooltip => el.name,
         :icon    => obj ? obj.icon : nontreenode_icon(base_obj),
         :image   => obj ? obj.image : nil
+      }
+    else
+      text = !el.text.blank? ? el.text : el.name
+      {
+        :text => text,
+        :tip  => text,
+        :icon => ae_field_fonticon(el.name.underscore)
       }
     end
   end


### PR DESCRIPTION
The `else` block in `lookup_attrs` was handling some non-MiqAeService elements that are covered by `MiqAeClassHelper#ae_field_fonticon`, so I reorganized the code structure a bit. As we might not have the full list of all the possible non-MiqAeService elements, the `ae_field_fonticon` throws a descriptive error if an icon is missing.

The first commit fixes #714, but throws an exception as there is no fonticon defined for `Element`. The second commit adds a the missing icon that has been created by @epwinchell in #731.