### PR TITLE
Fix that attribute available_tags of struct isn't initialized

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -3,6 +3,7 @@ module ApplicationController::Filter
     :alias,
     :expression,
     :exp_available_tags,
+    :available_tags,
     :exp_available_fields,
     :exp_cfield,
     :exp_check,


### PR DESCRIPTION
`available_tags` attribute isn't initialized in
https://github.com/ManageIQ/manageiq-ui-classic/pull/414/commits/33f7f93ac3311bcdc572c9c76e6815f4b6a8a8df

(it isn't in euwe)
@miq-bot add_label euwe/no, bug
## **Test scenario**

@miq-bot assing @mzazrivec 
cc @isimluk 


![kzwykphany](https://cloud.githubusercontent.com/assets/14937244/24043607/af055fae-0b17-11e7-9a69-db595cdbd253.gif)
(maybe it needs to restart memcache)
```
[----] F, [2017-03-17T13:42:10.012966 #87308:3fdef292e2d8] FATAL -- : Error caught: [ActionView::Template::Error] undefined method `available_tags' for #<ApplicationController::Filter::Expression:0x007fbdea429c80>
Did you mean?  available_adv_searches
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/application_controller/filter/expression.rb:59:in `tags_for_display_filters'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/views/layouts/exp_atom/_edit_tag.html.haml:8:in `___sers_liborpichler_manageiq_manageiq_ui_classic_app_views_layouts_exp_atom__edit_tag_html_haml__3371184688831722423_70226828597240'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.2/lib/action_view/template.rb:159:in `block in render'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.2/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.2/lib/action_view/template.rb:354:in `instrument'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.2/lib/action_view/template.rb:157:in `render'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.2/lib/action_view/renderer/partial_renderer.rb:343:in `render_partial'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.2/lib/action_view/renderer/partial_renderer.rb:311:in `block in render'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.2/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.2/lib/active_support/notifications.rb:164:in `block in instrument'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.2/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.2/lib/active_support/notifications.rb:164:in `instrument'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.2/lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.2/lib/action_view/renderer/partial_renderer.rb:310:in `render'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.2/lib/action_view/renderer/renderer.rb:47:in `render_partial'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.2/lib/action_view/renderer/renderer.rb:21:in `render'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.2/lib/action_view/helpers/rendering_helper.rb:32:in `render'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/views/layouts/exp_atom/_editor.html.haml:68:in 
```
