### PR TITLE
Fix all users of CredentialsController to provide vm-scope

### DIFF
--- a/app/views/layouts/angular/_auth_service_account_angular.html.haml
+++ b/app/views/layouts/angular/_auth_service_account_angular.html.haml
@@ -4,7 +4,7 @@
 - vm_scope ||= false
 - main_scope = vm_scope ? "$parent.vm" : "$parent"
 
-%div{"ng-controller" => "CredentialsController"}
+%div{"ng-controller" => "CredentialsController", "vm-scope" => main_scope}
   %div{"ng-show" => ng_show}
     .form-group{"ng-class" => "{'has-error': angularForm.service_account.$invalid}"}
       %label.col-md-2.control-label{"for" => "service_account"}


### PR DESCRIPTION
Go to Compute > Clouds > Providers, create a new provider.
Pick the GCE type.

Before

```
angular.self-a4ec94b….js?body=1:10708 TypeError: Cannot read property 'formId' of undefined
    at new <anonymous> (credentials_controller.self-ec7bece….js?bod…:25)
    at $controllerInit (angular.self-a4ec94b….js?body=1:10593)
    at nodeLinkFn (angular.self-a4ec94b….js?body=1:9470)
    at compositeLinkFn (angular.self-a4ec94b….js?body=1:8811)
    at compositeLinkFn (angular.self-a4ec94b….js?body=1:8814)
    at publicLinkFn (angular.self-a4ec94b….js?body=1:8691)
    at ngIfWatchAction (angular.self-a4ec94b….js?body=1:27108)
    at Scope.$digest (angular.self-a4ec94b….js?body=1:17837)
    at ChildScope.$apply (angular.self-a4ec94b….js?body=1:18103)
    at HTMLSelectElement.<anonymous> (angular.self-a4ec94b….js?body=1:31995)
```
(And the Validate button is broken)

Now .. it works.

---

Introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/425, `CredentialsController` needs a `vm-scope` attribute to be able to determine the correct scope.

This change was not done in `app/views/layouts/angular/_auth_service_account_angular.html.haml` which caused adding a GCE provider to be broken.

Fixing.

Cc @AparnaKarve , @ZitaNemeckova 