### PR TITLE
MiqAeTools - simulate - handle unsetting Object Attribute type

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -438,7 +438,7 @@ Methods updated/added: %{method_stats}") % stat_options)
     #   @resolve[:new][:target_attr_name] = params[:target_attr_name] if params.has_key?(:target_attr_name)
     if params.key?(:target_class)
       @resolve[:new][:target_class] = params[:target_class]
-      targets = Rbac.filtered(params[:target_class]).select(:id, :name)
+      targets = Rbac.filtered(params[:target_class]).select(:id, :name) unless params[:target_class].blank?
       unless targets.nil?
         @resolve[:targets] = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
         @resolve[:new][:target_id] = nil

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -11,6 +11,19 @@ describe MiqAeToolsController do
       }
       controller.instance_variable_set(:@resolve, :throw_ready => true, :new => new)
       expect(controller).to receive(:render)
+      controller.instance_variable_set(:@_params, :target_class => '', :id => 'new')
+      controller.send(:form_field_changed)
+      expect(assigns(:resolve)[:new][:target_class]).to eq('')
+      expect(assigns(:resolve)[:new][:target_id]).to eq(nil)
+    end
+
+    it "resets target id to nil, when target class is Vm" do
+      new = {
+        :target_class => "EmsCluster",
+        :target_id    => 1
+      }
+      controller.instance_variable_set(:@resolve, :throw_ready => true, :new => new)
+      expect(controller).to receive(:render)
       controller.instance_variable_set(:@_params, :target_class => 'Vm', :id => 'new')
       controller.send(:form_field_changed)
       expect(assigns(:resolve)[:new][:target_class]).to eq('Vm')


### PR DESCRIPTION
Go to Automation > Automate > Simulation, enter request=`InspectMe`, do submit.
Then select an object attribute type, submit.
Unset the object attribute type - crash (visible in rails log, the second select doesn't dissapear)

Also reintroduces a test for this (broken by the same PR).

https://bugzilla.redhat.com/show_bug.cgi?id=1428905

---

Introduced in https://github.com/ManageIQ/manageiq/pull/10060, @pkomanek FYI .. also, try not to remove a spec and break it in the same PR ;) - the test was there, and it would have crashed :).