### PR TITLE
Update dashboard widget styling

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -101,6 +101,14 @@ li.brand-white-label.whitelabeled {
 
 /* Dashboard overrides */
 
+body#dashboard .blank-slate-pf {
+  padding: 0 !important;
+}
+
+.blank-slate-pf .pficon-warning-triangle-o:before {
+  color: #9c9c9c;
+}
+
 body#dashboard table {
   border: 0;
 }
@@ -116,16 +124,6 @@ body#dashboard table thead th {
 
 body#dashboard table td {
   border: none;
-}
-
-body#dashboard .dropdown-kebab-pf .dropdown-menu {
-  left: -136px;
-  margin-top: 11px;
-}
-
-body#dashboard .dropdown-kebab-pf .dropdown-menu:after,
-body#dashboard .dropdown-kebab-pf .dropdown-menu:before {
-  left: 127px;
 }
 
 /* Login overrides */

--- a/app/views/dashboard/_widget.html.haml
+++ b/app/views/dashboard/_widget.html.haml
@@ -2,14 +2,13 @@
 -# widget MiqWidget object
 - button_id = "btn_#{presenter.widget.id}"
 %div{:id => "w_#{presenter.widget.id}"}
-  .card-pf
-    .card-pf-heading
-      %h2.card-pf-title.sortable-handle{:style => "cursor:move"}
-        = h(presenter.widget.title)
-        .dropdown.dropdown-kebab-pf.pull-right
-          %button.btn.btn-link.dropdown-toggle{:type => "button", :id => button_id, "data-toggle" => "dropdown"}
+  .card-pf.card-pf-view
+    .card-pf-body
+      .card-pf-heading-kebab
+        .dropdown.pull-right.dropdown-kebab-pf
+          %button.btn.btn-link.dropdown-toggle{:type => "button", :id => button_id, "data-toggle" => "dropdown", "aria-haspopup" => "true"}
             %span.fa.fa-ellipsis-v
-          %ul.dropdown-menu{"aria-labelledby" => button_id}
+          %ul.dropdown-menu.dropdown-menu-right{"aria-labelledby" => button_id}
             - if role_allows?(:feature => "dashboard_add")
               %li
                 = presenter.button_close
@@ -24,6 +23,8 @@
               - if %w(chart).include?(presenter.widget.content_type)
                 %li
                   = presenter.button_zoom
+        %h2.card-pf-title.sortable-handle{:style => "cursor:move"}
+          = h(presenter.widget.title)
 
     - if presenter.widget.content_type == "menu"
       = render :partial => 'widget_menu', :locals => {:widget => presenter.widget}

--- a/app/views/dashboard/_widget_blank.html.haml
+++ b/app/views/dashboard/_widget_blank.html.haml
@@ -1,8 +1,10 @@
 -#
   Parameters:
     widget -- MiqWidget object
-.card-pf-body{:style => "text-align: center;"}
-  .mc{:id => "dd_w#{widget.id}_box",
-    :style => "#{@sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display: none;' : ''}"}
-    %h3= _('No data found.')
-    = _('If this widget is new or has just been added to your dashboard, the data is being generated and should be available soon.')
+.mc{:id => "dd_w#{widget.id}_box",
+:style => "#{@sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display: none;' : ''}"}
+.blank-slate-pf{:style => "padding: 10px"}
+  .blank-slate-pf-icon
+    %i.fa.fa-cog
+  %h1= _('No data found.')
+  %p= _('If this widget is new or has just been added to your dashboard, the data is being generated and should be available soon.')

--- a/app/views/dashboard/_widget_chart.html.haml
+++ b/app/views/dashboard/_widget_chart.html.haml
@@ -1,22 +1,28 @@
 -#
   Parameters:
     widget -- MiqWidget instance
-.card-pf-body.chart_widget
-  .mc{:id => "dd_w#{widget.id}_box",
-    :style => @sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display:none' : ''}
+.mc{:id => "dd_w#{widget.id}_box",
+  :style => @sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display:none' : ''}
 
-    - if widget.contents_for_user(current_user).contents.blank?
-      = _('No chart data found')
-      \. . .
-    - datum = widget.contents_for_user(current_user).contents
-    - if Charting.data_ok?(datum)
-      -# we need to count all charts to be able to display multiple
-      -# charts on a dashboard screen
-      - WidgetPresenter.chart_data.push(:xml => datum)
-      - chart_index = WidgetPresenter.chart_data.length - 1
-      - chart_data = Charting.deserialized(datum)
+  - if widget.contents_for_user(current_user).contents.blank?
+    .blank-slate-pf{:style => "padding: 10px"}
+      .blank-slate-pf-icon
+        %i.fa.fa-cog
+      %h1= _('No chart data found.')
 
-      = chart_local(chart_data,
-                    :id     => "miq_widgetchart_#{chart_index}".html_safe)
-    - else
-      = _('Invalid chart data. Try regenerating the widgets.')
+  - datum = widget.contents_for_user(current_user).contents
+  - if Charting.data_ok?(datum)
+    -# we need to count all charts to be able to display multiple
+    -# charts on a dashboard screen
+    - WidgetPresenter.chart_data.push(:xml => datum)
+    - chart_index = WidgetPresenter.chart_data.length - 1
+    - chart_data = Charting.deserialized(datum)
+
+    = chart_local(chart_data,
+                  :id     => "miq_widgetchart_#{chart_index}".html_safe)
+  - else
+    .blank-slate-pf{:style => "padding: 10px"}
+      .blank-slate-pf-icon
+        %i.pficon.pficon-warning-triangle-o
+      %h1= _('Invalid chart data.')
+      %p= _('Invalid chart data. Try regenerating the widgets.')

--- a/app/views/dashboard/_widget_menu.html.haml
+++ b/app/views/dashboard/_widget_menu.html.haml
@@ -1,18 +1,17 @@
 -#
   Parameters:
     widget      MiqWidget object
-.card-pf-body.menu_widget{:style => "padding: 0"}
-  .mc{:id => "dd_w#{widget.id}_box",
-    :style => @sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display: none;' : ''}
-    %table.table.table-hover
-      %tbody
-        - has_items = false
-        - widget.miq_widget_shortcuts.order("sequence").each do |ws|
-          - if ws.miq_shortcut && role_allows?(:feature => ws.miq_shortcut.rbac_feature_name, :any => true)
-            - has_items = true
-            %tr
-              %td
-                = link_to(ws.description, ws.miq_shortcut.url, :title => _("Click to go to this location"))
-        - unless has_items
-          = _('No shortcuts are authorized for this user, contact your Administrator')
-          \. . .
+.mc{:id => "dd_w#{widget.id}_box",
+  :style => @sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display: none;' : ''}
+  %table.table.table-hover
+    %tbody
+      - has_items = false
+      - widget.miq_widget_shortcuts.order("sequence").each do |ws|
+        - if ws.miq_shortcut && role_allows?(:feature => ws.miq_shortcut.rbac_feature_name, :any => true)
+          - has_items = true
+          %tr
+            %td
+              = link_to(ws.description, ws.miq_shortcut.url, :title => _("Click to go to this location"))
+      - unless has_items
+        = _('No shortcuts are authorized for this user, contact your Administrator')
+        \. . .

--- a/app/views/dashboard/_widget_report.html.haml
+++ b/app/views/dashboard/_widget_report.html.haml
@@ -1,11 +1,12 @@
 -#
   Parameters:
     widget -- MiqWidget object
-.card-pf-body.report_widget
-  .mc{:id => "dd_w#{widget.id}_box",
-    :style => @sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display: none;' : ''}
-    - if widget.contents_for_user(current_user).contents.blank?
-      = _('No Report data found')
-      \. . .
-    - else
-      = widget.contents_for_user(current_user).contents.html_safe
+.mc{:id => "dd_w#{widget.id}_box",
+:style => @sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display: none;' : ''}
+- if widget.contents_for_user(current_user).contents.blank?
+  .blank-slate-pf{:style => "padding: 10px"}
+    .blank-slate-pf-icon
+      %i.fa.fa-cog
+      %h1= _('No report data found.')
+- else
+  = widget.contents_for_user(current_user).contents.html_safe

--- a/app/views/dashboard/_widget_rss.html.haml
+++ b/app/views/dashboard/_widget_rss.html.haml
@@ -1,11 +1,13 @@
 -#
   Parameters:
     widget: MiqWidget object
-.card-pf-body.rss_widget{:style => "padding: 0"}
-  = hidden_div_if(@sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id), :id => "dd_w#{widget.id}_box") do
-    - if widget.contents_for_user(current_user).contents.blank?
-      = _('No RSS Feed data found')
-      \. . .
-    - else
-      = widget.contents_for_user(current_user).contents.gsub("https://localhost:3000",
-          "#{request.protocol}#{request.host}:#{request.port}").html_safe
+.rss_widget{:style => "padding: 0"}
+= hidden_div_if(@sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id), :id => "dd_w#{widget.id}_box") do
+  - if widget.contents_for_user(current_user).contents.blank?
+    .blank-slate-pf{:style => "padding: 10px"}
+      .blank-slate-pf-icon
+        %i.pficon.pficon-info
+      %h1= _('No RSS Feed data found')
+  - else
+    = widget.contents_for_user(current_user).contents.gsub("https://localhost:3000",
+      "#{request.protocol}#{request.host}:#{request.port}").html_safe


### PR DESCRIPTION
This PR updates the styling of the main dashboard widgets with the latest Patternfly Card markup, fixing a bug where the drop-downs in the right column widgets appear off the screen. It also adds PF "empty state" styling for the various widget types when no data is present.

https://bugzilla.redhat.com/show_bug.cgi?id=1426752

Old
<img width="1457" alt="screen shot 2017-03-17 at 10 29 32 am" src="https://cloud.githubusercontent.com/assets/1287144/24047700/e3a98962-0afc-11e7-89a1-09026c5324a4.png">

New
<img width="1455" alt="screen shot 2017-03-17 at 10 29 03 am" src="https://cloud.githubusercontent.com/assets/1287144/24047701/e3b18afe-0afc-11e7-9207-23ac1d57f842.png">
