### PR TITLE
Added "Copy from Provisioning" button on Retirement tab.

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -314,7 +314,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     var url = '/api/authentications?collection_class=' + typ + '&expand=resources&attributes=id,name' + sort_options;
     API.get(url).then(function (data) {
       vm[prefix + '_cloud_credentials'] = data.resources;
-      vm[prefix + '_cloud_credential'] = _.find(vm[prefix + '_cloud_credentials'], {id: vm.catalogItemModel[prefix + '_cloud_credential_id']});
+      vm['_' + prefix + '_cloud_credential'] = _.find(vm[prefix + '_cloud_credentials'], {id: vm.catalogItemModel[prefix + '_cloud_credential_id']});
     })
   };
 
@@ -403,5 +403,44 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     });
   }
 
+  $scope.cancelCopyProvisioning = function() {
+    closeConfirmationModal();
+  }
+
+  $scope.copyProvisioning = function() {
+    closeConfirmationModal();
+    vm.formOptions();
+    vm.catalogItemModel.retirement_repository_id = vm.catalogItemModel.provisioning_repository_id;
+    vm.catalogItemModel.retirement_playbook_id = vm.catalogItemModel.provisioning_playbook_id;
+    vm.catalogItemModel.retirement_machine_credential_id = vm.catalogItemModel.provisioning_machine_credential_id;
+    vm.catalogItemModel.retirement_network_credential_id = vm.catalogItemModel.provisioning_network_credential_id;
+    vm.catalogItemModel.retirement_cloud_type = vm.catalogItemModel.provisioning_cloud_type;
+    vm.catalogItemModel.retirement_cloud_credential_id = vm.catalogItemModel.provisioning_cloud_credential_id;
+    if (vm.catalogItemModel.retirement_cloud_type !== '')
+      $scope.cloudTypeChanged('retirement');
+    vm.catalogItemModel.retirement_inventory = vm.catalogItemModel.provisioning_inventory;
+    vm.catalogItemModel.retirement_dialog_existing = vm.catalogItemModel.provisioning_dialog_existing;
+    vm.catalogItemModel.retirement_dialog_id = vm.catalogItemModel.provisioning_dialog_id;
+    vm.catalogItemModel.retirement_dialog_name = vm.catalogItemModel.provisioning_dialog_name;
+    vm.catalogItemModel.retirement_key = '';
+    vm.catalogItemModel.retirement_value = '';
+    vm.catalogItemModel.retirement_variables = angular.copy(vm.catalogItemModel.provisioning_variables);
+  }
+
+  var closeConfirmationModal = function() {
+    angular.element('#confirmationModal').modal("hide");
+  }
+
   init();
 }]);
+
+// Javascript function to be called from confirmation modal outside of Angular controller.
+function cancelOrCopyProvisioning(buttonType) {
+  var scope = angular.element("#form_div").scope();
+  scope.$apply(function () {
+    if (buttonType == "cancel")
+      scope.cancelCopyProvisioning();
+    else
+      scope.copyProvisioning();
+  });
+}

--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -286,7 +286,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
         vm.catalogItemModel[prefix + '_playbook_id'] = '';
         vm.catalogItemModel[prefix + '_repository_id'] = id;
       } else {
-        vm['_' + prefix + '_playbook'] = _.find(vm[prefix + '_playbooks'], {id: vm.catalogItemModel[prefix + '_playbook_id']});
+        findObjectForDropDown(prefix, '_playbook', '_playbooks');
       }
     })
   };
@@ -314,9 +314,13 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     var url = '/api/authentications?collection_class=' + typ + '&expand=resources&attributes=id,name' + sort_options;
     API.get(url).then(function (data) {
       vm[prefix + '_cloud_credentials'] = data.resources;
-      vm['_' + prefix + '_cloud_credential'] = _.find(vm[prefix + '_cloud_credentials'], {id: vm.catalogItemModel[prefix + '_cloud_credential_id']});
+      findObjectForDropDown(prefix, '_cloud_credential', '_cloud_credentials');
     })
   };
+
+  var findObjectForDropDown = function(prefix, fieldName, listName) {
+    vm['_' + prefix + fieldName] = _.find(vm[prefix + listName], {id: vm.catalogItemModel[prefix + fieldName + '_id']});
+  }
 
   vm.playbookTypeChanged = function(prefix) {
     if (prefix === "retirement")

--- a/app/views/catalog/_confirmation_modal.html.haml
+++ b/app/views/catalog/_confirmation_modal.html.haml
@@ -1,0 +1,48 @@
+.modal.fade#confirmationModal{"tabindex"        => "-1",
+                             "role"            => "dialog",
+                             "aria-labelledby" => "confirmation_modal_label",
+                             "aria-describedby" => "modal",
+                             "aria-hidden"     => "true",
+                             "data-keyboard"   => "false",
+                             "data-backdrop"   => "static",
+                             :style            => "display: none"}
+  .modal-dialog
+    .modal-content
+      #search_notification{:style => "display: none;"}
+      .modal-header
+        %button.close{"data-dismiss" => "modal"}
+          %span{"aria-hidden" => "true"}
+            &times;
+          %span.sr-only
+            Close
+        %h4.modal-title#confirmation_modal_label
+          = _("Copy from Provisioning")
+      .modal-body
+        .form-group
+          %label.control-label.col-md-2
+            %img{:src => image_path("100/warning.png")}
+          .col-md-8
+            = _("Are you sure you want the retirement options to be copied from provisioning?")
+            %p
+            = _("Warning: You will loose all of your current retirement options if you continue with this action")
+      .modal-footer
+        #confirmation_modal_footer
+          = button_tag(_('Cancel'),
+                   :class   => "btn btn-default",
+                   :alt     => t = _("Cancel Copy from provisioning"),
+                   :title   => t,
+                   :onclick => "cancelOrCopyProvisioning('cancel')")
+          = button_tag(_('Copy'),
+                   :class   => "btn btn-primary",
+                   :alt     => t = _("Copy from provisioning"),
+                   :title   => t,
+                   :onclick => "cancelOrCopyProvisioning('copy')")
+
+:javascript
+  $(function(){
+    $('#confirmationModal').off("click");
+    $('#confirmationModal').on('click', '[data-dismiss="modal"]', function() {
+      $('#confirmationModal').modal("hide")
+    });
+  });
+

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -1,6 +1,22 @@
 - prefix ||= 'provisioning'
 .row
   .col-md-12.col-lg-6
+    - if prefix == "retirement"
+      = render :partial => 'catalog/confirmation_modal'
+      .form-group
+        %label.col-md-3.control-label
+          %table{:width => "100%", :align => "bottom"}
+            %tr
+              %td#buttons_on
+                %button{"type"          => "button",
+                        :class          => "btn btn-default",
+                        "data-toggle"   => "modal",
+                        "data-target"   => "#confirmationModal",
+                        "data-whatever" => "@mdo",
+                        :id             => "confirmation_modal",
+                        :title          => _("Copy from Provisioning")}
+                  = _('Copy from Provisioning')
+
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_repository_id.$invalid}"}
       %label.col-md-3.control-label{"for" => "vm.#{prefix}_repository_id"}
         = _('Repository')


### PR DESCRIPTION
Added Copy from Provisioning button on Retirement tab, that pops up a confirmation modal when button is pressed with Cancel/Copy buttons.

https://www.pivotaltracker.com/story/show/140338133

before
![before](https://cloud.githubusercontent.com/assets/3450808/24058156/6c2d3a54-0b20-11e7-9eca-d06f53260844.png)

after:
![copy_from_provisioning_button](https://cloud.githubusercontent.com/assets/3450808/24058082/1e0a8f3e-0b20-11e7-8f01-a251f7605a6b.png)
![copy_provisioning_confirmation_modal](https://cloud.githubusercontent.com/assets/3450808/24058087/20d6ae1e-0b20-11e7-9324-50b227b5e43e.png)

@epwinchell please review
@gmcculloug please review/test
cc @dclarizio 