### PR TITLE
Add filter selections for the ad-hoc metrics page

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
+++ b/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
@@ -9,6 +9,7 @@ ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', '
     dash.getTenants = httpUtils.getTenants;
     dash.refreshList = httpUtils.refreshList;
     dash.refreshGraph = httpUtils.refreshGraph;
+    dash.setFilterOptions = utils.setFilterOptions;
     dash.setPage = httpUtils.setPage;
 
     var pageSetup = function() {

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
@@ -70,9 +70,18 @@ angular.module('miq.util').factory('metricsConfigFactory', function() {
     ];
 
     dash.timeIntervals = [
-      {title: __("Min interval 1 Minute"), value: 1 * 60},
-      {title: __("Min interval 5 Minutes"), value: 5 * 60},
-      {title: __("Min interval 20 Minutes"), value: 20 * 60}
+      {title: __("1min Average"), value: 1 * 60},
+      {title: __("5min Average"), value: 5 * 60},
+      {title: __("20min Average"), value: 20 * 60},
+      {title: __("1h average"), value: 60 * 60},
+      {title: __("12h average"), value: 12 * 60 * 60}
+    ];
+
+    dash.filterType = "simple";
+
+    dash.filterTypes = [
+      {title: __("Advanced filters"), value: "advanced"},
+      {title: __("Simple filters"), value: "simple"}
     ];
 
     dash.dateOptions = {

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
@@ -75,6 +75,7 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
         if (utils.checkResponse(response) === false) {
           dash.tenantList = [];
           dash.tenant = {value: null};
+          dash.tagsLoaded = true;
           return;
         }
 

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-parse-url-factroy.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-parse-url-factroy.js
@@ -7,7 +7,7 @@ angular.module('miq.util').factory('metricsParseUrlFactory', function() {
     // TODO: get this values from GET/POST values ?
     dash.tenantList = [];
     dash.minBucketDurationInSecondes = 20 * 60;
-    dash.max_metrics = 1000;
+    dash.max_metrics = 10000;
     dash.items_per_page = 10;
   };
 });

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js
@@ -11,6 +11,45 @@ angular.module('miq.util').factory('metricsUtilsFactory', function() {
       return true;
     }
 
+    var setFilterOptionsAlpha = function(tagsData) {
+      for (var i = 0; i < tagsData.length; i++) {
+        var tagItem = tagsData[i];
+
+        dash.filterConfig.fields.push(
+          {
+            id: tagItem.tag,
+            title: tagItem.tag,
+            placeholder: sprintf(__('Filter by %s...'), tagItem.tag),
+            filterType: 'alpha'
+          });
+      }
+    }
+
+    var setFilterOptionsSelect = function(tagsData) {
+      for (var i = 0; i < tagsData.length; i++) {
+        var tagItem = tagsData[i];
+
+        dash.filterConfig.fields.push(
+          {
+            id: tagItem.tag,
+            title: tagItem.tag,
+            placeholder: sprintf(__('Filter by %s...'), tagItem.tag),
+            filterType: 'select',
+            filterValues: tagItem.options
+          });
+      }
+    }
+
+    var setFilterOptions = function() {
+      dash.filterConfig.fields = [];
+
+      if (dash.filterType === 'simple') {
+        setFilterOptionsSelect(dash.metricTags);
+      } else {
+        setFilterOptionsAlpha(dash.metricTags);
+      }
+    }
+
     var getMetricTagsData = function(response) {
       'use strict';
       dash.tagsLoaded = true;
@@ -23,16 +62,14 @@ angular.module('miq.util').factory('metricsUtilsFactory', function() {
 
       dash.filterConfig.fields = [];
       if (data && angular.isArray(data.metric_tags)) {
+        // filters available, apply filtering
         data.metric_tags.sort();
-        for (var i = 0; i < data.metric_tags.length; i++) {
-          dash.filterConfig.fields.push(
-            {
-              id: data.metric_tags[i],
-              title: data.metric_tags[i],
-              placeholder: sprintf(__('Filter by %s...'), data.metric_tags[i]),
-              filterType: 'alpha',
-            });
-        }
+
+        // remember the metric tags
+        dash.metricTags = data.metric_tags;
+
+        // apply dash.metricTags to the filter form
+        setFilterOptions();
       }
     }
 
@@ -66,7 +103,7 @@ angular.module('miq.util').factory('metricsUtilsFactory', function() {
         return;
       }
 
-      var data = response.data.data;
+      var data = response.data.data.sort(function(a, b) { return a.timestamp < b.timestamp; });
 
       item.lastValues = {};
       angular.forEach(data, function(d) {
@@ -102,7 +139,8 @@ angular.module('miq.util').factory('metricsUtilsFactory', function() {
       getMetricTagsData: getMetricTagsData,
       getContainerParamsData: getContainerParamsData,
       getContainerDashboardData: getContainerDashboardData,
-      checkResponse: checkResponse
+      checkResponse: checkResponse,
+      setFilterOptions: setFilterOptions
     }
   }
 });

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js
@@ -62,7 +62,6 @@ angular.module('miq.util').factory('metricsUtilsFactory', function() {
 
       dash.filterConfig.fields = [];
       if (data && angular.isArray(data.metric_tags)) {
-        // filters available, apply filtering
         data.metric_tags.sort();
 
         // remember the metric tags

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -103,7 +103,17 @@ class HawkularProxyService
       x["tags"].keys if x["tags"]
     end
 
-    tags.compact.flatten.uniq.sort
+    tags.compact.flatten.uniq.sort.map do |tag|
+      {:tag => tag, :options => metric_tags_options(tag, definitions)}
+    end
+  end
+
+  def metric_tags_options(tag, definitions)
+    options = definitions.map do |x|
+      x["tags"][tag] if x["tags"] && x["tags"].keys.include?(tag)
+    end
+
+    options.compact.flatten.uniq.sort
   end
 
   def get_data(id, params)

--- a/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
@@ -29,14 +29,18 @@
     %button.btn.btn-primary.pull-left{"type" => "button", "ng-click" => "dash.refreshGraph()"}
       = _("Refresh")
 
-    %dropdown.dropdown-kebab-pf.pull-left
+    %dropdown.dropdown-kebab-pf
       %button.btn.btn-link.dropdown-toggle{"type"          => "button",
                                            "data-toggle"   => "dropdown",
                                            "aria-haspopup" => "true",
                                            "aria-expanded" => "true"}
-        %span.fa.fa-ellipsis-v
+        %span.fa.fa-fw.fa-ellipsis-v
       %ul.dropdown-menu{"aria-labelledby" => "dropdownKebab"}
         %li{"ng-repeat" => "range in dash.timeIntervals"}
           %a{"href"     => "#",
              "ng-click" => "dash.minBucketDurationInSecondes = range.value; dash.refreshGraph()"}
-            {{range.title}}
+            .row
+              .col-md-9
+                {{range.title}}
+              .col
+                %span.pficon{"ng-class" => "{true: 'pficon-ok'}[dash.minBucketDurationInSecondes===range.value]"}

--- a/app/views/ems_container/ad_hoc/_list_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_list_view_form.html.haml
@@ -1,4 +1,4 @@
-.col-md-12.ad-hoc-tenant
+.col-md-12.tenant-filter-bar
   .form-group.pull-left.ad-hoc-tenant
     %button.btn.btn-primary{"type"        => "button",
                             "ng-disabled" => "!dash.tenantChanged",
@@ -28,7 +28,22 @@
                             "ng-disabled" => "!dash.itemSelected"}
       = _("View Graph")
 
-  = # TODO: pagination should move inside the #paging-div element once #592 is complete
+    %dropdown.dropdown-kebab-pf
+      %button.btn.btn-link.dropdown-toggle{"type"          => "button",
+                                           "data-toggle"   => "dropdown",
+                                           "aria-haspopup" => "true",
+                                           "aria-expanded" => "true"}
+        %span.fa.fa-fw.fa-ellipsis-v
+      %ul.dropdown-menu{"aria-labelledby" => "dropdownKebab"}
+        %li{"ng-repeat" => "range in dash.filterTypes"}
+          %a{"href"     => "#",
+             "ng-click" => "dash.filterType = range.value; dash.setFilterOptions()"}
+            .row
+              .col-md-9
+                {{range.title}}
+              .col
+                %span.pficon{"ng-class" => "{true: 'pficon-ok'}[dash.filterType===range.value]"}
+
   .form-group.pagination-div
     %ul.pagination.pagination-pf-back
       %li

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -19,7 +19,7 @@ describe('adHocMetricsController', function() {
     $httpBackend = _$httpBackend_;
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&query=get_tenants').respond(mock_tenants_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_system&query=metric_tags&limit=250').respond(mock_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_system&limit=1000&query=metric_definitions&tags={}&page=1&items_per_page=10').respond(mock_metrics_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_system&limit=10000&query=metric_definitions&tags={}&page=1&items_per_page=10').respond(mock_metrics_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauge&tenant=_system&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
     $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauge&tenant=_system&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
     $controller = _$controller_('adHocMetricsController');


### PR DESCRIPTION
**Description**

Compute > Containers > Providers - pick a provider - toolbar Monitoring > Ad hoc Metrics

Make filter options easier to discover. Make the filters input element a select instead of free text input.  

(*) an optional "Advansed" option is available the revert to text view for filtering-savvy users. 

**Screenshot**
![gifrecord_2017-03-19_132147](https://cloud.githubusercontent.com/assets/2181522/24080411/489586cc-0ca7-11e7-9bd9-b39b66a09a84.gif)
