### PR TITLE
Renamed listicon_image to a more descriptive fileicon

### DIFF
--- a/app/controllers/alerts_list_controller.rb
+++ b/app/controllers/alerts_list_controller.rb
@@ -22,8 +22,8 @@ class AlertsListController < ApplicationController
       'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
       'ManageIQ::Providers::Openshift::ContainerManager',
     ].each do |klass|
-      listicon_image = klass.constantize.decorate.listicon_image
-      res[klass] = ActionController::Base.helpers.image_path(listicon_image)
+      fileicon = klass.constantize.decorate.fileicon
+      res[klass] = ActionController::Base.helpers.image_path(fileicon)
     end
     render :json => res
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -878,7 +878,7 @@ class ApplicationController < ActionController::Base
         item = listicon_item(view, row['id'])
 
         new_row[:cells] << {:title => _('View this item'),
-                            :image => listicon_image(item, view),
+                            :image => fileicon(item, view),
                             :icon  => listicon_icon(item)}
       end
 
@@ -962,13 +962,13 @@ class ApplicationController < ActionController::Base
   end
 
   # Return the icon classname for the list view icon of a db,id pair
-  # this always supersedes listicon_image if not nil
+  # this always supersedes fileicon if not nil
   def listicon_icon(item)
     item.decorate.try(:fonticon)
   end
 
   # Return the image name for the list view icon of a db,id pair
-  def listicon_image(item, view)
+  def fileicon(item, view)
     default = "100/#{(@listicon || view.db).underscore}.png"
 
     image = case item
@@ -977,11 +977,11 @@ class ApplicationController < ActionController::Base
             when Storage
               "100/piecharts/datastore/#{calculate_pct_img(item.v_free_space_percent_of_total)}.png"
             when MiqRequest
-              item.decorate.listicon_image || "100/#{@listicon.downcase}.png"
+              item.decorate.fileicon || "100/#{@listicon.downcase}.png"
             when ManageIQ::Providers::CloudManager::AuthKeyPair
               "100/auth_key_pair.png"
             else
-              item.decorate.try(:listicon_image)
+              item.decorate.try(:fileicon)
             end
 
     image || default

--- a/app/controllers/ems_datawarehouse_controller.rb
+++ b/app/controllers/ems_datawarehouse_controller.rb
@@ -31,8 +31,8 @@ class EmsDatawarehouseController < ApplicationController
     ems_datawarehouse_path(*args)
   end
 
-  def listicon_image(item, _view)
-    item.decorate.try(:listicon_image)
+  def fileicon(item, _view)
+    item.decorate.try(:fileicon)
   end
 
   def new_ems_path

--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -30,8 +30,8 @@ class EmsMiddlewareController < ApplicationController
     new_ems_middleware_path
   end
 
-  def listicon_image(item, _view)
-    icon = item.decorate.try(:listicon_image)
+  def fileicon(item, _view)
+    icon = item.decorate.try(:fileicon)
   end
 
   def restful?

--- a/app/decorators/auth_private_key_decorator.rb
+++ b/app/decorators/auth_private_key_decorator.rb
@@ -3,7 +3,7 @@ class AuthPrivateKeyDecorator < MiqDecorator
     nil
   end
 
-  def self.listicon_image
+  def self.fileicon
     "100/auth_key_pair.png"
   end
 end

--- a/app/decorators/availability_zone_decorator.rb
+++ b/app/decorators/availability_zone_decorator.rb
@@ -3,7 +3,7 @@ class AvailabilityZoneDecorator < MiqDecorator
     'pficon pficon-zone'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/availability_zone.png'
   end
 end

--- a/app/decorators/cloud_network_decorator.rb
+++ b/app/decorators/cloud_network_decorator.rb
@@ -3,7 +3,7 @@ class CloudNetworkDecorator < MiqDecorator
     'product product-cloud_network'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/cloud_network.png'
   end
 end

--- a/app/decorators/cloud_object_store_container_decorator.rb
+++ b/app/decorators/cloud_object_store_container_decorator.rb
@@ -3,7 +3,7 @@ class CloudObjectStoreContainerDecorator < MiqDecorator
     'product product-cloud_object_store'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/cloud_object_store_container.png'
   end
 end

--- a/app/decorators/cloud_object_store_object_decorator.rb
+++ b/app/decorators/cloud_object_store_object_decorator.rb
@@ -3,7 +3,7 @@ class CloudObjectStoreObjectDecorator < MiqDecorator
     'product product-cloud_object_store'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/cloud_object_store_container.png'
   end
 end

--- a/app/decorators/cloud_subnet_decorator.rb
+++ b/app/decorators/cloud_subnet_decorator.rb
@@ -3,7 +3,7 @@ class CloudSubnetDecorator < MiqDecorator
     'pficon pficon-network'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/cloud_subnet.png'
   end
 end

--- a/app/decorators/cloud_tenant_decorator.rb
+++ b/app/decorators/cloud_tenant_decorator.rb
@@ -3,7 +3,7 @@ class CloudTenantDecorator < MiqDecorator
     'pficon pficon-cloud-tenant'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/cloud_tenant.png'
   end
 end

--- a/app/decorators/cloud_volume_backup_decorator.rb
+++ b/app/decorators/cloud_volume_backup_decorator.rb
@@ -3,7 +3,7 @@ class CloudVolumeBackupDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/cloud_volume.png'
   end
 end

--- a/app/decorators/cloud_volume_decorator.rb
+++ b/app/decorators/cloud_volume_decorator.rb
@@ -3,7 +3,7 @@ class CloudVolumeDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/cloud_volume.png'
   end
 end

--- a/app/decorators/cloud_volume_snapshot_decorator.rb
+++ b/app/decorators/cloud_volume_snapshot_decorator.rb
@@ -3,7 +3,7 @@ class CloudVolumeSnapshotDecorator < MiqDecorator
     'fa fa-camera'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/cloud_volume_snapshot.png'
   end
 end

--- a/app/decorators/configuration_profile_decorator.rb
+++ b/app/decorators/configuration_profile_decorator.rb
@@ -7,7 +7,7 @@ class ConfigurationProfileDecorator < MiqDecorator
     end
   end
 
-  def listicon_image
+  def fileicon
     if id.nil?
       "100/folder.png"
     else

--- a/app/decorators/configuration_script_source_decorator.rb
+++ b/app/decorators/configuration_script_source_decorator.rb
@@ -3,7 +3,7 @@ class ConfigurationScriptSourceDecorator < MiqDecorator
     "pficon pficon-repository"
   end
 
-  def self.listicon_image
+  def self.fileicon
     nil
   end
 end

--- a/app/decorators/configured_system_decorator.rb
+++ b/app/decorators/configured_system_decorator.rb
@@ -3,7 +3,7 @@ class ConfiguredSystemDecorator < MiqDecorator
     'product product-configured_system'
   end
 
-  def listicon_image
+  def fileicon
     "100/#{image_name.downcase}.png"
   end
 end

--- a/app/decorators/container_build_decorator.rb
+++ b/app/decorators/container_build_decorator.rb
@@ -3,7 +3,7 @@ class ContainerBuildDecorator < MiqDecorator
     'pficon pficon-build'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/container_build.png'
   end
 end

--- a/app/decorators/container_decorator.rb
+++ b/app/decorators/container_decorator.rb
@@ -3,7 +3,7 @@ class ContainerDecorator < MiqDecorator
     'fa fa-cube'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/container.png'
   end
 end

--- a/app/decorators/container_group_decorator.rb
+++ b/app/decorators/container_group_decorator.rb
@@ -3,7 +3,7 @@ class ContainerGroupDecorator < MiqDecorator
     'fa fa-cubes'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/container_group.png'
   end
 end

--- a/app/decorators/container_image_decorator.rb
+++ b/app/decorators/container_image_decorator.rb
@@ -3,7 +3,7 @@ class ContainerImageDecorator < MiqDecorator
     'pficon pficon-image'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/container_image.png'
   end
 end

--- a/app/decorators/container_image_registry_decorator.rb
+++ b/app/decorators/container_image_registry_decorator.rb
@@ -3,7 +3,7 @@ class ContainerImageRegistryDecorator < MiqDecorator
     'pficon pficon-registry'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/container_image_registry.png'
   end
 end

--- a/app/decorators/container_node_decorator.rb
+++ b/app/decorators/container_node_decorator.rb
@@ -3,7 +3,7 @@ class ContainerNodeDecorator < MiqDecorator
     'pficon pficon-container-node'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/container_node.png'
   end
 end

--- a/app/decorators/container_project_decorator.rb
+++ b/app/decorators/container_project_decorator.rb
@@ -3,7 +3,7 @@ class ContainerProjectDecorator < MiqDecorator
     'pficon pficon-project'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/container_project.png'
   end
 end

--- a/app/decorators/container_replicator_decorator.rb
+++ b/app/decorators/container_replicator_decorator.rb
@@ -3,7 +3,7 @@ class ContainerReplicatorDecorator < MiqDecorator
     'pficon pficon-replicator'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/container_replicator.png'
   end
 end

--- a/app/decorators/container_route_decorator.rb
+++ b/app/decorators/container_route_decorator.rb
@@ -3,7 +3,7 @@ class ContainerRouteDecorator < MiqDecorator
     'pficon pficon-route'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/container_route.png'
   end
 end

--- a/app/decorators/container_service_decorator.rb
+++ b/app/decorators/container_service_decorator.rb
@@ -3,7 +3,7 @@ class ContainerServiceDecorator < MiqDecorator
     'pficon pficon-service'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/container_service.png'
   end
 end

--- a/app/decorators/container_template_decorator.rb
+++ b/app/decorators/container_template_decorator.rb
@@ -3,7 +3,7 @@ class ContainerTemplateDecorator < MiqDecorator
     'product product-template'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/container_template.png'
   end
 end

--- a/app/decorators/ems_cluster_decorator.rb
+++ b/app/decorators/ems_cluster_decorator.rb
@@ -3,7 +3,7 @@ class EmsClusterDecorator < MiqDecorator
     'pficon pficon-cluster'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/ems_cluster.png'
   end
 end

--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -3,7 +3,7 @@ class ExtManagementSystemDecorator < MiqDecorator
     nil
   end
 
-  def listicon_image
+  def fileicon
     "svg/vendor-#{image_name}.svg"
   end
 end

--- a/app/decorators/flavor_decorator.rb
+++ b/app/decorators/flavor_decorator.rb
@@ -3,7 +3,7 @@ class FlavorDecorator < MiqDecorator
     'pficon pficon-flavor'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/flavor.png'
   end
 end

--- a/app/decorators/floating_ip_decorator.rb
+++ b/app/decorators/floating_ip_decorator.rb
@@ -3,7 +3,7 @@ class FloatingIpDecorator < MiqDecorator
     'fa fa-map-marker'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/floating_ip.png'
   end
 end

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -3,7 +3,7 @@ class HostDecorator < MiqDecorator
     'pficon pficon-screen'
   end
 
-  def listicon_image
+  def fileicon
     "svg/vendor-#{vmm_vendor_display.downcase}.svg"
   end
 end

--- a/app/decorators/lan_decorator.rb
+++ b/app/decorators/lan_decorator.rb
@@ -3,7 +3,7 @@ class LanDecorator < MiqDecorator
     'product product-network_switch'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/network_switch.png'
   end
 end

--- a/app/decorators/load_balancer_decorator.rb
+++ b/app/decorators/load_balancer_decorator.rb
@@ -3,7 +3,7 @@ class LoadBalancerDecorator < MiqDecorator
     'product product-load_balancer'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/load_balancer.png'
   end
 end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::AnsibleTower
       'product product-template'
     end
 
-    def self.listicon_image
+    def self.fileicon
       '100/configuration_script.png'
     end
   end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::AnsibleTower
       'product product-orchestration_stack'
     end
 
-    def self.listicon_image
+    def self.fileicon
       '100/orchestration_stack.png'
     end
   end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::AnsibleTower
       nil
     end
 
-    def self.listicon_image
+    def self.fileicon
       'svg/vendor-ansible.svg'
     end
   end

--- a/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'fa fa-lock'
     end
 
-    def self.listicon_image
+    def self.fileicon
       '100/authentication.png'
     end
   end

--- a/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'pficon pficon-folder-close'
     end
 
-    def self.listicon_image
+    def self.fileicon
       '100/inventory_group.png'
     end
   end

--- a/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'pficon pficon-folder-close'
     end
 
-    def self.listicon_image
+    def self.fileicon
       '100/inventory_group.png'
     end
   end

--- a/app/decorators/manageiq/providers/automation_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       nil
     end
 
-    def listicon_image
+    def fileicon
       "svg/vendor-#{image_name.downcase}.svg"
     end
   end

--- a/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'product product-orchestration_stack'
     end
 
-    def self.listicon_image
+    def self.fileicon
       "100/orchestration_stack.png"
     end
   end

--- a/app/decorators/manageiq/providers/configuration_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/configuration_manager_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       nil
     end
 
-    def listicon_image
+    def fileicon
       "svg/vendor-#{image_name.downcase}.svg"
     end
   end

--- a/app/decorators/manageiq/providers/embedded_ansible/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_ansible/automation_manager/playbook_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::EmbeddedAnsible
       nil
     end
 
-    def self.listicon_image
+    def self.fileicon
       'svg/vendor-ansible.svg'
     end
   end

--- a/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'fa fa-lock'
     end
 
-    def self.listicon_image
+    def self.fileicon
       '100/authentication.png'
     end
   end

--- a/app/decorators/manageiq/providers/embedded_automation_manager/configuration_script_source_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/configuration_script_source_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       "pficon pficon-repository"
     end
 
-    def self.listicon_image
+    def self.fileicon
       nil
     end
   end

--- a/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::Hawkular
       nil
     end
 
-    def self.listicon_image
+    def self.fileicon
       "svg/vendor-hawkular.svg"
     end
   end

--- a/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Kubernetes
   class ContainerManagerDecorator < MiqDecorator
-    def self.listicon_image
+    def self.fileicon
       "svg/vendor-kubernetes.svg"
     end
   end

--- a/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Openshift
   class ContainerManagerDecorator < MiqDecorator
-    def self.listicon_image
+    def self.fileicon
       "svg/vendor-openshift.svg"
     end
   end

--- a/app/decorators/manageiq/providers/storage_manager/cinder_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager/cinder_manager_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class StorageManager::CinderManagerDecorator < MiqDecorator
-    def self.listicon_image
+    def self.fileicon
       "svg/vendor-cinder.svg"
     end
   end

--- a/app/decorators/manageiq/providers/storage_manager/swift_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager/swift_manager_decorator.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class StorageManager::SwiftManagerDecorator < MiqDecorator
-    def self.listicon_image
+    def self.fileicon
       "svg/vendor-swift.svg"
     end
   end

--- a/app/decorators/middleware_datasource_decorator.rb
+++ b/app/decorators/middleware_datasource_decorator.rb
@@ -3,7 +3,7 @@ class MiddlewareDatasourceDecorator < MiqDecorator
     'fa fa-database'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/middleware_datasource.png'
   end
 end

--- a/app/decorators/middleware_deployment_decorator.rb
+++ b/app/decorators/middleware_deployment_decorator.rb
@@ -13,7 +13,7 @@ class MiddlewareDeploymentDecorator < MiqDecorator
     end
   end
 
-  def listicon_image
+  def fileicon
     if name.end_with? '.ear'
       '100/middleware_deployment_ear.png'
     elsif name.end_with? '.war'

--- a/app/decorators/middleware_domain_decorator.rb
+++ b/app/decorators/middleware_domain_decorator.rb
@@ -3,7 +3,7 @@ class MiddlewareDomainDecorator < MiqDecorator
     'pficon-domain'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/middleware_domain.png'
   end
 end

--- a/app/decorators/middleware_messaging_decorator.rb
+++ b/app/decorators/middleware_messaging_decorator.rb
@@ -3,7 +3,7 @@ class MiddlewareMessagingDecorator < MiqDecorator
     'fa fa-exchange'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/middleware_messaging.png'
   end
 end

--- a/app/decorators/middleware_server_decorator.rb
+++ b/app/decorators/middleware_server_decorator.rb
@@ -3,7 +3,7 @@ class MiddlewareServerDecorator < MiqDecorator
     nil
   end
 
-  def listicon_image
+  def fileicon
     case product
     when 'Hawkular'
       'svg/vendor-hawkular.svg'

--- a/app/decorators/middleware_server_group_decorator.rb
+++ b/app/decorators/middleware_server_group_decorator.rb
@@ -3,7 +3,7 @@ class MiddlewareServerGroupDecorator < MiqDecorator
     'pficon-server-group'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/middleware_server_group.png'
   end
 end

--- a/app/decorators/miq_request_decorator.rb
+++ b/app/decorators/miq_request_decorator.rb
@@ -8,7 +8,7 @@ class MiqRequestDecorator < MiqDecorator
     end
   end
 
-  def listicon_image
+  def fileicon
     case request_status.to_s.downcase
     when "ok"
       "100/checkmark.png"

--- a/app/decorators/network_port_decorator.rb
+++ b/app/decorators/network_port_decorator.rb
@@ -3,7 +3,7 @@ class NetworkPortDecorator < MiqDecorator
     'fa product-network_port'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/network_port.png'
   end
 end

--- a/app/decorators/network_router_decorator.rb
+++ b/app/decorators/network_router_decorator.rb
@@ -3,7 +3,7 @@ class NetworkRouterDecorator < MiqDecorator
     'pficon pficon-route'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/network_router.png'
   end
 end

--- a/app/decorators/persistent_volume_decorator.rb
+++ b/app/decorators/persistent_volume_decorator.rb
@@ -3,7 +3,7 @@ class PersistentVolumeDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/persistent_volume.png'
   end
 end

--- a/app/decorators/registry_item_decorator.rb
+++ b/app/decorators/registry_item_decorator.rb
@@ -3,7 +3,7 @@ class RegistryItemDecorator < MiqDecorator
     nil
   end
 
-  def listicon_image
+  def fileicon
     "100/#{image_name.downcase}.png"
   end
 end

--- a/app/decorators/resource_pool_decorator.rb
+++ b/app/decorators/resource_pool_decorator.rb
@@ -3,7 +3,7 @@ class ResourcePoolDecorator < MiqDecorator
     'pficon pficon-resource-pool'
   end
 
-  def listicon_image
+  def fileicon
     vapp ? '100/vapp.png' : '100/resource_pool.png'
   end
 end

--- a/app/decorators/security_group_decorator.rb
+++ b/app/decorators/security_group_decorator.rb
@@ -3,7 +3,7 @@ class SecurityGroupDecorator < MiqDecorator
     'pficon pficon-cloud-security'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/security_group.png'
   end
 end

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -3,7 +3,7 @@ class ServiceDecorator < MiqDecorator
     'pficon pficon-service'
   end
 
-  def listicon_image
+  def fileicon
     try(:picture) ? "/pictures/#{picture.basename}" : "100/service.png"
   end
 end

--- a/app/decorators/service_resource_decorator.rb
+++ b/app/decorators/service_resource_decorator.rb
@@ -3,7 +3,7 @@ class ServiceResourceDecorator < MiqDecorator
     resource_type.to_s == 'VmOrTemplate' ? 'pficon pficon-virtual-machine' : 'product product-template'
   end
 
-  def listicon_image
+  def fileicon
     resource_type.to_s == 'VmOrTemplate' ? '100/vm.png' : '100/service_template.png'
   end
 end

--- a/app/decorators/service_template_ansible_tower_decorator.rb
+++ b/app/decorators/service_template_ansible_tower_decorator.rb
@@ -3,7 +3,7 @@ class ServiceTemplateAnsibleTowerDecorator < MiqDecorator
     'product product-template'
   end
 
-  def listicon_image
+  def fileicon
     try(:picture) ? "/pictures/#{picture.basename}" : "100/service_template.png"
   end
 end

--- a/app/decorators/service_template_decorator.rb
+++ b/app/decorators/service_template_decorator.rb
@@ -3,7 +3,7 @@ class ServiceTemplateDecorator < MiqDecorator
     'product product-template'
   end
 
-  def listicon_image
+  def fileicon
     try(:picture) ? "/pictures/#{picture.basename}" : "100/service_template.png"
   end
 end

--- a/app/decorators/switch_decorator.rb
+++ b/app/decorators/switch_decorator.rb
@@ -3,7 +3,7 @@ class SwitchDecorator < MiqDecorator
     'product product-network_switch'
   end
 
-  def self.listicon_image
+  def self.fileicon
     '100/network_switch.png'
   end
 end

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -3,7 +3,7 @@ class VmOrTemplateDecorator < MiqDecorator
     nil
   end
 
-  def listicon_image
+  def fileicon
     "svg/vendor-#{vendor.downcase}.svg"
   end
 

--- a/app/decorators/windows_image_decorator.rb
+++ b/app/decorators/windows_image_decorator.rb
@@ -1,5 +1,5 @@
 class WindowsImageDecorator < MiqDecorator
-  def self.listicon_image
+  def self.fileicon
     'svg/os-windows_generic.svg'
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1508,7 +1508,7 @@ module ApplicationHelper
     x_tree && ((tree_with_advanced_search? && !@record) || @show_adv_search)
   end
 
-  def listicon_image_tag(db, row)
+  def fileicon_tag(db, row)
     icon = nil
     if %w(Job MiqTask).include?(db)
       if row["state"].downcase == "finished" && row["status"]
@@ -1613,7 +1613,7 @@ module ApplicationHelper
     if %w(MiqReportResult MiqSchedule MiqUserRole MiqWidget).include?(db)
       listicon_glyphicon_tag(db, row)
     else
-      listicon_image_tag(db, row)
+      fileicon_tag(db, row)
     end
   end
 

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -426,7 +426,7 @@ module QuadiconHelper
 
     output << content_tag(:div, :class => "flobj e72") do
       quadicon_link_to(url, **link_opts) do
-        quadicon_reflection_img(:path => item.decorate.listicon_image)
+        quadicon_reflection_img(:path => item.decorate.fileicon)
       end
     end
 
@@ -555,7 +555,7 @@ module QuadiconHelper
     output = []
 
     img_path = if item.decorate
-                 item.decorate.try(:listicon_image)
+                 item.decorate.try(:fileicon)
                else
                  "100/#{item.class.base_class.to_s.underscore}.png"
                end

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -145,7 +145,7 @@ module TextualSummaryHelper
 
   def textual_object_icon(object, klass)
     icon = object.decorate.try(:fonticon)
-    image = object.decorate.try(:listicon_image)
+    image = object.decorate.try(:fileicon)
 
     if icon || image
       {:icon => icon, :image => image}
@@ -160,7 +160,7 @@ module TextualSummaryHelper
 
   def textual_class_icon(klass)
     icon = klass.decorate.try(:fonticon)
-    image = klass.decorate.try(:listicon_image)
+    image = klass.decorate.try(:fileicon)
 
     if icon || image
       {:icon => icon, :image => image}

--- a/app/presenters/tree_node/ext_management_system.rb
+++ b/app/presenters/tree_node/ext_management_system.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class ExtManagementSystem < Node
-    set_attribute(:image) { @object.decorate.listicon_image }
+    set_attribute(:image) { @object.decorate.fileicon }
 
     set_attribute(:tooltip) do
       # # TODO: This should really leverage .base_model on an EMS

--- a/app/presenters/tree_node/service.rb
+++ b/app/presenters/tree_node/service.rb
@@ -2,7 +2,7 @@ module TreeNode
   class Service < Node
     set_attributes(:image, :icon) do
       if @object.picture
-        image = @object.decorate.listicon_image
+        image = @object.decorate.fileicon
       else
         icon = @object.decorate.fonticon
       end

--- a/app/presenters/tree_node/service_template.rb
+++ b/app/presenters/tree_node/service_template.rb
@@ -2,7 +2,7 @@ module TreeNode
   class ServiceTemplate < Node
     set_attributes(:image, :icon) do
       if @object.picture
-        image = @object.decorate.listicon_image
+        image = @object.decorate.fileicon
       else
         icon = @object.decorate.fonticon
       end

--- a/app/presenters/tree_node/windows_image.rb
+++ b/app/presenters/tree_node/windows_image.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class WindowsImage < Node
-    set_attribute(:image) { @object.decorate.listicon_image }
+    set_attribute(:image) { @object.decorate.fileicon }
   end
 end

--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -60,7 +60,7 @@ class MiddlewareTopologyService < TopologyService
     data[:display_kind] = entity_display_type(entity)
 
     unless glyph? entity
-      data[:icon] = ActionController::Base.helpers.image_path(entity.decorate.try(:listicon_image))
+      data[:icon] = ActionController::Base.helpers.image_path(entity.decorate.try(:fileicon))
     end
 
     if entity.kind_of?(Vm)

--- a/lib/miq_decorator.rb
+++ b/lib/miq_decorator.rb
@@ -12,12 +12,12 @@ class MiqDecorator < SimpleDelegator
     end
 
     # Initialize these two attributes with default to nil
-    attr_reader :fonticon, :listicon_image
+    attr_reader :fonticon, :fileicon
   end
 
   # Call the class methods with identical names if these are not set
   delegate :fonticon, :to => :class
-  delegate :listicon_image, :to => :class
+  delegate :fileicon, :to => :class
 end
 
 module MiqDecorator::Instance

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -36,7 +36,7 @@ describe MiqRequestController do
     it "displays miq_request for parent_tenant, when request was added by child_parent" do
       login_as user_parent_tenant
       controller.instance_variable_set(:@settings, {})
-      allow_any_instance_of(MiqRequestController).to receive(:listicon_image)
+      allow_any_instance_of(MiqRequestController).to receive(:fileicon)
 
       view, _pages = controller.send(:get_view, MiqRequest, {})
       expect(view.table.data.count).to eq(1)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1124,10 +1124,10 @@ describe ApplicationHelper do
     end
   end
 
-  context "#listicon_image_tag" do
+  context "#fileicon_tag" do
     it "returns correct image for job record based upon it's status" do
       job_attrs = {"state" => "running", "status" => "ok"}
-      image = helper.listicon_image_tag("Job", job_attrs)
+      image = helper.fileicon_tag("Job", job_attrs)
       expect(image).to eq("<i class=\"pficon pficon-running\" title=\"Status = Running\"></i>")
     end
   end


### PR DESCRIPTION
We agreed with @himdel and @epwinchell that the `listicon_image` is not the most descriptive name for a decorator method returning a path to a file.

@miq-bot add_label refactoring, euwe/no, graphics