### PR TITLE
Remove Y bottom padding for charts

### DIFF
--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -58,7 +58,7 @@ module ReportFormatter
       mri.chart = {
         :miqChart => type,
         :data     => {:columns => [], :names => {}},
-        :axis     => {:x => {:tick => {}}, :y => {:tick => {}}},
+        :axis     => {:x => {:tick => {}}, :y => {:tick => {}, :padding => {:bottom => 0}}},
         :tooltip  => {:format => {}},
         :miq      => {:name_table => {}, :category_table => {}},
         :legend   => {}
@@ -97,7 +97,7 @@ module ReportFormatter
         return unless format
 
         axis_formatter = {:function => format, :options => options}
-        mri.chart[:axis][:y] = {:tick => {:format => axis_formatter}}
+        mri.chart[:axis][:y][:tick] = {:format => axis_formatter}
         mri.chart[:miq][:format] = axis_formatter
       end
     end


### PR DESCRIPTION
Remove Y bottom padding for charts

Screenshots:

Before:
![screenshot from 2017-03-20 15-07-37](https://cloud.githubusercontent.com/assets/9535558/24103416/7c6c2b26-0d7f-11e7-9457-7c9e98d90f08.png)

After:
![screenshot from 2017-03-20 15-11-16](https://cloud.githubusercontent.com/assets/9535558/24103418/7df47ba6-0d7f-11e7-815b-5c386b1dcab6.png)
