### PR TITLE
Fix volume attach/detach flash messages

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -198,8 +198,8 @@ class CloudVolumeController < ApplicationController
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
       add_flash(_("Attaching Cloud Volume \"%{volume_name}\" to %{vm_name} finished") % {
-        :name    => volume_name,
-        :vm_name => vm.name
+        :volume_name => volume_name,
+        :vm_name     => vm.name
       })
     else
       add_flash(_("Unable to attach Cloud Volume \"%{volume_name}\" to %{vm_name}: %{details}") % {
@@ -255,14 +255,14 @@ class CloudVolumeController < ApplicationController
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
       add_flash(_("Detaching Cloud Volume \"%{volume_name}\" from %{vm_name} finished") % {
-        :name    => volume_name,
-        :vm_name => vm.name
+        :volume_name => volume_name,
+        :vm_name     => vm.name
       })
     else
       add_flash(_("Unable to detach Cloud Volume \"%{volume_name}\" from %{vm_name}: %{details}") % {
-        :name    => volume_name,
-        :vm_name => vm.name,
-        :details => task.message
+        :volume_name => volume_name,
+        :vm_name     => vm.name,
+        :details     => task.message
       }, :error)
     end
 


### PR DESCRIPTION
Flash message that is displayed right after a volume is attached/detached, doe not properly substitute variables because the volume name variable was incorrect (`name` instead of `volume_name`).

This patch updates the flash messagae substitutions.

Before the change:

```
Attaching Cloud Volume "%{volume_name}" to %{vm_name} finished
Detaching Cloud Volume "%{volume_name}" from %{vm_name} finished
```

After this change:

```
Attaching Cloud Volume "vol-aws1" to miq-t2.micro finished
Detaching Cloud Volume "vol-aws1" from miq-t2.micro finished
```