### PR TITLE
Enable attach/detach operations to storage manager

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -454,6 +454,10 @@ module EmsCommon
       javascript_redirect :controller => "cloud_tenant", :action => "edit", :id => find_checked_items[0]
     elsif params[:pressed] == "cloud_volume_new"
       javascript_redirect :controller => "cloud_volume", :action => "new", :storage_manager_id => params[:id]
+    elsif params[:pressed] == "cloud_volume_attach"
+      javascript_redirect :controller => "cloud_volume", :action => "attach", :id => find_checked_items[0]
+    elsif params[:pressed] == "cloud_volume_detach"
+      javascript_redirect :controller => "cloud_volume", :action => "detach", :id => find_checked_items[0]
     elsif params[:pressed] == "cloud_volume_edit"
       javascript_redirect :controller => "cloud_volume", :action => "edit", :id => find_checked_items[0]
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",


### PR DESCRIPTION
Attaching volume is currently not possible from within the list of cloud volumes of a chosen storage manager because the handler in `ems_common` does not have a path for the button (even though attach/detach option is enabled).

This patch adds the missing handlers and redirects to the required `cloud_volume` controller.

Video: http://x.k00.fr/6wmos (apologies for a short switch to the terminal, but I had a `binding.pry` there).

Somewhat related to https://github.com/ManageIQ/manageiq-ui-classic/pull/715 where I added ability to [create new cloud volume](https://github.com/ManageIQ/manageiq-ui-classic/pull/715/files#diff-b15abebae5d7479a3f420968741aa04eR497) from within the storage manager volume list.

@miq-bot add_label bug,storage