### PR TITLE
Fix multilabel tables for Container entities

### DIFF
--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -30,7 +30,7 @@ module ContainerGroupHelper::TextualSummary
         condition.status,
       ]
     end
-    TextualGroup.new(_("Conditions"), h)
+    TextualMultilabel.new(_("Conditions"), h)
   end
 
   def textual_group_smart_management
@@ -73,7 +73,7 @@ module ContainerGroupHelper::TextualSummary
       volume_values[0][0] = volume.name if volume_values.length > 0
       h[:values] += volume_values
     end
-    TextualGroup.new(_("Volumes"), h)
+    TextualMultilabel.new(_("Volumes"), h)
   end
 
   #

--- a/app/helpers/container_service_helper/textual_summary.rb
+++ b/app/helpers/container_service_helper/textual_summary.rb
@@ -22,7 +22,7 @@ module ContainerServiceHelper::TextualSummary
         config.node_port
       ]
     end
-    TextualGroup.new(_("Port Configurations"), h)
+    TextualMultilabel.new(_("Port Configurations"), h)
   end
 
   def textual_group_relationships

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -37,7 +37,7 @@ module EmsContainerHelper::TextualSummary
         (cs.error || "")
       ]
     end
-    TextualGroup.new(_("Component Statuses"), h)
+    TextualMultilabel.new(_("Component Statuses"), h)
   end
 
   def textual_group_smart_management

--- a/app/helpers/persistent_volume_helper/textual_summary.rb
+++ b/app/helpers/persistent_volume_helper/textual_summary.rb
@@ -34,7 +34,7 @@ module PersistentVolumeHelper::TextualSummary
 
   def textual_group_capacity
     labels = [_("Resource"), _("Quantity")]
-    TextualGroup.new(_("Capacity"), :labels => labels, :values => @record.capacity)
+    TextualMultilabel.new(_("Capacity"), :labels => labels, :values => @record.capacity)
   end
 
   #

--- a/spec/controllers/container_build_controller_spec.rb
+++ b/spec/controllers/container_build_controller_spec.rb
@@ -17,6 +17,7 @@ describe ContainerBuildController do
     get :show, :params => { :id => container_build.id }
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
+    expect(response).to render_template('shared/summary/_textual_multilabel')
     expect(assigns(:breadcrumbs)).to eq([{:name => "Builds",
                                           :url  => "/container_build/show_list?page=&refresh=y"},
                                          {:name => "Test Build (Summary)",

--- a/spec/controllers/container_controller_spec.rb
+++ b/spec/controllers/container_controller_spec.rb
@@ -133,6 +133,7 @@ describe ContainerController do
 
       expect(response).to render_template('layouts/_textual_groups_generic')
       expect(response).to render_template('shared/summary/_textual_tags')
+      expect(response).to render_template('shared/summary/_textual_multilabel')
       expect(response.status).to eq(200)
     end
   end

--- a/spec/controllers/container_group_controller_spec.rb
+++ b/spec/controllers/container_group_controller_spec.rb
@@ -52,6 +52,7 @@ describe ContainerGroupController do
       it do
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => "layouts/listnav/_container_group")
+        is_expected.to render_template('shared/summary/_textual_multilabel')
       end
     end
   end

--- a/spec/controllers/container_image_controller_spec.rb
+++ b/spec/controllers/container_image_controller_spec.rb
@@ -63,6 +63,7 @@ describe ContainerImageController do
       it do
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => "layouts/listnav/_container_image")
+        is_expected.to render_template('shared/summary/_textual_multilabel')
       end
     end
   end

--- a/spec/controllers/container_node_controller_spec.rb
+++ b/spec/controllers/container_node_controller_spec.rb
@@ -38,6 +38,7 @@ describe ContainerNodeController do
       it do
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => "layouts/listnav/_container_node")
+        is_expected.to render_template('shared/summary/_textual_multilabel')
       end
     end
   end

--- a/spec/controllers/container_project_controller_spec.rb
+++ b/spec/controllers/container_project_controller_spec.rb
@@ -38,6 +38,7 @@ describe ContainerProjectController do
       it do
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => "layouts/listnav/_container_project")
+        is_expected.to render_template('shared/summary/_textual_multilabel')
       end
     end
   end

--- a/spec/controllers/container_service_controller_spec.rb
+++ b/spec/controllers/container_service_controller_spec.rb
@@ -38,6 +38,7 @@ describe ContainerServiceController do
       it do
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => "layouts/listnav/_container_service")
+        is_expected.to render_template('shared/summary/_textual_multilabel')
       end
     end
   end

--- a/spec/controllers/container_template_controller_spec.rb
+++ b/spec/controllers/container_template_controller_spec.rb
@@ -17,6 +17,7 @@ describe ContainerTemplateController do
     get :show, :params => { :id => container_template.id }
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
+    expect(response).to render_template('shared/summary/_textual_multilabel')
     expect(assigns(:breadcrumbs)).to eq([{:name => "Container Templates",
                                           :url  => "/container_template/show_list?page=&refresh=y"},
                                          {:name => "Test Template (Summary)",

--- a/spec/controllers/persistent_volume_controller_spec.rb
+++ b/spec/controllers/persistent_volume_controller_spec.rb
@@ -61,6 +61,7 @@ describe PersistentVolumeController do
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => 'layouts/_textual_groups_generic')
         is_expected.to render_template(:partial => 'layouts/listnav/_persistent_volume')
+        is_expected.to render_template('shared/summary/_textual_multilabel')
       end
     end
   end


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1423450

Issue introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/274. The data in multilabel tables is not displayed, we should use `TextualMultilabel` instead of `TextualGroup`.

Before:
![ser](https://cloud.githubusercontent.com/assets/11769555/24143175/8756b3dc-0e31-11e7-8de3-a0bd1b9101d1.png)

After:
![serafter](https://cloud.githubusercontent.com/assets/11769555/24143236/b5dd425c-0e31-11e7-9efe-1691a3faa7bc.png)

