### PR TITLE
Do not store available_tags in session

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -3,7 +3,6 @@ module ApplicationController::Filter
     :alias,
     :expression,
     :exp_available_tags,
-    :available_tags,
     :exp_available_fields,
     :exp_cfield,
     :exp_check,
@@ -42,7 +41,7 @@ module ApplicationController::Filter
     end
 
     def drop_cache
-      @available_adv_searches = nil
+      @available_adv_searches = @available_tags = nil
     end
 
     def exp_available_cfields # fields on exp_model for check_all, check_any, and check_count operation
@@ -57,10 +56,10 @@ module ApplicationController::Filter
       if exp_model == '_display_filter_'
         exp_available_tags
       else
-        self.available_tags ||= MiqExpression.model_details(exp_model, :typ             => "tag",
-                                                                       :include_model   => true,
-                                                                       :include_my_tags => use_mytags,
-                                                                       :userid          => User.current_user.userid)
+        @available_tags ||= MiqExpression.model_details(exp_model, :typ             => 'tag',
+                                                                   :include_model   => true,
+                                                                   :include_my_tags => use_mytags,
+                                                                   :userid          => User.current_user.userid)
       end
     end
 


### PR DESCRIPTION
They need to be memoized within a single http request, however they
shall not be memoized among multiple requests.

Stored in session since: 33f3ca551125990cdf058aa2032938ba79744171

@miq-bot assign @mzazrivec 