### PR TITLE
Fix rbac checking on items

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1374,6 +1374,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def find_checked_items_with_rbac(klass, prefix = nil)
+    items = find_checked_items(prefix)
+    assert_rbac(current_user, klass, items)
+    items
+  end
+
   # Common Saved Reports button handler routines
   def process_saved_reports(saved_reports, task)
     success_count = 0

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -208,7 +208,7 @@ module ApplicationController::CiProcessing
   # Retire 1 or more VMs
   def retirevms
     assert_privileges(params[:pressed])
-    vms = find_checked_items
+    vms = find_checked_items_with_rbac(VmOrTemplate)
     if !%w(orchestration_stack service).include?(request.parameters["controller"]) && !%w(orchestration_stacks).include?(params[:display]) &&
        VmOrTemplate.find(vms).any? { |vm| !vm.supports_retire? }
       add_flash(_("Set Retirement Date does not apply to selected %{model}") %


### PR DESCRIPTION
We dont check RBAC on records when using `find_checked_items` method. Add `find_checked_items_with_rbac` method which works almost same way, but control RBAC on records and return exception when user dont have rights.

Pending backend PR: https://github.com/ManageIQ/manageiq/pull/14454