### PR TITLE
Fix set owneship toolbar when instance doesn't have provider

### DIFF
--- a/app/helpers/application_helper/button/set_ownership.rb
+++ b/app/helpers/application_helper/button/set_ownership.rb
@@ -3,7 +3,7 @@ class ApplicationHelper::Button::SetOwnership < ApplicationHelper::Button::Basic
 
   def disabled?
     @error_message = _('Ownership is controlled by tenant mapping') if
-      @record.ext_management_system.tenant_mapping_enabled?
+      @record.try(:ext_management_system).try(:tenant_mapping_enabled?)
     @error_message.present?
   end
 end

--- a/spec/helpers/application_helper/buttons/set_ownership_spec.rb
+++ b/spec/helpers/application_helper/buttons/set_ownership_spec.rb
@@ -21,5 +21,10 @@ describe ApplicationHelper::Button::SetOwnership do
       let(:tenant_mapping_enabled) { false }
       it_behaves_like 'an enabled button'
     end
+
+    context 'when vm is not belong to any Vm' do
+      let(:ext_management_system)  { nil }
+      it_behaves_like 'an enabled button'
+    end
   end
 end


### PR DESCRIPTION
follow up of https://github.com/ManageIQ/manageiq-ui-classic/pull/649

## test scenario
when you click on instance without provider, it throws error because it relies on provider so I added `try`s

@miq-bot add_label bug, euwe/no
@miq-bot assign @mzazrivec 

thanks @jzigmund 
