### PR TITLE
Fix actions' icons of policy events

### DIFF
--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -116,6 +116,16 @@ class TreeBuilderPolicy < TreeBuilder
 
     success = count_only_or_objects(count_only, pol_rec ? pol_rec.actions_for_event(parent, :success) : [])
     failure = count_only_or_objects(count_only, pol_rec ? pol_rec.actions_for_event(parent, :failure) : [])
+    unless count_only
+      add_flag_to(success, :success) unless success.empty?
+      add_flag_to(failure, :failure) unless failure.empty?
+    end
     success + failure
+  end
+
+  def add_flag_to(array, flag)
+    array.each do |i|
+      i.instance_variable_set(:@flag, flag)
+    end
   end
 end

--- a/app/presenters/tree_node/miq_action.rb
+++ b/app/presenters/tree_node/miq_action.rb
@@ -3,20 +3,16 @@ module TreeNode
     set_attribute(:title, &:description)
     set_attribute(:icon) do
       if @options[:tree] != :action_tree
-        if @options[:tree] == :policy_profile_tree
-          policy_id = @parent_id.split('-')[2].split('_').first
-          event_id  = @parent_id.split('-').last
-        else
-          policy_id = @parent_id.split('_')[2].split('-').last
-          event_id  = @parent_id.split('_').last.split('-').last
-        end
-        p  = ::MiqPolicy.find_by_id(ApplicationRecord.uncompress_id(policy_id))
-        ev = ::MiqEventDefinition.find_by_id(ApplicationRecord.uncompress_id(event_id))
-
-        p.action_result_for_event(@object, ev) ? "pficon pficon-ok" : "pficon pficon-error-circle-o"
+        flag_of(@object) == :success ? "pficon pficon-ok" : "pficon pficon-error-circle-o"
       else
         @object.decorate.fonticon
       end
+    end
+
+    private
+
+    def flag_of(object)
+      object.instance_variable_get(:@flag)
     end
   end
 end


### PR DESCRIPTION
The tree node was not able to get information about the action's flag inside the builder, so I augmented the returned instances by adding new instance variable with the flag.

https://bugzilla.redhat.com/show_bug.cgi?id=1410910