### PR TITLE
Changes to Ansible service summary screen.

### DIFF
--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -1,19 +1,24 @@
-= render :partial => "layouts/textual_groups_generic"
-- if @record.type == "ServiceAnsiblePlaybook"
-  #services_tab
-    - job = @record.try(:job, "Retirement")
-    - unless job
-      -# show header when Retirement tab is not visible,
-      -# tabs are only displayed when there are are more than 1 tab on screen
-      %hr
-      %h3= _("Provisioning")
-    %ul.nav.nav-tabs
+#services_tab
+  %ul.nav.nav-tabs
+    = miq_tab_header("details") do
+      = _("Details")
+    - if @record.type == "ServiceAnsiblePlaybook"
+      - job = @record.try(:job, "Retirement")
       = miq_tab_header("provisioning") do
         = _("Provisioning")
       - if job
         = miq_tab_header("retirement") do
           = _("Retirement")
-    .tab-content
+  .tab-content
+    = miq_tab_content("details", 'default', :class => 'cm-tab') do
+      = render :partial => "layouts/textual_groups_generic"
+      .row
+        .col-md-12.col-lg-6
+          %h3
+            = _('VMs')
+          - if @view
+            = render :partial => "layouts/gtl", :locals => {:view => @view}
+    - if @record.type == "ServiceAnsiblePlaybook"
       = miq_tab_content("provisioning", 'default', :class => 'cm-tab') do
         = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_provisioning_group_list}
         - if @job && @job.try(:raw_stdout)
@@ -22,14 +27,6 @@
         = miq_tab_content("retirement", 'default', :class => 'cm-tab') do
           = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_retirement_group_list}
           = render :partial => "layouts/textual_code_mirror", :locals => {:label => 'Standard Output', :value => job.raw_stdout, :mode => "htmlmixed", :text_area_id => "retirement_output"}
-  :javascript
-    miq_tabs_init('#services_tab');
-    miq_refresh_code_mirror();
-- else
-  .row
-    .col-md-12.col-lg-6
-      %h3
-        = _('VMs')
-
-      - if @view
-        = render :partial => "layouts/gtl", :locals => {:view => @view}
+:javascript
+  miq_tabs_init('#services_tab');
+  miq_refresh_code_mirror();


### PR DESCRIPTION
Added changes to show Properties/Lifecycle & List of VMs on first tab, labelled "Details" and show Provisioning/Retirement jobs related data on their own tabs respectively.
Before:
![before](https://cloud.githubusercontent.com/assets/3450808/24160981/9accce4e-0e39-11e7-976b-18e07eedc303.png)

After:
![after](https://cloud.githubusercontent.com/assets/3450808/24160918/67a8e8ea-0e39-11e7-884a-dd59cde7c2eb.png)
![after1](https://cloud.githubusercontent.com/assets/3450808/24160919/696f7946-0e39-11e7-818e-bd65159bfea4.png)

@gmcculloug please review.
