### PR TITLE
Hiding Network Credentials drop down from UI

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -213,11 +213,11 @@
                 = _('Machine Credential')
               .col-md-9
                 = h(provisioning[:machine_credential])
-            .form-group
-              %label.col-md-3.control-label
-                = _('Network Credential')
-              .col-md-9
-                = h(provisioning[:network_credential])
+            -#.form-group
+            -#  %label.col-md-3.control-label
+            -#    = _('Network Credential')
+            -#  .col-md-9
+            -#    = h(provisioning[:network_credential])
             .form-group
               %label.col-md-3.control-label
                 = _('Cloud Credential')

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -61,18 +61,18 @@
                     'pf-select'        => true}
               %option{"value" => ""}
                 = "<#{_('Choose')}>"
-        .form-group
-          %label.col-md-3.control-label{"for" => "vm.#{prefix}_network_credential_id"}
-            = _('Network Credential')
-          .col-md-9
-            %select{"ng-model"         => "vm._#{prefix}_network_credential",
-                    "name"             => "#{prefix}_network_credential_id",
-                    'ng-options'       => 'network_credential as network_credential.name for network_credential in vm.network_credentials',
-                    :checkchange       => true,
-                    "data-live-search" => "true",
-                    'pf-select'        => true}
-              %option{"value" => ""}
-                = "<#{_('Choose')}>"
+        -#.form-group
+        -#  %label.col-md-3.control-label{"for" => "vm.#{prefix}_network_credential_id"}
+        -#    = _('Network Credential')
+        -#  .col-md-9
+        -#    %select{"ng-model"         => "vm._#{prefix}_network_credential",
+        -#            "name"             => "#{prefix}_network_credential_id",
+        -#            'ng-options'       => 'network_credential as network_credential.name for network_credential in vm.network_credentials',
+        -#            :checkchange       => true,
+        -#            "data-live-search" => "true",
+        -#            'pf-select'        => true}
+        -#      %option{"value" => ""}
+        -#        = "<#{_('Choose')}>"
 
         .form-group
           %label.col-md-3.control-label{"for" => "vm.#{prefix}_cloud_type"}


### PR DESCRIPTION
Hiding Network Credentials drop down from UI until we have support to add/edit Network type Credentials in UI.

https://www.pivotaltracker.com/story/show/141970189

before:
![before_network_cred_remove](https://cloud.githubusercontent.com/assets/3450808/24161765/b216de30-0e3b-11e7-8b0f-6a3dc6c4cb88.png)

![before_757_changes](https://cloud.githubusercontent.com/assets/3450808/24162635/98d2b072-0e3e-11e7-8093-0c165247a01d.png)


after
![after_network_cred_removed](https://cloud.githubusercontent.com/assets/3450808/24161772/b4eff682-0e3b-11e7-9001-e67130cc0f73.png)

![after_757_changes](https://cloud.githubusercontent.com/assets/3450808/24162648/a0442462-0e3e-11e7-97df-09ee0935105b.png)


@gmcculloug please review.