### PR TITLE
Sets default security_protocol for middleware

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -328,6 +328,7 @@ module Mixins
     def security_protocol_default
       case controller_name
       when "ems_container" then "ssl-with-validation"
+      when "ems_middleware" then "non-ssl"
       else "ssl"
       end
     end


### PR DESCRIPTION
Sets the default security protocol for middleware.

I missed to push this commit to #460. 
This is used when editing an old middleware endpoint which didn't have any `Security Protocol`

It will turn this:
![dsp_before](https://cloud.githubusercontent.com/assets/3845764/24164560/24a044e6-0e3c-11e7-9e12-d7073c5dff60.png)


Into this:
![dsp_after](https://cloud.githubusercontent.com/assets/3845764/24164524/0501d028-0e3c-11e7-99cd-38fc12dc83da.png)

@miq-bot add_label middleware euwe/no enhancement.

@AparnaKarve could you please review?
