### PR TITLE
Move security protocol

### DIFF
--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -17,38 +17,38 @@
     .col-md-8{"ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra' || emsCommonModel.emstype == 'vmware_cloud'"}
       - prefix == "amqp" ? security_protocols = @amqp_security_protocols : security_protocols = @openstack_security_protocols
       = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose')}>", nil]] + security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       options_for_select([["<#{_('Choose')}>", nil]] + security_protocols, :disabled => ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "ng-required"                 => true,
                        "ng-change"                   => "openstackSecurityProtocolChanged()",
                        "selectpicker-for-select-tag" => "",
-                       "prefix"                      => "#{prefix}",
+                       "prefix"                      => prefix.to_s,
                        "reset-validation-status"     => "#{prefix}_auth_status")
     .col-md-8{"ng-if" => "emsCommonModel.emstype == 'nuage_network'"}
       = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose')}>", nil]] + @nuage_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       options_for_select([["<#{_('Choose')}>", nil]] + @nuage_security_protocols, :disabled => ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "required"                    => defined?(security_protocol_not_required) ? false : true,
                        "selectpicker-for-select-tag" => "")
     .col-md-8{"ng-if" => "emsCommonModel.emstype == 'scvmm'"}
       = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose')}>", nil]] + @scvmm_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       options_for_select([["<#{_('Choose')}>", nil]] + @scvmm_security_protocols, :disabled => ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "",
-                       "prefix"                      => "#{prefix}",
+                       "prefix"                      => prefix.to_s,
                        "reset-validation-status"     => "#{prefix}_auth_status")
     .col-md-8{"ng-if" => "emsCommonModel.ems_controller == 'ems_container'"}
       = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose')}>", nil]] + @container_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       options_for_select([["<#{_('Choose')}>", nil]] + @container_security_protocols, :disabled => ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "",
-                       "prefix"                      => "#{prefix}",
+                       "prefix"                      => prefix.to_s,
                        "reset-validation-status"     => "#{prefix}_auth_status")
     .col-md-8{"ng-if" => "emsCommonModel.emstype == 'hawkular'"}
       = select_tag("#{prefix}_security_protocol",
@@ -70,12 +70,12 @@
                           "id"                      => "#{prefix}_hostname",
                           "name"                    => "#{prefix}_hostname",
                           "ng-model"                => "#{ng_model}.#{prefix}_hostname",
-                          "maxlength"               => "#{MAX_NAME_LEN}",
-                          "ng-required"             => "#{ng_reqd_hostname}",
+                          "maxlength"               => MAX_NAME_LEN.to_s,
+                          "ng-required"             => ng_reqd_hostname.to_s,
                           "ng-trim"                 => false,
                           "detect-spaces"           => "",
                           "checkchange"             => "",
-                          "prefix"                  => "#{prefix}",
+                          "prefix"                  => prefix.to_s,
                           "reset-validation-status" => "#{prefix}_auth_status"}
       %span.help-block{"ng-show" => "angularForm.#{prefix}_hostname.$error.required"}
         = _("Required")
@@ -101,11 +101,11 @@
                           "name"                        => "#{prefix}_api_port",
                           "ng-model"                    => "#{ng_model}.#{prefix}_api_port",
                           "maxlength"                   => 15,
-                          "ng-required"                 => "#{ng_reqd_api_port}",
+                          "ng-required"                 => ng_reqd_api_port.to_s,
                           "checkchange"                 => "",
                           "ng-trim"                     => false,
                           "detect-spaces"               => "",
-                          "prefix"                      => "#{prefix}",
+                          "prefix"                      => prefix.to_s,
                           "reset-validation-depends-on" => %w(hawkular metrics).include?(prefix) ? "#{prefix}_hostname" : "",
                           "reset-validation-status"     => "#{prefix}_auth_status",
                           "pattern"                     => "^[1-9]\\d*$"}
@@ -151,7 +151,7 @@
              "ng-true-value"   => "true",
              "ng-false-value"  => "false",
              "ng-model"        => "#{ng_model}.#{prefix}_tls_verify",
-             "prefix"          => "#{prefix}"}
+             "prefix"          => prefix.to_s}
 
 %div{"ng-if" => defined?(tls_ca_certs_hide) ? false : true}
   .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm' || " +                                             |
@@ -168,7 +168,7 @@
                              "ng-disabled" => "emsCommonModel.emstype == 'rhevm' && !#{ng_model}.#{prefix}_tls_verify",
                              "ng-required" => false,
                              "ng-trim"     => false,
-                             "prefix"      => "#{prefix}",
+                             "prefix"      => prefix.to_s,
                              "reset-validation-status" => "#{prefix}_auth_status"}
       %span.help-block
         = _("Paste here the trusted CA certificates, in PEM format.")
@@ -182,7 +182,7 @@
                         "id"            => "realm",
                         "name"          => "realm",
                         "ng-model"      => "emsCommonModel.realm",
-                        "maxlength"     => "#{MAX_NAME_LEN}",
+                        "maxlength"     => MAX_NAME_LEN.to_s,
                         "required"      => "",
                         "checkchange"   => "",
                         "auto-focus"    => "",

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -3,6 +3,64 @@
 - ng_reqd_hostname ||= true
 - ng_reqd_api_port ||= true
 
+%div{"ng-if" => defined?(security_protocol_hide) ? false : true}
+  .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_security_protocol.$invalid}",
+              "ng-if"    => "emsCommonModel.emstype == 'openstack' || " +                              |
+                            "emsCommonModel.emstype == 'openstack_infra' || " +                        |
+                            "emsCommonModel.emstype == 'nuage_network' || " +                          |
+                            "(emsCommonModel.emstype == 'vmware_cloud' && '#{prefix}' === 'amqp') || " |
+                            "emsCommonModel.emstype == 'scvmm' || " +                                  |
+                            "emsCommonModel.ems_controller == 'ems_container' || " +                   |
+                            "emsCommonModel.emstype == 'hawkular'"}                                    |
+    %label.col-md-2.control-label{"for" => "#{prefix}_security_protocol"}
+      = _('Security Protocol')
+    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra' || emsCommonModel.emstype == 'vmware_cloud'"}
+      - prefix == "amqp" ? security_protocols = @amqp_security_protocols : security_protocols = @openstack_security_protocols
+      = select_tag("#{prefix}_security_protocol",
+                       options_for_select([["<#{_('Choose')}>", nil]] + security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
+                       "checkchange"                 => "",
+                       "ng-required"                 => true,
+                       "ng-change"                   => "openstackSecurityProtocolChanged()",
+                       "selectpicker-for-select-tag" => "",
+                       "prefix"                      => "#{prefix}",
+                       "reset-validation-status"     => "#{prefix}_auth_status")
+    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'nuage_network'"}
+      = select_tag("#{prefix}_security_protocol",
+                       options_for_select([["<#{_('Choose')}>", nil]] + @nuage_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
+                       "checkchange"                 => "",
+                       "required"                    => defined?(security_protocol_not_required) ? false : true,
+                       "selectpicker-for-select-tag" => "")
+    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'scvmm'"}
+      = select_tag("#{prefix}_security_protocol",
+                       options_for_select([["<#{_('Choose')}>", nil]] + @scvmm_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
+                       "checkchange"                 => "",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "",
+                       "prefix"                      => "#{prefix}",
+                       "reset-validation-status"     => "#{prefix}_auth_status")
+    .col-md-8{"ng-if" => "emsCommonModel.ems_controller == 'ems_container'"}
+      = select_tag("#{prefix}_security_protocol",
+                       options_for_select([["<#{_('Choose')}>", nil]] + @container_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
+                       "checkchange"                 => "",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "",
+                       "prefix"                      => "#{prefix}",
+                       "reset-validation-status"     => "#{prefix}_auth_status")
+    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'hawkular'"}
+      = select_tag("#{prefix}_security_protocol",
+                       options_for_select([["<#{_('Choose')}>", nil]] + @hawkular_security_protocols, "disabled" => ["<#{_('Choose')}>", nil]),
+                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
+                       "checkchange"                 => "",
+                       "required"                    => "",
+                       "ng-change"                   => "hawkularSecurityProtocolChanged()",
+                       "selectpicker-for-select-tag" => "",
+                       "prefix"                      => prefix.to_s,
+                       "reset-validation-status"     => "#{prefix}_auth_status")
+
 %div{"ng-if" => defined?(hostname_hide) ? false : true}
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_hostname.$invalid}"}
     %label.col-md-2.control-label{"for" => "#{prefix}_hostname"}
@@ -78,63 +136,6 @@
       %span.help-block{"ng-show" => "angularForm.#{prefix}_database_name.$error.detectedSpaces"}
         = _("Spaces are prohibited")
 
-%div{"ng-if" => defined?(security_protocol_hide) ? false : true}
-  .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_security_protocol.$invalid}",
-              "ng-if"    => "emsCommonModel.emstype == 'openstack' || " +                              |
-                            "emsCommonModel.emstype == 'openstack_infra' || " +                        |
-                            "emsCommonModel.emstype == 'nuage_network' || " +                          |
-                            "(emsCommonModel.emstype == 'vmware_cloud' && '#{prefix}' === 'amqp') || " |
-                            "emsCommonModel.emstype == 'scvmm' || " +                                  |
-                            "emsCommonModel.ems_controller == 'ems_container' || " +                   |
-                            "emsCommonModel.emstype == 'hawkular'"}                                    |
-    %label.col-md-2.control-label{"for" => "#{prefix}_security_protocol"}
-      = _('Security Protocol')
-    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra' || emsCommonModel.emstype == 'vmware_cloud'"}
-      - prefix == "amqp" ? security_protocols = @amqp_security_protocols : security_protocols = @openstack_security_protocols
-      = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose')}>", nil]] + security_protocols, disabled: ["<#{_('Choose')}>", nil]),
-                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
-                       "checkchange"                 => "",
-                       "ng-required"                 => true,
-                       "ng-change"                   => "openstackSecurityProtocolChanged()",
-                       "selectpicker-for-select-tag" => "",
-                       "prefix"                      => "#{prefix}",
-                       "reset-validation-status"     => "#{prefix}_auth_status")
-    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'nuage_network'"}
-      = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose')}>", nil]] + @nuage_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
-                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
-                       "checkchange"                 => "",
-                       "required"                    => defined?(security_protocol_not_required) ? false : true,
-                       "selectpicker-for-select-tag" => "")
-    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'scvmm'"}
-      = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose')}>", nil]] + @scvmm_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
-                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
-                       "checkchange"                 => "",
-                       "required"                    => "",
-                       "selectpicker-for-select-tag" => "",
-                       "prefix"                      => "#{prefix}",
-                       "reset-validation-status"     => "#{prefix}_auth_status")
-    .col-md-8{"ng-if" => "emsCommonModel.ems_controller == 'ems_container'"}
-      = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose')}>", nil]] + @container_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
-                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
-                       "checkchange"                 => "",
-                       "required"                    => "",
-                       "selectpicker-for-select-tag" => "",
-                       "prefix"                      => "#{prefix}",
-                       "reset-validation-status"     => "#{prefix}_auth_status")
-    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'hawkular'"}
-      = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose')}>", nil]] + @hawkular_security_protocols, "disabled" => ["<#{_('Choose')}>", nil]),
-                       "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
-                       "checkchange"                 => "",
-                       "required"                    => "",
-                       "ng-change"                   => "hawkularSecurityProtocolChanged()",
-                       "selectpicker-for-select-tag" => "",
-                       "prefix"                      => prefix.to_s,
-                       "reset-validation-status"     => "#{prefix}_auth_status")
 
 %div{"ng-if" => defined?(tls_verify_hide) ? false : true}
   .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm'"}


### PR DESCRIPTION
As pointed by @abonas on https://github.com/ManageIQ/manageiq-ui-classic/pull/460#issuecomment-284731339 it would be better to have `security protocol` before `port`.
@Loicavenel commented that we should at least reverse `port` and `security protocol` (https://github.com/ManageIQ/manageiq-ui-classic/pull/460#issuecomment-286418453).
@cben proposed to mimic the URI structure (protocol://hostname:port) (https://github.com/ManageIQ/manageiq-ui-classic/pull/460#issuecomment-286479273) which is included on this PR.

Since this fields are shared among other providers I'm doing this change in a separate PR expecting other provider maintainers who use these two fields would comment / review that it indeed won't break anything for them or at least notify them of this change.

If needed I could move `security protocol` before `port`.

Additionally I'm fixing ham-lint warnings on that file.

Here are some screenshots of providers that i saw are using the `Security Protocol`.

## Containers provider
---
![screenshot from 2017-03-21 13-34-39](https://cloud.githubusercontent.com/assets/3845764/24167140/ac149830-0e43-11e7-8363-eb55deec45ca.png)

---
![screenshot from 2017-03-21 13-34-34](https://cloud.githubusercontent.com/assets/3845764/24167141/ac17fbec-0e43-11e7-878c-00a41c293878.png)

## Infrastructure provider
---
![screenshot from 2017-03-21 13-33-42](https://cloud.githubusercontent.com/assets/3845764/24167142/ac1f78cc-0e43-11e7-8bbb-93c877c51c4c.png)

---
![screenshot from 2017-03-21 13-33-36](https://cloud.githubusercontent.com/assets/3845764/24167145/ac369eee-0e43-11e7-8763-b9a9960011dd.png)

---
![screenshot from 2017-03-23 13-07-55](https://cloud.githubusercontent.com/assets/3845764/24265690/6225457c-0fd2-11e7-9dfa-5c992ec81cf5.png)

## Cloud provider
---
![screenshot from 2017-03-21 13-32-47](https://cloud.githubusercontent.com/assets/3845764/24167143/ac26773a-0e43-11e7-9ac3-a1967cc40901.png)

## Middleware provider
---
![screenshot from 2017-03-21 13-14-24](https://cloud.githubusercontent.com/assets/3845764/24167144/ac33771e-0e43-11e7-97c2-c7328e2ba92d.png)


@cben could you please take a look?