### PR TITLE
Fixed undefined method `each' for nil:NilClass error on retirement tab

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -309,25 +309,27 @@
                       %th
                         = _("Default value")
                     %tbody
-                      - @record.config_info[:retirement][:extra_vars].each do |key, value|
-                        %tr
-                          %td
-                            = h(key)
-                          %td
-                            = h(value)
+                      - if retirement[:extra_vars]
+                        - retirement[:extra_vars].each do |key, value|
+                          %tr
+                            %td
+                              = h(key)
+                            %td
+                              = h(value)
               .form-group
                 %label.col-md-3.control-label
                   = _('Dialog')
                 .col-md-9
-                  - if role_allows?(:feature => "dialog_accord", :any => true)
-                    - params = {:controller => 'miq_ae_customization', :action => 'show', :id => "dg-#{to_cid(retirement[:dialog_id])}"}
-                    = link_to(retirement[:dialog],
-                            params,
-                            "data-miq_sparkle_on"  => true,
-                            "data-miq_sparkle_off" => true,
-                            :title                 => retirement[:dialog])
-                  - else
-                    = h(retirement[:dialog])
+                  - if retirement[:dialog]
+                    - if role_allows?(:feature => "dialog_accord", :any => true)
+                      - params = {:controller => 'miq_ae_customization', :action => 'show', :id => "dg-#{to_cid(retirement[:dialog_id])}"}
+                      = link_to(retirement[:dialog],
+                              params,
+                              "data-miq_sparkle_on"  => true,
+                              "data-miq_sparkle_off" => true,
+                              :title                 => retirement[:dialog])
+                    - else
+                      = h(retirement[:dialog])
 
 :javascript
   miq_tabs_init("#st_tabs");


### PR DESCRIPTION
Now that retirement hash is returned with remove_resources value, had to add checks around extra_vars loops to fix undefined method `each' for nil:NilClass error. And also only show Dialog name/link if dialog was selected on retirement tab.

@gmcculloug  please review, i was seeing this error while accessing catalog item that i had save Remove Resources value for.