### PR TITLE
Hiding Network Credentials on retirement tab on summary screen

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -281,11 +281,11 @@
                   = _('Machine Credential')
                 .col-md-9
                   = h(retirement[:machine_credential])
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Network Credential')
-                .col-md-9
-                  = h(retirement[:network_credential])
+              -#.form-group
+              -#  %label.col-md-3.control-label
+              -#    = _('Network Credential')
+              -#  .col-md-9
+              -#    = h(retirement[:network_credential])
               .form-group
                 %label.col-md-3.control-label
                   = _('Cloud Credential')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/141970189

@gmcculloug realised i didnt remove `Network Credential` from Retirement tab on catalog Item summary, this PR can be merged after https://github.com/ManageIQ/manageiq-ui-classic/pull/762 is merged

before
![before](https://cloud.githubusercontent.com/assets/3450808/24171695/d6278bce-0e5b-11e7-8182-092a5dae153a.png)

after
![after](https://cloud.githubusercontent.com/assets/3450808/24171698/da9be16e-0e5b-11e7-929c-760f63bf8711.png)
