### PR TITLE
Sanitize hawkular error messages in ad-hoc page

### DIFF
--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -59,7 +59,7 @@ class HawkularProxyService
   rescue StandardError => e
     {
       :parameters => params,
-      :error      => e
+      :error      => ActionView::Base.full_sanitizer.sanitize(e.message)
     }
   end
 


### PR DESCRIPTION
**Description** 

Compute > Containers > Providers - pick a provider - toolbar Monitoring > Ad hoc Metrics

Sanitize hawkular error messages in ad-hoc page

**Screenshot before**
![screenshot-localhost 3000-2017-03-22-14-53-22](https://cloud.githubusercontent.com/assets/2181522/24198725/aa9d3418-0f0f-11e7-9cc4-e8b766d0ac47.png)

**Screenshot after**
![screenshot-localhost 3000-2017-03-22-14-52-06](https://cloud.githubusercontent.com/assets/2181522/24198728/af62bff4-0f0f-11e7-8052-d31691a4dbe2.png)
