### PR TITLE
Fixed checks around retirement dialog values.

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -208,9 +208,9 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     if (configData.retirement_cloud_credential_id !== '')
       catalog_item['config_info']['retirement']['cloud_credential_id'] = configData.retirement_cloud_credential_id;
 
-    if (configData.retirement_dialog_id !== '') {
+    if (angular.isDefined(vm.catalogItemModel.retirement_dialog_id) && configData.retirement_dialog_id !== '') {
       catalog_item['config_info']['retirement']['dialog_id'] = configData.retirement_dialog_id;
-    } else if (configData.retirement_dialog_name !== '')
+    } else if (angular.isDefined(vm.catalogItemModel.retirement_dialog_name) && configData.retirement_dialog_name !== '')
       catalog_item['config_info']['retirement']['new_dialog_name'] = configData.retirement_dialog_name;
 
     return catalog_item;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1797,11 +1797,7 @@ class CatalogController < ApplicationController
     playbook_details[:provisioning][:machine_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential.find_by(:id => provision[:credential_id]).name
     playbook_details[:provisioning][:network_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential.find_by(:id => provision[:network_credential_id]).name if provision[:network_credential_id]
     playbook_details[:provisioning][:cloud_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential.find_by(:id => provision[:cloud_credential_id]).name if provision[:cloud_credential_id]
-    if provision[:dialog_id]
-      dialog = Dialog.find_by(:id => provision[:dialog_id])
-      playbook_details[:provisioning][:dialog] = dialog.name
-      playbook_details[:provisioning][:dialog_id] = dialog.id
-    end
+    fetch_dialog(playbook_details, provision[:dialog_id], :provisioning)
 
     if @record.config_info[:retirement]
       retirement = @record.config_info[:retirement]
@@ -1813,14 +1809,17 @@ class CatalogController < ApplicationController
         playbook_details[:retirement][:machine_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential.find_by(:id => retirement[:credential_id]).name
         playbook_details[:retirement][:network_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential.find_by(:id => retirement[:network_credential_id]).name if retirement[:network_credential_id]
         playbook_details[:retirement][:cloud_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential.find_by(:id => retirement[:cloud_credential_id]).name if retirement[:cloud_credential_id]
-        if retirement[:dialog_id]
-          dialog = Dialog.find_by(:id => retirement[:dialog_id])
-          playbook_details[:retirement][:dialog] = dialog.name
-          playbook_details[:retirement][:dialog_id] = dialog.id
-        end
+        fetch_dialog(playbook_details, retirement[:dialog_id], :retirement)
       end
     end
     playbook_details
+  end
+
+  def fetch_dialog(playbook_details, dialog_id, key)
+    return nil if dialog_id.nil?
+    dialog = Dialog.find_by(:id => dialog_id)
+    playbook_details[key][:dialog] = dialog.name
+    playbook_details[key][:dialog_id] = dialog.id
   end
 
   def open_parent_nodes(record)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1797,8 +1797,8 @@ class CatalogController < ApplicationController
     playbook_details[:provisioning][:machine_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential.find_by(:id => provision[:credential_id]).name
     playbook_details[:provisioning][:network_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential.find_by(:id => provision[:network_credential_id]).name if provision[:network_credential_id]
     playbook_details[:provisioning][:cloud_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential.find_by(:id => provision[:cloud_credential_id]).name if provision[:cloud_credential_id]
-    dialog = provision[:dialog_id] ? Dialog.find_by(:id => provision[:dialog_id]) : Dialog.find_by(:name => provision[:dialog_name])
-    if dialog
+    if provision[:dialog_id]
+      dialog = Dialog.find_by(:id => provision[:dialog_id])
       playbook_details[:provisioning][:dialog] = dialog.name
       playbook_details[:provisioning][:dialog_id] = dialog.id
     end
@@ -1813,8 +1813,8 @@ class CatalogController < ApplicationController
         playbook_details[:retirement][:machine_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential.find_by(:id => retirement[:credential_id]).name
         playbook_details[:retirement][:network_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential.find_by(:id => retirement[:network_credential_id]).name if retirement[:network_credential_id]
         playbook_details[:retirement][:cloud_credential] = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential.find_by(:id => retirement[:cloud_credential_id]).name if retirement[:cloud_credential_id]
-        dialog = provision[:dialog_id] ? Dialog.find_by(:id => retirement[:dialog_id]) : Dialog.find_by(:name => retirement[:dialog_name])
-        if dialog
+        if retirement[:dialog_id]
+          dialog = Dialog.find_by(:id => retirement[:dialog_id])
           playbook_details[:retirement][:dialog] = dialog.name
           playbook_details[:retirement][:dialog_id] = dialog.id
         end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -739,4 +739,67 @@ describe CatalogController do
       expect(assigns(:edit)[:new][:available_resources].count).to eq(2)
     end
   end
+
+  context "#fetch_playbook_details" do
+    let(:auth) { FactoryGirl.create(:authentication, :name => "machine_cred", :manager_ref => 6, :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential") }
+    let(:repository) { FactoryGirl.create(:configuration_script_source, :manager => ems, :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource") }
+    let(:inventory_root_group) { FactoryGirl.create(:inventory_root_group, :name => 'Demo Inventory') }
+    let(:ems) do
+      FactoryGirl.create(:automation_manager_ansible_tower, :inventory_root_groups => [inventory_root_group], :provider => FactoryGirl.create(:provider_embedded_ansible))
+    end
+    let(:dialog) { FactoryGirl.create(:dialog, :label => "Some Label") }
+    let(:playbook) do
+      FactoryGirl.create(:embedded_playbook,
+                         :configuration_script_source => repository,
+                         :manager                     => ems,
+                         :inventory_root_group        => inventory_root_group)
+    end
+
+    it "returns playbook service template details for provision & retirement tabs for summary screen" do
+      options = {
+        :name        => 'test_ansible_catalog_item',
+        :description => 'test ansible',
+        :display     => true,
+        :config_info => {
+          :provision  => {
+            :new_dialog_name => 'test_dialog',
+            :hosts           => 'many',
+            :credential_id   => auth.id,
+            :repository_id   => repository.id,
+            :playbook_id     => playbook.id,
+            :dialog_id       => dialog.id
+          },
+          :retirement => {
+            :new_dialog_name => 'test_dialog',
+            :hosts           => 'many',
+            :credential_id   => auth.id,
+            :repository_id   => repository.id,
+            :playbook_id     => playbook.id,
+            :dialog_id       => dialog.id
+          }
+        }
+      }
+      service_template = double("ServiceTemplateAnsiblePlaybook", options)
+      controller.instance_variable_set(:@record, service_template)
+      playbook_details = controller.send(:fetch_playbook_details)
+      st_details = {
+        :provisioning => {
+          :repository         => repository.name,
+          :playbook           => playbook.name,
+          :machine_credential => auth.name,
+          :dialog             => "Some Label",
+          :dialog_id          => dialog.id
+        },
+        :retirement   => {
+          :remove_resources   => nil,
+          :repository         => repository.name,
+          :playbook           => playbook.name,
+          :machine_credential => auth.name,
+          :dialog             => "Some Label",
+          :dialog_id          => dialog.id
+        }
+      }
+      expect(playbook_details).to eq(st_details)
+    end
+  end
 end

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -41,8 +41,7 @@ describe('catalogItemFormController', function() {
           hosts: undefined,
           extra_vars: Object({  }),
           network_credential_id: undefined,
-          cloud_credential_id: undefined,
-          dialog_id: undefined
+          cloud_credential_id: undefined
         }
       }
     };


### PR DESCRIPTION
Retirement dialog is not a required field, so it is not always defined, checking if it is defined and has a value before setting it in retirement hash to be sent up via API call.

@syncrou please test this should fix the issue you found when trying to save new dialog name on Retirement tab.
@gmcculloug please review