### PR TITLE
Fix filters in config mgmt Configured systems

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -419,14 +419,14 @@ module ApplicationController::Filter
     end
 
     if ["delete", "saveit"].include?(params[:button])
-      if @edit[:in_explorer] || x_active_tree == :storage_tree
-        if "configuration_manager_cs_filter_tree" == x_active_tree.to_s
-          build_configuration_manager_tree(:configuration_manager_cs_filter, x_active_tree)
-        else
-          tree_type = x_active_tree.to_s.sub(/_tree/, '').to_sym
-          builder = TreeBuilder.class_for_type(tree_type)
-          tree = builder.new(x_active_tree, tree_type, @sb)
-        end
+      if x_active_tree.to_s == "configuration_manager_cs_filter_tree"
+        build_configuration_manager_tree(:configuration_manager_cs_filter, x_active_tree)
+        build_accordions_and_trees
+        load_or_clear_adv_search
+      elsif @edit[:in_explorer] || x_active_tree == :storage_tree
+        tree_type = x_active_tree.to_s.sub(/_tree/, '').to_sym
+        builder = TreeBuilder.class_for_type(tree_type)
+        tree = builder.new(x_active_tree, tree_type, @sb)
       elsif %w(ems_cloud ems_infra).include?(@layout)
         build_listnav_search_list(@view.db)
       else

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -947,7 +947,7 @@ module ApplicationController::Filter
     # Restore @edit hash if it's saved in @settings
     @expkey = :expression                                               # Reset to use default expression key
     if session[:adv_search] && session[:adv_search][model.to_s]
-      @edit = copy_hash(session[:adv_search][model.to_s])
+      @edit = copy_hash(session[:edit])
       # default search doesnt exist or if it is marked as hidden
       if @edit && @edit[:expression] && !@edit[:expression][:selected].blank? &&
          !MiqSearch.exists?(@edit[:expression][:selected][:id])

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -82,7 +82,7 @@ class ProviderForemanController < ApplicationController
     session[:edit] = @edit
     @explorer = true
 
-    if x_active_tree != :configuration_manager_cs_filter_tree || x_node == "root"
+    if (x_active_tree != :configuration_manager_cs_filter_tree || x_node == "root") && params[:button] != 'saveit'
       listnav_search_selected(0)
     else
       @nodetype, id = parse_nodetype_and_id(valid_active_node(x_node))
@@ -96,6 +96,8 @@ class ProviderForemanController < ApplicationController
           self.x_node = params[:id]
           quick_search_show
         end
+      elsif x_active_tree == :configuration_manager_cs_filter_tree && params[:button] != 'saveit'
+        listnav_search_selected(id)
       end
     end
   end

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -97,7 +97,7 @@ class ProviderForemanController < ApplicationController
           quick_search_show
         end
       elsif x_active_tree == :configuration_manager_cs_filter_tree && params[:button] != 'saveit'
-        listnav_search_selected(id)
+        listnav_search_selected(from_cid(id))
       end
     end
   end

--- a/app/presenters/tree_builder_configuration_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_configuration_manager_configured_systems.rb
@@ -2,7 +2,7 @@ class TreeBuilderConfigurationManagerConfiguredSystems < TreeBuilderConfiguredSy
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "ManageIQ::Providers::ForemanProvider::ConfigurationManager::ConfiguredSystem"}
+    {:leaf => "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"}
   end
 
   def root_options


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1429519

Fix saving a new filter in expression editor
in Configuration -> Management -> Configured systems
and enable displaying flash message about successful saving.

Fix disappearing tree view after saving a filter.
Enable displaying name of a filter under Global/My Filters
in tree view.

Fix applying selected filter from Global/My Filters
in accordion when clicking on the name of a filter.

Fix disappearing of tree view when deleting loaded
filter in expression editor.

Before:
![mgmt_before2](https://cloud.githubusercontent.com/assets/13417815/24253106/b0726234-0fdf-11e7-8a87-56b8c8ae80c7.png)
![mgmt_before3](https://cloud.githubusercontent.com/assets/13417815/24253116/b5217db0-0fdf-11e7-9d28-272e1bba59e4.png)
![mgmt_before1](https://cloud.githubusercontent.com/assets/13417815/24253120/b6cae21e-0fdf-11e7-9c5b-5145769bce81.png)

After:
![mgmt_after4](https://cloud.githubusercontent.com/assets/13417815/24253198/eef64b7e-0fdf-11e7-9f5e-650fc0e967af.png)
![mgmt_after1](https://cloud.githubusercontent.com/assets/13417815/24253209/f5f118e6-0fdf-11e7-9147-8e5ffcb19ffd.png)
![mgmt_after2](https://cloud.githubusercontent.com/assets/13417815/24253222/fe9020c8-0fdf-11e7-8e10-f7f30395571f.png)
![mgmt_after3](https://cloud.githubusercontent.com/assets/13417815/24253225/0096e4a6-0fe0-11e7-98db-fa8f9546c3d0.png)
