### PR TITLE
Crop the powerstate svg in quadicons using border-radius

### DIFF
--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -55,9 +55,12 @@ img.tiny { margin: 0; padding: 0;width:20px;height:20px; border: 0; vertical-ali
 .quadicon:hover{ padding: 1px 0 0 1px;}
 
 // adjust power state images for use in quad icon //
-.b72 img[src*="currentstate"] {
-  clip-path: inset(0 0 2px 0 round 0 12px 0 0);
-  -webkit-clip-path: inset(0 0 2px 0 round 0 12px 0 0);
+.b72 .stretch {
+  background-repeat: no-repeat;
+  width: 35px;
+  height: 32px;
+  margin: -3px 0 -2px 1px;
+  border-top-right-radius: 15px;
 }
 
 .b72 img[src*="archived"], .b72 img[src*="template"], .b72 img[src*="disconnected"], .b72 img[src*="orphaned"], .b72 img[src*="never"], img[src*="retired"], .b72 img[src*="unknown"] {

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -456,6 +456,30 @@ module QuadiconHelper
     output.collect(&:html_safe).join('').html_safe
   end
 
+  def currentstate_icon(state)
+    path = "svg/currentstate-#{h(state)}.svg"
+    if %w(
+      retired
+      standby
+      unknown
+      archived
+      orphaned
+      template
+      disconnected
+      install_failed
+      not_responding
+      non_operational
+      template-no-host
+      preparing_for_maintenance
+    ).include?(state)
+      flobj_img_simple(path, "b72")
+    else
+      content_tag(:div, :class => "flobj b72") do
+        content_tag(:div, '', :class => "stretch", :style => "background-image: url('#{image_path(path)}')")
+      end
+    end
+  end
+
   # Renders a quadicon for hosts
   #
   def render_host_quadicon(item, options)
@@ -465,7 +489,7 @@ module QuadiconHelper
       output << flobj_img_simple("layout/base.png")
 
       output << flobj_p_simple("a72", item.vms.size)
-      output << flobj_img_simple("svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b72")
+      output << currentstate_icon(item.normalized_state.downcase)
       output << flobj_img_simple(img_for_host_vendor(item), "c72")
       output << flobj_img_simple(img_for_auth_status(item), "d72")
       output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
@@ -714,7 +738,7 @@ module QuadiconHelper
     if settings(:quadicons, item.class.base_model.name.underscore.to_sym)
       output << flobj_img_simple("layout/base.png")
       output << flobj_img_simple("svg/os-#{h(item.os_image_name.downcase)}.svg", "a72")
-      output << flobj_img_simple("svg/currentstate-#{h(item.normalized_state.downcase)}.svg", "b72")
+      output << currentstate_icon(item.normalized_state.downcase)
       output << flobj_img_simple("svg/vendor-#{h(item.vendor.downcase)}.svg", "c72")
 
       unless item.get_policies.empty?


### PR DESCRIPTION
There are some issues with `svg-clip-path` when using Firefox:
![screenshot from 2017-03-23 15-54-19](https://cloud.githubusercontent.com/assets/649130/24253587/01400ef4-0fe1-11e7-8ca0-e7291e8bc72e.png)

This PR sets the powerstate image as a background, stretches it to the whole quad and crops the edge using `border-radius-top-right`:
![screenshot from 2017-03-23 20-14-38](https://cloud.githubusercontent.com/assets/649130/24265927/6d2b834a-1005-11e7-9697-daf210d4d710.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1432485
