### PR TITLE
Display Filters tabs in Load balancers page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1284,6 +1284,7 @@ module ApplicationHelper
           flavor
           floating_ip
           host
+          load_balancer
           middleware_datasource
           middleware_deployment
           middleware_domain


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1429523

Enable displaying Filters and My Filters tabs
in Networks -> Load Balancers page.

Before:
![load_balancer1](https://cloud.githubusercontent.com/assets/13417815/24258868/5670e868-0fef-11e7-9a54-33ec671451bf.png)

After:
![load_balancer2](https://cloud.githubusercontent.com/assets/13417815/24258871/586e4e44-0fef-11e7-9f48-44a75d0a54a3.png)
