### PR TITLE
API (js) - handle non-2** (and 1**) responses as errors

### DIFF
--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -155,8 +155,18 @@
   }
 
   function process_response(response) {
-    if (response.status === 204)  // No content
+    if (response.status === 204) {
+      // No content
       return null;
+    }
+
+    if (response.status >= 300) {
+      // Not 1** or 2**
+      return response.json()
+        .then(function(obj) {
+          return Promise.reject(obj);
+        });
+    }
 
     return response.json();
   }

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -1,6 +1,6 @@
 /* global miqAjaxButton miqBuildCalendar miqButtons miqJqueryRequest miqRESTAjaxButton miqSparkleOff miqSparkleOn */
 
-ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', '$log', function($timeout, $document, $q, $log) {
+ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', function($timeout, $document, $q) {
   this.storedPasswordPlaceholder = "●●●●●●●●";
 
   this.showButtons = function() {
@@ -124,11 +124,14 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', '$log
 
     return serializedObj;
   };
+
   this.handleFailure = function(e) {
     miqSparkleOff();
+
     if (e.message) {
-      $log.log(e.message);
+      console.error(e.message);
     }
+
     return $q.reject(e);
   };
 }]);


### PR DESCRIPTION
When API returns a 404 and you have code like..

```
API.get(...)
  .then(handleSuccess)
  .catch(handleError)
```

You'd expect `handleError` to be called.

But, until now, these would all call `handleSuccess`.

Fixing that :).

Also, updating `miqService.handleFailure` to `console.error` the error, so that we can see it in devel mode at least.

(A separate PR that makes `handleFailure` actually handle the failure and show a flash message will follow, that will need either a separate function or some more changes to be compatible with existing code. - so, after PTO :).)

Cc: @ZitaNemeckova , @mzazrivec 