### PR TITLE
Display Cluster Resource Pool

### DIFF
--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -191,7 +191,7 @@ module EmsClusterHelper::TextualSummary
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager::EmsCluster)
 
     textual_link(@record.resource_pools,
-                 :as   => EmsCluster,
+                 :as   => ResourcePool,
                  :link => url_for_only_path(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'resource_pools'))
   end
 


### PR DESCRIPTION
Code fix to display Resource Pools value/icon for selected Cluster.

https://bugzilla.redhat.com/show_bug.cgi?id=1324610

Screen capture prior to code fix below:
![cluster resource pools caption prior to code fix](https://cloud.githubusercontent.com/assets/552686/24267140/9cf83076-0fc6-11e7-8e06-fab70583c9e1.png)


Screen capture post code fix:
![cluster resource pools caption post code fix](https://cloud.githubusercontent.com/assets/552686/24267155/a3b882b2-0fc6-11e7-8b93-a44482123ff3.png)

