### PR TITLE
inject API service to angular code using the API

### DIFF
--- a/app/assets/javascripts/angular_modules/module_notifications.js
+++ b/app/assets/javascripts/angular_modules/module_notifications.js
@@ -1,2 +1,7 @@
-miqHttpInject(
-  angular.module('miq.notifications', ['ui.bootstrap', 'patternfly', 'ManageIQ', 'miq.util']));
+miqHttpInject(angular.module('miq.notifications', [
+  'ManageIQ',
+  'miq.api',
+  'miq.util',
+  'patternfly',
+  'ui.bootstrap',
+]));

--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -1,9 +1,9 @@
 angular.module('miq.notifications')
   .service('eventNotifications', eventNotifications);
 
-eventNotifications.$inject = ['$timeout'];
+eventNotifications.$inject = ['$timeout', 'API'];
 
-function eventNotifications($timeout) {
+function eventNotifications($timeout, API) {
   if (!ManageIQ.angular.eventNotificationsData) {
     ManageIQ.angular.eventNotificationsData = {
       state: {

--- a/app/assets/javascripts/services/post_service.js
+++ b/app/assets/javascripts/services/post_service.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.service('postService', ["miqService", "$timeout", "$window", function(miqService, $timeout, $window) {
+ManageIQ.angular.app.service('postService', ['miqService', '$timeout', '$window', 'API', function(miqService, $timeout, $window, API) {
 
   this.saveRecord = function(apiURL, redirectURL, updateObject, successMsg) {
     miqService.sparkleOn();


### PR DESCRIPTION
We have two (almost identical) things called `API` in js code:

  * `window.API` (global) - code to communicate with the API from non-angular code
  * `API` angular service - the same code, wrapped in angular to trigger the [`$digest` cycle](https://www.ng-book.com/p/The-Digest-Loop-and-apply/)

Using the global from angular code is always a mistake, since this won't trigger the digest cycle on response - leading to weird timing issues like the response being noticed by our code only when the user clicks something, etc.

Fixing all our angular code to use the angular version instead of the global.


Ping @mzazrivec - I believe you've hit one of those bugs recently.. (or was it @ZitaNemeckova ?)