### PR TITLE
API - rename non-angular API code to vanillaJsAPI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
   "extends": [],
 
   "globals": {
-    "API": false, // local: miq_api.js
+    "vanillaJsAPI": false, // local: miq_api.js
     "ManageIQ": false, // local: mig_global.js
     "Promise": false, // bower: es6-shim
     "_": false, // bower: lodash

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -7,7 +7,7 @@ var miqInitNotifications = function () {
     disconnected: function () {
       var _this = this;
       // Try to request a new ws_token if disconnected, reconnecting will happen automatically
-      API.ws_init().then(null, function () {
+      vanillaJsAPI.ws_init().then(null, function () {
         console.warn("Unable to retrieve a valid ws_token!");
         // Disconnect permanently if the ws_token cannot be fetched
         _this.consumer.connection.close({ allowReconnect: false })

--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -10,10 +10,11 @@
  * API.logout() - clears login info, no return
  * API.autorenew() - registers a 60second interval to query /api, returns a function to clear the interval
  *
- * can also be used from angular - depend on miq.api module and use the API service
- * when used as an angular service, all the promises are $q, so they work within the angular digest cycle
- *
  * the API token is persisted into sessionStorage
+ *
+ * the angular service is called API, and lives in the miq.api module
+ * the pure-JS version used to be called API as well, but given the confusion this caused in angular code, we're calling it vanillaJsAPI now
+ *
  */
 
 (function() {
@@ -114,7 +115,7 @@
     });
   };
 
-  window.API = API;
+  window.vanillaJsAPI = API;
 
 
   function process_options(o) {
@@ -177,19 +178,19 @@ angular.module('miq.api', [])
 .factory('API', ['$q', function($q) {
   var angularify = function(what) {
     return function() {
-      return $q.when(what.apply(API, arguments));
+      return $q.when(what.apply(vanillaJsAPI, arguments));
     };
   };
 
   return {
-    get: angularify(API.get),
-    post: angularify(API.post),
-    delete: angularify(API.delete),
-    put: angularify(API.put),
-    patch: angularify(API.patch),
-    options: angularify(API.options),
-    login: angularify(API.login),
-    logout: API.logout,
-    autorenew: API.autorenew,
+    get: angularify(vanillaJsAPI.get),
+    post: angularify(vanillaJsAPI.post),
+    delete: angularify(vanillaJsAPI.delete),
+    put: angularify(vanillaJsAPI.put),
+    patch: angularify(vanillaJsAPI.patch),
+    options: angularify(vanillaJsAPI.options),
+    login: angularify(vanillaJsAPI.login),
+    logout: vanillaJsAPI.logout,
+    autorenew: vanillaJsAPI.autorenew,
   };
 }]);

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -805,7 +805,7 @@ function miqEnterPressed(e) {
 // Send login authentication via ajax
 function miqAjaxAuth(url) {
   miqEnableLoginFields(false);
-  miqSparkleOn(); // miqJqueryRequest starts sparkle either way, but API.login doesn't
+  miqSparkleOn(); // miqJqueryRequest starts sparkle either way, but API login doesn't
 
   var credentials = {
     login: $('#user_name').val(),
@@ -813,9 +813,9 @@ function miqAjaxAuth(url) {
     serialized: miqSerializeForm('login_div'),
   }
 
-  API.login(credentials.login, credentials.password)
+  vanillaJsAPI.login(credentials.login, credentials.password)
   .then(function() {
-    return API.ws_init();
+    return vanillaJsAPI.ws_init();
   })
   .then(function() {
     // API login ok, now do the normal one
@@ -824,7 +824,7 @@ function miqAjaxAuth(url) {
       data: credentials.serialized,
     });
 
-    // TODO API.autorenew is called on (non-login) page load - when?
+    // TODO vanillaJsAPI.autorenew is called on (non-login) page load - when?
   })
   .then(null, function() {
     add_flash(__("Incorrect username or password"), 'error', { id: 'auth_failed' });

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -36,7 +36,7 @@
         ManageIQ.charts.provider = "#{Charting.backend}";
         ManageIQ.browser = "#{j browser_info(:name_ui)}";
         ManageIQ.controller = "#{j controller_name}";
-        API.autorenew();
+        vanillaJsAPI.autorenew();
 
       - if ::Settings.server.asynchronous_notifications
         :javascript

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -20,6 +20,6 @@
       = yield
 
     :javascript
-      API.logout();
+      vanillaJsAPI.logout();
       delete localStorage['patternfly-navigation-secondary'];
       delete localStorage['patternfly-navigation-tertiary'];


### PR DESCRIPTION
**Depends on**: https://github.com/ManageIQ/manageiq-ui-classic/pull/788 (merged)

Renamed to prevent confusion with the angular API service.

(discussion about the name came from https://github.com/ManageIQ/manageiq-ui-classic/pull/788, if anybody comes with a better one.. :))

Cc @AparnaKarve 