### PR TITLE
Custom buttons for list views

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1484,6 +1484,10 @@ function miqToolbarOnClick(_e) {
       } else {
         params = miqSerializeForm(button.data('url_parms'));
       }
+    } else if (button.data('url_parms').match("id=LIST")) {
+      // this is used by custom buttons in lists
+      params = button.data('url_parms').split("?")[1] +
+        "&miq_grid_checks=" + ManageIQ.gridChecks.join(',');
     } else {
       params = button.data('url_parms').split("?")[1];
     }

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -106,11 +106,14 @@ module ApplicationController::Buttons
       @edit[:new][:name] = params[:name] if params[:name]
       @edit[:new][:display] = params[:display] == "1" if params[:display]
       @edit[:new][:open_url] = params[:open_url] == "1" if params[:open_url]
+      @edit[:new][:display_for] = params[:display_for] if params[:display_for]
+      @edit[:new][:submit_how] = params[:submit_how] if params[:submit_how]
       @edit[:new][:description] = params[:description] if params[:description]
       @edit[:new][:button_image] = params[:button_image].to_i if params[:button_image]
       @edit[:new][:dialog_id] = params[:dialog_id] if params[:dialog_id]
       visibility_box_edit
     end
+
     render :update do |page|
       page << javascript_prologue
       if params.key?(:instance_name) || params.key?(:other_name) || params.key?(:target_class)
@@ -757,8 +760,10 @@ module ApplicationController::Buttons
       button[:options][:button_image] ||= {}
       button[:options][:button_image] = @edit[:new][:button_image]
     end
-    button[:options][:display] = @edit[:new][:display]
-    button[:options][:open_url] = @edit[:new][:open_url]
+
+    %i(display open_url display_for submit_how).each do |key|
+      button[:options][key] = @edit[:new][key]
+    end
     button.visibility ||= {}
     if @edit[:new][:visibility_typ] == "role"
       roles = []
@@ -846,6 +851,8 @@ module ApplicationController::Buttons
       :button_image   => @custom_button.options.try(:[], :button_image).to_s,
       :display        => @custom_button.options.try(:[], :display).nil? ? true : @custom_button.options[:display],
       :open_url       => @custom_button.options.try(:[], :open_url) ? @custom_button.options[:open_url] : false,
+      :display_for    => @custom_button.options.try(:[], :display_for) ? @custom_button.options[:display_for] : 'single',
+      :submit_how     => @custom_button.options.try(:[], :submit_how) ? @custom_button.options[:submit_how] : 'all',
       :object_message => @custom_button.uri_message || "create",
     )
     @edit[:current] = copy_hash(@edit[:new])

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -289,7 +289,13 @@ module ApplicationController::Buttons
       objs = [obj]
     end
 
+    if objs.length == 0
+      render_flash(_("Error executing custom button: No item was selected."), :error)
+      return
+    end
+
     @right_cell_text = _("%{record} - \"%{button_text}\"") % {:record => obj.name, :button_text => button.name}
+
     if button.resource_action.dialog_id
       options = {
         :header     => @right_cell_text,
@@ -876,7 +882,7 @@ module ApplicationController::Buttons
       :display        => @custom_button.options.try(:[], :display).nil? ? true : @custom_button.options[:display],
       :open_url       => @custom_button.options.try(:[], :open_url) ? @custom_button.options[:open_url] : false,
       :display_for    => @custom_button.options.try(:[], :display_for) ? @custom_button.options[:display_for] : 'single',
-      :submit_how     => @custom_button.options.try(:[], :submit_how) ? @custom_button.options[:submit_how] : 'all',
+      :submit_how     => @custom_button.options.try(:[], :submit_how) ? @custom_button.options[:submit_how] : 'one',
       :object_message => @custom_button.uri_message || "create",
     )
     @edit[:current] = copy_hash(@edit[:new])

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -285,7 +285,7 @@ module ApplicationController::Buttons
       objs = Rbac.filtered(cls.where(:id => find_checked_items))
       obj = objs.first
     else
-      obj = Rbac.filtered_object(cls.find_by_id(params[:id].to_i))
+      obj = Rbac.filtered_object(cls.find(params[:id].to_i))
       objs = [obj]
     end
 

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -289,7 +289,7 @@ module ApplicationController::Buttons
       objs = [obj]
     end
 
-    if objs.length == 0
+    if objs.empty?
       render_flash(_("Error executing custom button: No item was selected."), :error)
       return
     end

--- a/app/controllers/mixins/custom_buttons.rb
+++ b/app/controllers/mixins/custom_buttons.rb
@@ -9,17 +9,24 @@ module Mixins::CustomButtons
 
   def custom_toolbar_explorer?
     if x_tree
-      if (@display == "main" && @record) || (@lastaction == "show_list")
-        true
+      if @display == "main" && @record
+        Mixins::CustomToolbarResult.new(:single)
+      elsif @lastaction == "show_list"
+        Mixins::CustomToolbarResult.new(:list)
       else
-        :blank
+        'blank_view_tb'
       end
     end
   end
 
   def custom_toolbar_simple?
-    (@record && @lastaction == "show" && @display == "main") ||
-      (@lastaction == "show_list")
+    if @record && @lastaction == "show" && @display == "main"
+      Mixins::CustomToolbarResult.new(:single)
+    elsif @lastaction == "show_list"
+      Mixins::CustomToolbarResult.new(:list)
+    else
+      nil
+    end
   end
 
   class_methods do

--- a/app/controllers/mixins/custom_buttons.rb
+++ b/app/controllers/mixins/custom_buttons.rb
@@ -24,8 +24,6 @@ module Mixins::CustomButtons
       Mixins::CustomToolbarResult.new(:single)
     elsif @lastaction == "show_list"
       Mixins::CustomToolbarResult.new(:list)
-    else
-      nil
     end
   end
 

--- a/app/controllers/mixins/custom_buttons.rb
+++ b/app/controllers/mixins/custom_buttons.rb
@@ -1,13 +1,13 @@
 module Mixins::CustomButtons
   extend ActiveSupport::Concern
 
-  def custom_toolbar?
+  def custom_toolbar
     return nil unless self.class.instance_eval { @custom_buttons }
 
-    @explorer ? custom_toolbar_explorer? : custom_toolbar_simple?
+    @explorer ? custom_toolbar_explorer : custom_toolbar_simple
   end
 
-  def custom_toolbar_explorer?
+  def custom_toolbar_explorer
     if x_tree
       if @display == "main" && @record
         Mixins::CustomButtons::Result.new(:single)
@@ -19,7 +19,7 @@ module Mixins::CustomButtons
     end
   end
 
-  def custom_toolbar_simple?
+  def custom_toolbar_simple
     if @record && @lastaction == "show" && @display == "main"
       Mixins::CustomButtons::Result.new(:single)
     elsif @lastaction == "show_list"

--- a/app/controllers/mixins/custom_buttons.rb
+++ b/app/controllers/mixins/custom_buttons.rb
@@ -8,11 +8,8 @@ module Mixins::CustomButtons
   end
 
   def custom_toolbar_explorer?
-    if x_tree                # Make sure we have the trees defined
-      if x_node == "root" || # If on a root, create placeholder toolbar
-         !@record            #   or no record showing
-        :blank
-      elsif @display == "main"
+    if x_tree
+      if (@display == "main" && @record) || (@lastaction == "show_list")
         true
       else
         :blank
@@ -21,7 +18,8 @@ module Mixins::CustomButtons
   end
 
   def custom_toolbar_simple?
-    @record && @lastaction == "show" && @display == "main"
+    (@record && @lastaction == "show" && @display == "main") ||
+      (@lastaction == "show_list")
   end
 
   class_methods do

--- a/app/controllers/mixins/custom_buttons.rb
+++ b/app/controllers/mixins/custom_buttons.rb
@@ -10,9 +10,9 @@ module Mixins::CustomButtons
   def custom_toolbar_explorer?
     if x_tree
       if @display == "main" && @record
-        Mixins::CustomToolbarResult.new(:single)
+        Mixins::CustomButtons::Result.new(:single)
       elsif @lastaction == "show_list"
-        Mixins::CustomToolbarResult.new(:list)
+        Mixins::CustomButtons::Result.new(:list)
       else
         'blank_view_tb'
       end
@@ -21,9 +21,9 @@ module Mixins::CustomButtons
 
   def custom_toolbar_simple?
     if @record && @lastaction == "show" && @display == "main"
-      Mixins::CustomToolbarResult.new(:single)
+      Mixins::CustomButtons::Result.new(:single)
     elsif @lastaction == "show_list"
-      Mixins::CustomToolbarResult.new(:list)
+      Mixins::CustomButtons::Result.new(:list)
     end
   end
 

--- a/app/controllers/mixins/custom_buttons/result.rb
+++ b/app/controllers/mixins/custom_buttons/result.rb
@@ -1,5 +1,5 @@
-module Mixins
-  CustomToolbarResult = Struct.new(:plural_form) do
+module Mixins::CustomButtons
+  Result = Struct.new(:plural_form) do
     def plural_form_matches(button)
       if plural_form == :list
         %w(list both).include?(button.options.try(:[], :display_for))

--- a/app/controllers/mixins/custom_toolbar_result.rb
+++ b/app/controllers/mixins/custom_toolbar_result.rb
@@ -1,0 +1,13 @@
+module Mixins
+  CustomToolbarResult = Struct.new(:plural_form) do
+    def plural_form_matches(button)
+      if plural_form == :list
+        %w(list both).include?(button.options.try(:[], :display_for))
+
+      else # :single
+        %w(nil single both).include?(button.options.try(:[], :display_for))
+
+      end
+    end
+  end
+end

--- a/app/controllers/mixins/custom_toolbar_result.rb
+++ b/app/controllers/mixins/custom_toolbar_result.rb
@@ -5,7 +5,7 @@ module Mixins
         %w(list both).include?(button.options.try(:[], :display_for))
 
       else # :single
-        %w(nil single both).include?(button.options.try(:[], :display_for))
+        [nil, 'single', 'both'].include?(button.options.try(:[], :display_for))
 
       end
     end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -285,7 +285,7 @@ class ServiceController < ApplicationController
     record_showing = type && ["Service"].include?(TreeBuilder.get_model_for_prefix(type))
     if x_active_tree == :svcs_tree && !@in_a_form && !@sb[:action]
       if record_showing && @sb[:action].nil?
-        cb_tb = build_toolbar("custom_buttons_tb")
+        cb_tb = build_toolbar(Mixins::CustomToolbarResult.new(:sinle))
       else
         v_tb = build_toolbar("x_gtl_view_tb")
       end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -285,9 +285,9 @@ class ServiceController < ApplicationController
     record_showing = type && ["Service"].include?(TreeBuilder.get_model_for_prefix(type))
     if x_active_tree == :svcs_tree && !@in_a_form && !@sb[:action]
       if record_showing && @sb[:action].nil?
-        cb_tb = build_toolbar(Mixins::CustomToolbarResult.new(:single))
+        cb_tb = build_toolbar(Mixins::CustomButtons::Result.new(:single))
       else
-        cb_tb = build_toolbar(Mixins::CustomToolbarResult.new(:list))
+        cb_tb = build_toolbar(Mixins::CustomButtons::Result.new(:list))
         v_tb = build_toolbar("x_gtl_view_tb")
       end
       c_tb = build_toolbar(center_toolbar_filename)

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -285,8 +285,9 @@ class ServiceController < ApplicationController
     record_showing = type && ["Service"].include?(TreeBuilder.get_model_for_prefix(type))
     if x_active_tree == :svcs_tree && !@in_a_form && !@sb[:action]
       if record_showing && @sb[:action].nil?
-        cb_tb = build_toolbar(Mixins::CustomToolbarResult.new(:sinle))
+        cb_tb = build_toolbar(Mixins::CustomToolbarResult.new(:single))
       else
+        cb_tb = build_toolbar(Mixins::CustomToolbarResult.new(:list))
         v_tb = build_toolbar("x_gtl_view_tb")
       end
       c_tb = build_toolbar(center_toolbar_filename)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1197,10 +1197,10 @@ module VmCommon
       record_showing = type && ["Vm", "MiqTemplate"].include?(TreeBuilder.get_model_for_prefix(type))
       c_tb = build_toolbar(center_toolbar_filename) # Use vm or template tb
       if record_showing
-        cb_tb = build_toolbar(Mixins::CustomToolbarResult.new(:single))
+        cb_tb = build_toolbar(Mixins::CustomButtons::Result.new(:single))
         v_tb = build_toolbar("x_summary_view_tb")
       else
-        cb_tb = build_toolbar(Mixins::CustomToolbarResult.new(:list))
+        cb_tb = build_toolbar(Mixins::CustomButtons::Result.new(:list))
         v_tb = build_toolbar("x_gtl_view_tb")
       end
     elsif ["compare", "drift"].include?(@sb[:action])

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1197,7 +1197,7 @@ module VmCommon
       record_showing = type && ["Vm", "MiqTemplate"].include?(TreeBuilder.get_model_for_prefix(type))
       c_tb = build_toolbar(center_toolbar_filename) # Use vm or template tb
       if record_showing
-        cb_tb = build_toolbar("custom_buttons_tb")
+        cb_tb = build_toolbar(Mixins::CustomToolbarResult.new(:single))
         v_tb = build_toolbar("x_summary_view_tb")
       else
         v_tb = build_toolbar("x_gtl_view_tb")

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1200,6 +1200,7 @@ module VmCommon
         cb_tb = build_toolbar(Mixins::CustomToolbarResult.new(:single))
         v_tb = build_toolbar("x_summary_view_tb")
       else
+        cb_tb = build_toolbar(Mixins::CustomToolbarResult.new(:list))
         v_tb = build_toolbar("x_gtl_view_tb")
       end
     elsif ["compare", "drift"].include?(@sb[:action])

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1157,6 +1157,11 @@ module VmCommon
       end
       # Add adv search filter to header
       @right_cell_text += @edit[:adv_search_applied][:text] if @edit && @edit[:adv_search_applied]
+
+      # save model being displayed for custom buttons
+      @tree_selected_model = if model.present?
+                               model.constantize
+                             end
     end
 
     if @edit && @edit.fetch_path(:adv_search_applied, :qs_exp) # If qs is active, save it in history

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -718,7 +718,7 @@ module ApplicationHelper
     end
 
     toolbars['center_tb'] = center_toolbar_filename
-    toolbars['custom_tb'] = controller.custom_toolbar?
+    toolbars['custom_tb'] = controller.custom_toolbar
 
     toolbars['view_tb'] = inner_layout_present? ? x_view_toolbar_filename : view_toolbar_filename
     toolbars

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -720,10 +720,6 @@ module ApplicationHelper
     toolbars['center_tb'] = center_toolbar_filename
     toolbars['custom_tb'] = controller.custom_toolbar?
 
-    #if custom_toolbar
-    #  custom_toolbar# == :blank ? 'blank_view_tb' : 'custom_buttons_tb'
-    #end
-
     toolbars['view_tb'] = inner_layout_present? ? x_view_toolbar_filename : view_toolbar_filename
     toolbars
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -718,11 +718,11 @@ module ApplicationHelper
     end
 
     toolbars['center_tb'] = center_toolbar_filename
+    toolbars['custom_tb'] = controller.custom_toolbar?
 
-    custom_toolbar = controller.custom_toolbar?
-    if custom_toolbar
-      toolbars['custom_tb'] = custom_toolbar == :blank ? 'blank_view_tb' : 'custom_buttons_tb'
-    end
+    #if custom_toolbar
+    #  custom_toolbar# == :blank ? 'blank_view_tb' : 'custom_buttons_tb'
+    #end
 
     toolbars['view_tb'] = inner_layout_present? ? x_view_toolbar_filename : view_toolbar_filename
     toolbars

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -58,12 +58,15 @@ class ApplicationHelper::ToolbarBuilder
     @view_context.respond_to?(:controller) ? @view_context.controller : @view_context
   end
 
+  def model_for_custom_toolbar
+    controller.instance_eval { @tree_selected_model } || controller.class.model
+  end
+
   # According to toolbar name in parameter `toolbar_name` either returns class
   # for generic toolbar, or starts building custom toolbar
   def toolbar_class(toolbar_name)
     if Mixins::CustomButtons::Result === toolbar_name
-      model = @record ? @record.class : controller.class.model
-      custom_toolbar_class(model, @record, toolbar_name)
+      custom_toolbar_class(toolbar_name)
     else
       predefined_toolbar_class(toolbar_name)
     end
@@ -280,7 +283,12 @@ class ApplicationHelper::ToolbarBuilder
     end
   end
 
-  def custom_toolbar_class(model, record, toolbar_result)
+  def custom_toolbar_class(toolbar_result)
+    model = @record ? @record.class : model_for_custom_toolbar
+    build_custom_toolbar_class(model, @record, toolbar_result)
+  end
+
+  def build_custom_toolbar_class(model, record, toolbar_result)
     # each custom toolbar is an anonymous subclass of this class
 
     toolbar = Class.new(ApplicationHelper::Toolbar::Basic)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -57,7 +57,6 @@ class ApplicationHelper::ToolbarBuilder
   # According to toolbar name in parameter `toolbar_name` either returns class
   # for generic toolbar, or starts building custom toolbar
   def toolbar_class(toolbar_name)
-    binding.pry
     if Mixins::CustomToolbarResult === toolbar_name
       model = @record ? @record.class : @view_context.controller.class.model
       custom_toolbar_class(model, @record, toolbar_name)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -61,7 +61,7 @@ class ApplicationHelper::ToolbarBuilder
   # According to toolbar name in parameter `toolbar_name` either returns class
   # for generic toolbar, or starts building custom toolbar
   def toolbar_class(toolbar_name)
-    if Mixins::CustomToolbarResult === toolbar_name
+    if Mixins::CustomButtons::Result === toolbar_name
       model = @record ? @record.class : controller.class.model
       custom_toolbar_class(model, @record, toolbar_name)
     else

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -54,11 +54,15 @@ class ApplicationHelper::ToolbarBuilder
     class_name.constantize
   end
 
+  def controller
+    @view_context.respond_to?(:controller) ? @view_context.controller : @view_context
+  end
+
   # According to toolbar name in parameter `toolbar_name` either returns class
   # for generic toolbar, or starts building custom toolbar
   def toolbar_class(toolbar_name)
     if Mixins::CustomToolbarResult === toolbar_name
-      model = @record ? @record.class : @view_context.controller.class.model
+      model = @record ? @record.class : controller.class.model
       custom_toolbar_class(model, @record, toolbar_name)
     else
       predefined_toolbar_class(toolbar_name)

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -71,8 +71,7 @@
       .col-md-8
         = select_tag("display_for",
                      options_for_select([[_('Single entity'), 'single'], [_('List'), 'list'], [_('Single and list'), 'both']], @edit[:new][:display_for]),
-                     "data-miq_sparkle_on" => true,
-                    )
+                     "data-miq_sparkle_on" => true)
     -# TODO: temporary disabled until the backend supports "submit all"
     -#    .form-group
     -#      %label.control-label.col-md-2

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -73,15 +73,15 @@
                      options_for_select([[_('Single entity'), 'single'], [_('List'), 'list'], [_('Single and list'), 'both']], @edit[:new][:display_for]),
                      "data-miq_sparkle_on" => true,
                     )
-
-    .form-group
-      %label.control-label.col-md-2
-        = _('Submit')
-      .col-md-8
-        = select_tag("submit_how",
-                     options_for_select([[_('Submit all'), 'all'], [_('One by one'), 'one']], @edit[:new][:submit_how]),
-                     "data-miq_sparkle_on" => true,
-                    )
+    -# TODO: temporary disabled until the backend supports "submit all"
+    -#    .form-group
+    -#      %label.control-label.col-md-2
+    -#        = _('Submit')
+    -#      .col-md-8
+    -#        = select_tag("submit_how",
+    -#                     options_for_select([[_('Submit all'), 'all'], [_('One by one'), 'one']], @edit[:new][:submit_how]),
+    -#                     "data-miq_sparkle_on" => true,
+    -#                    )
 
   = render(:partial => "layouts/ae_resolve_options",
     :locals         => {:resolve => @edit,

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -56,15 +56,32 @@
         = _('Dialog')
       .col-md-8
         = select_tag('dialog_id',
-                      options_for_select(([[_("<None>"), nil]]) + Array(@edit[:new][:available_dialogs].invert).sort_by { |a| a.first.downcase }, @edit[:new][:dialog_id]),
+                      options_for_select([[_("<None>"), nil]] + Array(@edit[:new][:available_dialogs].invert).sort_by { |a| a.first.downcase }, @edit[:new][:dialog_id]),
                       "data-miq_sparkle_on" => true,
                       :class => "selectpicker")
     .form-group
       %label.control-label.col-md-2
         = _('Open URL')
       .col-md-8
-        = check_box_tag("open_url", "1", @edit[:new][:open_url],
-                               "data-miq_observe_checkbox" => {:interval => '.5', :url => url}.to_json)
+        = check_box_tag("open_url", "1", @edit[:new][:open_url], "data-miq_observe_checkbox" => {:interval => '.5', :url => url}.to_json)
+
+    .form-group
+      %label.control-label.col-md-2
+        = _('Display for')
+      .col-md-8
+        = select_tag("display_for",
+                     options_for_select([[_('Single entity'), 'single'], [_('List'), 'list'], [_('Single and list'), 'both']], @edit[:new][:display_for]),
+                     "data-miq_sparkle_on" => true,
+                    )
+
+    .form-group
+      %label.control-label.col-md-2
+        = _('Submit')
+      .col-md-8
+        = select_tag("submit_how",
+                     options_for_select([[_('Submit all'), 'all'], [_('One by one'), 'one']], @edit[:new][:submit_how]),
+                     "data-miq_sparkle_on" => true,
+                    )
 
   = render(:partial => "layouts/ae_resolve_options",
     :locals         => {:resolve => @edit,
@@ -75,5 +92,7 @@
            :locals  => {:rec_id => @custom_button ? @custom_button.id : 'new', :action => "automate_button_field_changed"})
 :javascript
   miqInitSelectPicker();
-  miqSelectPickerEvent("button_image", "#{url}")
-  miqSelectPickerEvent('dialog_id', '#{url}')
+  miqSelectPickerEvent('button_image', '#{url}');
+  miqSelectPickerEvent('dialog_id', '#{url}');
+  miqSelectPickerEvent('display_for', '#{url}');
+  miqSelectPickerEvent('submit_how', '#{url}');

--- a/app/views/shared/buttons/_ab_show.html.haml
+++ b/app/views/shared/buttons/_ab_show.html.haml
@@ -37,11 +37,12 @@
       = _('Display for')
     .col-md-8
       = @custom_button.options[:display_for]
-  .form-group
-    %label.control-label.col-md-2
-      = _('Submit')
-    .col-md-8
-      = @custom_button.options[:submit_how]
+  -# TODO: temporary disabled until the backend supports "submit all"
+  -#  .form-group
+  -#    %label.control-label.col-md-2
+  -#      = _('Submit')
+  -#    .col-md-8
+  -#      = @custom_button.options[:submit_how]
 %hr
 
 %h3

--- a/app/views/shared/buttons/_ab_show.html.haml
+++ b/app/views/shared/buttons/_ab_show.html.haml
@@ -32,6 +32,16 @@
       = _('Open URL')
     .col-md-8
       = h(@custom_button.options.key?(:open_url) ? @custom_button.options[:open_url] : false)
+  .form-group
+    %label.control-label.col-md-2
+      = _('Display for')
+    .col-md-8
+      = @custom_button.options[:display_for]
+  .form-group
+    %label.control-label.col-md-2
+      = _('Submit')
+    .col-md-8
+      = @custom_button.options[:submit_how]
 %hr
 
 %h3

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -16,15 +16,15 @@ describe ApplicationHelper, "::ToolbarBuilder" do
 
     shared_examples "no custom buttons" do
       it ("#get_custom_buttons") do
-        expect(toolbar_builder.get_custom_buttons(subject.class, subject, Mixins::CustomToolbarResult.new(:single))).to be_blank
+        expect(toolbar_builder.get_custom_buttons(subject.class, subject, Mixins::CustomButtons::Result.new(:single))).to be_blank
       end
 
       it ("#custom_button_selects") do
-        expect(toolbar_builder.custom_button_selects(subject.class, subject, Mixins::CustomToolbarResult.new(:single))).to be_blank
+        expect(toolbar_builder.custom_button_selects(subject.class, subject, Mixins::CustomButtons::Result.new(:single))).to be_blank
       end
 
       it ("#custom_toolbar_class") do
-        expect(toolbar_builder.custom_toolbar_class(subject.class, subject, Mixins::CustomToolbarResult.new(:single)).definition).to be_blank
+        expect(toolbar_builder.custom_toolbar_class(subject.class, subject, Mixins::CustomButtons::Result.new(:single)).definition).to be_blank
       end
 
       it("#record_to_service_buttons") { expect(toolbar_builder.record_to_service_buttons(subject)).to be_blank }
@@ -57,7 +57,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :buttons      => [expected_button1]
         }
 
-        expect(toolbar_builder.get_custom_buttons(subject.class, subject, Mixins::CustomToolbarResult.new(:single))).to eq([expected_button_set])
+        expect(toolbar_builder.get_custom_buttons(subject.class, subject, Mixins::CustomButtons::Result.new(:single))).to eq([expected_button_set])
       end
 
       it "#record_to_service_buttons" do
@@ -89,7 +89,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
         }
         items = [button_set_item1]
         name = "custom_buttons_#{@button_set.name}"
-        result = toolbar_builder.custom_button_selects(subject.class, subject, Mixins::CustomToolbarResult.new(:single))
+        result = toolbar_builder.custom_button_selects(subject.class, subject, Mixins::CustomButtons::Result.new(:single))
         expect(result).to eq([:name => name, :items => items])
       end
 
@@ -117,7 +117,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :items   => button_set_item1_items
         }
         group_name = "custom_buttons_#{@button_set.name}"
-        expect(toolbar_builder.custom_toolbar_class(subject.class, subject, Mixins::CustomToolbarResult.new(:single)).definition[group_name].buttons).to eq([button_set_item1])
+        expect(toolbar_builder.custom_toolbar_class(subject.class, subject, Mixins::CustomButtons::Result.new(:single)).definition[group_name].buttons).to eq([button_set_item1])
       end
     end
 

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -23,8 +23,8 @@ describe ApplicationHelper, "::ToolbarBuilder" do
         expect(toolbar_builder.custom_button_selects(subject.class, subject, Mixins::CustomButtons::Result.new(:single))).to be_blank
       end
 
-      it ("#custom_toolbar_class") do
-        expect(toolbar_builder.custom_toolbar_class(subject.class, subject, Mixins::CustomButtons::Result.new(:single)).definition).to be_blank
+      it ("#build_custom_toolbar_class") do
+        expect(toolbar_builder.build_custom_toolbar_class(subject.class, subject, Mixins::CustomButtons::Result.new(:single)).definition).to be_blank
       end
 
       it("#record_to_service_buttons") { expect(toolbar_builder.record_to_service_buttons(subject)).to be_blank }
@@ -93,7 +93,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
         expect(result).to eq([:name => name, :items => items])
       end
 
-      it "#custom_toolbar_class" do
+      it "#build_custom_toolbar_class" do
         escaped_button1_text = CGI.escapeHTML(@button1.name.to_s)
         button1 = {
           :id        => "custom__custom_#{@button1.id}",
@@ -117,7 +117,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :items   => button_set_item1_items
         }
         group_name = "custom_buttons_#{@button_set.name}"
-        expect(toolbar_builder.custom_toolbar_class(subject.class, subject, Mixins::CustomButtons::Result.new(:single)).definition[group_name].buttons).to eq([button_set_item1])
+        expect(toolbar_builder.build_custom_toolbar_class(subject.class, subject, Mixins::CustomButtons::Result.new(:single)).definition[group_name].buttons).to eq([button_set_item1])
       end
     end
 

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -15,15 +15,15 @@ describe ApplicationHelper, "::ToolbarBuilder" do
     let(:user) { FactoryGirl.create(:user, :role => "super_administrator") }
 
     shared_examples "no custom buttons" do
-      it ("#get_custom_buttons") do
+      it "#get_custom_buttons" do
         expect(toolbar_builder.get_custom_buttons(subject.class, subject, Mixins::CustomButtons::Result.new(:single))).to be_blank
       end
 
-      it ("#custom_button_selects") do
+      it "#custom_button_selects" do
         expect(toolbar_builder.custom_button_selects(subject.class, subject, Mixins::CustomButtons::Result.new(:single))).to be_blank
       end
 
-      it ("#build_custom_toolbar_class") do
+      it "#build_custom_toolbar_class" do
         expect(toolbar_builder.build_custom_toolbar_class(subject.class, subject, Mixins::CustomButtons::Result.new(:single)).definition).to be_blank
       end
 

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -15,9 +15,9 @@ describe ApplicationHelper, "::ToolbarBuilder" do
     let(:user) { FactoryGirl.create(:user, :role => "super_administrator") }
 
     shared_examples "no custom buttons" do
-      it("#get_custom_buttons")        { expect(toolbar_builder.get_custom_buttons(subject)).to be_blank }
-      it("#custom_buttons_hash")       { expect(toolbar_builder.custom_buttons_hash(subject)).to be_blank }
-      it("#custom_toolbar_class")      { expect(toolbar_builder.custom_toolbar_class(subject).definition).to be_blank }
+      it("#get_custom_buttons")        { expect(toolbar_builder.get_custom_buttons(subject.class, subject)).to be_blank }
+      it("#custom_button_selects")     { expect(toolbar_builder.custom_button_selects(subject.class, subject)).to be_blank }
+      it("#custom_toolbar_class")      { expect(toolbar_builder.custom_toolbar_class(subject.class, subject).definition).to be_blank }
       it("#record_to_service_buttons") { expect(toolbar_builder.record_to_service_buttons(subject)).to be_blank }
     end
 
@@ -48,14 +48,14 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :buttons      => [expected_button1]
         }
 
-        expect(toolbar_builder.get_custom_buttons(subject)).to eq([expected_button_set])
+        expect(toolbar_builder.get_custom_buttons(subject.class, subject)).to eq([expected_button_set])
       end
 
       it "#record_to_service_buttons" do
         expect(toolbar_builder.record_to_service_buttons(subject)).to be_blank
       end
 
-      it "#custom_buttons_hash" do
+      it "#custom_button_selects" do
         escaped_button1_text = CGI.escapeHTML(@button1.name.to_s)
         button1 = {
           :id        => "custom__custom_#{@button1.id}",
@@ -80,7 +80,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
         }
         items = [button_set_item1]
         name = "custom_buttons_#{@button_set.name}"
-        expect(toolbar_builder.custom_buttons_hash(subject)).to eq([:name => name, :items => items])
+        expect(toolbar_builder.custom_button_selects(subject.class, subject)).to eq([:name => name, :items => items])
       end
 
       it "#custom_toolbar_class" do
@@ -107,7 +107,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :items   => button_set_item1_items
         }
         group_name = "custom_buttons_#{@button_set.name}"
-        expect(toolbar_builder.custom_toolbar_class(subject).definition[group_name].buttons).to eq([button_set_item1])
+        expect(toolbar_builder.custom_toolbar_class(subject.class, subject).definition[group_name].buttons).to eq([button_set_item1])
       end
     end
 

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -15,9 +15,18 @@ describe ApplicationHelper, "::ToolbarBuilder" do
     let(:user) { FactoryGirl.create(:user, :role => "super_administrator") }
 
     shared_examples "no custom buttons" do
-      it("#get_custom_buttons")        { expect(toolbar_builder.get_custom_buttons(subject.class, subject)).to be_blank }
-      it("#custom_button_selects")     { expect(toolbar_builder.custom_button_selects(subject.class, subject)).to be_blank }
-      it("#custom_toolbar_class")      { expect(toolbar_builder.custom_toolbar_class(subject.class, subject).definition).to be_blank }
+      it ("#get_custom_buttons") do
+        expect(toolbar_builder.get_custom_buttons(subject.class, subject, Mixins::CustomToolbarResult.new(:single))).to be_blank
+      end
+
+      it ("#custom_button_selects") do
+        expect(toolbar_builder.custom_button_selects(subject.class, subject, Mixins::CustomToolbarResult.new(:single))).to be_blank
+      end
+
+      it ("#custom_toolbar_class") do
+        expect(toolbar_builder.custom_toolbar_class(subject.class, subject, Mixins::CustomToolbarResult.new(:single)).definition).to be_blank
+      end
+
       it("#record_to_service_buttons") { expect(toolbar_builder.record_to_service_buttons(subject)).to be_blank }
     end
 
@@ -48,7 +57,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :buttons      => [expected_button1]
         }
 
-        expect(toolbar_builder.get_custom_buttons(subject.class, subject)).to eq([expected_button_set])
+        expect(toolbar_builder.get_custom_buttons(subject.class, subject, Mixins::CustomToolbarResult.new(:single))).to eq([expected_button_set])
       end
 
       it "#record_to_service_buttons" do
@@ -80,7 +89,8 @@ describe ApplicationHelper, "::ToolbarBuilder" do
         }
         items = [button_set_item1]
         name = "custom_buttons_#{@button_set.name}"
-        expect(toolbar_builder.custom_button_selects(subject.class, subject)).to eq([:name => name, :items => items])
+        result = toolbar_builder.custom_button_selects(subject.class, subject, Mixins::CustomToolbarResult.new(:single))
+        expect(result).to eq([:name => name, :items => items])
       end
 
       it "#custom_toolbar_class" do
@@ -107,7 +117,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :items   => button_set_item1_items
         }
         group_name = "custom_buttons_#{@button_set.name}"
-        expect(toolbar_builder.custom_toolbar_class(subject.class, subject).definition[group_name].buttons).to eq([button_set_item1])
+        expect(toolbar_builder.custom_toolbar_class(subject.class, subject, Mixins::CustomToolbarResult.new(:single)).definition[group_name].buttons).to eq([button_set_item1])
       end
     end
 

--- a/spec/shared/controllers/shared_example_for_custom_buttons_spec.rb
+++ b/spec/shared/controllers/shared_example_for_custom_buttons_spec.rb
@@ -4,7 +4,7 @@ shared_examples 'controller with custom buttons' do
     controller.instance_variable_set(:@lastaction, 'show')
     controller.instance_variable_set(:@record, true)
 
-    expect(controller.custom_toolbar?).to be_a_kind_of Mixins::CustomButtons::Result
+    expect(controller.custom_toolbar).to be_a_kind_of Mixins::CustomButtons::Result
   end
 
   it "has no custom toolbar when showing main view w/o @record" do
@@ -12,7 +12,7 @@ shared_examples 'controller with custom buttons' do
     controller.instance_variable_set(:@lastaction, 'show')
     controller.instance_variable_set(:@record, nil)
 
-    expect(controller.custom_toolbar?).to be_falsey
+    expect(controller.custom_toolbar).to be_falsey
   end
 
   it "has no custom toolbar when not showing main view w/ @record" do
@@ -20,7 +20,7 @@ shared_examples 'controller with custom buttons' do
     controller.instance_variable_set(:@lastaction, 'show')
     controller.instance_variable_set(:@record, true)
 
-    expect(controller.custom_toolbar?).to be_falsey
+    expect(controller.custom_toolbar).to be_falsey
   end
 end
 
@@ -34,7 +34,7 @@ shared_examples 'explorer controller with custom buttons' do
       :trees       => {"my_tree" => {:active_node => 'root'}}
     )
 
-    expect(controller.custom_toolbar?).to eq('blank_view_tb')
+    expect(controller.custom_toolbar).to eq('blank_view_tb')
   end
 
   it "has no custom toolbar when not showing main view w/ @record" do
@@ -47,7 +47,7 @@ shared_examples 'explorer controller with custom buttons' do
       :trees       => {"my_tree" => {:active_node => 'v-1r35'}}
     )
 
-    expect(controller.custom_toolbar?).to eq('blank_view_tb')
+    expect(controller.custom_toolbar).to eq('blank_view_tb')
   end
 
   it "has custom toolbar when showing main view w/ @record" do
@@ -60,6 +60,6 @@ shared_examples 'explorer controller with custom buttons' do
       :trees       => {"my_tree" => {:active_node => 'v-1r35'}}
     )
 
-    expect(controller.custom_toolbar?).to be_a_kind_of Mixins::CustomButtons::Result
+    expect(controller.custom_toolbar).to be_a_kind_of Mixins::CustomButtons::Result
   end
 end

--- a/spec/shared/controllers/shared_example_for_custom_buttons_spec.rb
+++ b/spec/shared/controllers/shared_example_for_custom_buttons_spec.rb
@@ -4,7 +4,7 @@ shared_examples 'controller with custom buttons' do
     controller.instance_variable_set(:@lastaction, 'show')
     controller.instance_variable_set(:@record, true)
 
-    expect(controller.custom_toolbar?).to be true
+    expect(controller.custom_toolbar?).to be_a_kind_of Mixins::CustomToolbarResult
   end
 
   it "has no custom toolbar when showing main view w/o @record" do
@@ -34,7 +34,7 @@ shared_examples 'explorer controller with custom buttons' do
       :trees       => {"my_tree" => {:active_node => 'root'}}
     )
 
-    expect(controller.custom_toolbar?).to eq(:blank)
+    expect(controller.custom_toolbar?).to eq('blank_view_tb')
   end
 
   it "has no custom toolbar when not showing main view w/ @record" do
@@ -47,7 +47,7 @@ shared_examples 'explorer controller with custom buttons' do
       :trees       => {"my_tree" => {:active_node => 'v-1r35'}}
     )
 
-    expect(controller.custom_toolbar?).to eq(:blank)
+    expect(controller.custom_toolbar?).to eq('blank_view_tb')
   end
 
   it "has custom toolbar when showing main view w/ @record" do
@@ -60,6 +60,6 @@ shared_examples 'explorer controller with custom buttons' do
       :trees       => {"my_tree" => {:active_node => 'v-1r35'}}
     )
 
-    expect(controller.custom_toolbar?).to be(true)
+    expect(controller.custom_toolbar?).to be_a_kind_of Mixins::CustomToolbarResult
   end
 end

--- a/spec/shared/controllers/shared_example_for_custom_buttons_spec.rb
+++ b/spec/shared/controllers/shared_example_for_custom_buttons_spec.rb
@@ -4,7 +4,7 @@ shared_examples 'controller with custom buttons' do
     controller.instance_variable_set(:@lastaction, 'show')
     controller.instance_variable_set(:@record, true)
 
-    expect(controller.custom_toolbar?).to be_a_kind_of Mixins::CustomToolbarResult
+    expect(controller.custom_toolbar?).to be_a_kind_of Mixins::CustomButtons::Result
   end
 
   it "has no custom toolbar when showing main view w/o @record" do
@@ -60,6 +60,6 @@ shared_examples 'explorer controller with custom buttons' do
       :trees       => {"my_tree" => {:active_node => 'v-1r35'}}
     )
 
-    expect(controller.custom_toolbar?).to be_a_kind_of Mixins::CustomToolbarResult
+    expect(controller.custom_toolbar?).to be_a_kind_of Mixins::CustomButtons::Result
   end
 end


### PR DESCRIPTION
Adding custom button support for lists.

* adding options when editing custom buttons
* displaying custom toolbar or list screens
* handling selection of multiple items by custom buttons
* passing list of items to automate (partly, backend work needed to make all options work)

pivotal: https://www.pivotaltracker.com/story/show/140944305

I have disabled the "submit all" option in the UI as it is not (yet) supported by the backend.

![cust-butt-list](https://cloud.githubusercontent.com/assets/51095/24860654/f8435a72-1df5-11e7-9942-830a82f3fe86.png)

![cut-butt2](https://cloud.githubusercontent.com/assets/51095/24860956/39e12558-1df7-11e7-8609-cdcc12f6a741.png)
