### PR TITLE
Fix password placeholders in credential summary

### DIFF
--- a/app/helpers/ansible_credential_helper/textual_summary.rb
+++ b/app/helpers/ansible_credential_helper/textual_summary.rb
@@ -16,7 +16,13 @@ module AnsibleCredentialHelper::TextualSummary
       options << key
 
       define_singleton_method "textual_#{key}" do
-        {:label => _(value[:label]), :value => value[:type] == :password ? '*****' : @record.options[key], :title => _(value[:help_text])}
+        h = {:label => _(value[:label]), :title => _(value[:help_text])}
+        h[:value] = if value[:type] == :password && @record.options[key].present?
+                      '●●●●●●●●'
+                    else
+                      @record.options[key]
+                    end
+        h
       end
     end
 


### PR DESCRIPTION
Fixes:
* password placeholder to be consistent with the rest of our UI
* display password placeholder only if it's actually set

Before:
![pass-placeholder-before](https://cloud.githubusercontent.com/assets/6648365/24291238/672c167a-1088-11e7-9a59-9a14a2d770e7.jpg)

After:
![pass-placeholder-after](https://cloud.githubusercontent.com/assets/6648365/24291247/6f101ca6-1088-11e7-9f33-a8bca4c6b8bc.jpg)
