### PR TITLE
Fix duplicate DOM IDs and broken flash messages in miq_ae_class_controller 

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -284,34 +284,25 @@ class MiqAeClassController < ApplicationController
     replace_trees_by_presenter(presenter, :ae => build_ae_tree) unless replace_trees.blank?
 
     if @sb[:action] == "miq_ae_field_seq"
-      if @flash_array
-        replace_partial_div = :flash_msg_div
-      end
-      update_partial_div = :class_fields_div
-      update_partial = "fields_seq_form"
+      presenter.update(:class_fields_div, r[:partial => "fields_seq_form"])
+
     elsif @sb[:action] == "miq_ae_domain_priority_edit"
-      if @flash_array
-        replace_partial_div = :flash_msg_div
-      end
-      update_partial_div = :ns_list_div
-      update_partial = "domains_priority_form"
+      presenter.update(:ns_list_div, r[:partial => "domains_priority_form"])
+
     elsif MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
-      if @flash_array
-        replace_partial_div = :flash_msg_div
-      end
-      update_partial_div = :main_div
-      update_partial = "copy_objects_form"
+      presenter.update(:main_div, r[:partial => "copy_objects_form"])
+
     else
       if @sb[:action] == "miq_ae_class_edit"
         @sb[:active_tab] = 'props'
       else
         @sb[:active_tab] ||= 'instances'
       end
-      update_partial_div = :main_div
-      update_partial = "all_tabs"
+      presenter.update(:main_div, r[:partial => 'all_tabs'])
     end
-    presenter.replace(replace_partial_div, r[:partial => "layouts/flash_msg"]) if replace_partial_div
-    presenter.update(update_partial_div, r[:partial => update_partial]) if update_partial
+
+    presenter.replace('flash_msg_div', r[:partial => "layouts/flash_msg"]) if @flash_array
+
     if @in_a_form
       action_url =  create_action_url(nodes.first)
       # incase it was hidden for summary screen, and incase there were no records on show_list

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1268,7 +1268,7 @@ class MiqAeClassController < ApplicationController
     @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
-      page.replace_html("class_fields_div", :partial => "class_fields")
+      page.replace("class_fields_div", :partial => "class_fields")
       page << javascript_for_miq_button_visibility(@changed)
       page << "miqSparkle(false);"
     end
@@ -1282,7 +1282,7 @@ class MiqAeClassController < ApplicationController
     @dtype_combo_xml = build_dtype_options
     render :update do |page|
       page << javascript_prologue
-      page.replace_html("class_fields_div", :partial => "class_fields")
+      page.replace("class_fields_div", :partial => "class_fields")
       page << javascript_for_miq_button_visibility(@changed)
       page << "miqSparkle(false);"
     end
@@ -1302,7 +1302,7 @@ class MiqAeClassController < ApplicationController
     @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
-      page.replace_html("class_fields_div", :partial => "class_fields")
+      page.replace("class_fields_div", :partial => "class_fields")
       page << javascript_for_miq_button_visibility(@changed)
       page << "miqSparkle(false);"
     end

--- a/app/views/miq_ae_class/_all_tabs.html.haml
+++ b/app/views/miq_ae_class/_all_tabs.html.haml
@@ -1,3 +1,4 @@
+= render :partial => "layouts/flash_msg"
 #ae_tabs
   -# Toplevel Tabbar
   - nodes = x_node.split('-')

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -2,7 +2,6 @@
   - if x_node.split('-')[0] == "aec" || params[:pressed] || %w(field_select field_accept field_delete).include?(params[:action])
     - if !@in_a_form_fields
       / Show Schema
-      = render :partial => "layouts/flash_msg"
       %h3= _('Schema')
       - if @ae_class.ae_fields.present?
         %table.table.table-striped.table-bordered
@@ -46,8 +45,7 @@
       - url = url_for_only_path(:action => 'fields_form_field_changed', :id => (@ae_class.id || 'new'))
       - obs = {:interval => '.5', :url => url}.to_json
       / Edit Schema
-      #form_div
-        = render :partial => "layouts/flash_msg"
+      .form_div
         %h3= _('Schema')
         %table.table.table-striped.table-bordered
           %thead
@@ -76,7 +74,7 @@
                       - combo_name = "fields_#{fname}#{i}"
                       - combo_options  = (fname == "aetype" ? @combo_xml : @dtype_combo_xml)
                       - combo_url  = "/miq_ae_class/fields_form_field_changed/#{@ae_class.id || 'new'}"
-                      #form-group
+                      .form-group
                         = select_tag(combo_name,
                           options_for_select(combo_options, field[fname]),
                           "title" => "Choose",
@@ -122,7 +120,7 @@
                     - combo_name = "field_#{fname}"
                     - combo_options  = @edit[:new]["#{fname}s".to_sym]
                     - combo_url  = "/miq_ae_class/fields_form_field_changed/#{@ae_class.id || 'new'}"
-                    #form-group
+                    .form-group
                       = select_tag(combo_name,
                           options_for_select(combo_options, session[:field_data][fname]),
                           "title" => "Choose",

--- a/app/views/miq_ae_class/_class_instances.html.haml
+++ b/app/views/miq_ae_class/_class_instances.html.haml
@@ -1,6 +1,5 @@
 #class_instances_div
   - if !@in_a_form
-    = render :partial => "layouts/flash_msg"
     %h3= _('Instances')
     - if @record.ae_instances.present?
       %table#class_instances_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
@@ -29,5 +28,4 @@
                :locals  => {:message => _("No instances found")}
   - elsif @edit[:new][:ae_inst]
     #form_div
-      = render :partial => "layouts/flash_msg"
       = render :partial => "instance_form", :locals => {:prefix => "cls_"}

--- a/app/views/miq_ae_class/_class_methods.html.haml
+++ b/app/views/miq_ae_class/_class_methods.html.haml
@@ -1,6 +1,5 @@
 #class_methods_div
   - if !@in_a_form
-    = render :partial => "layouts/flash_msg"
     %h3= _('Methods')
     - if @record.ae_methods.present?
       %table#class_methods_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
@@ -28,6 +27,5 @@
       = render :partial => "layouts/info_msg",
                :locals  => {:message => _("No methods found")}
   - elsif @edit[:new][:fields]
-    #form_div
-      = render :partial => "layouts/flash_msg"
+    .form_div
       = render :partial => "method_form", :locals  => {:prefix => "cls_"}

--- a/app/views/miq_ae_class/_class_props.html.haml
+++ b/app/views/miq_ae_class/_class_props.html.haml
@@ -1,7 +1,6 @@
 #class_props_div
   - if x_node.split('-')[0] == "aec" || params[:pressed] || ["field_select","field_accept","field_delete"].include?(params[:action]) || (x_node.split('-')[0] == "aen" && params[:button] == "reset")
     - if !@in_a_form_props
-      = render :partial => "layouts/flash_msg"
       %h3= _('Properties')
       %table.table.table-striped.table-bordered
         %tbody
@@ -34,5 +33,4 @@
     - else
       #form_div
         %div{:style => "padding-top: 10px;"}
-        = render :partial => "layouts/flash_msg"
         = render :partial => "class_form"


### PR DESCRIPTION
* flash message related IDs are duplicate
* class_fields_div is nesting (messed up update and replace)
* form_group and form_div are used many times

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1405178

