### PR TITLE
Add a link from container nodes to the ad-hoc page

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
+++ b/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
@@ -57,6 +57,8 @@ ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', '
 
       var _tenant = dash.tenant.value || dash.DEFAULT_TENANT;
       dash.url = '/container_dashboard/data' + dash.providerId  + '/?live=true&tenant=' + _tenant;
+
+      setAppliedFilters();
     }
 
     var filterChange = function (filters, addOnly) {
@@ -68,6 +70,7 @@ ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', '
       if (dash.filterConfig.appliedFilters.length === 0) {
         dash.applied = false;
         dash.itemSelected = false;
+        dash.tagsLoaded = true;
         dash.items = [];
         dash.page = 1;
         dash.pages = 1;
@@ -109,6 +112,24 @@ ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', '
       // add a filter but only add (do not apply)
       filterChange(null, true);
     };
+
+    var setAppliedFilters = function() {
+      // if user did not send any tags, just exit
+      if (!dash.params.tags) return;
+
+      // add the user defined tags as filters
+      var tags = JSON.parse(dash.params.tags);
+      angular.forEach(tags, function(value, key) {
+        dash.filterConfig.appliedFilters.push({
+          id: key,
+          title: key,
+          value: value,
+        });
+      });
+
+      // apply the new filters
+      filterChange();
+    }
 
     dash.applyFilters = function() {
       dash.applied = true;

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-parse-url-factroy.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-parse-url-factroy.js
@@ -1,13 +1,41 @@
 angular.module('miq.util').factory('metricsParseUrlFactory', function() {
+  var re = /([^&=]+)=?([^&]*)/g;
+  var decodeRE = /\+/g;  // Regex for replacing addition symbol with a space
+  var decode = function(str) {
+    return decodeURIComponent( str.replace(decodeRE, ' ') );
+  };
+
+  var parseParams = function(query) {
+    var params = {};
+    var e;
+
+    e = re.exec(query);
+    while (e) {
+      var k = decode( e[1] );
+      var v = decode( e[2] );
+
+      if (k.substring(k.length - 2) === '[]') {
+        k = k.substring(0, k.length - 2);
+        (params[k] || (params[k] = [])).push(v);
+      } else {
+        params[k] = v;
+      }
+
+      e = re.exec(query);
+    }
+    return params;
+  };
+
   return function(dash, $window) {
     // get the pathname and remove trailing / if exist
     var pathname = $window.location.pathname.replace(/\/$/, '');
+
+    dash.params = parseParams($window.location.search);
     dash.providerId = '/' + (/^\/[^\/]+\/([r\d]+)$/.exec(pathname)[1]);
 
-    // TODO: get this values from GET/POST values ?
     dash.tenantList = [];
-    dash.minBucketDurationInSecondes = 20 * 60;
-    dash.max_metrics = 10000;
-    dash.items_per_page = 10;
+    dash.minBucketDurationInSecondes = parseInt(dash.params.bucket, 10) || 20 * 60;
+    dash.max_metrics = parseInt(dash.params.max_metrics, 10) || 10000;
+    dash.items_per_page = parseInt(dash.params.items_per_page, 10) || 10;
   };
 });

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -20,6 +20,13 @@ module Mixins
         show_timeline if respond_to?(:show_timeline)
       when "performance"
         show_performance if respond_to?(:show_performance)
+      when "ad_hoc_metrics"
+        if @record && @record.try(:ems_id)
+          ems = ExtManagementSystem.find(@record.ems_id)
+          tags = {:type => "node", :hostname => @record.name}.to_json
+          url = polymorphic_path(ems, :display => "ad_hoc_metrics", :tags => tags)
+          redirect_to(url)
+        end
       when "compliance_history"
         show_compliance_history if respond_to?(:show_compliance_history)
       when "topology"

--- a/app/helpers/application_helper/toolbar/container_node_center.rb
+++ b/app/helpers/application_helper/toolbar/container_node_center.rb
@@ -23,6 +23,14 @@ class ApplicationHelper::Toolbar::ContainerNodeCenter < ApplicationHelper::Toolb
           :url       => "/show",
           :url_parms => "?display=performance"),
         button(
+          :ems_container_ad_hoc_metrics,
+          'fa fa-tachometer fa-1xplus',
+          N_('Show Ad hoc Metrics for this Provider'),
+          N_('Ad hoc Metrics'),
+          :url       => "/show",
+          :url_parms => "?display=ad_hoc_metrics"
+        ),
+        button(
           :ems_container_launch_external_logging,
           'product product-monitoring fa-lg',
           N_('Open a new browser window with the External Logging Presentation UI. ' \


### PR DESCRIPTION
**Description**
Compute > Containers > Container Nodes - pick a node - toolbar Monitoring > Ad hoc Metrics

Add a link from container nodes to the ad-hoc page

**Screenshots**
![gifrecord_2017-03-27_162936](https://cloud.githubusercontent.com/assets/2181522/24358736/c4a5e888-130a-11e7-8da1-29c78d712c0b.gif)
