### PR TITLE
Add control that id is not nil otherwise set it to new

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -182,6 +182,10 @@ class TreeBuilder
     end
   end
 
+  def group_id
+    (@group.present? && @group.id.present?) ? @group.id : 'new'
+  end
+
   def set_locals_for_render
     {
       :tree_id    => "#{@name}box",

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -33,9 +33,13 @@ class TreeBuilderBelongsToHac < TreeBuilder
      :selected             => @selected}
   end
 
+  def group_id
+    (@group.present? && @group.id.present?) ? @group.id : 'new'
+  end
+
   def set_locals_for_render
     locals = super
-    locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
+    locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{group_id}___",
                   :oncheck           => @edit ? "miqOnCheckUserFilters" : nil,
                   :checkboxes        => true,
                   :highlight_changes => true,

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -33,10 +33,6 @@ class TreeBuilderBelongsToHac < TreeBuilder
      :selected             => @selected}
   end
 
-  def group_id
-    (@group.present? && @group.id.present?) ? @group.id : 'new'
-  end
-
   def set_locals_for_render
     locals = super
     locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{group_id}___",

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -32,9 +32,13 @@ class TreeBuilderTags < TreeBuilder
     (@edit && @edit.fetch_path(:new, :filters, path)) || (@filters && @filters.key?(path))
   end
 
+  def group_id
+    (@group.present? && @group.id.present?) ? @group.id : 'new'
+  end
+
   def set_locals_for_render
     locals = super
-    locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
+    locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{group_id}___",
                   :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
                   :checkboxes        => true,
                   :highlight_changes => true,

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -32,10 +32,6 @@ class TreeBuilderTags < TreeBuilder
     (@edit && @edit.fetch_path(:new, :filters, path)) || (@filters && @filters.key?(path))
   end
 
-  def group_id
-    (@group.present? && @group.id.present?) ? @group.id : 'new'
-  end
-
   def set_locals_for_render
     locals = super
     locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{group_id}___",

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -61,7 +61,7 @@ describe TreeBuilderBelongsToHac do
                         true,
                         :edit     => edit,
                         :filters  => {},
-                        :group    => group,
+                        :group    => nil,
                         :selected => {})
   end
 
@@ -80,7 +80,7 @@ describe TreeBuilderBelongsToHac do
       expect(subject.send(:set_locals_for_render)).to include(:onclick           => false,
                                                               :tree_state        => true,
                                                               :checkboxes        => true,
-                                                              :check_url         => "/ops/rbac_group_field_changed/#{group.id || "new"}___",
+                                                              :check_url         => "/ops/rbac_group_field_changed/new___",
                                                               :oncheck           => nil,
                                                               :highlight_changes => true)
     end

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -29,7 +29,7 @@ describe TreeBuilderTags do
     it 'set locals for render correctly' do
       locals = @tags_tree.send(:set_locals_for_render)
       expect(locals[:checkboxes]).to eq(true)
-      expect(locals[:check_url]).to eq("/ops/rbac_group_field_changed/#{@group.id || "new"}___")
+      expect(locals[:check_url]).to eq("/ops/rbac_group_field_changed/#{@group.id}___")
       expect(locals[:highlight_changes]).to eq(true)
       expect(locals[:oncheck]).to eq(nil)
       expect(locals[:cfmeNoClick]).to eq(true)
@@ -72,7 +72,15 @@ describe TreeBuilderTags do
                                        :tag_tree,
                                        {},
                                        true,
-                                       :edit => @edit, :filters => @filters, :group => @group)
+                                       :edit => @edit, :filters => @filters, :group => nil)
+    end
+    it 'set locals for render correctly' do
+      locals = @tags_tree.send(:set_locals_for_render)
+      expect(locals[:checkboxes]).to eq(true)
+      expect(locals[:check_url]).to eq("/ops/rbac_group_field_changed/new___")
+      expect(locals[:highlight_changes]).to eq(true)
+      expect(locals[:oncheck]).to eq("miqOnCheckUserFilters")
+      expect(locals[:cfmeNoClick]).to eq(true)
     end
     it 'sets second level nodes correctly' do
       selected_kid = @tags_tree.send(:x_get_classification_kids, @folder_selected, false)


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/379 .  So @miq-bot add_label euwe/yes, darga/yes, bug, trees

https://bugzilla.redhat.com/show_bug.cgi?id=1434857

Configuration -> Access Control -> Group -> Configuration -> Add new Group -> select anything from trees

Before:
<img width="873" alt="screen shot 2017-03-27 at 5 13 10 pm" src="https://cloud.githubusercontent.com/assets/9210860/24363655/c9cc7650-1310-11e7-9537-4e65db22b528.png">

After:
<img width="867" alt="screen shot 2017-03-27 at 5 14 41 pm" src="https://cloud.githubusercontent.com/assets/9210860/24363703/e4f9557e-1310-11e7-9efb-3c0daaf2f2a5.png">
