### PR TITLE
Fix bug where performance pages would not appear for Middleware Servers

### DIFF
--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -17,11 +17,11 @@ module Mixins
 
       # these methods are defined in MoreShowActions
       when "timeline"
-        show_timeline if respond_to?(:timeline)
+        show_timeline if respond_to?(:show_timeline)
       when "performance"
-        show_performance if respond_to?(:performance)
+        show_performance if respond_to?(:show_performance)
       when "compliance_history"
-        show_compliance_history if respond_to?(:compliance_history)
+        show_compliance_history if respond_to?(:show_compliance_history)
       when "topology"
         show_topology
 


### PR DESCRIPTION
Behavior before: For Middleware Servers, Middleware Messagings and
Middleware Datasources, when clicking on "Monitoring > Utilization" button,
utilization page was not being open, showing server details page without menu
items instead.

This fixes the problem by check for the correct methods when dispatching
from GenericShowMixin.

Bugzilla Link: https://bugzilla.redhat.com/show_bug.cgi?id=1433036