### PR TITLE
Fix cloud volume edit form

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -44,6 +44,9 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$scope', 'miqServ
     // model attribute with AWS.
     $scope.cloudVolumeModel.aws_volume_type = data.volume_type;
 
+    // Update the IOPS based on the current volume size.
+    $scope.sizeChanged($scope.cloudVolumeModel.size);
+
     $scope.modelCopy = angular.copy( $scope.cloudVolumeModel );
     miqService.sparkleOff();
   }

--- a/app/views/cloud_volume/edit.html.haml
+++ b/app/views/cloud_volume/edit.html.haml
@@ -3,6 +3,19 @@
   %h3
     = _('Edit Volume')
   .form-horizontal
+    .form-group{"ng-class" => "{'has-error': angularForm.storage_manager_id.$invalid}"}
+      %label.col-md-2.control-label
+        = _('Storage Manager')
+      .col-md-8
+        = select_tag("storage_manager_id",
+                     options_for_select([[@volume.ext_management_system.name, @volume.ext_management_system.id]]),
+                     "ng-model"                    => "cloudVolumeModel.storage_manager_id",
+                     "required"                    => "",
+                     "disabled"                    => true,
+                     "selectpicker-for-select-tag" => "")
+        %span.help-block{"ng-show" => "angularForm.storage_manager_id.$error.required"}
+          = _("Required")
+
     = render :partial => "common_new_edit"
 
   %table{:width => '100%'}
@@ -25,5 +38,5 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', '');
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
   miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_volume/edit.html.haml
+++ b/app/views/cloud_volume/edit.html.haml
@@ -25,4 +25,5 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
+  ManageIQ.angular.app.value('storageManagerId', '');
   miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_volume/edit.html.haml
+++ b/app/views/cloud_volume/edit.html.haml
@@ -1,4 +1,4 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => ""}
+%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => "", "ng-show" => "afterGet"}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Edit Volume')


### PR DESCRIPTION
With the introduction of support for adding cloud volumes to a specific storage manager, the edit form failed to provide parameter to its controller. Since edit form is not using it, it sets it to an empty value.

@miq-bot add_label bug,storage
@miq-bot assign @AparnaKarve 

@AparnaKarve this is an attempt to resolve the issue with the edit form you [mentioned](https://github.com/ManageIQ/manageiq-ui-classic/pull/715#issuecomment-289585889).