### PR TITLE
Broken titles for a new automate buttons and groups 

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -590,7 +590,7 @@ module ApplicationController::Buttons
     @layout = "miq_ae_automate_button"
     @sb[:button_groups] = nil
     @sb[:buttons] = nil
-    replace_right_cell(:action => "group_edit")
+    replace_right_cell(:nodetype => "group_edit")
   end
 
   def button_new_edit(typ)
@@ -611,7 +611,7 @@ module ApplicationController::Buttons
     @layout = "miq_ae_automate_button"
     @sb[:buttons] = nil
     @sb[:button_groups] = nil
-    replace_right_cell(:action => "button_edit")
+    replace_right_cell(:nodetype => "button_edit")
   end
 
   # Set form variables for button add/edit

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1862,7 +1862,7 @@ class CatalogController < ApplicationController
 
   # Replace the right cell of the explorer
   def replace_right_cell(options = {})
-    action, replace_trees = options.values_at(:action, :replace_trees)
+    action, replace_trees = options.values_at(:nodetype, :replace_trees)
     @explorer = true
 
     # FIXME: make this functional


### PR DESCRIPTION
This PR fix a broken titles for a new automate buttons and groups.

based on: https://bugzilla.redhat.com/show_bug.cgi?id=1379348

before:
![automate-old](https://cloud.githubusercontent.com/assets/19405716/24395724/de12af18-13a0-11e7-89db-9e3bdd46a832.png)
after:
![automate-new](https://cloud.githubusercontent.com/assets/19405716/24395732/e4a6cf62-13a0-11e7-8571-91eafd27bb05.png)

