### PR TITLE
Add cockpit button for cloud instance.

### DIFF
--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -128,4 +128,15 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
     ),
   ])
   include ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
+  button_group('vm_access', [
+    button(
+      :cockpit_console,
+      'pficon pficon-screen fa-lg',
+      N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),
+      N_('Web Console'),
+      # :image   => "cockpit",
+      :url   => "launch_cockpit",
+      :klass => ApplicationHelper::Button::CockpitConsole
+    )
+  ])
 end


### PR DESCRIPTION
Fixes:

https://bugzilla.redhat.com/show_bug.cgi?id=1414543

Not sure if we want just the button (as I added) or we want the full access menu.

Seems to me the access menu has only one valid option in the cloud atm. so adding just the button

ping @dclarizio .