### PR TITLE
Don't set calendar dates globally in ops/explorer.html

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -75,7 +75,7 @@ function miqInitWidgetPulldown() {
 }
 
 function miqCalendarDateConversion(server_offset) {
-  return moment().utcOffset(Number(server_offset) / 60);
+  return moment().utcOffset(Number(server_offset) / 60).toDate();
 }
 
 // The expressions variable is used only in the following two functions

--- a/app/views/report/explorer.html.haml
+++ b/app/views/report/explorer.html.haml
@@ -18,4 +18,4 @@
 
 -# Create from/to date JS vars to limit calendar starting from
 :javascript
-  ManageIQ.calendar.calDateFrom = miqCalendarDateConversion("#{@timezone_offset}").toDate();
+  ManageIQ.calendar.calDateFrom = miqCalendarDateConversion("#{@timezone_offset}");


### PR DESCRIPTION
Reproducer:
* navigate to Configuration -> Diagnostics -> Zone -> C & U Gap Collection
* navigate away (to a different controller)
* Click back on Configuration

First time in the C& U Gap Collection page, the error won't show, since the to be removed
javascript code wouldn't be called.

Second time in that page, the code would be executed -> javascript error.

https://bugzilla.redhat.com/show_bug.cgi?id=1432461