### PR TITLE
Ansible credentials - getBack - don't use default parametrs

### DIFF
--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -101,7 +101,7 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
     miqService.sparkleOff();
   }
 
-  function getBack(message, warning = false, error = false) {
+  function getBack(message, warning, error) {
     var url = '/ansible_credential/show_list' + '?flash_msg=' + message + '&escape=true';
 
     if (warning) {


### PR DESCRIPTION
Breaks the build, because es5 does not support default parameters.
(Although most browsers do now :).)

Just removing, since both false and undefined are falsy.

@Fryguy this should fix the Docker build failures :)

Cc @mzazrivec (sorry ;))