### PR TITLE
Fix ad-hoc page css for new Patternfly version

### DIFF
--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -1,8 +1,17 @@
 .miq-metrics {
-  overflow-x:hidden;
+  overflow-x: hidden;
+  overflow-y: hidden;
 
   .ad-hoc-toolbar {
     margin-left: 10px;
+  }
+  .toolbar-pf {
+    .toolbar-pf-actions {
+      .form-group {
+        margin-bottom: 0;
+        border: 0;
+      }
+    }
   }
 
   .ad-hoc-tenant {
@@ -21,15 +30,11 @@
       margin-left: 0;
     }
   }
-
-  .form-group {
-    &.toolbar-pf-filter {
-      margin-bottom: 0;
-    }
-
-    &.toolbar-actions.ng-scope {
-      margin-bottom: 0;
-    }
+  .form-group.toolbar-pf-filter {
+    margin-bottom: 0;
+  }
+  .form-group.toolbar-actions.ng-scope {
+    margin-bottom: 0;
   }
 
   .pagination {
@@ -58,14 +63,10 @@
     .form-group.toolbar-actions.ng-scope {
       margin-bottom: 10px;
     }
-
-    .dropdown-kebab-pf .dropdown-menu {
-      left: 0;
-    }
-
-    .toolbar-pf-actions .dropdown-kebab-pf {
-      float: none;
-      margin-left: 10px;
+    .toolbar-pf-actions {
+      .dropdown-kebab-pf {
+        float: none;
+      }
     }
   }
 
@@ -74,7 +75,6 @@
     padding-top: 10px;
     margin-bottom: 0;
   }
-
   .line-chart {
     min-height: calc(100vh - 347px);
     margin-top: 36px;
@@ -92,32 +92,37 @@
     overflow-x: hidden;
     overflow-y: hidden;
 
-    .form-group {
-      &.toolbar-actions.ng-scope {
-        width: calc(100% - 425px);
+    .list-group-item-container {
+      margin-top: 10px;
+    }
+    .form-group.toolbar-actions.ng-scope {
+      width: calc(100% - 485px);
+      border: 0;
+    }
+    .dropdown-kebab-pf {
+      .dropdown-menu {
+        left: -5px;
       }
     }
-
-    .dropdown-kebab-pf .dropdown-menu {
-      left: -5px;
-    }
-
-    .toolbar-pf-actions .dropdown-kebab-pf {
-      float: none;
-      margin-left: 10px;
-    }
-
-    .filter-pf.filter-fields .form-group {
-      width: 410px;
-    }
-
-    .toolbar-pf .form-group {
-      .btn-group {
-        margin-left: 0;
+    .toolbar-pf-actions {
+      .dropdown-kebab-pf {
+        float: none;
+        margin-left: 0px;
       }
-
-      .btn {
-        margin-left: 0;
+    }
+    .filter-pf.filter-fields {
+      .form-group {
+        width: 410px;
+      }
+    }
+    .toolbar-pf {
+      .form-group {
+        .btn-group {
+          margin-left: 0;
+        }
+        .btn {
+          margin-left: 0;
+        }
       }
     }
   }
@@ -157,11 +162,15 @@
     min-width: 100px;
   }
 
-  .filters-selector .btn {
-    margin-left: 0;
+  .filters-selector {
+    .btn {
+      margin-left: 0;
+    }
   }
 
-  .tenants-selector .btn {
-    margin-left: 0;
+  .tenants-selector {
+    .btn {
+      margin-left: 0;
+    }
   }
 }

--- a/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
@@ -34,7 +34,7 @@
                                            "data-toggle"   => "dropdown",
                                            "aria-haspopup" => "true",
                                            "aria-expanded" => "true"}
-        %span.fa.fa-fw.fa-ellipsis-v
+        %span.fa.fa-ellipsis-v
       %ul.dropdown-menu{"aria-labelledby" => "dropdownKebab"}
         %li{"ng-repeat" => "range in dash.timeIntervals"}
           %a{"href"     => "#",

--- a/app/views/ems_container/ad_hoc/_list_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_list_view_form.html.haml
@@ -13,7 +13,7 @@
                                           "data-live-search" => "true",
                                           "data-actions-box" => "true"}
 
-.ad-hoc-toolbar.filters-selector{"pf-toolbar" => "", "config" => "dash.toolbarConfig"}
+.ad-hoc-toolbar.filters-selector{"pf-toolbar" => "", "id" => "filters-selector", "config" => "dash.toolbarConfig"}
   %actions
     %button.btn.btn-default{"type"        => "button",
                             "ng-click"    => "dash.doAddFilter()",
@@ -33,7 +33,7 @@
                                            "data-toggle"   => "dropdown",
                                            "aria-haspopup" => "true",
                                            "aria-expanded" => "true"}
-        %span.fa.fa-fw.fa-ellipsis-v
+        %span.fa.fa-ellipsis-v
       %ul.dropdown-menu{"aria-labelledby" => "dropdownKebab"}
         %li{"ng-repeat" => "range in dash.filterTypes"}
           %a{"href"     => "#",


### PR DESCRIPTION
**Description**
https://github.com/ManageIQ/manageiq-ui-classic/pull/402 updated the Patternfly version in ManageIQ, this PR has some little css fixes for the ad-hoc page.

**Screenshot**
_Broken_
![screenshot-localhost 3000-2017-03-28-17-56-40](https://cloud.githubusercontent.com/assets/2181522/24412013/ff3aca56-13df-11e7-8fa7-a89ffca2f942.png)

_Fixed css_
![screenshot-localhost 3000-2017-03-29-16-55-42](https://cloud.githubusercontent.com/assets/2181522/24458154/c89d836e-14a0-11e7-9d4e-e6f08f7bc35b.png)

