### PR TITLE
Set afterGet when the OPTIONS data is actually retrieved

### DIFF
--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -38,7 +38,6 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
         .then(setManagerResource)
         .catch(miqService.handleFailure);
 
-      vm.afterGet = true;
       vm.modelCopy = angular.copy( vm.credentialModel );
       miqService.sparkleOff();
     }
@@ -77,6 +76,7 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
     for (var opt in vm.credential_options) {
       vm.select_options.push({'value': opt, 'label': vm.credential_options[opt].label});
     }
+    vm.afterGet = true;
   }
 
   function getCredentialFormData(response) {


### PR DESCRIPTION
 `API` calls are async and therefore `afterGet` needs to be set once we have actually retrieved the data in `getCredentialOptions` from the `API.options('/api/authentications')` call.

Without this change, there is a chance that one could see an empty dropdown for a few brief seconds when the form is loaded as seen in the screenshot --
<img width="1221" alt="screen shot 2017-03-28 at 1 03 00 pm" src="https://cloud.githubusercontent.com/assets/1538216/24427050/7ee206f6-13be-11e7-8711-a0a8d0283971.png">
