### PR TITLE
Fix delete button under Configuration > Diagnostics

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -801,7 +801,7 @@ module OpsController::Diagnostics
   def diagnostics_set_form_vars
     active_node = x_node
     if active_node && active_node.split('-').first == "z"
-      @record = @selected_server = Zone.find_by_id(from_cid(active_node.split('-').last))
+      @record = @selected_zone = @selected_server = Zone.find_by_id(from_cid(active_node.split('-').last))
       @sb[:selected_server_id] = @selected_server.id
       @sb[:selected_typ] = "zone"
       if @selected_server.miq_servers.length >= 1 &&

--- a/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
@@ -15,19 +15,19 @@ class ApplicationHelper::Toolbar::DiagnosticsZoneCenter < ApplicationHelper::Too
       t,
       :items => [
         button(
-          :zone_delete_server,
+          :zone_delete,
           'pficon pficon-delete fa-lg',
           t = proc do
-            _('Delete Server %{server_name} [%{server_id}]') % {:server_name => @record.name, :server_id => @record.id}
+            _('Delete Zone %{server_name} [%{server_id}]') % {:server_name => @selected_zone.name, :server_id => @selected_zone.id}
           end,
           t,
           :confirm => proc do
-                        _("Do you want to delete Server %{server_name} [%{server_id}]?") % {
-                          :server_name => @record.name,
-                          :server_id   => @record.id
+                        _("Do you want to delete Zone %{server_name} [%{server_id}]?") % {
+                          :server_name => @selected_zone.name,
+                          :server_id   => @selected_zone.id
                         }
                       end,
-          :klass => ApplicationHelper::Button::ZoneDeleteServer
+          :klass => ApplicationHelper::Button::ZoneDelete
         ),
         button(
           :zone_role_start,


### PR DESCRIPTION
Currently selecting a zone in the accordion and clicking the Configuration dropdown will show the first server for the zone. This is mostly due to the use of the incorrect button class. This changes things to use ApplicationHelper::Button::ZoneDelete to display button for deleting the selected zone.

**Before:**

![screen shot 2017-03-28 at 4 10 35 pm](https://cloud.githubusercontent.com/assets/39493/24431737/a043dd10-13d2-11e7-887a-7b382c91a1af.png)

**After**
![screen shot 2017-03-28 at 4 08 18 pm](https://cloud.githubusercontent.com/assets/39493/24431741/a8f330d2-13d2-11e7-9d25-543077571287.png)


Addresses:
https://bugzilla.redhat.com/show_bug.cgi?id=1425456