### PR TITLE
Adjust custom menu load path to match split repositories.

### DIFF
--- a/app/presenters/menu/custom_loader.rb
+++ b/app/presenters/menu/custom_loader.rb
@@ -9,7 +9,7 @@ module Menu
     def load_custom_items
       @sections = []
       @items    = []
-      Dir.glob(File.join(File.dirname(__FILE__), "../../../product/menubar/*.yml")).each do |f|
+      Dir.glob(Rails.root.join('product/menubar/*.yml')).each do |f|
         load_custom_item(f)
       end
       [@sections, @items]


### PR DESCRIPTION
fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1428735

@mzazrivec, @h-kataria : review please?

Can be tested by changing the single line on an appliance. The file is located e.g.:

```
/opt/rh/cfme-gemset
./bundler/gems/manageiq-ui-classic-741917e74d1a/app/presenters/menu/custom_loader.rb
```