### PR TITLE
Use angular-ui-bootstrap from bower, not gem

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,8 +10,8 @@
 //= require angular
 //= require angular-drag-and-drop-lists
 //= require angular-patternfly-sass/dist/angular-patternfly
-//= require angular-ui-bootstrap
-//= require angular-ui-bootstrap-tpls
+//= require angular-bootstrap/ui-bootstrap
+//= require angular-bootstrap/ui-bootstrap-tpls
 //= require angular-sanitize
 //= require angular.validators
 //= require moment
@@ -49,7 +49,6 @@
 //= require bootstrap-select
 //= require bootstrap-hover-dropdown
 //= require bootstrap-switch
-//= require angular-ui-bootstrap
 //= require angular-bootstrap-switch
 //= require angular-ui-codemirror
 //= require patternfly-bootstrap-treeview

--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -3,7 +3,6 @@ require 'sass-rails'
 require 'coffee-rails'
 require 'patternfly-sass'
 require 'lodash-rails'
-require 'angular-ui-bootstrap-rails'
 require 'jquery-hotkeys-rails'
 
 module ManageIQ

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.0.0", ">= 5.0.0.1"
 
-  s.add_dependency "angular-ui-bootstrap-rails", "~>0.13.0"
   s.add_dependency "coffee-rails"
   s.add_dependency "jquery-hotkeys-rails"
   s.add_dependency "lodash-rails", "~>3.10.0"


### PR DESCRIPTION
For some reason we still used the gem, but the version was fixed to one incompatible with current angular-patternfly.

Dropping the gem dependency and updating application.js to use the bower one.

@yaacov this should fix the problem you've been seeing in https://github.com/ManageIQ/manageiq-ui-classic/pull/826, can you please verify?