### PR TITLE
Fixed quadicon link for automation providers

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -33,7 +33,7 @@ class AutomationManagerController < ApplicationController
   end
 
   def managed_group_kls
-    ManageIQ::Providers::AutomationManager::InventoryGroup
+    ManageIQ::Providers::AutomationManager::InventoryRootGroup
   end
 
   def manager_prefix
@@ -113,7 +113,7 @@ class AutomationManagerController < ApplicationController
     nodes = x_node.split('-')
     case nodes.first
     when "root" then find_record(ManageIQ::Providers::AnsibleTower::AutomationManager, params[:id])
-    when "at", "e"   then find_record(ManageIQ::Providers::AutomationManager::InventoryGroup, params[:id])
+    when "at", "e" then find_record(ManageIQ::Providers::AutomationManager::InventoryRootGroup, params[:id])
     when "f"    then find_record(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem, params[:id])
     when "xx" then
       case nodes.second
@@ -264,7 +264,7 @@ class AutomationManagerController < ApplicationController
       options = {:model                 => "ManageIQ::Providers::AutomationManager::InventoryRootGroup",
                  :match_via_descendants => ConfiguredSystem,
                  :where_clause          => ["ems_id IN (?)", provider.id],
-                 :gtl_dbname            => "automation_manager_groups"}
+                 :gtl_dbname            => "automation_manager_providers"}
       process_show_list(options)
       record_model = ui_lookup(:model => self.class.model_to_name(model || TreeBuilder.get_model_for_prefix(@nodetype)))
       @right_cell_text = _("%{model} \"%{name}\"") % {:name  => provider.name,
@@ -283,7 +283,7 @@ class AutomationManagerController < ApplicationController
   end
 
   def inventory_group_node(id, model)
-    @record = @inventory_group_record = find_record(ManageIQ::Providers::AutomationManager::InventoryGroup, id) if model
+    @record = @inventory_group_record = find_record(ManageIQ::Providers::AutomationManager::InventoryRootGroup, id) if model
 
     if @inventory_group_record.nil?
       self.x_node = "root"

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -113,7 +113,7 @@ class AutomationManagerController < ApplicationController
     nodes = x_node.split('-')
     case nodes.first
     when "root" then find_record(ManageIQ::Providers::AnsibleTower::AutomationManager, params[:id])
-    when "at"   then find_record(ManageIQ::Providers::AutomationManager::InventoryGroup, params[:id])
+    when "at", "e"   then find_record(ManageIQ::Providers::AutomationManager::InventoryGroup, params[:id])
     when "f"    then find_record(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem, params[:id])
     when "xx" then
       case nodes.second
@@ -228,8 +228,8 @@ class AutomationManagerController < ApplicationController
     end
 
     case model
-    when "ManageIQ::Providers::AnsibleTower::AutomationManager"
-      provider_list(id, model)
+    when "ManageIQ::Providers::AnsibleTower::AutomationManager", "ExtManagementSystem"
+      provider_list(id, "ManageIQ::Providers::AnsibleTower::AutomationManager")
     when "EmsFolder"
       inventory_group_node(id, model)
     when "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem", "ConfiguredSystem"
@@ -261,7 +261,7 @@ class AutomationManagerController < ApplicationController
       cs_provider_node(provider)
     else
       @no_checkboxes = true
-      options = {:model                 => "ManageIQ::Providers::AutomationManager::InventoryGroup",
+      options = {:model                 => "ManageIQ::Providers::AutomationManager::InventoryRootGroup",
                  :match_via_descendants => ConfiguredSystem,
                  :where_clause          => ["ems_id IN (?)", provider.id],
                  :gtl_dbname            => "automation_manager_groups"}

--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -92,5 +92,5 @@ class ConfigurationJobController < ApplicationController
   end
   helper_method :textual_group_list
 
-  menu_section :conf
+  menu_section :aut
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -208,6 +208,8 @@ module ApplicationHelper
             "vm_or_template"
           elsif record.kind_of?(VmOrTemplate)
             controller_for_vm(model_for_vm(record))
+          elsif record.kind_of?(ManageIQ::Providers::AutomationManager)
+            "automation_manager"
           elsif record.kind_of?(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook)
             "ansible_playbook"
           elsif record.kind_of?(ManageIQ::Providers::EmbeddedAutomationManager::Authentication)
@@ -284,10 +286,10 @@ module ApplicationHelper
         elsif ["Vm"].include?(view.db) && parent && request.parameters[:controller] != "vm"
           # this is to handle link to a vm in vm explorer from service explorer
           return url_for_only_path(:controller => "vm_or_template", :action => "show") + "/"
-        elsif %w(ConfigurationProfile EmsFolder).include?(view.db) &&
+        elsif %w(ConfigurationProfile).include?(view.db) &&
               request.parameters[:controller] == "provider_foreman"
           return url_for_only_path(:action => action, :id => nil) + "/"
-        elsif %w(ManageIQ::Providers::AutomationManager::InventoryGroup EmsFolder).include?(view.db) &&
+        elsif %w(ManageIQ::Providers::AutomationManager::InventoryRootGroup EmsFolder).include?(view.db) &&
               request.parameters[:controller] == "automation_manager"
           return url_for_only_path(:action => action, :id => nil) + "/"
         elsif %w(ConfiguredSystem).include?(view.db) && (request.parameters[:controller] == "provider_foreman" || request.parameters[:controller] == "automation_manager")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -208,7 +208,8 @@ module ApplicationHelper
             "vm_or_template"
           elsif record.kind_of?(VmOrTemplate)
             controller_for_vm(model_for_vm(record))
-          elsif record.kind_of?(ManageIQ::Providers::AutomationManager)
+          elsif record.kind_of?(ManageIQ::Providers::AnsibleTower::AutomationManager) ||
+                record.kind_of?(ManageIQ::Providers::ExternalAutomationManager::InventoryRootGroup)
             "automation_manager"
           elsif record.kind_of?(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook)
             "ansible_playbook"
@@ -237,7 +238,7 @@ module ApplicationHelper
                     )
     elsif @host && ["Patch", "GuestApplication"].include?(db)
       return url_for_only_path(:controller => "host", :action => @lastaction, :id => @host, :show => @id)
-    elsif %w(ConfiguredSystem ConfigurationProfile EmsFolder).include?(db)
+    elsif %w(ConfiguredSystem ConfigurationProfile).include?(db)
       return url_for_only_path(:controller => "provider_foreman", :action => @lastaction, :id => @record, :show => @id)
     else
       controller, action = db_to_controller(db, action)

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -618,10 +618,10 @@ class ApplicationHelper::ToolbarChooser
 
   def automation_manager_providers_tree_center_tb(nodes)
     case nodes.first
-    when "root" then  "automation_manager_providers_center_tb"
-    when "at"   then  "automation_manager_provider_center_tb"
-    when "f"    then  inventory_group_center_tb
-    when "xx"   then  "configured_systems_ansible_center_tb"
+    when "root"    then "automation_manager_providers_center_tb"
+    when "at", "e" then "automation_manager_provider_center_tb"
+    when "f"       then  inventory_group_center_tb
+    when "xx"      then  "configured_systems_ansible_center_tb"
     end
   end
 

--- a/app/views/layouts/show_pdf.html.haml
+++ b/app/views/layouts/show_pdf.html.haml
@@ -4,7 +4,7 @@
   = render_quadicon(@record, :mode => :icon, :size => 72)
 - if @record.kind_of?(ConfigurationProfile)
   = render :partial => "#{controller}/main_configuration_profile"
-- elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::InventoryGroup)
+- elsif @record.kind_of?(ManageIQ::Providers::ExternalAutomationManager::InventoryGroup)
   = render :partial => "#{controller}/main_inventory_group"
 - elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::ConfigurationScript)
   = render :partial => "#{controller}/configuration_script"

--- a/app/views/layouts/show_pdf.html.haml
+++ b/app/views/layouts/show_pdf.html.haml
@@ -4,7 +4,7 @@
   = render_quadicon(@record, :mode => :icon, :size => 72)
 - if @record.kind_of?(ConfigurationProfile)
   = render :partial => "#{controller}/main_configuration_profile"
-- elsif @record.kind_of?(ManageIQ::Providers::ExternalAutomationManager::InventoryGroup)
+- elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::InventoryGroup)
   = render :partial => "#{controller}/main_inventory_group"
 - elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::ConfigurationScript)
   = render :partial => "#{controller}/configuration_script"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,7 @@ Rails.application.routes.draw do
         explorer
         form_fields
         show
+        x_show
         show_list
         tagging_edit
       ),

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -225,6 +225,11 @@ describe ApplicationHelper do
       expect(subject).to eq(helper.url_for_db(helper.controller_for_vm(helper.model_for_vm(@record)), @action))
     end
 
+    it "when record is ManageIQ::Providers::AutomationManager" do
+      @record = ManageIQ::Providers::AutomationManager.new
+      expect(subject).to eq("/automation_manager/#{@action}")
+    end
+
     it "when record is not VmOrTemplate" do
       @record = FactoryGirl.create(:host)
       expect(subject).to eq(helper.url_for_db(@record.class.base_class.to_s, @action))

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -225,8 +225,8 @@ describe ApplicationHelper do
       expect(subject).to eq(helper.url_for_db(helper.controller_for_vm(helper.model_for_vm(@record)), @action))
     end
 
-    it "when record is ManageIQ::Providers::AutomationManager" do
-      @record = ManageIQ::Providers::AutomationManager.new
+    it "when record is ManageIQ::Providers::AnsibleTower::AutomationManager" do
+      @record = ManageIQ::Providers::AnsibleTower::AutomationManager.new
       expect(subject).to eq("/automation_manager/#{@action}")
     end
 


### PR DESCRIPTION
Fixes the switch to grid view for Ansible Tower Provider. 
Also Fixes the link to the Inventory group list from the provider quadicon.

Depends on https://github.com/ManageIQ/manageiq/pull/14691

https://bugzilla.redhat.com/show_bug.cgi?id=1427926

![screenshot from 2017-04-10 14-45-39](https://cloud.githubusercontent.com/assets/12769982/24907104/bb00dc78-1e88-11e7-81ff-375a1ee5a1ef.png)
![screenshot from 2017-04-10 14-45-43](https://cloud.githubusercontent.com/assets/12769982/24907103/baff69ba-1e88-11e7-8311-50c80da6f5e0.png)
