### PR TITLE
Fix button rendering issue in log collection form

### DIFF
--- a/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
@@ -42,8 +42,6 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
   };
 
   $scope.logProtocolChanged = function() {
-    $scope.$broadcast('setNewRecord');
-
     if(miqDBBackupService.knownProtocolsList.indexOf($scope.logCollectionModel.log_protocol) == -1 &&
        $scope.logCollectionModel.log_protocol != '') {
       var url = $scope.logProtocolChangedUrl;

--- a/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
@@ -42,16 +42,17 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
   };
 
   $scope.logProtocolChanged = function() {
+    miqService.sparkleOn();
     if(miqDBBackupService.knownProtocolsList.indexOf($scope.logCollectionModel.log_protocol) == -1 &&
        $scope.logCollectionModel.log_protocol != '') {
       var url = $scope.logProtocolChangedUrl;
-      miqService.sparkleOn();
       $http.get(url + serverId + '?log_protocol=' + $scope.logCollectionModel.log_protocol)
         .then(getLogProtocolData)
         .catch(miqService.handleFailure);
     }
     $scope.$broadcast('reactiveFocus');
     miqDBBackupService.logProtocolChanged($scope.logCollectionModel);
+    miqService.sparkleOff();
   };
 
   $scope.isBasicInfoValid = function() {


### PR DESCRIPTION
`Save` and `Reset` buttons did not render in the log collection form since `newRecord` was set incorrectly to `true`. This was fixed.

Also added a spinner at the start of `logProtocolChanged` primarily for QE to assist them in their automated tests. 

https://bugzilla.redhat.com/show_bug.cgi?id=1436367
https://bugzilla.redhat.com/show_bug.cgi?id=1436326


Before:
<img width="1199" alt="screen shot 2017-03-29 at 4 02 23 pm" src="https://cloud.githubusercontent.com/assets/1538216/24480437/30c5aece-1499-11e7-8a29-3a47e5911682.png">


After:
<img width="1202" alt="screen shot 2017-03-29 at 3 57 15 pm" src="https://cloud.githubusercontent.com/assets/1538216/24480443/38e5d0a2-1499-11e7-83c7-f8cdb022bdda.png">
