### PR TITLE
Fix non explorer set ownerships screen

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -100,7 +100,7 @@ module ApplicationController::CiProcessing
     @ownershipitems ||= begin
       ownership_scope = klass.where(:id => ownership_items)
       ownership_scope = ownership_scope.with_ownership if klass.respond_to?(:with_ownership)
-      ownership_scope.order(:name)
+      Rbac.filtered(ownership_scope.order(:name))
     end
   end
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -41,16 +41,16 @@ module ApplicationController::CiProcessing
       ownership_items = recs.collect(&:to_i)
     end
 
+    if filter_ownership_items(get_class_from_controller_param(controller), ownership_items).empty?
+      add_flash(_('None of the selected items allow ownership changes'), :error)
+      @refresh_div = "flash_msg_div"
+      @refresh_partial = "layouts/flash_msg"
+      return
+    end
+
     if @explorer
       @sb[:explorer] = true
       ownership(ownership_items)
-      if @ownershipitems.empty?
-        add_flash(_('None of the selected items allow ownership changes'), :error)
-
-        @refresh_div = "flash_msg_div"
-        @refresh_partial = "layouts/flash_msg"
-        return
-      end
     else
       if role_allows?(:feature => "vm_ownership")
         drop_breadcrumb(:name => _("Set Ownership"), :url => "/vm_common/ownership")


### PR DESCRIPTION
caused in https://github.com/ManageIQ/manageiq-ui-classic/pull/649

Opening set ownership screen from non explorer list was not taken into account and it was causing error.

**Solution:**
move check `if we have access to set ownership screen` to place where it will be common for explorer and non-explorer screen and then we can flash display message.

**Test scenario - reach set ownership screen from non-explorer screen**
(Steps to Reproduce:
1. Add RHOS provider with OSP mapping enabled as Admin user
2. Navigate to Compute -> Clouds -> Providers -> RHOS7GA -> Images
3. Select one image (without clicking on it).
4. Configuration -> Set ownership)

**Links**
https://bugzilla.redhat.com/show_bug.cgi?id=1436597

cc @martinpovolny @h-kataria 
@miq-bot assign @mzazrivec 
@miq-bot bug, euwe/yes

