### PR TITLE
Containers: redact username and password from custom attributes values when displaying

### DIFF
--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -124,9 +124,25 @@ module EmsContainerHelper::TextualSummary
     TextualGroup.new(_("Custom Attributes"), textual_miq_custom_attributes)
   end
 
+  def redact_username_and_password(value)
+    begin
+      uri = URI.parse(value)
+      uri.password = '***' if uri.password
+      uri.user = '***' if uri.user
+      uri.to_s
+    rescue # dont reduct in case the value was malformed, to allow debugging it.
+      value
+    end
+  end
+
   def textual_miq_custom_attributes
     attrs = @record.custom_attributes
     return nil if attrs.blank?
-    attrs.sort_by(&:name).collect { |a| {:label => a.name.tr("_", " "), :value => a.value} }
+    attrs.sort_by(&:name).collect do |a|
+      {
+        :label => a.name.tr("_", " "),
+        :value => redact_username_and_password(a.value)
+      }
+    end
   end
 end


### PR DESCRIPTION
This will hide sensitive information from being displayed as plain text.

![redacted_custom_attributes](https://cloud.githubusercontent.com/assets/3123328/24498020/ecd2cab4-1545-11e7-8d3e-8388084756c5.png)


BZ https://bugzilla.redhat.com/show_bug.cgi?id=1418791