### PR TITLE
No revert for "active" snapshot

### DIFF
--- a/app/helpers/application_helper/button/vm_snapshot_revert.rb
+++ b/app/helpers/application_helper/button/vm_snapshot_revert.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::VmSnapshotRevert < ApplicationHelper::Button::Basic
-  needs :@record
+  needs :@record, :@active
 
   def visible?
     return false if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
@@ -7,9 +7,10 @@ class ApplicationHelper::Button::VmSnapshotRevert < ApplicationHelper::Button::B
   end
 
   def disabled?
-    @error_message = unless @record.supports_revert_to_snapshot?
-                       @record.unsupported_reason(:revert_to_snapshot)
-                     end
+    @error_message = @record.try(:revert_to_snapshot_denied_message, @active)
+    @error_message ||= unless @record.supports_revert_to_snapshot?
+                         @record.unsupported_reason(:revert_to_snapshot)
+                       end
     @error_message.present?
   end
 end


### PR DESCRIPTION
In the snapshot screen when the "active" snapshot is selected
the revert button should be disabled for RHV.

If VM is up, the 'revert' button is disabled due to VM status is UP.
If VM is down and the active snapshot is selected, the 'revert' button
is disabled due to selection of 'active' snapshot.

http://bugzilla.redhat.com/1396068
![revervmtsnapshots](https://cloud.githubusercontent.com/assets/316242/24662628/4c9c48aa-195e-11e7-9b15-01d5fed28301.png)

