### PR TITLE
Fix tenant chanage

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
+++ b/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
@@ -58,6 +58,7 @@ ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', '
       var _tenant = dash.tenant.value || dash.DEFAULT_TENANT;
       dash.url = '/container_dashboard/data' + dash.providerId  + '/?live=true&tenant=' + _tenant;
 
+      httpUtils.getMetricTags();
       setAppliedFilters();
     }
 

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
@@ -89,8 +89,6 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
             dash.tenant = dash.tenantList[i];
           }
         });
-
-        getMetricTags();
       });
     }
 


### PR DESCRIPTION
**Description**

https://github.com/ManageIQ/manageiq-ui-classic/pull/690 Introduced a regression in the tenant change.

The "Set Tenant" button stopped getting the new tags.

**Screenshot**
Problem, init does not update filters:
![gifrecord_2017-03-30_150224](https://cloud.githubusercontent.com/assets/2181522/24503425/b8d0d7fa-155a-11e7-8482-e0585d7b894c.gif)

Fix, init does update filters:
![gifrecord_2017-03-30_144055](https://cloud.githubusercontent.com/assets/2181522/24503006/e22631ec-1558-11e7-989a-0f182083a40e.gif)


