### PR TITLE
[WIP] Don't depend on bower deps for rake spec

### DIFF
--- a/app/helpers/application_helper/import_export_helper.rb
+++ b/app/helpers/application_helper/import_export_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper::ImportExportHelper
   def status_icon_image_path(exists)
-    icon_name = exists ? "100/checkmark" : "16/equal-green"
-    image_path("#{icon_name}.png")
+    icon_name = exists ? "100/checkmark.png" : "16/equal-green.png"
+    ActionController::Base.helpers.image_path(icon_name)
   end
 
   def status_description(exists)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,6 +1,13 @@
 = render :partial => 'layouts/doctype'
 %html.layout-pf.layout-pf-fixed.transitions{:lang => I18n.locale.to_s.sub('-', '_')}
-  - if @report_only
+  - if Rails.env.test?
+    -# skipping javascripts and stuff for specs
+    %body
+      - if block_given?
+        = yield
+      - else
+        = render :partial => "layouts/content"
+  - elsif @report_only
     %head
       %title
         = "%{product}: %{title}" % {:product => I18n.t('product.name'), :title => @layout.titleize}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,8 +77,20 @@ RSpec.configure do |config|
 end
 
 # This bypasses the lookup of Javascript dependencies in (ruby) tests
-class << ActionController::Base.helpers
-  def image_path(path, _options = {})
-    "/assets/#{path}"
+ActionView::Helpers::AssetUrlHelper.module_eval {
+  def asset_path(source, _options = {})
+    "/assets/#{source}"
   end
-end
+}
+
+Sprockets::SassProcessor::Functions.module_eval {
+  def asset_path(path, _options= {})
+    Autoload::Sass::Script::String.new("/assets/#{path}", :string)
+  end
+}
+
+#Sprockets::Rails::LegacyAssetUrlHelper.module_eval {
+#  def asset_path(source, _options = {})
+#    "/assets/#{source}"
+#  end
+#}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,7 @@ end
 
 # This bypasses the lookup of Javascript dependencies in (ruby) tests
 class << ActionController::Base.helpers
-  def image_path(path, options = {})
-    path
+  def image_path(path, _options = {})
+    "/assets/#{path}"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,3 +75,10 @@ RSpec.configure do |config|
     EvmSpecHelper.clear_caches { example.run }
   end
 end
+
+# This bypasses the lookup of Javascript dependencies in (ruby) tests
+class << ActionController::Base.helpers
+  def image_path(path, options = {})
+    path
+  end
+end

--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -6,7 +6,9 @@ cd spec/manageiq
 source tools/ci/setup_vmdb_configs.sh
 cd -
 
-source tools/ci/setup_js_env.sh
+if [ "$TEST_SUITE" = "spec:javascript" ]; then
+  source tools/ci/setup_js_env.sh
+fi
 
 # HACK: Temporary workaround until we can get the cross-repo scripts working properly
 # source spec/manageiq/tools/ci/setup_ruby_env.sh


### PR DESCRIPTION
Given the still relatively frequent bower failures on travis (not that frequent when `bower.json` doesn't change, but rather frequent for a while after that), and the fact that we don't really depend on any functionality from bower in ruby specs, I'd like to skip `bower install` in `rake spec` and only do so for `rake spec:javascript`.

TODO:
   * [ ] get the number of failures when `vendor/` is missing from ~300 to 0 (started on ~600)
   * [ ] figure out how to override the module method for all classes, or go one by one
   * [ ] redefine stylesheet_*_tag and javascripts_*_tag instead of changing the layouts
   * [ ] optionally throw for `image_path` when the image doesn't exist (possibly except for the sass variant since we probably reference some patternfly images somewhere)

Cc @romanblanco, @skateman 