### PR TITLE
Update angular version to 1.6.*

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,13 +17,13 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.5.8",
-    "angular-animate": "~1.5.8",
+    "angular": "~1.6.3",
+    "angular-animate": "~1.6.3",
     "angular-bootstrap-switch": "~0.5.1",
     "angular-dragdrop": "~1.0.13",
-    "angular-mocks": "~1.5.8",
+    "angular-mocks": "~1.6.3",
     "angular-patternfly-sass": "~3.23.1",
-    "angular-sanitize": "~1.5.8",
+    "angular-sanitize": "~1.6.3",
     "angular-ui-codemirror": "~0.3.0",
     "angular-ui-sortable": "~0.16.1",
     "angular.validators": "~4.4.2",
@@ -62,6 +62,9 @@
     "patternfly-bootstrap-treeview": "~2.1.1",
     "moment": ">=2.10.5",
     "d3": "~3.5.0",
-    "jquery": "~2.2.4"
+    "jquery": "~2.2.4",
+    "angular": "~1.6.3",
+    "angular-sanitize": "~1.6.3",
+    "angular-animate": "~1.6.3"
   }
 }


### PR DESCRIPTION
This upgrades our angular version from 1.5.* to 1.6.*.

TODO:

   * [x] use `$onInit` in components, `bindings` are not available from the constructor itself (`$onChange` is fine too) - VERIFIED no component using `bindings` is touching them in the constructor
   * [x] remove $http..success - verify we can close https://github.com/ManageIQ/manageiq-ui-classic/issues/102
   * [x] (we're not using ng-model-options so no differences there)
   * [x] go through the detailed descriptions in ... to make sure https://docs.angularjs.org/guide/migration#migrating-from-1-5-to-1-6
   * [x] go through the detailed descriptions in .. to make sure https://github.com/angular/angular.js/blob/master/CHANGELOG.md#160-rainbow-tsunami-2016-12-08
   * [x] look into the sandbox removal carefully
   * [x] look into jqLite being more jQuery3-like - not using `.css()` or `.data()` in angular code, and `attr` only on `d3` objects in topology

(not dependencies yet still related TODOs)
   * [ ] move to jQuery 3
   * [ ] move to Rx.js 5 (https://github.com/ManageIQ/manageiq-ui-classic/pull/18)
   * [ ] move to ESLint 4 (http://eslint.org/docs/4.0.0/user-guide/migrating-to-4.0.0)