### PR TITLE
Retrieve manager resource from backend and inject in Ansible Credentials form

### DIFF
--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 'credentialId', 'miqService', 'API', function($window, credentialId,  miqService, API) {
+ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 'credentialId', 'managerResourceId', 'miqService', 'API', function($window, credentialId, managerResourceId, miqService, API) {
   var vm = this;
 
   var init = function() {
@@ -29,14 +29,11 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
         .then(getCredentialFormData)
         .catch(miqService.handleFailure);
     } else {
+      vm.credentialModel.manager_resource = { "href": "/api/providers/" + managerResourceId };
+
       vm.select_options.push({'label':__('<Choose>'), 'value': ''});
       // FIXME: this should go away once https://github.com/ManageIQ/manageiq/pull/14483 is merged
       vm.credentialModel.organization = 1; // work-around, organization id needs to be filled in automatically by the backend
-
-      // credential creation requires manager_resource
-      API.get('/api/providers?collection_class=ManageIQ::Providers::EmbeddedAutomationManager')
-        .then(setManagerResource)
-        .catch(miqService.handleFailure);
 
       vm.modelCopy = angular.copy( vm.credentialModel );
       miqService.sparkleOff();
@@ -111,10 +108,6 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
     }
 
     $window.location.href = url;
-  }
-
-  function setManagerResource(response) {
-    vm.credentialModel.manager_resource = { "href": response.resources[0].href };
   }
 
   // FIXME: this should go away once https://github.com/ManageIQ/manageiq/pull/14483 is merged

--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -39,6 +39,7 @@ class AnsibleCredentialController < ApplicationController
     drop_breadcrumb(:name => _("Add a new Credential"), :url => "/ansible_credential/new")
     @in_a_form = true
     @id = 'new'
+    @manager_resource = ExtManagementSystem.where(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager").first
   end
 
   def edit

--- a/app/views/ansible_credential/_credential_form.html.haml
+++ b/app/views/ansible_credential/_credential_form.html.haml
@@ -44,4 +44,5 @@
 
 :javascript
   ManageIQ.angular.app.value('credentialId', '#{@id}');
+  ManageIQ.angular.app.value('managerResourceId', '#{@manager_resource.try(:id)}');
   miq_bootstrap('#form_div');


### PR DESCRIPTION
The main idea here is to minimize using GETs in the angular form if possible, for a potentially better performance and a faster loading form.
Also, more importantly, I'm trying to implement a good practice of minimizing HTTP requests in the forms, given the fact that we are now getting so REST API-heavy.

In the Credentials form we have one area where we can remove the API GET call that retrieves the `manager resource`
...since all that we really need is the `manager resource id` which can very well be retrieved on the Rails side and then can be injected in the angular form.

I have some data here that gives us an idea of how much time we could potentially save by removing that extra GET call. 
Note that machine speeds vary, network speeds vary, so this is really a rough ballpark.

Production mode (113 ms) -
<img width="1326" alt="screen shot 2017-03-30 at 7 07 25 am" src="https://cloud.githubusercontent.com/assets/1538216/24510615/9564f65c-151e-11e7-8a29-0f5ac5d497d3.png">

Development mode (511 ms) -
<img width="1345" alt="screen shot 2017-03-30 at 7 55 09 am" src="https://cloud.githubusercontent.com/assets/1538216/24510774/f95029a2-151e-11e7-8451-4ad0813b06dd.png">

Now 113 ms in Production mode may not sound too impressive, but I think that every little bit counts and matters in the long run, and it's a step in the right direction since  it's also about the good practice of minimizing HTTP requests.
(Currently I do not have the data of how much time Rails takes to retrieve the `manager resource` but I'm inclined to think that it would be a less expensive operation compared to an API call.)

Hopefully, this practice of minimizing HTTP requests will be implemented across all our present/future REST API forms in simple creative ways (like in this example) either by leveraging Rails itself (applicable to Classic-UI only) or by refactoring the API.




