### PR TITLE
Replace the missed `find_by_id_filter`

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -272,7 +272,7 @@ class CloudVolumeController < ApplicationController
     @storage_manager_choices = {}
     if params[:storage_manager_id]
       @storage_manager_id = params[:storage_manager_id]
-      ems = find_by_id_filtered(ExtManagementSystem, @storage_manager_id)
+      ems = find_record_with_rbac(ExtManagementSystem, @storage_manager_id)
       @storage_manager_choices[ems.name] = ems.id
     else
       ExtManagementSystem.all.each { |ems| @storage_manager_choices[ems.name] = ems.id if ems.supports_block_storage? }


### PR DESCRIPTION
Commit dad34557eb21d21317126a51f30f9384197c0ea4 seems to have missed one `find_by_id_filter` causing the cloud voulme controller to fail when requiesting the form for a `new` cloud volume. This patch replaces the call with `find_record_with_rbac`.

@miq-bot add_label bug
@miq-bot assign @romanblanco 

/cc @AparnaKarve because we have discussed this error in gitter