### PR TITLE
Use API to get block storage manager for volumes

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -269,13 +269,8 @@ class CloudVolumeController < ApplicationController
     assert_privileges("cloud_volume_new")
     @volume = CloudVolume.new
     @in_a_form = true
-    @storage_manager_choices = {}
     if params[:storage_manager_id]
-      @storage_manager_id = params[:storage_manager_id]
-      ems = find_record_with_rbac(ExtManagementSystem, @storage_manager_id)
-      @storage_manager_choices[ems.name] = ems.id
-    else
-      ExtManagementSystem.all.each { |ems| @storage_manager_choices[ems.name] = ems.id if ems.supports_block_storage? }
+      @storage_manager = find_record_with_rbac(ExtManagementSystem, params[:storage_manager_id])
     end
     drop_breadcrumb(
       :name => _("Add New %{model}") % {:model => ui_lookup(:table => 'cloud_volume')},

--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -1,18 +1,20 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => ""}
+%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => "", "ng-show" => "afterGet"}
   = render :partial => "layouts/flash_msg"
   .form-horizontal
     .form-group{"ng-class" => "{'has-error': angularForm.storage_manager_id.$invalid}"}
       %label.col-md-2.control-label
         = _('Storage Manager')
       .col-md-8
-        = select_tag("storage_manager_id",
-                     options_for_select((@storage_manager_id.nil? ? [["<#{_('Choose')}>", nil]] : []) + @storage_manager_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
-                     "ng-model"                    => "cloudVolumeModel.storage_manager_id",
-                     "ng-change"                   => "storageManagerChanged(cloudVolumeModel.storage_manager_id)",
-                     "required"                    => "",
-                     "disabled"                    => !@storage_manager_id.nil?,
-                     :checkchange                  => true,
-                     "selectpicker-for-select-tag" => "")
+        %select{"name"       => "storage_manager_id",
+                "ng-model"   => "cloudVolumeModel.storage_manager_id",
+                "ng-options" => "mgr.id as mgr.name for mgr in storageManagers",
+                "ng-change"  => "storageManagerChanged(cloudVolumeModel.storage_manager_id)",
+                "required"   => "",
+                "disabled"   => !@storage_manager.nil?,
+                :checkchange => true,
+                "pf-select"  => "true"}
+          %option{"value" => "", "disabled" => ""}
+            = "<#{_('Choose')}>"
         %span.help-block{"ng-show" => "angularForm.storage_manager_id.$error.required"}
           = _("Required")
 
@@ -88,5 +90,5 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id || "new"}');
-  ManageIQ.angular.app.value('storageManagerId', '#{@storage_manager_id}');
+  ManageIQ.angular.app.value('storageManagerId', '#{@storage_manager.try(:id)}');
   miq_bootstrap('#form_div');


### PR DESCRIPTION
Instead of using instance variables to pass the list of available block storage managers to the form we are exploiting the capabilities of the API to return the list of storage managers supporting `block_storage`.

This patch removes the logic from the ruby controller and adds the required API calls to the JS controller. In order to deal with the asynchronous nature of data retrieval, this patch also changes how `afterGet` is set to ensure that all the required information is in place.

A video showing the form for creating new cloud volumes: http://x.k00.fr/ha2qj.

It first shows how the form behaves when cloud volumes are created for a specific block storage manager and then also how it behaves when creating a volume from the list of volumes from all block storage managers.

@miq-bot add_label storage,refactoring
@miq-bot assign @AparnaKarve 

/cc @miha-plesko Could be useful with regards to https://github.com/ManageIQ/manageiq-ui-classic/pull/651.