### PR TITLE
Adds Topology in the menu for Physical Infrastructure

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -80,6 +80,7 @@ module Menu
         Menu::Section.new(:phy, N_("Physical Infrastructure"), 'fa fa-plus fa-2x', [
           Menu::Item.new('ems_physical_infra',    N_('Providers'), 'ems_physical_infra',    {:feature => 'ems_physical_infra_show_list'},    '/ems_physical_infra'),
           Menu::Item.new('physical_server', N_('Servers'),   'physical_server', {:feature => 'physical_server_show_list'}, '/physical_server'),
+          Menu::Item.new('physical_infra_topology', N_('Topology'), 'physical_infra_topology', {:feature => 'physical_infra_topology', :any => true}, '/physical_infra_topology')
         ])
       end
 


### PR DESCRIPTION
Requires the Product Feature id in https://github.com/ManageIQ/manageiq/pull/14589

<img width="651" alt="screen shot 2017-03-30 at 5 12 52 pm" src="https://cloud.githubusercontent.com/assets/1538216/24531219/2de00514-156c-11e7-9413-bc1574a99620.png">


@himdel As requested, Topology would now appear in the default menu, but for the menu to be visible you would need https://github.com/ManageIQ/manageiq/pull/14589 merged.
