### PR TITLE
Only include coffeescript/sass compilers in dev mode/compile-phase

### DIFF
--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -1,7 +1,24 @@
 require 'rails/all'
-require 'sass-rails'
-require 'coffee-rails'
-require 'patternfly-sass'
+
+# Since we serve our assets directly through apache on an appliance after they
+# are pre-compiled, there is no need to have sass/coffeescript loaded in the
+# application, so we can save a bit of resources by not loading these two.
+#
+# That said, we still need to load both of these when pre-compiling the assets
+# in production mode, so if Rake is defined, load things like we used to.
+#
+# For this to work properly, it is dependent on patternfly/patternfly-sass#150
+if ENV["RAILS_ENV"] != "production" || defined?(Rake)
+  require 'sass-rails'
+  require 'coffee-rails'
+  require 'patternfly-sass'
+else
+  require 'bootstrap-sass/engine'
+  require 'font_awesome/sass/rails/engine'
+
+  require 'patternfly-sass/engine'
+end
+
 require 'lodash-rails'
 require 'jquery-hotkeys-rails'
 


### PR DESCRIPTION
Since we serve our assets directly through apache on an appliance after they are pre-compiled, there is no need to have sass/coffeescript loaded in the application, so we can save a bit of resources by not loading these two.

That said, we still need to load both of these when pre-compiling the assets in production mode, so if `Rake` is defined, load things like we used to.

For this to work properly, it is dependent on https://github.com/patternfly/patternfly-sass/pull/150


Links
-----
* https://github.com/patternfly/patternfly-sass/pull/150