### PR TITLE
Menu highlighting - use menu_section instead of @layout, when possible

### DIFF
--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -9,7 +9,7 @@ class AnsibleCredentialController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
 
-  menu_section :ansible
+  menu_section :ansible_credentials
   toolbar :ansible_credential
 
   def self.display_methods

--- a/app/controllers/ansible_playbook_controller.rb
+++ b/app/controllers/ansible_playbook_controller.rb
@@ -9,7 +9,7 @@ class AnsiblePlaybookController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
 
-  menu_section :ansible
+  menu_section :ansible_playbooks
 
   def self.model
     ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook

--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -9,7 +9,7 @@ class AnsibleRepositoryController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
 
-  menu_section :ansible
+  menu_section :ansible_repositories
   toolbar :ansible_repository
 
   def self.display_methods

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1983,7 +1983,7 @@ class ApplicationController < ActionController::Base
     section_id = menu_section_id(params)
     return if section_id.nil?
 
-    section = Menu::Manager.section(section_id)
+    section = Menu::Manager.section(section_id) || Menu::Manager.section_for_item_id(section_id.to_s)
     return if section.nil?
 
     url = URI.parse(request.url).path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1980,10 +1980,10 @@ class ApplicationController < ActionController::Base
   end
 
   def remember_tab
-    section_id = menu_section_id(params)
-    return if section_id.nil?
+    section_or_item_id = menu_section_id(params)
+    return if section_or_item_id.nil?
 
-    section = Menu::Manager.section(section_id) || Menu::Manager.section_for_item_id(section_id.to_s)
+    section = Menu::Manager.section(section_or_item_id) || Menu::Manager.section_for_item_id(section_or_item_id.to_s)
     return if section.nil?
 
     url = URI.parse(request.url).path

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -8,6 +8,8 @@ class AutomationManagerController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::ManagerControllerMixin
 
+  menu_section :automation_manager
+
   def self.model
     ManageIQ::Providers::AutomationManager
   end
@@ -560,6 +562,4 @@ class AutomationManagerController < ApplicationController
       replace_right_cell
     end
   end
-
-  menu_section :aut
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1000,7 +1000,7 @@ module ApplicationHelper
 
     # FIXME remove @layout condition when every controller sets menu_section properly
     item.id.to_sym == active ||
-    item.id.to_sym == @layout.to_sym ? 'active' : nil
+      item.id.to_sym == @layout.to_sym ? 'active' : nil
   end
 
   def section_nav_class(section)
@@ -1019,7 +1019,7 @@ module ApplicationHelper
 
     # FIXME remove to_s, to_sym once all items use symbol ids
     section.contains_item_id?(active.to_s) ||
-    section.contains_item_id?(active.to_sym) ? 'active' : nil
+      section.contains_item_id?(active.to_sym) ? 'active' : nil
   end
 
   def render_flash_msg?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -995,22 +995,31 @@ module ApplicationHelper
     link_to(link_text, link_params, tag_args)
   end
 
-  def primary_nav_class(nav_id)
-    test_layout = @layout
-    # FIXME: exception behavior to remove
-    test_layout = 'my_tasks' if %w(my_tasks my_ui_tasks all_tasks all_ui_tasks).include?(@layout)
-    test_layout = 'cloud_volume' if @layout == 'cloud_volume_snapshot' || @layout == 'cloud_volume_backup'
-    test_layout = 'cloud_object_store_container' if @layout == 'cloud_object_store_object'
+  def item_nav_class(item)
+    active = controller.menu_section_id(controller.params) || @layout.to_sym
 
-    Menu::Manager.item_in_section?(test_layout, nav_id) ? 'active' : nil
+    # FIXME remove @layout condition when every controller sets menu_section properly
+    item.id.to_sym == active ||
+    item.id.to_sym == @layout.to_sym ? 'active' : nil
   end
 
-  def secondary_nav_class(item)
-    item.items.collect(&:id).include?(@layout) ? 'active' : nil
-  end
+  def section_nav_class(section)
+    active = controller.menu_section_id(controller.params) || @layout.to_sym
 
-  def tertiary_nav_class(item)
-    item.id == @layout ? 'active' : nil
+    if section.parent.nil?
+      # first-level, fallback to old logic for now
+      # FIXME: exception behavior to remove
+      active = 'my_tasks' if %w(my_tasks my_ui_tasks all_tasks all_ui_tasks).include?(@layout)
+      active = 'cloud_volume' if @layout == 'cloud_volume_snapshot' || @layout == 'cloud_volume_backup'
+      active = 'cloud_object_store_container' if @layout == 'cloud_object_store_object'
+      active = active.to_sym
+    end
+
+    return 'active' if section.id.to_sym == active
+
+    # FIXME remove to_s, to_sym once all items use symbol ids
+    section.contains_item_id?(active.to_s) ||
+    section.contains_item_id?(active.to_sym) ? 'active' : nil
   end
 
   def render_flash_msg?

--- a/app/presenters/menu/manager.rb
+++ b/app/presenters/menu/manager.rb
@@ -5,7 +5,7 @@ module Menu
     class << self
       extend Forwardable
 
-      delegate %i(menu item_in_section? item section section_id_string_to_symbol each) => :instance
+      delegate %i(menu item_in_section? item section section_id_string_to_symbol each section_for_item_id) => :instance
     end
 
     private
@@ -33,6 +33,17 @@ module Menu
       # prevent .to_sym call on section_id
       section_id = section_id_string_to_symbol(section_id) if section_id.kind_of?(String)
       @id_to_section[section_id]
+    end
+
+    def section_for_item_id(item_id)
+      found = nil
+      @id_to_section.each do |_id, section|
+        next unless section.contains_item_id?(item_id)
+
+        found = section if !found || section.parent
+      end
+
+      found
     end
 
     def item_in_section?(item_id, section_id)

--- a/app/views/layouts/_vertical_navbar.html.haml
+++ b/app/views/layouts/_vertical_navbar.html.haml
@@ -2,7 +2,7 @@
   %ul#maintab.list-group
     - Menu::Manager.menu do |menu_section|
       - if menu_section.visible?
-        %li.list-group-item.secondary-nav-item-pf{"data-target" => "#menu-#{menu_section.id}", :class => primary_nav_class(menu_section.id)}
+        %li.list-group-item.secondary-nav-item-pf{"data-target" => "#menu-#{menu_section.id}", :class => section_nav_class(menu_section)}
           %a{:href => menu_section.url, :onclick => 'return miqCheckForChanges()'}
             %span{:class => menu_section.icon}
             %span.list-group-item-value
@@ -18,13 +18,13 @@
               %ul.list-group
                 - menu_section.items.each do |menu_item|
                   - if menu_item.visible? && menu_item.leaf?
-                    %li.list-group-item{:class => tertiary_nav_class(menu_item)}
+                    %li.list-group-item{:class => item_nav_class(menu_item)}
                       %a{:href => menu_item.url, :onclick => 'return miqCheckForChanges()'}
                         %span.list-group-item-value
                           = _(menu_item.name)
 
                   - elsif menu_item.visible?
-                    %li.list-group-item.tertiary-nav-item-pf{"data-target" => "#menu-#{menu_item.id}", :class => secondary_nav_class(menu_item)}
+                    %li.list-group-item.tertiary-nav-item-pf{"data-target" => "#menu-#{menu_item.id}", :class => section_nav_class(menu_item)}
                       %a{:href => menu_item.url, :onclick => 'return miqCheckForChanges()'}
                         %span.list-group-item-value
                           = _(menu_item.name)
@@ -37,7 +37,7 @@
                         %ul.list-group
                           - menu_item.items.each do |menu_item_deep|
                             - if menu_item_deep.visible?
-                              %li.list-group-item{:class => menu_item_deep.id == @layout ? 'active' : nil}
+                              %li.list-group-item{:class => item_nav_class(menu_item_deep)}
                                 %a{:href => menu_item_deep.url, :onclick => 'return miqCheckForChanges()'}
                                   %span.list-group-item-value
                                     = _(menu_item_deep.name)
@@ -51,7 +51,7 @@
               %ul.list-group
                 - menu_section.items.each do |menu_item|
                   - if menu_item.visible?
-                    %li.list-group-item{:class => tertiary_nav_class(menu_item)}
+                    %li.list-group-item{:class => item_nav_class(menu_item)}
                       %a{:href => menu_item.url, :onclick => 'return miqCheckForChanges()'}
                         %span.list-group-item-value
                           = _(menu_item.name)


### PR DESCRIPTION
We already have `menu_section` in (most) controllers, that mentions the specific place in the menu you can find it. (And can be overriden via a `menu_section_id(params)` method if more logic is needed.)

But until now, for highlighting the active menu section, subsection and item, we relied on `@layout` and some extra special cases.

Updated the menu to use `menu_section` when available, and preserve the special cases for now, until we can go through all the controllers... (This also lets us use `menu_section :item_id` instead of `menu_section :section_id`.)


Fixes #765 
https://bugzilla.redhat.com/show_bug.cgi?id=1431072

Cc @skateman, @mzazrivec, @ZitaNemeckova