### PR TITLE
Allow node reselect in trees where is no other way to get back

### DIFF
--- a/app/presenters/tree_builder_automation_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_automation_manager_configured_systems.rb
@@ -9,7 +9,7 @@ class TreeBuilderAutomationManagerConfiguredSystems < TreeBuilder
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true)
+    locals.merge!(:autoload => true, :allow_reselect => true)
   end
 
   def root_options

--- a/app/presenters/tree_builder_configuration_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_configuration_manager_configured_systems.rb
@@ -9,7 +9,7 @@ class TreeBuilderConfigurationManagerConfiguredSystems < TreeBuilder
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true)
+    locals.merge!(:autoload => true, :allow_reselect => true)
   end
 
   def root_options

--- a/app/presenters/tree_builder_containers_filter.rb
+++ b/app/presenters/tree_builder_containers_filter.rb
@@ -10,7 +10,7 @@ class TreeBuilderContainersFilter < TreeBuilder
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true)
+    locals.merge!(:autoload => true, :allow_reselect => true)
   end
 
   def root_options

--- a/app/presenters/tree_builder_images_filter.rb
+++ b/app/presenters/tree_builder_images_filter.rb
@@ -5,11 +5,9 @@ class TreeBuilderImagesFilter < TreeBuilderVmsFilter
 
   def set_locals_for_render
     locals = super
-    locals.merge!(
-      :tree_id   => "images_filter_treebox",
-      :tree_name => "images_filter_tree",
-      :autoload  => false
-    )
+    locals.merge!(:tree_id   => "images_filter_treebox",
+                  :tree_name => "images_filter_tree",
+                  :autoload  => false)
   end
 
   def root_options

--- a/app/presenters/tree_builder_instances_filter.rb
+++ b/app/presenters/tree_builder_instances_filter.rb
@@ -5,11 +5,9 @@ class TreeBuilderInstancesFilter < TreeBuilderVmsFilter
 
   def set_locals_for_render
     locals = super
-    locals.merge!(
-      :tree_id   => "instances_filter_treebox",
-      :tree_name => "instances_filter_tree",
-      :autoload  => false
-    )
+    locals.merge!(:tree_id   => "instances_filter_treebox",
+                  :tree_name => "instances_filter_tree",
+                  :autoload  => false)
   end
 
   def root_options

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -7,7 +7,7 @@ class TreeBuilderStorage < TreeBuilder
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true)
+    locals.merge!(:autoload => true, :allow_reselect => true)
   end
 
   def root_options

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -2,13 +2,13 @@ class TreeBuilderVmsFilter < TreeBuilder
   def tree_init_options(_tree_name)
     {
       :open_all => true,
-      :leaf      => 'ManageIQ::Providers::InfraManager::Vm'
+      :leaf     => 'ManageIQ::Providers::InfraManager::Vm'
     }
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:tree_id => "vms_filter_treebox", :tree_name => "vms_filter_tree")
+    locals.merge!(:tree_id => "vms_filter_treebox", :tree_name => "vms_filter_tree", :allow_reselect => true)
   end
 
   def root_options

--- a/app/presenters/tree_builder_vms_instances_filter.rb
+++ b/app/presenters/tree_builder_vms_instances_filter.rb
@@ -5,9 +5,8 @@ class TreeBuilderVmsInstancesFilter < TreeBuilderVmsFilter
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:tree_id        => "vms_instances_filter_treebox",
-                  :tree_name      => "vms_instances_filter_tree",
-                  :allow_reselect => true)
+    locals.merge!(:tree_id   => "vms_instances_filter_treebox",
+                  :tree_name => "vms_instances_filter_tree")
   end
 
   def root_options


### PR DESCRIPTION
Some views are displaying lists of elements that are not available on the left-side tree. If an element's summary screen is being displayed, there is nothing to select in the left-side tree, so it remains on the previously highlighted element, making it unclickable. This allows reselection in such cases, as it allows clicking on an already selected treenode.

https://bugzilla.redhat.com/show_bug.cgi?id=1438361