### PR TITLE
Reset dialog options

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -441,6 +441,9 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
 
   vm.toggleDialogSelection = function(prefix, selected_value) {
     vm.catalogItemModel[prefix + "_dialog_existing"] = selected_value;
+    vm._provisioning_dialog = ""
+    vm.catalogItemModel[prefix + "_dialog_id"] = ""
+    vm.catalogItemModel[prefix  + "_dialog_name"] = ""
   };
 
   vm.fieldsRequired = function(prefix) {


### PR DESCRIPTION
Reset dialog options when switching between dialog existing/create new options. Not resetting those is causing dialog_id to be sent up with transaction even when user has entered new dialog name in the text box during an edit of catalog item.

https://bugzilla.redhat.com/show_bug.cgi?id=1436765

@syncrou please test/review.