### PR TITLE
Fixed variable name to display value of extra_vars on Retirement tab

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -314,8 +314,8 @@
                       %th
                         = _("Default value")
                     %tbody
-                      - if retirement[:extra_vars]
-                        - retirement[:extra_vars].each do |key, value|
+                      - if @record.config_info[:retirement][:extra_vars]
+                        - @record.config_info[:retirement][:extra_vars].each do |key, value|
                           %tr
                             %td
                               = h(key)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1437496

@syncrou @gmcculloug please review/test

before:
![before](https://cloud.githubusercontent.com/assets/3450808/24569112/a93b88ca-1632-11e7-9ffc-6034f4ed6843.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/24569105/a3eea2f8-1632-11e7-936d-975a6d86569b.png)
