### PR TITLE
Add Smart Jdbc driver defaults

### DIFF
--- a/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
+++ b/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
@@ -41,11 +41,11 @@ function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, i
 
   ManageIQ.angular.rxSubject.subscribe(function(event) {
     var eventType = event.type,
-        operation = event.operation,
-        timeout = event.timeout;
+      operation = event.operation,
+      timeout = event.timeout;
 
     $scope.paramsModel = $scope.paramsModel || {};
-    if (eventType == 'mwServerOps'  && operation) {
+    if (eventType === 'mwServerOps'  && operation) {
       $scope.paramsModel.serverId = angular.element('#mw_param_server_id').val();
       $scope.paramsModel.operation = operation;
       $scope.paramsModel.operationTitle = formatOpDisplayName(operation) + ' ' + _('Server');
@@ -59,8 +59,7 @@ function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, i
   // Server Ops
   /////////////////////////////////////////////////////////////////////////
 
-  $scope.runOperation = function () {
-    //$scope.$broadcast('mwSeverOpsEvent', $scope.paramsModel);
+  $scope.runOperation = function() {
     var newMwServerOpsEvent = {},
       mwServerTypePart = {type: 'mwSeverOpsEvent'};
     angular.extend(newMwServerOpsEvent, mwServerTypePart, $scope.paramsModel);
@@ -86,11 +85,11 @@ function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, i
     $scope.resetDeployForm();
   };
 
-  $scope.showDatasourceListener = function () {
+  $scope.showDatasourceListener = function() {
     // just here to 'Button not implemented'
   };
 
-  $scope.resetDeployForm = function () {
+  $scope.resetDeployForm = function() {
     $scope.deployAddModel.enableDeployment = true;
     $scope.deployAddModel.forceDeploy = false;
     $scope.deployAddModel.runtimeName = undefined;
@@ -105,7 +104,7 @@ function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, i
     }
   });
 
-  $scope.addDeployment = function () {
+  $scope.addDeployment = function() {
     miqService.sparkleOn();
     $scope.$broadcast('mwAddDeploymentEvent', $scope.deployAddModel);
   };
@@ -114,12 +113,12 @@ function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, i
   // Add JDBC Driver
   /////////////////////////////////////////////////////////////////////////
 
-  $scope.showJdbcDriverListener = function () {
+  $scope.showJdbcDriverListener = function() {
     $scope.resetJdbcDriverForm();
     $scope.jdbcDriverModel.showDeployModal = true;
   };
 
-  $scope.resetJdbcDriverForm = function () {
+  $scope.resetJdbcDriverForm = function() {
     $scope.jdbcDriverModel = {};
     $scope.jdbcDriverModel.serverId = angular.element('#server_id').val();
     $scope.jdbcDriverModel.xaDatasource = true;
@@ -154,7 +153,7 @@ function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, i
     }
   });
 
-  $scope.addJdbcDriver = function () {
+  $scope.addJdbcDriver = function() {
     miqService.sparkleOn();
     $scope.$broadcast('mwAddJdbcDriverEvent', $scope.jdbcDriverModel);
   };
@@ -182,23 +181,20 @@ function MwServerGroupOpsController(miqService, serverGroupOpsService) {
 
 function MwServerOpsControllerFactory(miqService, serverOpsService) {
 
-    ManageIQ.angular.rxSubject.subscribe(function(event) {
+  ManageIQ.angular.rxSubject.subscribe(function(event) {
+    if (event.type === 'mwSeverOpsEvent') {
+      miqService.sparkleOn();
 
-      if(event.type == 'mwSeverOpsEvent') {
-        miqService.sparkleOn();
-
-        serverOpsService.runOperation(event.serverId, event.operation, event.timeout)
-          .then(function (response) {
-              miqService.miqFlash('success', response);
-            },
-            function (error) {
-              miqService.miqFlash('error', error);
-
-            }).finally(function () {
-
+      serverOpsService.runOperation(event.serverId, event.operation, event.timeout)
+        .then(function(response) {
+          miqService.miqFlash('success', response);
+        },
+        function(error) {
+          miqService.miqFlash('error', error);
+        }).finally(function() {
           miqService.sparkleOff();
         });
-      }
+    }
   });
 }
 
@@ -223,13 +219,13 @@ function ServerOpsServiceFactory($http, $q, isGroup) {
     var payload = {
       'id': id,
       'operation': operation,
-      'timeout': timeout
+      'timeout': timeout,
     };
 
     var url = '/middleware_server' + (isGroup ? '_group' : '') + '/run_operation'
     $http.post(url, angular.toJson(payload))
       .then(
-        function (response) { // success
+        function(response) { // success
           var data = response.data;
 
           if (data.status === 'ok') {
@@ -238,18 +234,18 @@ function ServerOpsServiceFactory($http, $q, isGroup) {
             deferred.reject(data.msg);
           }
         })
-      .catch(function () {
+      .catch(function() {
         deferred.reject(errorMsg);
       })
-      .finally(function () {
+      .finally(function() {
         angular.element("#modal_param_div").modal('hide');
         // we should already be resolved and promises can only fire once
         deferred.resolve(data.msg);
       });
     return deferred.promise;
-  }
+  };
   return {
-    runOperation: runOperation
+    runOperation: runOperation,
   };
 }
 

--- a/app/views/middleware_server/_add_jdbc_driver.html.haml
+++ b/app/views/middleware_server/_add_jdbc_driver.html.haml
@@ -30,6 +30,26 @@
                        :locals => {:object_name => "jdbc_driver", :method => "file", :custom_options => {"ng-required" => "true", "ng-model" => "jdbcDriverModel.filePath", "require-file" => "handle"}}
 
           .form-group
+            %label.col-md-4.control-label{:for => "xa_driver_ds_cb"}
+              = _("XA Datasource:")
+            .col-md-8
+              %input#xa_driver_ds_cb{:type      => "checkbox",
+                              "bs-switch"       => "",
+                              "switch-on-text"  => _("Yes"),
+                              "switch-off-text" => _("No"),
+                              "switch-change"   => "onDriverXaChange()",
+                              "ng-model"        => "jdbcDriverModel.xaDatasource"}
+
+          .form-group
+            %label.col-md-4.control-label{:for => "choose_datasource_input"}
+              = _("Datasource:")
+            .col-md-8
+              %select.form-control#chooose_driver_ds{"name"        => "choose_driver_ds_input",
+                                                     "ng-model"    => "jdbcDriverModel.selectedDatasource",
+                                                     "ng-options"  => "c.label for c in jdbcDriverModel.datasources track by c.id",
+                                                     "ng-required" => "false"}
+
+          .form-group
             %label.col-md-4.control-label{:for => "jdbc_driver_name_input"}
               = _("Driver Name")
             .col-md-8


### PR DESCRIPTION
This adds intelligent defaults when Adding JDBC Driver instead of having to know what the options are to key in.

![jdbc-defaults mov](https://cloud.githubusercontent.com/assets/1312165/24594714/a5daa054-17e4-11e7-8800-cae3e77fd88c.gif)

Here is the old(current) **Add JDBC Driver** screen:
<img width="593" alt="add-driver-original" src="https://cloud.githubusercontent.com/assets/1312165/24583219/0fb7e9d4-16f8-11e7-9aa1-9c1612e0b21a.png">
We really can't do much here as far as validations because the above scenario is correct -- so there needs to be very loose validation. To counter this, we will provide intelligent defaults instead. This eliminates the need to look up these values and is consistent with the **Add Datasource** screens as they use the same services.

The new screen with intelligent defaults:
<img width="596" alt="manageiq__middleware_servers" src="https://cloud.githubusercontent.com/assets/1312165/24583322/2d5e4214-16fb-11e7-8c76-0a3ecf8b200b.png">

This also brings it in alignment with the **Add Datasource** wizard.

### Links

- https://bugzilla.redhat.com/show_bug.cgi?id=1383637



