### PR TITLE
Instance variable instead of a blockvar for TreeNode::AvailabilityZone

### DIFF
--- a/app/presenters/tree_node/availability_zone.rb
+++ b/app/presenters/tree_node/availability_zone.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class AvailabilityZone < Node
-    set_attribute(:tooltip) { |object| _("Availability Zone: %{name}") % {:name => object.name} }
+    set_attribute(:tooltip) { _("Availability Zone: %{name}") % {:name => @object.name} }
   end
 end


### PR DESCRIPTION
This is inconsistent with all the other `TreeNode::` subclasses. Alphabetically this is the first file with `set_attribute` so there is a high chance that someone would use it as an example.