### PR TITLE
Only show visible custom attributes

### DIFF
--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -1,5 +1,6 @@
 module ContainerSummaryHelper
   include TextualMixins::TextualName
+  include TextualMixins::TextualVisibleCustomAttributes
 
   def textual_ems
     textual_link(@record.ext_management_system)
@@ -75,12 +76,6 @@ module ContainerSummaryHelper
 
   def textual_group_miq_custom_attributes
     TextualGroup.new(_("Custom Attributes"), textual_miq_custom_attributes)
-  end
-
-  def textual_miq_custom_attributes
-    attrs = @record.custom_attributes
-    return nil if attrs.blank?
-    attrs.sort_by(&:name).collect { |a| {:label => a.name.tr("_", " "), :value => a.value} }
   end
 
   def textual_group_container_selectors

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module EmsContainerHelper::TextualSummary
   include TextualMixins::TextualRefreshStatus
   include TextualMixins::TextualAuthenticationsStatus
   include TextualMixins::TextualMetricsStatus
+  include TextualMixins::TextualVisibleCustomAttributes
   #
   # Groups
   #
@@ -122,27 +123,5 @@ module EmsContainerHelper::TextualSummary
 
   def textual_group_miq_custom_attributes
     TextualGroup.new(_("Custom Attributes"), textual_miq_custom_attributes)
-  end
-
-  def redact_username_and_password(value)
-    begin
-      uri = URI.parse(value)
-      uri.password = '***' if uri.password
-      uri.user = '***' if uri.user
-      uri.to_s
-    rescue # dont reduct in case the value was malformed, to allow debugging it.
-      value
-    end
-  end
-
-  def textual_miq_custom_attributes
-    attrs = @record.custom_attributes
-    return nil if attrs.blank?
-    attrs.sort_by(&:name).collect do |a|
-      {
-        :label => a.name.tr("_", " "),
-        :value => redact_username_and_password(a.value)
-      }
-    end
   end
 end

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module HostHelper::TextualSummary
   include TextualMixins::TextualDevices
   include TextualMixins::TextualOsInfo
   include TextualMixins::TextualVmmInfo
+  include TextualMixins::TextualVisibleCustomAttributes
   # TODO: Determine if DoNav + url_for + :title is the right way to do links, or should it be link_to with :title
 
   #
@@ -404,12 +405,6 @@ module HostHelper::TextualSummary
       h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'event_logs')
     end
     h
-  end
-
-  def textual_miq_custom_attributes
-    attrs = @record.miq_custom_attributes
-    return nil if attrs.blank?
-    attrs.sort_by(&:name).collect { |a| {:label => a.name, :value => a.value} }
   end
 
   def textual_ems_custom_attributes

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module ServiceHelper::TextualSummary
   include TextualMixins::TextualDescription
   include TextualMixins::TextualGroupTags
   include TextualMixins::TextualName
+  include TextualMixins::TextualVisibleCustomAttributes
   #
   # Groups
   #
@@ -174,12 +175,6 @@ module ServiceHelper::TextualSummary
 
   def textual_created
     {:label => _("Created On"), :value => format_timezone(@record.created_at)}
-  end
-
-  def textual_miq_custom_attributes
-    attrs = @record.miq_custom_attributes
-    return nil if attrs.blank?
-    attrs.sort_by(&:name).collect { |a| {:label => a.name, :value => a.value} }
   end
 
   def textual_status

--- a/app/helpers/textual_mixins/textual_visible_custom_attributes.rb
+++ b/app/helpers/textual_mixins/textual_visible_custom_attributes.rb
@@ -1,0 +1,21 @@
+module TextualMixins::TextualVisibleCustomAttributes
+  def redact_username_and_password(value)
+    uri = URI.parse(value)
+    uri.password = '***' if uri.password
+    uri.user = '***' if uri.user
+    uri.to_s
+  rescue # dont reduct in case the value was malformed, to allow debugging it.
+    value
+  end
+
+  def textual_miq_custom_attributes
+    attrs = @record.miq_custom_visible
+    return nil if attrs.blank?
+    attrs.sort_by(&:name).collect do |a|
+      {
+        :label => a.name.tr("_", " "),
+        :value => redact_username_and_password(a.value)
+      }
+    end
+  end
+end

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -11,6 +11,7 @@ module VmCloudHelper::TextualSummary
   include TextualMixins::TextualPowerState
   include TextualMixins::TextualRegion
   include TextualMixins::TextualScanHistory
+  include TextualMixins::TextualVisibleCustomAttributes
   # TODO: Determine if DoNav + url_for + :title is the right way to do links, or should it be link_to with :title
 
   #
@@ -285,12 +286,6 @@ module VmCloudHelper::TextualSummary
   def textual_vmsafe_timeout
     return nil unless @record.vmsafe_enable
     {:label => _("Timeout (ms)"), :value => @record.vmsafe_timeout_ms}
-  end
-
-  def textual_miq_custom_attributes
-    attrs = @record.miq_custom_attributes
-    return nil if attrs.blank?
-    attrs.sort_by(&:name).collect { |a| {:label => a.name, :value => a.value} }
   end
 
   def textual_ems_custom_attributes

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -13,6 +13,7 @@ module VmHelper::TextualSummary
   include TextualMixins::TextualScanHistory
   include TextualMixins::TextualDevices
   include TextualMixins::TextualVmmInfo
+  include TextualMixins::TextualVisibleCustomAttributes
   # TODO: Determine if DoNav + url_for + :title is the right way to do links, or should it be link_to with :title
 
   #
@@ -748,12 +749,6 @@ module VmHelper::TextualSummary
   def textual_vmsafe_timeout
     return nil unless @record.vmsafe_enable
     {:label => _("Timeout (ms)"), :value => @record.vmsafe_timeout_ms}
-  end
-
-  def textual_miq_custom_attributes
-    attrs = @record.miq_custom_attributes
-    return nil if attrs.blank?
-    attrs.sort_by(&:name).collect { |a| {:label => a.name, :value => a.value} }
   end
 
   def textual_ems_custom_attributes


### PR DESCRIPTION
Based on https://github.com/ManageIQ/manageiq/pull/14611, This will only show custom attributes where `visible => true`.

Due to CodeClimate's insistence I had to also create a mixin for visible custom attributes and I also included the redact function in it.