### PR TITLE
Determine model properly in set owner ship screen

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -26,7 +26,7 @@ module ApplicationController::CiProcessing
     if !session[:checked_items].nil? && @lastaction == "set_checked_items"
       recs = session[:checked_items]
     else
-      recs = find_checked_ids_with_rbac(get_class_from_controller_param(params[:controller]))
+      recs = find_checked_ids_with_rbac(get_class_from_controller_param(controller))
     end
     if recs.blank?
       id = find_id_with_rbac(get_class_from_controller_param(params[:controller]), params[:id])


### PR DESCRIPTION
introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/852

we are determining model from controller(`params[:controller]`) but for
some cases controller is not related to model, for example
when the list is non-explorer screen(this test scenario is also causing error):

Summary page of cloud provider,
click on images/instances,
choose one and click on set ownership screen
=> controller is here ems_cloud so we need to use variable `controller` where we can inherit the model.

cc @romanblanco @martinpovolny 

@miq-bot @mzazrivec 



