### PR TITLE
GET -> POST for set ownership screen

### DIFF
--- a/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
+++ b/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
@@ -14,7 +14,7 @@ ManageIQ.angular.app.controller('ownershipFormController', ['$http', '$scope', '
     ManageIQ.angular.scope = $scope;
 
     miqService.sparkleOn();
-    $http.get('ownership_form_fields/' + objectIds.join(','))
+    $http.post('ownership_form_fields', {object_ids: objectIds})
       .then(getOwnershipFormData)
       .catch(miqService.handleFailure);
   };

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -7,7 +7,7 @@ module ApplicationController::CiProcessing
   end
 
   def ownership_form_fields
-    render :json => build_ownership_hash(params[:id].split(/\s*,\s*/))
+    render :json => build_ownership_hash(params[:object_ids])
   end
 
   # Set Ownership selected db records

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2803,7 +2803,6 @@ Rails.application.routes.draw do
         retire
         service_form_fields
         show
-        ownership_form_fields
       ),
       :post => %w(
         button
@@ -2820,6 +2819,7 @@ Rails.application.routes.draw do
         x_button
         x_history
         x_show
+        ownership_form_fields
       ) +
                dialog_runner_post
     },
@@ -2935,7 +2935,6 @@ Rails.application.routes.draw do
         right_size
         show
         show_list
-        ownership_form_fields
       ),
       :post => %w(
         edit_vm
@@ -2961,6 +2960,7 @@ Rails.application.routes.draw do
         genealogy_tree_selected
         ownership_update
         wait_for_task
+        ownership_form_fields
       ) +
                ownership_post +
                pre_prov_post
@@ -2990,7 +2990,6 @@ Rails.application.routes.draw do
         detach
         evacuate
         evacuate_form_fields
-        ownership_form_fields
         associate_floating_ip
         associate_floating_ip_form_fields
         disassociate_floating_ip
@@ -3059,6 +3058,7 @@ Rails.application.routes.draw do
         associate_floating_ip_vm
         disassociate_floating_ip_vm
         wait_for_task
+        ownership_form_fields
       ) +
                adv_search_post +
                compare_post +
@@ -3091,7 +3091,6 @@ Rails.application.routes.draw do
         retire
         show
         tagging_edit
-        ownership_form_fields
       ) +
                compare_get,
       :post => %w(
@@ -3149,6 +3148,7 @@ Rails.application.routes.draw do
         wait_for_task
         win32_services
         ownership_update
+        ownership_form_fields
       ) +
                adv_search_post +
                compare_post +
@@ -3181,7 +3181,6 @@ Rails.application.routes.draw do
         util_report_download
         utilization
         vm_show
-        ownership_form_fields
       ) +
                compare_get,
       :post => %w(
@@ -3250,6 +3249,7 @@ Rails.application.routes.draw do
         x_search_by_name
         x_show
         ownership_update
+        ownership_form_fields
       ) +
                adv_search_post +
                compare_post +

--- a/spec/javascripts/controllers/ownership/ownership_form_controller_spec.js
+++ b/spec/javascripts/controllers/ownership/ownership_form_controller_spec.js
@@ -24,7 +24,7 @@ describe('ownershipFormController', function() {
   beforeEach(inject(function(_$controller_) {
     var ownershipFormResponse = { user:  'testUser2',
                                   group: 'testGroup2'};
-    $httpBackend.whenGET('ownership_form_fields/1000000000001,1000000000003').respond(ownershipFormResponse);
+    $httpBackend.whenPOST('ownership_form_fields', { object_ids: [1000000000001,1000000000003]}).respond(ownershipFormResponse);
     $httpBackend.flush();
   }));
 


### PR DESCRIPTION
Reason: Length of GET request is limited.

We have set ownership screens only for services and  Images/Instances/Vm/Templates.

## Test scenarios:
Open set ownership for Images/Instances/Vm/Templates:
- directly from menu (for example Compute -> Cloud -> Instances)
- from provider's summary page Compute -> Cloud -> any provider summary page -> Instances)
- from summary pages of Images/Instances/Vm/Templates:

Open set ownership for Services:
- directly from menu (for example Services -> My services
- from summary pages of any service:

cc @himdel @mzazrivec 
@miq-bot add_label technical_dept
@miq-bot assign @martinpovolny 
