### PR TITLE
[WIP]Broken titles for a new automate buttons and groups.

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -226,7 +226,8 @@ class MiqAeCustomizationController < ApplicationController
   end
 
   def replace_right_cell(options = {})
-    nodetype, replace_trees = options.values_at(:nodetype, :replace_trees)
+    nodetype, replace_trees = options.values_at(:action, :replace_trees)
+    nodetype ||= options[:nodetype]
     # fixme, don't call all the time
     build_ae_tree(:automate, :automate_tree) # Build Catalog Items tree
     trees = {}


### PR DESCRIPTION
This PR fix a broken titles for a new automate buttons and groups.

based on: https://bugzilla.redhat.com/show_bug.cgi?id=1379348

Automation/Automate/Customization

before:
![de12af18-13a0-11e7-89db-9e3bdd46a832](https://cloud.githubusercontent.com/assets/19405716/24609352/d13a36a6-187a-11e7-9d2a-5c892381ac64.png)
after:
![e4a6cf62-13a0-11e7-8571-91eafd27bb05](https://cloud.githubusercontent.com/assets/19405716/24609374/e3ea7568-187a-11e7-9179-99d0927818c3.png)



