### PR TITLE
Always return true for visible

### DIFF
--- a/app/helpers/application_helper/button/host_protect.rb
+++ b/app/helpers/application_helper/button/host_protect.rb
@@ -1,7 +1,0 @@
-class ApplicationHelper::Button::HostProtect < ApplicationHelper::Button::Basic
-  needs :@record
-
-  def visible?
-    true
-  end
-end

--- a/app/helpers/application_helper/button/host_protect.rb
+++ b/app/helpers/application_helper/button/host_protect.rb
@@ -2,6 +2,6 @@ class ApplicationHelper::Button::HostProtect < ApplicationHelper::Button::Basic
   needs :@record
 
   def visible?
-    @record.smart?
+    true
   end
 end

--- a/app/helpers/application_helper/toolbar/host_center.rb
+++ b/app/helpers/application_helper/toolbar/host_center.rb
@@ -77,7 +77,7 @@ class ApplicationHelper::Toolbar::HostCenter < ApplicationHelper::Toolbar::Basic
           'pficon pficon-edit fa-lg',
           N_('Manage Policies for this item'),
           N_('Manage Policies'),
-          :klass => ApplicationHelper::Button::HostProtect),
+          :klass => ApplicationHelper::Button::Basic),
         button(
           :host_tag,
           'pficon pficon-edit fa-lg',


### PR DESCRIPTION
The `smart` column is deprecated, so we're trying to remove it. However, it's removal does affect one method in the UI.

https://github.com/ManageIQ/manageiq/pull/14594

As per the comments by @gmcculloug in that issue, this should always be true.