### PR TITLE
Added force_encoding to display contents of stdout correctly on screen

### DIFF
--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -22,11 +22,19 @@
       = miq_tab_content("provisioning", 'default', :class => 'cm-tab') do
         = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_provisioning_group_list}
         - if @job && @job.try(:raw_stdout)
-          = render :partial => "layouts/textual_code_mirror", :locals => {:label => 'Standard Output', :value => @job.raw_stdout, :mode => "htmlmixed", :text_area_id => "provision_output"}
+          = render :partial => "layouts/textual_code_mirror",
+                   :locals  => {:label        => _('Standard Output'),
+                                :value        => @job.raw_stdout.force_encoding("UTF-8"),
+                                :mode         => "htmlmixed",
+                                :text_area_id => "provision_output"}
       - if job
         = miq_tab_content("retirement", 'default', :class => 'cm-tab') do
           = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_retirement_group_list}
-          = render :partial => "layouts/textual_code_mirror", :locals => {:label => 'Standard Output', :value => job.raw_stdout, :mode => "htmlmixed", :text_area_id => "retirement_output"}
+          = render :partial => "layouts/textual_code_mirror",
+                   :locals  => {:label        => _('Standard Output'),
+                                :value        => job.raw_stdout.force_encoding("UTF-8"),
+                                :mode         => "htmlmixed",
+                                :text_area_id => "retirement_output"}
 :javascript
   miq_tabs_init('#services_tab');
   miq_refresh_code_mirror();


### PR DESCRIPTION
Added force_encoding to display contents of stdout to pass them to codemirror so it can be correctly on screen to fix the following error:
[----] F, [2017-04-03T11:48:28.706445 #7517:50b9460] FATAL -- : Error caught: [ActionView::Template::Error] incompatible character encodings: UTF-8 and ASCII-8BIT

https://bugzilla.redhat.com/show_bug.cgi?id=1437906

@gmcculloug @syncrou can you please review/test.

after fix:
![after_fix](https://cloud.githubusercontent.com/assets/3450808/24631440/4836f2fe-188e-11e7-93fd-2e464162c526.png)

