### PR TITLE
Enable lifecycle toolbar for the Active Services list and remove extra pop-up alert

### DIFF
--- a/app/helpers/application_helper/toolbar/service/lifecycle_mixin.rb
+++ b/app/helpers/application_helper/toolbar/service/lifecycle_mixin.rb
@@ -7,6 +7,7 @@ module ApplicationHelper::Toolbar::Service::LifecycleMixin
         t = N_('Lifecycle'),
         t,
         :enabled => false,
+        :onwhen  => "1+",
         :items   => [
           included_class.button(
             :service_retire,

--- a/app/helpers/application_helper/toolbar/service_center.rb
+++ b/app/helpers/application_helper/toolbar/service_center.rb
@@ -62,9 +62,8 @@ class ApplicationHelper::Toolbar::ServiceCenter < ApplicationHelper::Toolbar::Ba
         button(
           :service_retire,
           'fa fa-clock-o fa-lg',
-          t = N_('Set Retirement Date for this Service'),
+          t = N_('Set Retirement Dates for this Service'),
           t,
-          :confirm => N_("Set Retirement this Service?"),
           :klass   => ApplicationHelper::Button::ServiceRetire
         ),
         button(


### PR DESCRIPTION
Enable lifecycle toolbar for the Active Services list and Remove the extra popup message for 'Retire Service by date'

https://bugzilla.redhat.com/show_bug.cgi?id=1437733