### PR TITLE
Stop spinner on Container Image Condition screen

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -90,7 +90,7 @@ module ApplicationController::Filter
     token = params[:token].to_i
     if token == @edit[@expkey][:exp_token] || # User selected same token as already selected
        (@edit[@expkey][:exp_token] && @edit[:edit_exp].key?("???")) # or new token in process
-      javascript_flash
+      javascript_flash(:spinner_off => true)
     else
       exp = exp_find_by_token(@edit[@expkey][:expression], token)
       @edit[:edit_exp] = copy_hash(exp)


### PR DESCRIPTION
Stop spinner for ??? expression links

https://bugzilla.redhat.com/show_bug.cgi?id=1434896

**Testing**
This has ramifications for the advanced search under VMs, but that seems to suffer the same problem before this change.

Thanks, @h-kataria for the solution