### PR TITLE
Deduplicate Ansible/foreman controllers.

### DIFF
--- a/app/assets/javascripts/controllers/automation_manager/automation_manager_form_controller.js
+++ b/app/assets/javascripts/controllers/automation_manager/automation_manager_form_controller.js
@@ -26,14 +26,14 @@ ManageIQ.angular.app.controller('automationManagerFormController', ['$http', '$s
     $scope.automationManagerModel.log_password = '';
     $scope.automationManagerModel.log_verify = '';
 
-    $http.get('/automation_manager/automation_manager_form_fields/' + automationManagerFormId)
+    $http.get('/automation_manager/form_fields/' + automationManagerFormId)
       .then(getAutomationManagerNewFormDataComplete)
       .catch(miqService.handleFailure);
   } else {
     $scope.newRecord = false;
     miqService.sparkleOn();
 
-    $http.get('/automation_manager/automation_manager_form_fields/' + automationManagerFormId)
+    $http.get('/automation_manager/form_fields/' + automationManagerFormId)
       .then(getAutomationManagerFormDataComplete)
       .catch(miqService.handleFailure);
 

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -25,7 +25,7 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
   if (providerForemanFormId == 'new') {
     vm.newRecord = true;
 
-    $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId)
+    $http.get('/provider_foreman/form_fields/' + providerForemanFormId)
       .then(getProviderForemanFormData)
       .catch(miqService.handleFailure);
   } else {
@@ -33,7 +33,7 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
 
     miqService.sparkleOn();
 
-    $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId)
+    $http.get('/provider_foreman/form_fields/' + providerForemanFormId)
       .then(getProviderForemanFormData)
       .catch(miqService.handleFailure);
   }

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -58,8 +58,8 @@ class AutomationManagerController < ApplicationController
     render_tagging_form
   end
 
-  def automation_manager_form_fields
-    assert_privileges("automation_manager_edit_provider")
+  def form_fields
+    assert_privileges("#{priviledge_prefix}_edit_provider")
     # set value of read only zone text box, when there is only single zone
     if params[:id] == "new"
       return render :json => {:zone => Zone.in_my_region.size >= 1 ? Zone.in_my_region.first.name : nil}

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -58,23 +58,6 @@ class AutomationManagerController < ApplicationController
     render_tagging_form
   end
 
-  def form_fields
-    assert_privileges("#{privilege_prefix}_edit_provider")
-    # set value of read only zone text box, when there is only single zone
-    if params[:id] == "new"
-      return render :json => {:zone => Zone.in_my_region.size >= 1 ? Zone.in_my_region.first.name : nil}
-    end
-
-    manager = find_record(concrete_model, params[:id])
-    provider = manager.provider
-
-    render :json => {:name       => provider.name,
-                     :zone       => provider.zone.name,
-                     :url        => provider.url,
-                     :verify_ssl => provider.verify_ssl,
-                     :log_userid => provider.authentications.first.userid}
-  end
-
   def load_or_clear_adv_search
     adv_search_build("ConfiguredSystem")
     session[:edit] = @edit

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -38,7 +38,7 @@ class AutomationManagerController < ApplicationController
     'automation_manager'
   end
 
-  def priviledge_prefix
+  def privilege_prefix
     'automation_manager'
   end
 
@@ -59,7 +59,7 @@ class AutomationManagerController < ApplicationController
   end
 
   def form_fields
-    assert_privileges("#{priviledge_prefix}_edit_provider")
+    assert_privileges("#{privilege_prefix}_edit_provider")
     # set value of read only zone text box, when there is only single zone
     if params[:id] == "new"
       return render :json => {:zone => Zone.in_my_region.size >= 1 ? Zone.in_my_region.first.name : nil}

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -241,11 +241,6 @@ class AutomationManagerController < ApplicationController
     ManageIQ::Providers::AnsibleTower::Provider
   end
 
-  def find_or_build_provider
-    @provider = provider_class.new if params[:id] == "new"
-    @provider ||= find_record(ManageIQ::Providers::AutomationManager, params[:id]).provider
-  end
-
   def features
     [
       {:role     => "automation_manager_providers",

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -34,8 +34,12 @@ class AutomationManagerController < ApplicationController
     'automation_manager'
   end
 
+  def priviledge_prefix
+    'automation_manager'
+  end
+
   def new
-    assert_privileges("automation_manager_add_provider")
+    assert_privileges("#{priviledge_prefix}_add_provider")
     @provider_manager = ManageIQ::Providers::AnsibleTower::AutomationManager.new
     @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
     render_form
@@ -50,7 +54,7 @@ class AutomationManagerController < ApplicationController
       add_provider
       save_provider
     else
-      assert_privileges("automation_manager_edit_provider")
+      assert_privileges("#{priviledge_prefix}_edit_provider")
       manager_id            = from_cid(params[:miq_grid_checks] || params[:id] || find_checked_items[0])
       @provider_manager     = find_record(ManageIQ::Providers::AnsibleTower::AutomationManager, manager_id)
       @providerdisplay_type = self.class.model_to_name(@provider_manager.type)
@@ -59,7 +63,7 @@ class AutomationManagerController < ApplicationController
   end
 
   def delete
-    assert_privileges("automation_manager_delete_provider")
+    assert_privileges("#{priviledge_prefix}_delete_provider")
     checked_items = find_checked_items
     checked_items.push(params[:id]) if checked_items.empty? && params[:id]
     providers = ManageIQ::Providers::AutomationManager.where(:id => checked_items).includes(:provider).collect(&:provider)
@@ -85,7 +89,7 @@ class AutomationManagerController < ApplicationController
   end
 
   def refresh
-    assert_privileges("automation_manager_refresh_provider")
+    assert_privileges("#{priviledge_prefix}_refresh_provider")
     @explorer = true
     manager_button_operation('refresh_ems', _('Refresh'))
     replace_right_cell

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -470,7 +470,7 @@ module Mixins
     end
 
     def new
-      assert_privileges("#{priviledge_prefix}_add_provider")
+      assert_privileges("#{privilege_prefix}_add_provider")
       @provider_manager = concrete_model.new
       @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
       render_form
@@ -485,7 +485,7 @@ module Mixins
         add_provider
         save_provider
       else
-        assert_privileges("#{priviledge_prefix}_edit_provider")
+        assert_privileges("#{privilege_prefix}_edit_provider")
         manager_id            = from_cid(params[:miq_grid_checks] || params[:id] || find_checked_items[0])
         @provider_manager     = find_record(concrete_model, manager_id)
         @providerdisplay_type = self.class.model_to_name(@provider_manager.type)
@@ -494,7 +494,7 @@ module Mixins
     end
 
     def delete
-      assert_privileges("#{priviledge_prefix}_delete_provider")
+      assert_privileges("#{privilege_prefix}_delete_provider")
       checked_items = find_checked_items
       checked_items.push(params[:id]) if checked_items.empty? && params[:id]
       providers = Rbac.filtered(concrete_model.where(:id => checked_items).includes(:provider).collect(&:provider))
@@ -520,7 +520,7 @@ module Mixins
     end
 
     def refresh
-      assert_privileges("#{priviledge_prefix}_refresh_provider")
+      assert_privileges("#{privilege_prefix}_refresh_provider")
       @explorer = true
       manager_button_operation('refresh_ems', _('Refresh'))
       replace_right_cell

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -266,6 +266,23 @@ module Mixins
       replace_right_cell
     end
 
+    def form_fields
+      assert_privileges("#{privilege_prefix}_edit_provider")
+      # set value of read only zone text box, when there is only single zone
+      if params[:id] == "new"
+        return render :json => {:zone => Zone.in_my_region.size >= 1 ? Zone.in_my_region.first.name : nil}
+      end
+
+      manager = find_record(concrete_model, params[:id])
+      provider = manager.provider
+
+      render :json => {:name       => provider.name,
+                       :zone       => provider.zone.name,
+                       :url        => provider.url,
+                       :verify_ssl => provider.verify_ssl,
+                       :log_userid => provider.authentications.first.userid}
+    end
+
     private
 
     def replace_right_cell(options = {})

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -8,6 +8,11 @@ module Mixins
       redirect_to :action => 'explorer', :flash_msg => @flash_array.try(:fetch_path, 0, :message)
     end
 
+    def find_or_build_provider
+      @provider = provider_class.new if params[:id] == "new"
+      @provider ||= find_record(self.class.model, params[:id]).provider
+    end
+
     def add_provider
       find_or_build_provider
       sync_form_to_instance

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -454,7 +454,7 @@ module Mixins
     def find_record(model, id)
       raise _("Invalid input") unless is_integer?(from_cid(id))
       begin
-        record = model.where(:id => from_cid(id)).first
+        record = Rbac.filtered(model.where(:id => from_cid(id))).first
       rescue ActiveRecord::RecordNotFound, StandardError => ex
         if @explorer
           self.x_node = "root"
@@ -497,7 +497,7 @@ module Mixins
       assert_privileges("#{priviledge_prefix}_delete_provider")
       checked_items = find_checked_items
       checked_items.push(params[:id]) if checked_items.empty? && params[:id]
-      providers = concrete_model.where(:id => checked_items).includes(:provider).collect(&:provider)
+      providers = Rbac.filtered(concrete_model.where(:id => checked_items).includes(:provider).collect(&:provider))
       if providers.empty?
         add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => "providers"), :task => "deletion"}, :error)
       else

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -209,7 +209,64 @@ module Mixins
       end
     end
 
-    private ###########
+    def new
+      assert_privileges("#{privilege_prefix}_add_provider")
+      @provider_manager = concrete_model.new
+      @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
+      render_form
+    end
+
+    def edit
+      @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
+      case params[:button]
+      when "cancel"
+        cancel_provider
+      when "save"
+        add_provider
+        save_provider
+      else
+        assert_privileges("#{privilege_prefix}_edit_provider")
+        manager_id            = from_cid(params[:miq_grid_checks] || params[:id] || find_checked_items[0])
+        @provider_manager     = find_record(concrete_model, manager_id)
+        @providerdisplay_type = self.class.model_to_name(@provider_manager.type)
+        render_form
+      end
+    end
+
+    def delete
+      assert_privileges("#{privilege_prefix}_delete_provider")
+      checked_items = find_checked_items
+      checked_items.push(params[:id]) if checked_items.empty? && params[:id]
+      providers = Rbac.filtered(concrete_model.where(:id => checked_items).includes(:provider).collect(&:provider))
+      if providers.empty?
+        add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => "providers"), :task => "deletion"}, :error)
+      else
+        providers.each do |provider|
+          AuditEvent.success(
+            :event        => "provider_record_delete_initiated",
+            :message      => "[#{provider.name}] Record delete initiated",
+            :target_id    => provider.id,
+            :target_class => provider.type,
+            :userid       => session[:userid]
+          )
+          provider.destroy_queue
+        end
+
+        add_flash(n_("Delete initiated for %{count} Provider",
+                     "Delete initiated for %{count} Providers",
+                     providers.length) % {:count => providers.length})
+      end
+      replace_right_cell
+    end
+
+    def refresh
+      assert_privileges("#{privilege_prefix}_refresh_provider")
+      @explorer = true
+      manager_button_operation('refresh_ems', _('Refresh'))
+      replace_right_cell
+    end
+
+    private
 
     def replace_right_cell(options = {})
       replace_trees = options[:replace_trees]
@@ -467,63 +524,6 @@ module Mixins
 
     def title
       _("Providers")
-    end
-
-    def new
-      assert_privileges("#{privilege_prefix}_add_provider")
-      @provider_manager = concrete_model.new
-      @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
-      render_form
-    end
-
-    def edit
-      @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
-      case params[:button]
-      when "cancel"
-        cancel_provider
-      when "save"
-        add_provider
-        save_provider
-      else
-        assert_privileges("#{privilege_prefix}_edit_provider")
-        manager_id            = from_cid(params[:miq_grid_checks] || params[:id] || find_checked_items[0])
-        @provider_manager     = find_record(concrete_model, manager_id)
-        @providerdisplay_type = self.class.model_to_name(@provider_manager.type)
-        render_form
-      end
-    end
-
-    def delete
-      assert_privileges("#{privilege_prefix}_delete_provider")
-      checked_items = find_checked_items
-      checked_items.push(params[:id]) if checked_items.empty? && params[:id]
-      providers = Rbac.filtered(concrete_model.where(:id => checked_items).includes(:provider).collect(&:provider))
-      if providers.empty?
-        add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => "providers"), :task => "deletion"}, :error)
-      else
-        providers.each do |provider|
-          AuditEvent.success(
-            :event        => "provider_record_delete_initiated",
-            :message      => "[#{provider.name}] Record delete initiated",
-            :target_id    => provider.id,
-            :target_class => provider.type,
-            :userid       => session[:userid]
-          )
-          provider.destroy_queue
-        end
-
-        add_flash(n_("Delete initiated for %{count} Provider",
-                     "Delete initiated for %{count} Providers",
-                     providers.length) % {:count => providers.length})
-      end
-      replace_right_cell
-    end
-
-    def refresh
-      assert_privileges("#{privilege_prefix}_refresh_provider")
-      @explorer = true
-      manager_button_operation('refresh_ems', _('Refresh'))
-      replace_right_cell
     end
   end
 end

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -468,5 +468,62 @@ module Mixins
     def title
       _("Providers")
     end
+
+    def new
+      assert_privileges("#{priviledge_prefix}_add_provider")
+      @provider_manager = concrete_model.new
+      @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
+      render_form
+    end
+
+    def edit
+      @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
+      case params[:button]
+      when "cancel"
+        cancel_provider
+      when "save"
+        add_provider
+        save_provider
+      else
+        assert_privileges("#{priviledge_prefix}_edit_provider")
+        manager_id            = from_cid(params[:miq_grid_checks] || params[:id] || find_checked_items[0])
+        @provider_manager     = find_record(concrete_model, manager_id)
+        @providerdisplay_type = self.class.model_to_name(@provider_manager.type)
+        render_form
+      end
+    end
+
+    def delete
+      assert_privileges("#{priviledge_prefix}_delete_provider")
+      checked_items = find_checked_items
+      checked_items.push(params[:id]) if checked_items.empty? && params[:id]
+      providers = concrete_model.where(:id => checked_items).includes(:provider).collect(&:provider)
+      if providers.empty?
+        add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => "providers"), :task => "deletion"}, :error)
+      else
+        providers.each do |provider|
+          AuditEvent.success(
+            :event        => "provider_record_delete_initiated",
+            :message      => "[#{provider.name}] Record delete initiated",
+            :target_id    => provider.id,
+            :target_class => provider.type,
+            :userid       => session[:userid]
+          )
+          provider.destroy_queue
+        end
+
+        add_flash(n_("Delete initiated for %{count} Provider",
+                     "Delete initiated for %{count} Providers",
+                     providers.length) % {:count => providers.length})
+      end
+      replace_right_cell
+    end
+
+    def refresh
+      assert_privileges("#{priviledge_prefix}_refresh_provider")
+      @explorer = true
+      manager_button_operation('refresh_ems', _('Refresh'))
+      replace_right_cell
+    end
   end
 end

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -34,7 +34,7 @@ class ProviderForemanController < ApplicationController
     'configuration_manager'
   end
 
-  def priviledge_prefix
+  def privilege_prefix
     'provider_foreman'
   end
 
@@ -77,7 +77,7 @@ class ProviderForemanController < ApplicationController
   end
 
   def form_fields
-    assert_privileges("#{priviledge_prefix}_edit_provider")
+    assert_privileges("#{privilege_prefix}_edit_provider")
     # set value of read only zone text box, when there is only single zone
     if params[:id] == "new"
       return render :json => {:zone => Zone.in_my_region.size >= 1 ? Zone.in_my_region.first.name : nil}

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -261,11 +261,6 @@ class ProviderForemanController < ApplicationController
     ManageIQ::Providers::Foreman::Provider
   end
 
-  def find_or_build_provider
-    @provider = provider_class.new if params[:id] == "new"
-    @provider ||= find_record(ManageIQ::Providers::ConfigurationManager, params[:id]).provider # TODO: Why is params[:id] an ExtManagementSystem ID instead of Provider ID?
-  end
-
   def features
     [{:role     => "providers_accord",
       :role_any => true,

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -30,8 +30,12 @@ class ProviderForemanController < ApplicationController
     'configuration_manager'
   end
 
+  def priviledge_prefix
+    'provider_foreman'
+  end
+
   def new
-    assert_privileges("provider_foreman_add_provider")
+    assert_privileges("#{priviledge_prefix}_add_provider")
     @provider_manager = ManageIQ::Providers::ConfigurationManager.new
     @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
     render_form
@@ -46,7 +50,7 @@ class ProviderForemanController < ApplicationController
       add_provider
       save_provider
     else
-      assert_privileges("provider_foreman_edit_provider")
+      assert_privileges("#{priviledge_prefix}_edit_provider")
       manager_id            = from_cid(params[:miq_grid_checks] || params[:id] || find_checked_items[0])
       @provider_manager     = find_record(ManageIQ::Providers::ConfigurationManager, manager_id)
       @providerdisplay_type = self.class.model_to_name(@provider_manager.type)
@@ -55,8 +59,8 @@ class ProviderForemanController < ApplicationController
   end
 
   def delete
-    assert_privileges("provider_foreman_delete_provider") # TODO: Privelege name should match generic ways from Infra and Cloud
-    checked_items = find_checked_items # TODO: Checked items are managers, not providers.  Make them providers
+    assert_privileges("#{priviledge_prefix}_delete_provider")
+    checked_items = find_checked_items
     checked_items.push(params[:id]) if checked_items.empty? && params[:id]
     providers = ManageIQ::Providers::ConfigurationManager.where(:id => checked_items).includes(:provider).collect(&:provider)
     if providers.empty?
@@ -81,7 +85,7 @@ class ProviderForemanController < ApplicationController
   end
 
   def refresh
-    assert_privileges("provider_foreman_refresh_provider")
+    assert_privileges("#{priviledge_prefix}_refresh_provider")
     @explorer = true
     manager_button_operation('refresh_ems', _('Refresh'))
     replace_right_cell

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -76,23 +76,6 @@ class ProviderForemanController < ApplicationController
     render_tagging_form
   end
 
-  def form_fields
-    assert_privileges("#{privilege_prefix}_edit_provider")
-    # set value of read only zone text box, when there is only single zone
-    if params[:id] == "new"
-      return render :json => {:zone => Zone.in_my_region.size >= 1 ? Zone.in_my_region.first.name : nil}
-    end
-
-    manager = find_record(concrete_model, params[:id])
-    provider = manager.provider
-
-    render :json => {:name       => provider.name,
-                     :zone       => provider.zone.name,
-                     :url        => provider.url,
-                     :verify_ssl => provider.verify_ssl,
-                     :log_userid => provider.authentications.first.userid}
-  end
-
   def load_or_clear_adv_search
     adv_search_build("ConfiguredSystem")
     session[:edit] = @edit

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -38,63 +38,6 @@ class ProviderForemanController < ApplicationController
     'provider_foreman'
   end
 
-  def new
-    assert_privileges("#{priviledge_prefix}_add_provider")
-    @provider_manager = concrete_model.new
-    @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
-    render_form
-  end
-
-  def edit
-    @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
-    case params[:button]
-    when "cancel"
-      cancel_provider
-    when "save"
-      add_provider
-      save_provider
-    else
-      assert_privileges("#{priviledge_prefix}_edit_provider")
-      manager_id            = from_cid(params[:miq_grid_checks] || params[:id] || find_checked_items[0])
-      @provider_manager     = find_record(concrete_model, manager_id)
-      @providerdisplay_type = self.class.model_to_name(@provider_manager.type)
-      render_form
-    end
-  end
-
-  def delete
-    assert_privileges("#{priviledge_prefix}_delete_provider")
-    checked_items = find_checked_items
-    checked_items.push(params[:id]) if checked_items.empty? && params[:id]
-    providers = concrete_model.where(:id => checked_items).includes(:provider).collect(&:provider)
-    if providers.empty?
-      add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => "providers"), :task => "deletion"}, :error)
-    else
-      providers.each do |provider|
-        AuditEvent.success(
-          :event        => "provider_record_delete_initiated",
-          :message      => "[#{provider.name}] Record delete initiated",
-          :target_id    => provider.id,
-          :target_class => provider.type,
-          :userid       => session[:userid]
-        )
-        provider.destroy_queue
-      end
-
-      add_flash(n_("Delete initiated for %{count} Provider",
-                   "Delete initiated for %{count} Providers",
-                   providers.length) % {:count => providers.length})
-    end
-    replace_right_cell
-  end
-
-  def refresh
-    assert_privileges("#{priviledge_prefix}_refresh_provider")
-    @explorer = true
-    manager_button_operation('refresh_ems', _('Refresh'))
-    replace_right_cell
-  end
-
   def provision
     assert_privileges("provider_foreman_configured_system_provision") if x_active_accord == :configuration_manager_providers
     assert_privileges("configured_system_provision") if x_active_accord == :configuration_manager_cs_filter

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -76,8 +76,8 @@ class ProviderForemanController < ApplicationController
     render_tagging_form
   end
 
-  def provider_foreman_form_fields
-    assert_privileges("provider_foreman_edit_provider")
+  def form_fields
+    assert_privileges("#{priviledge_prefix}_edit_provider")
     # set value of read only zone text box, when there is only single zone
     if params[:id] == "new"
       return render :json => {:zone => Zone.in_my_region.size >= 1 ? Zone.in_my_region.first.name : nil}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,7 +159,7 @@ Rails.application.routes.draw do
       :get  => %w(
         download_data
         explorer
-        automation_manager_form_fields
+        form_fields
         show
         show_list
         tagging_edit
@@ -2623,7 +2623,7 @@ Rails.application.routes.draw do
         download_data
         download_summary_pdf
         explorer
-        provider_foreman_form_fields
+        form_fields
         show
         show_list
         tagging_edit

--- a/spec/javascripts/controllers/automation_manager/automation_manager_form_controller_spec.js
+++ b/spec/javascripts/controllers/automation_manager/automation_manager_form_controller_spec.js
@@ -21,7 +21,7 @@ describe('automationManagerFormController', function() {
     };
 
     $httpBackend = _$httpBackend_;
-    $httpBackend.whenGET('/automation_manager/automation_manager_form_fields/new').respond(automationManagerFormResponse);
+    $httpBackend.whenGET('/automation_manager/form_fields/new').respond(automationManagerFormResponse);
     $controller = _$controller_('automationManagerFormController', {
       $scope: $scope,
       automationManagerFormId: 'new',
@@ -70,7 +70,7 @@ describe('automationManagerFormController', function() {
       };
 
       beforeEach(inject(function(_$controller_) {
-        $httpBackend.whenGET('/automation_manager/automation_manager_form_fields/12345').respond(automationManagerFormResponse);
+        $httpBackend.whenGET('/automation_manager/form_fields/12345').respond(automationManagerFormResponse);
         $controller = _$controller_('automationManagerFormController',
           {
             $scope: $scope,

--- a/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
+++ b/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
@@ -21,7 +21,7 @@ describe('providerForemanFormController', function() {
     };
 
     $httpBackend = _$httpBackend_;
-    $httpBackend.whenGET('/provider_foreman/provider_foreman_form_fields/new').respond(providerForemanFormResponse);
+    $httpBackend.whenGET('/provider_foreman/form_fields/new').respond(providerForemanFormResponse);
     vm = _$controller_('providerForemanFormController', {
       $scope: $scope,
       providerForemanFormId: 'new',
@@ -70,7 +70,7 @@ describe('providerForemanFormController', function() {
       };
 
       beforeEach(inject(function(_$controller_) {
-        $httpBackend.whenGET('/provider_foreman/provider_foreman_form_fields/12345').respond(providerForemanFormResponse);
+        $httpBackend.whenGET('/provider_foreman/form_fields/12345').respond(providerForemanFormResponse);
         vm = _$controller_('providerForemanFormController',
           {
             $scope: $scope,

--- a/spec/routing/provider_foreman_routing_spec.rb
+++ b/spec/routing/provider_foreman_routing_spec.rb
@@ -9,7 +9,7 @@ describe 'routes for ProviderForeman' do
   %w(
     download_data
     explorer
-    provider_foreman_form_fields
+    form_fields
     tagging_edit
     show
     show_list


### PR DESCRIPTION
ping @lgalis 

`app/assets/javascripts/controllers/automation_manager/automation_manager_form_controller.js` and `app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js` also look c-n-ped except @AparnaKarve already refactored one of them for new Angular.
Duplicate effort :-(

`config/routes.rb` fragments will also be (almost) identical