### PR TITLE
Remove hack for competability with patternfly < v3.21

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
@@ -107,15 +107,7 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
     var refreshGraph = function() {
       dash.loadCount = 0;
       dash.loadingData = true;
-
-      // TODO: becaouse of a bug in Angular-Patternfly version < v3.21.0 we need this hack
-      // it cleans the graph cache, so we can draw new data on a chart that already has some other data.
-      // please remove the folowing 2 lines once Angular-Patternfly version is >= v3.21
-      var chartScope = $('#ad-hoc-metrics-chartlineChart').scope();
-      if (chartScope) chartScope.chartConfig.data.columns = [];
-
       dash.chartData = {};
-
       dash.selectedItems = dash.items.filter(function(item) { return item.selected });
 
       for (var i = 0; i < dash.selectedItems.length; i++) {


### PR DESCRIPTION
**Description**

Remove hack for compatibility with patternfly < v3.21
This hack is not needed since https://github.com/ManageIQ/manageiq-ui-classic/pull/402 is merged.