### PR TITLE
Use manager_resource only to create Repository

### DIFF
--- a/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
@@ -8,7 +8,6 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
       name: '',
       description: '',
       scm_type: 'git',
-      manager_resource: {},
       scm_url: '',
       authentication_id: null,
       scm_branch: '',
@@ -16,10 +15,6 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
       scm_delete_on_update: false,
       scm_update_on_launch: false,
     };
-
-    API.get('/api/providers?collection_class=ManageIQ::Providers::EmbeddedAutomationManager')
-      .then(getManagerResource)
-      .catch(miqService.handleFailure);
 
     vm.model = 'repositoryModel';
 
@@ -37,9 +32,9 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
         .then(getRepositoryFormData)
         .catch(miqService.handleFailure);
     } else {
-      vm.afterGet = true;
-      vm.modelCopy = angular.copy( vm.repositoryModel );
-      miqService.sparkleOff();
+      API.get('/api/providers?collection_class=ManageIQ::Providers::EmbeddedAutomationManager')
+        .then(getManagerResource)
+        .catch(miqService.handleFailure);
     }
   };
 
@@ -70,12 +65,16 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
       .catch(miqService.handleFailure);
   };
 
-  var getRepositoryFormData = function(response) {
-    var data = response;
-    Object.assign(vm.repositoryModel, data);
+  function setForm() {
     vm.modelCopy = angular.copy( vm.repositoryModel );
     vm.afterGet = true;
     miqService.sparkleOff();
+  }
+
+  var getRepositoryFormData = function(response) {
+    var data = response;
+    Object.assign(vm.repositoryModel, data);
+    setForm();
   };
 
   var getBack = function(response) {
@@ -117,6 +116,7 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
     } else {
       vm.repositoryModel.manager_resource = {'href': response.resources[0].href};
     }
+    setForm();
   };
   init();
 }]);


### PR DESCRIPTION
API needs `manager_resource` only for creating Repository. If send in update request Tower API will throw error as it's unwanted.
Before:
evm.log
`[----] E, [2017-03-30T04:15:55.556899 #15338:fb7138] ERROR -- : MIQ(MiqQueue#deliver) Message id: [1000000009518], Error: [undefined method 'manager_resource=' for #<AnsibleTowerClient::Project:0x0000000e5695d8>]`
After:
No error and Repository gets created.

https://bugzilla.redhat.com/show_bug.cgi?id=1437377

@miq-bot add_label bug, automation/ansible, fine/yes, euwe/no

@mzazrivec please review