### PR TITLE
Fix ad-hoc page title regression

### DIFF
--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -25,5 +25,13 @@ class ContainerNodeController < ApplicationController
     end
   end
 
+  def show_ad_hoc_metrics
+    if @record && @record.try(:ems_id)
+      ems = ExtManagementSystem.find(@record.ems_id)
+      tags = {:type => "node", :hostname => @record.name}.to_json
+      redirect_to polymorphic_path(ems, :display => "ad_hoc_metrics", :tags => tags)
+    end
+  end
+
   menu_section :cnt
 end

--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -27,7 +27,7 @@ class ContainerNodeController < ApplicationController
 
   def show_ad_hoc_metrics
     if @record && @record.try(:ems_id)
-      ems = ExtManagementSystem.find(@record.ems_id)
+      ems = find_record_with_rbac(ExtManagementSystem, @record.ems_id)
       tags = {:type => "node", :hostname => @record.name}.to_json
       redirect_to polymorphic_path(ems, :display => "ad_hoc_metrics", :tags => tags)
     end

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -21,12 +21,7 @@ module Mixins
       when "performance"
         show_performance if respond_to?(:show_performance)
       when "ad_hoc_metrics"
-        if @record && @record.try(:ems_id)
-          ems = ExtManagementSystem.find(@record.ems_id)
-          tags = {:type => "node", :hostname => @record.name}.to_json
-          url = polymorphic_path(ems, :display => "ad_hoc_metrics", :tags => tags)
-          redirect_to(url)
-        end
+        show_ad_hoc_metrics if respond_to?(:show_ad_hoc_metrics)
       when "compliance_history"
         show_compliance_history if respond_to?(:show_compliance_history)
       when "topology"


### PR DESCRIPTION
**Description**

In https://github.com/ManageIQ/manageiq-ui-classic/pull/810 I introduced a regression where calls with "ad_hoc_metrics" that did not have a `@record.ems_id` ( e.g. `ExManagementSystem` ) did not call the relevant `custom_display_modes` ( e.g. `show_ad_hoc_metrics` ) as they did before.

This PR fixes that behaviour.

**Screenshot**
_Bug_
![screenshot-localhost 3000-2017-04-04-11-50-58](https://cloud.githubusercontent.com/assets/2181522/24652283/f0ac1706-1939-11e7-900b-039c85d52b5c.png)
_Fix_
![screenshot-localhost 3000-2017-04-04-13-24-09](https://cloud.githubusercontent.com/assets/2181522/24652311/0cc36cc8-193a-11e7-8d45-e1bde13e2577.png)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1439030