### PR TITLE
Get rid of angular.is*

### DIFF
--- a/app/assets/javascripts/controllers/alerts/alerts_list_controller.js
+++ b/app/assets/javascripts/controllers/alerts/alerts_list_controller.js
@@ -17,7 +17,7 @@ angular.module('alertsCenter').controller('alertsListController',
           return nextUpdate.id === existingAlert.id;
         });
 
-        if (angular.isDefined(matchingAlert)) {
+        if (matchingAlert !== undefined) {
           nextUpdate.isExpanded = matchingAlert.isExpanded;
         }
       });

--- a/app/assets/javascripts/controllers/alerts/alerts_most_recent_controller.js
+++ b/app/assets/javascripts/controllers/alerts/alerts_most_recent_controller.js
@@ -16,7 +16,7 @@ angular.module('alertsCenter').controller('alertsMostRecentController',
           return nextUpdate.id === existingAlert.id;
         });
 
-        if (angular.isDefined(matchingAlert)) {
+        if (matchingAlert !== undefined) {
           nextUpdate.isExpanded = matchingAlert.isExpanded;
         }
       });

--- a/app/assets/javascripts/controllers/alerts/alerts_overview_controller.js
+++ b/app/assets/javascripts/controllers/alerts/alerts_overview_controller.js
@@ -210,7 +210,7 @@ angular.module('alertsCenter').controller('alertsOverviewController',
       var foundGroup;
       var groupCategory = category;
 
-      if (angular.isUndefined(category)) {
+      if (category === undefined) {
         foundGroup = vm.unGroupedGroup;
       } else {
         angular.forEach(vm.groups, function(nextGroup) {

--- a/app/assets/javascripts/controllers/alerts/alerts_overview_controller.js
+++ b/app/assets/javascripts/controllers/alerts/alerts_overview_controller.js
@@ -161,7 +161,7 @@ angular.module('alertsCenter').controller('alertsOverviewController',
 
     vm.showGroupAlerts = function(item, status) {
       var locationRef = "/alerts_list/show?name=" + item.name;
-      if (angular.isDefined(status)) {
+      if (status !== undefined) {
         locationRef += "&severity=" + status;
       }
       $window.location.href = locationRef;

--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -210,7 +210,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     var retirement = catalog_item['config_info']['retirement'];
     retirement['hosts'] = configData.retirement_inventory;
     retirement['extra_vars'] = configData.retirement_variables;
-    if (angular.isDefined(vm.catalogItemModel.retirement_repository_id) && configData.retirement_repository_id !== '') {
+    if (vm.catalogItemModel.retirement_repository_id !== undefined && configData.retirement_repository_id !== '') {
       retirement['repository_id'] = configData.retirement_repository_id;
       retirement['playbook_id'] = configData.retirement_playbook_id;
       retirement['credential_id'] = configData.retirement_machine_credential_id;

--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -68,7 +68,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
   };
 
   var getRemoveResourcesTypes = function () {
-    if (angular.isUndefined(vm.catalogItemModel.retirement_repository_id) || vm.catalogItemModel.retirement_repository_id === '') {
+    if (vm.catalogItemModel.retirement_repository_id === undefined || vm.catalogItemModel.retirement_repository_id === '') {
       vm.catalogItemModel.retirement_remove_resources = 'yes_without_playbook';
       vm['remove_resources_types'] = {
         "No": "no_without_playbook",

--- a/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-config-auth-settings-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-config-auth-settings-controller.js
@@ -58,7 +58,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
         return true;
       }
 
-      if (angular.isUndefined($scope.data.authentication.htPassword)) {
+      if ($scope.data.authentication.htPassword === undefined) {
         return false;
       }
 

--- a/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-config-auth-settings-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-config-auth-settings-controller.js
@@ -50,7 +50,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
     };
 
     var validString = function(value) {
-      return angular.isDefined(value) && value.length > 0;
+      return value !== undefined && value.length > 0;
     };
 
     var validHtPassword = function() {
@@ -75,7 +75,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       }
 
       return (
-        angular.isDefined($scope.data.authentication.ldap) &&
+        $scope.data.authentication.ldap !== undefined &&
         validString($scope.data.authentication.ldap.id) &&
         validString($scope.data.authentication.ldap.email) &&
         validString($scope.data.authentication.ldap.name) &&
@@ -95,7 +95,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       }
 
       return (
-        angular.isDefined($scope.data.authentication.requestHeader) &&
+        $scope.data.authentication.requestHeader !== undefined &&
         validString($scope.data.authentication.requestHeader.challengeUrl) &&
         validString($scope.data.authentication.requestHeader.loginUrl) &&
         validString($scope.data.authentication.requestHeader.clientCA) &&
@@ -109,7 +109,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       }
 
       return (
-        angular.isDefined($scope.data.authentication.openId) &&
+        $scope.data.authentication.openId !== undefined &&
         validString($scope.data.authentication.openId.clientId) &&
         validString($scope.data.authentication.openId.clientSecret) &&
         validString($scope.data.authentication.openId.subClaim) &&
@@ -124,7 +124,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       }
 
       return (
-        angular.isDefined($scope.data.authentication.google) &&
+        $scope.data.authentication.google !== undefined &&
         validString($scope.data.authentication.google.clientId) &&
         validString($scope.data.authentication.google.clientSecret) &&
         validString($scope.data.authentication.google.hostedDomain)
@@ -137,7 +137,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       }
 
       return (
-        angular.isDefined($scope.data.authentication.github) &&
+        $scope.data.authentication.github !== undefined &&
         validString($scope.data.authentication.github.clientId) &&
         validString($scope.data.authentication.github.clientSecret)
       );

--- a/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-config-auth-settings-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-config-auth-settings-controller.js
@@ -75,7 +75,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       }
 
       return (
-        !angular.isUndefined($scope.data.authentication.ldap) &&
+        angular.isDefined($scope.data.authentication.ldap) &&
         validString($scope.data.authentication.ldap.id) &&
         validString($scope.data.authentication.ldap.email) &&
         validString($scope.data.authentication.ldap.name) &&
@@ -95,7 +95,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       }
 
       return (
-        !angular.isUndefined($scope.data.authentication.requestHeader) &&
+        angular.isDefined($scope.data.authentication.requestHeader) &&
         validString($scope.data.authentication.requestHeader.challengeUrl) &&
         validString($scope.data.authentication.requestHeader.loginUrl) &&
         validString($scope.data.authentication.requestHeader.clientCA) &&
@@ -109,7 +109,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       }
 
       return (
-        !angular.isUndefined($scope.data.authentication.openId) &&
+        angular.isDefined($scope.data.authentication.openId) &&
         validString($scope.data.authentication.openId.clientId) &&
         validString($scope.data.authentication.openId.clientSecret) &&
         validString($scope.data.authentication.openId.subClaim) &&
@@ -124,7 +124,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       }
 
       return (
-        !angular.isUndefined($scope.data.authentication.google) &&
+        angular.isDefined($scope.data.authentication.google) &&
         validString($scope.data.authentication.google.clientId) &&
         validString($scope.data.authentication.google.clientSecret) &&
         validString($scope.data.authentication.google.hostedDomain)
@@ -137,7 +137,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       }
 
       return (
-        !angular.isUndefined($scope.data.authentication.github) &&
+        angular.isDefined($scope.data.authentication.github) &&
         validString($scope.data.authentication.github.clientId) &&
         validString($scope.data.authentication.github.clientSecret)
       );

--- a/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-config-settings-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-config-settings-controller.js
@@ -25,7 +25,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
     };
 
     $scope.validateStorageNode = function() {
-      if (angular.isUndefined($scope.data.storageNodes) || $scope.data.storageNodes.length != 1) {
+      if ($scope.data.storageNodes === undefined || $scope.data.storageNodes.length != 1) {
         if ($scope.data.serverConfigType == 'integratedNFS') {
           $scope.data.serverConfigType = 'none';
         }
@@ -36,7 +36,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
     };
 
     $scope.validateInfraNode = function() {
-      if (angular.isUndefined($scope.data.infrastructureNodes) || $scope.data.infrastructureNodes.length == 0) {
+      if ($scope.data.infrastructureNodes === undefined || $scope.data.infrastructureNodes.length == 0) {
         $scope.data.configureRouter = false;
         return false;
       }

--- a/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-config-settings-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-config-settings-controller.js
@@ -21,7 +21,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
     };
 
     var validString = function(value) {
-      return angular.isDefined(value) && value.length > 0;
+      return value !== undefined && value.length > 0;
     };
 
     $scope.validateStorageNode = function() {

--- a/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-details-cdn-channel-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-details-cdn-channel-controller.js
@@ -19,7 +19,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
     };
 
     var validString = function(value) {
-      return angular.isDefined(value) && value.length > 0;
+      return value !== undefined && value.length > 0;
     };
 
     $scope.validateForm = function() {

--- a/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-details-create-vms-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-details-create-vms-controller.js
@@ -69,7 +69,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
     };
 
     var validString = function(value) {
-      return angular.isDefined(value) && value.length > 0;
+      return value !== undefined && value.length > 0;
     };
 
     $scope.masterCountValid = function(count) {
@@ -84,17 +84,17 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       var valid =  $scope.masterCountValid($scope.data.createMastersCount) && $scope.nodeCountValid($scope.data.createNodesCount);
       valid = valid &&
         validString($scope.data.createMastersBaseName) &&
-        angular.isDefined($scope.data.createMastersMemory) &&
-        angular.isDefined($scope.data.createMastersCpu) &&
-        angular.isDefined($scope.data.createMastersDisk) &&
+        $scope.data.createMastersMemory !== undefined &&
+        $scope.data.createMastersCpu !== undefined &&
+        $scope.data.createMastersDisk !== undefined &&
         validString($scope.data.createNodesBaseName);
 
 
       if (!$scope.data.createNodesLikeMasters) {
         valid = valid &&
-          angular.isDefined($scope.data.createNodesMemory) &&
-          angular.isDefined($scope.data.createNodesCpu) &&
-          angular.isDefined($scope.data.createNodesDisk);
+          $scope.data.createNodesMemory !== undefined &&
+          $scope.data.createNodesCpu !== undefined &&
+          $scope.data.createNodesDisk !== undefined;
       }
 
       if (valid) {

--- a/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-details-general-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-details-general-controller.js
@@ -15,7 +15,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
             name: provider.provider.name
           })
         });
-        if (angular.isDefined($scope.existingProviders) && $scope.existingProviders.length > 0) {
+        if ($scope.existingProviders !== undefined && $scope.existingProviders.length > 0) {
           $scope.data.existingProviderId = $scope.existingProviders[0].id;
           $scope.data.existingProvider = $scope.existingProviders[0];
         }
@@ -27,7 +27,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
             name: provider.provider.name
           })
         });
-        if (angular.isDefined($scope.newVmProviders) && $scope.newVmProviders.length > 0) {
+        if ($scope.newVmProviders !== undefined && $scope.newVmProviders.length > 0) {
           $scope.data.newVmProviderId = $scope.newVmProviders[0].id;
           $scope.data.newVmProvider = $scope.newVmProviders[0];
         }
@@ -38,7 +38,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
       }
     };
     $scope.updateProviderName = function() {
-      $scope.deploymentDetailsGeneralComplete = angular.isDefined($scope.data.providerName) && $scope.data.providerName.length > 0;
+      $scope.deploymentDetailsGeneralComplete = $scope.data.providerName !== undefined && $scope.data.providerName.length > 0;
     };
   }
 ]);

--- a/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-master-nodes-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-master-nodes-controller.js
@@ -341,7 +341,7 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
     };
 
     var validString = function(value) {
-      return angular.isDefined(value) && value.length > 0;
+      return value !== undefined && value.length > 0;
     };
 
     $scope.updateNodeSettings = function () {

--- a/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-review-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy_provider/deploy-provider-review-controller.js
@@ -5,9 +5,9 @@ miqHttpInject(angular.module('miq.containers.providersModule')).controller('cont
 
     // Find the data!
     var next = $scope;
-    while (angular.isUndefined($scope.data)) {
+    while ($scope.data === undefined) {
       next = next.$parent;
-      if (angular.isUndefined(next)) {
+      if (next === undefined) {
         $scope.data = {};
       } else {
         $scope.data = next.wizardData;

--- a/app/assets/javascripts/controllers/container_deployment/modal_dialog/modal-dialog-directive.js
+++ b/app/assets/javascripts/controllers/container_deployment/modal_dialog/modal-dialog-directive.js
@@ -18,12 +18,12 @@ angular.module('miq.dialogs').directive('miqModal', function () {
     controller: ['$scope', function($scope) {
       $scope.settings = {};
 
-      if (angular.isUndefined($scope.showHeader)) {
+      if ($scope.showHeader === undefined) {
         $scope.settings.showHeader = true;
       } else {
         $scope.settings.showHeader = $scope.showHeader !== 'false';
       }
-      if (angular.isUndefined($scope.showClose)) {
+      if ($scope.showClose === undefined) {
         $scope.settings.showClose = true;
       } else {
         $scope.settings.showClose = $scope.showClose !== 'false';

--- a/app/assets/javascripts/controllers/container_deployment/wizard/wizard-directive.js
+++ b/app/assets/javascripts/controllers/container_deployment/wizard/wizard-directive.js
@@ -35,7 +35,7 @@ angular.module('miq.wizard').directive('miqWizard', function () {
         $scope.stepCount = 0;
       }
 
-      if (angular.isUndefined($scope.wizardReady)) {
+      if ($scope.wizardReady === undefined) {
         $scope.wizardReady = true;
       }
 
@@ -115,7 +115,7 @@ angular.module('miq.wizard').directive('miqWizard', function () {
       //if edit mode is truthy, then all steps are marked as completed
       $scope.$watch('[editMode, steps.length]', function () {
         var editMode = $scope.editMode;
-        if (angular.isUndefined(editMode) || (editMode === null)) {
+        if (editMode === undefined || (editMode === null)) {
           return;
         }
 

--- a/app/assets/javascripts/controllers/container_deployment/wizard/wizard-directive.js
+++ b/app/assets/javascripts/controllers/container_deployment/wizard/wizard-directive.js
@@ -72,7 +72,7 @@ angular.module('miq.wizard').directive('miqWizard', function () {
       this.getReviewSteps = function() {
         return $scope.steps.filter(function(step){
           return !step.disabled &&
-            (angular.isDefined(step.reviewTemplate) || step.getReviewSteps().length > 0);
+            (step.reviewTemplate !== undefined || step.getReviewSteps().length > 0);
         });
       };
 
@@ -196,7 +196,7 @@ angular.module('miq.wizard').directive('miqWizard', function () {
           watchSelectedStep();
 
           // Make sure current step is not undefined
-          if (angular.isDefined($scope.currentStep)) {
+          if ($scope.currentStep !== undefined) {
             $scope.currentStep = step.wzTitle;
           }
 

--- a/app/assets/javascripts/controllers/container_deployment/wizard/wizard-directive.js
+++ b/app/assets/javascripts/controllers/container_deployment/wizard/wizard-directive.js
@@ -72,7 +72,7 @@ angular.module('miq.wizard').directive('miqWizard', function () {
       this.getReviewSteps = function() {
         return $scope.steps.filter(function(step){
           return !step.disabled &&
-            (!angular.isUndefined(step.reviewTemplate) || step.getReviewSteps().length > 0);
+            (angular.isDefined(step.reviewTemplate) || step.getReviewSteps().length > 0);
         });
       };
 
@@ -196,7 +196,7 @@ angular.module('miq.wizard').directive('miqWizard', function () {
           watchSelectedStep();
 
           // Make sure current step is not undefined
-          if (!angular.isUndefined($scope.currentStep)) {
+          if (angular.isDefined($scope.currentStep)) {
             $scope.currentStep = step.wzTitle;
           }
 

--- a/app/assets/javascripts/controllers/container_deployment/wizard/wizard-directive.js
+++ b/app/assets/javascripts/controllers/container_deployment/wizard/wizard-directive.js
@@ -31,7 +31,7 @@ angular.module('miq.wizard').directive('miqWizard', function () {
       $scope.context = {};
       this.context = $scope.context;
 
-      if (!angular.isNumber($scope.stepCount)) {
+      if (!_.isNumber($scope.stepCount)) {
         $scope.stepCount = 0;
       }
 
@@ -188,7 +188,7 @@ angular.module('miq.wizard').directive('miqWizard', function () {
           step.selected = true;
 
           $timeout(function() {
-            if (angular.isFunction(step.onShow)) {
+            if (_.isFunction(step.onShow)) {
               step.onShow();
             }
           }, 100);
@@ -294,7 +294,7 @@ angular.module('miq.wizard').directive('miqWizard', function () {
         var enabledSteps = $scope.getEnabledSteps();
         var stepTo;
 
-        if (angular.isNumber(step)) {
+        if (_.isNumber(step)) {
           stepTo = enabledSteps[step];
         } else {
           stepTo = stepByTitle(step);
@@ -317,7 +317,7 @@ angular.module('miq.wizard').directive('miqWizard', function () {
         }
 
         // Check if callback is a function
-        if (angular.isFunction(callback)) {
+        if (_.isFunction(callback)) {
           if (callback($scope.selectedStep)) {
             if (index === enabledSteps.length - 1) {
               this.finish();
@@ -354,7 +354,7 @@ angular.module('miq.wizard').directive('miqWizard', function () {
         }
 
         // Check if callback is a function
-        if (angular.isFunction(callback)) {
+        if (_.isFunction(callback)) {
           if (callback($scope.selectedStep)) {
             if (index === 0) {
               throw new Error("Can't go back. It's already in step 0");

--- a/app/assets/javascripts/controllers/container_deployment/wizard/wizard-step-directive.js
+++ b/app/assets/javascripts/controllers/container_deployment/wizard/wizard-step-directive.js
@@ -72,7 +72,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
 
       $scope.getReviewSteps = function() {
         var reviewSteps = $scope.getEnabledSteps().filter(function(step){
-          return angular.isDefined(step.reviewTemplate);
+          return step.reviewTemplate !== undefined;
         });
         return reviewSteps;
       };
@@ -231,7 +231,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
             watchSelectedStep();
 
             // Make sure current step is not undefined
-            if (angular.isDefined($scope.currentStep)) {
+            if ($scope.currentStep !== undefined) {
               $scope.currentStep = step.wzTitle;
             }
 

--- a/app/assets/javascripts/controllers/container_deployment/wizard/wizard-step-directive.js
+++ b/app/assets/javascripts/controllers/container_deployment/wizard/wizard-step-directive.js
@@ -31,7 +31,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
       $scope.context = {};
       this.context = $scope.context;
 
-      if (!angular.isNumber($scope.subStepCount)) {
+      if (!_.isNumber($scope.subStepCount)) {
         $scope.subStepCount = 0;
       }
       if ($scope.nextEnabled === undefined) {
@@ -224,7 +224,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
           if (step) {
             step.selected = true;
 
-            if (angular.isFunction($scope.selectedStep.onShow)) {
+            if (_.isFunction($scope.selectedStep.onShow)) {
               $scope.selectedStep.onShow();
             }
 
@@ -313,7 +313,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
         var enabledSteps = $scope.getEnabledSteps();
         var stepTo;
 
-        if (angular.isNumber(step)) {
+        if (_.isNumber(step)) {
           stepTo = enabledSteps[step];
         } else {
           stepTo = stepByTitle(step);
@@ -330,7 +330,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
         var index = stepIdx($scope.selectedStep);
 
         // Check if callback is a function
-        if (angular.isFunction(callback)) {
+        if (_.isFunction(callback)) {
           if (callback($scope.selectedStep)) {
             if (index === enabledSteps.length - 1) {
               return false;
@@ -361,7 +361,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
         var index = stepIdx($scope.selectedStep);
 
         // Check if callback is a function
-        if (angular.isFunction(callback)) {
+        if (_.isFunction(callback)) {
           if (callback($scope.selectedStep)) {
             if (index === 0) {
               return false;

--- a/app/assets/javascripts/controllers/container_deployment/wizard/wizard-step-directive.js
+++ b/app/assets/javascripts/controllers/container_deployment/wizard/wizard-step-directive.js
@@ -72,7 +72,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
 
       $scope.getReviewSteps = function() {
         var reviewSteps = $scope.getEnabledSteps().filter(function(step){
-          return !angular.isUndefined(step.reviewTemplate);
+          return angular.isDefined(step.reviewTemplate);
         });
         return reviewSteps;
       };
@@ -231,7 +231,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
             watchSelectedStep();
 
             // Make sure current step is not undefined
-            if (!angular.isUndefined($scope.currentStep)) {
+            if (angular.isDefined($scope.currentStep)) {
               $scope.currentStep = step.wzTitle;
             }
 

--- a/app/assets/javascripts/controllers/container_deployment/wizard/wizard-step-directive.js
+++ b/app/assets/javascripts/controllers/container_deployment/wizard/wizard-step-directive.js
@@ -34,33 +34,33 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
       if (!angular.isNumber($scope.subStepCount)) {
         $scope.subStepCount = 0;
       }
-      if (angular.isUndefined($scope.nextEnabled)) {
+      if ($scope.nextEnabled === undefined) {
         $scope.nextEnabled = true;
       }
-      if (angular.isUndefined($scope.prevEnabled)) {
+      if ($scope.prevEnabled === undefined) {
         $scope.prevEnabled = true;
       }
-      if (angular.isUndefined($scope.nextTooltip)) {
+      if ($scope.nextTooltip === undefined) {
         $scope.nextEnabled = true;
       }
-      if (angular.isUndefined($scope.prevToolitp)) {
+      if ($scope.prevToolitp === undefined) {
         $scope.prevEnabled = true;
       }
-      if (angular.isUndefined($scope.showReview)) {
+      if ($scope.showReview === undefined) {
         $scope.showReview = false;
       }
-      if (angular.isUndefined($scope.showReviewDetails)) {
+      if ($scope.showReviewDetails === undefined) {
         $scope.showReviewDetails = false;
       }
-      if (angular.isUndefined($scope.stepPriority)) {
+      if ($scope.stepPriority === undefined) {
         $scope.stepPriority = 999;
       } else {
         $scope.stepPriority = parseInt($scope.stepPriority, 10);
       }
-      if (angular.isUndefined($scope.okToNavAway)) {
+      if ($scope.okToNavAway === undefined) {
         $scope.okToNavAway = true;
       }
-      if (angular.isUndefined($scope.allowClickNav)) {
+      if ($scope.allowClickNav === undefined) {
         $scope.allowClickNav = true;
       }
 
@@ -103,7 +103,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
       };
 
       $scope.isNextEnabled = function () {
-        var enabled = angular.isUndefined($scope.nextEnabled) || $scope.nextEnabled;
+        var enabled = $scope.nextEnabled === undefined || $scope.nextEnabled;
         if ($scope.substeps) {
           angular.forEach($scope.getEnabledSteps(), function(step) {
             enabled = enabled && step.nextEnabled;
@@ -113,7 +113,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
       };
 
       $scope.isPrevEnabled = function () {
-        var enabled = angular.isUndefined($scope.prevEnabled) || $scope.prevEnabled;
+        var enabled = $scope.prevEnabled === undefined || $scope.prevEnabled;
         if ($scope.substeps) {
           angular.forEach($scope.getEnabledSteps(), function(step) {
             enabled = enabled && step.prevEnabled;
@@ -144,7 +144,7 @@ angular.module('miq.wizard').directive('miqWizardStep', function() {
       //if edit mode is truthy, then all steps are marked as completed
       $scope.$watch('[editMode, steps.length]', function() {
         var editMode = $scope.editMode;
-        if (angular.isUndefined(editMode) || (editMode === null)) {
+        if (editMode === undefined || (editMode === null)) {
           return;
         }
 

--- a/app/assets/javascripts/controllers/container_deployment/wizard/wizard-substep-directive.js
+++ b/app/assets/javascripts/controllers/container_deployment/wizard/wizard-substep-directive.js
@@ -23,35 +23,35 @@ angular.module('miq.wizard').directive('miqWizardSubstep', function() {
     require: '^miq-wizard-step',
     templateUrl: '/static/wizard-substep.html',
     controller: ['$scope', function($scope) {
-      if (angular.isUndefined($scope.nextEnabled)) {
+      if ($scope.nextEnabled === undefined) {
         $scope.nextEnabled = true;
       }
-      if (angular.isUndefined($scope.prevEnabled)) {
+      if ($scope.prevEnabled === undefined) {
         $scope.prevEnabled = true;
       }
-      if (angular.isUndefined($scope.nextTooltip)) {
+      if ($scope.nextTooltip === undefined) {
         $scope.nextEnabled = true;
       }
-      if (angular.isUndefined($scope.prevToolitp)) {
+      if ($scope.prevToolitp === undefined) {
         $scope.prevEnabled = true;
       }
-      if (angular.isUndefined($scope.showReviewDetails)) {
+      if ($scope.showReviewDetails === undefined) {
         $scope.showReviewDetails = false;
       }
-      if (angular.isUndefined($scope.stepPriority)) {
+      if ($scope.stepPriority === undefined) {
         $scope.stepPriority = 999;
       } else {
         $scope.stepPriority = parseInt($scope.stepPriority);
       }
-      if (angular.isUndefined($scope.okToNavAway)) {
+      if ($scope.okToNavAway === undefined) {
         $scope.okToNavAway = true;
       }
-      if (angular.isUndefined($scope.allowClickNav)) {
+      if ($scope.allowClickNav === undefined) {
         $scope.allowClickNav = true;
       }
 
       $scope.isPrevEnabled = function () {
-        var enabled = angular.isUndefined($scope.prevEnabled) || $scope.prevEnabled;
+        var enabled = $scope.prevEnabled === undefined || $scope.prevEnabled;
         if ($scope.substeps) {
           angular.forEach($scope.getEnabledSteps(), function(step) {
             enabled = enabled && step.prevEnabled;

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -417,7 +417,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.postValidationModelRegistry = function(prefix) {
-    if (angular.isUndefined($scope.postValidationModel)) {
+    if ($scope.postValidationModel === undefined) {
       $scope.postValidationModel = {default: {},
                                     amqp: {},
                                     metrics: {},

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -104,13 +104,13 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
       $scope.emsCommonModel.openstack_infra_providers_exist = data.openstack_infra_providers_exist;
 
-      $scope.emsCommonModel.provider_id                     = angular.isDefined(data.provider_id) ? data.provider_id.toString() : "";
+      $scope.emsCommonModel.provider_id                     = data.provider_id !== undefined ? data.provider_id.toString() : "";
 
-      $scope.emsCommonModel.default_api_port                = angular.isDefined(data.default_api_port) && data.default_api_port !== '' ? data.default_api_port.toString() : $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
-      $scope.emsCommonModel.amqp_api_port                   = angular.isDefined(data.amqp_api_port) && data.amqp_api_port !== '' ? data.amqp_api_port.toString() : '5672';
-      $scope.emsCommonModel.hawkular_api_port               = angular.isDefined(data.hawkular_api_port) && data.hawkular_api_port !== '' ? data.hawkular_api_port.toString() : '443';
-      $scope.emsCommonModel.metrics_api_port                = angular.isDefined(data.metrics_api_port) && data.metrics_api_port !== '' ? data.metrics_api_port.toString() : '';
-      $scope.emsCommonModel.metrics_database_name           = angular.isDefined(data.metrics_database_name) && data.metrics_database_name !== '' ? data.metrics_database_name : data.metrics_default_database_name;
+      $scope.emsCommonModel.default_api_port                = data.default_api_port !== undefined && data.default_api_port !== '' ? data.default_api_port.toString() : $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
+      $scope.emsCommonModel.amqp_api_port                   = data.amqp_api_port !== undefined && data.amqp_api_port !== '' ? data.amqp_api_port.toString() : '5672';
+      $scope.emsCommonModel.hawkular_api_port               = data.hawkular_api_port !== undefined && data.hawkular_api_port !== '' ? data.hawkular_api_port.toString() : '443';
+      $scope.emsCommonModel.metrics_api_port                = data.metrics_api_port !== undefined && data.metrics_api_port !== '' ? data.metrics_api_port.toString() : '';
+      $scope.emsCommonModel.metrics_database_name           = data.metrics_database_name !== undefined && data.metrics_database_name !== '' ? data.metrics_database_name : data.metrics_default_database_name;
       $scope.emsCommonModel.api_version                     = data.api_version;
       $scope.emsCommonModel.default_security_protocol       = data.default_security_protocol;
       $scope.emsCommonModel.realm                           = data.realm;
@@ -228,9 +228,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       return true;
     } else if(($scope.currentTab == "amqp") &&
       ($scope.emsCommonModel.amqp_hostname) &&
-      ($scope.emsCommonModel.amqp_userid != '' && angular.isDefined($scope.angularForm.amqp_userid) && $scope.angularForm.amqp_userid.$valid &&
-       $scope.emsCommonModel.amqp_password != '' && angular.isDefined($scope.angularForm.amqp_password) && $scope.angularForm.amqp_password.$valid &&
-       $scope.emsCommonModel.amqp_verify != '' && angular.isDefined($scope.angularForm.amqp_verify) && $scope.angularForm.amqp_verify.$valid)) {
+      ($scope.emsCommonModel.amqp_userid != '' && $scope.angularForm.amqp_userid !== undefined && $scope.angularForm.amqp_userid.$valid &&
+       $scope.emsCommonModel.amqp_password != '' && $scope.angularForm.amqp_password !== undefined && $scope.angularForm.amqp_password.$valid &&
+       $scope.emsCommonModel.amqp_verify != '' && $scope.angularForm.amqp_verify !== undefined && $scope.angularForm.amqp_verify.$valid)) {
       return true;
     } else if(($scope.currentTab == "default" && $scope.emsCommonModel.emstype == "azure") &&
       ($scope.emsCommonModel.azure_tenant_id != '' && $scope.angularForm.azure_tenant_id.$valid) &&
@@ -525,7 +525,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   $scope.radioSelectionChanged = function() {
     if ($scope.emsCommonModel.event_stream_selection === "ceilometer" ||
         $scope.emsCommonModel.event_stream_selection === "none") {
-      if (angular.isDefined($scope.postValidationModel)) {
+      if ($scope.postValidationModel !== undefined) {
         $scope.emsCommonModel.amqp_hostname = $scope.postValidationModel.amqp.amqp_hostname;
         $scope.emsCommonModel.amqp_api_port = $scope.postValidationModel.amqp.amqp_api_port;
         $scope.emsCommonModel.amqp_security_protocol = $scope.postValidationModel.amqp.amqp_security_protocol;

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -417,7 +417,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.postValidationModelRegistry = function(prefix) {
-    if (!angular.isDefined($scope.postValidationModel)) {
+    if (angular.isUndefined($scope.postValidationModel)) {
       $scope.postValidationModel = {default: {},
                                     amqp: {},
                                     metrics: {},

--- a/app/assets/javascripts/controllers/header/header_controller.js
+++ b/app/assets/javascripts/controllers/header/header_controller.js
@@ -34,7 +34,7 @@ function HeaderCtrl($scope, eventNotifications, $timeout) {
       text: 0
     };
 
-    if (angular.isArray(groups)) {
+    if (_.isArray(groups)) {
       angular.forEach(groups, function(group) {
         notificationCount.text += group.unreadCount;
       });

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js
@@ -61,7 +61,7 @@ angular.module('miq.util').factory('metricsUtilsFactory', function() {
       var data = response.data;
 
       dash.filterConfig.fields = [];
-      if (data && angular.isArray(data.metric_tags)) {
+      if (data && _.isArray(data.metric_tags)) {
         data.metric_tags.sort();
 
         // remember the metric tags
@@ -120,7 +120,7 @@ angular.module('miq.util').factory('metricsUtilsFactory', function() {
 
       if (data.length > 1) {
         var prevValue = data[1].value;
-        if (angular.isNumber(lastValue) && angular.isNumber(prevValue)) {
+        if (_.isNumber(lastValue) && _.isNumber(prevValue)) {
           var change;
           if (prevValue !== 0 && lastValue !== 0) {
             change = Math.round((lastValue - prevValue) / lastValue);

--- a/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
+++ b/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
@@ -31,7 +31,7 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
 
   var clearGroupWatchers = function() {
     angular.forEach(vm.notificationGroups, function (group) {
-      if (angular.isFunction(group.watcher)) {
+      if (_.isFunction(group.watcher)) {
         group.watcher();
       }
     });

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -278,7 +278,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       $scope.updateDisksAddRemove();
 
       angular.forEach($scope.reconfigureModel.vmdisks, function(disk) {
-        if (angular.isDefined($scope.reconfigureModel.vmdisks[disk])
+        if ($scope.reconfigureModel.vmdisks[disk] !== undefined
           && $scope.reconfigureModel.vmdisks[disk].add_remove === '' ) {
           $scope.reconfigureModel.vmdisks[disk].delete_backing = false;
         }

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -87,7 +87,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
 
       $scope.timer_items        = timerOptionService.getOptions($scope.scheduleModel.timer_typ);
 
-      if (data.filter_type === 'all' || (angular.isDefined(data.protocol) && data.protocol !== null)) {
+      if (data.filter_type === 'all' || (data.protocol !== undefined && data.protocol !== null)) {
         $scope.filterValuesEmpty = true;
       } else {
         buildFilterList(data);
@@ -97,7 +97,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
       }
 
       if (data.filter_type === null &&
-        (angular.isDefined(data.protocol) && data.protocol !== null && data.protocol !== 'Samba')) {
+        (data.protocol !== undefined && data.protocol !== null && data.protocol !== 'Samba')) {
         $scope.scheduleModel.filter_typ = 'all';
       }
 

--- a/app/assets/javascripts/directives/configuration/min_time_check.js
+++ b/app/assets/javascripts/directives/configuration/min_time_check.js
@@ -3,7 +3,7 @@ ManageIQ.angular.app.directive('minTimeCheck', function() {
     require: 'ngModel',
     link: function (scope, _elem, attrs, ctrl) {
       scope.$watch(attrs.ngModel, function() {
-        if (angular.isDefined(ctrl.viewValue)) {
+        if (ctrl.viewValue !== undefined) {
           setSomePeriodCheckedValidity(ctrl, attrs);
         }
       });

--- a/app/assets/javascripts/directives/detect_spaces.js
+++ b/app/assets/javascripts/directives/detect_spaces.js
@@ -3,7 +3,7 @@ ManageIQ.angular.app.directive('detectSpaces', function() {
     require: 'ngModel',
     link: function (_scope, _elem, _attrs, ctrl) {
       ctrl.$validators.detectedSpaces = function (modelValue, viewValue) {
-        if (!angular.isDefined(viewValue) || (angular.isDefined(viewValue) && !detectedSpaces(viewValue))) {
+        if (angular.isUndefined(viewValue) || (angular.isDefined(viewValue) && !detectedSpaces(viewValue))) {
           return true;
         }
         return false;

--- a/app/assets/javascripts/directives/detect_spaces.js
+++ b/app/assets/javascripts/directives/detect_spaces.js
@@ -3,7 +3,7 @@ ManageIQ.angular.app.directive('detectSpaces', function() {
     require: 'ngModel',
     link: function (_scope, _elem, _attrs, ctrl) {
       ctrl.$validators.detectedSpaces = function (modelValue, viewValue) {
-        if (angular.isUndefined(viewValue) || (angular.isDefined(viewValue) && !detectedSpaces(viewValue))) {
+        if (angular.isUndefined(viewValue) || (viewValue !== undefined && !detectedSpaces(viewValue))) {
           return true;
         }
         return false;

--- a/app/assets/javascripts/directives/detect_spaces.js
+++ b/app/assets/javascripts/directives/detect_spaces.js
@@ -3,7 +3,7 @@ ManageIQ.angular.app.directive('detectSpaces', function() {
     require: 'ngModel',
     link: function (_scope, _elem, _attrs, ctrl) {
       ctrl.$validators.detectedSpaces = function (modelValue, viewValue) {
-        if (angular.isUndefined(viewValue) || (viewValue !== undefined && !detectedSpaces(viewValue))) {
+        if (viewValue === undefined || (viewValue !== undefined && !detectedSpaces(viewValue))) {
           return true;
         }
         return false;

--- a/app/assets/javascripts/directives/validation/reset_validation_status.js
+++ b/app/assets/javascripts/directives/validation/reset_validation_status.js
@@ -16,13 +16,13 @@ ManageIQ.angular.app.directive('resetValidationStatus', ['$rootScope', function(
 
 var adjustValidationStatus = function(value, scope, ctrl, attrs, rootScope) {
   if(scope.checkAuthentication === true &&
-     angular.isDefined(scope.postValidationModel) &&
-     angular.isDefined(scope.postValidationModel[attrs.prefix])) {
+     scope.postValidationModel !== undefined &&
+     scope.postValidationModel[attrs.prefix] !== undefined) {
     var modelPostValidationObject = angular.copy(scope.postValidationModel[attrs.prefix]);
     delete modelPostValidationObject[ctrl.$name];
 
     var modelObject = angular.copy(scope[scope.model]);
-    if(angular.isDefined(modelObject[ctrl.$name])) {
+    if(modelObject[ctrl.$name] !== undefined) {
       delete modelObject[ctrl.$name];
     }
 

--- a/app/assets/javascripts/directives/validation/validation_status.js
+++ b/app/assets/javascripts/directives/validation/validation_status.js
@@ -3,7 +3,7 @@ ManageIQ.angular.app.directive('validationStatus', ['$rootScope', function($root
     require: 'ngModel',
     link: function (scope, elem, attrs, ctrl) {
       ctrl.$validators.validationRequired = function (modelValue, viewValue) {
-        if (angular.isDefined(viewValue) && viewValue === true) {
+        if (viewValue !== undefined && viewValue === true) {
           scope.postValidationModelRegistry(attrs.prefix);
           return true;
         } else {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -293,7 +293,7 @@ function miqDimDiv(divname, status) {
 // Check for changes and prompt
 function miqCheckForChanges() {
   if (ManageIQ.angular.scope) {
-    if (angular.isDefined(ManageIQ.angular.scope.angularForm) &&
+    if (ManageIQ.angular.scope.angularForm !== undefined &&
       ManageIQ.angular.scope.angularForm.$dirty &&
       !miqDomElementExists('ignore_form_changes')) {
       var answer = confirm(__("Abandon changes?"));

--- a/app/assets/javascripts/services/alerts_center_service.js
+++ b/app/assets/javascripts/services/alerts_center_service.js
@@ -130,7 +130,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
         });
 
         // set parameter value (use 'true' if empty)
-        var filterValue = angular.isUndefined(filter[1]) ? true : filter[1];
+        var filterValue = filter[1] === undefined ? true : filter[1];
         filterValue = decodeURIComponent(filterValue);
 
         var filterField = _.find(fields, function(field) {
@@ -668,7 +668,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
           _this.displayFilters.push(summaryItem.displayType);
         }
 
-        if (angular.isUndefined(item.severity)) {
+        if (item.severity === undefined) {
           item.severity = 'info';
         }
         summaryItem[item.severity].push(item);
@@ -684,7 +684,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
     if (response.results && response.results.length > 0) {
       newState = response.results[0];
 
-      if (angular.isUndefined(_this.editItem.alert_actions)) {
+      if (_this.editItem.alert_actions === undefined) {
         _this.editItem.alert_actions = [];
       }
       _this.editItem.alert_actions.push(newState);

--- a/app/assets/javascripts/services/alerts_center_service.js
+++ b/app/assets/javascripts/services/alerts_center_service.js
@@ -136,7 +136,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
         var filterField = _.find(fields, function(field) {
           return field.id === filterId;
         });
-        if (angular.isDefined(filterField)) {
+        if (filterField !== undefined) {
           currentFilters.push({
             id: filterField.id,
             value: filterValue,
@@ -472,7 +472,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
       updateAlert.numComments = 0;
       for (i = 0; i < updateAlert.alert_actions.length; i++) {
         actionUser = _this.getUserByIdOrUserId(updateAlert.alert_actions[i].user_id);
-        updateAlert.alert_actions[i].username = angular.isDefined(actionUser) ? actionUser.name : '';
+        updateAlert.alert_actions[i].username = actionUser !== undefined ? actionUser.name : '';
 
         // Bump the comments count if a comment was made
         if (updateAlert.alert_actions[i].comment) {
@@ -495,7 +495,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
       id: alertData.id,
       description: alertData.description,
       assignee: alertData.assignee,
-      acknowledged: angular.isDefined(alertData.acknowledged) ? alertData.acknowledged : false,
+      acknowledged: alertData.acknowledged !== undefined ? alertData.acknowledged : false,
       hostName: alertData.resource.name,
       hostType: hostType,
       hostImg: _this.icons[hostType],
@@ -523,7 +523,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
     newAlert.lastUpdate = newAlert.evaluated_on;
     newAlert.numComments = 0;
 
-    if (angular.isDefined(alertData.assignee)) {
+    if (alertData.assignee !== undefined) {
       newAlert.assigned = true;
       newAlert.assignee_name = alertData.assignee.name;
       newAlert.assignee_id = alertData.assignee.id;
@@ -555,7 +555,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
         return provider.id === item.ems_id;
       });
 
-      if (angular.isDefined(alertProvider)) {
+      if (alertProvider !== undefined) {
         key = 'providers';
         objectType = getObjectType(alertProvider);
         objectName = alertProvider.name;
@@ -636,7 +636,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
                 matchingTag = _.find(_this.tags, function(nextTag) {
                   return nextTag.id === providerTag.id;
                 });
-                if (angular.isDefined(matchingTag)) {
+                if (matchingTag !== undefined) {
                   summaryItem.tags.push({
                     id: providerTag.id,
                     categoryName: matchingTag.categorization.category.name,
@@ -652,7 +652,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
                 foundTag = _.find(summaryItem.tags, function(nextTag) {
                   return nextTag.categoryTitle === nextCategory;
                 });
-                if (angular.isDefined(foundTag)) {
+                if (foundTag !== undefined) {
                   summaryItem[nextCategory] = foundTag.title;
                 }
               });
@@ -707,7 +707,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
 
       notifyObservers();
 
-      if (angular.isDefined(_this.doAfterStateChange)) {
+      if (_this.doAfterStateChange !== undefined) {
         _this.newComment = '';
         _this.doAfterStateChange();
         _this.doAfterStateChange = undefined;

--- a/app/assets/javascripts/services/alerts_center_service.js
+++ b/app/assets/javascripts/services/alerts_center_service.js
@@ -119,7 +119,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
   _this.getFiltersFromLocation = function(searchString, fields) {
     var currentFilters = [];
 
-    if (angular.isString(searchString)) {
+    if (_.isString(searchString)) {
       var filterString = searchString.slice(1);
       var filters = filterString.split('&');
       _.forEach(filters, function(nextFilter) {
@@ -152,7 +152,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
   function filterStringCompare(value1, value2) {
     var match = false;
 
-    if (angular.isString(value1) && angular.isString(value2)) {
+    if (_.isString(value1) && _.isString(value2)) {
       match = value1.toLowerCase().indexOf(value2.toLowerCase()) !== -1;
     }
 

--- a/app/assets/javascripts/services/catalog/catalog_item_data.js
+++ b/app/assets/javascripts/services/catalog/catalog_item_data.js
@@ -2,7 +2,7 @@ ManageIQ.angular.app.service('catalogItemDataFactory', ['API', function(API) {
   var urlBase = '/api/service_templates';
 
   this.getCatalogItemData = function (st_id) {
-    if(angular.isDefined(st_id)) {
+    if(st_id !== undefined) {
       return API.get(urlBase + '/' + miqUncompressedId(st_id))
     }
   };

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -129,7 +129,7 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', funct
   this.handleFailure = function(e) {
     miqSparkleOff();
 
-    if (angular.isDefined(e.error) && angular.isDefined(e.error.message)) {
+    if (e.error !== undefined && e.error.message !== undefined) {
       console.error(e.error.message);
       miqFlash('error', e.error.message);
     } else if (e.message) {


### PR DESCRIPTION
`angular.isDefined(foo)` -> `foo !== undefined`
`angular.isUndefined(foo)` -> `foo === undefined`

because these are standard JS now, so no need to use functions, especially since these don't exist in angular(2).

`angular.isFoo` -> `lodash.isFoo` (where Foo = String, Array, Number and Function)

because these arent' angular2's responsibility either.

https://www.pivotaltracker.com/story/show/143023099