### PR TITLE
Remove useless angular.bind

### DIFF
--- a/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
+++ b/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
@@ -85,9 +85,7 @@ function MwAddDatasourceCtrl($scope, $rootScope, miqService, mwAddDatasourceServ
     miqService.sparkleOff();
   });
 
-  $scope.$watch(angular.bind(this, function() {
-    return vm.step2DsModel.selectedJdbcDriver;
-  }), function(driverSelection) {
+  $scope.$watch('vm.step2DsModel.selectedJdbcDriver', function(driverSelection) {
     var dsSelection = mwAddDatasourceService.findDsSelectionFromDriver(driverSelection);
     if (dsSelection) {
       vm.step1DsModel.datasourceName = dsSelection.name;

--- a/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
+++ b/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
@@ -10,9 +10,7 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
   vm.drawerExpanded = sessionStorage.getItem(cookieId + "-expanded") == 'true';
   vm.notificationsDrawerShown = eventNotifications.state().drawerShown;
 
-  var watchExpanded = $scope.$watch(angular.bind(vm, function () {
-    return vm.drawerExpanded;
-  }), function () {
+  var watchExpanded = $scope.$watch('vm.drawerExpanded', function() {
     sessionStorage.setItem(cookieId + "-expanded", vm.drawerExpanded);
   });
 
@@ -21,9 +19,9 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
       if (group.watcher) {
         group.watcher();
       }
-      group.watcher = $scope.$watch(angular.bind(vm, function () {
+      group.watcher = $scope.$watch(function () {
         return vm.notificationGroups[index];
-      }), function(newVal) {
+      }, function(newVal) {
         sessionStorage.setItem(cookieId + "-" + newVal.notificationType + "-open", newVal.open);
       }, true);
     });


### PR DESCRIPTION
Prefer function.bind instead, but in this case, these would bind a `this` to functions which never used them.

Furthermore, most of these would just return a simple value and could be replaced by string