### PR TITLE
$scope.$on('destroy') should be '$destroy'

### DIFF
--- a/app/assets/javascripts/controllers/header/header_controller.js
+++ b/app/assets/javascripts/controllers/header/header_controller.js
@@ -46,7 +46,7 @@ function HeaderCtrl($scope, eventNotifications, $timeout) {
 
   eventNotifications.registerObserverCallback(refresh);
 
-  $scope.$on('destroy', destroy);
+  $scope.$on('$destroy', destroy);
 
   refresh();
 }

--- a/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
+++ b/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
@@ -88,7 +88,7 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
 
   eventNotifications.registerObserverCallback(refresh);
 
-  $scope.$on('destroy', destroy);
+  $scope.$on('$destroy', destroy);
 
   if (vm.notificationsDrawerShown) {
     angular.element(document).ready(watchPositioning);

--- a/app/assets/javascripts/controllers/notifications/toast_list_controller.js
+++ b/app/assets/javascripts/controllers/notifications/toast_list_controller.js
@@ -28,7 +28,7 @@ function ToastListCtrl($scope, eventNotifications, $timeout) {
 
   eventNotifications.registerObserverCallback(refresh);
 
-  $scope.$on('destroy', destroy);
+  $scope.$on('$destroy', destroy);
 
   refresh();
 }


### PR DESCRIPTION
`$scope.$on('destroy', ...)` listens for a custom event called destroy, which we never produce.

The intent behind that code was definitely to listen for the `$destroy` event which happens when destroying the scope.