### PR TITLE
JS flash messages - unify, don't roundtrip to backend and back

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -35,6 +35,7 @@
 //= require kubernetes-topology-graph/dist/topology-graph
 //= require miq_browser_detect
 //= require miq_application
+//= require miq_flash
 //= require miq_change_stored_password
 //= require miq_qe
 //= require git_import

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -98,14 +98,16 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
   }
 
   function getBack(message, warning, error) {
-    var url = '/ansible_credential/show_list' + '?flash_msg=' + message + '&escape=true';
+    var url = '/ansible_credential/show_list';
+    var flash = { message: message };
 
     if (warning) {
-      url += '&flash_warning=true&flash_error=false';
+      flash.level = 'warning';
     } else if (error) {
-      url += '&flash_warning=false&flash_error=true';
+      flash.level = 'error';
     }
 
+    miqFlashLater(flash);
     $window.location.href = url;
   }
 

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -1,3 +1,5 @@
+/* global miqFlashLater */
+
 ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 'credentialId', 'miqService', 'API', function($window, credentialId,  miqService, API) {
   var vm = this;
 

--- a/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
@@ -41,7 +41,11 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
     var message = $scope.newRecord ? __('Add of Repository cancelled by user.') : sprintf(__('Edit of Repository \"%s\" cancelled by user.'), vm.repositoryModel.name);
-    var url = '/ansible_repository/show_list' + '?flash_msg=' + message + '&escape=true&flash_warning=true&flash_error=false';
+    var url = '/ansible_repository/show_list';
+    miqFlashLater({
+      message: message,
+      level: 'warning',
+    });
     window.location.href = url;
   };
 
@@ -95,11 +99,13 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
         message = sprintf(__('Edit of Repository \"%s\" was successfully initialized.'), vm.repositoryModel.name);
       }
     }
-    var url = '/ansible_repository/show_list' + '?flash_msg=' + message + '&escape=true';
+
+    var url = '/ansible_repository/show_list';
     if (error) {
       miqService.miqFlash('error', message);
       miqService.sparkleOff();
     } else {
+      miqFlashLater({ message: message });
       window.location.href = url;
     }
   };

--- a/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
@@ -1,3 +1,5 @@
+/* global miqFlashLater */
+
 ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'repositoryId', 'miqService', 'API', function($scope, repositoryId,  miqService, API) {
   var vm = this;
 

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -867,56 +867,6 @@ function miqAjaxExtAuth(url) {
   });
 }
 
-// add a flash message to an existing #flash_msg_div
-// levels are error, warning, info, success
-function add_flash(msg, level, options) {
-  level = level || 'success';
-  options = options || {};
-  var cls = { alert: '', icon: '' };
-
-  switch (level) {
-    case 'error':
-      cls.alert = 'alert alert-danger';
-      cls.icon = 'pficon pficon-error-circle-o';
-      break;
-    case 'warning':
-      cls.alert = 'alert alert-warning';
-      cls.icon = 'pficon pficon-warning-triangle-o';
-      break;
-    case 'info':
-      cls.alert = 'alert alert-info';
-      cls.icon = 'pficon pficon-info';
-      break;
-    case 'success':
-      cls.alert = 'alert alert-success';
-      cls.icon = 'pficon pficon-ok';
-      break;
-  }
-
-  var icon_span = $('<span class="' + cls.icon + '"></span>');
-
-  var text_strong = $('<strong></strong>');
-  text_strong.text(msg);
-
-  var alert_div = $('<div class="' + cls.alert + '"></div>');
-  alert_div.append(icon_span, text_strong);
-
-  var text_div = $('<div class="flash_text_div"></div>');
-  text_div.attr('title', __('Click to remove message'));
-  text_div.on('click', function() {
-    text_div.remove();
-  });
-  text_div.append(alert_div);
-
-  // if options.id is provided, only one flash message with that id may exist
-  if (options.id) {
-    $('#' + options.id).filter('#flash_msg_div > *').remove();
-    text_div.attr('id', options.id);
-  }
-
-  $('#flash_msg_div').append(text_div).show();
-}
-
 function miqEnableLoginFields(enabled) {
   $('#user_name').prop('readonly', !enabled);
   $('#user_password').prop('readonly', !enabled);

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -57,6 +57,7 @@ function miqOnLoad() {
 
   miqInitAccordions();
   miqInitMainContent();
+  miqFlashSaved();
 }
 
 function miqPrepRightCellForm(tree) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -331,9 +331,7 @@ function miqValidateButtons(h_or_s, prefix) {
   var buttonsOnId = prefix + 'validate_buttons_on';
   var buttonsOffId = prefix + 'validate_buttons_off';
 
-  if (miqDomElementExists('flash_msg_div')) {
-    $('flash_msg_div').hide();
-  }
+  $('#flash_msg_div').hide();
 
   if (h_or_s == "show") {
     if (miqDomElementExists(buttonsOnId)) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1,4 +1,4 @@
-/* global dialogFieldRefresh miqBrowserDetect miqExpressionPrefill miqGridCheckAll miqGridGetCheckedRows miqLoadTL miqMenu miqValueStylePrefill performFiltering */
+/* global dialogFieldRefresh miqBrowserDetect miqExpressionPrefill miqGridCheckAll miqGridGetCheckedRows miqLoadTL miqMenu miqValueStylePrefill performFiltering add_flash miqFlashLater */
 
 // MIQ specific JS functions
 

--- a/app/assets/javascripts/miq_flash.js
+++ b/app/assets/javascripts/miq_flash.js
@@ -23,30 +23,32 @@ function add_flash(msg, level, options) {
       cls.alert = 'alert alert-success';
       cls.icon = 'pficon pficon-ok';
       break;
+    default:
+      throw("add_flash: unknown level: " + level);
   }
 
-  var icon_span = $('<span class="' + cls.icon + '"></span>');
+  var iconSpan = $('<span class="' + cls.icon + '"></span>');
 
-  var text_strong = $('<strong></strong>');
-  text_strong.text(msg);
+  var textStrong = $('<strong></strong>');
+  textStrong.text(msg);
 
-  var alert_div = $('<div class="' + cls.alert + '"></div>');
-  alert_div.append(icon_span, text_strong);
+  var alertDiv = $('<div class="' + cls.alert + '"></div>');
+  alertDiv.append(iconSpan, textStrong);
 
-  var text_div = $('<div class="flash_text_div"></div>');
-  text_div.attr('title', __('Click to remove message'));
-  text_div.on('click', function() {
-    text_div.remove();
+  var textDiv = $('<div class="flash_text_div"></div>');
+  textDiv.attr('title', __('Click to remove message'));
+  textDiv.on('click', function() {
+    textDiv.remove();
   });
-  text_div.append(alert_div);
+  textDiv.append(alertDiv);
 
   // if options.id is provided, only one flash message with that id may exist
   if (options.id) {
     $('#' + options.id).filter('#flash_msg_div > *').remove();
-    text_div.attr('id', options.id);
+    textDiv.attr('id', options.id);
   }
 
-  $('#flash_msg_div').append(text_div).show();
+  $('#flash_msg_div').append(textDiv).show();
 }
 
 function _miqFlashLoad() {

--- a/app/assets/javascripts/miq_flash.js
+++ b/app/assets/javascripts/miq_flash.js
@@ -70,5 +70,10 @@ function miqFlashSaved() {
     add_flash(obj.message, obj.level);
   });
 
+  miqFlashClearSaved();
+}
+
+// also called on login
+function miqFlashClearSaved() {
   _miqFlashSave([]);
 }

--- a/app/assets/javascripts/miq_flash.js
+++ b/app/assets/javascripts/miq_flash.js
@@ -10,6 +10,7 @@ function add_flash(msg, level, options) {
       cls.alert = 'alert alert-danger';
       cls.icon = 'pficon pficon-error-circle-o';
       break;
+    case 'warn':  // miqFlash compatibility
     case 'warning':
       cls.alert = 'alert alert-warning';
       cls.icon = 'pficon pficon-warning-triangle-o';

--- a/app/assets/javascripts/miq_flash.js
+++ b/app/assets/javascripts/miq_flash.js
@@ -48,3 +48,27 @@ function add_flash(msg, level, options) {
 
   $('#flash_msg_div').append(text_div).show();
 }
+
+function _miqFlashLoad() {
+  return JSON.parse(sessionStorage.getItem('flash_msgs') || '[]');
+}
+function _miqFlashSave(arr) {
+  return sessionStorage.setItem('flash_msgs', JSON.stringify(arr));
+}
+
+// stores a flash message (keys: message, level) for later
+function miqFlashLater(object) {
+  var ary = _miqFlashLoad();
+  ary.push(object);
+  _miqFlashSave(ary);
+}
+
+// shows all stored flash messages
+function miqFlashSaved() {
+  var ary = _miqFlashLoad();
+  ary.forEach(function(obj) {
+    add_flash(obj.message, obj.level);
+  });
+
+  _miqFlashSave([]);
+}

--- a/app/assets/javascripts/miq_flash.js
+++ b/app/assets/javascripts/miq_flash.js
@@ -1,0 +1,49 @@
+// add a flash message to an existing #flash_msg_div
+// levels are error, warning, info, success
+function add_flash(msg, level, options) {
+  level = level || 'success';
+  options = options || {};
+  var cls = { alert: '', icon: '' };
+
+  switch (level) {
+    case 'error':
+      cls.alert = 'alert alert-danger';
+      cls.icon = 'pficon pficon-error-circle-o';
+      break;
+    case 'warning':
+      cls.alert = 'alert alert-warning';
+      cls.icon = 'pficon pficon-warning-triangle-o';
+      break;
+    case 'info':
+      cls.alert = 'alert alert-info';
+      cls.icon = 'pficon pficon-info';
+      break;
+    case 'success':
+      cls.alert = 'alert alert-success';
+      cls.icon = 'pficon pficon-ok';
+      break;
+  }
+
+  var icon_span = $('<span class="' + cls.icon + '"></span>');
+
+  var text_strong = $('<strong></strong>');
+  text_strong.text(msg);
+
+  var alert_div = $('<div class="' + cls.alert + '"></div>');
+  alert_div.append(icon_span, text_strong);
+
+  var text_div = $('<div class="flash_text_div"></div>');
+  text_div.attr('title', __('Click to remove message'));
+  text_div.on('click', function() {
+    text_div.remove();
+  });
+  text_div.append(alert_div);
+
+  // if options.id is provided, only one flash message with that id may exist
+  if (options.id) {
+    $('#' + options.id).filter('#flash_msg_div > *').remove();
+    text_div.attr('id', options.id);
+  }
+
+  $('#flash_msg_div').append(text_div).show();
+}

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -62,11 +62,11 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', funct
     $(outerMost).append(outerBox);
     $(outerMost).appendTo($("#flash_msg_div"));
   };
-  var miqFlash = this.miqFlash;
 
+  // FIXME: usually we just hide it, merge the logic
   this.miqFlashClear = function() {
     $('#flash_msg_div').text("");
-  }
+  };
 
   this.saveable = function(form) {
     return form.$valid && form.$dirty;
@@ -131,10 +131,10 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', funct
 
     if (angular.isDefined(e.error) && angular.isDefined(e.error.message)) {
       console.error(e.error.message);
-      miqFlash('error', e.error.message);
+      this.miqFlash('error', e.error.message);
     } else if (e.message) {
       console.error(e.message);
-      miqFlash('error', e.message);
+      this.miqFlash('error', e.message);
     }
 
     return $q.reject(e);

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -1,4 +1,4 @@
-/* global miqAjaxButton miqBuildCalendar miqButtons miqJqueryRequest miqRESTAjaxButton miqSparkleOff miqSparkleOn */
+/* global miqAjaxButton miqBuildCalendar miqButtons miqJqueryRequest miqRESTAjaxButton miqSparkleOff miqSparkleOn add_flash */
 
 ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', function($timeout, $document, $q) {
   this.storedPasswordPlaceholder = "●●●●●●●●";
@@ -40,27 +40,9 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', funct
     miqSparkleOff();
   };
 
-  // FIXME: merge with add_flash in miq_application.js
   this.miqFlash = function(type, msg) {
-    $('#flash_msg_div').text("");
-    $("#flash_msg_div").show();
-    var outerMost = $("<div id='flash_text_div' onclick=$('#flash_msg_div').text(''); title='" + __("Click to remove messages") + "'>");
-    var txt = $('<strong>' + msg + '</strong>');
-
-    if(type == "error") {
-      var outerBox = $('<div class="alert alert-danger">');
-      var innerSpan = $('<span class="pficon pficon-error-circle-o">');
-    } else if (type == "warn") {
-      var outerBox = $('<div class="alert alert-warning">');
-      var innerSpan = $('<span class="pficon pficon-warning-triangle-o">');
-    } else if (type == "success") {
-      var outerBox = $('<div class="alert alert-success">');
-      var innerSpan = $('<span class="pficon pficon-ok">');
-    }
-    $(outerBox).append(innerSpan);
-    $(outerBox).append(txt);
-    $(outerMost).append(outerBox);
-    $(outerMost).appendTo($("#flash_msg_div"));
+    this.miqFlashClear();
+    add_flash(msg, type);
   };
 
   // FIXME: usually we just hide it, merge the logic

--- a/app/assets/javascripts/services/post_service.js
+++ b/app/assets/javascripts/services/post_service.js
@@ -1,3 +1,5 @@
+/* global miqFlashLater */
+
 ManageIQ.angular.app.service('postService', ['miqService', '$timeout', '$window', 'API', function(miqService, $timeout, $window, API) {
 
   this.saveRecord = function(apiURL, redirectURL, updateObject, successMsg) {

--- a/app/assets/javascripts/services/post_service.js
+++ b/app/assets/javascripts/services/post_service.js
@@ -16,7 +16,8 @@ ManageIQ.angular.app.service('postService', ['miqService', '$timeout', '$window'
           miqService.miqFlash('error', msg);
           miqService.sparkleOff();
         } else {
-          $window.location.href = redirectURL + '&flash_msg=' + successMsg;
+          miqFlashLater({ message: successMsg });
+          $window.location.href = redirectURL;
         }
       });
     }
@@ -38,7 +39,8 @@ ManageIQ.angular.app.service('postService', ['miqService', '$timeout', '$window'
           miqService.miqFlash('error', msg);
           miqService.sparkleOff();
         } else {
-          $window.location.href = redirectURL + '&flash_msg=' + successMsg;
+          miqFlashLater({ message: successMsg });
+          $window.location.href = redirectURL;
         }
       });
     }
@@ -46,7 +48,8 @@ ManageIQ.angular.app.service('postService', ['miqService', '$timeout', '$window'
 
   this.cancelOperation = function(redirectURL, msg) {
     $timeout(function () {
-      $window.location.href = redirectURL + '&flash_msg=' + msg;
+      miqFlashLater({ message: msg });
+      $window.location.href = redirectURL;
     });
   };
 }]);

--- a/app/views/dashboard/saml_login.html.haml
+++ b/app/views/dashboard/saml_login.html.haml
@@ -7,8 +7,10 @@
   %body
     - if api_auth_token && validation_url
       :javascript
+        miqFlashClearSaved();
         sessionStorage.miq_token = '#{j_str api_auth_token}';
         window.location = '#{j_str validation_url}';
     - else
       :javascript
+        miqFlashClearSaved();
         window.location = '/dashboard/logout';

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -23,3 +23,4 @@
       vanillaJsAPI.logout();
       delete localStorage['patternfly-navigation-secondary'];
       delete localStorage['patternfly-navigation-tertiary'];
+      miqFlashClearSaved();


### PR DESCRIPTION
Right now, we have 2 ways of displaying flash messages in JS (+ all the others in ruby):

   * `add_flash(message, level = 'success', options = {})`
   * `miqService.miqFlash(level, message)`

Unified so that `miqFlash` uses `add_flash` (but also clears previous, because compatibility).

Also, when leaving an angular form, an url is generated with `?flash_msg=...` and the browser is redirected there, so the flash message takes a round trip to the server and back, just to be displayed. That's a problem because nobody removes it from the URL after, so the message is then shown again on any other request where we just change the current url parameters.

Introducing `miqFlashLater({ message: ..., level: ... })` which queues the flash message (saves in the browser's `sessionStorage`), and `miqFlashSaved` which shows these messages when called (and clears them).

The data is cleaned on login, and `miqFlashSaved` is called from `miqOnLoad`.

The rest simply updates all our angular code to use `miqFlashLater` instead of `?flash_msg=` in the URL.

https://bugzilla.redhat.com/show_bug.cgi?id=1437361