### PR TITLE
Move methods dealing with RBAC on lists and items to a mixin.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,8 @@ class ApplicationController < ActionController::Base
   include Mixins::MenuSection
   include Mixins::GenericToolbarMixin
   include Mixins::CustomButtons
+  include Mixins::CheckedIdMixin
+
   helper ToolbarHelper
   helper JsHelper
   helper QuadiconHelper
@@ -1356,83 +1358,6 @@ class ApplicationController < ActionController::Base
     end
   end # set_config
 
-  # Common routine to find checked items on a page (checkbox ids are "check_xxx" where xxx is the item id or index)
-  def find_checked_items(prefix = nil)
-    if !params[:miq_grid_checks].blank?
-      return params[:miq_grid_checks].split(",").collect { |c| from_cid(c) }
-    else
-      prefix = "check" if prefix.nil?
-      items = []
-      params.each do |var, val|
-        vars = var.to_s.split("_")
-        if vars[0] == prefix && val == "1"
-          ids = vars[1..-1].collect { |v| v = from_cid(v) }  # Decompress any compressed ids
-          items.push(ids.join("_"))
-        end
-      end
-      return items
-    end
-  end
-
-  # Test RBAC on every item checked
-  # Params:
-  #   klass - class of accessed objects
-  # Returns:
-  #   array of checked items. If user does not have rigts for it,
-  #   raises exception
-  def find_checked_ids_with_rbac(klass, prefix = nil)
-    items = find_checked_items(prefix)
-    assert_rbac(klass, items)
-    items
-  end
-
-  # Test RBAC on every item checked
-  # Params:
-  #   klass - class of accessed objects
-  # Returns:
-  #   array of records. If user does not have rigts for it,
-  #   raises exception
-  def find_checked_records_with_rbac(klass, ids=nil)
-    ids ||= find_checked_items
-    filtered = Rbac.filtered(klass.where(:id => ids))
-    raise _("Unauthorized object or action") unless ids.length == filtered.length
-    filtered
-  end
-
-  # Test RBAC in case there is only one record
-  # Params:
-  #   klass - class of accessed object
-  #   id    - accessed object id
-  # Returns:
-  #   database record of checked item. If user does not have rights for it,
-  #   raises an exception
-  def find_record_with_rbac(klass, id, options = {})
-    raise _("Invalid input") unless is_integer?(id)
-    tested_object = klass.find_by(:id => id)
-    if tested_object.nil?
-      raise(_("User '%{user_id}' is not authorized to access '%{model}' record id '%{record_id}'") %
-              {:user_id   => current_userid,
-               :record_id => id,
-               :model     => ui_lookup(:model => klass.to_s)})
-    end
-    Rbac.filtered_object(tested_object, :user => current_user, :named_scope => options[:named_scope]) ||
-      raise(_("User '%{user_id}' is not authorized to access '%{model}' record id '%{record_id}'") %
-              {:user_id   => current_userid,
-               :record_id => id,
-               :model     => ui_lookup(:model => klass.to_s)})
-  end
-
-  # Test RBAC in case there is only one record
-  # Params:
-  #   klass - class of accessed object
-  #   id    - accessed object id
-  # Returns:
-  #   id of checked item. If user does not have rights for it,
-  #   raises an exception
-  def find_id_with_rbac(klass, id)
-    assert_rbac(klass, Array.wrap(id))
-    id
-  end
 
   # Common Saved Reports button handler routines
   def process_saved_reports(saved_reports, task)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2239,26 +2239,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Find a record by model name and ID, set flash errors for not found/not authorized
-  def find_by_model_and_id_check_rbac(model, id, resource_name = nil)
-    rec = model.constantize.find_by_id(id)
-    if rec
-      begin
-        authrec = find_record_with_rbac(model.constantize, id)
-      rescue ActiveRecord::RecordNotFound
-      rescue => @bang
-      end
-    end
-    if rec.nil?
-      record_name = resource_name ? "#{ui_lookup(:model => model)} '#{resource_name}'" : "The selected record"
-      add_flash(_("%{record_name} no longer exists in the database") % {:record_name => record_name}, :error)
-    elsif authrec.nil?
-      add_flash(_("You are not authorized to view %{model_name} '%{resource_name}'") %
-        {:model_name => ui_lookup(:model => rec.class.base_model.to_s), :resource_name => resource_name}, :error)
-    end
-    rec
-  end
-
   def get_record_display_name(record)
     return record.label                      if record.respond_to?("label")
     return record.description                if record.respond_to?("description") && !record.description.nil?

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -507,7 +507,7 @@ module ApplicationController::Performance
 
   # Send error message if record is found and authorized, else return the record
   def perf_menu_record_valid(model, id, resource_name)
-    rec = find_by_model_and_id_check_rbac(model, id, resource_name)
+    rec = find_record_with_rbac_flash(model.constantize, id, resource_name)
     unless @flash_array.blank?
       javascript_flash(:spinner_off => true)
       return false

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -8,7 +8,6 @@ class CloudNetworkController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
-  include Mixins::CheckedIdMixin
   include Mixins::GenericFormMixin
 
   PROVIDERS_NETWORK_TYPES = {

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -8,7 +8,6 @@ class CloudSubnetController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
-  include Mixins::CheckedIdMixin
   include Mixins::GenericFormMixin
 
   def self.display_methods

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -6,7 +6,6 @@ class CloudTenantController < ApplicationController
   after_action :set_session_data
 
   include Mixins::GenericListMixin
-  include Mixins::CheckedIdMixin
   include Mixins::GenericButtonMixin
   include Mixins::GenericFormMixin
   include Mixins::GenericSessionMixin

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -5,7 +5,6 @@ class CloudVolumeController < ApplicationController
   after_action :set_session_data
 
   include Mixins::GenericListMixin
-  include Mixins::CheckedIdMixin
   include Mixins::GenericFormMixin
   include Mixins::GenericSessionMixin
 

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -4,7 +4,6 @@ class FloatingIpController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
-  include Mixins::CheckedIdMixin
   include Mixins::GenericButtonMixin
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -5,7 +5,6 @@ class HostAggregateController < ApplicationController
   after_action :set_session_data
 
   include Mixins::GenericListMixin
-  include Mixins::CheckedIdMixin
   include Mixins::GenericSessionMixin
 
   def show

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -6,5 +6,82 @@ module Mixins
       checked_items = find_checked_items
       checked_items[0] if checked_items.length == 1
     end
+
+    # Common routine to find checked items on a page (checkbox ids are
+    # "check_xxx" where xxx is the item id or index)
+    def find_checked_items(prefix = nil)
+      if params[:miq_grid_checks].present?
+        params[:miq_grid_checks].split(",").collect { |c| from_cid(c) }
+      else
+        prefix = "check" if prefix.nil?
+        params.each_with_object([]) do |(var, val), items|
+          vars = var.to_s.split("_")
+          if vars[0] == prefix && val == "1"
+            ids = vars[1..-1].collect { |v| from_cid(v) }
+            items << ids.join("_")
+          end
+        end
+      end
+    end
+
+    # Test RBAC on every item checked
+    # Params:
+    #   klass - class of accessed objects
+    # Returns:
+    #   array of checked items. If user does not have rigts for it,
+    #   raises exception
+    def find_checked_ids_with_rbac(klass, prefix = nil)
+      items = find_checked_items(prefix)
+      assert_rbac(klass, items)
+      items
+    end
+
+    # Test RBAC on every item checked
+    # Params:
+    #   klass - class of accessed objects
+    # Returns:
+    #   array of records. If user does not have rigts for it,
+    #   raises exception
+    def find_checked_records_with_rbac(klass, ids = nil)
+      ids ||= find_checked_items
+      filtered = Rbac.filtered(klass.where(:id => ids))
+      raise _("Unauthorized object or action") unless ids.length == filtered.length
+      filtered
+    end
+
+    # Test RBAC in case there is only one record
+    # Params:
+    #   klass - class of accessed object
+    #   id    - accessed object id
+    # Returns:
+    #   database record of checked item. If user does not have rights for it,
+    #   raises an exception
+    def find_record_with_rbac(klass, id, options = {})
+      raise _("Invalid input") unless is_integer?(id)
+      tested_object = klass.find_by(:id => id)
+      if tested_object.nil?
+        raise(_("User '%{user_id}' is not authorized to access '%{model}' record id '%{record_id}'") %
+                {:user_id   => current_userid,
+                 :record_id => id,
+                 :model     => ui_lookup(:model => klass.to_s)})
+      end
+      Rbac.filtered_object(tested_object, :user => current_user, :named_scope => options[:named_scope]) ||
+        raise(_("User '%{user_id}' is not authorized to access '%{model}' record id '%{record_id}'") %
+                {:user_id   => current_userid,
+                 :record_id => id,
+                 :model     => ui_lookup(:model => klass.to_s)})
+    end
+
+    # Test RBAC in case there is only one record
+    # Params:
+    #   klass - class of accessed object
+    #   id    - accessed object id
+    # Returns:
+    #   id of checked item. If user does not have rights for it,
+    #   raises an exception
+    def find_id_with_rbac(klass, id)
+      assert_rbac(klass, Array.wrap(id))
+      id
+    end
   end
 end

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -8,7 +8,6 @@ class NetworkRouterController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
-  include Mixins::CheckedIdMixin
   include Mixins::GenericFormMixin
 
   def self.display_methods

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -4,7 +4,6 @@ class SecurityGroupController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
-  include Mixins::CheckedIdMixin
   include Mixins::GenericButtonMixin
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin


### PR DESCRIPTION
The goal is to unify the patterns. Moving forward we want to limit the different patterns we have in the code and use a common set of methods. These methods will be placed in a single mixin.

This is just the initial move of the methods to the mixin and including the mixin in all controllers.