### PR TITLE
Rate editor shall not depend on soon-to-be-removed-cols

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -513,6 +513,7 @@ class ChargebackController < ApplicationController
       temp = detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES)
       temp[:group] = detail.chargeable_field.group
       temp[:description] = detail.chargeable_field.description
+      temp[:per_unit_display] = detail.per_unit_display
       temp[:per_time] ||= "hourly"
 
       temp[:currency] = detail.detail_currency.id

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -517,7 +517,6 @@ class ChargebackController < ApplicationController
       temp[:per_time] ||= "hourly"
 
       temp[:currency] = detail.detail_currency.id
-      temp[:detail_measure] = detail.detail_measure
 
       if detail.detail_measure.present?
         temp[:detail_measure] = {}

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -512,6 +512,7 @@ class ChargebackController < ApplicationController
     rate_details.each_with_index do |detail, detail_index|
       temp = detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES)
       temp[:group] = detail.chargeable_field.group
+      temp[:description] = detail.chargeable_field.description
       temp[:per_time] ||= "hourly"
 
       temp[:currency] = detail.detail_currency.id

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -48,7 +48,7 @@
           %td{:align => "right"}
             = tier.fixed_rate ? tier.fixed_rate : 0.0
           %td{:align => "right"}
-            = detail.chargeable_field.group == 'fixed' && tier.variable_rate.zero? ? '-' : tier.variable_rate
+            = detail.chargeable_field.fixed? && tier.variable_rate.zero? ? '-' : tier.variable_rate
           %td{:align => "right", :rowspan => num_tiers}
             = detail.show_rates
         - (1..num_tiers.to_i - 1).each do |tier_index|
@@ -61,7 +61,7 @@
             %td{:align => "right"}
               = tier.fixed_rate
             %td{:align => "right"}
-              = (detail.chargeable_field.group == 'fixed' && tier.variable_rate.zero?) ? '-' : tier.variable_rate
+              = (detail.chargeable_field.fixed? && tier.variable_rate.zero?) ? '-' : tier.variable_rate
         %tr
           %td{:colspan => "9"}
 

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -27,19 +27,19 @@
         %th= _("Variable")
     %tbody
       /Currency code is the same for all the chargeback_rate_details
-      - @record.chargeback_rate_details.to_a.sort_by { |rd| [rd[:group].downcase, rd[:description].downcase] }.each_with_index do |detail, detail_index|
+      - @record.chargeback_rate_details.to_a.sort_by { |rd| [rd.chargeable_field.group.downcase, rd.chargeable_field.description.downcase] }.each_with_index do |detail, detail_index|
       - tiers = detail.chargeback_tiers.order(:start)
-        - @cur_group = detail[:group] if @cur_group.nil?
-        - if @cur_group != detail[:group]
-          - @cur_group = detail[:group]
+        - @cur_group = detail.chargeable_field.group if @cur_group.nil?
+        - if @cur_group != detail.chargeable_field.group
+          - @cur_group = detail.chargeable_field.group
           %tr
             %td.active{:colspan => "9", :style => "background-color: #f5f5f5;"} &nbsp;
         - num_tiers = detail.chargeback_tiers.to_a.blank? ? "1" : tiers.to_a.length.to_s
         %tr.rdetail
           %td{:rowspan => num_tiers}
-            = h(rate_detail_group(detail[:group]))
+            = h(rate_detail_group(detail.chargeable_field.group))
           %td{:rowspan => num_tiers}
-            = detail[:description]
+            = detail.chargeable_field.description
           - tier = tiers.first
           %td
             = tier.start ? tier.start : 0
@@ -48,7 +48,7 @@
           %td{:align => "right"}
             = tier.fixed_rate ? tier.fixed_rate : 0.0
           %td{:align => "right"}
-            = detail[:group] == 'fixed' && tier.variable_rate.zero? ? '-' : tier.variable_rate
+            = detail.chargeable_field.group == 'fixed' && tier.variable_rate.zero? ? '-' : tier.variable_rate
           %td{:align => "right", :rowspan => num_tiers}
             = detail.show_rates
         - (1..num_tiers.to_i - 1).each do |tier_index|
@@ -61,7 +61,7 @@
             %td{:align => "right"}
               = tier.fixed_rate
             %td{:align => "right"}
-              = (detail[:group] == 'fixed' && tier.variable_rate.zero?) ? '-' : tier.variable_rate
+              = (detail.chargeable_field.group == 'fixed' && tier.variable_rate.zero?) ? '-' : tier.variable_rate
         %tr
           %td{:colspan => "9"}
 


### PR DESCRIPTION
Continuation of https://github.com/ManageIQ/manageiq/issues/13375

Preparing to drop metric, group, source, description, and chargeback_rate_detail_measure_id from `chargeback_rate_details` table.