### PR TITLE
Eslint angular rules update

### DIFF
--- a/app/assets/javascripts/controllers/.eslintrc.json
+++ b/app/assets/javascripts/controllers/.eslintrc.json
@@ -11,9 +11,12 @@
     "angular/log": 0,
     "angular/no-service-method": 0,
     "angular/di": [ "error", "array" ], // strictDi
+    "angular/controller-as": 2,
+    "angular/prefer-component": 2,
+    "angular/no-http-callback": 2,
+    "angular/on-destroy": 1,
 
     // only warnings for now
-    "angular/controller-as": 1,
     "angular/module-getter": 1,
     "angular/no-services": [ "warn", ["$http"] ],
 


### PR DESCRIPTION
We should now require controllerAs, and strongly prefer components over directives.

Since we're moving to 1.6, we also need to error on $http.success/failure.

And `$on('$destroy')` is a useful warning since we had all the places wrong - #908 :).