### PR TITLE
Enable configuration button for container images

### DIFF
--- a/app/helpers/application_helper/button/smart_state_scan.rb
+++ b/app/helpers/application_helper/button/smart_state_scan.rb
@@ -8,14 +8,6 @@ class ApplicationHelper::Button::SmartStateScan < ApplicationHelper::Button::Bas
     end
   end
 
-  def calculate_properties
-    super
-    if disabled?
-      self[:onwhen] = nil
-      self[:title] = @error_message
-    end
-  end
-
   def disabled?
     check_smart_roles
     @error_message.present?

--- a/app/helpers/application_helper/button/smart_state_scan.rb
+++ b/app/helpers/application_helper/button/smart_state_scan.rb
@@ -1,12 +1,18 @@
 class ApplicationHelper::Button::SmartStateScan < ApplicationHelper::Button::Basic
-  needs :@record
-
   def check_smart_roles
     my_zone = MiqServer.my_server.my_zone
     MiqServer::ServerSmartProxy::SMART_ROLES.each do |role|
       unless MiqServer.all.any? { |s| s.has_active_role?(role) && (s.my_zone == my_zone) }
         @error_message = _("There is no server with the #{role} role enabled")
       end
+    end
+  end
+
+  def calculate_properties
+    super
+    if disabled?
+      self[:onwhen] = nil
+      self[:title] = @error_message
     end
   end
 


### PR DESCRIPTION
**Description**
Enable configuration button for container images, currently we do not show the "scan image" button in the images page.

Compute > Containers > Container Images

**Screenshots**
_Bug_
![screenshot-localhost 3000-2017-04-04-17-31-24](https://cloud.githubusercontent.com/assets/2181522/24662007/94fcabf0-195c-11e7-9dda-44cd096537f7.png)

_Fix with role enabled (no selected items)_
![screenshot from 2017-04-04 17-37-44](https://cloud.githubusercontent.com/assets/2181522/24662417/ad9ec1c4-195d-11e7-9a2b-54cacc1b7d4c.jpg)

_Fix with role enabled (has selected items)_
![screenshot from 2017-04-04 17-37-55](https://cloud.githubusercontent.com/assets/2181522/24662418/ad9fd474-195d-11e7-8f1d-1d3d59ea5761.jpg)


_Fix with role disabled_
![screenshot from 2017-04-04 17-25-55](https://cloud.githubusercontent.com/assets/2181522/24661844/2d0065dc-195c-11e7-859d-2ed109338f32.jpg)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1438248