### PR TITLE
Fix cancelling delete on saved filter

### DIFF
--- a/app/views/layouts/_adv_search_footer.html.haml
+++ b/app/views/layouts/_adv_search_footer.html.haml
@@ -27,15 +27,19 @@
                    :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "apply")}');")
     - if @edit[@expkey][:selected] && @edit[@expkey][:selected][:typ] != "default" && @edit[@expkey][:selected][:id] != 0
       - if admin_user? || @edit[@expkey][:selected][:typ] == "user"
-        - confirm_msg = _("Delete the %{model} filter named %{filter}?") % {:model  => ui_lookup(:model => @edit[@expkey][:exp_mode]),
-                                                                            :filter => @edit[:adv_search_name]}
-
-        = button_tag(_('Delete'),
-                   :class   => "btn btn-danger",
-                   'data-confirm' => confirm_msg,
-                   :alt     => t = _("Delete the filter named %{filter_name}") % {:filter_name => @edit[@expkey][:selected][:description]},
-                   :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "delete")}');")
+        - actual_filter = @edit[@expkey][:selected][:description]
+        - confirm_msg = _("Delete the %{model} filter named %{filter}?") % {:model  => ui_lookup(:model => @edit[@expkey][:exp_model]),
+                                                                            :filter => actual_filter}
+        - t = _("Delete the filter named %{filter_name}") % {:filter_name => actual_filter}
+        = link_to('Delete',
+                  url_for_only_path(:action => 'adv_search_button',
+                                    :button => "delete"),
+                  :alt           => t,
+                  :class         => "btn btn-danger",
+                  'data-confirm' => confirm_msg,
+                  "data-method"  => :post,
+                  :remote        => true,
+                  :title         => t)
     - if @edit[@expkey][:exp_table].flatten.first == "???"
       = button_tag(_("Save"),
                    :class => "btn btn-primary disabled",


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1436243

Fix 'Cancel' button in a confirmation dialog
for deleting of a saved filter in Advanced search.
This button has caused deleting of the filter.
Now it closes the dialog and returns to Advanced search.
'Delete' button works well, as usually.

Fix displaying name of a filter when confirmation
dialog opens.

Before:
![cancel1](https://cloud.githubusercontent.com/assets/13417815/24665771/a6d97e78-195e-11e7-8613-664394c3bc61.png)
![cancel2](https://cloud.githubusercontent.com/assets/13417815/24666014/5e64d9d4-195f-11e7-8892-5a31dacd54bc.png)
![cancel3](https://cloud.githubusercontent.com/assets/13417815/24666017/601a141a-195f-11e7-82bd-b7c73b11a813.png)

After:
![cancel4](https://cloud.githubusercontent.com/assets/13417815/24666347/5bf91966-1960-11e7-9c69-ce5926d86128.png)
![cancel5](https://cloud.githubusercontent.com/assets/13417815/24666420/90934b42-1960-11e7-8d32-94637da6afb5.png)
