### PR TITLE
Moved menus under Automation maintab around

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -220,9 +220,9 @@ module Menu
 
       def automation_menu_section
         Menu::Section.new(:aut, N_("Automation"), 'fa fa-recycle', [
-          automate_menu_section,
           ansible_menu_section,
-          automation_manager_menu_section
+          automation_manager_menu_section,
+          automate_menu_section
         ])
       end
 
@@ -235,9 +235,9 @@ module Menu
 
       def ansible_menu_section
         Menu::Section.new(:ansible, N_("Ansible"), 'fa fa-recycle', [
-          Menu::Item.new('ansible_credentials', N_('Credentials'), 'embedded_automation_manager_credentials', {:feature => 'embedded_automation_manager_credentials', :any => true}, '/ansible_credential'),
           Menu::Item.new('ansible_playbooks', N_('Playbooks'), 'embedded_configuration_script_payload', {:feature => 'embedded_configuration_script_payload'}, '/ansible_playbook', :any => true),
           Menu::Item.new('ansible_repositories', N_('Repositories'), 'embedded_configuration_script_source', {:feature => 'embedded_configuration_script_source'}, '/ansible_repository', :any => true),
+          Menu::Item.new('ansible_credentials', N_('Credentials'), 'embedded_automation_manager_credentials', {:feature => 'embedded_automation_manager_credentials', :any => true}, '/ansible_credential'),
         ])
       end
 


### PR DESCRIPTION
Moved menus under Automation manitab around to make Ansible/Playbooks as default landing page when clicking on maintab Automation or when clicking on second level tab Ansible.

https://bugzilla.redhat.com/show_bug.cgi?id=1437189

before:
![before](https://cloud.githubusercontent.com/assets/3450808/24673116/26903964-1945-11e7-8d35-2c7875e36ac5.png)

![before2](https://cloud.githubusercontent.com/assets/3450808/24675754/59a86af2-194e-11e7-919d-fe5e2c6e6eb4.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/24673122/29e3ea70-1945-11e7-8f93-78c9bceab371.png)

![after2](https://cloud.githubusercontent.com/assets/3450808/24675764/5ee58cde-194e-11e7-9ee2-8c770cc31aa1.png)


@dclarizio please review.