### PR TITLE
Physical infra topology - fix icon name comment

### DIFF
--- a/app/services/ui_service_mixin.rb
+++ b/app/services/ui_service_mixin.rb
@@ -29,7 +29,7 @@ module UiServiceMixin
       :CloudTenant             => {:type => "glyph", :icon => "\uE904", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-cloud-tenant
       :LoadBalancer            => {:type => "glyph", :icon => "\uE637", :fontfamily => "IcoMoon"},                 # product-load_balancer
       :Tag                     => {:type => "glyph", :icon => "\uF02b", :fontfamily => "FontAwesome"},             # fa-tag
-      :PhysicalServer          => {:type => "glyph", :icon => "\uE91a", :fontfamily => "PatternFlyIcons-webfont"}, # product-physical_server
+      :PhysicalServer          => {:type => "glyph", :icon => "\uE91a", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-server-group
       :Openstack               => {:type => "image", :icon => provider_icon(:Openstack)},
       :Amazon                  => {:type => "image", :icon => provider_icon(:Amazon)},
       :Azure                   => {:type => "image", :icon => provider_icon(:Azure)},

--- a/app/views/physical_infra_topology/show.html.haml
+++ b/app/views/physical_infra_topology/show.html.haml
@@ -10,7 +10,7 @@
         %svg.kube-topology
           %g.EntityLegend.PhysicalInfra
             %circle{:r => "17"}
-            -# pficon-physical_servers
+            -# pficon-server-group
             %text{:y => "9"} &#xe91a;
         %label
           = _("Physical Servers")


### PR DESCRIPTION
we're using comments to keep the info about fonticon names where we have to use the hex code because SVG.

This fixes 2 such comments (same icon, different places) - introduced in #656.

Cc @AparnaKarve 