### PR TITLE
fix selector table title to be consistent with the actoual oc field

### DIFF
--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -84,7 +84,7 @@ module ContainerSummaryHelper
   end
 
   def textual_group_container_selectors
-    TextualGroup.new(_("Node Selector"), textual_key_value_group(@record.selector_parts.to_a))
+    TextualGroup.new(_("Selector"), textual_key_value_group(@record.selector_parts.to_a))
   end
 
   def textual_group_container_node_selectors


### PR DESCRIPTION
Fix the Replicators Selector table to be consistent with the openshift field. (Node Selector -> Selector)
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1437509
Before:
![screenshot from 2017-04-05 11-41-40](https://cloud.githubusercontent.com/assets/8366181/24701784/7b144a1a-1a04-11e7-9ef2-0352651a907b.png)
After:
![screenshot from 2017-04-05 11-49-29](https://cloud.githubusercontent.com/assets/8366181/24701792/80165468-1a04-11e7-9080-ac2bf766418e.png)

cc: @simon3z @zakiva 