### PR TITLE
Move show_ad_hoc_metrics from GenericShowMixin to custom_display_modes

### DIFF
--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -33,5 +33,9 @@ class ContainerNodeController < ApplicationController
     end
   end
 
+  def self.custom_display_modes
+    %w(ad_hoc_metrics)
+  end
+
   menu_section :cnt
 end

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -20,8 +20,6 @@ module Mixins
         show_timeline if respond_to?(:show_timeline)
       when "performance"
         show_performance if respond_to?(:show_performance)
-      when "ad_hoc_metrics"
-        show_ad_hoc_metrics if respond_to?(:show_ad_hoc_metrics)
       when "compliance_history"
         show_compliance_history if respond_to?(:show_compliance_history)
       when "topology"


### PR DESCRIPTION
The switch in `GenericShowMixin.show` is meant only for the common actions.
Since `show_ad_hoc_metrics` is only implemented for `ContainerNodeController`, it should not be there.

There is however a mechanism for that - `GenericShowMixin.show` calls `custom_display_modes` which can return a whitelist of additional supported methods.

Changing to use that :).

---

Introduced in #810 and #901 => adding `fine/yes`.

Cc @yaacov, @martinpovolny (sorry for not catching this during the review)