### PR TITLE
package.json - add engines section

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
     "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-react": "^5.1.1",
     "eslint-plugin-standard": "^2.0.1"
+  },
+  "engines": {
+    "node": ">= 6.9.1",
+    "npm": ">= 3.10.3"
   }
 }


### PR DESCRIPTION
We should start depending on specific node & npm versions (or at least minimal), since we're going to start using npm more.

This adds version constraints identical to SUI (& api-mocks) - which are available in current builds.