### PR TITLE
Fix topology view styling issues

### DIFF
--- a/app/assets/stylesheets/container_topology.css
+++ b/app/assets/stylesheets/container_topology.css
@@ -4,6 +4,10 @@
     stroke-dasharray: 5.5;
 }
 
+.container_topology .legend { /* prevents tooltip from conflicting with the nav bar*/
+  margin-left: 40px;
+}
+
 .container_topology g.EntityLegend {
     transform: translate(21px,21px);
 }

--- a/app/views/infra_topology/show.html.haml
+++ b/app/views/infra_topology/show.html.haml
@@ -1,4 +1,4 @@
-- tooltipOptions = {"tooltip-placement" => "bottom-right", "tooltip" => "{{legendTooltip}}"}
+- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
 .container_topology{'ng-controller' => "infraTopologyController"}
   .row.toolbar-pf
     .col-md-12

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -6,6 +6,6 @@
           = h(breadcrumbs[:name])
     %li.active
       = @title
-- elsif @layout == "container_topology"
+- elsif @layout.end_with?("_topology")
 - else
   %br

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -1,4 +1,4 @@
-- tooltipOptions = {"tooltip-placement" => "bottom-right", "tooltip" => "{{legendTooltip}}"}
+- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
 .container_topology{'ng-controller' => "middlewareTopologyController"}
   .row.toolbar-pf
     .col-md-12

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -1,4 +1,4 @@
-- tooltipOptions = {"tooltip-placement" => "bottom-right", "tooltip" => "{{legendTooltip}}"}
+- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
 .container_topology{'ng-controller' => "networkTopologyController"}
   .row.toolbar-pf
     .col-md-12


### PR DESCRIPTION
The PR adjusts the placement of the Topology legend and tooltip to prevent conflicts with the navigation bar. It also removes an extra BR tag that caused the toolbar to sit too low.

https://bugzilla.redhat.com/show_bug.cgi?id=1432851
https://bugzilla.redhat.com/show_bug.cgi?id=1400831

Old

<img width="581" alt="screen shot 2017-04-05 at 11 47 55 am" src="https://cloud.githubusercontent.com/assets/1287144/24714180/c45a5124-19f5-11e7-953b-0b8aeb6db9a1.png">
<img width="667" alt="screen shot 2017-04-05 at 11 47 29 am" src="https://cloud.githubusercontent.com/assets/1287144/24714179/c45231ba-19f5-11e7-8e5a-52301257659e.png">
<img width="690" alt="screen shot 2017-04-05 at 11 47 06 am" src="https://cloud.githubusercontent.com/assets/1287144/24714178/c44fd51e-19f5-11e7-9cd3-808aeb1f531e.png">


New

<img width="699" alt="screen shot 2017-04-05 at 11 45 02 am" src="https://cloud.githubusercontent.com/assets/1287144/24714060/6017a1d0-19f5-11e7-8d4b-f7ba57203a22.png">
<img width="616" alt="screen shot 2017-04-05 at 11 44 45 am" src="https://cloud.githubusercontent.com/assets/1287144/24714061/601a44a8-19f5-11e7-8c7a-89c8ab42bd2a.png">
<img width="641" alt="screen shot 2017-04-05 at 11 44 30 am" src="https://cloud.githubusercontent.com/assets/1287144/24714062/6023f6b0-19f5-11e7-811b-17d5684e9683.png">
