### PR TITLE
Speed up VM edit screen (includes RBAC)

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1390,7 +1390,11 @@ module VmCommon
     @edit[:current][:custom_1] = @edit[:new][:custom_1] = @record.custom_1.to_s
     @edit[:current][:description] = @edit[:new][:description] = @record.description.to_s
     @edit[:pchoices] = {}                                 # Build a hash for the parent choices box
-    VmOrTemplate.all.each { |vm| @edit[:pchoices][vm.name + " -- #{vm.location}"] =  vm.id unless vm.id == @record.id }   # Build a hash for the parents to choose from, not matching current VM
+    parent_item_scope = VmOrTemplate.where.not(:id => @record.id)
+    @edit[:pchoices] = parent_item_scope.pluck(:name, :location, :id).each_with_object({}) do |vm, memo|
+      memo[vm[0] + " -- #{vm[1]}"] = vm[2]
+    end
+
     @edit[:pchoices]['"no parent"'] = -1                        # Add "no parent" entry
     if @record.parents.length == 0                                            # Set the currently selected parent
       @edit[:new][:parent] = -1

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1390,7 +1390,7 @@ module VmCommon
     @edit[:current][:custom_1] = @edit[:new][:custom_1] = @record.custom_1.to_s
     @edit[:current][:description] = @edit[:new][:description] = @record.description.to_s
     @edit[:pchoices] = {}                                 # Build a hash for the parent choices box
-    parent_item_scope = VmOrTemplate.where.not(:id => @record.id)
+    parent_item_scope = Rbac.filtered(VmOrTemplate.where.not(:id => @record.id))
     @edit[:pchoices] = parent_item_scope.pluck(:name, :location, :id).each_with_object({}) do |vm, memo|
       memo[vm[0] + " -- #{vm[1]}"] = vm[2]
     end
@@ -1415,9 +1415,11 @@ module VmCommon
 
     # Build a hash for the VMs to choose from, only if they have no parent
     available_item_scope = VmOrTemplate.where.not(:id => ids_with_parents)
-    @edit[:choices] = available_item_scope.pluck(:name, :location, :id).each_with_object({}) do |vm, memo|
-      memo[vm[0] + " -- #{vm[1]}"] = vm[2]
-    end
+    @edit[:choices] = Rbac.filtered(available_item_scope)
+                          .pluck(:name, :location, :id)
+                          .each_with_object({}) do |vm, memo|
+                            memo[vm[0] + " -- #{vm[1]}"] = vm[2]
+                          end
 
     @edit[:new][:kids].each_key { |key| @edit[:choices].delete(key) }   # Remove any VMs that are in the kids list box from the choices
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1407,7 +1407,18 @@ module VmCommon
     vms.each { |vm| @edit[:new][:kids][vm.name + " -- #{vm.location}"] = vm.id }      # Build a hash for the kids list box
 
     @edit[:choices] = {}
-    VmOrTemplate.all.each { |vm| @edit[:choices][vm.name + " -- #{vm.location}"] =  vm.id if vm.parents.length == 0 }   # Build a hash for the VMs to choose from, only if they have no parent
+    # items with parents
+    ids_with_parents = Relationship.filtered(VmOrTemplate, nil)
+                                   .where.not(:ancestry => ['', nil])
+                                   .in_relationship('genealogy')
+                                   .pluck(:resource_id)
+
+    # Build a hash for the VMs to choose from, only if they have no parent
+    available_item_scope = VmOrTemplate.where.not(:id => ids_with_parents)
+    @edit[:choices] = available_item_scope.pluck(:name, :location, :id).each_with_object({}) do |vm, memo|
+      memo[vm[0] + " -- #{vm[1]}"] = vm[2]
+    end
+
     @edit[:new][:kids].each_key { |key| @edit[:choices].delete(key) }   # Remove any VMs that are in the kids list box from the choices
 
     @edit[:choices].delete(@record.name + " -- #{@record.location}")                                    # Remove the current VM from the choices list


### PR DESCRIPTION
**Main purpose**
- we had for each VmOrTemplate query to Relationship table to ask if the VmOrTemplate has parents 
now [I am getting ids](https://github.com/ManageIQ/manageiq-ui-classic/commit/eec0250e7fa4d8414708474f4fe453bd09079f3f) of VmOrTemplate with parents and then excluding such ids.
- add also RBAC

Note:
Now I can open screen with 80 000 objects but next issue on my list is that we have lot of data from `@edit[:pchoices]` and `@edit[:choices]`((built here) in `session` 
for 80 000 objects we about 20 MB in session.

cc @kbrock @martinpovolny 
@miq-bot add_label performance
@miq-bot assign @mzazrivec 
