### PR TITLE
Allow the Live Migrate and Evacuate Instance actions to support multiple instances at once.

### DIFF
--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_evacuate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_evacuate_form_controller.js
@@ -11,19 +11,27 @@ ManageIQ.angular.app.controller('vmCloudEvacuateFormController', ['$http', '$sco
 
   ManageIQ.angular.scope = $scope;
 
-  $http.get('/vm_cloud/evacuate_form_fields/' + vmCloudEvacuateFormId)
-    .then(getEvacuateFormData)
-    .catch(miqService.handleFailure);
+  if (vmCloudEvacuateFormId) {
+    $http.get('/vm_cloud/evacuate_form_fields/' + vmCloudEvacuateFormId)
+      .then(getEvacuateFormData)
+      .catch(miqService.handleFailure);
+  }
 
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
-    var url = '/vm_cloud/evacuate_vm/' + vmCloudEvacuateFormId + '?button=cancel';
+    var url = '/vm_cloud/evacuate_vm?button=cancel';
+    if (vmCloudEvacuateFormId) {
+      url = '/vm_cloud/evacuate_vm/' + vmCloudEvacuateFormId + '?button=cancel';
+    }
     miqService.miqAjaxButton(url);
   };
 
   $scope.submitClicked = function() {
     miqService.sparkleOn();
-    var url = '/vm_cloud/evacuate_vm/' + vmCloudEvacuateFormId + '?button=submit';
+    var url = '/vm_cloud/evacuate_vm?button=submit';
+    if (vmCloudEvacuateFormId) {
+      url = '/vm_cloud/evacuate_vm/' + vmCloudEvacuateFormId + '?button=submit';
+    }
     miqService.miqAjaxButton(url, true);
   };
 

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
@@ -14,19 +14,28 @@ ManageIQ.angular.app.controller('vmCloudLiveMigrateFormController', ['$http', '$
 
   ManageIQ.angular.scope = $scope;
 
-  $http.get('/vm_cloud/live_migrate_form_fields/' + vmCloudLiveMigrateFormId)
-    .then(getLiveMigrateFormData)
-    .catch(miqService.handleFailure);
+  if (vmCloudLiveMigrateFormId) {
+    $http.get('/vm_cloud/live_migrate_form_fields/' + vmCloudLiveMigrateFormId)
+      .then(getLiveMigrateFormData)
+      .catch(miqService.handleFailure);
+  }
 
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
-    var url = '/vm_cloud/live_migrate_vm/' + vmCloudLiveMigrateFormId + '?button=cancel';
+    var url = '/vm_cloud/live_migrate_vm/?button=cancel';
+    if (vmCloudLiveMigrateFormId) {
+      url = '/vm_cloud/live_migrate_vm/' + vmCloudLiveMigrateFormId + '?button=cancel';
+    }
+
     miqService.miqAjaxButton(url);
   };
 
   $scope.submitClicked = function() {
     miqService.sparkleOn();
-    var url = '/vm_cloud/live_migrate_vm/' + vmCloudLiveMigrateFormId + '?button=submit';
+    var url = '/vm_cloud/live_migrate_vm?button=submit';
+    if (vmCloudLiveMigrateFormId) {
+      url = '/vm_cloud/live_migrate_vm/' + vmCloudLiveMigrateFormId + '?button=submit';
+    }
     miqService.miqAjaxButton(url, true);
   };
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -522,9 +522,7 @@ module ApplicationController::CiProcessing
     assert_privileges("instance_live_migrate")
     case params[:button]
     when "cancel"
-      add_flash(_("Live migration of %{models} was cancelled by the user") % {
-        :models => ui_lookup(:tables => "vm_cloud")
-      })
+      add_flash(_("Live migration of Instances was cancelled by the user"))
     when "submit"
       @live_migrate_items = VmOrTemplate.find(session[:live_migrate_items]).sort_by(&:name)
       @live_migrate_items.each do |vm|
@@ -593,9 +591,7 @@ module ApplicationController::CiProcessing
     assert_privileges("instance_evacuate")
     case params[:button]
     when "cancel"
-      add_flash(_("Evacuation of %{models} was cancelled by the user") % {
-        :models => ui_lookup(:tables => "vm_cloud")
-      })
+      add_flash(_("Evacuation of Instances was cancelled by the user"))
     when "submit"
       @evacuate_items = VmOrTemplate.find(session[:evacuate_items]).sort_by(&:name)
       @evacuate_items.each do |vm|

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -463,7 +463,7 @@ module ApplicationController::CiProcessing
 
   def livemigratevms
     assert_privileges("instance_live_migrate")
-    recs = find_checked_items_with_rbac(VmOrTemplate)
+    recs = find_checked_ids_with_rbac(VmOrTemplate)
     recs = [params[:id].to_i] if recs.blank?
     session[:live_migrate_items] = recs
     if @explorer
@@ -474,20 +474,6 @@ module ApplicationController::CiProcessing
     end
   end
   alias instance_live_migrate livemigratevms
-    # @record = find_by_id_filtered(VmOrTemplate, recs.first)
-    # if @record.supports_live_migrate?
-    #   if @explorer
-    #     live_migrate
-    #     @refresh_partial = "vm_common/live_migrate"
-    #   else
-    #     javascript_redirect :controller => 'vm', :action => 'live_migrate', :rec_id => @record.id, :escape => false
-    #   end
-    # else
-    #   add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
-    #     :instance => ui_lookup(:table => 'vm_cloud'),
-    #     :name     => @record.name,
-    #     :details  => @record.unsupported_reason(:live_migrate)}, :error)
-    # end
 
   def live_migrate
     assert_privileges("instance_live_migrate")
@@ -536,15 +522,15 @@ module ApplicationController::CiProcessing
     assert_privileges("instance_live_migrate")
     case params[:button]
     when "cancel"
-      add_flash(_("Live migration of %{model} was cancelled by the user") % {
-        :model => ui_lookup(:tables => "vm_cloud")
+      add_flash(_("Live migration of %{models} was cancelled by the user") % {
+        :models => ui_lookup(:tables => "vm_cloud")
       })
     when "submit"
       @live_migrate_items = VmOrTemplate.find(session[:live_migrate_items]).sort_by(&:name)
       @live_migrate_items.each do |vm|
         if vm.supports_live_migrate?
           options = {
-            :hostname         => params['auto_select_host'] == 'on' ? nil : params[:destination_host],
+            :hostname         => params['auto_select_host'] == 'on' ? nil : params['destination_host'],
             :block_migration  => params['block_migration']   == 'on',
             :disk_over_commit => params['disk_over_commit']  == 'on'
           }
@@ -555,8 +541,8 @@ module ApplicationController::CiProcessing
           add_flash(_("Queued live migration of Instance \"%{name}\"") % {:name => vm.name})
         else
           add_flash(_("Unable to live migrate Instance \"%{name}\": %{details}") % {
-            :name     => vm.name,
-            :details  => vm.unsupported_reason(:live_migrate)
+            :name    => vm.name,
+            :details => vm.unsupported_reason(:live_migrate)
           }, :error)
         end
       end
@@ -570,110 +556,69 @@ module ApplicationController::CiProcessing
     end
   end
 
-  def live_migrate_finished
-    task_id = session[:async][:params][:task_id]
-    vm_id = session[:async][:params][:id]
-    vm = find_record_with_rbac(VmOrTemplate, vm_id)
-    task = MiqTask.find(task_id)
-    if MiqTask.status_ok?(task.status)
-      add_flash(_("Live migration of Instance \"%{name}\" complete.") % {:name => vm.name})
-    else
-      add_flash(_("Unable to live migrate Instance \"%{name}\": %{details}") % {
-        :name    => vm.name,
-        :details => get_error_message_from_fog(task.message)
-      }, :error)
-    end
-    @breadcrumbs.pop if @breadcrumbs
-    session[:edit] = nil
-    params[:id] = vm.id.to_s # reset id in params for show
-    @record = nil
-    @sb[:action] = nil
-    if @sb[:explorer]
-      replace_right_cell
-    else
-      session[:flash_msgs] = @flash_array.dup
-      javascript_redirect previous_breadcrumb_url
-    end
-  end
-
   def evacuate
     assert_privileges("instance_evacuate")
     @record ||= VmOrTemplate.find_by_id(params[:rec_id])
     drop_breadcrumb(
-      :name => _("Evacuate Instance '%{name}'") % {:name => @record.name},
+      :name => _("Evacuate Instances"),
       :url  => "/vm_cloud/evacuate"
     ) unless @explorer
     @sb[:explorer] = @explorer
     @in_a_form = true
     @evacuate = true
+
+    @evacuate_items = VmOrTemplate.find(session[:evacuate_items]).sort_by(&:name)
+    build_targets_hash(@evacuate_items)
+    @view = get_db_view(VmOrTemplate)
+    @view.table = MiqFilter.records2table(@evacuate_items, @view.cols + ['id'])
+
     render :action => "show" unless @explorer
   end
 
   def evacuatevms
     assert_privileges("instance_evacuate")
-    recs = find_checked_items
+    recs = find_checked_ids_with_rbac(VmOrTemplate)
     recs = [params[:id].to_i] if recs.blank?
-    @record = find_record_with_rbac(VmOrTemplate, recs.first)
-    if @record.supports_evacuate?
-      if @explorer
-        evacuate
-        @refresh_partial = "vm_common/evacuate"
-      else
-        javascript_redirect :controller => 'vm', :action => 'evacuate', :rec_id => @record.id, :escape => false
-      end
+    session[:evacuate_items] = recs
+    if @explorer
+      evacuate
+      @refresh_partial = "vm_common/evacuate"
     else
-      add_flash(_("Unable to evacuate %{instance} \"%{name}\": %{details}") % {
-        :instance => ui_lookup(:table => 'vm_cloud'),
-        :name     => @record.name,
-        :details  => @record.unsupported_reason(:evacuate)}, :error)
+      javascript_redirect :controller => 'vm', :action => 'evacuate', :escape => false
     end
   end
   alias instance_evacuate evacuatevms
 
   def evacuate_vm
     assert_privileges("instance_evacuate")
-    @record = find_record_with_rbac(VmOrTemplate, params[:id])
-
     case params[:button]
     when "cancel"
-      add_flash(_("Evacuation of %{model} \"%{name}\" was cancelled by the user") % {
-        :model => ui_lookup(:table => "vm_cloud"), :name => @record.name})
-      @record = @sb[:action] = nil
+      add_flash(_("Evacuation of %{models} was cancelled by the user") % {
+        :models => ui_lookup(:tables => "vm_cloud")
+      })
     when "submit"
-      if @record.supports_evacuate?
-        if params['auto_select_host'] == 'on'
-          hostname = nil
+      @evacuate_items = VmOrTemplate.find(session[:evacuate_items]).sort_by(&:name)
+      @evacuate_items.each do |vm|
+        if vm.supports_evacuate?
+          options = {
+            :hostname          => params['auto_select_host']  == 'on' ? nil : params['destination_host'],
+            :on_shared_storage => params['on_shared_storage'] == 'on',
+            :admin_password    => params['on_shared_storage'] == 'on' ? nil : params['admin_password']
+          }
+          task_id = vm.class.evacuate_queue(session[:userid], vm, options)
+          unless task_id.kind_of?(Integer)
+            add_flash(_("Instance evacuation task failed."), :error)
+          end
+          add_flash(_("Queued evacuation of Instance \"%{name}\"") % {:name => vm.name})
         else
-          hostname = params[:destination_host]
+          add_flash(_("Unable to evacuate Instance \"%{name}\": %{details}") % {
+            :name    => vm.name,
+            :details => vm.unsupported_reason(:evacuate)
+          }, :error)
         end
-        on_shared_storage = params[:on_shared_storage] == 'on'
-        admin_password = on_shared_storage ? nil : params[:admin_password]
-        begin
-          @record.evacuate_queue(
-            session[:userid],
-            :hostname          => hostname,
-            :on_shared_storage => on_shared_storage,
-            :admin_password    => admin_password
-          )
-          add_flash(_("Evacuating %{instance} \"%{name}\"") % {
-            :instance => ui_lookup(:table => 'vm_cloud'),
-            :name     => @record.name})
-        rescue => ex
-          add_flash(_("Unable to evacuate %{instance} \"%{name}\": %{details}") % {
-            :instance => ui_lookup(:table => 'vm_cloud'),
-            :name     => @record.name,
-            :details  => get_error_message_from_fog(ex)}, :error)
-        end
-      else
-        add_flash(_("Unable to evacuate %{instance} \"%{name}\": %{details}") % {
-          :instance => ui_lookup(:table => 'vm_cloud'),
-          :name     => @record.name,
-          :details  => @record.unsupported_reason(:evacuate)}, :error)
       end
-      params[:id] = @record.id.to_s # reset id in params for show
-      @record = nil
-      @sb[:action] = nil
     end
+    @sb[:action] = nil
     if @sb[:explorer]
       replace_right_cell
     else

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1496,11 +1496,11 @@ module VmCommon
       action = nil
     when "live_migrate"
       partial = "vm_common/live_migrate"
-      header = _("Live Migrating %{model}") % {:name => name, :model => ui_lookup(:tables => table)}
+      header = _("Live Migrating %{models}") % {:models => ui_lookup(:tables => table)}
       action = "live_migrate_vm"
     when "evacuate"
       partial = "vm_common/evacuate"
-      header = _("Evacuating %{model} \"%{name}\"") % {:name => name, :model => ui_lookup(:table => table)}
+      header = _("Evacuating %{models}") % {:models => ui_lookup(:tables => table)}
       action = "evacuate_vm"
     when "associate_floating_ip"
       partial = "vm_common/associate_floating_ip"

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1496,7 +1496,7 @@ module VmCommon
       action = nil
     when "live_migrate"
       partial = "vm_common/live_migrate"
-      header = _("Live Migrating %{model} \"%{name}\"") % {:name => name, :model => ui_lookup(:table => table)}
+      header = _("Live Migrating %{model}") % {:name => name, :model => ui_lookup(:tables => table)}
       action = "live_migrate_vm"
     when "evacuate"
       partial = "vm_common/evacuate"

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -155,7 +155,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
         button(
           :instance_live_migrate,
           'product product-migrate fa-lg',
-          t = N_('Migrate selected Instance'),
+          t = N_('Migrate selected Instances'),
           t,
           :url_parms => 'main_div',
           :enabled   => false,
@@ -163,11 +163,11 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
         button(
           :instance_evacuate,
           'product product-migrate fa-lg',
-          t = N_('Evacuate selected Instance'),
+          t = N_('Evacuate selected Instances'),
           t,
           :url_parms => 'main_div',
           :enabled   => false,
-          :onwhen    => '1')
+          :onwhen    => '1+')
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -159,7 +159,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           t,
           :url_parms => 'main_div',
           :enabled   => false,
-          :onwhen    => '1'),
+          :onwhen    => '1+'),
         button(
           :instance_evacuate,
           'product product-migrate fa-lg',

--- a/app/views/vm_common/_evacuate.html.haml
+++ b/app/views/vm_common/_evacuate.html.haml
@@ -52,7 +52,7 @@
   %hr
   %div
     %h3
-      = n_("1 Instance to be Evacuated", "#{@evacuate_items.length} Instances to be Evacuated", @evacuate_items.length)
+      = n_("1 Instance to be Evacuated", "%{amount} Instances to be Evacuated", @evacuate_items.length) % {:amount => @evacuate_items.length}
     - if @evacuate_items
       - @embedded = true
       - @quadicon_no_url = true

--- a/app/views/vm_common/_evacuate.html.haml
+++ b/app/views/vm_common/_evacuate.html.haml
@@ -48,6 +48,16 @@
                   'paging_div_buttons_state_enabled' => true,
                   'paging_div_buttons_id'            => "angular_paging_div_buttons",
                   'paging_div_buttons_type'          => "Submit"}
+
+  %hr
+  %div
+    %h3
+      = n_("1 Instance to be Evacuated", "#{@evacuate_items.length} Instances to be Evacuated", @evacuate_items.length)
+    - if @evacuate_items
+      - @embedded = true
+      - @quadicon_no_url = true
+      = render :partial => "layouts/gtl"
+
 - unless @explorer
   %table{:width => '100%'}
     %tr
@@ -65,5 +75,5 @@
             :onclick => "miqAjaxButton('#{url_for_only_path(:action => "evacuate_vm", :id => "#{@record.id}", :button => "cancel")}');")
 
 :javascript
-  ManageIQ.angular.app.value('vmCloudEvacuateFormId', '#{@record.id}');
+  ManageIQ.angular.app.value('vmCloudEvacuateFormId', "#{@evacuate_items.length == 1 ? @evacuate_items[0].id : ''}");
   miq_bootstrap('#form_div');

--- a/app/views/vm_common/_live_migrate.html.haml
+++ b/app/views/vm_common/_live_migrate.html.haml
@@ -52,6 +52,16 @@
                   'paging_div_buttons_state_enabled' => true,
                   'paging_div_buttons_id'            => "angular_paging_div_buttons",
                   'paging_div_buttons_type'          => "Submit"}
+
+  %hr
+  %div
+    %h3
+      = n_("1 Instance to be Live Migrated", "#{@live_migrate_items.length} Instances to be Live Migrated", @live_migrate_items.length)
+    - if @live_migrate_items
+      - @embedded = true
+      - @quadicon_no_url = true
+      = render :partial => "layouts/gtl"
+
 - unless @explorer
   %table{:width => '100%'}
     %tr
@@ -71,5 +81,5 @@
 
 
 :javascript
-  ManageIQ.angular.app.value('vmCloudLiveMigrateFormId', '#{@record.id}');
+  ManageIQ.angular.app.value('vmCloudLiveMigrateFormId', "#{@live_migrate_items.length == 1 ? @live_migrate_items[0].id : ''}");
   miq_bootstrap('#form_div');

--- a/app/views/vm_common/_live_migrate.html.haml
+++ b/app/views/vm_common/_live_migrate.html.haml
@@ -56,7 +56,7 @@
   %hr
   %div
     %h3
-      = n_("1 Instance to be Live Migrated", "#{@live_migrate_items.length} Instances to be Live Migrated", @live_migrate_items.length)
+      = n_("1 Instance to be Live Migrated", "%{amount} Instances to be Live Migrated", @live_migrate_items.length) % {:amount => @live_migrate_items.length}
     - if @live_migrate_items
       - @embedded = true
       - @quadicon_no_url = true

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -105,10 +105,10 @@ describe VmCloudController do
       controller.instance_variable_set(:@edit,
                                        :new      => {},
                                        :explorer => false)
+      session[:live_migrate_items] = [vm_openstack.id]
       expect(VmCloud).to receive(:live_migrate_queue)
       post :live_migrate_vm, :params => {
-        :button => 'submit',
-        :id     => vm_openstack.id
+        :button => 'submit'
       }
       expect(response.status).to eq(200)
     end
@@ -129,10 +129,10 @@ describe VmCloudController do
       controller.instance_variable_set(:@edit,
                                        :new      => {},
                                        :explorer => false)
-      expect_any_instance_of(VmCloud).to receive(:evacuate_queue)
+      session[:evacuate_items] = [vm_openstack.id]
+      expect(VmCloud).to receive(:evacuate_queue)
       post :evacuate_vm, :params => {
-        :button => 'submit',
-        :id     => vm_openstack.id
+        :button => 'submit'
       }
       expect(response.status).to eq(200)
     end


### PR DESCRIPTION
Now that https://github.com/ManageIQ/manageiq/pull/14604 has been merged and the backend will send notifications when Live Migrate and Evacuate actions complete, the respective forms can be updated to be fully asynchronous and support acting on multiple instances.

![evacuate_instances](https://cloud.githubusercontent.com/assets/628956/24729894/650ac49a-1a2e-11e7-99c1-ca3e55957ebd.png)
![live_migrates](https://cloud.githubusercontent.com/assets/628956/24729895/650bb454-1a2e-11e7-947a-289ddc2125b5.png)
