### PR TITLE
UI for Embedded Ansible Provider refresh

### DIFF
--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -8,6 +8,7 @@ class AnsibleCredentialController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
+  include Mixins::EmbeddedAnsibleRefreshMixin
 
   menu_section :ansible_credentials
   toolbar :ansible_credential
@@ -48,6 +49,11 @@ class AnsibleCredentialController < ApplicationController
                     :url  => "/ansible_credential/edit/#{params[:id]}")
     @in_a_form = true
     @id = auth.id
+  end
+
+  def credential_refresh
+    # Targeted refresh for embedded ansible hasn't been implemented yet
+    embedded_ansible_refresh
   end
 
   private

--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -8,6 +8,7 @@ class AnsibleRepositoryController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
+  include Mixins::EmbeddedAnsibleRefreshMixin
 
   menu_section :ansible_repositories
   toolbar :ansible_repository
@@ -73,6 +74,11 @@ class AnsibleRepositoryController < ApplicationController
 
   def display_playbooks
     nested_list("ansible_playbook", ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook)
+  end
+
+  def repository_refresh
+    # Targeted refresh for embedded ansible hasn't been implemented yet
+    embedded_ansible_refresh
   end
 
   private

--- a/app/controllers/mixins/embedded_ansible_refresh_mixin.rb
+++ b/app/controllers/mixins/embedded_ansible_refresh_mixin.rb
@@ -1,0 +1,15 @@
+module Mixins
+  module EmbeddedAnsibleRefreshMixin
+    def embedded_ansible_refresh
+      begin
+        embedded_ansible = ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first
+        ManageIQ::Providers::EmbeddedAnsible::AutomationManager.refresh_ems([embedded_ansible.id])
+        add_flash(_("Embedded Ansible Provider refresh has been successfully initiated"))
+      rescue => ex
+        add_flash(_("An error occurred while initiating Embedded Ansible Provider refresh: %{error}") % {:error => ex}, :error)
+      end
+      session[:flash_msgs] = @flash_array
+      javascript_redirect :action => 'show_list'
+    end
+  end
+end

--- a/app/helpers/application_helper/toolbar/ansible_credentials_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_credentials_center.rb
@@ -6,6 +6,17 @@ class ApplicationHelper::Toolbar::AnsibleCredentialsCenter < ApplicationHelper::
       t = N_('Configuration'),
       t,
       :items => [
+       button(
+          :embedded_automation_manager_credentials_refresh,
+          'fa fa-refresh fa-lg',
+          N_('Refresh Embedded Ansible Provider'),
+          N_('Refresh Embedded Ansible Provider'),
+          :klass => ApplicationHelper::Button::EmbeddedAnsible,
+          :url       => "credential_refresh",
+          :url_parms => "main_div",
+          :confirm   => N_("Refresh relationships for all items from Embedded Ansible Provider?"),
+          :enabled   => true),
+        separator,
         button(
           :embedded_automation_manager_credentials_add,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
@@ -7,6 +7,17 @@ class ApplicationHelper::Toolbar::AnsibleRepositoriesCenter < ApplicationHelper:
       t,
       :items => [
         button(
+          :embedded_configuration_script_source_refresh,
+          'fa fa-refresh fa-lg',
+          N_('Refresh Embedded Ansible Provider'),
+          N_('Refresh Embedded Ansible Provider'),
+          :klass => ApplicationHelper::Button::EmbeddedAnsible,
+          :url       => "repository_refresh",
+          :url_parms => "main_div",
+          :confirm   => N_("Refresh relationships for all items from Embedded Ansible Provider?"),
+          :enabled   => true),
+        separator,
+        button(
           :embedded_configuration_script_source_add,
           'pficon pficon-edit fa-lg',
           t = N_('Add New Repository'),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2025,6 +2025,7 @@ Rails.application.routes.draw do
       ),
       :post => %w(
         button
+        credential_refresh
         show_list
       )
     },
@@ -2053,6 +2054,7 @@ Rails.application.routes.draw do
         button
         edit
         new
+        repository_refresh
         show_list
       )
     },


### PR DESCRIPTION
Embedded Ansible refresh (non-targeted) has been added into toolbars for
Ansible Credentials and Repositories.

Backend PR: https://github.com/ManageIQ/manageiq/pull/14664

![ansible-refresh-01](https://cloud.githubusercontent.com/assets/6648365/24749885/0ad5016a-1ac5-11e7-97e2-92e8240e527d.jpg)
![ansible-refresh-02](https://cloud.githubusercontent.com/assets/6648365/24749886/0adb87e2-1ac5-11e7-82a4-7d04b9b3a57e.jpg)


https://bugzilla.redhat.com/show_bug.cgi?id=1436982