### PR TITLE
Remove the *TopologyApplication angular modules

### DIFF
--- a/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
@@ -1,8 +1,4 @@
-/* global miqHttpInject */
-
-miqHttpInject(angular.module('cloudTopologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
-.controller('cloudTopologyController', CloudTopologyCtrl);
-
+angular.module('ManageIQ').controller('cloudTopologyController', CloudTopologyCtrl);
 CloudTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
 
 function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {

--- a/app/assets/javascripts/controllers/topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/container_topology_controller.js
@@ -1,8 +1,4 @@
-/* global miqHttpInject */
-
-miqHttpInject(angular.module('containerTopologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
-.controller('containerTopologyController', ContainerTopologyCtrl);
-
+angular.module('ManageIQ').controller('containerTopologyController', ContainerTopologyCtrl);
 ContainerTopologyCtrl.$inject = ['$scope', '$http', '$interval', 'topologyService', '$window', 'miqService'];
 
 function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $window, miqService) {

--- a/app/assets/javascripts/controllers/topology/infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/infra_topology_controller.js
@@ -1,8 +1,4 @@
-/* global miqHttpInject */
-
-miqHttpInject(angular.module('infraTopologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
-.controller('infraTopologyController', InfraTopologyCtrl);
-
+angular.module('ManageIQ').controller('infraTopologyController', InfraTopologyCtrl);
 InfraTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
 
 function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {

--- a/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
@@ -1,7 +1,4 @@
-/* global miqHttpInject */
-miqHttpInject(angular.module('mwTopologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
-  .controller('middlewareTopologyController', MiddlewareTopologyCtrl);
-
+angular.module('ManageIQ').controller('middlewareTopologyController', MiddlewareTopologyCtrl);
 MiddlewareTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
 
 function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {

--- a/app/assets/javascripts/controllers/topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/network_topology_controller.js
@@ -1,8 +1,4 @@
-/* global miqHttpInject */
-
-miqHttpInject(angular.module('netTopologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
-.controller('networkTopologyController', NetworkTopologyCtrl);
-
+angular.module('ManageIQ').controller('networkTopologyController', NetworkTopologyCtrl);
 NetworkTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
 
 function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {

--- a/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
@@ -1,8 +1,4 @@
-/* global miqHttpInject */
-
-miqHttpInject(angular.module('physicalInfraTopologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
-  .controller('physicalInfraTopologyController', physicalInfraTopologyCtrl);
-
+angular.module('ManageIQ').controller('physicalInfraTopologyController', physicalInfraTopologyCtrl);
 physicalInfraTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
 
 function physicalInfraTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -8,6 +8,7 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'miq.api',
   'miq.card',
   'miq.util',
+  'kubernetesUI',
 ]);
 miqHttpInject(ManageIQ.angular.app);
 

--- a/app/views/cloud_topology/show.html.haml
+++ b/app/views/cloud_topology/show.html.haml
@@ -48,4 +48,4 @@
   %kubernetes-topology-graph{:items => "items", :relations => "relations", :kinds => "kinds"}
 
 :javascript
-  miq_bootstrap('.topology', 'cloudTopologyApp');
+  miq_bootstrap('.topology');

--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -77,4 +77,4 @@
   %kubernetes-topology-graph{:items => "items", :relations => "relations", :kinds => "kinds"}
 
 :javascript
-  miq_bootstrap('.topology', 'containerTopologyApp');
+  miq_bootstrap('.topology');

--- a/app/views/infra_topology/show.html.haml
+++ b/app/views/infra_topology/show.html.haml
@@ -48,4 +48,4 @@
   %kubernetes-topology-graph{:items => "items", :relations => "relations", :kinds => "kinds"}
 
 :javascript
-  miq_bootstrap('.topology', 'infraTopologyApp');
+  miq_bootstrap('.topology');

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -69,4 +69,4 @@
   %kubernetes-topology-graph.middleware{:items => "items", :relations => "relations", :kinds => "kinds"}
 
 :javascript
-  miq_bootstrap('.topology', 'mwTopologyApp');
+  miq_bootstrap('.topology');

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -96,4 +96,4 @@
   %kubernetes-topology-graph{:items => "items", :relations => "relations", :kinds => "kinds"}
 
 :javascript
-  miq_bootstrap('.topology', 'netTopologyApp');
+  miq_bootstrap('.topology');

--- a/app/views/physical_infra_topology/show.html.haml
+++ b/app/views/physical_infra_topology/show.html.haml
@@ -24,4 +24,4 @@
   %kubernetes-topology-graph{:items => "items", :relations => "relations", :kinds => "kinds"}
 
 :javascript
-  miq_bootstrap('.topology', 'physicalInfraTopologyApp');
+  miq_bootstrap('.topology');

--- a/spec/javascripts/controllers/cloud/cloud_topology_controller_spec.js
+++ b/spec/javascripts/controllers/cloud/cloud_topology_controller_spec.js
@@ -4,7 +4,7 @@ describe('cloudTopologyController', function() {
     var cloud_tenant = { id:"396086e5-7b0d-11e5-8286-18037327aaeb",  item:{display_kind:"CloudTenant", name:"admin", kind:"CloudTenant", id:"396086e5-7b0d-11e5-8286-18037327aaeb", miq_id:"100012"}};
     var cloud_provider = { id:"4",  item:{display_kind:"Openstack", name:"myProvider", kind:"CloudManager", id:"2", miq_id:"2"}};
 
-    beforeEach(module('cloudTopologyApp'));
+    beforeEach(module('ManageIQ'));
 
     beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, $location) {
       spyOn($location, 'absUrl').and.returnValue('/network_topology/show');

--- a/spec/javascripts/controllers/containers/container_topology_controller_spec.js
+++ b/spec/javascripts/controllers/containers/container_topology_controller_spec.js
@@ -6,7 +6,7 @@ describe('containerTopologyController', function() {
     var vm = { id:"4",  item:{display_kind:"VM", kind:"Vm", id:"4", miq_id:"25"}};
     var pod = { id:"3",  item:{display_kind:"Pod", kind:"ContainerGroup", id:"3"}};
 
-    beforeEach(module('containerTopologyApp'));
+    beforeEach(module('ManageIQ'));
 
     beforeEach(function() {
       var $window = {location: { pathname: '/ems_container/1' }};

--- a/spec/javascripts/controllers/infra/infra_topology_controller_spec.js
+++ b/spec/javascripts/controllers/infra/infra_topology_controller_spec.js
@@ -4,7 +4,7 @@ describe('infraTopologyController', function() {
     var cluster = { id:"396086e5-7b0d-11e5-8286-18037327aaeb",  item:{display_kind:"EmsCluster", name:"overcloud-Compute-xr5gaw2saehi", kind:"EmsCluster", id:"396086e5-7b0d-11e5-8286-18037327aaeb", miq_id:"100012"}};
     var infra_provider = { id:"4",  item:{display_kind:"Openstack", name:"myProvider", kind:"InfraManager", id:"2", miq_id:"2"}};
 
-    beforeEach(module('infraTopologyApp'));
+    beforeEach(module('ManageIQ'));
 
     beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, $location) {
       spyOn($location, 'absUrl').and.returnValue('/infra_topology/show');

--- a/spec/javascripts/controllers/middleware/middleware_topology_controller_spec.js
+++ b/spec/javascripts/controllers/middleware/middleware_topology_controller_spec.js
@@ -90,7 +90,7 @@ describe('middlewareTopologyController', function () {
     }
   };
 
-  beforeEach(module('mwTopologyApp'));
+  beforeEach(module('ManageIQ'));
 
   beforeEach(inject(function (_$httpBackend_, $rootScope, _$controller_, $location) {
     spyOn($location, 'absUrl').and.returnValue('/middleware_topology/show');

--- a/spec/javascripts/controllers/network/network_topology_controller_spec.js
+++ b/spec/javascripts/controllers/network/network_topology_controller_spec.js
@@ -4,7 +4,7 @@ describe('networkTopologyController', function() {
     var cloud_subnet = { id:"396086e5-7b0d-11e5-8286-18037327aaeb",  item:{display_kind:"CloudSubnet", name:"EmsRefreshSpec-SubnetPrivate_3000", kind:"CloudSubnet", id:"396086e5-7b0d-11e5-8286-18037327aaeb", miq_id:"100012"}};
     var network_provider = { id:"4",  item:{display_kind:"Openstack", name:"myProvider", kind:"NetworkManager", id:"2", miq_id:"2"}};
 
-    beforeEach(module('netTopologyApp'));
+    beforeEach(module('ManageIQ'));
 
     beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, $location) {
       spyOn($location, 'absUrl').and.returnValue('/network_topology/show');


### PR DESCRIPTION
@himdel told me that we actually don't need any [royal navies](https://github.com/ManageIQ/manageiq-ui-classic/pull/932), so I'm retiring them and using a diplomatic solution (the `ManageIQ` module) instead.

Pivotal story: https://www.pivotaltracker.com/story/show/143239019