### PR TITLE
Replace start_form_div with ng-cloak

### DIFF
--- a/app/assets/javascripts/directives/start_form_div.js
+++ b/app/assets/javascripts/directives/start_form_div.js
@@ -1,9 +1,0 @@
-ManageIQ.angular.app.directive('startFormDiv', ['$timeout', function($timeout) {
-  return {
-    link: function(scope, _elem, attr) {
-      $timeout(function () {
-        angular.element('#' + attr.startFormDiv).show();
-      });
-    },
-  };
-}]);

--- a/app/views/auth_key_pair_cloud/_form.html.haml
+++ b/app/views/auth_key_pair_cloud/_form.html.haml
@@ -3,10 +3,11 @@
   %br
   %br
 
-.form-horizontal{:id => 'start_form_div', :style => 'display:none'}
+.form-horizontal
   %form#form_div{:name           => 'angularForm',
                  'ng-controller' => 'keyPairCloudFormController',
                  'ng-show'       => 'afterGet',
+                 'ng-cloak'      => '',
                  :novalidate     => true}
     = render :partial => 'layouts/flash_msg'
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
@@ -20,8 +21,7 @@
                             :maxlength       => MAX_NAME_LEN,
                             :required        => true,
                             :checkchange     => '',
-                            'auto-focus'     => true,
-                            'start-form-div' => 'start_form_div'}
+                            'auto-focus'     => true}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
     .form-group

--- a/app/views/automation_manager/_form.html.haml
+++ b/app/views/automation_manager/_form.html.haml
@@ -1,9 +1,10 @@
 - @angular_form = true
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
+.form-horizontal
   %form#form_div{:name           => "angularForm",
                  'ng-controller' => "automationManagerFormController",
                  'ng-show'       => "afterGet",
+                 'ng-cloak'      => '',
                  :novalidate     => true}
     = render :partial => "layouts/flash_msg"
     %br
@@ -17,8 +18,7 @@
                             :maxlength       => MAX_NAME_LEN,
                             :required        => "",
                             :checkchange     => true,
-                            "auto-focus"     => "",
-                            "start-form-div" => "start_form_div"}
+                            "auto-focus"     => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
 

--- a/app/views/configuration/_timeprofile_form.html.haml
+++ b/app/views/configuration/_timeprofile_form.html.haml
@@ -3,15 +3,14 @@
   %br
   %br
 
-%form.form-horizontal#form_div{:name            => "angularForm",
-                               'ng-controller'  => "timeProfileFormController as vm",
-                               "miq-form"       => true,
-                               'ng-show'        => "vm.afterGet",
-                               "model"          => "vm.timeProfileModel",
-                               "model-copy"     => 'vm.modelCopy',
-                               :novalidate      => true,
-                               :style           => 'display: none',
-                               "start-form-div" => "form_div"}
+%form.form-horizontal#form_div{:name           => "angularForm",
+                               'ng-controller' => "timeProfileFormController as vm",
+                               "miq-form"      => true,
+                               'ng-show'       => "vm.afterGet",
+                               'ng-cloak'      => "",
+                               "model"         => "vm.timeProfileModel",
+                               "model-copy"    => 'vm.modelCopy',
+                               :novalidate     => true}
   = render :partial => "layouts/flash_msg"
   .form-group{"ng-class" => "{'has-error': angularForm.description.$invalid}"}
     %label.col-md-2.control-label{"for" => "description"}

--- a/app/views/ems_container/_form.html.haml
+++ b/app/views/ems_container/_form.html.haml
@@ -1,21 +1,21 @@
 - @angular_form = true
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
+.form-horizontal{'ng-cloak' => '',
+                 'ng-show'  => 'afterGet'}
   = render :partial => "layouts/flash_msg"
   %div
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_name"}
         = _('Name')
       .col-md-4
-        %input.form-control{"type"           => "text",
-                            "id"             => "ems_name",
-                            "name"           => "name",
-                            "ng-model"       => "emsCommonModel.name",
-                            "maxlength"      => MAX_NAME_LEN,
-                            "required"       => "",
-                            "checkchange"    => "",
-                            "auto-focus"     => "",
-                            "start-form-div" => "start_form_div"}
+        %input.form-control{"type"        => "text",
+                            "id"          => "ems_name",
+                            "name"        => "name",
+                            "ng-model"    => "emsCommonModel.name",
+                            "maxlength"   => MAX_NAME_LEN,
+                            "required"    => "",
+                            "checkchange" => "",
+                            "auto-focus"  => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
 

--- a/app/views/ems_datawarehouse/_form.html.haml
+++ b/app/views/ems_datawarehouse/_form.html.haml
@@ -1,21 +1,22 @@
 - @angular_form = true
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
+.form-horizontal
   = render :partial => "layouts/flash_msg"
   %div
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_name"}
         = _('Name')
       .col-md-8
-        %input.form-control{"type"           => "text",
-                            "id"             => "ems_name",
-                            "name"           => "name",
-                            "ng-model"       => "emsCommonModel.name",
-                            "maxlength"      => MAX_NAME_LEN.to_s,
-                            "required"       => "",
-                            "checkchange"    => "",
-                            "auto-focus"     => "",
-                            "start-form-div" => "start_form_div"}
+        %input.form-control{"type"        => "text",
+                            "id"          => "ems_name",
+                            "name"        => "name",
+                            "ng-model"    => "emsCommonModel.name",
+                            "maxlength"   => MAX_NAME_LEN.to_s,
+                            "required"    => "",
+                            "checkchange" => "",
+                            "auto-focus"  => "",
+                            'ng-cloak'    => '',
+                            'ng-show'     => 'afterGet'}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
 

--- a/app/views/ems_infra/_form.html.haml
+++ b/app/views/ems_infra/_form.html.haml
@@ -1,21 +1,21 @@
 - @angular_form = true
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
+.form-horizontal{'ng-cloak' => '',
+                 'ng-show'  => 'afterGet'}
   = render :partial => "layouts/flash_msg"
   %div
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_name"}
         = _('Name')
       .col-md-4
-        %input.form-control{"type"           => "text",
-                            "id"             => "ems_name",
-                            "name"           => "name",
-                            "ng-model"       => "emsCommonModel.name",
-                            "maxlength"      => "#{MAX_NAME_LEN}",
-                            "required"       => "",
-                            "checkchange"    => "",
-                            "auto-focus"     => "",
-                            "start-form-div" => "start_form_div"}
+        %input.form-control{"type"        => "text",
+                            "id"          => "ems_name",
+                            "name"        => "name",
+                            "ng-model"    => "emsCommonModel.name",
+                            "maxlength"   => "#{MAX_NAME_LEN}",
+                            "required"    => "",
+                            "checkchange" => "",
+                            "auto-focus"  => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
 

--- a/app/views/ems_middleware/_form.html.haml
+++ b/app/views/ems_middleware/_form.html.haml
@@ -1,21 +1,21 @@
 - @angular_form = true
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
+.form-horizontal{'ng-cloak' => '',
+                 'ng-show'  => 'afterGet'}
   = render :partial => "layouts/flash_msg"
   %div
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_name"}
         = _('Name')
       .col-md-8
-        %input.form-control{"type"           => "text",
-                            "id"             => "ems_name",
-                            "name"           => "name",
-                            "ng-model"       => "emsCommonModel.name",
-                            "maxlength"      => "#{MAX_NAME_LEN}",
-                            "required"       => "",
-                            "checkchange"    => "",
-                            "auto-focus"     => "",
-                            "start-form-div" => "start_form_div"}
+        %input.form-control{"type"        => "text",
+                            "id"          => "ems_name",
+                            "name"        => "name",
+                            "ng-model"    => "emsCommonModel.name",
+                            "maxlength"   => "#{MAX_NAME_LEN}",
+                            "required"    => "",
+                            "checkchange" => "",
+                            "auto-focus"  => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
 

--- a/app/views/ems_physical_infra/_form.html.haml
+++ b/app/views/ems_physical_infra/_form.html.haml
@@ -1,21 +1,21 @@
 - @angular_form = true
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
+.form-horizontal{'ng-cloak' => '',
+                 'ng-show'  => 'afterGet'}
   = render :partial => "layouts/flash_msg"
   %div
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_name"}
         = _('Name')
       .col-md-8
-        %input.form-control{"type"           => "text",
-                            "id"             => "ems_name",
-                            "name"           => "name",
-                            "ng-model"       => "emsCommonModel.name",
-                            "maxlength"      => "#{MAX_NAME_LEN}",
-                            "required"       => "",
-                            "checkchange"    => "",
-                            "auto-focus"     => "",
-                            "start-form-div" => "start_form_div"}
+        %input.form-control{"type"        => "text",
+                            "id"          => "ems_name",
+                            "name"        => "name",
+                            "ng-model"    => "emsCommonModel.name",
+                            "maxlength"   => "#{MAX_NAME_LEN}",
+                            "required"    => "",
+                            "checkchange" => "",
+                            "auto-focus"  => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
 

--- a/app/views/host/_form.html.haml
+++ b/app/views/host/_form.html.haml
@@ -1,14 +1,14 @@
 - @angular_form = true
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
+.form-horizontal
   %form#form_div{"name"            => "angularForm",
                  "ng-controller"   => "hostFormController",
+                 'ng-cloak'        => '',
                  "ng-show"         => "afterGet",
                  "form-fields-url" => "/#{controller_name}/host_form_fields/",
                  "create-url"      => "/#{controller_name}/create/",
                  "update-url"      => "/#{controller_name}/update/",
-                 "novalidate"      => true,
-                 "start-form-div"  => "start_form_div"}
+                 "novalidate"      => true}
     = render :partial => "layouts/flash_msg"
     - if session[:host_items].nil?
       %div
@@ -17,14 +17,14 @@
             %label.col-md-2.control-label{"for" => "name"}
               = _("Name")
             .col-md-8
-              %input.form-control{"type"           => "text",
-                                  "id"             => "name",
-                                  "name"           => "name",
-                                  "ng-model"       => "hostModel.name",
-                                  "maxlength"      => "#{MAX_NAME_LEN}",
-                                  "miqrequired"    => "",
-                                  "checkchange"    => "",
-                                  "auto-focus"     => ""}
+              %input.form-control{"type"        => "text",
+                                  "id"          => "name",
+                                  "name"        => "name",
+                                  "ng-model"    => "hostModel.name",
+                                  "maxlength"   => "#{MAX_NAME_LEN}",
+                                  "miqrequired" => "",
+                                  "checkchange" => "",
+                                  "auto-focus"  => ""}
               %span.help-block{"ng-show" => "angularForm.name.$error.miqrequired"}
                 = _("Required")
           .form-group{"ng-class" => "{'has-error': angularForm.hostname.$invalid}"}

--- a/app/views/ops/_schedule_form.html.haml
+++ b/app/views/ops/_schedule_form.html.haml
@@ -1,8 +1,9 @@
 - @angular_form = true
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
+.form-horizontal
   %form#form_div{"name"          => "angularForm",
                  "ng-controller" => "scheduleFormController",
+                 'ng-cloak'      => '',
                  "ng-show"       => "afterGet"}
     = render :partial => "layouts/flash_msg"
     %div
@@ -11,15 +12,14 @@
           %label.col-md-2.control-label{"for" => "name"}
             = _("Name")
           .col-md-8
-            %input.form-control{"type"           => "text",
-                                "id"             => "name",
-                                "name"           => "name",
-                                "ng-model"       => "scheduleModel.name",
-                                "maxlength"      => "#{MAX_NAME_LEN}",
-                                "miqrequired"    => "",
-                                "checkchange"    => "",
-                                "auto-focus"     => "",
-                                "start-form-div" => "start_form_div"}
+            %input.form-control{"type"        => "text",
+                                "id"          => "name",
+                                "name"        => "name",
+                                "ng-model"    => "scheduleModel.name",
+                                "maxlength"   => "#{MAX_NAME_LEN}",
+                                "miqrequired" => "",
+                                "checkchange" => "",
+                                "auto-focus"  => ""}
             %span.help-block{"ng-show" => "angularForm.name.$error.miqrequired"}
               = _("Required")
         .form-group{"ng-class" => "{'has-error': angularForm.description.$invalid}"}

--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -1,8 +1,9 @@
 - @angular_form = true
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
+.form-horizontal
   %form#form_div{:name           => "angularForm",
                  'ng-controller' => "providerForemanFormController as vm",
+                 'ng-cloak'      => '',
                  'ng-show'       => "vm.afterGet",
                  "miq-form"      => true,
                  "model"         => "vm.providerForemanModel",
@@ -14,14 +15,13 @@
       %label.col-md-2.control-label
         = _("Name")
       .col-md-8
-        %input.form-control{:type            => "text",
-                            :name            => "name",
-                            'ng-model'       => "vm.providerForemanModel.name",
-                            :maxlength       => MAX_NAME_LEN,
-                            :required        => "",
-                            :checkchange     => true,
-                            "auto-focus"     => "",
-                            "start-form-div" => "start_form_div"}
+        %input.form-control{:type        => "text",
+                            :name        => "name",
+                            'ng-model'   => "vm.providerForemanModel.name",
+                            :maxlength   => MAX_NAME_LEN,
+                            :required    => "",
+                            :checkchange => true,
+                            "auto-focus" => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
 

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -1,21 +1,21 @@
 - @angular_form = true
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
+.form-horizontal{'ng-cloak' => '',
+                 'ng-show'  => 'afterGet'}
   = render :partial => "layouts/flash_msg"
   %div
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_name"}
         = _('Name')
       .col-md-4
-        %input.form-control{"type"           => "text",
-                            "id"             => "ems_name",
-                            "name"           => "name",
-                            "ng-model"       => "emsCommonModel.name",
-                            "maxlength"      => "#{MAX_NAME_LEN}",
-                            "required"       => "",
-                            "checkchange"    => "",
-                            "auto-focus"     => "",
-                            "start-form-div" => "start_form_div"}
+        %input.form-control{"type"        => "text",
+                            "id"          => "ems_name",
+                            "name"        => "name",
+                            "ng-model"    => "emsCommonModel.name",
+                            "maxlength"   => "#{MAX_NAME_LEN}",
+                            "required"    => "",
+                            "checkchange" => "",
+                            "auto-focus"  => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
 


### PR DESCRIPTION
Instead of using custom start-form-div uses ng-cloak and ng-show to prevent flickering of a form.

@miq-bot add_label angular dialogs, refactoring

@himdel please review :)