### PR TITLE
Fix Add Datasource via existing driver Issue

### DIFF
--- a/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
+++ b/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
@@ -23,9 +23,6 @@ function MwAddDatasourceCtrl($scope, $rootScope, miqService, mwAddDatasourceServ
       'driverClass': vm.step2DsModel.driverClass,
       'datasourceProperties': dsPropsHash(vm.step3DsModel.dsProps),
       'connectionUrl': vm.step3DsModel.connectionUrl,
-      'userName': vm.step3DsModel.userName,
-      'password': vm.step3DsModel.password,
-      'securityDomain': vm.step3DsModel.securityDomain,
     };
   };
 
@@ -74,6 +71,20 @@ function MwAddDatasourceCtrl($scope, $rootScope, miqService, mwAddDatasourceServ
           driverClass: '',
         });
     }
+    if (vm.step3DsModel.userName !== '' && vm.step3DsModel.password !== '') {
+      angular.extend(payload,
+        {
+          userName: vm.step3DsModel.userName,
+          password: vm.step3DsModel.password,
+        });
+    }
+    if (vm.step3DsModel.securityDomain !== '') {
+      angular.extend(payload,
+        {
+          securityDomain: vm.step3DsModel.securityDomain,
+        });
+    }
+
     mwAddDatasourceService.sendAddDatasource(payload).then(
       function(result) { // success
         miqService.miqFlash(result.data.status, result.data.msg);
@@ -125,17 +136,17 @@ function MwAddDatasourceCtrl($scope, $rootScope, miqService, mwAddDatasourceServ
     vm.step2DsModel.driverClass = dsSelection.driverClass;
 
     mwAddDatasourceService.getExistingJdbcDrivers(serverId).then(function(result) {
-      var filteredResult;
+      var filteredDrivers;
       if (vm.chooseDsModel.xaDatasource) {
-        filteredResult = _.filter(result, function(item) {
+        filteredDrivers = _.filter(result, function(item) {
           return item.xaDsClass != null;
         });
       } else {
-        filteredResult = _.filter(result, function(item) {
+        filteredDrivers = _.filter(result, function(item) {
           return item.driverClass != null;
         });
       }
-      vm.step2DsModel.existingJdbcDrivers = filteredResult;
+      vm.step2DsModel.existingJdbcDrivers = filteredDrivers;
     }).catch(function(errorMsg) {
       miqService.miqFlash(errorMsg.data.status, errorMsg.data.msg);
     });

--- a/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
+++ b/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
@@ -97,15 +97,13 @@ function MwAddDatasourceCtrl($scope, $rootScope, miqService, mwAddDatasourceServ
   });
 
   $scope.$watch('vm.step2DsModel.selectedJdbcDriver', function(driverSelection) {
-    var dsSelection = mwAddDatasourceService.findDsSelectionFromDriver(driverSelection);
-    if (dsSelection) {
-      vm.step1DsModel.datasourceName = dsSelection.name;
-      vm.step1DsModel.jndiName = dsSelection.jndiName;
-      vm.step2DsModel.jdbcDriverName = dsSelection.driverName;
-      vm.step3DsModel.connectionUrl = '';
+    if (driverSelection) {
+      vm.step1DsModel.datasourceName = driverSelection.id;
+      vm.step2DsModel.jdbcDriverName = driverSelection.label;
+      vm.step2DsModel.jdbcModuleName = driverSelection.moduleName;
     }
     if (mwAddDatasourceService.isXaDriver(driverSelection)) {
-      vm.step2DsModel.xaDsClass = driverSelection.xaDsClass;
+      vm.step2DsModel.driverClass = driverSelection.xaDsClass;
     } else {
       vm.step2DsModel.driverClass = driverSelection.driverClass;
     }
@@ -135,21 +133,22 @@ function MwAddDatasourceCtrl($scope, $rootScope, miqService, mwAddDatasourceServ
     vm.step2DsModel.jdbcModuleName = dsSelection.driverModuleName;
     vm.step2DsModel.driverClass = dsSelection.driverClass;
 
-    mwAddDatasourceService.getExistingJdbcDrivers(serverId).then(function(result) {
-      var filteredDrivers;
-      if (vm.chooseDsModel.xaDatasource) {
-        filteredDrivers = _.filter(result, function(item) {
-          return item.xaDsClass != null;
-        });
-      } else {
-        filteredDrivers = _.filter(result, function(item) {
-          return item.driverClass != null;
-        });
-      }
-      vm.step2DsModel.existingJdbcDrivers = filteredDrivers;
+    mwAddDatasourceService.getExistingJdbcDrivers(serverId).then(function(drivers) {
+      vm.step2DsModel.existingJdbcDrivers = vm.filterXa(vm.chooseDsModel.xaDatasource, drivers);
     }).catch(function(errorMsg) {
       miqService.miqFlash(errorMsg.data.status, errorMsg.data.msg);
     });
+  };
+
+  vm.filterXa = function(isXa, drivers) {
+    var filteredDrivers;
+
+    if (isXa) {
+      filteredDrivers = _.filter(drivers, function(driver) { return driver.xaDsClass != null; });
+    } else {
+      filteredDrivers = _.filter(drivers, function(driver) { return driver.driverClass != null; });
+    }
+    return filteredDrivers;
   };
 
   vm.addDatasourceStep1Back = function() {

--- a/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_service.js
+++ b/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_service.js
@@ -119,6 +119,7 @@ function MwAddDatasourceService($http, $q) {
         .map(function(driver) {
           return {'id': driver.properties['Driver Name'].toUpperCase(),
                   'label': driver.properties['Driver Name'],
+                  'moduleName': driver.properties['Module Name'],
                   'xaDsClass': driver.properties['XA DS Class'],
                   'driverClass': driver.properties['Driver Class']};
       })


### PR DESCRIPTION
This fixes an issue where the JDBC Driver for existing drivers that was not pulling the data from the WildFly/EAP server but instead, incorrectly from defaults. So it would always try to create the datasource using the **default name** (like 'h2') instead of the **custom name** returned from the Wildfly server. Another issue, where username/password/securityDomain was empty it would send them as empty strings to the server instead of not sending them at all.

![ds-add-fail mov](https://cloud.githubusercontent.com/assets/1312165/24872450/5b8d1a92-1dd2-11e7-956c-1c8cdf36e95a.gif)


### Links

- https://bugzilla.redhat.com/show_bug.cgi?id=1427141

### Testing Instructions
As this is an asynchronous operation, the best way to test this is to monitor the logs of the WildFly/EAP server and make sure there are no errors during Datasource creation. *Running the Hawkular Agent in debug logging mode helps if there are issues*
