### PR TITLE
Option to repeat redeploying existing deployment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
   "extends": [],
 
   "globals": {
+    "sendDataWithRx": false,
     "vanillaJsAPI": false, // local: miq_api.js
     "ManageIQ": false, // local: mig_global.js
     "Promise": false, // bower: es6-shim

--- a/app/assets/javascripts/controllers/middleware_deployment/middleware_deployment_controller.js
+++ b/app/assets/javascripts/controllers/middleware_deployment/middleware_deployment_controller.js
@@ -20,16 +20,23 @@ function MwAddDeploymentController($scope, $http, miqService) {
     })
       .then(
         function(result) { // success
+          if (result.data.error_type === 'EXISTS') {
+            sendDataWithRx({
+              type: 'mwReloadDeployDialog',
+              msg: result.data.msg
+            });
+          } else {
+            angular.element("#modal_d_div").modal('hide');
+          }
           miqService.miqFlash(result.data.status, result.data.msg);
+          miqService.sparkleOff();
         },
         function() { // error
           var msg = sprintf(__('Unable to deploy %s on this server %s"'), data.runtimeName,
               (isGroupDeployment ? ' group.' : '.'));
           miqService.miqFlash('error', msg);
-        })
-      .finally(function() {
-        angular.element("#modal_d_div").modal('hide');
-        miqService.sparkleOff();
-      });
+          angular.element("#modal_d_div").modal('hide');
+          miqService.sparkleOff();
+        });
   });
 }

--- a/app/assets/javascripts/controllers/middleware_deployment/middleware_deployment_controller.js
+++ b/app/assets/javascripts/controllers/middleware_deployment/middleware_deployment_controller.js
@@ -20,7 +20,7 @@ function MwAddDeploymentController($scope, $http, miqService) {
     })
       .then(
         function(result) { // success
-          if (result.data.error_type === 'EXISTS') {
+          if (result.data.error_type === miqService.deploymentExists) {
             sendDataWithRx({
               type: 'mwReloadDeployDialog',
               msg: result.data.msg
@@ -29,14 +29,15 @@ function MwAddDeploymentController($scope, $http, miqService) {
             angular.element("#modal_d_div").modal('hide');
           }
           miqService.miqFlash(result.data.status, result.data.msg);
-          miqService.sparkleOff();
         },
         function() { // error
-          var msg = sprintf(__('Unable to deploy %s on this server %s"'), data.runtimeName,
+          var msg = sprintf(__('Unable to deploy %s on this server %s'), data.runtimeName,
               (isGroupDeployment ? ' group.' : '.'));
           miqService.miqFlash('error', msg);
           angular.element("#modal_d_div").modal('hide');
-          miqService.sparkleOff();
-        });
+        })
+      .finally(function() {
+        miqService.sparkleOff();
+      });
   });
 }

--- a/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
+++ b/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
@@ -53,6 +53,11 @@ function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, i
       $scope.paramsModel.timeout = timeout;
       $scope.$apply();
     }
+
+    if (eventType === 'mwReloadDeployDialog') {
+      $scope.warnMsg = event.msg;
+      $scope.$apply();
+    }
   });
 
   // //////////////////////////////////////////////////////////////////////
@@ -94,6 +99,7 @@ function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, i
     $scope.deployAddModel.forceDeploy = false;
     $scope.deployAddModel.runtimeName = undefined;
     $scope.deployAddModel.filePath = undefined;
+    $scope.warnMsg = undefined;
     angular.element('#deploy_div :file#upload_file').val('');
     angular.element('#deploy_div input[type="text"]:disabled').val('');
   };
@@ -238,4 +244,3 @@ function ServerOpsServiceFactory($http, $q, isGroup) {
     runOperation: runOperation,
   };
 }
-

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -4,6 +4,7 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', funct
   var miqService = this;
 
   this.storedPasswordPlaceholder = "●●●●●●●●";
+  this.deploymentExists = 'EXISTS';
 
   this.showButtons = function() {
     miqButtons('show');

--- a/app/controllers/mixins/middleware_deployments_mixin.rb
+++ b/app/controllers/mixins/middleware_deployments_mixin.rb
@@ -16,9 +16,9 @@ module Mixins::MiddlewareDeploymentsMixin
 
   def find_existing_deployment
     if @is_server
-      MiddlewareDeployment.find_by(:name => @deployment_name, :server_id => @entity_id)
+      MiddlewareDeployment.find_by(:name => @deployment_name, :server_id => from_cid(@entity_id))
     else
-      MiddlewareDeployment.find_by(:name => @deployment_name, :server_group_id => @entity_id)
+      MiddlewareDeployment.find_by(:name => @deployment_name, :server_group_id => from_cid(@entity_id))
     end
   end
 
@@ -60,8 +60,9 @@ module Mixins::MiddlewareDeploymentsMixin
                 _('Deployment "%{deployment}" already exists on this server group.') % {:deployment => @deployment_name}
               end
         render :json => {
-          :status => :warn,
-          :msg    => msg
+          :status     => :warn,
+          :error_type => "EXISTS",
+          :msg        => msg
         }
         return false
       end

--- a/app/views/middleware_shared/_deploy.html.haml
+++ b/app/views/middleware_shared/_deploy.html.haml
@@ -21,6 +21,9 @@
           %h4.modal-title#mw_modal_label
             = _("Add Middleware Deployment")
         .modal-body
+          .alert.alert-warning{"ng-if" => "warnMsg"}
+            %span.pficon.pficon-warning-triangle-o
+            {{warnMsg}}
           %input#server_id{:type => "hidden", :value => params[:id]}
           .form-group
             %label.col-md-4.control-label{:for => "enable_deployment_cb"}


### PR DESCRIPTION
When deployments exists for current server or server group do not hide dialog and show warning message. This way user can decide what he wants to do, rename deployment or force upload it. If user closes dialog all data are lost (as it used to be).

This PR also includes small bug fix for file `middleware_deployments_mixin.rb` where we were finding `MiddlewareDeployment` by it's name and `@entity_id` but this ID could be short ID (`10r11`) so even if deployment existed with such a name on this server it wasn't properly filtered.

New dialog after error about existing deployment exists:
![selection_146](https://cloud.githubusercontent.com/assets/3439771/24759989/86fe2b1e-1ae7-11e7-9aef-4c912e8ab4ec.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1377603
