### PR TITLE
Prefer SingleForwardable

### DIFF
--- a/app/helpers/application_helper/toolbar/basic.rb
+++ b/app/helpers/application_helper/toolbar/basic.rb
@@ -1,10 +1,7 @@
 class ApplicationHelper::Toolbar::Basic
   include Singleton
-
-  class << self
-    extend Forwardable
-    delegate %i(button select twostate separator definition button_group custom_content) => :instance
-  end
+  extend SingleForwardable
+  delegate %i(button select twostate separator definition button_group custom_content) => :instance
 
   attr_reader :definition
 


### PR DESCRIPTION
This provides a slightly more terse declaration to extending
`Forwardable` on the singleton class.

Tiny :scissors: 

@miq-bot add-label refactoring