### PR TITLE
Fixed multiple 'VM Console' buttons appearing on VMs

### DIFF
--- a/app/helpers/application_helper/button/vm_webmks_console.rb
+++ b/app/helpers/application_helper/button/vm_webmks_console.rb
@@ -2,11 +2,11 @@ class ApplicationHelper::Button::VmWebmksConsole < ApplicationHelper::Button::Vm
   needs :@record
 
   def visible?
-    @record.console_supported?('WebMKS')
+    console_supports_type?('WebMKS') if vmware? && @record.console_supported?('WebMKS')
   end
 
   def disabled?
-    @error_message = _('The web-based console is not available because the VM is not powered on') unless on?
+    @error_message = _('The web-based WebMKS console is not available because the VM is not powered on') unless on?
     @error_message.present?
   end
 end

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -249,7 +249,7 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
         button(
           :vm_console,
           'pficon pficon-screen fa-lg',
-          N_('Open a web-based console for this VM'),
+          N_('Open a web-based MKS console for this VM'),
           N_('VM Console'),
           :url     => "console",
           :confirm => N_("Opening a VM web-based console can take a while and requires that the VMware MKS plugin version configured for Management Engine already be installed and working.  Are you sure?"),
@@ -257,10 +257,10 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
         button(
           :vm_webmks_console,
           'pficon pficon-screen fa-lg',
-          N_('Open a web-based console for this VM'),
+          N_('Open a web-based WebMKS console for this VM'),
           N_('VM Console'),
           :url     => "console",
-          :confirm => N_("Open a web-based console for this VM"),
+          :confirm => N_("Open a WebMKS console for this VM"),
           :klass   => ApplicationHelper::Button::VmWebmksConsole),
         button(
           :vm_vnc_console,

--- a/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
@@ -1,0 +1,34 @@
+describe ApplicationHelper::Button::VmWebmksConsole do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:record) { FactoryGirl.create(:vm) }
+  let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
+
+  describe '#visible?' do
+    subject { button.visible? }
+    context 'when record.vendor == vmware' do
+      let(:record) { FactoryGirl.create(:vm_vmware) }
+      it_behaves_like 'vm_console_visible?', 'WebMKS', :vm_vmware => true
+    end
+    context 'when record.vendor != vmware' do
+      context 'and WebMKS is not a supported console' do
+        it_behaves_like 'vm_console_record_types', :vm_openstack => nil, :vm_redhat => nil
+      end
+    end
+  end
+
+  describe '#calculate_properties?' do
+    before { allow(record).to receive(:current_state).and_return(power_state) }
+    before(:each) { button.calculate_properties }
+
+    context 'when record.vendor == vmware' do
+      let(:power_state) { 'on' }
+      let(:ems) { FactoryGirl.create(:ems_vmware) }
+      let(:record) { FactoryGirl.create(:vm_vmware, :ems_id => ems.id) }
+
+      context 'and the power is on' do
+        it_behaves_like 'vm_console_with_power_state_on_off',
+                        "The web-based WebMKS console is not available because the VM is not powered on"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before:
![1439226-before](https://cloud.githubusercontent.com/assets/1630348/24769010/deb6085a-1ad2-11e7-815c-38a9dc7426d3.png)

After:
![1439226-after](https://cloud.githubusercontent.com/assets/1630348/24769018/e822c6f8-1ad2-11e7-972d-b6c8c06bf8fa.png)

Called method to verify VMware Console selection set in Configuration and added console names in button titles to minimize user confusion due to identical titles.

https://bugzilla.redhat.com/show_bug.cgi?id=1439226