### PR TITLE
Fix and modernise cloud volume forms

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -268,13 +268,8 @@ class CloudVolumeController < ApplicationController
     assert_privileges("cloud_volume_new")
     @volume = CloudVolume.new
     @in_a_form = true
-    @storage_manager_choices = {}
     if params[:storage_manager_id]
-      @storage_manager_id = params[:storage_manager_id]
-      ems = find_record_with_rbac(ExtManagementSystem, @storage_manager_id)
-      @storage_manager_choices[ems.name] = ems.id
-    else
-      ExtManagementSystem.all.each { |ems| @storage_manager_choices[ems.name] = ems.id if ems.supports_block_storage? }
+      @storage_manager = find_record_with_rbac(ExtManagementSystem, params[:storage_manager_id])
     end
     drop_breadcrumb(
       :name => _("Add New %{model}") % {:model => ui_lookup(:table => 'cloud_volume')},

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -1,10 +1,61 @@
+.form-group{"ng-class" => "{'has-error': angularForm.storage_manager_id.$invalid}"}
+  %label.col-md-2.control-label
+    = _('Storage Manager')
+  .col-md-8
+    %select{"name"        => "storage_manager_id",
+            "ng-model"    => "vm.cloudVolumeModel.storage_manager_id",
+            "ng-options"  => "mgr.id|number as mgr.name for mgr in vm.storageManagers",
+            "ng-change"   => "vm.storageManagerChanged(vm.cloudVolumeModel.storage_manager_id)",
+            "required"    => "",
+            "disabled"    => !@storage_manager.nil? || !@volume.id.nil?,
+            :checkchange  => true,
+            "pf-select"   => true}
+      %option{"value" => "", "disabled" => ""}
+        = "<#{_('Choose')}>"
+    %span.help-block{"ng-show" => "angularForm.storage_manager_id.$error.required"}
+      = _("Required")
+
+.form-group{"ng-class" => "{'has-error': angularForm.cloud_tenant_id.$invalid}",
+            "ng-if"    => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::StorageManager::CinderManager'"}
+  %label.col-md-2.control-label
+    = _('Cloud Tenant')
+  .col-md-8
+    %select{"name"        => "cloud_tenant_id",
+            "ng-model"    => "vm.cloudVolumeModel.cloud_tenant_id",
+            "ng-options"  => "tenant.id as tenant.name for tenant in vm.cloudTenantChoices",
+            "ng-disabled" => "!vm.newRecord",
+            "required"    => "",
+            :checkchange  => true,
+            "pf-select"   => true}
+      %option{"value" => "", "disabled" => ""}
+        = "<#{_('Choose')}>"
+    %span.help-block{"ng-show" => "angularForm.cloud_tenant_id.$error.required"}
+      = _("Required")
+
+.form-group{"ng-class" => "{'has-error': angularForm.aws_availability_zone_id.$invalid}",
+            "ng-if"    => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+  %label.col-md-2.control-label
+    = _('Availability Zone')
+  .col-md-8
+    %select{"name"        => "aws_availability_zone_id",
+            "ng-model"    => "vm.cloudVolumeModel.aws_availability_zone_id",
+            "ng-options"  => "az.ems_ref as az.name for az in vm.availabilityZoneChoices",
+            "required"    => "",
+            "ng-disabled" => "!vm.newRecord",
+            :checkchange  => true,
+            "pf-select"   => true}
+      %option{"value" => "", "disabled" => ""}
+        = "<#{_('Choose')}>"
+    %span.help-block{"ng-show" => "angularForm.aws_availability_zone_id.$error.required"}
+      = _("Required")
+
 .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
   %label.col-md-2.control-label
     = _('Volume Name')
   .col-md-8
     %input.form-control{:type          => "text",
                         :name          => "name",
-                        'ng-model'     => "cloudVolumeModel.name",
+                        'ng-model'     => "vm.cloudVolumeModel.name",
                         'ng-maxlength' => 128,
                         :required      => "",
                         :checkchange   => true}
@@ -12,18 +63,18 @@
       = _("Required")
 
 .form-group{"ng-class" => "{'has-error': angularForm.aws_volume_type.$invalid}",
-            "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+            "ng-if"    => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
   %label.col-md-2.control-label
     = _('Cloud Volume Type')
   .col-md-8
-    %select{"name"                        => "aws_volume_type",
-            "ng-model"                    => "cloudVolumeModel.aws_volume_type",
-            "ng-options"                  => "voltype.type as voltype.name for voltype in awsVolumeTypes",
-            "ng-change"                   => "awsVolumeTypeChanged(cloudVolumeModel.aws_volume_type)",
-            "ng-disabled" 				  => "formId != 'new' && cloudVolumeModel.aws_volume_type == 'standard'",
-            "required"                    => "",
-            :checkchange                  => true,
-            "selectpicker-for-select-tag" => ""}
+    %select{"name"        => "aws_volume_type",
+            "ng-model"    => "vm.cloudVolumeModel.aws_volume_type",
+            "ng-options"  => "voltype.type as voltype.name for voltype in vm.awsVolumeTypes",
+            "ng-change"   => "vm.awsVolumeTypeChanged(vm.cloudVolumeModel.aws_volume_type)",
+            "ng-disabled" => "!vm.newRecord && vm.cloudVolumeModel.aws_volume_type == 'standard'",
+            "required"    => "",
+            :checkchange  => true,
+            "pf-select"   => true}
       %option{"value" => "", "disabled" => ""}
         = "<#{_('Choose')}>"
     %span.help-block{"ng-show" => "angularForm.aws_volume_type.$error.required"}
@@ -35,26 +86,41 @@
   .col-md-8
     %input.form-control{:type          => "text",
                         :name          => "size",
-                        'ng-model'     => "cloudVolumeModel.size",
+                        'ng-model'     => "vm.cloudVolumeModel.size",
                         'ng-maxlength' => 10,
-                        'ng-change'    => "sizeChanged(cloudVolumeModel.size)",
-                        'ng-disabled'  => "formId != 'new' && (cloudVolumeModel.emstype != 'ManageIQ::Providers::Amazon::StorageManager::Ebs' || cloudVolumeModel.aws_volume_type == 'standard')",
+                        'ng-change'    => "vm.sizeChanged(vm.cloudVolumeModel.size)",
+                        'ng-disabled'  => "!vm.canModifyVolumeSize()",
                         :required      => "",
                         :checkchange   => true}
     %span.help-block{"ng-show" => "angularForm.size.$error.required"}
       = _("Required")
 
 .form-group{"ng-class" => "{'has-error': angularForm.aws_iops.$invalid}",
-            "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+            "ng-if"    => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
   %label.col-md-2.control-label
     = _('IOPS')
   .col-md-8
     %input.form-control{:type          => "text",
                         :name          => "aws_iops",
-                        'ng-model'     => "cloudVolumeModel.aws_iops",
+                        'ng-model'     => "vm.cloudVolumeModel.aws_iops",
                         'ng-maxlength' => 50,
-                        'ng-disabled'  => "cloudVolumeModel.aws_volume_type != 'io1'",
-                        "ng-required"  => "cloudVolumeModel.aws_volume_type == 'io1'",
+                        'ng-disabled'  => "vm.cloudVolumeModel.aws_volume_type != 'io1'",
+                        "ng-required"  => "vm.cloudVolumeModel.aws_volume_type == 'io1'",
                         :checkchange   => true}
-    %span.help-block{"ng-show" => "cloudVolumeModel.aws_volume_type == 'io1' && angularForm.aws_iops.$error.required"}
+    %span.help-block{"ng-show" => "vm.cloudVolumeModel.aws_volume_type == 'io1' && angularForm.aws_iops.$error.required"}
       = _("Required")
+
+.form-group{"ng-if" => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+  %label.col-md-2.control-label
+    = _('Encryption')
+  .col-md-8
+    %input.form-control{"bs-switch"       => "",
+                        :data             => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+                        :type             => "checkbox",
+                        :name             => "aws_encryption",
+                        'ng-model'        => "vm.cloudVolumeModel.aws_encryption",
+                        'switch-readonly' => "!vm.newRecord",
+                        'ng-disabled'     => "!vm.newRecord",
+                        :checkchange      => ""}
+
+= render :partial => "layouts/angular/generic_form_buttons"

--- a/app/views/cloud_volume/attach.html.haml
+++ b/app/views/cloud_volume/attach.html.haml
@@ -1,4 +1,10 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => ""}
+%form#form_div{:name           => "angularForm",
+               'ng-controller' => "cloudVolumeFormController as vm",
+               "ng-show"       => "vm.afterGet",
+               "ng-cloak"      => "",
+               "miq-form"      => true,
+               "model"         => "vm.cloudVolumeModel",
+               "model-copy"    => "vm.modelCopy"}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Attach Volume')
@@ -9,7 +15,7 @@
       .col-md-8
         = select_tag("vm_id",
                       options_for_select([["<#{_('Choose')}>", nil]] + @vm_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
-                      "ng-model"                    => "cloudVolumeModel.vm_id",
+                      "ng-model"                    => "vm.cloudVolumeModel.vm_id",
                       "required"                    => true,
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
@@ -19,29 +25,31 @@
       .col-md-8
         %input.form-control{:type          => "text",
                             :name          => "device_path",
-                            'ng-model'     => "cloudVolumeModel.device_path",
+                            'ng-model'     => "vm.cloudVolumeModel.device_path",
                             'ng-maxlength' => 128,
                             :miqrequired   => false,
                             :checkchange   => true}
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = button_tag(_("Attach"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "attachClicked()",
-                       "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
-          = button_tag(_("Reset"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "resetClicked()",
-                       "ng-disabled" => "angularForm.$pristine",
-                       "ng-class"    => "{ disabled: angularForm.$pristine}")
-          = button_tag(_("Cancel"),
-                        :class     => "btn btn-default",
-                        "ng-click" => "cancelAttachClicked()")
+  .clearfix
+  .pull-right.button-group.edit_buttons
+    %miq-button{:name      => t = _("Attach"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "vm.saveable(angularForm)",
+                'on-click' => "vm.attachClicked(angularForm)",
+                :primary   => 'true'}
+    %miq-button{:name      => t = _("Reset"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "!angularForm.$pristine",
+                'on-click' => "vm.resetClicked(angularForm)"}
+    %miq-button{:name      => t = _("Cancel"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "true",
+                'on-click' => "vm.cancelAttachClicked(angularForm)"}
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
   miq_bootstrap('#form_div');

--- a/app/views/cloud_volume/backup_new.html.haml
+++ b/app/views/cloud_volume/backup_new.html.haml
@@ -1,4 +1,8 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController"}
+%form#form_div{:name => "angularForm",
+               'ng-controller' => "cloudVolumeFormController as vm",
+               "miq-form"      => true,
+               "model"         => "vm.cloudVolumeModel",
+               "model-copy"    => "vm.modelCopy"}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Basic Information')
@@ -9,7 +13,7 @@
       .col-md-8
         %input.form-control{:type          => "text",
                             :name          => "backup_name",
-                            'ng-model'     => "cloudVolumeModel.backup_name",
+                            'ng-model'     => "vm.cloudVolumeModel.backup_name",
                             'ng-maxlength' => 128,
                             :miqrequired   => true,
                             :checkchange   => true}
@@ -17,30 +21,33 @@
       %label.col-md-2.control-label
         = _('Incremental?')
       .col-md-8
-        %input{:type         => "checkbox",
-               :name         => "incremental",
-               'ng-model'    => "cloudVolumeModel.incremental",
-               :miqrequired  => true,
-               :checkchange  => true}
+        %input.form-control{"bs-switch"   => "",
+                            :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+                            :type         => "checkbox",
+                            :name         => "incremental",
+                            'ng-model'    => "vm.cloudVolumeModel.incremental",
+                            :checkchange  => true}
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = button_tag(_("Save"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "backupCreateClicked()",
-                       "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
-          = button_tag(_("Reset"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "resetClicked()",
-                       "ng-disabled" => "angularForm.$pristine",
-                       "ng-class"    => "{ disabled: angularForm.$pristine}")
-          = button_tag(_("Cancel"),
-                        :class     => "btn btn-default",
-                        "ng-click" => "cancelBackupCreateClicked()")
+  .clearfix
+  .pull-right.button-group.edit_buttons
+    %miq-button{:name      => t = _("Save"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "vm.saveable(angularForm)",
+                'on-click' => "vm.backupCreateClicked(angularForm)",
+                :primary   => 'true'}
+    %miq-button{:name      => t = _("Reset"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "!angularForm.$pristine",
+                'on-click' => "vm.resetClicked(angularForm)"}
+    %miq-button{:name      => t = _("Cancel"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "true",
+                'on-click' => "vm.cancelBackupCreateClicked(angularForm)"}
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
   miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_volume/backup_select.html.haml
+++ b/app/views/cloud_volume/backup_select.html.haml
@@ -1,4 +1,8 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController"}
+%form#form_div{:name => "angularForm",
+               'ng-controller' => "cloudVolumeFormController as vm",
+               "miq-form"      => true,
+               "model"         => "vm.cloudVolumeModel",
+               "model-copy"    => "vm.modelCopy"}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Basic Information')
@@ -9,30 +13,31 @@
       .col-md-8
         = select_tag("backup_id",
           options_for_select([["<#{_('Choose')}>", nil]] + @backup_choices.sort),
-                      "ng-model"                    => "cloudVolumeModel.backup_id",
-                      "required"                    => "",
-                      :miqrequired                  => true,
-                      :checkchange                  => true,
-                      "selectpicker-for-select-tag" => "")
+                      "ng-model"   => "vm.cloudVolumeModel.backup_id",
+                      "required"   => "",
+                      :checkchange => true,
+                      "pf-select"  => true)
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = button_tag(_("Save"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "backupRestoreClicked()",
-                       "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
-          = button_tag(_("Reset"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "resetClicked()",
-                       "ng-disabled" => "angularForm.$pristine",
-                       "ng-class"    => "{ disabled: angularForm.$pristine}")
-          = button_tag(_("Cancel"),
-                        :class     => "btn btn-default",
-                        "ng-click" => "cancelBackupRestoreClicked()")
+  .clearfix
+  .pull-right.button-group.edit_buttons
+    %miq-button{:name      => t = _("Save"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "vm.saveable(angularForm)",
+                'on-click' => "vm.backupRestoreClicked(angularForm)",
+                :primary   => 'true'}
+    %miq-button{:name      => t = _("Reset"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "!angularForm.$pristine",
+                'on-click' => "vm.resetClicked(angularForm)"}
+    %miq-button{:name      => t = _("Cancel"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "true",
+                'on-click' => "vm.cancelBackupCreateClicked(angularForm)"}
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
   miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_volume/detach.html.haml
+++ b/app/views/cloud_volume/detach.html.haml
@@ -1,4 +1,10 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => ""}
+%form#form_div{:name           => "angularForm",
+               'ng-controller' => "cloudVolumeFormController as vm",
+               "ng-show"       => "vm.afterGet",
+               "ng-cloak"      => "",
+               "miq-form"      => true,
+               "model"         => "vm.cloudVolumeModel",
+               "model-copy"    => "vm.modelCopy"}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Detach Volume')
@@ -9,24 +15,26 @@
       .col-md-8
         = select_tag("vm_id",
                       options_for_select([["<#{_('Choose')}>", nil]] + @vm_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
-                      "ng-model"                    => "cloudVolumeModel.vm_id",
-                      "required"                    => true,
-                      :checkchange                  => true,
-                      "selectpicker-for-select-tag" => "")
+                      "ng-model"   => "vm.cloudVolumeModel.vm_id",
+                      "required"   => true,
+                      :checkchange => true,
+                      "pf-select"  => true)
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = button_tag(_("Detach"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "detachClicked()",
-                       "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
-          = button_tag(_("Cancel"),
-                        :class     => "btn btn-default",
-                        "ng-click" => "cancelDetachClicked()")
+  .clearfix
+  .pull-right.button-group.edit_buttons
+    %miq-button{:name      => t = _("Detach"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "vm.saveable(angularForm)",
+                'on-click' => "vm.detachClicked(angularForm)",
+                :primary   => 'true'}
+    %miq-button{:name      => t = _("Cancel"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "true",
+                'on-click' => "vm.cancelDetachClicked(angularForm)"}
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
   miq_bootstrap('#form_div');

--- a/app/views/cloud_volume/edit.html.haml
+++ b/app/views/cloud_volume/edit.html.haml
@@ -1,28 +1,17 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => ""}
+%form#form_div{:name           => "angularForm",
+               'ng-controller' => "cloudVolumeFormController as vm",
+               "ng-show"       => "vm.afterGet",
+               "ng-cloak"      => "",
+               "miq-form"      => true,
+               "model"         => "vm.cloudVolumeModel",
+               "model-copy"    => "vm.modelCopy"}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Edit Volume')
   .form-horizontal
     = render :partial => "common_new_edit"
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = button_tag(_("Save"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "saveClicked()",
-                       "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{ disabled: cloudVolumeForm.$pristine || angularForm.$invalid}")
-          = button_tag(_("Reset"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "resetClicked()",
-                       "ng-disabled" => "angularForm.$pristine",
-                       "ng-class"    => "{ disabled: cloudVolumeForm.$pristine}")
-          = button_tag(_("Cancel"),
-                        :class     => "btn btn-default",
-                        "ng-click" => "cancelClicked()")
-
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
   miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -1,92 +1,15 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => ""}
+%form#form_div{:name           => "angularForm",
+               'ng-controller' => "cloudVolumeFormController as vm",
+               "ng-show"       => "vm.afterGet",
+               "ng-cloak"      => "",
+               "miq-form"      => true,
+               "model"         => "vm.cloudVolumeModel",
+               "model-copy"    => "vm.modelCopy"}
   = render :partial => "layouts/flash_msg"
   .form-horizontal
-    .form-group{"ng-class" => "{'has-error': angularForm.storage_manager_id.$invalid}"}
-      %label.col-md-2.control-label
-        = _('Storage Manager')
-      .col-md-8
-        = select_tag("storage_manager_id",
-                     options_for_select((@storage_manager_id.nil? ? [["<#{_('Choose')}>", nil]] : []) + @storage_manager_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
-                     "ng-model"                    => "cloudVolumeModel.storage_manager_id",
-                     "ng-change"                   => "storageManagerChanged(cloudVolumeModel.storage_manager_id)",
-                     "required"                    => "",
-                     "disabled"                    => !@storage_manager_id.nil?,
-                     :checkchange                  => true,
-                     "selectpicker-for-select-tag" => "")
-        %span.help-block{"ng-show" => "angularForm.storage_manager_id.$error.required"}
-          = _("Required")
-
-    .form-group{"ng-class" => "{'has-error': angularForm.cloud_tenant_id.$invalid}",
-                "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::StorageManager::CinderManager'"}
-      %label.col-md-2.control-label
-        = _('Cloud Tenant')
-      .col-md-8
-        %select{"name"                        => "cloud_tenant_id",
-                "ng-model"                    => "cloudVolumeModel.cloud_tenant_id",
-                "ng-options"                  => "tenant.id as tenant.name for tenant in cloudTenantChoices",
-                "required"                    => "",
-                :checkchange                  => true,
-                "selectpicker-for-select-tag" => ""}
-          %option{"value" => "", "disabled" => ""}
-            = "<#{_('Choose')}>"
-        %span.help-block{"ng-show" => "angularForm.cloud_tenant_id.$error.required"}
-          = _("Required")
-
-    .form-group{"ng-class" => "{'has-error': angularForm.aws_availability_zone_id.$invalid}",
-                "ng-if"    => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
-      %label.col-md-2.control-label
-        = _('Availability Zone')
-      .col-md-8
-        %select{"name"                        => "aws_availability_zone_id",
-                "ng-model"                    => "cloudVolumeModel.aws_availability_zone_id",
-                "ng-options"                  => "az.ems_ref as az.name for az in availabilityZoneChoices",
-                "required"                    => "",
-                :checkchange                  => true,
-                "selectpicker-for-select-tag" => ""}
-          %option{"value" => "", "disabled" => ""}
-            = "<#{_('Choose')}>"
-        %span.help-block{"ng-show" => "angularForm.aws_availability_zone_id.$error.required"}
-          = _("Required")
-
     = render :partial => "common_new_edit"
-
-    .form-group{"ng-if" => "cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
-      %label.col-md-2.control-label
-        = _('Encryption')
-      .col-md-8
-        %input.form-control{"bs-switch"  => "",
-                            :data        => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
-                            :type        => "checkbox",
-                            :name        => "encryption",
-                            'ng-model'   => "cloudVolumeModel.aws_encryption",
-                            :checkchange => true}
-
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          - if @volume.id.nil?
-            = button_tag(_("Add"),
-                         :class        => "btn btn-primary",
-                         "ng-class"    => "{ disabled: angularForm.$invalid}",
-                         "ng-disabled" => "angularForm.$invalid",
-                         "ng-click"    => "addClicked()")
-          - else
-            = button_tag(_("Save"),
-                         :class        => "btn btn-primary",
-                         "ng-click"    => "saveClicked()",
-                         "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                         "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
-            = button_tag(_("Reset"),
-                         :class        => "btn btn-primary",
-                         "ng-click"    => "resetClicked()",
-                         "ng-disabled" => "angularForm.$pristine",
-                         "ng-class"    => "{ disabled: angularForm.$pristine}")
-          = button_tag(_("Cancel"),
-                        :class     => "btn btn-default",
-                        "ng-click" => "cancelClicked()")
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id || "new"}');
-  ManageIQ.angular.app.value('storageManagerId', '#{@storage_manager_id}');
+  ManageIQ.angular.app.value('storageManagerId', '#{@storage_manager.try(:id)}');
   miq_bootstrap('#form_div');

--- a/app/views/cloud_volume/snapshot_new.html.haml
+++ b/app/views/cloud_volume/snapshot_new.html.haml
@@ -1,4 +1,8 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController"}
+%form#form_div{:name           => "angularForm",
+               'ng-controller' => "cloudVolumeFormController as vm",
+               "miq-form"      => true,
+               "model"         => "vm.cloudVolumeModel",
+               "model-copy"    => "vm.modelCopy"}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Basic Information')
@@ -9,29 +13,31 @@
       .col-md-8
         %input.form-control{:type          => "text",
                             :name          => "snapshot_name",
-                            'ng-model'     => "cloudVolumeModel.snapshot_name",
+                            'ng-model'     => "vm.cloudVolumeModel.snapshot_name",
                             'ng-maxlength' => 128,
                             :miqrequired   => true,
                             :checkchange   => true}
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = button_tag(_("Save"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "snapshotCreateClicked()",
-                       "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
-          = button_tag(_("Reset"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "resetClicked()",
-                       "ng-disabled" => "angularForm.$pristine",
-                       "ng-class"    => "{ disabled: angularForm.$pristine}")
-          = button_tag(_("Cancel"),
-                        :class     => "btn btn-default",
-                        "ng-click" => "cancelSnapshotCreateClicked()")
+  .clearfix
+  .pull-right.button-group.edit_buttons
+    %miq-button{:name      => t = _("Save"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "vm.saveable(angularForm)",
+                'on-click' => "vm.snapshotCreateClicked(angularForm)",
+                :primary   => 'true'}
+    %miq-button{:name      => t = _("Reset"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "!angularForm.$pristine",
+                'on-click' => "vm.resetClicked(angularForm)"}
+    %miq-button{:name      => t = _("Cancel"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => "true",
+                'on-click' => "vm.cancelSnapshotCreateClicked(angularForm)"}
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
   miq_bootstrap(jQuery('#form_div'));


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1443188

Introduction of the ability to create cloud volumes for a specific block storage manager broke the remaining forms dealing with cloud volumes. The reason for this was that the Angular controller required additional parameter specifying the target block storage manager.

In an attempt to update these forms, various issues were raised (e.g. display of form fields in the new vs. edit form, use of legacy form control tags, mixing of the API and rails controller data, ...). This resulted in a more comprehensive update of the cloud volume forms, introducing two main enhancements (besides fixing the forms):

* Use of APIs in Angular controller: some of the data was provided by rails controller while the other was already retrieved through and API. This commit tries to use API as much as possible.

* Use of "controller as vm": when rewriting the controller it was easy to introduce this change to bring cloud volume views and controller closer to the current best practices

I've made five videos showing different operations on cloud volumes (all show OpenStack Cinder and Amazon EBS):
1. Creating new cloud volumes http://x.k00.fr/lph6r
2. Editing cloud volume http://x.k00.fr/gx691
3. Attaching cloud volumes http://x.k00.fr/q1tz7
4. Detaching cloud volumes http://x.k00.fr/gh2m6
5. Creating snapshots http://x.k00.fr/8krc7

This replaces two other PRs that actually lead to the decision to make more massive change:
* #861: introduction of the API
* #816: attempt to fix the edit form, that in turn revealed that all other operations are also broken; when @AparnaKarve requested to also show the fields that are not editable, it became clear that we need the API to get all required information and that... lead to this PR.

@miq-bot add_label wip