### PR TITLE
Fix the missed `find_checked_ids_with_rbac`

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -426,11 +426,11 @@ class CloudVolumeController < ApplicationController
   def delete_volumes
     assert_privileges("cloud_volume_delete")
     volumes = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "cloud_volume")
-                find_checked_items_with_rbac(CloudVolume)
+                find_checked_ids_with_rbac(CloudVolume)
               elsif params[:id].present?
                 [params[:id]]
               else
-                find_checked_items_with_rbac(CloudVolume)
+                find_checked_ids_with_rbac(CloudVolume)
               end
 
     if volumes.empty?


### PR DESCRIPTION
It appears that one occurrence of the previously used `find_checked_items_with_rbac` was missed while renaming the function. This one is used while deleting cloud volumes.

@miq-bot add_label bug