### PR TITLE
Fix issue with timezones when adding new schedule

### DIFF
--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -152,9 +152,9 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     } else {
       if ($scope.scheduleModel.action_typ === 'automation_request') {
         // should ignore list of targets as this list can be really long no need to send that up to server
-        var moreUrlParams = $.param(miqService.serializeModelWithIgnoredFields($scope.scheduleModel, ["targets"]));
+        var moreUrlParams = $.param(miqService.serializeModelWithIgnoredFields($scope.scheduleModel, ["targets", "time_zone"]));
         if (moreUrlParams) {
-          url += '&' + decodeURIComponent(moreUrlParams);
+          url += '&' + decodeURIComponent(moreUrlParams) + encodeURIComponent($scope.scheduleModel.time_zone);
         }
       }
       miqService.miqAjaxButton(url, serializeFields);


### PR DESCRIPTION
When adding a new automate task schedule the value for time zones are decoded, then if a time zone contains an ampersand (like `Eastern (US & Canada`) the value is split on the ampersand. This change leaves the time zone encoded when sent to the server.

https://bugzilla.redhat.com/show_bug.cgi?id=1435735

This bug also exists in Fine and Euwe

@miq-bot add_label bug, fine/yes, euwe/yes

/cc @h-kataria 