### PR TITLE
Avoid storing @edit[:pchoice] to session in vm edit

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1742,7 +1742,10 @@ module VmCommon
           # if @edit[:new][k].is_a?(Hash)
           msg = msg + k.to_s + ":[" + @edit[:current][k].keys.join(",") + "] to [" + @edit[:new][k].keys.join(",") + "]"
         elsif k == :parent
-          msg = msg + k.to_s + ":[" + parent_choices.invert[@edit[:current][k]] + "] to [" + parent_choices.invert[@edit[:new][k]] + "]"
+          parent_choices_invert = parent_choices.invert
+          current_parent_choice = parent_choices_invert[@edit[:current][k]]
+          new_parent_choice     = parent_choices_invert[@edit[:new][k]]
+          msg = "#{msg}#{k}:[#{current_parent_choice}] to [#{new_parent_choice}]"
         else
           msg = msg + k.to_s + ":[" + @edit[:current][k].to_s + "] to [" + @edit[:new][k].to_s + "]"
         end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -988,8 +988,8 @@ module VmCommon
       choices = parent_item_scope.pluck(:name, :location, :id).each_with_object({}) do |vm, memo|
         memo[vm[0] + " -- #{vm[1]}"] = vm[2]
       end
-      choices['"no parent"'] = -1 # Add "no parent" entry
-      choices
+      # Add "no parent" entry as 1 entry in hash
+      {'"no parent"' => -1}.merge(choices)
     end
   end
 

--- a/app/views/vm_common/_form.html.haml
+++ b/app/views/vm_common/_form.html.haml
@@ -41,7 +41,7 @@
         = _('Parent VM')
       .col-md-8
         = select_tag("chosen_parent",
-                      options_for_select(@edit[:pchoices].sort, @edit[:new][:parent]),
+                      options_for_select(parent_choices.sort, @edit[:new][:parent]),
                       :multiple => false,
                       "data-miq_sparkle_on" => true,
                       "data-miq_sparkle_off" => true,

--- a/app/views/vm_common/_form.html.haml
+++ b/app/views/vm_common/_form.html.haml
@@ -41,7 +41,7 @@
         = _('Parent VM')
       .col-md-8
         = select_tag("chosen_parent",
-                      options_for_select(parent_choices.sort, @edit[:new][:parent]),
+                      options_for_select(parent_choices, @edit[:new][:parent]),
                       :multiple => false,
                       "data-miq_sparkle_on" => true,
                       "data-miq_sparkle_off" => true,


### PR DESCRIPTION
I am doing this suggested changes:
https://github.com/ManageIQ/manageiq-ui-classic/pull/927#issuecomment-291921096

with 80 000 items:
Now we only ~10 MB instead of (~20 MB) in session.

Next step is to get rid off also `@edit[:choice]`

@miq-bot assign @martinpovolny 
