### PR TITLE
Fix misplaced ng-cloak in ems_datawarehouse

### DIFF
--- a/app/views/ems_datawarehouse/_form.html.haml
+++ b/app/views/ems_datawarehouse/_form.html.haml
@@ -1,6 +1,7 @@
 - @angular_form = true
 
-.form-horizontal
+.form-horizontal{'ng-cloak' => '',
+                 'ng-show'  => 'afterGet'}
   = render :partial => "layouts/flash_msg"
   %div
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
@@ -14,9 +15,7 @@
                             "maxlength"   => MAX_NAME_LEN.to_s,
                             "required"    => "",
                             "checkchange" => "",
-                            "auto-focus"  => "",
-                            'ng-cloak'    => '',
-                            'ng-show'     => 'afterGet'}
+                            "auto-focus"  => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
 


### PR DESCRIPTION
1. enable `Settings.product.datawarehouse_manager`
1. go to `Datawarehouse > Providers > Configuration > Add a New Datawarehouse Provider`
1. (load with browser network throttling enabled)

Without this, the form will render twice, with just one input hidden the first time.
With this, the form will display only when fully loaded.

(Introduced in #938)

Cc @ZitaNemeckova 