### PR TITLE
Fix RBAC for Cloud Tenant Controller

### DIFF
--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -190,9 +190,9 @@ class CloudTenantController < ApplicationController
     assert_privileges("cloud_tenant_delete")
 
     tenants = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "cloud_tenant")
-                find_checked_items
+                find_checked_records_with_rbac(CloudTenant)
               else
-                [params[:id]]
+                [find_record_with_rbac(CloudTenant, params[:id])]
               end
 
     if tenants.empty?
@@ -200,11 +200,8 @@ class CloudTenantController < ApplicationController
     end
 
     tenants_to_delete = []
-    tenants.each do |tenant_id|
-      tenant = CloudTenant.find_by_id(tenant_id)
-      if tenant.nil?
-        add_flash(_("Cloud Tenant no longer exists."), :error)
-      elsif !tenant.vms.empty?
+    tenants.each do |tenant|
+      if tenant.vms.present?
         add_flash(_("Cloud Tenant \"%{name}\" cannot be removed because it is attached to one or more %{instances}") % {
           :name      => tenant.name,
           :instances => ui_lookup(:tables => 'vm_cloud')}, :warning)


### PR DESCRIPTION
Fix RBAC for Cloud Tenant Controller, and refactor `delete_cloud_tenants` method a bit.