### PR TITLE
Refactor taskbar_in_header? for readability

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -576,12 +576,15 @@ module ApplicationHelper
   end
 
   def hide_taskbar_in_header?
-    (@layout == "" &&
-      %w(auth_error
+    return true if @layout == "" &&
+      %w(
+         auth_error
          change_tab
          show
-        ).include?(controller.action_name)) ||
-      %w(about
+      ).include?(controller.action_name)
+
+    return true if %w(
+         about
          chargeback
          container_dashboard
          ems_infra_dashboard
@@ -605,8 +608,11 @@ module ApplicationHelper
          report
          rss
          server_build
-        ).include?(@layout) ||
-      (@layout == "configuration" && @tabform != "ui_4")
+        ).include?(@layout)
+
+    return true if @layout == "configuration" && @tabform != "ui_4"
+
+    false
   end
 
   def taskbar_in_header?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -572,18 +572,14 @@ module ApplicationHelper
     return false if @explorer
     return false if controller.action_name.end_with?("tagging_edit")
 
-    ! hide_taskbar_in_header?
-  end
-
-  def hide_taskbar_in_header?
-    return true if @layout == "" &&
+    return false if @layout == "" &&
       %w(
          auth_error
          change_tab
          show
       ).include?(controller.action_name)
 
-    return true if %w(
+    return false if %w(
          about
          chargeback
          container_dashboard
@@ -610,9 +606,9 @@ module ApplicationHelper
          server_build
         ).include?(@layout)
 
-    return true if @layout == "configuration" && @tabform != "ui_4"
+    return false if @layout == "configuration" && @tabform != "ui_4"
 
-    false
+    true
   end
 
   def taskbar_in_header?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -568,46 +568,53 @@ module ApplicationHelper
     nil
   end
 
-  def taskbar_in_header?
-    if @show_taskbar.nil?
-      @show_taskbar = false
-      if ! (@layout == "" &&
-        %w(auth_error
-           change_tab
-           show
-          ).include?(controller.action_name) ||
-        %w(about
-           chargeback
-           container_dashboard
-           ems_infra_dashboard
-           exception
-           miq_ae_automate_button
-           miq_ae_class
-           miq_ae_export
-           miq_ae_tools
-           miq_capacity_bottlenecks
-           miq_capacity_planning
-           miq_capacity_utilization
-           miq_capacity_waste
-           miq_policy
-           miq_policy_export
-           miq_policy_rsop
-           monitor_alerts_overview
-           monitor_alerts_list
-           monitor_alerts_most_recent
-           ops
-           pxe
-           report
-           rss
-           server_build
-          ).include?(@layout) ||
-        (@layout == "configuration" && @tabform != "ui_4")) && !controller.action_name.end_with?("tagging_edit")
-        unless @explorer
-          @show_taskbar = true
-        end
+  def show_taskbar_in_header?
+    show_taskbar = false
+    if ! (@layout == "" &&
+      %w(auth_error
+         change_tab
+         show
+        ).include?(controller.action_name) ||
+      %w(about
+         chargeback
+         container_dashboard
+         ems_infra_dashboard
+         exception
+         miq_ae_automate_button
+         miq_ae_class
+         miq_ae_export
+         miq_ae_tools
+         miq_capacity_bottlenecks
+         miq_capacity_planning
+         miq_capacity_utilization
+         miq_capacity_waste
+         miq_policy
+         miq_policy_export
+         miq_policy_rsop
+         monitor_alerts_overview
+         monitor_alerts_list
+         monitor_alerts_most_recent
+         ops
+         pxe
+         report
+         rss
+         server_build
+        ).include?(@layout) ||
+      (@layout == "configuration" && @tabform != "ui_4")) && !controller.action_name.end_with?("tagging_edit")
+      unless @explorer
+        show_taskbar = true
       end
     end
-    @show_taskbar
+    show_taskbar
+  end
+
+  def taskbar_in_header?
+    # this is just @show_taskbar ||= show_taskbar_in_header? .. but nil
+    if @show_taskbar.nil?
+      @show_taskbar = show_taskbar_in_header?
+    else
+      @show_taskbar
+    end
   end
 
   # checking if any of the toolbar is visible

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -576,11 +576,11 @@ module ApplicationHelper
   end
 
   def hide_taskbar_in_header?
-    @layout == "" &&
+    (@layout == "" &&
       %w(auth_error
          change_tab
          show
-        ).include?(controller.action_name) ||
+        ).include?(controller.action_name)) ||
       %w(about
          chargeback
          container_dashboard

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -569,6 +569,8 @@ module ApplicationHelper
   end
 
   def show_taskbar_in_header?
+    return false if @explorer
+
     show_taskbar = false
     if ! (@layout == "" &&
       %w(auth_error
@@ -601,9 +603,7 @@ module ApplicationHelper
          server_build
         ).include?(@layout) ||
       (@layout == "configuration" && @tabform != "ui_4")) && !controller.action_name.end_with?("tagging_edit")
-      unless @explorer
-        show_taskbar = true
-      end
+      show_taskbar = true
     end
     show_taskbar
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -570,6 +570,7 @@ module ApplicationHelper
 
   def show_taskbar_in_header?
     return false if @explorer
+    return false if controller.action_name.end_with?("tagging_edit")
 
     ! (@layout == "" &&
       %w(auth_error
@@ -601,7 +602,7 @@ module ApplicationHelper
          rss
          server_build
         ).include?(@layout) ||
-      (@layout == "configuration" && @tabform != "ui_4")) && !controller.action_name.end_with?("tagging_edit")
+      (@layout == "configuration" && @tabform != "ui_4"))
   end
 
   def taskbar_in_header?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -572,7 +572,11 @@ module ApplicationHelper
     return false if @explorer
     return false if controller.action_name.end_with?("tagging_edit")
 
-    ! (@layout == "" &&
+    ! hide_taskbar_in_header?
+  end
+
+  def hide_taskbar_in_header?
+    @layout == "" &&
       %w(auth_error
          change_tab
          show
@@ -602,7 +606,7 @@ module ApplicationHelper
          rss
          server_build
         ).include?(@layout) ||
-      (@layout == "configuration" && @tabform != "ui_4"))
+      (@layout == "configuration" && @tabform != "ui_4")
   end
 
   def taskbar_in_header?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -571,8 +571,7 @@ module ApplicationHelper
   def show_taskbar_in_header?
     return false if @explorer
 
-    show_taskbar = false
-    if ! (@layout == "" &&
+    ! (@layout == "" &&
       %w(auth_error
          change_tab
          show
@@ -603,9 +602,6 @@ module ApplicationHelper
          server_build
         ).include?(@layout) ||
       (@layout == "configuration" && @tabform != "ui_4")) && !controller.action_name.end_with?("tagging_edit")
-      show_taskbar = true
-    end
-    show_taskbar
   end
 
   def taskbar_in_header?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -572,39 +572,40 @@ module ApplicationHelper
     return false if @explorer
     return false if controller.action_name.end_with?("tagging_edit")
 
-    return false if @layout == "" &&
-      %w(
-         auth_error
-         change_tab
-         show
-      ).include?(controller.action_name)
+    hide_actions = %w(
+      auth_error
+      change_tab
+      show
+    )
+    return false if @layout == "" && hide_actions.include?(controller.action_name)
 
-    return false if %w(
-         about
-         chargeback
-         container_dashboard
-         ems_infra_dashboard
-         exception
-         miq_ae_automate_button
-         miq_ae_class
-         miq_ae_export
-         miq_ae_tools
-         miq_capacity_bottlenecks
-         miq_capacity_planning
-         miq_capacity_utilization
-         miq_capacity_waste
-         miq_policy
-         miq_policy_export
-         miq_policy_rsop
-         monitor_alerts_overview
-         monitor_alerts_list
-         monitor_alerts_most_recent
-         ops
-         pxe
-         report
-         rss
-         server_build
-        ).include?(@layout)
+    hide_layouts = %w(
+      about
+      chargeback
+      container_dashboard
+      ems_infra_dashboard
+      exception
+      miq_ae_automate_button
+      miq_ae_class
+      miq_ae_export
+      miq_ae_tools
+      miq_capacity_bottlenecks
+      miq_capacity_planning
+      miq_capacity_utilization
+      miq_capacity_waste
+      miq_policy
+      miq_policy_export
+      miq_policy_rsop
+      monitor_alerts_list
+      monitor_alerts_most_recent
+      monitor_alerts_overview
+      ops
+      pxe
+      report
+      rss
+      server_build
+    )
+    return false if hide_layouts.include?(@layout)
 
     return false if @layout == "configuration" && @tabform != "ui_4"
 


### PR DESCRIPTION
`taskbar_in_header?` is an `unless` within a huge `if ! (30 lines) || ! conditon`, withing a `nil?` condition.

Refactored to split the `@show_taskbar` assignment from the main logic,
and split the huge conditional into multiple `return false if ...` stanzas.

@martinpovolny Would you double-check the logic please?
Tried to make the commits as a series of simple steps...