### PR TITLE
Fix quadicons under service catalogs

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -395,8 +395,7 @@ module QuadiconHelper
     image ||= "layout/base-single.png"
 
     content_tag(:div, :class => "flobj #{cls}") do
-      tag(:img, :border => 0, :src => ActionController::Base.helpers.image_path(image),
-          :width => size, :height => size)
+      image_tag(image, :size => size)
     end
   end
 
@@ -561,11 +560,7 @@ module QuadiconHelper
   def render_non_listicon_single_quadicon(item, options)
     output = []
 
-    img_path = if item.decorate
-                 item.decorate.try(:fileicon)
-               else
-                 "100/#{item.class.base_class.to_s.underscore}.png"
-               end
+    img_path = item.try(:decorate).try(:fileicon) || "100/#{item.class.base_class.to_s.underscore}.png"
 
     output << flobj_img_simple("layout/base-single.png")
     output << flobj_img_simple(img_path, "e72")


### PR DESCRIPTION
The change in decorators effects how this quadicon determines which icon to display. This changes the single quadicon to check for the return of `fileicon` explicitly since `item.decorate` will usually (always?) be true.

**Before**
![screen shot 2017-04-07 at 4 16 53 pm](https://cloud.githubusercontent.com/assets/39493/24822936/319e8f48-1bae-11e7-821e-82cdb15d2776.png)

**After**
![screen shot 2017-04-07 at 4 16 15 pm](https://cloud.githubusercontent.com/assets/39493/24822943/3713e388-1bae-11e7-8183-0794c0fb4b84.png)

@epwinchell Can you confirm this is the correct rendering?

Addresses:
https://bugzilla.redhat.com/show_bug.cgi?id=1439517