### PR TITLE
Catch SSLError too when adding a provider

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -475,7 +475,7 @@ module Mixins
       client = ems.class.raw_connect(endpoint.hostname, endpoint.port,
                                      :service => :openshift, :bearer => token, :ssl_options => ssl_options)
       client.get_route('hawkular-metrics', 'openshift-infra').try(:spec).try(:host)
-    rescue KubeException => e
+    rescue KubeException, OpenSSL::SSL::SSLError => e
       $log.warn("MIQ(#{controller_name}_controller-#{action_name}): get_hostname_from_routes error: #{e}")
       nil
     end


### PR DESCRIPTION
Expands #314.
KubeException already covers the common "certificate verify failed" SSL errors but not rarer ones like "does not match the server certificate".
This might be resolved in Kubeclient or RestClient one day (https://github.com/abonas/kubeclient/issues/240) but it's blocked on backward compatibility concerns so let's catch it here for now.

So currently some SSL errors can crash `get_hostname_from_routes` leading to no indication except stacktrace in log:
![sslerror-crash](https://cloud.githubusercontent.com/assets/273688/24836744/02afbd94-1d2d-11e7-95a3-d77d9c979e45.png)
This has also been observed as a ["Unexpected error encountered" screen](https://bugzilla.redhat.com/attachment.cgi?id=1266655) which does show the error but makes it hard to proceed.
https://bugzilla.redhat.com/show_bug.cgi?id=1436221

Any SSL error will probably fail both `get_hostname_from_routes` and the main validation code.
With this fix, the error from validation will then be displayed in a red flash:
![sslerror](https://cloud.githubusercontent.com/assets/273688/24836770/762036f0-1d2d-11e7-83fb-2b1acbe8a74a.png)

@miq-bot add-label compute/containers, bug, blocker, fine/yes
(per flags on https://bugzilla.redhat.com/show_bug.cgi?id=1436221)

@moolitayer @h-kataria Please review.

P.S. @h-kataria I think ems_common controller used to be more robust, with errors showing in UI, and at some point became more fragile due to JS/JSON response mismatch.