### PR TITLE
Change RHVM to RHV

### DIFF
--- a/app/helpers/application_helper/discover.rb
+++ b/app/helpers/application_helper/discover.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
         "ipmi"            => _("IPMI"),
         "kvm"             => _("KVM"),
         "msvirtualserver" => _("MS vCenter"),
-        "rhevm"           => _("Red Hat Virtualization Manager"),
+        "rhevm"           => _("Red Hat Virtualization"),
         "scvmm"           => _("Microsoft System Center VMM"),
         "virtualcenter"   => _("VMware vCenter"),
         "vmwareserver"    => _("VMware Server"),


### PR DESCRIPTION
Change "Red Hat Virtualization Manager" to "Red Hat Virtualization"

Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1403358

https://github.com/ManageIQ/manageiq-providers-ovirt/pull/6
https://github.com/ManageIQ/manageiq/pull/14703