### PR TITLE
[WIP] Fallback for hawkular hostname if no route found

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -431,7 +431,7 @@ module Mixins
 
         if hawkular_hostname.blank?
           default_key = params[:default_password] || ems.authentication_key
-          hawkular_hostname = get_hostname_from_routes(ems, default_endpoint, default_key)
+          hawkular_hostname = get_hostname_from_routes(ems, default_endpoint, default_key) || hostname
         end
         hawkular_endpoint = {:role => :hawkular, :hostname => hawkular_hostname, :port => hawkular_api_port}
         hawkular_endpoint.merge!(endpoint_security_options(hawkular_security_protocol, hawkular_tls_ca_certs))

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -202,13 +202,13 @@ describe EmsContainerController do
       it "tolerates missing hawkular-metrics route" do
         expect_get_route { nil }
         test_creating('openshift')
-        expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq(nil)
+        expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq('mytest.com')
       end
 
       it "tolerates errors fetching hawkular-metrics route" do
         expect_get_route { raise KubeException.new(418, "I'm a Teapot", double('response')) }
         test_creating('openshift')
-        expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq(nil)
+        expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq('mytest.com')
       end
     end
 


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1437138

Fall back to pre https://github.com/ManageIQ/manageiq-ui-classic/pull/37 behavior if no route found 