### PR TITLE
Use textarea for ssh key in Machine Credentials

### DIFF
--- a/app/assets/javascripts/components/ansible-credential-options.js
+++ b/app/assets/javascripts/components/ansible-credential-options.js
@@ -29,9 +29,10 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
         '{{ __(attr.label) }}',
        '</label>',
        '<div ng-switch="attr.type" class="text">',
-         // password
+         // password or ssh input (must be textarea to prevent EOL getting lost)
          '<div ng-switch-when="password" class="col-md-8">',
-           '<input type="password" class="form-control" title="{{ __(attr.help_text) }}" ng-model="vm.model[name]">',
+           '<input ng-if="!attr.multiline" type="password" class="form-control" title="{{ __(attr.help_text) }}" ng-model="vm.model[name]">',
+           '<textarea ng-if="attr.multiline" class="form-control" title="{{ __(attr.help_text) }}" ng-model="vm.model[name]"></textarea>',
          '</div>',
          // select
          '<div ng-switch-when="choice" class="col-md-8">',


### PR DESCRIPTION
Using textarea prevents lost of EOL chars which was making input invalid

@miq-bot add_label fine/yes, wip, automation/ansible, bug,  pending core

Waiting on https://github.com/ManageIQ/manageiq/pull/14707 (merged)

https://bugzilla.redhat.com/show_bug.cgi?id=1439589