### PR TITLE
Change typ to 'service' for Service/Requests page

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -532,6 +532,7 @@ module ApplicationController::MiqRequestMethods
     case tab_name
     when "ae"                then "miq_request_ae"
     when "host"              then "miq_request_host"
+    when "service"           then "miq_request_service"
     else                          "miq_request_vm"  # Includes "vm"
     end
   end

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -411,10 +411,10 @@ class MiqRequestController < ApplicationController
 
   def get_request_tab_type
     case @layout
-    when "miq_request_ae"                then "AutomateRequest"
-    when "miq_request_configured_system" then "MiqProvisionConfiguredSystemRequest"
-    when "miq_request_host"              then "MiqHostProvisionRequest"
-    when "miq_request_vm"                then "MiqProvisionRequest"
+    when "miq_request_ae"                        then "AutomateRequest"
+    when "miq_request_configured_system"         then "MiqProvisionConfiguredSystemRequest"
+    when "miq_request_host"                      then "MiqHostProvisionRequest"
+    when "miq_request_vm", "miq_request_service" then "MiqProvisionRequest"
     end
   end
 

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -40,7 +40,7 @@ module Menu
           Menu::Item.new('services',       N_('My Services'), 'service',     {:feature => 'service', :any => true},     '/service/explorer'),
           Menu::Item.new('catalogs',       N_('Catalogs'),    'catalog',     {:feature => 'catalog', :any => true},     '/catalog/explorer'),
           Menu::Item.new('vm_or_template', N_('Workloads'),   'vm_explorer', {:feature => 'vm_explorer', :any => true}, '/vm_or_template/explorer'),
-          Menu::Item.new('miq_request_vm', N_('Requests'),    'miq_request', {:feature => 'miq_request_show_list'},     '/miq_request?typ=vm')
+          Menu::Item.new('miq_request_vm', N_('Requests'),    'miq_request', {:feature => 'miq_request_show_list'},     '/miq_request?typ=service')
         ])
       end
 


### PR DESCRIPTION
Distinguish 'Services/Requests' action and don't display pagination for the Request lists

https://bugzilla.redhat.com/show_bug.cgi?id=1436316