### PR TITLE
Edit vm screen: use sql instead of ruby and reuse method

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1427,12 +1427,7 @@ module VmCommon
                                    .pluck(:resource_id)
 
     # Build a hash for the VMs to choose from, only if they have no parent
-    available_item_scope = VmOrTemplate.where.not(:id => ids_with_parents + [@record.id] + vms.pluck(:id))
-    @edit[:choices] = Rbac.filtered(available_item_scope)
-                          .pluck(:name, :location, :id)
-                          .each_with_object({}) do |vm, memo|
-                            memo[vm[0] + " -- #{vm[1]}"] = vm[2]
-                          end
+    @edit[:choices] = parent_choices(ids_with_parents + [@record.id] + vms.pluck(:id))
 
     @edit[:current][:parent] = @edit[:new][:parent]
     @edit[:current][:kids] = @edit[:new][:kids].dup

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1426,14 +1426,12 @@ module VmCommon
                                    .pluck(:resource_id)
 
     # Build a hash for the VMs to choose from, only if they have no parent
-    available_item_scope = VmOrTemplate.where.not(:id => ids_with_parents + [@record.id])
+    available_item_scope = VmOrTemplate.where.not(:id => ids_with_parents + [@record.id] + vms.pluck(:id))
     @edit[:choices] = Rbac.filtered(available_item_scope)
                           .pluck(:name, :location, :id)
                           .each_with_object({}) do |vm, memo|
                             memo[vm[0] + " -- #{vm[1]}"] = vm[2]
                           end
-
-    @edit[:new][:kids].each_key { |key| @edit[:choices].delete(key) }   # Remove any VMs that are in the kids list box from the choices
 
     @edit[:current][:parent] = @edit[:new][:parent]
     @edit[:current][:kids] = @edit[:new][:kids].dup

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1426,7 +1426,7 @@ module VmCommon
                                    .pluck(:resource_id)
 
     # Build a hash for the VMs to choose from, only if they have no parent
-    available_item_scope = VmOrTemplate.where.not(:id => ids_with_parents)
+    available_item_scope = VmOrTemplate.where.not(:id => ids_with_parents + [@record.id])
     @edit[:choices] = Rbac.filtered(available_item_scope)
                           .pluck(:name, :location, :id)
                           .each_with_object({}) do |vm, memo|
@@ -1434,8 +1434,6 @@ module VmCommon
                           end
 
     @edit[:new][:kids].each_key { |key| @edit[:choices].delete(key) }   # Remove any VMs that are in the kids list box from the choices
-
-    @edit[:choices].delete(@record.name + " -- #{@record.location}")                                    # Remove the current VM from the choices list
 
     @edit[:current][:parent] = @edit[:new][:parent]
     @edit[:current][:kids] = @edit[:new][:kids].dup

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -980,15 +980,16 @@ module VmCommon
     replace_right_cell
   end
 
-  def parent_choices
+  def parent_choices(exclude_ids = nil)
     @parent_choices = {}
-    @parent_choices[@record.id] ||= begin
-      parent_item_scope = Rbac.filtered(VmOrTemplate.where.not(:id => @record.id).order(:name))
+    ids = exclude_ids ? exclude_ids : @record.id
+    @parent_choices[Digest::MD5.hexdigest(ids.inspect)] ||= begin
+      parent_item_scope = Rbac.filtered(VmOrTemplate.where.not(:id => ids).order(:name))
       choices = parent_item_scope.pluck(:name, :location, :id).each_with_object({}) do |vm, memo|
         memo[vm[0] + " -- #{vm[1]}"] = vm[2]
       end
       # Add "no parent" entry as 1 entry in hash
-      {'"no parent"' => -1}.merge(choices)
+      exclude_ids ? choices : {'"no parent"' => -1}.merge(choices)
     end
   end
 

--- a/app/views/vm_common/_form.html.haml
+++ b/app/views/vm_common/_form.html.haml
@@ -41,7 +41,7 @@
         = _('Parent VM')
       .col-md-8
         = select_tag("chosen_parent",
-                      options_for_select(parent_choices, @edit[:new][:parent]),
+                      options_for_select(parent_choices_with_no_parent_choice, @edit[:new][:parent]),
                       :multiple => false,
                       "data-miq_sparkle_on" => true,
                       "data-miq_sparkle_off" => true,


### PR DESCRIPTION
follow up of https://github.com/ManageIQ/manageiq-ui-classic/pull/959
this is just refactoring, not removing data `@edit[:choices]` from a session yet - this data needs to be in session so we have to convert it to array ids - in follow up PR

cc @mzazrivec 

@miq-bot assign  @martinpovolny 

@miq-bot add_label refactoring, technical debt