### PR TITLE
miqService - don't assume this === miqService in methods

### DIFF
--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -1,6 +1,8 @@
 /* global miqAjaxButton miqBuildCalendar miqButtons miqJqueryRequest miqRESTAjaxButton miqSparkleOff miqSparkleOn add_flash */
 
 ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', function($timeout, $document, $q) {
+  var miqService = this;
+
   this.storedPasswordPlaceholder = "●●●●●●●●";
 
   this.showButtons = function() {
@@ -41,7 +43,7 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', funct
   };
 
   this.miqFlash = function(type, msg) {
-    this.miqFlashClear();
+    miqService.miqFlashClear();
     add_flash(msg, type);
   };
 
@@ -113,10 +115,10 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', funct
 
     if (e.error !== undefined && e.error.message !== undefined) {
       console.error(e.error.message);
-      this.miqFlash('error', e.error.message);
+      miqService.miqFlash('error', e.error.message);
     } else if (e.message) {
       console.error(e.message);
-      this.miqFlash('error', e.message);
+      miqService.miqFlash('error', e.message);
     }
 
     return $q.reject(e);


### PR DESCRIPTION
```
this.foo = function() {
  this.bar();
}
```

works when called as `miqService.foo()` but not for example in `.then(miqService.foo)`.

Making all these explicit by `var miqService = this;`.

Introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/911 => `fine/yes`.


Fixes `miqFlash` failing in `miqService.handleFailure` calls.