### PR TITLE
Change summary icon on infra providers screen

### DIFF
--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -82,7 +82,7 @@ module EmsInfraHelper::TextualSummary
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
     label     = "#{title_for_hosts} & #{title_for_clusters}"
     available = @record.number_of(:ems_folders) > 0 && @record.ems_folder_root
-    h         = {:label => label, :icon => "pficon pficon-virtual-machine", :value => available ? _("Available") : _("N/A")}
+    h         = {:label => label, :icon => "pficon pficon-screen", :value => available ? _("Available") : _("N/A")}
     if available
       h[:link]  = ems_infra_path(@record.id, :display => 'ems_folders')
       h[:title] = _("Show %{label}") % {:label => label}


### PR DESCRIPTION
This sets the icon for Hosts / Nodes & Clusters to `pficon-screen` on the Infra > Providers summary screen.

In Euwe this summary had a more custom icon:
<img width="300" alt="screen shot 2017-04-10 at 9 51 55 am" src="https://cloud.githubusercontent.com/assets/39493/24872960/14844970-1dd4-11e7-8770-e7ecfd418a3f.png">

When images were replaced with font icons it became this:
<img width="305" alt="screen shot 2017-04-10 at 9 46 48 am" src="https://cloud.githubusercontent.com/assets/39493/24873001/2f85d07c-1dd4-11e7-82e6-ee9740ee2a27.png">

This PR changes it to the screen icon per @epwinchell 
<img width="321" alt="screen shot 2017-04-10 at 9 45 50 am" src="https://cloud.githubusercontent.com/assets/39493/24873018/42c81050-1dd4-11e7-94b5-a1b666463571.png">
 

https://bugzilla.redhat.com/show_bug.cgi?id=1439781

/cc @dclarizio 