### PR TITLE
Fix server state incorrectly reported

### DIFF
--- a/app/helpers/middleware_server_helper/textual_summary.rb
+++ b/app/helpers/middleware_server_helper/textual_summary.rb
@@ -45,7 +45,7 @@ module MiddlewareServerHelper::TextualSummary
   def textual_server_state
     {
       :label => _('Server State'),
-      :value => @record.properties['Server State'].to_s.capitalize
+      :value => (@record.properties['Calculated Server State'] || @record.properties['Server State']).to_s.capitalize
     }
   end
 


### PR DESCRIPTION
Server state was being reported based only on inventory data. This will
report server state based on a combination of inventory data and
availability metrics, if EMS/provider features it.

https://bugzilla.redhat.com/show_bug.cgi?id=1438816

This PR goes together with ManageIQ/manageiq-providers-hawkular#6. Merge order is not important and is not required to merge simultaneously.

When server is running, inventory state is reported:
![screenshot from 2017-04-10 13-23-23](https://cloud.githubusercontent.com/assets/23639005/24876546/b89cd73a-1df1-11e7-8205-c68a7dbb5d7a.png)

When server is down, availability metric state is reported:
![screenshot from 2017-04-10 13-23-32](https://cloud.githubusercontent.com/assets/23639005/24876563/c8735314-1df1-11e7-97ee-d46c636ec91f.png)

