### PR TITLE
Use function getBack in .then instead of result of that function

### DIFF
--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -58,13 +58,13 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
 
   vm.saveClicked = function(angularForm) {
     API.put('/api/authentications/' + credentialId, vm.credentialModel)
-       .then(getBack(sprintf(__("Modification of Credential \"%s\" has been successfully queued."), vm.credentialModel.name), false))
+       .then(getBack.bind(vm, sprintf(__("Modification of Credential \"%s\" has been successfully queued."), vm.credentialModel.name), false, false))
        .catch(miqService.handleFailure);
   };
 
   vm.addClicked = function(angularForm) {
     API.post('/api/authentications/', vm.credentialModel)
-       .then(getBack(sprintf(__("Add of Credential \"%s\" has been successfully queued."), vm.credentialModel.name)))
+       .then(getBack.bind(vm, sprintf(__("Add of Credential \"%s\" has been successfully queued."), vm.credentialModel.name), false, false))
        .catch(miqService.handleFailure);
   };
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1437373

In Firefox without disabled notifications. 
Automation -> Ansible -> Credentials -> Configuration -> Add/Edit Credentials -> Add/Save button

Before:
There is a toaster error message after adding/saving a credentials.
After:
No toaster error message.

@miq-bot add_label bug, fine/yes, automation/ansible

@AparnaKarve please review. Thanks :) 