### PR TITLE
Refactor the TopologyService and its subclasses

### DIFF
--- a/app/services/cloud_topology_service.rb
+++ b/app/services/cloud_topology_service.rb
@@ -17,12 +17,10 @@ class CloudTopologyService < TopologyService
       :cloud_tenants      => [:tags, :vms => :tags],
     ]
 
-    entity_relationships = { :CloudManager => build_entity_relationships(included_relations) }
-
     preloaded = @providers.includes(included_relations)
 
     preloaded.each do |entity|
-      topo_items, links = build_recursive_topology(entity, entity_relationships[:CloudManager], topo_items, links)
+      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
     end
 
     populate_topology(topo_items, links, build_kinds, icons)

--- a/app/services/cloud_topology_service.rb
+++ b/app/services/cloud_topology_service.rb
@@ -3,15 +3,16 @@ class CloudTopologyService < TopologyService
 
   @provider_class = ManageIQ::Providers::CloudManager
 
+  @included_relations = [
+    :tags,
+    :availability_zones => [:tags, :vms => :tags],
+    :cloud_tenants      => [:tags, :vms => :tags],
+  ]
+
   def build_topology
+    included_relations = self.class.instance_variable_get(:@included_relations)
     topo_items = {}
     links = []
-
-    included_relations = [
-      :tags,
-      :availability_zones => [:tags, :vms => :tags],
-      :cloud_tenants      => [:tags, :vms => :tags],
-    ]
 
     preloaded = @providers.includes(included_relations)
 

--- a/app/services/cloud_topology_service.rb
+++ b/app/services/cloud_topology_service.rb
@@ -9,20 +9,6 @@ class CloudTopologyService < TopologyService
     :cloud_tenants      => [:tags, :vms => :tags],
   ]
 
-  def build_topology
-    included_relations = self.class.instance_variable_get(:@included_relations)
-    topo_items = {}
-    links = []
-
-    preloaded = @providers.includes(included_relations)
-
-    preloaded.each do |entity|
-      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
-    end
-
-    populate_topology(topo_items, links, build_kinds, icons)
-  end
-
   def entity_display_type(entity)
     if entity.kind_of?(ManageIQ::Providers::CloudManager)
       entity.class.short_token

--- a/app/services/cloud_topology_service.rb
+++ b/app/services/cloud_topology_service.rb
@@ -3,10 +3,6 @@ class CloudTopologyService < TopologyService
 
   @provider_class = ManageIQ::Providers::CloudManager
 
-  def entity_type(entity)
-    entity.class.name.demodulize
-  end
-
   def build_topology
     topo_items = {}
     links = []

--- a/app/services/container_project_topology_service.rb
+++ b/app/services/container_project_topology_service.rb
@@ -8,27 +8,25 @@ class ContainerProjectTopologyService < TopologyService
     topo_items = {}
     links = []
 
-    entity_relationships = { :ContainerProject => { :ContainerGroups => {
-                                                      :Containers          => nil,
-                                                      :ContainerReplicator => nil,
-                                                      :ContainerServices   => { :ContainerRoutes => nil },
-                                                      :ContainerNode      => { :lives_on => {:Host => nil}}
-                                                    }
-                                                  }
-                           }
+    included_relations = [
+      :container_groups => [
+        :containers,
+        :container_replicator,
+        :container_node     => [
+          :lives_on => [:host]
+        ],
+        :container_services => [:container_routes]
+      ]
+    ]
 
-    preloaded = @providers.includes(:container_groups => [:containers,
-                                                          :container_replicator,
-                                                          :container_node => [:lives_on => [:host]],
-                                                          :container_services => [:container_routes]])
+    preloaded = @providers.includes(included_relations)
 
     preloaded.each do |entity|
-      topo_items, links = build_recursive_topology(entity, entity_relationships[:ContainerProject], topo_items, links)
+      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
     end
 
     populate_topology(topo_items, links, build_kinds, icons)
   end
-
 
   def build_kinds
     kinds = [:ContainerReplicator, :ContainerGroup, :Container, :ContainerNode,

--- a/app/services/container_project_topology_service.rb
+++ b/app/services/container_project_topology_service.rb
@@ -4,20 +4,21 @@ class ContainerProjectTopologyService < TopologyService
 
   @provider_class = ContainerProject
 
+  @included_relations = [
+    :container_groups => [
+      :containers,
+      :container_replicator,
+      :container_node     => [
+        :lives_on => [:host]
+      ],
+      :container_services => [:container_routes]
+    ]
+  ]
+
   def build_topology
+    included_relations = self.class.instance_variable_get(:@included_relations)
     topo_items = {}
     links = []
-
-    included_relations = [
-      :container_groups => [
-        :containers,
-        :container_replicator,
-        :container_node     => [
-          :lives_on => [:host]
-        ],
-        :container_services => [:container_routes]
-      ]
-    ]
 
     preloaded = @providers.includes(included_relations)
 

--- a/app/services/container_project_topology_service.rb
+++ b/app/services/container_project_topology_service.rb
@@ -15,20 +15,6 @@ class ContainerProjectTopologyService < TopologyService
     ]
   ]
 
-  def build_topology
-    included_relations = self.class.instance_variable_get(:@included_relations)
-    topo_items = {}
-    links = []
-
-    preloaded = @providers.includes(included_relations)
-
-    preloaded.each do |entity|
-      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
-    end
-
-    populate_topology(topo_items, links, build_kinds, icons)
-  end
-
   def build_kinds
     kinds = [:ContainerReplicator, :ContainerGroup, :Container, :ContainerNode,
              :ContainerService, :Host, :Vm, :ContainerRoute, :ContainerManager, :ContainerProject]

--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -4,20 +4,21 @@ class ContainerTopologyService < TopologyService
 
   @provider_class = ManageIQ::Providers::ContainerManager
 
+  @included_relations = [
+    :container_nodes => [
+      :container_groups => [
+        :containers,
+        :container_replicator,
+        :container_services => [:container_routes]
+      ],
+      :lives_on         => [:host]
+    ]
+  ]
+
   def build_topology
+    included_relations = self.class.instance_variable_get(:@included_relations)
     topo_items = {}
     links = []
-
-    included_relations = [
-      :container_nodes => [
-        :container_groups => [
-          :containers,
-          :container_replicator,
-          :container_services => [:container_routes]
-        ],
-        :lives_on         => [:host]
-      ]
-    ]
 
     preloaded = @providers.includes(included_relations)
 

--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -15,20 +15,6 @@ class ContainerTopologyService < TopologyService
     ]
   ]
 
-  def build_topology
-    included_relations = self.class.instance_variable_get(:@included_relations)
-    topo_items = {}
-    links = []
-
-    preloaded = @providers.includes(included_relations)
-
-    preloaded.each do |entity|
-      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
-    end
-
-    populate_topology(topo_items, links, build_kinds, icons)
-  end
-
   def build_kinds
     kinds = [:ContainerReplicator, :ContainerGroup, :Container, :ContainerNode,
              :ContainerService, :Host, :Vm, :ContainerRoute, :ContainerManager]

--- a/app/services/infra_topology_service.rb
+++ b/app/services/infra_topology_service.rb
@@ -3,6 +3,17 @@ class InfraTopologyService < TopologyService
 
   @provider_class = ManageIQ::Providers::InfraManager
 
+  @included_relations = [
+    :tags,
+    :ems_clusters => [
+      :tags,
+      :hosts => [
+        :tags,
+        :vms => :tags
+      ]
+    ],
+  ]
+
   def entity_type(entity)
     if entity.kind_of?(Host)
       entity.class.base_class.name.demodulize
@@ -12,19 +23,9 @@ class InfraTopologyService < TopologyService
   end
 
   def build_topology
+    included_relations = self.class.instance_variable_get(:@included_relations)
     topo_items = {}
     links = []
-
-    included_relations = [
-      :tags,
-      :ems_clusters => [
-        :tags,
-        :hosts => [
-          :tags,
-          :vms => :tags
-        ]
-      ],
-    ]
 
     preloaded = @providers.includes(included_relations)
 

--- a/app/services/infra_topology_service.rb
+++ b/app/services/infra_topology_service.rb
@@ -22,20 +22,6 @@ class InfraTopologyService < TopologyService
     end
   end
 
-  def build_topology
-    included_relations = self.class.instance_variable_get(:@included_relations)
-    topo_items = {}
-    links = []
-
-    preloaded = @providers.includes(included_relations)
-
-    preloaded.each do |entity|
-      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
-    end
-
-    populate_topology(topo_items, links, build_kinds, icons)
-  end
-
   def entity_display_type(entity)
     if entity.kind_of?(ManageIQ::Providers::InfraManager)
       entity.class.short_token

--- a/app/services/infra_topology_service.rb
+++ b/app/services/infra_topology_service.rb
@@ -26,11 +26,10 @@ class InfraTopologyService < TopologyService
       ],
     ]
 
-    entity_relationships = {:InfraManager => build_entity_relationships(included_relations)}
     preloaded = @providers.includes(included_relations)
 
     preloaded.each do |entity|
-      topo_items, links = build_recursive_topology(entity, entity_relationships[:InfraManager], topo_items, links)
+      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
     end
 
     populate_topology(topo_items, links, build_kinds, icons)

--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -3,21 +3,22 @@ class MiddlewareTopologyService < TopologyService
 
   @provider_class = ManageIQ::Providers::MiddlewareManager
 
+  @included_relations = [
+    :middleware_domains => [
+      :middleware_server_groups => [:middleware_servers => nil]
+    ],
+    :middleware_servers => [
+      :middleware_deployments,
+      :middleware_datasources,
+      :middleware_messagings,
+      :lives_on => [:host]
+    ]
+  ]
+
   def build_topology
+    included_relations = self.class.instance_variable_get(:@included_relations)
     topo_items = {}
     links = []
-
-    included_relations = [
-      :middleware_domains => [
-        :middleware_server_groups => [:middleware_servers => nil]
-      ],
-      :middleware_servers => [
-        :middleware_deployments,
-        :middleware_datasources,
-        :middleware_messagings,
-        :lives_on => [:host]
-      ]
-    ]
 
     preloaded = @providers.includes(included_relations)
 

--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -40,12 +40,10 @@ class NetworkTopologyService < TopologyService
       ]
     ]
 
-    entity_relationships = {:NetworkManager => build_entity_relationships(included_relations)}
-
     preloaded = @providers.includes(included_relations)
 
     preloaded.each do |entity|
-      topo_items, links = build_recursive_topology(entity, entity_relationships[:NetworkManager], topo_items, links)
+      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
     end
 
     populate_topology(topo_items, links, build_kinds, icons)

--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -36,20 +36,6 @@ class NetworkTopologyService < TopologyService
     end
   end
 
-  def build_topology
-    included_relations = self.class.instance_variable_get(:@included_relations)
-    topo_items = {}
-    links      = []
-
-    preloaded = @providers.includes(included_relations)
-
-    preloaded.each do |entity|
-      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
-    end
-
-    populate_topology(topo_items, links, build_kinds, icons)
-  end
-
   def entity_display_type(entity)
     if entity.kind_of?(ManageIQ::Providers::NetworkManager)
       entity.class.short_token

--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -7,7 +7,7 @@ class NetworkTopologyService < TopologyService
     if entity.kind_of?(CloudNetwork)
       entity.class.base_class.name.demodulize
     else
-      entity.class.name.demodulize
+      super
     end
   end
 

--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -3,14 +3,15 @@ class PhysicalInfraTopologyService < TopologyService
 
   @provider_class = ManageIQ::Providers::PhysicalInfraManager
 
+  @included_relations = [
+    :tags,
+    :physical_servers => [:tags],
+  ]
+
   def build_topology
+    included_relations = self.class.instance_variable_get(:@included_relations)
     topo_items = {}
     links = []
-
-    included_relations = [
-      :tags,
-      :physical_servers => [:tags],
-    ]
 
     preloaded = @providers.includes(included_relations)
 

--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -8,20 +8,6 @@ class PhysicalInfraTopologyService < TopologyService
     :physical_servers => [:tags],
   ]
 
-  def build_topology
-    included_relations = self.class.instance_variable_get(:@included_relations)
-    topo_items = {}
-    links = []
-
-    preloaded = @providers.includes(included_relations)
-
-    preloaded.each do |entity|
-      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
-    end
-
-    populate_topology(topo_items, links, build_kinds, icons)
-  end
-
   def entity_display_type(entity)
     if entity.kind_of?(ManageIQ::Providers::PhysicalInfraManager)
       entity.class.short_token

--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -3,10 +3,6 @@ class PhysicalInfraTopologyService < TopologyService
 
   @provider_class = ManageIQ::Providers::PhysicalInfraManager
 
-  def entity_type(entity)
-    entity.class.name.demodulize
-  end
-
   def build_topology
     topo_items = {}
     links = []

--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -16,11 +16,10 @@ class PhysicalInfraTopologyService < TopologyService
       :physical_servers => [:tags],
     ]
 
-    entity_relationships = {:PhysicalInfraManager => build_entity_relationships(included_relations)}
     preloaded = @providers.includes(included_relations)
 
     preloaded.each do |entity|
-      topo_items, links = build_recursive_topology(entity, entity_relationships[:PhysicalInfraManager], topo_items, links)
+      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
     end
 
     populate_topology(topo_items, links, build_kinds, icons)

--- a/app/services/topology_service.rb
+++ b/app/services/topology_service.rb
@@ -49,6 +49,20 @@ class TopologyService
     }
   end
 
+  def build_topology
+    included_relations = self.class.instance_variable_get(:@included_relations)
+    topo_items = {}
+    links = []
+
+    preloaded = @providers.includes(included_relations)
+
+    preloaded.each do |entity|
+      topo_items, links = build_recursive_topology(entity, build_entity_relationships(included_relations), topo_items, links)
+    end
+
+    populate_topology(topo_items, links, build_kinds, icons)
+  end
+
   def build_recursive_topology(entity, entity_relationships_mapping, topo_items, links)
     unless entity.nil?
       topo_items[entity_id(entity)] = build_entity_data(entity)


### PR DESCRIPTION
There was some copy-pasted and unnecessarily asymmetric code that has been unified and the common part has been moved to the parent class.

Pivotal story: https://www.pivotaltracker.com/story/show/143239019