### PR TITLE
Order Methods displayed under Automate Class

### DIFF
--- a/app/views/miq_ae_class/_class_methods.html.haml
+++ b/app/views/miq_ae_class/_class_methods.html.haml
@@ -9,7 +9,7 @@
           %th
           %th
         %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}
-          - @record.ae_methods.each do |record|
+          - @record.ae_methods.order(:name).each do |record|
             - next if record.name == '$'
             - cls_cid = "#{class_prefix(record.class)}-#{ApplicationRecord.compress_id(record.id)}"
             %tr{'data-click-id' => cls_cid}


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1439911

Order methods displayed in the right side frame under the Methods
tab when reaching Automation -> Automate -> Explorer and choosing
a class with different methods.

Before:
![automation_class1](https://cloud.githubusercontent.com/assets/13417815/24915014/4600381c-1ed6-11e7-8666-ac4b07c76bd5.png)

After:
![automation_class2](https://cloud.githubusercontent.com/assets/13417815/24915021/4f27f90c-1ed6-11e7-9fe8-273470a18241.png)
