### PR TITLE
Fix Openstack Services textual helper

### DIFF
--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -65,7 +65,7 @@ module HostHelper::TextualSummary
 
   def textual_group_openstack_service_status
     return nil unless @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager::Host)
-    TextualGroup.new(_("OpenStack Service Status"), textual_generate_openstack_status)
+    TextualMultilink.new(_("OpenStack Service Status"), :items => textual_generate_openstack_status)
   end
 
   def textual_group_openstack_hardware_status


### PR DESCRIPTION
Openstack services table on Host page looks to be broken since a UI refactoring.

Updated textual helper object to make required fields visible.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1434552