### PR TITLE
Topology header - fix Enter in search

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1448,7 +1448,7 @@ function miqToolbarOnClick(_e) {
     // support data-function and data-function-data
     var fn = new Function("return " + button.data('function')); // eval - returns a function returning the right function
     fn().call(button, button.data('functionData'));
-    return;
+    return false;
   } else {
     // No url specified, run standard button ajax transaction
     if (typeof button.data('explorer') != "undefined" && button.data('explorer')) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1579,7 +1579,7 @@ function miqHideSearchClearButton() {
   // Show the clear button upon entering text in the search input
   $(".search-pf .has-clear .form-control").keyup(function () {
     var t = $(this);
-    t.next('button').toggle(Boolean(t.val()));
+    t.nextAll('button.clear').toggle(Boolean(t.val()));
   });
   // Upon clicking the clear button, empty the entered text and hide the clear button
   $(".search-pf .has-clear .clear").click(function () {

--- a/app/views/shared/_topology_header_toolbar.html.haml
+++ b/app/views/shared/_topology_header_toolbar.html.haml
@@ -19,6 +19,14 @@
 
       %input#search_topology.form-control{:type         => 'search',
                                           'placeholder' => _("Search")}
+
+      -# this hidden button is a workaround
+      -# pressing enter in ^input triggers a *click* event on the next button
+      -# without this, that button is resetSearch, which ..is undesirable :)
+      %button.hidden{'data-function'      => 'miqCallAngular',
+                     'data-function-data' => {:name => 'searchNode',
+                                              :args => []}.to_json}
+
       %button.clear{'aria-hidden'        => 'true',
                     'data-function'      => 'miqCallAngular',
                     'data-function-data' => {:name => 'resetSearch',

--- a/app/views/shared/_topology_header_toolbar.html.haml
+++ b/app/views/shared/_topology_header_toolbar.html.haml
@@ -1,19 +1,32 @@
 .form-group.text
   %label.topology-checkbox.checkbox-inline
-    %input#box_display_names{:type => "checkbox"}
+    %input#box_display_names{:type => 'checkbox'}
     = _("Display Names")
+
 .form-group
-  %button.btn.btn-default{'data' => {'function' => 'miqCallAngular', 'function-data' => '{"name":"refresh", "args":[]}'}}
-    %i{:class => "fa fa-refresh fa-lg"}
+  %button.btn.btn-default{'data-function'      => 'miqCallAngular',
+                          'data-function-data' => {:name => 'refresh',
+                                                   :args => []}.to_json}
+    %i.fa.fa-refresh.fa-lg
     = _("Refresh")
-%form.search-pf.topology-search{:role => "form"}
+
+%form.search-pf.topology-search{:role     => 'form',
+                                :onsubmit => 'miqCallAngular({ name: "searchNode", args: [] }); return false'}
   .form-group.has-clear
     .search-pf-input-group
-      %label.sr-only{:for => "search"}
+      %label.sr-only{:for => 'search'}
         = _("Search")
-      %input#search_topology.form-control{'placeholder' => _("Search"), 'type' => "search", "ng-model" => "search.query"}
-        %button.clear{"aria-hidden" => "true", :type => "button", 'data' => {'function' => 'miqCallAngular', 'function-data' => '{"name":"resetSearch", "args":[]}'}}
-          %span.pficon.pficon-close
+
+      %input#search_topology.form-control{:type         => 'search',
+                                          'placeholder' => _("Search")}
+      %button.clear{'aria-hidden'        => 'true',
+                    'data-function'      => 'miqCallAngular',
+                    'data-function-data' => {:name => 'resetSearch',
+                                             :args => []}.to_json}
+        %span.pficon.pficon-close
+
   .form-group.search-button
-    %button.btn.btn-default.search-topology-button{:type => "button",  'data' => {'function' => 'miqCallAngular', 'function-data' => '{"name":"searchNode", "args":[]}'}}
+    %button.btn.btn-default.search-topology-button{'data-function'      => 'miqCallAngular',
+                                                   'data-function-data' => {:name => 'searchNode',
+                                                                            :args => []}.to_json}
       %span.fa.fa-search


### PR DESCRIPTION
In https://github.com/ManageIQ/manageiq-ui-classic/pull/955, we merged the various toolbar-like things into a proper custom toolbar. But this introduced a regression - since the whole custom toolbar is a form, pressing enter in the search box would submit the form. (ref: https://github.com/ManageIQ/manageiq-ui-classic/pull/955#issuecomment-293111219)

So.. catching the submit event to trigger the same action as the same button.

..except for some reason, when pressing Enter in an input in this form, the browser creates a *click* event on the button immediately following that input - which is the clear button, so .. not ideal :).

Adding a hidden button that triggers the right action as a workaround, and updating the `miqHideSearchClearButton` code to be able to cope.

---

The long term goal for this is to have this as an angular component that talks with the right TopologyController via an observable, but turns out we can't have angular in custom toolbars quite yet - https://github.com/ManageIQ/ui-components/issues/64.

Cc @AparnaKarve, @skateman 

Aparna.. this should fix the issue, but not sure how much luck you'll have using this for https://bugzilla.redhat.com/show_bug.cgi?id=1401823 in `fine` (assuming that BZ is meant for `fine`), since before #955, most topologies used `shared/_topology_header.html.haml`, which is not a proper toolbar but *is* angular.