### PR TITLE
Show the display value for the dropdown in the automation dialog

### DIFF
--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -10,12 +10,19 @@ module ApplicationHelper::Dialogs
   end
 
   def dialog_dropdown_selected_value(field)
-    values = field.values
-    if values && values.to_h.include?(field.value)
-      values.to_h[field.value]
-    else
-      field.value
+    if !field.values || field.values.empty?
+      return field.value
     end
+
+    values = field.values.to_h
+    result = field.value.split(',').collect do |val|
+      if values.include?(val)
+        values.to_h[val]
+      else
+        val
+      end
+    end
+    result.join(',')
   end
 
   def category_tags(category_id)

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -9,6 +9,15 @@ module ApplicationHelper::Dialogs
     values
   end
 
+  def dialog_dropdown_selected_value(field)
+    values = field.values
+    if values && values.to_h.include?(field.value)
+      values.to_h[field.value]
+    else
+      field.value
+    end
+  end
+
   def category_tags(category_id)
     classification = Classification.find_by(:id => category_id)
     return [] if classification.nil?

--- a/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
@@ -3,7 +3,7 @@
   - selected ||= wf.value(field.name)
   = select_tag(field.name, options_for_select(select_values,
                                               selected),
-                                              drop_down_options(field, url))  
+                                              drop_down_options(field, url))
 
   :javascript
     dialogFieldRefresh.initializeDialogSelectPicker(
@@ -35,6 +35,5 @@
           dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
         });
       });
-
 - else
-  = h(field.value.nil? ? "<None>" : field.value)
+  = h(field.value.nil? ? "<None>" : dialog_dropdown_selected_value(field))

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -53,11 +53,27 @@ describe ApplicationHelper::Dialogs do
       end
     end
 
+    context "shows a list of display values for multiselect" do
+      let(:values) { [%w(key1 Val1), %w(key2 Val2), %w(key3 Val3), %w(key4 Val4)] }
+      let(:value) { 'key2,key4' }
+      it "returns the key value for the selected item" do
+        expect(helper.dialog_dropdown_selected_value(dialog_field)).to eq('Val2,Val4')
+      end
+    end
+
+    context "shows a list of display values and keys for multiselect when some keys not in values" do
+      let(:values) { [%w(key1 Val1), %w(key2 Val2), %w(key3 Val3), %w(key4 Val4)] }
+      let(:value) { 'oldkey,key4' }
+      it "returns the key value for the selected item" do
+        expect(helper.dialog_dropdown_selected_value(dialog_field)).to eq('oldkey,Val4')
+      end
+    end
+
     context "when the drop down option list is empty" do
       let(:values) {}
       let(:value) { 'key' }
 
-      it "returns nil if the options list is empty" do
+      it "returns the field value if the options list is empty" do
         expect(helper.dialog_dropdown_selected_value(dialog_field)).to eq('key')
       end
     end

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -33,6 +33,36 @@ describe ApplicationHelper::Dialogs do
     end
   end
 
+  describe "#dialog_dropdown_selected_value" do
+    let(:dialog_field) { instance_double("DialogFieldDropDownList", :values => values, :type => type, :value => value) }
+    let(:type) { "OneDropDown" }
+    let(:values) { [%w(key1 Val1), %w(key2 Val2)] }
+    let(:value) { nil }
+
+    context "when the the selected item exists in the values list" do
+      let(:value) { 'key2' }
+      it "returns the value for the selected item" do
+        expect(helper.dialog_dropdown_selected_value(dialog_field)).to eq('Val2')
+      end
+    end
+
+    context "when the the selected item does not exists in the values list" do
+      let(:value) { 'oldkey' }
+      it "returns the key value for the selected item" do
+        expect(helper.dialog_dropdown_selected_value(dialog_field)).to eq('oldkey')
+      end
+    end
+
+    context "when the drop down option list is empty" do
+      let(:values) {}
+      let(:value) { 'key' }
+
+      it "returns nil if the options list is empty" do
+        expect(helper.dialog_dropdown_selected_value(dialog_field)).to eq('key')
+      end
+    end
+  end
+
   describe "#category_tags" do
     before do
       allow(Classification).to receive(:find_by).with(:id => 123).and_return(classification)

--- a/spec/views/shared/dialogs/_dialog_field_drop_down_list.html.haml_spec.rb
+++ b/spec/views/shared/dialogs/_dialog_field_drop_down_list.html.haml_spec.rb
@@ -1,0 +1,18 @@
+describe "shared/dialogs/dialog_field_drop_down_list.html.haml" do
+  context 'display field value' do
+    before do
+      @edit = false
+      attributes = {:values => [[nil, "<Choose>"], %w(Value1 Desc1), %w(Value2 Desc2)]}
+      value = 'Value2'
+      @field = DialogFieldDropDownList.new(:id => 1,
+                                           :name => 'Options List Field',
+                                           :type => 'DialogFieldDropDownList',
+                                           :attributes => attributes, :value => value)
+    end
+
+    it 'shows the display value for the dropdown field' do
+      render :partial => "/shared/dialogs/dialog_field_drop_down_list.html.haml", :locals => {:edit => @edit, :field => @field}
+      expect(rendered).to eq("Desc2\n")
+    end
+  end
+end


### PR DESCRIPTION
Show the display value for the dropdown in the automation dialog

https://bugzilla.redhat.com/show_bug.cgi?id=1436701

A dropdown in a service dialog displays the second value during edit and the first in the request summary. With this PR, the second value will be displayed in the summary to match the edit dialog form.

![screenshot from 2017-04-13 12-54-47](https://cloud.githubusercontent.com/assets/12769982/25015122/7497a1a6-2048-11e7-8e2d-689661beb3c7.png)

![screenshot from 2017-04-13 12-54-03](https://cloud.githubusercontent.com/assets/12769982/25015126/7a075bcc-2048-11e7-94c8-ade3554062e5.png)

