### PR TITLE
Disable CRUD for Network provider elements for non-OpenStack providers

### DIFF
--- a/app/helpers/application_helper/button/floating_ip_new.rb
+++ b/app/helpers/application_helper/button/floating_ip_new.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Button::FloatingIpNew < ApplicationHelper::Button::ButtonNewDiscover
+  def calculate_properties
+    super
+    if disabled?
+      self[:title] = _("No cloud providers support creating floating IPs.")
+    end
+  end
+
+  # disable button if no active providers support create action
+  def disabled?
+    EmsNetwork.all.none? { |ems| FloatingIp.class_by_ems(ems).supports_create? }
+  end
+end

--- a/app/helpers/application_helper/button/network_router_new.rb
+++ b/app/helpers/application_helper/button/network_router_new.rb
@@ -8,6 +8,6 @@ class ApplicationHelper::Button::NetworkRouterNew < ApplicationHelper::Button::B
 
   # disable button if no active providers support create action
   def disabled?
-    EmsNetwork.all.none? { |ems| NetworkRouter.class_by_ems(ems).supports_create? }
+    EmsNetwork.all.none? { |ems| NetworkRouter.class_by_ems(ems).supports_create_network_router? }
   end
 end

--- a/app/helpers/application_helper/button/network_router_new.rb
+++ b/app/helpers/application_helper/button/network_router_new.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Button::NetworkRouterNew < ApplicationHelper::Button::ButtonNewDiscover
+  def calculate_properties
+    super
+    if disabled?
+      self[:title] = _("No cloud providers support creating network routers.")
+    end
+  end
+
+  # disable button if no active providers support create action
+  def disabled?
+    EmsNetwork.all.none? { |ems| NetworkRouter.class_by_ems(ems).supports_create? }
+  end
+end

--- a/app/helpers/application_helper/button/security_group_new.rb
+++ b/app/helpers/application_helper/button/security_group_new.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Button::SecurityGroupNew < ApplicationHelper::Button::ButtonNewDiscover
+  def calculate_properties
+    super
+    if disabled?
+      self[:title] = _("No cloud providers support creating security groups.")
+    end
+  end
+
+  # disable button if no active providers support create action
+  def disabled?
+    EmsNetwork.all.none? { |ems| SecurityGroup.class_by_ems(ems).supports_create? }
+  end
+end

--- a/app/helpers/application_helper/toolbar/floating_ips_center.rb
+++ b/app/helpers/application_helper/toolbar/floating_ips_center.rb
@@ -12,7 +12,9 @@ class ApplicationHelper::Toolbar::FloatingIpsCenter < ApplicationHelper::Toolbar
             :floating_ip_new,
             'pficon pficon-add-circle-o fa-lg',
             t = N_('Add a new Floating IP'),
-            t),
+            t,
+            :klass => ApplicationHelper::Button::FloatingIpNew
+          ),
           separator,
           # TODO: Uncomment until cross controllers show_list issue fully in place
           # https://github.com/ManageIQ/manageiq/pull/12551

--- a/app/helpers/application_helper/toolbar/network_routers_center.rb
+++ b/app/helpers/application_helper/toolbar/network_routers_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::NetworkRoutersCenter < ApplicationHelper::Tool
             'pficon pficon-add-circle-o fa-lg',
             t = N_('Add a new Router'),
             t,
-            :klass => ApplicationHelper::Button::ButtonNewDiscover
+            :klass => ApplicationHelper::Button::NetworkRouterNew
           ),
           separator,
           button(

--- a/app/helpers/application_helper/toolbar/security_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/security_groups_center.rb
@@ -13,7 +13,8 @@ class ApplicationHelper::Toolbar::SecurityGroupsCenter < ApplicationHelper::Tool
             'pficon pficon-add-circle-o fa-lg',
             t = N_('Add a new Security Group'),
             t,
-            :klass => ApplicationHelper::Button::SecurityGroupNew),
+            :klass => ApplicationHelper::Button::SecurityGroupNew
+          ),
           separator,
           # TODO: Uncomment until cross controllers show_list issue fully in place
           # https://github.com/ManageIQ/manageiq/pull/12551

--- a/app/helpers/application_helper/toolbar/security_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/security_groups_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::SecurityGroupsCenter < ApplicationHelper::Tool
             'pficon pficon-add-circle-o fa-lg',
             t = N_('Add a new Security Group'),
             t,
-            :klass => ApplicationHelper::Button::ButtonNewDiscover),
+            :klass => ApplicationHelper::Button::SecurityGroupNew),
           separator,
           # TODO: Uncomment until cross controllers show_list issue fully in place
           # https://github.com/ManageIQ/manageiq/pull/12551

--- a/spec/helpers/application_helper/buttons/floating_ip_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/floating_ip_new_spec.rb
@@ -1,0 +1,33 @@
+describe ApplicationHelper::Button::FloatingIpNew do
+  describe '#disabled?' do
+    it "when at least one provider supports floating ip create then the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_openstack)
+      button = described_class.new(view_context, {}, {}, {})
+      expect(button.disabled?).to be false
+    end
+
+    it "when no provider supports floating ip create then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when no provider supports floating ip create the button has an error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      button.calculate_properties
+      expect(button[:title]).to eq("No cloud providers support creating floating IPs.")
+    end
+
+    it "when at least one provider supports floating ip create, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_openstack)
+      button = described_class.new(view_context, {}, {}, {})
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/network_router_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/network_router_new_spec.rb
@@ -1,0 +1,33 @@
+describe ApplicationHelper::Button::NetworkRouterNew do
+  describe '#disabled?' do
+    it "when at least one provider supports network router create then the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_openstack)
+      button = described_class.new(view_context, {}, {}, {})
+      expect(button.disabled?).to be false
+    end
+
+    it "when no provider supports network router create then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when no provider supports network router create the button has an error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      button.calculate_properties
+      expect(button[:title]).to eq("No cloud providers support creating network routers.")
+    end
+
+    it "when at least one provider supports network router create, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_openstack)
+      button = described_class.new(view_context, {}, {}, {})
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/security_group_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/security_group_new_spec.rb
@@ -1,0 +1,33 @@
+describe ApplicationHelper::Button::SecurityGroupNew do
+  describe '#disabled?' do
+    it "when at least one provider supports security group create then the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_openstack)
+      button = described_class.new(view_context, {}, {}, {})
+      expect(button.disabled?).to be false
+    end
+
+    it "when no provider supports security group create then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when no provider supports security group create the button has an error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      button.calculate_properties
+      expect(button[:title]).to eq("No cloud providers support creating security groups.")
+    end
+
+    it "when at least one provider supports security group create, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_openstack)
+      button = described_class.new(view_context, {}, {}, {})
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end


### PR DESCRIPTION
Disable CRUD for Network provider elements (like `Network Routers`, `Floating IPs`, `Security Groups`) for non-Openstack providers.

https://bugzilla.redhat.com/show_bug.cgi?id=1440684

Configuration Menu for ` Networks -> Security Groups` when at least one OpenStack Network Manager exists
`Add a New Security Group` is **enabled**

<img width="1382" alt="screen shot 2017-04-12 at 4 58 44 pm" src="https://cloud.githubusercontent.com/assets/1538216/24984313/6674685e-1fa1-11e7-93bd-71a5b4954b6b.png">

Configuration Menu for ` Networks -> Security Groups` when OpenStack Network Managers do not exist
`Add a New Security Group` is **disabled**

<img width="1377" alt="screen shot 2017-04-12 at 4 09 18 pm" src="https://cloud.githubusercontent.com/assets/1538216/24984268/2898efdc-1fa1-11e7-8114-3daa33ff1e50.png">

Screenshots for `Add a New Network Router` and `Add a new Floating IP` would be similar in the presense/absence of an OpenStack Network Manager
