### PR TITLE
moving testing gems capybara, jasmine over from main repo

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "guard-rspec", '~> 4.7.3'
   s.add_development_dependency "simplecov"
+  s.add_development_dependency "capybara", "~> 2.5.0"
+  s.add_development_dependency "jasmine"
 end


### PR DESCRIPTION
These tests depend upon jasmine for javascript
and capybara for integration tests

Moving them closer to the source

Please let me know if no one uses jasmine.