### PR TITLE
Don't render quadicon in PDF summaries

### DIFF
--- a/app/views/layouts/show_pdf.html.haml
+++ b/app/views/layouts/show_pdf.html.haml
@@ -1,7 +1,6 @@
 = render :partial => "layouts/pdf_styles"
 - controller = %w(miq_template vm_infra vm_or_template vm).include?(controller_name) ? "vm_common" : controller_name
-#xyz_main
-  = render_quadicon(@record, :mode => :icon, :size => 72)
+
 - if @record.kind_of?(ConfigurationProfile)
   = render :partial => "#{controller}/main_configuration_profile"
 - elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::InventoryGroup)


### PR DESCRIPTION
Do not attempt to render quadicon in PDF download, it doesn’t seem to work and can cause problems.

Addresses this BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1428580

Examples of quadicon in PDFs (only the name of the background image):

![screen shot 2017-04-11 at 3 37 35 pm](https://cloud.githubusercontent.com/assets/39493/24933764/e42a42da-1ecc-11e7-9bf9-18157f9bdc1c.png)

![screen shot 2017-04-11 at 3 39 17 pm](https://cloud.githubusercontent.com/assets/39493/24933794/14c56e1a-1ecd-11e7-9af3-130997f7b6be.png)
