### PR TITLE
[FINE] Retrieve search results on a Return(13) key press event

### DIFF
--- a/app/views/shared/_topology_header.html.haml
+++ b/app/views/shared/_topology_header.html.haml
@@ -11,7 +11,10 @@
     .form-group.has-clear
       .search-pf-input-group
         %label.sr-only{:for => "search"} Search
-        %input#search.form-control{'placeholder' => _("Search"), 'type' => "search", "ng-model" => "search.query"}
+        %input#search.form-control{"placeholder" => _("Search"),
+                                   "type"        => "search",
+                                   "ng-model"    => "search.query",
+                                   "ng-keypress" => "$event.which === 13 ? searchNode() : 0"}
           %button.clear{"aria-hidden" => "true", :type => "button", "ng-click" => "resetSearch()"}
             %span.pficon.pficon-close
     .form-group.search-button


### PR DESCRIPTION
Added changes to the Search box to respond to a `Return(13)` key press event and perform the search on the Topology graph.

https://bugzilla.redhat.com/show_bug.cgi?id=1401823