### PR TITLE
Remove duplicate flash_msg_div from automate explorer.

### DIFF
--- a/app/views/miq_ae_class/_instance_fields.html.haml
+++ b/app/views/miq_ae_class/_instance_fields.html.haml
@@ -2,7 +2,6 @@
 %h3= _('Fields')
 #instance_fields_div
   - if !@in_a_form
-    = render :partial => "layouts/flash_msg"
 
     %table#instance_fields_grid.table.table-striped.table-bordered
       %thead
@@ -48,5 +47,4 @@
 
   - else
     #form_div
-      = render :partial => "layouts/flash_msg"
       = render :partial => "instance_form", :locals => {:prefix => ""}

--- a/app/views/miq_ae_class/_ns_details.html.haml
+++ b/app/views/miq_ae_class/_ns_details.html.haml
@@ -1,7 +1,6 @@
 #ns_details_div
   - unless @in_a_form
     = render :partial => 'layouts/info_msg', :locals => {:message => @version_message} if @version_message
-    = render :partial => "layouts/flash_msg"
     %table#ns_details_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
       %thead
         %th.table-view-pf-select

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -3,7 +3,6 @@
     - unless @version_messages.blank?
       - @version_messages.each do |msg|
         = render :partial => 'layouts/info_msg', :locals => {:message => msg}
-    = render :partial => "layouts/flash_msg"
     %table#ns_list_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
       %thead
         %th.table-view-pf-select
@@ -41,7 +40,6 @@
 
   - else
     - url = url_for_only_path(:action => 'form_ns_field_changed', :id => (@ae_ns.id || 'new'))
-    = render :partial => "layouts/flash_msg"
     #form_ns_div
       %h3
         = _('Info')


### PR DESCRIPTION
app/views/miq_ae_class/_all_tabs.html.haml has a flash_msg_div and all
these are included below that. Some are even included more than once.
Therefor removing the flash_msg_div.

Automate --> Explorer --> automate instance