### PR TITLE
Add hint to check Hawkular when error originates from the Hawkular cl…

### DIFF
--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -78,7 +78,7 @@ class HawkularProxyService
   rescue StandardError => e
     {
       :parameters => params,
-      :error      => ActionView::Base.full_sanitizer.sanitize(e.message)
+      :error      => ActionView::Base.full_sanitizer.sanitize(e.message) + " " + _("(Please check your Hawkular server)")
     }
   end
 


### PR DESCRIPTION
**Description**
Add hint to "please check Hawkular server" when error originates from the Hawkular client.

Currently an error message originating from Hawkular will appear to the user the same way as an error originated from ManageIQ. This new hint will help users identify the problem more quickly.

**Screenshots**
_With hint_
![screenshot-localhost 3000-2017-04-12-16-46-14](https://cloud.githubusercontent.com/assets/2181522/24961292/ff975bdc-1fa0-11e7-8303-adda7137f610.png)

_Without hint_
![screenshot-localhost 3000-2017-04-12-16-50-35](https://cloud.githubusercontent.com/assets/2181522/24961291/ff9437f4-1fa0-11e7-984e-57cddf1f4c35.png)

**

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1439852