### PR TITLE
Rename button IDs according the controller_name(s) in which are used

### DIFF
--- a/app/helpers/application_helper/toolbar/ems_block_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_block_storages_center.rb
@@ -38,7 +38,7 @@ class ApplicationHelper::Toolbar::EmsBlockStoragesCenter < ApplicationHelper::To
                    :onwhen  => "1+",
                    :items   => [
                      button(
-                       :ems_storage_protect,
+                       :ems_block_storage_protect,
                        'pficon pficon-edit fa-lg',
                        N_('Manage Policies for the selected Block Storage Managers'),
                        N_('Manage Policies'),
@@ -46,7 +46,7 @@ class ApplicationHelper::Toolbar::EmsBlockStoragesCenter < ApplicationHelper::To
                        :enabled   => false,
                        :onwhen    => "1+"),
                      button(
-                       :ems_storage_tag,
+                       :ems_block_storage_tag,
                        'pficon pficon-edit fa-lg',
                        N_('Edit Tags for the selected Block Storage Managers'),
                        N_('Edit Tags'),

--- a/app/helpers/application_helper/toolbar/ems_object_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_object_storages_center.rb
@@ -38,7 +38,7 @@ class ApplicationHelper::Toolbar::EmsObjectStoragesCenter < ApplicationHelper::T
                    :onwhen  => "1+",
                    :items   => [
                      button(
-                       :ems_storage_protect,
+                       :ems_object_storage_protect,
                        'pficon pficon-edit fa-lg',
                        N_('Manage Policies for the selected Object Storage Managers'),
                        N_('Manage Policies'),
@@ -46,7 +46,7 @@ class ApplicationHelper::Toolbar::EmsObjectStoragesCenter < ApplicationHelper::T
                        :enabled   => false,
                        :onwhen    => "1+"),
                      button(
-                       :ems_storage_tag,
+                       :ems_object_storage_tag,
                        'pficon pficon-edit fa-lg',
                        N_('Edit Tags for the selected Object Storage Managers'),
                        N_('Edit Tags'),


### PR DESCRIPTION
It hasn't worked as the button IDs needs to use the controller name where are displayed, fixing according to that approach.

https://bugzilla.redhat.com/show_bug.cgi?id=1440108

UPDATE: Adding the link to the main repo PR to extend the product features for ```role_allows?``` call - https://github.com/ManageIQ/manageiq/pull/14745