### PR TITLE
fix cockpit button

### DIFF
--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -18,7 +18,7 @@ class ContainerNodeController < ApplicationController
   def launch_cockpit
     node = identify_record(params[:id], ContainerNode)
 
-    if node.ipaddress
+    if node.kubernetes_hostname
       javascript_open_window(node.cockpit_url.to_s)
     else
       javascript_flash(:text => node.unsupported_reason(:launch_cockpit), :severity => :error, :spinner_off => true)


### PR DESCRIPTION
Using `node.kubernetes_hostname` instead of old and deprecated `node.ipaddress`

Those functions were replaced in https://github.com/ManageIQ/manageiq/pull/13704. I forgot to make the change here as well.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1440204