### PR TITLE
[FINE] Use topology_header for Container Topology

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -6,14 +6,11 @@ miqHttpInject(angular.module('topologyApp', ['kubernetesUI', 'ui.bootstrap', 'Ma
 ContainerTopologyCtrl.$inject = ['$scope', '$http', '$interval', 'topologyService', '$window', 'miqService'];
 
 function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $window, miqService) {
-  ManageIQ.angular.scope = $scope;
-  miqHideSearchClearButton();
   var self = this;
   $scope.vs = null;
   var icons = null;
 
   var d3 = window.d3;
-  $scope.d3 = d3;
 
   $scope.refresh = function() {
     var id, type;
@@ -50,7 +47,6 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
   $scope.legendTooltip = __("Click here to show/hide entities of this type");
 
   $scope.show_hide_names = function() {
-    $scope.checkboxModel.value = $('input#box_display_names')[0].checked
     var vertices = $scope.vs;
 
     if ($scope.checkboxModel.value) {
@@ -62,7 +58,6 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
     }
   };
 
-  $('input#box_display_names').click($scope.show_hide_names)
   $scope.refresh();
   var promise = $interval($scope.refresh, 1000 * 60 * 3);
 
@@ -285,17 +280,17 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
   };
 
   $scope.searchNode = function() {
-    var svg = topologyService.getSVG($scope.d3);
-    var query = $('input#search_topology')[0].value;
+    var svg = topologyService.getSVG(d3);
+    var query = $scope.search.query;
 
     topologyService.searchNode(svg, query);
   };
 
   $scope.resetSearch = function() {
-    topologyService.resetSearch($scope.d3);
+    topologyService.resetSearch(d3);
 
     // Reset the search term in search input
-    $('input#search_topology')[0].value = "";
+    $scope.search.query = "";
   };
 
   function getContainerTopologyData(response) {

--- a/app/helpers/application_helper/toolbar/topology_center.rb
+++ b/app/helpers/application_helper/toolbar/topology_center.rb
@@ -1,3 +1,2 @@
 class ApplicationHelper::Toolbar::TopologyCenter < ApplicationHelper::Toolbar::Basic
-  custom_content('custom', :partial => 'shared/topology_header_toolbar')
 end

--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -1,5 +1,8 @@
 - tooltip_options = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
 .container_topology{'ng-controller' => "containerTopologyController"}
+  .row.toolbar-pf
+    .col-md-12
+      = render :partial => "shared/topology_header"
   .legend
     %label#selected
     %div{'ng-if' => "kinds"}


### PR DESCRIPTION
To be consistent with other Topology screens, Container Topology needs to use `_topology_header` as it's toolbar

This change would also automatically address retrieving search results on a `Return(13)` key press event, which was fixed for other topologies in https://github.com/ManageIQ/manageiq-ui-classic/pull/1010

https://bugzilla.redhat.com/show_bug.cgi?id=1401823