### PR TITLE
Replaces default icons for “catalog” and “catalog items”

### DIFF
--- a/app/decorators/service_template_catalog_decorator.rb
+++ b/app/decorators/service_template_catalog_decorator.rb
@@ -1,5 +1,5 @@
 class ServiceTemplateCatalogDecorator < MiqDecorator
   def self.fonticon
-    'product product-template'
+    'pficon pficon-folder-close'
   end
 end

--- a/app/decorators/service_template_decorator.rb
+++ b/app/decorators/service_template_decorator.rb
@@ -1,6 +1,6 @@
 class ServiceTemplateDecorator < MiqDecorator
   def self.fonticon
-    'product product-template'
+    'fa fa-cube'
   end
 
   def fileicon


### PR DESCRIPTION
This PR replaces the "T" used to represent catalogs with a closed folder in: service catalogs, catalog items, and catalogs. It also replaces the default icon "T" used to represent catalog items with a cube.

Relates to: https://github.com/ManageIQ/manageiq-ui-classic/pull/971

https://bugzilla.redhat.com/show_bug.cgi?id=1439779

Old
<img width="322" alt="screen shot 2017-04-12 at 3 02 39 pm" src="https://cloud.githubusercontent.com/assets/1287144/24974778/67d07f72-1f91-11e7-8435-85df0eb7968e.png">

New
<img width="327" alt="screen shot 2017-04-12 at 2 59 16 pm" src="https://cloud.githubusercontent.com/assets/1287144/24974779/67d5a060-1f91-11e7-8da1-46854748fcc6.png">