### PR TITLE
Revert "Replaces default icons for “catalog” and “catalog items”"

### DIFF
--- a/app/decorators/service_template_catalog_decorator.rb
+++ b/app/decorators/service_template_catalog_decorator.rb
@@ -1,5 +1,5 @@
 class ServiceTemplateCatalogDecorator < MiqDecorator
   def self.fonticon
-    'pficon pficon-folder-close'
+    'product product-template'
   end
 end

--- a/app/decorators/service_template_decorator.rb
+++ b/app/decorators/service_template_decorator.rb
@@ -1,6 +1,6 @@
 class ServiceTemplateDecorator < MiqDecorator
   def self.fonticon
-    'fa fa-cube'
+    'product product-template'
   end
 
   def fileicon


### PR DESCRIPTION
Reverts ManageIQ/manageiq-ui-classic#1024 due to failing specs that I hadn't noticed.