### PR TITLE
Do not enable disabled button when items are selected

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -42,9 +42,15 @@ class ApplicationHelper::Button::Basic < Hash
   #   self[:prompt]  -- the user has to confirm the action
   #   self[:hidden]  -- the button is not displayed in the toolbar
   #   self[:text]    -- text for the button
+  #   self[:onwhen]  -- enable button if items are selected
   def calculate_properties
-    self[:enabled] = !disabled? if self[:enabled].nil?
-    self[:title] = @error_message if @error_message.present?
+    enabled = !disabled?
+    self[:enabled] = enabled if self[:enabled].nil?
+
+    unless self[:enabled] || enabled
+      self[:onwhen] = nil
+      self[:title] = @error_message if @error_message.present?
+    end
   end
 
   # Check if all instance variables for that button works with are set and

--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -45,8 +45,14 @@ class ApplicationHelper::Button::Basic < Hash
   #   self[:onwhen]  -- enable button if items are selected
   def calculate_properties
     enabled = !disabled?
+
+    # if :enabled is not set, use disabled?
     self[:enabled] = enabled if self[:enabled].nil?
 
+    # if disabled? is true and user did not specify that :enabled is true
+    # then:
+    #     set :onwhen to nil => do not enable when user select items
+    #     set :title to error => show user the error message
     unless self[:enabled] || enabled
       self[:onwhen] = nil
       self[:title] = @error_message if @error_message.present?

--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -43,6 +43,9 @@ class ApplicationHelper::Button::Basic < Hash
   #   self[:hidden]  -- the button is not displayed in the toolbar
   #   self[:text]    -- text for the button
   #   self[:onwhen]  -- enable button if items are selected
+  #
+  # If disabled? is true, disable onwhen and set state and title unless
+  # user specifically enabled the button
   def calculate_properties
     enabled = !disabled?
 


### PR DESCRIPTION
**Description**

Currently the `:onwhen` property override the `disabled?` method of a button. If a disabled button has the `:onwhen` set, it will become enabled if user select an item from the list.

Currently the `disabled?` method is not called if `self[:enabled].nil?` is false, so the `@error_message` variable is not being set, and does not replace the `:title`.

This PR:
a. Remove the `:onwhen` property of a disabled item
b. Calls the `disabled?` method, to set the `@error_message` variable

| :enable | disabled? | => |:enabled | :title | :onwhen |  
|-----------|--------------|-|-----------|-------|-------------|
| true | true/false | |true | unchenged | unchanged |
| false | true | | false | error | nil |
| false | false | | false | unchenged | unchanged |
| nil | true | | false | error | nil |
| nil | false | | true | unchenged | unchanged |

**Screenshots**

_Bug_
![screenshot-localhost 3000-2017-04-13-10-54-21](https://cloud.githubusercontent.com/assets/2181522/24996166/7b06e00a-203a-11e7-8c9a-3bb17467c8a9.png)

_Fix_
![screenshot from 2017-04-13 11-04-53](https://cloud.githubusercontent.com/assets/2181522/24996178/89efffde-203a-11e7-912a-41f35b882905.jpg)

_Fix when `disabled?` is false_
![screenshot from 2017-04-13 11-18-40](https://cloud.githubusercontent.com/assets/2181522/24996329/17bd09f6-203b-11e7-9ac3-fd22b499a9c6.jpg)

Duplicate of:
https://github.com/ManageIQ/manageiq-ui-classic/pull/943
Fixes a bug related to this BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1438248

Closes #943 