### PR TITLE
Update current.userid when userid is changed

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -715,6 +715,7 @@ module OpsController::OpsRbac
 
     if record.valid? && !flash_errors? && record.save
       set_role_features(record) if what == "role"
+      self.current_user = record if what == 'user' && @edit[:current][:userid] == current_userid
       AuditEvent.success(build_saved_audit(record, add_pressed))
       subkey = (key == :group) ? :description : :name
       add_flash(_("%{model} \"%{name}\" was saved") % {:model => what.titleize, :name => @edit[:new][subkey]})


### PR DESCRIPTION
When logged user's userid is updated by UI,
his userid is not changed in the session

For updating userid in session is used
method `current_user=` from `ApplicationController::CurrentUser`

@miq-bot add_label bug 
cc @mzazrivec 

@miq-bot assign @martinpovolny 

**Test scenario**

![userid](https://cloud.githubusercontent.com/assets/14937244/24996950/201ca9ae-2035-11e7-9f71-3d7c3f7d1c07.gif)


```
[----] F, [2017-04-13T10:34:59.753301 #16596:3fea6e445fa0] FATAL -- : ActionView::Template::Error (undefined method `current_group_id=' for nil:NilClass):
[----] F, [2017-04-13T10:34:59.753451 #16596:3fea6e445fa0] FATAL -- :      9:           = I18n.t("product.name_full")
    10:         .product-versions-pf
    11:           %ul.list-unstyled
    12:             - [[_("Version"),        h(vmdb_build_info(:version) + "." + vmdb_build_info(:build))],
    13:               [_("Server Name"),     h(appliance_name)],
    14:               [_("User Name"),       h(current_user.name)],
    15:               [_("User Role"),       h(user_role_name)],
[----] F, [2017-04-13T10:34:59.753496 #16596:3fea6e445fa0] FATAL -- :
[----] F, [2017-04-13T10:34:59.753557 #16596:3fea6e445fa0] FATAL -- : /Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/application_controller/current_user.rb:34:in `block in current_user'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/application_controller/current_user.rb:33:in `tap'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/application_controller/current_user.rb:33:in `current_user'
actionpack (5.0.2) lib/abstract_controller/helpers.rb:68:in `current_user'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/views/layouts/_about_modal.html.haml:12:in `___sers_liborpichler_manageiq_manageiq_ui_classic_app_views_layouts__about_modal_html_haml___2708884880756652404_70275971837000'
actionview (5.0.2) lib/action_view/template.rb:159:in `block in render'
activesupport (5.0.2) lib/active_support/notifications.rb:166:in `instrument'
actionview (5.0.2) lib/action_view/template.rb:354:in `instrument'
actionview (5.0.2) lib/action_view/template.rb:157:in `render'
actionview (5.0.2) lib/action_view/renderer/partial_renderer.rb:343:in `render_partial'
actionview (5.0.2) lib/action_view/renderer/partial_renderer.rb:311:in `block in render'
actionview (5.0.2) lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
activesupport (5.0.2) lib/active_support/notifications.rb:164:in `block in instrument'
activesupport (5.0.2) lib/active_support/notifications/instrumenter.rb:21:in `instrument'
activesupport (5.0.2) lib/active_support/notifications.rb:164:in `instrument'
actionview (5.0.2) lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
actionview (5.0.2) lib/action_view/renderer/partial_renderer.rb:310:in `render'
actionview (5.0.2) lib/action_view/renderer/renderer.rb:47:in `render_partial'
```


