### PR TITLE
Hide back button on provider dashboard screens

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -731,6 +731,8 @@ module ApplicationHelper
   def display_back_button?
     # don't need to back button if @record is not there or @record doesnt have name or
     # evm_display_name column, i.e MiqProvisionRequest
+    return false if @display == "dashboard"
+
     if (@lastaction != "show" || (@lastaction == "show" && @display != "main")) &&
        @record &&
        (@record.respond_to?('name') && !@record.name.nil?)


### PR DESCRIPTION
Currently the back button is displayed on provider dashboards but they are non-functional. This removes the button.

**Addresses**
https://bugzilla.redhat.com/show_bug.cgi?id=1441956

**Testing**
I checked the container and infra providers dashboards, both had this behavior.


**Before**
![screen shot 2017-04-13 at 11 46 53 am](https://cloud.githubusercontent.com/assets/39493/25019403/4a0f572a-203f-11e7-918d-0244c33fe189.png)

**After**
![screen shot 2017-04-13 at 11 45 04 am](https://cloud.githubusercontent.com/assets/39493/25019430/5dba0b80-203f-11e7-925b-71343390d929.png)

