### PR TITLE
Set @showlinks to true in tagging_edit to set correct quadicon links

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -4,6 +4,7 @@ module ApplicationController::Tags
   # Edit user, group or tenant tags
   def tagging_edit(db = nil, assert = true)
     assert_privileges("#{controller_for_common_methods}_tag") if assert
+    @showlinks = true
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
     case params[:button]
     when "cancel"

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -240,7 +240,7 @@ module QuadiconHelper
     if quadicon_in_explorer_view?
       quadicon_build_explorer_url(item, row)
     else
-      url_for_db(quadicon_model_name(item), "show", item)
+      url_for_db(controller_name, "show", item)
     end
   end
 

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -226,6 +226,7 @@ describe QuadiconHelper do
   describe "#render_quadicon_text" do
     before(:each) do
       @settings = {:display => {:quad_truncate => "m"}}
+      allow(controller).to receive(:controller_name).and_return("service")
     end
 
     let(:item) do
@@ -277,6 +278,10 @@ describe QuadiconHelper do
     end
 
     context "when item is an EmsCluster" do
+      before do
+        allow(controller).to receive(:controller_name).and_return("ems_cluster")
+      end
+
       let(:ems) do
         FactoryGirl.build(:ems_cluster)
       end
@@ -312,6 +317,10 @@ describe QuadiconHelper do
     end
 
     context "when item is a StorageManager" do
+      before do
+        allow(controller).to receive(:controller_name).and_return("storage_manager")
+      end
+
       let(:stor) do
         FactoryGirl.create(:storage_manager, :name => "Store Man")
       end
@@ -327,6 +336,10 @@ describe QuadiconHelper do
     end
 
     context "when item is a FloatingIP" do
+      before do
+        allow(controller).to receive(:controller_name).and_return("floating_ip")
+      end
+
       let(:item) do
         FactoryGirl.create(:floating_ip_openstack)
       end
@@ -344,6 +357,10 @@ describe QuadiconHelper do
     end
 
     context "when item is an Authentication" do
+      before do
+        allow(controller).to receive(:controller_name).and_return("auth_key_pair_cloud")
+      end
+
       let(:item) do
         FactoryGirl.create(:authentication)
       end
@@ -450,6 +467,7 @@ describe QuadiconHelper do
     context "default case" do
       before(:each) do
         @id = item.id
+        allow(controller).to receive(:controller_name).and_return("vm")
       end
 
       let(:item) do
@@ -504,6 +522,7 @@ describe QuadiconHelper do
   describe "#render_quadicon_label" do
     before(:each) do
       @settings = {:display => {:quad_truncate => "m"}}
+      allow(controller).to receive(:controller_name).and_return("service")
     end
 
     subject { helper.render_quadicon_label(item, row) }


### PR DESCRIPTION
Before (incorrect link in quadicon):
<img width="1367" alt="screen shot 2017-04-13 at 12 20 51 pm" src="https://cloud.githubusercontent.com/assets/1538216/25020579/d071bfde-2043-11e7-86dd-c0851c412402.png">



After (correct link in quadicon)
<img width="1373" alt="screen shot 2017-04-13 at 12 18 46 pm" src="https://cloud.githubusercontent.com/assets/1538216/25020495/72c81b76-2043-11e7-8349-5ffbd937df46.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1440151