### PR TITLE
Fix for inability to edit/add service dialog imported from CF 4.0 to 4.2

### DIFF
--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -69,15 +69,7 @@
 
                         - else
                           - if field.values.length > 1
-                            - if field.sort_by.to_s != "none"
-                              - if field.data_type == "integer"
-                                - val = field.values.sort_by { |d| field.sort_by == :value ? d.first.to_i : d.last.to_i }
-                                - val = val.reverse if field.sort_order == :descending
-                              - else
-                                - val = field.values.sort_by { |d| field.sort_by == :value ? d.first : d.last }
-                                - val = val.reverse if field.sort_order == :descending
-                            - else
-                              - val = copy_array(field.values)
+                            - val = copy_array(field.values)
 
                             - if field.type == "DialogFieldDropDownList"
                               - if field.required


### PR DESCRIPTION
This removes unnecessary logic from the view that is already being handled by the `values` method, and is tested. The previous logic that was in the view was also blowing up on certain dialogs, where when the `data_type` was not set to integer, it was attempting to sort without first calling `to_s` on the values, which was causing a nil comparison to string error.

This fix, in combination with a memcache size increase, should resolve the issue that is being reported in the below linked BZ.

https://bugzilla.redhat.com/show_bug.cgi?id=1435758

@miq-bot assign @gmcculloug 
@miq-bot add_label euwe/yes, fine/yes, bug