### PR TITLE
Make Physical Infrastructure a prototype feature [Depends on core/14784]

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -6,9 +6,9 @@ module Menu
         Menu::Section.new(:compute, N_("Compute"), 'pficon pficon-cpu', [
           clouds_menu_section,
           infrastructure_menu_section,
-          physical_infrastructure_menu_section,
+          ::Settings.product.physical_infrastructure ? physical_infrastructure_menu_section : nil,
           container_menu_section
-        ])
+        ].compact)
       end
 
       def configuration_menu_section


### PR DESCRIPTION
A new setting has been added to allow Physical Infrastructure to be hidden.  This UI change uses that setting to hide/show the Physical Infrastructure menu item.

Depends on:  https://github.com/ManageIQ/manageiq/pull/14784