### PR TITLE
Fix policy delete/copy buttons

### DIFF
--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -121,7 +121,12 @@ module MiqPolicyController::Policies
       add_flash(_("%{models} no longer exists") % {:models => ui_lookup(:model => "MiqPolicy")},
                 :error)
     else
-      policies.push(params[:id])
+      if pol.read_only
+        add_flash(_("%{models} is read only") % {:models => ui_lookup(:model => "MiqPolicy")},
+        :error)
+      else
+        policies.push(params[:id])
+      end
       self.x_node = @new_policy_node = policies_node(pol.mode, pol.towhat)
     end
     process_policies(policies, "destroy") unless policies.empty?

--- a/app/helpers/application_helper/button/policy_copy.rb
+++ b/app/helpers/application_helper/button/policy_copy.rb
@@ -1,5 +1,6 @@
-class ApplicationHelper::Button::PolicyCopy < ApplicationHelper::Button::PolicyButton
+class ApplicationHelper::Button::PolicyCopy < ApplicationHelper::Button::Basic
   def visible?
     x_active_tree == :policy_tree
   end
+  delegate :x_active_tree, :to => :@view_context
 end

--- a/app/helpers/application_helper/button/policy_delete.rb
+++ b/app/helpers/application_helper/button/policy_delete.rb
@@ -1,6 +1,7 @@
 class ApplicationHelper::Button::PolicyDelete < ApplicationHelper::Button::PolicyButton
   def disabled?
-    @error_message = _('Policies that belong to Profiles can not be deleted') unless @policy.memberof.empty?
+    super
+    @error_message ||= _('Policies that belong to Profiles can not be deleted') unless @policy.memberof.empty?
     @error_message.present?
   end
 end

--- a/app/helpers/application_helper/toolbar/miq_policy_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_center.rb
@@ -31,8 +31,7 @@ class ApplicationHelper::Toolbar::MiqPolicyCenter < ApplicationHelper::Toolbar::
                           }
                         end,
           :url_parms => "main_div",
-          :klass     => ApplicationHelper::Button::PolicyCopy,
-          :options   => {:feature => 'policy_copy'}),
+          :klass     => ApplicationHelper::Button::PolicyCopy),
         button(
           :policy_delete,
           'pficon pficon-delete fa-lg',


### PR DESCRIPTION
Fix policy delete/copy buttons. You should be always be able to copy policy and you shouldn't be able to delete read only policy.

https://bugzilla.redhat.com/show_bug.cgi?id=1434865