### PR TITLE
Fixed alphabetical order in Labels table 

### DIFF
--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -187,10 +187,4 @@ module ContainerSummaryHelper
       ]
     end
   end
-
-  private
-
-  def textual_key_value_group(items)
-    items.collect { |item| {:label => item.name.to_s, :value => item.value.to_s} }
-  end
 end

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -48,6 +48,11 @@ module TextualSummaryHelper
     }
   end
 
+  def textual_key_value_group(items)
+    res = items.collect { |item| {:label => item.name.to_s, :value => item.value.to_s} }
+    res.sort_by { |k| k[:label] }
+  end
+
   def textual_tags
     label = _("%{name} Tags") % {:name => session[:customer_name]}
     h = {:label => label}

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -107,7 +107,7 @@ module VmHelper::TextualSummary
   end
 
   def textual_group_labels
-    TextualGroup.new(_("Labels"), textual_labels)
+    TextualGroup.new(_("Labels"), textual_key_value_group(@record.custom_attributes))
   end
 
   def textual_group_power_management
@@ -758,12 +758,6 @@ module VmHelper::TextualSummary
 
   def textual_ems_custom_attributes
     attrs = @record.ems_custom_attributes
-    return nil if attrs.blank?
-    attrs.sort_by(&:name).collect { |a| {:label => a.name, :value => a.value} }
-  end
-
-  def textual_labels
-    attrs = @record.custom_attributes
     return nil if attrs.blank?
     attrs.sort_by(&:name).collect { |a| {:label => a.name, :value => a.value} }
   end


### PR DESCRIPTION
Fixed the alphabetical order in the Labels table to suit with openshift.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1439782

cc: @himdel @zakiva 
@simon3z 

Before:
![screenshot from 2017-04-18 17-10-19](https://cloud.githubusercontent.com/assets/8366181/25135631/97eeeb02-245b-11e7-82d5-7cd0e3ce668c.png)
After:
![screenshot from 2017-04-18 17-12-39](https://cloud.githubusercontent.com/assets/8366181/25135638/9b88bd60-245b-11e7-8dc1-97fd559eb7e9.png)


