### PR TITLE
Fix toolbar buttons after network provider refresh

### DIFF
--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -14,15 +14,17 @@
   */
   function subscribeToSubject() {
     ManageIQ.angular.rxSubject.subscribe(function(event) {
-      if (event.eventType === 'updateToolbarCount') {
-        this.MiQToolbarSettingsService.setCount(event.countSelected);
-      } else if (event.rowSelect) {
-        this.onRowSelect(event.rowSelect);
-      } else if (event.redrawToolbar) {
-         this.onUpdateToolbar(event.redrawToolbar);
-      } else if (event.update) {
-        this.onUpdateItem(event);
-      }
+      this.$timeout(function() {
+        if (event.eventType === 'updateToolbarCount') {
+          this.MiQToolbarSettingsService.setCount(event.countSelected);
+        } else if (event.rowSelect) {
+          this.onRowSelect(event.rowSelect);
+        } else if (event.redrawToolbar) {
+           this.onUpdateToolbar(event.redrawToolbar);
+        } else if (event.update) {
+          this.onUpdateItem(event);
+        }
+      }.bind(this));
     }.bind(this),
     function (err) {
       console.error('Angular RxJs Error: ', err);
@@ -51,11 +53,12 @@
   * @param $location service for managing browser's location.
   * this contructor will assign all params to `this`, it will init endpoits, set if toolbar is used on list page.
   */
-  var ToolbarController = function(MiQToolbarSettingsService, MiQEndpointsService, $scope, $location) {
+  var ToolbarController = function(MiQToolbarSettingsService, MiQEndpointsService, $scope, $location, $timeout) {
     this.MiQToolbarSettingsService = MiQToolbarSettingsService;
     this.MiQEndpointsService = MiQEndpointsService;
     this.$scope = $scope;
     this.$location = $location;
+    this.$timeout = $timeout;
     initEndpoints(this.MiQEndpointsService);
     this.isList = _.contains(location.pathname, 'show_list');
   }
@@ -65,9 +68,6 @@
   */
   ToolbarController.prototype.onRowSelect = function(data) {
     this.MiQToolbarSettingsService.checkboxClicked(data.checked);
-    if(!this.$scope.$$phase) {
-      this.$scope.$digest();
-    }
   }
 
   /**
@@ -141,18 +141,12 @@
 
   ToolbarController.prototype.onUpdateToolbar = function(toolbarObject) {
     this.updateToolbar(toolbarObject);
-    if(!this.$scope.$$phase) {
-      this.$scope.$digest();
-    }
   }
 
   ToolbarController.prototype.onUpdateItem = function(updateData) {
     var toolbarItem = _.find(_.flatten(this.toolbarItems), {id: updateData.update});
     if (toolbarItem && toolbarItem.hasOwnProperty(updateData.type)) {
       toolbarItem[updateData.type] = updateData.value;
-      if(!this.$scope.$$phase) {
-        this.$scope.$digest();
-      }
     }
   }
 
@@ -164,7 +158,7 @@
     this.setClickHandler();
   }
 
-  ToolbarController.$inject = ['MiQToolbarSettingsService', 'MiQEndpointsService', '$scope', '$location'];
+  ToolbarController.$inject = ['MiQToolbarSettingsService', 'MiQEndpointsService', '$scope', '$location', '$timeout'];
   miqHttpInject(angular.module('ManageIQ.toolbar'))
     .controller('miqToolbarController', ToolbarController);
 })();

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1513,7 +1513,7 @@ class ApplicationController < ActionController::Base
     render :update do |page|
       page << javascript_prologue
       page.replace(:flash_msg_div, :partial => "layouts/flash_msg")           # Replace the flash message
-      page << "miqSetButtons(0, 'center_tb');" # Reset the center toolbar
+      page << "sendDataWithRx({eventType: 'updateToolbarCount', countSelected: 0})"
       if layout_uses_listnav?
         page.replace(:listnav_div, :partial => "layouts/listnav")               # Replace accordion, if list_nav_div is there
       end


### PR DESCRIPTION
After pressing the ```Configuration -> Refresh relationships and power states``` on Network Providers list view, it unchecked chosen items from the list but the toolbars have not been updated (user was able to click on Policy toolbar with no selected item), I've noticed this issue appeared on all Provider list views, not only on Network ones (as the BZ description).

The fix has been made with @himdel's assistance - we removed the usage of ```$$phase``` internal variable to check ```$digest``` cycle, rather use ```$timeout```

https://bugzilla.redhat.com/show_bug.cgi?id=1440118