### PR TITLE
Fix 'Save' button state in Edit Management Engine Relationship for VM/Instance

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -597,7 +597,7 @@ module VmCommon
 
   def evm_relationship_get_form_vars
     @record = VmOrTemplate.find_by_id(@edit[:vm_id])
-    @edit[:new][:server] = params[:server_id] if params[:server_id]
+    @edit[:new][:server] = params[:server_id] == "" ? nil : params[:server_id] if params[:server_id]
   end
 
   def evm_relationship_update

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -310,6 +310,26 @@ describe VmOrTemplateController do
     end
   end
 
+  context '#evm_relationship_get_form_vars' do
+    before :each do
+      @vm = FactoryGirl.create(:vm_vmware)
+      edit = {:vm_id => @vm.id, :new => {:server => nil}}
+      controller.instance_variable_set(:@edit, edit)
+    end
+
+    it 'does not set new server when params[:server_id] is not set' do
+      controller.instance_variable_set(:@_params, :server_id => '')
+      controller.send(:evm_relationship_get_form_vars)
+      expect(assigns(:edit)[:new][:server]).to be(nil)
+    end
+
+    it 'sets new server when params[:server_id] is set' do
+      controller.instance_variable_set(:@_params, :server_id => '42')
+      controller.send(:evm_relationship_get_form_vars)
+      expect(assigns(:edit)[:new][:server]).to eq(controller.params[:server_id])
+    end
+  end
+
   include_examples '#download_summary_pdf', :vm_cloud
   include_examples '#download_summary_pdf', :vm_infra
 end


### PR DESCRIPTION
Reset 'Save' button to nil when no server is selected to disable the button.

https://bugzilla.redhat.com/show_bug.cgi?id=1442736