### PR TITLE
Also post check tree nodes top-to-bottom when required

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -503,6 +503,7 @@ function miqInitTree(options, tree) {
   // Pre-process partially checkbox state for parent nodes
   if (options.post_check && options.hierarchical_check) {
     var nodes = [];
+    var parents = [];
     var stack = tree.slice(0);
 
     // Collect nodes
@@ -511,18 +512,35 @@ function miqInitTree(options, tree) {
       nodes.push(node);
 
       if (node.nodes) {
+        parents.push(node);
         node.nodes.forEach(function (child) {
-          if (child.nodes) {
-            stack.push(child);
-          }
+          stack.push(child);
         });
       }
     }
 
-    // Process nodes
+
+    // Process nodes top-to-bottom
+    nodes.reverse();
     while (nodes.length > 0) {
-      var node = nodes.pop();
-      if (!node.state) node.state = {};
+      var parent = nodes.pop();
+      if (!parent.nodes) {
+        continue;
+      }
+      if (!parent.state) {
+        parent.state = {};
+      }
+      parent.nodes.forEach(function (node) {
+        if (parent.state.checked === true) {
+          if (!node.state) node.state = {};
+          node.state.checked = true;
+        }
+      });
+    }
+
+    // Process nodes bottom-to-top
+    while (parents.length > 0) {
+      var node = parents.pop();
       node.state.checked = node.nodes.map(function(node) {
         return node.state ? node.state.checked : false;
       }).reduce(function (acc, curr) {

--- a/spec/javascripts/miq_tree_spec.js
+++ b/spec/javascripts/miq_tree_spec.js
@@ -1,3 +1,78 @@
 describe('miq_tree', function() {
+  describe('miqInitTree', function () {
+    describe('post_check', function () {
+      it('checks child nodes', function () {
+        $('body').append($('<div id="testbox">'));
 
+        miqInitTree({tree_id: "testbox", post_check: true, hierarchical_check: true}, [
+          {
+            key: "1",
+            text: "Parent unset, children partial",
+            nodes: [
+              {
+                key: "1-1",
+                text: "Child 1",
+                state: {
+                  checked: true
+                }
+              },
+              {
+                key: "1-2",
+                text: "Child 2",
+                state: {
+                  checked: false
+                }
+              }
+            ]
+          },
+          {
+            key: "2",
+            text: "Parent set, children unset",
+            state: {
+              checked: true
+            },
+            nodes: [
+              {
+                key: "2-1",
+                text: "Child 1"
+              },
+              {
+                key: "2-2",
+                text: "Child 2"
+              }
+            ]
+          },
+          {
+            key: "3",
+            text: "Parent set, children partial",
+            state: {
+              checked: true
+            },
+            nodes: [
+              {
+                key: "3-1",
+                text: "Child 1",
+                state: {
+                  checked: false
+                }
+              },
+              {
+                key: "3-2",
+                text: "Child 2",
+                state: {
+                  checked: true
+                }
+              }
+            ]
+          }
+        ]);
+        expect(miqTreeFindNodeByKey('test', '1').state.checked).toBe(undefined);
+        expect(miqTreeFindNodeByKey('test', '2').state.checked).toBe(true);
+        expect(miqTreeFindNodeByKey('test', '2-1').state.checked).toBe(true);
+        expect(miqTreeFindNodeByKey('test', '2-2').state.checked).toBe(true);
+        expect(miqTreeFindNodeByKey('test', '3').state.checked).toBe(true);
+        expect(miqTreeFindNodeByKey('test', '3-1').state.checked).toBe(true);
+      });
+    });
+  });
 });


### PR DESCRIPTION
The `post_check` feature is a post-processing for hierarchical checkboxes, it was able to set a node's checked state based on their childrens'. This PR introduces the same logic in the opposite way, if a parent node is checked, it also sets the child nodes' state to checked.

FYI @hayesr 