### PR TITLE
Zero the toolbar count when asked

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -451,27 +451,7 @@ function miqSetButtons(count, button_div) {
     return
   }
 
-  if (button_div.match("_tb$")) {
-    var toolbar = $('#' + button_div);
-
-    // Non-dropdown master buttons
-    toolbar.find('button:not(.dropdown-toggle)').each(function (_k, v) {
-      var button = $(v);
-      miqButtonOnWhen(button, button.data('onwhen'), count);
-    });
-
-    // Dropdown master buttons
-    toolbar.find('button.dropdown-toggle').each(function (_k, v) {
-      var button = $(v);
-      miqButtonOnWhen(button, button.data('onwhen'), count);
-    });
-
-    // Dropdown button items
-    toolbar.find('ul.dropdown-menu > li > a').each(function (_k, v) {
-      var button = $(v);
-      miqButtonOnWhen(button.parent(), button.data('onwhen'), count);
-    });
-  } else if (button_div.match("_buttons$")) { // Handle buttons that are not part of miq toolbars
+  if (button_div.match("_buttons$")) { // Handle buttons that are not part of miq toolbars
     if (count === 0) {
       $("#" + button_div + " button[id$=on_1]").prop('disabled', true);
     } else if (count == 1) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -447,11 +447,18 @@ function miqButtonOnWhen(button, onwhen, count) {
 
 // Set the buttons in a div based on the count of checked items passed in
 function miqSetButtons(count, button_div) {
-  if (!miqDomElementExists(button_div)) {
-    return
+  if (button_div.match("_tb$") && count === 0) {
+    // FIXME: this should be happening regardless of `count === 0`
+    // ..but that needs more refactoring around miqUpdateAllCheckboxes, miqUpdateButtons, etc.
+    sendDataWithRx({
+      eventType: 'updateToolbarCount',
+      countSelected: count,
+    });
+
+    return;
   }
 
-  if (button_div.match("_buttons$")) { // Handle buttons that are not part of miq toolbars
+  if (miqDomElementExists(button_div) && button_div.match("_buttons$")) { // Handle buttons that are not part of miq toolbars
     if (count === 0) {
       $("#" + button_div + " button[id$=on_1]").prop('disabled', true);
     } else if (count == 1) {


### PR DESCRIPTION
Before the toolbar refactor, `miqSetButtons` would set the right counts for toolbar.

This no longer happens and `miqSetButtons` is almost dead .. except it is still being called in all the places where we want to reset the counts.

So, adding a special condition to reset the toolbar count when count = 0.

https://bugzilla.redhat.com/show_bug.cgi?id=1440142

(also added euwe/yes because this is also related to https://bugzilla.redhat.com/show_bug.cgi?id=1440118, together with https://github.com/ManageIQ/manageiq-ui-classic/pull/1054)

---

This needs more cleanup, and complete refactoring of `miqUpdateButtons` and `miqUpdateAllCheckboxes` and `miqSetButtons` (and related code), but for now .. this fixes the bug :).

When testing, the changes from #1054 are also needed to get consistent behaviour without extra clicking.