### PR TITLE
Skip links for quadicons in PDFs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -150,6 +150,10 @@ class ApplicationController < ActionController::Base
   end
 
   def download_summary_pdf
+    # do not build quadicon links
+    @embedded = true
+    @showlinks = false
+
     @record = identify_record(params[:id])
     yield if block_given?
     return if record_no_longer_exists?(@record)


### PR DESCRIPTION
Under Infra > Networking, downloading a PDF of a switch summary causes an exception because url-building code can't determine the right controller for a switch. This just skips building a url for quadicons rendered in a PDF.

Solves the error in this bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1428580

—but currently quadicons do not render in PDFs, something to be addressed in a future PR.

@dclarizio @epwinchell this is an alternative to #1009 