### PR TITLE
Fix storage_manager_id when adding a new cloud volume

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -457,7 +457,7 @@ module EmsCommon
     elsif params[:pressed] == "cloud_volume_new"
       javascript_redirect :controller         => "cloud_volume",
                           :action             => "new",
-                          :storage_manager_id => find_id_with_rbac(CloudVolume, params[:id])
+                          :storage_manager_id => params[:id]
     elsif params[:pressed] == "cloud_volume_attach"
       javascript_redirect :controller => "cloud_volume",
                           :action     => "attach",


### PR DESCRIPTION
The error below is seen when a new Cloud Volume is added from the Storage Manager Summary screen,

```
[----] F, [2017-04-18T17:33:46.472740 #2526:3fedbc66de1c] FATAL -- : Error caught: [RuntimeError] Unauthorized object or action
/Users/aparnakarve/rh/master/manageiq/plugins/manageiq-ui-classic/app/controllers/application_controller.rb:2057:in `assert_rbac'
/Users/aparnakarve/rh/master/manageiq/plugins/manageiq-ui-classic/app/controllers/mixins/checked_id_mixin.rb:83:in `find_id_with_rbac'
/Users/aparnakarve/rh/master/manageiq/plugins/manageiq-ui-classic/app/controllers/ems_common.rb:460:in `button'
```

Issue introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/997/commits/9f513f94dda3a10e62f6b7535686758d7ed32a3f

@romanblanco Please review.

https://bugzilla.redhat.com/show_bug.cgi?id=1445095