### PR TITLE
Move metrics scss require to application.css

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,6 +24,7 @@
  *= require container_topology
  *= require middleware_topology
  *= require network_topology
+ *= require metrics
  *= require service_dialogs
  *= require xml_display
  *= require patternfly-timeline/dist/timeline

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -36,7 +36,6 @@ $login-container-details-border-color-rgba: rgba(0, 0, 0, 0.5);
 @import "header_background"; // sets a custom background image in the header
 @import "about_modal_background"; // sets a custom background image in the 'About' modal
 @import "timeline"; // used for the patternfly-timeline styles
-@import "metrics";
 @import "alerts";
 
 .login-pf #brand img { // sets size of brand.svg on login screen (upstream only)


### PR DESCRIPTION
**Description**

The `main.scss ` file is a special file used in downstream projects to override the look and feel of the UI.
The `metrics.scss` layout is currently part of this special file. We should use the `application.css` file for layout that we do not want downstream projects to override.

This PR move the require `metrics.scss` file to the `application.css` file.

**Screenshot**

_A downstream project layout broken_
![screenshot-10 8 197 127-2017-04-19-06-26-47](https://cloud.githubusercontent.com/assets/2181522/25162755/d5170dc6-24cd-11e7-8c10-34f00a19dce0.png)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1443356