### PR TITLE
Fix typo that caused win32 services icon to disappear

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -563,7 +563,7 @@ module VmHelper::TextualSummary
     os = @record.os_image_name.downcase
     return nil if os == "unknown" || os =~ /linux/
     num = @record.number_of(:win32_services)
-    h = {:label => _("Win32 Services"), :icon0 => "fa fa-cog", :value => num}
+    h = {:label => _("Win32 Services"), :icon => "fa fa-cog", :value => num}
     if num > 0
       h[:title] = n_("Show the Win32 Service installed on this VM", "Show the Win32 Services installed on this VM", num)
       h[:explorer] = true


### PR DESCRIPTION
**Before:**
![screenshot from 2017-04-19 09-44-40](https://cloud.githubusercontent.com/assets/649130/25168703/d4f1388c-24e4-11e7-8022-ed3d431fcd9f.png)

**After:**
![screenshot from 2017-04-19 09-42-52](https://cloud.githubusercontent.com/assets/649130/25168707/dabda8e0-24e4-11e7-858f-b5bd24b7bfb2.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1443062