### PR TITLE
Fix duplicate DOM IDs in access control.

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -2,7 +2,7 @@
   - url = url_for_only_path(:action => 'rbac_group_field_changed', :id => (@edit[:group_id] || "new"))
   - combo_url = "/ops/rbac_group_field_changed/#{@edit[:group_id] || 'new'}"
 = render :partial => "layouts/flash_msg"
-#main_div
+#group_info
   %h3
     = _("Group Information")
   - if @edit

--- a/app/views/ops/_rbac_groups_list.html.haml
+++ b/app/views/ops/_rbac_groups_list.html.haml
@@ -1,5 +1,4 @@
 - if x_node == "xx-g"
-  #main_div
-    - if @view
-      = render(:partial => 'layouts/x_gtl',
-               :locals  => {:action_url => "rbac_groups_list"})
+  - if @view
+    = render(:partial => 'layouts/x_gtl',
+             :locals  => {:action_url => "rbac_groups_list"})

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -1,7 +1,7 @@
 - if @edit
   - url = url_for_only_path(:action => 'rbac_role_field_changed', :id => (@edit[:role_id] || "new"))
 = render :partial => "layouts/flash_msg"
-#main_div
+#role_info
   .row
     .col-md-12.col-lg-6
       %h3

--- a/app/views/ops/_rbac_roles_list.html.haml
+++ b/app/views/ops/_rbac_roles_list.html.haml
@@ -1,5 +1,4 @@
 - if x_node == "xx-ur"
-  #main_div
-    - if @view
-      = render(:partial => 'layouts/x_gtl',
-               :locals  => {:action_url => "rbac_roles_list"})
+  - if @view
+    = render(:partial => 'layouts/x_gtl',
+             :locals  => {:action_url => "rbac_roles_list"})

--- a/app/views/ops/_rbac_tenant_details.html.haml
+++ b/app/views/ops/_rbac_tenant_details.html.haml
@@ -1,5 +1,5 @@
 = render :partial => "layouts/flash_msg"
-#main_div
+#tenant_info
   - type = @tenant.tenant? ? "Tenant" : "Project"
   %h3
     = _("%{type} Information") % {:type => type}

--- a/app/views/ops/_rbac_tenants_list.html.haml
+++ b/app/views/ops/_rbac_tenants_list.html.haml
@@ -1,5 +1,4 @@
 - if x_node == "xx-tn"
-  #main_div
-    - if @view
-      = render(:partial => 'layouts/x_gtl',
-               :locals  => {:action_url => "rbac_tenants_list"})
+  - if @view
+    = render(:partial => 'layouts/x_gtl',
+             :locals  => {:action_url => "rbac_tenants_list"})

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -6,9 +6,10 @@
 - if @edit
   - url = url_for_only_path(:action => 'rbac_user_field_changed', :id => (@edit[:user_id] || "new"))
 - observe_url_json = {:interval => '.5', :url => url}.to_json
-= render :partial => "layouts/flash_msg"
 - disabled = @edit && @edit[:new][:userid] == "admin"
-#main_div
+
+= render :partial => "layouts/flash_msg"
+#user_info
   %h3
     = _("User Information")
   .form-horizontal

--- a/app/views/ops/_rbac_users_list.html.haml
+++ b/app/views/ops/_rbac_users_list.html.haml
@@ -1,5 +1,4 @@
 - if x_node == "xx-u"
-  #main_div
-    - if @view
-      = render(:partial => 'layouts/x_gtl',
-               :locals  => {:action_url => "rbac_users_list"})
+  - if @view
+    = render(:partial => 'layouts/x_gtl',
+             :locals  => {:action_url => "rbac_users_list"})


### PR DESCRIPTION
A careful review is needed here. I tried clicking around but a second pair of eyes looking at the UI and if things still work is a must here.

Settings --> Access Control --> Users, Groups, Roles, Tenants (both lists and single items)