### PR TITLE
Fix duplicate DOM id on the login page.

### DIFF
--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -15,7 +15,7 @@
                  :locals  => {:login => true})
 
         #invalid_sso_credentials_flash{:style => "display: none"}
-          #flash_text_div{:title => _("Click to remove message")}
+          .flash_text_div{:title => _("Click to remove message")}
             .alert.alert-danger
               %span.pficon.pficon-error-circle-o
               %strong= _("Invalid Single Sign-On credentials")

--- a/app/views/layouts/_flash_msg.html.haml
+++ b/app/views/layouts/_flash_msg.html.haml
@@ -2,7 +2,7 @@
 
 %div{:id => flash_div_id, :style => ("display: none" unless @flash_array)}
   - if @flash_array
-    %div{:id => "flash_text_div"}
+    .flash_text_div
       - @flash_array.each do |fl|
         - case fl[:level]
         - when :error


### PR DESCRIPTION
The `flash_text_div` is 2x an ID and 1x a class. Making it a class fixes
the duplicate DOM id on the login page.