### PR TITLE
Remove indexing of continaer images for chargeback reports

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1413,9 +1413,6 @@ module ReportController::Reports::Editor
       provider.container_projects.all.each do |project|
         @cb_entities_by_provider_id[provider.id][:container_project][project.id] = project.name
       end
-      provider.container_images.all.each do |image|
-        @cb_entities_by_provider_id[provider.id][:container_image][image.id] = image.name
-      end
     end
   end
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1442158

remove filtering by container image in chargeback report filter tab.
The filter isnt useful in this specific use case and jams the UI when there are too many images. Filtering for projects and vms remains intact.

@lpichler @gtanzillo Please review
cc @simon3z 
