### PR TITLE
Hide resolved alerts

### DIFF
--- a/app/assets/javascripts/services/alerts_center_service.js
+++ b/app/assets/javascripts/services/alerts_center_service.js
@@ -409,7 +409,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
 
   _this.getAlertsData = function(limit, offset, filters, sortField, sortAscending) {
     var deferred = $q.defer();
-    var resourceOptions = '?expand=resources,alert_actions&attributes=assignee,resource';
+    var resourceOptions = '?expand=resources,alert_actions&attributes=assignee,resource&filter[]=resolved=false';
     var limitOptions = '';
     var offsetOptions = '';
     var sortOptions = '';


### PR DESCRIPTION
Only open alerts should be visible in the screen. Currently for most alert type, resolved is always nil, this effects mostly container providers