### PR TITLE
Don't clip calendar control in C&U screen

### DIFF
--- a/app/views/ops/_diagnostics_cu_repair_tab.html.haml
+++ b/app/views/ops/_diagnostics_cu_repair_tab.html.haml
@@ -34,6 +34,7 @@
         = datepicker_input_tag("miq_date_2",   |
           @edit[:new][:end_date],              |
           :readonly               => true,     |
+          "data-date-orientation" => "bottom", |
           "data-miq_observe_date" => url_json) |
 
   .note= _("Note: Gap Collection is only available for VMware vSphere Infrastructures")


### PR DESCRIPTION
Before:
![calendar-before](https://cloud.githubusercontent.com/assets/6648365/25178655/0faf03ec-2507-11e7-9caf-1d527fc6fede.jpg)

After:
![calendar-after](https://cloud.githubusercontent.com/assets/6648365/25178661/13a86808-2507-11e7-8c36-6995a737effc.jpg)


https://bugzilla.redhat.com/show_bug.cgi?id=1418462