### PR TITLE
Escape timeline JSON properly

### DIFF
--- a/app/assets/javascripts/miq_timeline.js
+++ b/app/assets/javascripts/miq_timeline.js
@@ -117,3 +117,22 @@
     }
   };
 })(ManageIQ);
+
+function miqInitTimeline(json) {
+  if (!json) {
+    return;
+  }
+
+  var parsed = JSON.parse(json);
+
+  var start, end;
+  if (!ManageIQ.calendar.calDateFrom || !ManageIQ.calendar.calDateTo) {
+    end = new Date();
+    start = new Date(end - 24 * 60 * 60 * 1000 * 7);
+  } else {
+    start = new Date(ManageIQ.calendar.calDateFrom);
+    end = new Date(ManageIQ.calendar.calDateTo);
+  }
+
+  ManageIQ.Timeline.load(parsed, start, end);
+}

--- a/app/views/dashboard/_tl_detail.html.haml
+++ b/app/views/dashboard/_tl_detail.html.haml
@@ -7,7 +7,7 @@
   - elsif @report
     #chart_placeholder{:style => 'position: relative'}
     = render(:partial => 'layouts/timeline',
-        :locals         => {:tl_json          =>  @tl_json || {},
+        :locals         => {:tl_json          =>  @tl_json,
                             :data_action      => "timeline_data"})
     - if @report.filter_summary
       = @report.filter_summary

--- a/app/views/layouts/_timeline.html.haml
+++ b/app/views/layouts/_timeline.html.haml
@@ -1,13 +1,3 @@
 - tl_json ||= nil
-%script{:type => "text/javascript"}
-  - if tl_json
-    var json = JSON.parse('#{tl_json}'.replace(/&quot;/g, '"'));
-    var start, end;
-    if (!ManageIQ.calendar.calDateFrom || !ManageIQ.calendar.calDateTo) {
-    end = new Date();
-    start = new Date(end - 24 * 60 * 60 * 1000 * 7);
-    } else {
-    start = new Date(ManageIQ.calendar.calDateFrom);
-    end = new Date(ManageIQ.calendar.calDateTo);
-    }
-    ManageIQ.Timeline.load(json, start, end);
+:javascript
+  miqInitTimeline('#{j_str tl_json}');

--- a/app/views/layouts/_tl_detail.html.haml
+++ b/app/views/layouts/_tl_detail.html.haml
@@ -4,7 +4,7 @@
     %fieldset
       #chart_placeholder{:style => 'position: relative'}
       = render(:partial => 'layouts/timeline',
-        :locals         => {:tl_json          =>  @tl_json || {},
+        :locals         => {:tl_json          =>  @tl_json,
                             :data_action      => "timeline_data"})
   - else
     .timeline-empty-state

--- a/app/views/miq_capacity/_bottlenecks_tl_detail.html.haml
+++ b/app/views/miq_capacity/_bottlenecks_tl_detail.html.haml
@@ -3,7 +3,7 @@
   - elsif @sb[:bottlenecks][:report]
     #chart_placeholder{:style => 'position: relative'}
     = render(:partial => "layouts/timeline",
-             :locals  => {:tl_json       => @tl_json || {},
+             :locals  => {:tl_json       => @tl_json,
                           :position_time => session[:tl_position]})
     - if @sb[:bottlenecks][:report].filter_summary
       = @sb[:bottlenecks][:report].filter_summary


### PR DESCRIPTION
when used with `%script`, the resulting json is html-escaped and broken

using `:javascript` now, and moving the logic to a proper function

also removed code using empty hash to provide a default value for a json string.

https://bugzilla.redhat.com/show_bug.cgi?id=1440058