### PR TITLE
Add flash messages partial view to the edit form of chargeback rates

### DIFF
--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -1,5 +1,6 @@
 - url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => @edit[:rec_id] || "new")
 - currency = ChargebackRateDetailCurrency.currencies_for_select
+= render :partial => "layouts/flash_msg"
 #form_div
   %h3
     = _('Basic Info')

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -1,4 +1,3 @@
-= render :partial => "layouts/flash_msg"
 - if @edit && @edit[:current]
   = render :partial => "cb_rate_edit"
 - else


### PR DESCRIPTION
The bug was caused by https://github.com/ManageIQ/manageiq/pull/12154, so I've removed the flash message partial from show view and add it to edit view (for new, copy, edit chargeback is used edit view).

https://bugzilla.redhat.com/show_bug.cgi?id=1441152