### PR TITLE
Fix AvailabilityZone broken by GenericShow refactoring.

### DIFF
--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -56,7 +56,6 @@ class AvailabilityZoneController < ApplicationController
       @showtype = @display
 
     when "timeline"
-      @record = find_record_with_rbac(AvailabilityZone, session[:tl_record_id])
       show_timeline
 
     end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1443529

The extra line is called from show_timeline and RBAC is already checked at the beginning of the method.