### PR TITLE
Clean up chargeback rates views

### DIFF
--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -1,74 +1,71 @@
-- if @edit && @edit[:current]
-  = render :partial => "cb_rate_edit"
-- else
-  %h3= _('Basic Info')
-  .form-horizontal.static
-    .form-group
-      %label.col-md-2.control-label
-        = _('Description')
-      .col-md-8
-        %p.form-control-static
-          = h(@record.description)
-  %hr
-  %h3= _('Rate Details')
-  %table.table.table-bordered
-    %thead
-      %tr
-        %th{:rowspan => "2"}= _('Group')
-        %th{:rowspan => "2"}= _('Description')
-        %th{:colspan => "2"}= _('Range')
-        %th{:colspan => "2"}= _('Rate')
-        %th{:rowspan => "2"}= _('Units')
-      %tr
-        %th= _("Start")
-        %th= _("Finish")
-        %th= _("Fixed")
-        %th= _("Variable")
-    %tbody
-      /Currency code is the same for all the chargeback_rate_details
-      - @record.chargeback_rate_details.to_a.sort_by { |rd| [rd[:group].downcase, rd[:description].downcase] }.each_with_index do |detail, detail_index|
-      - tiers = detail.chargeback_tiers.order(:start)
-        - @cur_group = detail[:group] if @cur_group.nil?
-        - if @cur_group != detail[:group]
-          - @cur_group = detail[:group]
-          %tr
-            %td.active{:colspan => "9", :style => "background-color: #f5f5f5;"} &nbsp;
-        - num_tiers = detail.chargeback_tiers.to_a.blank? ? "1" : tiers.to_a.length.to_s
-        %tr.rdetail
-          %td{:rowspan => num_tiers}
-            = h(rate_detail_group(detail[:group]))
-          %td{:rowspan => num_tiers}
-            = detail[:description]
-          - tier = tiers.first
-          %td
-            = tier.start ? tier.start : 0
-          %td
-            = tier.finish ? tier.finish : Float::INFINITY.to_s
-          %td{:align => "right"}
-            = tier.fixed_rate ? tier.fixed_rate : 0.0
-          %td{:align => "right"}
-            = detail[:group] == 'fixed' && tier.variable_rate.zero? ? '-' : tier.variable_rate
-          %td{:align => "right", :rowspan => num_tiers}
-            = detail.show_rates
-        - (1..num_tiers.to_i - 1).each do |tier_index|
-          - tier = tiers.to_a[tier_index]
-          %tr.rdetail
-            %td
-              = tier.start
-            %td
-              = tier.finish
-            %td{:align => "right"}
-              = tier.fixed_rate
-            %td{:align => "right"}
-              = (detail[:group] == 'fixed' && tier.variable_rate.zero?) ? '-' : tier.variable_rate
+%h3= _('Basic Info')
+.form-horizontal.static
+  .form-group
+    %label.col-md-2.control-label
+      = _('Description')
+    .col-md-8
+      %p.form-control-static
+        = h(@record.description)
+%hr
+%h3= _('Rate Details')
+%table.table.table-bordered
+  %thead
+    %tr
+      %th{:rowspan => "2"}= _('Group')
+      %th{:rowspan => "2"}= _('Description')
+      %th{:colspan => "2"}= _('Range')
+      %th{:colspan => "2"}= _('Rate')
+      %th{:rowspan => "2"}= _('Units')
+    %tr
+      %th= _("Start")
+      %th= _("Finish")
+      %th= _("Fixed")
+      %th= _("Variable")
+  %tbody
+    /Currency code is the same for all the chargeback_rate_details
+    - @record.chargeback_rate_details.to_a.sort_by { |rd| [rd[:group].downcase, rd[:description].downcase] }.each_with_index do |detail, detail_index|
+    - tiers = detail.chargeback_tiers.order(:start)
+      - @cur_group = detail[:group] if @cur_group.nil?
+      - if @cur_group != detail[:group]
+        - @cur_group = detail[:group]
         %tr
-          %td{:colspan => "9"}
+          %td.active{:colspan => "9", :style => "background-color: #f5f5f5;"} &nbsp;
+      - num_tiers = detail.chargeback_tiers.to_a.blank? ? "1" : tiers.to_a.length.to_s
+      %tr.rdetail
+        %td{:rowspan => num_tiers}
+          = h(rate_detail_group(detail[:group]))
+        %td{:rowspan => num_tiers}
+          = detail[:description]
+        - tier = tiers.first
+        %td
+          = tier.start ? tier.start : 0
+        %td
+          = tier.finish ? tier.finish : Float::INFINITY.to_s
+        %td{:align => "right"}
+          = tier.fixed_rate ? tier.fixed_rate : 0.0
+        %td{:align => "right"}
+          = detail[:group] == 'fixed' && tier.variable_rate.zero? ? '-' : tier.variable_rate
+        %td{:align => "right", :rowspan => num_tiers}
+          = detail.show_rates
+      - (1..num_tiers.to_i - 1).each do |tier_index|
+        - tier = tiers.to_a[tier_index]
+        %tr.rdetail
+          %td
+            = tier.start
+          %td
+            = tier.finish
+          %td{:align => "right"}
+            = tier.fixed_rate
+          %td{:align => "right"}
+            = (detail[:group] == 'fixed' && tier.variable_rate.zero?) ? '-' : tier.variable_rate
+      %tr
+        %td{:colspan => "9"}
 
-    :javascript
-      $('tbody tr.rdetail').hover(
-        function () {
-          $("tr[id = '"+this.id+"']").addClass("active");
-        }, function() {
-          $("tr[id = '"+this.id+"']").removeClass("active");
-        }
-      );
+  :javascript
+    $('tbody tr.rdetail').hover(
+      function () {
+        $("tr[id = '"+this.id+"']").addClass("active");
+      }, function() {
+        $("tr[id = '"+this.id+"']").removeClass("active");
+      }
+    );

--- a/app/views/chargeback/_cb_rates.html.haml
+++ b/app/views/chargeback/_cb_rates.html.haml
@@ -1,4 +1,0 @@
-- if @edit && @edit[:current]
-  = render :partial => "cb_rate_edit"
-- else
-  = render :partial => 'layouts/x_gtl', :locals => {:action_url => "cb_rates_list"}

--- a/app/views/chargeback/_rates_tabs.html.haml
+++ b/app/views/chargeback/_rates_tabs.html.haml
@@ -1,9 +1,9 @@
 #rates_tabs_div
-  -# Toplevel Tabbar
-  - if x_active_tree == :cb_rates_tree
-    - if x_node == "root"
-      = render :partial => "rates_list"
-    - elsif %w(Compute Storage).include?(x_node.split('-').last)
-      = render :partial => "cb_rates"
-    - else
-      = render :partial => "cb_rate_show"
+  - if x_node == "root"
+    = render :partial => "rates_list"
+  - elsif @edit && @edit[:new] && params[:pressed] && params[:pressed] != "chargeback_rates_delete"
+    = render :partial => "cb_rate_edit"
+  - elsif %w(Compute Storage).include?(x_node.split('-').last)
+    = render :partial => 'layouts/x_gtl', :locals => {:action_url => "cb_rates_list"}
+  - else
+    = render :partial => "cb_rate_show"


### PR DESCRIPTION
As I was working on https://github.com/ManageIQ/manageiq-ui-classic/pull/1076, I've noticed unnecessary calling render of the edit view through the show view, so I've made this cleanup (also removed unnecessary condition of the x_active_tree and removed 1 view that decided to what to render, where 1 conditional branch was again edit view - 2nd branch was moved to upper view)