### PR TITLE
Display Ansible Tower Job Templates filters

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -851,6 +851,7 @@ module ApplicationHelper
        cloud_tenant
        cloud_volume
        configuration_job
+       configuration_scripts
        container
        container_build
        container_group

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -22,12 +22,33 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    roots = ManageIQ::Providers::AnsibleTower::AutomationManager
-    count_only_or_objects_filtered(count_only, roots, "name", :match_via_descendants => ConfigurationScript)
+    objects = []
+    templates = Rbac.filtered(ManageIQ::Providers::AnsibleTower::AutomationManager.order("lower(name)"), :match_via_descendants => ConfigurationScript)
+
+    templates.each do |temp|
+      objects.push(temp)
+    end
+
+    objects.push(:id          => "global",
+                 :text        => _("Global Filters"),
+                 :icon        => "pficon pficon-folder-close",
+                 :tip         => _("Global Shared Filters"),
+                 :cfmeNoClick => true)
+    objects.push(:id          => "my",
+                 :text        => _("My Filters"),
+                 :icon        => "pficon pficon-folder-close",
+                 :tip         => _("My Personal Filters"),
+                 :cfmeNoClick => true)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_cmat_kids(object, count_only)
     scripts = ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.where(:manager_id => object.id)
     count_only_or_objects_filtered(count_only, scripts, "name")
+  end
+
+  def x_get_tree_custom_kids(object, count_only, options)
+    objects = MiqSearch.where(:db => options[:leaf]).filters_by_type(object[:id])
+    count_only_or_objects(count_only, objects, 'description')
   end
 end

--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -1,5 +1,5 @@
 #accordion.panel-group
-  - if @accords.length == 1 # there is no need for JavaScript if only one accordion is present
+  - if @accords.present? && @accords.length == 1 # there is no need for JavaScript if only one accordion is present
     .panel.panel-default
       .panel-heading
         %h4.panel-title
@@ -8,7 +8,7 @@
       .panel-collapse.collapse.in
         .panel-body{:id => @accords.first[:container]}
           = render :partial => 'shared/explorer_tree', :locals => {:name => @accords.first[:name]}
-  - elsif @accords.length > 1
+  - elsif @accords.present? && @accords.length > 1
     - accord_names = @accords.map { |accord| accord[:name].to_sym }
     - @accords.each_with_index do |a, i|
       = miq_accordion_panel(a[:title], accord_names.include?(@sb[:active_accord]) ? a[:name].to_sym == @sb[:active_accord] : i == 0, a[:container]) do


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1435714

Display Ansible Tower Job Templates filters in accordion
in Automation -> Ansible Tower -> Explorer -> Job Templates.
Correct condition in` _explorer.html.haml` not to fail if `nil`.
