### PR TITLE
Fix calendar position on C & U gap collection tab

### DIFF
--- a/app/views/ops/_diagnostics_cu_repair_tab.html.haml
+++ b/app/views/ops/_diagnostics_cu_repair_tab.html.haml
@@ -26,6 +26,7 @@
         = datepicker_input_tag("miq_date_1",   |
           @edit[:new][:start_date],            |
           :readonly               => true,     |
+          "data-date-orientation" => "bottom", |
           "data-miq_observe_date" => url_json) |
     .form-group
       %label.col-md-2.control-label
@@ -34,6 +35,7 @@
         = datepicker_input_tag("miq_date_2",   |
           @edit[:new][:end_date],              |
           :readonly               => true,     |
+          "data-date-orientation" => "bottom", |
           "data-miq_observe_date" => url_json) |
 
   .note= _("Note: Gap Collection is only available for VMware vSphere Infrastructures")


### PR DESCRIPTION
This PR forces the datapicker box to drop-down so that the controls aren't cropped by the toolbar.

https://bugzilla.redhat.com/show_bug.cgi?id=1439853

Old
![screen shot 2017-04-19 at 2 16 53 pm](https://cloud.githubusercontent.com/assets/1287144/25195222/ea0819f4-250a-11e7-8b3a-652da891cca9.png)

New
![screen shot 2017-04-19 at 2 16 34 pm](https://cloud.githubusercontent.com/assets/1287144/25195223/ea094932-250a-11e7-9f53-eb3677b7f56a.png)
