### PR TITLE
Remove ArbitrationProfile reference

### DIFF
--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -101,8 +101,6 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
 
   def nontreenode_icon(obj)
     case obj
-    when ArbitrationProfile
-      'fa fa-list-ul'
     when Authentication
       'fa fa-lock'
     when CloudResourceQuota


### PR DESCRIPTION
Removing ArbitrationProfile reference as it is being deleted from MIQ (https://github.com/ManageIQ/manageiq/pull/14796 / https://github.com/ManageIQ/manageiq/pull/14776)

@miq-bot add_label refactoring 