### PR TITLE
Spec for configuration manager providers sort by url

### DIFF
--- a/app/views/layouts/listnav/_configuration_job.html.haml
+++ b/app/views/layouts/listnav/_configuration_job.html.haml
@@ -15,7 +15,7 @@
         - if role_allows?(:feature => "provider_foreman_view") && @record.ext_management_system
           %li
             = link_to("#{ui_lookup(:model => @record.ext_management_system.class.to_s)}: #{@record.ext_management_system.name}",
-              {:controller => "provider_foreman", :action => 'explorer', :id => "at-#{to_cid(@record.ext_management_system.id)}"},
+              {:controller => "automation_manager", :action => 'explorer', :id => "at-#{to_cid(@record.ext_management_system.id)}"},
               :title => _("Show parent %s for this Job") % ui_lookup(:model => @record.ext_management_system.class.to_s))
         - if role_allows?(:feature => "service_view") && @record.service
           %li

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -60,6 +60,16 @@ describe ProviderForemanController do
     expect(response.body).to_not be_empty
   end
 
+  it "renders explorer sorted by url" do
+    login_as user_with_feature(%w(providers_accord configured_systems_filter_accord))
+    FactoryGirl.create(:provider_foreman, :name => "foremantest1", :url => "z_url")
+    FactoryGirl.create(:provider_foreman, :name => "foremantest2", :url => "a_url")
+
+    get :explorer, :params => {:sortby => '2'}
+    expect(response.status).to eq(200)
+    expect(response.body).to match('a_url(.|\n)*z_url')
+  end
+
   context "renders explorer based on RBAC" do
     it "renders explorer based on RBAC access to feature 'configured_system_tag'" do
       login_as user_with_feature %w(configured_system_tag)


### PR DESCRIPTION
Spec for configuration manager providers sort by url

Depends on https://github.com/ManageIQ/manageiq/pull/14810
https://bugzilla.redhat.com/show_bug.cgi?id=1384330