### PR TITLE
[WIP] Base64 encode images for PDFs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,6 +36,7 @@ class ApplicationController < ActionController::Base
   helper ToolbarHelper
   helper JsHelper
   helper QuadiconHelper
+  helper ImageEncodeHelper
 
   helper CloudResourceQuotaHelper
 
@@ -155,6 +156,9 @@ class ApplicationController < ActionController::Base
     # do not build quadicon links
     @embedded = true
     @showlinks = false
+
+    # encode images and embed in HTML that is sent to Prince
+    @base64_encode_images = true
 
     @record = identify_record(params[:id])
     yield if block_given?

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -166,7 +166,7 @@ module ApplicationController::ReportDownloads
 
       disable_client_cache
       html_string = render_to_string(:template => "/layouts/show_pdf", :layout => false)
-      pdf_data = PdfGenerator.pdf_from_string(html_string, "pdf_summary")
+      pdf_data = PdfGenerator.pdf_from_string(html_string, "pdf_summary.css")
       send_data(pdf_data,
                 :type     => "application/pdf",
                 :filename => filename_timestamp("#{klass}_#{@record.name}_summary") + '.pdf'

--- a/app/helpers/image_encode_helper.rb
+++ b/app/helpers/image_encode_helper.rb
@@ -1,0 +1,33 @@
+module ImageEncodeHelper
+  def encodable_image_tag(source, options = {})
+    image_tag(encodable_image_source(source), options)
+  end
+  alias eimage_tag encodable_image_tag
+
+  def encodable_image_source(source)
+    if base64_encode_images? && source.present?
+      base64_encoded_uri(source)
+    else
+      path_to_image(source)
+    end
+  end
+  alias eimage_source encodable_image_source
+
+  def base64_encode_images?
+    @base64_encode_images
+  end
+
+  def base64_encoded_uri(source)
+    asset = Rails.application.assets[source]
+
+    if asset.content_type == 'image/svg+xml'
+      encoding = 'charset=utf-8'
+      data = CGI.escape(asset.source).gsub('+', '%20')
+    else
+      encoding = 'base64'
+      data = Base64.encode64(asset.source)
+    end
+
+    "data:#{asset.content_type};#{encoding},#{data}"
+  end
+end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -330,7 +330,7 @@ module QuadiconHelper
   def quadicon_reflection_img(options = {})
     path = options.delete(:path) || "layout/reflection.png"
     options = { :border => 0, :size => 72 }.merge(options)
-    quadicon_img_tag(path, options)
+    encodable_image_tag(path, options)
   end
 
   CLASSLY_NAMED_ITEMS = %w(
@@ -391,42 +391,11 @@ module QuadiconHelper
     value.first(trunc_to / 2) + "..." + value.last(trunc_to / 2)
   end
 
-  def quadicon_img_tag(path = nil, options = {})
-    # if quadicon_encode_images? && path.present?
-    #   quadicon_encoded_img(path, options)
-    # else
-    #   image_tag(image_path(path), options)
-    # end
-    image_tag(quadicon_img_path(path), options)
-  end
-
-  def quadicon_img_path(path = nil)
-    if quadicon_encode_images? && path.present?
-      quadicon_encoded_uri(path)
-    else
-      image_path(path)
-    end
-  end
-
-  def quadicon_encoded_uri(path)
-    asset = Rails.application.assets[path]
-
-    if asset.content_type == 'image/svg+xml'
-      encoding = 'charset=utf-8'
-      data = CGI.escape(asset.source).gsub('+', '%20')
-    else
-      encoding = 'base64'
-      data = Base64.encode64(asset.source)
-    end
-
-    "data:#{asset.content_type};#{encoding},#{data}"
-  end
-
   def flobj_img_simple(image = nil, cls = '', size = 72)
     image ||= "layout/base-single.png"
 
     content_tag(:div, :class => "flobj #{cls}") do
-      quadicon_img_tag(image, :size => size)
+      encodable_image_tag(image, :size => size)
     end
   end
 
@@ -485,7 +454,7 @@ module QuadiconHelper
   def currentstate_icon(state)
     path = "svg/currentstate-#{h(state)}.svg"
     content_tag(:div, :class => "flobj b72") do
-      content_tag(:div, '', :class => "stretch", :style => "background-image: url('#{quadicon_img_path(path)}')")
+      content_tag(:div, '', :class => "stretch", :style => "background-image: url('#{encodable_image_source(path)}')")
     end
   end
 

--- a/app/views/layouts/show_pdf.html.haml
+++ b/app/views/layouts/show_pdf.html.haml
@@ -1,6 +1,6 @@
 = render :partial => "layouts/pdf_styles"
 - controller = %w(miq_template vm_infra vm_or_template vm).include?(controller_name) ? "vm_common" : controller_name
-#xyz_main
+#xyz_main.encode_images
   = render_quadicon(@record, :mode => :icon, :size => 72, :encode_images => true)
 - if @record.kind_of?(ConfigurationProfile)
   = render :partial => "#{controller}/main_configuration_profile"

--- a/app/views/layouts/show_pdf.html.haml
+++ b/app/views/layouts/show_pdf.html.haml
@@ -1,7 +1,7 @@
 = render :partial => "layouts/pdf_styles"
 - controller = %w(miq_template vm_infra vm_or_template vm).include?(controller_name) ? "vm_common" : controller_name
 #xyz_main
-  = render_quadicon(@record, :mode => :icon, :size => 72)
+  = render_quadicon(@record, :mode => :icon, :size => 72, :encode_images => true)
 - if @record.kind_of?(ConfigurationProfile)
   = render :partial => "#{controller}/main_configuration_profile"
 - elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::InventoryGroup)


### PR DESCRIPTION
This begins to fix quadicon rendering in PDFs.

Due to the repo split and image digests, the paths for images do not correspond to their location on disk, this prevents Prince from finding them and breaks any rendering with images.

- [x] Correct CSS path
- [x] Images (png, gif, svgs) in image tags
- [ ] Images in style attribute backgrounds
- [ ] Images in stylesheet backgrounds
- [ ] Fonticons

**Related:**
- https://github.com/ManageIQ/manageiq/pull/14793
- https://bugzilla.redhat.com/show_bug.cgi?id=1447940
