### PR TITLE
Create credentialModel elements once required data is available

### DIFF
--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -99,7 +99,7 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
 
         var item = vm.credential_options[vm.credentialModel.type]['attributes'][key];
         if (response.options[key]
-          && !(item.hasOwnProperty('type') && item['type'] === 'password')) {
+          && ! (item.hasOwnProperty('type') && item['type'] === 'password')) {
           vm.credentialModel[key] = response.options[key];
         }
       });

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -93,21 +93,16 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
 
     // we need to wait for vm.credential_options here
     optionsPromise.then(function() {
+      // we need to merge options and vm.credentialModel
       Object.keys(vm.credential_options[vm.credentialModel.type].attributes).forEach(function(key) {
         vm.credentialModel[key] = '';
-      });
 
-      // we need to merge options and vm.credentialModel
-      for (var opt in response.options) {
-        var item = vm.credential_options[vm.credentialModel.type]['attributes'][opt];
-
-        // void the password fields first
-        if (item.hasOwnProperty('type') && item['type'] === 'password') {
-          vm.credentialModel[opt] = '';
-        } else {
-          vm.credentialModel[opt] = response.options[opt];
+        var item = vm.credential_options[vm.credentialModel.type]['attributes'][key];
+        if (response.options[key]
+          && !(item.hasOwnProperty('type') && item['type'] === 'password')) {
+          vm.credentialModel[key] = response.options[key];
         }
-      }
+      });
 
       vm.modelCopy = angular.copy( vm.credentialModel );
     });

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -91,6 +91,10 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
     vm.credentialModel.name = response.name;
     vm.credentialModel.type = response.type;
 
+    _.forEach(vm.credential_options[vm.credentialModel.type]['attributes'], function(_value, key) {
+      vm.credentialModel[key] = '';
+    });
+
     // we need to wait for vm.credential_options here
     optionsPromise.then(function() {
       // we need to merge options and vm.credentialModel

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -91,12 +91,12 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
     vm.credentialModel.name = response.name;
     vm.credentialModel.type = response.type;
 
-    _.forEach(vm.credential_options[vm.credentialModel.type]['attributes'], function(_value, key) {
-      vm.credentialModel[key] = '';
-    });
-
     // we need to wait for vm.credential_options here
     optionsPromise.then(function() {
+      Object.keys(vm.credential_options[vm.credentialModel.type].attributes).forEach(function(key) {
+        vm.credentialModel[key] = '';
+      });
+
       // we need to merge options and vm.credentialModel
       for (var opt in response.options) {
         var item = vm.credential_options[vm.credentialModel.type]['attributes'][opt];


### PR DESCRIPTION
In order to create valid `model` and `modelCopy` objects for dirty-checking to work correctly, create (and initialize) all `credentialModel` elements  once the required data (like `vm.credential_options` and `vm.credentialModel.type`) is available.
