### PR TITLE
Add the ability to customize JDBC Driver/Datasource defaults if not using standard options

### DIFF
--- a/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_service.js
+++ b/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_service.js
@@ -32,6 +32,9 @@ function MwAddDatasourceService($http, $q) {
     {id: 'MYSQL', label: 'MySql', name: 'MySqlDS', jndiName: 'java:jboss/datasources/MySqlDS',
       driverName: 'mysql', driverModuleName: 'com.mysql', driverClass: 'com.mysql.jdbc.Driver',
       connectionUrl: '://localhost:3306/db_name'},
+    {id: 'OTHER', label: __('Other...'), name: '', jndiName: '',
+      driverName: '', driverModuleName: '', driverClass: '',
+      connectionUrl: ''},
   ];
   var xaDatasources = [
     {id: 'H2', label: 'H2 XA', name: 'H2XADS', jndiName: 'java:/H2XADS',
@@ -107,6 +110,14 @@ function MwAddDatasourceService($http, $q) {
         ServerName: 'localhost',
       },
       connectionUrl: '://localhost:4100/db_name'},
+    {id: 'OTHER', label: __('Other XA...'), name: '',
+      jndiName: '',
+      driverName: '', driverModuleName: '',
+      driverClass: '',
+      properties: {
+        DatabaseName: '',
+      },
+      connectionUrl: ''},
   ];
 
   self.getExistingJdbcDrivers = function(serverId) {


### PR DESCRIPTION
Add the capability to provide an "Other..." option to customize both **JDBC Driver** defaults and **Add Datasource** (*they both use the same angular service data*). If one is using something *other* than the standard driver defaults we have provided, then give the user **blank fields** to add their own settings without having to delete each fields defaults. This is really just a usability feature for non-standard drivers.

<img width="902" alt="other" src="https://cloud.githubusercontent.com/assets/1312165/25210490/f41ccc1c-2534-11e7-851a-2a8257a1d1ee.png">

Here is a screenshot further illustrating the 'Other...' options blanking out the standard defaults provided:

<img width="897" alt="blank-options" src="https://cloud.githubusercontent.com/assets/1312165/25210794/7271b41e-2536-11e7-9bc7-d65933f52393.png">
