### PR TITLE
ToolbarController - always $digest after Rx message

### DIFF
--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -1,5 +1,4 @@
-(function(){
-
+(function() {
   function isButton(item) {
     return item.type === 'button';
   }
@@ -19,7 +18,7 @@
       } else if (event.rowSelect) {
         this.onRowSelect(event.rowSelect);
       } else if (event.redrawToolbar) {
-         this.onUpdateToolbar(event.redrawToolbar);
+        this.onUpdateToolbar(event.redrawToolbar);
       } else if (event.update) {
         this.onUpdateItem(event);
       }
@@ -29,10 +28,10 @@
         this.$scope.$digest();
       }
     }.bind(this),
-    function (err) {
+    function(err) {
       console.error('Angular RxJs Error: ', err);
     },
-    function () {
+    function() {
       console.debug('Angular RxJs subject completed, no more events to catch.');
     });
   }
@@ -97,11 +96,8 @@
         this.toolbarItems = toolbarItems.items;
         this.dataViews = toolbarItems.dataViews;
       }.bind(this));
-  }
+  };
 
-  /**
-  *
-  */
   ToolbarController.prototype.setClickHandler = function() {
     var buttons = _
       .chain(this.toolbarItems)
@@ -110,7 +106,7 @@
         return (item && item.hasOwnProperty('items')) ? item.items : item;
       })
       .flatten()
-      .filter(function(item){
+      .filter(function(item) {
         return item.type &&
           (isButton(item) || isButtonTwoState(item))
       })
@@ -120,11 +116,11 @@
         }
       })
       .value();
-  }
+  };
 
- /**
- * Public method for changing view over data.
- */
+  /**
+   * Public method for changing view over data.
+   */
   ToolbarController.prototype.onViewClick = function(item, $event) {
     if (item.url.indexOf('/') === 0) {
       var delimiter = (item.url === '/') ? '' : '/';
@@ -134,23 +130,23 @@
     } else {
       miqToolbarOnClick.bind($event.delegateTarget)($event);
     }
-  }
+  };
 
   ToolbarController.prototype.initObject = function(toolbarString) {
     subscribeToSubject.bind(this)();
     this.updateToolbar(JSON.parse(toolbarString));
-  }
+  };
 
   ToolbarController.prototype.onUpdateToolbar = function(toolbarObject) {
     this.updateToolbar(toolbarObject);
-  }
+  };
 
   ToolbarController.prototype.onUpdateItem = function(updateData) {
     var toolbarItem = _.find(_.flatten(this.toolbarItems), {id: updateData.update});
     if (toolbarItem && toolbarItem.hasOwnProperty(updateData.type)) {
       toolbarItem[updateData.type] = updateData.value;
     }
-  }
+  };
 
   ToolbarController.prototype.updateToolbar = function(toolbarObject) {
     toolbarItems = this.MiQToolbarSettingsService.generateToolbarObject(toolbarObject);
@@ -158,7 +154,7 @@
     this.dataViews = toolbarItems.dataViews;
     this.defaultViewUrl();
     this.setClickHandler();
-  }
+  };
 
   ToolbarController.$inject = ['MiQToolbarSettingsService', 'MiQEndpointsService', '$scope', '$location'];
   miqHttpInject(angular.module('ManageIQ.toolbar'))

--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -23,6 +23,11 @@
       } else if (event.update) {
         this.onUpdateItem(event);
       }
+
+      // sync changes
+      if (! this.$scope.$$phase) {
+        this.$scope.$digest();
+      }
     }.bind(this),
     function (err) {
       console.error('Angular RxJs Error: ', err);
@@ -65,9 +70,6 @@
   */
   ToolbarController.prototype.onRowSelect = function(data) {
     this.MiQToolbarSettingsService.checkboxClicked(data.checked);
-    if(!this.$scope.$$phase) {
-      this.$scope.$digest();
-    }
   }
 
   /**
@@ -141,18 +143,12 @@
 
   ToolbarController.prototype.onUpdateToolbar = function(toolbarObject) {
     this.updateToolbar(toolbarObject);
-    if(!this.$scope.$$phase) {
-      this.$scope.$digest();
-    }
   }
 
   ToolbarController.prototype.onUpdateItem = function(updateData) {
     var toolbarItem = _.find(_.flatten(this.toolbarItems), {id: updateData.update});
     if (toolbarItem && toolbarItem.hasOwnProperty(updateData.type)) {
       toolbarItem[updateData.type] = updateData.value;
-      if(!this.$scope.$$phase) {
-        this.$scope.$digest();
-      }
     }
   }
 


### PR DESCRIPTION
Replaces https://github.com/ManageIQ/manageiq-ui-classic/pull/1054 - Cc @jzigmund 

I gave up on trying to use `$timeout`, seems like to much code is dependent on the synchronous nature right now :(.

So this just makes sure that `$digest` is called every time we gate an observable message, not only in the other cases. (Also verified that those methods are never called from anywhere else..)

(`fine/yes` because related to https://bugzilla.redhat.com/show_bug.cgi?id=1440118 )