### PR TITLE
Remove unused build_tags_tree calls

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -870,7 +870,6 @@ module ApplicationController::MiqRequestMethods
           @edit[:template_sortdir] ||= "ASC"
           @edit[:template_sortcol] ||= "name"
           build_vm_grid(@edit[:wf].send("allowed_templates"), @edit[:vm_sortdir], @edit[:vm_sortcol], build_template_filter)
-          build_tags_tree(@edit[:wf], @edit[:new][:vm_tags], true)
           if @edit[:wf].supports_pxe?
             build_pxe_img_grid(@edit[:wf].send("allowed_images"), @edit[:pxe_img_sortdir], @edit[:pxe_img_sortcol])
             build_host_grid(@edit[:wf].send("allowed_hosts"), @edit[:host_sortdir], @edit[:host_sortcol])

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -793,7 +793,6 @@ module ApplicationController::MiqRequestMethods
           end
         end
         @options[tag_symbol_for_workflow] ||= []  # Initialize if came back nil from record
-        build_tags_tree(options[:wf], @options[tag_symbol_for_workflow], false) if @miq_request.resource_type != "VmMigrateRequest"
         unless ["MiqHostProvisionRequest", "VmMigrateRequest"].include?(@miq_request.resource_type)
           svm = VmOrTemplate.where(:id => @options[:src_vm_id][0]).first if @options[:src_vm_id] && @options[:src_vm_id][0]
           @sb[:vm_os] = svm.platform if svm

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -883,7 +883,6 @@ module ApplicationController::MiqRequestMethods
         else
           @edit[:template_sortdir] ||= "ASC"
           @edit[:template_sortcol] ||= "name"
-          build_tags_tree(@edit[:wf], @edit[:new][:tag_ids], true)
           build_pxe_img_grid(@edit[:wf].send("allowed_images"), @edit[:pxe_img_sortdir], @edit[:pxe_img_sortcol])
           build_iso_img_grid(@edit[:wf].send("allowed_iso_images"), @edit[:iso_img_sortdir], @edit[:iso_img_sortcol])
           build_host_grid(@edit[:wf].send("allowed_hosts"), @edit[:host_sortdir], @edit[:host_sortcol])


### PR DESCRIPTION
Services -> Catalogs -> click some items

Compute -> Infrastructure -> Virtual Machines -> choose VM or template -> Lifecycle -> Provision VM (removed tree call)-> Purpose tab (tree call)

Compute -> Infrastructure -> Hosts/Nodes -> choose host or node -> Lifecycle -> Provision item (removed tree call)-> Purpose tab (tree call)

@miq-bot add_label wip, trees, refactoring

