### PR TITLE
Use to_human method for virtual custom attributes

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1441,7 +1441,7 @@ module ReportController::Reports::Editor
     rpt.col_order.each_with_index do |col, idx|
       if col.starts_with?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
         field_key = rpt.db + "-" + col
-        field_value =_("Labels: %{name}") % { :name => col.gsub(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX, "") }
+        field_value = CustomAttributeMixin.to_human(col)
       elsif !col.include?(".")  # Main table field
         field_key = rpt.db + "-" + col
         field_value = friendly_model_name(rpt.db) +


### PR DESCRIPTION
depends on https://github.com/ManageIQ/manageiq/pull/14835 (Merged)

in selected fields in the report definition
This is part of feature 'add section to virtual custom attributes' full described in https://github.com/ManageIQ/manageiq/pull/14837

**Test scenario:**
Let's have container images and their custom attributes:
then custom attributes look in report definition in UI:
before
![screen shot 2017-04-25 at 11 09 58](https://cloud.githubusercontent.com/assets/14937244/25377744/a8c10daa-29a8-11e7-97d3-a47d19133bb0.png)

after
![screen shot 2017-04-25 at 11 07 37](https://cloud.githubusercontent.com/assets/14937244/25377749/ab774a96-29a8-11e7-9100-c5bef09d43e0.png)




### All PRs:
https://github.com/ManageIQ/manageiq/pull/14835 <- Merged
**https://github.com/ManageIQ/manageiq-ui-classic/pull/1099** <- This PR
https://github.com/ManageIQ/manageiq/pull/14837 <- Last PR








