### PR TITLE
Correct disk table styling

### DIFF
--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -126,10 +126,10 @@
           %th= _('Type')
           %th{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Mode')
           %th= _('Size')
-          %th.table-view-pf-select
-          %th.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Dependent')
-          %th.table-view-pf-select= _('Delete Backing')
-          %th.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'redhat'}= _('Bootable')
+          %th
+          %th{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Dependent')
+          %th= _('Delete Backing')
+          %th{"ng-if" => @reconfigitems.first.vendor == 'redhat'}= _('Bootable')
           %th= _('Actions')
         %tbody
           %tr{"ng-if"       => "reconfigureModel.addEnabled",
@@ -163,7 +163,7 @@
                                   "ng-change"   => "hdChanged()"}
               %span{"style" => "color:red", "ng-show" => "rowForm.dvcSize.$invalid"}
                 = _(" Valid numeric disk size required ")
-            %td.table-view-pf-select
+            %td
               = select_tag('hdUnit',
                        options_for_select(%w(MB GB)),
                        "ng-model"                    => "reconfigureModel.hdUnit",
@@ -171,14 +171,14 @@
                        "data-width"                  => "auto",
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
-            %td.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
+            %td{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
               %input{"bs-switch" => "",
                      :data       => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"      => "checkbox",
                      "name"      => "cb_dependent",
                      "ng-model"  => "reconfigureModel.cb_dependent"}
-            %td.table-view-pf-select
-            %td.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
+            %td
+            %td{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
               %input{"bs-switch" => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",
@@ -195,9 +195,9 @@
               {{disk.hdMode}}
             %td
               {{disk.hdSize}}
-            %td.table-view-pf-select
+            %td
               {{disk.hdUnit}}
-            %td.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
+            %td{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
               %input{"bs-switch"     => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",
@@ -206,7 +206,7 @@
                      "switch-active" => "{{disk.add_remove!='add'}}",
                      "ng-readonly"   => "disk.add_remove=='add'",
                      "ng-if"         => "disk.add_remove=='add'"}
-            %td.table-view-pf-select
+            %td
               %input{"bs-switch"     => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",
@@ -215,7 +215,7 @@
                      "ng-readonly"   => "disk.add_remove=='remove'",
                      "switch-active" => "{{disk.add_remove!='remove'}}",
                      "ng-if"         => "disk.add_remove!='add'"}
-            %td.table-view-pf-select{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
+            %td{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
               %input{"bs-switch"     => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",


### PR DESCRIPTION
The disks table on the vm reconfigured screen was using the "table-view-pf-select" class, which caused the cells to wrap unnecessarily. This PR removes the unneeded class.

https://bugzilla.redhat.com/show_bug.cgi?id=1439669

Old
<img width="1003" alt="screen shot 2017-04-20 at 4 40 41 pm" src="https://cloud.githubusercontent.com/assets/1287144/25251746/5ef8318a-25e8-11e7-8e33-6abbf6a6e108.png">

New
<img width="1008" alt="screen shot 2017-04-20 at 4 40 07 pm" src="https://cloud.githubusercontent.com/assets/1287144/25251747/5ef8a07a-25e8-11e7-9955-7c24f31465cd.png">
