### PR TITLE
Fixed no flash message issue while retiring a service

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -2012,7 +2012,6 @@ module ApplicationController::CiProcessing
   end
   alias_method :instance_retire_now, :retirevms_now
   alias_method :vm_retire_now, :retirevms_now
-  alias_method :service_retire_now, :retirevms_now
   alias_method :orchestration_stack_retire_now, :retirevms_now
 
   def check_compliance_vms

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -179,6 +179,12 @@ class ServiceController < ApplicationController
     replace_right_cell(:action => 'retire')
   end
 
+  def service_retire_now
+    @explorer = true
+    retirevms_now
+    replace_right_cell
+  end
+
   def service_set_record_vars(svc)
     svc.name = params[:name] if params[:name]
     svc.description = params[:description] if params[:description]


### PR DESCRIPTION
This issue is visible from the Service Summary page.

To fix this, the  `service_retire_now` method was added that was missed while refactoring `x_ button` in `service_controller`
(can be traced back to this commit: https://github.com/ManageIQ/manageiq-ui-classic/pull/240/commits/497f89a375e2b4fcb6302c05564ac52a7850b83a)

https://bugzilla.redhat.com/show_bug.cgi?id=1442112

@mzazrivec Please review.