### PR TITLE
Close spinner when firing Database GC.

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -396,7 +396,7 @@ module OpsController::Diagnostics
     else
       add_flash(_("Database Garbage Collection successfully initiated"))
     end
-    javascript_flash
+    javascript_flash(:spinner_off => true)
   end
 
   # to delete orphaned records for user that was delete from db


### PR DESCRIPTION
A regression caused by flash message refactoring.

https://bugzilla.redhat.com/show_bug.cgi?id=1442793