### PR TITLE
Fix wrong selection in Hosts/Nodes & Clusters tree

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1083,6 +1083,10 @@ module OpsController::OpsRbac
       else                                          # Belongsto tag checked
         class_prefix, id = parse_nodetype_and_id(params[:id])
         klass = TreeBuilder.get_model_for_prefix(class_prefix)
+        # If ExtManagementSystem is returned get specific class
+        if klass == 'ExtManagementSystem'
+          klass = ExtManagementSystem.find(from_cid(id)).class.to_s
+        end
         if params[:check] == "0"                    #   unchecked
           @edit[:new][:belongsto].delete("#{klass}_#{from_cid(id)}") #     Remove the tag from the belongsto hash
         else


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1443127

Configuration -> Access Control -> add a new group with some providers selected in Hosts/Nodes & Clusters tab
Configuration -> Access Control  -> edit added group -> try deselect selected provider

Before:
<img width="871" alt="screen shot 2017-04-21 at 3 17 22 pm" src="https://cloud.githubusercontent.com/assets/9210860/25279298/3e6cea1e-26a6-11e7-9c40-8ec913fda5c6.png">
After:
<img width="874" alt="screen shot 2017-04-21 at 3 15 50 pm" src="https://cloud.githubusercontent.com/assets/9210860/25279287/3911f99c-26a6-11e7-969e-9dfafa5f8848.png">

@miq-bot add_label bug, trees, fine/yes, blocker