### PR TITLE
Move set tenant button to the right of selector

### DIFF
--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -186,7 +186,7 @@
   }
 
   .tenant-filter-bar {
-    margin-left: 5px;
+    margin-left: 0;
     .dropdown-menu.open {
       margin-top: -11px;
     }

--- a/app/views/ems_container/ad_hoc/_list_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_list_view_form.html.haml
@@ -1,10 +1,5 @@
 .col-md-12.tenant-filter-bar
   .form-group.pull-left.ad-hoc-tenant
-    %button.btn.btn-primary{"type"        => "button",
-                            "ng-disabled" => "!dash.tenantChanged",
-                            "ng-click"    => "dash.refreshTenant()"}
-      = _("Set Tenant")
-
     %select.selectpicker.tenants-selector{"pf-select"        => "",
                                           "id"               => "tenant-slector",
                                           "ng-options"       => "o.label for o in dash.tenantList",
@@ -12,6 +7,11 @@
                                           "ng-change"        => "dash.tenantChanged = true",
                                           "data-live-search" => "true",
                                           "data-actions-box" => "true"}
+
+    %button.btn.btn-primary{"type"        => "button",
+                            "ng-disabled" => "!dash.tenantChanged",
+                            "ng-click"    => "dash.refreshTenant()"}
+      = _("Set Hawkular Tenant")
 
 .ad-hoc-toolbar.filters-selector{"pf-toolbar" => "", "id" => "filters-selector", "config" => "dash.toolbarConfig"}
   %actions


### PR DESCRIPTION
**Description**

On 20 Apr 2017 review we identified this problems:
a. The action button is on the left instead of right of selector.
b. The title is "Set Tenant" but it's not ManageIQ's tenant, it Hawkular's tenant.

**Screenshot**
_Before_
![screenshot-localhost 3000-2017-04-23-10-36-22](https://cloud.githubusercontent.com/assets/2181522/25311729/deb36b86-2810-11e7-80e6-e59677e7c435.png)

_After_
![screenshot-localhost 3000-2017-04-23-10-34-39](https://cloud.githubusercontent.com/assets/2181522/25311728/deb34660-2810-11e7-9b90-11eb317fef88.png)