### PR TITLE
Rescue all errors in get_hostname_from_routes

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -475,7 +475,7 @@ module Mixins
       client = ems.class.raw_connect(endpoint.hostname, endpoint.port,
                                      :service => :openshift, :bearer => token, :ssl_options => ssl_options)
       client.get_route('hawkular-metrics', 'openshift-infra').try(:spec).try(:host)
-    rescue KubeException, OpenSSL::SSL::SSLError => e
+    rescue StandardError => e
       $log.warn("MIQ(#{controller_name}_controller-#{action_name}): get_hostname_from_routes error: #{e}")
       nil
     end


### PR DESCRIPTION
#972 was not enough, e.g. OpenSSL::X509::CertificateError parsing errors still spill through.
Turns out `OpenSSL::SSL::SSLError` is not the parent of all openssl errors, that would be `OpenSSL::OpenSSLError` :-(

But I won't repeating the mistake a third time, let's catch everything. This function is a best-effort guess anyway.

https://bugzilla.redhat.com/show_bug.cgi?id=1436221 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1441670 (fine)
This is an improvement, but not a sufficient fixes.
I'll follow up with at least one PR to make the backend return exceptions as JSON.  Should have done that long ago, would have saved a lot of effort testing & triaging.

Before, with a malformed custom CA:
![trusted-ca-garbage-not-displayed](https://cloud.githubusercontent.com/assets/273688/25312632/fb128b02-2826-11e7-8568-d62e4f442d3b.png)

After:
![trusted-ca-garbage-err](https://cloud.githubusercontent.com/assets/273688/25312915/46b4deba-282d-11e7-9700-8857a3c18e57.png)

The "header is too long" message is too unclear :-(  It's not even clear what field the error refers to.
This is a case where the model doesn't even pass rails validations, I'm looking at reporting this better...

@miq-bot add-label compute/containers, bug, fine/yes, blocker

@yaacov @moolitayer @AparnaKarve Please review.