### PR TITLE
Set Ad hoc page layot to be without listnave

### DIFF
--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -37,17 +37,18 @@ module ApplicationHelper::PageLayouts
       storage_pod
     ).include?(@layout)
 
+    return false if %w(
+      ad_hoc_metrics
+      consumption
+      dialog_provision
+      topology
+    ).include?(@showtype)
+
     return false if dashboard_no_listnav?
 
     return false if @layout.starts_with?("miq_request")
 
-    return false if @showtype == "dialog_provision"
-
     return false if @showtype == "dashboard" && @lastaction.ends_with?("_dashboard")
-
-    return false if @showtype == "consumption"
-
-    return false if @showtype == "topology"
 
     return false if controller.action_name.end_with?("tagging_edit")
 


### PR DESCRIPTION
**Description**

On 20 Apr 2017 review we decided that the Ad Hoc page should be without navlist:

a. The Ad-Hoc page is a "Dasboard" style page and should use a navlist less layout. 

**Screenshot**
_Before_

![screenshot-localhost 3000-2017-04-23-15-38-49](https://cloud.githubusercontent.com/assets/2181522/25313652/3d149e3c-283b-11e7-93fa-f9a654d564d9.png)

_After_
![screenshot-localhost 3000-2017-04-23-15-36-59](https://cloud.githubusercontent.com/assets/2181522/25313651/3d1332ae-283b-11e7-9e04-7ebe03e32a9e.png)