### PR TITLE
Map Tags - Edit - fix

### DIFF
--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -11,22 +11,22 @@ module OpsController::Settings::LabelTagMapping
   # This const is arranged as a model => provider hash so we can figure the provider
   # when editing an existing mapping.
   MAPPABLE_ENTITIES = {
-    nil => nil, # map all entities
-    "Vm" => "Amazon",
-    "Image" => "Amazon",
-    "ContainerProject" => "Kubernetes",
-    "ContainerRoute" => "Kubernetes",
-    "ContainerNode" => "Kubernetes",
+    nil                   => nil, # map all entities
+    "Vm"                  => "Amazon",
+    "Image"               => "Amazon",
+    "ContainerProject"    => "Kubernetes",
+    "ContainerRoute"      => "Kubernetes",
+    "ContainerNode"       => "Kubernetes",
     "ContainerReplicator" => "Kubernetes",
-    "ContainerService" => "Kubernetes",
-    "ContainerGroup" => "Kubernetes",
-    "ContainerBuild" => "Kubernetes"
+    "ContainerService"    => "Kubernetes",
+    "ContainerGroup"      => "Kubernetes",
+    "ContainerBuild"      => "Kubernetes"
   }.freeze
 
   # TODO: support per-provider "All Amazon" etc?
   # Currently we have only global "All".  For backward compatibility the categories
   # are named "kubernetes::..."
-  ALL_PREFIX = 'kubernetes'
+  ALL_PREFIX = 'kubernetes'.freeze
 
   def label_tag_mapping_edit
     case params[:button]

--- a/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
+++ b/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
@@ -15,9 +15,9 @@ describe OpsController do
       post :label_tag_mapping_edit, :button => 'add'
     end
 
-    def use_form_to_create_scoped_mapping
+    def use_form_to_create_amazon_mapping
       post :label_tag_mapping_edit
-      post :label_tag_mapping_field_changed, :id => 'new', :entity => 'Amazon::Vm'
+      post :label_tag_mapping_field_changed, :id => 'new', :entity => 'Vm'
       post :label_tag_mapping_field_changed, :id => 'new', :label_name => 'some-amazon-label'
       post :label_tag_mapping_field_changed, :id => 'new', :category => 'Amazon Vms'
       post :label_tag_mapping_edit, :button => 'add'
@@ -34,7 +34,7 @@ describe OpsController do
     end
 
     it "creates new scoped mapping on save" do
-      use_form_to_create_scoped_mapping
+      use_form_to_create_amazon_mapping
       mapping = ContainerLabelTagMapping.last
       expect(mapping.labeled_resource_type).to eq('Vm')
       expect(mapping.label_name).to eq('some-amazon-label')
@@ -75,7 +75,7 @@ describe OpsController do
     end
 
     it "can edit an existing scoped mapping" do
-      use_form_to_create_scoped_mapping
+      use_form_to_create_amazon_mapping
       mapping = ContainerLabelTagMapping.last
 
       post :label_tag_mapping_edit, :id => mapping.id.to_s


### PR DESCRIPTION
Currently, we store mappings without the provider, e.g. "Image" not "Amazon::Image".
This broke Edit, because once stored and loaded back it didn't reconstruct the provider.

BZ's:
https://bugzilla.redhat.com/show_bug.cgi?id=1444112

https://bugzilla.redhat.com/show_bug.cgi?id=1444110

Fix by rewriting around the underlying assumption that entity strings belong to at most 1 provider.

Moved the const to UI, will need separate PR to remove it from the model.

@miq-bot add-label bug
