### PR TITLE
Change error message flash of existing label to more informative

### DIFF
--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -153,7 +153,7 @@ module OpsController::Settings::LabelTagMapping
 
     # UI currently can't allow 2 mappings for same (entity, label).
     if Classification.find_by_name(cat_name)
-      add_flash(_("Mapping for %{entity}, %{label} already exists") %
+      add_flash(_("Mapping for %{entity}, Label \"%{label}\" already exists") %
                   {:entity => entity_ui_name_or_all(entity), :label => label_name}, :error)
       javascript_flash
       return


### PR DESCRIPTION
Added **Label** and **""** for clarity

![fix_flash_map_tags3](https://cloud.githubusercontent.com/assets/20948594/25327685/c56a315a-28dd-11e7-9846-4d49b8c50bcf.png)

BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1444110

@miq-bot add-label bug

@serenamarie125 @cben @h-kataria PTAL