### PR TITLE
Add legend to ad hoc chart

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
@@ -34,7 +34,7 @@ angular.module('miq.util').factory('metricsConfigFactory', function() {
 
     // Graphs
     dash.chartConfig = {
-      legend       : { show: false },
+      legend       : { show: true },
       chartId      : 'ad-hoc-metrics-chart',
       point        : { r: 1 },
       axis         : {


### PR DESCRIPTION
**Description**

On discussion with @Loicavenel we decided that the charts require legend.

**Screenshots**

Before
![screenshot-localhost 3000-2017-04-24-12-24-29](https://cloud.githubusercontent.com/assets/2181522/25330644/06732c00-28e9-11e7-9e0a-c35be8b26623.png)

After
![screenshot-localhost 3000-2017-04-24-12-22-46](https://cloud.githubusercontent.com/assets/2181522/25330647/0b4715de-28e9-11e7-9f78-c23e3f88fa70.png)
