### PR TITLE
Fix layout regression

### DIFF
--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -21,6 +21,7 @@ class EmsContainerController < ApplicationController
   end
 
   def show_list
+    @showtype = "main"
     process_show_list(:gtl_dbname => 'emscontainer')
   end
 

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -40,6 +40,7 @@ module ApplicationHelper::PageLayouts
     return false if %w(
       ad_hoc_metrics
       consumption
+      dashboard
       dialog_provision
       topology
     ).include?(@showtype)
@@ -47,8 +48,6 @@ module ApplicationHelper::PageLayouts
     return false if dashboard_no_listnav?
 
     return false if @layout.starts_with?("miq_request")
-
-    return false if @showtype == "dashboard" && @lastaction.ends_with?("_dashboard")
 
     return false if controller.action_name.end_with?("tagging_edit")
 


### PR DESCRIPTION
**Description**

Sorry ... in https://github.com/ManageIQ/manageiq-ui-classic/pull/1121 I caused a regression.

When navigating back from the `ad-hoc` page back to the `providers` page, the layout stay without listnav.

**Screenshot**
Before ( When navigating back from the ad-hoc page )
![screenshot-localhost 3000-2017-04-24-13-13-22](https://cloud.githubusercontent.com/assets/2181522/25332634/db3bc068-28ef-11e7-94e9-45a23e205e56.png)

After
![screenshot-localhost 3000-2017-04-24-13-11-53](https://cloud.githubusercontent.com/assets/2181522/25332642/e15f2944-28ef-11e7-9d02-8e0eeb3e2fce.png)
