### PR TITLE
[WIP] display openshift_annotations for container images

### DIFF
--- a/app/controllers/container_image_controller.rb
+++ b/app/controllers/container_image_controller.rb
@@ -10,7 +10,7 @@ class ContainerImageController < ApplicationController
     [
       %i(properties container_labels compliance),
       %i(relationships smart_management configuration openscap_failed_rules),
-      %i(env container_docker_labels)
+      %i(env container_docker_labels annotations)
     ]
   end
   helper_method :textual_group_list

--- a/app/helpers/container_image_helper/textual_summary.rb
+++ b/app/helpers/container_image_helper/textual_summary.rb
@@ -131,4 +131,8 @@ module ContainerImageHelper
   def textual_group_container_docker_labels
     TextualGroup.new(_("Docker Labels"), textual_key_value_group(@record.docker_labels.to_a))
   end
+
+  def textual_group_annotations
+    TextualGroup.new(_("Annotations"), textual_key_value_group(@record.annotations.to_a))
+  end
 end


### PR DESCRIPTION
Displaying openshift_annotations for container images.

depends on https://github.com/ManageIQ/manageiq/pull/14850