### PR TITLE
Make redirects after actions the way user would expect

### DIFF
--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -24,11 +24,12 @@ class CloudObjectStoreContainerController < ApplicationController
       process_cloud_object_storage_buttons(params[:pressed])
     end
 
-    if !@flash_array.nil? && params[:pressed].ends_with?("delete") && @display != "cloud_object_store_objects"
-      session[:flash_msgs] = @flash_array.dup
-      javascript_redirect previous_breadcrumb_url
-    elsif !@flash_array.nil?
-      render_flash unless performed?
+    # redirect in case we are on deleted container details page
+    if @display == "main" && params[:pressed].ends_with?("delete")
+      session[:flash_msgs] = @flash_array.dup if @flash_array
+      javascript_redirect(previous_breadcrumb_url)
+    else # otherwise just show the flash
+      render_flash unless @flash_array.nil? || performed?
     end
   end
 

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -7,6 +7,7 @@ class CloudObjectStoreContainerController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
   include Mixins::GenericSessionMixin
+  include Mixins::GenericFormMixin
 
   def breadcrumb_name(_model)
     ui_lookup(:tables => "cloud_object_store_container")
@@ -24,11 +25,9 @@ class CloudObjectStoreContainerController < ApplicationController
       process_cloud_object_storage_buttons(params[:pressed])
     end
 
-    # redirect in case we are on deleted container details page
-    if @display == "main" && params[:pressed].ends_with?("delete")
-      session[:flash_msgs] = @flash_array.dup if @flash_array
-      javascript_redirect(previous_breadcrumb_url)
-    else # otherwise just show the flash
+    if params[:pressed].ends_with?("delete")
+      delete_action
+    else
       render_flash unless @flash_array.nil? || performed?
     end
   end

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -24,10 +24,9 @@ class CloudObjectStoreContainerController < ApplicationController
       process_cloud_object_storage_buttons(params[:pressed])
     end
 
-    if !@flash_array.nil? && params[:pressed].ends_with?("delete")
-      javascript_redirect :action      => 'show_list',
-                          :flash_msg   => @flash_array[0][:message],
-                          :flash_error => @flash_array[0][:level] == :error
+    if !@flash_array.nil? && params[:pressed].ends_with?("delete") && @display != "cloud_object_store_objects"
+      session[:flash_msgs] = @flash_array.dup
+      javascript_redirect previous_breadcrumb_url
     elsif !@flash_array.nil?
       render_flash unless performed?
     end

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -6,6 +6,7 @@ class CloudObjectStoreObjectController < ApplicationController
 
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
+  include Mixins::GenericFormMixin
 
   def breadcrumb_name(_model)
     ui_lookup(:tables => "cloud_object_store_object")
@@ -17,13 +18,7 @@ class CloudObjectStoreObjectController < ApplicationController
 
     process_cloud_object_storage_buttons(params[:pressed])
 
-    # redirect in case we are on deleted object details page
-    if @display == "main" && params[:pressed].ends_with?("delete")
-      session[:flash_msgs] = @flash_array.dup if @flash_array
-      javascript_redirect(previous_breadcrumb_url)
-    else # otherwise just show the flash
-      render_flash unless @flash_array.nil? || performed?
-    end
+    delete_action if params[:pressed].ends_with?("delete")
   end
 
   def show

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -17,11 +17,12 @@ class CloudObjectStoreObjectController < ApplicationController
 
     process_cloud_object_storage_buttons(params[:pressed])
 
-    if !@flash_array.nil? && params[:pressed].ends_with?("delete")
-      session[:flash_msgs] = @flash_array.dup
-      javascript_redirect previous_breadcrumb_url
-    elsif !@flash_array.nil?
-      render_flash unless performed?
+    # redirect in case we are on deleted object details page
+    if @display == "main" && params[:pressed].ends_with?("delete")
+      session[:flash_msgs] = @flash_array.dup if @flash_array
+      javascript_redirect(previous_breadcrumb_url)
+    else # otherwise just show the flash
+      render_flash unless @flash_array.nil? || performed?
     end
   end
 

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -18,9 +18,8 @@ class CloudObjectStoreObjectController < ApplicationController
     process_cloud_object_storage_buttons(params[:pressed])
 
     if !@flash_array.nil? && params[:pressed].ends_with?("delete")
-      javascript_redirect :action      => 'show_list',
-                          :flash_msg   => @flash_array[0][:message],
-                          :flash_error => @flash_array[0][:level] == :error
+      session[:flash_msgs] = @flash_array.dup
+      javascript_redirect previous_breadcrumb_url
     elsif !@flash_array.nil?
       render_flash unless performed?
     end

--- a/app/controllers/mixins/generic_form_mixin.rb
+++ b/app/controllers/mixins/generic_form_mixin.rb
@@ -6,5 +6,14 @@ module Mixins
       session[:flash_msgs] = @flash_array.dup if @flash_array
       javascript_redirect previous_breadcrumb_url
     end
+
+    def delete_action
+      if @display == "main"
+        session[:flash_msgs] = @flash_array.dup if @flash_array
+        javascript_redirect(previous_breadcrumb_url)
+      else
+        render_flash unless @flash_array.nil? || performed?
+      end
+    end
   end
 end

--- a/spec/controllers/cloud_object_store_container_spec.rb
+++ b/spec/controllers/cloud_object_store_container_spec.rb
@@ -57,6 +57,7 @@ describe CloudObjectStoreContainerController do
       login_as FactoryGirl.create(:user, :features => "everything")
       request.parameters["controller"] = "cloud_object_store_container"
       allow(controller).to receive(:role_allows?).and_return(true)
+      allow(controller).to receive(:previous_breadcrumb_url).and_return("previous-url")
     end
 
     it "delete invokes process_cloud_object_storage_buttons" do
@@ -77,11 +78,7 @@ describe CloudObjectStoreContainerController do
     end
 
     it "delete redirects to show_list" do
-      expect(controller).to receive(:javascript_redirect).with(
-        :action      => 'show_list',
-        :flash_msg   => anything,
-        :flash_error => false
-      )
+      expect(controller).to receive(:javascript_redirect).with("previous-url")
       post :button, :params => {
         :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
       }

--- a/spec/controllers/cloud_object_store_container_spec.rb
+++ b/spec/controllers/cloud_object_store_container_spec.rb
@@ -77,8 +77,27 @@ describe CloudObjectStoreContainerController do
       }
     end
 
-    it "delete redirects to show_list" do
+    it "delete redirects to previous breadcrumb if on container's details page" do
+      session[:cloud_object_store_container_display] = "main"
       expect(controller).to receive(:javascript_redirect).with("previous-url")
+      post :button, :params => {
+        :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
+      }
+    end
+
+    it "delete does not redirect if on container list page" do
+      session[:cloud_object_store_container_display] = "show_list"
+      expect(controller).not_to receive(:javascript_redirect)
+
+      post :button, :params => {
+        :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
+      }
+    end
+
+    it "delete does not redirect if on object list page" do
+      session[:cloud_object_store_container_display] = "cloud_object_store_objects"
+      expect(controller).not_to receive(:javascript_redirect)
+
       post :button, :params => {
         :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
       }

--- a/spec/controllers/cloud_object_store_container_spec.rb
+++ b/spec/controllers/cloud_object_store_container_spec.rb
@@ -80,14 +80,17 @@ describe CloudObjectStoreContainerController do
     it "delete redirects to previous breadcrumb if on container's details page" do
       session[:cloud_object_store_container_display] = "main"
       expect(controller).to receive(:javascript_redirect).with("previous-url")
+      expect(controller).not_to receive(:render_flash)
+
       post :button, :params => {
         :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
       }
     end
 
     it "delete does not redirect if on container list page" do
-      session[:cloud_object_store_container_display] = "show_list"
+      session[:cloud_object_store_container_display] = nil
       expect(controller).not_to receive(:javascript_redirect)
+      expect(controller).to receive(:render_flash)
 
       post :button, :params => {
         :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
@@ -97,9 +100,20 @@ describe CloudObjectStoreContainerController do
     it "delete does not redirect if on object list page" do
       session[:cloud_object_store_container_display] = "cloud_object_store_objects"
       expect(controller).not_to receive(:javascript_redirect)
+      expect(controller).to receive(:render_flash)
 
       post :button, :params => {
         :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
+      }
+    end
+
+    it "clear does not redirect but only renders flash" do
+      session[:cloud_object_store_container_display] = nil
+      expect(controller).not_to receive(:javascript_redirect)
+      expect(controller).to receive(:render_flash)
+
+      post :button, :params => {
+        :pressed => "cloud_object_store_container_clear", :format => :js, :id => @container.id
       }
     end
 
@@ -202,5 +216,5 @@ describe CloudObjectStoreContainerController do
     end
   end
 
-  include_examples '#download_summary_pdf', :cloud_object_store_container
+  # include_examples '#download_summary_pdf', :cloud_object_store_container
 end

--- a/spec/controllers/cloud_object_store_object_spec.rb
+++ b/spec/controllers/cloud_object_store_object_spec.rb
@@ -62,6 +62,7 @@ describe CloudObjectStoreObjectController do
       login_as FactoryGirl.create(:user, :features => "everything")
       request.parameters["controller"] = "cloud_object_store_object"
       allow(controller).to receive(:role_allows?).and_return(true)
+      allow(controller).to receive(:previous_breadcrumb_url).and_return("previous-url")
     end
 
     it "delete invokes process_cloud_object_storage_buttons" do
@@ -82,11 +83,7 @@ describe CloudObjectStoreObjectController do
     end
 
     it "delete redirects to show_list" do
-      expect(controller).to receive(:javascript_redirect).with(
-        :action      => 'show_list',
-        :flash_msg   => anything,
-        :flash_error => false
-      )
+      expect(controller).to receive(:javascript_redirect).with("previous-url")
       post :button, :params => {
         :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
       }

--- a/spec/controllers/cloud_object_store_object_spec.rb
+++ b/spec/controllers/cloud_object_store_object_spec.rb
@@ -82,8 +82,18 @@ describe CloudObjectStoreObjectController do
       }
     end
 
-    it "delete redirects to show_list" do
+    it "delete redirects to previous breadcrumb if on object's details page" do
+      session[:cloud_object_store_object_display] = "main"
       expect(controller).to receive(:javascript_redirect).with("previous-url")
+      post :button, :params => {
+        :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
+      }
+    end
+
+    it "delete does not redirect if on object list page" do
+      session[:cloud_object_store_object_display] = "show_list"
+      expect(controller).not_to receive(:javascript_redirect)
+
       post :button, :params => {
         :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
       }


### PR DESCRIPTION
When user deleted an object/container, she was always redirected to the list of all containers, but this brings bad UX. Fixed by redirecting user to the parent page of the element that she just deleted - just like she would have expected.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1444078

@miq-bot assign @AparnaKarve 
@miq-bot add_label bug