### PR TITLE
Display paging controls on PXE/Customization Templates list

### DIFF
--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -47,6 +47,7 @@ class PxeController < ApplicationController
     @explorer = true
 
     build_accordions_and_trees
+    return if request.xml_http_request?
 
     @right_cell_div ||= "pxe_server_list"
     @right_cell_text ||= _("All PXE Servers")
@@ -156,14 +157,14 @@ class PxeController < ApplicationController
                         end
     when :customization_templates_tree
       presenter.update(:main_div, r[:partial => "template_list"])
-      nodes = nodetype.split('_')
+      presenter.update(:paging_div, r[:partial => "layouts/x_pagingcontrols"])
       if @in_a_form
         right_cell_text =
           if @ct.id.blank?
             _("Adding a new %{model}") % {:model => ui_lookup(:model => "PxeCustomizationTemplate")}
           else
-            @edit ? _("Editing %{model} \"%{name}\"") % {:name  => @ct.name, :model => ui_lookup(:model => "PxeCustomizationTemplate")} :
-                    _("%{model} \"%{name}\"") % {:name  => @ct.name, :model => ui_lookup(:model => "PxeCustomizationTemplate")}
+            @edit ? _("Editing %{model} \"%{name}\"") % {:name => @ct.name, :model => ui_lookup(:model => "PxeCustomizationTemplate")} :
+                    _("%{model} \"%{name}\"") % {:name => @ct.name, :model => ui_lookup(:model => "PxeCustomizationTemplate")}
           end
         # resetting ManageIQ.oneTransition.oneTrans when tab loads
         presenter.reset_one_trans


### PR DESCRIPTION
Added updating ```paging_div``` with the x_pagingcontrols partial view and fixed double rendered error.

Previously the paging controls were not displayed when user came to the list view through selected group of the templates in the tree (tree_select - JS request), but after refresh the page (explorer - HTML request) the controls have been displayed, and when user changed the paging settings it finished with double render error.

https://bugzilla.redhat.com/show_bug.cgi?id=1442751