### PR TITLE
Find correct klass for rbac check for `retirevms`

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -215,15 +215,7 @@ module ApplicationController::CiProcessing
   # Retire 1 or more items (vms, stacks, services)
   def retirevms
     assert_privileges(params[:pressed])
-    klass = get_class_from_controller_param(params[:controller])
-    selected_items = find_checked_ids_with_rbac(klass)
-    if !%w(orchestration_stack service).include?(request.parameters["controller"]) && !%w(orchestration_stacks).include?(params[:display]) &&
-       VmOrTemplate.find(selected_items).any? { |vm| !vm.supports_retire? }
-      add_flash(_("Set Retirement Date does not apply to selected %{model}") %
-        {:model => ui_lookup(:table => "miq_template")}, :error)
-      javascript_flash(:scroll_top => true)
-      return
-    end
+
     # check to see if coming from show_list or drilled into vms from another CI
     if request.parameters[:controller] == "vm" || %w(all_vms instances vms).include?(params[:display])
       rec_cls = "vm"
@@ -234,6 +226,15 @@ module ApplicationController::CiProcessing
     elsif request.parameters[:controller] == "orchestration_stack" || %w(orchestration_stacks).include?(params[:display])
       rec_cls = "orchestration_stack"
       bc_msg = _("Retire Orchestration Stack")
+    end
+    klass = get_class_from_controller_param(params[:controller])
+    selected_items = find_checked_ids_with_rbac(klass)
+    if !%w(orchestration_stack service).include?(request.parameters["controller"]) && !%w(orchestration_stacks).include?(params[:display]) &&
+       VmOrTemplate.find(selected_items).any? { |vm| !vm.supports_retire? }
+      add_flash(_("Set Retirement Date does not apply to selected %{model}") %
+        {:model => ui_lookup(:table => "miq_template")}, :error)
+      javascript_flash(:scroll_top => true)
+      return
     end
     if selected_items.blank?
       session[:retire_items] = [params[:id]]

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -227,7 +227,7 @@ module ApplicationController::CiProcessing
       rec_cls = "orchestration_stack"
       bc_msg = _("Retire Orchestration Stack")
     end
-    klass = get_class_from_controller_param(params[:controller])
+    klass = rec_cls ? rec_cls.camelize.constantize : get_class_from_controller_param(params[:controller])
     selected_items = find_checked_ids_with_rbac(klass)
     if !%w(orchestration_stack service).include?(request.parameters["controller"]) && !%w(orchestration_stacks).include?(params[:display]) &&
        VmOrTemplate.find(selected_items).any? { |vm| !vm.supports_retire? }


### PR DESCRIPTION
One would think that retirevms method would operate on Vm records.
That's not the case. Caveat programmer!

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1442691

Introduced in 457b085.

Addressing:
```
Error caught: [NoMethodError] undefined method `all' for nil:NilClass
lib/rbac/filterer.rb:545:in `apply_scope'
lib/rbac/filterer.rb:205:in `search'
lib/rbac/filterer.rb:112:in `search'
lib/rbac.rb:3:in `search'
manageiq-ui-classic-d32ec1b1bfc2/app/controllers/application_controller.rb:2265:in `assert_rbac'
manageiq-ui-classic-d32ec1b1bfc2/app/controllers/mixins/checked_id_mixin.rb:35:in `find_checked_ids_with_rbac'
manageiq-ui-classic-d32ec1b1bfc2/app/controllers/application_controller/ci_processing.rb:219:in `retirevms'
```

@miq-bot add_label bug, fine/yes