### PR TITLE
Introduce a universal method for testing RBAC on checked items

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -322,7 +322,8 @@ module ApplicationController::Performance
 
   # display timeline for the selected CI
   def timeline_selected(chart_click_data, data_row, ts)
-    return [true, nil] unless @record = perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"])
+    @record = perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"])
+    return [true, nil] unless @record
     controller = data_row["resource_type"].underscore
     new_opts = tl_session_data(controller) || ApplicationController::Timelines::Options.new
     new_opts[:model] = data_row["resource_type"]
@@ -436,7 +437,8 @@ module ApplicationController::Performance
 
   # Create daily/hourly chart for selected CI
   def chart_selected(chart_click_data, data_row, ts)
-    return [true, nil] unless @record = perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"])
+    @record = perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"])
+    return [true, nil] unless @record
     # Set the perf options in the selected controller's sandbox
     cont = data_row["resource_type"].underscore.downcase.to_sym
     session[:sandboxes][cont] ||= {}

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -524,12 +524,16 @@ module ApplicationController::Performance
 
   # Send error message if record is found and authorized, else return the record
   def perf_menu_record_valid(model, id, resource_name)
-    rec = find_record_with_rbac_flash(model.constantize, id, resource_name)
+    record = find_records_with_rbac(model.constantize, id)
+    if record.empty?
+      record_name = resource_name ? "#{ui_lookup(:model => model)} '#{resource_name}'" : _("The selected record")
+      add_flash(_("%{record_name} no longer exists in the database") % {:record_name => record_name}, :error)
+    end
     unless @flash_array.blank?
       javascript_flash(:spinner_off => true)
       return false
     end
-    rec  # Record is found and authorized
+    record # Record is found and authorized
   end
 
   # Load a chart miq_report object from YML

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -225,7 +225,7 @@ module ApplicationController::Performance
 
   # display the CI selected from a Top chart
   def display_current_top(data_row)
-    unless perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"], data_row["resource_name"])
+    unless perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"])
       return [true, nil]
     end
     javascript_redirect :controller => data_row["resource_type"].underscore,
@@ -322,7 +322,7 @@ module ApplicationController::Performance
 
   # display timeline for the selected CI
   def timeline_selected(chart_click_data, data_row, ts)
-    return [true, nil] unless @record = perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"], data_row["resource_name"])
+    return [true, nil] unless @record = perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"])
     controller = data_row["resource_type"].underscore
     new_opts = tl_session_data(controller) || ApplicationController::Timelines::Options.new
     new_opts[:model] = data_row["resource_type"]
@@ -436,7 +436,7 @@ module ApplicationController::Performance
 
   # Create daily/hourly chart for selected CI
   def chart_selected(chart_click_data, data_row, ts)
-    return [true, nil] unless @record = perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"], data_row["resource_name"])
+    return [true, nil] unless @record = perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"])
     # Set the perf options in the selected controller's sandbox
     cont = data_row["resource_type"].underscore.downcase.to_sym
     session[:sandboxes][cont] ||= {}
@@ -523,7 +523,7 @@ module ApplicationController::Performance
   end
 
   # Send error message if record is found and authorized, else return the record
-  def perf_menu_record_valid(model, id, resource_name)
+  def perf_menu_record_valid(model, id)
     record = find_records_with_rbac(model.constantize, id)
     if record.empty?
       add_flash(_("Can't access selected record"))

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -526,8 +526,7 @@ module ApplicationController::Performance
   def perf_menu_record_valid(model, id, resource_name)
     record = find_records_with_rbac(model.constantize, id)
     if record.empty?
-      record_name = resource_name ? "#{ui_lookup(:model => model)} '#{resource_name}'" : _("The selected record")
-      add_flash(_("%{record_name} no longer exists in the database") % {:record_name => record_name}, :error)
+      add_flash(_("Can't access selected record"))
     end
     unless @flash_array.blank?
       javascript_flash(:spinner_off => true)

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -134,12 +134,7 @@ class CloudSubnetController < ApplicationController
 
   def delete_subnets
     assert_privileges("cloud_subnet_delete")
-    subnets = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "cloud_subnet") || @lastaction.nil?
-                find_checked_records_with_rbac(CloudSubnet)
-              else
-                [find_record_with_rbac(CloudSubnet, params[:id])]
-              end
-
+    subnets = find_records_with_rbac(CloudSubnet, nil)
     if subnets.empty?
       add_flash(_("No Cloud Subnet were selected for deletion."), :error)
     end

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -134,7 +134,7 @@ class CloudSubnetController < ApplicationController
 
   def delete_subnets
     assert_privileges("cloud_subnet_delete")
-    subnets = find_records_with_rbac(CloudSubnet, nil)
+    subnets = find_records_with_rbac(CloudSubnet, checked_or_params)
     if subnets.empty?
       add_flash(_("No Cloud Subnet were selected for deletion."), :error)
     end

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -420,7 +420,7 @@ class CloudVolumeController < ApplicationController
   # delete selected volumes
   def delete_volumes
     assert_privileges("cloud_volume_delete")
-    volumes = find_records_with_rbac(CloudVolume, nil)
+    volumes = find_records_with_rbac(CloudVolume, checked_or_params)
     if volumes.empty?
       add_flash(_("No %{models} were selected for deletion.") % {
         :models => ui_lookup(:tables => "cloud_volume")

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -420,14 +420,7 @@ class CloudVolumeController < ApplicationController
   # delete selected volumes
   def delete_volumes
     assert_privileges("cloud_volume_delete")
-    volumes = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "cloud_volume")
-                find_checked_ids_with_rbac(CloudVolume)
-              elsif params[:id].present?
-                [params[:id]]
-              else
-                find_checked_ids_with_rbac(CloudVolume)
-              end
-
+    volumes = find_records_with_rbac(CloudVolume, nil)
     if volumes.empty?
       add_flash(_("No %{models} were selected for deletion.") % {
         :models => ui_lookup(:tables => "cloud_volume")
@@ -435,8 +428,7 @@ class CloudVolumeController < ApplicationController
     end
 
     volumes_to_delete = []
-    volumes.each do |v|
-      volume = CloudVolume.find_by_id(v)
+    volumes.each do |volume|
       if volume.nil?
         add_flash(_("%{model} no longer exists.") % {:model => ui_lookup(:table => "cloud_volume")}, :error)
       elsif !volume.attachments.empty?

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -117,7 +117,6 @@ module Mixins
       obj
     end
 
-
     # Find a record by model and id and test it with RBAC
     # Params:
     #   klass   - class of accessed objects
@@ -132,10 +131,10 @@ module Mixins
     def find_records_with_rbac(klass, ids, options = {})
       ids ||= checked_or_params
       filtered = Rbac.filtered(klass.where(:id => ids),
-                               :user => current_user,
+                               :user        => current_user,
                                :named_scope => options[:named_scope])
       unless ids.length == filtered.length
-        unauthorized_record = (ids - filtered.map { |record| record.id }).first
+        unauthorized_record = (ids - filtered.map(&:id)).first
         raise(_("User '%{userid}' is not authorized to access '%{model}' record id '%{record_id}'") %
               {:user_id   => current_userid,
                :record_id => unauthorized_record,

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -101,30 +101,6 @@ module Mixins
     end
 
     # !============================================!
-    # PLEASE PREFER find_records_with_rbac OVER THIS
-    # !============================================!
-    #
-    # Find a record by model and ID.
-    # Set flash errors for not found/not authorized.
-    def find_record_with_rbac_flash(model, id, resource_name = nil)
-      tested_object = klass.find(id)
-      if tested_object.nil?
-        record_name = resource_name ? "#{ui_lookup(:model => model)} '#{resource_name}'" : _("The selected record")
-        add_flash(_("%{record_name} no longer exists in the database") % {:record_name => record_name}, :error)
-        return nil
-      end
-
-      checked_object = Rbac.filtered_object(tested_object, :user => current_user)
-      if checked_object.nil?
-        add_flash(_("You are not authorized to view %{model_name} '%{resource_name}'") %
-          {:model_name => ui_lookup(:model => tested_object.class.base_model.to_s), :resource_name => resource_name}, :error)
-        return nil
-      end
-
-      checked_object
-    end
-
-    # !============================================!
     # PLEASE PREFER checked_or_params OVER THIS
     # !============================================!
     #
@@ -160,12 +136,6 @@ module Mixins
                                :named_scope => options[:named_scope])
       unless ids.length == filtered.length
         unauthorized_record = (ids - filtered.map { |record| record.id }).first
-        if options[:with_flash]
-          add_flash(_("You are not authorized to view '%{model}' record id '%{record_id}'") %
-                    {:record_id => unauthorized_record,
-                     :model     => ui_lookup(:model => klass.to_s)}, :error)
-          return nil
-        end
         raise(_("User '%{userid}' is not authorized to access '%{model}' record id '%{record_id}'") %
               {:user_id   => current_userid,
                :record_id => unauthorized_record,

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -122,7 +122,6 @@ module Mixins
     #   either sets flash or raises exception
     #
     def find_records_with_rbac(klass, ids, options = {})
-      ids ||= checked_or_params
       filtered = Rbac.filtered(klass.where(:id => ids),
                                :user        => current_user,
                                :named_scope => options[:named_scope])

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -115,8 +115,7 @@ module Mixins
     # Params:
     #   klass   - class of accessed objects
     #   ids     - accessed object ids
-    #   options - :with_flash : set flash in case user is not authorized,
-    # TODO:       :named_scope :
+    #   options - :named_scope :
     #
     # Returns:
     #   Array of selected class instances. If user does not have rights for it,

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -53,7 +53,7 @@ module Mixins
     def find_checked_records_with_rbac(klass, ids = nil)
       ids ||= find_checked_items
       filtered = Rbac.filtered(klass.where(:id => ids))
-      raise _("Unauthorized object or action") unless ids.length == filtered.length
+      raise _("Can't access selected records") unless ids.length == filtered.length
       filtered
     end
 
@@ -72,16 +72,10 @@ module Mixins
       raise _("Invalid input") unless is_integer?(id)
       tested_object = klass.find_by(:id => id)
       if tested_object.nil?
-        raise(_("User '%{user_id}' is not authorized to access '%{model}' record id '%{record_id}'") %
-                {:user_id   => current_userid,
-                 :record_id => id,
-                 :model     => ui_lookup(:model => klass.to_s)})
+        raise(_("Can't access selected records"))
       end
       Rbac.filtered_object(tested_object, :user => current_user, :named_scope => options[:named_scope]) ||
-        raise(_("User '%{user_id}' is not authorized to access '%{model}' record id '%{record_id}'") %
-                {:user_id   => current_userid,
-                 :record_id => id,
-                 :model     => ui_lookup(:model => klass.to_s)})
+        raise(_("Can't access selected records"))
     end
 
     # !============================================!
@@ -133,13 +127,7 @@ module Mixins
       filtered = Rbac.filtered(klass.where(:id => ids),
                                :user        => current_user,
                                :named_scope => options[:named_scope])
-      unless ids.length == filtered.length
-        unauthorized_record = (ids - filtered.map(&:id)).first
-        raise(_("User '%{userid}' is not authorized to access '%{model}' record id '%{record_id}'") %
-              {:user_id   => current_userid,
-               :record_id => unauthorized_record,
-               :model     => ui_lookup(:model => klass.to_s)})
-      end
+      raise(_("Can't access selected records")) unless ids.length == filtered.length
       filtered
     end
 

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -657,7 +657,7 @@ describe ApplicationController do
     it "Verify flash error message when passed in ID no longer exists in database" do
       record = controller.send(:identify_record, "1", ExtManagementSystem)
       expect(record).to be_nil
-      expect(assigns(:bang).message).to match(/User 'user[0-9]+' is not authorized to access 'Provider' record id '1'/)
+      expect(assigns(:bang).message).to match(/Can't access selected records/)
     end
 
     it "Verify @record is set for passed in ID" do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -17,7 +17,7 @@ describe ApplicationController do
     end
 
     it "Verify flash error message when passed in id no longer exists in database" do
-      expect { controller.send(:find_record_with_rbac, ExtManagementSystem, "1") }.to raise_error(RuntimeError, match(/User 'user[0-9]+' is not authorized to access 'Provider' record id '1'/))
+      expect { controller.send(:find_record_with_rbac, ExtManagementSystem, "1") }.to raise_error(RuntimeError, match(/Can't access selected records/))
     end
 
     it "Verify record gets set when valid id is passed in" do

--- a/spec/controllers/mixins/checked_id_mixin_spec.rb
+++ b/spec/controllers/mixins/checked_id_mixin_spec.rb
@@ -12,29 +12,29 @@ describe Mixins::CheckedIdMixin do
     end
     # create records
     before :each do
-      @vm_1 = FactoryGirl.create(:vm_or_template, :id => 1000000000001)
-      @vm_2 = FactoryGirl.create(:vm_or_template, :id => 1000000000002)
-      @vm_3 = FactoryGirl.create(:vm_or_template, :id => 1000000000003)
+      @vm1 = FactoryGirl.create(:vm_or_template, :id => 1_000_000_000_001)
+      @vm2 = FactoryGirl.create(:vm_or_template, :id => 1_000_000_000_002)
+      @vm3 = FactoryGirl.create(:vm_or_template, :id => 1_000_000_000_003)
     end
 
     subject { mixin.send(:find_records_with_rbac, model, id) }
 
     context 'when single record is checked in show list' do
       let(:model) { VmOrTemplate }
-      let(:id) { [1000000000001] }
-      it { is_expected.to eq([@vm_1]) }
+      let(:id) { [1_000_000_000_001] }
+      it { is_expected.to eq([@vm1]) }
     end
 
     context 'when multiple records are checked in show list' do
       let(:model) { VmOrTemplate }
-      let(:id) { [1000000000001, 1000000000002] }
-      it { is_expected.to eq([@vm_1, @vm_2]) }
+      let(:id) { [1_000_000_000_001, 1_000_000_000_002] }
+      it { is_expected.to eq([@vm1, @vm2]) }
     end
 
     context 'when user is not authorized to access the record' do
-      before { allow(Rbac).to receive(:filtered).and_return([@vm_1, @vm_2]) }
+      before { allow(Rbac).to receive(:filtered).and_return([@vm1, @vm2]) }
       let(:model) { VmOrTemplate }
-      let(:id) { [1000000000001, 1000000000002, 1000000000003] }
+      let(:id) { [1_000_000_000_001, 1_000_000_000_002, 1_000_000_000_003] }
       it 'is expected to raise exeption' do
         expect { subject }.to raise_error("Can't access selected records")
       end
@@ -42,7 +42,7 @@ describe Mixins::CheckedIdMixin do
 
     context 'when user tries to access non-existent record' do
       let(:model) { VmOrTemplate }
-      let(:id) { [1000000000001, 1000000000002, 1000000000004] }
+      let(:id) { [1_000_000_000_001, 1_000_000_000_002, 1_000_000_000_004] }
       it 'is expected to raise exeption' do
         expect { subject }.to raise_error("Can't access selected records")
       end

--- a/spec/controllers/mixins/checked_id_mixin_spec.rb
+++ b/spec/controllers/mixins/checked_id_mixin_spec.rb
@@ -1,0 +1,51 @@
+describe Mixins::CheckedIdMixin do
+  describe '#find_records_with_rbac' do
+    # include tested mixin
+    let(:mixin) { Object.new.tap { |s| s.singleton_class.send(:include, described_class) } }
+    # create user, user role and group
+    let(:user_role) { FactoryGirl.create(:miq_user_role) }
+    let(:group) { FactoryGirl.create(:miq_group, :miq_user_role => user_role) }
+    let(:current_user) { FactoryGirl.create(:user, :miq_groups => [group]) }
+    before :each do
+      allow(mixin).to receive(:current_user).and_return(current_user)
+      allow(current_user).to receive(:get_timezone).and_return("Prague")
+    end
+    # create records
+    before :each do
+      @vm_1 = FactoryGirl.create(:vm_or_template, :id => 1000000000001)
+      @vm_2 = FactoryGirl.create(:vm_or_template, :id => 1000000000002)
+      @vm_3 = FactoryGirl.create(:vm_or_template, :id => 1000000000003)
+    end
+
+    subject { mixin.send(:find_records_with_rbac, model, id) }
+
+    context 'when single record is checked in show list' do
+      let(:model) { VmOrTemplate }
+      let(:id) { [1000000000001] }
+      it { is_expected.to eq([@vm_1]) }
+    end
+
+    context 'when multiple records are checked in show list' do
+      let(:model) { VmOrTemplate }
+      let(:id) { [1000000000001, 1000000000002] }
+      it { is_expected.to eq([@vm_1, @vm_2]) }
+    end
+
+    context 'when user is not authorized to access the record' do
+      before { allow(Rbac).to receive(:filtered).and_return([@vm_1, @vm_2]) }
+      let(:model) { VmOrTemplate }
+      let(:id) { [1000000000001, 1000000000002, 1000000000003] }
+      it 'is expected to raise exeption' do
+        expect { subject }.to raise_error("Can't access selected records")
+      end
+    end
+
+    context 'when user tries to access non-existent record' do
+      let(:model) { VmOrTemplate }
+      let(:id) { [1000000000001, 1000000000002, 1000000000004] }
+      it 'is expected to raise exeption' do
+        expect { subject }.to raise_error("Can't access selected records")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/1134

- Adding a new prefered methods for testing RBAC on checked items and using it on places where it is possible to do so without major changes.

- Examples for using the method

- removed ` find_record_with_rbac_flash` introduced in #912