### PR TITLE
Removed unnecessary escaping from assigned server role treenodes

### DIFF
--- a/app/presenters/tree_node/assigned_server_role.rb
+++ b/app/presenters/tree_node/assigned_server_role.rb
@@ -3,9 +3,9 @@ module TreeNode
     set_attributes(:title, :image, :klass) do
       title = ViewHelper.content_tag(:strong) do
         if @options[:tree] == :servers_by_role_tree
-          "#{_('Server')}: #{ERB::Util.html_escape(@object.name)} [#{@object.id}]"
+          "#{_('Server')}: #{@object.name} [#{@object.id}]"
         else
-          "Role: #{ERB::Util.html_escape(@object.server_role.description)}"
+          "Role: #{@object.server_role.description}"
         end
       end
 


### PR DESCRIPTION
There is a `content_tag` around the escaped strings, therefore, it's obsolete to call `html_escape` as it has its own escaping mechanism. This also fixes the escaped `&amp` in the linked BZ.

**Before:**
![screenshot from 2017-04-24 16-40-51](https://cloud.githubusercontent.com/assets/649130/25342617/d0a19e6c-290c-11e7-84b5-7c8dc2fd0b60.png)


**After:**
![screenshot from 2017-04-24 16-40-11](https://cloud.githubusercontent.com/assets/649130/25342597/c217a224-290c-11e7-946e-d5de58af27d6.png)



https://bugzilla.redhat.com/show_bug.cgi?id=1444794