### PR TITLE
Use correct params for find_record_with_rbac in resize method

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -372,7 +372,7 @@ module ApplicationController::CiProcessing
 
   def resize
     assert_privileges("instance_resize")
-    @record ||= find_record_with_rbac(session[:userid], params[:rec_id])
+    @record ||= find_record_with_rbac(VmOrTemplate, params[:rec_id])
     unless @explorer
       drop_breadcrumb(
         :name => _("Reconfigure Instance '%{name}'") % {:name => @record.name},


### PR DESCRIPTION
find_record_with_rbac expects ActiveRecord like class as first parameter.
During previous refactoring a mistake was introduced and session[:userid] was
passed as first parameter and that caused "undefined method `find_by' for
"admin":String [vm/resize]" when trying to go to reconfigure a VM dialog page.

This corrects that.

https://bugzilla.redhat.com/show_bug.cgi?id=1445005