### PR TITLE
[WIP] provider Validate button: better error reporting

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -56,13 +56,17 @@ module Mixins
       @in_a_form = true
       begin
         set_ems_record_vars(verify_ems, :validate)
-        result, details = verify_ems.authentication_check(params[:cred_type],
-                                                          :save     => false,
-                                                          :database => params[:metrics_database_name])
-        if result
-          add_flash(_("Credential validation was successful"))
+        unless verify_ems.valid?
+          add_flash(_("Errors: %{details}") % {:details => verify_ems.errors.full_messages.join(', ')}, :error)
         else
-          add_flash(_("Credential validation was not successful: %{details}") % {:details => details}, :error)
+          result, details = verify_ems.authentication_check(params[:cred_type],
+                                                            :save     => false,
+                                                            :database => params[:metrics_database_name])
+          if result
+            add_flash(_("Credential validation was successful"))
+          else
+            add_flash(_("Credential validation was not successful: %{details}") % {:details => details}, :error)
+          end
         end
       rescue => err
         $log.warn("MIQ(#{controller_name}_controller-#{action_name}): #{err.class.name}: #{err}")

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -53,16 +53,22 @@ module Mixins
 
     def update_ems_button_validate(verify_ems = nil)
       verify_ems ||= find_record_with_rbac(model, params[:id])
-      set_ems_record_vars(verify_ems, :validate)
       @in_a_form = true
-      result, details = verify_ems.authentication_check(params[:cred_type],
-                                                        :save     => false,
-                                                        :database => params[:metrics_database_name])
-
-      if result
-        add_flash(_("Credential validation was successful"))
-      else
-        add_flash(_("Credential validation was not successful: %{details}") % {:details => details}, :error)
+      begin
+        set_ems_record_vars(verify_ems, :validate)
+        result, details = verify_ems.authentication_check(params[:cred_type],
+                                                          :save     => false,
+                                                          :database => params[:metrics_database_name])
+        if result
+          add_flash(_("Credential validation was successful"))
+        else
+          add_flash(_("Credential validation was not successful: %{details}") % {:details => details}, :error)
+        end
+      rescue => err
+        $log.warn("MIQ(#{controller_name}_controller-#{action_name}): #{err.class.name}: #{err}")
+        add_flash(_("Credential validation error: %{error_class}: %{error}") %
+                  {:error_class => err.class.name, :error => err.to_s},
+                  :error)
       end
 
       render :json => {:message => @flash_array.last(1)[0][:message], :level => @flash_array.last(1)[0][:level]}


### PR DESCRIPTION
Attempt at 2 improvements for provider [Validate] button, mostly motivated by that pesky custom CA field.


## 1st commit: show the error
Fix root problem of exceptions possibly crashing the UI and sending HTML/RJS for crash screen where frontend expects JSON.  (similar to #1126 but moved upward.)

Before:
![trusted-ca-garbage-not-displayed](https://cloud.githubusercontent.com/assets/273688/25341666/3aaa2018-2912-11e7-8bfe-d14a8916beac.png)
After:
![trusted-ca-garbage-err2](https://cloud.githubusercontent.com/assets/273688/25341657/32f96496-2912-11e7-958d-e09144bbf6f7.png)

## 2nd commit: use rails validations to attribute errors to fields
This runs model validations first. The benefit is the errors mention the field that caused them:
![trusted-ca-garbage-err3](https://cloud.githubusercontent.com/assets/273688/25341979/4c096ee4-2913-11e7-9993-114a42bb9d1a.png)
The drawback is they run on the whole EMS, including fields from other endpoints than the one you pressed [Validate] on.  It also means now you'd need non-blank Name before [Validate].

@AparnaKarve @moolitayer @yaacov @jhernand @josejulio What do you think?  Do we want those at all?  Can we have them fine/yes?  Better ideas?