### PR TITLE
Enable Ansible refresh button after first successful refresh is complete

### DIFF
--- a/app/helpers/application_helper/button/embedded_ansible.rb
+++ b/app/helpers/application_helper/button/embedded_ansible.rb
@@ -1,6 +1,7 @@
 class ApplicationHelper::Button::EmbeddedAnsible < ApplicationHelper::Button::Basic
   def disabled?
-    if ManageIQ::Providers::EmbeddedAnsible::Provider.count != 1
+    if ManageIQ::Providers::EmbeddedAnsible::Provider.count != 1 ||
+       ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first.try(:last_refresh_status) != "success"
       @error_message = _("Embedded Ansible Role is not enabled.")
     end
     @error_message.present?

--- a/spec/helpers/application_helper/buttons/embedded_ansible_spec.rb
+++ b/spec/helpers/application_helper/buttons/embedded_ansible_spec.rb
@@ -6,6 +6,7 @@ describe ApplicationHelper::Button::EmbeddedAnsible do
     before do
       # Add embedded Ansible provider if there is none
       FactoryGirl.create(:provider_embedded_ansible) if ManageIQ::Providers::EmbeddedAnsible::Provider.count == 0
+      allow_any_instance_of(ManageIQ::Providers::EmbeddedAnsible::AutomationManager).to receive(:last_refresh_status).and_return("success")
     end
     it '#disabled? returns false' do
       expect(subject.disabled?).to be false


### PR DESCRIPTION
There's a few minutes window between enabling embedded ansible role and the moment
when everything is actually ready on the backend side (i.e. the time the first successful
refresh of ansible  tower finishes).

https://bugzilla.redhat.com/show_bug.cgi?id=1444874