### PR TITLE
Fix enabled Export button on Custom Reports Export

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -351,24 +351,6 @@ function miqValidateButtons(h_or_s, prefix) {
   }
 }
 
-// Convert Button image to hyperlink
-function toggleConvertButtonToLink(button, url, toggle) {
-  if (toggle) {
-    button.removeClass('dimmed');
-    if (!button.parent().is('a[href]')) {
-      button
-        .wrap($('<a/>')
-          .attr('href', url)
-          .attr('title', button.attr('alt')));
-    }
-  } else {
-    button.addClass('dimmed');
-    if (button.parent().is('a[href]')) {
-      button.unwrap();
-    }
-  }
-}
-
 // update all checkboxes on a form when the masterToggle checkbox is changed
 // parms: button_div=<id of div with buttons to update>
 function miqUpdateAllCheckboxes(button_div) {

--- a/app/views/layouts/_x_edit_buttons.html.haml
+++ b/app/views/layouts/_x_edit_buttons.html.haml
@@ -173,10 +173,12 @@
     - else
       -# export_button
       = button_tag(_("Export"),
-        :class  => "btn btn-primary #{@export_reports.empty? ? "disabled" : ""}",
-        :type   => "application/txt",
-        :id     => "export_button",
-        :alt    => _("Download Report to YAML"))
+        :class    => "btn btn-primary",
+        :type     => "application/txt",
+        :id       => "export_button",
+        :alt      => _("Download Report to YAML"),
+        :disabled => true)
+
 - elsif ["compare"].include?(@sb[:action])
   #buttons
     -# Button to cancel policy simulation and return to latest tree node

--- a/app/views/report/_export_custom_reports.html.haml
+++ b/app/views/report/_export_custom_reports.html.haml
@@ -41,9 +41,16 @@
           options_for_select(@export_reports.sort),
           :size              => 15,
           :style             => "width:400px; min-width:375px; background-color:#fff; border: 0px;",
-          :multiple          => true,
-          :onchange          => "toggleConvertButtonToLink($('#export_button'),
-                                  'download_report', $('#choices_chosen').val() != null);")
+          :multiple          => true)
+
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent("choices_chosen", "#{url}");
+          $('#choices_chosen').on("change",
+            function() {
+              if ($(this).val()) {
+                $('#export_button').prop('disabled', false);
+              } else {
+                $('#export_button').prop('disabled', true);
+              }
+            });


### PR DESCRIPTION
Removed old style of disabling button (via CSS class), replaced ```onchange``` function from select tag to avoid adding ```dimmed``` css class to the Export Button, and use JS on("change") to deal with the button
disabled attribute.

Generally it's bugfix to enable/disable Export button in Custom Reports Export page, according to some/any selected custom reports.

https://bugzilla.redhat.com/show_bug.cgi?id=1442720