### PR TITLE
Fixed the mixin method cancel_action to display flash messages

### DIFF
--- a/app/controllers/mixins/generic_form_mixin.rb
+++ b/app/controllers/mixins/generic_form_mixin.rb
@@ -3,6 +3,7 @@ module Mixins
     def cancel_action(message)
       session[:edit] = nil
       add_flash(message, :warning)
+      session[:flash_msgs] = @flash_array.dup if @flash_array
       javascript_redirect previous_breadcrumb_url
     end
   end


### PR DESCRIPTION
There are cases when `javascript_redirect` needs to be supplied with the `previous_breadcrumb_url` parameter in order to do proper redirection of the page.

In non-explorer screens currently, when we specify `javascript_redirect` with `previous_breadcrumb_url`, the only way to display the flash message is to save them in `session[:flash_msgs]`

This issue of the Cancel flash message not being displayed was discovered while investigating https://bugzilla.redhat.com/show_bug.cgi?id=1442773.
(note that although the current PR is related to the BZ, the BZ itself is about a different issue)