### PR TITLE
Rename column header in Container Template screen

### DIFF
--- a/app/controllers/container_template_controller.rb
+++ b/app/controllers/container_template_controller.rb
@@ -9,7 +9,7 @@ class ContainerTemplateController < ApplicationController
   private
 
   def textual_group_list
-    [%i(properties objects parameters), %i(relationships container_labels smart_management)]
+    [%i(properties parameters objects), %i(relationships container_labels smart_management)]
   end
   helper_method :textual_group_list
 

--- a/app/helpers/container_template_helper/textual_summary.rb
+++ b/app/helpers/container_template_helper/textual_summary.rb
@@ -18,7 +18,7 @@ module ContainerTemplateHelper::TextualSummary
   end
 
   def textual_group_objects
-    labels = [_("Kind"), _("Name")]
+    labels = [_("Kind"), _("Name*")]
     values = @record.objects.collect { |obj| [obj[:kind], obj[:metadata][:name] || obj[:metadata][:generateName]] }
     TextualMultilabel.new(_("Objects"), :labels => labels, :values => values)
   end

--- a/app/views/container_template/show.html.haml
+++ b/app/views/container_template/show.html.haml
@@ -2,3 +2,4 @@
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == 'main'
   = render :partial => "layouts/textual_groups_generic"
+  = render :partial => "layouts/container_template_note"

--- a/app/views/layouts/_container_template_note.html.haml
+++ b/app/views/layouts/_container_template_note.html.haml
@@ -1,0 +1,1 @@
+%small= _("*The values above may contain variable parameters that are filled in at instantiation.")


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1434760

Adding a note to clarify that the objects names can consist of parameters. 

![objectste](https://cloud.githubusercontent.com/assets/11769555/25577415/7a09b0f0-2e6e-11e7-9863-83df6a7b7e5e.png)
