### PR TITLE
Move jasmine dependency from manageiq, force 2.5.2

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -31,4 +31,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "guard-rspec", '~> 4.7.3'
   s.add_development_dependency "simplecov"
+
+  # core because jasmine has < 3.0, not < 2.6
+  s.add_development_dependency "jasmine",  "~> 2.5.2"
+  s.add_development_dependency "jasmine-core",  "~> 2.5.2"
 end


### PR DESCRIPTION
jasmine 2.6.0 came out, breaking JS specs - we need to force 2.5* for now
and the dependency was still in manageiq, moving to ui-classic.

(The core dependency is because jasmine-core is the actual jasmine, but jasmine 2.5 depends on jasmine-core >2.5 <3.0 meaning it would pick up 2.6 anyway without this.)

This is the second part of https://github.com/ManageIQ/manageiq/pull/14870 .. but this time, the UI PR needs to be merged first.  (Euwe version in https://github.com/ManageIQ/manageiq/pull/14871.)
