### PR TITLE
RJS fixes for miq_ae class/instance edit.

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -543,12 +543,7 @@ class MiqAeClassController < ApplicationController
   def form_instance_field_changed
     return unless load_edit("aeinst_edit__#{params[:id]}", "replace_cell__explorer")
     get_instances_form_vars
-
-    render :update do |page|
-      page << javascript_prologue
-      @changed = (@edit[:current] != @edit[:new])
-      page << javascript_for_miq_button_visibility(@changed)
-    end
+    javascript_miq_button_visibility(@edit[:current] != @edit[:new])
   end
 
   def update_instance
@@ -796,12 +791,7 @@ class MiqAeClassController < ApplicationController
   def form_field_changed
     return unless load_edit("aeclass_edit__#{params[:id]}", "replace_cell__explorer")
     get_form_vars
-    @changed = (@edit[:new] != @edit[:current])
-    render :update do |page|
-      page << javascript_prologue
-      page.replace_html(@refresh_div, :partial => @refresh_partial) if @refresh_div
-      page << javascript_for_miq_button_visibility(@changed)
-    end
+    javascript_miq_button_visibility(@edit[:new] != @edit[:current])
   end
 
   # AJAX driven routine to check for changes in ANY field on the form
@@ -811,7 +801,6 @@ class MiqAeClassController < ApplicationController
     @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
-      page.replace_html(@refresh_div, :partial => @refresh_partial) if @refresh_div
       unless ["up", "down"].include?(params[:button])
         if params[:field_datatype] == "password"
           page << javascript_hide("field_default_value")

--- a/app/views/miq_ae_class/_class_add.html.haml
+++ b/app/views/miq_ae_class/_class_add.html.haml
@@ -1,5 +1,4 @@
 #add_class_props_div
-= render :partial => "layouts/flash_msg"
 - if @in_a_form_fields && x_node.split('-')[0] == "aec" || params[:pressed] || %w(field_select field_accept field_delete).include?(params[:action])
   #form_div
     = render :partial => "class_form"


### PR DESCRIPTION
The 2 `*changed` methods only need to update the (ok, reset, cancel) buttons.

For that we have a method: `javascript_miq_button_visibility`.

The `@refresh_div` should be never set -- removing the line.

And finally the `flash_div` is already present in the page one level up.

Ping @skateman : what was the situation when the flash was not showing as expected?