### PR TITLE
enable s3 prototype to fix specs

### DIFF
--- a/spec/controllers/cloud_object_store_container_spec.rb
+++ b/spec/controllers/cloud_object_store_container_spec.rb
@@ -149,6 +149,13 @@ describe CloudObjectStoreContainerController do
 
     context "in Amazon S3" do
       before do
+        stub_settings_merge(
+          :prototype => {
+            :amazon => {
+              :s3 => true
+            }
+          }
+        )
         @cloud_manager = FactoryGirl.create(:ems_amazon)
         @ems = @cloud_manager.s3_storage_manager
 


### PR DESCRIPTION
Fixes broken specs by enabling the s3 prototype introduced in https://github.com/ManageIQ/manageiq-providers-amazon/pull/213

proof:

```
❯ be rspec spec/controllers/cloud_object_store_container_spec.rb

Randomized with seed 1655
........FFF..

Failures:

  1) CloudObjectStoreContainerController create object store container in Amazon S3 aws regions
     Failure/Error: :parent_emstype     => "ManageIQ::Providers::Amazon::CloudManager",

     NoMethodError:
       undefined method `id' for nil:NilClass
     # ./spec/controllers/cloud_object_store_container_spec.rb:159:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:75:in `block (3 levels) in <top (required)>'
     # ./spec/manageiq/spec/support/evm_spec_helper.rb:28:in `clear_caches'
     # ./spec/spec_helper.rb:75:in `block (2 levels) in <top (required)>'

  2) CloudObjectStoreContainerController create object store container in Amazon S3 create behaves like queue create container task builds add new container screen
     Failure/Error: :parent_emstype     => "ManageIQ::Providers::Amazon::CloudManager",

     NoMethodError:
       undefined method `id' for nil:NilClass
     Shared Example Group: "queue create container task" called from ./spec/controllers/cloud_object_store_container_spec.rb:170
     # ./spec/controllers/cloud_object_store_container_spec.rb:159:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:75:in `block (3 levels) in <top (required)>'
     # ./spec/manageiq/spec/support/evm_spec_helper.rb:28:in `clear_caches'
     # ./spec/spec_helper.rb:75:in `block (2 levels) in <top (required)>'

  3) CloudObjectStoreContainerController create object store container in Amazon S3 create behaves like queue create container task queues the create cloud object store container action form
     Failure/Error: :parent_emstype     => "ManageIQ::Providers::Amazon::CloudManager",

     NoMethodError:
       undefined method `id' for nil:NilClass
     Shared Example Group: "queue create container task" called from ./spec/controllers/cloud_object_store_container_spec.rb:170
     # ./spec/controllers/cloud_object_store_container_spec.rb:159:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:75:in `block (3 levels) in <top (required)>'
     # ./spec/manageiq/spec/support/evm_spec_helper.rb:28:in `clear_caches'
     # ./spec/spec_helper.rb:75:in `block (2 levels) in <top (required)>'

Finished in 1 minute 13.75 seconds (files took 13.24 seconds to load)
13 examples, 3 failures

Failed examples:

rspec ./spec/controllers/cloud_object_store_container_spec.rb:173 # CloudObjectStoreContainerController create object store container in Amazon S3 aws regions
rspec ./spec/controllers/cloud_object_store_container_spec.rb:139 # CloudObjectStoreContainerController create object store container in Amazon S3 create behaves like queue create container task builds add new container screen
rspec ./spec/controllers/cloud_object_store_container_spec.rb:144 # CloudObjectStoreContainerController create object store container in Amazon S3 create behaves like queue create container task queues the create cloud object store container action form

Randomized with seed 1655

Coverage report generated for RSpec to /Users/hild/src/manageiq-ui-classic/coverage. 12449 / 38434 LOC (32.39%) covered.

~/src/manageiq-ui-classic master* 1m 44s
❯ be rspec spec/controllers/cloud_object_store_container_spec.rb

Randomized with seed 27177
.............

Finished in 5.41 seconds (files took 11.51 seconds to load)
13 examples, 0 failures

Randomized with seed 27177

Coverage report generated for RSpec to /Users/hild/src/manageiq-ui-classic/coverage. 13064 / 39565 LOC (33.02%) covered.

```