### PR TITLE
Fix IE 11 & Edge styling issue in Topology legend

### DIFF
--- a/app/assets/stylesheets/topology.css
+++ b/app/assets/stylesheets/topology.css
@@ -40,6 +40,11 @@ kubernetes-topology-icon svg {
   display: inline-block;
 }
 
+_:-ms-fullscreen, :root kubernetes-topology-icon svg,  /* IE11 hack */
+_:-ms-lang(x), _:-webkit-full-screen, kubernetes-topology-icon svg /* Edge hack */{
+  padding: 20px 0 0 20px;  
+}
+
 .kube-topology g text.attached-label {
   display: none;
 }


### PR DESCRIPTION
This PR fixes a issue where the Topology entity icons are cropped in both IE11 & Edge
https://bugzilla.redhat.com/show_bug.cgi?id=1444119

Old:
<img width="588" alt="screen shot 2017-04-25 at 2 03 03 pm" src="https://cloud.githubusercontent.com/assets/1287144/25400240/ee3cafb2-29bf-11e7-8b52-fad3c3b03080.png">

New:
<img width="788" alt="screen shot 2017-04-25 at 1 46 51 pm" src="https://cloud.githubusercontent.com/assets/1287144/25400239/ee3c09c2-29bf-11e7-8506-1a2fc9a30a4a.png">
