### PR TITLE
Connect clusterless hosts directly to the provider in infra topology

### DIFF
--- a/app/services/infra_topology_service.rb
+++ b/app/services/infra_topology_service.rb
@@ -5,12 +5,16 @@ class InfraTopologyService < TopologyService
 
   @included_relations = [
     :tags,
-    :ems_clusters => [
+    :ems_clusters      => [
       :tags,
       :hosts => [
         :tags,
         :vms => :tags
       ]
+    ],
+    :clusterless_hosts => [
+      :tags,
+      :vms => :tags
     ],
   ]
 

--- a/app/services/topology_service.rb
+++ b/app/services/topology_service.rb
@@ -69,7 +69,7 @@ class TopologyService
       unless entity_relationships_mapping.nil?
         entity_relationships_mapping.keys.each do |rel_name|
           relations = entity.send(rel_name.to_s.underscore.downcase)
-          if relations.kind_of?(ActiveRecord::Associations::CollectionProxy)
+          if relations.respond_to?(:each)
             relations.each do |relation|
               build_rel_data_and_links(entity, entity_relationships_mapping, rel_name, links, relation, topo_items)
             end


### PR DESCRIPTION
If an infra provider has clusterless hosts, they aren't displayed in the topology view. This PR connects these hosts directly to the provider using the `clusterless_hosts` method. Depends on: https://github.com/ManageIQ/manageiq/pull/14884

https://bugzilla.redhat.com/show_bug.cgi?id=1440263
