### PR TITLE
Fix VmCloud Resize/Reconfigure form bugs

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -400,12 +400,12 @@ module ApplicationController::CiProcessing
         begin
           flavor_id = params['flavor_id']
           flavor = find_record_with_rbac(Flavor, flavor_id)
-          old_flavor = @record.flavor
+          old_flavor_name = @record.flavor.try(:name) || _("unknown")
           @record.resize_queue(session[:userid], flavor)
           add_flash(_("Reconfiguring %{instance} \"%{name}\" from %{old_flavor} to %{new_flavor}") % {
             :instance   => ui_lookup(:table => 'vm_cloud'),
             :name       => @record.name,
-            :old_flavor => old_flavor.name,
+            :old_flavor => old_flavor_name,
             :new_flavor => flavor.name})
         rescue => ex
           add_flash(_("Unable to reconfigure %{instance} \"%{name}\": %{details}") % {

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -439,7 +439,7 @@ module ApplicationController::CiProcessing
     unless @record.ext_management_system.nil?
       @record.ext_management_system.flavors.each do |ems_flavor|
         # include only flavors with root disks at least as big as the instance's current root disk.
-        if (ems_flavor != @record.flavor) && (ems_flavor.root_disk_size >= @record.flavor.root_disk_size)
+        if @record.flavor.nil? || ((ems_flavor != @record.flavor) && (ems_flavor.root_disk_size >= @record.flavor.root_disk_size))
           flavors << {:name => ems_flavor.name_with_details, :id => ems_flavor.id}
         end
       end

--- a/app/views/vm_common/_resize.html.haml
+++ b/app/views/vm_common/_resize.html.haml
@@ -26,18 +26,18 @@
                   'paging_div_buttons_id'            => "angular_paging_div_buttons",
                   'paging_div_buttons_type'          => "Submit"}
 
-- unless @explorer
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        = button_tag(_("Submit"),
-                     :class        => "btn btn-primary",
-                     "ng-click"    => "submitClicked()",
-                     "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                     "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
-        = button_tag(_("Cancel"),
-                      :class     => "btn btn-default",
-                      "ng-click" => "cancelClicked()")
+  - unless @explorer
+    %table{:width => '100%'}
+      %tr
+        %td{:align => 'right'}
+          = button_tag(_("Submit"),
+                       :class        => "btn btn-primary",
+                       "ng-click"    => "submitClicked()",
+                       "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
+                       "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
+          = button_tag(_("Cancel"),
+                        :class     => "btn btn-default",
+                        "ng-click" => "cancelClicked()")
 
 :javascript
   ManageIQ.angular.app.value('vmCloudResizeFormId', '#{@record.id}');


### PR DESCRIPTION
This fixes a bug where the buttons on the Resize form don't work if you access the form from outside of an explorer view.
https://bugzilla.redhat.com/show_bug.cgi?id=1445011

This also fixes a bug where retrieving data to populate the form throws an exception because the VM to be resized does not have a flavor. 
https://bugzilla.redhat.com/show_bug.cgi?id=1445018