### PR TITLE
Get right fields in Adv search in Automation Ansible Tower

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -423,7 +423,7 @@ module ApplicationController::Filter
         build_configuration_manager_tree(:configuration_manager_cs_filter, x_active_tree)
         build_accordions_and_trees
         load_or_clear_adv_search
-      elsif @edit[:in_explorer] || x_active_tree == :storage_tree
+      elsif @edit[:in_explorer] || %w(storage_tree configuration_scripts_tree).include?(x_active_tree.to_s)
         tree_type = x_active_tree.to_s.sub(/_tree/, '').to_sym
         builder = TreeBuilder.class_for_type(tree_type)
         tree = builder.new(x_active_tree, tree_type, @sb)
@@ -448,7 +448,7 @@ module ApplicationController::Filter
       end
 
       if ["delete", "saveit"].include?(params[:button])
-        if @edit[:in_explorer] || x_active_tree == :storage_tree
+        if @edit[:in_explorer] || %w(storage_tree configuration_scripts_tree).include?(x_active_tree.to_s)
           tree_name = x_active_tree.to_s
           page.replace("#{tree_name}_div", :partial => "shared/tree", :locals => {
             :tree => tree,

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -63,7 +63,7 @@ class AutomationManagerController < ApplicationController
   end
 
   def load_or_clear_adv_search
-    adv_search_build("ConfiguredSystem")
+    adv_search_build(configuration_manager_scripts_tree(x_active_tree))
     session[:edit] = @edit
     @explorer = true
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -986,6 +986,15 @@ module ApplicationHelper
     end
   end
 
+  def configuration_manager_scripts_tree(tree)
+    case tree
+    when :automation_manager_cs_filter_tree, :configuration_manager_cs_filter_tree
+      "ConfiguredSystem"
+    when :configuration_scripts_tree
+      "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript"
+    end
+  end
+
   def object_types_for_flash_message(klass, record_ids)
     if klass == VmOrTemplate
       object_ary = klass.where(:id => record_ids).collect { |rec| ui_lookup(:model => model_for_vm(rec).to_s) }


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1443640

Get right fields to choose when creating a filter in Advanced search
and choosing 'Field' under <Choose> option in Automation -> Ansible Tower
-> Explorer -> Job Templates.
Fix disappearing accordion after saving a filter in Advanced search
in the same page.

Issue with more info and printscreens:
https://github.com/ManageIQ/manageiq-ui-classic/issues/1074