### PR TITLE
Parse the column/field name correctly in reports

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -412,7 +412,7 @@ module ReportController::Reports::Editor
     f = @edit[:new][:field_order][f_idx]  # Get the field element
     field_sub_type = MiqExpression.get_col_info(f.last)[:format_sub_type]
     field_data_type = MiqExpression.get_col_info(f.last)[:data_type]
-    field_name = f.last.include?(".") ? f.last.split(".").last.tr("-", ".") : f.last.split("-").last
+    field_name = MiqExpression.parse_field_or_tag(f.last).report_column
     case parm
     when "style"  # New CSS class chosen
       if value.blank?

--- a/app/views/report/_form_styling.html.haml
+++ b/app/views/report/_form_styling.html.haml
@@ -18,7 +18,7 @@
     %tbody
       - @edit[:new][:field_order].each_with_index do |f, f_idx|
         - field_type = MiqExpression.get_col_info(f.last.split("__").first)[:format_sub_type]
-        - col_name = f.last.include?(".") ? f.last.split(".").last.gsub("-", ".") : f.last.split("-").last
+        - col_name = MiqExpression.parse_field_or_tag(f.last).report_column
         - styles = @edit.fetch_path(:new, :col_options, col_name, :style) || []
         %tr
           %td


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1402547

When creating a report, the field names were not being stored properly in `col_options` because of how the field was being [parsed](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/report_controller/reports/editor.rb#L415). 

For example, the field `Vm.miq_provision.miq_request-requester_name` was being parsed as `miq_request.v_approved_by` instead of the correct `miq_provision.miq_request.v_approved_by`, causing the `MiqExpression` to never evaluate to true and therefore not styling the report correctly. This PR leverages a new function added to `MiqExpression::Field` to get the correct column name

Here are some gifs to display what was happening (sorry, they're a bit long):
Before:
![bz_fix_before](https://cloud.githubusercontent.com/assets/2433314/25451095/059bed9c-2a8f-11e7-9391-376aade97c5a.gif)

After:
![bz_fix_after_2](https://cloud.githubusercontent.com/assets/2433314/25451115/0e9c2c54-2a8f-11e7-96e1-b5e0491148a8.gif)

@miq-bot add_label cloud intel/reporting, wip, bug
