### PR TITLE
Ensure that error indicator appears on Hawkular tab

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -195,7 +195,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.service_account_auth_status     = data.service_account_auth_status;
       $scope.emsCommonModel.metrics_auth_status             = true;
       $scope.emsCommonModel.ssh_keypair_auth_status         = true;
-      $scope.emsCommonModel.hawkular_auth_status            = true;
+      $scope.emsCommonModel.hawkular_auth_status            = data.hawkular_auth_status;
       $scope.emsCommonModel.vmware_cloud_api_version        = '9.0';
       miqService.sparkleOff();
 

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -289,7 +289,7 @@ module Mixins
                        :bearer_token_exists        => @ems.authentication_token(:bearer).nil? ? false : true,
                        :ems_controller             => controller_name,
                        :default_auth_status        => default_auth_status,
-                       :hawkular_auth_status       => hawkular_auth_status.nil? ? true : hawkular_auth_status,
+                       :hawkular_auth_status       => hawkular_auth_status,
       } if controller_name == "ems_container"
 
       if controller_name == "ems_middleware"

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -265,8 +265,8 @@
                                  :locals  => {:ng_show                => true,
                                               :ng_model               => "#{ng_model}",
                                               :id                     => record.id,
-                                              :ng_reqd_hostname       => "false",
-                                              :ng_reqd_api_port       => "false",
+                                              :ng_reqd_hostname       => "true",
+                                              :ng_reqd_api_port       => "true",
                                               :prefix                 => "hawkular"}
             = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                        :locals  => {:ng_show           => true,


### PR DESCRIPTION
Display the `Hawkular` tab error indicator while adding a new Container Provider.

<img width="1219" alt="screen shot 2017-04-27 at 9 58 21 am" src="https://cloud.githubusercontent.com/assets/1538216/25494904/1db48b54-2b30-11e7-891a-94b58908ad72.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1445735
