### PR TITLE
Physical Server quadicon 

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -580,6 +580,7 @@ class ConfigurationController < ApplicationController
       @edit[:new][:quadicons][:ems_cloud] = params[:quadicons_ems_cloud] == "true" if params[:quadicons_ems_cloud]
       @edit[:new][:quadicons][:host] = params[:quadicons_host] == "true" if params[:quadicons_host]
       @edit[:new][:quadicons][:vm] = params[:quadicons_vm] == "true" if params[:quadicons_vm]
+      @edit[:new][:quadicons][:physical_server] = params[:quadicons_physical_server] == "true" if params[:quadicons_physical_server]
       @edit[:new][:quadicons][:miq_template] = params[:quadicons_miq_template] == "true" if params[:quadicons_miq_template]
       if ::Settings.product.proto # Hide behind proto setting - Sprint 34
         @edit[:new][:quadicons][:service] = params[:quadicons_service] == "true" if params[:quadicons_service]

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -1,6 +1,6 @@
 class PhysicalServerDecorator < MiqDecorator
   def fileicon
-    "svg/vendor-#{vendor.downcase}.svg"
+    "svg/vendor-#{label_for_vendor.downcase}.svg"
   end
 
   def self.fonticon

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -3,20 +3,7 @@ class PhysicalServerDecorator < MiqDecorator
     "svg/vendor-#{vendor.downcase}.svg"
   end
 
-  def fonticon
+  def self.fonticon
     'pficon pficon-server'
-  end
-
-  def img_for_physical_vendor
-    "svg/vendor-#{label_for_vendor.downcase}.svg"
-  end
-
-  def img_for_health_state
-    case health_state
-    when "Valid"    then "svg/healthstate-normal.svg"
-    when "Critical" then "svg/healthstate-critical.svg"
-    when "None"     then "svg/healthstate-unknown.svg"
-    when "Warning"  then "100/warning.png"
-    end
   end
 end

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -1,0 +1,14 @@
+class PhysicalServerDecorator < MiqDecorator
+  def img_for_physical_vendor
+    "svg/vendor-#{label_for_vendor.downcase}.svg"
+  end
+
+  def img_for_health_state
+    case health_state
+    when "Valid"    then "svg/healthstate-normal.svg"
+    when "Critical" then "svg/healthstate-critical.svg"
+    when "None"     then "svg/healthstate-unknown.svg"
+    when "Warning"  then "100/warning.png"
+    end
+  end
+end

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -1,4 +1,12 @@
 class PhysicalServerDecorator < MiqDecorator
+  def fileicon
+    "svg/vendor-#{vendor.downcase}.svg"
+  end
+
+  def fonticon
+    'pficon pficon-server'
+  end
+
   def img_for_physical_vendor
     "svg/vendor-#{label_for_vendor.downcase}.svg"
   end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -226,12 +226,12 @@ module QuadiconHelper
 
       output << flobj_p_simple("a72", (item.host ? 1 : 0))
       output << flobj_img_simple("svg/currentstate-#{h(item.power_state.downcase)}.svg", "b72")
-      output << flobj_img_simple(item.decorate.fileicon, "c72")
+      output << flobj_img_simple(item.ext_management_system.decorate.fileicon, "c72")
       output << flobj_img_simple(img_for_health_state(item), "d72")
       output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
     else
       output << flobj_img_simple(size)
-      output << flobj_img_simple(width * 1.8, item.decorate.fileicon, "e72")
+      output << flobj_img_simple(width * 1.8, item.ext_management_system.decorate.fileicon, "e72")
     end
 
     if options[:typ] == :listnav

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -151,10 +151,6 @@ module QuadiconHelper
     end
   end
 
-  def img_for_physical_vendor(item)
-    "svg/vendor-#{h(item.label_for_vendor.downcase)}.svg"
-  end
-
   # FIXME: Even better would be to ask the object what method to use
   def quadicon_builder_factory(item, options)
     case quadicon_builder_name_from(item)
@@ -230,8 +226,8 @@ module QuadiconHelper
 
       output << flobj_p_simple("a72", (item.host ? 1 : 0))
       output << flobj_img_simple("svg/currentstate-#{h(item.power_state.downcase)}.svg", "b72")
-      output << flobj_img_simple(img_for_physical_vendor(item), "c72")
-      output << flobj_img_simple(img_for_health_state(item), "d72")
+      output << flobj_img_simple(item.decorate.img_for_physical_vendor, "c72")
+      output << flobj_img_simple(item.decorate.img_for_health_state, "d72")
       output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
     else
       output << flobj_img_simple(size)
@@ -701,15 +697,6 @@ module QuadiconHelper
               end
 
     output.collect(&:html_safe).join('').html_safe
-  end
-
-  def img_for_health_state(item)
-    case item.health_state
-    when "Valid"    then "svg/healthstate-normal.svg"
-    when "Critical" then "svg/healthstate-critical.svg"
-    when "None"     then "svg/healthstate-unknown.svg"
-    when "Warning"  then "100/warning.png"
-    end
   end
 
   # Renders a storage quadicon

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -393,7 +393,7 @@ module QuadiconHelper
   end
 
   def quadicon_named_for_base_model?(item)
-    %w(VmOrTempalte PhysicalServer).include?(item.class.base_model.name)
+    %w(VmOrTemplate PhysicalServer).include?(item.class.base_model.name)
   end
 
   def quadicon_builder_name_from(item)

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -226,12 +226,12 @@ module QuadiconHelper
 
       output << flobj_p_simple("a72", (item.host ? 1 : 0))
       output << flobj_img_simple("svg/currentstate-#{h(item.power_state.downcase)}.svg", "b72")
-      output << flobj_img_simple(item.decorate.img_for_physical_vendor, "c72")
-      output << flobj_img_simple(item.decorate.img_for_health_state, "d72")
+      output << flobj_img_simple(item.decorate.fileicon, "c72")
+      output << flobj_img_simple(img_for_health_state(item), "d72")
       output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
     else
       output << flobj_img_simple(size)
-      output << flobj_img_simple(width * 1.8, img_for_physical_vendor(item), "e72")
+      output << flobj_img_simple(width * 1.8, item.decorate.fileicon, "e72")
     end
 
     if options[:typ] == :listnav
@@ -697,6 +697,15 @@ module QuadiconHelper
               end
 
     output.collect(&:html_safe).join('').html_safe
+  end
+
+  def img_for_health_state(item)
+    case item.health_state
+    when "Valid"    then "svg/healthstate-normal.svg"
+    when "Critical" then "svg/healthstate-critical.svg"
+    when "None"     then "svg/healthstate-unknown.svg"
+    when "Warning"  then "100/warning.png"
+    end
   end
 
   # Renders a storage quadicon

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -225,13 +225,13 @@ module QuadiconHelper
       output << flobj_img_simple("layout/base.png")
 
       output << flobj_p_simple("a72", (item.host ? 1 : 0))
-      output << flobj_img_simple("svg/currentstate-#{h(item.power_state.downcase)}.svg", "b72")
+      output << flobj_img_simple("svg/currentstate-#{h(item.power_state.try(:downcase))}.svg", "b72")
       output << flobj_img_simple(item.ext_management_system.decorate.fileicon, "c72")
       output << flobj_img_simple(img_for_health_state(item), "d72")
       output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
     else
-      output << flobj_img_simple(size)
-      output << flobj_img_simple(width * 1.8, item.ext_management_system.decorate.fileicon, "e72")
+      output << flobj_img_simple
+      output << flobj_img_simple(item.ext_management_system.decorate.fileicon, "e72")
     end
 
     if options[:typ] == :listnav
@@ -703,8 +703,8 @@ module QuadiconHelper
     case item.health_state
     when "Valid"    then "svg/healthstate-normal.svg"
     when "Critical" then "svg/healthstate-critical.svg"
-    when "None"     then "svg/healthstate-unknown.svg"
     when "Warning"  then "100/warning.png"
+    else "svg/healthstate-unknown.svg"
     end
   end
 

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -260,7 +260,7 @@ module QuadiconHelper
         end
       end
     end
-    safe_join(output.collect(&:html_safe))
+    safe_join(output)
   end
 
   # FIXME: Even better would be to ask the object what name to use
@@ -561,11 +561,11 @@ module QuadiconHelper
     if settings(:quadicons, db_for_quadicon)
       output << flobj_img_simple("layout/base.png")
       item_count = case item
-                  when EmsPhysicalInfra then item.physical_servers.size
-                  when EmsCloud         then item.total_vms
-                  else
-                    item.hosts.size
-                  end
+                   when EmsPhysicalInfra then item.physical_servers.size
+                   when EmsCloud         then item.total_vms
+                   else
+                     item.hosts.size
+                   end
       output << flobj_p_simple("a72", item_count)
       output << flobj_p_simple("b72", item.total_miq_templates) if item.kind_of?(EmsCloud)
       output << flobj_img_simple("svg/vendor-#{h(item.image_name)}.svg", "c72")
@@ -705,7 +705,7 @@ module QuadiconHelper
 
   def img_for_health_state(item)
     case item.health_state
-    when "Valid"    then "100/healthstate-normal.png"
+    when "Valid"    then "svg/healthstate-normal.svg"
     when "Critical" then "svg/healthstate-critical.svg"
     when "None"     then "svg/healthstate-unknown.svg"
     when "Warning"  then "100/warning.png"

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -151,6 +151,10 @@ module QuadiconHelper
     end
   end
 
+  def img_for_physical_vendor(item)
+    "svg/vendor-#{h(item.label_for_vendor.downcase)}.svg"
+  end
+
   # FIXME: Even better would be to ask the object what method to use
   def quadicon_builder_factory(item, options)
     case quadicon_builder_name_from(item)
@@ -163,6 +167,7 @@ module QuadiconHelper
     when 'single_quad'           then render_single_quad_quadicon(item, options)
     when 'storage'               then render_storage_quadicon(item, options)
     when 'vm_or_template'        then render_vm_or_template_quadicon(item, options)
+    when 'physical_server'       then render_physical_server_quadicon(item, options)
     else
       raise "unknown quadicon kind - #{quadicon_builder_name_from(item)}"
     end
@@ -214,6 +219,48 @@ module QuadiconHelper
       url = quadicon_build_label_url(item, row)
       quadicon_link_to(url, **opts) { content }
     end
+  end
+
+  # Renders a quadicon for PhysicalServer
+  #
+  def render_physical_server_quadicon(item, options)
+    output = []
+    if settings(:quadicons, :physical_server)
+      output << flobj_img_simple("layout/base.png")
+
+      output << flobj_p_simple("a72", (item.host ? 1 : 0))
+      output << flobj_img_simple("svg/currentstate-#{h(item.power_state.downcase)}.svg", "b72")
+      output << flobj_img_simple(img_for_physical_vendor(item), "c72")
+      output << flobj_img_simple(img_for_health_state(item), "d72")
+      output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?
+    else
+      output << flobj_img_simple(size)
+      output << flobj_img_simple(width * 1.8, img_for_physical_vendor(item), "e72")
+    end
+
+    if options[:typ] == :listnav
+      # Listnav, no href needed
+      output << content_tag(:div, :class => 'flobj') do
+        tag(:img, :src => ActionController::Base.helpers.image_path("layout/reflection.png"), :border => 0)
+      end
+    else
+      href = if quadicon_show_links?
+               if quadicon_edit_key?(:hostitems)
+                 "/physical_server/edit/?selected_physical_server=#{item.id}"
+               else
+                 url_for_record(item)
+               end
+             end
+
+      output << content_tag(:div, :class => 'flobj') do
+        title = _("Name: %{name} ") % {:name => h(item.name)}
+
+        link_to(href, :title => title) do
+          quadicon_reflection_img
+        end
+      end
+    end
+    safe_join(output.collect(&:html_safe))
   end
 
   # FIXME: Even better would be to ask the object what name to use
@@ -334,6 +381,7 @@ module QuadiconHelper
   end
 
   CLASSLY_NAMED_ITEMS = %w(
+    PhysicalServer
     EmsCluster
     ResourcePool
     Repository
@@ -345,13 +393,17 @@ module QuadiconHelper
   ).freeze
 
   def quadicon_named_for_base_class?(item)
-    %w(ExtManagementSystem Host).include?(item.class.base_class.name)
+    %w(ExtManagementSystem Host PhysicalServer).include?(item.class.base_class.name)
+  end
+
+  def quadicon_named_for_base_model?(item)
+    %w(VmOrTempalte PhysicalServer).include?(item.class.base_model.name)
   end
 
   def quadicon_builder_name_from(item)
     builder_name = if CLASSLY_NAMED_ITEMS.include?(item.class.name)
                      item.class.name.underscore
-                   elsif item.kind_of?(VmOrTemplate)
+                   elsif quadicon_named_for_base_model?(item)
                      item.class.base_model.to_s.underscore
                    elsif item.kind_of?(ManageIQ::Providers::ConfigurationManager)
                      "single_quad"
@@ -508,7 +560,13 @@ module QuadiconHelper
 
     if settings(:quadicons, db_for_quadicon)
       output << flobj_img_simple("layout/base.png")
-      output << flobj_p_simple("a72", item.kind_of?(EmsCloud) ? item.total_vms : item.hosts.size)
+      item_count = case item
+                  when EmsPhysicalInfra then item.physical_servers.size
+                  when EmsCloud         then item.total_vms
+                  else
+                    item.hosts.size
+                  end
+      output << flobj_p_simple("a72", item_count)
       output << flobj_p_simple("b72", item.total_miq_templates) if item.kind_of?(EmsCloud)
       output << flobj_img_simple("svg/vendor-#{h(item.image_name)}.svg", "c72")
       output << flobj_img_simple(img_for_auth_status(item), "d72")
@@ -643,6 +701,15 @@ module QuadiconHelper
               end
 
     output.collect(&:html_safe).join('').html_safe
+  end
+
+  def img_for_health_state(item)
+    case item.health_state
+    when "Valid"    then "100/healthstate-normal.png"
+    when "Critical" then "svg/healthstate-critical.svg"
+    when "None"     then "svg/healthstate-unknown.svg"
+    when "Warning"  then "100/warning.png"
+    end
   end
 
   # Renders a storage quadicon

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -155,13 +155,14 @@ module UiConstants
   # Default UI settings
   DEFAULT_SETTINGS = {
     :quadicons => { # Show quad icons, by resource type
-      :service      => true,
-      :ems          => true,
-      :ems_cloud    => true,
-      :host         => true,
-      :miq_template => true,
-      :storage      => true,
-      :vm           => true
+      :service         => true,
+      :ems             => true,
+      :ems_cloud       => true,
+      :host            => true,
+      :miq_template    => true,
+      :physical_server => true,
+      :storage         => true,
+      :vm              => true
     },
     :views     => { # List view setting, by resource type
       :authkeypaircloud                         => "list",

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -18,6 +18,7 @@
              [role_allows?(:feature => "host_show_list"),      _("Host"),                                 "host"],
              [role_allows?(:feature => "storage_show_list"),   ui_lookup(:table => "storages"),           "storage"],
              [true,                                           _("VM"),                                   "vm"],
+             [true,                                           _("Physical Server"),                                   "physical_server"],
              [true,                                           _("Template"),                             "miq_template"]].each do |icons_checkbox|
             - if icons_checkbox[0]
               .form-group


### PR DESCRIPTION
This PR contains:
- Quadicon for physical server
![image](https://cloud.githubusercontent.com/assets/5839808/25497461/0ba4b68e-2b5b-11e7-9239-c1d6f8cd7a6d.png)

depends on:
1. [#15129](https://github.com/ManageIQ/manageiq/pull/15129)

