### PR TITLE
Ansible refresh button: correctly send miq_grid_checks

### DIFF
--- a/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
@@ -15,6 +15,7 @@ class ApplicationHelper::Toolbar::AnsibleRepositoriesCenter < ApplicationHelper:
           :url       => "repository_refresh",
           :confirm   => N_("Refresh selected Ansible Repositories?"),
           :enabled   => false,
+          :url_parms => 'unused_div',
           :onwhen    => "1+"),
         separator,
         button(


### PR DESCRIPTION
Without this change, the ansible refresh button would not send `miq_grid_checks` parameter
when launched from ansible repositories list view. Without this change, the button would be
effectively useless in ansible repo list view.

Discovered by @durandom in https://github.com/ManageIQ/manageiq-ui-classic/pull/1083/files#r113627921