### PR TITLE
Fix duplicate DOM id when saving advanced search.

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -450,14 +450,10 @@ module ApplicationController::Filter
       if ["delete", "saveit"].include?(params[:button])
         if @edit[:in_explorer] || x_active_tree == :storage_tree
           tree_name = x_active_tree.to_s
-          if "configuration_manager_cs_filter_tree_tree" == tree_name
-            page.replace_html("#{tree_name}_div", :partial => "provider_foreman/#{tree_name}")
-          else
-            page.replace_html("#{tree_name}_div", :partial => "shared/tree", :locals => {
-              :tree => tree,
-              :name => tree_name
-            })
-          end
+          page.replace("#{tree_name}_div", :partial => "shared/tree", :locals => {
+            :tree => tree,
+            :name => tree_name
+          })
         else
           page.replace(:listnav_div, :partial => "layouts/listnav")
         end


### PR DESCRIPTION
The generiv tree partial contains the div being replaced so we need to
call 'replace' rather than 'replace_html'.

Second, the forman related partial does not exist at all therefor the
branch is a nonsense.

ping @isimluk 