### PR TITLE
Key Pair (angular) - don't sparkleOff when waiting for task

### DIFF
--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -32,11 +32,10 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
         var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
         vm.keyPairModel.ems_id = vm.keyPairModel.ems.id;
         if (serializeFields) {
-            miqService.miqAjaxButton(url, miqService.serializeModel(vm.keyPairModel));
+            miqService.miqAjaxButton(url, miqService.serializeModel(vm.keyPairModel), { complete: false });
         } else {
-            miqService.miqAjaxButton(url, false);
+            miqService.miqAjaxButton(url);
         }
-        miqService.sparkleOff();
     };
 
     vm.cancelClicked = function() {

--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -1,73 +1,70 @@
 ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope', 'keyPairFormId', 'miqService', function($http, $scope, keyPairFormId, miqService) {
-    var vm = this;
-    var init = function() {
-        vm.keyPairModel = {
-            name: '',
-            public_key: '',
-            ems_id: ''
-        };
-        vm.formId = keyPairFormId;
-        vm.afterGet = false;
-        vm.modelCopy = angular.copy( vm.keyPairModel );
-        vm.model = 'keyPairModel';
-        vm.ems_choices = [];
-        vm.saveable = miqService.saveable;
-        ManageIQ.angular.scope = vm;
+  var vm = this;
 
-        miqService.sparkleOn();
-        $http.get('/auth_key_pair_cloud/ems_form_choices')
-          .then(getAuthKeyPairCloudFormDataComplete)
-          .catch(miqService.handleFailure);
-
-        if (keyPairFormId == 'new') {
-            vm.newRecord = true;
-        } else {
-            vm.newRecord = false;
-        }
+  var init = function() {
+    vm.keyPairModel = {
+      name: '',
+      public_key: '',
+      ems_id: '',
     };
 
-    var keyPairEditButtonClicked = function(buttonName, serializeFields) {
-        miqService.sparkleOn();
+    vm.formId = keyPairFormId;
+    vm.afterGet = false;
+    vm.modelCopy = angular.copy( vm.keyPairModel );
+    vm.model = 'keyPairModel';
+    vm.ems_choices = [];
+    vm.saveable = miqService.saveable;
+    vm.newRecord = keyPairFormId == 'new';
 
-        var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
-        vm.keyPairModel.ems_id = vm.keyPairModel.ems.id;
-        if (serializeFields) {
-            miqService.miqAjaxButton(url, miqService.serializeModel(vm.keyPairModel), { complete: false });
-        } else {
-            miqService.miqAjaxButton(url);
-        }
-    };
+    ManageIQ.angular.scope = vm;
 
-    vm.cancelClicked = function() {
-        keyPairEditButtonClicked('cancel', false);
-        $scope.angularForm.$setPristine(true);
-    };
+    miqService.sparkleOn();
+    $http.get('/auth_key_pair_cloud/ems_form_choices')
+      .then(getAuthKeyPairCloudFormDataComplete)
+      .catch(miqService.handleFailure);
+  };
 
-    vm.resetClicked = function() {
-        vm.keyPairModel = angular.copy( vm.modelCopy );
-        $scope.angularForm.$setPristine(true);
-        miqService.miqFlash("warn", __("All changes have been reset"));
-    };
+  var keyPairEditButtonClicked = function(buttonName, serializeFields) {
+    miqService.sparkleOn();
 
-    vm.saveClicked = function() {
-        keyPairEditButtonClicked('save', true);
-        $scope.angularForm.$setPristine(true);
-    };
+    var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
+    vm.keyPairModel.ems_id = vm.keyPairModel.ems.id;
+    if (serializeFields) {
+      miqService.miqAjaxButton(url, miqService.serializeModel(vm.keyPairModel), { complete: false });
+    } else {
+      miqService.miqAjaxButton(url);
+    }
+  };
 
-    vm.addClicked = function() {
-        vm.saveClicked();
-    };
+  vm.cancelClicked = function() {
+    keyPairEditButtonClicked('cancel', false);
+    $scope.angularForm.$setPristine(true);
+  };
 
-    function getAuthKeyPairCloudFormDataComplete(response) {
-      var data = response.data;
+  vm.resetClicked = function() {
+    vm.keyPairModel = angular.copy( vm.modelCopy );
+    $scope.angularForm.$setPristine(true);
+    miqService.miqFlash("warn", __("All changes have been reset"));
+  };
 
-      vm.ems_choices = data.ems_choices;
-      if (vm.ems_choices.length > 0) {
-        vm.keyPairModel.ems = vm.ems_choices[0];
-      }
-      vm.afterGet = true;
-      miqService.sparkleOff();
+  vm.saveClicked = function() {
+    keyPairEditButtonClicked('save', true);
+    $scope.angularForm.$setPristine(true);
+  };
+
+  vm.addClicked = vm.saveClicked;
+
+  function getAuthKeyPairCloudFormDataComplete(response) {
+    var data = response.data;
+
+    vm.ems_choices = data.ems_choices;
+    if (vm.ems_choices.length > 0) {
+      vm.keyPairModel.ems = vm.ems_choices[0];
     }
 
-    init();
+    vm.afterGet = true;
+    miqService.sparkleOff();
+  }
+
+  init();
 }]);

--- a/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
+++ b/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
@@ -68,7 +68,7 @@ describe('keyPairCloudFormController', function() {
         });
 
         it('delegates to miqService.miqAjaxButton', function() {
-            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=save', miqService.serializeModel(vm.keyPairModel));
+            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=save', miqService.serializeModel(vm.keyPairModel), { complete: false });
         });
     });
 
@@ -86,7 +86,7 @@ describe('keyPairCloudFormController', function() {
         });
 
         it('delegates to miqService.restAjaxButton', function() {
-            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=cancel', false);
+            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=cancel');
         });
     });
 });

--- a/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
+++ b/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
@@ -1,92 +1,99 @@
 describe('keyPairCloudFormController', function() {
-    var $scope, vm, $httpBackend, miqService;
+  var $scope, vm, $httpBackend, miqService;
 
-    beforeEach(module('ManageIQ'));
+  beforeEach(module('ManageIQ'));
 
-    beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _miqService_) {
-        miqService = _miqService_;
-        spyOn(miqService, 'showButtons');
-        spyOn(miqService, 'hideButtons');
-        spyOn(miqService, 'buildCalendar');
-        spyOn(miqService, 'miqAjaxButton');
-        spyOn(miqService, 'sparkleOn');
-        spyOn(miqService, 'sparkleOff');
-        $scope = $rootScope.$new();
-        spyOn($scope, '$broadcast');
+  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _miqService_) {
+    miqService = _miqService_;
+    spyOn(miqService, 'showButtons');
+    spyOn(miqService, 'hideButtons');
+    spyOn(miqService, 'buildCalendar');
+    spyOn(miqService, 'miqAjaxButton');
+    spyOn(miqService, 'sparkleOn');
+    spyOn(miqService, 'sparkleOff');
+    $scope = $rootScope.$new();
+    spyOn($scope, '$broadcast');
 
-        //$scope.hostForm.$invalid = false;
-        $httpBackend = _$httpBackend_;
-        var providerResponse = {"ems_choices":
-            [{"name": "OS1", "id":5}
-        ]};
+    //$scope.hostForm.$invalid = false;
+    $httpBackend = _$httpBackend_;
+    var providerResponse = {"ems_choices":
+      [{"name": "OS1", "id":5}
+    ]};
 
-        $httpBackend.whenGET('/auth_key_pair_cloud/ems_form_choices').respond(providerResponse);
-        vm = _$controller_('keyPairCloudFormController as vm', {
-            $scope: $scope,
-            keyPairFormId: 'new',
-            miqService: miqService
-        });
-    }));
+    $httpBackend.whenGET('/auth_key_pair_cloud/ems_form_choices').respond(providerResponse);
+    vm = _$controller_('keyPairCloudFormController as vm', {
+      $scope: $scope,
+      keyPairFormId: 'new',
+      miqService: miqService
+    });
+  }));
 
-    afterEach(function() {
-        $httpBackend.verifyNoOutstandingExpectation();
-        $httpBackend.verifyNoOutstandingRequest();
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('initialization', function() {
+    beforeEach(function() {
+      $httpBackend.flush();
+
+      $scope.angularForm = {
+        $setPristine: function(value) {}
+      };
     });
 
-    describe('initialization', function() {
-        beforeEach(function() {
-            $httpBackend.flush();
-            $scope.angularForm = {
-                $setPristine: function(value) {}
-            };
-        });
-        describe('when the keyPairFormId is new', function() {
-            it('sets the name to blank', function () {
-                expect(vm.keyPairModel.name).toEqual('');
-            });
-            it('sets the hostname to blank', function () {
-                expect(vm.keyPairModel.public_key).toEqual('');
-            });
-        });
+    describe('when the keyPairFormId is new', function() {
+      it('sets the name to blank', function () {
+        expect(vm.keyPairModel.name).toEqual('');
+      });
+
+      it('sets the hostname to blank', function () {
+        expect(vm.keyPairModel.public_key).toEqual('');
+      });
+    });
+  });
+
+  describe('#saveClicked', function() {
+    beforeEach(function() {
+      $httpBackend.flush();
+
+      $scope.angularForm = {
+        $setPristine: function(value) {},
+      };
+
+      vm.saveClicked();
     });
 
-    describe('#saveClicked', function() {
-        beforeEach(function() {
-            $httpBackend.flush();
-            $scope.angularForm = {
-                $setPristine: function(value) {},
-            };
-            vm.saveClicked();
-        });
-
-        it('turns the spinner on via the miqService', function() {
-            expect(miqService.sparkleOn).toHaveBeenCalled();
-        });
-
-        it('turns the spinner on twice', function() {
-            expect(miqService.sparkleOn.calls.count()).toBe(2);
-        });
-
-        it('delegates to miqService.miqAjaxButton', function() {
-            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=save', miqService.serializeModel(vm.keyPairModel), { complete: false });
-        });
+    it('turns the spinner on via the miqService', function() {
+      expect(miqService.sparkleOn).toHaveBeenCalled();
     });
 
-    describe('#cancelClicked', function() {
-        beforeEach(function() {
-            $httpBackend.flush();
-            $scope.angularForm = {
-                $setPristine: function(value) {},
-            };
-            vm.cancelClicked();
-        });
-
-        it('turns the spinner on via the miqService', function() {
-            expect(miqService.sparkleOn).toHaveBeenCalled();
-        });
-
-        it('delegates to miqService.restAjaxButton', function() {
-            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=cancel');
-        });
+    it('turns the spinner on twice', function() {
+      expect(miqService.sparkleOn.calls.count()).toBe(2);
     });
+
+    it('delegates to miqService.miqAjaxButton', function() {
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=save', miqService.serializeModel(vm.keyPairModel), { complete: false });
+    });
+  });
+
+  describe('#cancelClicked', function() {
+    beforeEach(function() {
+      $httpBackend.flush();
+
+      $scope.angularForm = {
+        $setPristine: function(value) {},
+      };
+
+      vm.cancelClicked();
+    });
+
+    it('turns the spinner on via the miqService', function() {
+      expect(miqService.sparkleOn).toHaveBeenCalled();
+    });
+
+    it('delegates to miqService.restAjaxButton', function() {
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=cancel');
+    });
+  });
 });


### PR DESCRIPTION
related to https://bugzilla.redhat.com/show_bug.cgi?id=1444520

Since https://github.com/ManageIQ/manageiq-ui-classic/pull/136, we're using the task queue for saving auth key pairs.

Which means the save request suceeds, disables sparkle, and then we wait for stuff to happen.

.. adding `{ complete: false }`, in line with the rest of controllers using the task queue.