### PR TITLE
miq_tabs_init - use observe queue for tab switching too

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -976,7 +976,7 @@ function miq_tabs_init(id, url) {
     } else if (typeof(url) != 'undefined') {
       // Load remote tab if an URL is specified
       var currTabTarget = $(e.target).attr('href').substring(1);
-      miqJqueryRequest(url + '/?tab_id=' + currTabTarget, {beforeSend: true})
+      miqObserveRequest(url + '/?tab_id=' + currTabTarget, {beforeSend: true})
         .catch(function(err){
           add_flash(__("Error requesting data from server"), 'error');
           console.log(err);


### PR DESCRIPTION
Since many tab switches are in forms, especially non-angular form, we have a timing bug where a tab switch request can happen before all the changes to inputs are processed.

Changing so that tabs use the observe queue as well.

Cc @jkrocil, @lkhomenk