### PR TITLE
Fix tags format

### DIFF
--- a/app/helpers/container_build_helper/textual_summary.rb
+++ b/app/helpers/container_build_helper/textual_summary.rb
@@ -13,9 +13,7 @@ module ContainerBuildHelper::TextualSummary
   end
 
   def textual_group_smart_management
-    items = %w(tags)
-    i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-    TextualTags.new(_("Smart Management"), i)
+    TextualTags.new(_("Smart Management"), %i(tags))
   end
 
   def textual_group_build_instances

--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -34,9 +34,7 @@ module ContainerGroupHelper::TextualSummary
   end
 
   def textual_group_smart_management
-    items = %w(tags)
-    i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-    TextualTags.new(_("Smart Management"), i)
+    TextualTags.new(_("Smart Management"), %i(tags))
   end
 
   @@key_dictionary = [

--- a/app/helpers/container_helper/textual_summary.rb
+++ b/app/helpers/container_helper/textual_summary.rb
@@ -22,9 +22,7 @@ module ContainerHelper::TextualSummary
   end
 
   def textual_group_smart_management
-    items = %w(tags)
-    i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-    TextualTags.new(_("Smart Management"), i)
+    TextualTags.new(_("Smart Management"), %i(tags))
   end
 
   #

--- a/app/helpers/container_image_helper/textual_summary.rb
+++ b/app/helpers/container_image_helper/textual_summary.rb
@@ -26,9 +26,7 @@ module ContainerImageHelper
     end
 
     def textual_group_smart_management
-      items = %w(tags)
-      i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-      TextualTags.new(_("Smart Management"), i)
+      TextualTags.new(_("Smart Management"), %i(tags))
     end
 
     def textual_group_openscap_failed_rules

--- a/app/helpers/container_image_registry_helper/textual_summary.rb
+++ b/app/helpers/container_image_registry_helper/textual_summary.rb
@@ -13,9 +13,7 @@ module ContainerImageRegistryHelper
     end
 
     def textual_group_smart_management
-      items = %w(tags)
-      i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-      TextualGroup.new(_("Smart Management"), i)
+      TextualTags.new(_("Smart Management"), %i(tags))
     end
 
     #

--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -41,9 +41,7 @@ module ContainerNodeHelper::TextualSummary
   end
 
   def textual_group_smart_management
-    items = %w(tags)
-    i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-    TextualGroup.new(_("Smart Management"), i)
+    TextualTags.new(_("Smart Management"), %i(tags))
   end
 
   #

--- a/app/helpers/container_project_helper/textual_summary.rb
+++ b/app/helpers/container_project_helper/textual_summary.rb
@@ -18,9 +18,7 @@ module ContainerProjectHelper::TextualSummary
   end
 
   def textual_group_smart_management
-    items = %w(tags)
-    i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-    TextualTags.new(_("Smart Management"), i)
+    TextualTags.new(_("Smart Management"), %i(tags))
   end
 
   def textual_group_quota

--- a/app/helpers/container_replicator_helper/textual_summary.rb
+++ b/app/helpers/container_replicator_helper/textual_summary.rb
@@ -15,9 +15,7 @@ module ContainerReplicatorHelper::TextualSummary
   end
 
   def textual_group_smart_management
-    items = %w(tags)
-    i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-    TextualTags.new(_("Smart Management"), i)
+    TextualTags.new(_("Smart Management"), %i(tags))
   end
 
   #

--- a/app/helpers/container_route_helper/textual_summary.rb
+++ b/app/helpers/container_route_helper/textual_summary.rb
@@ -12,9 +12,7 @@ module ContainerRouteHelper::TextualSummary
   end
 
   def textual_group_smart_management
-    items = %w(tags)
-    i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-    TextualGroup.new(_("Smart Management"), i)
+    TextualTags.new(_("Smart Management"), %i(tags))
   end
 
   #

--- a/app/helpers/container_service_helper/textual_summary.rb
+++ b/app/helpers/container_service_helper/textual_summary.rb
@@ -33,9 +33,7 @@ module ContainerServiceHelper::TextualSummary
   end
 
   def textual_group_smart_management
-    items = %w(tags)
-    i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-    TextualGroup.new(_("Smart Management"), i)
+    TextualTags.new(_("Smart Management"), %i(tags))
   end
 
   #

--- a/app/helpers/container_template_helper/textual_summary.rb
+++ b/app/helpers/container_template_helper/textual_summary.rb
@@ -12,9 +12,7 @@ module ContainerTemplateHelper::TextualSummary
   end
 
   def textual_group_smart_management
-    items = %w(tags)
-    i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-    TextualGroup.new(_("Smart Management"), i)
+    TextualTags.new(_("Smart Management"), %i(tags))
   end
 
   def textual_group_objects

--- a/app/helpers/persistent_volume_helper/textual_summary.rb
+++ b/app/helpers/persistent_volume_helper/textual_summary.rb
@@ -27,9 +27,7 @@ module PersistentVolumeHelper::TextualSummary
   end
 
   def textual_group_smart_management
-    items = %w(tags)
-    i = items.collect { |m| send("textual_#{m}") }.flatten.compact
-    TextualTags.new(_("Smart Management"), i)
+    TextualTags.new(_("Smart Management"), %i(tags))
   end
 
   def textual_group_capacity


### PR DESCRIPTION
**Description**

Description of problem:
Smart management tags are not show on current format on the following views:
1. Routes
2. Container Services
3. Nodes
4. Container Templates
5. Image Registries

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1439776

**Screenshoots**

![screenshot-localhost 3000-2017-04-27-17-06-02](https://cloud.githubusercontent.com/assets/2181522/25487553/3d547d7e-2b6d-11e7-8be9-6fdf91a406e8.png)
![screenshot-localhost 3000-2017-04-27-17-07-57](https://cloud.githubusercontent.com/assets/2181522/25487554/3d55d2c8-2b6d-11e7-9143-38dee361754f.png)
![screenshot-localhost 3000-2017-04-27-17-08-49](https://cloud.githubusercontent.com/assets/2181522/25487555/3d565e82-2b6d-11e7-8c4b-96cffa0049ad.png)
![screenshot-localhost 3000-2017-04-27-17-14-49](https://cloud.githubusercontent.com/assets/2181522/25487557/3d5d305e-2b6d-11e7-8555-666af10e8009.png)
![screenshot-localhost 3000-2017-04-27-17-15-47](https://cloud.githubusercontent.com/assets/2181522/25487556/3d5a36ce-2b6d-11e7-9591-6979a864d4af.png)

