### PR TITLE
Settings/server: Move flash message one level up fixing duplicate DOM ids.

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -521,10 +521,7 @@ class OpsController < ApplicationController
     locals = set_form_locals if @in_a_form
     build_supported_depots_for_select
 
-    presenter = ExplorerPresenter.new(
-      :active_tree => x_active_tree,
-    )
-    # Update the tree with any new nodes
+    presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
     presenter[:add_nodes] = add_nodes if add_nodes
 
     r = proc { |opts| render_to_string(opts) }
@@ -534,6 +531,8 @@ class OpsController < ApplicationController
     handle_bottom_cell(nodetype, presenter, r, locals)
     x_active_tree_replace_cell(nodetype, presenter, r)
     extra_js_commands(presenter)
+
+    presenter.replace(:flash_msg_div, r[:partial => "layouts/flash_msg"]) if @flash_array
 
     render :json => presenter.for_render
   end
@@ -673,7 +672,6 @@ class OpsController < ApplicationController
     if %w(accordion_select change_tab tree_select).include?(params[:action])
       presenter.replace(:ops_tabs, r[:partial => "all_tabs"])
     elsif nodetype == "group_seq"
-      presenter.replace(:flash_msg_div, r[:partial => "layouts/flash_msg"])
       presenter.update(:rbac_details, r[:partial => "ldap_seq_form"])
     elsif nodetype == "tenant_edit"         # schedule edit
       # when editing/adding schedule in settings tree

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -14,6 +14,7 @@
         = miq_tab_content("settings_evm_servers", @sb[:active_tab]) do
           = render :partial => "settings_evm_servers_tab"
     - elsif selected?(x_node, "svr")
+      = render :partial => "layouts/flash_msg"
       - cur_svr_id = from_cid(x_node.split("-").last).to_i
       %ul.nav.nav-tabs
         = miq_tab_header("settings_server", @sb[:active_tab]) do

--- a/app/views/ops/_settings_advanced_tab.html.haml
+++ b/app/views/ops/_settings_advanced_tab.html.haml
@@ -1,6 +1,5 @@
 - if @sb[:active_tab] == "settings_advanced"
   - url = url_for_only_path(:action => 'settings_form_field_changed', :id => @sb[:active_tab].split('_').last)
-  = render :partial => "layouts/flash_msg"
   #form_div
     .alert.alert-danger
       %span.pficon-layered

--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -1,6 +1,5 @@
 - if @sb[:active_tab] == "settings_authentication"
   - url = url_for_only_path(:action => 'settings_form_field_changed', :id => @sb[:active_tab].split('_').last)
-  = render :partial => "layouts/flash_msg"
   %h3
     = _("Authentication")
   .form-horizontal

--- a/app/views/ops/_settings_custom_logos_tab.html.haml
+++ b/app/views/ops/_settings_custom_logos_tab.html.haml
@@ -1,6 +1,5 @@
 - if @sb[:active_tab] == "settings_custom_logos"
   - url = url_for_only_path(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_')[1]}_#{@sb[:active_tab].split('_').last}")
-  = render :partial => "layouts/flash_msg"
   %h3= _("Custom Logo Image (Shown on top right of all screens)")
   - if File.exist?(@logo_file)
     = image_tag("/upload/custom_logo.png?#{rand(99_999_999)}")

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -1,6 +1,5 @@
 - if @sb[:active_tab] == "settings_server"
   - url = url_for_only_path(:action => 'settings_form_field_changed', :id => @sb[:active_tab].split('_').last)
-  = render :partial => "layouts/flash_msg"
   %h3
     = _("Basic Information")
   .form-horizontal

--- a/app/views/ops/_settings_workers_tab.html.haml
+++ b/app/views/ops/_settings_workers_tab.html.haml
@@ -1,6 +1,5 @@
 - if @sb[:active_tab] == "settings_workers"
   - url = url_for_only_path(:action => 'settings_form_field_changed', :id => @sb[:active_tab].split('_').last)
-  = render :partial => "layouts/flash_msg"
   .row
     .col-md-12.col-lg-6
       %hr

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -329,7 +329,7 @@ describe OpsController do
         allow(controller).to receive(:check_privileges).and_return(true)
         allow(controller).to receive(:assert_privileges).and_return(true)
         seed_session_trees('ops', :settings_tree, 'root')
-        expect(controller).to receive(:render_to_string).with(any_args).twice
+        expect(controller).to receive(:render_to_string).with(any_args).exactly(3).times
         post :change_tab, :params => {:tab_id => tab}
       end
 


### PR DESCRIPTION
Settings/server: Move flash message one level up fixing duplicate DOM ids.

Go to Ops/server (active server) and click through tabs + try save and cancel.