### PR TITLE
Fix duplicate DOM id in textual summaries.

### DIFF
--- a/app/views/ops/_db_list.html.haml
+++ b/app/views/ops/_db_list.html.haml
@@ -1,3 +1,2 @@
 %div{:style => "padding-top: 10px"}
-#main_div
-  = render :partial => 'layouts/x_gtl', :locals => {:action_url => "db_list"}
+= render :partial => 'layouts/x_gtl', :locals => {:action_url => "db_list"}

--- a/app/views/shared/summary/_textual_listview.html.haml
+++ b/app/views/shared/summary/_textual_listview.html.haml
@@ -1,4 +1,4 @@
-#fieldset
+%fieldset
   %h3
     = title
   %table.table.table-bordered.table-striped.table-hover.table-summary-screen


### PR DESCRIPTION
The `fieldset` is a typo and `#main_div` is already above `#tab_all_tabs_div`.