### PR TITLE
Fix Replication tab ellipsis styling

### DIFF
--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -78,21 +78,20 @@
             %td{:class => "action-cell"}
               %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-disabled" => "!subscriptionValid()",  "ng-click" => "addSubscription()"}= _('Accept')
 
-            %td{:class => "action-cell", :style => "width: 5px"}
-              %a{:class => "dropdown-toggle", "data-toggle" => "dropdown", :style => "cursor: pointer; cursor: hand;"}
-                .dropdown.pull-right.dropdown-kebab-pf
-                  .btn.btn-link.btn-block.dropdown-toggle
-                    %span.fa.fa-ellipsis-v
-                  %ul.dropdown-menu.dropdown-menu-right.3
-                    %li
-                      %a{:class => "disabled", "ng-show" => "!subscriptionValid()"}
-                        = _('Validate')
-                    %li
-                      %a{"ng-show" => "subscriptionValid()", "ng-click" => "validateSubscription()"}
-                        = _('Validate')
-                    %li
-                      %a{"ng-click" => "discardSubscription()"}
-                        = _('Discard')
+            %td
+              .dropdown.pull-right.dropdown-kebab-pf
+                %button.btn.btn-link.dropdown-toggle{"data-toggle" => "dropdown", "aria-haspopup" => "true"}
+                  %span.fa.fa-ellipsis-v
+                %ul.dropdown-menu.dropdown-menu-right.3
+                  %li
+                    %a{:class => "disabled", "ng-show" => "!subscriptionValid()"}
+                      = _('Validate')
+                  %li
+                    %a{"ng-show" => "subscriptionValid()", "ng-click" => "validateSubscription()"}
+                      = _('Validate')
+                  %li
+                    %a{"ng-click" => "discardSubscription()"}
+                      = _('Discard')
 
           %tr{"ng-repeat" => "subscription in pglogicalReplicationModel.subscriptions track by $index", "ng-form" => "rowForm", "ng-class" => "{'danger': showCancelDelete($index)}"}
             %td{"ng-if" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
@@ -152,37 +151,35 @@
             %td{:class => "action-cell","ng-show" => "!showCancelDelete($index) && !pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)"}
               %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-disabled" => "addInProgress()",  "ng-click" => "enableSubscriptionUpdate($index)"}= _('Update')
 
-            %td{:class => "action-cell", :style => "width: 5px", "ng-show" => "!showCancelDelete($index) && !pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)"}
-              %a{:class => "dropdown-toggle", "data-toggle" => "dropdown", :style => "cursor: pointer; cursor: hand;"}
-                .dropdown.pull-right.dropdown-kebab-pf
-                  .btn.btn-link.btn-block.dropdown-toggle
-                    %span.fa.fa-ellipsis-v
-                  %ul.dropdown-menu.dropdown-menu-right.3
-                    %li
-                      %a{"ng-click" => "removeSubscription($index)"}
-                        = _('Delete')
-                    %li
-                      %a{"ng-click" => "validateSubscription($index)"}
-                        = _('Validate')
+            %td{"ng-show" => "!showCancelDelete($index) && !pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)"}
+              .dropdown.pull-right.dropdown-kebab-pf
+                %button.btn.btn-link.dropdown-toggle{"data-toggle" => "dropdown", "aria-haspopup" => "true"}
+                  %span.fa.fa-ellipsis-v
+                %ul.dropdown-menu.dropdown-menu-right.3
+                  %li
+                    %a{"ng-click" => "removeSubscription($index)"}
+                      = _('Delete')
+                  %li
+                    %a{"ng-click" => "validateSubscription($index)"}
+                      = _('Validate')
 
             %td{:class => "action-cell", "ng-show" => "!showCancelDelete($index) && pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index"}
               %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-disabled" => "!subscriptionValid()", "ng-click" => "addSubscription($index)"}= _('Accept')
 
-            %td{:class => "action-cell", :style => "width: 5px", "ng-show" => "!showCancelDelete($index) && pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index"}
-              %a{:class => "dropdown-toggle", "data-toggle" => "dropdown", :style => "cursor: pointer; cursor: hand;"}
-                .dropdown.pull-right.dropdown-kebab-pf
-                  .btn.btn-link.btn-block.dropdown-toggle
-                    %span.fa.fa-ellipsis-v
-                  %ul.dropdown-menu.dropdown-menu-right.3
-                    %li
-                      %a{:class => "disabled", "ng-show" => "!subscriptionValid()"}
-                        = _('Validate')
-                    %li
-                      %a{"ng-show" => "subscriptionValid()", "ng-click" => "validateSubscription($index)"}
-                        = _('Validate')
-                    %li
-                      %a{"ng-click" => "discardSubscription($index)"}
-                        = _('Discard')
+            %td{"ng-show" => "!showCancelDelete($index) && pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index"}
+              .dropdown.pull-right.dropdown-kebab-pf
+                %button.btn.btn-link.dropdown-toggle{"data-toggle" => "dropdown", "aria-haspopup" => "true"}
+                  %span.fa.fa-ellipsis-v
+                %ul.dropdown-menu.dropdown-menu-right.3
+                  %li
+                    %a{:class => "disabled", "ng-show" => "!subscriptionValid()"}
+                      = _('Validate')
+                  %li
+                    %a{"ng-show" => "subscriptionValid()", "ng-click" => "validateSubscription($index)"}
+                      = _('Validate')
+                  %li
+                    %a{"ng-click" => "discardSubscription($index)"}
+                      = _('Discard')
     .exclusion_list_div{"ng-if" => "pglogicalReplicationModel.replication_type == 'remote'"}
       %h3
         = _('Excluded Tables')


### PR DESCRIPTION
This PR cleans up the markup so that the entire table cell, rather than just the narrow ellipsis, is clickable.

https://bugzilla.redhat.com/show_bug.cgi?id=1398745

Old
![screen shot 2017-04-27 at 1 08 53 pm](https://cloud.githubusercontent.com/assets/1287144/25495309/b35139cc-2b4a-11e7-8dae-1252cdb4a548.png)

New
![screen shot 2017-04-27 at 1 08 05 pm](https://cloud.githubusercontent.com/assets/1287144/25495310/b35d9ac8-2b4a-11e7-8d78-f01d6d9981a8.png)
