### PR TITLE
[FINE] [BACKPORT] Fix exception when listing available flavors for a flavorless vm

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -360,7 +360,7 @@ module ApplicationController::CiProcessing
     unless @record.ext_management_system.nil?
       @record.ext_management_system.flavors.each do |ems_flavor|
         # include only flavors with root disks at least as big as the instance's current root disk.
-        if (ems_flavor != @record.flavor) && (ems_flavor.root_disk_size >= @record.flavor.root_disk_size)
+        if @record.flavor.nil? || ((ems_flavor != @record.flavor) && (ems_flavor.root_disk_size >= @record.flavor.root_disk_size))
           @flavors[ems_flavor.name_with_details] = ems_flavor.id
         end
       end
@@ -416,12 +416,12 @@ module ApplicationController::CiProcessing
     when "submit"
       if @record.supports_resize?
         begin
-          old_flavor = @record.flavor
+          old_flavor_name = @record.flavor.try(:name) || _("unknown")
           @record.resize_queue(session[:userid], flavor)
           add_flash(_("Reconfiguring %{instance} \"%{name}\" from %{old_flavor} to %{new_flavor}") % {
             :instance   => ui_lookup(:table => 'vm_cloud'),
             :name       => @record.name,
-            :old_flavor => old_flavor.name,
+            :old_flavor => old_flavor_name,
             :new_flavor => flavor.name})
         rescue => ex
           add_flash(_("Unable to reconfigure %{instance} \"%{name}\": %{details}") % {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1445018
Backported from 394aeb8

https://github.com/ManageIQ/manageiq-ui-classic/pull/1163

@petrblaho 
@tzumainn 