### PR TITLE
Fixed quadicon text links.

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -240,7 +240,7 @@ module QuadiconHelper
     if quadicon_in_explorer_view?
       quadicon_build_explorer_url(item, row)
     else
-      url_for_db(controller_name, "show", item)
+      url_for_record(item)
     end
   end
 

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -328,7 +328,7 @@ describe QuadiconHelper do
       subject { helper.render_quadicon_text(stor, row) }
 
       it "renders a link to storage_manager" do
-        @id = stor.id
+        @id = ApplicationRecord.compress_id(stor.id)
 
         expect(subject).to have_selector('a')
         expect(subject).to include("/storage_manager/show/#{@id}")
@@ -349,10 +349,10 @@ describe QuadiconHelper do
       subject { helper.render_quadicon_text(item, row) }
 
       it "renders a label based on the address" do
-        @id = item.id
+        @id = ApplicationRecord.compress_id(item.id)
 
         expect(subject).to have_link(item.address)
-        expect(subject).to include("/floating_ip/show/#{item.id}")
+        expect(subject).to include("/floating_ip/show/#{@id}")
       end
     end
 
@@ -372,8 +372,9 @@ describe QuadiconHelper do
       subject { helper.render_quadicon_text(item, row) }
 
       it 'renders a link with auth_key_pair_cloud path' do
+        cid = ApplicationRecord.compress_id(item.id)
         expect(subject).to have_link("Auth")
-        expect(subject).to include('href="/auth_key_pair_cloud/show"')
+        expect(subject).to include("href=\"/auth_key_pair_cloud/show/#{cid}\"")
       end
     end
 
@@ -488,9 +489,9 @@ describe QuadiconHelper do
         )
 
         subject = helper.render_quadicon_text(item, row)
-
+        cid = ApplicationRecord.compress_id(item.id)
         expect(subject).to include("evm")
-        expect(subject).to include("/vm/show/#{item.id}")
+        expect(subject).to include("/vm_infra/show/#{cid}")
       end
 
       it 'renders a link with the row key if set' do
@@ -506,9 +507,10 @@ describe QuadiconHelper do
         row = Ruport::Data::Record.new(:id => rand(9999), "name" => "name")
 
         subject = helper.render_quadicon_text(item, row)
+        cid = ApplicationRecord.compress_id(item.id)
 
         expect(subject).to include("name")
-        expect(subject).to include("/vm/show/#{item.id}")
+        expect(subject).to include("/vm_infra/show/#{cid}")
       end
     end
   end


### PR DESCRIPTION
- Links when clicking on quadicon title text were broken when going to any grid/tile view thru relationships. i.e "Provider -> list of Hosts", "Provider -> List of VMs". Changed code to use same method to determine link that is being used to generate link for actual quadicon.
- Fixed existing spec tests appropriately.

https://bugzilla.redhat.com/show_bug.cgi?id=1446212

@hayesr @dclarizio please review.