### PR TITLE
Task managemenet gtl

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -296,10 +296,10 @@ class ApplicationController < ActionController::Base
     if params[:model] && %w(miq_tasks).include?(params[:model])
       options = jobs_info
     end
-    if params[:model_id] && (params[:model_id].kind_of?(Integer) || /\A\d+\z/.match(params[:model_id]))
-      curr_model_id = Integer(params[:model_id])
+    if params[:model_id]
+      curr_model_id = from_cid(params[:model_id])
       unless curr_model_id.nil?
-        options[:parent] = identify_record(params[:model_id]) if params[:model_id] && options[:parent].nil?
+        options[:parent] = identify_record(curr_model_id, controller_to_model) if curr_model_id && options[:parent].nil?
       end
     end
     options[:parent] = options[:parent] || @parent
@@ -326,7 +326,7 @@ class ApplicationController < ActionController::Base
     if model_view.nil? && params[:active_tree]
       model_view = vm_model_from_active_tree(params[:active_tree].to_sym)
     end
-    if model_view.nil? && CONTROLLER_TO_MODEL[self.class.model.to_s].nil? && params[:model]
+    if model_view.nil? && params[:model]
       model_view = model_string_to_constant(params[:model])
     end
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1106,6 +1106,7 @@ module ApplicationController::CiProcessing
   end
 
   def guest_applications
+    @use_action = true
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
     @db = params[:db] ? params[:db] : request.parameters[:controller]
     session[:db] = @db unless @db.nil?
@@ -1143,6 +1144,7 @@ module ApplicationController::CiProcessing
   end
 
   def patches
+    @use_action = true
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
     @db = params[:db] ? params[:db] : request.parameters[:controller]
     session[:db] = @db unless @db.nil?
@@ -1169,6 +1171,7 @@ module ApplicationController::CiProcessing
   end
 
   def groups
+    @use_action = true
     @explorer = true if request.xml_http_request? && explorer_controller? # Ajax request means in explorer
     @db = params[:db] ? params[:db] : request.parameters[:controller]
     session[:db] = @db unless @db.nil?
@@ -1196,6 +1199,7 @@ module ApplicationController::CiProcessing
   end
 
   def users
+    @use_action = true
     @explorer = true if request.xml_http_request? && explorer_controller? # Ajax request means in explorer
     @db = params[:db] ? params[:db] : request.parameters[:controller]
     session[:db] = @db unless @db.nil?
@@ -1223,6 +1227,7 @@ module ApplicationController::CiProcessing
   end
 
   def hosts
+    @use_action = true
     @explorer = true if request.xml_http_request? && explorer_controller? # Ajax request means in explorer
     @db = params[:db] ? params[:db] : request.parameters[:controller]
     @db = 'switch' if @db == 'infra_networking'
@@ -2847,6 +2852,7 @@ module ApplicationController::CiProcessing
   end
 
   def show_association(action, display_name, listicon, method, klass, association = nil, conditions = nil)
+    params[:display] = klass.name
     # Ajax request means in explorer, or if current explorer is one of the explorer controllers
     @explorer = true if request.xml_http_request? && explorer_controller?
     if @explorer  # Save vars for tree history array

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -338,8 +338,8 @@ module ApplicationHelper
         return ems_networks_path
       end
       # If we do not want to use redirect or any kind of click action
-      if %w(Job VmdbDatabaseSetting VmdbDatabaseConnection VmdbIndex).include?(view.db) &&
-         %w(miq_task ops).include?(params[:controller])
+      if %w(Job VmdbDatabaseSetting VmdbDatabaseConnection VmdbIndex MiqTask).include?(view.db) &&
+         %w(miq_task ops miq_task).include?(params[:controller])
         return false
       end
       if @explorer
@@ -398,7 +398,6 @@ module ApplicationHelper
       else
         controller = "vm_cloud" if controller == "template_cloud"
         controller = "vm_infra" if controller == "template_infra"
-        action = "jobs" if controller == "miq_task"
         return url_for_only_path(:controller => controller, :action => action, :id => nil) + "/"
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -396,6 +396,7 @@ module ApplicationHelper
       else
         controller = "vm_cloud" if controller == "template_cloud"
         controller = "vm_infra" if controller == "template_infra"
+        action = "jobs" if controller == "miq_task"
         return url_for_only_path(:controller => controller, :action => action, :id => nil) + "/"
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -228,6 +228,8 @@ module ApplicationHelper
                       @display
                     elsif params[:db]
                       params[:db]
+                    elsif params[:display]
+                      params[:display]
                     elsif defined? controller.class.model
                       controller.class.model.to_s.tableize
                     end

--- a/app/views/layouts/angular/_gtl.html.haml
+++ b/app/views/layouts/angular/_gtl.html.haml
@@ -1,5 +1,6 @@
 - current_model = model_to_report_data
 - gtl_type_string = j_str(@gtl_type)
+- active_tree = x_active_tree unless params[:display] || @use_action
 - selected_records = @edit[:object_ids] unless @edit.nil? || @edit[:object_ids].nil?
 - selected_records = @edit[:pol_items] unless @edit.nil? || @edit[:pol_items].nil?
 - selected_records = params[:rec_ids] unless params.nil? || params[:rec_ids].nil?
@@ -41,7 +42,7 @@
     name: 'reportDataController',
     data: {
       modelName: '#{h(j_str(current_model))}',
-      activeTree: '#{x_active_tree}',
+      activeTree: '#{active_tree}',
       gtlType: '#{h(gtl_type_string)}',
       currId: '#{h(j_str(params[:id])) unless @display.nil?}',
       sortColIdx: '#{@sortcol}',


### PR DESCRIPTION
### Fixes #1187
Where it tried to generate `miq_task/show` url which is incorrect for this screen, so instead use `miq_task/jobs` for detail of each task.

### Fixes for nested views
When in nested explorer view we have to identify correct display model. This is tricky because most of explorer nested actions does not set `@display` so we have to get the correct model from `params[:action]` so set `@use_action` in actions which are nested lists for both `vm_infra` and `vm_cloud`. Also if we are in `vm_infra` couple of nested views are generic and need to set `params[:display]` based on class which is passed to it.

### General fixes
When shortened ID was passed as model_id incorrect model was used so we have to unshorten such ID. And use `controller_to_model` so we will filter over `VmOrtemplate` when necessary. 