### PR TITLE
Do not change parent for report data if active tree is present

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -296,7 +296,7 @@ class ApplicationController < ActionController::Base
     if params[:model] && %w(miq_tasks).include?(params[:model])
       options = jobs_info
     end
-    if params[:model_id]
+    if params[:model_id] && !params[:active_tree]
       curr_model_id = from_cid(params[:model_id])
       unless curr_model_id.nil?
         options[:parent] = identify_record(curr_model_id, controller_to_model) if curr_model_id && options[:parent].nil?


### PR DESCRIPTION
### Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/1193
When navigating to VMs and setting ownership for them we do not want to change parent based on selected `model_id` and controller's model. Because controller's model and current model are same thing.