### PR TITLE
Add listnav for physical_server to host

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1313,6 +1313,7 @@ module ApplicationHelper
           offline
           orchestration_stack
           persistent_volume
+          physical_server
           resource_pool
           retired
           security_group
@@ -1381,6 +1382,7 @@ module ApplicationHelper
              network_router
              orchestration_stack
              persistent_volume
+             physical_server
              policy
              resource_pool
              scan_profile

--- a/app/views/layouts/listnav/_physical_server.html.haml
+++ b/app/views/layouts/listnav/_physical_server.html.haml
@@ -1,0 +1,22 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render_quadicon(@record, :mode => :icon, :size => 72, :typ => :listnav)
+
+    = miq_accordion_panel(_("Properties"), false, "ems_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to(_('Summary'), {:action => 'show', :id => @record, :display => 'main'}, {:title => _("Show Summary")})
+
+    = miq_accordion_panel(_("Relationships"), false, "ems_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        - if  @record.ext_management_system
+          %li
+            = link_to("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
+              ems_physical_infra_path(@record.ext_management_system.id),
+              :title => _("Show this parent Provider"))
+        - if @record.host
+          %li
+            = link_to("#{ui_lookup(:table => "host")}: #{@record.host.name}",
+              "/host/show/#{@record.host.id}",
+              :title => _("Show Host"))


### PR DESCRIPTION
This PR implements part of the PhysicalServer#Show view template.

-app/views/layouts/listnav/_physical_server.html.haml for physical server - host. Shows the hosts relationships/properties in physical server page.


![captura de tela de 2017-05-09 16-06-27](https://cloud.githubusercontent.com/assets/17187082/25867738/e8e18b98-34d0-11e7-8770-f32de416e635.png)
![captura de tela de 2017-05-09 16-06-37](https://cloud.githubusercontent.com/assets/17187082/25867739/e90013ba-34d0-11e7-9948-37ea123dbcd5.png)
![captura de tela de 2017-05-09 16-06-46](https://cloud.githubusercontent.com/assets/17187082/25867740/e903cad2-34d0-11e7-8bac-bf192765d116.png)
