### PR TITLE
Fix buttons enabling/disabling on Ops/Edit Group when changing the tabs

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -200,10 +200,12 @@ class OpsController < ApplicationController
     _, group_id = TreeBuilder.extract_node_model_and_id(x_node)
     @sb[:active_rbac_group_tab] = tab_id
     @edit = session[:edit]
+    explorer_opts = {}
+    explorer_opts[:show_miq_buttons] = session[:changed] if @edit
 
     rbac_group_get_details(group_id)
 
-    presenter = ExplorerPresenter.new
+    presenter = ExplorerPresenter.new(explorer_opts)
 
     # needed to make tooolbar Configuration > Edit still work after lazy-loading a tab
     presenter[:record_id] = group_id

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -799,7 +799,7 @@ module OpsController::OpsRbac
     when "role"  then rbac_role_get_form_vars
     end
 
-    changed = (@edit[:new] != @edit[:current])
+    session[:changed] = changed = (@edit[:new] != @edit[:current])
     bad = false
     if rec_type == "group"
       bad = (@edit[:new][:role].blank? || @edit[:new][:group_tenant].blank?)


### PR DESCRIPTION
It's fixing the bug on Edit Group screen, when user's made a change and not click to 'Save' button, but change the Tab, the Save button became inactive. (i.e. he's changed something in Host / Nodes tab, and then changed to Red Hat Tags Tab).

https://bugzilla.redhat.com/show_bug.cgi?id=1445674