### PR TITLE
Fix for Service Catalogs: Dialogs are hanging and keeps buffering

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -2,15 +2,15 @@
 
 var dialogFieldRefresh = {
   listenForAutoRefreshMessages: function(autoRefreshOptions, callbackFunction) {
-    var thisIsTheFieldToUpdate = function(event) {
-      var tabIndex = event.data.tabIndex;
-      var groupIndex = event.data.groupIndex;
-      var fieldIndex = event.data.fieldIndex;
+    var thisIsTheFieldToUpdate = function(data) {
+      var tabIndex = data.tabIndex;
+      var groupIndex = data.groupIndex;
+      var fieldIndex = data.fieldIndex;
       return tabIndex === autoRefreshOptions.tab_index && groupIndex === autoRefreshOptions.group_index && fieldIndex === autoRefreshOptions.field_index;
     };
 
-    window.addEventListener('message', function(event) {
-      if (thisIsTheFieldToUpdate(event)) {
+    $(document).on('autoRefresh', function(_event, data) {
+      if (thisIsTheFieldToUpdate(data)) {
         callbackFunction.call();
       }
     });
@@ -181,11 +181,11 @@ var dialogFieldRefresh = {
       nextAvailable = nextAvailable[0];
 
       if (nextAvailable !== undefined) {
-        parent.postMessage({
+        $(document).trigger('autoRefresh', {
           tabIndex: nextAvailable.tab_index,
           groupIndex: nextAvailable.group_index,
           fieldIndex: nextAvailable.field_index,
-        }, '*');
+        });
       }
     }
   },

--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -2,7 +2,7 @@
 
 var dialogFieldRefresh = {
   unbindAllPreviousListeners: function() {
-    $(document).off('autoRefresh');
+    $(document).off('dialog::autoRefresh');
   },
 
   listenForAutoRefreshMessages: function(autoRefreshOptions, callbackFunction) {
@@ -13,7 +13,7 @@ var dialogFieldRefresh = {
       return tabIndex === autoRefreshOptions.tab_index && groupIndex === autoRefreshOptions.group_index && fieldIndex === autoRefreshOptions.field_index;
     };
 
-    $(document).on('autoRefresh', function(_event, data) {
+    $(document).on('dialog::autoRefresh', function(_event, data) {
       if (thisIsTheFieldToUpdate(data)) {
         callbackFunction.call();
       }
@@ -185,7 +185,7 @@ var dialogFieldRefresh = {
       nextAvailable = nextAvailable[0];
 
       if (nextAvailable !== undefined) {
-        $(document).trigger('autoRefresh', {
+        $(document).trigger('dialog::autoRefresh', {
           tabIndex: nextAvailable.tab_index,
           groupIndex: nextAvailable.group_index,
           fieldIndex: nextAvailable.field_index,

--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -1,6 +1,10 @@
 /* global miqInitSelectPicker miqSelectPickerEvent miqSparkle miqSparkleOn */
 
 var dialogFieldRefresh = {
+  unbindAllPreviousListeners: function() {
+    $(document).off('autoRefresh');
+  },
+
   listenForAutoRefreshMessages: function(autoRefreshOptions, callbackFunction) {
     var thisIsTheFieldToUpdate = function(data) {
       var tabIndex = data.tabIndex;

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -1,5 +1,9 @@
 - wf = @edit[:wf] if @edit && @edit[:wf]
 = render :partial => "layouts/flash_msg"
+
+:javascript
+  dialogFieldRefresh.unbindAllPreviousListeners();
+
 .row
   .col-md-12.col-lg-12
     #dialog_tabs

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -36,6 +36,18 @@ describe('dialogFieldRefresh', function() {
     });
   });
 
+  describe('#unbindAllPreviousListeners', function() {
+    beforeEach(function() {
+      spyOn($.fn, 'off');
+    });
+
+    it('unbinds all autoRefresh messages from the document', function() {
+      dialogFieldRefresh.unbindAllPreviousListeners();
+      expect($.fn.off.calls.mostRecent().object).toEqual(document);
+      expect($.fn.off).toHaveBeenCalledWith('autoRefresh');
+    });
+  });
+
   describe('#addOptionsToDropDownList', function() {
     var data = {};
 

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -1,4 +1,41 @@
 describe('dialogFieldRefresh', function() {
+  describe('#listenForAutoRefreshMessages', function() {
+    context('when an autoRefresh event gets triggered', function() {
+      var callback;
+      var autoRefreshOptions;
+
+      beforeEach(function() {
+        callback = jasmine.createSpyObj('callback', ['call']);
+        autoRefreshOptions = {
+          tab_index: 1,
+          group_index: 2,
+          field_index: 3
+        };
+        dialogFieldRefresh.listenForAutoRefreshMessages(autoRefreshOptions, callback);
+      });
+
+      context('when the tab index, group index, and field index match the corresponding field', function() {
+        beforeEach(function() {
+          $(document).trigger('autoRefresh', {tabIndex: 1, groupIndex: 2, fieldIndex: 3});
+        });
+
+        it('executes the callback', function() {
+          expect(callback.call).toHaveBeenCalled();
+        });
+      });
+
+      context('when the tab index, group index, and field index do not match the corresponding field', function() {
+        beforeEach(function() {
+          $(document).trigger('autoRefresh', {tabIndex: 1, groupIndex: 1, fieldIndex: 3});
+        });
+
+        it('does not execute the callback', function() {
+          expect(callback.call).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
   describe('#addOptionsToDropDownList', function() {
     var data = {};
 
@@ -581,13 +618,13 @@ describe('dialogFieldRefresh', function() {
 
   describe('#triggerAutoRefresh', function() {
     beforeEach(function() {
-      spyOn(parent, 'postMessage');
+      spyOn($.fn, 'trigger');
     });
 
     context('when the trigger passed in falsy', function() {
       it('does not post any messages', function() {
         dialogFieldRefresh.triggerAutoRefresh({trigger: ""});
-        expect(parent.postMessage).not.toHaveBeenCalled();
+        expect($.fn.trigger).not.toHaveBeenCalled();
       });
     });
 
@@ -602,7 +639,7 @@ describe('dialogFieldRefresh', function() {
         });
 
         it('does not post a message', function() {
-          expect(parent.postMessage).not.toHaveBeenCalled();
+          expect($.fn.trigger).not.toHaveBeenCalled();
         });
       });
 
@@ -619,7 +656,7 @@ describe('dialogFieldRefresh', function() {
         });
 
         it('posts a message', function() {
-          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 1, groupIndex: 1, fieldIndex: 2}, '*');
+          expect($.fn.trigger).toHaveBeenCalledWith('autoRefresh', {tabIndex: 1, groupIndex: 1, fieldIndex: 2});
         });
       });
     });
@@ -635,7 +672,7 @@ describe('dialogFieldRefresh', function() {
         });
 
         it('does not post a message', function() {
-          expect(parent.postMessage).not.toHaveBeenCalled();
+          expect($.fn.trigger).not.toHaveBeenCalled();
         });
       });
 
@@ -652,7 +689,7 @@ describe('dialogFieldRefresh', function() {
         });
 
         it('posts a message', function() {
-          expect(parent.postMessage).toHaveBeenCalledWith({tabIndex: 1, groupIndex: 1, fieldIndex: 2}, '*');
+          expect($.fn.trigger).toHaveBeenCalledWith('autoRefresh', {tabIndex: 1, groupIndex: 1, fieldIndex: 2});
         });
       });
     });

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -16,7 +16,7 @@ describe('dialogFieldRefresh', function() {
 
       context('when the tab index, group index, and field index match the corresponding field', function() {
         beforeEach(function() {
-          $(document).trigger('autoRefresh', {tabIndex: 1, groupIndex: 2, fieldIndex: 3});
+          $(document).trigger('dialog::autoRefresh', {tabIndex: 1, groupIndex: 2, fieldIndex: 3});
         });
 
         it('executes the callback', function() {
@@ -26,7 +26,7 @@ describe('dialogFieldRefresh', function() {
 
       context('when the tab index, group index, and field index do not match the corresponding field', function() {
         beforeEach(function() {
-          $(document).trigger('autoRefresh', {tabIndex: 1, groupIndex: 1, fieldIndex: 3});
+          $(document).trigger('dialog::autoRefresh', {tabIndex: 1, groupIndex: 1, fieldIndex: 3});
         });
 
         it('does not execute the callback', function() {
@@ -44,7 +44,7 @@ describe('dialogFieldRefresh', function() {
     it('unbinds all autoRefresh messages from the document', function() {
       dialogFieldRefresh.unbindAllPreviousListeners();
       expect($.fn.off.calls.mostRecent().object).toEqual(document);
-      expect($.fn.off).toHaveBeenCalledWith('autoRefresh');
+      expect($.fn.off).toHaveBeenCalledWith('dialog::autoRefresh');
     });
   });
 
@@ -668,7 +668,7 @@ describe('dialogFieldRefresh', function() {
         });
 
         it('posts a message', function() {
-          expect($.fn.trigger).toHaveBeenCalledWith('autoRefresh', {tabIndex: 1, groupIndex: 1, fieldIndex: 2});
+          expect($.fn.trigger).toHaveBeenCalledWith('dialog::autoRefresh', {tabIndex: 1, groupIndex: 1, fieldIndex: 2});
         });
       });
     });
@@ -701,7 +701,7 @@ describe('dialogFieldRefresh', function() {
         });
 
         it('posts a message', function() {
-          expect($.fn.trigger).toHaveBeenCalledWith('autoRefresh', {tabIndex: 1, groupIndex: 1, fieldIndex: 2});
+          expect($.fn.trigger).toHaveBeenCalledWith('dialog::autoRefresh', {tabIndex: 1, groupIndex: 1, fieldIndex: 2});
         });
       });
     });


### PR DESCRIPTION
This problem arose from having multiple dialogs with auto-refreshable fields, and then when cancelling an order of one, attempting to order a different one. Since it is not a full page refresh when cancelling, the javascript that is listening for the messages stays intact and attempts to auto-refresh a field that does not exist.

This fix will replace the old `postMessage` way of triggering auto refreshes for dialog fields with jQuery bindings and toggles. This then allows us to unbind all the previous listeners. As a plus, it is now easier to test the `listenForAutoRefreshMessages` function and I've included that as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1442811

@miq-bot add_label euwe/yes, fine/yes, bug

/cc @gmcculloug 

@himdel Please review or tag someone else that can review. Thanks!