### PR TITLE
Add network data in physical server page

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -1,0 +1,60 @@
+module PhysicalServerHelper::TextualSummary
+  def textual_group_properties
+    TextualGroup.new(_("Properties"), %i(name model product_name manufacturer machine_type serial_number ems_ref))
+  end
+
+  def textual_group_relationships
+    TextualGroup.new(_("Relationships"), %i(host)) 
+  end
+
+  def textual_group_compliance
+  end
+
+  def textual_group_networks
+    TextualGroup.new(_("Networks"), %i(mac ipv4 ipv6))
+  end
+
+  def textual_host
+    {:label => _("Host"), :value => @record.host.try(:name), :icon => "pficon pficon-virtual-machine", :link => url_for(:controller => 'host', :action => 'show', :id => @record.host.try(:id))}
+  end
+
+  def textual_name
+    {:label => _("Server name"), :value => @record.name }
+  end
+
+  def textual_product_name
+    {:label => _("Product Name"), :value => @record.product_name }
+  end
+
+  def textual_manufacturer
+    {:label => _("Manufacturer"), :value => @record.manufacturer }
+  end
+
+  def textual_machine_type
+    {:label => _("Machine Type"), :value => @record.machine_type }
+  end
+
+  def textual_serial_number
+    {:label => _("Serial Number"), :value => @record.serial_number }
+  end
+
+  def textual_ems_ref
+    {:label => _("UUID"), :value => @record.ems_ref }
+  end
+
+  def textual_model
+    {:label => _("Model"), :value => @record.model}
+  end
+
+  def textual_mac
+    {:label =>  _("Mac Address"), :value => @record.hardware.guest_devices.collect { |device| device[:address] }.join(", ") }
+  end
+
+  def textual_ipv4
+    {:label =>  _("IPV4 Address"), :value => @record.hardware.guest_devices.collect { |device| device.network.ipaddress }.join(", ") }
+  end
+
+  def textual_ipv6
+    {:label =>  _("IPV6 Address"), :value => @record.hardware.guest_devices.collect { |device| device.network.ipv6address }.join(", ") }
+  end
+end

--- a/app/views/physical_server/_main.html.haml
+++ b/app/views/physical_server/_main.html.haml
@@ -1,0 +1,4 @@
+= render :partial => "layouts/flash_msg"
+.row
+  .col-md-12.col-lg-6
+    TODO: add groups


### PR DESCRIPTION
This PR is able to: 
Create new session of networks details in the physical server page using attributes of "guest_devices.network" .
Was added the following attributes in the session:
    - Mac Address
    - IPV4 Address
    - IPV6 Address 
Depends on:
- [#1168](https://github.com/ManageIQ/manageiq-ui-classic/pull/1168)
- [#1162](https://github.com/ManageIQ/manageiq-ui-classic/pull/1162)

![network_session](https://cloud.githubusercontent.com/assets/12627705/25543841/74224f18-2c2e-11e7-862b-53b15ee84427.png)
