### PR TITLE
Add VMWare vApp type to the Create Orchestration Template type list

### DIFF
--- a/app/views/catalog/_ot_add.html.haml
+++ b/app/views/catalog/_ot_add.html.haml
@@ -35,7 +35,8 @@
                        options_for_select({"Amazon CloudFormation" => "OrchestrationTemplateCfn",
                                            "OpenStack Heat" => "OrchestrationTemplateHot",
                                            "Microsoft Azure" => "OrchestrationTemplateAzure",
-                                           "VNF" => "OrchestrationTemplateVnfd",},
+                                           "VNF" => "OrchestrationTemplateVnfd",
+                                           "VMWare vApp" => "ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate"},
                                           @edit[:new][:type]),
                        :class => "selectpicker")
           :javascript

--- a/spec/views/catalog/_ot_add.html.haml_spec.rb
+++ b/spec/views/catalog/_ot_add.html.haml_spec.rb
@@ -1,0 +1,13 @@
+describe "catalog/_ot_add.html.haml" do
+  before do
+    set_controller_for_view("catalog")
+    set_controller_for_view_to_be_nonrestful
+    @edit = {:new => {}}
+    assign(:sb, :active_accordion => 'ot_accord')
+  end
+
+  it "the orchestration type dropdown includes the vApp type" do
+    render
+    expect(rendered).to include('VMWare vApp')
+  end
+end


### PR DESCRIPTION
Add VMWare vApp type to the Create Orchestration Template type list

https://bugzilla.redhat.com/show_bug.cgi?id=1446399