### PR TITLE
Allow to explicitly disable hawkular in containers

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -48,6 +48,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       host_default_vnc_port_start: '',
       host_default_vnc_port_end: '',
       event_stream_selection: '',
+      metrics_selection: '',
       bearer_token_exists: false,
       ems_controller: '',
       default_auth_status: '',
@@ -137,6 +138,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.host_default_vnc_port_end       = data.host_default_vnc_port_end;
 
       $scope.emsCommonModel.event_stream_selection          = data.event_stream_selection;
+      $scope.emsCommonModel.metrics_selection               = data.metrics_selection;
+      $scope.emsCommonModel.metrics_selection_default       = data.metrics_selection_default;
 
       $scope.emsCommonModel.bearer_token_exists             = data.bearer_token_exists;
 
@@ -182,6 +185,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.openstack_infra_providers_exist = data.openstack_infra_providers_exist;
       $scope.emsCommonModel.default_api_port                = '';
       $scope.emsCommonModel.amqp_api_port                   = '5672';
+      $scope.emsCommonModel.metrics_selection               = data.metrics_selection;
       $scope.emsCommonModel.hawkular_api_port               = '443';
       $scope.emsCommonModel.api_version                     = 'v2';
       $scope.emsCommonModel.ems_controller                  = data.ems_controller;
@@ -303,6 +307,10 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.$broadcast('clearErrorOnTab', {tab: "amqp"});
     }
 
+    if ($scope.emsCommonModel.metrics_selection === "hawkular_disabled") {
+      $scope.$broadcast('clearErrorOnTab', {tab: "hawkular"});
+    }
+
     var authStatus = $scope.currentTab + "_auth_status";
     if ($scope.emsCommonModel[authStatus] === true) {
       $scope.postValidationModelRegistry($scope.currentTab);
@@ -332,6 +340,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   $scope.providerTypeChanged = function() {
     if ($scope.emsCommonModel.ems_controller === 'ems_container') {
       $scope.emsCommonModel.default_api_port = "8443"; // TODO: correct per-type port
+      $scope.emsCommonModel.metrics_selection = "hawkular_".concat($scope.emsCommonModel.metrics_selection_default);
       // Container types are nearly identical, no point resetting most fields on type change.
       return;
     }
@@ -534,6 +543,12 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         $scope.emsCommonModel.amqp_verify = $scope.postValidationModel.amqp.amqp_verify;
       }
       $scope.$broadcast('clearErrorOnTab', {tab: "amqp"});
+    }
+  };
+
+  $scope.containerMetricsChanged = function() {
+    if ($scope.emsCommonModel.metrics_selection === "hawkular_disabled") {
+      $scope.$broadcast('clearErrorOnTab', {tab: "hawkular"});
     }
   };
 

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -37,6 +37,10 @@ class EmsContainerController < ApplicationController
     ems_form_fields
   end
 
+  def retrieve_metrics_selection
+    @ems.endpoints.count == 1 ? 'hawkular_disabled' : 'hawkular_enabled'
+  end
+
   private
 
   def textual_group_list

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -261,25 +261,47 @@
       = miq_tab_content('hawkular', 'default') do
         .form-group
           .col-md-12.col-md-12
-            = render :partial => "layouts/angular-bootstrap/endpoints_angular",
-                                 :locals  => {:ng_show                => true,
-                                              :ng_model               => "#{ng_model}",
-                                              :id                     => record.id,
-                                              :ng_reqd_hostname       => "true",
-                                              :ng_reqd_api_port       => "true",
-                                              :prefix                 => "hawkular"}
-            = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
-                       :locals  => {:ng_show           => true,
-                                    :ng_model          => "#{ng_model}",
-                                    :main_scope        => main_scope,
-                                    :ng_show_userid    => "false",
-                                    :ng_show_password  => "false",
-                                    :ng_show_verify    => "false",
-                                    :validate_url      => validate_url,
-                                    :id                => record.id,
-                                    :prefix            => "hawkular",
-                                    :verify_title_off  => _("hawkular URL and API port fields are needed to perform validation."),
-                                    :basic_info_needed => true}
+            %label.radio-inline.control-label{"for" => "container_hawkular_disabled"}
+              %input{:type         => "radio",
+                     :name         => "metrics_selection",
+                     :id           => "container_hawkular_disabled",
+                     :ng_checked   => "emsCommonModel.metrics_selection == hawkular_disabled",
+                     :value        => "hawkular_disabled",
+                     :ng_model     => "emsCommonModel.metrics_selection",
+                     :ng_change    => "containerMetricsChanged()",
+                     :checkchange  => ""}
+              = _("Disabled")
+            %label.radio-inline.control-label{"for" => "container_hawkular_enabled"}
+              %input{:type         => "radio",
+                     :name         => "metrics_selection",
+                     :id           => "container_hawkular_enabled",
+                     :ng_checked   => "emsCommonModel.metrics_selection == hawkular_enabled",
+                     :value        => "hawkular_enabled",
+                     :ng_model     => "emsCommonModel.metrics_selection",
+                     :checkchange  => ""}
+              = _("Enabled")
+            %hr
+            %div{"ng-if" => "emsCommonModel.metrics_selection == 'hawkular_enabled'"}
+
+              = render :partial => "layouts/angular-bootstrap/endpoints_angular",
+                                   :locals  => {:ng_show                => true,
+                                                :ng_model               => ng_model.to_s,
+                                                :id                     => record.id,
+                                                :ng_reqd_hostname       => "true",
+                                                :ng_reqd_api_port       => "true",
+                                                :prefix                 => "hawkular"}
+              = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                         :locals  => {:ng_show           => true,
+                                      :ng_model          => ng_model.to_s,
+                                      :main_scope        => main_scope,
+                                      :ng_show_userid    => "false",
+                                      :ng_show_password  => "false",
+                                      :ng_show_verify    => "false",
+                                      :validate_url      => validate_url,
+                                      :id                => record.id,
+                                      :prefix            => "hawkular",
+                                      :verify_title_off  => _("hawkular URL and API port fields are needed to perform validation."),
+                                      :basic_info_needed => true}
         .form-group
           .col-md-12
             %span{:style => "color:black"}


### PR DESCRIPTION
Allow to explicitly disable the hawkular endpoint.

When selecting 'disabled' a provider with one endpoint should be created (`default`).
When selecting 'enabled' a provider with two endpoint should be created (`default` & `hawkular`).

Before
![before](https://cloud.githubusercontent.com/assets/3010449/25692295/1500df7e-30aa-11e7-9562-a654158ea3a3.png)

After(default)
![by_default_hawkular_is_enabled](https://cloud.githubusercontent.com/assets/3010449/25692319/4bb46446-30aa-11e7-9914-f502e5ec3e7f.png)

After(disabled)
![disabled](https://cloud.githubusercontent.com/assets/3010449/25806855/626cacf0-340d-11e7-808b-89c992d138c8.png)

See also: 
- https://github.com/ManageIQ/manageiq/pull/14990
- https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/7

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1437138
