### PR TITLE
Added "Escalate Privilege" checkbox

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -22,6 +22,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       provisioning_key: '',
       provisioning_value: '',
       provisioning_variables: {},
+      provisioning_become_enabled: false,
       provisioning_editMode: false,
       retirement_repository_id: '',
       retirement_playbook_id: '',
@@ -33,6 +34,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       retirement_value: '',
       retirement_variables: {},
       retirement_editMode: false,
+      retirement_become_enabled: false,
     };
     getRemoveResourcesTypes();
     vm.provisioning_cloud_type = '';
@@ -112,6 +114,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     vm.catalogItemModel.provisioning_dialog_name = configData.provision.new_dialog_name;
     vm.catalogItemModel.provisioning_key = '';
     vm.catalogItemModel.provisioning_value = '';
+    vm.catalogItemModel.provisioning_become_enabled = configData.provision.become_enabled
     setExtraVars('provisioning_variables', configData.provision.extra_vars);
 
     if (typeof configData.retirement.repository_id !== 'undefined') {
@@ -121,6 +124,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       vm.catalogItemModel.retirement_remove_resources = configData.retirement.remove_resources;
       vm.catalogItemModel.retirement_machine_credential_id = configData.retirement.credential_id;
     }
+    vm.catalogItemModel.retirement_become_enabled = configData.retirement.become_enabled
     vm.catalogItemModel.retirement_network_credential_id = configData.retirement.network_credential_id;
     vm.catalogItemModel.retirement_cloud_credential_id = setIfDefined(configData.retirement.cloud_credential_id);
     vm.catalogItemModel.retirement_inventory = configData.retirement.hosts;
@@ -205,7 +209,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
         }
       }
     }
-
+    catalog_item['config_info']['provision']['become_enabled'] = configData.provisioning_become_enabled;
     if (configData.provisioning_network_credential_id !== '')
       catalog_item['config_info']['provision']['network_credential_id'] = configData.provisioning_network_credential_id;
 
@@ -228,6 +232,9 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       retirement['repository_id'] = configData.retirement_repository_id;
       retirement['playbook_id'] = configData.retirement_playbook_id;
       retirement['credential_id'] = configData.retirement_machine_credential_id;
+    }
+    if (vm.catalogItemModel.retirement_playbook_id !== undefined && configData.retirement_playbook_id !== '') {
+      catalog_item['config_info']['retirement']['become_enabled'] = configData.retirement_become_enabled;
     }
     if (configData.retirement_network_credential_id !== '')
       catalog_item['config_info']['retirement']['network_credential_id'] = configData.retirement_network_credential_id;
@@ -423,6 +430,12 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
 
   vm.retirement_repository_selected = function() {
     return vm.catalogItemModel.retirement_repository_id !== '';
+  }
+
+  vm.retirement_playbook_selected = function(prefix) {
+    if (prefix === "provisioning")
+      return true;
+    return vm.catalogItemModel.retirement_playbook_id !== '';
   }
 
   vm.removeKeyValue = function(prefix, key) {

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1801,6 +1801,7 @@ class CatalogController < ApplicationController
     playbook_details[:provisioning][:network_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential, provision[:network_credential_id]) if provision[:network_credential_id]
     playbook_details[:provisioning][:cloud_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential, provision[:cloud_credential_id]) if provision[:cloud_credential_id]
     fetch_dialog(playbook_details, provision[:dialog_id], :provisioning)
+    playbook_details[:provisioning][:become_enabled] = provision[:become_enabled] == true ? _('Yes') : _('No')
 
     if @record.config_info[:retirement]
       retirement = @record.config_info[:retirement]
@@ -1813,6 +1814,7 @@ class CatalogController < ApplicationController
         playbook_details[:retirement][:network_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential, retirement[:network_credential_id]) if retirement[:network_credential_id]
         playbook_details[:retirement][:cloud_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential, retirement[:cloud_credential_id]) if retirement[:cloud_credential_id]
       end
+      playbook_details[:retirement][:become_enabled] = retirement[:become_enabled] == true ? _('Yes') : _('No')
     end
     playbook_details
   end

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -228,6 +228,11 @@
                 = _('Hosts')
               .col-md-9
                 = h(@record.config_info[:provision][:hosts])
+            .form-group
+              %label.col-md-3.control-label
+                = _('Escalate Privilege')
+              .col-md-9
+                = h(provisioning[:become_enabled])
         .col-md-12.col-lg-6
           .form-horizontal.static
             .form-group
@@ -297,6 +302,11 @@
                   = _('Hosts')
                 .col-md-9
                   = h(@record.config_info[:retirement][:hosts])
+              .form-group
+                %label.col-md-3.control-label
+                  = _('Escalate Privilege')
+                .col-md-9
+                  = h(retirement[:become_enabled])
               .form-group
                 %label.col-md-3.control-label
                   = _('Remove Resources')

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -107,7 +107,18 @@
                             "checkchange" => true}
           %span.help-block{"ng-show" => "angularForm.#{prefix}_inventory.$error.miqrequired"}
             = _("Required")
-
+    #escalate_privilege{"ng-if" => "vm.retirement_playbook_selected('#{prefix}')"}
+      .form-group
+        %label.col-md-3.control-label
+          = _("Escalate Privilege")
+        .col-md-9
+          %input#become_enabled{"bs-switch"       => "",
+                                "type"            => "checkbox",
+                                "name"            => "#{prefix}_become_enabled",
+                                "ng-model"        => "#{ng_model}.#{prefix}_become_enabled",
+                                "switch-on-text"  => _("Yes"),
+                                "switch-off-text" => _("No"),
+                                "checkchange"     => ""}
     - if prefix == "retirement"
       .form-group
         %label.col-md-3.control-label{"for" => "catalog_id"}

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -787,13 +787,15 @@ describe CatalogController do
           :playbook           => playbook.name,
           :machine_credential => auth.name,
           :dialog             => "Some Label",
-          :dialog_id          => dialog.id
+          :dialog_id          => dialog.id,
+          :become_enabled     => "No"
         },
         :retirement   => {
           :remove_resources   => nil,
           :repository         => repository.name,
           :playbook           => playbook.name,
-          :machine_credential => auth.name
+          :machine_credential => auth.name,
+          :become_enabled     => "No"
         }
       }
       expect(playbook_details).to eq(st_details)
@@ -829,13 +831,15 @@ describe CatalogController do
         :provisioning => {
           :repository         => nil,
           :playbook           => playbook.name,
-          :machine_credential => auth.name
+          :machine_credential => auth.name,
+          :become_enabled     => "No"
         },
         :retirement   => {
           :remove_resources   => nil,
           :repository         => repository.name,
           :playbook           => nil,
-          :machine_credential => auth.name
+          :machine_credential => auth.name,
+          :become_enabled     => "No"
         }
       }
       expect(playbook_details).to eq(st_details)

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -33,6 +33,7 @@ describe('catalogItemFormController', function() {
             'var1': {'default': 'default_val1'},
             'var2': {'default': 'default_val2'}
           },
+          become_enabled: undefined,
           network_credential_id: undefined
         },
         retirement: {


### PR DESCRIPTION
Added "Escalate Privilege" checkbox switch on both Provisioning & Retirement tabs in form and on Summary screen to display the selected values. Default value for the new checkbox is false.

https://bugzilla.redhat.com/show_bug.cgi?id=1445377

@gmcculloug @bzwei please review/test.

backend work in https://github.com/ManageIQ/manageiq/pull/14929

screenshot:
![catalog_item_form_prov_tab](https://cloud.githubusercontent.com/assets/3450808/25581586/ba1c0502-2e56-11e7-8349-49f8d32f3313.png)

![catalog_item_form_ret_tab](https://cloud.githubusercontent.com/assets/3450808/25581590/bf0808cc-2e56-11e7-8384-7acbc440a64f.png)

![catalog_item_summary_prov_tab](https://cloud.githubusercontent.com/assets/3450808/25581598/c443e342-2e56-11e7-9493-71dceaf2f334.png)

![catalog_item_summary_retirement_tab](https://cloud.githubusercontent.com/assets/3450808/25581601/c77e23c4-2e56-11e7-97c9-b4d4252d69d0.png)

