### PR TITLE
Add uid to report fields VM Chargeback Report

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -11,6 +11,7 @@ module ReportController::Reports::Editor
     -archived
     -chargeback_rates
     -vm_guid
+    -vm_uid
   ).freeze
 
   def miq_report_new


### PR DESCRIPTION
`-vm_uid` needs to be added to `CHARGEBACK_ALLOWED_FIELD_SUFFIXES` to make it available in Available Fields when creating a new VM chargeback report. 

![screen shot 2017-05-01 at 10 44 00 am](https://cloud.githubusercontent.com/assets/2433314/25582461/7039dc8e-2e5b-11e7-9980-5cef4aeebd52.png)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1433411

@miq-bot add_label bug, cloud intel/reporting