### PR TITLE
Advanced search bar ansible tower fix

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -262,6 +262,7 @@ class AutomationManagerController < ApplicationController
     elsif x_active_tree == :configuration_scripts_tree
       cs_provider_node(provider)
     else
+      @show_adv_search = true
       @no_checkboxes = true
       options = {:model                 => "ManageIQ::Providers::AutomationManager::InventoryRootGroup",
                  :match_via_descendants => ConfiguredSystem,
@@ -279,6 +280,7 @@ class AutomationManagerController < ApplicationController
                :match_via_descendants => ConfigurationScript,
                :where_clause          => ["manager_id IN (?)", provider.id],
                :gtl_dbname            => "automation_manager_configuration_scripts"}
+    @show_adv_search = true
     process_show_list(options)
     @right_cell_text = _("%{model} \"%{name}\"") % {:name  => provider.name,
                                                     :model => "#{ui_lookup(:tables => "job_templates")} under "}
@@ -291,6 +293,7 @@ class AutomationManagerController < ApplicationController
       self.x_node = "root"
       get_node_info("root")
     else
+      @show_adv_search = true
       options = {:model                 => "ConfiguredSystem",
                  :match_via_descendants => ConfiguredSystem,
                  :where_clause          => ["inventory_root_group_id IN (?)", from_cid(@inventory_group_record.id)],
@@ -308,6 +311,7 @@ class AutomationManagerController < ApplicationController
 
   def configuration_scripts_list(id, model)
     return configuration_script_node(id) if id
+    @show_adv_search = true
     @listicon = "configuration_script"
     if x_active_tree == :configuration_scripts_tree
       options = {:model      => model.to_s,
@@ -319,11 +323,13 @@ class AutomationManagerController < ApplicationController
 
   def configuration_script_node(id)
     @record = @configuration_script_record = find_record(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript, id)
+    @show_adv_search = false
     display_node(id, nil)
   end
 
   def default_node
     return unless x_node == "root"
+    @show_adv_search = true
     if x_active_tree == :automation_manager_providers_tree
       options = {:model      => "ManageIQ::Providers::AnsibleTower::AutomationManager",
                  :gtl_dbname => "automation_manager_providers"}

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -346,7 +346,7 @@ module Mixins
     end
 
     def display_adv_searchbox
-      !(@configured_system_record || @in_a_form || group_summary_tab_selected?)
+      !(@configured_system_record || @configuration_script_record || @in_a_form || group_summary_tab_selected?)
     end
 
     def miq_search_node

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -341,7 +341,9 @@ describe AutomationManagerController do
       search_text = controller.instance_variable_get(:@search_text)
       expect(search_text).to eq("manager")
       view = controller.instance_variable_get(:@view)
+      show_adv_search = controller.instance_variable_get(:@show_adv_search)
       expect(view.table.data.size).to eq(2)
+      expect(show_adv_search).to eq(true)
     end
 
     it "renders tree_select for ansible tower job templates tree node" do
@@ -351,6 +353,11 @@ describe AutomationManagerController do
       controller.instance_variable_set(:@_params, :id => "at-" + ApplicationRecord.compress_id(@automation_manager1.id))
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
+      show_adv_search = controller.instance_variable_get(:@show_adv_search)
+      expect(show_adv_search).to eq(true)
+      expect(view.table.data.size).to eq(2)
+      expect(show_adv_search).to eq(true)
+
       expect(view.table.data[0].name).to eq("ConfigScript3")
       expect(view.table.data[1].name).to eq("ConfigScript1")
     end
@@ -450,7 +457,8 @@ describe AutomationManagerController do
 
       seed_session_trees('automation_manager', :automation_manager_cs_filter, "cs-#{tree_node_id}")
       get :explorer
-
+      show_adv_search = controller.instance_variable_get(:@show_adv_search)
+      expect(show_adv_search).to be_falsey
       expect(response.status).to eq(200)
       expect(response).to render_template(:partial => 'layouts/_textual_groups_generic')
     end
@@ -476,6 +484,8 @@ describe AutomationManagerController do
       allow(controller).to receive(:x_active_accord).and_return(:configuration_scripts)
       allow(controller).to receive(:x_node).and_return(tree_node_id)
       get :explorer
+      show_adv_search = controller.instance_variable_get(:@show_adv_search)
+      expect(show_adv_search).to eq(false)
       expect(response.status).to eq(200)
       expect(response.body).to include("Question Name")
       expect(response.body).to include("Question Description")


### PR DESCRIPTION
Display the advanced bar on list pages in Ansible Tower and not on summary pages.

https://bugzilla.redhat.com/show_bug.cgi?id=1395744

To reproduce:
1.Open a tower provider summary
2.Select the Job Templates accordion
3. Go to Compute->Cloud->Providers
4. Return to Tower->Explorer
