### PR TITLE
Add RBAC for requesters in MiqRequest

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -482,10 +482,10 @@ class MiqRequestController < ApplicationController
     opts[:reason_text] = nil
     opts[:types] = request_types_for_dropdown
 
-    opts[:users] = MiqRequest.where(
+    opts[:users] = Rbac::Filterer.filtered(MiqRequest.where(
       :type       => request_types_for_model.keys,
       :created_on => (30.days.ago.utc)..(Time.now.utc)
-    ).each_with_object({}) do |r, h|
+    )).each_with_object({}) do |r, h|
       h[r.requester_id] =  if r.requester.nil?
                              (_("%{name} (no longer exists)") % {:name => r.requester_name})
                            else


### PR DESCRIPTION
Services -> Requests -> select box requesters


### Test scenario
```
My Company ->
  ServiceMaster ->
    ServiceA
    ServiceB
```

ServiceB user was able to see ServiceA's and another requester in the
select box and he should see only his requests or of his children.

before 
<img width="958" alt="screen shot 2017-05-02 at 13 19 37" src="https://cloud.githubusercontent.com/assets/14937244/25616015/b49aa6bc-2f3a-11e7-84fe-6f8f721b809b.png">

after
<img width="1102" alt="screen shot 2017-05-02 at 13 25 45" src="https://cloud.githubusercontent.com/assets/14937244/25616053/de942362-2f3a-11e7-82e3-f6a3da0e7fd2.png">


### Links
https://bugzilla.redhat.com/show_bug.cgi?id=1375722


cc @gtanzillo 

@miq-bot assign @martinpovolny 
