### PR TITLE
Fix calling correct method for list image

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1133,7 +1133,7 @@ class ApplicationController < ActionController::Base
             when Storage
               "100/piecharts/datastore/#{calculate_pct_img(item.v_free_space_percent_of_total)}.png"
             when MiqRequest
-              item.decorate.listicon_image || "100/#{@listicon.downcase}.png" if @listicon.try(:downcase)
+              item.decorate.fileicon || "100/#{@listicon.downcase}.png" if @listicon.try(:downcase)
             when Account
               "100/#{item.accttype}.png"
             when SystemService

--- a/app/decorators/miq_provision_decorator.rb
+++ b/app/decorators/miq_provision_decorator.rb
@@ -1,5 +1,5 @@
 class MiqProvisionDecorator < MiqDecorator
-  def self.listicon_image
+  def self.fileicon
     '100/miq_request.png'
   end
 end

--- a/app/decorators/miq_worker_decorator.rb
+++ b/app/decorators/miq_worker_decorator.rb
@@ -1,5 +1,5 @@
 class MiqWorkerDecorator < MiqDecorator
-  def listicon_image
+  def fileicon
     "100/processmanager-#{normalized_type}.png"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1625,7 +1625,7 @@ module ApplicationHelper
   end
 
   def listicon_glyphicon(item)
-    [item.decorate.try(:fonticon), item.decorate.try(:secondary_icon), item.decorate.try(:listicon_image)] if item
+    [item.decorate.try(:fonticon), item.decorate.try(:secondary_icon), item.decorate.try(:fileicon)] if item
   end
   private :listicon_glyphicon
 


### PR DESCRIPTION
There is only `MiqRequestDecorator#fileicon`
so we have to call this method.
introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/592

cc @karelhala 
@miq-bot assign @himdel  
