### PR TITLE
When selecting schedules accordion return correct show_url record

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -3,7 +3,7 @@
   var MAIN_CONTETN_ID = 'main-content';
   var EXPAND_TREES = ['savedreports_treebox', 'widgets_treebox'];
   var TREES_WITHOUT_PARENT = ['pxe', 'ops'];
-  var TREE_TABS_WITHOUT_PARENT = ['action_tree', 'alert_tree'];
+  var TREE_TABS_WITHOUT_PARENT = ['action_tree', 'alert_tree', 'schedules_tree'];
   var USE_TREE_ID = ['automation_manager'];
 
   function isAllowedParent(initObject) {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -388,7 +388,7 @@ module ApplicationHelper
                  PxeImageType
                  IsoDatastore
                  CustomizationTemplate).include?(view.db) &&
-              %w(miq_policy ops pxe).include?(params[:controller])
+              %w(miq_policy ops pxe report).include?(params[:controller])
           return "/#{params[:controller]}/tree_select/?id=#{TreeBuilder.get_prefix_for_model(view.db)}"
         elsif %w(MiqPolicy).include?(view.db) && %w(miq_policy).include?(params[:controller])
           return "/#{params[:controller]}/tree_select/?id=#{x_node}"


### PR DESCRIPTION
### Fixed #1215
Wrong URL was returned in #592 for schedule items. Now it returns `/report/tree_select/?id=msc` to which `report_data_controller.js` will append `-{item.id}`.