### PR TITLE
Default ordering for report data should be ASC not DESC

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1307,7 +1307,7 @@ class ApplicationController < ActionController::Base
       @sortcol = 0
       @sortdir = "ASC"
     end
-    @sortdir = params[:is_ascending] ? 'ASC' : 'DESC' if defined? params[:is_ascending]
+    @sortdir = params[:is_ascending] ? 'ASC' : 'DESC' unless params[:is_ascending].nil?
     @sortcol
   end
 

--- a/spec/controllers/application_controller/report_data_spec.rb
+++ b/spec/controllers/application_controller/report_data_spec.rb
@@ -5,7 +5,7 @@ describe ApplicationController do
       "current"  => 1,
       "items"    => 0,
       "total"    => 0,
-      "sort_dir" => "DESC",
+      "sort_dir" => "ASC",
       "sort_col" => 0
     }
   end

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -358,8 +358,8 @@ describe AutomationManagerController do
       expect(view.table.data.size).to eq(2)
       expect(show_adv_search).to eq(true)
 
-      expect(view.table.data[0].name).to eq("ConfigScript3")
-      expect(view.table.data[1].name).to eq("ConfigScript1")
+      expect(view.table.data[0].name).to eq("ConfigScript1")
+      expect(view.table.data[1].name).to eq("ConfigScript3")
     end
 
     it "calls get_view with the associated dbname for the Ansible Tower Providers accordion" do

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -326,7 +326,7 @@ describe ProviderForemanController do
       expect(gtl_init_data[:data][:currId]).to eq(ems_id)
       expect(gtl_init_data[:data][:isExplorer]).to eq(true)
       view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].description).to eq("testprofile2")
+      expect(view.table.data[0].description).to eq("testprofile")
 
       controller.instance_variable_set(:@search_text, "2")
       controller.send(:tree_select)
@@ -341,7 +341,7 @@ describe ProviderForemanController do
       expect(gtl_init_data[:data][:currId]).to eq(config_profile_id2)
       expect(gtl_init_data[:data][:isExplorer]).to eq(true)
       view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].hostname).to eq("test2b_configured_system")
+      expect(view.table.data[0].hostname).to eq("test2a_configured_system")
 
       controller.instance_variable_set(:@search_text, "2b")
       controller.send(:tree_select)
@@ -375,7 +375,7 @@ describe ProviderForemanController do
       expect(gtl_init_data[:data][:activeTree]).to eq("configuration_manager_providers_tree")
       expect(gtl_init_data[:data][:currId]).to eq(ems_id)
       expect(gtl_init_data[:data][:isExplorer]).to eq(true)
-      expect(view.table.data[0].data).to include('description' => "testprofile2")
+      expect(view.table.data[0].data).to include('description' => "testprofile")
       expect(view.table.data[2]).to include('description' => _("Unassigned Profiles Group"),
                                             'name'        => _("Unassigned Profiles Group"))
     end


### PR DESCRIPTION
### Fixes #1212
When #592 was merged it changed default ordering from `ASC` to `DESC` this PR reverse this change to use `ASC` as default ordering direction.