### PR TITLE
Do not fail if the method is not defined on the topology graph

### DIFF
--- a/app/services/topology_service.rb
+++ b/app/services/topology_service.rb
@@ -66,7 +66,8 @@ class TopologyService
 
       relations.each_pair do |head, tail|
         # Apply the generator graph's first node on the entity
-        children = entity.send(head.to_s.underscore.downcase)
+        method = head.to_s.underscore.downcase
+        children = entity.send(method) if entity.respond_to?(method)
         next if children.nil?
         # Push the child/children to the stack with the chunked generator graph
         if children.respond_to?(:each)


### PR DESCRIPTION
This is a hot-fix for https://bugzilla.redhat.com/show_bug.cgi?id=1446822

Before: :joy_cat: :cry: :cloud: 

![screenshot from 2017-05-02 15-41-15](https://cloud.githubusercontent.com/assets/535866/25620362/6bfabf64-2f4e-11e7-8be8-89726c04297d.png)



After:  :unicorn: :rainbow: :sunny:

![screenshot from 2017-05-02 15-44-01](https://cloud.githubusercontent.com/assets/535866/25620364/6e581e96-2f4e-11e7-9b38-b41b5d85a7a4.png)

If the model/relationships for topology graph is not specified well it might fail with this error: 

```
[----] F, [2017-04-28T19:05:32.796056 #2206:3fe951523850] FATAL -- : Error caught: [NoMethodError] undefined method `host' for #<ManageIQ::Providers::Kubernetes::ContainerManager::Container:0x007fd2ad585098>
/opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/activemodel-5.0.2/lib/active_model/attribute_methods.rb:433:in `method_missing'
/opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/bundler/gems/manageiq-ui-classic-70ba36ca1c67/app/services/topology_service.rb:69:in `block in map_to_graph'
```

Let's make it more robust.

@miq-bot assign @skateman 
@miq_bot add_label bug, topology, blocker
/cc @abonas @theute 