### PR TITLE
Crosslinked containers on middleware topology graph

### DIFF
--- a/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
@@ -103,13 +103,20 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
         if (iconInfo.type != 'glyph') {
           return;
         }
+        var fontFamily = 'font-family:' + iconInfo.fontfamily + ';';
         $(this).text(iconInfo.icon)
           .attr('class', 'glyph')
-          .attr('style', 'font-family:' + iconInfo.fontfamily + ';')
+          .attr('style', fontFamily)
           .attr('x', 0)
           .attr('y', 8);
-      })
 
+        // override some properties for container glyph, because it looks too small and alignment is wrong
+        if (d.item.kind === 'Container') {
+          $(this).text(iconInfo.icon)
+          .attr('style', 'font-size: 20px;' + fontFamily)
+          .attr('y', 7)
+        }
+      })
 
     added.selectAll('title').text(function(d) {
       return topologyService.tooltip(d).join('\n');
@@ -154,7 +161,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
           width: 23,
           r: 19
         };
-      case "Vm":
+      case 'Vm':
         return {
           x: defaultDimensions.x,
           y: defaultDimensions.y,

--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -11,11 +11,11 @@ class MiddlewareTopologyService < TopologyService
       :middleware_deployments,
       :middleware_datasources,
       :middleware_messagings,
-      :lives_on => [:host]
+      :lives_on => [:host, :container]
     ]
   ]
 
-  @kinds = %i(MiddlewareDeployment MiddlewareDatasource MiddlewareDomain MiddlewareManager Vm MiddlewareServer MiddlewareServerGroup MiddlewareMessaging)
+  @kinds = %i(MiddlewareDeployment MiddlewareDatasource MiddlewareDomain MiddlewareManager Vm Container MiddlewareServer MiddlewareServerGroup MiddlewareMessaging)
 
   def build_topology
     topology = super
@@ -67,7 +67,7 @@ class MiddlewareTopologyService < TopologyService
   end
 
   def glyph?(entity)
-    [MiddlewareDatasource, MiddlewareDeployment, Vm, MiddlewareDomain, MiddlewareServerGroup, MiddlewareMessaging]
+    [MiddlewareDatasource, MiddlewareDeployment, Vm, Container, MiddlewareDomain, MiddlewareServerGroup, MiddlewareMessaging]
       .any? { |klass| entity.kind_of? klass }
   end
 end

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -42,6 +42,13 @@
             %text{:y => "9"} &#xE90f;
         %label
           = _("VMs")
+      %kubernetes-topology-icon{tooltipOptions, :kind => "Container"}
+        %svg.kube-topology
+          %g.EntityLegend
+            %circle{:r => "17"}
+            %text{:y => "7", :class => "fa fa-cube glyph"} &#xF1B2;
+        %label
+          = _("Containers")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareDomain"}
         %svg.kube-topology
           %g.MiddlewareDomain{:transform => "translate(21, 21)"}


### PR DESCRIPTION
/cc @abonas, @theute 

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1446822

Displaying a link to container in the topology graph:

![screenshot from 2017-05-02 17-43-27](https://cloud.githubusercontent.com/assets/535866/25626415/bc76e8c6-2f5f-11e7-80f9-742364120b7b.png)


This PR depends on hot-fix in this PR https://github.com/ManageIQ/manageiq-ui-classic/pull/1221
David, could you pls review?
@miq-bot assign @skateman 
@miq-bot add_label enhancement, topology, middleware
