### PR TITLE
Fix checkbox alignment on button screens

### DIFF
--- a/app/views/shared/buttons/_ab_list.html.haml
+++ b/app/views/shared/buttons/_ab_list.html.haml
@@ -73,9 +73,14 @@
         .col-md-8
           = @record.name.split('|').first
           - display = @record.set_data.key?(:display) ? @record.set_data[:display] : true
-          = check_box_tag(display, true, display, :disabled => true)
           &nbsp;
-          = _("Display on Button")
+          .checkbox-inline
+            %label{:style => "font-weight: normal"}
+              = check_box_tag(display, true, display, :disabled => true)
+              = _('Display on Button')
+
+
+
       .form-group
         %label.control-label.col-md-2
           = _('Button Hover Text')

--- a/app/views/shared/buttons/_ab_show.html.haml
+++ b/app/views/shared/buttons/_ab_show.html.haml
@@ -9,9 +9,12 @@
     .col-md-8
       = @custom_button.name
       - display = @custom_button.options.key?(:display) ? @custom_button.options[:display] : true
-      = check_box_tag(display, true, display, :disabled => true)
       &nbsp;
-      = _('Display on Button')
+      .checkbox-inline
+        %label{:style => "font-weight: normal"}
+          = check_box_tag(display, true, display, :disabled => true)
+          = _('Display on Button')
+
   .form-group
     %label.control-label.col-md-2
       = _('Button Hover Text')


### PR DESCRIPTION
This PR adjusted the styling of checkboxes for better alignment with surrounding text on the Automate customization screens.

https://bugzilla.redhat.com/show_bug.cgi?id=1398535

Old
![screen shot 2017-05-02 at 2 42 53 pm](https://cloud.githubusercontent.com/assets/1287144/25633735/2959572c-2f46-11e7-9707-a154546d6a5e.png)

New
![screen shot 2017-05-02 at 2 43 10 pm](https://cloud.githubusercontent.com/assets/1287144/25633734/294e15b0-2f46-11e7-8a79-be6a2fb77f95.png)
