### PR TITLE
Better password management in Ansible Credential Form

### DIFF
--- a/app/assets/javascripts/components/ansible-credential-options.js
+++ b/app/assets/javascripts/components/ansible-credential-options.js
@@ -3,6 +3,7 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
     model: '=',
     options: '<',
     type: '<',
+    newRecord: '<',
     storedPasswordPlaceholder: '<',
   },
 
@@ -46,13 +47,13 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
        '<div ng-switch="attr.type" class="text">',
          // password or ssh input (must be textarea to prevent EOL getting lost)
          '<div ng-switch-when="password" class="col-md-8">',
-           '<input ng-if="!attr.multiline" type="password" value="{{vm.storedPasswordPlaceholder}}" class="form-control" title="{{ __(attr.help_text) }}" ng-disabled="true" ng-hide="vm[name]">',
-           '<textarea ng-if="attr.multiline" class="form-control" title="{{ __(attr.help_text) }}" ng-disabled="true" ng-hide="vm[name]">{{vm.storedPasswordPlaceholder}}</textarea>',
-           '<input ng-if="!attr.multiline" type="password" class="form-control" title="{{ __(attr.help_text) }}" ng-hide="!vm[name]" auto-focus="reactiveFocus" ng-model="vm.model[name]">',
-           '<textarea ng-if="attr.multiline" class="form-control" title="{{ __(attr.help_text) }}" ng-hide="!vm[name]" auto-focus="reactiveFocus" ng-model="vm.model[name]"></textarea>',
+           '<input ng-if="!attr.multiline" type="password" value="{{vm.storedPasswordPlaceholder}}" class="form-control" title="{{ __(attr.help_text) }}" ng-disabled="true" ng-hide="vm[name] || vm.newRecord">',
+           '<textarea ng-if="attr.multiline" class="form-control" title="{{ __(attr.help_text) }}" ng-disabled="true" ng-hide="vm[name] || vm.newRecord">{{vm.storedPasswordPlaceholder}}</textarea>',
+           '<input ng-if="!attr.multiline" type="password" class="form-control" title="{{ __(attr.help_text) }}" ng-hide="!vm[name] && !vm.newRecord" auto-focus="reactiveFocus" ng-model="vm.model[name]">',
+           '<textarea ng-if="attr.multiline" class="form-control" title="{{ __(attr.help_text) }}" ng-hide="!vm[name] && !vm.newRecord" auto-focus="reactiveFocus" ng-model="vm.model[name]"></textarea>',
          '</div>',
-         '<a href="" ng-switch-when="password" ng-hide="vm[name]" ng-click="vm.updatePassword(name)">{{__("Update")}}</a>',
-         '<a href="" ng-switch-when="password" ng-hide="!vm[name]" ng-click="vm.cancelPassword(name)">{{__("Cancel")}}</a>',
+         '<a href="" ng-switch-when="password" ng-hide="vm[name] || vm.newRecord" ng-click="vm.updatePassword(name)">{{__("Update")}}</a>',
+         '<a href="" ng-switch-when="password" ng-hide="!vm[name] || vm.newRecord" ng-click="vm.cancelPassword(name)">{{__("Cancel")}}</a>',
          // select
          '<div ng-switch-when="choice" class="col-md-8">',
             '<select pf-select ng-options="opt as opt for opt in attr.choices" class="form-control" ng-model="vm.model[name]" />',

--- a/app/assets/javascripts/components/ansible-credential-options.js
+++ b/app/assets/javascripts/components/ansible-credential-options.js
@@ -3,6 +3,7 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
     model: '=',
     options: '<',
     type: '<',
+    storedPasswordPlaceholder: '<',
   },
 
   controllerAs: 'vm',

--- a/app/assets/javascripts/components/ansible-credential-options.js
+++ b/app/assets/javascripts/components/ansible-credential-options.js
@@ -27,7 +27,7 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
 
     this.updatePassword = function(name) {
       this[name] = true;
-      this.model[name] = "";
+      this.model[name] = '';
       // The temp variable is required to make the form dirty and enable Save button
       this.model[name + '_temp'] = this.storedPasswordPlaceholder;
       $scope.$broadcast('reactiveFocus');

--- a/app/assets/javascripts/components/ansible-credential-options.js
+++ b/app/assets/javascripts/components/ansible-credential-options.js
@@ -4,6 +4,7 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
     options: '<',
     type: '<',
     newRecord: '<',
+    reset: '=',
     storedPasswordPlaceholder: '<',
   },
 
@@ -52,7 +53,7 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
            '<input ng-if="!attr.multiline" type="password" class="form-control" title="{{ __(attr.help_text) }}" ng-hide="!vm[name] && !vm.newRecord" auto-focus="reactiveFocus" ng-model="vm.model[name]">',
            '<textarea ng-if="attr.multiline" class="form-control" title="{{ __(attr.help_text) }}" ng-hide="!vm[name] && !vm.newRecord" auto-focus="reactiveFocus" ng-model="vm.model[name]"></textarea>',
          '</div>',
-         '<a href="" ng-switch-when="password" ng-hide="vm[name] || vm.newRecord" ng-click="vm.updatePassword(name)">{{__("Update")}}</a>',
+         '<a href="" ng-switch-when="password" adjust-on-reset="{{name}}" ng-hide="vm[name] || vm.newRecord" ng-click="vm.updatePassword(name)">{{__("Update")}}</a>',
          '<a href="" ng-switch-when="password" ng-hide="!vm[name] || vm.newRecord" ng-click="vm.cancelPassword(name)">{{__("Cancel")}}</a>',
          // select
          '<div ng-switch-when="choice" class="col-md-8">',

--- a/app/assets/javascripts/components/ansible-credential-options.js
+++ b/app/assets/javascripts/components/ansible-credential-options.js
@@ -5,6 +5,7 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
     type: '<',
     newRecord: '<',
     reset: '=',
+    deleteFromModel: '=',
     storedPasswordPlaceholder: '<',
   },
 
@@ -30,6 +31,7 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
       this.model[name] = '';
       // The temp variable is required to make the form dirty and enable Save button
       this.model[name + '_temp'] = this.storedPasswordPlaceholder;
+      this.deleteFromModel.push(name + '_temp');
       $scope.$broadcast('reactiveFocus');
     };
 

--- a/app/assets/javascripts/components/ansible-credential-options.js
+++ b/app/assets/javascripts/components/ansible-credential-options.js
@@ -26,12 +26,15 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
     this.updatePassword = function(name) {
       this[name] = true;
       this.model[name] = "";
+      // The temp variable is required to make the form dirty and enable Save button
+      this.model[name + '_temp'] = this.storedPasswordPlaceholder;
       $scope.$broadcast('reactiveFocus');
     };
 
     this.cancelPassword = function(name) {
       this[name] = false;
       this.model[name] = undefined;
+      this.model[name + '_temp'] = undefined;
     };
   }],
 

--- a/app/assets/javascripts/components/ansible-credential-options.js
+++ b/app/assets/javascripts/components/ansible-credential-options.js
@@ -22,6 +22,17 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
     this.$onChanges = function(changes) {
       this.setOptions();
     };
+
+    this.updatePassword = function(name) {
+      this[name] = true;
+      this.model[name] = "";
+      $scope.$broadcast('reactiveFocus');
+    };
+
+    this.cancelPassword = function(name) {
+      this[name] = false;
+      this.model[name] = undefined;
+    };
   }],
 
   template: [
@@ -32,9 +43,13 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
        '<div ng-switch="attr.type" class="text">',
          // password or ssh input (must be textarea to prevent EOL getting lost)
          '<div ng-switch-when="password" class="col-md-8">',
-           '<input ng-if="!attr.multiline" type="password" class="form-control" title="{{ __(attr.help_text) }}" ng-model="vm.model[name]">',
-           '<textarea ng-if="attr.multiline" class="form-control" title="{{ __(attr.help_text) }}" ng-model="vm.model[name]"></textarea>',
+           '<input ng-if="!attr.multiline" type="password" value="{{vm.storedPasswordPlaceholder}}" class="form-control" title="{{ __(attr.help_text) }}" ng-disabled="true" ng-hide="vm[name]">',
+           '<textarea ng-if="attr.multiline" class="form-control" title="{{ __(attr.help_text) }}" ng-disabled="true" ng-hide="vm[name]">{{vm.storedPasswordPlaceholder}}</textarea>',
+           '<input ng-if="!attr.multiline" type="password" class="form-control" title="{{ __(attr.help_text) }}" ng-hide="!vm[name]" auto-focus="reactiveFocus" ng-model="vm.model[name]">',
+           '<textarea ng-if="attr.multiline" class="form-control" title="{{ __(attr.help_text) }}" ng-hide="!vm[name]" auto-focus="reactiveFocus" ng-model="vm.model[name]"></textarea>',
          '</div>',
+         '<a href="" ng-switch-when="password" ng-hide="vm[name]" ng-click="vm.updatePassword(name)">{{__("Update")}}</a>',
+         '<a href="" ng-switch-when="password" ng-hide="!vm[name]" ng-click="vm.cancelPassword(name)">{{__("Cancel")}}</a>',
          // select
          '<div ng-switch-when="choice" class="col-md-8">',
             '<select pf-select ng-options="opt as opt for opt in attr.choices" class="form-control" ng-model="vm.model[name]" />',

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -21,6 +21,8 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
     ManageIQ.angular.scope = vm;
     vm.saveable = miqService.saveable;
 
+    vm.storedPasswordPlaceholder = miqService.storedPasswordPlaceholder;
+
     miqService.sparkleOn();
 
     // get credential specific options for all supported credential types

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -115,6 +115,8 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
 
           if (response.options[key]) {
             vm.credentialModel[key] = response.options[key];
+          } else if (response[key]) {
+            vm.credentialModel[key] = response[key];
           }
         }
       });

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -96,16 +96,18 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
     // we need to wait for vm.credential_options here
     optionsPromise.then(function() {
       // we need to merge options and vm.credentialModel
-      for (var opt in response.options) {
-        var item = vm.credential_options[vm.credentialModel.type]['attributes'][opt];
+      Object.keys(vm.credential_options[vm.credentialModel.type].attributes).forEach(function(key) {
+        vm.credentialModel[key] = '';
+
+        var item = vm.credential_options[vm.credentialModel.type]['attributes'][key];
 
         // void the password fields first
         if (item.hasOwnProperty('type') && item['type'] === 'password') {
-          vm.credentialModel[opt] = '';
+          vm.credentialModel[key] = '';
         } else {
-          vm.credentialModel[opt] = response.options[opt];
+          vm.credentialModel[key] = response.options[key];
         }
-      }
+      });
 
       vm.modelCopy = angular.copy( vm.credentialModel );
     });

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -106,9 +106,9 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
     optionsPromise.then(function() {
       // we need to merge options and vm.credentialModel
       Object.keys(vm.credential_options[vm.credentialModel.type].attributes).forEach(function(key) {
-        var item = vm.credential_options[vm.credentialModel.type]['attributes'][key];
+        var item = vm.credential_options[vm.credentialModel.type].attributes[key];
 
-        if (item.hasOwnProperty('type') && item['type'] === 'password') {
+        if (item.hasOwnProperty('type') && item.type === 'password') {
           // Password fields do not get stored in the model
         } else {
           vm.credentialModel[key] = '';

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -97,15 +97,16 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
     optionsPromise.then(function() {
       // we need to merge options and vm.credentialModel
       Object.keys(vm.credential_options[vm.credentialModel.type].attributes).forEach(function(key) {
-        vm.credentialModel[key] = '';
-
         var item = vm.credential_options[vm.credentialModel.type]['attributes'][key];
 
-        // void the password fields first
         if (item.hasOwnProperty('type') && item['type'] === 'password') {
-          vm.credentialModel[key] = '';
+          // Password fields do not get stored in the model
         } else {
-          vm.credentialModel[key] = response.options[key];
+          vm.credentialModel[key] = '';
+
+          if (response.options[key]) {
+            vm.credentialModel[key] = response.options[key];
+          }
         }
       });
 

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -60,6 +60,7 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
   vm.resetClicked = function(angularForm) {
     vm.credentialModel = angular.copy( vm.modelCopy );
     angularForm.$setPristine(true);
+    toggleResetFlag();
     miqService.miqFlash("warn", __("All changes have been reset"));
   };
 
@@ -74,6 +75,14 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
        .then(getBack.bind(vm, sprintf(__("Add of Credential \"%s\" has been successfully queued."), vm.credentialModel.name), false, false))
        .catch(miqService.handleFailure);
   };
+
+  function toggleResetFlag() {
+    if (vm.reset) {
+      vm.reset = ! vm.reset;
+    } else {
+      vm.reset = true;
+    }
+  }
 
   function retrievedCredentialDetails() {
     vm.afterGet = true;

--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -14,6 +14,7 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
 
     vm.credential_options = {};
     vm.select_options = [];
+    vm.deleteFromModel = [];
 
     vm.newRecord = credentialId === 'new';
     vm.afterGet = false;
@@ -65,7 +66,7 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
   };
 
   vm.saveClicked = function(angularForm) {
-    API.put('/api/authentications/' + credentialId, vm.credentialModel)
+    API.put('/api/authentications/' + credentialId, purgeModel())
        .then(getBack.bind(vm, sprintf(__("Modification of Credential \"%s\" has been successfully queued."), vm.credentialModel.name), false, false))
        .catch(miqService.handleFailure);
   };
@@ -75,6 +76,10 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
        .then(getBack.bind(vm, sprintf(__("Add of Credential \"%s\" has been successfully queued."), vm.credentialModel.name), false, false))
        .catch(miqService.handleFailure);
   };
+
+  function purgeModel() {
+    return _.omit(vm.credentialModel, vm.deleteFromModel);
+  }
 
   function toggleResetFlag() {
     if (vm.reset) {

--- a/app/assets/javascripts/directives/ansible_credentials/adjust_on_reset.js
+++ b/app/assets/javascripts/directives/ansible_credentials/adjust_on_reset.js
@@ -1,0 +1,9 @@
+ManageIQ.angular.app.directive('adjustOnReset', function() {
+  return {
+    link: function(scope, _elem, attr) {
+      scope.$watch('vm.reset', function() {
+        scope.vm.cancelPassword(attr.adjustOnReset);
+      });
+    },
+  };
+});

--- a/app/assets/javascripts/directives/form_changed.js
+++ b/app/assets/javascripts/directives/form_changed.js
@@ -36,6 +36,8 @@ ManageIQ.angular.app.directive('formChanged', function() {
         // TODO in lodash 4 it's _.isEqualWith
         if (_.isEqual(model(), modelCopy(), compare)) {
           ctrl.$setPristine();
+        } else {
+          ctrl.$setDirty();
         }
       });
     },

--- a/app/views/ansible_credential/_credential_form.html.haml
+++ b/app/views/ansible_credential/_credential_form.html.haml
@@ -39,6 +39,7 @@
     %ansible-credential-options{:model                        => 'vm.credentialModel',
                                 :options                      => 'vm.credential_options',
                                 :type                         => 'vm.credentialModel.type',
+                                :reset                        => 'vm.reset',
                                 'new-record'                  => 'vm.newRecord',
                                 'stored-password-placeholder' => 'vm.storedPasswordPlaceholder'}
 

--- a/app/views/ansible_credential/_credential_form.html.haml
+++ b/app/views/ansible_credential/_credential_form.html.haml
@@ -36,9 +36,10 @@
         .col-md-8
           {{ vm.credential_options[vm.credentialModel.type].label }}
 
-    %ansible-credential-options{:model   => 'vm.credentialModel',
-                                :options => 'vm.credential_options',
-                                :type    => 'vm.credentialModel.type'}
+    %ansible-credential-options{:model                        => 'vm.credentialModel',
+                                :options                      => 'vm.credential_options',
+                                :type                         => 'vm.credentialModel.type',
+                                'stored-password-placeholder' => 'vm.storedPasswordPlaceholder'}
 
     = render :partial => 'layouts/angular/generic_form_buttons'
 

--- a/app/views/ansible_credential/_credential_form.html.haml
+++ b/app/views/ansible_credential/_credential_form.html.haml
@@ -39,6 +39,7 @@
     %ansible-credential-options{:model                        => 'vm.credentialModel',
                                 :options                      => 'vm.credential_options',
                                 :type                         => 'vm.credentialModel.type',
+                                'new-record'                  => 'vm.newRecord',
                                 'stored-password-placeholder' => 'vm.storedPasswordPlaceholder'}
 
     = render :partial => 'layouts/angular/generic_form_buttons'

--- a/app/views/ansible_credential/_credential_form.html.haml
+++ b/app/views/ansible_credential/_credential_form.html.haml
@@ -41,6 +41,7 @@
                                 :type                         => 'vm.credentialModel.type',
                                 :reset                        => 'vm.reset',
                                 'new-record'                  => 'vm.newRecord',
+                                'delete-from-model'           => 'vm.deleteFromModel',
                                 'stored-password-placeholder' => 'vm.storedPasswordPlaceholder'}
 
     = render :partial => 'layouts/angular/generic_form_buttons'


### PR DESCRIPTION
Password fields in the form would now be displayed as bulleted dots.

The UX for the Password fields now matches the Provider password fields UX as shown in the screenshots below

<img width="1222" alt="screen shot 2017-05-02 at 2 22 32 pm" src="https://cloud.githubusercontent.com/assets/1538216/25640022/dedae70e-2f42-11e7-8cf2-03da4766b66b.png">
<img width="1217" alt="screen shot 2017-05-02 at 2 22 42 pm" src="https://cloud.githubusercontent.com/assets/1538216/25640023/e0eddeac-2f42-11e7-928d-de8b649d2a02.png">


Other than the UX, changes include not including password fields in the model while in the Edit form, unless the user decides to update them.

As discussed in https://github.com/ManageIQ/manageiq/issues/14900, we need a few improvements in the OPTIONS call to address the `userid` issue. 
While that is being worked on, I have currently used a workaround that would populate the `userid` field in the form in 	8383a4c


https://bugzilla.redhat.com/show_bug.cgi?id=1446033
