### PR TITLE
Fix Features Tree for "everything under" features

### DIFF
--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -6,7 +6,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
   def initialize(name, type, sandbox, build, role:, editable: false)
     @role     = role
     @editable = editable
-    @features = @role.miq_product_features.order(:identifier).pluck(:identifier)
+    @features = @role.miq_product_features.map(&:identifier)
 
     @root_counter = []
 

--- a/app/presenters/tree_node/menu/item.rb
+++ b/app/presenters/tree_node/menu/item.rb
@@ -4,12 +4,24 @@ module TreeNode
       set_attribute(:key)      { "#{@options[:node_id_prefix]}__#{@object.feature}" }
       set_attribute(:title)    { _(details[:name]) }
       set_attribute(:tooltip)  { _(details[:description]) || _(details[:name]) }
-      set_attribute(:selected) { @options[:features].include?(@object.feature) }
+      set_attribute(:selected) { parent_selected? || self_selected? }
 
       private
 
       def details
         ::MiqProductFeature.obj_features[@object.feature].try(:[], :feature).try(:details)
+      end
+
+      def feature_parent
+        ::MiqProductFeature.obj_features[::MiqProductFeature.feature_parent(@object.feature)][:feature]
+      end
+
+      def parent_selected?
+        @options[:features].include?(feature_parent.identifier)
+      end
+
+      def self_selected?
+        @options[:features].include?(@object.feature)
       end
     end
   end


### PR DESCRIPTION
Go to Configuration > Access Control > Roles, pick a role - the tree is on the right, in the role detail.

In #137 we set the select state of a node based on whether the role has the feature identifier for the corresponding part of the tree. Then we depend on the client side to check parents and children of that node. However, some features have no equivalent in the menu, so when the role has a feature like "Everything under Ansible" nothing would be selected.

See:
https://bugzilla.redhat.com/show_bug.cgi?id=1442796

This should not be backported.

@dclarizio @skateman @martinpovolny @himdel 
Checking nodes with only Javascript was too good to be true. We have to do a little work on the server to cover cases like this.

@miq-bot add_label bug, fine/no, euwe/no