### PR TITLE
Use properties in the model when retrieving the ansible repo for editing

### DIFF
--- a/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
@@ -79,7 +79,11 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
 
   var getRepositoryFormData = function(response) {
     var data = response;
-    Object.assign(vm.repositoryModel, data);
+    for (var key in vm.repositoryModel) {
+      if (vm.repositoryModel.hasOwnProperty( key ) && data.hasOwnProperty( key ) ) {
+        vm.repositoryModel[key] = data[key];
+      }
+    }
     setForm();
   };
 

--- a/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
@@ -18,6 +18,7 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
       scm_update_on_launch: false,
     };
 
+    vm.attributes = ['name', 'description', 'scm_type', 'scm_url', 'authentication_id', 'scm_branch:', 'scm_clean', 'scm_delete_on_update', 'scm_update_on_launch'];
     vm.model = 'repositoryModel';
 
     ManageIQ.angular.scope = vm;
@@ -30,7 +31,7 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
       .catch(miqService.handleFailure);
 
     if (repositoryId !== 'new') {
-      API.get('/api/configuration_script_sources/' + repositoryId)
+      API.get('/api/configuration_script_sources/' + repositoryId + '?attributes=' + vm.attributes.join(','))
         .then(getRepositoryFormData)
         .catch(miqService.handleFailure);
     } else {
@@ -79,11 +80,10 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
 
   var getRepositoryFormData = function(response) {
     var data = response;
-    for (var key in vm.repositoryModel) {
-      if (vm.repositoryModel.hasOwnProperty( key ) && data.hasOwnProperty( key ) ) {
-        vm.repositoryModel[key] = data[key];
-      }
+    if ( data.hasOwnProperty( 'href' ) ) {
+      delete data.href;
     }
+    Object.assign(vm.repositoryModel, data);
     setForm();
   };
 


### PR DESCRIPTION
Only copy the properties in the model when retrieving the Ansible repository info for editing

https://bugzilla.redhat.com/show_bug.cgi?id=1445995
- fixes the extra attributes sent to the tower gem for repository edit

/cc @jameswnl 
/cc @ZitaNemeckova 