### PR TITLE
Floating IP related crosslinks for load balancers

### DIFF
--- a/app/controllers/load_balancer_controller.rb
+++ b/app/controllers/load_balancer_controller.rb
@@ -10,7 +10,7 @@ class LoadBalancerController < ApplicationController
   include Mixins::GenericShowMixin
 
   def self.display_methods
-    %w(instances)
+    %w(instances network_ports floating_ips security_groups)
   end
 
   private

--- a/app/controllers/network_port_controller.rb
+++ b/app/controllers/network_port_controller.rb
@@ -15,7 +15,7 @@ class NetworkPortController < ApplicationController
   helper_method :textual_group_list
 
   def self.display_methods
-    %w(cloud_subnets floating_ips)
+    %w(cloud_subnets floating_ips security_groups)
   end
 
   menu_section :net

--- a/app/helpers/floating_ip_helper/textual_summary.rb
+++ b/app/helpers/floating_ip_helper/textual_summary.rb
@@ -38,6 +38,8 @@ module FloatingIpHelper::TextualSummary
   end
 
   def textual_instance
+    return unless @record.vm
+
     label    = ui_lookup(:table => "vm_cloud")
     instance = @record.vm
     h        = {:label => label, :icon => "pficon pficon-virtual-machine"}

--- a/app/helpers/load_balancer_helper/textual_summary.rb
+++ b/app/helpers/load_balancer_helper/textual_summary.rb
@@ -11,8 +11,10 @@ module LoadBalancerHelper::TextualSummary
   end
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i(parent_ems_cloud ems_network cloud_tenant instances network_ports
-                                                floating_ips security_groups))
+    TextualGroup.new(
+      _("Relationships"),
+      %i(parent_ems_cloud ems_network cloud_tenant instances network_ports floating_ips security_groups)
+    )
   end
 
   #

--- a/app/helpers/load_balancer_helper/textual_summary.rb
+++ b/app/helpers/load_balancer_helper/textual_summary.rb
@@ -11,7 +11,8 @@ module LoadBalancerHelper::TextualSummary
   end
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i(parent_ems_cloud ems_network cloud_tenant instances))
+    TextualGroup.new(_("Relationships"), %i(parent_ems_cloud ems_network cloud_tenant instances network_ports
+                                                floating_ips security_groups))
   end
 
   #
@@ -58,5 +59,17 @@ module LoadBalancerHelper::TextualSummary
       h[:title] = _("Show all %{label}") % {:label => label}
     end
     h
+  end
+
+  def textual_network_ports
+    @record.network_ports
+  end
+
+  def textual_floating_ips
+    @record.floating_ips
+  end
+
+  def textual_security_groups
+    @record.security_groups
   end
 end

--- a/app/helpers/network_port_helper/textual_summary.rb
+++ b/app/helpers/network_port_helper/textual_summary.rb
@@ -16,7 +16,7 @@ module NetworkPortHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(parent_ems_cloud ems_network cloud_tenant instance cloud_subnets floating_ips host)
+      %i(parent_ems_cloud ems_network cloud_tenant device cloud_subnets floating_ips security_groups host)
     )
   end
 
@@ -47,17 +47,22 @@ module NetworkPortHelper::TextualSummary
     @record.ext_management_system.try(:parent_manager)
   end
 
-  def textual_instance
-    label    = ui_lookup(:table => "vm_cloud")
-    instance = @record.device
-    h        = nil
-    if instance && role_allows?(:feature => "vm_show")
-      h = {:label => label, :icon => "pficon pficon-virtual-machine"}
-      h[:value] = instance.name
-      h[:link]  = url_for_only_path(:controller => 'vm_cloud', :action => 'show', :id => instance.id)
-      h[:title] = _("Show %{label}") % {:label => label}
+  def textual_device
+    device = @record.device
+    if device.kind_of?(VmOrTemplate)
+      label    = ui_lookup(:table => "vm_cloud")
+      instance = @record.device
+      h        = nil
+      if instance && role_allows?(:feature => "vm_show")
+        h         = {:label => label, :icon => "pficon pficon-virtual-machine"}
+        h[:value] = instance.name
+        h[:link]  = url_for_only_path(:controller => 'vm_cloud', :action => 'show', :id => instance.id)
+        h[:title] = _("Show %{label}") % {:label => label}
+      end
+      h
+    else
+      device
     end
-    h
   end
 
   def textual_cloud_tenant
@@ -70,6 +75,10 @@ module NetworkPortHelper::TextualSummary
 
   def textual_floating_ips
     @record.floating_ips
+  end
+
+  def textual_security_groups
+    @record.security_groups
   end
 
   def textual_host

--- a/app/views/load_balancer/show.html.haml
+++ b/app/views/load_balancer/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if ["instances"].include?(@display) && @showtype != "compare"
+  - if %w(instances network_ports floating_ips security_groups).include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"

--- a/app/views/network_port/show.html.haml
+++ b/app/views/network_port/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if ["instances", "cloud_subnets", "floating_ips"].include?(@display) && @showtype != "compare"
+  - if ["instances", "cloud_subnets", "floating_ips", "security_groups"].include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"

--- a/app/views/network_port/show.html.haml
+++ b/app/views/network_port/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if ["instances", "cloud_subnets", "floating_ips", "security_groups"].include?(@display) && @showtype != "compare"
+  - if %w(instances cloud_subnets floating_ips security_groups).include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/14969

Floating IP related crosslinks for load balancers, namely
floating_ips, networks_ports and security_groups.

Partially fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1387616