### PR TITLE
Add alerts to dashboard

### DIFF
--- a/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
@@ -7,6 +7,7 @@
       // Obj-status cards init
       $scope.objectStatus = {
         providers:  dashboardUtilsFactory.createProvidersStatus(),
+        alerts:     dashboardUtilsFactory.createAlertsStatus(),
         nodes:      dashboardUtilsFactory.createNodesStatus(),
         containers: dashboardUtilsFactory.createContainersStatus(),
         registries: dashboardUtilsFactory.createRegistriesStatus(),
@@ -109,6 +110,7 @@
           }
         }
 
+        dashboardUtilsFactory.updateAlertsStatus($scope.objectStatus.alerts, data.alerts);
         dashboardUtilsFactory.updateStatus($scope.objectStatus.nodes, data.status.nodes);
         dashboardUtilsFactory.updateStatus($scope.objectStatus.containers, data.status.containers);
         dashboardUtilsFactory.updateStatus($scope.objectStatus.registries, data.status.registries);

--- a/app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js
+++ b/app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js
@@ -6,6 +6,13 @@ angular.module('miq.util').factory('dashboardUtilsFactory', function() {
       notifications: []
     };
   };
+  var createAlertsStatus = function() {
+    return {
+      title: __("Alerts"),
+      count: 0,
+      notifications: []
+    };
+  };
   var createNodesStatus = function() {
     return {
       title: __("Nodes"),
@@ -70,6 +77,17 @@ angular.module('miq.util').factory('dashboardUtilsFactory', function() {
       notification: {}
     };
   };
+  var updateAlertsStatus = function (statusObject, data) {
+    statusObject.notification = [];
+    statusObject.count = 0;
+    delete statusObject.href;
+
+    if (data) {
+      statusObject.href = data.href;
+      statusObject.count = data.count;
+      statusObject.notifications = data.notifications;
+    }
+  };
   var updateStatus = function (statusObject, data) {
     statusObject.notification = {};
     if (data) {
@@ -100,6 +118,7 @@ angular.module('miq.util').factory('dashboardUtilsFactory', function() {
   return {
     parseDate: parseDate,
     createProvidersStatus: createProvidersStatus,
+    createAlertsStatus: createAlertsStatus,
     createNodesStatus: createNodesStatus,
     createContainersStatus: createContainersStatus,
     createRegistriesStatus: createRegistriesStatus,
@@ -108,6 +127,7 @@ angular.module('miq.util').factory('dashboardUtilsFactory', function() {
     createServicesStatus: createServicesStatus,
     createImagesStatus: createImagesStatus,
     createRoutesStatus: createRoutesStatus,
+    updateAlertsStatus: updateAlertsStatus,
     updateStatus: updateStatus
   };
 });

--- a/app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js
+++ b/app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js
@@ -83,9 +83,7 @@ angular.module('miq.util').factory('dashboardUtilsFactory', function() {
     delete statusObject.href;
 
     if (data) {
-      statusObject.href = data.href;
-      statusObject.count = data.count;
-      statusObject.notifications = data.notifications;
+      angular.forEach(data, function(v, k) { statusObject[k] = v; });
     }
   };
   var updateStatus = function (statusObject, data) {

--- a/app/assets/stylesheets/container_providers_dashboard.scss
+++ b/app/assets/stylesheets/container_providers_dashboard.scss
@@ -44,7 +44,7 @@
     line-height: 1.1;
 }
 
-.alerts-card .card-pf {
+.alerts-card .card-pf, .provider-card .card-pf {
     min-height: 132px;
     padding-left: 0px;
 }

--- a/app/assets/stylesheets/container_providers_dashboard.scss
+++ b/app/assets/stylesheets/container_providers_dashboard.scss
@@ -44,6 +44,11 @@
     line-height: 1.1;
 }
 
+.alerts-card .card-pf {
+    min-height: 132px;
+    padding-left: 0px;
+}
+
 .provider-card {
     min-height: 140px;
     padding-left: 0px;

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -98,8 +98,11 @@ class ContainerDashboardService
   end
 
   def alerts
+    errors = 0
+    warnings = 0
+
     relation = @ems ? @ems.miq_alert_statuses : MiqAlertStatus.where.not(:ems_id => nil)
-    warnings, errors = relation.group(:severity).count.values_at(*%w(warning error))
+    warnings, errors = relation.group(:severity).count.values_at(*%w(warning error)) if relation.present?
 
     errors_struct = errors > 0 ? {:iconClass => "pficon pficon-error-circle-o", :count => errors} : nil
     warnings_struct = warnings > 0 ? {:iconClass => "pficon pficon-warning-triangle-o", :count => warnings} : nil

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -98,13 +98,8 @@ class ContainerDashboardService
   end
 
   def alerts
-    if @ems.present?
-      warnings = @ems.miq_alert_statuses.where(:severity => "warning").count
-      errors = @ems.miq_alert_statuses.where(:severity => "error").count
-    else
-      warnings = MiqAlertStatus.where.not(:ems_id => nil).where(:severity => "warning").count
-      errors = MiqAlertStatus.where.not(:ems_id => nil).where(:severity => "error").count
-    end
+    relation = @ems ? @ems.miq_alert_statuses : MiqAlertStatus.where.not(:ems_id => nil)
+    warnings, errors = relation.group(:severity).count.values_at(*%w(warning error))
 
     errors_struct = errors > 0 ? {:iconClass => "pficon pficon-error-circle-o", :count => errors} : nil
     warnings_struct = warnings > 0 ? {:iconClass => "pficon pficon-warning-triangle-o", :count => warnings} : nil

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -98,7 +98,8 @@ class ContainerDashboardService
   end
 
   def alerts
-    relation = @ems ? @ems.miq_alert_statuses : MiqAlertStatus.where.not(:ems_id => nil)
+    provider_ids = ManageIQ::Providers::ContainerManager.all.pluck(:id)
+    relation = @ems ? @ems.miq_alert_statuses : MiqAlertStatus.where(:ems_id => provider_ids)
     alerts_status = relation.present? ? relation.group(:severity).count.values_at('error', 'warning') : [nil, nil]
 
     errors = alerts_status[0] || 0

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -98,11 +98,11 @@ class ContainerDashboardService
   end
 
   def alerts
-    errors = 0
-    warnings = 0
-
     relation = @ems ? @ems.miq_alert_statuses : MiqAlertStatus.where.not(:ems_id => nil)
-    warnings, errors = relation.group(:severity).count.values_at(*%w(warning error)) if relation.present?
+    alerts_status = relation.present? ? relation.group(:severity).count.values_at('error', 'warning') : [nil, nil]
+
+    errors = alerts_status[0] || 0
+    warnings = alerts_status[1] || 0
 
     errors_struct = errors > 0 ? {:iconClass => "pficon pficon-error-circle-o", :count => errors} : nil
     warnings_struct = warnings > 0 ? {:iconClass => "pficon pficon-warning-triangle-o", :count => warnings} : nil

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -105,19 +105,19 @@ class ContainerDashboardService
       warnings = MiqAlertStatus.where.not(:ems_id => nil).where(:severity => "warning").count
       errors = MiqAlertStatus.where.not(:ems_id => nil).where(:severity => "error").count
     end
+
+    errors_struct = errors > 0 ? {:iconClass => "pficon pficon-error-circle-o", :count => errors} : nil
+    warnings_struct = warnings > 0 ? {:iconClass => "pficon pficon-warning-triangle-o", :count => warnings} : nil
+    notifications = if (errors + warnings) > 0
+                      [errors_struct, warnings_struct].compact
+                    else
+                      [{:iconClass => "pficon-large pficon-ok"}]
+                    end
+
     {
-      :count         => warnings + errors,
+      :count         => (errors + warnings) > 0 ? (errors + warnings) : nil,
       :href          => @controller.url_for_only_path(:action => 'show', :controller => :alerts_overview),
-      :notifications => [
-        {
-          :iconClass => "pficon pficon-error-circle-o",
-          :count     => errors
-        },
-        {
-          :iconClass => "pficon pficon-warning-triangle-o",
-          :count     => warnings
-        }
-      ]
+      :notifications => notifications
     }
   end
 

--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -13,10 +13,10 @@
           :status                     => "objectStatus.providers",
           "ng-if"                     => "!isSingleProvider"}
     .col-xs-12.col-sm-12.col-md-2
-      %div{:layout                     => "tall",
-          "pf-aggregate-status-card"  => "",
-          "show-top-border"           => "true",
-          :status                     => "objectStatus.alerts"}
+      .alerts-card{:layout                     => "tall",
+                  "pf-aggregate-status-card"  => "",
+                  "show-top-border"           => "true",
+                  :status                     => "objectStatus.alerts"}
     .col-xs-12.col-sm-12.col-md-8
       .row
         .col-xs-6.col-sm-6.col-md-3

--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -12,7 +12,12 @@
           "show-top-border"           => "true",
           :status                     => "objectStatus.providers",
           "ng-if"                     => "!isSingleProvider"}
-    .col-xs-12.col-sm-12.col-md-10
+    .col-xs-12.col-sm-12.col-md-2
+      %div{:layout                     => "tall",
+          "pf-aggregate-status-card"  => "",
+          "show-top-border"           => "true",
+          :status                     => "objectStatus.alerts"}
+    .col-xs-12.col-sm-12.col-md-8
       .row
         .col-xs-6.col-sm-6.col-md-3
           %div{:layout                    => "mini",
@@ -64,7 +69,7 @@
               :url                       => "navigation"}
 
   .row.row-tile-pf
-    .col-xs-12.col-sm-6.col-md-7
+    .col-xs-12.col-sm-6.col-md-8
       %div{"head-title"   => _("Aggregated Node Utilization"),
           :hidetopborder => "true",
           "pf-card"      => ""}
@@ -92,7 +97,7 @@
             %span.trend-footer-pf{"ng-class" => "{ 'chart-transparent-text': !memoryUsageData }"}
               {{memoryUsageConfig.timeFrame}}
 
-    .col-xs-12.col-sm-6.col-md-5
+    .col-xs-12.col-sm-6.col-md-4
       .row.row-tile-pf
         .col-xs-12.col-sm-12.col-md-12
           %div{"head-title" => "{{networkUtilizationConfig.headTitle}}",
@@ -121,7 +126,7 @@
               {{imageEntityTrendConfig.timeFrame}}
 
   .row.row-tile-pf.row-tile-pf-last
-    .col-xs-12.col-sm-6.col-md-7
+    .col-xs-12.col-sm-6.col-md-8
       %div{"column-sizing-class"          => "col-xs-8 col-sm-6 col-md-6",
           "heat-map-usage-legend-labels" => "nodeHeatMapUsageLegendLabels",
           "heatmap-chart-height"         => "dashboardHeatmapChartHeight",
@@ -130,7 +135,7 @@
           :hidetopborder                 => "true",
           :title                         => _("Node Utilization")}
 
-    .col-xs-12.col-sm-6.col-md-5
+    .col-xs-12.col-sm-6.col-md-4
       .row.row-tile-pf
         .col-xs-12.col-sm-12.col-md-12
           %div{"head-title" => "{{podEntityTrendConfig.headTitle}}",

--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -1,17 +1,15 @@
 .container-fluid.container-tiles-pf.containers-dashboard.miq-dashboard-view{"ng-controller" => "containerDashboardController as dashboard"}
-  = render :partial => "layouts/flash_msg"
   .row.row-tile-pf
     .col-xs-12.col-sm-12.col-md-2
-      .card-pf.card-pf-accented.card-pf-aggregate-status.provider-status-card
-        %h2.card-pf-title
-          %img.provider-icon-small{"ng-src" =>"{{providerTypeIconImage}}"}
-          {{providerTypeName}}
-          %img.provider-icon-small{"ng-src" =>"{{providerStatusIconImage}}"}
-      %div{:layout                     => "tall",
-          "pf-aggregate-status-card"  => "",
-          "show-top-border"           => "true",
-          :status                     => "objectStatus.providers",
-          "ng-if"                     => "!isSingleProvider"}
+      .provider-card{"pf-card"         => "",
+                    "show-top-border" => "true",
+                    "ng-if"           => "isSingleProvider"}
+        %img.provider-icon-large{"ng-src" =>"{{providerTypeIconImage}}"}
+      .provider-card{:layout                     => "tall",
+                    "pf-aggregate-status-card"  => "",
+                    "show-top-border"           => "true",
+                    :status                     => "objectStatus.providers",
+                    "ng-if"                     => "!isSingleProvider"}
     .col-xs-12.col-sm-12.col-md-2
       .alerts-card{:layout                     => "tall",
                   "pf-aggregate-status-card"  => "",

--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -1,15 +1,17 @@
 .container-fluid.container-tiles-pf.containers-dashboard.miq-dashboard-view{"ng-controller" => "containerDashboardController as dashboard"}
+  = render :partial => "layouts/flash_msg"
   .row.row-tile-pf
     .col-xs-12.col-sm-12.col-md-2
-      .provider-card{"pf-card"         => "",
-                    "show-top-border" => "true",
-                    "ng-if"           => "isSingleProvider"}
-        %img.provider-icon-large{"ng-src" =>"{{providerTypeIconImage}}"}
-      .provider-card{:layout                     => "tall",
-                    "pf-aggregate-status-card"  => "",
-                    "show-top-border"           => "true",
-                    :status                     => "objectStatus.providers",
-                    "ng-if"                     => "!isSingleProvider"}
+      .card-pf.card-pf-accented.card-pf-aggregate-status.provider-status-card
+        %h2.card-pf-title
+          %img.provider-icon-small{"ng-src" =>"{{providerTypeIconImage}}"}
+          {{providerTypeName}}
+          %img.provider-icon-small{"ng-src" =>"{{providerStatusIconImage}}"}
+      %div{:layout                     => "tall",
+          "pf-aggregate-status-card"  => "",
+          "show-top-border"           => "true",
+          :status                     => "objectStatus.providers",
+          "ng-if"                     => "!isSingleProvider"}
     .col-xs-12.col-sm-12.col-md-2
       .alerts-card{:layout                     => "tall",
                   "pf-aggregate-status-card"  => "",

--- a/spec/javascripts/fixtures/json/container_dashboard_no_data_response.json
+++ b/spec/javascripts/fixtures/json/container_dashboard_no_data_response.json
@@ -56,6 +56,11 @@
         "iconImage": "...kubernetes..."
       }
     ],
+    "alerts": {
+      "count": 1,
+      "href": "/alerts_overview/show",
+      "notifications": []
+    },
     "ems_utilization": {
       "interval_name": "realtime",
       "xy_data": {

--- a/spec/javascripts/fixtures/json/container_dashboard_response.json
+++ b/spec/javascripts/fixtures/json/container_dashboard_response.json
@@ -72,6 +72,20 @@
         "iconImage": "...kubernetes..."
       }
     ],
+    "alerts": {
+      "count": 5,
+      "href": "/alerts_overview/show",
+      "notifications": [
+        {
+          "count": 2,
+          "iconImage": "...error..."
+        },
+        {
+          "count": 1,
+          "iconImage": "...warning..."
+        }
+      ]
+    },
     "ems_utilization": {
       "interval_name": "daily",
       "xy_data": {


### PR DESCRIPTION
Depends on ManageIQ/manageiq#14976

**Description**

We are discussing adding alerts to the dashboard:

> ...
> The current containers dashboard does not provide a summary of Alerts NOR ability to drill down to the Alerts area.
> ...
> Mockup  and comments make sense to me. Unless there are objections or other comments I think we could start working on this.

This PR is a POC for adding alerts to the dashboard.

**Screenshots**

System
![screenshot-localhost 3000-2017-05-03-11-14-20](https://cloud.githubusercontent.com/assets/2181522/25656109/32a1a2a2-3000-11e7-9544-c2d12a4f46a0.png)

One Provider
![screenshot-localhost 3000-2017-05-03-11-14-00](https://cloud.githubusercontent.com/assets/2181522/25656108/3296fca8-3000-11e7-95cf-65b75b3460c4.png)

Current
![currentdashboard](https://cloud.githubusercontent.com/assets/2181522/25656601/7cfcf958-3002-11e7-9fa4-36e90729c7f9.png)

Mockup
![dashboard4x2-addalerts](https://cloud.githubusercontent.com/assets/2181522/25656602/7cfd86f2-3002-11e7-9ad9-c4de5990ef07.png)

