### PR TITLE
Add load balancer's floating ip to the topology view

### DIFF
--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -6,10 +6,14 @@ class NetworkTopologyService < TopologyService
     :availability_zones => [
       :vms => [
         :tags,
-        :load_balancers  => :tags,
         :floating_ips    => :tags,
         :cloud_tenant    => :tags,
-        :security_groups => :tags
+        :security_groups => :tags,
+        :load_balancers  => [
+          :tags,
+          :floating_ips,
+          :security_groups,
+        ]
       ]
     ],
     :cloud_subnets      => [


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/14969

Add load balancer's floating ip to the topology view. The N+1 removal is done in https://github.com/ManageIQ/manageiq/pull/14978

Partially fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1387610