### PR TITLE
[FINE] Adding the containers to the middleware topology graph

### DIFF
--- a/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
@@ -101,13 +101,20 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
         if (iconInfo.type != 'glyph') {
           return;
         }
+        var fontFamily = 'font-family:' + iconInfo.fontfamily + ';';
         $(this).text(iconInfo.icon)
           .attr('class', 'glyph')
-          .attr('style', 'font-family:' + iconInfo.fontfamily + ';')
+          .attr('style', fontFamily)
           .attr('x', 0)
           .attr('y', 8);
-      })
 
+        // override some properties for container glyph, because it looks too small and alignment is wrong
+        if (d.item.kind === 'Container') {
+          $(this).text(iconInfo.icon)
+          .attr('style', 'font-size: 20px;' + fontFamily)
+          .attr('y', 7)
+        }
+      })
 
     added.selectAll('title').text(function(d) {
       return topologyService.tooltip(d).join('\n');
@@ -152,7 +159,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
           width: 23,
           r: 19
         };
-      case "Vm":
+      case 'Vm':
         return {
           x: defaultDimensions.x,
           y: defaultDimensions.y,

--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -72,12 +72,12 @@ class MiddlewareTopologyService < TopologyService
   end
 
   def glyph?(entity)
-    [MiddlewareDatasource, MiddlewareDeployment, Vm, MiddlewareDomain, MiddlewareServerGroup, MiddlewareMessaging]
+    [MiddlewareDatasource, MiddlewareDeployment, Vm, Container, MiddlewareDomain, MiddlewareServerGroup, MiddlewareMessaging]
       .any? { |klass| entity.kind_of? klass }
   end
 
   def build_kinds
-    kinds = [:MiddlewareDeployment, :MiddlewareDatasource, :MiddlewareDomain, :MiddlewareManager, :Vm,
+    kinds = [:MiddlewareDeployment, :MiddlewareDatasource, :MiddlewareDomain, :MiddlewareManager, :Vm, :Container,
              :MiddlewareServer, :MiddlewareServerGroup, :MiddlewareMessaging]
     build_legend_kinds(kinds)
   end

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -45,6 +45,13 @@
             %text{:y => "9"} &#xE90f;
         %label
           = _("VMs")
+      %kubernetes-topology-icon{tooltipOptions, :kind => "Container"}
+        %svg.kube-topology
+          %g.EntityLegend
+            %circle{:r => "17"}
+            %text{:y => "7", :class => "fa fa-cube glyph"} &#xF1B2;
+        %label
+          = _("Containers")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareDomain"}
         %svg.kube-topology
           %g.MiddlewareDomain{:transform => "translate(21, 21)"}

--- a/spec/services/middleware_topology_service_spec.rb
+++ b/spec/services/middleware_topology_service_spec.rb
@@ -12,7 +12,7 @@ describe MiddlewareTopologyService do
   describe "#build_kinds" do
     it "creates the expected number of entity types" do
       supported_kinds = [:MiddlewareServer, :MiddlewareDeployment, :MiddlewareDatasource, :MiddlewareManager, :Vm,
-                         :MiddlewareDomain, :MiddlewareServerGroup, :MiddlewareMessaging]
+                         :Container, :MiddlewareDomain, :MiddlewareServerGroup, :MiddlewareMessaging]
       expect(middleware_topology_service.build_kinds.keys).to match_array(supported_kinds)
     end
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1447686

this is back-porting PR of https://github.com/ManageIQ/manageiq-ui-classic/pull/1223
It depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/1226 that has been already merged.

I saw it working as shown on the screenshot:
![screenshot from 2017-05-03 16-25-29](https://cloud.githubusercontent.com/assets/535866/25665888/346fbdac-301f-11e7-9c1d-134bdac9f6a4.png)

@miq-bot assign @simaishi 
@miq-bot add_label blocker, middleware, compute/containers, topology
/cc @abonas @pilhuhn 