### PR TITLE
Add rendering of flash_array if present to report data (GTL)

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -1,3 +1,4 @@
+/* global add_flash */
 (function() {
   var COTNROLLER_NAME = 'reportDataController';
   var MAIN_CONTETN_ID = 'main-content';
@@ -283,7 +284,6 @@
     initObject.modelName = decodeURIComponent(initObject.modelName);
     this.initObjects(initObject);
     this.setExtraClasses(initObject.gtlType);
-    this.showMessage = this.$location.search().flash_msg;
     return this.getData(initObject.modelName,
                         initObject.activeTree,
                         initObject.currId,
@@ -405,6 +405,9 @@
           }
         }
         this.onItemSelect(isCurrentOpsWorkerSelected(this.gtlData.rows, this.initObject), true);
+        gtlData.messages && gtlData.messages.forEach(function(oneMessage) {
+          add_flash(oneMessage.msg, oneMessage.level);
+        });
         return gtlData;
       }.bind(this));
   };

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -386,7 +386,7 @@ class ApplicationController < ActionController::Base
     render :json => {
       :settings => settings,
       :data     => view_to_hash(current_view),
-      :messages => @flash_array || session[:flash_msg]
+      :messages => @flash_array
     }
   end
 

--- a/app/views/layouts/angular/_gtl.html.haml
+++ b/app/views/layouts/angular/_gtl.html.haml
@@ -7,10 +7,7 @@
 - selected_records = selected_records.map(&:to_i) if !selected_records.nil? && selected_records.first.kind_of?(String)
 - selected_records = selected_records.map(&:id) if !selected_records.nil? && !selected_records.first.kind_of?(Integer)
 #miq-gtl-view{"ng-controller" => "reportDataController as dataCtrl"}
-  #flash_msg_div
-  .msg-info{"ng-show" => "dataCtrl.showMessage && dataCtrl.showMessage !== ''"}
-    = render(:partial => "layouts/info_msg",
-               :locals => {:message => "{{dataCtrl.showMessage}}"})
+  = render(:partial => "layouts/flash_msg")
   %miq-tile-view{"ng-if"            => "dataCtrl.gtlType === 'grid' || dataCtrl.gtlType === 'tile'",
                  "ng-class"         => "{'no-action': dataCtrl.initObject.showUrl === ''}",
                  "settings"         => "dataCtrl.settings",


### PR DESCRIPTION
### Fixes no messages which happens outside fetching report data
As @skateman proposed if any message happens outside fetching data for GTL these messages are not shown (generally when refreshing provider and such). So we should use `= render(:partial => "layouts/flash_msg")` to show these messages.