### PR TITLE
Add support for displaying location LED state

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -2,7 +2,7 @@ module PhysicalServerHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i(name model product_name manufacturer machine_type serial_number ems_ref memory cores)
+      %i(name model product_name manufacturer machine_type serial_number ems_ref memory cores loc_led_state)
     )
   end
 
@@ -85,5 +85,9 @@ module PhysicalServerHelper::TextualSummary
 
   def textual_ipv6
     {:label =>  _("IPV6 Address"), :value => @record.hardware.guest_devices.collect { |device| device.network.ipv6address }.join(", ") }
+  end
+
+  def textual_loc_led_state
+    {:label => _("Identify LED State"), :value => @record.location_led_state}
   end
 end


### PR DESCRIPTION
Added support for displaying the location LED state on the physical server summary page.

![loc-led-state](https://cloud.githubusercontent.com/assets/23690141/25915820/a5fbf6ea-3590-11e7-96f7-8aa494e37afd.PNG)
