### PR TITLE
Check :sort_by: :none to keep the field values in the order that they are inserted in the file.

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -256,7 +256,9 @@
                   - opts = [["<#{_('Choose')}>", nil]]
               - else
                 - opts = multiple ? [] : [["<#{_('None')}>", nil]]
-              - if field_hash[:data_type] == :integer
+              - if field_hash[:sort_by] == :none
+                - opts += Array(field_hash[:values].invert)
+              - elsif field_hash[:data_type] == :integer
                 - opts += Array(field_hash[:values].invert).sort_by(&:last)
               - else
                 - opts += Array(field_hash[:values].invert).sort_by { |a| a.first.downcase }


### PR DESCRIPTION
Part of [#manageiq/14981](https://github.com/ManageIQ/manageiq/pull/14981).

https://bugzilla.redhat.com/show_bug.cgi?id=1389010

