### PR TITLE
Add support for displaying power state

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -34,7 +34,7 @@ class PhysicalServerController < ApplicationController
 
   def textual_group_list
     [
-      %i(properties relationships),
+      %i(properties relationships power_management),
     ]
   end
   helper_method :textual_group_list

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -13,6 +13,13 @@ module PhysicalServerHelper::TextualSummary
     )
   end
 
+  def textual_group_power_management
+    TextualGroup.new(
+      _("Power Management"),
+      %i(power_state)
+    )
+  end
+
   def textual_group_compliance
   end
 
@@ -54,5 +61,9 @@ module PhysicalServerHelper::TextualSummary
 
   def textual_cores
     {:label => _("CPU total cores"), :value => @record.hardware.cpu_total_cores }
+  end
+
+  def textual_power_state
+    {:label => _("Power State"), :value => @record.power_state}
   end
 end


### PR DESCRIPTION
Added support for displaying power state on the physical server summary page.

![power-state](https://cloud.githubusercontent.com/assets/23690141/25915719/5d1ddc90-3590-11e7-8cd6-e995f0543f0b.PNG)
