### PR TITLE
Add support for displaying server health state

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -2,7 +2,7 @@ module PhysicalServerHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i(name model product_name manufacturer machine_type serial_number ems_ref memory cores loc_led_state)
+      %i(name model product_name manufacturer machine_type serial_number ems_ref memory cores health_state loc_led_state)
     )
   end
 
@@ -120,5 +120,9 @@ module PhysicalServerHelper::TextualSummary
 
   def textual_lowest_rack_unit
     {:label => _("Lowest rack name"), :value => @record.asset_details['lowest_rack_unit']}
+  end
+
+  def textual_health_state
+    {:label => _("Health State"), :value => @record.health_state}
   end
 end


### PR DESCRIPTION
Added support for displaying server health state on the physical server summary page.

![health-state](https://cloud.githubusercontent.com/assets/23690141/25915486/9b99a518-358f-11e7-8602-5bd6e3772ea0.PNG)
