### PR TITLE
Add support for displaying firmware details

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -34,7 +34,7 @@ class PhysicalServerController < ApplicationController
 
   def textual_group_list
     [
-      %i(properties networks relationships power_management assets),
+      %i(properties networks relationships power_management assets firmware_details),
     ]
   end
   helper_method :textual_group_list

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -13,13 +13,6 @@ module PhysicalServerHelper::TextualSummary
     )
   end
 
-  def textual_group_power_management
-    TextualGroup.new(
-      _("Power Management"),
-      %i(power_state)
-    )
-  end
-
   def textual_group_compliance
   end
 
@@ -31,6 +24,21 @@ module PhysicalServerHelper::TextualSummary
     TextualGroup.new(
       _("Assets"),
       %i(support_contact description location room_id rack_name lowest_rack_unit)
+    )
+  end
+
+  def textual_group_power_management
+    TextualGroup.new(
+      _("Power Management"),
+      %i(power_state)
+    )
+  end
+
+  def textual_group_firmware_details
+    TextualCustom.new(
+      _("Firmware"),
+      "textual_firmware_table",
+      %i(fw_details)
     )
   end
 
@@ -124,5 +132,14 @@ module PhysicalServerHelper::TextualSummary
 
   def textual_health_state
     {:label => _("Health State"), :value => @record.health_state}
+  end
+
+  def textual_fw_details
+    fw_details = []
+    @record.hardware.firmwares.each do |fw|
+      fw_details.push(:label => fw.name, :value => fw.version)
+    end
+
+    {:value => fw_details}
   end
 end

--- a/app/views/physical_server/_textual_firmware_table.html.haml
+++ b/app/views/physical_server/_textual_firmware_table.html.haml
@@ -1,0 +1,17 @@
+- items = expand_textual_group(items)
+- if items.present?
+  %table.table.table-bordered.table-striped.table-summary-screen
+    %thead
+      %tr
+        %th{:colspan => "3"}
+          = title
+      %tr
+        %th Name
+        %th Version
+    - items.each do |item|
+      - item[:value].each do |subitem|
+        %tr
+          %td
+            = subitem[:label]
+          %td
+            = subitem[:value]


### PR DESCRIPTION
Added support for displaying firmware details on the physical server summary page.

![firmware-details](https://cloud.githubusercontent.com/assets/23690141/25915611/0ca4cdfa-3590-11e7-9211-309a17b13d8a.PNG)
