### PR TITLE
TreeBuilderReportReport reduce queries

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -233,10 +233,8 @@ class TreeBuilder
   #   [Object, {Object1 => {}, Object2 => {Object2a => {}}}]
   #
   def object_from_ancestry(object)
-    if object.kind_of?(Array) && object.size == 2 && object[1].kind_of?(Hash)
-      obj = object.first
-      children = object.last
-      [obj, children]
+    if object.kind_of?(Array) && object.size == 2 && (object[1].kind_of?(Hash) || object[1].kind_of?(Array))
+      object
     else
       [object, nil]
     end

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -28,41 +28,37 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, options)
-    objects = []
-    @rpt_menu.each_with_index do |r, i|
-      objects.push(
-        :id    => i.to_s,
-        :text  => r[0],
-        :icon  => "pficon #{@grp_title == r[0] ? 'pficon-folder-close-blue' : 'pficon-folder-close'}",
-        :tip   => r[0]
-      )
+    objects = @rpt_menu.each_with_index.map do |r, i|
       # load next level of folders when building the tree
       @tree_state.x_tree(options[:tree])[:open_nodes].push("xx-#{i}")
+      folder_hash(i.to_s, r[0], @grp_title == r[0])
     end
     count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
-    objects = []
     nodes = object[:full_id] ? object[:full_id].split('-') : object[:id].to_s.split('-')
-    if nodes.length == 1 && @rpt_menu[nodes.last.to_i][1].kind_of?(Array)
-      @rpt_menu[nodes.last.to_i][1].each_with_index do |r, i|
-        objects.push(
-          :id    => "#{nodes.last.split('-').last}-#{i}",
-          :text  => r[0],
-          :icon  => "pficon #{@grp_title == @rpt_menu[nodes.last.to_i][0] ? 'pficon-folder-close-blue' : 'pficon-folder-close'}",
-          :tip   => r[0]
-        )
+    node_id = nodes.last.to_i
+    if nodes.length == 1 && @rpt_menu[node_id][1].kind_of?(Array)
+      child_names = @rpt_menu[node_id][1]
+      return child_names.size if count_only
+      child_names.each_with_index.map do |r, i|
+        folder_hash("#{node_id}-#{i}", r[0], @grp_title == @rpt_menu[node_id][0])
       end
-    elsif nodes.length >= 2 # || (object[:full_id] && object[:full_id].split('_').length == 2)
+    elsif nodes.length >= 2
       el1 = nodes.length == 2 ? nodes[0].split('_').first.to_i : nodes[1].split('_').first.to_i
-      @rpt_menu[el1][1][nodes.last.to_i][1].each_with_index do |r|
-        objects.push(MiqReport.find_by_name(r))
-        # break after adding 1 report for a count_only,
-        # don't need to go thru them all to determine if node has children
-        break if count_only
-      end
+      child_names = @rpt_menu[el1][1][node_id][1]
+      return child_names.size if count_only
+      MiqReport.where(:name => child_names)
     end
-    count_only_or_objects(count_only, objects)
+  end
+
+  def folder_hash(id, text, blue)
+    {
+      :id    => id,
+      :text  => text,
+      :icon  => "pficon #{blue ? 'pficon-folder-close-blue' : 'pficon-folder-close'}",
+      :tip   => text
+    }
   end
 end

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -1,4 +1,5 @@
 class TreeBuilderReportReports < TreeBuilderReportReportsClass
+  REPORTS_IN_TREE = true
   private
 
   def initialize(name, type, sandbox, build = true)
@@ -26,39 +27,39 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
     }
   end
 
-  # Get root nodes count/array for explorer tree
+  # Get root node and all children report folders. (will call get_tree_custom_kids to get report details)
   def x_get_tree_roots(count_only, options)
-    objects = @rpt_menu.each_with_index.map do |r, i|
+    return @rpt_menu.size if count_only
+    @rpt_menu.each_with_index.each_with_object({}) do |(r, node_id), a|
       # load next level of folders when building the tree
-      @tree_state.x_tree(options[:tree])[:open_nodes].push("xx-#{i}")
-      folder_hash(i.to_s, r[0], @grp_title == r[0])
+      @tree_state.x_tree(options[:tree])[:open_nodes].push("xx-#{node_id}")
+
+      root_node = folder_hash(node_id.to_s, r[0], @grp_title == r[0])
+      child_nodes = @rpt_menu[node_id][1].each_with_index.each.map do |child_r, child_id|
+        folder_hash("#{node_id}-#{child_id}", child_r[0], @grp_title == @rpt_menu[node_id][0])
+      end
+      # returning a child hash says "there are no children"
+      child_nodes = child_nodes.each_with_object({}) { |c, cn| cn[c] = {} } unless REPORTS_IN_TREE
+
+      a[root_node] = child_nodes
     end
-    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
     nodes = object[:full_id] ? object[:full_id].split('-') : object[:id].to_s.split('-')
+    parent_id = nodes[-2].split('_').first.to_i
     node_id = nodes.last.to_i
-    if nodes.length == 1 && @rpt_menu[node_id][1].kind_of?(Array)
-      child_names = @rpt_menu[node_id][1]
-      return child_names.size if count_only
-      child_names.each_with_index.map do |r, i|
-        folder_hash("#{node_id}-#{i}", r[0], @grp_title == @rpt_menu[node_id][0])
-      end
-    elsif nodes.length >= 2
-      el1 = nodes.length == 2 ? nodes[0].split('_').first.to_i : nodes[1].split('_').first.to_i
-      child_names = @rpt_menu[el1][1][node_id][1]
-      return child_names.size if count_only
-      MiqReport.where(:name => child_names)
-    end
+
+    child_names = @rpt_menu[parent_id][1][node_id][1]
+    count_only ? child_names.size : MiqReport.where(:name => child_names)
   end
 
   def folder_hash(id, text, blue)
     {
-      :id    => id,
-      :text  => text,
-      :icon  => "pficon #{blue ? 'pficon-folder-close-blue' : 'pficon-folder-close'}",
-      :tip   => text
+      :id   => id,
+      :text => text,
+      :icon => "pficon #{blue ? 'pficon-folder-close-blue' : 'pficon-folder-close'}",
+      :tip  => text
     }
   end
 end


### PR DESCRIPTION
related to #1228

# Overview

The page `/reports/explorer` uses many builders, but this PR is only focused on one.

`TreeBuilderReportReports` is simple:

- The root nodes are high-level report categories (from the menu)
- The child nodes are low-level report categories (from the menu)
- The grandchild nodes are `MiqReport` records (names from the menu).

# Before

- The number of grandchildren is counted from the database.
- Grandchildren are looked up individually.

# After

- There are no counts for grandchild since the values come from the menu.
- Grandchildren are looked up using a single query per child (the parent of the grandchildren).

# Numbers

|     ms |query | query ms |     rows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|  313.5 |   51 | 111.1 |      468 | #1228 applied
|  258.7 |   23 |  86.6 |      440 | #1288 and this applied
| 17.5% | 55% | 22.1% | 6% | diff

Note: While #1228 and this PR are independent, the numbers seemed more honest if they included that patch in place.

# Expanded Reports Numbers

|       ms |query | query ms |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  2,895.3 |  803 | 1,891.5 |      823 | #1228 applied
|  1,408.6 |  444 |   787.3 |      823 | #1228 and this applied
| 51.3% | 45% | 58.4% | 0 | diff

These are the numbers when all report categories are expanded. Since report records are brought back, the `count(*)` savings are lost, but the N+1 really shines through.

Please treat these numbers with a grain of salt, it is unlikely that a user will ever expand all levels of the tree and then refresh the screen.

# High Git Change count

Since the `@rpt_menu` lookups confused me, I renamed and added many variables

Also, it seemed simpler to group the category lookups into one method (i.e.: `get_tree_roots`) and the report node lookups into another (e.g.: `get_custom_kids`).

I can reduce the lines changed significantly if you prefer that route.

# Added feature

@dclarizio mentioned that we want to remove report names from the menu. I added a switch (i.e.: `REPORTS_IN_TREE`) to document how to do this.

This prevents the report lookup so the worst case numbers go from 803 queries down to the 23.

# Bug

Tree builders work in a few ways:

1. level by level - e.g.: root returns `[node1, node2]`, level1 returns `[node11, node12]`, level2...
2. complete tree - e.g. root returns `{node1 => {node11 => {}, node12 => {}}, node2 => {}}`
3. partial tree - e.g.: root returns `{node1 => [node11, node12], node2 => []}`, and level2 returns `[node111, node 1112]`

It turns out that the 3rd use case did not work properly. I made a change in `tree_builder.rb` to address this issue.
