### PR TITLE
Fix virtual custom attribute column with underscore when it is added

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1157,10 +1157,12 @@ module ReportController::Reports::Editor
       if field.include?("__")                         # Check for pivot calculated field
         f = field.split("-")[1].split("__").first     # Grab the field name after the hyphen, before the "__"
         rpt.cols.push(f) unless rpt.cols.include?(f)  # Add the original field, if not already there
+        rpt.col_order.push(field.split("-")[1])       # Add the field to the col_order array
       else
         rpt.cols.push(field.split("-")[1])            # Grab the field name after the hyphen
+        rpt.col_order.push(field.split("-")[1])       # Add the field to the col_order array
       end
-      rpt.col_order.push(field.split("-")[1])         # Add the field to the col_order array
+
       if field == sortby1                             # Is this the first sort field?
         rpt.sortby = [@edit[:new][:sortby1].split("-")[1]] + rpt.sortby # Put the field first in the sortby array
       elsif field == sortby2                          # Is this the second sort field?

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1159,8 +1159,9 @@ module ReportController::Reports::Editor
         rpt.cols.push(f) unless rpt.cols.include?(f)  # Add the original field, if not already there
         rpt.col_order.push(field.split("-")[1])       # Add the field to the col_order array
       else
-        rpt.cols.push(field.split("-")[1])            # Grab the field name after the hyphen
-        rpt.col_order.push(field.split("-")[1])       # Add the field to the col_order array
+        field_column = MiqExpression::Field.parse(field).column
+        rpt.cols.push(field_column)
+        rpt.col_order.push(field_column) # Add the field to the col_order array
       end
 
       if field == sortby1                             # Is this the first sort field?


### PR DESCRIPTION
Let's have any ContainerImages and also let's have custom attributes for any of them with name which contains `_`.
When there are such columns then only part is saved to the MiqReport.
example of custom attribute:
```
    [74] #<CustomAttribute:0x007ff3f17b2d10> {
                        :id => 1000000000897,
                   :section => "docker_labels",
                      :name => "io.k8s.display-name",
                     :value => "Curator 3.5.1",
             :resource_type => "ContainerImage",
               :resource_id => 1000000000087,
                    :source => "openshift",
               :description => nil,
        :value_interpolated => nil,
               :unique_name => nil,
          :serialized_value => "Curator 3.5.1"
    }
```
before
![d6edkoucpd](https://cloud.githubusercontent.com/assets/14937244/25696028/dbb00266-30b5-11e7-8a4f-4e6d43cf3e5a.gif)

after
![fntmwguhek](https://cloud.githubusercontent.com/assets/14937244/25696016/cb48b468-30b5-11e7-9fc8-5f95f44a055c.gif)

@miq-bot add_label fine/yes, euwe/yes, bug

cc @zeari 

@miq-bot assign @martinpovolny 

## Links
adding this fix as part of https://bugzilla.redhat.com/show_bug.cgi?id=1434077  
