### PR TITLE
Switch Configuration button with Policy button in Key Pairs 

### DIFF
--- a/app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb
@@ -1,24 +1,4 @@
 class ApplicationHelper::Toolbar::AuthKeyPairCloudsCenter < ApplicationHelper::Toolbar::Basic
-  button_group('auth_key_pair_cloud_policy', [
-    select(
-      :auth_key_pair_cloud_policy_choice,
-      'fa fa-shield fa-lg',
-      t = N_('Policy'),
-      t,
-      :enabled => false,
-      :onwhen  => "1+",
-      :items   => [
-        button(
-          :auth_key_pair_cloud_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit tags for the selected items'),
-          N_('Edit Tags'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
   button_group('auth_key_pair_cloud_vmdb', [
     select(
       :auth_key_pair_cloud_vmdb_choice,
@@ -40,6 +20,26 @@ class ApplicationHelper::Toolbar::AuthKeyPairCloudsCenter < ApplicationHelper::T
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Key Pairs and ALL of their components will be permanently removed!"),
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
+  button_group('auth_key_pair_cloud_policy', [
+    select(
+      :auth_key_pair_cloud_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :auth_key_pair_cloud_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit tags for the selected items'),
+          N_('Edit Tags'),
+          :url_parms => "main_div",
           :enabled   => false,
           :onwhen    => "1+"),
       ]


### PR DESCRIPTION
Fixes an inconsistency in Key Pairs toolbar. Everywhere Configuration is left of Policy. 

Before:
<img width="1204" alt="screen shot 2017-05-04 at 1 57 08 pm" src="https://cloud.githubusercontent.com/assets/9210860/25702918/8ffc3146-30d3-11e7-8d33-1a2cc2d15694.png">
After:
<img width="1195" alt="screen shot 2017-05-04 at 2 07 33 pm" src="https://cloud.githubusercontent.com/assets/9210860/25702921/925816b2-30d3-11e7-8eff-42d915e69b5a.png">

@miq-bot add_label toolbars

@romanblanco please review