### PR TITLE
CatalogController - fix typo in default assignment

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1675,7 +1675,7 @@ class CatalogController < ApplicationController
 
   # Get all info for the node about to be displayed
   def get_node_info(treenodeid, _show_list = true)
-    @explorer |= true
+    @explorer ||= true
     @nodetype, id = parse_nodetype_and_id(valid_active_node(treenodeid))
     # saving this so it can be used while adding buttons/groups in buttons editor
     @sb[:applies_to_id] = from_cid(id)


### PR DESCRIPTION
`@explorer |= true` is clearly a typo, introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/592#discussion_r105016607

Fixing :)