### PR TITLE
Use fonticon classes instead of font-family+utf8 in topology 

### DIFF
--- a/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
@@ -198,9 +198,11 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService,
         if (iconInfo.type != 'glyph')
           return;
 
-        $(this).text(iconInfo.icon)
+        /* global fontIconChar */
+        var fonticon = fontIconChar(iconInfo.class);
+        $(this).text(fonticon.char)
           .attr("class", "glyph")
-          .attr('font-family', iconInfo.fontfamily);
+          .attr('font-family', fonticon.font);
       })
 
       .attr("y", function(d) {

--- a/app/assets/javascripts/controllers/topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/container_topology_controller.js
@@ -202,9 +202,11 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
         if (iconInfo.type != 'glyph')
           return;
 
-        $(this).text(iconInfo.icon)
+        /* global fontIconChar */
+        var fonticon = fontIconChar(iconInfo.class);
+        $(this).text(fonticon.char)
           .attr("class", "glyph")
-          .attr('font-family', iconInfo.fontfamily);
+          .attr('font-family', fonticon.font);
       })
 
       .attr("y", function(d) {

--- a/app/assets/javascripts/controllers/topology/infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/infra_topology_controller.js
@@ -183,9 +183,11 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService,
         if (iconInfo.type != 'glyph')
           return;
 
-        $(this).text(iconInfo.icon)
+        /* global fontIconChar */
+        var fonticon = fontIconChar(iconInfo.class);
+        $(this).text(fonticon.char)
           .attr("class", "glyph")
-          .attr('font-family', iconInfo.fontfamily);
+          .attr('font-family', fonticon.font);
       })
 
       .attr("y", function(d) {

--- a/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
@@ -103,8 +103,10 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
         if (iconInfo.type != 'glyph') {
           return;
         }
-        var fontFamily = 'font-family:' + iconInfo.fontfamily + ';';
-        $(this).text(iconInfo.icon)
+        /* global fontIconChar */
+        var fonticon = fontIconChar(iconInfo.class);
+        var fontFamily = 'font-family:' + fonticon.font + ';';
+        $(this).text(fonticon.char)
           .attr('class', 'glyph')
           .attr('style', fontFamily)
           .attr('x', 0)
@@ -112,7 +114,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
 
         // override some properties for container glyph, because it looks too small and alignment is wrong
         if (d.item.kind === 'Container') {
-          $(this).text(iconInfo.icon)
+          $(this).text(fonticon.char)
             .attr('style', 'font-size: 20px;' + fontFamily)
             .attr('y', 7);
         }

--- a/app/assets/javascripts/controllers/topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/network_topology_controller.js
@@ -183,9 +183,11 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
         if (iconInfo.type != 'glyph')
           return;
 
-        $(this).text(iconInfo.icon)
+        /* global fontIconChar */
+        var fonticon = fontIconChar(iconInfo.class);
+        $(this).text(fonticon.char)
           .attr("class", "glyph")
-          .attr('font-family', iconInfo.fontfamily);
+          .attr('font-family', fonticon.font);
       })
 
       .attr("y", function(d) {

--- a/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
@@ -183,9 +183,11 @@ function physicalInfraTopologyCtrl($scope, $http, $interval, $location, topology
         if (iconInfo.type != 'glyph')
           return;
 
-        $(this).text(iconInfo.icon)
+        /* global fontIconChar */
+        var fonticon = fontIconChar(iconInfo.class);
+        $(this).text(fonticon.char)
           .attr("class", "glyph")
-          .attr('font-family', iconInfo.fontfamily);
+          .attr('font-family', fonticon.font);
       })
 
       .attr("y", function(d) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1716,3 +1716,13 @@ function miqFormatNotification(text, bindings) {
   });
   return str;
 }
+
+var fontIconChar = _.memoize(function (klass) {
+  var tmp = document.createElement('i');
+  tmp.className = 'hidden ' + klass;
+  document.body.appendChild(tmp);
+  var char = window.getComputedStyle(tmp, ':before').content.replace(/'|"/g, '');
+  var font = window.getComputedStyle(tmp).fontFamily;
+  tmp.remove();
+  return {font: font, char: char};
+});

--- a/app/services/ui_service_mixin.rb
+++ b/app/services/ui_service_mixin.rb
@@ -1,44 +1,45 @@
 module UiServiceMixin
   def icons
     {
-      :AvailabilityZone        => {:type => "glyph", :icon => "\uE911", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-zone
-      :ContainerReplicator     => {:type => "glyph", :icon => "\uE624", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-replicator
-      :ContainerProject        => {:type => "glyph", :icon => "\uE905", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-project
-      :ContainerGroup          => {:type => "glyph", :icon => "\uF1B3", :fontfamily => "FontAwesome"},             # fa-cubes
-      :ContainerNode           => {:type => "glyph", :icon => "\uE621", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-container-node
-      :ContainerService        => {:type => "glyph", :icon => "\uE61E", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-service
-      :ContainerRoute          => {:type => "glyph", :icon => "\uE625", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-route
-      :Container               => {:type => "glyph", :icon => "\uF1B2", :fontfamily => "FontAwesome"},             # fa-cube
-      :EmsCluster              => {:type => "glyph", :icon => "\uE620", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-cluster
-      :Host                    => {:type => "glyph", :icon => "\uE600", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-screen
-      :Vm                      => {:type => "glyph", :icon => "\uE90f", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-virtual-machine
-      :MiddlewareDatasource    => {:type => "glyph", :icon => "\uF1C0", :fontfamily => "FontAwesome"},             # fa-database
-      :MiddlewareDeployment    => {:type => "glyph", :icon => "\uF0f6", :fontfamily => "FontAwesome"},             # fa-file-text-o
-      :MiddlewareDeploymentEar => {:type => "glyph", :icon => "\uE626", :fontfamily => "icomoon"},                 # product-file-ear-o
-      :MiddlewareDeploymentWar => {:type => "glyph", :icon => "\uE627", :fontfamily => "icomoon"},                 # product-file-war-o
-      :MiddlewareDomain        => {:type => "glyph", :icon => "\uE919", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-domain
-      :MiddlewareMessaging     => {:type => "glyph", :icon => "\uF0EC", :fontfamily => "FontAwesome"},             # fa-exchange (placeholder)
-      :MiddlewareServerGroup   => {:type => "glyph", :icon => "\uE91a", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-server-group
-      :Kubernetes              => {:type => "image", :icon => provider_icon(:Kubernetes)},
-      :Openshift               => {:type => "image", :icon => provider_icon(:Openshift)},
-      :CloudSubnet             => {:type => "glyph", :icon => "\uE909", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-network
-      :NetworkRouter           => {:type => "glyph", :icon => "\uE625", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-route
-      :SecurityGroup           => {:type => "glyph", :icon => "\uE903", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-cloud-security
-      :FloatingIp              => {:type => "glyph", :icon => "\uF041", :fontfamily => "FontAwesome"},             # fa-map-marker
-      :CloudNetwork            => {:type => "glyph", :icon => "\uE62c", :fontfamily => "IcoMoon"},                 # product-cloud_network
-      :CloudTenant             => {:type => "glyph", :icon => "\uE904", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-cloud-tenant
-      :LoadBalancer            => {:type => "glyph", :icon => "\uE637", :fontfamily => "IcoMoon"},                 # product-load_balancer
-      :Tag                     => {:type => "glyph", :icon => "\uF02b", :fontfamily => "FontAwesome"},             # fa-tag
-      :PhysicalServer          => {:type => "glyph", :icon => "\uE91a", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-server-group
-      :Openstack               => {:type => "image", :icon => provider_icon(:Openstack)},
+      :AvailabilityZone        => {:type => "glyph", :class => 'pficon pficon-zone'},
+      :CloudNetwork            => {:type => "glyph", :class => 'product product-cloud_network'},
+      :CloudSubnet             => {:type => "glyph", :class => 'pficon pficon-network'},
+      :CloudTenant             => {:type => "glyph", :class => 'pficon pficon-cloud-tenant'},
+      :Container               => {:type => "glyph", :class => 'fa fa-cube'},
+      :ContainerGroup          => {:type => "glyph", :class => 'fa fa-cubes'},
+      :ContainerNode           => {:type => "glyph", :class => 'pficon pficon-container-node'},
+      :ContainerProject        => {:type => "glyph", :class => 'pficon pficon-project'},
+      :ContainerReplicator     => {:type => "glyph", :class => 'pficon pficon-replicator'},
+      :ContainerRoute          => {:type => "glyph", :class => 'pficon pficon-route'},
+      :ContainerService        => {:type => "glyph", :class => 'pficon pficon-service'},
+      :EmsCluster              => {:type => "glyph", :class => 'pficon pficon-cluster'},
+      :FloatingIp              => {:type => "glyph", :class => 'fa fa-map-marker'},
+      :Host                    => {:type => "glyph", :class => 'pficon pficon-screen'},
+      :LoadBalancer            => {:type => "glyph", :class => 'product product-load_balancer'},
+      :MiddlewareDatasource    => {:type => "glyph", :class => 'fa fa-database'},
+      :MiddlewareDeployment    => {:type => "glyph", :class => 'fa fa-file-text-o'},
+      :MiddlewareDeploymentEar => {:type => "glyph", :class => 'product product-file-ear-o'},
+      :MiddlewareDeploymentWar => {:type => "glyph", :class => 'product product-file-war-o'},
+      :MiddlewareDomain        => {:type => "glyph", :class => 'pficon pficon-domain'},
+      :MiddlewareMessaging     => {:type => "glyph", :class => 'fa fa-exchange (placeholder)'},
+      :MiddlewareServerGroup   => {:type => "glyph", :class => 'pficon pficon-server-group'},
+      :NetworkRouter           => {:type => "glyph", :class => 'pficon pficon-route'},
+      :PhysicalServer          => {:type => "glyph", :class => 'pficon pficon-server-group'},
+      :SecurityGroup           => {:type => "glyph", :class => 'pficon pficon-cloud-security'},
+      :Tag                     => {:type => "glyph", :class => 'fa fa-tag'},
+      :Vm                      => {:type => "glyph", :class => 'pficon pficon-virtual-machine'},
+
       :Amazon                  => {:type => "image", :icon => provider_icon(:Amazon)},
       :Azure                   => {:type => "image", :icon => provider_icon(:Azure)},
       :Google                  => {:type => "image", :icon => provider_icon(:Google)},
-      :Microsoft               => {:type => "image", :icon => provider_icon(:Microsoft)},
-      :Redhat                  => {:type => "image", :icon => provider_icon(:Redhat)},
-      :Vmware                  => {:type => "image", :icon => provider_icon(:Vmware)},
+      :Kubernetes              => {:type => "image", :icon => provider_icon(:Kubernetes)},
       :Lenovo                  => {:type => "image", :icon => provider_icon(:Lenovo)},
+      :Microsoft               => {:type => "image", :icon => provider_icon(:Microsoft)},
       :Nuage                   => {:type => "image", :icon => provider_icon(:Nuage_Network)},
+      :Openshift               => {:type => "image", :icon => provider_icon(:Openshift)},
+      :Openstack               => {:type => "image", :icon => provider_icon(:Openstack)},
+      :Redhat                  => {:type => "image", :icon => provider_icon(:Redhat)},
+      :Vmware                  => {:type => "image", :icon => provider_icon(:Vmware)}
     }
   end
 


### PR DESCRIPTION
As the topology graph is an SVG, it's not possible to use fonticon CSS classes inside. The workaround was to fetch the font family + UTF8 character for each node and declare them in the `UiServiceMixin`. This is not very efficient and also a place where we can easily introduce icon inconsistency or iconsistency :rofl:.

I created the `fontIconChar` JS function that converts a CSS icon class to a font family and character combo. The function is [memoized](https://lodash.com/docs/4.17.4#memoize), so it doesn't touches the DOM when its called multiple times with the same arguments. This function was :cry:  ~copy-pasted~ :cry:  applied :cry:  in every `TopologyController`, but in the future we want to have this call in a single place.

@martinpovolny @himdel what do you think?

Pivotal story: https://www.pivotaltracker.com/story/show/143239019