### PR TITLE
Move the UiServiceMixin inclusion to TopologyService

### DIFF
--- a/app/services/cloud_topology_service.rb
+++ b/app/services/cloud_topology_service.rb
@@ -1,6 +1,4 @@
 class CloudTopologyService < TopologyService
-  include UiServiceMixin
-
   @provider_class = ManageIQ::Providers::CloudManager
 
   @included_relations = [

--- a/app/services/container_project_topology_service.rb
+++ b/app/services/container_project_topology_service.rb
@@ -1,6 +1,4 @@
 class ContainerProjectTopologyService < ContainerTopologyService
-  include UiServiceMixin
-
   @provider_class = ContainerProject
 
   @included_relations = [

--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -1,6 +1,4 @@
 class ContainerTopologyService < TopologyService
-  include UiServiceMixin
-
   @provider_class = ManageIQ::Providers::ContainerManager
 
   @included_relations = [

--- a/app/services/infra_topology_service.rb
+++ b/app/services/infra_topology_service.rb
@@ -1,6 +1,4 @@
 class InfraTopologyService < TopologyService
-  include UiServiceMixin
-
   @provider_class = ManageIQ::Providers::InfraManager
 
   @included_relations = [

--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -1,6 +1,4 @@
 class MiddlewareTopologyService < TopologyService
-  include UiServiceMixin
-
   @provider_class = ManageIQ::Providers::MiddlewareManager
 
   @included_relations = [

--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -1,6 +1,4 @@
 class NetworkTopologyService < TopologyService
-  include UiServiceMixin
-
   @provider_class = ManageIQ::Providers::NetworkManager
 
   @included_relations = [

--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -1,6 +1,4 @@
 class PhysicalInfraTopologyService < TopologyService
-  include UiServiceMixin
-
   @provider_class = ManageIQ::Providers::PhysicalInfraManager
 
   @included_relations = [

--- a/app/services/topology_service.rb
+++ b/app/services/topology_service.rb
@@ -1,4 +1,6 @@
 class TopologyService
+  include UiServiceMixin
+
   def initialize(provider_id = nil)
     provider_class = self.class.instance_variable_get(:@provider_class)
     # If the provider ID is not set, the topology needs to be generated for all the providers


### PR DESCRIPTION
The `*TopologyService` classes included this mixin, but the [`icons`](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/services/ui_service_mixin.rb#L2) was [called only](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/services/topology_service.rb#L42) in their parent `TopologyService` class.

Pivotal story: https://www.pivotaltracker.com/story/show/143239019

@miq-bot add_label refactoring, topology, fine/no
