### PR TITLE
Displayed Physical Server Hardware info

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -2,7 +2,7 @@ module PhysicalServerHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i(name model product_name manufacturer machine_type serial_number ems_ref)
+      %i(name model product_name manufacturer machine_type serial_number ems_ref memory cores)
     )
   end
 
@@ -46,5 +46,13 @@ module PhysicalServerHelper::TextualSummary
 
   def textual_model
     {:label => _("Model"), :value => @record.model}
+  end
+
+  def textual_memory
+    {:label => _("Total memory (mb)"), :value => @record.hardware.memory_mb }
+  end
+
+  def textual_cores
+    {:label => _("CPU total cores"), :value => @record.hardware.cpu_total_cores }
   end
 end

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -9,7 +9,8 @@ describe PhysicalServerController do
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)
-      physical_server = FactoryGirl.create(:physical_server)
+      computer_system = FactoryGirl.create(:computer_system, :hardware => FactoryGirl.create(:hardware))
+      physical_server = FactoryGirl.create(:physical_server, :computer_system => computer_system)
       get :show, :params => {:id => physical_server.id}
     end
     it { expect(response.status).to eq(200) }


### PR DESCRIPTION
This PR is able to:
-Display Physical Server hardware information (total memory and total cores)

![image](https://cloud.githubusercontent.com/assets/5839808/25850629/6985f6c2-3499-11e7-9725-65701df23bad.png)

