### PR TITLE
Add network data in physical server details table

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -34,7 +34,7 @@ class PhysicalServerController < ApplicationController
 
   def textual_group_list
     [
-      %i(properties relationships power_management),
+      %i(properties networks relationships power_management),
     ]
   end
   helper_method :textual_group_list

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -23,6 +23,10 @@ module PhysicalServerHelper::TextualSummary
   def textual_group_compliance
   end
 
+  def textual_group_networks
+    TextualGroup.new(_("Networks"), %i(mac ipv4 ipv6))
+  end
+
   def textual_host
     {:label => _("Host"), :value => @record.host.try(:name), :icon => "pficon pficon-virtual-machine", :link => url_for(:controller => 'host', :action => 'show', :id => @record.host.try(:id))}
   end
@@ -65,5 +69,17 @@ module PhysicalServerHelper::TextualSummary
 
   def textual_power_state
     {:label => _("Power State"), :value => @record.power_state}
+  end
+
+  def textual_mac
+    {:label =>  _("Mac Address"), :value => @record.hardware.guest_devices.collect { |device| device[:address] }.join(", ") }
+  end
+
+  def textual_ipv4
+    {:label =>  _("IPV4 Address"), :value => @record.hardware.guest_devices.collect { |device| device.network.ipaddress }.join(", ") }
+  end
+
+  def textual_ipv6
+    {:label =>  _("IPV6 Address"), :value => @record.hardware.guest_devices.collect { |device| device.network.ipv6address }.join(", ") }
   end
 end


### PR DESCRIPTION
This PR is able to:
Create new session of networks details in the physical server page using attributes of "guest_devices.network" .
Was added the following attributes in the session:
- Mac Address
- IPV4 Address
- IPV6 Address

Depends on [#46](https://github.com/ManageIQ/manageiq-providers-lenovo/pull/46)

![network_session](https://cloud.githubusercontent.com/assets/12627705/25543841/74224f18-2c2e-11e7-862b-53b15ee84427.png)
