### PR TITLE
Verify VM power status is not Nil when displaying Cloud Topology

### DIFF
--- a/app/services/cloud_topology_service.rb
+++ b/app/services/cloud_topology_service.rb
@@ -38,7 +38,7 @@ class CloudTopologyService < TopologyService
     if entity.kind_of?(ManageIQ::Providers::CloudManager)
       entity.authentications.blank? ? 'Unknown' : entity.authentications.first.status.try(:capitalize)
     elsif entity.kind_of?(Vm)
-      entity.power_state.capitalize
+      entity.power_state.nil? ? 'Unknown' : entity.power_state.capitalize
     elsif entity.kind_of?(AvailabilityZone)
       'OK'
     elsif entity.kind_of?(CloudTenant)


### PR DESCRIPTION

https://bugzilla.redhat.com/show_bug.cgi?id=1447795

Screen shots before and after code fix:

![bz1447795_compute clouds topolgy run time error dialog in ui](https://cloud.githubusercontent.com/assets/552686/25714642/85610656-30ad-11e7-9de7-c9aceae2481d.png)

Topology display after code fix:
![bz1447795_compute clouds topology after code fix](https://cloud.githubusercontent.com/assets/552686/25714664/9883ea6e-30ad-11e7-8501-8d15329da08e.png)
