### PR TITLE
[minor] Removing unnecessary item in the 'schema' definition of the topology graph

### DIFF
--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -9,7 +9,7 @@ class MiddlewareTopologyService < TopologyService
       :middleware_deployments,
       :middleware_datasources,
       :middleware_messagings,
-      :lives_on => [:host, :container]
+      :lives_on => [:host]
     ]
   ]
 


### PR DESCRIPTION
In commit 2f5f9d97c, I blindly added the :containers to the
@included_relations, but it's not necessary there, because the lives_on
returns the Container entity itself (there is no need to call container
on Container entity). Now, it just works because there is a check if the
method actually exist before calling it (c1a12135f), but still.

Fine should be fine w/o it.

@miq-bot add_label topology, bug