### PR TITLE
Removed _main.html.haml and cleaned up _show.html.haml

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -31,4 +31,9 @@ class PhysicalServerController < ApplicationController
 
     process_show_list
   end
+
+  def textual_group_list
+    []
+  end
+  helper_method :textual_group_list
 end

--- a/app/views/physical_server/_main.html.haml
+++ b/app/views/physical_server/_main.html.haml
@@ -1,4 +1,0 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    TODO: add groups

--- a/app/views/physical_server/show.html.haml
+++ b/app/views/physical_server/show.html.haml
@@ -1,6 +1,5 @@
 #main_div
-    - arr = %w(physical_server physical_servers)
-    - if arr.include?(@display) && @showtype != "compare"
-        = render(:partial => "layouts/gtl", :locals => {:action_url => "show/#{@ph_server.id}"})
-    - else
-        = render(:partial => @showtype)
+  - if %w(physical_servers).include?(@display)
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  - else
+    = render :partial => 'layouts/textual_groups_generic'

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -1,0 +1,26 @@
+describe PhysicalServerController do
+  include CompressedIds
+
+  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+  let(:zone) { FactoryGirl.build(:zone) }
+
+  describe "#show" do
+    render_views
+    before(:each) do
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as FactoryGirl.create(:user)
+      physical_server = FactoryGirl.create(:physical_server)
+      get :show, :params => {:id => physical_server.id}
+    end
+    it { expect(response.status).to eq(200) }
+  end
+
+  describe "#show_list" do
+    before(:each) do
+      stub_user(:features => :all)
+      FactoryGirl.create(:physical_server)
+      get :show_list
+    end
+    it { expect(response.status).to eq(200) }
+  end
+end


### PR DESCRIPTION
This is a follow-up to #1162 

@GabrielSVinha You will notice that `textual_group_list` is an empty array for now.
Add `%i(properties)`, `%i(relationships)` entries in this array and the required methods for those as and when you create PRs related to that topic.

@martinpovolny Please review