### PR TITLE
Move topology context menu under a mixin in topologyService

### DIFF
--- a/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
@@ -11,6 +11,8 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService,
   var d3 = window.d3;
   $scope.d3 = d3;
 
+  topologyService.mixinContextMenu(this, $scope);
+
   $scope.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
@@ -54,68 +56,6 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService,
   $scope.$on('$destroy', function() {
     $interval.cancel(promise);
   });
-
-  var contextMenuShowing = false;
-
-  d3.select("body").on('click', function() {
-    if(contextMenuShowing) {
-      removeContextMenu();
-    }
-  });
-
-  var removeContextMenu = function() {
-    d3.event.preventDefault();
-    d3.select(".popup").remove();
-    contextMenuShowing = false;
-  };
-
-  self.contextMenu = function contextMenu(_that, data) {
-    if(contextMenuShowing) {
-      removeContextMenu();
-    } else {
-      d3.event.preventDefault();
-
-      var canvas = d3.select("kubernetes-topology-graph");
-      var mousePosition = d3.mouse(canvas.node());
-
-      var popup = canvas.append("div")
-        .attr("class", "popup")
-        .style("left", mousePosition[0] + "px")
-        .style("top", mousePosition[1] + "px");
-      popup.append("h5").text("Actions on " + data.item.display_kind);
-
-      buildContextMenuOptions(popup, data);
-
-      var canvasSize = [
-        canvas.node().offsetWidth,
-        canvas.node().offsetHeight
-      ];
-
-      var popupSize = [
-        popup.node().offsetWidth,
-        popup.node().offsetHeight
-      ];
-
-      if (popupSize[0] + mousePosition[0] > canvasSize[0]) {
-        popup.style("left", "auto");
-        popup.style("right", 0);
-      }
-
-      if (popupSize[1] + mousePosition[1] > canvasSize[1]) {
-        popup.style("top", "auto");
-        popup.style("bottom", 0);
-      }
-      contextMenuShowing = !contextMenuShowing;
-    }
-  };
-
-  var buildContextMenuOptions = function(popup, data) {
-    if (data.item.kind == "Tag") {
-      return false;
-    }
-
-    topologyService.addContextMenuOption(popup, "Go to summary page", data, self.dblclick);
-  };
 
   $scope.$on("render", function(ev, vertices, added) {
     /*
@@ -226,13 +166,6 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService,
     /* Don't do default rendering */
     ev.preventDefault();
   });
-
-  this.dblclick = function dblclick(d) {
-    if (d.item.kind == "Tag") {
-      return false;
-    }
-    window.location.assign(topologyService.geturl(d));
-  };
 
   this.getIcon = function getIcon(d) {
     switch(d.item.kind) {

--- a/app/assets/javascripts/controllers/topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/container_topology_controller.js
@@ -11,6 +11,8 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
   var d3 = window.d3;
   $scope.d3 = d3;
 
+  topologyService.mixinContextMenu(this, $scope);
+
   $scope.refresh = function() {
     var id, type;
     var pathname = $window.location.pathname.replace(/\/$/, '');
@@ -52,64 +54,6 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
   $scope.$on('$destroy', function() {
     $interval.cancel(promise);
   });
-
-  var contextMenuShowing = false;
-
-  d3.select("body").on('click', function() {
-    if(contextMenuShowing) {
-      removeContextMenu();
-    }
-  });
-
-  var removeContextMenu = function() {
-      d3.event.preventDefault();
-      d3.select(".popup").remove();
-      contextMenuShowing = false;
-  };
-
-  self.contextMenu = function contextMenu(_that, data) {
-    if (contextMenuShowing) {
-      removeContextMenu();
-    } else {
-      d3.event.preventDefault();
-
-      var canvas = d3.select("kubernetes-topology-graph");
-      var mousePosition = d3.mouse(canvas.node());
-
-      var popup = canvas.append("div")
-          .attr("class", "popup")
-          .style("left", mousePosition[0] + "px")
-          .style("top", mousePosition[1] + "px");
-      popup.append("h5").text("Actions on " + data.item.display_kind);
-
-      buildContextMenuOptions(popup, data);
-
-      var canvasSize = [
-        canvas.node().offsetWidth,
-        canvas.node().offsetHeight
-      ];
-
-      var popupSize = [
-        popup.node().offsetWidth,
-        popup.node().offsetHeight
-      ];
-
-      if (popupSize[0] + mousePosition[0] > canvasSize[0]) {
-        popup.style("left", "auto");
-        popup.style("right", 0);
-      }
-
-      if (popupSize[1] + mousePosition[1] > canvasSize[1]) {
-        popup.style("top", "auto");
-        popup.style("bottom", 0);
-      }
-      contextMenuShowing = !contextMenuShowing;
-    }
-  };
-
-  var buildContextMenuOptions = function(popup, data) {
-    topologyService.addContextMenuOption(popup, "Go to summary page", data, self.dblclick);
-  };
 
   $scope.$on("render", function(ev, vertices, added) {
     /*
@@ -231,10 +175,6 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
     /* Don't do default rendering */
     ev.preventDefault();
   });
-
-  this.dblclick = function dblclick(d) {
-    window.location.assign(topologyService.geturl(d));
-  };
 
   this.getIcon = function getIcon(d) {
     switch(d.item.kind) {

--- a/app/assets/javascripts/controllers/topology/infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/infra_topology_controller.js
@@ -11,6 +11,8 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService,
   var d3 = window.d3;
   $scope.d3 = d3;
 
+  topologyService.mixinContextMenu(this, $scope);
+
   $scope.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
@@ -39,68 +41,6 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService,
   $scope.$on('$destroy', function() {
     $interval.cancel(promise);
   });
-
-  var contextMenuShowing = false;
-
-  d3.select("body").on('click', function() {
-    if(contextMenuShowing) {
-      removeContextMenu();
-    }
-  });
-
-  var removeContextMenu = function() {
-      d3.event.preventDefault();
-      d3.select(".popup").remove();
-      contextMenuShowing = false;
-  };
-
-  self.contextMenu = function contextMenu(_that, data) {
-    if(contextMenuShowing) {
-      removeContextMenu();
-    } else {
-      d3.event.preventDefault();
-
-      var canvas = d3.select("kubernetes-topology-graph");
-      var mousePosition = d3.mouse(canvas.node());
-
-      var popup = canvas.append("div")
-          .attr("class", "popup")
-          .style("left", mousePosition[0] + "px")
-          .style("top", mousePosition[1] + "px");
-      popup.append("h5").text("Actions on " + data.item.display_kind);
-
-      buildContextMenuOptions(popup, data);
-
-      var canvasSize = [
-        canvas.node().offsetWidth,
-        canvas.node().offsetHeight
-      ];
-
-      var popupSize = [
-        popup.node().offsetWidth,
-        popup.node().offsetHeight
-      ];
-
-      if (popupSize[0] + mousePosition[0] > canvasSize[0]) {
-        popup.style("left", "auto");
-        popup.style("right", 0);
-      }
-
-      if (popupSize[1] + mousePosition[1] > canvasSize[1]) {
-        popup.style("top", "auto");
-        popup.style("bottom", 0);
-      }
-      contextMenuShowing = !contextMenuShowing;
-    }
-  };
-
-  var buildContextMenuOptions = function(popup, data) {
-    if (data.item.kind == "Tag") {
-      return false;
-    }
-
-    topologyService.addContextMenuOption(popup, "Go to summary page", data, self.dblclick);
-  };
 
   $scope.$on("render", function(ev, vertices, added) {
     /*
@@ -211,13 +151,6 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService,
     /* Don't do default rendering */
     ev.preventDefault();
   });
-
-  this.dblclick = function dblclick(d) {
-    if (d.item.kind == "Tag") {
-      return false;
-    }
-    window.location.assign(topologyService.geturl(d));
-  };
 
   this.getIcon = function getIcon(d) {
     switch(d.item.kind) {

--- a/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
@@ -10,6 +10,8 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
   $scope.d3 = d3;
   var icons;
 
+  topologyService.mixinContextMenu(this, $scope);
+
   $scope.refresh = function() {
     var id;
     if ($location.absUrl().match('show/$') || $location.absUrl().match('show$')) {
@@ -51,6 +53,9 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
       })
       .attr('class', function(d) {
         return topologyService.getItemStatusClass(d);
+      })
+      .on('contextmenu', function(d) {
+        self.contextMenu(this, d);
       });
     added.append('title');
     added.on('dblclick', function(d) {
@@ -72,6 +77,9 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
       })
       .attr('width', function(d) {
         return self.getCircleDimensions(d).width;
+      })
+      .on('contextmenu', function(d) {
+        self.contextMenu(this, d);
       });
 
     // attached labels
@@ -105,6 +113,9 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
             .attr('style', 'font-size: 20px;' + fontFamily)
             .attr('y', 7);
         }
+      })
+      .on('contextmenu', function(d) {
+        self.contextMenu(this, d);
       });
 
     added.selectAll('title').text(function(d) {
@@ -125,10 +136,6 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     }
 
     return icons[d.item.display_kind];
-  };
-
-  self.dblclick = function dblclick(d) {
-    window.location.assign(topologyService.geturl(d));
   };
 
   self.getCircleDimensions = function getCircleDimensions(d) {

--- a/app/assets/javascripts/controllers/topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/network_topology_controller.js
@@ -11,6 +11,8 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
   var d3 = window.d3;
   $scope.d3 = d3;
 
+  topologyService.mixinContextMenu(this, $scope);
+
   $scope.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
@@ -39,68 +41,6 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
   $scope.$on('$destroy', function() {
     $interval.cancel(promise);
   });
-
-  var contextMenuShowing = false;
-
-  d3.select("body").on('click', function() {
-    if(contextMenuShowing) {
-      removeContextMenu();
-    }
-  });
-
-  var removeContextMenu = function() {
-      d3.event.preventDefault();
-      d3.select(".popup").remove();
-      contextMenuShowing = false;
-  };
-
-  self.contextMenu = function contextMenu(_that, data) {
-    if(contextMenuShowing) {
-      removeContextMenu();
-    } else {
-      d3.event.preventDefault();
-
-      var canvas = d3.select("kubernetes-topology-graph");
-      var mousePosition = d3.mouse(canvas.node());
-
-      var popup = canvas.append("div")
-          .attr("class", "popup")
-          .style("left", mousePosition[0] + "px")
-          .style("top", mousePosition[1] + "px");
-      popup.append("h5").text("Actions on " + data.item.display_kind);
-
-      buildContextMenuOptions(popup, data);
-
-      var canvasSize = [
-        canvas.node().offsetWidth,
-        canvas.node().offsetHeight
-      ];
-
-      var popupSize = [
-        popup.node().offsetWidth,
-        popup.node().offsetHeight
-      ];
-
-      if (popupSize[0] + mousePosition[0] > canvasSize[0]) {
-        popup.style("left", "auto");
-        popup.style("right", 0);
-      }
-
-      if (popupSize[1] + mousePosition[1] > canvasSize[1]) {
-        popup.style("top", "auto");
-        popup.style("bottom", 0);
-      }
-      contextMenuShowing = !contextMenuShowing;
-    }
-  };
-
-  var buildContextMenuOptions = function(popup, data) {
-    if (data.item.kind == "Tag") {
-      return false;
-    }
-
-    topologyService.addContextMenuOption(popup, "Go to summary page", data, self.dblclick);
-  };
 
   $scope.$on("render", function(ev, vertices, added) {
     /*
@@ -211,13 +151,6 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
     /* Don't do default rendering */
     ev.preventDefault();
   });
-
-  this.dblclick = function dblclick(d) {
-    if (d.item.kind == "Tag") {
-      return false;
-    }
-    window.location.assign(topologyService.geturl(d));
-  };
 
   this.getIcon = function getIcon(d) {
     switch(d.item.kind) {

--- a/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
@@ -11,6 +11,8 @@ function physicalInfraTopologyCtrl($scope, $http, $interval, $location, topology
   var d3 = window.d3;
   $scope.d3 = d3;
 
+  topologyService.mixinContextMenu(this, $scope);
+
   $scope.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
@@ -39,68 +41,6 @@ function physicalInfraTopologyCtrl($scope, $http, $interval, $location, topology
   $scope.$on('$destroy', function() {
     $interval.cancel(promise);
   });
-
-  var contextMenuShowing = false;
-
-  d3.select("body").on('click', function() {
-    if(contextMenuShowing) {
-      removeContextMenu();
-    }
-  });
-
-  var removeContextMenu = function() {
-    d3.event.preventDefault();
-    d3.select(".popup").remove();
-    contextMenuShowing = false;
-  };
-
-  self.contextMenu = function contextMenu(_that, data) {
-    if(contextMenuShowing) {
-      removeContextMenu();
-    } else {
-      d3.event.preventDefault();
-
-      var canvas = d3.select("kubernetes-topology-graph");
-      var mousePosition = d3.mouse(canvas.node());
-
-      var popup = canvas.append("div")
-        .attr("class", "popup")
-        .style("left", mousePosition[0] + "px")
-        .style("top", mousePosition[1] + "px");
-      popup.append("h5").text("Actions on " + data.item.display_kind);
-
-      buildContextMenuOptions(popup, data);
-
-      var canvasSize = [
-        canvas.node().offsetWidth,
-        canvas.node().offsetHeight
-      ];
-
-      var popupSize = [
-        popup.node().offsetWidth,
-        popup.node().offsetHeight
-      ];
-
-      if (popupSize[0] + mousePosition[0] > canvasSize[0]) {
-        popup.style("left", "auto");
-        popup.style("right", 0);
-      }
-
-      if (popupSize[1] + mousePosition[1] > canvasSize[1]) {
-        popup.style("top", "auto");
-        popup.style("bottom", 0);
-      }
-      contextMenuShowing = !contextMenuShowing;
-    }
-  };
-
-  var buildContextMenuOptions = function(popup, data) {
-    if (data.item.kind == "Tag") {
-      return false;
-    }
-
-    topologyService.addContextMenuOption(popup, __("Go to summary page"), data, self.dblclick);
-  };
 
   $scope.$on("render", function(ev, vertices, added) {
     /*
@@ -211,13 +151,6 @@ function physicalInfraTopologyCtrl($scope, $http, $interval, $location, topology
     /* Don't do default rendering */
     ev.preventDefault();
   });
-
-  this.dblclick = function dblclick(d) {
-    if (d.item.kind == "Tag") {
-      return false;
-    }
-    window.location.assign(topologyService.geturl(d));
-  };
 
   this.getIcon = function getIcon(d) {
     switch(d.item.kind) {


### PR DESCRIPTION
Removing some copy-pasted code that wasn't copy-pasted to the middleware screens. It has been moved to a mixin and also introduced on the middleware topology screen.
![duplicate](https://cloud.githubusercontent.com/assets/649130/25744469/5f560090-319a-11e7-805b-65420fecc0e0.gif)

Pivotal story: https://www.pivotaltracker.com/story/show/143239019

@miq-bot add_label refactoring, topology, fine/no
@miq-bot assign @himdel