### PR TITLE
Fix unknown errors for image-based icons in middleware topology

### DIFF
--- a/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
@@ -56,10 +56,11 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     added.on('dblclick', function(d) {
       return self.dblclick(d);
     });
+
     added.append('image')
       .attr('xlink:href', function(d) {
         var iconInfo = self.getIcon(d);
-        return (iconInfo.type == 'glyph' ? '' : iconInfo.icon);
+        return (iconInfo.type == 'glyph' ? null : iconInfo.icon);
       })
       .attr('y', function(d) {
         return self.getCircleDimensions(d).y;


### PR DESCRIPTION
This is happening in development only. If D3 receives an empty string as a path to an image, it tries to render it and makes the browser sad :sob: 

![screenshot from 2017-05-05 14-27-20](https://cloud.githubusercontent.com/assets/649130/25745410/0129e572-319f-11e7-9eff-ebec629a603a.png)

However, if the path is `null`, D3 will ignore the element and the browser will be happy :tada:

@miq-bot add_label bug, topology, fine/no
@miq-bot assign @himdel 