### PR TITLE
Remove association for template only

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1596,6 +1596,9 @@ class ApplicationController < ActionController::Base
   end
 
   def get_db_view(db, options = {})
+    if db == "ManageIQ_Providers_InfraManager_Template" && options[:association] == "all_vms_and_templates"
+      options[:association] = nil
+    end
     MiqReport.load_from_view_options(db, current_user, options, db_view_yaml_cache)
   end
 


### PR DESCRIPTION
### Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/1270
To check this navigate to `Compute` -> `Infrastructure` -> `Virtual machines` expand `Templates` and click on one template. While being on detail of said template click in toolbar `Configuration` -> `Set Ownership`