### PR TITLE
Removed incorrect class from compare button.

### DIFF
--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -34,8 +34,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Compare Selected items'),
           :url_parms => "main_div",
           :enabled   => false,
-          :onwhen    => "2+",
-          :klass     => ApplicationHelper::Button::InstanceCheckCompare),
+          :onwhen    => "2+"),
         separator,
         button(
           :instance_edit,

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -20,9 +20,8 @@ describe OrchestrationStackController do
         get :show, :params => {:id => record.id, :display => "instances"}
       end
 
-      it 'does not render compliance check and comparison buttons' do
+      it 'does not render compliance check button' do
         expect(response.body).not_to include('instance_check_compliance')
-        expect(response.body).not_to include('instance_compare')
       end
 
       it "renders the listnav" do


### PR DESCRIPTION
Removed accidentally added incorrect class to Cloud Instance Compare button in sha ef3b49d88bb14ed8cb011ef0f903c7ae5e0663af

https://bugzilla.redhat.com/show_bug.cgi?id=1447971

before
![before](https://cloud.githubusercontent.com/assets/3450808/25749775/a48c4cb8-317d-11e7-801d-e68b62a7b2e1.png)

after
![after](https://cloud.githubusercontent.com/assets/3450808/25749777/a7d6af1c-317d-11e7-92a3-4c4a744f1fc9.png)

@dclarizio please review.