### PR TITLE
Add groups for PhysicalServer#show page

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -33,7 +33,9 @@ class PhysicalServerController < ApplicationController
   end
 
   def textual_group_list
-    []
+    [
+      %i(properties relationships),
+    ]
   end
   helper_method :textual_group_list
 end


### PR DESCRIPTION
This Pull Request add the groups in physical server controller to show in Physical Server summary page.

Adds the following groups:

- properties;
- relationships;

Depends on: https://github.com/ManageIQ/manageiq-ui-classic/pull/1295 https://github.com/ManageIQ/manageiq-ui-classic/pull/1281