### PR TITLE
Refactor Textual Summary archtecture

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -1,10 +1,16 @@
 module PhysicalServerHelper::TextualSummary
   def textual_group_properties
-    %i(name model product_name manufacturer machine_type serial_number ems_ref)
+    TextualGroup.new(
+      _("Properties"),
+      %i(name model product_name manufacturer machine_type serial_number ems_ref)
+    )
   end
 
   def textual_group_relationships
-    %i(host)
+    TextualGroup.new(
+      _("Relationships"),
+      %i(host)
+    )
   end
 
   def textual_group_compliance


### PR DESCRIPTION
This Pull Request makes changes in:

- app/helpers/physical_server_helper/textual_summary.rb

In order to appear Physical Server summary page with the following properties:

- name 
- model
- product_name
- manufacturer
- machine_type
- serial_number
- ems_ref (UUID)

Depends on:
- https://github.com/ManageIQ/manageiq-ui-classic/pull/1281 

![captura de tela de 2017-05-05 13-14-32](https://cloud.githubusercontent.com/assets/17187082/25754156/a15411b8-3194-11e7-9f31-3b4da01e51dc.png)

