### PR TITLE
Display summary tags for the ansible playbook services

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -137,7 +137,7 @@ class ServiceController < ApplicationController
 
   def textual_group_list
     if @record.type == "ServiceAnsiblePlaybook"
-      [%i(properties), %i(lifecycle)]
+      [%i(properties), %i(lifecycle tags)]
     else
       [%i(properties lifecycle relationships miq_custom_attributes), %i(vm_totals tags)]
     end

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -67,5 +67,17 @@ describe ServiceController do
     end
   end
 
+  context "#show" do
+    render_views
+
+    it 'contains the associated tags for the ansible service template' do
+      EvmSpecHelper.local_miq_server
+      record = FactoryGirl.create(:service_ansible_playbook)
+      get :explorer, :params => { :id => "s-#{record.id}" }
+      expect(response.status).to eq(200)
+      expect(response.body).to include('Smart Management')
+    end
+  end
+
   it_behaves_like "explorer controller with custom buttons"
 end


### PR DESCRIPTION
Display tags for the ansible playbook services in the summary screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1448291

![screenshot from 2017-05-05 17-11-24](https://cloud.githubusercontent.com/assets/12769982/25764482/065e398c-31b6-11e7-9c5b-d9d2abe865ce.png)
