### PR TITLE
Add feature buttons for physical server toolbar 

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -36,4 +36,7 @@ class PhysicalServerController < ApplicationController
     []
   end
   helper_method :textual_group_list
+
+  def button
+  end
 end

--- a/app/helpers/application_helper/toolbar/physical_server_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_server_center.rb
@@ -1,0 +1,83 @@
+class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'physical_server_operations',
+    [
+      select(
+        :physical_server_power_choice,
+        'fa fa-power-off fa-lg',
+        N_('Power Functions'),
+        N_('Power'),
+        :items => [
+          button(
+            :physical_server_power_on,
+            nil,
+            N_('Power on the server'),
+            N_('Power On'),
+            :image     => "power_on",
+            :url_parms => "main_div",
+            :confirm   => N_("Power on the server?"),
+            :options   => {:feature => :power_on}
+          ),
+          button(
+            :physical_server_power_off,
+            nil,
+            N_('Power off the server'),
+            N_('Power Off'),
+            :image     => "power_off",
+            :url_parms => "main_div",
+            :confirm   => N_("Power off the server?"),
+            :options   => {:feature => :power_off}
+          ),
+          button(
+            :physical_server_restart,
+            nil,
+            N_('Restart the server'),
+            N_('Restart'),
+            :image     => "power_reset",
+            :url_parms => "main_div",
+            :confirm   => N_("Restart the server?"),
+            :options   => {:feature => :restart}
+          ),
+        ]
+      ),
+      select(
+        :physical_server_identify_choice,
+        nil,
+        N_('Identify LED Operations'),
+        N_('Identify'),
+        :items => [
+          button(
+            :physical_server_blink_loc_led,
+            nil,
+            N_('Blink the Identify LED'),
+            N_('Blink LED'),
+            :image     => "blank_button",
+            :url_parms => "main_div",
+            :confirm   => N_("Blink the Identify LED?"),
+            :options   => {:feature => :blink_loc_led}
+          ),
+          button(
+            :physical_server_turn_on_loc_led,
+            nil,
+            N_('Turn on the Idenfity LED'),
+            N_('Turn On LED'),
+            :image     => "blank_button",
+            :url_parms => "main_div",
+            :confirm   => N_("Turn on the Identify LED?"),
+            :options   => {:feature => :turn_on_loc_led}
+          ),
+          button(
+            :physical_server_turn_off_loc_led,
+            nil,
+            N_('Turn off the Identify LED'),
+            N_('Turn Off LED'),
+            :image     => "blank_button",
+            :url_parms => "main_div",
+            :confirm   => N_("Turn off the Identify LED?"),
+            :options   => {:feature => :turn_off_loc_led}
+          ),
+        ]
+      ),
+    ]
+  )
+end

--- a/app/helpers/application_helper/toolbar/physical_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_servers_center.rb
@@ -1,0 +1,95 @@
+class ApplicationHelper::Toolbar::PhysicalServersCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'physical_servers_operations',
+    [
+      select(
+        :physical_server_power_choice,
+        'fa fa-power-off fa-lg',
+        N_('Power Operations'),
+        N_('Power'),
+        :items => [
+          button(
+            :physical_server_power_on,
+            nil,
+            N_('Power on the selected servers'),
+            N_('Power On'),
+            :image     => "power_on",
+            :url_parms => "main_div",
+            :confirm   => N_("Power on the selected servers?"),
+            :enabled   => false,
+            :onwhen    => "1+",
+            :options   => {:feature => :power_on}
+          ),
+          button(
+            :physical_server_power_off,
+            nil,
+            N_('Power off the selected servers'),
+            N_('Power Off'),
+            :image     => "power_off",
+            :url_parms => "main_div",
+            :confirm   => N_("Power off the selected servers?"),
+            :enabled   => false,
+            :onwhen    => "1+",
+            :options   => {:feature => :power_off}
+          ),
+          button(
+            :physical_server_restart,
+            nil,
+            N_('Restart the selected servers'),
+            N_('Restart'),
+            :image     => "power_reset",
+            :url_parms => "main_div",
+            :confirm   => N_("Restart the selected servers?"),
+            :enabled   => false,
+            :onwhen    => "1+",
+            :options   => {:feature => :restart}
+          ),
+        ]
+      ),
+      select(
+        :physical_server_identify_choice,
+        nil,
+        N_('Identify LED Operations'),
+        N_('Identify'),
+        :items => [
+          button(
+            :physical_server_blink_loc_led,
+            nil,
+            N_('Blink the Identify LED'),
+            N_('Blink LED'),
+            :image     => "blank_button",
+            :url_parms => "main_div",
+            :confirm   => N_("Blink the Identify LED?"),
+            :enabled   => false,
+            :onwhen    => "1+",
+            :options   => {:feature => :blink_loc_led}
+          ),
+          button(
+            :physical_server_turn_on_loc_led,
+            nil,
+            N_('Turn on the Idenfity LED'),
+            N_('Turn On LED'),
+            :image     => "blank_button",
+            :url_parms => "main_div",
+            :confirm   => N_("Turn on the Identify LED?"),
+            :enabled   => false,
+            :onwhen    => "1+",
+            :options   => {:feature => :turn_on_loc_led}
+          ),
+          button(
+            :physical_server_turn_off_loc_led,
+            nil,
+            N_('Turn off the Identify LED'),
+            N_('Turn Off LED'),
+            :image     => "blank_button",
+            :url_parms => "main_div",
+            :confirm   => N_("Turn off the Identify LED?"),
+            :enabled   => false,
+            :onwhen    => "1+",
+            :options   => {:feature => :turn_off_loc_led}
+          ),
+        ]
+      ),
+    ]
+  )
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -527,6 +527,7 @@ class ApplicationHelper::ToolbarChooser
               middleware_messaging
               orchestration_stack
               physical_infra_topology
+              physical_server
               resource_pool
               container_template
               ems_block_storage


### PR DESCRIPTION
This pull request implements buttons features and view settings for physical server toolbar:

- app/helpers/application_helper/physical_server_center.rb
- app/helpers/application_helper/physical_servers_center.rb
And the feature buttons:

- app/helpers/application_helper/button/physical_server_feature_button.rb
- app/helpers/application_helper/button/physical_server_feature_button_with_disable.rb

Implemented for PhysicalServer#show and PhysicalServer#show_list

Depends on the actions implemented in https://github.com/ManageIQ/manageiq-ui-classic/pull/1298

![](https://cloud.githubusercontent.com/assets/17187082/25661897/d7eefe34-2fe8-11e7-9ef2-ddc3ffb74b31.png)