### PR TITLE
Add new fields to middleware Add JDBC Driver Dialog for XA JDBC Driver

### DIFF
--- a/app/assets/javascripts/controllers/middleware_jdbc_driver/middleware_jdbc_driver_controller.js
+++ b/app/assets/javascripts/controllers/middleware_jdbc_driver/middleware_jdbc_driver_controller.js
@@ -17,6 +17,8 @@ function MwAddJdbcDriverController($scope, $http, miqService) {
     fd.append('driverName', data.driverName);
     fd.append('moduleName', data.moduleName);
     fd.append('driverClass', data.driverClass);
+    fd.append('driverXaDatasourceClassName', data.driverXaDatasourceClassName);
+    fd.append('jdbcCompliant', data.jdbcCompliant);
     if (data.majorVersion) {
       fd.append('majorVersion', data.majorVersion);
     }

--- a/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
+++ b/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
@@ -127,25 +127,21 @@ function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, i
   $scope.resetJdbcDriverForm = function() {
     $scope.jdbcDriverModel = {};
     $scope.jdbcDriverModel.serverId = angular.element('#server_id').val();
-    $scope.jdbcDriverModel.xaDatasource = true;
-    $scope.jdbcDriverModel.datasources = mwAddDatasourceService.getXaDatasources();
-    $scope.jdbcDriverModel.selectedDatasource = undefined;
+    $scope.jdbcDriverModel.jdbcCompliant = true;
+    $scope.jdbcDriverModel.driverXaDatasourceClassName = '';
+    $scope.jdbcDriverModel.databases = mwAddDatasourceService.getDatasources();
+    $scope.jdbcDriverModel.selectedDatabase = undefined;
     angular.element('#jdbc_add_div :file#jdbc_driver_file').val('');
     angular.element('#jdbc_add_div input[type="text"]:disabled').val('');
     $scope.$broadcast('mwAddJdbcDriverReset');
   };
 
-  $scope.onDriverXaChange = function() {
-    if ($scope.jdbcDriverModel) {
-      $scope.jdbcDriverModel.datasources = mwAddDatasourceService.getDatasources($scope.jdbcDriverModel.xaDatasource);
-    }
-  };
-
-  $scope.$watch('jdbcDriverModel.selectedDatasource', function(newValue) {
+  $scope.$watch('jdbcDriverModel.selectedDatabase', function(newValue) {
     if (newValue) {
       $scope.jdbcDriverModel.driverName = newValue.driverName;
       $scope.jdbcDriverModel.moduleName = newValue.driverModuleName;
       $scope.jdbcDriverModel.driverClass = newValue.driverClass;
+      $scope.jdbcDriverModel.driverXaDatasourceClassName = '';
     }
   });
 

--- a/app/views/middleware_server/_add_jdbc_driver.html.haml
+++ b/app/views/middleware_server/_add_jdbc_driver.html.haml
@@ -29,24 +29,15 @@
               = render :partial => "shared/file_chooser",
                        :locals => {:object_name => "jdbc_driver", :method => "file", :custom_options => {"ng-required" => "true", "ng-model" => "jdbcDriverModel.filePath", "require-file" => "handle"}}
 
-          .form-group
-            %label.col-md-4.control-label{:for => "xa_driver_ds_cb"}
-              = _("XA Datasource:")
-            .col-md-8
-              %input#xa_driver_ds_cb{:type      => "checkbox",
-                              "bs-switch"       => "",
-                              "switch-on-text"  => _("Yes"),
-                              "switch-off-text" => _("No"),
-                              "switch-change"   => "onDriverXaChange()",
-                              "ng-model"        => "jdbcDriverModel.xaDatasource"}
+
 
           .form-group
             %label.col-md-4.control-label{:for => "choose_datasource_input"}
-              = _("Datasource:")
+              = _("Database Template:")
             .col-md-8
-              %select.form-control#chooose_driver_ds{"name"        => "choose_driver_ds_input",
-                                                     "ng-model"    => "jdbcDriverModel.selectedDatasource",
-                                                     "ng-options"  => "c.label for c in jdbcDriverModel.datasources track by c.id",
+              %select.form-control#chooose_driver_db{"name"        => "choose_driver_db_input",
+                                                     "ng-model"    => "jdbcDriverModel.selectedDatabase",
+                                                     "ng-options"  => "c.label for c in jdbcDriverModel.databases track by c.id",
                                                      "ng-required" => "false"}
 
           .form-group
@@ -90,11 +81,21 @@
                                                           "ng-required"  => "true",
                                                           "placeholder"  => _("Enter JDBC Driver Class"),
                                                           "ng-model"     => "jdbcDriverModel.driverClass"}
-
             .col-sm-2
             .col-sm-10
               %p.ng-error-messages{"ng-show" => "jdbcAddForm.jdbc_driver_class_input.$dirty && jdbcAddForm.jdbc_driver_class_input.$error.required"}
                 = _("Required")
+
+          .form-group
+            %label.col-md-4.control-label{:for => "jdbc_xa_driver_class_input"}
+              = _(" Driver XA Datasource Class")
+            .col-md-8
+              %input.form-control#driver_xa_datasource_class_name_input{:type       => "text",
+                                                          "name"         => "driver_xa_datasource_class_name_input",
+                                                          "ng-disabled"  => "!jdbcDriverModel.filePath",
+                                                          "placeholder"  => _("Enter Driver XA Driver Class"),
+                                                          "ng-model"     => "jdbcDriverModel.xaDriverClass"}
+
 
           .form-group
             %label.col-md-4.control-label{:for => "major_version_input"}
@@ -115,6 +116,16 @@
                                                       "ng-disabled" => "!jdbcDriverModel.filePath",
                                                       "placeholder" => _("Enter Minor Version"),
                                                       "ng-model"    => "jdbcDriverModel.minorVersion"}
+
+          .form-group
+            %label.col-md-4.control-label{:for => "jdbc_compliant_cb"}
+              = _("JDBC Compliant :")
+            .col-md-8
+              %input#jdbc_compliant_cb{:type    => "checkbox",
+                              "bs-switch"       => "",
+                              "switch-on-text"  => _("Yes"),
+                              "switch-off-text" => _("No"),
+                              "ng-model"        => "jdbcDriverModel.jdbcCompliant"}
 
         .modal-footer
           %button.btn.btn-default.dialog-cancel-button{:type => "button",


### PR DESCRIPTION
While we have had XA Datasource working we have found some issues with XA JDBC Driver creation. This and couple other backend PRs address the issue. The original premise was that the JDBC Driver was associated with either a XA or non-XA driver jar (just like Datasources are *either* XA or non-XA but not both).  However, the JDBC driver (jar) support non-XA and *can also* support XA optionally. So one driver *can* support both.

<img width="592" alt="jdbc-driver-xa" src="https://cloud.githubusercontent.com/assets/1312165/25768298/ca92f37e-31b6-11e7-9130-fb3f234f3ff5.png">

- [x] Add new fields to UI
- [x] Add new fields to JSON transfer with backend
- [ ] End to End, Testing with new Hawkular Services with backend changes (once new Hawkular Services available)

### Links

- https://bugzilla.redhat.com/show_bug.cgi?id=1447925

- https://issues.jboss.org/browse/HWKAGENT-174






