### PR TITLE
Fix the storage manager id for cloud volume views

### DIFF
--- a/app/views/cloud_object_store_container/new.html.haml
+++ b/app/views/cloud_object_store_container/new.html.haml
@@ -61,5 +61,5 @@
   = render :partial => "layouts/angular/generic_form_buttons"
 
 :javascript
-  ManageIQ.angular.app.value('storageManagerId', '#{@storage_manager.try(:id)}');
+  ManageIQ.angular.app.value('storageManagerId', #{@storage_manager.try(:id) || "undefined"});
   miq_bootstrap('#form_div');

--- a/app/views/cloud_volume/attach.html.haml
+++ b/app/views/cloud_volume/attach.html.haml
@@ -51,5 +51,5 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
+  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
   miq_bootstrap('#form_div');

--- a/app/views/cloud_volume/backup_new.html.haml
+++ b/app/views/cloud_volume/backup_new.html.haml
@@ -49,5 +49,5 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
+  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
   miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_volume/backup_select.html.haml
+++ b/app/views/cloud_volume/backup_select.html.haml
@@ -39,5 +39,5 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
+  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
   miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_volume/detach.html.haml
+++ b/app/views/cloud_volume/detach.html.haml
@@ -36,5 +36,5 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
+  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
   miq_bootstrap('#form_div');

--- a/app/views/cloud_volume/edit.html.haml
+++ b/app/views/cloud_volume/edit.html.haml
@@ -13,5 +13,5 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
+  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
   miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -11,5 +11,5 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id || "new"}');
-  ManageIQ.angular.app.value('storageManagerId', '#{@storage_manager.try(:id)}');
+  ManageIQ.angular.app.value('storageManagerId', #{@storage_manager.try(:id) || "undefined"});
   miq_bootstrap('#form_div');

--- a/app/views/cloud_volume/snapshot_new.html.haml
+++ b/app/views/cloud_volume/snapshot_new.html.haml
@@ -39,5 +39,5 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id}');
+  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
   miq_bootstrap(jQuery('#form_div'));


### PR DESCRIPTION
Instead of passing the ID of a storage manager from ruby to JS
controller as a string, this patch provides them as numbers (int). This
should help selecting the storage manager if it is provided by the
controller and should be fixed (for example, when creating a new cloud
volume for a specific storage manager or when editing an existing cloud
volume).

@AparnaKarve What do you think about this solution? Previously, I was passing the ID as string because I didn't know that raw number would also work (all other code I think was using strings). This patch now works for all three cases:

* creating new cloud volume with no pre-determined storage manager, i.e. visiting URL `http://localhost:3000/cloud_volume/new`

* creating cloud volume for a specific storage manager, i.e. `http://localhost:3000/cloud_volume/new?storage_manager_id=23`

* editing existing cloud volume

/cc @tzumainn I would appreciate if you could test your QE test that identified the problem with `|number` ([PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/1292))