### PR TITLE
Hawkular hostname detection changes

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -276,6 +276,14 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     }
   };
 
+  $scope.isDetectionEnabled = function() {
+    return ($scope.currentTab == "hawkular" && $scope.emsCommonModel.ems_controller == "ems_container") &&
+      ($scope.emsCommonModel.emstype == "openshift") &&
+      ($scope.emsCommonModel.default_hostname && $scope.emsCommonModel.default_api_port) &&
+      ($scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid) &&
+      ($scope.emsCommonModel.default_verify != '' && $scope.angularForm.default_verify.$valid);
+  };
+
   var emsCommonEditButtonClicked = function(buttonName, _serializeFields, $event) {
     miqService.sparkleOn();
     var url = $scope.updateUrl + '?button=' + buttonName;
@@ -316,6 +324,16 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     if ($scope.emsCommonModel[authStatus] === true) {
       $scope.postValidationModelRegistry($scope.currentTab);
     }
+  };
+
+  $scope.detectClicked = function($event) {
+    miqService.sparkleOn();
+    miqService.detectWithRest($event, $scope.actionUrl)
+      .then(function success(data) {
+        $scope.updateHawkularHostname(data.hostname);
+        miqService.miqFlash(data.level, data.message);
+        miqSparkleOff();
+      });
   };
 
   $scope.saveClicked = function($event, formSubmit) {
@@ -530,6 +548,10 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
   $scope.updateAuthStatus = function(updatedValue) {
     $scope.angularForm[$scope.authType + '_auth_status'].$setViewValue(updatedValue);
+  };
+
+  $scope.updateHawkularHostname = function(value) {
+    $scope.emsCommonModel.hawkular_hostname = value;
   };
 
   $scope.radioSelectionChanged = function() {

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -75,6 +75,12 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', 'API'
     }, 200);
   };
 
+  this.detectWithRest = function($event, url) {
+    angular.element('#button_name').val('detect');
+    miqSparkleOn();
+    return $q.when(miqRESTAjaxButton(url, $event.target, 'json'));
+  };
+
   this.validateWithAjax = function (url) {
     miqSparkleOn();
     miqAjaxButton(url, true);

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -37,6 +37,60 @@ class EmsContainerController < ApplicationController
     ems_form_fields
   end
 
+  def update
+    assert_privileges("#{permission_prefix}_edit")
+    if params[:button] == "detect"
+      update_ems_button_detect
+    else
+      super
+    end
+  end
+
+  def create
+    assert_privileges("#{permission_prefix}_new")
+    if params[:button] == "detect"
+      create_ems_button_detect
+    else
+      super
+    end
+  end
+
+  def create_ems_button_detect
+    ems = model.model_from_emstype(params[:emstype]).new
+    update_ems_button_detect(ems)
+  end
+
+  def update_ems_button_detect(verify_ems = nil)
+    verify_ems ||= find_record_with_rbac(model, params[:id])
+    set_ems_record_vars(verify_ems, :validate)
+    @in_a_form = true
+
+    result, details = get_hostname_from_routes(verify_ems)
+    if result
+      add_flash(_("Hawkular Route Detection: success"))
+    else
+      add_flash(_("Hawkular Route Detection: failure [%{details}]") % {:details => details}, :error)
+    end
+
+    render :json => {
+      :message  => @flash_array.last[:message],
+      :level    => @flash_array.last[:level],
+      :hostname => result
+    }
+  end
+
+  # TODO: move to backend
+  def get_hostname_from_routes(ems)
+    return nil, "Route detection not applicable for provider type" unless ems.class.respond_to?(:openshift_connect)
+    [
+      ems.connect(:service => :openshift).get_route('hawkular-metrics', 'openshift-infra').try(:spec).try(:host),
+      nil
+    ]
+  rescue StandardError => e
+    $log.warn("MIQ(#{controller_name}_controller-#{action_name}): get_hostname_from_routes error: #{e.message}")
+    [nil, e.message]
+  end
+
   def retrieve_metrics_selection
     @ems.endpoints.count == 1 ? 'hawkular_disabled' : 'hawkular_enabled'
   end

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -3,6 +3,7 @@
 - ng_reqd_hostname ||= true
 - ng_reqd_api_port ||= true
 - ng_reqd_db_name ||= false
+- detection ||= false
 
 %div{"ng-if" => defined?(security_protocol_hide) ? false : true}
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_security_protocol.$invalid}",
@@ -82,6 +83,17 @@
         = _("Required")
       %span.help-block{"ng-show" => "angularForm.#{prefix}_hostname.$error.detectedSpaces"}
         = _("Spaces are prohibited")
+
+    - detect = "detectClicked({target: '.detect_button'})"
+    %span
+      %miq-button.detect_button{"ng-if" => detection ? 'true' : 'false',
+                  :name            => _("Detect"),
+                  "on-click"       => detect,
+                  :enabled         => "isDetectionEnabled()",
+                  "disabled-title" => _("Required information missing"),
+                  "enabled-title"  => _("Detect Endpoint"),
+                  :xs              => 'true',
+                  :primary         => 'true'}
 
 %div{"ng-if" => defined?(apiport_hide) ? false : true}
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_api_port.$invalid}",

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -289,7 +289,8 @@
                                                 :id                     => record.id,
                                                 :ng_reqd_hostname       => "true",
                                                 :ng_reqd_api_port       => "true",
-                                                :prefix                 => "hawkular"}
+                                                :prefix                 => "hawkular",
+                                                :detection              => true}
               = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                          :locals  => {:ng_show           => true,
                                       :ng_model          => ng_model.to_s,


### PR DESCRIPTION
In container providers, before this change, if the hostname of a Hawkular endpoint is empty upon submission - we will attempt to detect it from a route leading to it in OpenShift. There is no indication to the user on the detection and no way of seeing the detected value pre submission.

This PR moves detection to be a button that only fills the form value.

no default hostname/port to use for detection - detect button is disabled
![manageiq containers providers](https://cloud.githubusercontent.com/assets/3010449/25803983/3f46fcf4-3402-11e7-9e9d-fb43bf12dfee.png)

detection available
![detection_available](https://cloud.githubusercontent.com/assets/3010449/25804040/77a454d4-3402-11e7-9707-235615e03b4b.png)

after detection validate becomes enabled
![validate](https://cloud.githubusercontent.com/assets/3010449/25804054/91e6ba94-3402-11e7-9c09-eab07e895f8b.png)

bug: https://bugzilla.redhat.com/show_bug.cgi?id=1437138