### PR TITLE
Containers provider Edit: handle hawkular port being null

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -108,7 +108,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
       $scope.emsCommonModel.default_api_port                = data.default_api_port !== undefined && data.default_api_port !== '' ? data.default_api_port.toString() : $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
       $scope.emsCommonModel.amqp_api_port                   = data.amqp_api_port !== undefined && data.amqp_api_port !== '' ? data.amqp_api_port.toString() : '5672';
-      $scope.emsCommonModel.hawkular_api_port               = data.hawkular_api_port !== undefined && data.hawkular_api_port !== '' ? data.hawkular_api_port.toString() : '443';
+      $scope.emsCommonModel.hawkular_api_port               = data.hawkular_api_port !== undefined && data.hawkular_api_port !== null && data.hawkular_api_port !== '' ? data.hawkular_api_port.toString() : '443';
       $scope.emsCommonModel.metrics_api_port                = data.metrics_api_port !== undefined && data.metrics_api_port !== '' ? data.metrics_api_port.toString() : '';
       $scope.emsCommonModel.metrics_database_name           = data.metrics_database_name !== undefined && data.metrics_database_name !== '' ? data.metrics_database_name : data.metrics_default_database_name;
       $scope.emsCommonModel.api_version                     = data.api_version;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1432070

- As a quirk of the way filling Hawkular endpoint was "optional" before #1172,
  it was possible to edit the port of a new provider, including leaving it blank, and still save.
  Such a provider was got port = null in DB (not sure why not "", but reproduced it).
  This should not be possible for new providers after #1172.

- We still need a way to Edit such existing providers.
  This PR makes Edit not crash but display port 443 (and save it upon Save).

before:
![port-null-edit-crash](https://cloud.githubusercontent.com/assets/273688/25799675/a33d6e5a-33ee-11e7-9977-26a2c0706407.png)
after:
![port-null-edit-443](https://cloud.githubusercontent.com/assets/273688/25799671/9d1ec46a-33ee-11e7-8746-0a7d4d204384.png)

@miq-bot add-labels compute/containers, bug