### PR TITLE
Use sort and rbac via count_only_or_objects_filtered

### DIFF
--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -22,13 +22,12 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    count_only_or_objects(count_only,
-                          Rbac.filtered(ManageIQ::Providers::AnsibleTower::AutomationManager.order("lower(name)"),
-                                        :match_via_descendants => ConfigurationScript), "name")
+    roots = ManageIQ::Providers::AnsibleTower::AutomationManager
+    count_only_or_objects_filtered(count_only, roots, "name", :match_via_descendants => ConfigurationScript)
   end
 
   def x_get_tree_cmat_kids(object, count_only)
-    count_only_or_objects(count_only,
-                          Rbac.filtered(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.where(:manager_id => object.id)), "name")
+    scripts = ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.where(:manager_id => object.id)
+    count_only_or_objects_filtered(count_only, scripts, "name")
   end
 end

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -21,13 +21,12 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
   end
 
   def x_get_tree_stc_kids(object, count_only)
-    # TODO: may want to order in rbac and not in sql
     templates = if object.id.nil?
-                  ServiceTemplate.where(:service_template_catalog_id => nil).order("lower(name)")
+                  ServiceTemplate.where(:service_template_catalog_id => nil)
                 else
                   object.service_templates
                 end
-    count_only_or_objects(count_only, Rbac.filtered(templates), 'name')
+    count_only_or_objects_filtered(count_only, templates, 'name')
   end
 
   # Handle custom tree nodes (object is a Hash)

--- a/app/presenters/tree_builder_catalogs_class.rb
+++ b/app/presenters/tree_builder_catalogs_class.rb
@@ -5,18 +5,18 @@ class TreeBuilderCatalogsClass < TreeBuilder
   private
 
   def x_get_tree_roots(count_only, options)
-    objects = Rbac.filtered(ServiceTemplateCatalog.all).sort_by { |o| o.name.downcase }
+    objects = count_only_or_objects_filtered(count_only, ServiceTemplateCatalog.all, "name")
     case options[:type]
     when :stcat
-      return count_only_or_objects(count_only, objects)
+      objects
     when :sandt
-      return count_only_or_objects(
-        count_only,
+      if count_only
+        objects + 1
+      else
         objects.unshift(ServiceTemplateCatalog.new(
           :name        => 'Unassigned',
-          :description => 'Unassigned Catalogs')),
-         nil
-      )
+          :description => 'Unassigned Catalogs'))
+      end
     end
   end
 end

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -57,6 +57,6 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
       "otvnf" => OrchestrationTemplateVnfd,
       "otvap" => ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate
     }
-    count_only_or_objects_filtered(count_only, classes[object[:id]].where(["orderable=?", true]), "name")
+    count_only_or_objects_filtered(count_only, classes[object[:id]].where(:orderable => true), "name")
   end
 end

--- a/app/presenters/tree_builder_report_roles.rb
+++ b/app/presenters/tree_builder_report_roles.rb
@@ -31,6 +31,6 @@ class TreeBuilderReportRoles < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     user  = User.current_user
     roles = user.super_admin_user? ? MiqGroup.non_tenant_groups_in_my_region : [user.current_group]
-    count_only_or_objects(count_only, roles.sort_by { |o| o.name.downcase }, 'name')
+    count_only_or_objects(count_only, roles, 'name')
   end
 end

--- a/app/presenters/tree_builder_report_schedules.rb
+++ b/app/presenters/tree_builder_report_schedules.rb
@@ -29,6 +29,6 @@ class TreeBuilderReportSchedules < TreeBuilder
               else
                 MiqSchedule.where(:towhat => 'MiqReport', :userid => User.current_user.userid)
               end
-    count_only_or_objects(count_only, objects.sort_by { |o| o.name.downcase }, 'name')
+    count_only_or_objects(count_only, objects, 'name')
   end
 end


### PR DESCRIPTION
This is just a refactor, and should have no performance improvements.

1) `count_only_or_objects` sorts elements. No need to manually sort the data first

2) `count_only_or_objects_filtered` is our friend

```ruby
def count_only_or_objects_filtered(count_only, objects, sort_by = nil, options = {}, &block)
  count_only_or_objects(count_only, Rbac.filtered(objects, options), sort_by, &block)
end
```

These are on the following screen:

Services > Cagalog | /catalog/explorer:
- app/presenters/tree_builder_catalog_items.rb ( I had no `"Unassigned"` in my database, not able to verify this)
- app/presenters/tree_builder_catalog_class.rb ( runs both `:stcat`, `:sandt` )
- app/presenters/tree_builder_orchestration_template.rb

Cloud Intel > Reports | /report/explorer
- app/presenters/tree_builder_report_roles.rb
- app/presenters/tree_builder_report_schedules.rb

Automation > Ansible Tower > Explorer   | /automation_manager/explorer
- app/presenters/tree_builder_automation_manager_configuration_scripts.rb

I was not able to view the automation tree builder. It should be triggered by `rebuild_trees(:configuration_scripts)`, but from the ui perspective, I have no idea how to do this.
