### PR TITLE
Fix the issue with schedule time which was reset when editing provisioning request.

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -833,7 +833,7 @@ module ApplicationController::MiqRequestMethods
       if @edit[:new][:schedule_time]
         @edit[:new][:schedule_time] = format_timezone(@edit[:new][:schedule_time], Time.zone, "raw")
         @edit[:new][:start_date] = "#{@edit[:new][:schedule_time].month}/#{@edit[:new][:schedule_time].day}/#{@edit[:new][:schedule_time].year}" # Set the start date
-        if params[:id]
+        if params[:req_id]
           @edit[:new][:start_hour] = @edit[:new][:schedule_time].hour.to_s
           @edit[:new][:start_min] = @edit[:new][:schedule_time].min.to_s
         else


### PR DESCRIPTION
The key in params is called req_id instead of id with existing request.

https://bugzilla.redhat.com/show_bug.cgi?id=1374005

@miq-bot add_label bug,fine/yes,euwe/yes,darga/yes,old dialogs