### PR TITLE
Add flash message partial to ems_container/_show_dashboard

### DIFF
--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -1,4 +1,5 @@
 .container-fluid.container-tiles-pf.containers-dashboard.miq-dashboard-view{"ng-controller" => "containerDashboardController as dashboard"}
+  = render :partial => "layouts/flash_msg"
   .row.row-tile-pf
     .col-xs-12.col-sm-12.col-md-2
       .provider-card{"pf-card"         => "",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1436341

Flash message for Infra Provider was added via https://github.com/ManageIQ/manageiq-ui-classic/pull/983

Compute -> Containers -> Providers -> any provider -> set view to Dashboard -> Configuration -> Edit this Provider -> Make small change or click Cancel

Before:
<img width="1172" alt="screen shot 2017-05-09 at 9 59 17 am" src="https://cloud.githubusercontent.com/assets/9210860/25840947/4535e1ec-349e-11e7-8bab-91332706f9f6.png">

After:
<img width="1181" alt="screen shot 2017-05-09 at 9 59 37 am" src="https://cloud.githubusercontent.com/assets/9210860/25840944/41657456-349e-11e7-8599-445e25904d36.png">

@miq-bot add_label bug, fine/yes