### PR TITLE
Fix displaying tag from DialogFieldTagControl

### DIFF
--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -47,7 +47,7 @@
       = button_tag(_("Save"), :class => edit ? 'btn btn-primary' : 'btn btn-primary disabled')
 
     - when 'DialogFieldTagControl'
-      - if edit         
+      - if edit
         = select_tag(field.name,
                      options_for_select(dialog_dropdown_select_values(field), wf.value(field.name)),
                      drop_down_options(field, url))
@@ -55,9 +55,9 @@
           dialogFieldRefresh.initializeDialogSelectPicker('#{field.name}', undefined, '#{url}', JSON.parse('#{j(auto_refresh_options.to_json)}'));
 
       - else
-        - value = wf.value(field.name) || ''
-        - classification_ids = value.split(',')
-        = h(Classification.where(:id => classification_ids).collect(&:description).join(', '))
+        - value = wf.value(field.name) || '' # it returns in format for example Clasification::id
+        - _, classification_id = value.split('::')
+        = h(Classification.find(classification_id).description)
 
     :javascript
       dialogFieldRefresh.setVisible($('#field_#{field.id}_tr'), #{field.visible});


### PR DESCRIPTION
We are able to keep only one value of selected
tag in DialogFieldTagControl, fix me if I am wrong

## Test Scenario
- Create Service Dialog With Tag Element
![screen shot 2017-05-09 at 15 29 34](https://cloud.githubusercontent.com/assets/14937244/25853318/b0003684-34cc-11e7-9979-dd277ee8609b.png)
- use it in service
- order the service and choose any tag
![screen shot 2017-05-09 at 15 29 34](https://cloud.githubusercontent.com/assets/14937244/25853293/9c76d21c-34cc-11e7-9a3e-df7616b0d8c2.png)
- review the request:

**Before:**
![screen shot 2017-05-09 at 15 57 13](https://cloud.githubusercontent.com/assets/14937244/25854453/548f4c64-34d0-11e7-8fa8-590a006acfce.png)

**After:**
<img width="1208" alt="screen shot 2017-05-09 at 15 33 25" src="https://cloud.githubusercontent.com/assets/14937244/25853384/e2496dfe-34cc-11e7-9ddd-060202f57b71.png">


@miq-bot assign @himdel  (not sure who is right person for the review)
@miq-bot add_label bug
