### PR TITLE
Added to_i to port & end_port attributes

### DIFF
--- a/app/helpers/security_group_helper/textual_summary.rb
+++ b/app/helpers/security_group_helper/textual_summary.rb
@@ -25,8 +25,8 @@ module SecurityGroupHelper::TextualSummary
         rule.network_protocol,
         rule.host_protocol,
         rule.direction,
-        rule.port,
-        rule.end_port,
+        rule.port.to_i,
+        rule.end_port.to_i,
         (rule.source_ip_range || rule.source_security_group.try(:name) || "<None>")
       ]
     end.sort

--- a/spec/helpers/security_group_helper/textual_summary_spec.rb
+++ b/spec/helpers/security_group_helper/textual_summary_spec.rb
@@ -1,0 +1,17 @@
+describe SecurityGroupHelper::TextualSummary do
+  describe ".textual_group_firewall" do
+    before do
+      login_as FactoryGirl.create(:user)
+    end
+
+    subject { textuclal_group_firewall }
+    it 'returns TextualTable struct with list of of firewall rules' do
+      firewall_rules = [
+        FactoryGirl.create(:firewall_rule, :name => "Foo", :display_name => "Foo", :port => 1234),
+        FactoryGirl.create(:firewall_rule, :name => "Foo", :display_name => "Foo")
+      ]
+      @record = FactoryGirl.create(:security_group_with_firewall_rules, :firewall_rules => firewall_rules )
+      expect(textual_group_firewall).to be_kind_of(Struct)
+    end
+  end
+end


### PR DESCRIPTION
Added to_i to 'port' & 'end_port' attributes, to prevent comparison of Array with Array error when there is no value provided for port or end_port fields.

https://bugzilla.redhat.com/show_bug.cgi?id=1449053

@dclarizio please review.