### PR TITLE
Make device path mandatory for EBS attachments

### DIFF
--- a/app/views/cloud_volume/attach.html.haml
+++ b/app/views/cloud_volume/attach.html.haml
@@ -19,16 +19,21 @@
                       "required"                    => true,
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
-    .form-group
+    .form-group{"ng-class" => "{'has-error': angularForm.device_path.$invalid}"}
       %label.col-md-2.control-label
-        = _('Device Mountpoint (optional)')
+        - if @volume.ext_management_system.type == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'
+          = _('Device Mountpoint')
+        - else
+          = _('Device Mountpoint (optional)')
       .col-md-8
         %input.form-control{:type          => "text",
                             :name          => "device_path",
                             'ng-model'     => "vm.cloudVolumeModel.device_path",
                             'ng-maxlength' => 128,
-                            :miqrequired   => false,
+                            "ng-required"  => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'",
                             :checkchange   => true}
+        %span.help-block{"ng-show" => "angularForm.device_path.$error.required"}
+          = _("Required")
 
   .clearfix
   .pull-right.button-group.edit_buttons


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1449279

Contrary to OpenStack, Amazon EBS requires device path to be specified
(e.g. `/dev/sdh`) when attaching a cloud volume. This patch makes the
device path field required in the UI form. For OpenStack the device path
remains optional.

The label will show the optional status of the device path field
depending on the storage manager type.

@miq-bot add_label bug