### PR TITLE
Add parent relationship for physical server textual summary

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module PhysicalServerHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(host)
+      %i(host ext_management_system)
     )
   end
 
@@ -18,6 +18,10 @@ module PhysicalServerHelper::TextualSummary
 
   def textual_host
     {:label => _("Host"), :value => @record.host.try(:name), :icon => "pficon pficon-virtual-machine", :link => url_for(:controller => 'host', :action => 'show', :id => @record.host.try(:id))}
+  end
+
+  def textual_ext_management_system
+    textual_link(ExtManagementSystem.find(@record.ems_id))
   end
 
   def textual_name

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -9,8 +9,9 @@ describe PhysicalServerController do
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)
+      ems = FactoryGirl.create(:ems_physical_infra)
       computer_system = FactoryGirl.create(:computer_system, :hardware => FactoryGirl.create(:hardware))
-      physical_server = FactoryGirl.create(:physical_server, :computer_system => computer_system)
+      physical_server = FactoryGirl.create(:physical_server, :computer_system => computer_system, :ems_id => ems.id)
       get :show, :params => {:id => physical_server.id}
     end
     it { expect(response.status).to eq(200) }


### PR DESCRIPTION
This Pull Request adds the parent provider relationship for the PhysicalServer#show page summary. Showing the Ems relative to its parent.

![captura de tela de 2017-05-09 19-10-29](https://cloud.githubusercontent.com/assets/17187082/25874843/d1041fd0-34ea-11e7-8d44-6afdd920b7d6.png)

In the example above, the EmsPhysicalInfra name is Lenovo and is shown below the host label.