### PR TITLE
Support base snapshot for EBS cloud volume provisioning

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -26,7 +26,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
 
     if (cloudVolumeFormId !== 'new') {
       // Fetch cloud volume data before showing the form.
-      API.get('/api/cloud_volumes/' + cloudVolumeFormId + '?attributes=ext_management_system.type,availability_zone.ems_ref')
+      API.get('/api/cloud_volumes/' + cloudVolumeFormId + '?attributes=ext_management_system.type,availability_zone.ems_ref,base_snapshot.ems_ref')
         .then(getCloudVolumeFormData)
         .catch(miqService.handleFailure);
     } else {
@@ -113,7 +113,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
 
   vm.storageManagerChanged = function(id) {
     miqService.sparkleOn();
-    API.get('/api/providers/' + id + '?attributes=type,parent_manager.availability_zones,parent_manager.cloud_tenants')
+    API.get('/api/providers/' + id + '?attributes=type,parent_manager.availability_zones,parent_manager.cloud_tenants,parent_manager.cloud_volume_snapshots')
       .then(getStorageManagerFormData)
       .catch(miqService.handleFailure);
   };
@@ -214,6 +214,11 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     vm.cloudVolumeModel.aws_volume_type = data.volume_type;
     vm.cloudVolumeModel.aws_availability_zone_id = data.availability_zone.ems_ref;
 
+    // If volume was created from snapshot and this snapshot still exists
+    if (data.base_snapshot) {
+      vm.cloudVolumeModel.aws_base_snapshot_id = data.base_snapshot.ems_ref;
+    }
+
     // Update the IOPS based on the current volume size.
     vm.sizeChanged(vm.cloudVolumeModel.size);
 
@@ -224,6 +229,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     vm.cloudVolumeModel.emstype = data.type;
     vm.cloudTenantChoices = data.parent_manager.cloud_tenants;
     vm.availabilityZoneChoices = data.parent_manager.availability_zones;
+    vm.baseSnapshotChoices = data.parent_manager.cloud_volume_snapshots;
 
     miqService.sparkleOff();
   };

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -684,21 +684,34 @@ class CloudVolumeController < ApplicationController
     # Depending on the storage manager type, collect required form params.
     case params[:emstype]
     when "ManageIQ::Providers::StorageManager::CinderManager"
-      cloud_tenant_id = params[:cloud_tenant_id] if params[:cloud_tenant_id]
-      cloud_tenant = find_record_with_rbac(CloudTenant, cloud_tenant_id)
-      options[:cloud_tenant] = cloud_tenant
-      options[:ems] = cloud_tenant.ext_management_system
+      options.merge!(cinder_manager_options)
     when "ManageIQ::Providers::Amazon::StorageManager::Ebs"
-      options[:volume_type] = params[:aws_volume_type] if params[:aws_volume_type]
-      # Only set IOPS if io1 (provisioned IOPS) and IOPS available
-      options[:iops] = params[:aws_iops] if options[:volume_type] == 'io1' && params[:aws_iops]
-      options[:availability_zone] = params[:aws_availability_zone_id] if params[:aws_availability_zone_id]
-      options[:encrypted] = params[:aws_encryption]
-
-      # Get the storage manager.
-      storage_manager_id = params[:storage_manager_id] if params[:storage_manager_id]
-      options[:ems] = find_record_with_rbac(ExtManagementSystem, storage_manager_id)
+      options.merge!(aws_ebs_options)
     end
+    options
+  end
+
+  def cinder_manager_options
+    options = {}
+    cloud_tenant_id = params[:cloud_tenant_id] if params[:cloud_tenant_id]
+    cloud_tenant = find_record_with_rbac(CloudTenant, cloud_tenant_id)
+    options[:cloud_tenant] = cloud_tenant
+    options[:ems] = cloud_tenant.ext_management_system
+    options
+  end
+
+  def aws_ebs_options
+    options = {}
+    options[:volume_type] = params[:aws_volume_type] if params[:aws_volume_type]
+    # Only set IOPS if io1 (provisioned IOPS) and IOPS available
+    options[:iops] = params[:aws_iops] if options[:volume_type] == 'io1' && params[:aws_iops]
+    options[:availability_zone] = params[:aws_availability_zone_id] if params[:aws_availability_zone_id]
+    options[:snapshot_id] = params[:aws_base_snapshot_id] if params[:aws_base_snapshot_id]
+    options[:encrypted] = params[:aws_encryption]
+
+    # Get the storage manager.
+    storage_manager_id = params[:storage_manager_id] if params[:storage_manager_id]
+    options[:ems] = find_record_with_rbac(ExtManagementSystem, storage_manager_id)
     options
   end
 

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -112,6 +112,20 @@
 
 .form-group{"ng-if" => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
   %label.col-md-2.control-label
+    = _('Base Snapshot')
+  .col-md-8
+    %select{"name"             => "aws_base_snapshot_id",
+            "ng-model"         => "vm.cloudVolumeModel.aws_base_snapshot_id",
+            "ng-options"       => "vs.ems_ref as vs.name for vs in vm.baseSnapshotChoices",
+            "ng-disabled"      => "!vm.newRecord",
+            :checkchange       => true,
+            "data-live-search" => "true",
+            "pf-select"        => true}
+      %option{"value" => "", "enabled" => ""}
+        = _('No snapshot')
+
+.form-group{"ng-if" => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+  %label.col-md-2.control-label
     = _('Encryption')
   .col-md-8
     %input.form-control{"bs-switch"       => "",


### PR DESCRIPTION
Add option to create new cloud volume from snapshot for AWS EBS Storage Maneger.
<img width="1278" alt="new_cloud_volume_form_with_snapshot_option" src="https://cloud.githubusercontent.com/assets/9213557/26146645/3995135e-3af1-11e7-9a42-5d42013258ca.png">
