### PR TITLE
Save new dialog value & other UI issues fixed

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -114,7 +114,11 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     vm.catalogItemModel.provisioning_dialog_name = configData.provision.new_dialog_name;
     vm.catalogItemModel.provisioning_key = '';
     vm.catalogItemModel.provisioning_value = '';
-    vm.catalogItemModel.provisioning_become_enabled = configData.provision.become_enabled
+    if (configData.provision.become_enabled === undefined) {
+      vm.catalogItemModel.provisioning_become_enabled = false;
+    } else {
+      vm.catalogItemModel.provisioning_become_enabled = configData.provision.become_enabled;
+    }
     setExtraVars('provisioning_variables', configData.provision.extra_vars);
 
     if (typeof configData.retirement.repository_id !== 'undefined') {
@@ -124,7 +128,11 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       vm.catalogItemModel.retirement_remove_resources = configData.retirement.remove_resources;
       vm.catalogItemModel.retirement_machine_credential_id = configData.retirement.credential_id;
     }
-    vm.catalogItemModel.retirement_become_enabled = configData.retirement.become_enabled
+    if (configData.retirement.become_enabled === undefined) {
+      vm.catalogItemModel.retirement_become_enabled = false;
+    } else {
+      vm.catalogItemModel.retirement_become_enabled = configData.retirement.become_enabled;
+    }
     vm.catalogItemModel.retirement_network_credential_id = configData.retirement.network_credential_id;
     vm.catalogItemModel.retirement_cloud_credential_id = setIfDefined(configData.retirement.cloud_credential_id);
     vm.catalogItemModel.retirement_inventory = configData.retirement.hosts;
@@ -216,7 +224,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     if (configData.provisioning_cloud_credential_id !== '')
       catalog_item['config_info']['provision']['cloud_credential_id'] = configData.provisioning_cloud_credential_id;
 
-    if (configData.provisioning_dialog_id !== '') {
+    if (configData.provisioning_dialog_id !== undefined && configData.provisioning_dialog_id !== '') {
       catalog_item['config_info']['provision']['dialog_id'] = configData.provisioning_dialog_id;
     } else if (configData.provisioning_dialog_name !== '')
       catalog_item['config_info']['provision']['new_dialog_name'] = configData.provisioning_dialog_name;
@@ -338,6 +346,14 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       }
     })
   };
+
+  // reset fields when retirement playbook type is changed
+  $scope.$watch('vm._retirement_playbook', function(value) {
+    if (value && (vm.catalogItemModel.retirement_inventory === undefined || vm.catalogItemModel.retirement_inventory === '')) {
+      vm.catalogItemModel.retirement_inventory = 'localhost';
+      vm.catalogItemModel.retirement_become_enabled = false;
+    }
+  });
 
   $scope.$watch('vm._provisioning_repository', function(value) {
     if (value) {

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -33,7 +33,7 @@ describe('catalogItemFormController', function() {
             'var1': {'default': 'default_val1'},
             'var2': {'default': 'default_val2'}
           },
-          become_enabled: undefined,
+          become_enabled: false,
           network_credential_id: undefined
         },
         retirement: {


### PR DESCRIPTION
Fixed saving of new dialog name, reset 'Hosts' field when playbook is selected on Retirement tab during edit and fixed issues related to initialization of Escalate Privilege switch

https://bugzilla.redhat.com/show_bug.cgi?id=1448228

@lgalis @bzwei please test.

Please see steps to recreate issues with Escalate Privilege switch & hosts field below:
To see Escalate Privilege switch in a weird state:
1. change value of escalate privilege field on a catalog item that was added prior to add of escalate privilege field, and press reset button
2. Save catalog item without playbook on retirement tab, then go to edit the same catalog item, and select playbook field on retirement tab.

Hosts field: Save a catalog item without a playbook on retirement tab. Go to edit the same catalog item, value of Hosts text box is empty, after selecting Playbook it should initialize Hosts text field.

