### PR TITLE
Redirect delete action to cloud volume controller

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -476,6 +476,10 @@ module EmsCommon
       javascript_redirect :controller => "cloud_volume",
                           :action     => "edit",
                           :id         => find_checked_ids_with_rbac(CloudVolume).first
+    elsif params[:pressed] == "cloud_volume_delete"
+      javascript_redirect :controller      => "cloud_volume",
+                          :action          => "delete_volumes",
+                          :miq_grid_checks => params[:miq_grid_checks]
     elsif params[:pressed] == "network_router_edit"
       javascript_redirect :controller => "network_router",
                           :action     => "edit",

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -477,6 +477,9 @@ module EmsCommon
                           :action     => "edit",
                           :id         => find_checked_ids_with_rbac(CloudVolume).first
     elsif params[:pressed] == "cloud_volume_delete"
+      # Clear CloudVolumeController's lastaction, since we are calling the delete_volumes from
+      # an external controller. This will ensure that the final redirect is properly handled.
+      session["#{CloudVolumeController.session_key_prefix}_lastaction".to_sym] = nil
       javascript_redirect :controller      => "cloud_volume",
                           :action          => "delete_volumes",
                           :miq_grid_checks => params[:miq_grid_checks]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -492,6 +492,7 @@ Rails.application.routes.draw do
         backup_select
         snapshot_new
         edit
+        delete_volumes
         cloud_volume_tenants
         index
         new


### PR DESCRIPTION
As it turned out, the delete action, when invoked from the `ems_storage`
view, did not have any effect on the selected cloud volumes. This patch
introduces a simple redirect to the
`CloudVolumeController.delete_volumes` ensuring the selected volumes are
deleted from the provider.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1449293

@miq-bot add_label bug,storage
@miq-bot assign @AparnaKarve 