### PR TITLE
Fix missing stylesheet extension

### DIFF
--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -166,7 +166,7 @@ module ApplicationController::ReportDownloads
 
       disable_client_cache
       html_string = render_to_string(:template => "/layouts/show_pdf", :layout => false)
-      pdf_data = PdfGenerator.pdf_from_string(html_string, "pdf_summary")
+      pdf_data = PdfGenerator.pdf_from_string(html_string, "pdf_summary.css")
       send_data(pdf_data,
                 :type     => "application/pdf",
                 :filename => filename_timestamp("#{klass}_#{@record.name}_summary") + '.pdf'

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -149,7 +149,7 @@ describe EmsCloudController do
     context "download pdf file" do
       before :each do
         stub_user(:features => :all)
-        allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
+        allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary.css').and_return("")
         get :download_summary_pdf, :params => {:id => ems_openstack.id}
       end
 
@@ -319,7 +319,7 @@ describe EmsContainerController do
       context "download pdf file" do
         before :each do
           stub_user(:features => :all)
-          allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
+          allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary.css').and_return("")
           get :download_summary_pdf, :params => {:id => ems_kubernetes_container.id}
         end
 


### PR DESCRIPTION
Referencing the file without an extension may have worked in older versions of Prince/Rails/etc. Now it seems necessary.

Core PR https://github.com/ManageIQ/manageiq/pull/14793 depends on this change.

Related to this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1447940

And part of the fixes in #1090

**Current look of PDFs**

![screen shot 2017-05-11 at 11 29 29 am](https://cloud.githubusercontent.com/assets/39493/25968550/c74467e0-3646-11e7-9288-891e19204e9d.png)


/cc @dclarizio 