### PR TITLE
Fix HTML5 Console in IE11

### DIFF
--- a/app/assets/javascripts/remote_consoles/vnc.js
+++ b/app/assets/javascripts/remote_consoles/vnc.js
@@ -23,7 +23,7 @@ $(function() {
     shared: true,
     view_only: false,
     onUpdateState: function(_, state, _, msg) {
-      if (['normal', 'loaded'].includes(state)) {
+      if (['normal', 'loaded'].indexOf(state) >= 0) {
         $('#connection-status').removeClass('label-danger label-warning').addClass('label-success');
         $('#connection-status').text(__('Connected'));
       } else if (state === 'disconnected') {


### PR DESCRIPTION
IE11 does not support the `.includes` function unfortunately.

https://bugzilla.redhat.com/show_bug.cgi?id=1448104