### PR TITLE
Only Host under Cluster have no checkbox

### DIFF
--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -9,7 +9,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     if [ExtManagementSystem, EmsCluster, Datacenter, EmsFolder, ResourcePool].any? { |klass| object.kind_of?(klass) }
       node[:select] = options.key?(:selected) && options[:selected].include?("#{object.class.name}_#{object[:id]}")
     end
-    node[:hideCheckbox] = true if object.kind_of?(Host)
+    node[:hideCheckbox] = true if object.kind_of?(Host) && object.ems_cluster_id.present?
     node[:cfmeNoClick] = true
     node[:checkable] = options[:checkable_checkboxes] if options.key?(:checkable_checkboxes)
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1445683

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/15

Configuration -> Access Control -> Groups -> any group -> Hosts/Nodes & Clusters

Before:
<img width="289" alt="screen shot 2017-05-12 at 10 43 29 am" src="https://cloud.githubusercontent.com/assets/9210860/25990395/e174c18c-36ff-11e7-9052-1eb73a6059ee.png">

After:
<img width="310" alt="screen shot 2017-05-12 at 10 36 07 am" src="https://cloud.githubusercontent.com/assets/9210860/25990211/3918272c-36ff-11e7-80be-5894c78cdf24.png">

@miq-bot add_label bug, trees, fine/yes

@h-kataria please review. Thanks :)