### PR TITLE
Display all services with 'display' = true in the Active and Retired Services trees

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -234,10 +234,10 @@ class ServiceController < ApplicationController
       @view, @pages = get_view(Vm, :parent => @record, :parent_method => :all_vms, :all_pages => true)  # Get the records (into a view) and the paginator
     when "Hash"
       if id == "asrv"
-        process_show_list(:where_clause => "retired is false and (services.display is TRUE or ancestry is null)")
+        process_show_list(:where_clause => "retired is false and services.display is TRUE")
         @right_cell_text = _("Active Services")
       else
-        process_show_list(:where_clause => "retired is true and (services.display is TRUE or ancestry is null)")
+        process_show_list(:where_clause => "retired is true and services.display is TRUE")
         @right_cell_text = _("Retired Services")
       end
     else      # Get list of child Catalog Items/Services of this node

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -234,10 +234,10 @@ class ServiceController < ApplicationController
       @view, @pages = get_view(Vm, :parent => @record, :parent_method => :all_vms, :all_pages => true)  # Get the records (into a view) and the paginator
     when "Hash"
       if id == "asrv"
-        process_show_list(:where_clause => "retired is false and services.display is TRUE")
+        process_show_list(:where_clause => "retired is false and services.display is true")
         @right_cell_text = _("Active Services")
       else
-        process_show_list(:where_clause => "retired is true and services.display is TRUE")
+        process_show_list(:where_clause => "retired is true and services.display is true")
         @right_cell_text = _("Retired Services")
       end
     else      # Get list of child Catalog Items/Services of this node

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -234,10 +234,10 @@ class ServiceController < ApplicationController
       @view, @pages = get_view(Vm, :parent => @record, :parent_method => :all_vms, :all_pages => true)  # Get the records (into a view) and the paginator
     when "Hash"
       if id == "asrv"
-        process_show_list(:where_clause => "retired is false and ancestry is null")
+        process_show_list(:where_clause => "retired is false and (services.display is TRUE or ancestry is null)")
         @right_cell_text = _("Active Services")
       else
-        process_show_list(:where_clause => "retired is true and ancestry is null")
+        process_show_list(:where_clause => "retired is true and (services.display is TRUE or ancestry is null)")
         @right_cell_text = _("Retired Services")
       end
     else      # Get list of child Catalog Items/Services of this node

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -36,7 +36,7 @@ class TreeBuilderServices < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
-    services = Rbac.filtered(Service.where("retired = ? AND (display = TRUE OR ancestry is null)", object[:id] != 'asrv'))
+    services = Rbac.filtered(Service.where(:retired => object[:id] != 'asrv', :display => true))
     if count_only
       services.size
     else

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -36,7 +36,7 @@ class TreeBuilderServices < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
-    services = Rbac.filtered(Service.where(:retired => object[:id] != 'asrv', :display => true))
+    services = Rbac.filtered(Service.where("retired = ? AND (display = TRUE OR ancestry is null)", object[:id] != 'asrv'))
     if count_only
       services.size
     else

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -36,7 +36,7 @@ class TreeBuilderServices < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
-    services = Rbac.filtered(Service.where(:retired => object[:id] != 'asrv', :ancestry => [nil, ""]))
+    services = Rbac.filtered(Service.where(:retired => object[:id] != 'asrv', :display => true))
     if count_only
       services.size
     else

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -14,28 +14,19 @@
       = miq_tab_content("details", 'default', :class => 'cm-tab') do
         = render :partial => "layouts/textual_groups_generic"
         - child_services = @record.direct_service_children.select(&:display)
-        - parent_service = @record.parent_service
         - unless child_services.blank?
-          %h3
-            = _('Child Services')
-          %table.table.table-striped.table-bordered.table-hover
-            %tbody
-              - child_services.sort_by { |o| o.name.downcase }.each do |s|
-                %tr{:onclick => "miqTreeActivateNode('svcs_tree', 's-#{to_cid(s.id)}');", :title => _("View this Service")}
-                  %td.table-view-pf-select
-                    %i.pficon.pficon-service
-                  %td
-                    = h(s.name)
-        - if parent_service && parent_service.display
-          %h3
-            = _('Parent Service')
-          %table.table.table-striped.table-bordered.table-hover
-            %tbody
-              %tr{:onclick => "miqTreeActivateNode('svcs_tree', 's-#{to_cid(parent_service.id)}');", :title => _("View this Service")}
-                %td.table-view-pf-select
-                  %i.pficon.pficon-service
-                %td
-                  = h(parent_service.name)
+          .row
+            .col-md-12.col-lg-6
+              %h3
+                = _('Child Services')
+              %table.table.table-striped.table-bordered.table-hover
+                %tbody
+                  - child_services.sort_by { |o| o.name.downcase }.each do |s|
+                    %tr{:onclick => "miqTreeActivateNode('svcs_tree', 's-#{to_cid(s.id)}');", :title => _("View this Service")}
+                      %td.table-view-pf-select
+                        %i.pficon.pficon-service
+                      %td
+                        = h(s.name)
         .row
           .col-md-12.col-lg-6
             %h3

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -13,6 +13,29 @@
     .tab-content
       = miq_tab_content("details", 'default', :class => 'cm-tab') do
         = render :partial => "layouts/textual_groups_generic"
+        - child_services = @record.direct_service_children.select(&:display)
+        - parent_service = @record.parent_service
+        - unless child_services.blank?
+          %h3
+            = _('Child Services')
+          %table.table.table-striped.table-bordered.table-hover
+            %tbody
+              - child_services.sort_by { |o| o.name.downcase }.each do |s|
+                %tr{:onclick => "miqTreeActivateNode('svcs_tree', 's-#{to_cid(s.id)}');", :title => _("View this Service")}
+                  %td.table-view-pf-select
+                    %i.pficon.pficon-service
+                  %td
+                    = h(s.name)
+        - if parent_service && parent_service.display
+          %h3
+            = _('Parent Service')
+          %table.table.table-striped.table-bordered.table-hover
+            %tbody
+              %tr{:onclick => "miqTreeActivateNode('svcs_tree', 's-#{to_cid(parent_service.id)}');", :title => _("View this Service")}
+                %td.table-view-pf-select
+                  %i.pficon.pficon-service
+                %td
+                  = h(parent_service.name)
         .row
           .col-md-12.col-lg-6
             %h3

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -8,9 +8,15 @@ describe TreeBuilderServices do
     active_nodes = kid_nodes(root_nodes[0])
     retired_nodes = kid_nodes(root_nodes[1])
     expect(active_nodes).to eq(
-      @service => {},
-      @service_c1 => {},
-      @service_c2 => {}
+      @service => {
+        @service_c1 => {
+          @service_c11 => {},
+          @service_c12 => {
+            @service_c121 => {}
+          }
+        },
+        @service_c2 => {}
+      }
     )
     expect(retired_nodes).to eq(@service_c3 => {})
   end
@@ -27,12 +33,12 @@ describe TreeBuilderServices do
 
   def create_deep_tree
     @service      = FactoryGirl.create(:service, :display => true, :retired => false)
-    @service_c1   = FactoryGirl.create(:service, :display => true, :retired => false)
+    @service_c1   = FactoryGirl.create(:service, :service => @service, :display => true, :retired => false)
     @service_c11  = FactoryGirl.create(:service, :service => @service_c1, :display => true, :retired => false)
     @service_c12  = FactoryGirl.create(:service, :service => @service_c1, :display => true, :retired => false)
     @service_c121 = FactoryGirl.create(:service, :service => @service_c12, :display => true, :retired => false)
-    @service_c2   = FactoryGirl.create(:service, :display => true, :retired => false)
+    @service_c2   = FactoryGirl.create(:service, :service => @service, :display => true, :retired => false)
     # hidden
-    @service_c3   = FactoryGirl.create(:service, :retired => true)
+    @service_c3   = FactoryGirl.create(:service, :service => @service, :retired => true, :display => true)
   end
 end


### PR DESCRIPTION
Display all services with the 'display' = true in the Active and Retired Services trees, regardless of ancestry. Added links to parent and direct children, if applicable, in the service summary.

https://bugzilla.redhat.com/show_bug.cgi?id=1444043

![screenshot from 2017-05-16 10-25-27](https://cloud.githubusercontent.com/assets/12769982/26111825/311c5728-3a24-11e7-8079-5dc89d4c4df6.png)
![screenshot from 2017-05-16 16-34-09](https://cloud.githubusercontent.com/assets/12769982/26127010/c8b69ff4-3a55-11e7-88eb-7c1727d90970.png)
![screenshot from 2017-05-16 16-34-18](https://cloud.githubusercontent.com/assets/12769982/26127011/c8b7f624-3a55-11e7-9296-b78c391d1d51.png)
