### PR TITLE
Fix Default tab error indicator for OpenStack Infra

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -176,6 +176,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     function getNewEmsFormDataComplete(response) {
       var data = response.data;
 
+      $scope.emsCommonModel.emstype                         = '';
       $scope.emsCommonModel.zone                            = data.zone;
       $scope.emsCommonModel.tenant_mapping_enabled          = data.tenant_mapping_enabled;
       $scope.emsCommonModel.emstype_vm                      = data.emstype_vm;

--- a/app/assets/javascripts/directives/validation/reset_validation_status.js
+++ b/app/assets/javascripts/directives/validation/reset_validation_status.js
@@ -27,7 +27,7 @@ var adjustValidationStatus = function(value, scope, ctrl, attrs, rootScope) {
     }
 
     if (scope[scope.model][attrs.resetValidationDependsOn] === '' ||
-        (value == scope.postValidationModel[attrs.prefix][ctrl.$name] && _.isMatch(modelObject, modelPostValidationObject))) {
+        (value === scope.postValidationModel[attrs.prefix][ctrl.$name] && _.isMatch(modelObject, modelPostValidationObject))) {
       scope[scope.model][attrs.resetValidationStatus] = true;
       rootScope.$broadcast('clearErrorOnTab', {tab: attrs.prefix});
     } else {


### PR DESCRIPTION
No error indicator is displayed on the `Default` tab when `OpenStack Infra` is selected in the `New Infra Provider` form
Also `New Cloud Provider` form shows 3 tabs right off the bat even though `Type` is not selected

Before (New Infra Provider Form with OpenStack selected and no error indicator on Default tab) --
<img width="1093" alt="screen shot 2017-05-12 at 2 51 21 pm" src="https://cloud.githubusercontent.com/assets/1538216/26018253/9008ce2e-3722-11e7-9318-6b4a4670b90d.png">

After (New Infra Provider Form with OpenStack selected and error indicator visible on Default tab) --
<img width="828" alt="screen shot 2017-05-12 at 2 49 27 pm" src="https://cloud.githubusercontent.com/assets/1538216/26018251/8cabfd3c-3722-11e7-8e66-abada619e92e.png">

---------------------------------

Before (New Cloud Provider Form with no Type selected and 3 tabs visible) --
<img width="1211" alt="screen shot 2017-05-12 at 2 50 53 pm" src="https://cloud.githubusercontent.com/assets/1538216/26018256/946796c6-3722-11e7-855f-c66fba290b37.png">

After (New Cloud Provider Form with no Type selected and no tabs visible) --
<img width="1207" alt="screen shot 2017-05-12 at 2 50 03 pm" src="https://cloud.githubusercontent.com/assets/1538216/26018309/e6d521c6-3722-11e7-9cdb-8d74468d6ab4.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1451130