### PR TITLE
Delete duplicate flash message display in Optimize Planning page

### DIFF
--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -552,6 +552,7 @@ class MiqCapacityController < ApplicationController
         page << javascript_reload_toolbars
         page << javascript_for_miq_button_visibility(session[:changed])
         page.replace("planning_options_div", :partial => "planning_options")
+        @flash_array = nil       # Make sure to reset flash message after initial display
         page.replace_html("main_div", :partial => "planning_tabs")
       end
     end


### PR DESCRIPTION
Display flash message only once when Reset button is clicked

https://bugzilla.redhat.com/show_bug.cgi?id=1381650

**Screen shot before code fix:**

![optimize planning reset button click with 2 flash messages](https://cloud.githubusercontent.com/assets/552686/26019610/7812f8f4-372b-11e7-8010-64846a8d0b0e.png)


**Screen shot post code fix:**

![optimize planning reset button 1 message post code fix](https://cloud.githubusercontent.com/assets/552686/26019615/7ccfff18-372b-11e7-96d4-8a04c7b7a7f7.png)

