### PR TITLE
Edit method name in spec for Cloud Subnet

### DIFF
--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -185,7 +185,7 @@ describe CloudSubnetController do
       let(:queue_options) do
         {
           :class_name  => @cloud_subnet.class.name,
-          :method_name => 'raw_delete_cloud_subnet',
+          :method_name => 'delete_cloud_subnet',
           :instance_id => @cloud_subnet.id,
           :priority    => MiqQueue::HIGH_PRIORITY,
           :role        => 'ems_operations',


### PR DESCRIPTION
In  https://github.com/ManageIQ/manageiq/pull/15087 there were `delete` and `raw_delete` methods added for Cloud Subnet.
Here's the method name changed in spec file from `raw_delete_cloud_subnet` to `delete_cloud_subnet`.