### PR TITLE
Fix wrong redirection on some tagging actions

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -337,6 +337,7 @@ module EmsCommon
       when "security_group_tag"               then tag(SecurityGroup)
       end
 
+      return if params[:pressed].include?("tag") && !%w(host_tag vm_tag miq_template_tag).include?(params[:pressed])
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       # Handle Host power buttons
       if host_power_button?(params[:pressed])


### PR DESCRIPTION
The cause of the problem is that the ems_common#button proceed after the calling tag method and replaced breadcrumbs. Then the tagging action checked wrong breadcrumb and made wrong redirection. This change is fixing the issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1440688