### PR TITLE
Fix for service catalog service dialog refresh function behaving differently

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -15,7 +15,7 @@ var dialogFieldRefresh = {
 
     $(document).on('dialog::autoRefresh', function(_event, data) {
       if (thisIsTheFieldToUpdate(data)) {
-        callbackFunction.call();
+        callbackFunction.call(null, data.initializingIndex);
       }
     });
   },
@@ -27,6 +27,7 @@ var dialogFieldRefresh = {
     }
 
     miqSelectPickerEvent(fieldName, url, {callback: function() {
+      autoRefreshOptions.initial_trigger = true;
       dialogFieldRefresh.triggerAutoRefresh(autoRefreshOptions);
       return true;
     }});
@@ -176,10 +177,18 @@ var dialogFieldRefresh = {
   triggerAutoRefresh: function(autoRefreshOptions) {
     if (Boolean(autoRefreshOptions.trigger) === true) {
       var autoRefreshableIndicies = autoRefreshOptions.auto_refreshable_field_indicies;
-      var currentIndex = autoRefreshOptions.current_index;
+      var currentIndex, initializingIndex;
+
+      if (autoRefreshOptions.initial_trigger === true) {
+        currentIndex = 0;
+        initializingIndex = autoRefreshOptions.current_index;
+      } else {
+        currentIndex = autoRefreshOptions.current_index;
+        initializingIndex = autoRefreshOptions.initializingIndex;
+      }
 
       var nextAvailable = $.grep(autoRefreshableIndicies, function(potential, potentialsIndex) {
-        return (potential.auto_refresh === true && potentialsIndex > currentIndex);
+        return (potential.auto_refresh === true && potentialsIndex > currentIndex && potentialsIndex !== initializingIndex);
       });
 
       nextAvailable = nextAvailable[0];
@@ -189,6 +198,7 @@ var dialogFieldRefresh = {
           tabIndex: nextAvailable.tab_index,
           groupIndex: nextAvailable.group_index,
           fieldIndex: nextAvailable.field_index,
+          initializingIndex: initializingIndex
         });
       }
     }

--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -51,6 +51,29 @@ var dialogFieldRefresh = {
     });
   },
 
+  refreshField: function(options, callback) {
+    var fieldType = options.type;
+
+    if (fieldType === "DialogFieldCheckBox") {
+      dialogFieldRefresh.refreshCheckbox(options.name, options.id, callback);
+    } else if (fieldType === "DialogFieldTextBox") {
+      dialogFieldRefresh.refreshTextBox(options.name, options.id, callback);
+    } else if (fieldType === "DialogFieldTextAreaBox") {
+      dialogFieldRefresh.refreshTextAreaBox(options.name, options.id, callback);
+    } else if (fieldType === "DialogFieldDropDownList") {
+      var selectedValue = $('select[name="' + options.name + '"]').val();
+      dialogFieldRefresh.refreshDropDownList(options.name, options.id, selectedValue, callback);
+    } else if (fieldType === "DialogFieldRadioButton") {
+      var checkedValue = $('input:radio[name="' + options.name + '"]:checked').val();
+
+      dialogFieldRefresh.refreshRadioList(options.name, options.id, checkedValue, options.url, options.auto_refresh_options, callback);
+    } else if (fieldType === "DialogFieldDateControl" || fieldType === "DialogFieldDateTimeControl") {
+      dialogFieldRefresh.refreshDateTime(options.name, options.id, callback);
+    } else {
+      add_flash(__("Field type is not a supported type!"), 'error');
+    }
+  },
+
   refreshCheckbox: function(fieldName, fieldId, callback) {
     miqSparkleOn();
 

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -181,7 +181,8 @@ module ApplicationHelper::Dialogs
         :field_index                     => auto_refresh_options_hash[:field_index],
         :auto_refreshable_field_indicies => auto_refresh_options_hash[:auto_refreshable_field_indicies],
         :current_index                   => auto_refresh_options_hash[:current_index],
-        :trigger                         => auto_refresh_options_hash[:trigger]
+        :trigger                         => auto_refresh_options_hash[:trigger],
+        :initial_trigger                 => auto_refresh_options_hash[:initial_trigger]
       }
     else
       {}

--- a/app/views/shared/dialogs/_auto_refresh_javascript.html.haml
+++ b/app/views/shared/dialogs/_auto_refresh_javascript.html.haml
@@ -1,0 +1,9 @@
+:javascript
+  dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function(initializingIndex) {
+    dialogFieldRefresh.refreshField(JSON.parse("#{j(refresh_field_parameters.to_json)}"), function() {
+      var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
+      jsonOptions.initializingIndex = initializingIndex;
+
+      dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
+    });
+  });

--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -47,7 +47,7 @@
       = button_tag(_("Save"), :class => edit ? 'btn btn-primary' : 'btn btn-primary disabled')
 
     - when 'DialogFieldTagControl'
-      - if edit         
+      - if edit
         = select_tag(field.name,
                      options_for_select(dialog_dropdown_select_values(field), wf.value(field.name)),
                      drop_down_options(field, url))

--- a/app/views/shared/dialogs/_dialog_field_check_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_check_box.html.haml
@@ -3,11 +3,12 @@
 - if field.dynamic
   - if field.auto_refresh
     :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
+      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function(initializingIndex) {
         dialogFieldRefresh.refreshCheckbox("#{field.name}", "#{field.id}", function() {
-          dialogFieldRefresh.triggerAutoRefresh(
-            JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
-          );
+          var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
+          jsonOptions.initializingIndex = initializingIndex;
+
+          dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
         });
       });
 
@@ -17,6 +18,9 @@
   :javascript
     $('#refresh-dynamic-checkbox-#{field.id}').click(function() {
       dialogFieldRefresh.refreshCheckbox("#{field.name}", "#{field.id}", function() {
-        dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+        var jsonOptions = JSON.parse('#{j(auto_refresh_options.to_json)}');
+        jsonOptions.initialTrigger = true;
+
+        dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
       });
     });

--- a/app/views/shared/dialogs/_dialog_field_check_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_check_box.html.haml
@@ -2,15 +2,12 @@
 
 - if field.dynamic
   - if field.auto_refresh
-    :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function(initializingIndex) {
-        dialogFieldRefresh.refreshCheckbox("#{field.name}", "#{field.id}", function() {
-          var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
-          jsonOptions.initializingIndex = initializingIndex;
+    - javascript_locals = {:auto_refresh_options     => auto_refresh_options,
+                           :refresh_field_parameters => {:type => field.type,
+                                                         :name => field.name,
+                                                         :id   => field.id}}
 
-          dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
-        });
-      });
+    = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
   - if field.show_refresh_button?
     = button_tag(_('Refresh'), :id => "refresh-dynamic-checkbox-#{field.id}", :class => "btn btn-default")

--- a/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
@@ -25,11 +25,12 @@
 - if field.dynamic
   - if field.auto_refresh
     :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
+      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function(initializingIndex) {
         dialogFieldRefresh.refreshDateTime("#{field.name}", "#{field.id}", function() {
-          dialogFieldRefresh.triggerAutoRefresh(
-            JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
-          );
+          var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
+          jsonOptions.initializingIndex = initializingIndex;
+
+          dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
         });
       });
 
@@ -39,6 +40,9 @@
   :javascript
     $('#refresh-dynamic-date-#{field.id}').click(function() {
       dialogFieldRefresh.refreshDateTime("#{field.name}", "#{field.id}", function() {
-        dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+        var jsonOptions = JSON.parse('#{j(auto_refresh_options.to_json)}');
+        jsonOptions.initialTrigger = true;
+
+        dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
       });
     });

--- a/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
@@ -24,15 +24,12 @@
 
 - if field.dynamic
   - if field.auto_refresh
-    :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function(initializingIndex) {
-        dialogFieldRefresh.refreshDateTime("#{field.name}", "#{field.id}", function() {
-          var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
-          jsonOptions.initializingIndex = initializingIndex;
+    - javascript_locals = {:auto_refresh_options     => auto_refresh_options,
+                           :refresh_field_parameters => {:type => field.type,
+                                                         :name => field.name,
+                                                         :id   => field.id}}
 
-          dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
-        });
-      });
+    = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
   - if field.show_refresh_button?
     = button_tag(_('Refresh'), :id => "refresh-dynamic-date-#{field.id}", :class => "btn btn-default")

--- a/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
@@ -15,16 +15,12 @@
 
   - if field.dynamic
     - if field.auto_refresh
-      :javascript
-        dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function(initializingIndex) {
-          var selectedValue = $('select[name="#{field.name}"]').val();
-          dialogFieldRefresh.refreshDropDownList("#{field.name}", "#{field.id}", selectedValue, function() {
-            var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
-            jsonOptions.initializingIndex = initializingIndex;
+      - javascript_locals = {:auto_refresh_options     => auto_refresh_options,
+                             :refresh_field_parameters => {:type => field.type,
+                                                           :name => field.name,
+                                                           :id   => field.id}}
 
-            dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
-          });
-        });
+      = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
     - if field.show_refresh_button?
       = button_tag(_('Refresh'), :id => "refresh-dynamic-field-#{field.id}", :class => "btn btn-default")

--- a/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
@@ -16,24 +16,29 @@
   - if field.dynamic
     - if field.auto_refresh
       :javascript
-        dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
+        dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function(initializingIndex) {
           var selectedValue = $('select[name="#{field.name}"]').val();
           dialogFieldRefresh.refreshDropDownList("#{field.name}", "#{field.id}", selectedValue, function() {
-            dialogFieldRefresh.triggerAutoRefresh(
-              JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
-            );
+            var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
+            jsonOptions.initializingIndex = initializingIndex;
+
+            dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
           });
         });
 
     - if field.show_refresh_button?
       = button_tag(_('Refresh'), :id => "refresh-dynamic-field-#{field.id}", :class => "btn btn-default")
-    :javascript
 
+    :javascript
       $('#refresh-dynamic-field-#{field.id}').click(function() {
         var selectedValue = $('select[name="#{field.name}"]').val();
         dialogFieldRefresh.refreshDropDownList("#{field.name}", "#{field.id}", selectedValue, function() {
-          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+          var jsonOptions = JSON.parse('#{j(auto_refresh_options.to_json)}');
+          jsonOptions.initialTrigger = true;
+
+          dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
         });
       });
+
 - else
   = h(field.value.nil? ? "<None>" : dialog_dropdown_selected_value(field))

--- a/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
@@ -21,21 +21,14 @@
 
 - if field.dynamic
   - if field.auto_refresh
-    :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function(initializingIndex) {
-        var checkedValue = $('input:radio[name="#{field.name}"]:checked').val();
+    - javascript_locals = {:auto_refresh_options     => auto_refresh_options,
+                           :refresh_field_parameters => {:type => field.type,
+                                                         :name => field.name,
+                                                         :id   => field.id,
+                                                         :url  => url,
+                                                         :auto_refresh_options => auto_refresh_options}}
 
-        dialogFieldRefresh.refreshRadioList("#{field.name}",
-                                            "#{field.id}",
-                                            checkedValue,
-                                            "#{url}",
-                                            JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
-          var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
-          jsonOptions.initializingIndex = initializingIndex;
-
-          dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
-        });
-      });
+    = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
   - if field.show_refresh_button?
     = button_tag(_('Refresh'), :id => "refresh-dynamic-field-#{field.id}", :class => "btn btn-default")

--- a/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
@@ -22,7 +22,7 @@
 - if field.dynamic
   - if field.auto_refresh
     :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
+      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function(initializingIndex) {
         var checkedValue = $('input:radio[name="#{field.name}"]:checked').val();
 
         dialogFieldRefresh.refreshRadioList("#{field.name}",
@@ -30,9 +30,10 @@
                                             checkedValue,
                                             "#{url}",
                                             JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
-          dialogFieldRefresh.triggerAutoRefresh(
-            JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
-          );
+          var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
+          jsonOptions.initializingIndex = initializingIndex;
+
+          dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
         });
       });
 
@@ -48,6 +49,9 @@
                                           checkedValue,
                                           "#{url}",
                                           JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
-        dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+        var jsonOptions = JSON.parse('#{j(auto_refresh_options.to_json)}');
+        jsonOptions.initialTrigger = true;
+
+        dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
       });
     });

--- a/app/views/shared/dialogs/_dialog_field_text_area_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_text_area_box.html.haml
@@ -1,16 +1,17 @@
 - if edit
-  = text_area_tag(field.name, field.value, textarea_tag_options(field, url, auto_refresh_options))
+  = text_area_tag(field.name, field.value, textarea_tag_options(field, url, auto_refresh_options.merge(:initial_trigger => true)))
 - else
   = h(field.value)
 
 - if field.dynamic
   - if field.auto_refresh
     :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function() {
+      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function(initializingIndex) {
         dialogFieldRefresh.refreshTextAreaBox("#{field.name}", "#{field.id}", function() {
-          dialogFieldRefresh.triggerAutoRefresh(
-            JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
-          );
+          var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
+          jsonOptions.initializingIndex = initializingIndex;
+
+          dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
         });
       });
 
@@ -20,6 +21,9 @@
     :javascript
       $('#refresh-dynamic-text-field-#{field.id}').click(function() {
         dialogFieldRefresh.refreshTextAreaBox("#{field.name}", "#{field.id}", function() {
-          dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+          var jsonOptions = JSON.parse('#{j(auto_refresh_options.to_json)}');
+          jsonOptions.initialTrigger = true;
+
+          dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
         });
       });

--- a/app/views/shared/dialogs/_dialog_field_text_area_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_text_area_box.html.haml
@@ -5,15 +5,12 @@
 
 - if field.dynamic
   - if field.auto_refresh
-    :javascript
-      dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse("#{j(auto_refresh_options.to_json)}"), function(initializingIndex) {
-        dialogFieldRefresh.refreshTextAreaBox("#{field.name}", "#{field.id}", function() {
-          var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
-          jsonOptions.initializingIndex = initializingIndex;
+    - javascript_locals = {:auto_refresh_options     => auto_refresh_options,
+                           :refresh_field_parameters => {:type => field.type,
+                                                         :name => field.name,
+                                                         :id   => field.id}}
 
-          dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
-        });
-      });
+    = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
   - if field.show_refresh_button?
     = button_tag(_('Refresh'), :id => "refresh-dynamic-text-field-#{field.id}", :class => "btn btn-default")

--- a/app/views/shared/dialogs/_dialog_field_text_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_text_box.html.haml
@@ -6,15 +6,12 @@
 
   - if field.dynamic
     - if field.auto_refresh
-      :javascript
-        dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse('#{j(auto_refresh_options.to_json)}'), function(initializingIndex) {
-          dialogFieldRefresh.refreshTextBox("#{field.name}", "#{field.id}", function() {
-            var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
-            jsonOptions.initializingIndex = initializingIndex;
+      - javascript_locals = {:auto_refresh_options     => auto_refresh_options,
+                             :refresh_field_parameters => {:type => field.type,
+                                                           :name => field.name,
+                                                           :id   => field.id}}
 
-            dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
-          });
-        });
+      = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
     - if field.show_refresh_button?
       = button_tag(_('Refresh'), :id => "refresh-dynamic-text-field-#{field.id}", :class => "btn btn-default")

--- a/app/views/shared/dialogs/_dialog_field_text_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_text_box.html.haml
@@ -1,17 +1,18 @@
 - if edit
   - if field.protected?
-    = password_field_tag(field.name + "__protected", field.value, textbox_tag_options(field, url, auto_refresh_options))
+    = password_field_tag(field.name + "__protected", field.value, textbox_tag_options(field, url, auto_refresh_options.merge(:initial_trigger => true)))
   - else
-    = text_field_tag(field.name, field.value, textbox_tag_options(field, url, auto_refresh_options))
+    = text_field_tag(field.name, field.value, textbox_tag_options(field, url, auto_refresh_options.merge(:initial_trigger => true)))
 
   - if field.dynamic
     - if field.auto_refresh
       :javascript
-        dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse('#{j(auto_refresh_options.to_json)}'), function() {
+        dialogFieldRefresh.listenForAutoRefreshMessages(JSON.parse('#{j(auto_refresh_options.to_json)}'), function(initializingIndex) {
           dialogFieldRefresh.refreshTextBox("#{field.name}", "#{field.id}", function() {
-            dialogFieldRefresh.triggerAutoRefresh(
-              JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}')
-            );
+            var jsonOptions = JSON.parse('#{j(auto_refresh_listening_options(auto_refresh_options, true).to_json)}');
+            jsonOptions.initializingIndex = initializingIndex;
+
+            dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
           });
         });
 
@@ -21,7 +22,10 @@
       :javascript
         $('#refresh-dynamic-text-field-#{field.id}').click(function() {
           dialogFieldRefresh.refreshTextBox("#{field.name}", "#{field.id}", function() {
-            dialogFieldRefresh.triggerAutoRefresh(JSON.parse('#{j(auto_refresh_options.to_json)}'));
+            var jsonOptions = JSON.parse('#{j(auto_refresh_options.to_json)}');
+            jsonOptions.initialTrigger = true;
+
+            dialogFieldRefresh.triggerAutoRefresh(jsonOptions);
           });
         });
 

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -114,7 +114,8 @@ describe ApplicationHelper::Dialogs do
         :field_index                     => "300",
         :auto_refreshable_field_indicies => [1, 2, 3],
         :current_index                   => 123,
-        :trigger                         => "true"
+        :trigger                         => "true",
+        :initial_trigger                 => true
       }
     end
 
@@ -161,7 +162,8 @@ describe ApplicationHelper::Dialogs do
               :field_index                     => "300",
               :auto_refreshable_field_indicies => [1, 2, 3],
               :current_index                   => 123,
-              :trigger                         => "true"
+              :trigger                         => "true",
+              :initial_trigger                 => true
             }.to_json
           )
         end
@@ -212,7 +214,8 @@ describe ApplicationHelper::Dialogs do
               :field_index                     => "300",
               :auto_refreshable_field_indicies => [1, 2, 3],
               :current_index                   => 123,
-              :trigger                         => "true"
+              :trigger                         => "true",
+              :initial_trigger                 => nil
             }.to_json
           )
         end
@@ -240,7 +243,8 @@ describe ApplicationHelper::Dialogs do
         :field_index                     => "300",
         :auto_refreshable_field_indicies => [1, 2, 3],
         :current_index                   => 123,
-        :trigger                         => "true"
+        :trigger                         => "true",
+        :initial_trigger                 => false
       }
     end
 
@@ -275,7 +279,8 @@ describe ApplicationHelper::Dialogs do
               :field_index                     => "300",
               :auto_refreshable_field_indicies => [1, 2, 3],
               :current_index                   => 123,
-              :trigger                         => "true"
+              :trigger                         => "true",
+              :initial_trigger                 => false
             }.to_json
           )
         end
@@ -339,7 +344,8 @@ describe ApplicationHelper::Dialogs do
               :field_index                     => "300",
               :auto_refreshable_field_indicies => [1, 2, 3],
               :current_index                   => 123,
-              :trigger                         => "true"
+              :trigger                         => "true",
+              :initial_trigger                 => nil
             }.to_json
           )
         end
@@ -400,7 +406,8 @@ describe ApplicationHelper::Dialogs do
               :field_index                     => "300",
               :auto_refreshable_field_indicies => [1, 2, 3],
               :current_index                   => 123,
-              :trigger                         => "true"
+              :trigger                         => "true",
+              :initial_trigger                 => nil
             }.to_json
           )
         end

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -144,6 +144,119 @@ describe('dialogFieldRefresh', function() {
     });
   });
 
+  describe('#refreshField', function() {
+    var options = {name: 'name', id: '123'};
+    var callback = function() { return 'the callback'; };
+
+    context('when the field type is DialogFieldCheckBox', function() {
+      beforeEach(function() {
+        options.type = 'DialogFieldCheckBox';
+        spyOn(dialogFieldRefresh, 'refreshCheckbox');
+      });
+
+      it('calls refreshCheckbox', function() {
+        dialogFieldRefresh.refreshField(options, callback);
+        expect(dialogFieldRefresh.refreshCheckbox).toHaveBeenCalledWith('name', '123', callback);
+      });
+    });
+
+    context('when the field type is DialogFieldTextBox', function() {
+      beforeEach(function() {
+        options.type = 'DialogFieldTextBox';
+        spyOn(dialogFieldRefresh, 'refreshTextBox');
+      });
+
+      it('calls refreshTextBox', function() {
+        dialogFieldRefresh.refreshField(options, callback);
+        expect(dialogFieldRefresh.refreshTextBox).toHaveBeenCalledWith('name', '123', callback);
+      });
+    });
+
+    context('when the field type is DialogFieldTextAreaBox', function() {
+      beforeEach(function() {
+        options.type = 'DialogFieldTextAreaBox';
+        spyOn(dialogFieldRefresh, 'refreshTextAreaBox');
+      });
+
+      it('calls refreshTextAreaBox', function() {
+        dialogFieldRefresh.refreshField(options, callback);
+        expect(dialogFieldRefresh.refreshTextAreaBox).toHaveBeenCalledWith('name', '123', callback);
+      });
+    });
+
+    context('when the field type is DialogFieldDropDownList', function() {
+      beforeEach(function() {
+        var html = '';
+        html += '<select name="name"><option selected="selected" value="1">One</option></select>';
+        setFixtures(html);
+
+        options.type = 'DialogFieldDropDownList';
+        spyOn(dialogFieldRefresh, 'refreshDropDownList');
+      });
+
+      it('calls refreshDropDownList', function() {
+        dialogFieldRefresh.refreshField(options, callback);
+        expect(dialogFieldRefresh.refreshDropDownList).toHaveBeenCalledWith('name', '123', '1', callback);
+      });
+    });
+
+    context('when the field type is DialogFieldRadioButton', function() {
+      beforeEach(function() {
+        var html = '';
+        html += '<input type="radio" name="name" value="1" checked /><input type="radio" name="name" value="2" />';
+        setFixtures(html);
+
+        options.type = 'DialogFieldRadioButton';
+        options.url = 'url';
+        options.auto_refresh_options = 'auto_refresh_options';
+        spyOn(dialogFieldRefresh, 'refreshRadioList');
+      });
+
+      it('calls refreshRadioList', function() {
+        dialogFieldRefresh.refreshField(options, callback);
+        expect(dialogFieldRefresh.refreshRadioList).toHaveBeenCalledWith(
+          'name', '123', '1', 'url', 'auto_refresh_options', callback
+        );
+      });
+    });
+
+    context('when the field type is DialogFieldDateControl', function() {
+      beforeEach(function() {
+        options.type = 'DialogFieldDateControl';
+        spyOn(dialogFieldRefresh, 'refreshDateTime');
+      });
+
+      it('calls refreshDateControl', function() {
+        dialogFieldRefresh.refreshField(options, callback);
+        expect(dialogFieldRefresh.refreshDateTime).toHaveBeenCalledWith('name', '123', callback);
+      });
+    });
+
+    context('when the field type is DialogFieldDateTimeControl', function() {
+      beforeEach(function() {
+        options.type = 'DialogFieldDateTimeControl';
+        spyOn(dialogFieldRefresh, 'refreshDateTime');
+      });
+
+      it('calls refreshDateTimeControl', function() {
+        dialogFieldRefresh.refreshField(options, callback);
+        expect(dialogFieldRefresh.refreshDateTime).toHaveBeenCalledWith('name', '123', callback);
+      });
+    });
+
+    context('when the field type is not supported', function() {
+      beforeEach(function() {
+        options.type = 'wrong';
+        spyOn(window, 'add_flash');
+      });
+
+      it('adds a flash message', function() {
+        dialogFieldRefresh.refreshField(options, callback);
+        expect(window.add_flash).toHaveBeenCalledWith(__("Field type is not a supported type!"), 'error');
+      });
+    });
+  });
+
   describe('#refreshCheckbox', function() {
     var loadedDoneFunction;
     var refreshCallback;


### PR DESCRIPTION
The problem this PR solves stems from if users had something like a text area with information at the top that they expected to be able to be auto-refreshed every time they made a change to a lower dialog field. Cascading auto-refresh was intended to only trigger fields from top to bottom and only *after* the field that did the triggering.

This PR will treat every trigger as if it's triggering from the "0th" element, that is, if the very first dialog field is listening for an auto-refresh, it will be refreshed when any other element triggers an auto-refresh. The element that did the triggering will not trigger itself.

https://bugzilla.redhat.com/show_bug.cgi?id=1439761

@miq-bot add_label bug, euwe/yes, fine/yes
@miq-bot assign @h-kataria 

@AparnaKarve, @h-kataria Can you guys review, or tag someone else to review? Thanks!

@gmcculloug I know javascript isn't your forte but wanted to tag you on this for the updates.