### PR TITLE
[WIP] Enable to download storage provider summary

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2103,6 +2103,11 @@ class ApplicationController < ActionController::Base
       @view ||= session[:view]                              #   Remember the previous @view
     end
 
+    if controller_name == "ems_cloud" && @lastaction == "show"
+      @view ||= session[:view]
+    else
+      @view = session[:view]
+    end
     # Save @edit key for the expression editor to use
     session[:expkey] = @expkey
     @edit[@expkey].drop_cache if @edit && @edit[@expkey]


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1439523

Enable to download storage provider (AWS) summary in TXT or CSV format
in Compute > Clouds > Providers in provider's summary page
for Storage Managers.

This PR fixes the bug only with another PR:
https://github.com/ManageIQ/manageiq/pull/15093