### PR TITLE
Add missing ownership routes for MiqTemplate

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2348,6 +2348,7 @@ Rails.application.routes.draw do
         edit
         edit_vm
         form_field_changed
+        ownership_form_fields
         show
       ) +
                ownership_post


### PR DESCRIPTION
Add missing ownership routes for MiqTemplate

https://bugzilla.redhat.com/show_bug.cgi?id=1448071

FINE PR - https://github.com/ManageIQ/manageiq-ui-classic/pull/1353

![screenshot from 2017-05-15 13-32-00](https://cloud.githubusercontent.com/assets/12769982/26070496/e983c7cc-3972-11e7-9c33-5871bfbc45ad.png)
