### PR TITLE
[FINE] Add missing ownership route for miq template

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2321,6 +2321,7 @@ Rails.application.routes.draw do
         edit
         show
         ownership
+        ownership_form_fields
       ),
       :post => %w(
         edit


### PR DESCRIPTION
Add missing ownership route for miq template

https://bugzilla.redhat.com/show_bug.cgi?id=1448071

![screenshot from 2017-05-15 14-13-08](https://cloud.githubusercontent.com/assets/12769982/26072177/a5d6505c-3978-11e7-8646-cb94613cc855.png)
