### PR TITLE
Changed API call to pass in region number get list of repos/playbooks

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalogItemFormId', 'miqService', 'postService', 'API', 'catalogItemDataFactory', function($scope, catalogItemFormId, miqService, postService, API, catalogItemDataFactory) {
+ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalogItemFormId', 'currentRegion', 'miqService', 'postService', 'API', 'catalogItemDataFactory', function($scope, catalogItemFormId, currentRegion, miqService, postService, API, catalogItemDataFactory) {
   var vm = this;
   var sort_options = "&sort_by=name&sort_order=ascending"
   var init = function() {
@@ -39,6 +39,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     getRemoveResourcesTypes();
     vm.provisioning_cloud_type = '';
     vm.retirement_cloud_type = '';
+    vm.currentRegion = currentRegion;
     vm.formId = catalogItemFormId;
     vm.afterGet = false;
     vm.model = "catalogItemModel";
@@ -260,7 +261,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     })
 
     // list of repositories
-    API.get("/api/configuration_script_sources?collection_class=ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource&expand=resources&attributes=id,name" + sort_options).then(function(data) {
+    API.get("/api/configuration_script_sources?collection_class=ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource&expand=resources&attributes=id,name&filter[]=region_number=" + vm.currentRegion + sort_options).then(function(data) {
       vm.repositories = data.resources;
       vm._retirement_repository = _.find(vm.repositories, {id: vm.catalogItemModel.retirement_repository_id});
       vm._provisioning_repository = _.find(vm.repositories, {id: vm.catalogItemModel.provisioning_repository_id});
@@ -326,8 +327,8 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
 
   // get playbooks for selected repository
   vm.repositoryChanged = function(prefix, id) {
-    API.get("/api/configuration_script_sources/" + id + "?attributes=configuration_script_payloads" + sort_options).then(function (data) {
-      vm[prefix + '_playbooks'] = data.configuration_script_payloads;
+    API.get("/api/configuration_script_sources/" + id + "/configuration_script_payloads?expand=resources&filter[]=region_number=" + vm.currentRegion + sort_options).then(function (data) {
+      vm[prefix + '_playbooks'] = data.resources;
       // if repository has changed
       if (id !== vm.catalogItemModel[prefix + '_repository_id']) {
         vm.catalogItemModel[prefix + '_playbook_id'] = '';

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -825,7 +825,9 @@ class CatalogController < ApplicationController
 
   def ansible_playbook?
     prov_type = params[:st_prov_type] ? params[:st_prov_type] : @record.prov_type
-    prov_type == "generic_ansible_playbook"
+    ansible_playbook = prov_type == "generic_ansible_playbook"
+    @current_region = MiqRegion.my_region.region if ansible_playbook
+    ansible_playbook
   end
   helper_method :ansible_playbook?
 

--- a/app/views/catalog/_st_angular_form.html.haml
+++ b/app/views/catalog/_st_angular_form.html.haml
@@ -66,5 +66,6 @@
 
 :javascript
   ManageIQ.angular.app.value('catalogItemFormId', '#{@record.id || "new"}');
+  ManageIQ.angular.app.value('currentRegion', '#{@current_region}');
   miq_bootstrap('#form_div');
 

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -1,5 +1,5 @@
 describe('catalogItemFormController', function() {
-  var $scope, $controller, postService;
+  var $scope, $controller, currentRegion, postService;
 
   beforeEach(module('ManageIQ'));
 
@@ -46,6 +46,7 @@ describe('catalogItemFormController', function() {
 
     $controller = _$controller_('catalogItemFormController', {
       $scope: $scope,
+      currentRegion: currentRegion,
       catalogItemFormId: 1000000000001
     });
   }));


### PR DESCRIPTION
Changed API call to get list of repos/playbooks to pass in current region number so only playbooks in current region are displayed in drop down.

https://bugzilla.redhat.com/show_bug.cgi?id=1449696

@gmcculloug please test/review. This is dependent on core PR https://github.com/ManageIQ/manageiq/pull/15070