### PR TITLE
Fix calendar position on Cluster C & U tab

### DIFF
--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -54,6 +54,7 @@
               h(@perf_options[:typ] == "Hourly" ? @perf_options[:hourly_date] : @perf_options[:daily_date]),
               :readonly               => "true",
               "data-miq_sparkle_on"   => true,
+              "data-date-orientation" => "bottom",
               "data-miq_observe_date" => {:url => url}.to_json)
 
         - unless @perf_options[:typ] == "Hourly"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1450463

This PR forces the datapicker box to drop-down so that the controls aren't cropped by the toolbar.

Old 
![screen shot 2017-05-16 at 10 22 11 am](https://cloud.githubusercontent.com/assets/1287144/26114649/dc1ec906-3a2b-11e7-82f5-862be8ab02b9.png)

New
![screen shot 2017-05-16 at 10 27 15 am](https://cloud.githubusercontent.com/assets/1287144/26114650/dc28053e-3a2b-11e7-9a48-892cbcff4218.png)