### PR TITLE
Remove only usage of RecursiveOpenStruct since it's overkill

### DIFF
--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -165,7 +165,7 @@ describe EmsCloudController do
 end
 
 describe EmsContainerController do
-  let(:myhawkularroute) { RecursiveOpenStruct.new(:spec => {:host => "myhawkularroute.com"}) }
+  let(:myhawkularroute) { double(:spec => double(:host => "myhawkularroute.com")) }
 
   def expect_get_route(&block)
     mock_client = double('kubeclient')

--- a/spec/services/container_dashboard_service_spec.rb
+++ b/spec/services/container_dashboard_service_spec.rb
@@ -1,7 +1,5 @@
-require 'recursive-open-struct'
-
 describe ContainerDashboardService do
-  let(:controller) { RecursiveOpenStruct.new(:current_user => {:get_timezone => "UTC"}) }
+  let(:controller) { double(:current_user => double(:get_timezone => "UTC", :id => 123)) }
   let(:time_profile) { FactoryGirl.create(:time_profile_utc) }
 
   before(:each) do


### PR DESCRIPTION
By properly removing or using and listing dependencies of
RecursiveOpenStruct, we can remove the implicit dependency in the main
manageiq repo.

See: https://github.com/ManageIQ/manageiq/pull/15096

@himdel please review