### PR TITLE
Remove duplicate code in ci_processing.

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -72,51 +72,6 @@ module ApplicationController::CiProcessing
     @redirect_id = obj[0]
   end
 
-  # Build the vm detail gtl view
-  def show_details(db, options = {})  # Pass in the db, parent vm is in @vm
-    association = options[:association]
-    conditions  = options[:conditions]
-    # generate the grid/tile/list url to come back here when gtl buttons are pressed
-    @gtl_url       = "/#{@db}/#{@listicon.pluralize}/#{@record.id}?"
-    @showtype      = "details"
-    @display       = "main"
-    @no_checkboxes = @no_checkboxes.nil? || @no_checkboxes
-    @showlinks     = true
-
-    @view, @pages = get_view(db,
-                             :parent      => @record,
-                             :association => association,
-                             :conditions  => conditions,
-                             :dbname      => "#{@db}item")  # Get the records into a view & paginator
-
-    if @explorer # In explorer?
-      @refresh_partial = "vm_common/#{@showtype}"
-      replace_right_cell
-    else
-      if pagination_request?
-        replace_gtl_main_div
-      elsif request.xml_http_request?
-        # reload toolbars - AJAX request
-        render :update do |page|
-          page << javascript_prologue
-          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-          page.replace_html("main_div", :partial => "shared/views/ems_common/show") # Replace main div area contents
-          page << javascript_reload_toolbars
-          page.replace_html("paging_div",
-                            :partial => 'layouts/pagingcontrols',
-                            :locals  => {:pages      => @pages,
-                                         :action_url => @lastaction,
-                                         :db         => @view.db,
-                                         :headers    => @view.headers})
-        end
-      elsif controller_name == "ems_cloud"
-        render :template => "shared/views/ems_common/show"
-      else
-        render :action => "show"
-      end
-    end
-  end
-
   def get_record(db)
     if db == "host"
       @host = @record = identify_record(params[:id], Host)


### PR DESCRIPTION
Related code was moved to app/controllers/mixins/explorer_show.rb in
https://github.com/ManageIQ/manageiq-ui-classic/pull/1237. This method
was left behind by accident.