### PR TITLE
New dialog name validation added.

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -535,6 +535,16 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     angular.element('#confirmationModal').modal("hide");
   }
 
+  $scope.dialogNameValidation = function() {
+    miqService.miqFlashClear();
+    $scope.angularForm.$setValidity("unchanged", true);
+
+    if (vm.dialogs.filter(function(e) { return e.label == vm.catalogItemModel.provisioning_dialog_name; }).length > 0) {
+      miqService.miqFlash("error", "Dialog name already exists");
+      $scope.angularForm.$setValidity("unchanged", false);
+    }
+  };
+
   init();
 }]);
 

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -228,6 +228,7 @@
         .col-md-6{"ng-class" => "{'has-error': angularForm.#{prefix}_dialog_name.$invalid}", "ng-if" => "#{ng_model}.#{prefix}_dialog_existing == 'create'"}
           %input.form-control{:type         => "text",
                               'ng-model'    => "#{ng_model}.#{prefix}_dialog_name",
+                              'ng-change'   => "dialogNameValidation()",
                               :name         => "vm.#{prefix}_dialog_name",
                               :maxlength    => 50,
                               "ng-required" => "vm.fieldsRequired('#{prefix}') && #{ng_model}.#{prefix}_dialog_existing == 'create'",


### PR DESCRIPTION
Show flash message and disable Add/Save button when user enters a dialog name in 'Create New' field that already exists in the db

https://bugzilla.redhat.com/show_bug.cgi?id=1449345

List of available Dialogs:
![existing_dialogs_list](https://cloud.githubusercontent.com/assets/3450808/26128911/148428a6-3a5c-11e7-84b4-571a0d0788f2.png)

After fix:
![after1](https://cloud.githubusercontent.com/assets/3450808/26128921/1a249548-3a5c-11e7-93c8-1c5ece0d7338.png)

![after2](https://cloud.githubusercontent.com/assets/3450808/26128926/1cf36632-3a5c-11e7-84c4-094c66c87194.png)

@gmcculloug @syncrou please test.
cc @dclarizio 