### PR TITLE
Tweak ad hoc page layout

### DIFF
--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -23,13 +23,14 @@
     margin-left: 15px;
   }
   .toolbar-pf {
-    .toolbar-pf-actions {
-      .form-group {
-        padding-right: 0;
-        margin-bottom: 0;
-        border: 0;
-      }
-    }
+    border: 0;
+  }
+  .graph-view .toolbar-pf .toolbar-pf-actions .form-group {
+    padding-right: 0;
+  }
+  .list-view .toolbar-pf .toolbar-pf-actions .form-group {
+    padding-right: 0;
+    margin-bottom: 0 !important;
   }
 
   .ad-hoc-tenant {
@@ -65,8 +66,12 @@
   .pagination-div {
     display: flex;
     float: right;
-    margin: 0;
-    margin-bottom: 0;
+    position: absolute;
+    top: 46px;
+    right: 5px;
+    margin-right: 5px;
+    padding-right: 0;
+    border: 0;
     .page-input {
       width: 40px;
       margin-left: 10px;
@@ -92,12 +97,10 @@
   }
 
   .list-view-container {
-    min-height: calc(100vh - 353px);
     padding-top: 10px;
     margin-bottom: 0;
   }
   .line-chart {
-    min-height: calc(100vh - 347px);
     margin-top: 36px;
     margin-left: 30px;
     margin-right: 50px;
@@ -105,7 +108,6 @@
   }
 
   .blank-slate-pf {
-    min-height: calc(100vh - 353px);
     margin-bottom: 0;
   }
 
@@ -135,13 +137,16 @@
       border-bottom: 1px solid #39a5dc;
     }
 
+    .list-group.list-view-pf.list-view-pf-view {
+      margin-top: 5px;
+    }
+
     .list-group-item-container {
       margin-top: 10px;
       padding: 15px;
       border: 0;
     }
     .form-group.toolbar-actions.ng-scope {
-      width: calc(100% - 435px);
       border: 0;
     }
     .dropdown-kebab-pf {

--- a/app/views/ems_container/ad_hoc/_list_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_list_view_form.html.haml
@@ -45,29 +45,29 @@
               .col
                 %span.pficon{"ng-class" => "{true: 'pficon-ok'}[dash.filterType===range.value]"}
 
-  .form-group.pagination-div
-    %ul.pagination.pagination-pf-back
-      %li
-        %a{"href"  => "#",
-           "ng-click" => "dash.setPage(1)",
-           "title" => _("First Page")}
-          %span.i.fa.fa-angle-double-left
-      %li
-        %a{"href"  => "#",
-           "ng-click" => "dash.setPage(dash.page - 1)",
-           "title" => _("Previous Page")}
-          %span.i.fa.fa-angle-left
+.form-group.pagination-div
+  %ul.pagination.pagination-pf-back
+    %li
+      %a{"href"  => "#",
+         "ng-click" => "dash.setPage(1)",
+         "title" => _("First Page")}
+        %span.i.fa.fa-angle-double-left
+    %li
+      %a{"href"  => "#",
+         "ng-click" => "dash.setPage(dash.page - 1)",
+         "title" => _("Previous Page")}
+        %span.i.fa.fa-angle-left
 
-    #pagination-title {{dash.pagesTitle}}
+  #pagination-title {{dash.pagesTitle}}
 
-    %ul.pagination.pagination-pf-forward
-      %li
-        %a{"href"  => "#",
-           "ng-click" => "dash.setPage(dash.page + 1)",
-           "title" => _("Next Page")}
-          %span.i.fa.fa-angle-right
-      %li
-        %a{"href"  => "#",
-           "ng-click" => "dash.setPage(dash.pages)",
-           "title" => _("Last Page")}
-          %span.i.fa.fa-angle-double-right
+  %ul.pagination.pagination-pf-forward
+    %li
+      %a{"href"  => "#",
+         "ng-click" => "dash.setPage(dash.page + 1)",
+         "title" => _("Next Page")}
+        %span.i.fa.fa-angle-right
+    %li
+      %a{"href"  => "#",
+         "ng-click" => "dash.setPage(dash.pages)",
+         "title" => _("Last Page")}
+        %span.i.fa.fa-angle-double-right


### PR DESCRIPTION
Compute > Containers > Providers - pick a provider - toolbar Monitoring > Ad hoc Metrics

**Description**
Make the margins between the ad hoc form and list smaller, the same size as the margin in the charts.

**Screenshots**
Before
![screenshot-localhost 3000-2017-05-17-11-54-19](https://cloud.githubusercontent.com/assets/2181522/26146192/f4e4908e-3af7-11e7-9366-1b845c13a2d0.png)

After
![screenshot-localhost 3000-2017-05-17-11-55-45](https://cloud.githubusercontent.com/assets/2181522/26146220/0dbd208a-3af8-11e7-8da9-e37a5dd76cbf.png)

