### PR TITLE
Add reload button to Ansible Repositories

### DIFF
--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -33,6 +33,28 @@ class AnsibleRepositoryController < ApplicationController
       javascript_redirect :action => 'new'
     elsif params[:pressed] == "embedded_configuration_script_source_delete"
       delete_repositories
+    elsif params[:pressed] == 'ansible_repositories_reload'
+      show_list
+      render :update do |page|
+        page << javascript_prologue
+        page.replace("gtl_div", :partial => "layouts/gtl")
+      end
+    elsif params[:pressed] == 'ansible_repository_reload'
+      @display = 'summary_only'
+      show
+      render :update do |page|
+        page << javascript_prologue
+        page.replace("main_div", :template => "ansible_repository/show")
+      end
+    end
+  end
+
+  def check_button_rbac
+    # Allow reload to skip RBAC check
+    if %w(ansible_repository_reload ansible_repositories_reload).include?(params[:pressed])
+      true
+    else
+      super
     end
   end
 

--- a/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
@@ -1,4 +1,13 @@
 class ApplicationHelper::Toolbar::AnsibleRepositoriesCenter < ApplicationHelper::Toolbar::Basic
+  button_group('ansible_repositories_reloading', [
+    button(
+      :ansible_repositories_reload,
+      'fa fa-repeat fa-lg',
+      N_('Reload the current display'),
+      N_('Reload'),
+      :url_parms => "main_div",
+      :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
+  ])
   button_group('ansible_repositories', [
     select(
       :ansible_repositories_configuration,

--- a/app/helpers/application_helper/toolbar/ansible_repository_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repository_center.rb
@@ -1,4 +1,13 @@
 class ApplicationHelper::Toolbar::AnsibleRepositoryCenter < ApplicationHelper::Toolbar::Basic
+  button_group('ansible_repositories_reloading', [
+    button(
+      :ansible_repository_reload,
+      'fa fa-repeat fa-lg',
+      N_('Reload the current display'),
+      N_('Reload'),
+      :url_parms => "main_div",
+      :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
+  ])
   button_group('ansible_repository', [
     select(
       :ansible_repository_configuration,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1448601

Ansible Repositories:
<img width="1196" alt="screen shot 2017-05-17 at 2 24 38 pm" src="https://cloud.githubusercontent.com/assets/9210860/26154012/219445dc-3b0e-11e7-878e-9b966fe925f9.png">

Ansible Repository:
<img width="758" alt="screen shot 2017-05-17 at 2 24 28 pm" src="https://cloud.githubusercontent.com/assets/9210860/26154003/18cb9db0-3b0e-11e7-9ac8-7b1e3ee9cbfc.png">

@miq-bot add_label bug, automation/ansible