### PR TITLE
Need to gsub occurrences of {{ }} in the output

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -141,6 +141,19 @@ class ServiceController < ApplicationController
 
   private
 
+  def sanitize_output(stdout)
+    htm = stdout.gsub('"', '\"')
+
+    regex_map = {
+      /'/  => "\\\\'",
+      /{{/ => '\{\{',
+      /}}/ => '\}\}'
+    }
+    regex_map.each_pair { |f, t| htm.gsub!(f, t) }
+    htm
+  end
+  helper_method :sanitize_output
+
   def textual_group_list
     if @record.type == "ServiceAnsiblePlaybook"
       [%i(properties), %i(lifecycle tags)]

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -42,8 +42,7 @@
             .form-horizontal.static
               .form-group
                 .col-md-9
-                  - htm = @job.raw_stdout('html').gsub('"', '\"').gsub("'", "\\\\'")
-                  %div{'ng-bind-html'=>"vm.sanitizeRenderHtml('#{htm}')"}
+                  %div{'ng-bind-html'=>"vm.sanitizeRenderHtml('#{sanitize_output(@job.raw_stdout('html'))}')"}
         - if job
           = miq_tab_content("retirement", 'default', :class => 'cm-tab') do
             = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_retirement_group_list}
@@ -52,8 +51,7 @@
             .form-horizontal.static
               .form-group
                 .col-md-9
-                  - htm = job.raw_stdout('html').gsub('"', '\"').gsub("'", "\\\\'")
-                  %div{'ng-bind-html'=>"vm.sanitizeRenderHtml('#{htm}')"}
+                  %div{'ng-bind-html'=>"vm.sanitizeRenderHtml('#{sanitize_output(job.raw_stdout('html'))}')"}
 :javascript
   miq_tabs_init('#services_tab');
   miq_bootstrap('#service_details', 'sanitizeRender');

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -79,5 +79,12 @@ describe ServiceController do
     end
   end
 
+  context "#sanitize_output" do
+    it "escapes characters in the output string" do
+      output = controller.send(:sanitize_output, "I'm \"Fred\" {{Flintstone}}")
+      expect(output).to eq("I\\'m \\\"Fred\\\" \\{\\{Flintstone\\}\\}")
+    end
+  end
+
   it_behaves_like "explorer controller with custom buttons"
 end


### PR DESCRIPTION
Moved gsub logic into a helper method. Having ", ', {{, }} characters in the output was causing an issue while rendering html using ngSanitize directive, needed to escape these characters to get the output to be displayed correctly on screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1451352
https://bugzilla.redhat.com/show_bug.cgi?id=1444853

@syncrou @gmcculloug please test/review.