### PR TITLE
miq_request fixes

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -5,10 +5,15 @@ function miqTreeObject(tree) {
 }
 
 function miqTreeFindNodeByKey(tree, key) {
-  return miqTreeObject(tree).getNodes().find(function (node) {
-    if (node.key == key) {
-      return node;
-    }
+  var tree = miqTreeObject(tree);
+
+  if (!tree) {
+    console.error("miqTreeFindNodeByKey: tree '" + tree + "' does not exist.");
+    return;
+  };
+
+  return tree.getNodes().find(function (node) {
+    return (node.key == key);
   });
 }
 

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -66,8 +66,7 @@ class MiqRequestController < ApplicationController
         show_list
         render :update do |page|
           page << javascript_prologue
-          page.replace("prov_options_div", :partial => "prov_options")
-          page.replace("gtl_div", :partial => "layouts/gtl")
+          page.replace("main_div", :template => "miq_request/show_list")
         end
       end
     else

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -27,7 +27,9 @@ class MiqRequestController < ApplicationController
       @refresh_partial = "layouts/flash_msg"
       @refresh_div = "flash_msg_div"
     end
+
     return if params[:pressed] == "miq_request_edit" && @refresh_partial == "reconfigure"
+
     if !@flash_array.nil? && params[:pressed] == "miq_request_delete"
       javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
     elsif ["miq_request_copy", "miq_request_edit"].include?(params[:pressed])
@@ -40,7 +42,7 @@ class MiqRequestController < ApplicationController
                           :prov_id        => @prov_id
     elsif params[:pressed].ends_with?("_edit")
       if @refresh_partial == "show_list"
-        javascript_redirect :action      => @refresh_partial,
+        javascript_redirect :action      => 'show_list',
                             :flash_msg   => _("Default Requests can not be edited"),
                             :flash_error => true
       else
@@ -70,16 +72,15 @@ class MiqRequestController < ApplicationController
         end
       end
     else
-      render :update do |page|
-        page << javascript_prologue
-        unless @refresh_partial.nil?
-          if @refresh_div == "flash_msg_div"
-            page.replace(@refresh_div, :partial => @refresh_partial)
-          else
-            page.replace_html(@refresh_div, :partial => @refresh_partial)
-          end
+      if @refresh_partial.nil?
+        render :nothing
+      elseif @refresh_div == "flash_msg_div"
+        javascript_flash
+      else
+        render :update do |page|
+          page << javascript_prologue
+          page.replace_html(@refresh_div, :partial => @refresh_partial)
         end
-        page.replace_html(@refresh_div, :action => @render_action) unless @render_action.nil?
       end
     end
   end

--- a/app/views/layouts/_gtl.html.haml
+++ b/app/views/layouts/_gtl.html.haml
@@ -1,5 +1,6 @@
 - button_div ||= "center_tb"
 - rec_display = ""
 - no_rec_display = "display:none"
+- no_flash_div ||= false
 #gtl_div
-  = render :partial => "layouts/angular/gtl"
+  = render :partial => "layouts/angular/gtl", :locals => {:no_flash_div => no_flash_div}

--- a/app/views/layouts/angular/_gtl.html.haml
+++ b/app/views/layouts/angular/_gtl.html.haml
@@ -1,4 +1,5 @@
 - current_model = model_to_report_data
+- no_flash_div ||= false
 - gtl_type_string = j_str(@gtl_type)
 - active_tree = x_active_tree unless params[:display] || @use_action
 - selected_records = @edit[:object_ids] unless @edit.nil? || @edit[:object_ids].nil?
@@ -7,7 +8,8 @@
 - selected_records = selected_records.map(&:to_i) if !selected_records.nil? && selected_records.first.kind_of?(String)
 - selected_records = selected_records.map(&:id) if !selected_records.nil? && !selected_records.first.kind_of?(Integer)
 #miq-gtl-view{"ng-controller" => "reportDataController as dataCtrl"}
-  = render(:partial => "layouts/flash_msg")
+  - unless no_flash_div
+    = render :partial => "layouts/flash_msg"
   %miq-tile-view{"ng-if"            => "dataCtrl.gtlType === 'grid' || dataCtrl.gtlType === 'tile'",
                  "ng-class"         => "{'no-action': dataCtrl.initObject.showUrl === ''}",
                  "settings"         => "dataCtrl.settings",

--- a/app/views/miq_request/_prov_options.html.haml
+++ b/app/views/miq_request/_prov_options.html.haml
@@ -1,6 +1,6 @@
-= render :partial => "layouts/flash_msg"
 - url = url_for_only_path(:action => 'prov_change_options')
 #prov_options_div
+  = render :partial => "layouts/flash_msg"
   %h3
     = _("Filter By")
   .form-horizontal
@@ -66,7 +66,6 @@
           = link_to(_("Default"),
             {:action => "prov_button", :button => "default"},
             :class                 => "btn btn-default",
-            :id                    => "apply",
             :alt                   => (t = _("Set filters to default")),
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true,

--- a/app/views/miq_request/show_list.html.haml
+++ b/app/views/miq_request/show_list.html.haml
@@ -1,3 +1,3 @@
 #main_div
   = render :partial => 'prov_options'
-  = render :partial => 'layouts/gtl'
+  = render :partial => 'layouts/gtl', :locals => {:no_flash_div => true}


### PR DESCRIPTION
* recover from a probem when setting up trees instead of dumping javascript stacktrace
please, see description in individual commits
* fix duplicate DOM ids
* `flash_div` outside `prov_options_div` means a new `flash_div` with each refresh

@himdel : please, read