### PR TITLE
Fix #show spec for Physical Server

### DIFF
--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -10,14 +10,15 @@ describe PhysicalServerController do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)
       ems = FactoryGirl.create(:ems_physical_infra)
+      asset_details = FactoryGirl.create(:asset_details)
       computer_system = FactoryGirl.create(:computer_system, :hardware => FactoryGirl.create(:hardware))
-      physical_server = FactoryGirl.create(:physical_server, :computer_system => computer_system, :ems_id => ems.id)
+      physical_server = FactoryGirl.create(:physical_server,
+                                           :asset_details   => asset_details,
+                                           :computer_system => computer_system,
+                                           :ems_id          => ems.id)
       get :show, :params => {:id => physical_server.id}
     end
-    it {
-      pending("temporarily skipping")
-      expect(response.status).to eq(200)
-    }
+    it { expect(response.status).to eq(200) }
   end
 
   describe "#show_list" do


### PR DESCRIPTION
Fixed the spec with `asset_details`, required to render textual summary views

`asset_details` factory was added in https://github.com/ManageIQ/manageiq/pull/15126