### PR TITLE
make textarea based item selector responsive

### DIFF
--- a/app/views/catalog/_column_lists.html.haml
+++ b/app/views/catalog/_column_lists.html.haml
@@ -1,52 +1,55 @@
 #column_lists
   - url = url_for_only_path(:action => 'st_catalog_form_field_changed', :id => (@edit[:rec_id] || "new"))
-  %table.form#formtest{:width => "100%"}
-    %tr
-      %td.widthed{:align => "left"}= _('Unassigned:')
-      %td
-      %td{:align => "left"}= _('Selected:')
-    %tr
-      %td{:align => "right", :valign => "top"}
-        = select_tag("available_fields[]",
-                     options_for_select(@edit[:new][:available_fields]),
-                     :multiple => true,
-                     :style    => "width: 450px",
-                     :size     => 8,
-                     :id       => "available_fields")
-      %td.text-center{:width => "40"}
-        .btn-group-vertical
-          - if @edit[:new][:available_fields].length == 0
-            %button.btn.btn-default.disabled
-              %i.fa.fa-angle-right.fa-lg
-          - else
-            - t = _("Move Selected buttons right")
-            %button.btn.btn-default{:title => t,
-              "data-submit"         => 'column_lists',
-              "data-miq_sparkle_on" => true,
-              :remote               => true,
-              "data-method"         => :post,
-              'data-click_url'      => {:url => "#{url}?button=right"}.to_json}
-              %i.fa.fa-angle-right.fa-lg
+  .col-md-5
+    = _('Unassigned:')
+    = select_tag("available_fields[]",
+             options_for_select(@edit[:new][:available_fields]),
+             :multiple => true,
+             :class    => "form-control",
+             :style    => "overflow-x: scroll;",
+             :size     => 8,
+             :id       => "available_fields")
 
-          - if @edit[:new][:fields].length == 0
-            %button.btn.btn-default.disabled
-              %i.fa.fa-angle-left.fa-lg
-          - else
-            - t = _("Move Selected buttons left")
-            %button.btn.btn-default{:title => t,
-              "data-submit"         => 'column_lists',
-              "data-miq_sparkle_on" => true,
-              :remote               => true,
-              "data-method"         => :post,
-              'data-click_url'      => {:url => "#{url}?button=left"}.to_json}
-              %i.fa.fa-angle-left.fa-lg
+  .col-md-1{:style => "padding: 10px"}
+    .spacer
+    .spacer
+    - if @edit[:new][:available_fields].length == 0
+      %button.btn.btn-default.btn-block.disabled
+        %i.fa.fa-angle-right.fa-lg.hidden-xs.hidden-sm
+        %i.fa.fa-angle-right.fa-lg.fa-rotate-90.hidden-md.hidden-lg
+    - else
+      - t = _("Move Selected buttons right")
+      %button.btn.btn-default.btn-block{:title => t,
+        "data-submit"         => 'column_lists',
+        "data-miq_sparkle_on" => true,
+        :remote               => true,
+        "data-method"         => :post,
+        'data-click_url'      => {:url => "#{url}?button=right"}.to_json}
+        %i.fa.fa-angle-right.fa-lg.hidden-xs.hidden-sm
+        %i.fa.fa-angle-right.fa-lg.fa-rotate-90.hidden-md.hidden-lg
 
+    - if @edit[:new][:fields].length == 0
+      %button.btn.btn-default.btn-block.disabled
+        %i.fa.fa-angle-left.fa-lg.hidden-xs.hidden-sm
+        %i.fa.fa-angle-left.fa-lg.fa-rotate-90.hidden-md.hidden-lg      
+    - else
+      - t = _("Move Selected buttons left")
+      %button.btn.btn-default.btn-block{:title => t,
+        "data-submit"         => 'column_lists',
+        "data-miq_sparkle_on" => true,
+        :remote               => true,
+        "data-method"         => :post,
+        'data-click_url'      => {:url => "#{url}?button=left"}.to_json}
+        %i.fa.fa-angle-left.fa-lg.hidden-xs.hidden-sm
+        %i.fa.fa-angle-left.fa-lg.fa-rotate-90.hidden-md.hidden-lg    
+      .spacer
 
-
-      %td{:align => "left", :valign => "top"}
-        = select_tag("selected_fields[]",
-                     options_for_select(@edit[:new][:fields], @selected),
-                     :multiple => true,
-                     :style    => "width: 450px",
-                     :size     => 8,
-                     :id       => "selected_fields")
+  .col-md-5
+    = _('Selected:')
+    = select_tag("selected_fields[]",
+             options_for_select(@edit[:new][:fields], @selected),
+             :multiple => true,
+             :class    => "form-control",
+             :style    => "overflow-x: scroll;",
+             :size     => 8,
+             :id       => "selected_fields")

--- a/app/views/miq_ae_class/_domains_priority_form.html.haml
+++ b/app/views/miq_ae_class/_domains_priority_form.html.haml
@@ -1,25 +1,31 @@
 = render :partial => "layouts/flash_msg"
 #domains_list
-  %table#formtest.form{:width => '50%'}
-    %tr
-      %td.widthed{:align => "left"}= _("Domains:")
-      %td
-    %tr
-      %td{:align => "left", :valign => "top"}
-        = select_tag('seq_fields[]',
-          options_for_select(@edit[:new][:domain_order], @selected),
-          :multiple => true, :style => "width: 450px", :size => 20, :id => "seq_fields")
-      %td{:width => "30", :align => "left", :valign => "middle"}
-        = link_image_if(:cond => (@edit[:new][:domain_order].length < 2),
-          :image              => image_path('toolbars/up.png'),
-          :opts_true          => {:class  => "dimmed small"},
-          :opts_false         => {:class  => "rollover small", :alt => t = _("Move selected fields up")},
-          :link               => {:action => 'priority_form_field_changed', :button => 'up', :id => "priority__edit"},
-          :opts_link          => {:remote => true, 'data-method' => :post, "data-submit" => "domains_list", :title => t})
-        = link_image_if(:cond => (@edit[:new][:domain_order].length < 2),
-          :image              => image_path('toolbars/down.png'),
-          :opts_true          => {:class => "dimmed small"},
-          :opts_false         => {:class => "rollover small", :alt => (t = _("Move selected fields down"))},
-          :link               => {:action => 'priority_form_field_changed', :button => 'down', :id => "priority__edit"},
-          :opts_link          => {:remote => true, 'data-method' => :post, "data-submit" => "domains_list", :title => t})
-  #div.note= _('* Select one or more consecutive groups to move up or down.')
+  .row
+    .col-md-7.col-sm-10.col-xs-10
+      = _("Domains:")
+      = select_tag('seq_fields[]',
+        options_for_select(@edit[:new][:domain_order], @selected),
+        :multiple => true, :class  => "form-control", :style => "overflow-x: scroll;", :size => 20, :id => "seq_fields")
+      %small= _('* Select one or more consecutive groups to move up or down.')
+
+    .col-md-1.col-sm-2.col-xs-2{:style => "padding: 10px"}
+      .spacer
+      .spacer
+        - if @edit[:new][:domain_order].length < 2
+          %button.btn.disabled.btn-block
+            %i.fa.fa-lg.fa-angle-up
+          %button.btn.disabled.btn-block
+            %i.fa.fa-lg.fa-angle-down
+        - else
+          - [[_("Move selected fields up"),   'domains_list', 'up',    'fa-angle-up'],
+             [_("Move selected fields down"), 'domains_list', 'down',  'fa-angle-down']].each do |title, chosen_div, action, arrow_style|
+            %button.btn.btn-default.btn-block{:title                 => title,
+                                              :remote                => true,
+                                              "data-submit"          => chosen_div,
+                                              "data-method"          => :post,
+                                              "data-miq_sparkle_on"  => true,
+                                              "data-miq_sparkle_off" => true,
+                                              "data-click_url"       => {:url => url_for_only_path(:action => 'priority_form_field_changed',
+                                                                                                   :button => action,
+                                                                                                   :id     => 'priority__edit')}.to_json}
+              %i.fa.fa-lg{:class => arrow_style}

--- a/app/views/miq_ae_class/_domains_priority_form.html.haml
+++ b/app/views/miq_ae_class/_domains_priority_form.html.haml
@@ -8,24 +8,10 @@
         :multiple => true, :class  => "form-control", :style => "overflow-x: scroll;", :size => 20, :id => "seq_fields")
       %small= _('* Select one or more consecutive groups to move up or down.')
 
-    .col-md-1.col-sm-2.col-xs-2{:style => "padding: 10px"}
-      .spacer
-      .spacer
-        - if @edit[:new][:domain_order].length < 2
-          %button.btn.disabled.btn-block
-            %i.fa.fa-lg.fa-angle-up
-          %button.btn.disabled.btn-block
-            %i.fa.fa-lg.fa-angle-down
-        - else
-          - [[_("Move selected fields up"),   'domains_list', 'up',    'fa-angle-up'],
-             [_("Move selected fields down"), 'domains_list', 'down',  'fa-angle-down']].each do |title, chosen_div, action, arrow_style|
-            %button.btn.btn-default.btn-block{:title                 => title,
-                                              :remote                => true,
-                                              "data-submit"          => chosen_div,
-                                              "data-method"          => :post,
-                                              "data-miq_sparkle_on"  => true,
-                                              "data-miq_sparkle_off" => true,
-                                              "data-click_url"       => {:url => url_for_only_path(:action => 'priority_form_field_changed',
-                                                                                                   :button => action,
-                                                                                                   :id     => 'priority__edit')}.to_json}
-              %i.fa.fa-lg{:class => arrow_style}
+    - button_params = @edit[:new][:domain_order].length >= 2 ? [[_("Move selected fields up"),   'domains_list', 'up',    'fa-angle-up'],
+                                                                [_("Move selected fields down"), 'domains_list', 'down',  'fa-angle-down']] : []
+    = render :partial => "shared/views/seq_selector_buttons",
+             :locals  => {:fields_count  => @edit[:new][:domain_order].length,
+                          :button_params => button_params,
+                          :button_action => 'priority_form_field_changed',
+                          :id            => 'priority__edit'}

--- a/app/views/miq_ae_class/_fields_seq_form.html.haml
+++ b/app/views/miq_ae_class/_fields_seq_form.html.haml
@@ -1,39 +1,33 @@
 = render :partial => "layouts/flash_msg"
 #column_lists
-  %p
-  %table#formtest.form{:width => '50%'}
-    %tr
-      %td.widthed{:align => "left"}= _('Class Schema Sequencing:')
-      %td
-    %tr
-      %td{:align => "left", :valign => "top"}
-        = select_tag('seq_fields[]',
-          options_for_select(@edit[:new][:fields_list], @selected),
-          :multiple => true, :style => "width: 450px", :size => 20, :id => "seq_fields")
-      %td{:width => "30", :align => "left", :valign => "middle"}
-        = link_image_if(:cond => (@edit[:new][:fields].length < 2),
-          :image              => image_path('toolbars/up.png'),
-          :opts_true          => {:class => "dimmed small"},
-          :opts_false         => {:class => "rollover small", :alt => (t = _("Move selected fields up"))},
-          :link               => {:action => 'fields_seq_field_changed', :button => 'up', :id => "seq"},
-          :opts_link          => {:title => t,
-            "data-miq_sparkle_on"        => true,
-            "data-miq_sparkle_off"       => true,
-            "data-submit"                => 'column_lists',
-            "data-method"                => :post,
-            :remote                      => true})
-        = link_image_if(:cond => (@edit[:new][:fields].length < 2),
-          :image              => image_path('toolbars/down.png'),
-          :opts_true          => {:class => "dimmed small"},
-          :opts_false         => {:class => "rollover small", :alt => (t = _("Move selected fields down"))},
-          :link               => {:action => 'fields_seq_field_changed', :button => 'down', :id => "seq"},
-          :opts_link          => {:title => t,
-            "data-miq_sparkle_on"        => true,
-            "data-miq_sparkle_off"       => true,
-            "data-submit"                => 'column_lists',
-            "data-method"                => :post,
-            :remote                      => true})
-  .note= _('* Select one or more consecutive fields to move up or down.')
+  .col-md-7.col-sm-10.col-xs-10
+    = _('Class Schema Sequencing:')
+    = select_tag('seq_fields[]',
+      options_for_select(@edit[:new][:fields_list], @selected),
+      :multiple => true, :class  => "form-control", :style => "overflow-x: scroll;", :size => 20, :id => "seq_fields")
+    %small= _('* Select one or more consecutive fields to move up or down.')
+  .col-md-1.col-sm-2.col-xs-2{:style => "padding: 10px"}
+    .spacer
+    .spacer
+      - if @edit[:new][:fields].length < 2
+        %button.btn.btn-block.disabled
+          %i.fa.fa-angle-up.fa-lg
+        %button.btn.btn-block.disabled
+          %i.fa.fa-angle-down.fa-lg
+      - else
+        - [[_("Move selected fields up"),   'column_lists', 'up',    'fa-angle-up'],
+           [_("Move selected fields down"), 'column_lists', 'down',  'fa-angle-down']].each do |title, chosen_div, action, arrow_style|
+          %button.btn.btn-default.btn-block{:title                 => title,
+                                            :remote                => true,
+                                            "data-submit"          => chosen_div,
+                                            "data-method"          => :post,
+                                            "data-miq_sparkle_on"  => true,
+                                            "data-miq_sparkle_off" => true,
+                                            "data-click_url"       => {:url => url_for_only_path(:action => 'fields_seq_field_changed',
+                                                                                                 :button => action,
+                                                                                                 :id     => 'seq')}.to_json}
+            %i.fa.fa-lg{:class => arrow_style}
+    .spacer
 :javascript
   // disable any other tabs on screen when in edit
   miq_tabs_disable_inactive('#ae_tabs');

--- a/app/views/miq_ae_class/_fields_seq_form.html.haml
+++ b/app/views/miq_ae_class/_fields_seq_form.html.haml
@@ -6,28 +6,15 @@
       options_for_select(@edit[:new][:fields_list], @selected),
       :multiple => true, :class  => "form-control", :style => "overflow-x: scroll;", :size => 20, :id => "seq_fields")
     %small= _('* Select one or more consecutive fields to move up or down.')
-  .col-md-1.col-sm-2.col-xs-2{:style => "padding: 10px"}
-    .spacer
-    .spacer
-      - if @edit[:new][:fields].length < 2
-        %button.btn.btn-block.disabled
-          %i.fa.fa-angle-up.fa-lg
-        %button.btn.btn-block.disabled
-          %i.fa.fa-angle-down.fa-lg
-      - else
-        - [[_("Move selected fields up"),   'column_lists', 'up',    'fa-angle-up'],
-           [_("Move selected fields down"), 'column_lists', 'down',  'fa-angle-down']].each do |title, chosen_div, action, arrow_style|
-          %button.btn.btn-default.btn-block{:title                 => title,
-                                            :remote                => true,
-                                            "data-submit"          => chosen_div,
-                                            "data-method"          => :post,
-                                            "data-miq_sparkle_on"  => true,
-                                            "data-miq_sparkle_off" => true,
-                                            "data-click_url"       => {:url => url_for_only_path(:action => 'fields_seq_field_changed',
-                                                                                                 :button => action,
-                                                                                                 :id     => 'seq')}.to_json}
-            %i.fa.fa-lg{:class => arrow_style}
-    .spacer
+
+  - button_params = @edit[:new][:fields].length >= 2 ? [[_("Move selected fields up"),   'column_lists', 'up',    'fa-angle-up'],
+                                                        [_("Move selected fields down"), 'column_lists', 'down',  'fa-angle-down']] : []
+  = render :partial => "shared/views/seq_selector_buttons",
+           :locals  => {:fields_count  => @edit[:new][:fields].length,
+                        :button_params => button_params,
+                        :button_action => 'fields_seq_field_changed',
+                        :id            => 'seq'}
+
 :javascript
   // disable any other tabs on screen when in edit
   miq_tabs_disable_inactive('#ae_tabs');

--- a/app/views/miq_policy/_action_options.html.haml
+++ b/app/views/miq_policy/_action_options.html.haml
@@ -136,54 +136,47 @@
             :form_action                 => "miq_action",
             :field_changed_url           => "action_field_changed"})
   - when "evaluate_alerts"
-    %h3
-      = _("Select Alerts to be Evaluated")
-    .form-horizontal
-      .form-group
-        .col-md-8
-          %table#formtest.form{:width => "100%"}
-            %tr
-              %td{:align => "left"}= _('Available Alerts:')
-              %td
-              %td.widthed{:align => "left"}= _(' Selected Alerts:')
-            %tr
-              %td.widthed{:align => "left", :valign => "top"}
-                %span#choices_chosen_div
-                  = select_tag('choices_chosen[]', options_for_select(@edit[:choices].sort),
-                    :multiple => true,
-                    :class    => "widthed",
-                    :size     => 8,
-                    :id       => "choices_chosen")
-                %p
-              %td{:width => "20", :valign => "middle"}
-                = link_to(image_tag(image_path('toolbars/right.png'), :class => "rollover small", :alt => (t = _("Move selected Alerts into this Action"))),
-                  {:action => 'action_edit',
-                   :button => 'move_right',
-                   :id => @action.id || 'new'},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  "data-submit"          => 'choices_chosen_div',
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
-                = link_to(image_tag(image_path('toolbars/left.png'), :class => "rollover small", :alt => (t = _("Remove selected Alerts from this Action"))),
-                  {:action => 'action_edit',
-                   :button => 'move_left',
-                   :id     => @action.id || 'new'},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  "data-submit"          => 'members_chosen_div',
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
-              %td{:align => "right", :valign => "top"}
-                %span#members_chosen_div
-                  = select_tag('members_chosen[]',
-                    options_for_select(@edit[:new][:alerts].sort),
-                    :multiple => true,
-                    :class    => "widthed",
-                    :size     => 8,
-                    :id       => "members_chosen")
+    %h3= _("Select Alerts to be Evaluated")
+    #formtest.form
+      .col-md-5
+        = _('Available Alerts:')
+        %span#choices_chosen_div
+          = select_tag('choices_chosen[]', options_for_select(@edit[:choices].sort),
+            :multiple => true,
+            :class    => "form-control",
+            :style    => "overflow-x: scroll;",
+            :size     => 8,
+            :id       => "choices_chosen")
+
+      .col-md-1{:style => "padding: 10px"}
+        .spacer
+        .spacer
+        - [[_("Move selected Alerts into this Action"),   'choices_chosen_div', 'move_right',    'fa-angle-right'],
+           [_("Remove selected Alerts from this Action"), 'members_chosen_div', 'move_left',     'fa-angle-left']].each do |title, chosen_div, action, arrow_style|
+          %button.btn.btn-default.btn-block{:title                 => title,
+                                            :remote                => true,
+                                            "data-submit"          => chosen_div,
+                                            "data-method"          => :post,
+                                            "data-miq_sparkle_on"  => true,
+                                            "data-miq_sparkle_off" => true,
+                                            "data-click_url"       => {:url => url_for_only_path(:action => 'action_edit',
+                                                                                                 :button => action,
+                                                                                                 :id     => @action.id || 'new')}.to_json}
+            %i.fa.fa-lg.hidden-xs.hidden-sm{:class => arrow_style}
+            %i.fa.fa-lg.fa-rotate-90.hidden-md.hidden-lg{:class => arrow_style}
+        .spacer
+          
+      .col-md-5
+        = _(' Selected Alerts:')
+        %span#members_chosen_div
+          = select_tag('members_chosen[]',
+            options_for_select(@edit[:new][:alerts].sort),
+            :multiple => true,
+            :class    => "form-control",
+            :style    => "overflow-x: scroll;",
+            :size     => 8,
+            :id       => "members_chosen")
+
   - when "snmp_trap"
     %h3
       = _("SNMP Trap Settings")
@@ -367,8 +360,3 @@
                   :class             => "form-control",
                   "data-miq_observe" => observe_with_interval)
                 = _('Enter a comma separated list of IP or DNS names')
-
-
-
-
-

--- a/app/views/miq_policy/_alert_profile_details.html.haml
+++ b/app/views/miq_policy/_alert_profile_details.html.haml
@@ -18,7 +18,8 @@
                 = text_field_tag("description", @edit[:new][:description],
                   :maxlength         => MAX_DESC_LEN,
                   "data-miq_observe" => observe_with_interval,
-                  :class             => "form-control")
+                  :class             => "form-control",
+                  :style             => "overflow-x: scroll;")
                 = javascript_tag(javascript_focus('description'))
               - else
                 %p.form-control-static= h(@alert_profile.description)
@@ -41,76 +42,65 @@
         %hr
       - elsif @edit
         %h3= _('Alert Selection')
-        %table#formtest.form
-          %tr
-            %td{:align => "left"}= _("Available %{model} Alerts:") % {:model => ui_lookup(:model => @edit[:new][:mode])}
-            %td
-            %td.widthed{:align => "left"}= _("Profile Alerts:")
-          %tr
-            %td.widthed{:align => "left", :valign => "top"}
-              %span#choices_chosen_div
-                = select_tag('choices_chosen[]', options_for_select(@edit[:choices].sort),
-                  :multiple => true,
-                  :class    => "widthed",
-                  :size     => 8,
-                  :id       => "choices_chosen")
-            %td{:width => "20", :valign => "middle"}
-              = link_to(image_tag(image_path('toolbars/right.png'), :border => "0", :class  => "rollover small", :alt => (t = _("Move selected Alerts into this Profile"))),
-                {:action => 'alert_profile_edit',
-                 :button => 'move_right',
-                 :id     => @alert_profile},
-                "data-miq_sparkle_on"  => true,
-                "data-miq_sparkle_off" => true,
-                "data-submit"          => 'choices_chosen_div',
-                "data-method"          => :post,
-                :remote                => true,
-                :title                 => t)
+        .col-md-5
+          = _("Available %{model} Alerts:") % {:model => ui_lookup(:model => @edit[:new][:mode])}
 
-              = link_to(image_tag(image_path('toolbars/allleft.png'), :border => "0", :class  => "rollover small", :alt => (t = _("Remove all Alerts from this Profile"))),
-                {:action => 'alert_profile_edit',
-                 :button => 'move_allleft',
-                 :id     => @alert_profile},
-                "data-miq_sparkle_on"  => true,
-                "data-miq_sparkle_off" => true,
-                "data-method"          => :post,
-                :remote                => true,
-                :title                 => t)
+          %span#choices_chosen_div
+            = select_tag('choices_chosen[]', options_for_select(@edit[:choices].sort),
+              :multiple => true,
+              :size     => 15,
+              :class    => "form-control",
+              :style    => "overflow-x: scroll;",
+              :id       => "choices_chosen")
 
-              = link_to(image_tag(image_path('toolbars/left.png'), :border => "0", :class  => "rollover small", :alt => (t = _("Remove selected Alerts from this Profile"))),
-                {:action => 'alert_profile_edit',
-                 :button => 'move_left',
-                 :id     => @alert_profile},
-                "data-miq_sparkle_on"  => true,
-                "data-miq_sparkle_off" => true,
-                "data-submit"          => 'members_chosen_div',
-                "data-method"          => :post,
-                :remote                => true,
-                :title                 => t)
+        .col-md-1{:style => "padding: 10px"}
+          .spacer
+          .spacer
+          - [[_("Move selected Alerts into this Profile"),   'choices_chosen_div', 'move_right',   'fa-angle-right'],
+             [_("Remove all Alerts from this Profile"),      nil,                  'move_allleft', 'fa-angle-double-left'],
+             [_("Remove selected Alerts from this Profile"), 'members_chosen_div', 'move_left',    'fa-angle-left']].each do |title, chosen_div, action, arrow_style|
+            %button.btn.btn-default.btn-block{:title => title,
+                                    :remote => true,
+                                    "data-submit" => chosen_div,
+                                    "data-method" => :post,
+                                    "data-miq_sparkle_on"  => true,
+                                    "data-miq_sparkle_off" => true,
+                                    "data-click_url" => {:url => url_for_only_path(:action => 'alert_profile_edit',
+                                                                         :button => action,
+                                                                         :id     => @alert_profile)}.to_json}
+              %i.fa.fa-lg.hidden-xs.hidden-sm{:class => arrow_style}
+              %i.fa.fa-lg.fa-rotate-90.hidden-md.hidden-lg{:class => arrow_style}
 
-            %td{:align => "right", :valign => "top"}
-              %span#members_chosen_div
-                = select_tag('members_chosen[]', options_for_select(@edit[:new][:alerts].sort),
-                  :multiple => true,
-                  :class    => "widthed",
-                  :size     => 8,
-                  :id       => "members_chosen")
-        %hr
+          .spacer
+
+        .col-md-5
+          = _("Profile Alerts:")
+          %span#members_chosen_div
+            = select_tag('members_chosen[]', options_for_select(@edit[:new][:alerts].sort),
+              :multiple => true,
+              :size     => 15,
+              :class    => "form-control",
+              :id       => "members_chosen")
+
 
       -# Notes field
       - if @edit
-        %h3
-          = _("Notes")
-          (
-          %span#notes_count
-            = @edit[:new][:notes] ? @edit[:new][:notes].length : 0
-          \/ 512)
-        = text_area_tag("notes", @edit[:new][:notes],
-          :rows => 4,
-          :maxlength                  => "512",
-          :counter                    => "notes_count",
-          "data-miq_check_max_length" => true,
-          "data-miq_observe"          => observe_with_interval)
-        %hr
+        .row
+          .col-md-12
+            %hr
+            %h3
+              = _("Notes")
+              (
+              %span#notes_count
+                = @edit[:new][:notes] ? @edit[:new][:notes].length : 0
+              \/ 512)
+            = text_area_tag("notes", @edit[:new][:notes],
+              :rows => 4,
+              :maxlength                  => "512",
+              :counter                    => "notes_count",
+              "data-miq_check_max_length" => true,
+              "data-miq_observe"          => observe_with_interval)
+            %hr
       - else
         %h3
           = _('Notes')

--- a/app/views/miq_policy/_event_details.html.haml
+++ b/app/views/miq_policy/_event_details.html.haml
@@ -30,97 +30,72 @@
                     %i{:class => p.decorate.fonticon}
                   %td
                     = p.description
-          %hr
       - else
         %h3= _("Order of Actions if ALL Conditions are True")
         - if @edit
-          %table#formtest.form{:width => "100%"}
-            %tr
-              %td{:align => "left"}= _('Available Actions:')
-              %td
-              %td.widthed{:align => "left"}= _(' Selected Actions:')
-            %tr
-              %td.widthed{:align => "left", :valign => "top"}
-                %span#choices_chosen_true_div
-                  = select_tag('choices_chosen_true[]',
-                    options_for_select(@edit[:choices_true].sort),
-                    :multiple => true,
-                    :class    => "widthed",
-                    :size     => 8,
-                    :id       => "choices_chosen_true")
-                %p
-              %td{:width => "20", :valign => "middle"}
-                - t = _("Move selected Actions into this Event")
-                = link_to(image_tag(image_path('toolbars/right.png'), :class => "rollover small", :alt => t),
-                  {:action => 'event_edit', :button => 'true_right', :id => @event},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  "data-submit"          => 'choices_chosen_true_div',
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
-                - t = _("Remove all Actions from this Event")
-                = link_to(image_tag(image_path('toolbars/allleft.png'), :class => "rollover small", :alt => t),
-                  {:action => 'event_edit', :button => 'true_allleft', :id => @event},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
-                - t = _("Remove selected Actions from this Event")
-                = link_to(image_tag(image_path('toolbars/left.png'), :class => "rollover small", :alt => t),
-                  {:action => 'event_edit', :button => 'true_left', :id => @event},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  "data-submit"          => 'members_chosen_true_div',
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
-              %td{:align => "right", :valign => "top"}
-                %span#members_chosen_true_div
-                  = select_tag('members_chosen_true[]',
-                    options_for_select(@edit[:new][:actions_true], @true_selected),
-                    :multiple => true,
-                    :class    => "widthed",
-                    :size     => 8,
-                    :id       => "members_chosen_true")
-              %td{:width => "20", :valign => "middle"}
-                - t = _("Move selected Action up")
-                = link_to(image_tag(image_path('toolbars/up.png'), :class => "rollover small", :alt => t),
-                  {:action => 'event_edit', :button  => 'true_up', :id => @event},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  "data-submit"          => 'members_chosen_true_div',
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
-                - t = _("Move selected Action down")
-                = link_to(image_tag(image_path('toolbars/down.png'), :class => "rollover small", :alt => t),
-                  {:action => 'event_edit', :button => 'true_down', :id => @event},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  "data-submit"          => 'members_chosen_true_div',
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
-                - t = _("Set selected Actions to Synchronous")
-                = link_to(image_tag(image_path('toolbars/syncr.png'), :class => "rollover small", :alt => t),
-                  {:action => 'event_edit', :button => 'true_sync', :id => @event},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  "data-submit"          => 'members_chosen_true_div',
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
-                - t = _("Set selected Actions to Asynchronous")
-                = link_to(image_tag(image_path('toolbars/asyncr.png'), :class => "rollover small", :alt => t),
-                  {:action => 'event_edit', :button => 'true_async', :id => @event},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  "data-submit"          => 'members_chosen_true_div',
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
+          .col-md-5
+            = _('Available Actions:')
+            %span#choices_chosen_true_div
+              = select_tag('choices_chosen_true[]',
+                options_for_select(@edit[:choices_true].sort),
+                :multiple => true,
+                :class    => "form-control",
+                :style    => "overflow-x: scroll;",
+                :size     => 8,
+                :id       => "choices_chosen_true")
+
+          .col-md-1{:style => "padding: 10px"}
+            .spacer
+            .spacer
+            - [[_("Move selected Actions into this Event"),   'choices_chosen_true_div', 'true_right',   'fa-angle-right'],
+               [_("Remove all Actions from this Event"),      nil,                       'true_allleft', 'fa-angle-double-left'],
+               [_("Remove selected Actions from this Event"), 'members_chosen_true_div', 'true_left',    'fa-angle-left']].each do |title, chosen_div, action, arrow_style|
+              %button.btn.btn-default.btn-block{:title => title,
+                                      :remote => true,
+                                      "data-submit" => chosen_div,
+                                      "data-method" => :post,
+                                      "data-miq_sparkle_on"  => true,
+                                      "data-miq_sparkle_off" => true,
+                                      "data-click_url" => {:url => url_for_only_path(:action => 'event_edit',
+                                                                           :button => action,
+                                                                           :id => @event)}.to_json}
+                %i.fa.fa-lg.hidden-xs.hidden-sm{:class => arrow_style}
+                %i.fa.fa-lg.fa-rotate-90.hidden-md.hidden-lg{:class => arrow_style}
+
+            .spacer
+          .col-md-5.col-sm-11.col-xs-11
+            = _(' Selected Actions:')
+            %span#members_chosen_true_div
+              = select_tag('members_chosen_true[]',
+                options_for_select(@edit[:new][:actions_true], @true_selected),
+                :multiple => true,
+                :class    => "form-control",
+                :style    => "overflow-x: scroll;",
+                :size     => 8,
+                :id       => "members_chosen_true")
+
+          .col-md-1.col-sm-1.col-xs-1{:style => "padding: 10px"}
+            .spacer
+            .spacer
+            - [[_("Move selected Action up"),              'members_chosen_true_div', 'true_up',    'fa-angle-up'],
+               [_("Move selected Action down"),            'members_chosen_true_div', 'true_down',  'fa-angle-down'],
+               [_("Set selected Actions to Synchronous"),  'members_chosen_true_div', 'true_sync',  'S'],
+               [_("Set selected Actions to Asynchronous"), 'members_chosen_true_div', 'true_async', 'A']].each do |title, chosen_div, action, arrow_style|
+              %button.btn.btn-default.btn-block{:title => title,
+                                      :remote => true,
+                                      "data-submit" => chosen_div,
+                                      "data-method" => :post,
+                                      "data-miq_sparkle_on"  => true,
+                                      "data-miq_sparkle_off" => true,
+                                      "data-click_url" => {:url => url_for_only_path(:action => 'event_edit',
+                                                                           :button => action,
+                                                                           :id => @event)}.to_json}
+                - if %w(A S).include?(arrow_style)
+                  =_(arrow_style)
+                - else
+                  %i.fa.fa-lg{:class => arrow_style}
+
+            .spacer
           %hr
         - else
           - if @event_true_actions.empty?
@@ -148,103 +123,75 @@
                       = a.v_synchronicity
                     %td
                       = a.action_type
-          %hr
 
+        %br{:style => "clear: both"}
         %h3= _("Order of Actions if ANY Conditions are False")
         - if @edit
-          %table#formtest.form{:width => "100%"}
-            %tr
-              %td{:align => "left"}= _("Available Actions:")
-              %td
-              %td.widthed{:align => "left"}= _(" Selected Actions:")
-            %tr
-              %td.widthed{:align => "left", :valign => "top"}
-                %span#choices_chosen_false_div
-                  = select_tag('choices_chosen_false[]',
-                    options_for_select(@edit[:choices_false].sort),
-                    :multiple => true,
-                    :class    => "widthed",
-                    :size     => 8,
-                    :id       => "choices_chosen_false")
-                %p
-              %td{:width => "20", :valign => "middle"}
-                - t = "Move selected Actions into this Event"
-                = link_to(image_tag(image_path('toolbars/right.png'), :class => "rollover small", :alt => t),
-                  {:action => 'event_edit', :button => 'false_right', :id => @event},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  "data-submit"          => 'choices_chosen_false_div',
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
 
-                - t = "Remove all Policies from this Profile"
-                = link_to(image_tag(image_path('toolbars/allleft.png'), :class => "rollover small", :alt => t),
-                  {:action => 'event_edit', :button => 'false_allleft', :id => @event},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
+          .col-md-5
+            = _("Available Actions:")
+            %span#choices_chosen_false_div
+              = select_tag('choices_chosen_false[]',
+                options_for_select(@edit[:choices_false].sort),
+                :multiple => true,
+                :class    => "form-control",
+                :style    => "overflow-x: scroll;",
+                :size     => 8,
+                :id       => "choices_chosen_false")
 
-                - t = "Remove selected Actions from this Event"
-                = link_to(image_tag(image_path('toolbars/left.png'), :class => "rollover small", :alt => t),
-                  {:action => 'event_edit', :button => 'false_left', :id => @event},
-                  "data-miq_sparkle_on"  => true,
-                  "data-miq_sparkle_off" => true,
-                  "data-submit"          => 'members_chosen_false_div',
-                  :remote                => true,
-                  "data-method"          => :post,
-                  :title                 => t)
+          .col-md-1{:style => "padding: 10px"}
+            .spacer
+            .spacer
+            - [[_("Move selected Actions into this Event"),   'choices_chosen_false_div', 'false_right',   'fa-angle-right'],
+               [_("Remove all Actions from this Event"),      nil,                       'false_allleft', 'fa-angle-double-left'],
+               [_("Remove selected Actions from this Event"), 'members_chosen_false_div', 'false_left',    'fa-angle-left']].each do |title, chosen_div, action, arrow_style|
+              %button.btn.btn-default.btn-block{:title => title,
+                                      :remote => true,
+                                      "data-submit" => chosen_div,
+                                      "data-method" => :post,
+                                      "data-miq_sparkle_on"  => true,
+                                      "data-miq_sparkle_off" => true,
+                                      "data-click_url" => {:url => url_for_only_path(:action => 'event_edit',
+                                                                           :button => action,
+                                                                           :id => @event)}.to_json}
+                %i.fa.fa-lg.hidden-xs.hidden-sm{:class => arrow_style}
+                %i.fa.fa-lg.fa-rotate-90.hidden-md.hidden-lg{:class => arrow_style}
 
-              %td{:align => "right", :valign => "top"}
-                %span#members_chosen_false_div
-                  = select_tag('members_chosen_false[]',
-                    options_for_select(@edit[:new][:actions_false], @false_selected),
-                    :multiple => true,
-                    :class    => "widthed",
-                    :size     => 8,
-                    :id       => "members_chosen_false")
-              %td{:width => "20", :valign => "middle"}
-                - t = "Move selected Action up"
-                = link_to(image_tag(image_path('toolbars/up.png'), :class => "rollover small", :alt => t),
-                {:action => 'event_edit', :button => 'false_up', :id => @event},
-                "data-miq_sparkle_on"  => true,
-                "data-miq_sparkle_off" => true,
-                "data-submit"          => 'members_chosen_false_div',
-                :remote                => true,
-                "data-method"          => :post,
-                :title                 => t)
+            .spacer
 
-                - t = "Move selected Action down"
-                = link_to(image_tag(image_path('toolbars/down.png'), :class => "rollover small", :alt => t),
-                {:action => 'event_edit', :button => 'false_down', :id => @event},
-                "data-miq_sparkle_on"  => true,
-                "data-miq_sparkle_off" => true,
-                "data-submit"          => 'members_chosen_false_div',
-                :remote                => true,
-                "data-method"          => :post,
-                :title                 => t)
+          .col-md-5.col-sm-11.col-xs-11
+            = _(" Selected Actions:")
+            %span#members_chosen_false_div
+              = select_tag('members_chosen_false[]',
+                options_for_select(@edit[:new][:actions_false], @false_selected),
+                :multiple => true,
+                :class    => "form-control",
+                :style    => "overflow-x: scroll;",
+                :size     => 8,
+                :id       => "members_chosen_false")
 
-                - t = "Set selected Actions to Synchronous"
-                = link_to(image_tag(image_path('toolbars/syncr.png'), :class => "rollover small", :alt => t),
-                {:action => 'event_edit', :button => 'false_sync', :id => @event},
-                "data-miq_sparkle_on"  => true,
-                "data-miq_sparkle_off" => true,
-                "data-submit"          => 'members_chosen_false_div',
-                :remote                => true,
-                "data-method"          => :post,
-                :title                 => t)
+          .col-md-1.col-sm-1.col-xs-1{:style => "padding: 10px"}
+            .spacer
+            .spacer
+            - [[_("Move selected Action up"),              'members_chosen_false_div', 'false_up',    'fa-angle-up'],
+               [_("Move selected Action down"),            'members_chosen_false_div', 'false_down',  'fa-angle-down'],
+               [_("Set selected Actions to Synchronous"),  'members_chosen_false_div', 'false_sync',  'S'],
+               [_("Set selected Actions to Asynchronous"), 'members_chosen_false_div', 'false_async', 'A']].each do |title, chosen_div, action, arrow_style|
+              %button.btn.btn-default.btn-block{:title => title,
+                                      :remote => true,
+                                      "data-submit" => chosen_div,
+                                      "data-method" => :post,
+                                      "data-miq_sparkle_on"  => true,
+                                      "data-miq_sparkle_off" => true,
+                                      "data-click_url" => {:url => url_for_only_path(:action => 'event_edit',
+                                                                           :button => action,
+                                                                           :id => @event)}.to_json}
+                - if %w(A S).include?(arrow_style)
+                  =_(arrow_style)
+                - else
+                  %i.fa.fa-lg{:class => arrow_style}
+            .spacer
 
-                - t = "Set selected Actions to Asynchronous"
-                = link_to(image_tag(image_path('toolbars/asyncr.png'), :class => "rollover small",  :alt => t),
-                {:action => 'event_edit', :button => 'false_async', :id => @event},
-                "data-miq_sparkle_on"  => true,
-                "data-miq_sparkle_off" => true,
-                "data-submit"          => 'members_chosen_false_div',
-                :remote                => true,
-                "data-method"          => :post,
-                :title                 => t)
         - else
           - if @event_false_actions.empty?
             = render :partial => 'layouts/info_msg', :locals => {:message => _("This Event has no false Actions.")}

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -74,46 +74,50 @@
       - if @edit
         - if @edit[:typ] == "conditions"
           %h3= _("Condition Selection")
-          %table#formtest.form{:width => "100%"}
-            %tr
-              %td{:align => "left"}= _("Available %{model} Conditions:") % {:model => ui_lookup(:model => @edit[:new][:towhat])}
-              %td
-              %td.widthed{:align => "left"}= _("Policy Conditions:")
-            %tr
-              %td.widthed{:align => "left", :valign => "top"}
-                %span#choices_chosen_div
-                  = select_tag('choices_chosen[]',
-                    options_for_select(@edit[:choices].sort),
-                    :multiple => true,
-                    :class    => "widthed",
-                    :size     => 8,
-                    :id       => "choices_chosen")
-                %p
-              %td{:width => "20", :valign => "middle"}
-                .btn-group-vertical
-                  - [[_("Move selected Conditions into this Policy"),   'choices_chosen_div', 'move_right',   'fa-angle-right'],
-                     [_("Remove all Conditions from this Policy"),      nil,                  'move_allleft', 'fa-angle-double-left'],
-                     [_("Remove selected Conditions from this Policy"), 'members_chosen_div', 'move_left',    'fa-angle-left']].each do |title, chosen_div, action, arrow_style|
-                    %button.btn.btn-default{:title => title,
-                                            :remote => true,
-                                            "data-submit" => chosen_div,
-                                            "data-method" => :post,
-                                            "data-miq_sparkle_on"  => true,
-                                            "data-miq_sparkle_off" => true,
-                                            "data-click_url" => {:url => url_for_only_path(:action => 'policy_edit',
-                                                                                 :button => action,
-                                                                                 :id => @policy)}.to_json}
-                      %i.fa{:class => arrow_style}
-              %td{:align => "right", :valign => "top"}
-                %span#members_chosen_div
-                  = select_tag('members_chosen[]',
-                    options_for_select(@edit[:new][:conditions].sort),
-                    :multiple => true,
-                    :class    => "widthed",
-                    :size     => 8,
-                    :id       => "members_chosen")
-          %strong
-            = _("* If all Conditions are removed from a Policy, it will be unconditional and always evaluate to true.")
+          .col-md-5
+            = _("Available %{model} Conditions:") % {:model => ui_lookup(:model => @edit[:new][:towhat])}
+            %span#choices_chosen_div
+              = select_tag('choices_chosen[]',
+                options_for_select(@edit[:choices].sort),
+                :multiple => true,
+                :size     => 15,
+                :class    => "form-control",
+                :style    => "overflow-x: scroll;",
+                :id       => "choices_chosen")
+            %small
+              = _("* If all Conditions are removed from a Policy, it will be unconditional and always evaluate to true.")
+
+          .col-md-1{:style => "padding: 10px"}
+            .spacer
+            .spacer
+            - [[_("Move selected Conditions into this Policy"),   'choices_chosen_div', 'move_right',   'fa-angle-right'],
+               [_("Remove all Conditions from this Policy"),      nil,                  'move_allleft', 'fa-angle-double-left'],
+               [_("Remove selected Conditions from this Policy"), 'members_chosen_div', 'move_left',    'fa-angle-left']].each do |title, chosen_div, action, arrow_style|
+              %button.btn.btn-default.btn-block{:title => title,
+                                      :remote => true,
+                                      "data-submit" => chosen_div,
+                                      "data-method" => :post,
+                                      "data-miq_sparkle_on"  => true,
+                                      "data-miq_sparkle_off" => true,
+                                      "data-click_url" => {:url => url_for_only_path(:action => 'policy_edit',
+                                                                           :button => action,
+                                                                           :id => @policy)}.to_json}           
+                %i.fa.fa-lg.hidden-xs.hidden-sm{:class => arrow_style}
+                %i.fa.fa-lg.fa-rotate-90.hidden-md.hidden-lg{:class => arrow_style}
+            .spacer
+
+          .col-md-5
+            = _("Policy Conditions:")
+            %br
+            %span#members_chosen_div
+              = select_tag('members_chosen[]',
+                options_for_select(@edit[:new][:conditions].sort),
+                :multiple => true,
+                :size     => 15,
+                :class    => "form-control",
+                :style    => "overflow-x: scroll;",
+                :id       => "members_chosen")
+
       - else
         %h3= _("Conditions")
         - if @policy_conditions.empty?

--- a/app/views/miq_policy/_profile_details.html.haml
+++ b/app/views/miq_policy/_profile_details.html.haml
@@ -26,56 +26,47 @@
 
     - if @edit
       %h3= _("Policy Selection")
-      %table#formtest.form{:width => "100%"}
-        %tr
-          %td{:align => "left"}= _("Available Policies:")
-          %td
-          %td.widthed{:align => "left"}= _("Profile Policies:")
-        %tr
-          %td{:align => "left", :class => "widthed", :valign => "top"}
-            %span#choices_chosen_div
-              = select_tag('choices_chosen[]',
-                options_for_select(@edit[:choices].sort),
-                :multiple => true,
-                :class    => "widthed",
-                :size     => 8,
-                :id       => "choices_chosen")
-            %p
-          %td{:width => "20", :valign => "middle"}
-            - t = _("Move selected Policies into this Profile")
-            = link_to(image_tag(image_path('toolbars/right.png'), :border => "0", :class  => "rollover small", :alt => t),
-              {:action => 'profile_edit', :button => 'move_right', :id => @profile},
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              "data-submit"          => 'choices_chosen_div',
-              :remote                => true,
-              "data-method"          => :post,
-              :title                 => t)
-            - t = _("Remove all Policies from this Profile")
-            = link_to(image_tag(image_path('toolbars/allleft.png'), :border => "0", :class  => "rollover small", :alt => t),
-              {:action => 'profile_edit', :button => 'move_allleft', :id => @profile},
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              :remote                => true,
-              "data-method"          => :post,
-              :title                 => t)
-            - t = _("Remove selected Policies from this Profile")
-            = link_to(image_tag(image_path('toolbars/left.png'), :border => "0", :class  => "rollover small", :alt => t),
-              {:action => 'profile_edit', :button => 'move_left', :id => @profile},
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              "data-submit"          => 'members_chosen_div',
-              :remote                => true,
-              "data-method"          => :post,
-              :title                 => t)
-          %td{:align => "right", :valign => "top"}
-            %span#members_chosen_div
-              = select_tag('members_chosen[]',
-                options_for_select(@edit[:new][:policies].sort),
-                :multiple => true,
-                :class    => "widthed",
-                :size     => 8,
-                :id       => "members_chosen")
+      .col-md-5
+        = _("Available Policies:")
+        %span#choices_chosen_div
+          = select_tag('choices_chosen[]',
+            options_for_select(@edit[:choices].sort),
+            :multiple => true,
+            :class    => "form-control",
+            :style    => "overflow-x: scroll;",
+            :size     => 8,
+            :id       => "choices_chosen")
+
+      .col-md-1{:style => "padding: 10px"}
+        .spacer
+        .spacer
+        - [[_("Move selected Policies into this Profile"),   'choices_chosen_div', 'move_right',   'fa-angle-right'],
+           [_("Remove all Policies from this Profile"),      nil,                  'move_allleft', 'fa-angle-double-left'],
+           [_("Remove selected Policies from this Profile"), 'members_chosen_div', 'move_left',    'fa-angle-left']].each do |title, chosen_div, action, arrow_style|
+          %button.btn.btn-default.btn-block{:title                 => title,
+                                            :remote                => true,
+                                            "data-submit"          => chosen_div,
+                                            "data-method"          => :post,
+                                            "data-miq_sparkle_on"  => true,
+                                            "data-miq_sparkle_off" => true,
+                                            "data-click_url"       => {:url => url_for_only_path(:action => 'profile_edit',
+                                                                                                 :button => action,
+                                                                                                 :id => @profile)}.to_json}
+            %i.fa.fa-lg.hidden-xs.hidden-sm{:class => arrow_style}
+            %i.fa.fa-lg.fa-rotate-90.hidden-md.hidden-lg{:class => arrow_style}
+        .spacer
+
+      .col-md-5
+        = _("Profile Policies:")
+        %span#members_chosen_div
+          = select_tag('members_chosen[]',
+            options_for_select(@edit[:new][:policies].sort),
+            :multiple => true,
+            :class    => "form-control",
+            :style    => "overflow-x: scroll;",
+            :size     => 8,
+            :id       => "members_chosen")
+      %br{:style => "clear: both"}
       %hr
     - else
       %h3= _("Policies")

--- a/app/views/ops/_ldap_seq_form.html.haml
+++ b/app/views/ops/_ldap_seq_form.html.haml
@@ -12,24 +12,11 @@
                  :id       => "seq_fields")
 
     %small= _("* Select one or more consecutive groups to move up or down.")
-  .col-md-1.col-sm-2.col-xs-2{:style => "padding: 10px"}
-    .spacer
-    .spacer
-    - if @edit[:new][:ldap_groups].length < 2
-      %button.btn.btn-block.disabled
-        %i.fa.fa-angle-up.fa-lg
-      %button.btn.btn-block.disabled
-        %i.fa.fa-angle-down.fa-lg
-    - else
-      - [[_("Move selected fields up"),   'column_lists', 'up',    'fa-angle-up'],
-         [_("Move selected fields down"), 'column_lists', 'down',  'fa-angle-down']].each do |title, chosen_div, action, arrow_style|
-        %button.btn.btn-default.btn-block{:title                 => title,
-                                          :remote                => true,
-                                          "data-submit"          => chosen_div,
-                                          "data-method"          => :post,
-                                          "data-miq_sparkle_on"  => true,
-                                          "data-miq_sparkle_off" => true,
-                                          "data-click_url"       => {:url => url_for_only_path(:action => 'rbac_group_field_changed',
-                                                                                               :button => action,
-                                                                                               :id     => 'seq')}.to_json}
-          %i.fa.fa-lg{:class => arrow_style}
+
+  - button_params = @edit[:new][:ldap_groups].length >= 2 ? [[_("Move selected fields up"),   'column_lists', 'up',    'fa-angle-up'],
+                                                             [_("Move selected fields down"), 'column_lists', 'down',  'fa-angle-down']] : []
+  = render :partial => "shared/views/seq_selector_buttons",
+           :locals  => {:fields_count  => @edit[:new][:ldap_groups].length,
+                        :button_params => button_params,
+                        :button_action => 'rbac_group_field_changed',
+                        :id            => 'seq'}

--- a/app/views/ops/_ldap_seq_form.html.haml
+++ b/app/views/ops/_ldap_seq_form.html.haml
@@ -1,49 +1,35 @@
 = render :partial => "layouts/flash_msg"
 #column_lists
-  .form-horizontal
-    .form-group
-      .col-md-8
-        %table.form#formtest{:width => "50%"}
-          %tr
-            %td.widthed{:align => "left"}
-              = _("User Group Sequencing for LDAP Look Up:")
-            %td
-          %tr
-            %td{:align => "left", :valign => "top"}
-              = select_tag('seq_fields[]',
-                           options_for_select(@edit[:new][:ldap_groups_list],
-                                              @selected),
-                           :multiple => true,
-                           :style    => "width: 450px",
-                           :size     => 20,
-                           :id       => "seq_fields")
-            %td{:align => "left", :valign => "middle", :width => "30"}
-              - if @edit[:new][:ldap_groups].length < 2
-                = image_tag(image_path('toolbars/up.png'),
-                            :class => "dimmed small")
-                = image_tag(image_path('toolbars/down.png'),
-                            :class => "dimmed small")
-              - else
-                = link_to(image_tag(image_path('toolbars/up.png'),
-                                    :class => "rollover small",
-                                    :alt   => _("Move selected fields up")),
-                          {:action      => 'rbac_group_field_changed',
-                           :button      => 'up',
-                           :id          => "seq"},
-                          "data-submit" => "column_lists",
-                          :remote       => true,
-                          "data-method" => :post,
-                          :title        => _("Move selected fields up"))
-                = link_to(image_tag(image_path('toolbars/down.png'),
-                                    :class => "rollover small",
-                                    :alt   => _("Move selected fields down")),
-                          {:action => 'rbac_group_field_changed',
-                           :button => 'down',
-                           :id     => "seq"},
-                           "data-submit" => "column_lists",
-                           :remote       => true,
-                           "data-method" => :post,
-                           :title        => _("Move selected fields down"))
-        .note
-          *
-          = _("Select one or more consecutive groups to move up or down.")
+  .col-md-7.col-sm-10.col-xs-10
+    = _("User Group Sequencing for LDAP Look Up:")
+    = select_tag('seq_fields[]',
+                 options_for_select(@edit[:new][:ldap_groups_list],
+                                    @selected),
+                 :multiple => true,
+                 :class    => "form-control",
+                 :style    => "overflow-x: scroll;",
+                 :size     => 20,
+                 :id       => "seq_fields")
+
+    %small= _("* Select one or more consecutive groups to move up or down.")
+  .col-md-1.col-sm-2.col-xs-2{:style => "padding: 10px"}
+    .spacer
+    .spacer
+    - if @edit[:new][:ldap_groups].length < 2
+      %button.btn.btn-block.disabled
+        %i.fa.fa-angle-up.fa-lg
+      %button.btn.btn-block.disabled
+        %i.fa.fa-angle-down.fa-lg
+    - else
+      - [[_("Move selected fields up"),   'column_lists', 'up',    'fa-angle-up'],
+         [_("Move selected fields down"), 'column_lists', 'down',  'fa-angle-down']].each do |title, chosen_div, action, arrow_style|
+        %button.btn.btn-default.btn-block{:title                 => title,
+                                          :remote                => true,
+                                          "data-submit"          => chosen_div,
+                                          "data-method"          => :post,
+                                          "data-miq_sparkle_on"  => true,
+                                          "data-miq_sparkle_off" => true,
+                                          "data-click_url"       => {:url => url_for_only_path(:action => 'rbac_group_field_changed',
+                                                                                               :button => action,
+                                                                                               :id     => 'seq')}.to_json}
+          %i.fa.fa-lg{:class => arrow_style}

--- a/app/views/report/_db_seq_form.html.haml
+++ b/app/views/report/_db_seq_form.html.haml
@@ -10,25 +10,12 @@
       :size     => 20,
       :id       => "seq_fields")
     %small= _('* Select one or more consecutive groups to move up or down.')
-    
-  .col-md-1.col-sm-2.col-xs-2{:style => "padding: 10px"}
-    .spacer
-    .spacer
-    - if @edit[:new][:dashboard_order].length < 2
-      %button.btn.disabled.btn-block
-        %i.fa.fa-lg.fa-angle-up
-      %button.btn.disabled.btn-block
-        %i.fa.fa-lg.fa-angle-down
-    - else
-      - [[_("Move selected fields up"),   'column_lists', 'up',    'fa-angle-up'],
-         [_("Move selected fields down"), 'column_lists', 'down',  'fa-angle-down']].each do |title, chosen_div, action, arrow_style|
-        %button.btn.btn-default.btn-block{:title                 => title,
-                                          :remote                => true,
-                                          "data-submit"          => chosen_div,
-                                          "data-method"          => :post,
-                                          "data-miq_sparkle_on"  => true,
-                                          "data-miq_sparkle_off" => true,
-                                          "data-click_url"       => {:url => url_for_only_path(:action => 'db_form_field_changed',
-                                                                                               :button => action,
-                                                                                               :id     => 'seq')}.to_json}
-          %i.fa.fa-lg{:class => arrow_style}
+
+  - button_params = @edit[:new][:dashboard_order].length >= 2 ? [[_("Move selected fields up"),   'column_lists', 'up',    'fa-angle-up'],
+                                                                 [_("Move selected fields down"), 'column_lists', 'down',  'fa-angle-down']] : []
+  = render :partial => "shared/views/seq_selector_buttons",
+           :locals  => {:fields_count  => @edit[:new][:dashboard_order].length,
+                        :button_params => button_params,
+                        :button_action => 'db_form_field_changed',
+                        :id            => 'seq'}
+

--- a/app/views/report/_db_seq_form.html.haml
+++ b/app/views/report/_db_seq_form.html.haml
@@ -1,38 +1,34 @@
 #column_lists
   = render :partial => "layouts/flash_msg"
-  %table#formtest.form{:width => "50%"}
-    %tr
-      %td.widthed{:align => "left"}
-        = _('Dashboards:')
-      %td
-    %tr
-      %td.left{:valign => "top"}
-        = select_tag('seq_fields[]',
-          options_for_select(@edit[:new][:dashboard_order], @selected),
-          :multiple => true,
-          :style    => "width: 450px",
-          :size     => 20,
-          :id       => "seq_fields")
-      %td{:width => "30", :align => "left", :valign => "middle"}
-        - if @edit[:new][:dashboard_order].length < 2
-          = image_tag(image_path('toolbars/up.png'), :class => "dimmed small")
-        - else
-          - t = _("Move selected fields up")
-          = link_to(image_tag(image_path('toolbars/up.png'), :class => "rollover small", :alt => t),
-            {:action => 'db_form_field_changed', :button => 'up', :id => "seq"},
-            "data-submit" => "column_lists",
-            :remote       => true,
-            "data-method" => :post,
-            :title        => t)
-        - if @edit[:new][:dashboard_order].length < 2
-          = image_tag(image_path('toolbars/down.png'), :class => "dimmed small")
-        - else
-          - t = _("Move selected fields down")
-          = link_to(image_tag(image_path('toolbars/down.png'), :class => "rollover small", :alt => t),
-            {:action => 'db_form_field_changed', :button => 'down', :id => "seq"},
-            "data-submit" => "column_lists",
-            :remote       => true,
-            "data-method" => :post,
-            :title        => t)
-    .note
-      = _('* Select one or more consecutive groups to move up or down.')
+  .col-md-7.col-sm-10.col-xs-10
+    = _('Dashboards:')
+    = select_tag('seq_fields[]',
+      options_for_select(@edit[:new][:dashboard_order], @selected),
+      :multiple => true,
+      :class    => "form-control",
+      :style    => "overflow-x: scroll;",
+      :size     => 20,
+      :id       => "seq_fields")
+    %small= _('* Select one or more consecutive groups to move up or down.')
+    
+  .col-md-1.col-sm-2.col-xs-2{:style => "padding: 10px"}
+    .spacer
+    .spacer
+    - if @edit[:new][:dashboard_order].length < 2
+      %button.btn.disabled.btn-block
+        %i.fa.fa-lg.fa-angle-up
+      %button.btn.disabled.btn-block
+        %i.fa.fa-lg.fa-angle-down
+    - else
+      - [[_("Move selected fields up"),   'column_lists', 'up',    'fa-angle-up'],
+         [_("Move selected fields down"), 'column_lists', 'down',  'fa-angle-down']].each do |title, chosen_div, action, arrow_style|
+        %button.btn.btn-default.btn-block{:title                 => title,
+                                          :remote                => true,
+                                          "data-submit"          => chosen_div,
+                                          "data-method"          => :post,
+                                          "data-miq_sparkle_on"  => true,
+                                          "data-miq_sparkle_off" => true,
+                                          "data-click_url"       => {:url => url_for_only_path(:action => 'db_form_field_changed',
+                                                                                               :button => action,
+                                                                                               :id     => 'seq')}.to_json}
+          %i.fa.fa-lg{:class => arrow_style}

--- a/app/views/shared/buttons/_column_lists.html.haml
+++ b/app/views/shared/buttons/_column_lists.html.haml
@@ -1,106 +1,113 @@
 #column_lists
-  %table#formtest.form{:width => "100%"}
-    %tr
-      - if x_active_tree == :ab_tree
-        %td.widthed{:align => "left"}
-          = _('Unassigned:')
-        %td
-      %td{:align => "left"}
-        = _('Selected:')
-    %tr
-      - if x_active_tree == :ab_tree
-        %td{:align => "right", :valign => "top"}
-          = select_tag('available_fields[]',
-            options_for_select(@edit[:new][:available_fields]),
-            :multiple => true,
-            :style    => "width: 450px",
-            :size     => 8,
-            :id       => "available_fields")
-        %td.text-center{:width => "40"}
-          .btn-group-vertical
-            - if @edit[:new][:available_fields].length == 0
-              %button.btn.btn-default.disabled
-                %i.fa.fa-angle-right.fa-lg
-            - else
-              - t = _("Move selected fields right")
-              %button.btn.btn-default{:title           => t,
-                                      :remote          => true,
-                                      "data-submit"    => 'column_lists',
-                                      "data-method"    => :post,
-                                      "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
-                                                                           :button => 'right',
-                                                                           :id     => @custom_button_set.id || 'new')}.to_json}
-                %i.fa.fa-angle-right.fa-lg
-            - if @edit[:new][:fields].length == 0
-              %button.btn.btn-default.disabled
-                %i.fa.fa-angle-left.fa-lg
-            - else
-              - t = _("Move selected fields left")
-              %button.btn.btn-default{:title           => t,
-                                      :remote          => true,
-                                      "data-submit"    => 'column_lists',
-                                      "data-method"    => :post,
-                                      "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
-                                                                           :button => 'left',
-                                                                           :id     => @custom_button_set.id || 'new')}.to_json}
-                %i.fa.fa-angle-left.fa-lg
-      %td{:align => "left", :valign => "top"}
-        = select_tag('selected_fields[]',
-          options_for_select(@edit[:new][:fields], @selected),
-          :multiple => true,
-          :style    => "width: 450px",
-          :size     => 8,
-          :id       => "selected_fields")
-      %td{:width => "30", :valign => "middle"}
-        - if @edit[:new][:fields].length < 2
-          %button.btn.btn-default.disabled
-            %i.fa.fa-angle-double-up.fa-lg
-        - else
-          - t = _("Move selected fields to top")
-          %button.btn.btn-default{:title           => t,
-                                  :remote          => true,
-                                  "data-submit"    => 'column_lists',
-                                  "data-method"    => :post,
-                                  "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
-                                                                       :button => 'top',
-                                                                       :id     => @custom_button_set.id || 'new')}.to_json}
-            %i.fa.fa-angle-double-up.fa-lg
-        - if @edit[:new][:fields].length < 2
-          %button.btn.btn-default.disabled
-            %i.fa.fa-angle-up.fa-lg
-        - else
-          - t = _("Move selected fields up")
-          %button.btn.btn-default{:title           => t,
-                                  :remote          => true,
-                                  "data-submit"    => 'column_lists',
-                                  "data-method"    => :post,
-                                  "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
-                                                                       :button => 'up',
-                                                                       :id     => @custom_button_set.id || 'new')}.to_json}
-            %i.fa.fa-angle-up.fa-lg
-        - if @edit[:new][:fields].length < 2
-          %button.btn.btn-default.disabled
-            %i.fa.fa-angle-down.fa-lg
-        - else
-          - t = _("Move selected fields down")
-          %button.btn.btn-default{:title           => t,
-                                  :remote          => true,
-                                  "data-submit"    => 'column_lists',
-                                  "data-method"    => :post,
-                                  "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
-                                                                       :button => 'down',
-                                                                       :id     => @custom_button_set.id || 'new')}.to_json}
-            %i.fa.fa-angle-down.fa-lg
-        - if @edit[:new][:fields].length < 2
-          %button.btn.btn-default.disabled
-            %i.fa.fa-angle-double-down.fa-lg
-        - else
-          - t = _("Move selected fields to bottom")
-          %button.btn.btn-default{:title           => t,
-                                  :remote          => true,
-                                  "data-submit"    => 'column_lists',
-                                  "data-method"    => :post,
-                                  "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
-                                                                       :button => 'bottom',
-                                                                       :id     => @custom_button_set.id || 'new')}.to_json}
-            %i.fa.fa-angle-double-down.fa-lg
+  - if x_active_tree == :ab_tree
+    .col-md-5
+      = _('Unassigned:')
+      = select_tag('available_fields[]',
+        options_for_select(@edit[:new][:available_fields]),
+        :multiple => true,
+        :class    => "form-control",
+        :style    => "overflow-x: scroll;",
+        :size     => 8,
+        :id       => "available_fields")
+  - if x_active_tree == :ab_tree
+    .col-md-1{:style => "padding: 10px"}
+      .spacer
+      .spacer
+      - if @edit[:new][:available_fields].length == 0
+        %button.btn.btn-default.btn-block.disabled
+          %i.fa.fa-angle-right.fa-lg.hidden-xs.hidden-sm
+          %i.fa.fa-lg.fa-angle-right.fa-rotate-90.hidden-md.hidden-lg
+      - else
+        - t = _("Move selected fields right")
+        %button.btn.btn-default.btn-block{:title           => t,
+                                :remote          => true,
+                                "data-submit"    => 'column_lists',
+                                "data-method"    => :post,
+                                "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
+                                                                     :button => 'right',
+                                                                     :id     => @custom_button_set.id || 'new')}.to_json}
+          %i.fa.fa-angle-right.fa-lg.hidden-xs.hidden-sm
+          %i.fa.fa-lg.fa-angle-right.fa-rotate-90.hidden-md.hidden-lg
+      - if @edit[:new][:fields].length == 0
+        %button.btn.btn-default.btn-block.disabled
+          %i.fa.fa-angle-left.fa-lg.hidden-xs.hidden-sm
+          %i.fa.fa-lg.fa-angle-left.fa-rotate-90.hidden-md.hidden-lg
+      - else
+        - t = _("Move selected fields left")
+        %button.btn.btn-default{:title           => t,
+                                :remote          => true,
+                                "data-submit"    => 'column_lists',
+                                "data-method"    => :post,
+                                "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
+                                                                     :button => 'left',
+                                                                     :id     => @custom_button_set.id || 'new')}.to_json}
+          %i.fa.fa-angle-left.fa-lg.hidden-xs.hidden-sm
+          %i.fa.fa-lg.fa-angle-left.fa-rotate-90.hidden-md.hidden-lg
+        .spacer
+
+    .col-md-5
+      = _('Selected:')
+      = select_tag('selected_fields[]',
+        options_for_select(@edit[:new][:fields], @selected),
+        :multiple => true,
+        :class    => "form-control",
+        :style    => "overflow-x: scroll;",
+        :size     => 8,
+        :id       => "selected_fields")
+
+    .col-md-1{:style => "padding: 10px"}
+      .spacer
+      .spacer
+      - if @edit[:new][:fields].length < 2
+        %button.btn.btn-default.btn-block.disabled
+          %i.fa.fa-angle-double-up.fa-lg
+      - else
+        - t = _("Move selected fields to top")
+        %button.btn.btn-default.btn-block{:title           => t,
+                                :remote          => true,
+                                "data-submit"    => 'column_lists',
+                                "data-method"    => :post,
+                                "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
+                                                                     :button => 'top',
+                                                                     :id     => @custom_button_set.id || 'new')}.to_json}
+          %i.fa.fa-angle-double-up.fa-lg
+      - if @edit[:new][:fields].length < 2
+        %button.btn.btn-default.btn-block.disabled
+          %i.fa.fa-angle-up.fa-lg
+      - else
+        - t = _("Move selected fields up")
+        %button.btn.btn-default.btn-block{:title           => t,
+                                :remote          => true,
+                                "data-submit"    => 'column_lists',
+                                "data-method"    => :post,
+                                "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
+                                                                     :button => 'up',
+                                                                     :id     => @custom_button_set.id || 'new')}.to_json}
+          %i.fa.fa-angle-up.fa-lg
+      - if @edit[:new][:fields].length < 2
+        %button.btn.btn-default.btn-block.disabled
+          %i.fa.fa-angle-down.fa-lg
+      - else
+        - t = _("Move selected fields down")
+        %button.btn.btn-default.btn-block{:title           => t,
+                                :remote          => true,
+                                "data-submit"    => 'column_lists',
+                                "data-method"    => :post,
+                                "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
+                                                                     :button => 'down',
+                                                                     :id     => @custom_button_set.id || 'new')}.to_json}
+          %i.fa.fa-angle-down.fa-lg
+      - if @edit[:new][:fields].length < 2
+        %button.btn.btn-default.btn-block.disabled
+          %i.fa.fa-angle-double-down.fa-lg
+      - else
+        - t = _("Move selected fields to bottom")
+        %button.btn.btn-default.btn-block{:title           => t,
+                                :remote          => true,
+                                "data-submit"    => 'column_lists',
+                                "data-method"    => :post,
+                                "data-click_url" => {:url => url_for_only_path(:action => 'group_form_field_changed',
+                                                                     :button => 'bottom',
+                                                                     :id     => @custom_button_set.id || 'new')}.to_json}
+          %i.fa.fa-angle-double-down
+        .spacer

--- a/app/views/shared/views/_seq_selector_buttons.html.haml
+++ b/app/views/shared/views/_seq_selector_buttons.html.haml
@@ -1,0 +1,21 @@
+.col-md-1.col-sm-2.col-xs-2{:style => "padding: 10px"}
+  .spacer
+  .spacer
+  - if fields_count < 2
+    %button.btn.btn-block.disabled
+      %i.fa.fa-angle-up.fa-lg
+    %button.btn.btn-block.disabled
+      %i.fa.fa-angle-down.fa-lg
+  - else
+    - button_params.each do |title, chosen_div, action, arrow_style|
+      %button.btn.btn-default.btn-block{:title                 => title,
+                                        :remote                => true,
+                                        "data-submit"          => chosen_div,
+                                        "data-method"          => :post,
+                                        "data-miq_sparkle_on"  => true,
+                                        "data-miq_sparkle_off" => true,
+                                        "data-click_url"       => {:url => url_for_only_path(:action => button_action,
+                                                                                             :button => action,
+                                                                                             :id     => id)}.to_json}
+        %i.fa.fa-lg{:class => arrow_style}
+  .spacer

--- a/app/views/vm_common/_form.html.haml
+++ b/app/views/vm_common/_form.html.haml
@@ -1,3 +1,4 @@
+
 #main_div
   - url = url_for_only_path(:action => 'form_field_changed', :id => (@record.id || "new"))
 
@@ -52,55 +53,58 @@
 
   %hr
   %h3= _('Child VM Selection')
-  %table#child-vm-select
-    %tr
-      %td.widthed{:align => "left"}= _('Child VMs:')
-      %td
-      %td{:align => "left"}= _('Available VMs:')
-    %tr
-      %td{:align => "right", :valign => "top"}
-        %div{:style => "overflow: auto; width: 400px; border: 1px solid #999999;"}
-          = select_tag('kids_chosen[]',
-            options_for_select(@edit[:new][:kids].sort),
-            :multiple => true,
-            :size => 15,
-            :style => "width: 400px",
-            :id => "kids_chosen")
-      %td.text-center{:width => "40"}
-        .btn-group-vertical
-          %button.btn.btn-default{:title => _("Move selected VMs to right"),
-            "data-submit"         => 'main_div',
-            "data-miq_sparkle_on" => true,
-            :remote               => true,
-            "data-method"         => :post,
-            'data-click_url' => {:url => "#{url}?button=right"}.to_json,
-            :id     => @record.id || "new"}
-            %i.fa.fa-angle-right.fa-lg
-          %button.btn.btn-default{:title => _("Move all VMs to right"),
-            "data-submit"         => 'main_div',
-            "data-miq_sparkle_on" => true,
-            :remote               => true,
-            "data-method"         => :post,
-            'data-click_url' => {:url => "#{url}?button=allright"}.to_json,
-            :id     => @record.id || "new"}
-            %i.fa.fa-angle-double-right.fa-lg
-          %button.btn.btn-default{:title => _("Move selected VMs to left"),
-            "data-submit"         => 'main_div',
-            "data-miq_sparkle_on" => true,
-            :remote               => true,
-            "data-method"         => :post,
-            'data-click_url' => {:url => "#{url}?button=left"}.to_json,
-            :id     => @record.id || "new"}
-            %i.fa.fa-angle-left.fa-lg
+  #child-vm-select
+    .col-md-5
+      = _('Child VMs:')
+      = select_tag('kids_chosen[]',
+        options_for_select(@edit[:new][:kids].sort),
+        :multiple => true,
+        :size     => 15,
+        :class    => "form-control",
+        :style    => "overflow-x: scroll;",
+        :id       => "kids_chosen")
 
-      %td{:align => "left", :valign => "top"}
-        %div{:style => "overflow: auto; width: 400px; border: 1px solid #999999;"}
-          = select_tag('choices_chosen[]',
-            options_for_select(@edit[:choices].sort),
-            :multiple => true,
-            :style => "width: 400px; min-width:375px; border: 0px;",
-            :size => 15,
-            :id => "choices_chosen")
+    .col-md-1{:style => "padding: 10px"}
+      .spacer
+      .spacer
+      %button.btn.btn-default.btn-block{:title => _("Move selected VMs to right"),
+        "data-submit"         => 'main_div',
+        "data-miq_sparkle_on" => true,
+        :remote               => true,
+        "data-method"         => :post,
+        'data-click_url' => {:url => "#{url}?button=right"}.to_json,
+        :id     => @record.id || "new"}
+        %i.fa.fa-angle-right.fa-lg.hidden-xs.hidden-sm
+        %i.fa.fa-angle-right.fa-lg.fa-rotate-90.hidden-md.hidden-lg
+      %button.btn.btn-default.btn-block{:title => _("Move all VMs to right"),
+        "data-submit"         => 'main_div',
+        "data-miq_sparkle_on" => true,
+        :remote               => true,
+        "data-method"         => :post,
+        'data-click_url' => {:url => "#{url}?button=allright"}.to_json,
+        :id     => @record.id || "new"}
+        %i.fa.fa-angle-double-right.fa-lg.hidden-xs.hidden-sm
+        %i.fa.fa-angle-double-right.fa-lg.fa-rotate-90.hidden-md.hidden-lg
+      %button.btn.btn-default.btn-block{:title => _("Move selected VMs to left"),
+        "data-submit"         => 'main_div',
+        "data-miq_sparkle_on" => true,
+        :remote               => true,
+        "data-method"         => :post,
+        'data-click_url' => {:url => "#{url}?button=left"}.to_json,
+        :id     => @record.id || "new"}
+        %i.fa.fa-angle-left.fa-lg.hidden-xs.hidden-sm
+        %i.fa.fa-angle-left.fa-lg.fa-rotate-90.hidden-md.hidden-lg
+      .spacer
+
+    .col-md-5
+      = _('Available VMs:')
+      = select_tag('choices_chosen[]',
+        options_for_select(@edit[:choices].sort),
+        :multiple => true,
+        :size     => 15,
+        :class    => "form-control",
+        :style    => "overflow-x: scroll;",
+        :id       => "choices_chosen")
 
   - unless @edit[:explorer]
     = render(:partial => '/layouts/edit_form_buttons', :locals  => {:action_url => "edit_vm", :ajax_buttons => true, :record_id => @record.id})


### PR DESCRIPTION
This PR redesigns the textarea-based "item selector" to be fully responsive, including converting png images to font icons.

#1314
https://www.pivotaltracker.com/n/projects/1613907/stories/123185601
https://bugzilla.redhat.com/show_bug.cgi?id=1374761

Old 

(full desktop)
<img width="1069" alt="screen shot 2017-05-17 at 4 19 05 pm" src="https://cloud.githubusercontent.com/assets/1287144/26174236/b110081e-3b1c-11e7-83a6-05b23fbbf45c.png">

(mobile)
<img width="650" alt="screen shot 2017-05-17 at 4 19 16 pm" src="https://cloud.githubusercontent.com/assets/1287144/26174235/b0ffbafe-3b1c-11e7-84a6-01a0d31506f9.png">


New
(full desktop)
<img width="813" alt="screen shot 2017-05-17 at 4 17 09 pm" src="https://cloud.githubusercontent.com/assets/1287144/26174140/6826dbdc-3b1c-11e7-9f5b-562c37c583d2.png">

(mobile)
<img width="742" alt="screen shot 2017-05-17 at 4 17 34 pm" src="https://cloud.githubusercontent.com/assets/1287144/26174139/681e2104-3b1c-11e7-8636-8e1c7ace382c.png">