### PR TITLE
Add condition to choose plural toolbar for show_list action

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -821,7 +821,9 @@ module ApplicationHelper
     end
 
     # FIXME: singular vs plural for controller.class.toolbar_singular
-    toolbars['center_tb'] = if controller.class.toolbar_singular.present?
+    toolbars['center_tb'] = if controller.class.toolbar_plural.present? && params[:action] == 'show_list'
+                              "#{controller.class.toolbar_plural}_center_tb"
+                            elsif controller.class.toolbar_singular.present?
                               "#{controller.class.toolbar_singular}_center_tb"
                             else
                               center_toolbar_filename


### PR DESCRIPTION
Wrong toolbar is selected for Repositories and Credentials show_list view. Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/1323 .

Automate -> Ansible -> Repositories -> Configuration
Automate -> Ansible -> Credentials -> Configuration

Before:
Repositories:
<img width="1176" alt="screen shot 2017-05-18 at 3 05 38 pm" src="https://cloud.githubusercontent.com/assets/9210860/26203456/a8b7131e-3bdb-11e7-9606-6481ab7ae09c.png">
Credentials:
<img width="1162" alt="screen shot 2017-05-18 at 3 05 53 pm" src="https://cloud.githubusercontent.com/assets/9210860/26203457/a8d697c0-3bdb-11e7-8051-4d5f13465338.png">

After:
Repositories:
<img width="1184" alt="screen shot 2017-05-18 at 3 02 07 pm" src="https://cloud.githubusercontent.com/assets/9210860/26203467/adc12dae-3bdb-11e7-827a-f32ca1b01532.png">
Credentials:
<img width="1158" alt="screen shot 2017-05-18 at 3 02 35 pm" src="https://cloud.githubusercontent.com/assets/9210860/26203468/adc600ae-3bdb-11e7-87c9-c17bd16de5e9.png">

@miq-bot add_label bug
