### PR TITLE
Fix oVirt metrics DB name validation

### DIFF
--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -2,6 +2,7 @@
 - prefix ||= "default"
 - ng_reqd_hostname ||= true
 - ng_reqd_api_port ||= true
+- ng_reqd_db_name ||= false
 
 %div{"ng-if" => defined?(security_protocol_hide) ? false : true}
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_security_protocol.$invalid}",
@@ -127,7 +128,7 @@
                           "name"          => "#{prefix}_database_name",
                           "ng-model"      => "#{ng_model}.#{prefix}_database_name",
                           "maxlength"     => 40,
-                          "required"      => defined?(database_name_required) ? true : false,
+                          "ng-required"   => ng_reqd_db_name.to_s,
                           "checkchange"   => "",
                           "ng-trim"       => false,
                           "detect-spaces" => ""}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -151,7 +151,7 @@
                                  :locals  => {:ng_show                => true,
                                               :ng_model               => "#{ng_model}",
                                               :id                     => record.id,
-                                              :database_name_required => true,
+                                              :ng_reqd_db_name        => "#{ng_model}.metrics_hostname != ''",
                                               :database_name_show     => true,
                                               :tls_verify_hide        => true,
                                               :tls_ca_certs_hide      => true,


### PR DESCRIPTION
Currently the 'Database name' field of the 'C & U Database' tab of the
authentication form is always mandatory. In addition the presence check
is done using the 'required' attribute. The result of that is that the
provider can't be edited unless that field is filled, even if the
metrics aren't enabled, and the fact that the validation failed isn't
explicitly shown in the 'C & U Database' tab header. To fix these issues
this patch changes the form to use 'ng-required' instead of 'required',
and to make the field mandatory only when the host name is not empty.

https://bugzilla.redhat.com/1451301