### PR TITLE
rhn_mirror role is being deleted

### DIFF
--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -66,7 +66,6 @@ module OpsController::Settings::RHN
     MiqServer.in_my_region.order(:name).collect do |server|
       status = server.rh_registered ? 'Unsubscribed' : 'Not registered'
       status = 'Subscribed' if server.rh_subscribed
-      status = 'Subscribed via Proxy' if server.rhn_mirror
 
       MiqHashStruct.new(
         :id                => server.id,


### PR DESCRIPTION
Do I need to remove anything else for enable / disable of the role?

See also: https://github.com/ManageIQ/manageiq/pull/15156