### PR TITLE
Add removing of old pagination when new report data is displayed

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -364,6 +364,8 @@
       var pagination = this.$document.getElementsByClassName('miq-pagination');
       var pagingDiv = this.$document.querySelector('#paging_div .col-md-12');
       if (pagination && pagination.length > 0 && pagingDiv) {
+        var oldPagination = pagingDiv.querySelector('div');
+        oldPagination ? oldPagination.remove() : null;
         pagingDiv.appendChild(pagination[0]);
       }
     }.bind(this));


### PR DESCRIPTION
### Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/132
There was an error when displaying every GTL report old pagination was visible.

#### Before
![selection_165](https://cloud.githubusercontent.com/assets/3439771/26247169/e6a97538-3c9c-11e7-8659-30bcb256e1f0.png)

#### After
![selection_166](https://cloud.githubusercontent.com/assets/3439771/26247176/eea76556-3c9c-11e7-9387-deed956059cf.png)

(Different kind of reports)