### PR TITLE
Hide tenant parent name when user(also with super_admin_role) cannot see it 

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -773,11 +773,9 @@ module OpsController::OpsRbac
                       get_view(MiqUserRole)
                     when "tenant"
                       view, pages = get_view(Tenant, :named_scope => :in_my_region)
-                      unless User.current_user.super_admin_user?
-                        view.table.data.map! do |x|
-                          x['parent_name'] = '' unless allowed_tenant_names.include?(x['parent_name'])
-                          x
-                        end
+                      view.table.data.map! do |x|
+                        x['parent_name'] = '' unless allowed_tenant_names.include?(x['parent_name'])
+                        x
                       end
                       [view, pages]
                     end


### PR DESCRIPTION
follow up https://github.com/ManageIQ/manageiq-ui-classic/pull/612/files

Tenancy has higher priority then super_admin role
 
# Links
https://github.com/ManageIQ/manageiq-ui-classic/pull/612/files
https://bugzilla.redhat.com/show_bug.cgi?id=1417874
https://bugzilla.redhat.com/show_bug.cgi?id=1430468

@miq-bot add_label bug

@miq-bot assign @mzazrivec 

