### PR TITLE
novnc-rails is a dependency here, not manageiq

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "patternfly-sass", "~> 3.23.1"
   s.add_dependency "sass-rails"
   s.add_dependency "high_voltage", "~> 3.0.0"
+  s.add_dependency "novnc-rails",  "~>0.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "guard-rspec", '~> 4.7.3'


### PR DESCRIPTION
As we try to organize dependencies, this gem was left in manageiq but belongs here.

Once this is merged, we can drop it from manageiq, here: https://github.com/ManageIQ/manageiq/issues/15166