### PR TITLE
Move the high voltage initializer here, where it's used

### DIFF
--- a/config/initializers/high_voltage.rb
+++ b/config/initializers/high_voltage.rb
@@ -1,0 +1,8 @@
+HighVoltage.configure do |config|
+  config.layout = false
+
+  config.routes = false
+
+  # app/views/static
+  config.content_path = 'static/'
+end

--- a/lib/manageiq-ui-classic.rb
+++ b/lib/manageiq-ui-classic.rb
@@ -3,4 +3,5 @@ require "manageiq/ui/classic/engine"
 require "manageiq/ui/classic/version"
 
 # load any engines that we depend on here
+require 'high_voltage'
 require "novnc-rails"


### PR DESCRIPTION
Move the high voltage initializer here, where it's used

Note, high_voltage is an engine so we must require it when
lib/manageiq-ui-classic is required.

Once this is merged, we can remove it from the main repo here:
https://github.com/ManageIQ/manageiq/pull/15171