### PR TITLE
Dependent engines are required, but not dependencies of said engine

### DIFF
--- a/lib/manageiq-ui-classic.rb
+++ b/lib/manageiq-ui-classic.rb
@@ -1,3 +1,6 @@
 require "manageiq/ui/classic"
 require "manageiq/ui/classic/engine"
 require "manageiq/ui/classic/version"
+
+# load any engines that we depend on here
+require "novnc-rails"


### PR DESCRIPTION
Followup to #1395

Basically, if you have an engine dependency, 1, in an app Gemfile,
it will be required and it's hooks would be added to the rails hooks.

If you add a second engine as a dependency, 2, as a dependency of the
first, 1, only 1 will be required.  You have to explicitly require 2
from 1.

https://bibwild.wordpress.com/2013/02/27/gem-depends-on-rails-engine-gem-gotcha-need-explicit-require/