### PR TITLE
PXE servers has no quadicon to render

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -192,6 +192,7 @@ module ApplicationHelper
       PxeImageType
       IsoDatastore
       MiqTask
+      PxeServer
     ).include? type
   end
 


### PR DESCRIPTION
### Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/1399
When fetching data for report data, do not try to render quadicon so the server does not throw error.