### PR TITLE
Ensure cloud tenant ID is read as string for cloud subnets

### DIFF
--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -68,7 +68,7 @@ class CloudSubnetController < ApplicationController
     network_manager = ExtManagementSystem.find(params[:id])
     tenants = []
     CloudTenant.where(:ems_id => network_manager.parent_ems_id).find_each do |tenant|
-      tenants << { 'name' => tenant.name, 'id' => tenant.id }
+      tenants << { 'name' => tenant.name, 'id' => tenant.id.to_s }
     end
     render :json => {
       :available_tenants => tenants


### PR DESCRIPTION
If the region ID is large enough, the cloud tenant ID is not parseable
as a string by angular.

https://bugzilla.redhat.com/show_bug.cgi?id=1448888