### PR TITLE
[WIP] ownership screen - limit user/group selects to 10/9 lines

### DIFF
--- a/app/views/shared/views/_ownership.html.haml
+++ b/app/views/shared/views/_ownership.html.haml
@@ -24,6 +24,7 @@
                       "ng-model"                    => "vm.ownershipModel.user",
                       "id"                          => "user_name",
                       "checkchange"                 => "",
+                      "data-size"                   => 10,
                       "selectpicker-for-select-tag" => "")
       %td{:width => "100"}
     .form-group{"ng-class" => "{'has-error': angularForm.group.$invalid}"}
@@ -39,6 +40,7 @@
                       "ng-model"                    => "vm.ownershipModel.group",
                       "id"                          => "group_name",
                       "checkchange"                 => "",
+                      "data-size"                   => 9,
                       "selectpicker-for-select-tag" => "")
 
   %hr


### PR DESCRIPTION
When setting ownership for just 1 (or 1 row of) item, the `#main_div` (well, actually, `#main-content > div`) is not tall enough to show all the items from a user/group select.

And that element has `overflow: hidden`, so the other values just get cut off.

Fixing by forcing the maximum number of lines to 10 (for users) and 9 (for groups, because 10 doesn't fit there).

Closes ManageIQ/manageiq#15177