### PR TITLE
Remove old require wbem from spec

### DIFF
--- a/app/helpers/application_helper/button/zone_delete.rb
+++ b/app/helpers/application_helper/button/zone_delete.rb
@@ -14,7 +14,6 @@ class ApplicationHelper::Button::ZoneDelete < ApplicationHelper::Button::Basic
 
   def relationships?
     @selected_zone.ext_management_systems.count > 0 ||
-      @selected_zone.storage_managers.count > 0 ||
       @selected_zone.miq_schedules.count > 0 ||
       @selected_zone.miq_servers.count > 0
   end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -566,9 +566,7 @@ module QuadiconHelper
     output << flobj_img_simple(img_path, "e72")
 
     unless options[:typ] == :listnav
-      name = if item.kind_of?(MiqCimInstance)
-               item.evm_display_name
-             elsif item.kind_of?(MiqProvisionRequest)
+      name = if item.kind_of?(MiqProvisionRequest)
                item.message
              else
                item.try(:name)

--- a/app/views/ops/_settings_evm_servers_tab.html.haml
+++ b/app/views/ops/_settings_evm_servers_tab.html.haml
@@ -51,12 +51,6 @@
             = @selected_zone.ext_management_systems.count
       .form-group
         %label.col-md-2.control-label
-          = _("Storage Managers")
-        .col-md-10
-          %p.form-control-static
-            = @selected_zone.storage_managers.count
-      .form-group
-        %label.col-md-2.control-label
           = _("Schedules")
         .col-md-10
           %p.form-control-static

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -5,7 +5,7 @@ describe ReportController do
     end
 
     let(:has_many_field_col) do
-      ['Vm.Storage.Storage Volumes.Disks : Storage Volume Class Hier', 'Vm.storage_volumes-class_hier']
+      ['Vm.Service.User.Miq Templates : Last Analysis Time', 'Vm.service.user.miq_templates-last_scan_attempt_on']
     end
 
     let(:cols) do

--- a/spec/helpers/application_helper/buttons/zone_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/zone_delete_spec.rb
@@ -15,15 +15,13 @@ describe ApplicationHelper::Button::ZoneDelete do
       let(:zone_name) { 'Default' }
       it_behaves_like 'a disabled button', "'Default' zone cannot be deleted"
     end
+
     context 'when selected zone is not the default one' do
       context 'and zone has ext_management_systems' do
         let(:set_relationships) { selected_zone.ext_management_systems << FactoryGirl.create(:ext_management_system) }
         it_behaves_like 'a disabled button', 'Cannot delete a Zone that has Relationships'
       end
-      context 'and zone hase storage_managers' do
-        let(:set_relationships) { selected_zone.storage_managers << FactoryGirl.create(:storage_manager, :name => 'M') }
-        it_behaves_like 'a disabled button', 'Cannot delete a Zone that has Relationships'
-      end
+
       context 'and zone has miq_schedules' do
         let(:set_relationships) do
           MiqServer.seed
@@ -31,10 +29,12 @@ describe ApplicationHelper::Button::ZoneDelete do
         end
         it_behaves_like 'a disabled button', 'Cannot delete a Zone that has Relationships'
       end
+
       context 'and zone has miq_servers' do
         let(:set_relationships) { selected_zone.miq_servers << FactoryGirl.create(:miq_server) }
         it_behaves_like 'a disabled button', 'Cannot delete a Zone that has Relationships'
       end
+
       context 'and zone has no relationships' do
         it_behaves_like 'an enabled button'
       end

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'wbem'
-
 RSpec.shared_examples :quadicon_with_link do
   it 'renders a quadicon with a link by default' do
     expect(subject).to have_selector('div.quadicon')


### PR DESCRIPTION
Introduced with this file in https://github.com/ManageIQ/manageiq/pull/9256, but back then, it was actually used.

Now, not so much (removed in #204). And now, it's causing [test failures](https://travis-ci.org/ManageIQ/manageiq-ui-classic/builds/234936179?utm_source=github_status&utm_medium=notification).

```
An error occurred while loading ./spec/helpers/quadicon_helper_spec.rb.
Failure/Error: require 'wbem'
LoadError:
  cannot load such file -- wbem
# ./spec/helpers/quadicon_helper_spec.rb:1:in `<top (required)>'
```

=> Removing the require.

Caused by ManageIQ/manageiq#15153

(Related PRs:
https://github.com/ManageIQ/manageiq-ui-classic/pull/1409
https://github.com/ManageIQ/manageiq-ui-classic/pull/1412
https://github.com/ManageIQ/manageiq-ui-classic/pull/1414
)