### PR TITLE
[WIP] Remove more WBEM and CIM references

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -566,9 +566,7 @@ module QuadiconHelper
     output << flobj_img_simple(img_path, "e72")
 
     unless options[:typ] == :listnav
-      name = if item.kind_of?(MiqCimInstance)
-               item.evm_display_name
-             elsif item.kind_of?(MiqProvisionRequest)
+      name = if item.kind_of?(MiqProvisionRequest)
                item.message
              else
                item.try(:name)

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'wbem'
-
 RSpec.shared_examples :quadicon_with_link do
   it 'renders a quadicon with a link by default' do
     expect(subject).to have_selector('div.quadicon')


### PR DESCRIPTION
Clean up remaining references to things removed by https://github.com/ManageIQ/manageiq/pull/15153

- [x] Remove `MiqCimInstance` from quadicon_helper.rb
- [ ] Remove (?) `storage_managers` from _settings_evm_servers_tab.html.haml
- [ ] Remove (?) `storage_managers` from zone_delete.rb
- [ ] Deal with storage volumes failure in report_controller/editor_spec.rb

