### PR TITLE
Set gtl buttons toolbar for automation manager when refreshed from hash

### DIFF
--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -29,6 +29,8 @@ class ApplicationHelper::ToolbarChooser
       @report ? "report_view_tb" : nil
     elsif @layout == 'provider_foreman'
       @showtype == 'main' ? "x_summary_view_tb" : "x_gtl_view_tb"
+    elsif @layout == 'automation_manager'
+      @record.try(:kind_of?, ManageIQ::Providers::AutomationManager::InventoryRootGroup) && @sb[:active_tab] == 'summary' ? "x_summary_view_tb" : "x_gtl_view_tb"
     else
       nil
     end

--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -153,4 +153,24 @@ describe ApplicationHelper, "ToolbarChooser" do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe '#x_view_toolbar_filename' do
+    before do
+      @record = FactoryGirl.create(:inventory_root_group)
+    end
+
+    context 'when the active tab is summary' do
+      it "displays summary toolbar" do
+        @sb = {:active_tab => 'summary'}
+        expect(ApplicationHelper::ToolbarChooser.new(nil, nil, :record => @record, :explorer => true, :layout => 'automation_manager', :sb => @sb).send(:x_view_toolbar_filename)).to eq("x_summary_view_tb")
+      end
+    end
+
+    context ' when the active tab is configured_systems' do
+      it "displays summary toolbar" do
+        @sb = {:active_tab => 'configured_systems'}
+        expect(ApplicationHelper::ToolbarChooser.new(nil, nil, :record => @record, :explorer => true, :layout => 'automation_manager', :sb => @sb).send(:x_view_toolbar_filename)).to eq("x_gtl_view_tb")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Set gtl buttons toolbar for automation manager when refreshed from hash by using the browser refresh button.

https://bugzilla.redhat.com/show_bug.cgi?id=1452425

To reproduce the problem - navigate to Ansible Tower and select a provider - the inventory groups will be listed on the right. Then, click the refresh button for the browser, not the application. The gtl buttons are not displayed.