### PR TITLE
Cloud Networks creation: provider type not required

### DIFF
--- a/app/assets/javascripts/controllers/cloud_network/cloud_network_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_network/cloud_network_form_controller.js
@@ -1,5 +1,5 @@
 ManageIQ.angular.app.controller('cloudNetworkFormController', ['$scope', 'cloudNetworkFormId', 'miqService', 'API', function($scope, cloudNetworkFormId, miqService, API) {
-  $scope.cloudNetworkModel = { name: '', ems_id: '', cloud_tenant_id: '', provider_network_type: ''  };
+  $scope.cloudNetworkModel = { name: '', ems_id: '', cloud_tenant_id: '' };
   $scope.formId = cloudNetworkFormId;
   $scope.afterGet = false;
   $scope.modelCopy = angular.copy( $scope.cloudNetworkModel );

--- a/app/views/cloud_network/new.html.haml
+++ b/app/views/cloud_network/new.html.haml
@@ -25,8 +25,6 @@
         = select_tag("provider_network_type",
           options_for_select([["<#{_('Choose')}>", nil]] + @network_provider_network_type_choices.sort),
                       "ng-model"                    => "cloudNetworkModel.provider_network_type",
-                      "required"                    => "",
-                      :miqrequired                  => false,
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
   %h3


### PR DESCRIPTION
Makes provider-type not required in order for any tenant to create non physical networks.
Also removes the default assignment from the javascript controller to avoid ending with an empty value.

https://bugzilla.redhat.com/show_bug.cgi?id=1454618
