### PR TITLE
Get rid of MiqCimInstance references + add wbem dependency

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -566,9 +566,7 @@ module QuadiconHelper
     output << flobj_img_simple(img_path, "e72")
 
     unless options[:typ] == :listnav
-      name = if item.kind_of?(MiqCimInstance)
-               item.evm_display_name
-             elsif item.kind_of?(MiqProvisionRequest)
+      name = if item.kind_of?(MiqProvisionRequest)
                item.message
              else
                item.try(:name)

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "guard-rspec", '~> 4.7.3'
   s.add_development_dependency "simplecov"
+  s.add_development_dependency "rubywbem"
 
   # core because jasmine has < 3.0, not < 2.6
   s.add_development_dependency "jasmine",  "~> 2.5.2"


### PR DESCRIPTION
Changes needed after https://github.com/ManageIQ/manageiq/pull/15153
which removed MiqCimInstance and `wbem` dependency from manageiq core.