### PR TITLE
Remove reference to MiqCimInstance as it was deleted

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -566,9 +566,7 @@ module QuadiconHelper
     output << flobj_img_simple(img_path, "e72")
 
     unless options[:typ] == :listnav
-      name = if item.kind_of?(MiqCimInstance)
-               item.evm_display_name
-             elsif item.kind_of?(MiqProvisionRequest)
+      name = if item.kind_of?(MiqProvisionRequest)
                item.message
              else
                item.try(:name)


### PR DESCRIPTION
Causing error on Catalogs, I think it's remnant/related to https://github.com/ManageIQ/manageiq/pull/15153