### PR TITLE
Add MiqRequest in not allowed quadicons

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -192,6 +192,7 @@ module ApplicationHelper
       PxeImageType
       IsoDatastore
       MiqTask
+      MiqRequest
       PxeServer
     ).include? type
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -194,6 +194,7 @@ module ApplicationHelper
       MiqTask
       MiqRequest
       PxeServer
+      Switch
     ).include? type
   end
 


### PR DESCRIPTION
### Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/1402
When loading request screen GTL tries to fetch quadicon for each request, but quadicons are not defined for MiqRequest model.

### Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/1418
When loading request screen GTL tries to fetch quadicon for each request, but quadicons are not defined for switch moel.