### PR TITLE
Removed not needed 'include_for_find' in 'MiqReportResult-all.yaml' and synch columns order with 'MiqReportResult.yaml' 

### DIFF
--- a/product/views/MiqReportResult-all.yaml
+++ b/product/views/MiqReportResult-all.yaml
@@ -43,11 +43,6 @@ col_order:
 - miq_group_description
 - status
 
-include_for_find:
-  :miq_task: {}
-  :miq_group: {}
-
-
 # Column titles, in order
 headers:
 - Queued At

--- a/product/views/MiqReportResult.yaml
+++ b/product/views/MiqReportResult.yaml
@@ -34,8 +34,8 @@ include:
 
 # Order of columns (from all tables)
 col_order:
-- last_run_on
 - created_on
+- last_run_on
 - report_source
 - userid
 - miq_group_description
@@ -43,8 +43,8 @@ col_order:
 
 # Column titles, in order
 headers:
-- Run At
 - Queued At
+- Run At
 - Source
 - Username
 - Group


### PR DESCRIPTION
This PR:
- Removed not needed `include_for_find`  - will speed-up view loading.
- There are 2 entries to show list of saved reports:  All reports and specific report.  Order of `Queued At` and `Run At` columns were different and this PR fixed it.

**BEFORE**:
<img width="935" alt="before1" src="https://cloud.githubusercontent.com/assets/6556758/26411617/4f089f7a-4074-11e7-8cf5-b69e6e3b9e9f.png">
<img width="937" alt="before2" src="https://cloud.githubusercontent.com/assets/6556758/26411638/574b04ac-4074-11e7-9888-fa81c24c3044.png">

**AFTER:**
<img width="936" alt="after1" src="https://cloud.githubusercontent.com/assets/6556758/26411713/8fc6ab7e-4074-11e7-989f-0ed06539e722.png">
<img width="946" alt="after2" src="https://cloud.githubusercontent.com/assets/6556758/26411723/95b9dd30-4074-11e7-8365-8920cb7e831b.png">

@miq-bot add-label fine/no

