### PR TITLE
Custom Reports export - add missing action to the button

### DIFF
--- a/app/views/layouts/_x_edit_buttons.html.haml
+++ b/app/views/layouts/_x_edit_buttons.html.haml
@@ -172,12 +172,13 @@
         :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item   => 0)}');")
     - else
       -# export_button
-      = button_tag(_("Export"),
-        :class    => "btn btn-primary",
+      = link_to(_("Export"),
+        {:action => action_url},
+        :class    => "btn btn-primary disabled",
         :type     => "application/txt",
-        :id       => "export_button",
-        :alt      => _("Download Report to YAML"),
-        :disabled => true)
+        :alt      => t = _("Download Report to YAML"),
+        :title    => t,
+        :id       => "export_button")
 
 - elsif ["compare"].include?(@sb[:action])
   #buttons

--- a/app/views/report/_export_custom_reports.html.haml
+++ b/app/views/report/_export_custom_reports.html.haml
@@ -49,8 +49,8 @@
           $('#choices_chosen').on("change",
             function() {
               if ($(this).val()) {
-                $('#export_button').prop('disabled', false);
+                $('#export_button').removeClass('disabled');
               } else {
-                $('#export_button').prop('disabled', true);
+                $('#export_button').addClass('disabled');
               }
             });


### PR DESCRIPTION
Go to CI > Reports, accordion Import/Export, pick "Custom Buttons".

The `Export` link in the bottom toolbar does not do anything. Which is not surprising since the button doesn't have any action :).

Adding the action.

Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/1423

Cc @zakiva, @jzigmund, @simon3z 
