### PR TITLE
Remove jquery-1.8 dependency after last use is gone

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,6 @@
     "fetch": "~1.0.0",
     "jasmine-jquery": "~2.1.1",
     "jquery": "~2.2.4",
-    "jquery-1.8": "~1.8.3",
     "jquery-ui": "jqueryui#~1.12.1",
     "jquery-ujs": "~1.2.2",
     "jquery.observe_field": "himdel/jquery.observe_field#~0.1.0",


### PR DESCRIPTION
It was used by vmrc consoles, removed in #979.