### PR TITLE
Memoize reporting available fields in template

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -809,6 +809,10 @@ module ReportController::Reports::Editor
     @reporting_available_fields[@edit[:new][:model]] ||= MiqExpression.reporting_available_fields(@edit[:new][:model], @edit[:new][:perf_interval])
   end
 
+  def reporting_available_fields_clear_cash
+    @reporting_available_fields = nil
+  end
+
   def move_cols_right
     if !params[:available_fields] || params[:available_fields].length == 0 || params[:available_fields][0] == ""
       add_flash(_("No fields were selected to move down"), :error)
@@ -816,7 +820,8 @@ module ReportController::Reports::Editor
       add_flash(_("Fields not added: Adding the selected %{count} fields will exceed the maximum of %{max} fields") % {:count => params[:available_fields].length + @edit[:new][:fields].length, :max => MAX_REPORT_COLUMNS},
                 :error)
     else
-      MiqExpression.reporting_available_fields(@edit[:new][:model], @edit[:new][:perf_interval]).each do |af| # Go thru all available columns
+      reporting_available_fields_clear_cash
+      cashed_reporting_available_fields.each do |af| # Go thru all available columns
         if params[:available_fields].include?(af[1])        # See if this column was selected to move
           unless @edit[:new][:fields].include?(af)          # Only move if it's not there already
             @edit[:new][:fields].push(af)                     # Add it to the new fields list

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1,6 +1,10 @@
 module ReportController::Reports::Editor
   extend ActiveSupport::Concern
 
+  included do
+    helper_method :cashed_reporting_available_fields, :cashed_reporting_available_fields
+  end
+
   CHARGEBACK_ALLOWED_FIELD_SUFFIXES = %w(
     _cost
     -owner_name
@@ -798,6 +802,10 @@ module ReportController::Reports::Editor
       @tl_changed = true
       @edit[:new][:tl_position] = params[:chosen_position]
     end
+  end
+
+  def cashed_reporting_available_fields
+    MiqExpression.reporting_available_fields(@edit[:new][:model], @edit[:new][:perf_interval])
   end
 
   def move_cols_right

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -805,7 +805,8 @@ module ReportController::Reports::Editor
   end
 
   def cashed_reporting_available_fields
-    MiqExpression.reporting_available_fields(@edit[:new][:model], @edit[:new][:perf_interval])
+    @reporting_available_fields ||= {}
+    @reporting_available_fields[@edit[:new][:model]] ||= MiqExpression.reporting_available_fields(@edit[:new][:model], @edit[:new][:perf_interval])
   end
 
   def move_cols_right

--- a/app/views/report/_column_lists.html.haml
+++ b/app/views/report/_column_lists.html.haml
@@ -6,7 +6,7 @@
       %td
     %tr
       %td{:align => "right", :valign => "top"}
-        - af = @edit[:new][:model] ? MiqExpression.reporting_available_fields(@edit[:new][:model], @edit[:new][:perf_interval]) - @edit[:new][:fields] : []
+        - af = @edit[:new][:model] ? cashed_reporting_available_fields - @edit[:new][:fields] : []
         = select_tag('available_fields[]',
           options_for_select(af),
           :multiple => true,
@@ -16,8 +16,7 @@
       %td
     %tr
       %td.text-center{:style => "padding-top: 15px;"}
-        - cond_down = @edit[:new][:model].nil? || MiqExpression.reporting_available_fields(@edit[:new][:model],
-                                                                                           @edit[:new][:perf_interval]).length == 0
+        - cond_down = @edit[:new][:model].nil? || cashed_reporting_available_fields.length == 0
         - cond_up = @edit[:new][:fields].length == 0
         - [['fa-angle-down', 'right', _("down"), cond_down],
            ['fa-angle-up',   'left',  _("up"),   cond_up]].each do |icon, button, text, condition|

--- a/app/views/report/_column_lists.html.haml
+++ b/app/views/report/_column_lists.html.haml
@@ -16,7 +16,7 @@
       %td
     %tr
       %td.text-center{:style => "padding-top: 15px;"}
-        - cond_down = @edit[:new][:model].nil? || cashed_reporting_available_fields.length == 0
+        - cond_down = @edit[:new][:model].nil? || cashed_reporting_available_fields.empty?
         - cond_up = @edit[:new][:fields].length == 0
         - [['fa-angle-down', 'right', _("down"), cond_down],
            ['fa-angle-up',   'left',  _("up"),   cond_up]].each do |icon, button, text, condition|


### PR DESCRIPTION
We need to keep method result of `reporting_available_fields` actual as possible, but operation 'move field down from available fields` (method `move_cols_right`)  is called in the controller and also in the template again - so there is memoizing possible.

> operation 'move field down from available fields` (method `move_cols_right`):
![iorx3wfwlm](https://cloud.githubusercontent.com/assets/14937244/26442355/7c245326-4134-11e7-8bba-e196beda0238.gif)

# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1446542
related(independent on this PR) PR for the BZ https://github.com/ManageIQ/manageiq/pull/15191
(together: approximately on my machine the time operation(length of ajax call when you click on the button) is decreased from ~ **5s to 1.5s**, )

@miq-bot add_label performance
@miq-bot assign @martinpovolny 
cc @mzazrivec 
