### PR TITLE
Add rbac for network managers

### DIFF
--- a/app/controllers/application_controller/network.rb
+++ b/app/controllers/application_controller/network.rb
@@ -2,6 +2,6 @@ module ApplicationController::Network
   extend ActiveSupport::Concern
 
   def network_managers
-    ManageIQ::Providers::Openstack::NetworkManager.all
+    Rbac::Filterer.filtered(ManageIQ::Providers::Openstack::NetworkManager).all
   end
 end

--- a/app/controllers/application_controller/network.rb
+++ b/app/controllers/application_controller/network.rb
@@ -2,10 +2,6 @@ module ApplicationController::Network
   extend ActiveSupport::Concern
 
   def network_managers
-    ExtManagementSystem.where(:type => "ManageIQ::Providers::Openstack::CloudManager").collect { |ems|
-      if ems.respond_to?(:network_manager) && ems.network_manager
-        ems.network_manager
-      end
-    }.compact
+    ManageIQ::Providers::Openstack::NetworkManager.all
   end
 end

--- a/app/controllers/application_controller/network.rb
+++ b/app/controllers/application_controller/network.rb
@@ -2,6 +2,6 @@ module ApplicationController::Network
   extend ActiveSupport::Concern
 
   def network_managers
-    Rbac::Filterer.filtered(ManageIQ::Providers::Openstack::NetworkManager).all
+    Rbac::Filterer.filtered(ManageIQ::Providers::Openstack::NetworkManager).select(:id, :name)
   end
 end


### PR DESCRIPTION
- use AR model to get the result
- add RBAC

introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/1343

@miq-bot add_label rbac, technical-dept

@miq-bot assign @martinpovolny 
cc @himdel 

for example it is in:

![screen shot 2017-05-25 at 15 11 32](https://cloud.githubusercontent.com/assets/14937244/26451472/796e1590-415c-11e7-8600-6fe09554e1b9.png)

### Next (if you are not against)
- transform the file to the controller mixin
- refactor with 'DRY' move this code to a method in the mixin
for example from : https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/network_router_controller.rb#L97
```
  network_managers.each do |network_manager|
      @network_provider_choices[network_manager.name] = network_manager.id
    end
```
