### PR TITLE
If provider is not running and UI wants to fetch JDBC drivers, close datasource modal

### DIFF
--- a/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
+++ b/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
@@ -132,10 +132,7 @@ function MwAddDatasourceCtrl($scope, $rootScope, miqService, mwAddDatasourceServ
     mwAddDatasourceService.getExistingJdbcDrivers(serverId).then(function(drivers) {
       vm.step2DsModel.existingJdbcDrivers = vm.filterXa(vm.chooseDsModel.xaDatasource, drivers);
     }).catch(function(errorMsg) {
-      var status = errorMsg.data.status || 'error';
-      miqService.miqFlash(status, errorMsg.data.msg);
-      angular.element('#modal_ds_div').modal('hide');
-      miqService.sparkleOff();
+      vm.warnMsg = errorMsg.data.msg;
     });
   };
 
@@ -207,6 +204,7 @@ function MwAddDatasourceCtrl($scope, $rootScope, miqService, mwAddDatasourceServ
   };
 
   vm.reset = function() {
+    vm.warnMsg = '';
     angular.element('#modal_ds_div').modal('hide');
     $scope.dsAddForm.$setPristine();
 

--- a/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
+++ b/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
@@ -132,7 +132,10 @@ function MwAddDatasourceCtrl($scope, $rootScope, miqService, mwAddDatasourceServ
     mwAddDatasourceService.getExistingJdbcDrivers(serverId).then(function(drivers) {
       vm.step2DsModel.existingJdbcDrivers = vm.filterXa(vm.chooseDsModel.xaDatasource, drivers);
     }).catch(function(errorMsg) {
-      miqService.miqFlash(errorMsg.data.status, errorMsg.data.msg);
+      var status = errorMsg.data.status || 'error';
+      miqService.miqFlash(status, errorMsg.data.msg);
+      angular.element('#modal_ds_div').modal('hide');
+      miqService.sparkleOff();
     });
   };
 

--- a/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_service.js
+++ b/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_service.js
@@ -124,21 +124,24 @@ function MwAddDatasourceService($http, $q) {
     var deferred = $q.defer();
     var BASE_URL = '/middleware_server/jdbc_drivers';
     var parameterizedUrl = BASE_URL + '?server_id=' + serverId;
+    var serverError = 'internal_server_error';
 
     $http.get(parameterizedUrl).then(function(driverData) {
-      var transformedData = _.chain(driverData.data.data)
-        .map(function(driver) {
-          return {'id': driver.properties['Driver Name'].toUpperCase(),
-                  'label': driver.properties['Driver Name'],
-                  'moduleName': driver.properties['Module Name'],
-                  'xaDsClass': driver.properties['XA DS Class'],
-                  'driverClass': driver.properties['Driver Class']};
-      })
-      .value();
+      if (driverData.data.status === serverError) {
+        deferred.reject(driverData.data);
+      } else {
+        var transformedData = _.chain(driverData.data.data)
+          .map(function(driver) {
+            return {'id': driver.properties['Driver Name'].toUpperCase(),
+                    'label': driver.properties['Driver Name'],
+                    'moduleName': driver.properties['Module Name'],
+                    'xaDsClass': driver.properties['XA DS Class'],
+                    'driverClass': driver.properties['Driver Class']};
+        })
+        .value();
 
-      deferred.resolve(transformedData);
-    }).catch(function(errorMsg) {
-      deferred.reject(errorMsg);
+        deferred.resolve(transformedData);
+      }
     });
     return deferred.promise;
   };

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -124,13 +124,13 @@ class MiddlewareServerController < ApplicationController
     render :json => {
       :status => :success, :data => drivers
     }
-  rescue StandardError => err
+  rescue StandardError => _err
     render :json => {
-        :status => :internal_server_error,
-        :data => {
-          :msg => _("Cannot connect to provider of server with ID: \"%s\". Is it running?") % params[:server_id]
-        }
+      :status => :internal_server_error,
+      :data   => {
+        :msg => _("Cannot connect to provider of server with ID: \"%s\". Is it running?") % params[:server_id]
       }
+    }
   end
 
   def add_datasource

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -128,7 +128,11 @@ class MiddlewareServerController < ApplicationController
     render :json => {
       :status => :internal_server_error,
       :data   => {
-        :msg => _("Cannot connect to provider of server with ID: \"%s\". Is it running?") % params[:server_id]
+        :msg => _("Cannot connect to provider \"%{provider}\" of server \"%{server}\". Is it running?") %
+                {
+                  :provider => mw_manager.name,
+                  :server   => mw_server.name
+                }
       }
     }
   end

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -125,7 +125,12 @@ class MiddlewareServerController < ApplicationController
       :status => :success, :data => drivers
     }
   rescue StandardError => err
-    render :json => {:msg => err.message}, :status => :internal_server_error
+    render :json => {
+        :status => :internal_server_error,
+        :data => {
+          :msg => _("Cannot connect to provider of server with ID: \"%s\". Is it running?") % params[:server_id]
+        }
+      }
   end
 
   def add_datasource

--- a/app/views/middleware_server/_add_datasource.html.haml
+++ b/app/views/middleware_server/_add_datasource.html.haml
@@ -20,6 +20,9 @@
           %h4.modal-title#mw_ds_modal_label
             = _("Create Datasource")
         .modal-body
+          .alert.alert-warning{"ng-if" => "vm.warnMsg"}
+            %span.pficon.pficon-warning-triangle-o
+            {{vm.warnMsg}}
           %input#ds_server_id{:type  => "hidden",
                               :value => params[:id]}
 

--- a/app/views/middleware_server/_add_datasource_step2.html.haml
+++ b/app/views/middleware_server/_add_datasource_step2.html.haml
@@ -19,7 +19,14 @@
         miq_tabs_init('#jdbc_tabs');
 
     .modal-footer
-      %button.btn.btn-default.dialog-cancel-button{:type      => "button",
+      %button.btn.btn-default.dialog-cancel-button{"ng-show"  => "vm.warnMsg",
+                                                   :type      => "button",
+                                                   "alt"      => (t = _("Close")),
+                                                   "title"    => t,
+                                                   "ng-click" => "vm.reset()"}
+        = t
+      %button.btn.btn-default.dialog-cancel-button{"ng-hide"  => "vm.warnMsg",
+                                                   :type      => "button",
                                                    "alt"      => (t = _("Cancel")),
                                                    "title"    => t,
                                                    "ng-click" => "vm.reset()"}

--- a/app/views/middleware_server/_add_datasource_step2.html.haml
+++ b/app/views/middleware_server/_add_datasource_step2.html.haml
@@ -24,12 +24,14 @@
                                                    "title"    => t,
                                                    "ng-click" => "vm.reset()"}
         = t
-      %button.btn.btn-default{:type      => "button",
+      %button.btn.btn-default{"ng-hide"  => "vm.warnMsg",
+                              :type      => "button",
                               "alt"      => (t = _("Back")),
                               "title"    => t,
                               "ng-click" => "vm.addDatasourceStep2Back()"}
         = t
-      %button.btn.btn-primary{:type         => "button",
+      %button.btn.btn-primary{"ng-hide"     => "vm.warnMsg",
+                              :type         => "button",
                               "alt"         => (t = _("Next")),
                               "title"       => t,
                               "ng-click"    => "vm.addDatasourceStep2Next()",


### PR DESCRIPTION
If user clicks on `Add datasource` but hawkular provider is not running show message that this server is not running, do not close modal and let user close it by himself.

#### Before:
![peek 2017-05-25 15-23](https://cloud.githubusercontent.com/assets/3439771/26451869/11d8881e-415e-11e7-9c37-3566ccdb5357.gif)
#### After:
![peek 2017-07-12 13-02](https://user-images.githubusercontent.com/3439771/28114768-84f07388-6702-11e7-90bf-395c4dc7c78b.gif)


EDIT: changed GIF which shows After state.

https://bugzilla.redhat.com/show_bug.cgi?id=1452981