### PR TITLE
Fix missing translations in cloud tenant summary screen

### DIFF
--- a/app/helpers/cloud_tenant_helper/textual_summary.rb
+++ b/app/helpers/cloud_tenant_helper/textual_summary.rb
@@ -92,26 +92,26 @@ module CloudTenantHelper::TextualSummary
   end
 
   def textual_security_groups
-    @record.security_groups
+    textual_link(@record.security_groups, :label => _('Security Groups'))
   end
 
   def textual_floating_ips
-    @record.floating_ips
+    textual_link(@record.floating_ips, :label => _('Floating IPs'))
   end
 
   def textual_network_routers
-    @record.network_routers
+    textual_link(@record.network_routers, :label => _('Network Routers'))
   end
 
   def textual_network_ports
-    @record.network_ports
+    textual_link(@record.network_ports, :label => _('Network Ports'))
   end
 
   def textual_cloud_networks
-    @record.cloud_networks
+    textual_link(@record.cloud_networks, :label => _('Cloud Networks'))
   end
 
   def textual_cloud_subnets
-    @record.cloud_subnets
+    textual_link(@record.cloud_subnets, :label => _('Cloud Subnets'))
   end
 end


### PR DESCRIPTION
Before
![cloud_tenant_before](https://cloud.githubusercontent.com/assets/6648365/26454082/4125b4e0-4166-11e7-8c7a-b6921904cf2b.jpg)

After
![cloud_tenant_after](https://cloud.githubusercontent.com/assets/6648365/26454106/5966a384-4166-11e7-9792-0d4225c8c576.jpg)

https://bugzilla.redhat.com/show_bug.cgi?id=1392776
