### PR TITLE
Add Physical Server relationship for Host summary page

### DIFF
--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -22,7 +22,7 @@ module HostHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(ems cluster availability_zone used_tenants storages resource_pools vms templates drift_history)
+      %i(ems cluster availability_zone used_tenants storages resource_pools vms templates drift_history physical_server)
     )
   end
 
@@ -233,6 +233,14 @@ module HostHelper::TextualSummary
       h[:link]  = url_for_only_path(:controller => 'ems_cluster', :action => 'show', :id => cluster)
     end
     h
+  end
+
+  def textual_physical_server
+    if @record.physical_server_id.nil?
+      {:label => _("Physical Server"), :value => _("None"), :icon => "pficon pficon-server"}
+    else
+      {:label => _("Physical Server"), :value => @record.physical_server.try(:name), :icon => "pficon pficon-server", :link => url_for(:controller => 'physical_server', :action => 'show', :id => @record.physical_server_id)}
+    end
   end
 
   def textual_storages

--- a/app/views/layouts/listnav/_host.html.haml
+++ b/app/views/layouts/listnav/_host.html.haml
@@ -119,6 +119,16 @@
             :record_id     => @record.id,
             :title         => _("Show %{host} drift history") % {:host => host_title})
 
+        - if role_allows?(:feature => "physical_server_show") && !@record.physical_server.nil?
+          %li
+            - physical_server_show = {:controller => "physical_server", :action => 'show', :id => @record.physical_server.id}
+            = link_to("#{ui_lookup(:model => "PhysicalServer")}: #{@record.physical_server.name}",
+              physical_server_show,
+              :title => _("Show Physical Server"))
+
+        - if role_allows?(:feature => "physical_server_show") && @record.physical_server.nil?
+          = li_link(:if => false, :text => "#{ui_lookup(:model => "PhysicalServer")}: #{_('None')}")
+
     = miq_accordion_panel(_("Security"), false, "host_sec") do
       %ul.nav.nav-pills.nav-stacked
         = li_link(:count => @record.number_of(:users),


### PR DESCRIPTION
Adds physical server link to Host summary page in relationship label.

![captura de tela de 2017-05-25 17-06-26](https://cloud.githubusercontent.com/assets/17187082/26468346/743ced34-416c-11e7-9740-f941c1d22782.png)
