### PR TITLE
Replace "r" with a helper method

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -282,7 +282,7 @@ module ApplicationController::Tags
     }
   end
 
-  def update_tagging_partials(presenter, r)
+  def update_tagging_partials(presenter)
     presenter.update(:main_div, r[:partial => 'layouts/tagging',
                                   :locals  => locals_for_tagging])
     presenter.update(:form_buttons_div, r[:partial => 'layouts/x_edit_buttons',

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -7,6 +7,7 @@ class AutomationManagerController < ApplicationController
 
   include Mixins::GenericSessionMixin
   include Mixins::ManagerControllerMixin
+  include Mixins::ExplorerPresenterMixin
 
   menu_section :automation_manager
 

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -396,7 +396,7 @@ class AutomationManagerController < ApplicationController
     node
   end
 
-  def update_partials(record_showing, presenter, r)
+  def update_partials(record_showing, presenter)
     if record_showing && valid_configured_system_record?(@configured_system_record)
       get_tagdata(@record)
       presenter.hide(:form_buttons_div)
@@ -434,7 +434,7 @@ class AutomationManagerController < ApplicationController
      :record_id  => @sb[:rec_id] || @edit[:object_ids] && @edit[:object_ids][0]}
   end
 
-  def update_service_dialog_partials(presenter, r)
+  def update_service_dialog_partials(presenter)
     presenter.update(:main_div, r[:partial => 'configscript_service_dialog',
                                   :locals  => locals_for_service_dialog])
     locals = {:record_id  => @edit[:rec_id],

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1922,7 +1922,6 @@ class CatalogController < ApplicationController
       :active_tree => x_active_tree,
       :add_nodes   => add_nodes
     )
-    r = proc { |opts| render_to_string(opts) }
     replace_trees_by_presenter(presenter, trees)
 
     if @sb[:buttons_node]

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -835,7 +835,6 @@ class ChargebackController < ApplicationController
     presenter = ExplorerPresenter.new(
       :active_tree => x_active_tree,
     )
-    r = proc { |opts| render_to_string(opts) }
     replace_trees_by_presenter(presenter, :cb_rates => cb_rates_build_tree) if replace_trees.include?(:cb_rates)
 
     # FIXME

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -6,6 +6,7 @@ class InfraNetworkingController < ApplicationController
   after_action :set_session_data
 
   include Mixins::GenericSessionMixin
+  include Mixins::ExplorerPresenterMixin
 
   def self.model
     Switch
@@ -334,13 +335,6 @@ class InfraNetworkingController < ApplicationController
     process_show_list(options) if @show_list
     @right_cell_text = _("All Switches")
     options
-  end
-
-  def rendering_objects
-    ExplorerPresenter.new(
-      :active_tree => x_active_tree,
-      :delete_node => @delete_node,
-    )
   end
 
   def render_form

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -354,19 +354,6 @@ class InfraNetworkingController < ApplicationController
     render :json => presenter.for_render
   end
 
-  def update_tree_and_render_list(replace_trees)
-    @explorer = true
-    get_node_info(x_node)
-    presenter = rendering_objects
-    replace_explorer_trees(replace_trees, presenter)
-
-    presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
-    rebuild_toolbars(false, presenter)
-    handle_bottom_cell(presenter)
-
-    render :json => presenter.for_render
-  end
-
   def replace_right_cell(options = {})
     action, presenter = options.values_at(:action, :presenter)
     @explorer = true

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -337,21 +337,19 @@ class InfraNetworkingController < ApplicationController
   end
 
   def rendering_objects
-    presenter = ExplorerPresenter.new(
+    ExplorerPresenter.new(
       :active_tree => x_active_tree,
       :delete_node => @delete_node,
     )
-    r = proc { |opts| render_to_string(opts) }
-    return presenter, r
   end
 
   def render_form
-    presenter, r = rendering_objects
+    presenter = rendering_objects
     @in_a_form = true
     presenter.update(:main_div, r[:partial => 'form', :locals => {:controller => 'infra_networking'}])
     update_title(presenter)
     rebuild_toolbars(false, presenter)
-    handle_bottom_cell(presenter, r)
+    handle_bottom_cell(presenter)
 
     render :json => presenter.for_render
   end
@@ -359,12 +357,12 @@ class InfraNetworkingController < ApplicationController
   def update_tree_and_render_list(replace_trees)
     @explorer = true
     get_node_info(x_node)
-    presenter, r = rendering_objects
-    replace_explorer_trees(replace_trees, presenter, r)
+    presenter = rendering_objects
+    replace_explorer_trees(replace_trees, presenter)
 
     presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     rebuild_toolbars(false, presenter)
-    handle_bottom_cell(presenter, r)
+    handle_bottom_cell(presenter)
 
     render :json => presenter.for_render
   end
@@ -401,8 +399,6 @@ class InfraNetworkingController < ApplicationController
       :delete_node => @delete_node, # Remove a new node from the tree
     )
 
-    r = proc { |opts| render_to_string(opts) }
-
     if record_showing
       presenter.hide(:form_buttons_div)
       presenter.update(:main_div, r[:partial => "layouts/textual_groups_generic"])
@@ -418,8 +414,8 @@ class InfraNetworkingController < ApplicationController
       presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     end
 
-    replace_search_box(presenter, r)
-    handle_bottom_cell(presenter, r)
+    replace_search_box(presenter)
+    handle_bottom_cell(presenter)
     rebuild_toolbars(record_showing, presenter)
     presenter[:right_cell_text] = @right_cell_text
     presenter[:osf_node] = x_node # Open, select, and focus on this node
@@ -497,7 +493,7 @@ class InfraNetworkingController < ApplicationController
     @sb[:infra_networking_search_text][:current_node] = x_node
   end
 
-  def update_partials(record_showing, presenter, r)
+  def update_partials(record_showing, presenter)
     if record_showing && valid_switch_record?(@record)
       get_tagdata(@record)
       presenter.hide(:form_buttons_div)
@@ -566,7 +562,7 @@ class InfraNetworkingController < ApplicationController
     end
   end
 
-  def replace_search_box(presenter, r)
+  def replace_search_box(presenter)
     # Replace the searchbox
     presenter.replace(:adv_searchbox_div,
                       r[:partial => 'layouts/x_adv_searchbox',
@@ -575,7 +571,7 @@ class InfraNetworkingController < ApplicationController
     presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
   end
 
-  def handle_bottom_cell(presenter, r)
+  def handle_bottom_cell(presenter)
     # Handle bottom cell
     if @pages || @in_a_form
       if @pages && !@in_a_form
@@ -651,11 +647,11 @@ class InfraNetworkingController < ApplicationController
     @in_a_form = true
     @right_cell_text = _("Edit Tags")
     clear_flash_msg
-    presenter, r = rendering_objects
-    update_tagging_partials(presenter, r)
+    presenter = rendering_objects
+    update_tagging_partials(presenter)
     presenter[:right_cell_text] = @right_cell_text
     rebuild_toolbars(false, presenter)
-    handle_bottom_cell(presenter, r)
+    handle_bottom_cell(presenter)
 
     render :json => presenter.for_render
   end

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -279,7 +279,6 @@ class MiqAeClassController < ApplicationController
       :remove_nodes    => add_nodes, # remove any existing nodes before adding child nodes to avoid duplication
       :add_nodes       => add_nodes,
     )
-    r = proc { |opts| render_to_string(opts) }
 
     replace_trees_by_presenter(presenter, :ae => build_ae_tree) unless replace_trees.blank?
 
@@ -2452,7 +2451,6 @@ class MiqAeClassController < ApplicationController
       :remove_nodes    => nil,
       :add_nodes       => nil,
     )
-    r = proc { |opts| render_to_string(opts) }
 
     update_partial_div = :main_div
     update_partial = "git_domain_refresh"

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -240,7 +240,6 @@ class MiqAeCustomizationController < ApplicationController
     @explorer = true
     presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
 
-    r = proc { |opts| render_to_string(opts) }
     replace_trees_by_presenter(presenter, trees)
     presenter[:osf_node] = x_node unless @in_a_form
 

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -479,7 +479,6 @@ class MiqCapacityController < ApplicationController
 
     v_tb = build_toolbar("miq_capacity_view_tb")
     presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
-    r = proc { |opts| render_to_string(opts) }
 
     presenter.load_chart(@sb[:util][:chart_data])
 
@@ -590,7 +589,6 @@ class MiqCapacityController < ApplicationController
   def planning_replace_right_cell
     v_tb = build_toolbar("miq_capacity_view_tb")
     presenter = ExplorerPresenter.new(:active_tree => @sb[:active_tree])
-    r = proc { |opts| render_to_string(opts) }
 
     presenter.load_chart(@sb[:planning][:chart_data])
 
@@ -609,7 +607,6 @@ class MiqCapacityController < ApplicationController
 
   def bottleneck_replace_right_cell
     presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
-    r = proc { |opts| render_to_string(opts) }
 
     presenter[:osf_node] = x_node
     if params.keys.any? { |param| param.include?('tl_report') }

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -502,8 +502,6 @@ class MiqPolicyController < ApplicationController
       :open_accord => params[:accord]
     )
 
-    r = proc { |opts| render_to_string(opts) }
-
     # Simply replace the tree partials to reload the trees
     replace_trees.each do |name|
       case name

--- a/app/controllers/mixins/explorer_presenter_mixin.rb
+++ b/app/controllers/mixins/explorer_presenter_mixin.rb
@@ -12,5 +12,12 @@ module Mixins
 
       render :json => presenter.for_render
     end
+
+    def rendering_objects
+      ExplorerPresenter.new(
+        :active_tree => x_active_tree,
+        :delete_node => @delete_node,
+      )
+    end
   end
 end

--- a/app/controllers/mixins/explorer_presenter_mixin.rb
+++ b/app/controllers/mixins/explorer_presenter_mixin.rb
@@ -1,0 +1,16 @@
+module Mixins
+  module ExplorerPresenterMixin
+    def update_tree_and_render_list(replace_trees)
+      @explorer = true
+      get_node_info(x_node)
+      presenter = rendering_objects
+      replace_explorer_trees(replace_trees, presenter)
+
+      presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
+      rebuild_toolbars(false, presenter)
+      handle_bottom_cell(presenter)
+
+      render :json => presenter.for_render
+    end
+  end
+end

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -400,19 +400,6 @@ module Mixins
       render :json => presenter.for_render
     end
 
-    def update_tree_and_render_list(replace_trees)
-      @explorer = true
-      get_node_info(x_node)
-      presenter = rendering_objects
-      replace_explorer_trees(replace_trees, presenter)
-
-      presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
-      rebuild_toolbars(false, presenter)
-      handle_bottom_cell(presenter)
-
-      render :json => presenter.for_render
-    end
-
     def update_title(presenter)
       @right_cell_text =
         case action_name

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -294,10 +294,10 @@ module Mixins
       trees = rebuild_trees(replace_trees)
 
       record_showing = leaf_record
-      presenter, r = rendering_objects
-      update_partials(record_showing, presenter, r)
-      replace_search_box(presenter, r)
-      handle_bottom_cell(presenter, r)
+      presenter = rendering_objects
+      update_partials(record_showing, presenter)
+      replace_search_box(presenter)
+      handle_bottom_cell(presenter)
       replace_trees_by_presenter(presenter, trees)
       rebuild_toolbars(record_showing, presenter)
       presenter[:right_cell_text] = @right_cell_text
@@ -356,21 +356,19 @@ module Mixins
     end
 
     def rendering_objects
-      presenter = ExplorerPresenter.new(
+      ExplorerPresenter.new(
         :active_tree => x_active_tree,
         :delete_node => @delete_node,
       )
-      r = proc { |opts| render_to_string(opts) }
-      return presenter, r
     end
 
     def render_form
-      presenter, r = rendering_objects
+      presenter = rendering_objects
       @in_a_form = true
       presenter.update(:main_div, r[:partial => 'form', :locals => {:controller => controller_name}])
       update_title(presenter)
       rebuild_toolbars(false, presenter)
-      handle_bottom_cell(presenter, r)
+      handle_bottom_cell(presenter)
 
       render :json => presenter.for_render
     end
@@ -380,11 +378,11 @@ module Mixins
       @in_a_form = true
       @right_cell_text = _("Edit Tags")
       clear_flash_msg
-      presenter, r = rendering_objects
-      update_tagging_partials(presenter, r)
+      presenter = rendering_objects
+      update_tagging_partials(presenter)
       update_title(presenter)
       rebuild_toolbars(false, presenter)
-      handle_bottom_cell(presenter, r)
+      handle_bottom_cell(presenter)
 
       render :json => presenter.for_render
     end
@@ -393,10 +391,10 @@ module Mixins
       return if %w(cancel save).include?(params[:button])
       @in_a_form = true
       clear_flash_msg
-      presenter, r = rendering_objects
-      update_service_dialog_partials(presenter, r)
+      presenter = rendering_objects
+      update_service_dialog_partials(presenter)
       rebuild_toolbars(false, presenter)
-      handle_bottom_cell(presenter, r)
+      handle_bottom_cell(presenter)
       presenter[:right_cell_text] = @right_cell_text
 
       render :json => presenter.for_render
@@ -405,12 +403,12 @@ module Mixins
     def update_tree_and_render_list(replace_trees)
       @explorer = true
       get_node_info(x_node)
-      presenter, r = rendering_objects
-      replace_explorer_trees(replace_trees, presenter, r)
+      presenter = rendering_objects
+      replace_explorer_trees(replace_trees, presenter)
 
       presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
       rebuild_toolbars(false, presenter)
-      handle_bottom_cell(presenter, r)
+      handle_bottom_cell(presenter)
 
       render :json => presenter.for_render
     end
@@ -441,7 +439,7 @@ module Mixins
       @sb["#{controller_name.underscore}_search_text".to_sym][:current_node] = x_node
     end
 
-    def replace_search_box(presenter, r)
+    def replace_search_box(presenter)
       # Replace the searchbox
       presenter.replace(:adv_searchbox_div,
                         r[:partial => 'layouts/x_adv_searchbox'])
@@ -449,7 +447,7 @@ module Mixins
       presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
     end
 
-    def handle_bottom_cell(presenter, r)
+    def handle_bottom_cell(presenter)
       # Handle bottom cell
       if @pages || @in_a_form
         if @pages && !@in_a_form

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -355,13 +355,6 @@ module Mixins
       @right_cell_text = _("All Configured Systems")
     end
 
-    def rendering_objects
-      ExplorerPresenter.new(
-        :active_tree => x_active_tree,
-        :delete_node => @delete_node,
-      )
-    end
-
     def render_form
       presenter = rendering_objects
       @in_a_form = true

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -209,8 +209,6 @@ class OpsController < ApplicationController
     # needed to make tooolbar Configuration > Edit still work after lazy-loading a tab
     presenter[:record_id] = group_id
 
-    r = proc { |opts| render_to_string(opts) }
-
     rendered = case tab_id
                when 'rbac_customer_tags'
                  r[:partial => 'ops/rbac_group/customer_tags']
@@ -527,12 +525,10 @@ class OpsController < ApplicationController
     presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
     presenter[:add_nodes] = add_nodes if add_nodes
 
-    r = proc { |opts| render_to_string(opts) }
-
     replace_explorer_trees(replace_trees, presenter)
     rebuild_toolbars(presenter)
-    handle_bottom_cell(nodetype, presenter, r, locals)
-    x_active_tree_replace_cell(nodetype, presenter, r)
+    handle_bottom_cell(nodetype, presenter, locals)
+    x_active_tree_replace_cell(nodetype, presenter)
     extra_js_commands(presenter)
 
     presenter.replace(:flash_msg_div, r[:partial => "layouts/flash_msg"]) if @flash_array
@@ -540,21 +536,21 @@ class OpsController < ApplicationController
     render :json => presenter.for_render
   end
 
-  def x_active_tree_replace_cell(nodetype, presenter, r)
+  def x_active_tree_replace_cell(nodetype, presenter)
     case x_active_tree
     when :rbac_tree
-      rbac_replace_right_cell(nodetype, presenter, r)
+      rbac_replace_right_cell(nodetype, presenter)
     when :settings_tree
-      settings_replace_right_cell(nodetype, presenter, r)
+      settings_replace_right_cell(nodetype, presenter)
     when :diagnostics_tree
-      diagnostics_replace_right_cell(nodetype, presenter, r)
+      diagnostics_replace_right_cell(nodetype, presenter)
     when :vmdb_tree # "root","tb", "ti","xx" # Check if vmdb root or table is selected
       # Need to replace all_tabs to show table name as tab label
       presenter.replace(:ops_tabs, r[:partial => "all_tabs"])
     end
   end
 
-  def diagnostics_replace_right_cell(nodetype, presenter, r)
+  def diagnostics_replace_right_cell(nodetype, presenter)
     # need to refresh all_tabs for server by roles and roles by servers screen
     # to show correct buttons on screen when tree node is selected
     if %w(accordion_select change_tab explorer tree_select).include?(params[:action]) ||
@@ -570,7 +566,7 @@ class OpsController < ApplicationController
     presenter[:build_calendar] = {} if x_node.split("-").first == "z"
   end
 
-  def settings_replace_right_cell(nodetype, presenter, r)
+  def settings_replace_right_cell(nodetype, presenter)
     case nodetype
     when "ze"     # zone edit
       # when editing zone in settings tree
@@ -670,7 +666,7 @@ class OpsController < ApplicationController
     end
   end
 
-  def rbac_replace_right_cell(nodetype, presenter, r)
+  def rbac_replace_right_cell(nodetype, presenter)
     @sb[:tab_label] = @tagging ? _("Tagging") : rbac_set_tab_label
     if %w(accordion_select change_tab tree_select).include?(params[:action])
       presenter.replace(:ops_tabs, r[:partial => "all_tabs"])
@@ -751,7 +747,7 @@ class OpsController < ApplicationController
     presenter[:record_id] = determine_record_id_for_presenter
   end
 
-  def handle_bottom_cell(nodetype, presenter, r, locals)
+  def handle_bottom_cell(nodetype, presenter, locals)
     # Handle bottom cell
     if @pages || @in_a_form
       if @pages

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -7,6 +7,7 @@ class ProviderForemanController < ApplicationController
 
   include Mixins::GenericSessionMixin
   include Mixins::ManagerControllerMixin
+  include Mixins::ExplorerPresenterMixin
 
   def self.model
     ManageIQ::Providers::ConfigurationManager

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -364,7 +364,7 @@ class ProviderForemanController < ApplicationController
     node
   end
 
-  def update_partials(record_showing, presenter, r)
+  def update_partials(record_showing, presenter)
     if record_showing && valid_configured_system_record?(@configured_system_record)
       get_tagdata(@record)
       presenter.hide(:form_buttons_div)

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -113,7 +113,6 @@ class PxeController < ApplicationController
     presenter = ExplorerPresenter.new(
       :active_tree => x_active_tree,
     )
-    r = proc { |opts| render_to_string(opts) }
 
     c_tb = build_toolbar(center_toolbar_filename) unless @in_a_form
     h_tb = build_toolbar('x_history_tb')

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -672,7 +672,6 @@ class ReportController < ApplicationController
        params[:action] == 'x_show'
       presenter[:add_nodes] = open_parent_nodes      # Open the parent nodes of selected record, if not open
     end
-    r = proc { |opts| render_to_string(opts) }
     presenter[:open_accord] = params[:accord] if params[:accord] # Open new accordion
 
     locals = set_form_locals if @in_a_form

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -324,7 +324,6 @@ class ServiceController < ApplicationController
       :active_tree     => x_active_tree,
       :right_cell_text => @right_cell_text
     )
-    r = proc { |opts| render_to_string(opts) }
 
     if Array(replace_trees).include?(:svcs)
       replace_trees_by_presenter(presenter, :svcs => build_svcs_tree)

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -424,10 +424,10 @@ class StorageController < ApplicationController
       trees[:storage]     = storage_build_tree     if replace_trees.include?(:storage)
       trees[:storage_pod] = storage_pod_build_tree if replace_trees.include?(:storage_pod)
     end
-    presenter, r = rendering_objects
-    update_partials(record_showing, presenter, r)
-    replace_search_box(presenter, r)
-    handle_bottom_cell(presenter, r)
+    presenter = rendering_objects
+    update_partials(record_showing, presenter)
+    replace_search_box(presenter)
+    handle_bottom_cell(presenter)
     replace_trees_by_presenter(presenter, trees)
     rebuild_toolbars(record_showing, presenter)
     case x_active_tree
@@ -465,7 +465,7 @@ class StorageController < ApplicationController
     @sb[:storage_search_text][:current_node] = x_node
   end
 
-  def update_partials(record_showing, presenter, r)
+  def update_partials(record_showing, presenter)
     if record_showing
       get_tagdata(@record)
       presenter.hide(:form_buttons_div)
@@ -479,7 +479,7 @@ class StorageController < ApplicationController
     end
   end
 
-  def replace_search_box(presenter, r)
+  def replace_search_box(presenter)
     # Replace the searchbox
     presenter.replace(:adv_searchbox_div,
                       r[:partial => 'layouts/x_adv_searchbox',
@@ -489,7 +489,7 @@ class StorageController < ApplicationController
   end
 
 
-  def handle_bottom_cell(presenter, r)
+  def handle_bottom_cell(presenter)
     # Handle bottom cell
     if @pages || @in_a_form
       if @pages && !@in_a_form
@@ -504,12 +504,10 @@ class StorageController < ApplicationController
   end
 
   def rendering_objects
-    presenter = ExplorerPresenter.new(
+    ExplorerPresenter.new(
       :active_tree => x_active_tree,
       :delete_node => @delete_node,
     )
-    r = proc { |opts| render_to_string(opts) }
-    return presenter, r
   end
 
   def render_tagging_form
@@ -517,11 +515,11 @@ class StorageController < ApplicationController
     @in_a_form = true
     @right_cell_text = _("Edit Tags for Datastore")
     clear_flash_msg
-    presenter, r = rendering_objects
-    update_tagging_partials(presenter, r)
+    presenter = rendering_objects
+    update_tagging_partials(presenter)
     # update_title(presenter)
     rebuild_toolbars(false, presenter)
-    handle_bottom_cell(presenter, r)
+    handle_bottom_cell(presenter)
 
     render :json => presenter.for_render
   end
@@ -529,12 +527,12 @@ class StorageController < ApplicationController
   def update_tree_and_render_list(replace_trees)
     @explorer = true
     get_node_info(x_node)
-    presenter, r = rendering_objects
-    replace_explorer_trees(replace_trees, presenter, r)
+    presenter = rendering_objects
+    replace_explorer_trees(replace_trees, presenter)
 
     presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     rebuild_toolbars(false, presenter)
-    handle_bottom_cell(presenter, r)
+    handle_bottom_cell(presenter)
 
     render :json => presenter.for_render
   end

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -504,13 +504,6 @@ class StorageController < ApplicationController
     end
   end
 
-  def rendering_objects
-    ExplorerPresenter.new(
-      :active_tree => x_active_tree,
-      :delete_node => @delete_node,
-    )
-  end
-
   def render_tagging_form
     return if %w(cancel save).include?(params[:button])
     @in_a_form = true

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -4,6 +4,7 @@ class StorageController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
   include Mixins::MoreShowActions
+  include Mixins::ExplorerPresenterMixin
 
   before_action :check_privileges
   before_action :get_session_data
@@ -518,19 +519,6 @@ class StorageController < ApplicationController
     presenter = rendering_objects
     update_tagging_partials(presenter)
     # update_title(presenter)
-    rebuild_toolbars(false, presenter)
-    handle_bottom_cell(presenter)
-
-    render :json => presenter.for_render
-  end
-
-  def update_tree_and_render_list(replace_trees)
-    @explorer = true
-    get_node_info(x_node)
-    presenter = rendering_objects
-    replace_explorer_trees(replace_trees, presenter)
-
-    presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     rebuild_toolbars(false, presenter)
     handle_bottom_cell(presenter)
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1232,8 +1232,6 @@ module VmCommon
 
     presenter.show(:default_left_cell).hide(:custom_left_cell)
 
-    r = proc { |opts| render_to_string(opts) }
-
     add_ajax = false
     if record_showing
       presenter.hide(:form_buttons_div)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1750,4 +1750,8 @@ module ApplicationHelper
   def parse_nodetype_and_id(x_node)
     x_node.split('_').last.split('-')
   end
+
+  def r
+    @r ||= proc { |opts| render_to_string(opts) }
+  end
 end


### PR DESCRIPTION
~~To be merged after: https://github.com/ManageIQ/manageiq-ui-classic/pull/1392~~

`r` was meant as a shortcut construct when cleaning up the UI code. I did not suppose people will be passing it aroung ;-)

So I replace the variable with a helper method, the call sites remain the same. The argument no longer needs to be passed around.