### PR TITLE
Rollback any changes to Dialog object when validating dialog elements.

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -1354,6 +1354,7 @@ module MiqAeCustomizationController::Dialogs
         end
       end
       validate ? dialog.validate! : dialog.save!
+      raise ActiveRecord::Rollback if validate
     end
   end
 

--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -82,10 +82,11 @@ describe MiqAeCustomizationController do
           :buttons     => "submit,reset,cancel"
         )
       end
-      it "loads record from not the session" do
+
+      before do
         field = {
           :id                => 9463,
-          :name              => "foo",
+          :name              => "foo_field",
           :label             => "first_drop_down",
           :description       => "first_drop_down",
           :typ               => "DialogFieldDropDownList",
@@ -100,7 +101,7 @@ describe MiqAeCustomizationController do
           :default_value     => 1,
           :force_multi_value => nil
         }
-        new_hash = {
+        @new_hash = {
           :label       => "Dialog 1",
           :description => "Dialog 1",
           :buttons     => ["submit"],
@@ -118,11 +119,27 @@ describe MiqAeCustomizationController do
             }
           ]
         }
-        controller.instance_variable_set(:@edit, :new => new_hash, :dialog_buttons => [])
+      end
 
+      it "loads record from not the session" do
+        controller.instance_variable_set(:@edit, :new => @new_hash, :dialog_buttons => [])
         controller.send(:dialog_set_record_vars, dialog, "foo")
-
         expect(dialog.dialog_tabs.first.dialog_groups.first.dialog_fields.first.options[:force_multi_value]).to be nil
+      end
+
+      it "Rollback values of dialog when validating dialog elements" do
+        controller.instance_variable_set(:@edit, :new => @new_hash, :dialog_buttons => [])
+        controller.send(:dialog_set_record_vars, dialog, true)
+        dialog.reload
+        expect(dialog.dialog_tabs).to be_kind_of(ActiveRecord::Associations::CollectionProxy)
+        expect(dialog.dialog_tabs.length).to eq(0)
+      end
+
+      it "saves values of dialog elements in a dialog when validate is false" do
+        controller.instance_variable_set(:@edit, :new => @new_hash, :dialog_buttons => [])
+        controller.send(:dialog_set_record_vars, dialog, false)
+        dialog.reload
+        expect(dialog.dialog_tabs.first.dialog_groups.first.dialog_fields.first.name).to eq('foo_field')
       end
     end
 


### PR DESCRIPTION
We need to update the actual Dialog object and it's child elements when edit is in progress, after user makes changes to any elements if they make selection in the tree, dialog is validated to make sure user does not try to leave the screen/node without adding valid data before they add/edit more child elements. Fix in this PR is rolling back any changes to actual dialog object after validating the Dialog to bring it back to it's original state to fix the issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1454428

@dclarizio please review.

before/after fix videos attached.
[service_dialog_fix.zip](https://github.com/ManageIQ/manageiq-ui-classic/files/1032870/service_dialog_fix.zip)


