### PR TITLE
Require just the engines/railties we need 

### DIFF
--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -1,4 +1,5 @@
-require 'rails/all'
+require 'rails/engine'
+require 'sprockets/railtie'
 
 # Since we serve our assets directly through apache on an appliance after they
 # are pre-compiled, there is no need to have sass/coffeescript loaded in the


### PR DESCRIPTION
A blank rails engine generated by rails doesn't require anything...[1]

Other engines do the sensible thing: require what they need [2]

We shouldn't make assumptions about the rails features the application
using the engine will want to use.

[1]
https://github.com/rails/rails/blob/0e453e9150f0ac9fa2bdff4511c3c806a3e45f49/railties/lib/rails/generators/rails/plugin/templates/lib/%25namespaced_name%25/engine.rb

[2] https://github.com/rails/coffee-rails/blob/db0659924c82f24e2665d799b1ab342078f2501d/lib/coffee/rails/engine.rb#L1