### PR TITLE
Check for base unit when adjusting unit label

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
+++ b/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
@@ -10,6 +10,7 @@ ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', '
     dash.refreshList = httpUtils.refreshList;
     dash.refreshGraph = httpUtils.refreshGraph;
     dash.setFilterOptions = utils.setFilterOptions;
+    dash.metricPrefix = utils.metricPrefix;
     dash.setPage = httpUtils.setPage;
 
     var pageSetup = function() {

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -52,4 +52,22 @@ describe('adHocMetricsController', function() {
       expect($controller.timeFilter.range_count).toBe(9);
     });
   });
+
+  describe('utility functions', function() {
+    it('should calculate units correctly', function() {
+      var m;
+
+      m = $controller.metricPrefix(10000, 'ms');
+      expect(m.multiplier).toBe(Math.pow(10, -3));
+      expect(m.unitLable).toBe('s');
+
+      m = $controller.metricPrefix(10000, 'ns');
+      expect(m.multiplier).toBe(Math.pow(10, -9));
+      expect(m.unitLable).toBe('s');
+
+      m = $controller.metricPrefix(10000, 's');
+      expect(m.multiplier).toBe(Math.pow(10, -3));
+      expect(m.unitLable).toBe('Ks');
+    });
+  });
 });


### PR DESCRIPTION
**Description**

Currently we do not check the base unit when creating the unit label.
For example 1000s will become 1Ks, and 1000ms will become 1Kms.

This is wrong, we want to take into account the base units.
For example 1000s will become 1Ks, and 1000ms will become 1s.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1456246

**Screenshots**

Bug
![screenshot-localhost 3000-2017-05-28-13-10-00](https://cloud.githubusercontent.com/assets/2181522/26528002/12af8470-43a9-11e7-9881-869a2ea6966f.png)

Fix
![screenshot-localhost 3000-2017-05-28-13-05-55](https://cloud.githubusercontent.com/assets/2181522/26528001/12a7ec9c-43a9-11e7-8165-60e8ba62b8e7.png)

