### PR TITLE
Display product.name instead of ManageIQ in remote console titles

### DIFF
--- a/app/views/layouts/remote_console.html.haml
+++ b/app/views/layouts/remote_console.html.haml
@@ -2,7 +2,7 @@
 %html{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
     %title
-      = _('ManageIQ HTML5 Remote Console')
+      = _('%{product_name} HTML5 Remote Console') % {:product_name => I18n.t('product.name')}
     = favicon_link_tag
     = stylesheet_link_tag 'application'
     -# Load the required JS based on the console type

--- a/app/views/vm_common/console_webmks.html.haml
+++ b/app/views/vm_common/console_webmks.html.haml
@@ -2,7 +2,7 @@
 %html{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
     %title
-      = _('ManageIQ WebMKS Remote Console')
+      = _('%{product_name} WebMKS Remote Console') % {:product_name => I18n.t('product.name')}
     = favicon_link_tag
     = stylesheet_link_tag 'webmks'
     = javascript_include_tag 'jquery', 'jquery-ui', 'webmks'


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1455632