### PR TITLE
Make selected items persistance

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
+++ b/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
@@ -26,6 +26,7 @@ ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', '
       dash.tenantChanged = false;
       dash.filterChanged = true;
       dash.itemSelected = false;
+      dash.selectedItems = [];
       dash.tagsLoaded = false;
       dash.applied = false;
       dash.showGraph = false;
@@ -72,6 +73,7 @@ ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', '
       if (dash.filterConfig.appliedFilters.length === 0) {
         dash.applied = false;
         dash.itemSelected = false;
+        dash.selectedItems = [];
         dash.tagsLoaded = true;
         dash.items = [];
         dash.page = 1;
@@ -91,6 +93,7 @@ ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', '
       // when change filter we automatically apply changes
       if (!addOnly) {
         dash.itemSelected = false;
+        dash.selectedItems = [];
         dash.items = [];
         dash.page = 1;
         dash.pages = 1;

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
@@ -1,12 +1,13 @@
 angular.module('miq.util').factory('metricsConfigFactory', function() {
   return function (dash) {
-    function selectionChange() {
-      dash.itemSelected = false;
-      for (var i = 0; i < dash.items.length && !dash.itemSelected; i++) {
-        if (dash.items[i].selected) {
-          dash.itemSelected = true;
-        }
+    function selectionChange(item) {
+      if (item.selected) {
+        dash.selectedItems.push(item);
+      } else {
+        dash.selectedItems = dash.selectedItems.filter(function( obj ) { return obj.id !== item.id; });
       }
+
+      dash.itemSelected = dash.selectedItems.length > 0;
     };
 
     dash.DEFAULT_TENANT = "_system";

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
@@ -13,6 +13,9 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
       }
 
       dash.items = data.metric_definitions.filter(function(item) {
+        var findSelectedItem = dash.selectedItems.find(function( obj ) { return obj.id === item.id; });
+        item.selected = typeof findSelectedItem !== 'undefined';
+
         return item.id && item.type;
       });
 
@@ -85,7 +88,6 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
     }
 
     var refreshList = function() {
-      dash.itemSelected = false;
       dash.loadingMetrics = true;
       var _tags = dash.tags !== {} ? '&tags=' + JSON.stringify(dash.tags) : '';
       var pagination = '&page=' + dash.page + '&items_per_page=' + dash.items_per_page;
@@ -99,7 +101,6 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
       dash.loadCount = 0;
       dash.loadingData = true;
       dash.chartData = {};
-      dash.selectedItems = dash.items.filter(function(item) { return item.selected });
 
       for (var i = 0; i < dash.selectedItems.length; i++) {
         var metric_id = dash.selectedItems[i].id;


### PR DESCRIPTION
**Description**

If the list of found metrics is large and they are split in multiple pages it is impossible to select metrics from different pages to graph them together.

For example, using the filter "hostname: ocp-c08-compute01", it is impossible to graph "machine/ocp-c08-compute01/filesystem/available//" (in page 1) together with "machine/ocp-c08-compute01/filesystem/limit//" (in page 2).

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1455896

**Screenshots**
![gifrecord_2017-05-29_122204](https://cloud.githubusercontent.com/assets/2181522/26544216/a02bc226-4469-11e7-8ada-f0a89f9c02aa.gif)
