### PR TITLE
fix topology max items feature

### DIFF
--- a/app/assets/javascripts/controllers/topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/container_topology_controller.js
@@ -218,7 +218,7 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
     $scope.relations = data.data.relations;
     $scope.kinds = data.data.kinds;
     icons = data.data.icons;
-    var size_limit = data.data.settings.containers_max_objects;
+    var size_limit = data.data.settings.containers_max_items;
 
     if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys($scope.kinds).length)) {
       $scope.kinds = currentSelectedKinds;

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -589,7 +589,7 @@ class ConfigurationController < ApplicationController
       @edit[:new][:perpage][:tile] = params[:perpage_tile].to_i if params[:perpage_tile]
       @edit[:new][:perpage][:list] = params[:perpage_list].to_i if params[:perpage_list]
       @edit[:new][:perpage][:reports] = params[:perpage_reports].to_i if params[:perpage_reports]
-      @edit[:new][:topology][:containers_max_objects] = params[:topology_containers_max_objects].to_i if params[:topology_containers_max_objects]
+      @edit[:new][:topology][:containers_max_items] = params[:topology_containers_max_items].to_i if params[:topology_containers_max_items]
       @edit[:new][:display][:theme] = params[:display_theme] unless params[:display_theme].nil?
       @edit[:new][:display][:bg_color] = params[:bg_color] unless params[:bg_color].nil?
       @edit[:new][:display][:reporttheme] = params[:display_reporttheme] unless params[:display_reporttheme].nil?

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -77,7 +77,7 @@
         %fieldset
           %h3
             = _('Topology Default Items in View')
-          - [[_("Containers"), "topology_containers_max_objects", :containers_max_objects]].each do |item_per_page|
+          - [[_("Containers"), "topology_containers_max_items", :containers_max_items]].each do |item_per_page|
             .form-group
               %label.col-md-3.control-label
                 = _(item_per_page[0])

--- a/spec/javascripts/fixtures/json/container_topology_response.json
+++ b/spec/javascripts/fixtures/json/container_topology_response.json
@@ -350,6 +350,6 @@
       "Kubernetes":{"type":"image","icon":"...kubernetes..."},
       "Openshift":{"type":"image","icon":"...openshift..."}
     },
-    "settings": { "containers_max_objects":100}
+    "settings": { "containers_max_items":100}
   }
 }


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1455892
Fixes the feature introduced in #95. Setting an item limit for topology didnt work since theres inconsistency with the naming of the limit.
`items` is the correct term so what this PR does is `s/objects/items/g` to fix the bug. 