### PR TITLE
Introducing pluggable menus

### DIFF
--- a/app/presenters/menu/custom_loader.rb
+++ b/app/presenters/menu/custom_loader.rb
@@ -1,0 +1,21 @@
+module Menu
+  module CustomLoader
+    @sections = []
+    @items = []
+
+    class << self
+      def load
+        [@sections, @items]
+      end
+
+      def register(item)
+        case item
+        when Menu::Section
+          @sections << item
+        when Menu::Item
+          @items << item
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/menu/manager.rb
+++ b/app/presenters/menu/manager.rb
@@ -85,7 +85,7 @@ module Menu
     end
 
     def load_custom_items
-      sections, items = Menu::CustomLoader.load
+      sections, items = Menu::YamlLoader.load
       merge_sections(sections)
       preprocess_sections
       merge_items(items)

--- a/app/presenters/menu/manager.rb
+++ b/app/presenters/menu/manager.rb
@@ -58,7 +58,7 @@ module Menu
 
     def initialize
       load_default_items
-      load_custom_items
+      load_custom_items(Menu::YamlLoader)
     end
 
     def merge_sections(sections)
@@ -84,8 +84,8 @@ module Menu
       end
     end
 
-    def load_custom_items
-      sections, items = Menu::YamlLoader.load
+    def load_custom_items(loader)
+      sections, items = loader.load
       merge_sections(sections)
       preprocess_sections
       merge_items(items)

--- a/app/presenters/menu/manager.rb
+++ b/app/presenters/menu/manager.rb
@@ -59,6 +59,7 @@ module Menu
     def initialize
       load_default_items
       load_custom_items(Menu::YamlLoader)
+      load_custom_items(Menu::CustomLoader)
     end
 
     def merge_sections(sections)

--- a/app/presenters/menu/yaml_loader.rb
+++ b/app/presenters/menu/yaml_loader.rb
@@ -1,5 +1,5 @@
 module Menu
-  class CustomLoader
+  class YamlLoader
     include Singleton
 
     def self.load

--- a/spec/presenters/menu/custom_menu_loader_spec.rb
+++ b/spec/presenters/menu/custom_menu_loader_spec.rb
@@ -1,4 +1,4 @@
-describe Menu::CustomLoader do
+describe Menu::YamlLoader do
   include Spec::Support::MenuHelper
 
   it "loads custom menu section" do
@@ -6,7 +6,7 @@ describe Menu::CustomLoader do
     begin
       expect(Dir).to receive(:glob).and_return([temp_file.path])
 
-      sections, items = Menu::CustomLoader.load
+      sections, items = described_class.load
       expect(sections.length).to be(1)
       expect(items.length).to be(0)
 
@@ -23,7 +23,7 @@ describe Menu::CustomLoader do
     begin
       expect(Dir).to receive(:glob).and_return([temp_file2.path, temp_file.path])
 
-      sections, items = Menu::CustomLoader.load
+      sections, items = described_class.load
       expect(sections.length).to be(1)
       expect(items.length).to be(1)
 

--- a/spec/presenters/menu/menu_manager_spec.rb
+++ b/spec/presenters/menu/menu_manager_spec.rb
@@ -2,7 +2,7 @@ describe Menu::Manager do
   include Spec::Support::MenuHelper
 
   before :each do
-    Singleton.__init__(Menu::CustomLoader)
+    Singleton.__init__(Menu::YamlLoader)
     Singleton.__init__(Menu::Manager)
   end
 
@@ -14,7 +14,7 @@ describe Menu::Manager do
     end
 
     it "loads custom menu items" do
-      expect(Menu::CustomLoader).to receive(:load).and_call_original
+      expect(Menu::YamlLoader).to receive(:load).and_call_original
       Menu::Manager.menu {}
     end
   end


### PR DESCRIPTION
These changes will allow us to declare menu items in external plugins. I implemented a new `Menu::CustomLoader` singleton, in which you can `.register` your menu items. For now this can be done from an [`initializer`](http://api.rubyonrails.org/classes/Rails/Engine.html#class-Rails::Engine-label-Configuration) block declared in a Rails Engine.

The `.register` method can take a `Menu::Section` or a `Menu::Item` as an argument with the [same syntax](https://github.com/ManageIQ/guides/blob/master/ui/menus.md) as we're using in the [`Menu::DefaultMenu`](https://github.com/ManageIQ/manageiq-ui-classic/blob/70aec6d45b200a44f7c81bb7357cb916c7290aff/app/presenters/menu/default_menu.rb).

For example this will create a new *Test* section with a *Test* item pointing to the `/test` URL:
```ruby
# inside a rails engine definition
initializer 'ui.plugin' do
  Menu::CustomLoader.register(
    Menu::Section.new(:spike, N_('Test'), 'fa fa-map-pin', [
      Menu::Item.new('plug', N_('Test'), 'some_feature', {:feature => 'some_feature', :any => true}, '/test')
    ])
)
end
```

In the future I'd like to take out the menu declarations into a better place, e.g. `app/menus` and have some kind of auto-registering feature inside the engine. The syntax of the menu declaration should be also DSL-ized and used in the `Menu::DefaultMenu` too.

@martinpovolny what do you think?