### PR TITLE
Display Adv search in Object Store Objects page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -858,6 +858,7 @@ module ApplicationHelper
        automation_manager
        cloud_network
        cloud_object_store_container
+       cloud_object_store_object
        cloud_subnet
        cloud_tenant
        cloud_volume
@@ -1515,6 +1516,7 @@ module ApplicationHelper
       automation_manager
       cloud_network
       cloud_object_store_container
+      cloud_object_store_object
       cloud_subnet
       cloud_tenant
       cloud_volume


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1444089

Display Search and Advanced search forms
in Cloud Object Store Objects page
and make them work.

Before:
![object_store0](https://cloud.githubusercontent.com/assets/13417815/26549903/90a933a8-447b-11e7-9a79-66d10a792b03.png)

After:
![store_object](https://cloud.githubusercontent.com/assets/13417815/26549912/9a6a0fb6-447b-11e7-9c34-2d2fecab5fc3.png)
