### PR TITLE
Enable to download AWS volumes snapshot summary

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -525,6 +525,7 @@ Rails.application.routes.draw do
     :cloud_volume_snapshot    => {
       :get  => %w(
         download_data
+        download_summary_pdf
         index
         show
         show_list


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1439629

Enable to download AWS volumes snapshot summary in PDF format
when reaching Storage > Block Storage > Volume Snapshots page
and clicking on one of the snapshots to get into summary page.

![snapshot](https://cloud.githubusercontent.com/assets/13417815/26551721/272dae78-4484-11e7-822b-3e2730d394aa.png)
