### PR TITLE
Displayed number of relationships between Hosts and Physical Server

### DIFF
--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -14,7 +14,7 @@ module EmsPhysicalInfraHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(physical_servers datastores vms)
+      %i(physical_servers datastores vms hosts)
     )
   end
 
@@ -60,6 +60,11 @@ module EmsPhysicalInfraHelper::TextualSummary
       h[:link] = "/ems_physical_infra/#{@ems.id}?display=physical_servers"
     end
     h
+  end
+
+  def textual_hosts
+    count_of_host_relationships = (@record.physical_servers.select{|server| server.host != nil}).length
+    h = {:label =>  _("Hosts"), :icon  =>  "pficon pficon-screen", :value => count_of_host_relationships}
   end
 
   def textual_guid

--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -63,8 +63,8 @@ module EmsPhysicalInfraHelper::TextualSummary
   end
 
   def textual_hosts
-    count_of_host_relationships = (@record.physical_servers.select{|server| server.host != nil}).length
-    h = {:label =>  _("Hosts"), :icon  =>  "pficon pficon-screen", :value => count_of_host_relationships}
+    count_of_host_relationships = (@record.physical_servers.select { |server| !server.host.nil? }).length
+    {:label => _("Hosts"), :icon => "pficon pficon-screen", :value => count_of_host_relationships}
   end
 
   def textual_guid


### PR DESCRIPTION
This PR display the number of host relationships to Physical Servers being managed by XClarity Provider.

![image](https://cloud.githubusercontent.com/assets/5839808/26581512/491f8184-4513-11e7-83a0-d8ffbeeeba41.png)
