### PR TITLE
Rendering status for servers and deployments in middleware topology

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -177,16 +177,22 @@ ManageIQ.angular.app.service('topologyService', function() {
       case "Running":
       case "Succeeded":
       case "Valid":
+      case "Enabled":
         return "success";
       case "NotReady":
       case "Failed":
       case "Error":
       case "Unreachable":
+      case "Down":
         return "error";
       case 'Warning':
       case 'Waiting':
       case 'Pending':
+      case 'Disabled':
+      case 'Reload required':
         return "warning";
+      case 'Starting':
+        return "information"; // defined in middleware_topology.css
       case 'Unknown':
       case 'Terminated':
         return "unknown";

--- a/app/assets/stylesheets/middleware_topology.css
+++ b/app/assets/stylesheets/middleware_topology.css
@@ -8,3 +8,8 @@
   font-size: 20px;
   fill: #555;
 }
+
+.middleware .kube-topology g circle.information {
+  stroke: #00c;
+}
+

--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -56,7 +56,12 @@ class MiddlewareTopologyService < TopologyService
       data[:icon] = ActionController::Base.helpers.image_path(entity.decorate.try(:fileicon))
     end
 
-    if entity.kind_of?(Vm)
+    case entity
+    when MiddlewareServer
+      data[:status] = entity.properties['Calculated Server State'].underscore.humanize if entity.properties['Calculated Server State']
+    when MiddlewareDeployment
+      data[:status] = entity.status.capitalize if entity.status
+    when Vm
       data[:status] = entity.power_state.capitalize
       data[:provider] = entity.ext_management_system.name
     end


### PR DESCRIPTION
Status of middleware servers and deployments are set when building
topology view. This renders the status in tooltips in related
topology nodes and also renders status colors.

Regarding colors:
- For middleware servers, when status is:
  * Down => red
  * Running => green
  * Reload required => amber
  * Starting => blue
- For deployments:
  * Enabled => green
  * Disabled => amber

This is the first step to cover ManageIQ/manageiq-providers-hawkular#5

![topology_screenshot](https://user-images.githubusercontent.com/23639005/26904309-f77d6860-4ba6-11e7-9807-6ebe90b4b804.png)
