### PR TITLE
Use scope instead of a query to get soft-deleted items

### DIFF
--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -7,7 +7,7 @@ class ContainerController < ApplicationController
   after_action :set_session_data
 
   def show_list
-    process_show_list(:where_clause => 'containers.deleted_on IS NULL')
+    process_show_list(:named_scope => :active)
   end
 
   private

--- a/app/controllers/container_group_controller.rb
+++ b/app/controllers/container_group_controller.rb
@@ -7,7 +7,7 @@ class ContainerGroupController < ApplicationController
   after_action :set_session_data
 
   def show_list
-    process_show_list(:where_clause => 'container_groups.deleted_on IS NULL')
+    process_show_list(:named_scope => :active)
   end
 
   private

--- a/app/controllers/container_image_controller.rb
+++ b/app/controllers/container_image_controller.rb
@@ -16,7 +16,7 @@ class ContainerImageController < ApplicationController
   helper_method :textual_group_list
 
   def show_list
-    process_show_list(:where_clause => 'container_images.deleted_on IS NULL')
+    process_show_list(:named_scope => :active)
   end
 
   def guest_applications

--- a/app/controllers/container_project_controller.rb
+++ b/app/controllers/container_project_controller.rb
@@ -7,7 +7,7 @@ class ContainerProjectController < ApplicationController
   after_action :set_session_data
 
   def show_list
-    process_show_list(:where_clause => 'container_projects.deleted_on IS NULL')
+    process_show_list(:named_scope => :active)
   end
 
   private

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -36,7 +36,7 @@ class ContainerDashboardService
         :href         => get_url_to_entity(:container_node)
       },
       :containers => {
-        :count        => @ems.present? ? @ems.containers.count : Container.where.not(:ext_management_system => nil).count,
+        :count        => @ems.present? ? @ems.containers.count : Container.not_deleted.count,
         :errorCount   => 0,
         :warningCount => 0,
         :href         => get_url_to_entity(:container)
@@ -48,13 +48,13 @@ class ContainerDashboardService
         :href         => get_url_to_entity(:container_image_registry)
       },
       :projects   => {
-        :count        => @ems.present? ? @ems.container_projects.count : ContainerProject.where.not(:ext_management_system => nil).count,
+        :count        => @ems.present? ? @ems.container_projects.count : ContainerProject.not_deleted.count,
         :errorCount   => 0,
         :warningCount => 0,
         :href         => get_url_to_entity(:container_project)
       },
       :pods       => {
-        :count        => @ems.present? ? @ems.container_groups.count : ContainerGroup.where.not(:ext_management_system => nil).count,
+        :count        => @ems.present? ? @ems.container_groups.count : ContainerGroup.not_deleted.count,
         :errorCount   => 0,
         :warningCount => 0,
         :href         => get_url_to_entity(:container_group)
@@ -66,7 +66,7 @@ class ContainerDashboardService
         :href         => get_url_to_entity(:container_service)
       },
       :images     => {
-        :count        => @ems.present? ? @ems.container_images.count : ContainerImage.where.not(:ext_management_system => nil).count,
+        :count        => @ems.present? ? @ems.container_images.count : ContainerImage.not_deleted.count,
         :errorCount   => 0,
         :warningCount => 0,
         :href         => get_url_to_entity(:container_image)

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -36,7 +36,7 @@ class ContainerDashboardService
         :href         => get_url_to_entity(:container_node)
       },
       :containers => {
-        :count        => @ems.present? ? @ems.containers.count : Container.not_deleted.count,
+        :count        => @ems.present? ? @ems.containers.count : Container.active.count,
         :errorCount   => 0,
         :warningCount => 0,
         :href         => get_url_to_entity(:container)
@@ -48,13 +48,13 @@ class ContainerDashboardService
         :href         => get_url_to_entity(:container_image_registry)
       },
       :projects   => {
-        :count        => @ems.present? ? @ems.container_projects.count : ContainerProject.not_deleted.count,
+        :count        => @ems.present? ? @ems.container_projects.count : ContainerProject.active.count,
         :errorCount   => 0,
         :warningCount => 0,
         :href         => get_url_to_entity(:container_project)
       },
       :pods       => {
-        :count        => @ems.present? ? @ems.container_groups.count : ContainerGroup.not_deleted.count,
+        :count        => @ems.present? ? @ems.container_groups.count : ContainerGroup.active.count,
         :errorCount   => 0,
         :warningCount => 0,
         :href         => get_url_to_entity(:container_group)
@@ -66,7 +66,7 @@ class ContainerDashboardService
         :href         => get_url_to_entity(:container_service)
       },
       :images     => {
-        :count        => @ems.present? ? @ems.container_images.count : ContainerImage.not_deleted.count,
+        :count        => @ems.present? ? @ems.container_images.count : ContainerImage.active.count,
         :errorCount   => 0,
         :warningCount => 0,
         :href         => get_url_to_entity(:container_image)


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/15251

Use scope instead of a query to get soft-deleted items. The rule
of thumb should be to never do specific queries and rather
move the logic to the models.