### PR TITLE
Put back form buttons on explorer screens.

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1339,6 +1339,12 @@ module VmCommon
         elsif action != "retire" && action != "reconfigure_update"
           presenter.update(:form_buttons_div, r[:partial => 'layouts/x_edit_buttons', :locals => locals])
         end
+
+        # Make sure the form_buttons_div is empty.
+        # it would remain on the screen if prior to retire some action that uses the form_buttons_div was used
+        # such as "edit tags" or "manage policies".
+        presenter.update(:form_buttons_div, '') if action == "retire"
+
         presenter.hide(:pc_div_1).show(:form_buttons_div)
       end
       presenter.show(:paging_div)

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -47,12 +47,11 @@
               .col-md-12
                 = yield
         .col-md-12.no-padding
+          = render :partial => 'layouts/x_form_buttons'
           .row.toolbar-pf#paging_div
             - if saved_report_paging?
               = render(:partial => 'layouts/saved_report_paging_bar',
                        :locals  => {:pages => @sb[:pages]})
-            - else
-              = render :partial => 'layouts/x_form_buttons'
 
         - unless simulate
           .resizer.hidden-xs

--- a/app/views/layouts/_saved_report_paging_bar.html.haml
+++ b/app/views/layouts/_saved_report_paging_bar.html.haml
@@ -20,6 +20,5 @@
                     :class       => "selectpicker dropup")
         :javascript
           miqSelectPickerEvent("ppsetting", "#{url}", {beforeSend: true, complete: true})
-    = render(:partial => '/layouts/x_form_buttons')
     :javascript
       miqInitSelectPicker();

--- a/app/views/layouts/_x_edit_buttons.html.haml
+++ b/app/views/layouts/_x_edit_buttons.html.haml
@@ -39,152 +39,153 @@
 - serialize ||= false
 
 
-- if action_url && !export_button
-  #buttons_on{:style => session[:changed] ? "" : "display: none;"}
-    - if record_id.blank? && multi_record.nil? && submit_button.nil? && continue_button.nil?
-      = button_tag(t = _('Add'),
-        :class   => "btn btn-primary",
-        :alt     => t,
-        :title   => t,
-        :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => "add")}', #{serialize});")
-    - else
-      - if apply_button
-        = link_to(_("Apply"),
-          {:action => action_url, :button => "apply", :id => record_id},
-          :method => apply_method,
-          :class => "btn btn-primary",
-          :alt   => apply_text,
-          :title => apply_text)
-      - elsif export_button
-        - t = _("Download Report to YAML")
+%div{:style => 'padding-top: 5px'}
+  - if action_url && !export_button
+    #buttons_on{:style => session[:changed] ? "" : "display: none;"}
+      - if record_id.blank? && multi_record.nil? && submit_button.nil? && continue_button.nil?
+        = button_tag(t = _('Add'),
+          :class   => "btn btn-primary",
+          :alt     => t,
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => "add")}', #{serialize});")
+      - else
+        - if apply_button
+          = link_to(_("Apply"),
+            {:action => action_url, :button => "apply", :id => record_id},
+            :method => apply_method,
+            :class => "btn btn-primary",
+            :alt   => apply_text,
+            :title => apply_text)
+        - elsif export_button
+          - t = _("Download Report to YAML")
+          = link_to(_("Export"),
+            {:action => action_url},
+            :class  => "btn btn-primary",
+            :type   => "application/txt",
+            :alt    => t,
+            :title  => t)
+        - elsif submit_button
+          = button_tag(t = _('Submit'),
+            :class   => "btn btn-primary",
+            :alt     => t,
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "submit")}');")
+        - elsif continue_button
+          = button_tag(t = _('Continue'),
+            :class   => "btn btn-primary",
+            :alt     => t,
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "continue")}');")
+        - elsif create_button
+          = button_tag(t = _('Create'),
+            :class   => "btn btn-primary",
+            :alt     => t,
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "create")}',true);")
+        - elsif copy_button
+          = button_tag(t = _('Copy'),
+            :class   => "btn btn-primary",
+            :alt     => t,
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "copy")}',true);")
+        - else
+          - if save_confirm_text
+            -# Ask for confirmation before saving
+            = button_tag(_('Save'),
+              :class   => "btn btn-primary",
+              :alt     => save_text,
+              :title   => save_text,
+              :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
+          - else
+            = button_tag(_('Save'),
+              :class   => "btn btn-primary",
+              :alt     => t = _("Save Changes"),
+              :title   => t,
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
+
+        - unless no_reset
+          = button_tag(_('Reset'),
+            :class   => "btn btn-default",
+            :alt     => t = _("Reset Changes"),
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "reset")}');")
+      - if default_button
+        = button_tag(_('Default'),
+          :class   => "btn btn-default",
+          :alt     => t = _("Reset All menus to %{product} defaults") % {:product => I18n.t('product.name')},
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update", :button => "default")}');")
+      - unless no_cancel
+        = button_tag(t = _('Cancel'),
+          :class   => "btn btn-default",
+          :alt     => t,
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}');")
+
+    #buttons_off{:style => session[:changed] ? "display: none;" : ""}
+      - if record_id.blank? && multi_record.nil? && submit_button.nil? && continue_button.nil?
+        = button_tag(_("Add"), :class => "btn btn-primary disabled")
+      - else
+        - if apply_button
+          = button_tag(_("Apply"), :class => "btn btn-primary disabled")
+        - elsif submit_button
+          = button_tag(_("Submit"), :class => "btn btn-primary disabled")
+        - elsif continue_button
+          = button_tag(_("Continue"), :class => "btn btn-primary disabled")
+        - elsif copy_button
+          = button_tag(_("Copy"), :class => "btn btn-primary disabled")
+        - else
+          = button_tag(_("Save"), :class => "btn btn-primary disabled")
+
+        - unless no_reset
+          = button_tag(_("Reset"), :class => "btn btn-default disabled")
+
+      - if default_button
+        = button_tag(_('Default'),
+          :class   => "btn btn-default",
+          :alt     => t = _("Reset All menus to %{product} defaults") % {:product => I18n.t('product.name')},
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update", :button => "default")}');")
+
+      - unless no_cancel
+        = button_tag(t = _('Cancel'),
+          :class   => "btn btn-default",
+          :alt     => t,
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}');")
+  - elsif record_id || export_button
+    -# show button to go back
+    #buttons
+      - if params[:action] == "policies" || %w(right_size).include?(@sb[:action])
+        - action = (params[:action] == "policies" ? "policy_sim" : "x_history")
+        -# Button to go back to policy simulation screen from 1 VMs policies
+        = button_tag(t = _('Back'),
+          :class   => "btn btn-default",
+          :alt     => t,
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action, :continue => true)}');")
+      - elsif %w(drift policy_sim).include?(@sb[:action])
+        -# Button to cancel policy simulation/drift and return to latest tree node
+        = button_tag(t = _('Cancel'),
+          :class   => "btn btn-default",
+          :alt     => t,
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item   => 0)}');")
+      - else
+        -# export_button
         = link_to(_("Export"),
           {:action => action_url},
-          :class  => "btn btn-primary",
-          :type   => "application/txt",
-          :alt    => t,
-          :title  => t)
-      - elsif submit_button
-        = button_tag(t = _('Submit'),
-          :class   => "btn btn-primary",
-          :alt     => t,
-          :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "submit")}');")
-      - elsif continue_button
-        = button_tag(t = _('Continue'),
-          :class   => "btn btn-primary",
-          :alt     => t,
-          :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "continue")}');")
-      - elsif create_button
-        = button_tag(t = _('Create'),
-          :class   => "btn btn-primary",
-          :alt     => t,
-          :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "create")}',true);")
-      - elsif copy_button
-        = button_tag(t = _('Copy'),
-          :class   => "btn btn-primary",
-          :alt     => t,
-          :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "copy")}',true);")
-      - else
-        - if save_confirm_text
-          -# Ask for confirmation before saving
-          = button_tag(_('Save'),
-            :class   => "btn btn-primary",
-            :alt     => save_text,
-            :title   => save_text,
-            :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
-        - else
-          = button_tag(_('Save'),
-            :class   => "btn btn-primary",
-            :alt     => t = _("Save Changes"),
-            :title   => t,
-            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
+          :class    => "btn btn-primary disabled",
+          :type     => "application/txt",
+          :alt      => t = _("Download Report to YAML"),
+          :title    => t,
+          :id       => "export_button")
 
-      - unless no_reset
-        = button_tag(_('Reset'),
-          :class   => "btn btn-default",
-          :alt     => t = _("Reset Changes"),
-          :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "reset")}');")
-    - if default_button
-      = button_tag(_('Default'),
-        :class   => "btn btn-default",
-        :alt     => t = _("Reset All menus to %{product} defaults") % {:product => I18n.t('product.name')},
-        :title   => t,
-        :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update", :button => "default")}');")
-    - unless no_cancel
+  - elsif ["compare"].include?(@sb[:action])
+    #buttons
+      -# Button to cancel policy simulation and return to latest tree node
       = button_tag(t = _('Cancel'),
         :class   => "btn btn-default",
         :alt     => t,
         :title   => t,
-        :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}');")
-
-  #buttons_off{:style => session[:changed] ? "display: none;" : ""}
-    - if record_id.blank? && multi_record.nil? && submit_button.nil? && continue_button.nil?
-      = button_tag(_("Add"), :class => "btn btn-primary disabled")
-    - else
-      - if apply_button
-        = button_tag(_("Apply"), :class => "btn btn-primary disabled")
-      - elsif submit_button
-        = button_tag(_("Submit"), :class => "btn btn-primary disabled")
-      - elsif continue_button
-        = button_tag(_("Continue"), :class => "btn btn-primary disabled")
-      - elsif copy_button
-        = button_tag(_("Copy"), :class => "btn btn-primary disabled")
-      - else
-        = button_tag(_("Save"), :class => "btn btn-primary disabled")
-
-      - unless no_reset
-        = button_tag(_("Reset"), :class => "btn btn-default disabled")
-
-    - if default_button
-      = button_tag(_('Default'),
-        :class   => "btn btn-default",
-        :alt     => t = _("Reset All menus to %{product} defaults") % {:product => I18n.t('product.name')},
-        :title   => t,
-        :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update", :button => "default")}');")
-
-    - unless no_cancel
-      = button_tag(t = _('Cancel'),
-        :class   => "btn btn-default",
-        :alt     => t,
-        :title   => t,
-        :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}');")
-- elsif record_id || export_button
-  -# show button to go back
-  #buttons
-    - if params[:action] == "policies" || %w(right_size).include?(@sb[:action])
-      - action = (params[:action] == "policies" ? "policy_sim" : "x_history")
-      -# Button to go back to policy simulation screen from 1 VMs policies
-      = button_tag(t = _('Back'),
-        :class   => "btn btn-default",
-        :alt     => t,
-        :title   => t,
-        :onclick => "miqAjaxButton('#{url_for_only_path(:action => action, :continue => true)}');")
-    - elsif %w(drift policy_sim).include?(@sb[:action])
-      -# Button to cancel policy simulation/drift and return to latest tree node
-      = button_tag(t = _('Cancel'),
-        :class   => "btn btn-default",
-        :alt     => t,
-        :title   => t,
-        :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item   => 0)}');")
-    - else
-      -# export_button
-      = link_to(_("Export"),
-        {:action => action_url},
-        :class    => "btn btn-primary disabled",
-        :type     => "application/txt",
-        :alt      => t = _("Download Report to YAML"),
-        :title    => t,
-        :id       => "export_button")
-
-- elsif ["compare"].include?(@sb[:action])
-  #buttons
-    -# Button to cancel policy simulation and return to latest tree node
-    = button_tag(t = _('Cancel'),
-      :class   => "btn btn-default",
-      :alt     => t,
-      :title   => t,
-      :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item => 0)}');")
+        :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item => 0)}');")


### PR DESCRIPTION
The buttons where included through the pagination partials that where
removed in
https://github.com/ManageIQ/manageiq-ui-classic/pull/1392

Todo:
  * ~~styling is broken~~
  * ~~VM --> "Set retirement date" has 2 sets of buttons and no paginator~~

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/1465