### PR TITLE
Fix Providers text and Cluster info in host listnav

### DIFF
--- a/app/views/layouts/listnav/_host.html.haml
+++ b/app/views/layouts/listnav/_host.html.haml
@@ -73,7 +73,7 @@
       %ul.nav.nav-pills.nav-stacked
         - if role_allows?(:feature => "ems_infra_show") && !@record.ext_management_system.nil?
           %li
-            = link_to("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
+            = link_to("#{ui_lookup(:table => "ems_infra")}: #{@record.ext_management_system.name}",
               ems_infra_path(@record.ext_management_system),
               :title => _("Show this parent %{provider} for this %{host}") % {:host => host_title, :provider => ui_lookup(:table => "ems_infra")})
 
@@ -83,6 +83,9 @@
             = link_to("#{cluster_title}: #{@record.ems_cluster.name}",
               {:controller => "ems_cluster", :action => 'show', :id => @record.ems_cluster.id.to_s},
               :title => _("Show parent %{cluster} for this %{host}") % {:host => host_title, :cluster => cluster_title})
+
+        - if role_allows?(:feature => "ems_cluster_show") && @record.ems_cluster.nil?
+          = li_link(:if => false, :text => "#{title_for_cluster}: #{_('None')}")
 
         - if role_allows?(:feature => "storage_show_list")
           = li_link(:count => @record.number_of(:storages),


### PR DESCRIPTION
The `Host` listnav had some inconsistencies with how the data was displayed in the Summary screen.

- Fixed the `Providers` text to display `Infrastructure Provider`
- Ensured that `Cluster: None` text (minus the link) is displayed in the listnav when the host does not have a cluser record associated with it

Before:
<img width="1298" alt="screen shot 2017-05-31 at 3 35 15 pm" src="https://cloud.githubusercontent.com/assets/1538216/26657074/c95507e4-4616-11e7-9cf8-7546b29b702c.png">

After:
<img width="1300" alt="screen shot 2017-05-31 at 3 23 33 pm" src="https://cloud.githubusercontent.com/assets/1538216/26657083/d238d35e-4616-11e7-9661-fa15e12ae5b1.png">
