### PR TITLE
Redirect appropriately after cancel is pressed while provisioning instances

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -82,9 +82,7 @@ module ApplicationController::MiqRequestMethods
         if @breadcrumbs && (@breadcrumbs.empty? || @breadcrumbs.last[:url] == "/vm/show_list")
           javascript_redirect :action => "show_list", :controller => "vm"
         else
-          # had to get id from breadcrumbs url, because there is no params[:id] when cancel is pressed on copy Request screen.
-          url = @breadcrumbs.last[:url].split('/')
-          javascript_redirect :controller => url[1], :action => url[2], :id => url[3]
+          javascript_redirect @breadcrumbs.last[:url]
         end
       end
     elsif params[:button] == "continue"       # Template chosen, start vm provisioning

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -75,16 +75,7 @@ module ApplicationController::MiqRequestMethods
       session[:flash_msgs] = @flash_array.dup unless session[:edit][:explorer]  # Put msg in session for next transaction to display
       @explorer = session[:edit][:explorer] ? session[:edit][:explorer] : false
       @edit = session[:edit] =  nil                                               # Clear out session[:edit]
-      if @explorer
-        @sb[:action] = nil
-        replace_right_cell
-      else
-        if @breadcrumbs && (@breadcrumbs.empty? || @breadcrumbs.last[:url] == "/vm/show_list")
-          javascript_redirect :action => "show_list", :controller => "vm"
-        else
-          javascript_redirect @breadcrumbs.last[:url]
-        end
-      end
+      prov_request_cancel_submit_response
     elsif params[:button] == "continue"       # Template chosen, start vm provisioning
       params[:button] = nil                   # Clear the incoming button
       @edit = session[:edit]                  # Grab what we need from @edit


### PR DESCRIPTION
When Cancel is pressed while provisioning instances, the redirect should use the last url stored in `@breadcrumbs`

https://bugzilla.redhat.com/show_bug.cgi?id=1451315
