### PR TITLE
Use matching via descendants for CloudNetwork model

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -297,6 +297,10 @@ class ApplicationController < ActionController::Base
     if params[:model] && %w(miq_tasks).include?(params[:model])
       options = jobs_info
     end
+    if params[:model] && %w(cloud_networks).include?(params[:model])
+      options = rbac_params
+    end
+
     if params[:model_id] && !params[:active_tree]
       curr_model_id = from_cid(params[:model_id])
       unless curr_model_id.nil?

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -18,6 +18,10 @@ class CloudNetworkController < ApplicationController
     "VXLAN" => "vxlan",
   }.freeze
 
+  def rbac_params
+    {:match_via_descendants => ManageIQ::Providers::NetworkManager}
+  end
+
   def self.display_methods
     %w(instances cloud_networks network_routers cloud_subnets)
   end


### PR DESCRIPTION

<img width="1212" alt="screen shot 2017-06-01 at 18 34 07" src="https://cloud.githubusercontent.com/assets/14937244/26691249/bea0ddb4-46fc-11e7-82fd-87c7bbf3f4c1.png">

we need to filter CloudNetworks also according to their Network Manager when this limitation is set up in user's group in tab Host & Cluster.

but for allowing this feature, [backend PR is needed.](https://github.com/ManageIQ/manageiq/pull/15271)

Links 
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1445163
* https://github.com/ManageIQ/manageiq/pull/15271

cc @mzazrivec 
@miq-bot assing @martinpovolny 

@miq-bot add_label bug