### PR TITLE
Move away from ArRegion directly

### DIFF
--- a/app/controllers/mixins/compressed_ids.rb
+++ b/app/controllers/mixins/compressed_ids.rb
@@ -1,5 +1,5 @@
 module CompressedIds
-  CID_OR_ID_MATCHER = ArRegion::CID_OR_ID_MATCHER
+  CID_OR_ID_MATCHER = ApplicationRecord::CID_OR_ID_MATCHER
   #
   # Methods to convert record id (id, fixnum, 12000000000056) to/from compressed id (cid, string, "12r56")
   #   for use in UI controls (i.e. tree node ids, pulldown list items, etc)


### PR DESCRIPTION
I am trying to extract ArRegion and it will likely have a different name.  Like the other lines in this file, it's clearer to depend on ApplicationRecord instead of ArRegion directly.