### PR TITLE
Fix Physical Server link in Physical Infra Summary page

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -120,6 +120,7 @@ module EmsCommon
         object_storage_managers
         orchestration_stacks
         persistent_volumes
+        physical_servers
         security_groups
         storage_managers
         storages

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -80,14 +80,50 @@ module EmsCommon
   class_methods do
     def display_methods
       %w(
-        availability_zones block_storage_managers cloud_networks cloud_object_store_containers cloud_subnets
-        cloud_tenants cloud_volumes cloud_volume_snapshots configuration_jobs container_builds container_groups
-        container_image_registries container_images container_nodes container_projects container_replicators
-        container_routes containers container_services container_templates ems_clusters flavors floating_ips
-        host_aggregates hosts images instances load_balancers middleware_datasources middleware_deployments
-        middleware_domains middleware_messagings middleware_server_groups middleware_servers miq_templates
-        network_ports network_routers object_storage_managers orchestration_stacks persistent_volumes
-        security_groups storage_managers storages vms
+        availability_zones
+        block_storage_managers
+        cloud_networks
+        cloud_object_store_containers
+        cloud_subnets
+        cloud_tenants
+        cloud_volumes
+        cloud_volume_snapshots
+        configuration_jobs
+        container_builds
+        container_groups
+        container_image_registries
+        container_images
+        container_nodes
+        container_projects
+        container_replicators
+        container_routes
+        containers
+        container_services
+        container_templates
+        ems_clusters
+        flavors
+        floating_ips
+        host_aggregates
+        hosts
+        images
+        instances
+        load_balancers
+        middleware_datasources
+        middleware_deployments
+        middleware_domains
+        middleware_messagings
+        middleware_server_groups
+        middleware_servers
+        miq_templates
+        network_ports
+        network_routers
+        object_storage_managers
+        orchestration_stacks
+        persistent_volumes
+        security_groups
+        storage_managers
+        storages
+        vms
       )
     end
 

--- a/app/views/layouts/listnav/_ems_physical_infra.html.haml
+++ b/app/views/layouts/listnav/_ems_physical_infra.html.haml
@@ -14,8 +14,7 @@
             :title      => _("Show Timelines"))
     = miq_accordion_panel(_("Relationships"), false, "ems_rel") do
       %ul.nav.nav-pills.nav-stacked
-        = li_link(:if => !(@record.number_of(:physical_servers) == 0),
-          :text       => _("Physical Servers"),
-          :record     => @record,
-          :display    => 'physical_servers',
-          :title      => _("Physical Servers"))
+        = li_link(:count => @record.number_of(:physical_servers),
+          :tables        => 'physical_servers',
+          :record        => @record,
+          :display       => 'physical_servers')

--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -1,11 +1,5 @@
 #main_div
-  - arr = %w(container_images container_image_registries containers container_replicators container_routes)
-  - arr.concat(%w(container_builds container_projects container_nodes container_services container_groups availability_zones host_aggregates))
-  - arr.concat(%w(middleware_servers middleware_server_groups middleware_deployments middleware_datasources middleware_domains middleware_messagings))
-  - arr.concat(%w(security_groups floating_ips cloud_subnets network_routers network_ports cloud_networks))
-  - arr.concat(%w(load_balancers container_templates))
-  - arr.concat(%w(cloud_tenants ems_clusters flavors resource_group hosts instances images miq_templates cloud_volumes))
-  - arr.concat(%w(storage_managers cloud_volume_snapshots orchestration_stacks vms storages miq_proxies persistent_volumes cloud_object_store_containers))
+  - arr = (controller_name.camelize + "Controller").constantize.display_methods
   - if arr.include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@ems.id}"}
   - elsif @showtype == "details"

--- a/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
+++ b/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
@@ -11,6 +11,7 @@ describe "shared/views/ems_common/show" do
     before do
       view.extend setup.helper
       allow(MiqServer).to receive(:my_zone).and_return("default")
+      allow(controller).to receive(:controller_name).and_return("ems_cloud")
       creds = {}
       creds[:amqp] = {:userid => "amqp_user", :password => "amqp_password"}
       ems.update_authentication(creds, :save => true)


### PR DESCRIPTION
The `physical_servers` entry had to be added to the whitelist in `display_methods` in order to make this link `http://localhost:3000/ems_physical_infra/1?display=physical_servers` work.

The PR also contains a DRY refactor in `app/views/shared/views/ems_common/_show.html.haml` where instead of repeating the entire list in `display_methods`, we would be simply using the existing list.

Also fixed the listnav to display the Physical Server count.

Before:
<img width="1393" alt="screen shot 2017-06-01 at 3 12 35 pm" src="https://cloud.githubusercontent.com/assets/1538216/26703534/fdfcefa2-46de-11e7-9221-bea4b2b58411.png">

After:
<img width="1389" alt="screen shot 2017-06-01 at 3 32 37 pm" src="https://cloud.githubusercontent.com/assets/1538216/26703661/9a05c7a2-46df-11e7-9507-c7c0bbbce9e3.png">


