### PR TITLE
Fix spec to use correct status of miq_task (CI failure)

### DIFF
--- a/spec/presenters/tree_node/miq_report_result_spec.rb
+++ b/spec/presenters/tree_node/miq_report_result_spec.rb
@@ -2,7 +2,8 @@ require 'shared/presenters/tree_node/common'
 
 describe TreeNode::MiqReportResult do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_report_result) }
+
+  let(:object) { FactoryGirl.create(:miq_report_result, :report => {}) }
 
   include_examples 'TreeNode::Node#key prefix', 'rr-'
   include_examples 'TreeNode::Node#icon', 'fa fa-arrow-right'


### PR DESCRIPTION
Node icon have not to be an error icon,
we need to add report to miq_report_result,
for now I am adding just empty report.

caused by https://github.com/ManageIQ/manageiq/pull/15134/commits/fa4ebc6544ed482cb48e664221ae4625c7597f7a

https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/238705812#L1267

cc @yrudman 
@miq-bot assign @mzazrivec 
