### PR TITLE
Allow to see saved reports after linked MiqTask deleted

### DIFF
--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -24,9 +24,9 @@ module ReportController::SavedReports
                          {:name => "#{rr.name} - #{format_timezone(rr.created_on, Time.zone, "gt")}"}
     if admin_user? || current_user.miq_group_ids.include?(rr.miq_group_id)
       @report_result_id = session[:report_result_id] = rr.id
+      @report_result = rr
       session[:report_result_runtime] = rr.last_run_on
-      task = MiqTask.find_by_id(rr.miq_task_id)
-      if task && MiqTask.status_ok?(task.status)
+      if rr.status.downcase == "complete"
         @report = rr.report_results
         session[:rpt_task_id] = nil
         if @report.blank?
@@ -77,8 +77,6 @@ module ReportController::SavedReports
             add_flash(_("No records found for this report"), :warning)
           end
         end
-      else      # report is queued/running/error
-        @report_result = rr
       end
     else
       add_flash(_("Report is not authorized for the logged in user"), :error)


### PR DESCRIPTION
**Issue**: UI controller did not allow access to report if linked task was deleted

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1450272

Related PR: ManageIQ/manageiq#15134

**BEFORE**:
<img width="1063" alt="before" src="https://cloud.githubusercontent.com/assets/6556758/26794821/3c5a8754-49f1-11e7-8db6-9cb40d547777.png">

**AFTER**:
![after](https://cloud.githubusercontent.com/assets/6556758/26794826/3f55bbf4-49f1-11e7-9d29-e2234c944fc3.png)


@miq-bot add-label bug, reporting
