### PR TITLE
BZ#1457491 - fix middleware providers broken links in timeline events

### DIFF
--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -107,7 +107,7 @@ module ReportFormatter
         elsif ems_container
           "<a href=/ems_container/#{to_cid(provider_id)}>#{text}</a>"
         elsif ems_mw
-          "<a href=/ems_middleware/show/#{to_cid(provider_id)}>#{text}</a>"
+          "<a href=/ems_middleware/#{to_cid(provider_id)}>#{text}</a>"
         else
           "<a href=/ems_infra/#{to_cid(provider_id)}>#{text}</a>"
         end


### PR DESCRIPTION
before the fix, the link contained `/show/` which is not working correctly

after the fix:
![provider_link](https://user-images.githubusercontent.com/6277245/26836060-81f78e00-4ae2-11e7-9366-cd46daa685fe.png)


@miq-bot add_label bug, middleware, events

https://bugzilla.redhat.com/show_bug.cgi?id=1457491