### PR TITLE
Added Verbosity drop down on both Provisioning & Retirement tabs

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -23,6 +23,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       provisioning_value: '',
       provisioning_variables: {},
       provisioning_become_enabled: false,
+      provisioning_verbosity: '0',
       provisioning_editMode: false,
       retirement_repository_id: '',
       retirement_playbook_id: '',
@@ -35,7 +36,9 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       retirement_variables: {},
       retirement_editMode: false,
       retirement_become_enabled: false,
+      retirement_verbosity: '0',
     };
+    getVerbosityTypes();
     getRemoveResourcesTypes();
     vm.provisioning_cloud_type = '';
     vm.retirement_cloud_type = '';
@@ -69,6 +72,17 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       });
     }
   };
+
+  var getVerbosityTypes = function() {
+    vm['verbosity_types'] = {
+      "0": "0 (Normal)",
+      "1": "1 (Verbose)",
+      "2": "2 (More Verbose)",
+      "3": "3 (Debug)",
+      "4": "4 (Connection Debug)",
+      "5": "5 (WinRM Debug)"
+    };
+  }
 
   var getRemoveResourcesTypes = function () {
     if (vm.catalogItemModel.retirement_repository_id === undefined || vm.catalogItemModel.retirement_repository_id === '') {
@@ -120,6 +134,13 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     } else {
       vm.catalogItemModel.provisioning_become_enabled = configData.provision.become_enabled;
     }
+
+    if (configData.provision.verbosity === undefined) {
+      vm.catalogItemModel.provisioning_verbosity = '0';
+    } else {
+      vm.catalogItemModel.provisioning_verbosity = configData.provision.verbosity;
+    }
+
     setExtraVars('provisioning_variables', configData.provision.extra_vars);
 
     if (typeof configData.retirement.repository_id !== 'undefined') {
@@ -134,6 +155,13 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     } else {
       vm.catalogItemModel.retirement_become_enabled = configData.retirement.become_enabled;
     }
+
+    if (configData.retirement.verbosity === undefined) {
+      vm.catalogItemModel.retirement_verbosity = '0';
+    } else {
+      vm.catalogItemModel.retirement_verbosity = configData.retirement.verbosity;
+    }
+
     vm.catalogItemModel.retirement_network_credential_id = configData.retirement.network_credential_id;
     vm.catalogItemModel.retirement_cloud_credential_id = setIfDefined(configData.retirement.cloud_credential_id);
     vm.catalogItemModel.retirement_inventory = configData.retirement.hosts;
@@ -214,6 +242,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
           playbook_id: configData.provisioning_playbook_id,
           credential_id: configData.provisioning_machine_credential_id,
           hosts: configData.provisioning_inventory,
+          verbosity: configData.provisioning_verbosity,
           extra_vars: formatExtraVars(configData.provisioning_variables)
         }
       }
@@ -231,7 +260,8 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       catalog_item['config_info']['provision']['new_dialog_name'] = configData.provisioning_dialog_name;
 
     catalog_item['config_info']['retirement'] = {
-      remove_resources: configData.retirement_remove_resources
+      remove_resources: configData.retirement_remove_resources,
+      verbosity: configData.retirement_verbosity
     }
 
     var retirement = catalog_item['config_info']['retirement'];
@@ -541,6 +571,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     vm.catalogItemModel.retirement_cloud_credential_id = vm.catalogItemModel.provisioning_cloud_credential_id;
     vm.catalogItemModel.retirement_inventory = vm.catalogItemModel.provisioning_inventory;
     vm.catalogItemModel.retirement_become_enabled = vm.catalogItemModel.provisioning_become_enabled;
+    vm.catalogItemModel.retirement_verbosity = vm.catalogItemModel.provisioning_verbosity;
     vm.catalogItemModel.retirement_key = '';
     vm.catalogItemModel.retirement_value = '';
     vm.catalogItemModel.retirement_variables = angular.copy(vm.catalogItemModel.provisioning_variables);

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -845,6 +845,20 @@ class CatalogController < ApplicationController
   end
   helper_method :remove_resources_display
 
+  def verbosity_display(verbosity)
+    verbosity ||= "0"
+    verbosity_hsh = {
+      "0" => "0 (Normal)",
+      "1" => "1 (Verbose)",
+      "2" => "2 (More Verbose)",
+      "3" => "3 (Debug)",
+      "4" => "4 (Connection Debug)",
+      "5" => "5 (WinRM Debug)"
+    }
+    verbosity_hsh[verbosity.to_s]
+  end
+  helper_method :verbosity_display
+
   def features
     [{:role     => "svc_catalog_accord",
       :role_any => true,
@@ -1803,6 +1817,7 @@ class CatalogController < ApplicationController
     playbook_details[:provisioning][:network_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential, provision[:network_credential_id]) if provision[:network_credential_id]
     playbook_details[:provisioning][:cloud_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential, provision[:cloud_credential_id]) if provision[:cloud_credential_id]
     fetch_dialog(playbook_details, provision[:dialog_id], :provisioning)
+    playbook_details[:provisioning][:verbosity] = provision[:verbosity]
     playbook_details[:provisioning][:become_enabled] = provision[:become_enabled] == true ? _('Yes') : _('No')
 
     if @record.config_info[:retirement]
@@ -1816,6 +1831,7 @@ class CatalogController < ApplicationController
         playbook_details[:retirement][:network_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential, retirement[:network_credential_id]) if retirement[:network_credential_id]
         playbook_details[:retirement][:cloud_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential, retirement[:cloud_credential_id]) if retirement[:cloud_credential_id]
       end
+      playbook_details[:retirement][:verbosity] = retirement[:verbosity]
       playbook_details[:retirement][:become_enabled] = retirement[:become_enabled] == true ? _('Yes') : _('No')
     end
     playbook_details

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -236,6 +236,11 @@
                 = _('Escalate Privilege')
               .col-md-9
                 = h(provisioning[:become_enabled])
+            .form-group
+              %label.col-md-3.control-label
+                = _('Verbosity')
+              .col-md-9
+                = h(verbosity_display(provisioning[:verbosity]))
         .col-md-12.col-lg-6
           .form-horizontal.static
             .form-group
@@ -315,6 +320,11 @@
                   = _('Remove Resources')
                 .col-md-9
                   = h(remove_resources_display(retirement[:remove_resources]))
+              .form-group
+                %label.col-md-3.control-label
+                  = _('Verbosity')
+                .col-md-9
+                  = h(verbosity_display(retirement[:verbosity]))
           .col-md-12.col-lg-6
             .form-horizontal.static
               .form-group

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -119,6 +119,16 @@
                                 "switch-on-text"  => _("Yes"),
                                 "switch-off-text" => _("No"),
                                 "checkchange"     => ""}
+
+    .form-group
+      %label.col-md-3.control-label
+        = _('Verbosity')
+      .col-md-9
+        %select{"ng-model"    => "vm.catalogItemModel.#{prefix}_verbosity",
+                "name"        => "#{prefix}_verbosity",
+                'ng-options'  => 'v as k for (v, k) in vm.verbosity_types',
+                'pf-select'   => true}
+
     - if prefix == "retirement"
       .form-group
         %label.col-md-3.control-label{"for" => "catalog_id"}

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -767,14 +767,16 @@ describe CatalogController do
             :credential_id   => auth.id,
             :repository_id   => repository.id,
             :playbook_id     => playbook.id,
-            :dialog_id       => dialog.id
+            :dialog_id       => dialog.id,
+            :verbosity       => 4
           },
           :retirement => {
             :new_dialog_name => 'test_dialog',
             :hosts           => 'many',
             :credential_id   => auth.id,
             :repository_id   => repository.id,
-            :playbook_id     => playbook.id
+            :playbook_id     => playbook.id,
+            :verbosity       => 0
           }
         }
       }
@@ -788,14 +790,16 @@ describe CatalogController do
           :machine_credential => auth.name,
           :dialog             => "Some Label",
           :dialog_id          => dialog.id,
-          :become_enabled     => "No"
+          :become_enabled     => "No",
+          :verbosity          => 4
         },
         :retirement   => {
           :remove_resources   => nil,
           :repository         => repository.name,
           :playbook           => playbook.name,
           :machine_credential => auth.name,
-          :become_enabled     => "No"
+          :become_enabled     => "No",
+          :verbosity          => 0
         }
       }
       expect(playbook_details).to eq(st_details)
@@ -813,14 +817,16 @@ describe CatalogController do
             :credential_id   => auth.id,
             :repository_id   => 1,
             :playbook_id     => playbook.id,
-            :dialog_id       => 2
+            :dialog_id       => 2,
+            :verbosity       => 4
           },
           :retirement => {
             :new_dialog_name => 'test_dialog',
             :hosts           => 'many',
             :credential_id   => auth.id,
             :repository_id   => repository.id,
-            :playbook_id     => 2
+            :playbook_id     => 2,
+            :verbosity       => 0
           }
         }
       }
@@ -832,17 +838,31 @@ describe CatalogController do
           :repository         => nil,
           :playbook           => playbook.name,
           :machine_credential => auth.name,
-          :become_enabled     => "No"
+          :become_enabled     => "No",
+          :verbosity          => 4
         },
         :retirement   => {
           :remove_resources   => nil,
           :repository         => repository.name,
           :playbook           => nil,
           :machine_credential => auth.name,
-          :become_enabled     => "No"
+          :become_enabled     => "No",
+          :verbosity          => 0
         }
       }
       expect(playbook_details).to eq(st_details)
+    end
+  end
+
+  context "#verbosity_display" do
+    it "returns readable display text for Verbosity field" do
+      verbosity = controller.send(:verbosity_display, '2')
+      expect(verbosity).to eq('2 (More Verbose)')
+    end
+
+    it "returns readable display text for Verbosity field" do
+      verbosity = controller.send(:verbosity_display, nil)
+      expect(verbosity).to eq('0 (Normal)')
     end
   end
 end

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -29,6 +29,7 @@ describe('catalogItemFormController', function() {
           playbook_id:          10000000000493,
           credential_id:        10000000000090,
           hosts:                'localhost',
+          verbosity:            '0',
           extra_vars:           {
             'var1': {'default': 'default_val1'},
             'var2': {'default': 'default_val2'}
@@ -38,6 +39,7 @@ describe('catalogItemFormController', function() {
         },
         retirement: {
           remove_resources: 'yes_without_playbook',
+          verbosity: '0',
         }
       }
     };


### PR DESCRIPTION
- Added new 'Verbosity' drop down on Playbook catalog item form and summary screen to display saved Verbosity field values.
- Added/Updated spec tests to verify changes

https://www.pivotaltracker.com/n/projects/1613907/stories/146545759
![verbosity_drop_down](https://user-images.githubusercontent.com/3450808/26943743-9c3d8954-4c54-11e7-8659-9b3728190833.png)

![catalog_item_form_verbosity](https://user-images.githubusercontent.com/3450808/26943747-9fbeb760-4c54-11e7-8b59-bbf5722f4937.png)

![catalog_item_summary_existing_item](https://cloud.githubusercontent.com/assets/3450808/26835641/be893364-4aa6-11e7-90f6-aac7ad284c93.png)

![verbosity_value_saved](https://cloud.githubusercontent.com/assets/3450808/26835652/c2c18d8c-4aa6-11e7-97c8-524f1c25ae89.png)

@gmcculloug @syncrou please review/test