### PR TITLE
Show hosts relationship in physical infra listnav

### DIFF
--- a/app/views/layouts/listnav/_ems_physical_infra.html.haml
+++ b/app/views/layouts/listnav/_ems_physical_infra.html.haml
@@ -14,7 +14,14 @@
             :title      => _("Show Timelines"))
     = miq_accordion_panel(_("Relationships"), false, "ems_rel") do
       %ul.nav.nav-pills.nav-stacked
-        = li_link(:count => @record.number_of(:physical_servers),
-          :tables        => 'physical_servers',
-          :record        => @record,
-          :display       => 'physical_servers')
+        %li
+          = li_link(:count => @record.number_of(:physical_servers),
+            :tables        => 'physical_servers',
+            :record        => @record,
+            :display       => 'physical_servers')
+
+          - hosts = (@record.physical_servers.select { |server| !server.host.nil? }).length
+          = li_link(:count => hosts,
+            :tables          => 'hosts',
+            :record          => @record,
+            :display         => 'hosts')


### PR DESCRIPTION
This Pull Request shows the Hosts related to a specific Ems Physical Infra.

Note that the relationship is indirect:

Physical Infra => Physical Servers => Hosts
![captura de tela de 2017-06-06 16-52-32](https://user-images.githubusercontent.com/17187082/26848724-d687bcac-4ad7-11e7-970b-00afabc89f9e.png)

