### PR TITLE
[WIP] Connect only non-archived through cloud tenants in the cloud topology

### DIFF
--- a/app/services/cloud_topology_service.rb
+++ b/app/services/cloud_topology_service.rb
@@ -4,7 +4,7 @@ class CloudTopologyService < TopologyService
   @included_relations = [
     :tags,
     :availability_zones => [:tags, :vms => :tags],
-    :cloud_tenants      => [:tags, :vms => :tags],
+    :cloud_tenants      => [:tags, :active_vms => :tags],
   ]
 
   @kinds = %i(CloudManager AvailabilityZone CloudTenant Vm Tag)


### PR DESCRIPTION
You need to have some archived VMs on a cloud provider to verify this issue. It also has a backend part: 
https://github.com/ManageIQ/manageiq/pull/15329

**Before:**
![screenshot from 2017-06-07 10-23-06](https://user-images.githubusercontent.com/649130/26869247-13c3a86c-4b6c-11e7-8009-54f3149a88ec.png)

**After:**
![screenshot from 2017-06-07 10-22-11](https://user-images.githubusercontent.com/649130/26869239-103179fe-4b6c-11e7-9790-8ab28a4ea95c.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1456031