### PR TITLE
Fix the placement of form buttons on the ops screens

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1531,9 +1531,12 @@ function miqInitAccordions() {
 function miqInitMainContent() {
   var toolbar = $('#toolbar');
   var footer = $('#paging_div');
+  var buttons = $('#form_buttons_div');
   var height = 0;
   if (footer.find('*:visible').length > 0) {
     height += footer.outerHeight();
+  } else if (buttons.find("*:visible").length > 0) {
+    height += buttons.outerHeight() + 5; // TODO: the styling of #form_buttons_div should be revisited
   }
   if (toolbar.find("*:visible").length > 0) {
     height += toolbar.outerHeight();


### PR DESCRIPTION
Before this got broken, the `#paging_div` contained the `#form_buttons_div` and the JS adjusted the parent's position only. As the `#form_buttons_div` is no longer the child of `#paging_div`, I had to adjust the JS with an extra test for the buttons' visibility.

This is a not very clean solution, but I will revisit it when refactoring the HTML layout + CSS styling of the right cell.

Fixes #1497 