### PR TITLE
Add support for monitoring selection in UI

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -10,13 +10,14 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       hostname: '',
       default_hostname: '',
       amqp_hostname: '',
-      hawkular_hostname: '',
       metrics_hostname: '',
+      metrics_selection: '',
+      metrics_api_port: '',
+      metrics_security_protocol: '',
+      metrics_tls_ca_certs: '',
       project: '',
       default_api_port: '',
       amqp_api_port: '',
-      hawkular_api_port: '',
-      metrics_api_port: '',
       api_version: '',
       default_security_protocol: '',
       default_tls_verify: true,
@@ -24,8 +25,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       realm: '',
       security_protocol: '',
       amqp_security_protocol: '',
-      hawkular_security_protocol: '',
-      hawkular_tls_ca_certs: '',
       provider_region: '',
       default_userid: '',
       default_password: '',
@@ -45,7 +44,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       host_default_vnc_port_start: '',
       host_default_vnc_port_end: '',
       event_stream_selection: '',
-      metrics_selection: '',
       bearer_token_exists: false,
       ems_controller: '',
       default_auth_status: '',
@@ -53,7 +51,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       service_account_auth_status: '',
       metrics_auth_status: '',
       ssh_keypair_auth_status: '',
-      hawkular_auth_status: '',
       vmware_cloud_api_version: ''
     };
     $scope.formId = emsCommonFormId;
@@ -96,7 +93,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.hostname                        = data.hostname;
       $scope.emsCommonModel.default_hostname                = data.default_hostname;
       $scope.emsCommonModel.amqp_hostname                   = data.amqp_hostname;
-      $scope.emsCommonModel.hawkular_hostname               = data.hawkular_hostname;
+      $scope.emsCommonModel.metrics_selection               = data.metrics_selection;
       $scope.emsCommonModel.metrics_hostname                = data.metrics_hostname;
       $scope.emsCommonModel.project                         = data.project;
 
@@ -105,9 +102,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.provider_id                     = data.provider_id !== undefined ? data.provider_id.toString() : "";
 
       $scope.emsCommonModel.default_api_port                = data.default_api_port !== undefined && data.default_api_port !== '' ? data.default_api_port.toString() : $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
+      $scope.emsCommonModel.metrics_port                    = data.metrics_port !== undefined && data.metrics_port !== '' ? data.metrics_port.toString() : '443';
       $scope.emsCommonModel.amqp_api_port                   = data.amqp_api_port !== undefined && data.amqp_api_port !== '' ? data.amqp_api_port.toString() : '5672';
-      $scope.emsCommonModel.hawkular_api_port               = data.hawkular_api_port !== undefined && data.hawkular_api_port !== '' ? data.hawkular_api_port.toString() : '443';
-      $scope.emsCommonModel.metrics_api_port                = data.metrics_api_port !== undefined && data.metrics_api_port !== '' ? data.metrics_api_port.toString() : '';
       $scope.emsCommonModel.metrics_database_name           = data.metrics_database_name !== undefined && data.metrics_database_name !== '' ? data.metrics_database_name : data.metrics_default_database_name;
       $scope.emsCommonModel.api_version                     = data.api_version;
       $scope.emsCommonModel.default_security_protocol       = data.default_security_protocol;
@@ -116,8 +112,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.default_tls_verify              = data.default_tls_verify;
       $scope.emsCommonModel.default_tls_ca_certs            = data.default_tls_ca_certs;
       $scope.emsCommonModel.amqp_security_protocol          = data.amqp_security_protocol !== '' ? data.amqp_security_protocol : 'non-ssl';
-      $scope.emsCommonModel.hawkular_security_protocol      = data.hawkular_security_protocol;
-      $scope.emsCommonModel.hawkular_tls_ca_certs           = data.hawkular_tls_ca_certs;
+      $scope.emsCommonModel.metrics_security_protocol       = data.metrics_security_protocol;
+      $scope.emsCommonModel.metrics_tls_ca_certs            = data.metrics_tls_ca_certs;
       $scope.emsCommonModel.provider_region                 = data.provider_region;
       $scope.emsCommonModel.default_userid                  = data.default_userid;
       $scope.emsCommonModel.amqp_userid                     = data.amqp_userid;
@@ -135,8 +131,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.host_default_vnc_port_end       = data.host_default_vnc_port_end;
 
       $scope.emsCommonModel.event_stream_selection          = data.event_stream_selection;
-      $scope.emsCommonModel.metrics_selection               = data.metrics_selection;
-      $scope.emsCommonModel.metrics_selection_default       = data.metrics_selection_default;
 
       $scope.emsCommonModel.bearer_token_exists             = data.bearer_token_exists;
 
@@ -146,7 +140,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.service_account_auth_status     = data.service_account_auth_status;
       $scope.emsCommonModel.metrics_auth_status             = data.metrics_auth_status;
       $scope.emsCommonModel.ssh_keypair_auth_status         = data.ssh_keypair_auth_status;
-      $scope.emsCommonModel.hawkular_auth_status            = data.hawkular_auth_status;
+      $scope.emsCommonModel.metrics_api_port                = data.metrics_api_port !== undefined && data.metrics_api_port !== '' ? data.metrics_api_port.toString() : ''
 
       if ($scope.emsCommonModel.default_userid !== '') {
         $scope.emsCommonModel.default_password = miqService.storedPasswordPlaceholder;
@@ -183,22 +177,22 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.openstack_infra_providers_exist = data.openstack_infra_providers_exist;
       $scope.emsCommonModel.default_api_port                = '';
       $scope.emsCommonModel.amqp_api_port                   = '5672';
-      $scope.emsCommonModel.metrics_selection               = data.metrics_selection;
-      $scope.emsCommonModel.hawkular_api_port               = '443';
       $scope.emsCommonModel.api_version                     = 'v2';
       $scope.emsCommonModel.ems_controller                  = data.ems_controller;
       $scope.emsCommonModel.ems_controller === 'ems_container' ? $scope.emsCommonModel.default_api_port = '8443' : $scope.emsCommonModel.default_api_port = '';
+      $scope.emsCommonModel.metrics_api_port                = '443';
+      $scope.emsCommonModel.metrics_selection               = data.metrics_selection;
       $scope.emsCommonModel.default_security_protocol       = data.default_security_protocol;
-      $scope.emsCommonModel.hawkular_security_protocol      = data.hawkular_security_protocol;
+      $scope.emsCommonModel.metrics_security_protocol       = data.metrics_security_protocol;
       $scope.emsCommonModel.default_tls_ca_certs            = data.default_tls_ca_certs;
-      $scope.emsCommonModel.hawkular_tls_ca_certs           = data.hawkular_tls_ca_certs;
+      $scope.emsCommonModel.metrics_tls_ca_certs            = data.metrics_tls_ca_certs;
       $scope.emsCommonModel.default_auth_status             = data.default_auth_status;
       $scope.emsCommonModel.amqp_auth_status                = data.amqp_auth_status;
       $scope.emsCommonModel.service_account_auth_status     = data.service_account_auth_status;
-      $scope.emsCommonModel.metrics_auth_status             = true;
       $scope.emsCommonModel.ssh_keypair_auth_status         = true;
-      $scope.emsCommonModel.hawkular_auth_status            = data.hawkular_auth_status;
+      $scope.emsCommonModel.metrics_auth_status             = data.metrics_auth_status;
       $scope.emsCommonModel.vmware_cloud_api_version        = '9.0';
+
       miqService.sparkleOff();
 
       $scope.afterGet  = true;
@@ -253,9 +247,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       ($scope.emsCommonModel.default_hostname != '' && $scope.emsCommonModel.default_api_port) &&
       ($scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid)) {
       return true;
-    } else if(($scope.currentTab == "hawkular" && $scope.emsCommonModel.ems_controller == "ems_container") &&
+    } else if(($scope.emsCommonModel.metrics_selection != "disabled" && $scope.emsCommonModel.ems_controller == "ems_container") &&
       ($scope.emsCommonModel.emstype) &&
-      ($scope.emsCommonModel.hawkular_hostname != '' && $scope.emsCommonModel.hawkular_api_port) &&
+      ($scope.emsCommonModel.metrics_hostname != '' && $scope.emsCommonModel.metrics_api_port) &&
       ($scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid)) {
       return true;
     } else if($scope.emsCommonModel.emstype == "gce" && $scope.emsCommonModel.project != '' &&
@@ -268,7 +262,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.isDetectionEnabled = function() {
-    return ($scope.currentTab == "hawkular" && $scope.emsCommonModel.ems_controller == "ems_container") &&
+    return ($scope.emsCommonModel.metrics_selection == "hawkular" && $scope.emsCommonModel.ems_controller == "ems_container") &&
       ($scope.emsCommonModel.emstype == "openshift") &&
       ($scope.emsCommonModel.default_hostname && $scope.emsCommonModel.default_api_port) &&
       ($scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid);
@@ -304,10 +298,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
     if ($scope.emsCommonModel.event_stream_selection === "ceilometer") {
       $scope.$broadcast('clearErrorOnTab', {tab: "amqp"});
-    }
-
-    if ($scope.emsCommonModel.metrics_selection === "hawkular_disabled") {
-      $scope.$broadcast('clearErrorOnTab', {tab: "hawkular"});
     }
 
     var authStatus = $scope.currentTab + "_auth_status";
@@ -346,11 +336,19 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     }
   };
 
+  $scope.metricSelectionChanged = function() {
+    if ($scope.emsCommonModel.metrics_selection == "disabled") {
+      $scope.changeAuthTab('default');
+      angular.element('.nav-tabs a[href="#default"]').tab('show');
+      angular.element("#metrics_tab").hide();
+    } else {
+      angular.element("#metrics_tab").show();
+    }
+  };
+
   $scope.providerTypeChanged = function() {
     if ($scope.emsCommonModel.ems_controller === 'ems_container') {
       $scope.emsCommonModel.default_api_port = "8443"; // TODO: correct per-type port
-      $scope.emsCommonModel.metrics_selection = "hawkular_".concat($scope.emsCommonModel.metrics_selection_default);
-      // Container types are nearly identical, no point resetting most fields on type change.
       return;
     }
     $scope.emsCommonModel.default_api_port = "";
@@ -431,9 +429,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     if ($scope.emsCommonModel.ssh_keypair_auth_status === true) {
       $scope.postValidationModelRegistry("ssh_keypair");
     }
-    if ($scope.emsCommonModel.hawkular_auth_status === true) {
-      $scope.postValidationModelRegistry("hawkular");
-    }
   };
 
   $scope.postValidationModelRegistry = function(prefix) {
@@ -441,8 +436,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.postValidationModel = {default: {},
                                     amqp: {},
                                     metrics: {},
-                                    ssh_keypair: {},
-                                    hawkular: {}}
+                                    ssh_keypair: {}
+      }
     }
     if (prefix === "default") {
       if ($scope.newRecord) {
@@ -477,17 +472,22 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         amqp_password:             amqp_password,
       };
     } else if (prefix === "metrics") {
-      if ($scope.newRecord) {
-        var metrics_password = $scope.emsCommonModel.metrics_password;
-      } else {
-        var metrics_password = $scope.emsCommonModel.metrics_password === "" ? "" : miqService.storedPasswordPlaceholder;
-      }
       var metricsValidationModel = {
-        metrics_hostname:          $scope.emsCommonModel.metrics_hostname,
-        metrics_api_port:          $scope.emsCommonModel.metrics_api_port,
-        metrics_userid:            $scope.emsCommonModel.metrics_userid,
-        metrics_password:          metrics_password,
+        metrics_hostname: $scope.emsCommonModel.metrics_hostname,
+        metrics_api_port: $scope.emsCommonModel.metrics_api_port,
       };
+      if ($scope.emsCommonModel.metrics_selection == "hawkular" || $scope.emsCommonModel.metrics_selection == "prometheus") {
+        metricsValidationModel.metrics_security_protocol = $scope.emsCommonModel.metrics_security_protocol;
+        metricsValidationModel.metrics_tls_ca_certs = $scope.emsCommonModel.metrics_tls_ca_certs;
+      } else {
+        if ($scope.newRecord) {
+          var metrics_password = $scope.emsCommonModel.metrics_password;
+        } else {
+          var metrics_password = $scope.emsCommonModel.metrics_password === "" ? "" : miqService.storedPasswordPlaceholder;
+        }
+        metricsValidationModel.metrics_userid = $scope.emsCommonModel.metrics_userid;
+        metricsValidationModel.metrics_password = metrics_password;
+      }
       $scope.postValidationModel['metrics'] = metricsValidationModel;
     } else if (prefix === "ssh_keypair") {
       if ($scope.newRecord) {
@@ -502,13 +502,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     } else if (prefix === "service_account") {
       $scope.postValidationModel['service_account'] = {
         service_account:           $scope.emsCommonModel.service_account
-      }
-    } else if (prefix === "hawkular") {
-      $scope.postValidationModel['hawkular'] = {
-        hawkular_hostname:          $scope.emsCommonModel.hawkular_hostname,
-        hawkular_api_port:          $scope.emsCommonModel.hawkular_api_port,
-        hawkular_security_protocol: $scope.emsCommonModel.hawkular_security_protocol,
-        hawkular_tls_ca_certs:      $scope.emsCommonModel.hawkular_tls_ca_certs,
       }
     }
   };
@@ -534,7 +527,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.updateHawkularHostname = function(value) {
-    $scope.emsCommonModel.hawkular_hostname = value;
+    $scope.emsCommonModel.metrics_hostname = value;
   };
 
   $scope.radioSelectionChanged = function() {
@@ -548,12 +541,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         $scope.emsCommonModel.amqp_password = $scope.postValidationModel.amqp.amqp_password;
       }
       $scope.$broadcast('clearErrorOnTab', {tab: "amqp"});
-    }
-  };
-
-  $scope.containerMetricsChanged = function() {
-    if ($scope.emsCommonModel.metrics_selection === "hawkular_disabled") {
-      $scope.$broadcast('clearErrorOnTab', {tab: "hawkular"});
     }
   };
 

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -92,7 +92,13 @@ class EmsContainerController < ApplicationController
   end
 
   def retrieve_metrics_selection
-    @ems.endpoints.count == 1 ? 'hawkular_disabled' : 'hawkular_enabled'
+    if @ems.connection_configurations.try(:prometheus)
+      "prometheus"
+    elsif @ems.connection_configurations.try(:hawkular)
+      "hawkular"
+    else
+      "disabled"
+    end
   end
 
   private

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -174,22 +174,20 @@ module Mixins
         keystone_v3_domain_id = @ems.keystone_v3_domain_id
       end
 
-      if @ems.connection_configurations.hawkular.try(:endpoint)
-        metrics_hostname = @ems.connection_configurations.hawkular.endpoint.hostname
-        metrics_port = @ems.connection_configurations.hawkular.endpoint.port
-        metrics_auth_status = @ems.authentication_status_ok?(:hawkular)
-        metrics_security_protocol = @ems.connection_configurations.hawkular.endpoint.security_protocol
-        metrics_security_protocol ||= security_protocol_default
-        metrics_tls_ca_certs = @ems.connection_configurations.hawkular.endpoint.certificate_authority
+      if respond_to?(:retrieve_metrics_selection)
+        metrics_selection = retrieve_metrics_selection.to_sym
+        connection_configurations_metrics_endpoint = @ems.connection_configurations.try(metrics_selection).try(:endpoint)
+      else
+        connection_configurations_metrics_endpoint = nil
       end
 
-      if @ems.connection_configurations.prometheus.try(:endpoint)
-        metrics_hostname = @ems.connection_configurations.prometheus.endpoint.hostname
-        metrics_port = @ems.connection_configurations.prometheus.endpoint.port
-        metrics_auth_status = @ems.authentication_status_ok?(:prometheus)
-        metrics_security_protocol = @ems.connection_configurations.prometheus.endpoint.security_protocol
+      if connection_configurations_metrics_endpoint
+        metrics_hostname = connection_configurations_metrics_endpoint.hostname
+        metrics_port = connection_configurations_metrics_endpoint.port
+        metrics_auth_status = @ems.authentication_status_ok?(metrics_selection)
+        metrics_security_protocol = connection_configurations_metrics_endpoint.security_protocol
         metrics_security_protocol ||= security_protocol_default
-        metrics_tls_ca_certs = @ems.connection_configurations.prometheus.endpoint.certificate_authority
+        metrics_tls_ca_certs = connection_configurations_metrics_endpoint.certificate_authority
       end
 
       if @ems.connection_configurations.default.try(:endpoint)

--- a/app/views/ems_container/_form.html.haml
+++ b/app/views/ems_container/_form.html.haml
@@ -63,6 +63,19 @@
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
 
+    .form-group{"ng-class" => "{'has-error': angularForm.metrics.$invalid}"}
+      %label.col-md-2.control-label{"for" => "prov_metrics"}
+        = _("Metrics")
+      .col-md-8
+        = select_tag('metrics_selection', options_for_select([[_("Disabled"), "disabled"], [_("Hawkular"), "hawkular"],
+                     [_("Prometheus"), "prometheus"]]),
+                     "ng-model"                    => "emsCommonModel.metrics_selection",
+                     "ng-change"                   => "metricSelectionChanged()",
+                     "checkchange"                 => "",
+                     "required"                    => "",
+                     "selectpicker-for-select-tag" => "")
+
+
   %hr
   = render :partial => "layouts/angular/multi_auth_credentials", :locals => {:record => @ems, :ng_model => "emsCommonModel"}
 

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -1,11 +1,8 @@
 - validate_url ||= (record.id || @selected_hosts) ? "update" : "create"
-- legendtext ||= _("Endpoints")
 - vm_scope   ||= false
 - main_scope  = vm_scope ? "$parent.vm" : "$parent"
 
 #auth_tabs
-  %h3
-    = legendtext
   %ul.nav.nav-tabs
     = miq_tab_header('default', nil, {'ng-click' => "changeAuthTab('default')"}) do
       %i{"error-on-tab" => "default", :style => "color:#cc0000"}
@@ -21,9 +18,10 @@
         %i{"error-on-tab" => "ssh_keypair", :style => "color:#cc0000"}
         = _("RSA key pair")
     - elsif controller_name == "ems_container"
-      = miq_tab_header('hawkular', nil, {'ng-click' => "changeAuthTab('hawkular')"}) do
-        %i{"error-on-tab" => "hawkular", :style => "color:#cc0000"}
-        = _("Hawkular")
+      = miq_tab_header('metrics', nil, 'ng-click' => "changeAuthTab('metrics')") do
+        %div{"ng-if" => "emsCommonModel.metrics_selection == 'prometheus' || emsCommonModel.metrics_selection == 'hawkular'"}
+          %i{"error-on-tab" => "metrics", :style => "color:#cc0000"}
+          = _("Metrics")
     - elsif controller_name == "host"
       = miq_tab_header('remote', nil, {'ng-click' => "changeAuthTab('remote')"}) do
         = _("Remote Login")
@@ -252,38 +250,17 @@
             %span{:style => "color:black"}
               = _("Used for SSH connection to all %{hosts} in this provider.") % {:hosts => title_for_hosts}
     - elsif controller_name == "ems_container"
-      = miq_tab_content('hawkular', 'default') do
+      = miq_tab_content('metrics', 'default') do
         .form-group
           .col-md-12.col-md-12
-            %label.radio-inline.control-label{"for" => "container_hawkular_disabled"}
-              %input{:type         => "radio",
-                     :name         => "metrics_selection",
-                     :id           => "container_hawkular_disabled",
-                     :ng_checked   => "emsCommonModel.metrics_selection == hawkular_disabled",
-                     :value        => "hawkular_disabled",
-                     :ng_model     => "emsCommonModel.metrics_selection",
-                     :ng_change    => "containerMetricsChanged()",
-                     :checkchange  => ""}
-              = _("Disabled")
-            %label.radio-inline.control-label{"for" => "container_hawkular_enabled"}
-              %input{:type         => "radio",
-                     :name         => "metrics_selection",
-                     :id           => "container_hawkular_enabled",
-                     :ng_checked   => "emsCommonModel.metrics_selection == hawkular_enabled",
-                     :value        => "hawkular_enabled",
-                     :ng_model     => "emsCommonModel.metrics_selection",
-                     :checkchange  => ""}
-              = _("Enabled")
-            %hr
-            %div{"ng-if" => "emsCommonModel.metrics_selection == 'hawkular_enabled'"}
-
+            %div{"ng-if" => "emsCommonModel.metrics_selection == 'hawkular'"}
               = render :partial => "layouts/angular-bootstrap/endpoints_angular",
                                    :locals  => {:ng_show                => true,
                                                 :ng_model               => ng_model.to_s,
                                                 :id                     => record.id,
                                                 :ng_reqd_hostname       => "true",
                                                 :ng_reqd_api_port       => "true",
-                                                :prefix                 => "hawkular",
+                                                :prefix                 => "metrics",
                                                 :detection              => true}
               = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                          :locals  => {:ng_show           => true,
@@ -293,8 +270,29 @@
                                       :ng_show_password  => "false",
                                       :validate_url      => validate_url,
                                       :id                => record.id,
-                                      :prefix            => "hawkular",
+                                      :prefix            => "metrics",
                                       :verify_title_off  => _("hawkular URL and API port fields are needed to perform validation."),
+                                      :basic_info_needed => true}
+
+            %div{"ng-if" => "emsCommonModel.metrics_selection == 'prometheus'"}
+              = render :partial => "layouts/angular-bootstrap/endpoints_angular",
+                                   :locals  => {:ng_show                => true,
+                                                :ng_model               => ng_model.to_s,
+                                                :id                     => record.id,
+                                                :ng_reqd_hostname       => "true",
+                                                :ng_reqd_api_port       => "true",
+                                                :prefix                 => "metrics"}
+              = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                         :locals  => {:ng_show           => true,
+                                      :ng_model          => ng_model.to_s,
+                                      :main_scope        => main_scope,
+                                      :ng_show_userid    => "false",
+                                      :ng_show_password  => "false",
+                                      :ng_show_verify    => "false",
+                                      :validate_url      => validate_url,
+                                      :id                => record.id,
+                                      :prefix            => "metrics",
+                                      :verify_title_off  => _("prometheus URL and API port fields are needed to perform validation."),
                                       :basic_info_needed => true}
         .form-group
           .col-md-12
@@ -388,7 +386,7 @@
     $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.ems_controller == 'ems_container'"}
   :javascript
-    miq_tabs_show_hide("#hawkular_tab", true);
+    miq_tabs_show_hide("#metrics_tab", true);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -85,13 +85,11 @@ describe EmsContainerController do
     context "adding new provider without hawkular endpoint" do
       def test_creating(emstype)
         raise ArgumentError, "Unsupported type [#{emstype}]" unless %w(kubernetes openshift).include?(emstype)
-        metrics_selection = "hawkular_#{emstype == 'kubernetes' ? 'disabled' : 'enabled'}"
         @ems = ExtManagementSystem.model_from_emstype(emstype).new
         controller.instance_variable_set(:@_params,
                                          :name              => 'NimiCule',
                                          :default_userid    => '_',
                                          :default_hostname  => 'mytest.com',
-                                         :metrics_selection => metrics_selection,
                                          :default_api_port  => '8443',
                                          :default_password  => 'valid-token',
                                          :emstype           => emstype)
@@ -106,7 +104,7 @@ describe EmsContainerController do
 
       it "doesn't probe openshift for kubernetes" do
         test_creating('openshift')
-        expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq(nil)
+        expect(@ems.connection_configurations.hawkular).to eq(nil)
       end
     end
 
@@ -118,18 +116,18 @@ describe EmsContainerController do
         end
 
         def test_setting_many_fields
-          controller.instance_variable_set(:@_params, :name                       => 'EMS 2',
-                                                      :default_userid             => '_',
-                                                      :default_hostname           => '10.10.10.11',
-                                                      :default_api_port           => '5000',
-                                                      :default_security_protocol  => 'ssl-with-validation-custom-ca',
-                                                      :default_tls_ca_certs       => '-----BEGIN DUMMY...',
-                                                      :default_password           => 'valid-token',
-                                                      :metrics_selection          => 'hawkular_enabled',
-                                                      :hawkular_hostname          => '10.10.10.10',
-                                                      :hawkular_api_port          => '8443',
-                                                      :hawkular_security_protocol => 'ssl-with-validation',
-                                                      :emstype                    => @type)
+          controller.instance_variable_set(:@_params, :name                      => 'EMS 2',
+                                                      :default_userid            => '_',
+                                                      :default_hostname          => '10.10.10.11',
+                                                      :default_api_port          => '5000',
+                                                      :default_security_protocol => 'ssl-with-validation-custom-ca',
+                                                      :default_tls_ca_certs      => '-----BEGIN DUMMY...',
+                                                      :default_password          => 'valid-token',
+                                                      :metrics_selection         => 'hawkular',
+                                                      :metrics_hostname          => '10.10.10.10',
+                                                      :metrics_api_port          => '8443',
+                                                      :metrics_security_protocol => 'ssl-with-validation',
+                                                      :emstype                   => @type)
           controller.send(:set_ems_record_vars, @ems)
           expect(@flash_array).to be_nil
           cc = @ems.connection_configurations
@@ -150,7 +148,7 @@ describe EmsContainerController do
 
         def test_setting_few_fields
           controller.remove_instance_variable(:@_params)
-          controller.instance_variable_set(:@_params, :name => 'EMS 3', :default_userid => '_', :metrics_selection => 'hawkular_enabled')
+          controller.instance_variable_set(:@_params, :name => 'EMS 3', :default_userid => '_')
           controller.send(:set_ems_record_vars, @ems)
           expect(@flash_array).to be_nil
           expect(@ems.authentication_token("bearer")).to eq('valid-token')
@@ -163,7 +161,7 @@ describe EmsContainerController do
           test_setting_many_fields
 
           test_setting_few_fields
-          expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq(nil)
+          expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq('10.10.10.10')
         end
 
         it "when editing openshift EMS" do
@@ -172,7 +170,7 @@ describe EmsContainerController do
           test_setting_many_fields
 
           test_setting_few_fields
-          expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq(nil)
+          expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq('10.10.10.10')
         end
       end
     end

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -139,21 +139,21 @@ describe EmsContainerController do
 
     it "Creates a provider with two endpoints if hawkular is enabled" do
       post :create, :params => {
-        "button"                     => "add",
-        "cred_type"                  => "hawkular",
-        "name"                       => "openshift_no_hawkular",
-        "emstype"                    => "openshift",
-        "zone"                       => 'default',
-        "default_security_protocol"  => "ssl-without-validation",
-        "default_hostname"           => "default_hostname",
-        "default_api_port"           => "5000",
-        "default_userid"             => "",
-        "default_password"           => "",
-        "provider_region"            => "",
-        "metrics_selection"          => "hawkular_enabled",
-        "hawkular_security_protocol" => "ssl-without-validation",
-        "hawkular_hostname"          => "hawkular_hostname",
-        "hawkular_api_port"          => "443",
+        "button"                    => "add",
+        "cred_type"                 => "hawkular",
+        "name"                      => "openshift_no_hawkular",
+        "emstype"                   => "openshift",
+        "zone"                      => 'default',
+        "default_security_protocol" => "ssl-without-validation",
+        "default_hostname"          => "default_hostname",
+        "default_api_port"          => "5000",
+        "default_userid"            => "",
+        "default_password"          => "",
+        "provider_region"           => "",
+        "metrics_selection"         => "hawkular",
+        "metrics_security_protocol" => "ssl-without-validation",
+        "metrics_hostname"          => "hawkular_hostname",
+        "metrics_api_port"          => "443",
       }
       expect(response.status).to eq(200)
       ems_openshift = ManageIQ::Providers::ContainerManager.first


### PR DESCRIPTION
Add support for "monitoring selection" in the UI as well as "Prometheus" time series db when adding a new provider.
![screencast_06-07-2017_07-15-52 pm](https://user-images.githubusercontent.com/8366181/26889924-653b773c-4bb8-11e7-9729-44f3daba2d6e.gif)


cc: @simon3z @moolitayer @yaacov 