### PR TITLE
Alerts with resolved=nil should be visible

### DIFF
--- a/app/assets/javascripts/services/alerts_center_service.js
+++ b/app/assets/javascripts/services/alerts_center_service.js
@@ -409,7 +409,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
 
   _this.getAlertsData = function(limit, offset, filters, sortField, sortAscending) {
     var deferred = $q.defer();
-    var resourceOptions = '?expand=resources,alert_actions&attributes=assignee,resource&filter[]=resolved=false';
+    var resourceOptions = '?expand=resources,alert_actions&attributes=assignee,resource&filter[]=resolved=false&filter[]=or+resolved=nil';
     var limitOptions = '';
     var offsetOptions = '';
     var sortOptions = '';


### PR DESCRIPTION
```
> MiqAlertStatus.last.resolved
...
=> nil 
```

Before:
![before](https://user-images.githubusercontent.com/3010449/26917953-c66ac0a0-4c38-11e7-991f-1a1043fcfd7d.png)


After:
![after](https://user-images.githubusercontent.com/3010449/26917484-23d8bdf2-4c37-11e7-9ec0-841e72c7da91.png)
