### PR TITLE
Display Host relationship in the Physical Infra Topology

### DIFF
--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -3,10 +3,10 @@ class PhysicalInfraTopologyService < TopologyService
 
   @included_relations = [
     :tags,
-    :physical_servers => [:tags],
+    :physical_servers => [:tags, :host => :tags],
   ]
 
-  @kinds = %i(PhysicalInfraManager PhysicalServer Tag)
+  @kinds = %i(PhysicalInfraManager PhysicalServer Host Tag)
 
   def entity_display_type(entity)
     if entity.kind_of?(ManageIQ::Providers::PhysicalInfraManager)

--- a/app/views/physical_infra_topology/show.html.haml
+++ b/app/views/physical_infra_topology/show.html.haml
@@ -11,6 +11,14 @@
             %text{:y => "9"} &#xe91a;
         %label
           = _("Physical Servers")
+      %kubernetes-topology-icon{tooltipOptions, :kind => "Host"}
+        %svg.kube-topology
+          %g.EntityLegend.PhysicalInfra
+            %circle{:r => "17"}
+            -# pficon-screen
+            %text{:y => "9"} &#xE600;
+        %label
+          = _("Hosts")
 
   .alert.alert-info.alert-dismissable
     %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}


### PR DESCRIPTION
Physical Infra Topology graph was updated to display the `Host` Relationship with `Physical Servers`

Before (No Hosts displayed)
<img width="1421" alt="screen shot 2017-06-07 at 4 09 11 pm" src="https://user-images.githubusercontent.com/1538216/26905334-af693c6c-4b9b-11e7-89ed-d41f56d4e53b.png">


After (`Physical Server` <-> `Host` association displayed)
<img width="1418" alt="screen shot 2017-06-07 at 4 05 10 pm" src="https://user-images.githubusercontent.com/1538216/26905292-6ba8d4ec-4b9b-11e7-91bd-77f80456cbbb.png">
