### PR TITLE
Fix empty settings error in containers topology

### DIFF
--- a/app/assets/javascripts/controllers/topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/container_topology_controller.js
@@ -218,20 +218,20 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
     $scope.relations = data.data.relations;
     $scope.kinds = data.data.kinds;
     icons = data.data.icons;
-    var size_limit = data.data.settings.containers_max_items;
 
     if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys($scope.kinds).length)) {
       $scope.kinds = currentSelectedKinds;
-    } else if (size_limit > 0) {
+    } else if (data.data.settings && data.data.settings.containers_max_items) {
+      var size_limit = data.data.settings.containers_max_items;
       var remove_hierarchy = ['Container',
-        'ContainerGroup',
-        'ContainerReplicator',
-        'ContainerService',
-        'ContainerRoute',
-        'Host',
-        'Vm',
-        'ContainerNode',
-        'ContainerManager'];
+                              'ContainerGroup',
+                              'ContainerReplicator',
+                              'ContainerService',
+                              'ContainerRoute',
+                              'Host',
+                              'Vm',
+                              'ContainerNode',
+                              'ContainerManager'];
       $scope.kinds = topologyService.reduce_kinds($scope.items, $scope.kinds, size_limit, remove_hierarchy);
     }
   }


### PR DESCRIPTION
Fix empty settings error in containers topology (https://github.com/ManageIQ/manageiq-ui-classic/pull/1453#issuecomment-304658335)

The error was:
![adc95f80-4480-11e7-86c8-c17a1bb2d003](https://user-images.githubusercontent.com/11256940/26923216-1ef99c3a-4c4a-11e7-99c6-f794c4e78427.png)

@himdel Please review
cc @simon3z 