### PR TITLE
Page layout methods refactoring

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -921,12 +921,6 @@ module ApplicationHelper
     @edit[:adv_search_open]  # Only allow field aliases for advanced searches
   end
 
-  def saved_report_paging?
-    # saved report doesn't use miq_report object,
-    # need to use a different paging view to page thru a saved report
-    @sb[:pages] && @html && [:reports_tree, :savedreports_tree, :cb_reports_tree].include?(x_active_tree)
-  end
-
   def pressed2model_action(pressed)
     pressed =~ /^(ems_cluster|miq_template|infra_networking)_(.*)$/ ? [$1, $2] : pressed.split('_', 2)
   end
@@ -1621,10 +1615,6 @@ module ApplicationHelper
        vms_filter
        vms_instances_filter
       ).include?(x_tree[:type])
-  end
-
-  def show_advanced_search?
-    x_tree && ((tree_with_advanced_search? && !@record) || @show_adv_search)
   end
 
   def listicon_glyphicon(item)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1488,69 +1488,6 @@ module ApplicationHelper
     end
   end
 
-  def show_adv_search?
-    show_search = %w(
-      auth_key_pair_cloud
-      availability_zone
-      automation_manager
-      cloud_network
-      cloud_object_store_container
-      cloud_object_store_object
-      cloud_subnet
-      cloud_tenant
-      cloud_volume
-      cloud_volume_backup
-      cloud_volume_snapshot
-      configuration_job
-      container
-      container_build
-      container_group
-      container_image
-      container_image_registry
-      container_node
-      container_project
-      container_replicator
-      container_route
-      container_service
-      container_template
-      ems_cloud
-      ems_cluster
-      ems_container
-      ems_infra
-      ems_middleware
-      ems_network
-      ems_physical_infra
-      ems_storage
-      flavor
-      floating_ip
-      host
-      host_aggregate
-      load_balancer
-      middleware_datasource
-      middleware_deployment
-      middleware_domain
-      middleware_messaging
-      middleware_server
-      miq_template
-      network_port
-      network_router
-      offline
-      orchestration_stack
-      persistent_volume
-      physical_server
-      provider_foreman
-      resource_pool
-      retired
-      security_group
-      service
-      templates
-      vm
-    )
-
-    (@lastaction == "show_list" && !session[:menu_click] && show_search.include?(@layout) && !@in_a_form) ||
-      (@explorer && x_tree && tree_with_advanced_search? && !@record)
-  end
-
   def db_for_quadicon
     case @layout
     when "ems_infra"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -733,20 +733,6 @@ module ApplicationHelper
     (@toolbars['history_tb'] != 'blank_view_tb' && @toolbars['history_tb'] != 'blank_view_tb' && @toolbars['view_tb'] != 'blank_view_tb')
   end
 
-  def inner_layout_present?
-    if @inner_layout_present.nil?
-      @inner_layout_present = false
-      if @explorer || params[:action] == "explorer" ||
-         (params[:controller] == "chargeback" && params[:action] == "chargeback") ||
-         (params[:controller] == "miq_ae_tools" && (params[:action] == "resolve" || params[:action] == "show")) ||
-         (params[:controller] == "miq_policy" && params[:action] == "rsop") ||
-         (params[:controller] == "miq_capacity")
-        @inner_layout_present = true
-      end
-    end
-    @inner_layout_present
-  end
-
   # Format a column in a report view for display on the screen
   def format_col_for_display(view, row, col, tz = nil)
     tz ||= ["miqschedule"].include?(view.db.downcase) ? MiqServer.my_server.server_timezone : Time.zone

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -126,4 +126,12 @@ module ApplicationHelper::PageLayouts
     @inner_layout_present
   end
 
+  def simulate?
+    @simulate ||= (
+      rsop = controller.controller_name == 'miq_policy' && controller.action_name == 'rsop'
+      resolve = controller.controller_name == 'miq_ae_tools' && controller.action_name == 'resolve'
+      planning = controller.controller_name == 'miq_capacity' && controller.action_name == 'planning'
+      rsop || resolve || planning
+    )
+  end
 end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -113,17 +113,13 @@ module ApplicationHelper::PageLayouts
   end
 
   def inner_layout_present?
-    if @inner_layout_present.nil?
-      @inner_layout_present = false
-      if @explorer || params[:action] == "explorer" ||
-         (params[:controller] == "chargeback" && params[:action] == "chargeback") ||
-         (params[:controller] == "miq_ae_tools" && (params[:action] == "resolve" || params[:action] == "show")) ||
-         (params[:controller] == "miq_policy" && params[:action] == "rsop") ||
-         (params[:controller] == "miq_capacity")
-        @inner_layout_present = true
-      end
-    end
-    @inner_layout_present
+    @inner_layout_present ||= (
+      @explorer || params[:action] == "explorer" ||
+      (params[:controller] == "chargeback" && params[:action] == "chargeback") ||
+      (params[:controller] == "miq_ae_tools" && (params[:action] == "resolve" || params[:action] == "show")) ||
+      (params[:controller] == "miq_policy" && params[:action] == "rsop") ||
+      (params[:controller] == "miq_capacity")
+    )
   end
 
   def simulate?

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -113,22 +113,24 @@ module ApplicationHelper::PageLayouts
   end
 
   def inner_layout_present?
-    @inner_layout_present ||= (
-      @explorer || params[:action] == "explorer" ||
-      (params[:controller] == "chargeback" && params[:action] == "chargeback") ||
-      (params[:controller] == "miq_ae_tools" && (params[:action] == "resolve" || params[:action] == "show")) ||
-      (params[:controller] == "miq_policy" && params[:action] == "rsop") ||
-      (params[:controller] == "miq_capacity")
-    )
+    @inner_layout_present ||=
+      begin
+        @explorer || params[:action] == "explorer" ||
+          (params[:controller] == "chargeback" && params[:action] == "chargeback") ||
+          (params[:controller] == "miq_ae_tools" && (params[:action] == "resolve" || params[:action] == "show")) ||
+          (params[:controller] == "miq_policy" && params[:action] == "rsop") ||
+          (params[:controller] == "miq_capacity")
+      end
   end
 
   def simulate?
-    @simulate ||= (
-      rsop = controller.controller_name == 'miq_policy' && controller.action_name == 'rsop'
-      resolve = controller.controller_name == 'miq_ae_tools' && controller.action_name == 'resolve'
-      planning = controller.controller_name == 'miq_capacity' && controller.action_name == 'planning'
-      rsop || resolve || planning
-    )
+    @simulate ||=
+      begin
+        rsop = controller.controller_name == 'miq_policy' && controller.action_name == 'rsop'
+        resolve = controller.controller_name == 'miq_ae_tools' && controller.action_name == 'resolve'
+        planning = controller.controller_name == 'miq_capacity' && controller.action_name == 'planning'
+        rsop || resolve || planning
+      end
   end
 
   def saved_report_paging?

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -140,4 +140,67 @@ module ApplicationHelper::PageLayouts
   def show_advanced_search?
     x_tree && ((tree_with_advanced_search? && !@record) || @show_adv_search)
   end
+
+  def show_adv_search?
+    show_search = %w(
+      auth_key_pair_cloud
+      availability_zone
+      automation_manager
+      cloud_network
+      cloud_object_store_container
+      cloud_object_store_object
+      cloud_subnet
+      cloud_tenant
+      cloud_volume
+      cloud_volume_backup
+      cloud_volume_snapshot
+      configuration_job
+      container
+      container_build
+      container_group
+      container_image
+      container_image_registry
+      container_node
+      container_project
+      container_replicator
+      container_route
+      container_service
+      container_template
+      ems_cloud
+      ems_cluster
+      ems_container
+      ems_infra
+      ems_middleware
+      ems_network
+      ems_physical_infra
+      ems_storage
+      flavor
+      floating_ip
+      host
+      host_aggregate
+      load_balancer
+      middleware_datasource
+      middleware_deployment
+      middleware_domain
+      middleware_messaging
+      middleware_server
+      miq_template
+      network_port
+      network_router
+      offline
+      orchestration_stack
+      persistent_volume
+      physical_server
+      provider_foreman
+      resource_pool
+      retired
+      security_group
+      service
+      templates
+      vm
+    )
+
+    (@lastaction == "show_list" && !session[:menu_click] && show_search.include?(@layout) && !@in_a_form) ||
+      (@explorer && x_tree && tree_with_advanced_search? && !@record)
+  end
 end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -111,4 +111,19 @@ module ApplicationHelper::PageLayouts
       "layouts/center_div_no_listnav"
     end
   end
+
+  def inner_layout_present?
+    if @inner_layout_present.nil?
+      @inner_layout_present = false
+      if @explorer || params[:action] == "explorer" ||
+         (params[:controller] == "chargeback" && params[:action] == "chargeback") ||
+         (params[:controller] == "miq_ae_tools" && (params[:action] == "resolve" || params[:action] == "show")) ||
+         (params[:controller] == "miq_policy" && params[:action] == "rsop") ||
+         (params[:controller] == "miq_capacity")
+        @inner_layout_present = true
+      end
+    end
+    @inner_layout_present
+  end
+
 end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -101,4 +101,14 @@ module ApplicationHelper::PageLayouts
       show
     ).include?(controller.action_name)
   end
+
+  def center_div_partial
+    if layout_uses_listnav?
+      "layouts/center_div_with_listnav"
+    elsif dashboard_no_listnav?
+      "layouts/center_div_dashboard_no_listnav"
+    else
+      "layouts/center_div_no_listnav"
+    end
+  end
 end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -134,4 +134,14 @@ module ApplicationHelper::PageLayouts
       rsop || resolve || planning
     )
   end
+
+  def saved_report_paging?
+    # saved report doesn't use miq_report object,
+    # need to use a different paging view to page thru a saved report
+    @sb[:pages] && @html && [:reports_tree, :savedreports_tree, :cb_reports_tree].include?(x_active_tree)
+  end
+
+  def show_advanced_search?
+    x_tree && ((tree_with_advanced_search? && !@record) || @show_adv_search)
+  end
 end

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -70,12 +70,7 @@
         #custom_left_cell
 - else
   #center_div{:style => "height: 100%;"}
-    - if layout_uses_listnav?
-      = render :partial => "layouts/center_div_with_listnav"
-    - elsif dashboard_no_listnav?
-      = render :partial => "layouts/center_div_dashboard_no_listnav"
-    - else
-      = render :partial => "layouts/center_div_no_listnav"
+    = render :partial => center_div_partial
 
 - if show_advanced_search?
   :javascript

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -4,12 +4,8 @@
     .row.max-height
       = yield
 - elsif inner_layout_present?
-  - rsop = controller.controller_name == 'miq_policy' && controller.action_name == 'rsop'
-  - resolve = controller.controller_name == 'miq_ae_tools' && controller.action_name == 'resolve'
-  - planning = controller.controller_name == 'miq_capacity' && controller.action_name == 'planning'
-  - simulate =  rsop || resolve || planning
   - session[:sidebar] ||= {}
-  - sidewidth = simulate ? 5 : session[:sidebar][params[:controller]] ||= 3
+  - sidewidth = simulate? ? 5 : session[:sidebar][params[:controller]] ||= 3
   - maindiv = 12 - sidewidth
   - sidebar = sidewidth == 0 ? 'hidden-md hidden-lg col-md-0' : "col-md-#{sidewidth} col-md-pull-#{maindiv}"
 
@@ -53,7 +49,7 @@
               = render(:partial => 'layouts/saved_report_paging_bar',
                        :locals  => {:pages => @sb[:pages]})
 
-        - unless simulate
+        - unless simulate?
           .resizer.hidden-xs
             .resizer-box
               .btn-group


### PR DESCRIPTION
Page layout is decided based on a number of criteria. Previously we extracted some of the test to a methods and put those in helpers.

But these methods are a bunch of lists and case statements that need to be updated with each new controller or complex view.

One of the ways to fix the problem is establisting some `layout` object that would hold all the information about a page's layout. For some controllers there might be just one static `layout` object for the whole controller, in some other cases there might be multiple such objects or the object may contain complex logic.

Anyway with introduction of the `layout` object the information about the layout of the page would not be hidden in the generic code but would live close to the controller or view. In case of plugins the `layout` object(s) for the controllers or views in the plugin will live in the plugin repository and not in the base repository.

Steps:
 * make sure that layout-related logic is extracted to helper methods and places in a single place
 * (next PR) introduce a `layout` object class
 * (next PR) make all the layout related helper methods consult `layout` object instance relevant in the given context and only if it's not available call the legacy logic.
