### PR TITLE
Clickable labels in policy's event assignment screen

### DIFF
--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -161,9 +161,10 @@
               %h3= h(k)
               - @edit[:allevents][k].sort_by(&:first).each do |e|
                 %div{:style => "width: 300px; height: 18px; float:left; padding: 0px 5px 0px 0px;"}
-                  = check_box_tag("event_#{e.last}", "1", @edit[:new][:events].include?(e.last) ? true : false,
-                    "data-miq_observe_checkbox" => {:url => url}.to_json)
-                  = h(e.first)
+                  %label
+                    = check_box_tag("event_#{e.last}", "1", @edit[:new][:events].include?(e.last) ? true : false,
+                      "data-miq_observe_checkbox" => {:url => url}.to_json)
+                    = h(e.first)
       - else
         %h3= _("Events")
         - if @policy_events.empty?


### PR DESCRIPTION
Control -> Explorer -> Policies -> [policy] -> Edit policy's event assignment: clicking on event label
would check / uncheck the checkbox as well.

Before, the checkbox labels weren't clickable:
![checkboxes-before](https://user-images.githubusercontent.com/6648365/26971154-665c4254-4d0c-11e7-9584-997912450166.jpg)

After, the checkbox labels are clickable (not really visible from the screenshot):
![checkboxes-after](https://user-images.githubusercontent.com/6648365/26971178-80a33eec-4d0c-11e7-99c2-6921da107b9c.jpg)

https://bugzilla.redhat.com/show_bug.cgi?id=1459496