### PR TITLE
Fix flash messages on the Instance attach/detach cloud volume form

### DIFF
--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -90,28 +90,28 @@ class VmCloudController < ApplicationController
   def attach_finished
     task_id = session[:async][:params][:task_id]
     vm_id = session[:async][:params][:id]
-    vm_name = session[:async][:params][:name]
+    vm = find_record_with_rbac(VmCloud, vm_id)
     volume_id = session[:async][:params][:volume_id]
     volume = find_record_with_rbac(CloudVolume, volume_id)
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
       add_flash(_("Attaching Cloud Volume \"%{volume_name}\" to %{vm_name} finished") % {
         :name    => volume.name,
-        :vm_name => vm_name
+        :vm_name => vm.name
       })
     else
       add_flash(_("Unable to attach Cloud Volume \"%{volume_name}\" to %{vm_name}: %{details}") % {
         :volume_name => volume.name,
-        :vm_name     => vm_name,
-        :details     => task.message
+        :vm_name     => vm.name,
+        :details     => get_error_message_from_fog(task.message)
       }, :error)
     end
 
     @breadcrumbs.pop if @breadcrumbs
     session[:edit] = nil
     session[:flash_msgs] = @flash_array.dup if @flash_array
-
-    javascript_redirect :action => "show", :id => vm_id
+    @record = @sb[:action] = nil
+    replace_right_cell
   end
 
   def detach_volume
@@ -147,28 +147,28 @@ class VmCloudController < ApplicationController
   def detach_finished
     task_id = session[:async][:params][:task_id]
     vm_id = session[:async][:params][:id]
-    vm_name = session[:async][:params][:name]
+    vm = find_record_with_rbac(VmCloud, vm_id)
     volume_id = session[:async][:params][:volume_id]
     volume = find_record_with_rbac(CloudVolume, volume_id)
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
       add_flash(_("Detaching Cloud Volume \"%{volume_name}\" from %{vm_name} finished") % {
         :name    => volume.name,
-        :vm_name => vm_name
+        :vm_name => vm.name
       })
     else
       add_flash(_("Unable to detach Cloud Volume \"%{volume_name}\" from %{vm_name}: %{details}") % {
         :volume_name => volume.name,
-        :vm_name     => vm_name,
-        :details     => task.message
+        :vm_name     => vm.name,
+        :details     => get_error_message_from_fog(task.message)
       }, :error)
     end
 
     @breadcrumbs.pop if @breadcrumbs
     session[:edit] = nil
     session[:flash_msgs] = @flash_array.dup if @flash_array
-
-    javascript_redirect :action => "show", :id => vm_id
+    @record = @sb[:action] = nil
+    replace_right_cell
   end
 
   def cancel_action(message)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1455100
* Fix missing instance name in flash messages
* Fix incorrect redirect behavior resulting in missing flash messages
* Parse out actual error message from the full fog error response
