### PR TITLE
CloudSubnet: IP version not displayed

### DIFF
--- a/app/assets/javascripts/controllers/cloud_subnet/cloud_subnet_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_subnet/cloud_subnet_form_controller.js
@@ -10,7 +10,7 @@ ManageIQ.angular.app.controller('cloudSubnetFormController', ['$http', '$scope',
   if (cloudSubnetFormId == 'new') {
     $scope.cloudSubnetModel.name = "";
     $scope.cloudSubnetModel.dhcp_enabled = true;
-    $scope.cloudSubnetModel.ip_version = '4';
+    $scope.cloudSubnetModel.network_protocol = '4';
     $scope.newRecord = true;
   } else {
     miqService.sparkleOn();
@@ -28,7 +28,7 @@ ManageIQ.angular.app.controller('cloudSubnetFormController', ['$http', '$scope',
     $scope.cloudSubnetModel.dhcp_enabled = data.dhcp_enabled;
     $scope.cloudSubnetModel.cidr = data.cidr;
     $scope.cloudSubnetModel.gateway = data.gateway;
-    $scope.cloudSubnetModel.ip_version = data.ip_version;
+    $scope.cloudSubnetModel.network_protocol = data.network_protocol;
 
     $scope.modelCopy = angular.copy( $scope.cloudSubnetModel );
     miqService.sparkleOff();

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -43,11 +43,11 @@ class CloudSubnetController < ApplicationController
     assert_privileges("cloud_subnet_edit")
     subnet = find_record_with_rbac(CloudSubnet, params[:id])
     render :json => {
-      :name         => subnet.name,
-      :cidr         => subnet.cidr,
-      :dhcp_enabled => subnet.dhcp_enabled,
-      :gateway      => subnet.gateway,
-      :ip_version   => subnet.ip_version,
+      :name             => subnet.name,
+      :cidr             => subnet.cidr,
+      :dhcp_enabled     => subnet.dhcp_enabled,
+      :gateway          => subnet.gateway,
+      :network_protocol => subnet.network_protocol
     }
   end
 
@@ -251,7 +251,7 @@ class CloudSubnetController < ApplicationController
   end
 
   def new_form_params
-    params[:ip_version] ||= "4"
+    params[:network_protocol] ||= "4"
     params[:dhcp_enabled] ||= false
     options = {}
     options[:name] = params[:name] if params[:name]
@@ -261,7 +261,7 @@ class CloudSubnetController < ApplicationController
     if params[:gateway]
       options[:gateway] = params[:gateway].blank? ? nil : params[:gateway]
     end
-    options[:ip_version] = params[:ip_version]
+    options[:ip_version] = params[:network_protocol]
     options[:cloud_tenant] = find_record_with_rbac(CloudTenant, params[:cloud_tenant_id]) if params[:cloud_tenant_id]
     options[:network_id] = params[:network_id] if params[:network_id]
     options[:enable_dhcp] = params[:dhcp_enabled]

--- a/app/views/cloud_subnet/edit.html.haml
+++ b/app/views/cloud_subnet/edit.html.haml
@@ -9,8 +9,8 @@
         = _('IP Version')
       .col-md-8
         %input.form-control{:type          => "text",
-                            :name          => "ip_version",
-                            'ng-model'     => "cloudSubnetModel.ip_version",
+                            :name          => "network_protocol",
+                            'ng-model'     => "cloudSubnetModel.network_protocol",
                             'ng-maxlength' => 2,
                             :miqrequired   => true,
                             :disabled      => true,

--- a/app/views/cloud_subnet/new.html.haml
+++ b/app/views/cloud_subnet/new.html.haml
@@ -40,9 +40,9 @@
       %label.col-md-2.control-label
         = _('IP Version')
       .col-md-8
-        = select_tag("ip_version",
+        = select_tag("network_protocol",
                       options_for_select([4, 6]),
-                      "ng-model"                    => "cloudSubnetModel.ip_version",
+                      "ng-model"                    => "cloudSubnetModel.network_protocol",
                       "required"                    => "",
                       :miqrequired                  => true,
                       :checkchange                  => true,


### PR DESCRIPTION
Use `network_protocol` instead of `ip_version` which match CloudSubnet field name and allows to display the value properly in the edit view.

![cloudsubnet_ip_version](https://user-images.githubusercontent.com/1901741/26961824-0dee0aee-4d25-11e7-880f-05f2cd5a01d0.png)
