### PR TITLE
Enable the cancel button on the custom form button partial

### DIFF
--- a/app/views/layouts/angular/_x_custom_form_buttons_angular.html.haml
+++ b/app/views/layouts/angular/_x_custom_form_buttons_angular.html.haml
@@ -15,4 +15,5 @@
   %miq-button{:name      => t = _("Cancel"),
               :title     => t,
               :alt       => t,
+              :enabled   => 'true',
               'on-click' => "cancelClicked($event)"}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1440115
as well as other latent bugs on forms using the same partial
where the cancel button was always disabled.