### PR TITLE
Include ems ref on the Cloud Network summary page

### DIFF
--- a/app/helpers/cloud_network_helper/textual_summary.rb
+++ b/app/helpers/cloud_network_helper/textual_summary.rb
@@ -7,7 +7,7 @@ module CloudNetworkHelper::TextualSummary
   #
 
   def textual_group_properties
-    TextualGroup.new(_("Properties"), %i(name type status))
+    TextualGroup.new(_("Properties"), %i(name type status ems_ref))
   end
 
   def textual_group_relationships
@@ -26,6 +26,11 @@ module CloudNetworkHelper::TextualSummary
 
   def textual_status
     @record.status
+  end
+
+  def textual_ems_ref
+    return nil if @record.ems_ref.blank?
+    {:label => _("ID within Provider"), :value => @record.ems_ref}
   end
 
   def textual_parent_ems_cloud


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1415764, which requested that ems ref be included in the list of properties on the Cloud Network summary page.

I've called the label "ID within Provider" because that was used on the VmCloud summary page, but I'm sure there's better terminology.

![screenshot from 2017-06-09 16-44-21](https://user-images.githubusercontent.com/628956/26993853-ea2fa0fa-4d32-11e7-9dbd-94d2efd55e8a.png)

