### PR TITLE
Set default port for lenovo provider form to 443

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -386,7 +386,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.default_api_port = "443";
       $scope.emsCommonModel.event_stream_selection = "none";
       $scope.emsCommonModel.amqp_security_protocol = 'non-ssl';
-    }else if ($scope.emsCommonModel.emstype === 'lenovo_ph_infra') {
+    } else if ($scope.emsCommonModel.emstype === 'lenovo_ph_infra') {
       $scope.emsCommonModel.default_api_port = "443";
     }
   };

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -386,6 +386,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.default_api_port = "443";
       $scope.emsCommonModel.event_stream_selection = "none";
       $scope.emsCommonModel.amqp_security_protocol = 'non-ssl';
+    }else if ($scope.emsCommonModel.emstype === 'lenovo_ph_infra') {
+      $scope.emsCommonModel.default_api_port = "443";
     }
   };
 


### PR DESCRIPTION
Pre-fills the provider form for adding a Lenovo provider to use the API port 443. See screenshot.  User may continue with the default or if they have configured Xclarity with a custom port they may modify.


![image](https://user-images.githubusercontent.com/6444418/27049436-4fa446e2-4f7d-11e7-8816-fa94ea4fa0c7.png)



@miq-bot  add_label compute/physical infrastructure, enhancement, graphics
