### PR TITLE
When available, use Mistral workflows to scale stacks

### DIFF
--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -68,7 +68,7 @@ class EmsInfraController < ApplicationController
         end
       end
 
-      update_stack(@stack, scale_parameters_formatted, params[:id], return_message, 'scaleup')
+      update_stack_up(@stack, scale_parameters_formatted, params[:id], return_message)
     end
   end
 
@@ -109,8 +109,8 @@ class EmsInfraController < ApplicationController
 
       # figure out scaledown parameters and update stack
       stack_parameters = get_scaledown_parameters(hosts, @infra, @compute_hosts)
-      return_message = _(" Scaling down to %{a} compute nodes") % {:a => stack_parameters['ComputeCount']}
-      update_stack(@stack, stack_parameters, params[:id], return_message, 'scaledown', {:services => services})
+
+      update_stack_down(@stack, stack_parameters, params[:id], hosts, :services => services)
     end
   end
 
@@ -184,33 +184,77 @@ class EmsInfraController < ApplicationController
     $log.error(message)
   end
 
-  def update_stack(stack, stack_parameters, provider_id, return_message, operation, additional_args = {})
+  def update_stack_up(stack, stack_parameters, provider_id, return_message)
+    if stack_is_ready?(stack) && stack_parameters_changed?(stack_parameters)
+      begin
+        if can_use_scale_up_workflow?
+          # OSP >= 10 use workflows
+          stack.scale_up_queue(session[:userid], stack_parameters)
+        else
+          # OSP < 10 use heat stack update
+          stack.update_stack_queue(session[:userid], nil, stack_parameters)
+        end
+        redirect_to ems_infra_path(provider_id, :flash_msg => return_message)
+      rescue => ex
+        log_and_flash_message(_("Unable to initiate scale up: %{message}") % {:message => ex})
+      end
+    end
+  end
+
+  def update_stack_down(stack, stack_parameters, provider_id, hosts, additional_args = {})
+    return_message = _(" Scaling down to %{a} compute nodes") % {:a => stack_parameters['ComputeCount']}
+    if stack_is_ready?(stack) && stack_parameters_changed?(stack_parameters)
+      begin
+        if can_use_scale_down_workflow?
+          # OSP >= 10 use workflows
+          stack.scale_down_queue(session[:userid], hosts)
+        else
+          # OSP < 10 use heat stack update
+          task_id = stack.update_stack_queue(session[:userid], nil, stack_parameters)
+          stack.queue_post_scaledown_task(additional_args[:services], task_id)
+        end
+        redirect_to ems_infra_path(provider_id, :flash_msg => return_message)
+      rescue => ex
+        log_and_flash_message(_("Unable to initiate scale down: %{message}") % {:message => ex})
+      end
+    end
+  end
+
+  def stack_is_ready?(stack)
     begin
       # Check if stack is ready to be updated
       update_ready = stack.update_ready?
     rescue => ex
       log_and_flash_message(_("Unable to update stack, obtaining of status failed: %{message}") %
-                            {:message => ex})
-      return
+                              {:message => ex})
+      false
     end
 
-    if !update_ready
+    unless update_ready
       add_flash(_("Provider stack is not ready to be updated, another operation is in progress."), :error)
-    elsif !stack_parameters.empty?
-      # A value was changed
-      begin
-        task_id = stack.update_stack_queue(session[:userid], nil, stack_parameters)
-        if operation == 'scaledown'
-          @stack.queue_post_scaledown_task(additional_args[:services], task_id)
-        end
-        redirect_to ems_infra_path(provider_id, :flash_msg => return_message)
-      rescue => ex
-        log_and_flash_message(_("Unable to initiate scaling: %{message}") % {:message => ex})
-      end
-    else
+    end
+    update_ready
+  end
+
+  def stack_parameters_changed?(stack_parameters)
+    if stack_parameters.empty?
       # No values were changed
       add_flash(_("A value must be changed or provider stack will not be updated."), :error)
+      false
     end
+    true
+  end
+
+  def can_use_scale_up_workflow?
+    !workflow_service.nil? && workflow_service.has_action?("tripleo.parameters.update") && workflow_service.has_workflow?("tripleo.deployment.v1.deploy_plan")
+  end
+
+  def can_use_scale_down_workflow?
+    !workflow_service.nil? && workflow_service.has_workflow?("tripleo.scale.v1.delete_node")
+  end
+
+  def workflow_service
+    @infra.workflow_service
   end
 
   def verify_hosts_for_scaledown(hosts)
@@ -257,7 +301,7 @@ class EmsInfraController < ApplicationController
     stack_parameters = {}
     stack_parameters['ComputeCount'] = compute_hosts.length - hosts.length
     stack_parameters['ComputeRemovalPolicies'] = [{:resource_list => parent_resource_names}]
-    return stack_parameters
+    stack_parameters
   end
 
   def restful?

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -105,15 +105,21 @@ describe EmsInfraController do
   describe "#scaling" do
     before do
       stub_user(:features => :all)
-      @ems = FactoryGirl.create(:ems_openstack_infra_with_stack)
+      @ems = instance_double("mock_infra_provider", :id => 1, :hosts => [1, 2])
+      allow(controller).to receive(:get_infra_provider).and_return(@ems)
+      allow(controller).to receive(:can_use_scale_up_workflow?).and_return(false)
+      p1 = instance_double("mock_stack_parameter1", :name => "compute-1::count", :value => 1)
+      p2 = instance_double("mock_stack_parameter2", :name => "controller-1::count", :value => 1)
+      stack_parameters = [p1, p2]
+      @orchestration_stack = instance_double("mock stack", :id => 1, :parameters => stack_parameters, :update_ready? => true)
+      allow(@ems).to receive(:direct_orchestration_stacks).and_return([@orchestration_stack])
       @orchestration_stack_parameter_compute = FactoryGirl.create(:orchestration_stack_parameter_openstack_infra_compute)
-
-      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
+      allow(@orchestration_stack)
         .to receive(:raw_status).and_return(["CREATE_COMPLETE", nil])
     end
 
     it "when values are not changed" do
-      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @ems.orchestration_stacks.first.id }
+      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @orchestration_stack.id }
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include(
@@ -121,7 +127,7 @@ describe EmsInfraController do
     end
 
     it "when values are changed, but exceed number of hosts available" do
-      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @ems.orchestration_stacks.first.id,
+      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @orchestration_stack.id,
            @orchestration_stack_parameter_compute.name => @ems.hosts.count * 2 }
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
@@ -130,13 +136,11 @@ describe EmsInfraController do
     end
 
     it "when values are changed, values do not exceed number of hosts available, and not using workflows" do
-      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .to receive(:raw_update_stack)
-      expect_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .not_to receive(:queue_post_scaledown_task)
-      expect_any_instance_of(EmsInfraController)
+      expect(@orchestration_stack).to receive(:update_stack_queue)
+      expect(@orchestration_stack).not_to receive(:queue_post_scaledown_task)
+      allow(controller)
         .to receive(:can_use_scale_up_workflow?).and_return(false)
-      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @ems.orchestration_stacks.first.id,
+      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @orchestration_stack.id,
            @orchestration_stack_parameter_compute.name => 2 }
       expect(controller.send(:flash_errors?)).to be_falsey
       expect(response.body).to include("redirected")
@@ -145,11 +149,9 @@ describe EmsInfraController do
     end
 
     it "when values are changed, values do not exceed number of hosts available, and using workflows" do
-      expect_any_instance_of(EmsInfraController)
-        .to receive(:can_use_scale_up_workflow?).and_return(true)
-      expect_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .to receive(:scale_up_queue)
-      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @ems.orchestration_stacks.first.id,
+      allow(controller).to receive(:can_use_scale_up_workflow?).and_return(true)
+      expect(@orchestration_stack).to receive(:scale_up_queue)
+      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @orchestration_stack.id,
                                   @orchestration_stack_parameter_compute.name => 2 }
       expect(controller.send(:flash_errors?)).to be_falsey
       expect(response.body).to include("redirected")
@@ -158,7 +160,7 @@ describe EmsInfraController do
     end
 
     it "when no orchestration stack is available" do
-      @ems = FactoryGirl.create(:ems_openstack_infra)
+      allow(@ems).to receive(:direct_orchestration_stacks).and_return([])
       post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => nil }
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
@@ -166,11 +168,9 @@ describe EmsInfraController do
     end
 
     it "when patch operation fails, an error message should be displayed" do
-      expect_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .to receive(:update_stack_queue) { raise "my error" }
-      expect_any_instance_of(EmsInfraController)
-        .to receive(:can_use_scale_up_workflow?).and_return(false)
-      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @ems.orchestration_stacks.first.id,
+      allow(@orchestration_stack).to receive(:update_stack_queue) { raise "my error" }
+      allow(controller).to receive(:can_use_scale_up_workflow?).and_return(false)
+      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @orchestration_stack.id,
            @orchestration_stack_parameter_compute.name => 2 }
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
@@ -178,9 +178,8 @@ describe EmsInfraController do
     end
 
     it "when operation in progress, an error message should be displayed" do
-      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .to receive(:raw_status).and_return(["CREATE_IN_PROGRESS", nil])
-      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @ems.orchestration_stacks.first.id,
+      allow(@orchestration_stack).to receive(:update_ready?).and_return(false)
+      post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @orchestration_stack.id,
            @orchestration_stack_parameter_compute.name => 2 }
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
@@ -192,23 +191,39 @@ describe EmsInfraController do
   describe "#scaledown" do
     before do
       stub_user(:features => :all)
-      @ems = FactoryGirl.create(:ems_openstack_infra_with_stack_and_compute_nodes)
-
-      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
+      @host1 = instance_double("mock_host0", :name => "Compute1-xxx", :id => 0, :maintenance => false, :number_of => 0, :uid_ems => 0, :ems_ref_obj => "openstack-perf-host-nova-instance", :cloud_services => "")
+      @host2 = instance_double("mock_host1", :name => "Compute2-xxx", :id => 1, :maintenance => true, :number_of => 0, :uid_ems => 1, :ems_ref_obj => "openstack-perf-host-nova-instance", :cloud_services => "")
+      @ems = instance_double("mock_infra_provider", :id => 1, :hosts => [@host1, @host2])
+      allow(controller).to receive(:get_infra_provider).and_return(@ems)
+      allow(controller).to receive(:can_use_scale_down_workflow?).and_return(false)
+      allow(controller).to receive(:get_hosts_to_scaledown_from_ids).and_return([@host2])
+      p1 = instance_double("mock_stack_parameter1", :name => "compute-1::count", :value => 1)
+      p2 = instance_double("mock_stack_parameter2", :name => "controller-1::count", :value => 1)
+      stack_parameters = [p1, p2]
+      r1 = instance_double("mock_stack_resource1", :physical_resource => "openstack-perf-host-nova-instance", :stack_id => 1)
+      r2 = instance_double("Mock_stack_resource2", :physical_resource => "1", :logical_resource => "1", :stack_id => 1)
+      stack_resources = [r1, r2]
+      @orchestration_stack = instance_double("mock stack", :class => "OrchestrationStack", :id => "1", :parameters => stack_parameters, :resources => stack_resources, :update_ready? => true, :ems_ref => "1")
+      allow(@ems).to receive(:direct_orchestration_stacks).and_return([@orchestration_stack])
+      allow(@ems).to receive(:orchestration_stacks).and_return([@orchestration_stack])
+      allow(controller).to receive(:find_record_with_rbac).and_return(@orchestration_stack)
+      @orchestration_stack_parameter_compute = FactoryGirl.create(:orchestration_stack_parameter_openstack_infra_compute)
+      allow(@orchestration_stack)
         .to receive(:raw_status).and_return(["CREATE_COMPLETE", nil])
     end
 
     it "when no compute hosts are selected" do
       post :scaledown, :params => {:id => @ems.id, :scaledown => "",
-           :orchestration_stack_id => @ems.orchestration_stacks.first.id, :host_ids => []}
+           :orchestration_stack_id => @orchestration_stack.id, :host_ids => []}
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include("No compute hosts were selected for scale down.")
     end
 
     it "when values are changed, but selected host is in incorrect state" do
+      allow(controller).to receive(:get_hosts_to_scaledown_from_ids).and_return([@host1])
       post :scaledown, :params => {:id => @ems.id, :scaledown => "",
-           :orchestration_stack_id => @ems.orchestration_stacks.first.id, :host_ids => [@ems.hosts[0].id]}
+           :orchestration_stack_id => @orchestration_stack.id, :host_ids => [@ems.hosts[0].id]}
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include(
@@ -216,14 +231,10 @@ describe EmsInfraController do
     end
 
     it "when values are changed, selected host is in correct state, and workflows are not used" do
-      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .to receive(:raw_update_stack)
-      expect_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .to receive(:queue_post_scaledown_task)
-      expect_any_instance_of(EmsInfraController)
-        .to receive(:can_use_scale_down_workflow?).and_return(false)
+      expect(@orchestration_stack).to receive(:update_stack_queue)
+      expect(@orchestration_stack).to receive(:queue_post_scaledown_task)
       post :scaledown, :params => {:id => @ems.id, :scaledown => "",
-           :orchestration_stack_id => @ems.orchestration_stacks.first.id, :host_ids => [@ems.hosts[1].id]}
+           :orchestration_stack_id => @orchestration_stack.id, :host_ids => [@ems.hosts[1].id]}
       expect(controller.send(:flash_errors?)).to be_falsey
       expect(response.body).to include("redirected")
       expect(response.body).to include("ems_infra")
@@ -231,12 +242,10 @@ describe EmsInfraController do
     end
 
     it "when values are changed, selected host is in correct state, and workflows are used" do
-      expect_any_instance_of(EmsInfraController)
-        .to receive(:can_use_scale_down_workflow?).and_return(true)
-      expect_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .to receive(:scale_down_queue)
+      allow(controller).to receive(:can_use_scale_down_workflow?).and_return(true)
+      expect(@orchestration_stack).to receive(:scale_down_queue)
       post :scaledown, :params => {:id => @ems.id, :scaledown => "",
-                                   :orchestration_stack_id => @ems.orchestration_stacks.first.id, :host_ids => [@ems.hosts[1].id]}
+                                   :orchestration_stack_id => @orchestration_stack.id, :host_ids => [@ems.hosts[1].id]}
       expect(controller.send(:flash_errors?)).to be_falsey
       expect(response.body).to include("redirected")
       expect(response.body).to include("ems_infra")
@@ -245,6 +254,7 @@ describe EmsInfraController do
 
     it "when no orchestration stack is available" do
       @ems = FactoryGirl.create(:ems_openstack_infra)
+      allow(controller).to receive(:get_infra_provider).and_return(@ems)
       post :scaledown, :params => {:id => @ems.id, :scaledown => "", :orchestration_stack_id => nil}
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
@@ -252,22 +262,18 @@ describe EmsInfraController do
     end
 
     it "when patch operation fails, an error message should be displayed" do
-      expect_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .to receive(:update_stack_queue) { raise "my error" }
-      expect_any_instance_of(EmsInfraController)
-        .to receive(:can_use_scale_down_workflow?).and_return(false)
+      expect(@orchestration_stack).to receive(:update_stack_queue) { raise "my error" }
       post :scaledown, :params => {:id => @ems.id, :scaledown => "",
-           :orchestration_stack_id => @ems.orchestration_stacks.first.id, :host_ids => [@ems.hosts[1].id]}
+           :orchestration_stack_id => @orchestration_stack.id, :host_ids => [@ems.hosts[1].id]}
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include("Unable to initiate scale down: my error")
     end
 
     it "when operation in progress, an error message should be displayed" do
-      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
-        .to receive(:raw_status).and_return(["CREATE_IN_PROGRESS", nil])
+      allow(@orchestration_stack).to receive(:update_ready?).and_return(false)
       post :scaledown, :params => {:id => @ems.id, :scaledown => "",
-           :orchestration_stack_id => @ems.orchestration_stacks.first.id, :host_ids => [@ems.hosts[1].id]}
+           :orchestration_stack_id => @orchestration_stack.id, :host_ids => [@ems.hosts[1].id]}
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include(


### PR DESCRIPTION
Modifies update_stack to queue tasks to scale up or down stacks
using Mistral if the workflows are available. Workflows are
available starting with OSP10.

For OSP9 and older environments, the existing behavior of updating
the stack directly is used.

Depends on https://github.com/ManageIQ/manageiq-providers-openstack/pull/55
