### PR TITLE
Add Tags to Ansible Tower Provider and Foreman Provider

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2235,6 +2235,8 @@ class ApplicationController < ActionController::Base
     case controller_name
     when "vm_infra", "vm_or_template", "vm_cloud"
       "vm"
+    when 'automation_manager'
+      "automation_manager_provider"
     else
       controller_name
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2237,6 +2237,8 @@ class ApplicationController < ActionController::Base
       "vm"
     when 'automation_manager'
       "automation_manager_provider"
+    when 'provider_foreman'
+      "configuration_manager_provider"
     else
       controller_name
     end

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -54,7 +54,7 @@ module ApplicationController::Explorer
     'live_migrate' => :s2, 'attach'           => :s2, 'detach'          => :s2,
     'evacuate'     => :s2, 'service_dialog'   => :s2, 'transform'       => :s2,
     'associate_floating_ip'    => :s2,
-    'disassociate_floating_ip' => :s2,
+    'disassociate_floating_ip' => :s2,"manager_provider_configured_system_tag" => :s2,
 
     # specials
     'perf'         => :show,
@@ -66,7 +66,7 @@ module ApplicationController::Explorer
   def x_button
     model, action = pressed2model_action(params[:pressed])
 
-    allowed_models = %w(common image instance vm miq_template provider storage configscript infra_networking)
+    allowed_models = %w(common image instance vm miq_template provider storage configscript infra_networking automation_manager_provider)
     raise ActionController::RoutingError.new('invalid button action') unless
       allowed_models.include?(model)
 
@@ -94,6 +94,8 @@ module ApplicationController::Explorer
           send(method, Storage)
         when 'infra_networking'
           send(method, Switch)
+        when 'automation_manager_provider'
+          send(method)
         else
           send(method, VmOrTemplate)
         end

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -54,7 +54,7 @@ module ApplicationController::Explorer
     'live_migrate' => :s2, 'attach'           => :s2, 'detach'          => :s2,
     'evacuate'     => :s2, 'service_dialog'   => :s2, 'transform'       => :s2,
     'associate_floating_ip'    => :s2,
-    'disassociate_floating_ip' => :s2,"manager_provider_configured_system_tag" => :s2,
+    'disassociate_floating_ip' => :s2,
 
     # specials
     'perf'         => :show,
@@ -66,7 +66,7 @@ module ApplicationController::Explorer
   def x_button
     model, action = pressed2model_action(params[:pressed])
 
-    allowed_models = %w(common image instance vm miq_template provider storage configscript infra_networking automation_manager_provider)
+    allowed_models = %w(common image instance vm miq_template provider storage configscript infra_networking automation_manager_provider configuration_manager_provider)
     raise ActionController::RoutingError.new('invalid button action') unless
       allowed_models.include?(model)
 
@@ -94,7 +94,7 @@ module ApplicationController::Explorer
           send(method, Storage)
         when 'infra_networking'
           send(method, Switch)
-        when 'automation_manager_provider'
+        when 'automation_manager_provider', 'configuration_manager_provider'
           send(method)
         else
           send(method, VmOrTemplate)

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -29,6 +29,10 @@ module ApplicationController::Tags
     tagging_edit('ManageIQ::Providers::AnsibleTower::AutomationManager')
   end
 
+  def configuration_manager_provider_tag
+    tagging_edit('ManageIQ::Providers::ConfigurationManager')
+  end
+
   alias_method :image_tag, :tagging_edit
   alias_method :instance_tag, :tagging_edit
   alias_method :vm_tag, :tagging_edit

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -25,6 +25,10 @@ module ApplicationController::Tags
     tagging_edit('Container')
   end
 
+  def automation_manager_provider_tag
+    tagging_edit('ManageIQ::Providers::AnsibleTower::AutomationManager')
+  end
+
   alias_method :image_tag, :tagging_edit
   alias_method :instance_tag, :tagging_edit
   alias_method :vm_tag, :tagging_edit

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -21,6 +21,7 @@ class AutomationManagerController < ApplicationController
 
   CM_X_BUTTON_ALLOWED_ACTIONS = {
     'configscript_service_dialog' => :configscript_service_dialog,
+    'automation_manager_tag' => :automation_manager_tag
   }.freeze
 
   def self.model_to_name(provmodel)

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -19,11 +19,6 @@ class AutomationManagerController < ApplicationController
     @table_name ||= "automation_manager"
   end
 
-  CM_X_BUTTON_ALLOWED_ACTIONS = {
-    'configscript_service_dialog' => :configscript_service_dialog,
-    'automation_manager_tag' => :automation_manager_tag
-  }.freeze
-
   def self.model_to_name(provmodel)
     if provmodel.include?("ManageIQ::Providers::AnsibleTower")
       Dictionary.gettext('ansible_tower', :type => :ui_title, :translate => false)

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -51,8 +51,8 @@ class AutomationManagerController < ApplicationController
     @explorer ||= true
     case x_active_accord
     when :automation_manager_providers
-      assert_privileges("automation_manager_provider_configured_system_tag")
-      tagging_edit('ConfiguredSystem', false)
+      assert_privileges("automation_manager_provider_tag")
+      tagging_edit('ManageIQ::Providers::AnsibleTower::AutomationManager', false)
     when :automation_manager_cs_filter
       assert_privileges("automation_manager_configured_system_tag")
       tagging_edit('ConfiguredSystem', false)

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -285,8 +285,12 @@ module Mixins
 
     private
 
+    def tag_action
+      (params[:action] == 'x_button'&& ['automation_manager_provider_tag', 'configuration_manager_provider_tag'].include?(params[:pressed])) || (params[:action] == 'tagging'&& params[:pressed] == 'reset')
+    end
+
     def replace_right_cell(options = {})
-      if (params[:action] == 'x_button'&& params[:pressed] == 'automation_manager_provider_tag') || (params[:action] == 'tagging'&& params[:pressed] == 'reset')
+      if tag_action
         render_tagging_form
         return
       end

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -286,6 +286,11 @@ module Mixins
     private
 
     def replace_right_cell(options = {})
+      if @in_a_form && @refresh_partial
+        presenter = ExplorerPresenter.new()
+        presenter.update(:main_div, r[:partial => @refresh_partial])
+        render :json => presenter.for_render
+      end
       replace_trees = options[:replace_trees]
       return if @in_a_form
       @explorer = true

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -286,7 +286,7 @@ module Mixins
     private
 
     def tag_action
-      (params[:action] == 'x_button'&& ['automation_manager_provider_tag', 'configuration_manager_provider_tag'].include?(params[:pressed])) || (params[:action] == 'tagging'&& params[:pressed] == 'reset')
+      (params[:action] == 'x_button' && %w(automation_manager_provider_tag configuration_manager_provider_tag).include?(params[:pressed])) || (params[:action] == 'tagging' && params[:pressed] == 'reset')
     end
 
     def replace_right_cell(options = {})

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -286,10 +286,9 @@ module Mixins
     private
 
     def replace_right_cell(options = {})
-      if @in_a_form && @refresh_partial
-        presenter = ExplorerPresenter.new()
-        presenter.update(:main_div, r[:partial => @refresh_partial])
-        render :json => presenter.for_render
+      if (params[:action] == 'x_button'&& params[:pressed] == 'automation_manager_provider_tag') || (params[:action] == 'tagging'&& params[:pressed] == 'reset')
+        render_tagging_form
+        return
       end
       replace_trees = options[:replace_trees]
       return if @in_a_form

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -69,8 +69,8 @@ class ProviderForemanController < ApplicationController
     @explorer = true
     case x_active_accord
     when :configuration_manager_providers
-      assert_privileges("provider_foreman_configured_system_tag")
-      tagging_edit('ConfiguredSystem', false)
+      assert_privileges("configuration_manager_provider_tag")
+      tagging_edit('ManageIQ::Providers::ConfigurationManager', false)
     when :configuration_manager_cs_filter
       assert_privileges("configured_system_tag")
       tagging_edit('ConfiguredSystem', false)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -922,7 +922,7 @@ module ApplicationHelper
   end
 
   def pressed2model_action(pressed)
-    pressed =~ /^(ems_cluster|miq_template|infra_networking)_(.*)$/ ? [$1, $2] : pressed.split('_', 2)
+    pressed =~ /^(ems_cluster|miq_template|infra_networking|automation_manager_provider)_(.*)$/ ? [$1, $2] : pressed.split('_', 2)
   end
 
   def model_for_ems(record)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -922,7 +922,7 @@ module ApplicationHelper
   end
 
   def pressed2model_action(pressed)
-    pressed =~ /^(ems_cluster|miq_template|infra_networking|automation_manager_provider)_(.*)$/ ? [$1, $2] : pressed.split('_', 2)
+    pressed =~ /^(ems_cluster|miq_template|infra_networking|automation_manager_provider|configuration_manager_provider)_(.*)$/ ? [$1, $2] : pressed.split('_', 2)
   end
 
   def model_for_ems(record)

--- a/app/helpers/application_helper/toolbar/automation_manager_provider_center.rb
+++ b/app/helpers/application_helper/toolbar/automation_manager_provider_center.rb
@@ -33,6 +33,21 @@ class ApplicationHelper::Toolbar::AutomationManagerProviderCenter < ApplicationH
         )
       ]
     ),
-  ]
-  )
+  ])
+  button_group('automation_manager_policy', [
+    select(
+      :automation_manager_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :items => [
+        button(
+          :automation_manager_provider_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for this Ansible Tower Provider'),
+          N_('Edit Tags'),
+        :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck)
+      ]
+    )
+  ])
 end

--- a/app/helpers/application_helper/toolbar/automation_manager_provider_center.rb
+++ b/app/helpers/application_helper/toolbar/automation_manager_provider_center.rb
@@ -44,9 +44,8 @@ class ApplicationHelper::Toolbar::AutomationManagerProviderCenter < ApplicationH
         button(
           :automation_manager_provider_tag,
           'pficon pficon-edit fa-lg',
-          N_('Edit Tags for this Ansible Tower Provider'),
-          N_('Edit Tags'),
-        :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck)
+          N_('Edit Tags for this Ansible Tower Providers'),
+          N_('Edit Tags'))
       ]
     )
   ])

--- a/app/helpers/application_helper/toolbar/automation_manager_providers_center.rb
+++ b/app/helpers/application_helper/toolbar/automation_manager_providers_center.rb
@@ -48,9 +48,28 @@ class ApplicationHelper::Toolbar::AutomationManagerProvidersCenter < Application
           :enabled   => false,
           :onwhen    => "1+"
         ),
-        separator,
+      ]
+    )
+  ])
+  button_group('automation_manager_policy', [
+    select(
+      :automation_manager_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :automation_manager_provider_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for the selected Ansible Tower Providers'),
+          N_('Edit Tags'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck,
+          :onwhen    => "1+"),
       ]
     ),
-  ]
-  )
+  ])
 end

--- a/app/helpers/application_helper/toolbar/configuration_manager_provider_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_manager_provider_center.rb
@@ -31,4 +31,19 @@ class ApplicationHelper::Toolbar::ConfigurationManagerProviderCenter < Applicati
       ]
     ),
   ])
+  button_group('configuration_manager_policy', [
+    select(
+      :configuration_manager_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :items => [
+        button(
+          :configuration_manager_provider_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for this Ansible Tower Providers'),
+          N_('Edit Tags'))
+      ]
+    )
+  ])
 end

--- a/app/helpers/application_helper/toolbar/configuration_manager_providers_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_manager_providers_center.rb
@@ -48,4 +48,21 @@ class ApplicationHelper::Toolbar::ConfigurationManagerProvidersCenter < Applicat
       ]
     ),
   ])
+  button_group('configuration_manager_policy', [
+    select(
+      :configuration_manager_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :items => [
+        button(
+          :configuration_manager_provider_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for this Foreman Provider'),
+          N_('Edit Tags'),
+          :url_parms => "main_div",
+          :onwhen    => "1+")
+      ]
+    )
+  ])
 end

--- a/app/helpers/application_helper/toolbar/configuration_manager_providers_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_manager_providers_center.rb
@@ -54,7 +54,9 @@ class ApplicationHelper::Toolbar::ConfigurationManagerProvidersCenter < Applicat
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :items => [
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
         button(
           :configuration_manager_provider_tag,
           'pficon pficon-edit fa-lg',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2702,6 +2702,7 @@ Rails.application.routes.draw do
         cs_form_field_changed
         users
         wait_for_task
+        x_button
       ) +
                adv_search_post +
                x_post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,6 +169,7 @@ Rails.application.routes.draw do
         form_fields
         show
         x_show
+        x_button
         show_list
         tagging_edit
       ),


### PR DESCRIPTION
Add logic to add toolbar button Edit Tags and Tag assignement screen for Ansible Tower Provider and Foreman Provider.

Waiting for https://github.com/ManageIQ/manageiq/pull/15437

Toolbar after:
<img width="1190" alt="screen shot 2017-06-13 at 2 08 20 pm" src="https://user-images.githubusercontent.com/9210860/27081706-e6281fde-5041-11e7-95b3-91da4926eb03.png">
<img width="1195" alt="screen shot 2017-06-13 at 2 07 54 pm" src="https://user-images.githubusercontent.com/9210860/27081707-e629fd72-5041-11e7-91ed-fc804a618ca6.png">

Tag Assignment Ansible Tower Provider:
<img width="894" alt="screen shot 2017-06-23 at 12 06 43 pm" src="https://user-images.githubusercontent.com/9210860/27480847-277a0d32-581a-11e7-90f5-0d46f690113d.png">

Tag Assignment Foreman Provider:
<img width="887" alt="screen shot 2017-06-23 at 12 06 02 pm" src="https://user-images.githubusercontent.com/9210860/27480846-27590646-581a-11e7-8606-98a9fd7d370f.png">

@miq-bot add_label bug, automation/ansible, wip

https://bugzilla.redhat.com/show_bug.cgi?id=1436846

TODO:

- [x] Toolbar button
- [x] Tag Assignment screen render
- [x]  Save
- [x]  Reset
- [x]  Cancel