### PR TITLE
Use HTML instead of SVG in the topology legends

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -22,7 +22,6 @@
  *= require topology
  *= require container_topology
  *= require middleware_topology
- *= require network_topology
  *= require metrics
  *= require service_dialogs
  *= require xml_display

--- a/app/assets/stylesheets/container_topology.css
+++ b/app/assets/stylesheets/container_topology.css
@@ -8,31 +8,6 @@
   margin-left: 40px;
 }
 
-.topology g.EntityLegend {
-    transform: translate(21px,21px);
-}
-
-.kube-topology g.EntityLegend.Infra text {
-    fill: #636363;
-}
-
-.kube-topology g.EntityLegend.Containers text {
-    fill: #1186C1;
-    font-size: 22px;
-}
-
-.kube-topology g.EntityLegend.Containers.Pod text,
-.kube-topology g.EntityLegend.Network.FloatingIp text,
-.kube-topology g.EntityLegend.Containers.Container text {
-    font-family: FontAwesome;
-    font-size: 19px;
-}
-
-.kube-topology g.EntityLegend.Network.CloudNetwork text {
-    font-family: IcoMoon;
-    font-size: 19px;
-}
-
 .kube-topology g text.glyph {
     font-size: 20px;
     fill: #1186C1;

--- a/app/assets/stylesheets/network_topology.css
+++ b/app/assets/stylesheets/network_topology.css
@@ -1,4 +1,0 @@
-.kube-topology g.EntityLegend.Network.LoadBalancer text.glyph {
-    font-family: IcoMoon;
-    fill: #000;
-}

--- a/app/assets/stylesheets/topology.css
+++ b/app/assets/stylesheets/topology.css
@@ -26,7 +26,6 @@ kubernetes-topology-graph {
 }
 
 kubernetes-topology-icon {
-  padding: 4px 11px 4px 2px !important;
   opacity: 0.4;
 }
 

--- a/app/views/cloud_topology/show.html.haml
+++ b/app/views/cloud_topology/show.html.haml
@@ -4,36 +4,20 @@
     %label#selected
     %div{'ng-if' => "kinds"}
       %kubernetes-topology-icon{tooltipOptions, :kind => "Vm"}
-        %svg.kube-topology
-          %g.EntityLegend.Infra
-            %circle{:r => "17"}
-            -# pficon-virtual-machine
-            %text{:y => "9"} &#xE90f;
         %label
+          %i.pficon.pficon-virtual-machine
           = _("VMs")
       %kubernetes-topology-icon{tooltipOptions, :kind => "AvailabilityZone"}
-        %svg.kube-topology
-          %g.EntityLegend.Network.CloudSubnet
-            %circle{:r => "17"}
-            -# pficon-network
-            %text{:y => "8"} &#xE911;
         %label
+          %i.pficon.pficon-zone
           = _("Availability Zones")
       %kubernetes-topology-icon{tooltipOptions, :kind => "CloudTenant"}
-        %svg.kube-topology
-          %g.EntityLegend.Cloud.CloudTenant
-            %circle{:r => "17"}
-            -# pficon-cloud-tenant
-            %text{:y => "9"} &#xE904;
         %label
+          %i.pficon.pficon-cloud-tenant
           = _("Cloud Tenants")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Tag"}
-        %svg.kube-topology
-          %g.EntityLegend.Network.FloatingIp
-            %circle{:r => "17"}
-            -# pficon-cloud-tenant
-            %text{:y => "9"} &#xF02b;
         %label
+          %i.fa.fa-tag
           = _("Tags")
 
   .alert.alert-info.alert-dismissable

--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -4,68 +4,36 @@
     %label#selected
     %div{'ng-if' => "kinds"}
       %kubernetes-topology-icon{tooltip_options, :kind => "ContainerReplicator"}
-        %svg.kube-topology
-          %g.EntityLegend.Containers
-            %circle{:r => "17"}
-            -# pficon-replicator
-            %text{:y => "8"} &#xE624;
         %label
+          %i.pficon.pficon-replicator
           = _("Replicators")
       %kubernetes-topology-icon{tooltip_options, :kind => "ContainerGroup"}
-        %svg.kube-topology
-          %g.EntityLegend.Containers.Pod
-            %circle{:r => "17"}
-            -# fa-cubes
-            %text{:x => "1", :y => "6"} &#xF1B3;
         %label
+          %i.fa.fa-cubes
           = _("Pods")
       %kubernetes-topology-icon{tooltip_options, :kind => "Container"}
-        %svg.kube-topology
-          %g.EntityLegend.Containers.Container
-            %circle{:r => "17"}
-            -# fa-cube
-            %text{:y => "7"} &#xF1B2;
         %label
+          %i.fa.fa-cube
           = _("Containers")
       %kubernetes-topology-icon{tooltip_options, :kind => "ContainerService"}
-        %svg.kube-topology
-          %g.EntityLegend.Containers
-            %circle{:r => "17"}
-            -# pficon-service
-            %text{:x => "-2", :y => "10"} &#xE61E;
         %label
+          %i.pficon.pficon-service
           = _("Services")
       %kubernetes-topology-icon{tooltip_options, :kind => "ContainerRoute"}
-        %svg.kube-topology
-          %g.EntityLegend.Containers
-            %circle{:r => "17"}
-            -# pficon-route
-            %text{:y => "8"} &#xE625;
         %label
+          %i.pficon.pficon-route
           = _("Routes")
       %kubernetes-topology-icon{tooltip_options, :kind => "ContainerNode"}
-        %svg.kube-topology
-          %g.EntityLegend.Containers
-            %circle{:r => "17"}
-            -# pficon-container-node
-            %text{:y => "9"} &#xE621;
         %label
+          %i.pficon.pficon-container-node
           = _("Nodes")
       %kubernetes-topology-icon{tooltip_options, :kind => "Vm"}
-        %svg.kube-topology
-          %g.EntityLegend.Infra
-            %circle{:r => "17"}
-            -# pficon-virtual-machine
-            %text{:y => "9"} &#xE90f;
         %label
+          %i.pficon.pficon-virtual-machine
           = _("VMs")
       %kubernetes-topology-icon{tooltip_options, :kind => "Host"}
-        %svg.kube-topology
-          %g.EntityLegend.Infra
-            %circle{:r => "17"}
-            -# pficon-screen
-            %text{:y => "9"} &#xE600;
         %label
+          %i.pficon.pficon-screen
           = _("Hosts")
 
   .alert.alert-info.alert-dismissable

--- a/app/views/infra_topology/show.html.haml
+++ b/app/views/infra_topology/show.html.haml
@@ -4,36 +4,20 @@
     %label#selected
     %div{'ng-if' => "kinds"}
       %kubernetes-topology-icon{tooltipOptions, :kind => "Host"}
-        %svg.kube-topology
-          %g.EntityLegend.Infra.Host
-            %circle{:r => "17"}
-            -# pficon-host
-            %text{:y => "8"} &#xE600;
         %label
+          %i.pficon.pficon-screen
           = _("Nodes")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Vm"}
-        %svg.kube-topology
-          %g.EntityLegend.Infra
-            %circle{:r => "17"}
-            -# pficon-virtual-machine
-            %text{:y => "9"} &#xE90f;
         %label
+          %i.pficon.pficon-virtual-machine
           = _("VMs")
       %kubernetes-topology-icon{tooltipOptions, :kind => "EmsCluster"}
-        %svg.kube-topology
-          %g.EntityLegend.Infra
-            %circle{:r => "17"}
-            -# pficon-cluster
-            %text{:y => "9"} &#xE620;
         %label
+          %i.pficon.pficon-cluster
           = _("Clusters")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Tag"}
-        %svg.kube-topology
-          %g.EntityLegend.Network.FloatingIp
-            %circle{:r => "17"}
-            -# pficon-cloud-tenant
-            %text{:y => "9"} &#xF02b;
         %label
+          %i.fa.fa-tag
           = _("Tags")
 
   .alert.alert-info.alert-dismissable

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -4,64 +4,36 @@
     %label#selected
     %div{'ng-if' => "kinds"}
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareServer"}
-        %svg.kube-topology
-          %g.MiddlewareServer{:transform => "translate(21, 21)"}
-            %circle{:r => "17"}
-            %image{:height => "20", :width => "20", :x => "-10", :y => "-10", "xlink:href" => image_path('svg/vendor-wildfly.svg')}
         %label
+          %img{:src => image_path('svg/vendor-wildfly.svg'), :width => 18, :height => 18}
           = _("Servers")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareDeployment"}
-        %svg.kube-topology
-          %g.MiddlewareDeployment{:transform => "translate(21, 21)"}
-            %circle{:r => "17"}
-            -# fa-file-text-o
-            %text{:x => "0", :y => "8", :class => "fa-file-text-o glyph"} &#xF0f6;
         %label
+          %i.fa.fa-file-text-o
           = _("Deployments")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareDatasource"}
-        %svg.kube-topology
-          %g.MiddlewareDatasource{:transform => "translate(21, 21)"}
-            %circle{:r => "17"}
-            -# fa-database
-            %text{:x => "0", :y => "6", :class => "fa fa-database glyph"} &#xF1C0;
         %label
+          %i.fa.fa-database
           = _("Datasources")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareMessaging"}
-        %svg.kube-topology
-          %g.MiddlewareMessaging{:transform => "translate(21, 21)"}
-            %circle{:r => "17"}
-            -# fa-exchange (placeholder)
-            %text{:x => "0", :y => "6", :class => "fa fa-exchange glyph"} &#xF0EC;
         %label
+          %i.fa.fa-exchange
           = _("Messaging")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Vm"}
-        %svg.kube-topology
-          %g.EntityLegend.Infra
-            %circle{:r => "17"}
-            -# pficon-virtual-machine
-            %text{:y => "9"} &#xE90f;
         %label
+          %i.pficon.pficon-virtual-machine
           = _("VMs")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Container"}
-        %svg.kube-topology
-          %g.EntityLegend
-            %circle{:r => "17"}
-            %text{:y => "7", :class => "fa fa-cube glyph"} &#xF1B2;
         %label
+          %i.fa.fa-cube
           = _("Containers")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareDomain"}
-        %svg.kube-topology
-          %g.MiddlewareDomain{:transform => "translate(21, 21)"}
-            %circle{:r => "17"}
-            %text{:x => "0", :y => "8", :class => "pficon-domain glyph"} &#xE919;
         %label
+          %i.pficon.pficon-domain
           = _("Domains")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareServerGroup"}
-        %svg.kube-topology
-          %g.MiddlewareServerGroup{:transform => "translate(21, 21)"}
-            %circle{:r => "17"}
-            %text{:x => "0", :y => "8", :class => "pficon-server-group glyph"} &#xE91A;
         %label
+          %i.pficon.pficon-server-group
           = _("Server Groups")
 
   .alert.alert-info.alert-dismissable

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -4,84 +4,44 @@
     %label#selected
     %div{'ng-if' => "kinds"}
       %kubernetes-topology-icon{tooltipOptions, :kind => "AvailabilityZone"}
-        %svg.kube-topology
-          %g.EntityLegend.Cloud.AvailabilityZone
-            %circle{:r => "17"}
-            -# pficon-network
-            %text{:y => "8"} &#xE911;
         %label
+          %i.pficon.pficon-zone
           = _("Availability Zones")
       %kubernetes-topology-icon{tooltipOptions, :kind => "CloudSubnet"}
-        %svg.kube-topology
-          %g.EntityLegend.Network.CloudSubnet
-            %circle{:r => "17"}
-            -# pficon-network
-            %text{:y => "8"} &#xE909;
         %label
+          %i.pficon.pficon-network
           = _("Cloud Subnets")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Vm"}
-        %svg.kube-topology
-          %g.EntityLegend.Infra
-            %circle{:r => "17"}
-            -# pficon-virtual-machine
-            %text{:y => "9"} &#xE90f;
         %label
+          %i.pficon.pficon-virtual-machine
           = _("VMs")
       %kubernetes-topology-icon{tooltipOptions, :kind => "SecurityGroup"}
-        %svg.kube-topology
-          %g.EntityLegend.Network.SecurityGroup
-            %circle{:r => "17"}
-            -# pficon-cloud-security
-            %text{:x => "0", :y => "9"} &#xE903;
         %label
+          %i.pficon.pficon-cloud-security
           = _("Security Groups")
       %kubernetes-topology-icon{tooltipOptions, :kind => "FloatingIp"}
-        %svg.kube-topology
-          %g.EntityLegend.Network.FloatingIp
-            %circle{:r => "17"}
-            -# fa-map-marker
-            %text{:y => "7"} &#xF041;
         %label
+          %i.fa.fa-map-marker
           = _("Floating Ips")
       %kubernetes-topology-icon{tooltipOptions, :kind => "CloudNetwork"}
-        %svg.kube-topology
-          %g.EntityLegend.Network.CloudNetwork
-            %circle{:r => "17"}
-            -# pficon-service
-            %text{:x => "0", :y => "9"} &#xE62C
         %label
+          %i.product.product-cloud_network
           = _("Cloud Networks")
       %kubernetes-topology-icon{tooltipOptions, :kind => "NetworkRouter"}
-        %svg.kube-topology
-          %g.EntityLegend.Network.NetworkRouter
-            %circle{:r => "17"}
-            -# pficon-route
-            %text{:x => "-1",:y => "7"} &#xE625;
         %label
+          %i.pficon.pficon-route
           = _("Network Routers")
       %kubernetes-topology-icon{tooltipOptions, :kind => "CloudTenant"}
-        %svg.kube-topology
-          %g.EntityLegend.Cloud.CloudTenant
-            %circle{:r => "17"}
-            -# pficon-cloud-tenant
-            %text{:y => "9"} &#xE904;
         %label
+          %i.pficon.pficon-cloud-tenant
           = _("Cloud Tenants")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Tag"}
-        %svg.kube-topology
-          %g.EntityLegend.Network.FloatingIp
-            %circle{:r => "17"}
-            -# pficon-cloud-tenant
-            %text{:y => "9"} &#xF02b;
         %label
+          %i.fa.fa-tag
           = _("Tags")
       %kubernetes-topology-icon{tooltipOptions, :kind => "LoadBalancer"}
-        %svg.kube-topology
-          %g.EntityLegend.Network.LoadBalancer
-            %circle{:r => "17"}
-            -# load_balancer
-            %text{:y => "8", :class => "glyph"} &#xE637;
         %label
+          %i.product.product-load_balancer
           = _("Load Balancer")
 
   .alert.alert-info.alert-dismissable

--- a/app/views/physical_infra_topology/show.html.haml
+++ b/app/views/physical_infra_topology/show.html.haml
@@ -4,20 +4,12 @@
     %label#selected
     %div{'ng-if' => "kinds"}
       %kubernetes-topology-icon{tooltipOptions, :kind => "PhysicalServer"}
-        %svg.kube-topology
-          %g.EntityLegend.PhysicalInfra
-            %circle{:r => "17"}
-            -# pficon-server-group
-            %text{:y => "9"} &#xe91a;
         %label
+          %i.pficon.pficon-server-group
           = _("Physical Servers")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Host"}
-        %svg.kube-topology
-          %g.EntityLegend.PhysicalInfra
-            %circle{:r => "17"}
-            -# pficon-screen
-            %text{:y => "9"} &#xE600;
         %label
+          %i.pficon.pficon-screen
           = _("Hosts")
 
   .alert.alert-info.alert-dismissable


### PR DESCRIPTION
This will help us to have a temporary and easier to maintain solution for the legends on topology screens as we won't need the know the Unicode characters of the used fonticons. It slightly changes the appearance as it doesn't define a circle around the icons, but the functionality remains the same.

**Before:**
![screenshot from 2017-06-14 09-21-06](https://user-images.githubusercontent.com/649130/27120242-197e4ac4-50e3-11e7-94cf-c317027f5cef.png)

**After:**
![screenshot from 2017-06-14 09-20-50](https://user-images.githubusercontent.com/649130/27120249-1d236fba-50e3-11e7-94bc-806f3d86b6c0.png)

This will also help us to remove the dependency on the old icomoon `product-` icons and move completely to `font-fabulous`.