### PR TITLE
Fix VM quadicon display

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -386,14 +386,10 @@ module QuadiconHelper
     %w(ExtManagementSystem Host PhysicalServer).include?(item.class.base_class.name)
   end
 
-  def quadicon_named_for_base_model?(item)
-    %w(VmOrTemplate PhysicalServer).include?(item.class.base_model.name)
-  end
-
   def quadicon_builder_name_from(item)
     builder_name = if CLASSLY_NAMED_ITEMS.include?(item.class.name)
                      item.class.name.underscore
-                   elsif quadicon_named_for_base_model?(item)
+                   elsif item.kind_of?(VmOrTemplate) || item.kind_of?(PhysicalServer)
                      item.class.base_model.to_s.underscore
                    elsif item.kind_of?(ManageIQ::Providers::ConfigurationManager)
                      "single_quad"


### PR DESCRIPTION
Reverts a change to the logic that chooses the quadicon builder method. The change causes most VM-types to be rendered using the single_quad method.

**Before**
![screen shot 2017-06-13 at 4 44 47 pm](https://user-images.githubusercontent.com/39493/27103799-ebd18054-5057-11e7-84dc-3171b060ac2c.png)

**After**
![screen shot 2017-06-13 at 4 43 39 pm](https://user-images.githubusercontent.com/39493/27103805-f0d830de-5057-11e7-8574-b48fe0ebdbb4.png)

/cc @h-kataria @epwinchell 