### PR TITLE
Fix middleware spec failures on master

### DIFF
--- a/spec/controllers/middleware_server_controller_spec.rb
+++ b/spec/controllers/middleware_server_controller_spec.rb
@@ -1,5 +1,9 @@
 describe MiddlewareServerController do
-  let(:server) { FactoryGirl.create(:hawkular_middleware_server, :properties => {}, :middleware_server_group => nil) }
+  let(:server) do
+    FactoryGirl.create(:hawkular_middleware_server, :properties              => {},
+                                                    :middleware_server_group => nil,
+                                                    :feed                    => '')
+  end
 
   render_views
   before(:each) do

--- a/spec/controllers/middleware_server_group_controller_spec.rb
+++ b/spec/controllers/middleware_server_group_controller_spec.rb
@@ -11,11 +11,17 @@ describe MiddlewareServerGroupController do
   end
 
   describe '#show' do
-    let(:group) { FactoryGirl.create(:hawkular_middleware_server_group, :properties => {}, :middleware_domain => nil) }
+    let(:group) do
+      FactoryGirl.create(:hawkular_middleware_server_group, :properties        => {},
+                                                            :middleware_domain => nil)
+    end
+
     let(:server) do
       FactoryGirl.create(:hawkular_middleware_server, :properties              => {},
-                                                      :middleware_server_group => group)
+                                                      :middleware_server_group => group,
+                                                      :feed                    => '')
     end
+
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1298,7 +1298,7 @@ describe ApplicationHelper do
         stub_user(:features => :all)
         allow(helper).to receive_messages(:controller_name => "ems_middleware")
         ems = FactoryGirl.create(:ems_hawkular)
-        MiddlewareDatasource.create(:ext_management_system => ems, :name => "Test Middleware")
+        FactoryGirl.create(:hawkular_middleware_datasource, :ext_management_system => ems, :name => "Test Middleware")
         expect(helper.multiple_relationship_link(ems, "middleware_datasource")).to eq("<li><a title=\"Show Middleware \
 Datasources\" href=\"/ems_middleware/#{ems.id}?display=middleware_datasources\">Middleware Datasources (1)</a></li>")
       end


### PR DESCRIPTION
One failure happens because accessing `feed` on a hawkular MiddlewareServer fails when `feed` is `nil`.
  Adding `feed => ''` where needed, but a proper solution will depend on https://github.com/ManageIQ/manageiq-providers-hawkular/pull/20/files#r121929594 - either that `unescape` needs to be called conditionally, or the factory needs to get updated to not allow `nil`.

The other happens because now a hawkular now only finds hawkular datasources, not a generic `MiddlewareDatasource`.

Cc @h-kataria , @martinpovolny 

(Failure on master - https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/242785462)