### PR TITLE
Update Policy Event Assignment styling

### DIFF
--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -33,9 +33,7 @@ module MiqPolicyController::Policies
 
     case params[:button]
     when "save", "add"
-      $log.info("===> Checking privileges...")
       assert_privileges("policy_#{@policy.id ? "edit" : "new"}")
-      $log.info("===> Privileges checked")
       policy = @policy.id.blank? ? MiqPolicy.new : MiqPolicy.find(@policy.id) # Get new or existing record
       policy.mode = @edit[:new][:mode]
       policy.towhat = @edit[:new][:towhat] if @policy.id.blank?               # Set model if new record
@@ -151,7 +149,7 @@ module MiqPolicyController::Policies
       params.keys.each do |field|
         if field.to_s.starts_with?("event_")
           event = field.to_s.split("_").last
-          if params[field] == "1"
+          if params[field] == "true"
             @edit[:new][:events].push(event)      # Add event to array
           else
             @edit[:new][:events].delete(event)    # Delete event from array

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -101,7 +101,7 @@
                                       "data-miq_sparkle_off" => true,
                                       "data-click_url" => {:url => url_for_only_path(:action => 'policy_edit',
                                                                            :button => action,
-                                                                           :id => @policy)}.to_json}           
+                                                                           :id => @policy)}.to_json}
                 %i.fa.fa-lg.hidden-xs.hidden-sm{:class => arrow_style}
                 %i.fa.fa-lg.fa-rotate-90.hidden-md.hidden-lg{:class => arrow_style}
             .spacer
@@ -157,14 +157,20 @@
         - if @edit[:typ] == "events"
           %h3= _("Event Selection")
           - @edit[:allevents].keys.sort.each do |k|
-            %fieldset
-              %h3= h(k)
-              - @edit[:allevents][k].sort_by(&:first).each do |e|
-                %div{:style => "width: 300px; height: 18px; float:left; padding: 0px 5px 0px 0px;"}
-                  %label
-                    = check_box_tag("event_#{e.last}", "1", @edit[:new][:events].include?(e.last) ? true : false,
-                      "data-miq_observe_checkbox" => {:url => url}.to_json)
+            .form-horizontal
+              .form-group
+                %label.col-md-3.control-label
+                  = h(k)
+                .col-md-8
+                  - @edit[:allevents][k].sort_by(&:first).each do |e|
+                    - checked = @edit[:new][:events].include?(e.last) ? true : false
+                    = check_box_tag("event_#{e.last}", 'true', checked, 
+                                    :class => "bootstrap-switch-mini", 
+                                    :data => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'})
                     = h(e.first)
+                    :javascript
+                      miqInitBootstrapSwitch("event_#{e.last}", "#{url}")
+                    %br
       - else
         %h3= _("Events")
         - if @policy_events.empty?


### PR DESCRIPTION
This PR addresses an issue where events were rendered in columns out of alphabetical order. The screen has been updated with Patternfly "form-horizontal" styling and bootstrap switches, like other areas of the UI.

https://bugzilla.redhat.com/show_bug.cgi?id=1459506

Old
<img width="945" alt="screen shot 2017-06-14 at 2 10 12 pm" src="https://user-images.githubusercontent.com/1287144/27147595-5ad7fb64-510b-11e7-8409-c95ced204834.png">

New
<img width="554" alt="screen shot 2017-06-14 at 2 06 21 pm" src="https://user-images.githubusercontent.com/1287144/27147596-5ae4f256-510b-11e7-85cf-8767acd208af.png">