### PR TITLE
Fix test with ems folder

### DIFF
--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -38,13 +38,16 @@ describe VmInfraController do
       let!(:ems) { FactoryGirl.create(:ems_vmware, :ems_folders => [ems_folder]) }
       let(:user)       { FactoryGirl.create(:user_admin) }
 
-      it "properly calls RBAC" do
+      before do
         EvmSpecHelper.create_guid_miq_server_zone
-
+        
         user.current_group.entitlement = Entitlement.create!
         user.current_group.entitlement.set_managed_filters([["/managed/service_level/gold"]])
         user.current_group.save
         login_as user
+      end
+
+      it "properly calls RBAC" do
         expect(Rbac.filtered([ems_folder], :match_via_descendants => "VmOrTemplate")).to(
           eq([ems_folder]))
       end

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -47,7 +47,7 @@ describe VmInfraController do
       end
 
       it "properly calls RBAC" do
-        expect(Rbac.filtered([ems_folder], :match_via_descendants => "VmOrTemplate", :user => user)).to(
+        expect(Rbac.filtered(EmsFolder, :match_via_descendants => "VmOrTemplate", :user => user)).to(
           eq([ems_folder]))
       end
     end

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -37,6 +37,7 @@ describe VmInfraController do
       let(:ems_folder) { FactoryGirl.create(:ems_folder) }
       let!(:ems) { FactoryGirl.create(:ems_vmware, :ems_folders => [ems_folder]) }
       let(:user)       { FactoryGirl.create(:user_admin) }
+      let(:vm)         { FactoryGirl.create(:vm_vmware, :ext_management_system => ems) }
 
       before do
         EvmSpecHelper.create_guid_miq_server_zone
@@ -44,9 +45,13 @@ describe VmInfraController do
         user.current_group.entitlement = Entitlement.create!
         user.current_group.entitlement.set_managed_filters([["/managed/service_level/gold"]])
         user.current_group.save
+        
+        ems_folder.add_child(vm)
       end
 
       it "properly calls RBAC" do
+        vm.tag_with('/managed/service_level/gold', :ns => '*')
+
         expect(Rbac.filtered(EmsFolder, :match_via_descendants => "VmOrTemplate", :user => user)).to eq([ems_folder])
       end
     end

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -34,12 +34,13 @@ describe VmInfraController do
     end
 
     context "#rbac_filtered_objects" do
+      let(:ems_folder) { FactoryGirl.create(:ems_folder) }
+      let!(:ems) { FactoryGirl.create(:ems_vmware, :ems_folders => [ems_folder]) }
+      let(:user)       { FactoryGirl.create(:user_admin) }
+
       it "properly calls RBAC" do
         EvmSpecHelper.create_guid_miq_server_zone
-        ems_folder = FactoryGirl.create(:ems_folder)
-        ems = FactoryGirl.create(:ems_vmware, :ems_folders => [ems_folder])
 
-        user = FactoryGirl.create(:user_admin)
         user.current_group.entitlement = Entitlement.create!
         user.current_group.entitlement.set_managed_filters([["/managed/service_level/gold"]])
         user.current_group.save

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -40,15 +40,14 @@ describe VmInfraController do
 
       before do
         EvmSpecHelper.create_guid_miq_server_zone
-        
+
         user.current_group.entitlement = Entitlement.create!
         user.current_group.entitlement.set_managed_filters([["/managed/service_level/gold"]])
         user.current_group.save
-        login_as user
       end
 
       it "properly calls RBAC" do
-        expect(Rbac.filtered([ems_folder], :match_via_descendants => "VmOrTemplate")).to(
+        expect(Rbac.filtered([ems_folder], :match_via_descendants => "VmOrTemplate", :user => user)).to(
           eq([ems_folder]))
       end
     end

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -47,8 +47,7 @@ describe VmInfraController do
       end
 
       it "properly calls RBAC" do
-        expect(Rbac.filtered(EmsFolder, :match_via_descendants => "VmOrTemplate", :user => user)).to(
-          eq([ems_folder]))
+        expect(Rbac.filtered(EmsFolder, :match_via_descendants => "VmOrTemplate", :user => user)).to eq([ems_folder])
       end
     end
 


### PR DESCRIPTION
fix travis failure https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/242877715

## What happened  💥 
this test was weird and it was passing by chance. it was revealed by refactoring in https://github.com/ManageIQ/manageiq/pull/15346. The combination of descendant filter and managed filter(tag filter) did not work properly, it displays resources regardless of user's tag filter.

## Fix 💉 
there is tagged user and he wanted to see EmsFolder, but there is nothing tagged.
[So fix is that I am adding vm and tagging it.](https://github.com/ManageIQ/manageiq-ui-classic/commit/63dff8cb7088ec420eb42b22d21961e52990ce45)

Other commits our just clean up. 
 

@miq-bot assign @himdel 
@miq-bot technical debt