### PR TITLE
Rename 'Cockpit Console' to 'Web Console', per cockpit product integration guidelines

### DIFF
--- a/app/helpers/application_helper/toolbar/container_node_center.rb
+++ b/app/helpers/application_helper/toolbar/container_node_center.rb
@@ -73,7 +73,7 @@ class ApplicationHelper::Toolbar::ContainerNodeCenter < ApplicationHelper::Toolb
       :cockpit_console,
       'pficon pficon-screen fa-lg',
       N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),
-      N_('Cockpit Console'),
+      N_('Web Console'),
       :url   => "launch_cockpit",
       :klass => ApplicationHelper::Button::CockpitConsole
     ),

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -280,7 +280,7 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           :cockpit_console,
           'pficon pficon-screen fa-lg',
           N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),
-          N_('Cockpit Console'),
+          N_('Web Console'),
           # :image   => "cockpit",
           :url   => "launch_cockpit",
           :klass => ApplicationHelper::Button::CockpitConsole

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -133,7 +133,7 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
       :cockpit_console,
       'pficon pficon-screen fa-lg',
       N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),
-      N_('Cockpit Console'),
+      N_('Web Console'),
       # :image   => "cockpit",
       :url   => "launch_cockpit",
       :klass => ApplicationHelper::Button::CockpitConsole


### PR DESCRIPTION
For details, see discussion in https://github.com/ManageIQ/manageiq-ui-classic/pull/1429 and https://bugzilla.redhat.com/show_bug.cgi?id=1441321.

But the gist of it is, ops ui & SUI should have consistent names for a (vnc, etc.) console and for cockpit and those names should be "VM Console" and "Web Console" (not "Cockpit Console" - https://github.com/cockpit-project/cockpit/wiki/Product-Integration). 

This reverts https://github.com/ManageIQ/manageiq-ui-classic/pull/1429 .

https://bugzilla.redhat.com/show_bug.cgi?id=1441321

Cc @dclarizio, @Loicavenel