### PR TITLE
All Conditions - use same folder icons as in tree

### DIFF
--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -18,6 +18,28 @@ class TreeBuilderCondition < TreeBuilder
     }
   end
 
+  # not using decorators for now because there are some inconsistencies
+  def self.folder_icon(klassname)
+    case klassname
+    when 'Host'
+      'pficon pficon-screen'
+    when 'Vm'
+      'pficon pficon-virtual-machine'
+    when 'ContainerReplicator'
+      'pficon pficon-replicator'
+    when 'ContainerGroup'
+      'fa fa-cubes'
+    when 'ContainerNode'
+      'pficon pficon-container-node'
+    when 'ContainerImage'
+      'pficon pficon-image'
+    when 'ExtManagementSystem'
+      'pficon pficon-server'
+    when 'PhysicalServer'
+      'pficon pficon-enterprise'
+    end
+  end
+
   # level 1 - host / vm
   def x_get_tree_roots(count_only, _options)
     text_i18n = {:Host                => _("Host Conditions"),
@@ -31,24 +53,8 @@ class TreeBuilderCondition < TreeBuilder
 
     objects = MiqPolicyController::UI_FOLDERS.collect do |model|
       text = text_i18n[model.name.to_sym]
-      icon = case model.to_s
-             when 'Host'
-               'pficon pficon-screen'
-             when 'Vm'
-               'pficon pficon-virtual-machine'
-             when 'ContainerReplicator'
-               'pficon pficon-replicator'
-             when 'ContainerGroup'
-               'fa fa-cubes'
-             when 'ContainerNode'
-               'pficon pficon-container-node'
-             when 'ContainerImage'
-               'pficon pficon-image'
-             when 'ExtManagementSystem'
-               'pficon pficon-server'
-             when 'PhysicalServer'
-               'pficon pficon-enterprise'
-             end
+      icon = self.class.folder_icon(model.to_s)
+
       {
         :id   => model.name.camelize(:lower),
         :icon => icon,

--- a/app/views/miq_policy/_condition_folders.html.haml
+++ b/app/views/miq_policy/_condition_folders.html.haml
@@ -7,6 +7,6 @@
           %tr{:title => _("View Condition"),
             :onclick => "miqTreeActivateNode('condition_tree', 'xx-#{f.camelize(:lower)}');"}
             %td.table-view-pf-select
-              %img{:src => image_path("100/#{f.underscore}.png")}
+              %i{:class => TreeBuilderCondition.folder_icon(f)}
             %td
               = _("%{object} Conditions") % {:object => ui_lookup(:model => f)}


### PR DESCRIPTION
in Control > Explorer > accordion Conditions,
click on All Conditions in the tree

The right side view is assuming a png image exists for each class, which is no longer true for `PhysicalServer` (and randomly blue for container classes).

Changing to use the same fonticons as the tree on the left side - `TreeBuilderCondition`.

Cc @epwinchell 

before:
![before](https://user-images.githubusercontent.com/289743/27196064-936ff1dc-51f8-11e7-909b-586c1c44e65f.png)


after:
![after](https://user-images.githubusercontent.com/289743/27196069-952d6400-51f8-11e7-81e5-5b75d7e8bdf9.png)
