### PR TITLE
Remove all `.ff` references in icon_customizations.scss

### DIFF
--- a/app/assets/stylesheets/icon_customizations.scss
+++ b/app/assets/stylesheets/icon_customizations.scss
@@ -65,15 +65,12 @@ opacity:0.6;
 
 /* custom button icons */
 .miq-custom-button-1 {
-  @extend .ff, .ff-hexagon;
   color: #2d7623; // pf-green-500
 }
 .miq-custom-button-2 {
-  @extend .ff, .ff-wavy-lines;
   color: #00659c; //pf-blue-500
 }
 .miq-custom-button-3 {
-  @extend .ff, .ff-diamond;
   color: #f5c12e; //pf-gold-300
 }
 .miq-custom-button-4 {
@@ -85,13 +82,10 @@ opacity:0.6;
   color: #ec7a08; //pf-orange-400
 }
 .miq-custom-button-6 {
-  @extend .ff, .ff-database-squeezed;
 }
 .miq-custom-button-7 {
-  @extend .ff, .ff-broom;
 }
 .miq-custom-button-8 {
-  @extend .ff, .ff-triangle;
   color: #cc0000; //pf-red-100
 }
 .miq-custom-button-9 {
@@ -111,7 +105,6 @@ opacity:0.6;
   color: #00659c; //pf-blue-500
 }
 .miq-custom-button-13 {
-  @extend .ff, .ff-synchronize;
   color: #00659c; //pf-blue-500
 }
 .miq-custom-button-14 {


### PR DESCRIPTION
After a rebase, I was unable to get to the login screen due to  errors related to `.ff` instances: 

```
[----] F, [2017-06-15T14:50:59.781503 #27593:3fe40a2a587c] FATAL -- : Error caught: [ActionView::Template::Error] ".miq-custom-button-1" failed to @extend ".ff".
The selector ".ff" was not found.
Use "@extend .ff !optional" if the extend should be able to fail.

~/manageiq-ui-classic/app/assets/stylesheets/icon_customizations.scss:68
```

Possibly related to https://github.com/ManageIQ/manageiq-ui-classic/pull/1477

