### PR TITLE
Display Physical Servers with Host in Physical Infra Textual Summary and listnav

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -319,6 +319,11 @@ class ApplicationController < ActionController::Base
         options[:parent] = identify_record(curr_model_id, controller_to_model) if curr_model_id && options[:parent].nil?
       end
     end
+
+    if params[:model] == "physical_servers_with_host"
+      options[:where_clause] = "physical_servers.id in (select hosts.physical_server_id from hosts)"
+    end
+
     options[:parent] = options[:parent] || @parent
     options[:association] = params[:model] if HAS_ASSOCATION.include? params[:model]
     options[:selected_ids] = params[:records]
@@ -383,7 +388,6 @@ class ApplicationController < ActionController::Base
     if options.nil? || options[:view].nil?
       model_view = process_params_model_view(params, options)
       @edit = session[:edit]
-      options_from_session(options)
       @view, settings = get_view(model_view, options)
     else
       @view = options[:view]
@@ -402,16 +406,6 @@ class ApplicationController < ActionController::Base
       :data     => view_to_hash(@view),
       :messages => @flash_array
     }
-  end
-
-  def options_from_session(options)
-    options[:parent_method] = session[:paged_view_search_options][:parent_method]
-    options[:supported_features_filter] = session[:paged_view_search_options][:supported_features_filter]
-    options[:all_pages] = session[:paged_view_search_options][:page]
-    options[:where_clause] = session[:paged_view_search_options][:where_clause]
-    options[:named_scope] = session[:paged_view_search_options][:named_scope]
-    options[:display_filter_hash] = session[:paged_view_search_options][:display_filter_hash]
-    options[:match_via_descendants] = session[:paged_view_search_options][:match_via_descendants]
   end
 
   def event_logs

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -383,6 +383,7 @@ class ApplicationController < ActionController::Base
     if options.nil? || options[:view].nil?
       model_view = process_params_model_view(params, options)
       @edit = session[:edit]
+      options_from_session(options)
       @view, settings = get_view(model_view, options)
     else
       @view = options[:view]
@@ -401,6 +402,16 @@ class ApplicationController < ActionController::Base
       :data     => view_to_hash(@view),
       :messages => @flash_array
     }
+  end
+
+  def options_from_session(options)
+    options[:parent_method] = session[:paged_view_search_options][:parent_method]
+    options[:supported_features_filter] = session[:paged_view_search_options][:supported_features_filter]
+    options[:all_pages] = session[:paged_view_search_options][:page]
+    options[:where_clause] = session[:paged_view_search_options][:where_clause]
+    options[:named_scope] = session[:paged_view_search_options][:named_scope]
+    options[:display_filter_hash] = session[:paged_view_search_options][:display_filter_hash]
+    options[:match_via_descendants] = session[:paged_view_search_options][:match_via_descendants]
   end
 
   def event_logs

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -321,7 +321,7 @@ class ApplicationController < ActionController::Base
     end
 
     if params[:model] == "physical_servers_with_host"
-      options[:where_clause] = "physical_servers.id in (select hosts.physical_server_id from hosts)"
+      options.merge!(generate_options)
     end
 
     options[:parent] = options[:parent] || @parent

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -77,6 +77,16 @@ module EmsCommon
     nested_list('hosts', Host, :breadcrumb_title => _("Managed Hosts"))
   end
 
+  def display_physical_servers
+    if params[:options] == 'physical_servers_with_host'
+      nested_list('physical_servers', PhysicalServer,
+                  :where_clause     => "physical_servers.id in (select hosts.physical_server_id from hosts)",
+                  :breadcrumb_title => _("Physical Servers with Host"))
+    else
+      nested_list('physical_servers', PhysicalServer, :breadcrumb_title => _("Physical Servers"))
+    end
+  end
+
   class_methods do
     def display_methods
       %w(

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -77,12 +77,6 @@ module EmsCommon
     nested_list('hosts', Host, :breadcrumb_title => _("Managed Hosts"))
   end
 
-  def display_physical_servers_with_host
-    nested_list('physical_servers', PhysicalServer,
-                :where_clause     => "physical_servers.id in (select hosts.physical_server_id from hosts)",
-                :breadcrumb_title => _("Physical Servers with Host"))
-  end
-
   class_methods do
     def display_methods
       %w(

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -77,14 +77,10 @@ module EmsCommon
     nested_list('hosts', Host, :breadcrumb_title => _("Managed Hosts"))
   end
 
-  def display_physical_servers
-    if params[:options] == 'physical_servers_with_host'
-      nested_list('physical_servers', PhysicalServer,
-                  :where_clause     => "physical_servers.id in (select hosts.physical_server_id from hosts)",
-                  :breadcrumb_title => _("Physical Servers with Host"))
-    else
-      nested_list('physical_servers', PhysicalServer, :breadcrumb_title => _("Physical Servers"))
-    end
+  def display_physical_servers_with_host
+    nested_list('physical_servers', PhysicalServer,
+                :where_clause     => "physical_servers.id in (select hosts.physical_server_id from hosts)",
+                :breadcrumb_title => _("Physical Servers with Host"))
   end
 
   class_methods do
@@ -131,6 +127,7 @@ module EmsCommon
         orchestration_stacks
         persistent_volumes
         physical_servers
+        physical_servers_with_host
         security_groups
         storage_managers
         storages

--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -45,6 +45,12 @@ class EmsPhysicalInfraController < ApplicationController
     }
   end
 
+  def display_physical_servers_with_host
+    nested_list('physical_servers', PhysicalServer,
+                :where_clause     => "physical_servers.id in (select hosts.physical_server_id from hosts)",
+                :breadcrumb_title => _("Physical Servers with Host"))
+  end
+
   private
 
   ############################

--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -46,9 +46,12 @@ class EmsPhysicalInfraController < ApplicationController
   end
 
   def display_physical_servers_with_host
-    nested_list('physical_servers', PhysicalServer,
-                :where_clause     => "physical_servers.id in (select hosts.physical_server_id from hosts)",
-                :breadcrumb_title => _("Physical Servers with Host"))
+    nested_list('physical_servers', PhysicalServer, generate_options)
+  end
+
+  def generate_options
+    {:where_clause     => "physical_servers.id in (select hosts.physical_server_id from hosts)",
+     :breadcrumb_title => _("Physical Servers with Host")}
   end
 
   private

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -181,6 +181,7 @@ module Mixins
       view_options = {:parent => @record}
       view_options[:association] = options[:association] if options.key?(:association)
       view_options[:parent_method] = options[:parent_method] if options.key?(:parent_method)
+      view_options[:where_clause] = options[:where_clause] if options.key?(:where_clause)
 
       @view, @pages = get_view(model, view_options)
       @showtype = @display

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -220,6 +220,7 @@ module ApplicationHelper
     "host_services"                          => SystemService,
     "chargebacks"                            => ChargebackRate,
     "playbooks"                              => ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook,
+    "physical_servers_with_host"             => PhysicalServer,
     "manageiq/providers/automation_managers" => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
   }.freeze
 
@@ -1046,7 +1047,7 @@ module ApplicationHelper
       check_changes ||= args[:check_changes]
       tag_attrs[:onclick] = 'return miqCheckForChanges()' if check_changes
       content_tag(:li) do
-        link_args = {:display => args[:display], :vat => args[:vat], :options => args[:options]}.compact
+        link_args = {:display => args[:display], :vat => args[:vat]}.compact
         if args[:record] && restful_routed?(args[:record])
           link_to(link_text, polymorphic_path(args[:record], link_args), tag_attrs)
         else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1046,7 +1046,7 @@ module ApplicationHelper
       check_changes ||= args[:check_changes]
       tag_attrs[:onclick] = 'return miqCheckForChanges()' if check_changes
       content_tag(:li) do
-        link_args = {:display => args[:display], :vat => args[:vat]}.compact
+        link_args = {:display => args[:display], :vat => args[:vat], :options => args[:options]}.compact
         if args[:record] && restful_routed?(args[:record])
           link_to(link_text, polymorphic_path(args[:record], link_args), tag_attrs)
         else

--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -14,7 +14,7 @@ module EmsPhysicalInfraHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(physical_servers datastores vms hosts)
+      %i(physical_servers datastores vms physical_servers_with_host)
     )
   end
 
@@ -62,9 +62,13 @@ module EmsPhysicalInfraHelper::TextualSummary
     h
   end
 
-  def textual_hosts
+  def textual_physical_servers_with_host
     count_of_host_relationships = (@record.physical_servers.select { |server| !server.host.nil? }).length
-    {:label => _("Hosts"), :icon => "pficon pficon-screen", :value => count_of_host_relationships}
+    h = {:label => _("Physical Servers with Host"), :icon => "pficon pficon-server", :value => count_of_host_relationships}
+    if count_of_host_relationships > 0
+      h[:link] = "/ems_physical_infra/#{@ems.id}?display=physical_servers&options=physical_servers_with_host"
+    end
+    h
   end
 
   def textual_guid

--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -66,7 +66,7 @@ module EmsPhysicalInfraHelper::TextualSummary
     count_of_host_relationships = (@record.physical_servers.select { |server| !server.host.nil? }).length
     h = {:label => _("Physical Servers with Host"), :icon => "pficon pficon-server", :value => count_of_host_relationships}
     if count_of_host_relationships > 0
-      h[:link] = "/ems_physical_infra/#{@ems.id}?display=physical_servers&options=physical_servers_with_host"
+      h[:link] = "/ems_physical_infra/#{@ems.id}?display=physical_servers_with_host"
     end
     h
   end

--- a/app/views/layouts/listnav/_ems_physical_infra.html.haml
+++ b/app/views/layouts/listnav/_ems_physical_infra.html.haml
@@ -22,6 +22,7 @@
 
           - hosts = (@record.physical_servers.select { |server| !server.host.nil? }).length
           = li_link(:count => hosts,
-            :tables          => 'hosts',
+            :text            => _('Physical Servers with Host'),
             :record          => @record,
-            :display         => 'hosts')
+            :display         => 'physical_servers',
+            :options         => 'physical_servers_with_host')

--- a/app/views/layouts/listnav/_ems_physical_infra.html.haml
+++ b/app/views/layouts/listnav/_ems_physical_infra.html.haml
@@ -22,7 +22,6 @@
 
           - hosts = (@record.physical_servers.select { |server| !server.host.nil? }).length
           = li_link(:count => hosts,
-            :text            => _('Physical Servers with Host'),
-            :record          => @record,
-            :display         => 'physical_servers',
-            :options         => 'physical_servers_with_host')
+            :text          => _('Physical Servers with Host'),
+            :record        => @record,
+            :display       => 'physical_servers_with_host')


### PR DESCRIPTION
The Physical Infra Summary screen now displays a link for `Physical Servers with Host` which is clickable if the Physical Servers are greater than 0.
(basically addressed the pending items in this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/1458 specified in the comment https://github.com/ManageIQ/manageiq-ui-classic/pull/1458#issuecomment-306570215


<img width="1422" alt="screen shot 2017-06-15 at 4 28 24 pm" src="https://user-images.githubusercontent.com/1538216/27205977-04fe6df2-51e9-11e7-9471-eb6252dfa1ea.png">

<img width="1420" alt="screen shot 2017-06-15 at 4 18 45 pm" src="https://user-images.githubusercontent.com/1538216/27205994-1d6dd3e6-51e9-11e7-8977-5b5a0ec24959.png">

