### PR TITLE
Extract and cleanup single_delete handling.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -96,6 +96,10 @@ class ApplicationController < ActionController::Base
     @table_name ||= model.name.underscore
   end
 
+  def table_name
+    self.class.table_name
+  end
+
   def self.session_key_prefix
     table_name
   end

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -36,8 +36,8 @@ class AuthKeyPairCloudController < ApplicationController
     delete_auth_key_pairs if params[:pressed] == 'auth_key_pair_cloud_delete'
     new if params[:pressed] == 'auth_key_pair_cloud_new'
 
-    if !@flash_array.nil? && params[:pressed] == "auth_key_pair_cloud_delete" && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
+    if single_delete_test
+      single_delete_redirect
     elsif params[:pressed] == "auth_key_pair_cloud_new"
       if @flash_array
         show_list

--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -50,8 +50,8 @@ class ConfigurationJobController < ApplicationController
       @refresh_div = "flash_msg_div"
     end
 
-    if !@flash_array.nil? && params[:pressed] == "configurations_job_delete" && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message]
+    if single_delete_test
+      single_delete_redirect
     elsif @refresh_div == "main_div" && @lastaction == "show_list"
       replace_gtl_main_div
     else

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -82,8 +82,8 @@ class EmsClusterController < ApplicationController
       @refresh_div = "flash_msg_div"
     end
 
-    if !@flash_array.nil? && params[:pressed] == "ems_cluster_delete" && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
+    if single_delete_test
+      single_delete_redirect
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -344,10 +344,8 @@ module EmsCommon
       check_if_button_is_implemented
     end
 
-    if !@flash_array.nil? && params[:pressed] == "#{@table_name}_delete" && @single_delete
-      javascript_redirect :action      => 'show_list',
-                          :flash_msg   => @flash_array[0][:message],
-                          :flash_error => @flash_array[0][:level] == :error
+    if single_delete_test
+      single_delete_redirect
     elsif params[:pressed] == "host_aggregate_edit"
       javascript_redirect :controller => "host_aggregate",
                           :action     => "edit",

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -144,7 +144,7 @@ module EmsCommon
     set_form_vars
     @in_a_form = true
     session[:changed] = nil
-    drop_breadcrumb(:name => _("Add New %{table}") % {:table => ui_lookup(:table => @table_name)},
+    drop_breadcrumb(:name => _("Add New %{table}") % {:table => ui_lookup(:table => table_name)},
                     :url  => "/#{controller_name}/new")
   end
 
@@ -160,7 +160,7 @@ module EmsCommon
     set_form_vars
     @in_a_form = true
     session[:changed] = false
-    drop_breadcrumb(:name => _("Edit %{object_type} '%{object_name}'") % {:object_type => ui_lookup(:tables => @table_name), :object_name => @ems.name},
+    drop_breadcrumb(:name => _("Edit %{object_type} '%{object_name}'") % {:object_type => ui_lookup(:tables => table_name), :object_name => @ems.name},
                     :url  => "/#{controller_name}/#{@ems.id}/edit")
   end
 
@@ -267,18 +267,18 @@ module EmsCommon
     else
       @refresh_div = "main_div" # Default div for button.rjs to refresh
       redirect_to :action => "new" if params[:pressed] == "new"
-      deleteemss if params[:pressed] == "#{@table_name}_delete"
-      refreshemss if params[:pressed] == "#{@table_name}_refresh"
+      deleteemss if params[:pressed] == "#{table_name}_delete"
+      refreshemss if params[:pressed] == "#{table_name}_refresh"
       #     scanemss if params[:pressed] == "scan"
-      tag(model) if params[:pressed] == "#{@table_name}_tag"
+      tag(model) if params[:pressed] == "#{table_name}_tag"
 
       # Edit Tags for Middleware Manager Relationship pages
       tag(@display.camelize.singularize) if @display && @display != 'main' &&
                                             params[:pressed] == "#{@display.singularize}_tag"
-      assign_policies(model) if params[:pressed] == "#{@table_name}_protect"
-      check_compliance(model) if params[:pressed] == "#{@table_name}_check_compliance"
-      edit_record if params[:pressed] == "#{@table_name}_edit"
-      if params[:pressed] == "#{@table_name}_timeline"
+      assign_policies(model) if params[:pressed] == "#{table_name}_protect"
+      check_compliance(model) if params[:pressed] == "#{table_name}_check_compliance"
+      edit_record if params[:pressed] == "#{table_name}_edit"
+      if params[:pressed] == "#{table_name}_timeline"
         @showtype = "timeline"
         @record = find_record_with_rbac(model, params[:id])
         @timeline = @timeline_filter = true
@@ -289,7 +289,7 @@ module EmsCommon
         javascript_redirect polymorphic_path(@record, :display => 'timeline')
         return
       end
-      if params[:pressed] == "#{@table_name}_perf"
+      if params[:pressed] == "#{table_name}_perf"
         @showtype = "performance"
         @record = find_record_with_rbac(model, params[:id])
         drop_breadcrumb(:name => _("%{name} Capacity & Utilization") % {:name => @record.name},
@@ -298,7 +298,7 @@ module EmsCommon
         javascript_redirect polymorphic_path(@record, :display => "performance")
         return
       end
-      if params[:pressed] == "#{@table_name}_ad_hoc_metrics"
+      if params[:pressed] == "#{table_name}_ad_hoc_metrics"
         @showtype = "ad_hoc_metrics"
         @record = find_record_with_rbac(model, params[:id])
         drop_breadcrumb(:name => @record.name + _(" (Ad hoc Metrics)"), :url => show_link(@record))
@@ -339,7 +339,7 @@ module EmsCommon
       custom_buttons if params[:pressed] == "custom_button"
 
       return if ["custom_button"].include?(params[:pressed])    # custom button screen, so return, let custom_buttons method handle everything
-      return if ["#{@table_name}_tag", "#{@table_name}_protect", "#{@table_name}_timeline"].include?(params[:pressed]) &&
+      return if ["#{table_name}_tag", "#{table_name}_protect", "#{table_name}_timeline"].include?(params[:pressed]) &&
                 @flash_array.nil? # Tag screen showing, so return
       check_if_button_is_implemented
     end
@@ -521,14 +521,14 @@ module EmsCommon
       model.refresh_ems(emss, true)
       add_flash(n_("%{task} initiated for %{count} %{model} from the %{product} Database",
                    "%{task} initiated for %{count} %{models} from the %{product} Database", emss.length) % \
-        {:task    => task_name(task).gsub("Ems", ui_lookup(:tables => @table_name)),
+        {:task    => task_name(task).gsub("Ems", ui_lookup(:tables => table_name)),
          :count   => emss.length,
          :product => I18n.t('product.name'),
-         :model   => ui_lookup(:table => @table_name),
-         :models  => ui_lookup(:tables => @table_name)})
-      AuditEvent.success(:userid => session[:userid], :event => "#{@table_name}_#{task}",
+         :model   => ui_lookup(:table => table_name),
+         :models  => ui_lookup(:tables => table_name)})
+      AuditEvent.success(:userid => session[:userid], :event => "#{table_name}_#{task}",
           :message => _("'%{task}' successfully initiated for %{table}") %
-            {:task => task, :table => pluralize(emss.length, ui_lookup(:tables => @table_name).to_s)},
+            {:task => task, :table => pluralize(emss.length, ui_lookup(:tables => table_name))},
           :target_class => model.to_s)
     elsif task == "destroy"
       model.where(:id => emss).order("lower(name)").each do |ems|
@@ -546,8 +546,8 @@ module EmsCommon
                    "Delete initiated for %{count} %{models} from the %{product} Database", emss.length) %
         {:count   => emss.length,
          :product => I18n.t('product.name'),
-         :model   => ui_lookup(:table => @table_name),
-         :models  => ui_lookup(:tables => @table_name)}) if @flash_array.nil?
+         :model   => ui_lookup(:table => table_name),
+         :models  => ui_lookup(:tables => table_name)}) if @flash_array.nil?
     else
       model.where(:id => emss).order("lower(name)").each do |ems|
         id = ems.id
@@ -557,13 +557,13 @@ module EmsCommon
         rescue => bang
           add_flash(_("%{model} \"%{name}\": Error during '%{task}': %{error_message}") %
             {:model => ui_lookup(:table => @table_name), :name => ems_name, :task => _(task.titleize), :error_message => bang.message}, :error)
-          AuditEvent.failure(:userid => session[:userid], :event => "#{@table_name}_#{task}",
+          AuditEvent.failure(:userid => session[:userid], :event => "#{table_name}_#{task}",
             :message      => _("%{name}: Error during '%{task}': %{message}") %
                           {:name => ems_name, :task => task, :message => bang.message},
             :target_class => model.to_s, :target_id => id)
         else
           add_flash(_("%{model} \"%{name}\": %{task} successfully initiated") % {:model => ui_lookup(:table => @table_name), :name => ems_name, :task => _(task.titleize)})
-          AuditEvent.success(:userid => session[:userid], :event => "#{@table_name}_#{task}",
+          AuditEvent.success(:userid => session[:userid], :event => "#{table_name}_#{task}",
                              :message      => _("%{name}: '%{task}' successfully initiated") % {:name => ems_name, :task => task},
                              :target_class => model.to_s, :target_id => id)
         end
@@ -578,25 +578,25 @@ module EmsCommon
     if @lastaction == "show_list" # showing a list, scan all selected emss
       emss = find_checked_items
       if emss.empty?
-        add_flash(_("No %{record} were selected for deletion") % {:record => ui_lookup(:table => @table_name)}, :error)
+        add_flash(_("No %{record} were selected for deletion") % {:record => ui_lookup(:table => table_name)}, :error)
       end
       process_emss(emss, "destroy") unless emss.empty?
       add_flash(n_("Delete initiated for %{count} %{model} from the %{product} Database",
                    "Delete initiated for %{count} %{models} from the %{product} Database", emss.length) %
         {:count   => emss.length,
          :product => I18n.t('product.name'),
-         :model   => ui_lookup(:table => @table_name),
-         :models  => ui_lookup(:tables => @table_name)}) if @flash_array.nil?
+         :model   => ui_lookup(:table => table_name),
+         :models  => ui_lookup(:tables => table_name)}) if @flash_array.nil?
     else # showing 1 ems, scan it
       if params[:id].nil? || model.find_by_id(params[:id]).nil?
-        add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:table => @table_name)}, :error)
+        add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:table => table_name)}, :error)
       else
         emss.push(params[:id])
       end
       process_emss(emss, "destroy") unless emss.empty?
       @single_delete = true unless flash_errors?
       add_flash(_("The selected %{record} was deleted") %
-        {:record => ui_lookup(:tables => @table_name)}) if @flash_array.nil?
+        {:record => ui_lookup(:tables => table_name)}) if @flash_array.nil?
     end
     if @lastaction == "show_list"
       show_list
@@ -611,20 +611,20 @@ module EmsCommon
     if @lastaction == "show_list" # showing a list, scan all selected emss
       emss = find_checked_items
       if emss.empty?
-        add_flash(_("No %{model} were selected for scanning") % {:model => ui_lookup(:table => @table_name)}, :error)
+        add_flash(_("No %{model} were selected for scanning") % {:model => ui_lookup(:table => table_name)}, :error)
       end
       process_emss(emss, "scan")  unless emss.empty?
       add_flash(n_("Analysis initiated for %{count} %{model} from the %{product} Database",
                    "Analysis initiated for %{count} %{models} from the %{product} Database", emss.length) %
         {:count   => emss.length,
          :product => I18n.t('product.name'),
-         :model   => ui_lookup(:table => @table_name),
-         :models  => ui_lookup(:tables => @table_name)}) if @flash_array.nil?
+         :model   => ui_lookup(:table => table_name),
+         :models  => ui_lookup(:tables => table_name)}) if @flash_array.nil?
       show_list
       @refresh_partial = "layouts/gtl"
     else # showing 1 ems, scan it
       if params[:id].nil? || model.find_by_id(params[:id]).nil?
-        add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:tables => @table_name)}, :error)
+        add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:tables => table_name)}, :error)
       else
         emss.push(params[:id])
       end
@@ -633,8 +633,8 @@ module EmsCommon
                    "Analysis initiated for %{count} %{models} from the %{product} Database", emss.length) %
         {:count   => emss.length,
          :product => I18n.t('product.name'),
-         :model   => ui_lookup(:table => @table_name),
-         :models  => ui_lookup(:tables => @table_name)}) if @flash_array.nil?
+         :model   => ui_lookup(:table => table_name),
+         :models  => ui_lookup(:tables => table_name)}) if @flash_array.nil?
       params[:display] = @display
       show
       if ["vms", "hosts", "storages"].include?(@display)
@@ -653,8 +653,8 @@ module EmsCommon
                  "Refresh initiated for %{count} %{models} from the %{product} Database", emss.length) %
       {:count   => emss.length,
        :product => I18n.t('product.name'),
-       :model   => ui_lookup(:table => @table_name),
-       :models  => ui_lookup(:tables => @table_name)})
+       :model   => ui_lookup(:table => table_name),
+       :models  => ui_lookup(:tables => table_name)})
   end
 
   # Refresh VM states for all selected or single displayed ems(s)
@@ -663,14 +663,14 @@ module EmsCommon
     if @lastaction == "show_list"
       emss = find_checked_items
       if emss.empty?
-        add_flash(_("No %{model} were selected for refresh") % {:model => ui_lookup(:table => @table_name)}, :error)
+        add_flash(_("No %{model} were selected for refresh") % {:model => ui_lookup(:table => table_name)}, :error)
       end
       call_ems_refresh(emss)
       show_list
       @refresh_partial = "layouts/gtl"
     else
       if params[:id].nil? || model.find_by_id(params[:id]).nil?
-        add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:table => @table_name)}, :error)
+        add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:table => table_name)}, :error)
       else
         call_ems_refresh([params[:id]])
       end

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -417,8 +417,8 @@ class HostController < ApplicationController
       @host = @record = identify_record(params[:id])
     end
 
-    if !@flash_array.nil? && params[:pressed] == "host_delete" && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
+    if single_delete_test
+      single_delete_redirect
     elsif params[:pressed].ends_with?("_edit") || ["host_miq_request_new", "#{pfx}_miq_request_new",
                                                    "#{pfx}_clone", "#{pfx}_migrate",
                                                    "#{pfx}_publish"].include?(params[:pressed])

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -48,8 +48,8 @@ module Mixins
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
         end
         drop_breadcrumb(:name => _("Edit %{table} '%{name}'") %
-          {:table => ui_lookup(:table => @table_name), :name => update_ems.name},
-                        :url  => "/#{@table_name}/edit/#{update_ems.id}")
+          {:table => ui_lookup(:table => table_name), :name => update_ems.name},
+                        :url  => "/#{table_name}/edit/#{update_ems.id}")
         @in_a_form = true
         render_flash
       end
@@ -88,7 +88,7 @@ module Mixins
       if ems.valid? && ems.save
         construct_edit_for_audit(ems)
         AuditEvent.success(build_created_audit(ems, @edit))
-        flash_msg = _("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:tables => @table_name),
+        flash_msg = _("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:tables => table_name),
                                                            :name  => ems.name}
         javascript_redirect :action    => 'show_list',
                             :flash_msg => flash_msg

--- a/app/controllers/mixins/generic_session_mixin.rb
+++ b/app/controllers/mixins/generic_session_mixin.rb
@@ -7,7 +7,6 @@ module Mixins
       prefix      = self.class.session_key_prefix
       @title      = respond_to?(:title) ? title : ui_lookup(:tables => self.class.table_name)
       @layout     = prefix
-      @table_name = request.parameters[:controller]
       @lastaction = session["#{prefix}_lastaction".to_sym]
       @display    = session["#{prefix}_display".to_sym]
       @filters    = session["#{prefix}_filters".to_sym]

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -106,8 +106,8 @@ class OrchestrationStackController < ApplicationController
       @refresh_div = "flash_msg_div"
     end
 
-    if !@flash_array.nil? && params[:pressed] == "orchestration_stack_delete" && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message]
+    if single_delete_test
+      single_delete_redirect
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -48,8 +48,8 @@ class ResourcePoolController < ApplicationController
 
     check_if_button_is_implemented
 
-    if !@flash_array.nil? && params[:pressed] == "resource_pool_delete" && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
+    if single_delete_test
+      single_delete_redirect
     elsif ["#{pfx}_miq_request_new", "#{pfx}_migrate", "#{pfx}_clone",
            "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -131,8 +131,8 @@ class StorageController < ApplicationController
       @refresh_div = "flash_msg_div"
     end
 
-    if !@flash_array.nil? && params[:pressed] == "storage_delete" && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
+    if single_delete_test
+      single_delete_redirect
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -54,7 +54,7 @@ module VmCommon
     end
     @vm = @record = identify_record(params[:id], VmOrTemplate) unless @lastaction == "show_list"
 
-    if single_delete_test
+    if single_delete_test(true)
       single_delete_redirect
     elsif params[:pressed].ends_with?("_edit")
       if @redirect_controller

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -54,8 +54,8 @@ module VmCommon
     end
     @vm = @record = identify_record(params[:id], VmOrTemplate) unless @lastaction == "show_list"
 
-    if !@flash_array.nil? && @single_delete
-      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
+    if single_delete_test
+      single_delete_redirect
     elsif params[:pressed].ends_with?("_edit")
       if @redirect_controller
         javascript_redirect :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id, :org_controller => @org_controller

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1667,4 +1667,16 @@ module ApplicationHelper
   def r
     @r ||= proc { |opts| render_to_string(opts) }
   end
+
+  # test if just succesfully deleted an entity that was being displayed
+  def single_delete_test
+    @flash_array.present? && params[:pressed] == "#{@table_name}_delete" && @single_delete
+  end
+
+  # redirect to show_list (after succesfully deleted the entity being displayed)
+  def single_delete_redirect
+    javascript_redirect :action      => 'show_list',
+                        :flash_msg   => @flash_array[0][:message],
+                        :flash_error => @flash_array[0][:level] == :error
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1670,7 +1670,7 @@ module ApplicationHelper
 
   # test if just succesfully deleted an entity that was being displayed
   def single_delete_test
-    @flash_array.present? && params[:pressed] == "#{@table_name}_delete" && @single_delete
+    @flash_array.present? && params[:pressed] == "#{table_name}_delete" && @single_delete
   end
 
   # redirect to show_list (after succesfully deleted the entity being displayed)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1668,9 +1668,10 @@ module ApplicationHelper
     @r ||= proc { |opts| render_to_string(opts) }
   end
 
-  # test if just succesfully deleted an entity that was being displayed
-  def single_delete_test
-    @flash_array.present? && params[:pressed] == "#{table_name}_delete" && @single_delete
+  # Test if just succesfully deleted an entity that was being displayed
+  def single_delete_test(any_button = false)
+    @flash_array.present? && @single_delete &&
+      (any_button || params[:pressed] == "#{table_name}_delete")
   end
 
   # redirect to show_list (after succesfully deleted the entity being displayed)


### PR DESCRIPTION
When entity being displayed is deleted, we need to redirect to the `show_list`.

Extract, cleanup, unify.