### PR TITLE
Do not run move of new pagination and remove of old one when new one is present

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -369,7 +369,12 @@
         var oldPagination = pagingDiv.querySelector('div');
         oldPagination ? oldPagination.remove() : null;
 
-        var col = $('<div class="col-md-12"></div>');
+        var cols = 12;
+        if ($('#form_buttons_div').css('display') !== 'none' && $('#form_buttons_div').children().length !== 0) {
+          cols = 10;
+        }
+
+        var col = $('<div class="col-md-' + cols + '"></div>');
         $(pagingDiv).append(col);
         col[0].appendChild(pagination[0]);
       }

--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -344,11 +344,6 @@
         angular.element(mainContent).addClass('miq-list-content');
       }
     }
-
-    var pagination = this.$document.getElementsByClassName('miq-pagination');
-    if (pagination && pagination.length > 0 && ! viewType) {
-      pagination[0].parentNode.removeChild(pagination[0]);
-    }
   };
 
   ReportDataController.prototype.activateNodeSilently = function(itemId) {
@@ -363,7 +358,14 @@
       $('table td.narrow').addClass('table-view-pf-select').removeClass('narrow');
       var pagination = this.$document.getElementsByClassName('miq-pagination');
       var pagingDiv = this.$document.querySelector('#paging_div');
-      if (pagination && pagination.length > 0 && pagingDiv) {
+      // If more than one angular pagination is present remove some left overs.
+      if (pagination.length !== 1) {
+        $(pagination).each(function(index, item) {
+          // keep the first one
+          index !== 0 && item.remove();
+        });
+      }
+      if (pagination && pagination.length > 0 && pagingDiv && $(pagingDiv).find(pagination).length !== 1) {
         var oldPagination = pagingDiv.querySelector('div');
         oldPagination ? oldPagination.remove() : null;
 


### PR DESCRIPTION
After Merge of https://github.com/ManageIQ/manageiq-ui-classic/commit/c0feb5057a6ffcc020634067206bef377ae1ebb8 there was bug when new pagination was present it was removed if page/sorting has changed. So do not run removing of pagination and moving such pagination if new one is already at correct place.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/1489