### PR TITLE
Add git protocol to URL for Ansible repo

### DIFF
--- a/app/assets/javascripts/directives/url_validation.js
+++ b/app/assets/javascripts/directives/url_validation.js
@@ -10,7 +10,7 @@ ManageIQ.angular.app.directive('urlValidation', function() {
       };
 
       var validUrl = function(s) {
-        return s.substring(0, 8) === 'https://' || s.substring(0, 7) === 'http://';
+        return s.substring(0, 8) === 'https://' || s.substring(0, 7) === 'http://' || s.substring(0, 4) === 'git@';
       };
     }
   }

--- a/app/assets/javascripts/directives/url_validation.js
+++ b/app/assets/javascripts/directives/url_validation.js
@@ -10,7 +10,7 @@ ManageIQ.angular.app.directive('urlValidation', function() {
       };
 
       var validUrl = function(s) {
-        return s.substring(0, 8) === 'https://' || s.substring(0, 7) === 'http://' || s.substring(0, 4) === 'git@';
+        return s.substring(0, 8) === 'https://' || s.substring(0, 7) === 'http://' || s.match(/^[-\w:.]+@.*:/);
       };
     }
   }

--- a/app/views/ansible_repository/_repository_form.html.haml
+++ b/app/views/ansible_repository/_repository_form.html.haml
@@ -53,7 +53,7 @@
         %span.help-block{"ng-show" => "angularForm.scm_url.$error.required"}
           = _("Required")
         %span.help-block{"ng-show" => "angularForm.scm_url.$error.urlValidation"}
-          = _("URL must include a protocol (http:// or https://)")
+          = _("URL must include a protocol (http://, https:// or git@)")
     .form-group
       %label.col-md-2.control-label
         = _('SCM credentials')

--- a/app/views/ansible_repository/_repository_form.html.haml
+++ b/app/views/ansible_repository/_repository_form.html.haml
@@ -53,7 +53,7 @@
         %span.help-block{"ng-show" => "angularForm.scm_url.$error.required"}
           = _("Required")
         %span.help-block{"ng-show" => "angularForm.scm_url.$error.urlValidation"}
-          = _("URL must include a protocol (http://, https:// or git@)")
+          = _("URL must include a protocol (http:// or https://) or be a valid SSH path (user@server:path)")
     .form-group
       %label.col-md-2.control-label
         = _('SCM credentials')


### PR DESCRIPTION
Allow git protocol as valid input

Automate -> Ansible -> Repositories -> Add/Edit Repository -> use URL with git protocol in URL field

Before:
Error message
After:
No error

https://bugzilla.redhat.com/show_bug.cgi?id=1452584

@miq-bot add_label automation/ansible, bug, fine/yes, blocker, wip