### PR TITLE
[FINE] Key Pair (angular) - don't sparkleOff when waiting for task

### DIFF
--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -29,12 +29,11 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
 
         var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
         $scope.keyPairModel.ems_id = $scope.keyPairModel.ems.id;
-        if(serializeFields) {
-            miqService.miqAjaxButton(url, miqService.serializeModel($scope.keyPairModel));
+        if (serializeFields) {
+            miqService.miqAjaxButton(url, miqService.serializeModel($scope.keyPairModel), { complete: false });
         } else {
-            miqService.miqAjaxButton(url, false);
+            miqService.miqAjaxButton(url);
         }
-        miqService.sparkleOff();
     };
 
     $scope.cancelClicked = function() {

--- a/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
+++ b/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
@@ -69,7 +69,7 @@ describe('keyPairCloudFormController', function() {
         });
 
         it('delegates to miqService.miqAjaxButton', function() {
-            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=save', miqService.serializeModel($scope.keyPairModel));
+            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=save', miqService.serializeModel($scope.keyPairModel), { complete: false });
         });
     });
 
@@ -77,7 +77,7 @@ describe('keyPairCloudFormController', function() {
         beforeEach(function() {
             $httpBackend.flush();
             $scope.angularForm = {
-                $setPristine: function (value){}
+                $setPristine: function (value) {},
             };
             $scope.cancelClicked();
         });
@@ -87,7 +87,7 @@ describe('keyPairCloudFormController', function() {
         });
 
         it('delegates to miqService.restAjaxButton', function() {
-            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=cancel', false);
+            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=cancel');
         });
     });
 });


### PR DESCRIPTION
This is a fine version of https://github.com/ManageIQ/manageiq-ui-classic/pull/1178 - sparkle when waiting for task when saving a cloud key pair.

(The difference from the master PR is only in that #1178 got rebased on top of #719 and also fixes some resulting whitespace issues.)

master BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1462278
fine BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1462287