### PR TITLE
Fixed titles and labels for Hosts & Clusters Openstack Providers

### DIFF
--- a/app/assets/javascripts/controllers/ems_infra_dashboard/ems_infra_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/ems_infra_dashboard/ems_infra_dashboard_controller.js
@@ -122,12 +122,15 @@
         $scope.clusterCpuUsage = infraChartsMixin.processHeatmapData($scope.clusterCpuUsage, data.heatmaps.clusterCpuUsage);
         $scope.clusterCpuUsage.loadingDone = true;
 
+        $scope.clusterChartTitle = data.heatmaps.title;
         $scope.clusterMemoryUsage =
           infraChartsMixin.processHeatmapData($scope.clusterMemoryUsage, data.heatmaps.clusterMemoryUsage);
         $scope.clusterMemoryUsage.loadingDone = true;
 
         // Recent Hosts
         $scope.recentHostsConfig = infraChartsMixin.chartConfig.recentHostsConfig;
+        $scope.recentHostsConfig.headTitle = data.recentHosts.title;
+        $scope.recentHostsConfig.label = data.recentHosts.label;
 
         // recent Hosts chart
         $scope.recentHostsData = infraChartsMixin.processRecentHostsData(data.recentHosts,

--- a/app/assets/javascripts/controllers/ems_infra_dashboard/util/infra-dashboard-utils-factory.js
+++ b/app/assets/javascripts/controllers/ems_infra_dashboard/util/infra-dashboard-utils-factory.js
@@ -49,8 +49,9 @@ angular.module('miq.util').factory('infraDashboardUtilsFactory', function() {
     statusObject.notification = {};
     if (data) {
       statusObject.count = data.count;
-      if (data.title)
+      if (data.title) {
         statusObject.title = data.title;
+      }
 
       if (data.errorCount > 0) {
         statusObject.notification = {

--- a/app/assets/javascripts/controllers/ems_infra_dashboard/util/infra-dashboard-utils-factory.js
+++ b/app/assets/javascripts/controllers/ems_infra_dashboard/util/infra-dashboard-utils-factory.js
@@ -8,7 +8,6 @@ angular.module('miq.util').factory('infraDashboardUtilsFactory', function() {
   };
   var createClustersStatus = function() {
     return {
-      title: __("Clusters"),
       iconClass: " pficon pficon-cluster",
       count: 0,
       notification: {}
@@ -16,7 +15,6 @@ angular.module('miq.util').factory('infraDashboardUtilsFactory', function() {
   };
   var createHostsStatus = function() {
     return {
-      title: __("Hosts"),
       iconClass: "pficon pficon-screen",
       count: 0,
       notification: {}
@@ -51,6 +49,9 @@ angular.module('miq.util').factory('infraDashboardUtilsFactory', function() {
     statusObject.notification = {};
     if (data) {
       statusObject.count = data.count;
+      if (data.title)
+        statusObject.title = data.title;
+
       if (data.errorCount > 0) {
         statusObject.notification = {
           iconClass: "pficon pficon-error-circle-o",

--- a/app/views/ems_infra/_show_dashboard.html.haml
+++ b/app/views/ems_infra/_show_dashboard.html.haml
@@ -20,12 +20,13 @@
                "show-top-border"          => "true",
                :status                    => "objectStatus.hosts",
                :url                       => "navigation"}
-        .col-xs-6.col-sm-6.col-md-3
-          %div{:layout                    => "mini",
-               "pf-aggregate-status-card" => "",
-               "show-top-border"          => "true",
-               :status                    => "objectStatus.datastores",
-               :url                       => "navigation"}
+        - unless @ems.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
+          .col-xs-6.col-sm-6.col-md-3
+            %div{:layout                    => "mini",
+                 "pf-aggregate-status-card" => "",
+                 "show-top-border"          => "true",
+                 :status                    => "objectStatus.datastores",
+                 :url                       => "navigation"}
         .col-xs-6.col-sm-6.col-md-3
           %div{:layout                    => "mini",
                "pf-aggregate-status-card" => "",
@@ -75,7 +76,7 @@
            :heatmaps                      => "heatmaps",
            "heatmaps-card"                => "",
            :hidetopborder                 => "true",
-           :title                         => _("Cluster Utilization")}
+           "title"                        => "{{clusterChartTitle}}"}
   .row.row-tile-pf.row-tile-pf-last
     .col-xs-12.col-sm-6.col-md-6
       %div{"head-title" => "{{recentHostsConfig.headTitle}}",

--- a/spec/javascripts/fixtures/json/ems_infra_dashboard_no_data_response.json
+++ b/spec/javascripts/fixtures/json/ems_infra_dashboard_no_data_response.json
@@ -31,6 +31,16 @@
       "clusterCpuUsage": null,
       "clusterMemoryUsage": null
     },
+    "recentHosts": {
+      "title": "Recent Hosts",
+      "label": "hosts",
+      "xData": [
+        "2015-11-26"
+      ],
+      "yData": [
+        3
+      ]
+    },
     "providers": [
       {
         "count": 1,

--- a/spec/javascripts/fixtures/json/ems_infra_dashboard_response.json
+++ b/spec/javascripts/fixtures/json/ems_infra_dashboard_response.json
@@ -47,6 +47,16 @@
         }
       ]
     },
+    "recentHosts": {
+      "title": "Recent Hosts",
+      "label": "hosts",
+      "xData": [
+        "2015-11-26"
+      ],
+      "yData": [
+        3
+      ]
+    },
     "providers": [
       {
         "count": 1,


### PR DESCRIPTION
- Changed to show Nodes/Deployment Roles as titles for Hosts/Clusters for Openstack Dashboards charts where appropriate on screen.
- Removed Datastores count chart for Openstack Provider.

https://bugzilla.redhat.com/show_bug.cgi?id=1430241

before
![before](https://user-images.githubusercontent.com/3450808/27236716-0782bfa0-5294-11e7-872b-598e7e4255ac.png)

after
![after](https://user-images.githubusercontent.com/3450808/27236712-0510297e-5294-11e7-8bff-624a3619383b.png)

Dashboard for other Infra providers is same as before
![after2](https://user-images.githubusercontent.com/3450808/27235910-c3d725e6-5290-11e7-97e2-e3abae8a22ca.png)

@dclarizio please review.