### PR TITLE
[WIP] Shows error message on pxe duplicate customization template name

### DIFF
--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -105,6 +105,8 @@ module PxeController::PxeCustomizationTemplates
       end
       if @edit[:new][:name].blank?
         add_flash(_("Name is required"), :error)
+      elsif CustomizationTemplate.all.pluck(:name).include?(@edit[:new][:name])
+        add_flash(_("Name has already been taken"), :error)
       end
       if @edit[:new][:typ].blank?
         add_flash(_("Type is required"), :error)


### PR DESCRIPTION
PXE customization templates shouldn't allow duplicates by name. Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1449116