### PR TITLE
[WIP] Disable click on tag edit screens

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -195,7 +195,7 @@
   ReportDataController.prototype.onItemClicked = function(item, event) {
     event.stopPropagation();
     event.preventDefault();
-    if (this.initObject.showUrl) {
+    if (this.initObject.showUrl && !this.settings.hideSelect) {
       var prefix = this.initObject.showUrl;
       var splitUrl = this.initObject.showUrl.split('/');
       if (this.initObject.isExplorer && isCurrentControllerOrPolicies(splitUrl)) {

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -365,6 +365,13 @@ table.table.table-summary-screen tbody td img {
 .quadicon { position:relative;float:left;padding: 0 1px 1px 0;width: 72px; height: 80px;color: #e3e4e4;text-transform: none;}
 .quadicon:hover{ padding: 1px 0 0 1px;}
 
+.quadicon.disabled {
+  &:hover {
+    cursor: default;
+    padding: 0 1px 1px 0;
+  }
+}
+
 /// adjust power state images for use in quad icon
 .b72 .stretch {
   background-repeat: no-repeat;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -388,6 +388,10 @@ class ApplicationController < ActionController::Base
       @view.table.data.push(options[:unassigned_profile_row])
       @targets_hash[options[:unassigned_profile_row]['id']] = options[:unassigned_configuration_profile]
     end
+
+    # disable quadicon hover effects
+    @quadicon_tag_edit = /edit_tags/ =~ @edit[:key] if @edit
+
     render :json => {
       :settings => settings,
       :data     => view_to_hash(@view),

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -146,6 +146,10 @@ module QuadiconHelper
       tag_options[:class] = ""
     end
 
+    if quadicon_policy_sim? || @quadicon_tag_edit
+      tag_options[:class] = "quadicon disabled"
+    end
+
     quadicon_tag(tag_options) do
       quadicon_builder_factory(item, options)
     end


### PR DESCRIPTION
![screen shot 2017-06-19 at 3 23 23 pm](https://user-images.githubusercontent.com/39493/27302008-41b4ed76-5503-11e7-9b03-1e485ef11c0e.png)

Currently items in a tag-edit screen are clickable. This fixes that.

Addresses
https://bugzilla.redhat.com/show_bug.cgi?id=1460685

@h-kataria @dclarizio 