### PR TITLE
Added hosts and vms relationship with physical server to physical Infra topology

### DIFF
--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -3,10 +3,16 @@ class PhysicalInfraTopologyService < TopologyService
 
   @included_relations = [
     :tags,
-    :physical_servers => [:tags, :host => :tags],
+    :physical_servers => [
+      :tags,
+      :host => [
+        :tags,
+        :vms => :tags
+      ]
+    ],
   ]
 
-  @kinds = %i(PhysicalInfraManager PhysicalServer Host Tag)
+  @kinds = %i(PhysicalInfraManager PhysicalServer Host Vm Tag)
 
   def entity_display_type(entity)
     if entity.kind_of?(ManageIQ::Providers::PhysicalInfraManager)

--- a/app/views/physical_infra_topology/show.html.haml
+++ b/app/views/physical_infra_topology/show.html.haml
@@ -11,6 +11,10 @@
         %label
           %i.pficon.pficon-screen
           = _("Hosts")
+      %kubernetes-topology-icon{tooltipOptions, :kind => "Vm"}
+        %label
+          %i.pficon.pficon-screen
+          = _("VMs")
 
   .alert.alert-info.alert-dismissable
     %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}


### PR DESCRIPTION
This PR shows:
- The Physical Infra topology containing the relationship between Provider/Physica Server/Host/Vm.

![image](https://user-images.githubusercontent.com/5839808/27303596-b6030632-5511-11e7-896c-25a927ffd336.png)





