### PR TITLE
Update patternfly-timeline to 1.0.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,7 @@
     "moment-timezone": "~0.4.1",
     "numeral": "~1.5.5",
     "patternfly-bootstrap-treeview": "~2.1.1",
-    "patternfly-timeline": "~1.0.3",
+    "patternfly-timeline": "~1.0.5",
     "phantomjs-polyfill": "~0.0.2",
     "qs": "~0.3.10",
     "rx-angular": "rx.angular#~1.1.3",


### PR DESCRIPTION
This PR updates patternfly-timeline from 1.0.3 to 1.0.5, fixing an IE11 scrolling bug. This is the original PF PR: https://github.com/patternfly/patternfly-timeline/pull/34

https://bugzilla.redhat.com/show_bug.cgi?id=1443511