### PR TITLE
Disable Code Climate check for the `undefined` keyword

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -42,6 +42,9 @@ engines:
   eslint:
     enabled: true
     channel: "eslint-3"
+    checks:
+      no-undefined:
+        enabled: false
   fixme:
     # let's enable later
     enabled: false


### PR DESCRIPTION
Disables Code Climate check for the `undefined` keyword in JS code.