### PR TITLE
Allow VMRC connection to a VMware provider accessed through IPv6

### DIFF
--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -46,12 +46,7 @@ module VmRemote
                   :api_version => @record.ext_management_system.api_version.to_s,
                   :os          => browser_info(:os),
                   :name        => @record.name,
-                  :vmrc_uri    => URI::Generic.build(:scheme   => "vmrc",
-                                                     :userinfo => "clone:#{params[:ticket]}",
-                                                     :host     => host,
-                                                     :port     => 443,
-                                                     :path     => "/",
-                                                     :query    => "moid=#{vmid}")
+                  :vmrc_uri    => build_vmrc_uri(host, vmid, params[:ticket])
                 }
               end
     render :template => "vm_common/console_#{console_type}",
@@ -128,5 +123,16 @@ module VmRemote
             end
       javascript_open_window(url)
     end
+  end
+
+  def build_vmrc_uri(host, vmid, ticket)
+    uri = URI::Generic.build(:scheme   => "vmrc",
+                             :userinfo => "clone:#{ticket}",
+                             :host     => host,
+                             :port     => 443,
+                             :path     => "/",
+                             :query    => "moid=#{vmid}").to_s
+    # VMRC doesn't like brackets around IPv6 addresses
+    uri.sub(/(.*)\[/, '\1').sub(/(.*)\]/, '\1')
   end
 end

--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -37,7 +37,7 @@ module VmRemote
                                                     :path   => "/ticket/#{params[:ticket]}")
                 }
               when "vmrc"
-                host = @record.ext_management_system.ipaddress || @record.ext_management_system.hostname
+                host = @record.ext_management_system.hostname || @record.ext_management_system.ipaddress
                 vmid = @record.ems_ref
                 {
                   :host        => host,


### PR DESCRIPTION
VMRC has a strange URI form where he doesn't need the brackets around an IPv6 address. The first commit favors the hostname of a provider in the generated URI while the second one removes the brackets from the final URI if required. These two PRs should solve the issue described here:

https://bugzilla.redhat.com/show_bug.cgi?id=1457970#c11