### PR TITLE
Validate cloud credentials on the queue 

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -76,7 +76,7 @@ module Mixins
       ems_type = model.model_from_emstype(params[:emstype])
       # TODO: queue authentication checks for all providers, not just cloud
       result, details = if params[:controller] == "ems_cloud"
-                          ems_type.queue_authentication_check(get_task_args(ems_type), session[:userid], params[:zone])
+                          ems_type.validate_credentials_task(get_task_args(ems_type), session[:userid], params[:zone])
                         else
                           realtime_authentication_check(ems_type.new)
                         end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -325,6 +325,16 @@ describe EmsCloudController do
       expect(mocked_infra).to receive(:authentication_check).with("default", hash_including(:save => false))
       controller.send(:create_ems_button_validate)
     end
+
+    it "does not queue the authentication check if it is a cloud provider with a ui role" do
+      session[:selected_roles] = ['user_interface']
+      allow(controller).to receive(:render)
+      allow(ExtManagementSystem).to receive(:model_from_emstype).and_return(mocked_infra_class)
+      controller.instance_variable_set(:@_params, :controller => "ems_cloud")
+
+      expect(mocked_infra_class).to receive(:raw_connect)
+      controller.send(:create_ems_button_validate)
+    end
   end
 
   describe "#test_toolbars" do

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -311,7 +311,7 @@ describe EmsCloudController do
       allow(ExtManagementSystem).to receive(:model_from_emstype).and_return(mocked_infra_class)
       controller.instance_variable_set(:@_params, :controller => "ems_cloud")
 
-      expect(mocked_infra_class).to receive(:queue_authentication_check)
+      expect(mocked_infra_class).to receive(:validate_credentials_task)
       controller.send(:create_ems_button_validate)
     end
 

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -308,11 +308,10 @@ describe EmsCloudController do
 
     it "queues the authentication type if it is a cloud provider" do
       allow(controller).to receive(:render)
-      allow(ExtManagementSystem).to receive(:model_from_emstype)
+      allow(ExtManagementSystem).to receive(:model_from_emstype).and_return(mocked_infra_class)
       controller.instance_variable_set(:@_params, :controller => "ems_cloud")
 
-      expect(MiqTask).to receive(:generic_action_with_callback)
-      expect(MiqTask).to receive(:wait_for_taskid)
+      expect(mocked_infra_class).to receive(:queue_authentication_check)
       controller.send(:create_ems_button_validate)
     end
 


### PR DESCRIPTION
~~### This is very WIP~~

This PR is for a [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1456406) related to provider validation not occurring in the specified zone and is related to the closed PR https://github.com/ManageIQ/manageiq/pull/4869 that began to work on validating credentials in the queue (I stole a bit of it, thanks @agrare!) 

I started to address some of the concerns from @Fryguy's [comment](https://github.com/ManageIQ/manageiq/pull/4869/files#r42282562) by doing the following:

* Getting rid of the temporary EMS 
* Calling the `raw_connect` class method

There are still a couple of things that need to be done for this to work completely:
~~* `raw_connect` for `amazon` and `vmware` need to be modified slightly to actually validate / not just pass back a connection (have been playing around with this locally to test this PR)~~
~~* need to encrypt the credentials before putting into the queue~~
~~* write specs~~
~~* fix whatever I inevitably broke 😛~~
Before I continue down this 🐰 hole, I wanted to start a discussion with this PR to see if there are other ideas and/or concerns about this approach. 

cc: @jrafanie @blomquisg 