### PR TITLE
Update "floating ip" icon

### DIFF
--- a/app/decorators/floating_ip_decorator.rb
+++ b/app/decorators/floating_ip_decorator.rb
@@ -1,6 +1,6 @@
 class FloatingIpDecorator < MiqDecorator
   def self.fonticon
-    'fa fa-map-marker'
+    'ff ff-floating-ip'
   end
 
   def self.fileicon

--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -58,13 +58,13 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           :klass => ApplicationHelper::Button::InstanceDetach),
         button(
           :instance_associate_floating_ip,
-          'fa fa-map-marker fa-lg',
+          'ff ff-floating-ip fa-lg',
           t = N_('Associate a Floating IP with this Instance'),
           t,
           :klass => ApplicationHelper::Button::InstanceAssociateFloatingIp),
         button(
           :instance_disassociate_floating_ip,
-          'fa fa-map-marker fa-lg',
+          'ff ff-floating-ip fa-lg',
           t = N_('Disassociate a Floating IP from this Instance'),
           t,
           :klass => ApplicationHelper::Button::InstanceDisassociateFloatingIp),

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -416,7 +416,7 @@ module VmHelper::TextualSummary
   def textual_floating_ips
     label = ui_lookup(:tables => "floating_ip")
     num   = @record.number_of(:floating_ips)
-    h     = {:label => label, :icon => "fa fa-map-marker", :value => num}
+    h     = {:label => label, :icon => "ff ff-floating-ip", :value => num}
     if num > 0 && role_allows?(:feature => "floating_ip_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true

--- a/app/services/ui_service_mixin.rb
+++ b/app/services/ui_service_mixin.rb
@@ -13,7 +13,7 @@ module UiServiceMixin
       :ContainerRoute          => {:type => "glyph", :class => 'pficon pficon-route'},
       :ContainerService        => {:type => "glyph", :class => 'pficon pficon-service'},
       :EmsCluster              => {:type => "glyph", :class => 'pficon pficon-cluster'},
-      :FloatingIp              => {:type => "glyph", :class => 'fa fa-map-marker'},
+      :FloatingIp              => {:type => "glyph", :class => 'ff ff-floating-ip'},
       :Host                    => {:type => "glyph", :class => 'pficon pficon-screen'},
       :LoadBalancer            => {:type => "glyph", :class => 'ff ff-load-balancer'},
       :MiddlewareDatasource    => {:type => "glyph", :class => 'fa fa-database'},

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -21,7 +21,7 @@
           = _("Security Groups")
       %kubernetes-topology-icon{tooltipOptions, :kind => "FloatingIp"}
         %label
-          %i.fa.fa-map-marker
+          %i.ff.ff-floating-ip
           = _("Floating Ips")
       %kubernetes-topology-icon{tooltipOptions, :kind => "CloudNetwork"}
         %label


### PR DESCRIPTION
This PR replaces "fa-map-marker" with "ff-floating-ip" on all screens.

<img width="493" alt="screen shot 2017-06-21 at 3 09 00 pm" src="https://user-images.githubusercontent.com/1287144/27402123-96ec6d64-5693-11e7-8a44-62cdda56a4e7.png">
