### PR TITLE
Pagination removal

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -418,35 +418,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Handle paging bar controls
-  def saved_report_paging
-    # Check new paging parms coming in
-    if params[:ppsetting]
-      @settings.store_path(:perpage, :reports, params[:ppsetting].to_i)
-      @sb[:pages][:current] = 1
-      total = @sb[:pages][:items] / settings(:perpage, :reports)
-      total += 1 if @sb[:pages][:items] % settings(:perpage, :reports) != 0
-      @sb[:pages][:total] = total
-    end
-    @sb[:pages][:current] = params[:page].to_i if params[:page]
-    @sb[:pages][:perpage] = settings(:perpage, :reports)
-
-    rr = MiqReportResult.find(@sb[:pages][:rr_id])
-    @html = report_build_html_table(rr.report_results,
-                                    rr.html_rows(:page     => @sb[:pages][:current],
-                                                 :per_page => @sb[:pages][:perpage]).join)
-
-    render :update do |page|
-      page << javascript_prologue
-      page.replace("report_html_div", :partial => "layouts/report_html")
-      page.replace_html("paging_div", :partial => 'layouts/saved_report_paging_bar',
-                                      :locals  => {:pages => @sb[:pages]})
-      page << javascript_hide_if_exists("form_buttons_div")
-      page << javascript_show_if_exists("rpb_div_1")
-      page << "miqSparkle(false)"
-    end
-  end
-
   # Common method to show a standalone report
   def report_only
     @report_only = true                 # Indicate stand alone report for views

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -4,6 +4,8 @@ class ChargebackController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  include Mixins::SavedReportPaging
+
   CB_X_BUTTON_ALLOWED_ACTIONS = {
     'chargeback_rates_copy'   => :cb_rate_edit,
     'chargeback_rates_delete' => :cb_rates_delete,

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -157,7 +157,6 @@ class MiqRequestController < ApplicationController
     session[:request_sortcol] = @sortcol
     session[:request_sortdir] = @sortdir
 
-    replace_gtl_main_div if pagination_request?
     {:view => @view, :pages => @pages}
   end
 
@@ -187,7 +186,6 @@ class MiqRequestController < ApplicationController
                       :url  => "/miq_request/show/#{@miq_request.id}?display=#{@display}")
     end
 
-    replace_gtl_main_div if pagination_request?
     @lastaction = "show"
   end
 

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -44,13 +44,6 @@ class MiqTaskController < ApplicationController
   # Show job list for the current user
   def jobs
     jobs_info
-    if pagination_request?
-      render :update do |page|
-        page << javascript_prologue
-        page.replace_html("gtl_div", :partial => "layouts/gtl", :locals => {:action_url => @lastaction})
-        page << "miqSparkle(false);"  # Need to turn off sparkle in case original ajax element gets replaced
-      end
-    end
   end
 
   def list_jobs

--- a/app/controllers/mixins/saved_report_paging.rb
+++ b/app/controllers/mixins/saved_report_paging.rb
@@ -1,0 +1,32 @@
+module Mixins
+  module SavedReportPaging
+    # Handle paging bar controls
+    def saved_report_paging
+      # Check new paging parms coming in
+      if params[:ppsetting]
+        @settings.store_path(:perpage, :reports, params[:ppsetting].to_i)
+        @sb[:pages][:current] = 1
+        total = @sb[:pages][:items] / settings(:perpage, :reports)
+        total += 1 if @sb[:pages][:items] % settings(:perpage, :reports) != 0
+        @sb[:pages][:total] = total
+      end
+      @sb[:pages][:current] = params[:page].to_i if params[:page]
+      @sb[:pages][:perpage] = settings(:perpage, :reports)
+
+      rr = MiqReportResult.find(@sb[:pages][:rr_id])
+      @html = report_build_html_table(rr.report_results,
+                                      rr.html_rows(:page     => @sb[:pages][:current],
+                                                   :per_page => @sb[:pages][:perpage]).join)
+
+      render :update do |page|
+        page << javascript_prologue
+        page.replace("report_html_div", :partial => "layouts/report_html")
+        page.replace_html("paging_div", :partial => 'layouts/saved_report_paging_bar',
+                                        :locals  => {:pages => @sb[:pages]})
+        page << javascript_hide_if_exists("form_buttons_div")
+        page << javascript_show_if_exists("rpb_div_1")
+        page << "miqSparkle(false)"
+      end
+    end
+  end
+end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -11,6 +11,7 @@ class ReportController < ApplicationController
   helper ApplicationHelper::ImportExportHelper
   include ReportHelper
   include Mixins::GenericSessionMixin
+  include Mixins::SavedReportPaging
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1128,15 +1128,12 @@ module ApplicationHelper
     true
   end
 
-  def pagination_request?
-    params[:ppsetting] || params[:searchtag] || params[:entry] ||
-      params[:sortby] || params[:sort_choice]
-  end
-
   # FIXME: params[:type] is used in multiple contexts, we should rename it to
   # :gtl_type or remove it as we move to the Angular GTL component
   def pagination_or_gtl_request?
-    pagination_request? || params[:type] || params[:page]
+    params[:ppsetting] || params[:searchtag] || params[:entry] ||
+      params[:sortby] || params[:sort_choice] ||
+      params[:type] || params[:page]
   end
 
   def update_gtl_div(action_url = 'explorer', button_div = 'center_tb')


### PR DESCRIPTION
Pagination cleanups:

  * Remove `pagination_request`. No longer needed.
  * Move `saved_report_paging` out of `ApplicationController`. Include it only where needed (reports, chargeback).

Resolves part of https://github.com/ManageIQ/manageiq/issues/615