### PR TITLE
Remove "items" keyword from list in my settings

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -53,14 +53,14 @@ module UiConstants
 
   # Per page choices and default
   PPCHOICES = [
-    [N_("5 items"), 5],
-    [N_("10 items"), 10],
-    [N_("20 items"), 20],
-    [N_("50 items"), 50],
-    [N_("100 items"), 100],
-    [N_("200 items"), 200],
-    [N_("500 items"), 500],
-    [N_("1000 items"), 1000]
+    [N_("5"), 5],
+    [N_("10"), 10],
+    [N_("20"), 20],
+    [N_("50"), 50],
+    [N_("100"), 100],
+    [N_("200"), 200],
+    [N_("500"), 500],
+    [N_("1000"), 1000]
   ]
 
   # Per page choices for task/jobs


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1422416

Remove "items" keyword from the dropdown list of Default Items Per Page.
Remove the keyword also from the dropdown list of Topology Default Items
in View.

Before:
![items1](https://user-images.githubusercontent.com/13417815/27439455-47fde982-5768-11e7-93ad-d0e68ca5f982.png)

After:
![items2](https://user-images.githubusercontent.com/13417815/27439460-49a9e452-5768-11e7-8c02-c0e5707c0373.png)
