### PR TITLE
Fix network address issue

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -91,15 +91,24 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_mac
-    {:label =>  _("Mac Address"), :value => @record.hardware.guest_devices.reject { |device| device.network.nil? }.collect { |device| device[:address] }.join(", ") }
+    # Currently, we only want to display the MAC addresses of devices that
+    # are associated with an entry in the networks table. This ensures that
+    # we only display management addresses.
+    {:label =>  _("MAC Address"), :value => @record.hardware.guest_devices.reject { |device| device.network.nil? }.collect { |device| device[:address] }.join(", ") }
   end
 
   def textual_ipv4
-    {:label =>  _("IPV4 Address"), :value => @record.hardware.guest_devices.reject { |device| device.network.nil? }.collect { |device| device.network.ipaddress }.join(", ") }
+    # It is possible for guest devices not to have network data (or a network
+    # hash). As a result, we need to exclude guest devices that don't have
+    # network data to prevent a nil class error from occurring.
+    {:label =>  _("IPv4 Address"), :value => @record.hardware.guest_devices.reject { |device| device.network.nil? }.collect { |device| device.network.ipaddress }.join(", ") }
   end
 
   def textual_ipv6
-    {:label =>  _("IPV6 Address"), :value => @record.hardware.guest_devices.reject { |device| device.network.nil? }.collect { |device| device.network.ipv6address }.join(", ") }
+    # It is possible for guest devices not to have network data (or a network
+    # hash). As a result, we need to exclude guest devices that don't have
+    # network data to prevent a nil class error from occurring.
+    {:label =>  _("IPv6 Address"), :value => @record.hardware.guest_devices.reject { |device| device.network.nil? }.collect { |device| device.network.ipv6address }.join(", ") }
   end
 
   def textual_loc_led_state

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -91,15 +91,15 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_mac
-    {:label =>  _("Mac Address"), :value => @record.hardware.guest_devices.collect { |device| device[:address] }.join(", ") }
+    {:label =>  _("Mac Address"), :value => @record.hardware.guest_devices.reject { |device| device.network.nil? }.collect { |device| device[:address] }.join(", ") }
   end
 
   def textual_ipv4
-    {:label =>  _("IPV4 Address"), :value => @record.hardware.guest_devices.collect { |device| device.network.ipaddress }.join(", ") }
+    {:label =>  _("IPV4 Address"), :value => @record.hardware.guest_devices.reject { |device| device.network.nil? }.collect { |device| device.network.ipaddress }.join(", ") }
   end
 
   def textual_ipv6
-    {:label =>  _("IPV6 Address"), :value => @record.hardware.guest_devices.collect { |device| device.network.ipv6address }.join(", ") }
+    {:label =>  _("IPV6 Address"), :value => @record.hardware.guest_devices.reject { |device| device.network.nil? }.collect { |device| device.network.ipv6address }.join(", ") }
   end
 
   def textual_loc_led_state


### PR DESCRIPTION
It is possible that a guest_device may not have network details (a network hash) defined. In this case, an error about "ipaddress" or "ipv6address" being undefined for NilClass might occur. As a result, we now exclude any devices not having network details before accessing their addresses.