### PR TITLE
Enabled 'Delete Saved Report' toolbar button

### DIFF
--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -89,6 +89,12 @@ module ReportController::SavedReports
   def saved_report_delete
     assert_privileges("saved_report_delete")
     savedreports = find_checked_items
+    unless savedreports.present?
+      report_result = x_node.split('_').last
+      savedreport = report_result.split('-').last
+      savedreports = Array.wrap(from_cid(savedreport))
+    end
+
     if savedreports.empty? && params[:id].present? && !MiqReportResult.exists?(params[:id].to_i)
       # saved report is being viewed in report accordion
       add_flash(_("Saved Report no longer exists"), :error)

--- a/app/helpers/application_helper/button/saved_report_delete.rb
+++ b/app/helpers/application_helper/button/saved_report_delete.rb
@@ -8,6 +8,6 @@ class ApplicationHelper::Button::SavedReportDelete < ApplicationHelper::Button::
   private
 
   def saved_report?
-    @view_context.active_tab == 'saved_reports'
+    %w(saved_reports report_info).include?(@view_context.active_tab)
   end
 end


### PR DESCRIPTION
Changing toolbar button visibility behaviour, so it's visible also on Reports Info page

Before:
![screenshot from 2017-06-22 17-06-27](https://user-images.githubusercontent.com/1187051/27441221-28317074-576d-11e7-9bea-1c713c678d00.png)
After:
![screenshot from 2017-06-22 17-04-33](https://user-images.githubusercontent.com/1187051/27441116-e437f096-576c-11e7-9688-1c7657ab734b.png)


Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1454600

Steps for Testing/QA
-------------------------------

(taken from BZ):

1.Navigate to Cloud Intel->Reports->Reports accordion
2.Generate any default reports
3.Go to Saved Report summary page
4.Try to delete saved report 
