### PR TITLE
Changed max length of name and description fields to be consistent

### DIFF
--- a/app/views/catalog/_st_angular_form.html.haml
+++ b/app/views/catalog/_st_angular_form.html.haml
@@ -17,7 +17,7 @@
                               "id"             => "name",
                               "name"           => "name",
                               "ng-model"       => "vm.catalogItemModel.name",
-                              "maxlength"      => "#{MAX_NAME_LEN}",
+                              "maxlength"      => 40,
                               "miqrequired"    => "",
                               "checkchange"    => "",
                               "auto-focus"     => ""}
@@ -31,7 +31,7 @@
                               "id"          => "description",
                               "name"        => "description",
                               "ng-model"    => "vm.catalogItemModel.description",
-                              "maxlength"   => "#{MAX_DESC_LEN}",
+                              "maxlength"   => 60,
                               "miqrequired" => "",
                               "checkchange" => ""}
           %span.help-block{"ng-show" => "angularForm.description.$error.miqrequired"}


### PR DESCRIPTION
Changed max length of name and description fields to be same as non-angular version of form that is in use for non-ansible type Catalog Item form.

https://bugzilla.redhat.com/show_bug.cgi?id=1447786

@epwinchell please review/test.