### PR TITLE
Added "Create Service Dialog from Container Template" support

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,5 +1,6 @@
 class CatalogController < ApplicationController
   include AutomateTreeHelper
+  include ServiceDialogCreationMixin
 
   before_action :check_privileges
   before_action :get_session_data
@@ -692,15 +693,7 @@ class CatalogController < ApplicationController
   end
 
   def ot_form_field_changed
-    id = params[:id]
-    return unless load_edit("ot_edit__#{id}", "replace_cell__explorer")
-    ot_edit_get_form_vars
-    render :update do |page|
-      page << javascript_prologue
-      page << javascript_hide("buttons_off")
-      page << javascript_show("buttons_on")
-      page << "miqSparkle(false);"
-    end
+    dialog_creation_form_field_changed("ot_edit__#{params[:id]}")
   end
 
   def ot_copy_submit

--- a/app/controllers/mixins/service_dialog_creation_mixin.rb
+++ b/app/controllers/mixins/service_dialog_creation_mixin.rb
@@ -1,0 +1,16 @@
+module ServiceDialogCreationMixin
+  extend ActiveSupport::Concern
+
+  private
+
+  def dialog_creation_form_field_changed(id)
+    return unless load_edit(id)
+    @edit[:new][:dialog_name] = params[:dialog_name] if params[:dialog_name]
+    render :update do |page|
+      page << javascript_prologue
+      page << javascript_hide("buttons_off")
+      page << javascript_show("buttons_on")
+      page << "miqSparkle(false);"
+    end
+  end
+end

--- a/app/helpers/application_helper/toolbar/container_template_center.rb
+++ b/app/helpers/application_helper/toolbar/container_template_center.rb
@@ -1,4 +1,19 @@
 class ApplicationHelper::Toolbar::ContainerTemplateCenter < ApplicationHelper::Toolbar::Basic
+  button_group('orchestration_template_vmdb', [
+    select(
+      :orchestration_template_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :service_dialog_from_ct,
+          'pficon pficon-add-circle-o fa-lg',
+          t = N_('Create Service Dialog from Container Template'),
+          t),
+      ]
+    ),
+  ])
   button_group('container_template_policy', [
     select(
       :container_template_policy_choice,

--- a/app/views/container_template/_service_dialog_from_ct.html.haml
+++ b/app/views/container_template/_service_dialog_from_ct.html.haml
@@ -1,0 +1,24 @@
+#form_div
+  #basic_info_div
+    = render :partial => "layouts/flash_msg"
+    - url = url_for_only_path(:action => "ct_form_field_changed", :id => @edit[:rec_id])
+    .form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _('Service Dialog Name')
+        .col-md-8
+          = text_field_tag("dialog_name",
+                           "",
+                           :autocomplete => 'off',
+                           :diabled => false,
+                           :class => "form-control",
+                           :maxlength => 255,
+                           "data-miq_observe" => {:interval => '.5',
+                                                  :url      => url}.to_json)
+  - unless @explorer
+    = render(:partial => '/layouts/edit_form_buttons',
+      :locals         => {:record_id => @edit[:rec_id],
+        :action_url          => 'service_dialog_from_ct_submit',
+        :noreset             => true,
+        :force_cancel_button => true,
+        :ajax_buttons        => true})

--- a/app/views/container_template/service_dialog_from_ct.html.haml
+++ b/app/views/container_template/service_dialog_from_ct.html.haml
@@ -1,0 +1,1 @@
+= render :partial => "service_dialog_from_ct"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -970,6 +970,7 @@ Rails.application.routes.draw do
         download_data
         download_summary_pdf
         index
+        service_dialog_from_ct
         show
         show_list
         tagging_edit
@@ -977,11 +978,13 @@ Rails.application.routes.draw do
       ),
       :post => %w(
         button
+        ct_form_field_changed
         dynamic_checkbox_refresh
         form_field_changed
         listnav_search_selected
         quick_search
         sections_field_changed
+        service_dialog_from_ct_submit
         show
         show_list
         tagging_edit


### PR DESCRIPTION
Added "Create Service Dialog from Container Template" button on Container Template summary screen.

https://www.pivotaltracker.com/story/show/147301019

![screenshot from 2017-06-23 17-15-13](https://user-images.githubusercontent.com/3450808/27500843-3837699e-5838-11e7-9e3e-00535b378754.png)

![screenshot from 2017-06-23 17-15-28](https://user-images.githubusercontent.com/3450808/27500851-3a836e3c-5838-11e7-94c9-719549522f76.png)
