### PR TITLE
Fix title in Add/Edit Button/Button Groups

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -631,6 +631,11 @@ module ApplicationController::Buttons
       return
     end
     group_set_form_vars
+    @right_cell_text = if typ == "new"
+                         _("Adding a new Button Group")
+                       else
+                         _("Editing Button Group \"%{name}\"") % {:name => @custom_button_set.name.split('|').first}
+                       end
     @in_a_form = true
     @lastaction = "automate_button"
     @layout = "miq_ae_automate_button"
@@ -653,12 +658,12 @@ module ApplicationController::Buttons
     @in_a_form = true
     session[:changed] = false
     @breadcrumbs = []
-    title = if typ == "new"
-              _("Add Button")
-            else
-              _("Edit of '%{description}' Button") % {:description => @custom_button.description}
-            end
-    drop_breadcrumb(:name => title, :url => "/miq_ae_customization/button_new")
+    @right_cell_text = if typ == "new"
+                         _("Adding a new Button")
+                       else
+                         _("Editing Button \"%{name}\"") % {:name => @custom_button.name}
+                       end
+    drop_breadcrumb(:name => @right_cell_text, :url => "/miq_ae_customization/button_new")
     @lastaction = "automate_button"
     @layout = "miq_ae_automate_button"
     @sb[:buttons] = nil

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -663,7 +663,6 @@ module ApplicationController::Buttons
                        else
                          _("Editing Button \"%{name}\"") % {:name => @custom_button.name}
                        end
-    drop_breadcrumb(:name => @right_cell_text, :url => "/miq_ae_customization/button_new")
     @lastaction = "automate_button"
     @layout = "miq_ae_automate_button"
     @sb[:buttons] = nil

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1986,20 +1986,8 @@ class CatalogController < ApplicationController
     replace_trees_by_presenter(presenter, trees)
 
     if @sb[:buttons_node]
-      if action == "button_edit"
-        right_cell_text = if @custom_button && @custom_button.id
-                            _("Editing Button \"%{name}\"") % {:name => @custom_button.name}
-                          else
-                            _("Adding a new Button")
-                          end
-      elsif action == "group_edit"
-        right_cell_text = if @custom_button_set && @custom_button_set.id
-                            _("Editing Button Group \"%{name}\"") % {:name => @custom_button_set.name.split('|').first}
-                          else
-                            _("Adding a new Button Group")
-                          end
-      elsif action == "group_reorder"
-        right_cell_text = _("Buttons Group Reorder")
+      if action == "group_reorder"
+        right_cell_text = _("Button Group Reorder")
       end
     end
     presenter[:right_cell_text] = right_cell_text


### PR DESCRIPTION
Catalog Buttons/Button Groups actions using shared code from ```app/controllers/application_controller/buttons.rb``` so set the titles there.

2nd commit is optional as I've noticed that we handle breadcrumbs there, but we don't display them.

https://bugzilla.redhat.com/show_bug.cgi?id=1460774