### PR TITLE
Disable some Code Climate warnings

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -45,6 +45,8 @@ engines:
     checks:
       no-undefined:
         enabled: false
+      quotes:
+        enabled: false
   fixme:
     # let's enable later
     enabled: false


### PR DESCRIPTION
Disables the following Code Climate warnings -

- ~Unary operator '!' must be followed by whitespace.~
- Strings must use singlequote.