### PR TITLE
Do not show flash message for GTL in Tag assignment

### DIFF
--- a/app/views/layouts/_tag_edit_items.html.haml
+++ b/app/views/layouts/_tag_edit_items.html.haml
@@ -8,4 +8,4 @@
     - @embedded = true
     - @quadicon_no_url = true
     - @gtl_type ||= settings(:views, :tagging)
-    = render :partial => "layouts/gtl"
+    = render :partial => "layouts/gtl", :locals => {:no_flash_div => true}


### PR DESCRIPTION
When reseting changes in any Tag Assignment there is flash message displayed twice. Removes flash message in GTL if GTL is in Tag Assignment

Before:
<img width="1198" alt="screen shot 2017-06-23 at 11 45 56 am" src="https://user-images.githubusercontent.com/9210860/27476580-9a8ec9ea-5809-11e7-9298-234e2a90c4b9.png">
After:
<img width="1201" alt="screen shot 2017-06-23 at 11 45 24 am" src="https://user-images.githubusercontent.com/9210860/27476579-9a8e3aac-5809-11e7-8efc-cbe80bf998eb.png">

@miq-bot add_label fine/no, GTLs, bug
