### PR TITLE
Don't redact custom attributes

### DIFF
--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -120,25 +120,9 @@ module EmsContainerHelper::TextualSummary
     TextualGroup.new(_("Custom Attributes"), textual_miq_custom_attributes)
   end
 
-  def redact_username_and_password(value)
-    begin
-      uri = URI.parse(value)
-      uri.password = '***' if uri.password
-      uri.user = '***' if uri.user
-      uri.to_s
-    rescue # dont reduct in case the value was malformed, to allow debugging it.
-      value
-    end
-  end
-
   def textual_miq_custom_attributes
     attrs = @record.custom_attributes
     return nil if attrs.blank?
-    attrs.sort_by(&:name).collect do |a|
-      {
-        :label => a.name.tr("_", " "),
-        :value => redact_username_and_password(a.value)
-      }
-    end
+    attrs.sort_by(&:name).collect { |a| {:label => a.name.tr("_", " "), :value => a.value} }
   end
 end


### PR DESCRIPTION
Depends on ManageIQ/manageiq#15398

---

This reverts commit 5c64095f5de07004149c817302894553b490e361 ( ManageIQ/manageiq-ui-classic#844 )

In fine, custom attributes are used for proxy settings in some providers. This meant we needed to redact potentially sensitive usernames and passwords when displaying such custom attributes.

For gaprindashvili, this will be moved to an `options` object on the manager ( ManageIQ/manageiq#15398 ), removing the need to redact these.

Removing..., this must be `fine/no`.

Cc @enoodle, @simon3z 