### PR TITLE
Rename check_suports_task to check_supports_task

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -304,7 +304,7 @@ module ApplicationController::CiProcessing
     cloud_object_store_button_operation(klass, task)
   end
 
-  def check_suports_task(items, klass, task, display_name)
+  def check_supports_task(items, klass, task, display_name)
     if klass.find(items).any? { |item| !item.supports?(task) }
 
       message = if items.length == 1
@@ -337,7 +337,7 @@ module ApplicationController::CiProcessing
       items = find_checked_ids_with_rbac(klass)
 
       return unless check_non_empty(items, display_name)
-      return unless check_suports_task(items, klass, task, display_name)
+      return unless check_supports_task(items, klass, task, display_name)
 
       process_objects(items, method, display_name)
     else
@@ -349,7 +349,7 @@ module ApplicationController::CiProcessing
         return
       end
 
-      return unless check_suports_task(items, klass, task, display_name)
+      return unless check_supports_task(items, klass, task, display_name)
 
       process_objects(items, method, display_name) unless items.empty?
     end


### PR DESCRIPTION
Introduced in #1555.

The word is *supports*, not *suports* ;)

Cc @martinpovolny 