### PR TITLE
Only use supports_reset check for displaying reset button

### DIFF
--- a/app/helpers/application_helper/button/instance_reset.rb
+++ b/app/helpers/application_helper/button/instance_reset.rb
@@ -2,7 +2,6 @@ class ApplicationHelper::Button::InstanceReset < ApplicationHelper::Button::Basi
   needs :@record
 
   def visible?
-    return true if @display == "instances"
     @record.supports_reset?
   end
 end


### PR DESCRIPTION
At the moment the VM instances display ignores the `supports_reset` check. I can see no good reason for doing so as it means the UI display will show a hard reset button for VM's that don't actually support it.

Followup to https://github.com/ManageIQ/manageiq/issues/9684