### PR TITLE
Rename handle buttons

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -23,8 +23,8 @@ module Mixins
 
         def reconfigure_update
           case params[:button]
-          when "cancel" then handle_cancel_button
-          when "submit" then handle_submit_button
+          when "cancel" then reconfigure_handle_cancel_button
+          when "submit" then reconfigure_handle_submit_button
           end
         end
 
@@ -234,7 +234,7 @@ module Mixins
           end
         end
 
-        def handle_cancel_button
+        def reconfigure_handle_cancel_button
           add_flash(_("VM Reconfigure Request was cancelled by the user"))
           if @sb[:explorer]
             @sb[:action] = nil
@@ -245,7 +245,7 @@ module Mixins
           end
         end
 
-        def handle_submit_button
+        def reconfigure_handle_submit_button
           options = {:src_ids => params[:objectIds]}
           if params[:cb_memory] == 'true'
             options[:vm_memory] = params[:memory_type] == "MB" ? params[:memory] : params[:memory].to_i * 1024

--- a/app/controllers/mixins/actions/vm_actions/retire.rb
+++ b/app/controllers/mixins/actions/vm_actions/retire.rb
@@ -78,7 +78,7 @@ module Mixins
           # Check RBAC for all items in session[:retire_items]
           @retireitems = find_records_with_rbac(kls, session[:retire_items]).sort_by(&:name)
           if params[:button]
-            flash = handle_form_buttons(kls)
+            flash = retire_handle_form_buttons(kls)
             add_flash(flash)
             if @sb[:explorer]
               replace_right_cell
@@ -110,14 +110,14 @@ module Mixins
 
         private
 
-        def handle_form_buttons(kls)
+        def retire_handle_form_buttons(kls)
           case params[:button]
-          when "cancel" then handle_cancel_button
+          when "cancel" then retire_handle_cancel_button
           when "save"   then handle_save_button(kls)
           end
         end
 
-        def handle_cancel_button
+        def retire_handle_cancel_button
           @sb[:action] = nil
           _("Set/remove retirement date was cancelled by the user")
         end


### PR DESCRIPTION
Because we are including these mixins in CI processing and these methods have very similiar names, I add mixin name prefix for each method.