### PR TITLE
Display a warning for large amount of objects in topology view

### DIFF
--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -42,6 +42,13 @@
     %span.pficon.pficon-info
     %strong
       = _("Click on the legend to show/hide entities, and double click/right click the entities in the graph to navigate to their summary pages.")
+  .alert.alert-warning.alert-dismissable
+    %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}
+      %span.pficon.pficon-close
+    %span.pficon.pficon-warning-triangle-o
+    %strong
+      = _("Note: displaying a very large number of objects in the topology display can adversely affect the performance of some web browsers.")
+
 
   = render :partial => "shared/topology/not_found"
 


### PR DESCRIPTION
Display a warning to the user for large amount of objects in container topology view:
**"Note: displaying a very large number of objects in the topology display can adversely affect the performance of some web browsers".**

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1455552
Screenshot:
![screenshot from 2017-06-28 10-13-29](https://user-images.githubusercontent.com/8366181/27624787-e0451dc4-5bea-11e7-95e7-feb0ea5f9aed.png)

cc: @simon3z  @zeari 
