### PR TITLE
travis - run bundler with --no-deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   matrix:
   - TEST_SUITE=spec
   - TEST_SUITE=spec:javascript
+bundler_args: --no-deployment
 before_install: source tools/ci/before_install.sh
 before_script: bundle exec rake $TEST_SUITE:setup
 script: bundle exec rake $TEST_SUITE


### PR DESCRIPTION
According to [the docs](https://docs.travis-ci.com/user/languages/ruby/#Travis-CI-uses-Bundler), travis runs bundler with `--deployment` when `Gemfile.lock` exists. It does, because `bin/setup` runs `bundle install` before that.

Which was fine until the combination of `rm Gemfile.lock ; bundle install ; bundle install --deployment` started [failing](https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/247045722) (`You are trying to install in deployment mode after changing your Gemfile`...) :).

I don't think we want `--deployment` since we're gitignoring `Gemfile.lock`.

This fixes travis in the sense that it gets to running the specs. Not quite enough to make it green, but I'd rather keep the PRs separate.

