### PR TITLE
Rename obsolete automation_manager_provider_configured_system_tag in specs

### DIFF
--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -93,7 +93,7 @@ describe AutomationManagerController do
 
   context "asserts correct privileges" do
     before do
-      login_as user_with_feature %w(automation_manager_provider_configured_system_tag)
+      login_as user_with_feature %w(automation_manager_provider_tag)
     end
 
     it "should raise an error for feature that user has no access to" do


### PR DESCRIPTION
The feature (`automation_manager_provider_configured_system_tag`) was incorrectly named, and got renamed in ManageIQ/manageiq#15437 (to `automation_manager_provider_tag`).

Since it no longer exists, it breaks the specs using it, renaming here as well :).

Cc @ZitaNemeckova, @h-kataria 

This should fix one of the remaining spec failures...

```

  1) AutomationManagerController asserts correct privileges should raise an error for feature that user has no access to
     Failure/Error: features = EvmSpecHelper.specific_product_features(*features)
     
     NoMethodError:
       undefined method `delete' for nil:NilClass
     # /home/himdel/manageiq/app/models/miq_product_feature.rb:123:in `seed_from_hash'
     # /home/himdel/manageiq/spec/support/evm_spec_helper.rb:101:in `seed_specific_product_features'
     # /home/himdel/manageiq/spec/support/evm_spec_helper.rb:93:in `specific_product_features'
     # ./spec/controllers/automation_manager_controller_spec.rb:612:in `user_with_feature'
     # ./spec/controllers/automation_manager_controller_spec.rb:96:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:75:in `block (3 levels) in <top (required)>'
     # /home/himdel/manageiq/spec/support/evm_spec_helper.rb:35:in `clear_caches'
     # ./spec/spec_helper.rb:75:in `block (2 levels) in <top (required)>'

```