### PR TITLE
Fix display of hosts on physical infra topology

### DIFF
--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -14,6 +14,14 @@ class PhysicalInfraTopologyService < TopologyService
 
   @kinds = %i(PhysicalInfraManager PhysicalServer Host Vm Tag)
 
+  def entity_type(entity)
+    if entity.kind_of?(Host)
+      entity.class.base_class.name.demodulize
+    else
+      super
+    end
+  end
+
   def entity_display_type(entity)
     if entity.kind_of?(ManageIQ::Providers::PhysicalInfraManager)
       entity.class.short_token


### PR DESCRIPTION
We have identified that in the Physical Infra Topology not all kind of Hosts were displayed. This PR enables this display.