### PR TITLE
Restore `@edit` with `session[:adv_search][model.to_s]`

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -947,11 +947,8 @@ module ApplicationController::Filter
     # Restore @edit hash if it's saved in @settings
     @expkey = :expression                                               # Reset to use default expression key
     if session[:adv_search] && session[:adv_search][model.to_s]
-      if session[:adv_search][model.to_s][@expkey]
-        @edit = copy_hash(session[:adv_search][model.to_s])
-      else
-        @edit = copy_hash(session[:edit])
-      end
+      adv_search_model = session[:adv_search][model.to_s]
+      @edit = copy_hash(adv_search_model[@expkey] ? adv_search_model : session[:edit])
       # default search doesnt exist or if it is marked as hidden
       if @edit && @edit[:expression] && !@edit[:expression][:selected].blank? &&
          !MiqSearch.exists?(@edit[:expression][:selected][:id])

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -947,7 +947,11 @@ module ApplicationController::Filter
     # Restore @edit hash if it's saved in @settings
     @expkey = :expression                                               # Reset to use default expression key
     if session[:adv_search] && session[:adv_search][model.to_s]
-      @edit = copy_hash(session[:edit])
+      if session[:adv_search][model.to_s][@expkey]
+        @edit = copy_hash(session[:adv_search][model.to_s])
+      else
+        @edit = copy_hash(session[:edit])
+      end
       # default search doesnt exist or if it is marked as hidden
       if @edit && @edit[:expression] && !@edit[:expression][:selected].blank? &&
          !MiqSearch.exists?(@edit[:expression][:selected][:id])


### PR DESCRIPTION
Prevent the crash described in the below BZ by assigning `@edit` from the value stored in `session` when `@expkey` exists.

https://bugzilla.redhat.com/show_bug.cgi?id=1465424

