### PR TITLE
Added "Container Template" type support in Catalog Item editor

### DIFF
--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -99,7 +99,7 @@
                          :class               => "selectpicker")
             :javascript
               miqSelectPickerEvent('manager_id', '#{url}')
-    - elsif @edit[:new][:st_prov_type] == "generic_ansible_tower"
+    - elsif %w(generic_ansible_tower generic_container_template).include?(@edit[:new][:st_prov_type])
       - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_managers]
       .form-group
         %label.col-md-2.control-label
@@ -115,7 +115,7 @@
         - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_templates]
         .form-group
           %label.col-md-2.control-label
-            = _('Ansible Tower Job Template')
+            = @edit[:new][:st_prov_type] == "generic_ansible_tower" ? _('Ansible Tower Job Template') : _('Container Template')
           .col-md-8
             = select_tag('template_id',
                           options_for_select(opts, @edit[:new][:template_id]),
@@ -145,49 +145,50 @@
                         :title                 => _("Remove this Provisioning Entry Point")) do
                 %i.pficon.pficon-close
           %span.input-group-addon{:style => "visibility:hidden"}
-    .form-group
-      %label.col-md-2.control-label{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
-        = _('Reconfigure Entry Point')
-      .col-md-8{:title => @edit[:new][:reconfigure_fqname]}
-        .input-group
-          = text_field_tag("reconfigure_fqname",
-                           @edit[:new][:reconfigure_fqname],
-                           :class             => "form-control",
-                           :onFocus           => 'miqShowAE_Tree("reconfigure");miqButtons("hide", "automate");',
-                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %span.input-group-btn
-            #reconfigure_fqname_div{:style => @edit[:new][:reconfigure_fqname] != "" ? "" : "display:none"}
-              = link_to({:action => 'ae_tree_select_discard',
-                         :typ => "reconfigure"},
-                        "data-miq_sparkle_on"  => true,
-                        "data-miq_sparkle_off" => true,
-                        "data-confirm"         => _("Are you sure you want to remove this Reconfigure Entry Point?"),
-                        "data-method"          => :post,
-                        :remote                => true,
-                        :class                 => "btn btn-default",
-                        :title                 => _("Remove this Reconfigure Entry Point")) do
-                %i.pficon.pficon-close
-          %span.input-group-addon{:style => "visibility:hidden"}
+    - unless @edit[:new][:st_prov_type] == 'generic_container_template'
+      .form-group
+        %label.col-md-2.control-label{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
+          = _('Reconfigure Entry Point')
+        .col-md-8{:title => @edit[:new][:reconfigure_fqname]}
+          .input-group
+            = text_field_tag("reconfigure_fqname",
+                             @edit[:new][:reconfigure_fqname],
+                             :class             => "form-control",
+                             :onFocus           => 'miqShowAE_Tree("reconfigure");miqButtons("hide", "automate");',
+                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+            %span.input-group-btn
+              #reconfigure_fqname_div{:style => @edit[:new][:reconfigure_fqname] != "" ? "" : "display:none"}
+                = link_to({:action => 'ae_tree_select_discard',
+                           :typ => "reconfigure"},
+                          "data-miq_sparkle_on"  => true,
+                          "data-miq_sparkle_off" => true,
+                          "data-confirm"         => _("Are you sure you want to remove this Reconfigure Entry Point?"),
+                          "data-method"          => :post,
+                          :remote                => true,
+                          :class                 => "btn btn-default",
+                          :title                 => _("Remove this Reconfigure Entry Point")) do
+                  %i.pficon.pficon-close
+            %span.input-group-addon{:style => "visibility:hidden"}
 
-    .form-group
-      %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
-        = _('Retirement Entry Point')
-      .col-md-8{:title => @edit[:new][:retire_fqname]}
-        .input-group
-          = text_field_tag("retire_fqname",
-                           @edit[:new][:retire_fqname],
-                           :class   => "form-control",
-                           :onFocus => 'miqShowAE_Tree("retire");miqButtons("hide", "automate");')
-          %span.input-group-btn
-            #retire_fqname_div{:style => @edit[:new][:retire_fqname] != "" ? "" : "display:none"}
-              = link_to({:action => 'ae_tree_select_discard',
-                         :typ => "retire"},
-                        "data-miq_sparkle_on"  => true,
-                        "data-miq_sparkle_off" => true,
-                        "data-confirm"         => _("Are you sure you want to remove this Retirement Entry Point?"),
-                        "data-method"          => :post,
-                        :remote                => true,
-                        :class                 => "btn btn-default",
-                        :title                 => _("Remove this Retirement Entry Point")) do
-                %i.pficon.pficon-close
-          %span.input-group-addon{:style => "visibility:hidden"}
+      .form-group
+        %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
+          = _('Retirement Entry Point')
+        .col-md-8{:title => @edit[:new][:retire_fqname]}
+          .input-group
+            = text_field_tag("retire_fqname",
+                             @edit[:new][:retire_fqname],
+                             :class   => "form-control",
+                             :onFocus => 'miqShowAE_Tree("retire");miqButtons("hide", "automate");')
+            %span.input-group-btn
+              #retire_fqname_div{:style => @edit[:new][:retire_fqname] != "" ? "" : "display:none"}
+                = link_to({:action => 'ae_tree_select_discard',
+                           :typ => "retire"},
+                          "data-miq_sparkle_on"  => true,
+                          "data-miq_sparkle_off" => true,
+                          "data-confirm"         => _("Are you sure you want to remove this Retirement Entry Point?"),
+                          "data-method"          => :post,
+                          :remote                => true,
+                          :class                 => "btn btn-default",
+                          :title                 => _("Remove this Retirement Entry Point")) do
+                  %i.pficon.pficon-close
+            %span.input-group-addon{:style => "visibility:hidden"}

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -71,6 +71,17 @@
               = _('Ansible Tower Job Template')
             .col-md-9
               = h(@record.try(:job_template).try(:name))
+        - elsif @record.prov_type == "generic_container_template"
+          .form-group
+            %label.col-md-3.control-label
+              = _('Provider')
+            .col-md-9
+              = h(provisioning[:provider_name])
+          .form-group
+            %label.col-md-3.control-label
+              = _('Container Template')
+            .col-md-9
+              = h(provisioning[:template_name])
         - unless @record.prov_type == "generic_ansible_playbook"
           - entry_points = [[_("Provisioning"), :fqname]]
           - unless @record.prov_type.try(:start_with?, "generic_")


### PR DESCRIPTION
Updated summary screen to show Container Template specific details

https://www.pivotaltracker.com/story/show/147300897

Something got messed up on original PR https://github.com/ManageIQ/manageiq-ui-classic/pull/1621, creating a new PR
![container_template_type_catalog_item](https://user-images.githubusercontent.com/3450808/27691964-85867670-5cb3-11e7-8f8a-dafaf7109ba1.png)

![catalog_item_form](https://user-images.githubusercontent.com/3450808/27698252-8b5f8850-5cc4-11e7-878e-605343b5ad1f.png)

![summary_screen](https://user-images.githubusercontent.com/3450808/27691995-95df54b0-5cb3-11e7-8d9c-f333bab9470a.png)
