### PR TITLE
CVE-2016-7047: API leaks any MiqReportResult

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -188,7 +188,7 @@ class ApplicationController < ActionController::Base
       rpt.generate_table(:userid => session[:userid])
     else
       rpt = if session[:report_result_id]
-              MiqReportResult.find(session[:report_result_id]).report_results
+              MiqReportResult.for_user(current_user).find(session[:report_result_id]).report_results
             elsif session[:rpt_task_id].present?
               MiqTask.find(session[:rpt_task_id]).task_results
             else
@@ -429,7 +429,7 @@ class ApplicationController < ActionController::Base
     end
     # Dashboard widget will send in report result id else, find report result in the sandbox
     search_id = params[:rr_id] ? params[:rr_id].to_i : @sb[:pages][:rr_id]
-    rr = MiqReportResult.find(search_id)
+    rr = MiqReportResult.for_user(current_user).find(search_id)
 
     session[:report_result_id] = rr.id  # Save report result id for render_zgraph
     session[:rpt_task_id]      = nil    # Clear out report task id, using a saved report
@@ -1282,7 +1282,7 @@ class ApplicationController < ActionController::Base
   def process_saved_reports(saved_reports, task)
     success_count = 0
     failure_count = 0
-    MiqReportResult.where(:id => saved_reports).order("lower(name)").each do |rep|
+    MiqReportResult.for_user(current_user).where(:id => saved_reports).order("lower(name)").each do |rep|
       begin
         rep.public_send(task) if rep.respond_to?(task) # Run the task
       rescue

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -184,7 +184,7 @@ class ApplicationController < ActionController::Base
   # Send chart data to the client
   def render_chart
     if params[:report]
-      rpt = MiqReport.find_by_name(params[:report])
+      rpt = MiqReport.for_user(current_user).find_by_name(params[:report])
       rpt.generate_table(:userid => session[:userid])
     else
       rpt = if session[:report_result_id]
@@ -855,7 +855,7 @@ class ApplicationController < ActionController::Base
     @data = []
     if !group.settings || group.settings[:report_menus].blank? || mode == "default"
       # array of all reports if menu not configured
-      @rep = MiqReport.all.sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
+      @rep = MiqReport.for_user(current_user).sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
       if tree_type == "timeline"
         @data = @rep.reject { |r| r.timeline.nil? }
       else
@@ -884,17 +884,7 @@ class ApplicationController < ActionController::Base
             @temp_title1 = title[1]
           end
           rptmenu.push([title[0], folders]) unless rptmenu.include?([title[0], folders])
-          if user.admin_user?
-            # for admin user show all the reports
-            reports.push(r.name) unless reports.include?(r.name)
-          else
-            # for non admin users, only show custom reports for their group
-            if title[1] == "Custom"
-              reports.push(r.name) if !reports.include?(r.name) && (r.miq_group && user.current_group.id == r.miq_group.id)
-            else
-              reports.push(r.name) unless reports.include?(r.name)
-            end
-          end
+          reports.push(r.name) unless reports.include?(r.name)
           folders.push([title[1], reports]) unless folders.include?([title[1], reports])
         end
       end
@@ -905,7 +895,7 @@ class ApplicationController < ActionController::Base
       @custom_folder = [@sb[:grp_title]]
       @custom_folder.push([subfolder]) unless @custom_folder.include?([subfolder])
 
-      custom = MiqReport.all.sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
+      custom = MiqReport.for_user(current_user).sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
       rep = custom.select do |r|
         r.rpt_type == "Custom" && (user.admin_user? || r.miq_group_id.to_i == current_group.try(:id))
       end.map(&:name).uniq

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -330,7 +330,7 @@ module ApplicationController::Filter
         @edit[@expkey].select_filter(s, true)
         @edit[:search_type] = s[:search_type] == 'global' ? 'global' : nil
       elsif @edit[@expkey][:exp_chosen_report]
-        r = MiqReport.find(@edit[@expkey][:exp_chosen_report].to_s)
+        r = MiqReport.for_user(current_user).find(@edit[@expkey][:exp_chosen_report].to_s)
         @edit[:new][@expkey] = r.conditions.exp
         @edit[@expkey][:exp_last_loaded] = nil                                # Clear the last search loaded
         @edit[:adv_search_report] = r.name                          # Save the report name
@@ -478,7 +478,7 @@ module ApplicationController::Filter
         @edit[@expkey][:exp_chosen_report] = nil
       else
         @edit[@expkey][:exp_chosen_report] = params[:chosen_report].to_i
-        @exp_to_load = exp_build_table(MiqReport.find(params[:chosen_report]).conditions.exp)
+        @exp_to_load = exp_build_table(MiqReport.for_user(current_user).find(params[:chosen_report]).conditions.exp)
       end
     end
     render :update do |page|

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -28,9 +28,9 @@ module ApplicationController::ReportDownloads
     end
 
     # Use rr frorm paging, if present
-    rr ||= MiqReportResult.find(@sb[:pages][:rr_id]) if @sb[:pages]
+    rr ||= MiqReportResult.for_user(current_user).find(@sb[:pages][:rr_id]) if @sb[:pages]
     # Use report_result_id in session, if present
-    rr ||= MiqReportResult.find(session[:report_result_id]) if session[:report_result_id]
+    rr ||= MiqReportResult.for_user(current_user).find(session[:report_result_id]) if session[:report_result_id]
 
     filename = filename_timestamp(rr.report.title)
     disable_client_cache
@@ -51,7 +51,7 @@ module ApplicationController::ReportDownloads
     unless params[:task_id] # First time thru, kick off the report generate task
       if render_type
         @sb[:render_type] = render_type
-        rr = MiqReportResult.find(session[:report_result_id]) # Get report task id from the session
+        rr = MiqReportResult.for_user(current_user).find(session[:report_result_id]) # Get report task id from the session
         task_id = rr.async_generate_result(@sb[:render_type], :userid     => session[:userid],
                                                               :session_id => request.session_options[:id])
         initiate_wait_for_task(:task_id => task_id)
@@ -79,7 +79,7 @@ module ApplicationController::ReportDownloads
   # Send rendered report data
   def send_report_data
     if @sb[:render_rr_id]
-      rr = MiqReportResult.find(@sb[:render_rr_id])
+      rr = MiqReportResult.for_user(current_user).find(@sb[:render_rr_id])
       filename = filename_timestamp(rr.report.title, 'export_filename')
       disable_client_cache
       generated_result = rr.get_generated_result(@sb[:render_type])
@@ -134,7 +134,7 @@ module ApplicationController::ReportDownloads
       miq_task = MiqTask.find(session[:rpt_task_id])
       miq_task.task_results
     elsif session[:report_result_id]
-      rr = MiqReportResult.find(session[:report_result_id])
+      rr = MiqReportResult.for_user(current_user).find(session[:report_result_id])
       report = rr.report_results
       report.report_run_time = rr.last_run_on
       report

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -340,7 +340,7 @@ class ChargebackController < ApplicationController
   end
 
   def cb_rpts_fetch_saved_report(id)
-    rr = MiqReportResult.find_by_id(from_cid(id.split('-').last))
+    rr = MiqReportResult.for_user(current_user).find_by_id(from_cid(id.split('-').last))
     if rr.nil?  # Saved report no longer exists
       @report = nil
       return
@@ -429,7 +429,8 @@ class ChargebackController < ApplicationController
         # On a saved report node
         cb_rpts_show_saved_report
         if @report
-          s = MiqReportResult.find_by_id(from_cid(nodes.last.split('-').last))
+          s = MiqReportResult.for_user(current_user).find_by_id(from_cid(nodes.last.split('-').last))
+
           @right_cell_div = "reports_list_div"
           @right_cell_text = _("Saved Chargeback Report \"%{last_run_on}\"") % {:last_run_on => format_timezone(s.last_run_on, Time.zone, "gtl")}
         else

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -444,7 +444,7 @@ class ChargebackController < ApplicationController
         unless @saved_reports.empty?
           @sb[:sel_saved_rep_id] = nodes[1]
           @right_cell_div = "reports_list_div"
-          miq_report = MiqReport.find(@sb[:miq_report_id])
+          miq_report = MiqReport.for_user(current_user).find(@sb[:miq_report_id])
           @right_cell_text = _("Saved Chargeback Reports \"%{report_name}\"") % {:report_name => miq_report.name}
           @sb[:parent_reports] = nil  unless @sb[:saved_reports].blank?    # setting it to nil so saved reports can be displayed, unless all saved reports were deleted
         else
@@ -469,7 +469,7 @@ class ChargebackController < ApplicationController
   def cb_rpts_get_all_reps(nodeid)
     return [] if nodeid.blank?
     @sb[:miq_report_id] = from_cid(nodeid)
-    miq_report = MiqReport.find(@sb[:miq_report_id])
+    miq_report = MiqReport.for_user(current_user).find(@sb[:miq_report_id])
     saved_reports = miq_report.miq_report_results.with_current_user_groups
                               .select("id, miq_report_id, name, last_run_on, report_source")
                               .order(:last_run_on => :desc)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -716,12 +716,12 @@ class DashboardController < ApplicationController
   end
 
   def build_timeline
-    @record = MiqReport.find_by_id(from_cid(params[:id]))
+    @record = MiqReport.for_user(current_user).find_by_id(from_cid(params[:id]))
     @ajax_action = "tl_generate"
   end
 
   def tl_gen_timeline_data
-    @report = MiqReport.find(from_cid(params[:id]))
+    @report = MiqReport.for_user(current_user).find(from_cid(params[:id]))
     @title  = @report.title
     @timeline = true unless @report # need to set this incase @report is not there, when switching between Management/Policy events
     return unless @report

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -428,7 +428,7 @@ class ReportController < ApplicationController
   def determine_rr_node_info
     nodes = x_node.split('-')
     show_saved_report
-    @record = MiqReportResult.find_by_id(from_cid(nodes.last))
+    @record = MiqReportResult.for_user(current_user).find_by_id(from_cid(nodes.last))
     @right_cell_text = _("Saved Report \"%{name} - %{timestamp}\"") % {
       :name      => @record.name,
       :timestamp => format_timezone(@record.created_on, Time.zone, "gt")}

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -450,7 +450,7 @@ class ReportController < ApplicationController
   def saved_reports_get_node_info
     nodes = x_node.split('-')
     get_all_reps(nodes[1])
-    miq_report = MiqReport.find(@sb[:miq_report_id])
+    miq_report = MiqReport.for_user(current_user).find(@sb[:miq_report_id])
     @sb[:sel_saved_rep_id] = nodes.last
     @right_cell_div        = "savedreports_list"
     @right_cell_text = _("Saved Report \"%{name}\"") % {:name  => miq_report.name}

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -262,11 +262,10 @@ module ReportController::Menus
 
   def edit_reports
     @edit[:selected_reports] = []
-    @edit[:available_reports] = []
     current_group_id = current_user.current_group.try(:id).to_i
     id = session[:node_selected].split('__')
     @selected = id[1].split(':')
-    all = MiqReport.all.sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
+    all = MiqReport.for_user(current_user).sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
     @all_reports = []
     all.each do |r|
       next if r.template_type != "report" && !r.template_type.blank?
@@ -274,7 +273,6 @@ module ReportController::Menus
     end
 
     @selected_reports = []
-    @available_reports = []
     @assigned_reports = []
 
     # calculating selected reports for selected folder
@@ -321,12 +319,7 @@ module ReportController::Menus
       end
     end
 
-    @all_reports.each do |rep|
-      unless @assigned_reports.include?(rep)
-        r = MiqReport.find_by_name(rep.strip)
-        @available_reports.push(rep) if @edit[:user_typ] || r.miq_group_id.to_i == current_group_id
-      end
-    end
+    @available_reports = @all_reports.reject { |r| @assigned_reports.include?(r) }
 
     @edit[:old_selected_reports] = @selected_reports.dup
     @edit[:old_available_reports] = @available_reports.dup

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -7,7 +7,7 @@ module ReportController::Reports
     assert_privileges("miq_report_run")
     self.x_active_tree = :reports_tree
     @sb[:active_tab] = "saved_reports"
-    rep = MiqReport.find(params[:id])
+    rep = MiqReport.for_user(current_user).find(params[:id])
     rep.queue_generate_table(:userid => session[:userid])
     title = rep.name
     nodes = x_node.split('-')
@@ -81,7 +81,7 @@ module ReportController::Reports
 
   def miq_report_delete
     assert_privileges("miq_report_delete")
-    rpt = MiqReport.find(params[:id])
+    rpt = MiqReport.for_user(current_user).find(params[:id])
 
     if rpt.miq_widgets.exists?
       render_flash(_("Report cannot be deleted if it's being used by one or more Widgets"), :error)
@@ -154,7 +154,7 @@ module ReportController::Reports
         x_node.split('-').last :
         x_node.split('-').last.split('_')[0] if nodeid.nil?
     @sb[:miq_report_id] = from_cid(nodeid)
-    @record = @miq_report = MiqReport.find(@sb[:miq_report_id])
+    @record = @miq_report = MiqReport.for_user(current_user).find(@sb[:miq_report_id])
     if @sb[:active_tab] == "saved_reports" || x_active_tree == :savedreports_tree
       @force_no_grid_xml   = true
       @gtl_type            = "list"

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -22,7 +22,7 @@ module ReportController::Reports
   end
 
   def miq_report_save
-    rr               = MiqReportResult.find(@sb[:pages][:rr_id])
+    rr               = MiqReportResult.for_user(current_user).find(@sb[:pages][:rr_id])
     rr.save_for_user(session[:userid])                # Save the current report results for this user
     @_params[:sortby] = "last_run_on"
     view, _page = get_view(MiqReportResult, :named_scope => [:with_current_user_groups_and_report, @sb[:miq_report_id]])

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -31,7 +31,7 @@ module ReportController::Reports::Editor
       check_tabs
     else
       @sb[:miq_tab] = "edit_1"
-      @rpt          = MiqReport.find(params[:id])
+      @rpt          = MiqReport.for_user(current_user).find(params[:id])
       @rpt.id       = nil # Treat as a new report
       set_form_vars
     end
@@ -101,12 +101,12 @@ module ReportController::Reports::Editor
       @in_a_form = true
       @report = nil     # Clear any saved report object
       if params[:tab] # Came in to change the tab
-        @rpt = @edit[:rpt_id] ? MiqReport.find(@edit[:rpt_id]) :
+        @rpt = @edit[:rpt_id] ? MiqReport.for_user(current_user).find(@edit[:rpt_id]) :
             MiqReport.new
         check_tabs
       else
         @sb[:miq_tab] = "edit_1"
-        @rpt = params[:id] && params[:id] != "new" ? MiqReport.find(params[:id]) :
+        @rpt = params[:id] && params[:id] != "new" ? MiqReport.for_user(current_user).find(params[:id]) :
                 MiqReport.new
         if @rpt.rpt_type == "Default"
           flash = "Default reports can not be edited"

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -15,7 +15,7 @@ module ReportController::SavedReports
   end
 
   def fetch_saved_report(id)
-    rr = MiqReportResult.find_by_id(from_cid(id.split('-').last))
+    rr = MiqReportResult.for_user(current_user).find_by_id(from_cid(id.split('-').last))
     if rr.nil?  # Saved report no longer exists
       @report = nil
       return
@@ -95,13 +95,13 @@ module ReportController::SavedReports
       savedreports = Array.wrap(from_cid(savedreport))
     end
 
-    if savedreports.empty? && params[:id].present? && !MiqReportResult.exists?(params[:id].to_i)
+    if savedreports.empty? && params[:id].present? && !MiqReportResult.for_user(current_user).exists?(params[:id].to_i)
       # saved report is being viewed in report accordion
       add_flash(_("Saved Report no longer exists"), :error)
     else
       savedreports.push(params[:id]) if savedreports.blank?
       @report = nil
-      r = MiqReportResult.find(savedreports[0])
+      r = MiqReportResult.for_user(current_user).find(savedreports[0])
       @sb[:miq_report_id] = r.miq_report_id
       process_saved_reports(savedreports, "destroy")  unless savedreports.empty?
       add_flash(_("The selected Saved Report was deleted")) if @flash_array.nil?

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -377,7 +377,7 @@ module ReportController::Schedules
     @edit[:new][:filter] = params[:filter_typ] if params[:filter_typ]
     @edit[:new][:subfilter] = params[:subfilter_typ] if params[:subfilter_typ]
     if params[:repfilter_typ] && params[:repfilter_typ] != "<Choose>"
-      rep = MiqReport.find(params[:repfilter_typ].to_i)
+      rep = MiqReport.for_user(current_user).find(params[:repfilter_typ].to_i)
       @edit[:new][:repfilter] = rep.id
     elsif params[:repfilter_typ] && params[:repfilter_typ] == "<Choose>"
       @edit[:new][:repfilter] = nil

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -502,7 +502,7 @@ module ReportController::Widgets
       end
       @edit[:new][:subfilter] = params[:subfilter_typ] if params[:subfilter_typ]
       if params[:repfilter_typ] && params[:repfilter_typ] != "<Choose>"
-        @edit[:rpt] = MiqReport.find(params[:repfilter_typ].to_i)
+        @edit[:rpt] = MiqReport.for_user(current_user).find(params[:repfilter_typ].to_i)
         @edit[:new][:repfilter] = @edit[:rpt].id
       elsif params[:repfilter_typ] && params[:repfilter_typ] == "<Choose>"
         @edit[:new][:repfilter] = nil
@@ -511,7 +511,7 @@ module ReportController::Widgets
       @edit[:new][:subfilter] = "" if @edit[:new][:subfilter] == "<Choose>"
     elsif @sb[:wtype] == "c"
       if params[:repfilter_typ] && params[:repfilter_typ] != "<Choose>"
-        @edit[:rpt] = MiqReport.find(params[:repfilter_typ].to_i)
+        @edit[:rpt] = MiqReport.for_user(current_user).find(params[:repfilter_typ].to_i)
         @edit[:new][:repfilter] = @edit[:rpt].id
       end
       @edit[:new][:repfilter] = "" if params[:repfilter_typ] == "<Choose>"

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -45,7 +45,7 @@ describe ChargebackController do
 
   context "Saved chargeback rendering" do
     it "Saved chargeback reports renders paginagion buttons correctly" do
-      report = FactoryGirl.create(:miq_report_with_results)
+      report = FactoryGirl.create(:miq_report_with_results, :miq_group => User.current_user.current_group)
       report.extras = {:total_html_rows => 100}
       rp_id = report.id
       rr_id = report.miq_report_results[0].id

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -118,7 +118,8 @@ describe ReportController do
     end
 
     context "#miq_report_edit" do
-      before { stub_user(:features => :all) }
+      let(:user) { stub_user(:features => :all) }
+      before { user.save! }
 
       it "should build tabs with correct tab id after reset button is pressed to prevent error when changing tabs" do
         ApplicationController.handle_exceptions = true
@@ -126,6 +127,7 @@ describe ReportController do
         rep = FactoryGirl.create(
           :miq_report,
           :rpt_type   => "Custom",
+          :miq_group  => user.current_group,
           :db         => "Host",
           :name       => 'name',
           :title      => 'title',

--- a/spec/controllers/miq_report_controller/reports_spec.rb
+++ b/spec/controllers/miq_report_controller/reports_spec.rb
@@ -1,13 +1,14 @@
 describe ReportController, "::Reports" do
   describe "#miq_report_delete" do
+    let(:user) { FactoryGirl.create(:user, :features => :miq_report_delete) }
     before do
       EvmSpecHelper.local_miq_server # timezone stuff
-      login_as FactoryGirl.create(:user, :features => :miq_report_delete)
+      login_as user
     end
 
     it "deletes the report" do
       FactoryGirl.create(:miq_report)
-      report = FactoryGirl.create(:miq_report, :rpt_type => "Custom")
+      report = FactoryGirl.create(:miq_report, :rpt_type => "Custom", :miq_group => user.current_group)
       session['sandboxes'] = {
         controller.controller_name => { :active_tree => 'report_1',
                                         :trees       => {'report_1' => {:active_node => "xx-0_xx-0-0_rep-#{report.id}"}}


### PR DESCRIPTION
A flaw was found in the CloudForms API. A user with permissions to use the MiqReportResults capability within the API could potentially view data from other tenants or groups to which they should not have access.

Further, the attacker was able to schedule MiqReport run, thus they are in control (to extent) of what leaks.

https://access.redhat.com/security/cve/CVE-2016-7047

Depends on https://github.com/ManageIQ/manageiq/pull/15472