### PR TITLE
Disable delete button for the active snapshot on oVirt

### DIFF
--- a/app/helpers/application_helper/button/vm_snapshot_remove_one.rb
+++ b/app/helpers/application_helper/button/vm_snapshot_remove_one.rb
@@ -1,0 +1,11 @@
+class ApplicationHelper::Button::VmSnapshotRemoveOne < ApplicationHelper::Button::Basic
+  needs :@record, :@active
+
+  def disabled?
+    @error_message = @record.try(:remove_snapshot_denied_message, @active)
+    @error_message ||= unless @record.supports_remove_snapshot?
+                         @record.unsupported_reason(:remove_snapshot)
+                       end
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -310,8 +310,8 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           :confirm   => N_("The selected snapshot will be permanently deleted. Are you sure you want to delete the selected snapshot?"),
           :url_parms => "main_div",
           :onwhen    => "1",
-          :klass     => ApplicationHelper::Button::GenericFeatureButtonWithDisable,
-          :options   => {:feature => :remove_snapshot}),
+          :klass     => ApplicationHelper::Button::VmSnapshotRemoveOne
+        ),
         button(
           :vm_snapshot_delete_all,
           'pficon pficon-delete fa-lg',

--- a/spec/helpers/application_helper/buttons/vm_snapshot_remove_one_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_remove_one_spec.rb
@@ -1,0 +1,46 @@
+describe ApplicationHelper::Button::VmSnapshotRemoveOne do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:zone) { EvmSpecHelper.local_miq_server(:is_master => true).zone }
+  let(:ems) { FactoryGirl.create(:ems_redhat, :zone => zone, :name => 'Test EMS') }
+  let(:host) { FactoryGirl.create(:host) }
+  let(:record) do
+    record = FactoryGirl.create(:vm_redhat, :ems_id => ems.id, :host_id => host.id)
+    record.snapshots = [FactoryGirl.create(:snapshot,
+                                           :create_time       => 1.minute.ago,
+                                           :vm_or_template_id => record.id,
+                                           :name              => 'EvmSnapshot',
+                                           :description       => "Some Description",
+                                           :current           => 1)]
+    record
+  end
+  let(:button) { described_class.new(view_context, {}, {'record' => record, 'active' => active}, {}) }
+  let(:active) { true }
+  before do
+    allow(record.ext_management_system).to receive(:supports_snapshots?).and_return(true)
+  end
+  describe '#disabled?' do
+    subject { button.disabled? }
+    context 'when record.kind_of?(ManageIQ::Providers::Redhat::InfraManager::Vm)' do
+      context 'when record is active' do
+        it { is_expected.to be_truthy }
+      end
+      context 'when record is not active' do
+        let(:active) { false }
+        it { is_expected.to be_falsey }
+      end
+    end
+    context 'when !record.kind_of?(ManageIQ::Providers::Redhat::InfraManager::Vm)' do
+      let(:record) do
+        record = FactoryGirl.create(:vm_vmware, :ems_id => ems.id, :host_id => host.id)
+        record.snapshots = [FactoryGirl.create(:snapshot,
+                                               :create_time       => 1.minute.ago,
+                                               :vm_or_template_id => record.id,
+                                               :name              => 'EvmSnapshot',
+                                               :description       => "Some Description",
+                                               :current           => 1)]
+        record
+      end
+      it { is_expected.to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
Disable the delete button when the active snapshot is selected
for a vm on oVirt.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1443411

Depends on: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/54