### PR TITLE
[FINE] Fix displaying report result

### DIFF
--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -24,7 +24,6 @@ module ReportController::SavedReports
                          {:name => "#{rr.name} - #{format_timezone(rr.created_on, Time.zone, "gt")}"}
     if admin_user? || current_user.miq_group_ids.include?(rr.miq_group_id)
       @report_result_id = session[:report_result_id] = rr.id
-      @report_result = rr
       session[:report_result_runtime] = rr.last_run_on
       if rr.status.downcase == "complete"
         @report = rr.report_results
@@ -77,6 +76,8 @@ module ReportController::SavedReports
             add_flash(_("No records found for this report"), :warning)
           end
         end
+      else
+        @report_result = rr
       end
     else
       add_flash(_("Report is not authorized for the logged in user"), :error)

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -31,12 +31,15 @@ describe ReportController do
                            :binary_blob_id => binary_blob.id)
       end
 
-      it 'renders show' do
+      before do
         login_as user
         controller.instance_variable_set(:@html, "<h1>Test</h1>")
         allow(controller).to receive(:report_first_page)
         allow(report).to receive(:contains_records?).and_return(true)
         allow_any_instance_of(MiqReportResult).to receive(:report_results).and_return(report)
+      end
+
+      it 'renders show' do
         post :tree_select, :params => { :id => "rr-#{report_result.id}", :format => :js, :accord => 'savedreports' }
         expect(response).to render_template('shared/_report_chart_and_html')
       end

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -44,6 +44,12 @@ describe ReportController do
         expect(controller.instance_variable_get(:@report_result)).to be_nil
         expect(response).to render_template('shared/_report_chart_and_html')
       end
+
+      it 'renders show from CI -> Reports -> Reports -> Any Report' do
+        post :tree_select, :params => { :id => "xx-11_xx-11-0_rep-145_rr-#{report_result.id}", :format => :js, :accord => 'savedreports' }
+        expect(controller.instance_variable_get(:@report_result)).to be_nil
+        expect(response).to render_template('shared/_report_chart_and_html')
+      end
     end
 
     context "reports tree" do

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -41,6 +41,7 @@ describe ReportController do
 
       it 'renders show from CI -> Reports -> Saved Reports' do
         post :tree_select, :params => { :id => "rr-#{report_result.id}", :format => :js, :accord => 'savedreports' }
+        expect(controller.instance_variable_get(:@report_result)).to be_nil
         expect(response).to render_template('shared/_report_chart_and_html')
       end
     end

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -39,7 +39,7 @@ describe ReportController do
         allow_any_instance_of(MiqReportResult).to receive(:report_results).and_return(report)
       end
 
-      it 'renders show' do
+      it 'renders show from CI -> Reports -> Saved Reports' do
         post :tree_select, :params => { :id => "rr-#{report_result.id}", :format => :js, :accord => 'savedreports' }
         expect(response).to render_template('shared/_report_chart_and_html')
       end

--- a/spec/helpers/report_helper_spec.rb
+++ b/spec/helpers/report_helper_spec.rb
@@ -8,6 +8,9 @@ def create_and_generate_report_for_user(report_name, user_id)
   @rpt = MiqReport.where(:name => report_name).last
   @rpt.generate_table(:userid => user_id)
   report_result = @rpt.build_create_results(:userid => user_id)
+  miq_task = FactoryGirl.create(:miq_task)
+  miq_report_result = @rpt.miq_report_results.first
+  miq_report_result.update_attributes!(:miq_task => miq_task)
   report_result.reload
   @rpt
 end


### PR DESCRIPTION
caused by: https://github.com/ManageIQ/manageiq-ui-classic/pull/1488 and first commit of this PR is partial revert of https://github.com/ManageIQ/manageiq-ui-classic/pull/1488/commits/308fa6ffb15d33344b4d0b1cf091df8994c45125

we need to reach this condition https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/report/_report_list.html.haml#L5 it means that `@report_result` is set to nil.
yes, it looks like that there is not need to have `@report_result` but the revert seems like a safer solution.


before 
![m6si49kkva](https://user-images.githubusercontent.com/14937244/27698489-9036a3a8-5cf7-11e7-8555-9ef75a9d7d5d.gif)


after

![tuddwmheif](https://user-images.githubusercontent.com/14937244/27698500-928abed2-5cf7-11e7-9378-27984b0dee34.gif)

@miq-bot add_label bug, blocker
cc @gtanzillo @mzazrivec 

@miq-bot assign @himdel 

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1465387
master PR https://github.com/ManageIQ/manageiq-ui-classic/pull/1650
