### PR TITLE
fix broken "vm_transform" toolbar icon

### DIFF
--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           t),
         button(
           :vm_transform,
-          'pficon fa-random fa-lg',
+          'fa fa-random fa-lg',
           t = N_('Transform this VM to RHV'),
           t,
           :klass => ApplicationHelper::Button::TransformVmButton


### PR DESCRIPTION
This PR corrects the font-family used for "fa-random"

Before:
<img width="295" alt="screen shot 2017-06-29 at 2 50 05 pm" src="https://user-images.githubusercontent.com/1287144/27705045-9a376828-5cda-11e7-8202-0fa9ce743896.png">

After:
<img width="299" alt="screen shot 2017-06-29 at 2 50 22 pm" src="https://user-images.githubusercontent.com/1287144/27705044-9a2f9a58-5cda-11e7-835d-9df3a04cdf1b.png">