### PR TITLE
Add missing datastore nodes to HaC tree 

### DIFF
--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -63,6 +63,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
   def x_get_tree_datacenter_kids(parent, count_only)
     kids = []
     parent.folders.each do |child|
+      kids.concat([child]) if child.kind_of?(EmsFolder) && child.name == 'datastore'
       next unless child.kind_of?(EmsFolder) && child.name == "host"
       kids.concat(child.folders_only)
       kids.concat(child.clusters)


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/15

Configuration -> Access Control -> any group -> Hosts/Nodes & Clusters/ Deployment Roles

Before:
<img width="159" alt="screen shot 2017-06-30 at 2 44 04 pm" src="https://user-images.githubusercontent.com/9210860/27736033-a2220732-5da2-11e7-90fc-36a2fda02969.png">


After:
<img width="180" alt="screen shot 2017-06-30 at 2 39 47 pm" src="https://user-images.githubusercontent.com/9210860/27736040-a7d41f1c-5da2-11e7-871c-c2ef6cc222f4.png">


@miq-bot add_label wip, bug, trees

https://bugzilla.redhat.com/show_bug.cgi?id=1452640