### PR TITLE
Set Field value to a blank value to avoid crashes due to a nil value

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -764,6 +764,7 @@ module ApplicationController::Filter
     exp = exp_find_by_token(@edit[@expkey][:expression], token.to_i)
     case @edit[@expkey][:exp_typ]
     when "field"
+      @edit[@expkey][:exp_value] ||= ''
       if @edit[@expkey][:exp_field].nil?
         add_flash(_("A field must be chosen to commit this expression element"), :error)
       elsif @edit[@expkey][:exp_value] != :user_input &&


### PR DESCRIPTION
Expressions with field values of type `Text` must contain a blank string at the start in order to prevent crashes when a user clicks on the check mark mid-way before the expression is fully formed.

https://bugzilla.redhat.com/show_bug.cgi?id=1466778

To reproduce the issue (the crash), select `Build State` as the field value in the Provider Foreman Advanced Search Expression editor. Click on the check mark button without entering a value.