### PR TITLE
Check for tags in metric item

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js
@@ -157,6 +157,11 @@ angular.module('miq.util').factory('metricsUtilsFactory', function() {
         return;
       }
 
+      // make sure we have tags
+      if (! item.tags) {
+        item.tags = {};
+      }
+
       item.data = item.data.sort(function(a, b) { return a.timestamp > b.timestamp; });
       var maxValue = Math.max.apply(Math, item.data.map(function(o) { return o.value; }))
       var m = metricPrefix(maxValue, item.tags.units || '');


### PR DESCRIPTION
**Description**

When the item tags is missing, lines [162](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js#L162) and [165](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/assets/javascripts/controllers/live_metrics/util/metrics-utils-factory.js#L165) fail.

We must check tags array's pre-existence before trying to use it, ( the tags field is not a required filed, and can be `nil` in the responce ).
   
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1465562
