### PR TITLE
Update metric tags after updating metrics tenants

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
+++ b/app/assets/javascripts/controllers/live_metrics/ad_hoc_metrics_controller.js
@@ -19,9 +19,6 @@ ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', '
       // and set page config variables
       metricsParseUrlFactory(dash, $window);
       metricsConfigFactory(dash);
-
-      // load tenants
-      httpUtils.getTenants();
     }
 
     var initialization = function() {
@@ -59,10 +56,14 @@ ManageIQ.angular.app.controller('adHocMetricsController', ['$http', '$window', '
         actionsConfig: dash.actionsConfig
       };
 
-      var _tenant = dash.tenant.value || dash.DEFAULT_TENANT;
-      dash.url = '/container_dashboard/data' + dash.providerId  + '/?live=true&tenant=' + _tenant;
+      if (dash.tenant.value) {
+        // load filters
+        httpUtils.getMetricTags();
+      } else {
+        // load tenants and filters
+        httpUtils.getTenants();
+      }
 
-      httpUtils.getMetricTags();
       setAppliedFilters();
     }
 

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
@@ -77,6 +77,7 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
     };
 
     var getMetricTags = function() {
+      dash.url = '/container_dashboard/data' + dash.providerId  + '/?live=true&tenant=' + dash.tenant.value;
       $http.get(dash.url + '&query=metric_tags&limit=250')
         .then(getMetricTagsData)
         .catch(function(error) {
@@ -106,6 +107,9 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
             dash.tenant = dash.tenantList[i];
           }
         });
+
+        // update tag list
+        getMetricTags()
       });
     }
 

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -1,87 +1,136 @@
 describe('adHocMetricsController', function() {
-  var $scope, $controller, $httpBackend, pfViewUtils;
-  var mock_data = getJSONFixture('container_live_dashboard_response.json');
-  var mock_tenants_data = getJSONFixture('container_live_dashboard_tenant_response.json');
-  var mock_metrics_data = getJSONFixture('container_live_dashboard_metrics_response.json');
+  describe('with default tenenat', function() {
+    var $scope, $controller, $httpBackend, pfViewUtils;
+    var mock_data = getJSONFixture('container_live_dashboard_response.json');
+    var mock_tenants_data = getJSONFixture('container_live_dashboard_tenant_response.json');
+    var mock_metrics_data = getJSONFixture('container_live_dashboard_metrics_response.json');
 
-  beforeEach(module('ManageIQ'));
+    beforeEach(module('ManageIQ'));
 
-  beforeEach(function() {
-    var $window = {location: { pathname: '/ems_container/42' }};
-    module(function($provide) {
-      $provide.value('$window', $window);
+    beforeEach(function() {
+      var $window = {location: { pathname: '/ems_container/42' }};
+      module(function($provide) {
+        $provide.value('$window', $window);
+      });
+    });
+
+    beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_) {
+      $httpBackend = _$httpBackend_;
+      $httpBackend.when('GET','/container_dashboard/data/42/?live=true&query=get_tenants').respond(mock_tenants_data);
+      $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_system&query=metric_tags&limit=250').respond(mock_data);
+      $controller = _$controller_('adHocMetricsController');
+      $httpBackend.flush();
+
+      $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_system&limit=10000&query=metric_definitions&tags={}&page=1&items_per_page=8').respond(mock_metrics_data);
+      $controller.refreshList();
+      $httpBackend.flush();
+    }));
+
+    afterEach(function() {
+      $httpBackend.verifyNoOutstandingExpectation();
+      $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    describe('loading page data', function() {
+      it('should load tag list', function() {
+        expect($controller.filterConfig.fields.length).toBe(12);
+      });
+
+      it('should load metrics definitions', function() {
+        expect($controller.loadingMetrics).toBeDefined();
+        expect($controller.loadingMetrics).toBe(false);
+        expect($controller.items.length).toBe(2);
+      });
+    });
+
+    describe('count increment', function() {
+      it('should increment the count', function() {
+        $controller.countIncrement();
+        expect($controller.timeFilter.range_count).toBe(2);
+      });
+
+      it('should decrement the count', function() {
+        $controller.timeFilter.range_count = 10;
+        $controller.countDecrement();
+        expect($controller.timeFilter.range_count).toBe(9);
+      });
+    });
+
+    describe('utility functions', function() {
+      it('should calculate units correctly', function() {
+        var m;
+
+        m = $controller.metricPrefix(10000, 'ms');
+        expect(m.multiplier).toBe(Math.pow(10, -3));
+        expect(m.unitLabel).toBe('s');
+
+        m = $controller.metricPrefix(10000, 'ns');
+        expect(m.multiplier).toBe(Math.pow(10, -9));
+        expect(m.unitLabel).toBe('s');
+
+        m = $controller.metricPrefix(10000, 's');
+        expect(m.multiplier).toBe(Math.pow(10, -3));
+        expect(m.unitLabel).toBe('Ks');
+      });
+
+      it('should calculate differentials currectly', function() {
+        var data = [1, 2, 3, 4, 5, 6];
+
+        data = $controller.calcDataDifferentials(data);
+        expect(data).toEqual([1, 1, 1, 1, 1, null]);
+      });
+
+      it('differentials should not fail on missing data', function() {
+        var data = [1, 2, null, 4, 5, 6];
+
+        data = $controller.calcDataDifferentials(data);
+        expect(data).toEqual([1, null, null, 1, 1, null]);
+      });
     });
   });
 
-  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_) {
-    $httpBackend = _$httpBackend_;
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&query=get_tenants').respond(mock_tenants_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_system&query=metric_tags&limit=250').respond(mock_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_system&limit=10000&query=metric_definitions&tags={}&page=1&items_per_page=8').respond(mock_metrics_data);
-    $controller = _$controller_('adHocMetricsController');
-    $controller.refreshList();
-    $httpBackend.flush();
-  }));
+  describe('without default tenenat', function() {
+    var $scope, $controller, $httpBackend, pfViewUtils;
+    var mock_data = getJSONFixture('container_live_dashboard_response.json');
+    var mock_tenants_data = getJSONFixture('container_live_dashboard_wo_default_response.json');
+    var mock_metrics_data = getJSONFixture('container_live_dashboard_metrics_response.json');
 
-  afterEach(function() {
-    $httpBackend.verifyNoOutstandingExpectation();
-    $httpBackend.verifyNoOutstandingRequest();
-  });
+    beforeEach(module('ManageIQ'));
 
-  describe('loading page data', function() {
-    it('should load tag list', function() {
-      expect($controller.filterConfig.fields.length).toBe(12);
+    beforeEach(function() {
+      var $window = {location: { pathname: '/ems_container/42' }};
+      module(function($provide) {
+        $provide.value('$window', $window);
+      });
     });
 
-    it('should load metrics definitions', function() {
-      expect($controller.loadingMetrics).toBeDefined();
-      expect($controller.loadingMetrics).toBe(false);
-      expect($controller.items.length).toBe(2);
-    });
-  });
+    beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_) {
+      $httpBackend = _$httpBackend_;
+      $httpBackend.when('GET','/container_dashboard/data/42/?live=true&query=get_tenants').respond(mock_tenants_data);
+      $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_tags&limit=250').respond(mock_data);
+      $controller = _$controller_('adHocMetricsController');
+      $httpBackend.flush();
 
-  describe('count increment', function() {
-    it('should increment the count', function() {
-      $controller.countIncrement();
-      expect($controller.timeFilter.range_count).toBe(2);
-    });
+      $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&limit=10000&query=metric_definitions&tags={}&page=1&items_per_page=8').respond(mock_metrics_data);
+      $controller.refreshList();
+      $httpBackend.flush();
+    }));
 
-    it('should decrement the count', function() {
-      $controller.timeFilter.range_count = 10;
-      $controller.countDecrement();
-      expect($controller.timeFilter.range_count).toBe(9);
-    });
-  });
-
-  describe('utility functions', function() {
-    it('should calculate units correctly', function() {
-      var m;
-
-      m = $controller.metricPrefix(10000, 'ms');
-      expect(m.multiplier).toBe(Math.pow(10, -3));
-      expect(m.unitLabel).toBe('s');
-
-      m = $controller.metricPrefix(10000, 'ns');
-      expect(m.multiplier).toBe(Math.pow(10, -9));
-      expect(m.unitLabel).toBe('s');
-
-      m = $controller.metricPrefix(10000, 's');
-      expect(m.multiplier).toBe(Math.pow(10, -3));
-      expect(m.unitLabel).toBe('Ks');
+    afterEach(function() {
+      $httpBackend.verifyNoOutstandingExpectation();
+      $httpBackend.verifyNoOutstandingRequest();
     });
 
-    it('should calculate differentials currectly', function() {
-      var data = [1, 2, 3, 4, 5, 6];
+    describe('loading page data', function() {
+      it('should load tag list', function() {
+        expect($controller.filterConfig.fields.length).toBe(12);
+      });
 
-      data = $controller.calcDataDifferentials(data);
-      expect(data).toEqual([1, 1, 1, 1, 1, null]);
-    });
-
-    it('differentials should not fail on missing data', function() {
-      var data = [1, 2, null, 4, 5, 6];
-
-      data = $controller.calcDataDifferentials(data);
-      expect(data).toEqual([1, null, null, 1, 1, null]);
+      it('should load metrics definitions', function() {
+        expect($controller.loadingMetrics).toBeDefined();
+        expect($controller.loadingMetrics).toBe(false);
+        expect($controller.items.length).toBe(2);
+      });
     });
   });
 });

--- a/spec/javascripts/fixtures/json/container_live_dashboard_wo_default_response.json
+++ b/spec/javascripts/fixtures/json/container_live_dashboard_wo_default_response.json
@@ -1,0 +1,7 @@
+{
+  "tenants":
+    [
+      {"label": "Operations", "value": "_ops"},
+      {"label": "Default", "value": "default"}
+    ]
+}


### PR DESCRIPTION
**Description**

If the default tenant is missing and we try to get the tags-list, we will get an empty tag list.

We only know what tenant we will use, after we get the tenant-list. we can update the tags-list only after we get the tenant-list.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1465541

**Screenshots**

Before, default `_system` tenant is missing, we fall back to the `_ops` tenant, but do not update tags list:
![screenshot-localhost 3000-2017-07-02-10-36-02](https://user-images.githubusercontent.com/2181522/27768055-6cc2b6e2-5f12-11e7-96a6-2a24821d0788.png)

After, default `_system` tenant is missing, we fall back to the `_ops` tenant and update tags list:
![screenshot-localhost 3000-2017-07-02-10-38-38](https://user-images.githubusercontent.com/2181522/27768064-ab2b0fe2-5f12-11e7-9228-ac17ed9958a7.png)


