### PR TITLE
Fix alert status 'error' count and icon

### DIFF
--- a/app/views/shared/views/_show_alerts_overview.html.haml
+++ b/app/views/shared/views/_show_alerts_overview.html.haml
@@ -39,15 +39,15 @@
                 {{item.name}}
             .card-pf-body
               %p.card-pf-aggregate-status-notifications
-                %span.card-pf-aggregate-status-notification{"ng-if" => "item.danger.length > 0",
-                                                            "ng-mouseover" => "vm.onHoverAlerts(item.danger)",
+                %span.card-pf-aggregate-status-notification{"ng-if" => "item.error.length > 0",
+                                                            "ng-mouseover" => "vm.onHoverAlerts(item.error)",
                                                             "tooltip-template" => "'/static/alert-overview-popover.html'",
                                                             "tooltip-append-to-body" => "true",
                                                             "tooltip-class" => "miq-alerts-center",
                                                             "tooltip-popup-delay" => "1000"}
                   %a{"href" => "#", "ng-click" => "vm.showGroupAlerts(item, 'Error')"}
                     %span.pficon.pficon-error-circle-o
-                    {{item.danger.length}}
+                    {{item.error.length}}
                 %span.card-pf-aggregate-status-notification{"ng-if" => "item.warning.length > 0",
                                                             "ng-mouseover" => "vm.onHoverAlerts(item.warning)",
                                                             "tooltip-template" => "'/static/alert-overview-popover.html'",


### PR DESCRIPTION
Show severity count for MiqAlertStatus with severity = 'alert' in the alerts dashboard
Before:
![alerts_error_before](https://user-images.githubusercontent.com/3010449/27769328-fa1d8dba-5f2f-11e7-9483-26d9f13bb3d1.png)

After:
![alerts_error_after](https://user-images.githubusercontent.com/3010449/27769327-fa1b8b6e-5f2f-11e7-9b60-6d7f0d0af261.png)
