### PR TITLE
Change Description to Name in Access Control Groups

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -10,7 +10,7 @@
   .form-horizontal
     .form-group
       %label.col-md-2.control-label
-        = _("Description")
+        = _("Name")
       .col-md-8
         - if !@edit
           = h(@group.description)


### PR DESCRIPTION
Change Description to Name in Access Control Groups
https://www.pivotaltracker.com/n/projects/1613907/stories/147303211

## Screenshots:

### Before:
![screencapture-localhost-3000-ops-explorer-1499086217876](https://user-images.githubusercontent.com/9535558/27793616-172cbf46-5fff-11e7-8002-dc8bf66cbb86.png)

### After:
![screencapture-localhost-3000-ops-explorer-1499086176531](https://user-images.githubusercontent.com/9535558/27793620-193124b2-5fff-11e7-8deb-613fd2a917d3.png)

#### Edit:
![screencapture-localhost-3000-ops-explorer-1499767751792](https://user-images.githubusercontent.com/9535558/28063590-d7d6ff30-6631-11e7-86fa-7519681aa9cd.png)
