### PR TITLE
Fix form for CustomButton during saving/creating

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -794,7 +794,7 @@ module ApplicationController::Buttons
       add_flash(_('URL can be opened only by buttons for a single entity'), :error)
     end
 
-    if !button_hash[:dialog_id].empty? && button_hash[:display_for] != 'single'
+    if button_hash[:dialog_id].empty? && button_hash[:display_for] != 'single'
       add_flash(_('Dialog can be opened only by buttons for a single entity'), :error)
     end
 

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -794,7 +794,7 @@ module ApplicationController::Buttons
       add_flash(_('URL can be opened only by buttons for a single entity'), :error)
     end
 
-    if button_hash[:dialog_id].empty? && button_hash[:display_for] != 'single'
+    if (button_hash[:dialog_id].zero? || button_hash[:dialog_id].empty?) && button_hash[:display_for] != 'single'
       add_flash(_('Dialog can be opened only by buttons for a single entity'), :error)
     end
 


### PR DESCRIPTION
Fix handling integer 0 value as an empty value
in `button_hash[:dialog_id]` can be integer 0 and it have to be considered as empty value

@martinpovolny was the `!` unintended in https://github.com/ManageIQ/manageiq-ui-classic/pull/1382/commits/c569df9737c6975baab54fbbe01ebb942c5e9ff7 ?

## Reproducer
Automation -> Automate -> Customization -> Buttons accord.
Create group and create the button with unselected Dialog.

@miq-bot assing @mzazrivec 
@miq-bot add_label bug

## Error Log
```
F, [2017-07-03T15:27:06.439844 #32299] FATAL -- : Error caught: [NoMethodError] undefined method `empty?' for 0:Fixnum
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:797:in `button_valid?'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:480:in `ab_button_add'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:458:in `button_create_update'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:189:in `button_create'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.4/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.4/lib/abstract_controller/base.rb:188:in `process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.4/lib/action_controller/metal/rendering.rb:30:in `process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.4/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.4/lib/active_support/callbacks.rb:126:in `call'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.4/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.4/lib/active_support/callbacks.rb:455:in `call'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.4/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.4/lib/active_support/callbacks.rb:750:in `_run_process_action_callbacks'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.4/lib/active_support/callbacks.rb:90:in `run_callbacks'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.4/lib/abstract_controller/callbacks.rb:19:in `process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.4/lib/action_controller/metal/rescue.rb:20:in `process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.4/lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.4/lib/active_support/notifications.rb:164:in `block in instrument'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.4/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.4/lib/active_support/notifications.rb:164:in `instrument'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.4/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.4/lib/action_controller/metal/params_wrapper.rb:248:in `process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activerecord-5.0.4/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.4/lib/abstract_controller/base.rb:126:in `process'
/usr/local/opt/rbenv/versions/2.
```