### PR TITLE
app: Redirect to cockpit

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1072,6 +1072,7 @@ Rails.application.routes.draw do
     :dashboard                => {
       :get  => %w(
         auth_error
+        cockpit_redirect
         iframe
         change_tab
         index


### PR DESCRIPTION
Redirects the user to cockpit including a valid API token as a url fragment so that cockpit can validate the
current user.

Split from ManageIQ/manageiq#12506 post UI refactoring.