### PR TITLE
Fix displaying report result

### DIFF
--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -31,7 +31,6 @@ module ReportController::SavedReports
     end
 
     @report_result_id = session[:report_result_id] = rr.id
-    @report_result = rr
     session[:report_result_runtime] = rr.last_run_on
 
     return unless rr.status.downcase == "complete"

--- a/app/views/report/_report_list.html.haml
+++ b/app/views/report/_report_list.html.haml
@@ -2,7 +2,7 @@
   - if @sb[:active_accord] == :reports
     - if @in_a_form
       = render :partial => 'form'
-    - elsif @report && !@report_result
+    - elsif @report
       = render :partial => "layouts/flash_msg"
 
       = render :partial => 'shared/report_chart_and_html', :locals => {:chart => @render_chart, :html => @html, :report => @report}

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1226,9 +1226,10 @@ describe ReportController do
           controller.instance_variable_set(:@sb, :last_savedreports_id => nil)
           allow(controller).to receive(:get_all_reps)
           controller.send(:show_saved_report)
-          fetched_report_result = controller.instance_variable_get(:@report_result)
-          expect(fetched_report_result.id).to eq(@rpt.miq_report_results.first.id)
-          expect(fetched_report_result.miq_report.id).to eq(@rpt.id)
+          fetched_report_result_id = controller.instance_variable_get(:@report_result_id)
+          expect(fetched_report_result_id).to eq(@rpt.miq_report_results.first.id)
+          fetched_report = controller.instance_variable_get(:@report)
+          expect(fetched_report.id).to eq(@rpt.id)
         end
       end
     end


### PR DESCRIPTION
`@report_result` is useless, there is only need to keep @report_result_id 
Fine version https://github.com/ManageIQ/manageiq-ui-classic/pull/1632 -  there is test scenario

## Links
FINE: https://bugzilla.redhat.com/show_bug.cgi?id=1465387
@miq-bot add_label bug
cc @gtanzillo 
@miq-bot assign @martinpovolny 