### PR TITLE
Regulate encryption when creating new volume from snapshot

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API', 'cloudVolumeFormId', 'storageManagerId', function(miqService, API, cloudVolumeFormId, storageManagerId) {
+ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API', 'cloudVolumeFormId', 'storageManagerId', '$timeout', function(miqService, API, cloudVolumeFormId, storageManagerId, $timeout) {
   var vm = this;
 
   var init = function() {
@@ -165,6 +165,22 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     return vm.newRecord ||
       (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs' &&
         vm.cloudVolumeModel.aws_volume_type !== 'standard');
+  };
+
+  vm.awsBaseSnapshotChanged = function(baseSnapshotId) {
+    vm.encryptionDisabled = false;
+    $timeout(function() {
+      if (baseSnapshotId) {
+        for (var i = 0; i < vm.baseSnapshotChoices.length; i++) {
+          if (vm.baseSnapshotChoices[i].ems_ref === baseSnapshotId) {
+            vm.cloudVolumeModel.aws_encryption = vm.baseSnapshotChoices[i].encrypted === true;
+            vm.encryptionDisabled = true;
+          }
+        }
+      } else {
+        vm.cloudVolumeModel.aws_encryption = false;
+      }
+    }, 0);
   };
 
   function setForm() {

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -116,6 +116,7 @@
   .col-md-8
     %select{"name"             => "aws_base_snapshot_id",
             "ng-model"         => "vm.cloudVolumeModel.aws_base_snapshot_id",
+            "ng-change"        => "vm.awsBaseSnapshotChanged(vm.cloudVolumeModel.aws_base_snapshot_id)",
             "ng-options"       => "vs.ems_ref as vs.name for vs in vm.baseSnapshotChoices",
             "ng-disabled"      => "!vm.newRecord",
             :checkchange       => true,
@@ -133,8 +134,8 @@
                         :type             => "checkbox",
                         :name             => "aws_encryption",
                         'ng-model'        => "vm.cloudVolumeModel.aws_encryption",
-                        'switch-readonly' => "!vm.newRecord",
-                        'ng-disabled'     => "!vm.newRecord",
+                        'switch-readonly' => "{{!vm.newRecord || vm.encryptionDisabled}}",
+                        'ng-disabled'     => "!vm.newRecord || vm.encryptionDisabled",
                         :checkchange      => ""}
 
 = render :partial => "layouts/angular/generic_form_buttons"


### PR DESCRIPTION
When creating new CloudVolume from CloudVolumeSnapshot, it has to have the same encrypted property as a choosen snapshot. So if a snapshot, from which volume is made, is encrypted it means a new volume has to be encrypted too.

example video: https://app.koofr.net/links/8246bebf-dad9-46ce-ab56-5ba65697e60e

Reference: https://github.com/ManageIQ/manageiq-ui-classic/pull/1324#issuecomment-304106692