### PR TITLE
Add the ability to edit options settings for providers

### DIFF
--- a/app/assets/javascripts/components/provider-option-field-input.js
+++ b/app/assets/javascripts/components/provider-option-field-input.js
@@ -1,0 +1,16 @@
+ManageIQ.angular.app.component('providerOptionFieldInput', {
+  bindings: {
+    option: '<',
+    sectionName: '@',
+  },
+
+  controller: function() {
+    var ctrl = this;
+
+    ctrl.$onInit = function() {
+      ctrl.elemID = "provider_options_" + ctrl.sectionName + "_" + ctrl.option.name;
+    };
+  },
+
+  templateUrl: '/static/provider_option_field_input.html.haml',
+});

--- a/app/assets/javascripts/components/provier-option-section.js
+++ b/app/assets/javascripts/components/provier-option-section.js
@@ -1,0 +1,11 @@
+ManageIQ.angular.app.component('providerOptionSection', {
+  bindings: {
+    settings: '<',
+    label: '@',
+    helpText: '@',
+    sectionName: '@',
+  },
+
+  templateUrl: '/static/provider_option_section.html.haml',
+});
+

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '$attrs', 'emsCommonFormId', 'miqService', '$timeout', function($http, $scope, $attrs, emsCommonFormId, miqService, $timeout) {
+ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '$attrs', 'emsCommonFormId', 'miqService', '$timeout', 'API', function($http, $scope, $attrs, emsCommonFormId, miqService, $timeout, API) {
   var init = function() {
     $scope.emsCommonModel = {
       name: '',
@@ -10,6 +10,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       hostname: '',
       default_hostname: '',
       amqp_hostname: '',
+      provider_options: {},
       metrics_hostname: '',
       metrics_selection: '',
       metrics_api_port: '',
@@ -59,6 +60,12 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       prometheus_alerts_security_protocol: '',
       alerts_selection: '',
     };
+
+    $scope.emsOptionsModel = {
+      provider_options: {},
+      provider_options_original_values: {},
+    };
+
     $scope.formId = emsCommonFormId;
     $scope.afterGet = false;
     $scope.modelCopy = angular.copy( $scope.emsCommonModel );
@@ -177,6 +184,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.populatePostValidationModel();
 
       miqService.sparkleOff();
+
+      $scope.emsOptionsModel.provider_options_original_values = data.provider_options;
+      $scope.updateProviderOptionsDescription();
     }
 
     function getNewEmsFormDataComplete(response) {
@@ -377,6 +387,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.providerTypeChanged = function() {
+    $scope.updateProviderOptionsDescription();
     if ($scope.emsCommonModel.ems_controller === 'ems_container') {
       if ($scope.emsCommonModel.emstype === 'kubernetes') {
         $scope.emsCommonModel.default_api_port = "6443";
@@ -588,6 +599,53 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         $scope.emsCommonModel.amqp_password = $scope.postValidationModel.amqp.amqp_password;
       }
       $scope.$broadcast('clearErrorOnTab', {tab: "amqp"});
+    }
+  };
+
+  $scope.updateProviderOptionsDescription = function() {
+    API.options('/api/providers').then(function(response) {
+      $scope.setProviderOptionsDescription(response.data);
+    });
+  };
+
+  $scope.setProviderOptionsDescription = function(apiResponse) {
+    if (! apiResponse.hasOwnProperty("provider_settings")) return;
+    if (! apiResponse.provider_settings.hasOwnProperty($scope.emsCommonModel.emstype)) {
+      return;
+    }
+    $scope.emsOptionsModel.provider_options = apiResponse.provider_settings[$scope.emsCommonModel.emstype];
+    if ($scope.emsOptionsModel.provider_options.hasOwnProperty('advanced_settings')) {
+      var advanced_settings = $scope.emsOptionsModel.provider_options.advanced_settings.settings;
+      $scope.emsCommonModel.provider_options.advanced_settings = {};
+      for (var section in advanced_settings) {
+        if (advanced_settings.hasOwnProperty(section)) {
+          $scope.emsCommonModel.provider_options.advanced_settings[section] = {};
+          $scope.updateProviderOptionsOldValues(advanced_settings[section],
+            $scope.emsCommonModel.provider_options.advanced_settings[section]);
+        }
+      }
+    }
+    if ($scope.emsOptionsModel.provider_options.hasOwnProperty('proxy_settings')) {
+      $scope.emsCommonModel.provider_options.proxy_settings = {};
+      $scope.updateProviderOptionsOldValues($scope.emsOptionsModel.provider_options.proxy_settings,
+        $scope.emsCommonModel.provider_options.proxy_settings);
+    }
+  };
+
+  $scope.updateProviderOptionsOldValues = function(sourceSection, destSection) {
+    var section_name = _.snakeCase(sourceSection.label);
+    sourceSection.section_name = section_name;
+    for (var option in sourceSection.settings) {
+      if (sourceSection.settings.hasOwnProperty(option)) {
+        if ($scope.emsOptionsModel.provider_options_original_values.hasOwnProperty(section_name) &&
+          $scope.emsOptionsModel.provider_options_original_values[section_name].hasOwnProperty(option)) {
+          sourceSection.settings[option].value = $scope.emsOptionsModel.provider_options_original_values[section_name][option];
+        } else {
+          sourceSection.settings[option].value = "";
+        }
+        sourceSection.settings[option].name = option;
+        destSection[option] = sourceSection.settings[option];
+      }
     }
   };
 

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -282,7 +282,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         $scope.emsCommonModel.metrics_api_port) ||
        ($scope.currentTab === "alerts" &&
         $scope.emsCommonModel.prometheus_alerts_hostname !== '' &&
-        $scope.emsCommonModel.prometheus_alerts_api_port !== ''))) {
+        $scope.emsCommonModel.prometheus_alerts_api_port !== '') ||
+      ($scope.currentTab === "proxy_settings") || ($scope.currentTab === "advanced_settings"))) {
       return true;
     } else if($scope.emsCommonModel.emstype == "gce" && $scope.emsCommonModel.project != '' &&
       ($scope.currentTab == "default" ||

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -633,6 +633,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     }
   };
 
+  // Sets the values and names of the options in sourceSection and destSection from
+  // $scope.emsOptionsModel.provider_options_original_values if they exist there.
   $scope.updateProviderOptionsOldValues = function(sourceSection, destSection) {
     var section_name = _.snakeCase(sourceSection.label);
     sourceSection.section_name = section_name;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1540,10 +1540,7 @@ module ApplicationHelper
 
   def miq_tab_header(id, active = nil, options = {}, &_block)
     tag_options = {:class => "#{options[:class]} #{active == id ? 'active' : ''}",
-                   :id    => "#{id}_tab"}
-
-    tag_options['ng-click'] = options['ng-click'] if options.key?('ng-click')
-    tag_options[:onclick] = options[:onclick] if options.key?(:onclick)
+                   :id    => "#{id}_tab"}.merge!(options)
 
     content_tag(:li, tag_options) do
       content_tag(:a, :href => "##{id}", 'data-toggle' => 'tab') do
@@ -1560,7 +1557,10 @@ module ApplicationHelper
     classname << 'active' if active == id
     classname << 'lazy' if lazy
 
-    content_tag(:div, :id => id, :class => classname.join(' ')) do
+    options.delete(:lazy)
+    options.delete(:class)
+
+    content_tag(:div, :id => id, :class => classname.join(' '), **options) do
       yield unless lazy
     end
   end

--- a/app/views/ems_container/_form.html.haml
+++ b/app/views/ems_container/_form.html.haml
@@ -89,4 +89,8 @@
   %hr
   = render :partial => "layouts/angular/multi_auth_credentials", :locals => {:record => @ems, :ng_model => "emsCommonModel"}
 
+  %div{"ng-if" => "emsOptionsModel.provider_options.hasOwnProperty('proxy_settings') || emsOptionsModel.provider_options.hasOwnProperty('advanced_settings')"}
+    %hr
+    = render :partial => "/layouts/angular/per_provider_settings"
+
   = render :partial => "layouts/angular/x_edit_buttons_angular", :locals => {:record => @ems, :restful => true}

--- a/app/views/layouts/angular-bootstrap/_provider_advanced_settings.html.haml
+++ b/app/views/layouts/angular-bootstrap/_provider_advanced_settings.html.haml
@@ -1,0 +1,25 @@
+%h3
+  {{ emsOptionsModel.provider_options.advanced_settings.label }}
+%p
+  {{ emsOptionsModel.provider_options.advanced_settings.help_text }}
+%div{"ng-repeat" => "settings_section in emsOptionsModel.provider_options.advanced_settings.settings"}
+  %h4
+    {{ settings_section.label }}
+  %p
+    {{ settings_section.help_text }}
+  %div{"ng-repeat" => "option in settings_section.settings"}
+    .form-group{"ng-class" => "{{ \"{'has_error': angularForm.provider_options_\" + settings_section.section_name + \"_\" + option.name + \".$invalid}\" }}"}
+      %label.col-md-2.control-label{"for" => "{{ \"provider_options_\" + settings_section.section_name + \"_\" + option.name }}"}
+        {{ option.label }}
+      .col-md-4
+        %input.form-control{"type"          => "text",
+                            "ng-attr-id"    => "{{ \"provider_options_\" + settings_section.section_name + \"_\" + option.name }}",
+                            "ng-attr-name"  => "{{ \"provider_options_\" + settings_section.section_name + \"_\" + option.name }}",
+                            "ng-model"      => "emsCommonModel.provider_options.advanced_settings[settings_section.section_name][option.name].value",
+                            "ng-trim"       => false,
+                            "detect_spaces" => "",
+                            "placeholder"   => "{{ option.global_default }}",
+                            "title"         => "{{ option.help_text }}",
+                            "prefix"        => "provider_options"}
+        %span.help-block{"ng-show" => '{{ "angularForm.provider_options_" + settings_section.section_name + "_" + option.name + ".$error.detectedSpaces" }}'}
+          = _("Spaces are prohibited")

--- a/app/views/layouts/angular-bootstrap/_provider_advanced_settings.html.haml
+++ b/app/views/layouts/angular-bootstrap/_provider_advanced_settings.html.haml
@@ -1,7 +1,3 @@
-%h3
-  {{ emsOptionsModel.provider_options.advanced_settings.label }}
-%p
-  {{ emsOptionsModel.provider_options.advanced_settings.help_text }}
 %provider-option-section{"ng-repeat" => "section in emsOptionsModel.provider_options.advanced_settings.settings",
   "label"        => "{{ section.label }}",
   "help_text"    => "{{ section.help_text }}",

--- a/app/views/layouts/angular-bootstrap/_provider_advanced_settings.html.haml
+++ b/app/views/layouts/angular-bootstrap/_provider_advanced_settings.html.haml
@@ -2,24 +2,8 @@
   {{ emsOptionsModel.provider_options.advanced_settings.label }}
 %p
   {{ emsOptionsModel.provider_options.advanced_settings.help_text }}
-%div{"ng-repeat" => "settings_section in emsOptionsModel.provider_options.advanced_settings.settings"}
-  %h4
-    {{ settings_section.label }}
-  %p
-    {{ settings_section.help_text }}
-  %div{"ng-repeat" => "option in settings_section.settings"}
-    .form-group{"ng-class" => "{{ \"{'has_error': angularForm.provider_options_\" + settings_section.section_name + \"_\" + option.name + \".$invalid}\" }}"}
-      %label.col-md-2.control-label{"for" => "{{ \"provider_options_\" + settings_section.section_name + \"_\" + option.name }}"}
-        {{ option.label }}
-      .col-md-4
-        %input.form-control{"type"          => "text",
-                            "ng-attr-id"    => "{{ \"provider_options_\" + settings_section.section_name + \"_\" + option.name }}",
-                            "ng-attr-name"  => "{{ \"provider_options_\" + settings_section.section_name + \"_\" + option.name }}",
-                            "ng-model"      => "emsCommonModel.provider_options.advanced_settings[settings_section.section_name][option.name].value",
-                            "ng-trim"       => false,
-                            "detect_spaces" => "",
-                            "placeholder"   => "{{ option.global_default }}",
-                            "title"         => "{{ option.help_text }}",
-                            "prefix"        => "provider_options"}
-        %span.help-block{"ng-show" => '{{ "angularForm.provider_options_" + settings_section.section_name + "_" + option.name + ".$error.detectedSpaces" }}'}
-          = _("Spaces are prohibited")
+%provider-option-section{"ng-repeat" => "section in emsOptionsModel.provider_options.advanced_settings.settings",
+  "label"        => "{{ section.label }}",
+  "help_text"    => "{{ section.help_text }}",
+  "section_name" => "{{ section.section_name }}",
+  "settings"     => "section.settings"}

--- a/app/views/layouts/angular-bootstrap/_provider_proxy_settings.html.haml
+++ b/app/views/layouts/angular-bootstrap/_provider_proxy_settings.html.haml
@@ -1,0 +1,22 @@
+- prefix                 ||= 'provider_options'
+
+%h4
+  {{ emsOptionsModel.provider_options.proxy_settings.label }}
+%p
+  {{ emsOptionsModel.provider_options.proxy_settings.help_text }}
+%div{"ng-repeat" => "option in emsOptionsModel.provider_options.proxy_settings.settings"}
+  .form-group{"ng-class" => "{{ \"{'has_error': angularForm.provider_options_proxy_settings_\" + option.name + \".$invalid}\" }}"}
+    %label.col-md-2.control-label{"for" => "{{ \"provider_options_proxy_settings_\" + option.name }}"}
+      {{ option.label }}
+    .col-md-4
+      %input.form-control{"type"          => "text",
+                          "id"            => "{{ \"provider_options_proxy_settings_\" + option.name }}",
+                          "name"          => "{{ \"provider_options_proxy_settings_\" + option.name }}",
+                          "ng-model"      => "emsCommonModel.provider_options.proxy_settings[option.name].value",
+                          "ng-trim"       => false,
+                          "detect_spaces" => "",
+                          "placeholder"   => "{{ option.global_default }}",
+                          "title"         => "{{ option.help_text }}",
+                          "prefix"        => "#{prefix}"}
+      %span.help-block{"ng-show" => '{{ "angularForm.provider_options_proxy_settings_" + option.name + ".$error.detectedSpaces" }}'}
+        = _("Spaces are prohibited")

--- a/app/views/layouts/angular-bootstrap/_provider_proxy_settings.html.haml
+++ b/app/views/layouts/angular-bootstrap/_provider_proxy_settings.html.haml
@@ -1,22 +1,4 @@
-- prefix                 ||= 'provider_options'
-
-%h4
-  {{ emsOptionsModel.provider_options.proxy_settings.label }}
-%p
-  {{ emsOptionsModel.provider_options.proxy_settings.help_text }}
-%div{"ng-repeat" => "option in emsOptionsModel.provider_options.proxy_settings.settings"}
-  .form-group{"ng-class" => "{{ \"{'has_error': angularForm.provider_options_proxy_settings_\" + option.name + \".$invalid}\" }}"}
-    %label.col-md-2.control-label{"for" => "{{ \"provider_options_proxy_settings_\" + option.name }}"}
-      {{ option.label }}
-    .col-md-4
-      %input.form-control{"type"          => "text",
-                          "id"            => "{{ \"provider_options_proxy_settings_\" + option.name }}",
-                          "name"          => "{{ \"provider_options_proxy_settings_\" + option.name }}",
-                          "ng-model"      => "emsCommonModel.provider_options.proxy_settings[option.name].value",
-                          "ng-trim"       => false,
-                          "detect_spaces" => "",
-                          "placeholder"   => "{{ option.global_default }}",
-                          "title"         => "{{ option.help_text }}",
-                          "prefix"        => "#{prefix}"}
-      %span.help-block{"ng-show" => '{{ "angularForm.provider_options_proxy_settings_" + option.name + ".$error.detectedSpaces" }}'}
-        = _("Spaces are prohibited")
+%provider-option-section{"label"        => "{{ emsOptionsModel.provider_options.proxy_settings.label }}",
+                         "help_text"    => "{{ emsOptionsModel.provider_options.proxy_settings.help_text }}",
+                         "section_name" => "{{ emsOptionsModel.provider_options.proxy_settings.section_name }}",
+                         "settings"     => "emsOptionsModel.provider_options.proxy_settings.settings"}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -1,8 +1,12 @@
 - validate_url ||= (record.id || @selected_hosts) ? "update" : "create"
+- legendtext ||= _("Endpoints")
 - vm_scope   ||= false
 - main_scope  = vm_scope ? "$parent.vm" : "$parent"
 
+
 #auth_tabs
+  %h3
+    = legendtext
   %ul.nav.nav-tabs
     = miq_tab_header('default', nil, {'ng-click' => "changeAuthTab('default')"}) do
       %i{"error-on-tab" => "default", :style => "color:#cc0000"}
@@ -33,24 +37,8 @@
         = _("Web Services")
       = miq_tab_header('ipmi', nil, {'ng-click' => "changeAuthTab('ipmi')"}) do
         = _("IPMI")
-    = miq_tab_header('proxy_settings', nil, {'ng-click' => "changeAuthTab('proxy_settings')",
-                                             'ng-if'    => "emsOptionsModel.provider_options.hasOwnProperty('proxy_settings')"}) do
-      %i{"error-on-tab" => "hawkular", :style => "color:#cc0000"}
-      = _("Proxy Settings")
-    = miq_tab_header('advanced_settings', nil, {'ng-click' => "changeAuthTab('advanced_settings')",
-                                                'ng-if'    => "emsOptionsModel.provider_options.hasOwnProperty('advanced_settings')"}) do
-      %i{"error-on-tab" => "hawkular", :style => "color:#cc0000"}
-      = _("Advanced Settings")
 
   .tab-content
-    = miq_tab_content('proxy_settings', 'default', "ng-if".to_sym => "emsOptionsModel.provider_options.hasOwnProperty('proxy_settings')") do
-      .form-group
-        .col-md-12.col-md-12
-          = render :partial => "layouts/angular-bootstrap/provider_proxy_settings"
-    = miq_tab_content('advanced_settings', 'default', "ng-if".to_sym => "emsOptionsModel.provider_options.hasOwnProperty('advanced_settings')") do
-      .form-group
-        .col-md-12.col-md-12
-          = render :partial => "layouts/angular-bootstrap/provider_advanced_settings"
     = miq_tab_content('default', 'default') do
       .form-group
         .col-md-12{"ng-if" => "#{ng_model}.ems_controller == 'ems_container' || " +  |

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -33,8 +33,24 @@
         = _("Web Services")
       = miq_tab_header('ipmi', nil, {'ng-click' => "changeAuthTab('ipmi')"}) do
         = _("IPMI")
+    = miq_tab_header('proxy_settings', nil, {'ng-click' => "changeAuthTab('proxy_settings')",
+                                             'ng-if'    => "emsOptionsModel.provider_options.hasOwnProperty('proxy_settings')"}) do
+      %i{"error-on-tab" => "hawkular", :style => "color:#cc0000"}
+      = _("Proxy Settings")
+    = miq_tab_header('advanced_settings', nil, {'ng-click' => "changeAuthTab('advanced_settings')",
+                                                'ng-if'    => "emsOptionsModel.provider_options.hasOwnProperty('advanced_settings')"}) do
+      %i{"error-on-tab" => "hawkular", :style => "color:#cc0000"}
+      = _("Advanced Settings")
 
   .tab-content
+    = miq_tab_content('proxy_settings', 'default', "ng-if".to_sym => "emsOptionsModel.provider_options.hasOwnProperty('proxy_settings')") do
+      .form-group
+        .col-md-12.col-md-12
+          = render :partial => "layouts/angular-bootstrap/provider_proxy_settings"
+    = miq_tab_content('advanced_settings', 'default', "ng-if".to_sym => "emsOptionsModel.provider_options.hasOwnProperty('advanced_settings')") do
+      .form-group
+        .col-md-12.col-md-12
+          = render :partial => "layouts/angular-bootstrap/provider_advanced_settings"
     = miq_tab_content('default', 'default') do
       .form-group
         .col-md-12{"ng-if" => "#{ng_model}.ems_controller == 'ems_container' || " +  |

--- a/app/views/layouts/angular/_per_provider_settings.html.haml
+++ b/app/views/layouts/angular/_per_provider_settings.html.haml
@@ -1,0 +1,25 @@
+#settings_tabs
+  %h3
+    = _("Settings")
+  %ul.nav.nav-tabs
+    = miq_tab_header('proxy_settings', nil, 'ng-click' => "changeAuthTab('proxy_settings')",
+      'ng-if' => "emsOptionsModel.provider_options.hasOwnProperty('proxy_settings')") do
+      %i{"error-on-tab" => "proxy_settings", :style => "color:#cc0000"}
+      = _("Proxy")
+    = miq_tab_header('advanced_settings', nil, 'ng-click' => "changeAuthTab('advanced_settings')",
+      'ng-if' => "emsOptionsModel.provider_options.hasOwnProperty('advanced_settings')") do
+      %i{"error-on-tab" => "advanced_settings", :style => "color:#cc0000"}
+      = _("Advanced")
+
+  .tab-content
+    = miq_tab_content('proxy_settings', 'proxy_settings', "ng-if".to_sym => "emsOptionsModel.provider_options.hasOwnProperty('proxy_settings')") do
+      .form-group
+        .col-md-12.col-md-12
+          = render :partial => "layouts/angular-bootstrap/provider_proxy_settings"
+    = miq_tab_content('advanced_settings', 'proxy_settings', "ng-if".to_sym => "emsOptionsModel.provider_options.hasOwnProperty('advanced_settings')") do
+      .form-group
+        .col-md-12.col-md-12
+          = render :partial => "layouts/angular-bootstrap/provider_advanced_settings"
+
+:javascript
+  miq_tabs_init('#settings_tabs');

--- a/app/views/static/provider_option_field_input.html.haml
+++ b/app/views/static/provider_option_field_input.html.haml
@@ -1,0 +1,15 @@
+.form-group{"ng-class" => "{{ \"{'has_error': angularForm.\"  + $ctrl.elemID + \".$invalid}\" }}"}
+  %label.col-md-2.control-label{"for" => "{{ $ctrl.elemID }}"}
+    {{ $ctrl.option.label }}
+  .col-md-4
+    %input.form-control{"type"          => "text",
+                        "id"            => "{{ $ctrl.elemID }}",
+                        "name"          => "{{ $ctrl.elemID }}",
+                        "ng-model"      => "$ctrl.option.value",
+                        "ng-trim"       => false,
+                        "detect_spaces" => "",
+                        "placeholder"   => "{{ $ctrl.option.global_default }}",
+                        "title"         => "{{ $ctrl.option.help_text }}",
+                        "prefix"        => "{{ 'provider_options_' + $ctrl.sectionName }}"}
+    %span.help-block{"ng-show" => '{{ "angularForm." + $ctrl.elemID + ".$error.detectedSpaces" }}'}
+      = _("Spaces are prohibited")

--- a/app/views/static/provider_option_section.html.haml
+++ b/app/views/static/provider_option_section.html.haml
@@ -1,0 +1,7 @@
+%h4
+  {{ $ctrl.label }}
+%p
+  {{ $ctrl.helpText }}
+%provider-option-field-input{"ng-repeat" => "option in $ctrl.settings",
+  "option" => "option",
+  "section-name" => "{{ $ctrl.sectionName }}"}

--- a/app/views/static/provider_option_section.html.haml
+++ b/app/views/static/provider_option_section.html.haml
@@ -1,7 +1,3 @@
-%h4
-  {{ $ctrl.label }}
-%p
-  {{ $ctrl.helpText }}
 %provider-option-field-input{"ng-repeat" => "option in $ctrl.settings",
   "option" => "option",
   "section-name" => "{{ $ctrl.sectionName }}"}

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -183,6 +183,15 @@ describe EmsContainerController do
           test_setting_few_fields
           expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq('10.10.10.10')
         end
+
+        it 'updates provider options' do
+          @type = 'openshift'
+          @ems  = ManageIQ::Providers::Openshift::ContainerManager.new
+          controller.instance_variable_set(:@_params,
+                                           :provider_options_image_inspector_options_http_proxy => "example.com")
+          controller.send(:set_ems_record_vars, @ems)
+          expect(@ems.options[:image_inspector_options][:http_proxy]).to eq("example.com")
+        end
       end
     end
 

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -108,6 +108,37 @@ describe EmsContainerController do
     end
   end
 
+  describe "create with provider options" do
+    let(:zone) { FactoryGirl.build(:zone) }
+    let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+
+    before do
+      allow(controller).to receive(:check_privileges).and_return(true)
+      allow(controller).to receive(:assert_privileges).and_return(true)
+    end
+
+    it "Creates a provider with provider options" do
+      params = {
+        "button"                    => "add",
+        "name"                      => "openshift_no_hawkular",
+        "emstype"                   => "openshift",
+        "zone"                      => 'default',
+        "default_security_protocol" => "ssl-without-validation",
+        "default_hostname"          => "default_hostname",
+        "default_api_port"          => "5000",
+        "default_userid"            => "",
+        "default_password"          => "",
+        "provider_region"           => "",
+        "metrics_selection"         => "hawkular_disabled",
+      }
+      params["provider_options_image_inspector_options_http_proxy"] = "hello.com"
+      post :create, :params => params
+      expect(response.status).to eq(200)
+      ems_openshift = ManageIQ::Providers::ContainerManager.first
+      expect(ems_openshift.options[:image_inspector_options][:http_proxy]).to eq("hello.com")
+    end
+  end
+
   describe "Hawkular Disabled/Enabled" do
     let(:zone) { FactoryGirl.build(:zone) }
     let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -1,15 +1,17 @@
 describe('emsCommonFormController', function() {
-  var $scope, $controller, $httpBackend, miqService, compile;
+  var $scope, $controller, $httpBackend, miqService, compile, API;
 
   beforeEach(module('ManageIQ'));
 
-  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _miqService_, _$compile_) {
+  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _miqService_, _$compile_, _API_) {
     miqService = _miqService_;
     compile = _$compile_;
+    API = _API_;
     spyOn(miqService, 'miqAjaxButton');
     spyOn(miqService, 'restAjaxButton');
     spyOn(miqService, 'sparkleOn');
     spyOn(miqService, 'sparkleOff');
+    spyOn(API, 'options').and.callFake(function(url){ return Promise.resolve({}); });
     $scope = $rootScope.$new();
 
     var emsCommonFormResponse = {
@@ -29,7 +31,8 @@ describe('emsCommonFormController', function() {
           'createUrl': '/ems_cloud',
           'updateUrl': '/ems_cloud/12345'},
         emsCommonFormId: 'new',
-        miqService: miqService
+        miqService: miqService,
+        API: API
       });
   }));
 
@@ -102,7 +105,8 @@ describe('emsCommonFormController', function() {
             'createUrl': '/ems_cloud',
             'updateUrl': '/ems_cloud/12345'},
           emsCommonFormId: 12345,
-          miqService: miqService
+          miqService: miqService,
+          API: API
         });
       $httpBackend.flush();
     }));
@@ -167,7 +171,8 @@ describe('emsCommonFormController', function() {
             'createUrl': '/ems_cloud',
             'updateUrl': '/ems_cloud/update/'},
           emsCommonFormId: 12345,
-          miqService: miqService
+          miqService: miqService,
+          API: API
         });
       $httpBackend.flush();
     }));
@@ -232,7 +237,8 @@ describe('emsCommonFormController', function() {
             'createUrl': '/ems_cloud',
             'updateUrl': '/ems_cloud/update/'},
           emsCommonFormId: 12345,
-          miqService: miqService
+          miqService: miqService,
+          API: API
         });
       $httpBackend.flush();
     }));
@@ -374,20 +380,93 @@ describe('emsCommonFormController', function() {
       expect($scope.canValidateBasicInfo()).toBe(true);
     });
   });
+
+  describe('#updateProviderOptionsOldValues', function () {
+    it('sets sourceSection options in destSection', function () {
+      $httpBackend.flush();
+      $scope.emsOptionsModel.provider_options_original_values = {
+        test_settings: {
+          hello: "world",
+        },
+      };
+      $scope.emsOptionsModel.provider_options = {
+        test_settings:
+        { label: "test_settings", settings: { hello: {}}  }
+      };
+      $scope.emsCommonModel.provider_options = {};
+      $scope.emsCommonModel.provider_options.test_settings = {};
+      $scope.updateProviderOptionsOldValues($scope.emsOptionsModel.provider_options.test_settings,
+        $scope.emsCommonModel.provider_options.test_settings);
+      expect($scope.emsCommonModel.provider_options.test_settings.hello.value).toEqual("world");
+    });
+  });
+
+  describe('#setProviderOptionsDescription', function () {
+    beforeEach(inject(function() {
+      $httpBackend.flush();
+      $scope.emsCommonModel.emstype = 'kubernetes';
+      $scope.emsOptionsModel = {
+        provider_options:                 {},
+        provider_options_original_values: {},
+      };
+    }));
+
+    it ('updates options descriptions', function () {
+      $scope.emsCommonModel.emstype = 'kubernetes';
+      response = {
+        data: {
+          provider_settings: {
+            kubernetes: {
+              advanced_settings: {
+                settings: {
+                  my_settings_section: {
+                    label: "section_name_1",
+                    settings: {
+                      hello: {
+                        label:     'hello',
+                        help_text: 'help this text'
+                      }
+                    }
+                  }
+                }
+              },
+              proxy_settings: {
+                settings: {
+                  hello: {
+                    label:     'hello',
+                    help_text: 'help this text'
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      $scope.setProviderOptionsDescription(response.data);
+      expect($scope.emsOptionsModel
+        .provider_options
+        .advanced_settings
+        .settings
+        .my_settings_section
+        .settings.hello.label).toEqual('hello');
+    });
+  });
 });
 
 describe('emsCommonFormController in the context of ems infra provider', function() {
-  var $scope, $controller, $httpBackend, miqService, compile;
+  var $scope, $controller, $httpBackend, miqService, compile, API;
 
   beforeEach(module('ManageIQ'));
 
-  beforeEach(inject(function (_$httpBackend_, $rootScope, _$controller_, _miqService_, _$compile_) {
+  beforeEach(inject(function (_$httpBackend_, $rootScope, _$controller_, _miqService_, _$compile_, _API_) {
     miqService = _miqService_;
+    API = _API_;
     compile = _$compile_;
     spyOn(miqService, 'miqAjaxButton');
     spyOn(miqService, 'restAjaxButton');
     spyOn(miqService, 'sparkleOn');
     spyOn(miqService, 'sparkleOff');
+    spyOn(API, 'options').and.callFake(function(url){ return Promise.resolve({});});
     $scope = $rootScope.$new();
 
     var emsCommonFormResponse = {
@@ -410,7 +489,8 @@ describe('emsCommonFormController in the context of ems infra provider', functio
           'updateUrl': '/ems_infra/12345'
         },
         emsCommonFormId: 'new',
-        miqService: miqService
+          miqService: miqService,
+          API: API
       });
   }));
 
@@ -467,7 +547,8 @@ describe('emsCommonFormController in the context of ems infra provider', functio
             'updateUrl': '/ems_infra/12345'
           },
           emsCommonFormId: 12345,
-          miqService: miqService
+          miqService: miqService,
+          API: API
         });
       $httpBackend.flush();
     }));
@@ -524,7 +605,8 @@ describe('emsCommonFormController in the context of ems infra provider', functio
             'updateUrl': '/ems_infra/update/'
           },
           emsCommonFormId: 12345,
-          miqService: miqService
+          miqService: miqService,
+          API: API
         });
       $httpBackend.flush();
     }));
@@ -593,7 +675,8 @@ describe('emsCommonFormController in the context of ems infra provider', functio
             'updateUrl': '/ems_infra/update/'
           },
           emsCommonFormId: 12345,
-          miqService: miqService
+          miqService: miqService,
+          API: API
         });
       $httpBackend.flush();
     }));
@@ -629,17 +712,19 @@ describe('emsCommonFormController in the context of ems infra provider', functio
 });
 
 describe('emsCommonFormController in the context of ems middleware provider', function () {
-  var $scope, $controller, $httpBackend, miqService, compile;
+  var $scope, $controller, $httpBackend, miqService, compile, API;
 
   beforeEach(module('ManageIQ'));
 
-  beforeEach(inject(function (_$httpBackend_, $rootScope, _$controller_, _miqService_, _$compile_) {
+  beforeEach(inject(function (_$httpBackend_, $rootScope, _$controller_, _miqService_, _$compile_, _API_) {
     miqService = _miqService_;
+    API = _API_;
     compile = _$compile_;
     spyOn(miqService, 'miqAjaxButton');
     spyOn(miqService, 'restAjaxButton');
     spyOn(miqService, 'sparkleOn');
     spyOn(miqService, 'sparkleOff');
+    spyOn(API, 'options').and.callFake(function(url){ return Promise.resolve({});});
     $scope = $rootScope.$new();
 
     var emsCommonFormResponse = {
@@ -662,7 +747,8 @@ describe('emsCommonFormController in the context of ems middleware provider', fu
           'updateUrl': '/ems_middleware/12345'
         },
         emsCommonFormId: 'new',
-        miqService: miqService
+        miqService: miqService,
+        API: API
       });
   }));
 
@@ -714,7 +800,8 @@ describe('emsCommonFormController in the context of ems middleware provider', fu
             'updateUrl': '/ems_middleware/12345'
           },
           emsCommonFormId: 12345,
-          miqService: miqService
+          miqService: miqService,
+          API: API
         });
       $httpBackend.flush();
     }));

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -380,6 +380,129 @@ describe('emsCommonFormController', function() {
       expect($scope.canValidateBasicInfo()).toBe(true);
     });
   });
+});
+
+describe('emsCommonFormController in the context of container provider', function() {
+  var $scope, $controller, $httpBackend, miqService, compile, API;
+
+  beforeEach(module('ManageIQ'));
+
+  beforeEach(inject(function (_$httpBackend_, $rootScope, _$controller_, _miqService_, _$compile_, _API_) {
+    miqService = _miqService_;
+    API = _API_;
+    compile = _$compile_;
+    spyOn(miqService, 'miqAjaxButton');
+    spyOn(miqService, 'restAjaxButton');
+    spyOn(miqService, 'sparkleOn');
+    spyOn(miqService, 'sparkleOff');
+    spyOn(API, 'options').and.callFake(function(url){ return Promise.resolve({});});
+    $scope = $rootScope.$new();
+
+    var emsCommonFormResponse = {
+      name: '',
+      emstype: '',
+      zone: 'default',
+      emstype_vm: false,
+      default_api_port: '',
+      api_version: 'v2'
+    };
+    $httpBackend = _$httpBackend_;
+    $httpBackend.whenGET('/ems_container/ems_container_form_fields/new').respond(emsCommonFormResponse);
+    $controller = _$controller_('emsCommonFormController',
+      {
+        $scope: $scope,
+        $attrs: {
+          'formFieldsUrl': '/ems_container/ems_container_form_fields/',
+          'createUrl': '/ems_container',
+          'updateUrl': '/ems_container/12345'
+        },
+        emsCommonFormId: 'new',
+          miqService: miqService,
+          API: API
+      });
+  }));
+
+  afterEach(function () {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('when the emsCommonFormId is new', function () {
+    beforeEach(inject(function () {
+      $httpBackend.flush();
+    }));
+
+    it('sets the name to blank', function () {
+      expect($scope.emsCommonModel.name).toEqual('');
+    });
+
+    it('sets the type to kubernetes', function () {
+      expect($scope.emsCommonModel.emstype).toEqual('');
+    });
+
+    it('sets the zone to default', function () {
+      expect($scope.emsCommonModel.zone).toEqual('default');
+    });
+
+    it('sets the api_port to blank', function () {
+      expect($scope.emsCommonModel.default_api_port).toEqual('');
+    });
+
+    it('sets the api_version to v2', function () {
+      expect($scope.emsCommonModel.api_version).toEqual('v2');
+    });
+  });
+
+  describe('when the emsCommonFormId of existing provider', function () {
+    var basic_options_example = {
+      image_inspector_options: { http_proxy: 'example.com'},
+      proxy_settings: { http_proxy: 'example2.com' }
+    };
+
+    var emsCommonFormResponse = {
+      name: 'osp1',
+      emstype: 'kubernetes',
+      zone: 'default',
+      emstype_vm: false,
+      default_api_port: '',
+      provider_options: basic_options_example,
+      api_version: 'v2'
+    };
+
+    beforeEach(inject(function (_$controller_) {
+      $httpBackend.whenGET('/ems_container/ems_container_form_fields/12345').respond(emsCommonFormResponse);
+
+      $controller = _$controller_('emsCommonFormController',
+        {
+          $scope: $scope,
+          $attrs: {
+            'formFieldsUrl': '/ems_container/ems_container_form_fields/',
+            'createUrl': '/ems_container',
+            'updateUrl': '/ems_container/12345'
+          },
+          emsCommonFormId: 12345,
+          miqService: miqService,
+          API: API
+        });
+      $httpBackend.flush();
+    }));
+
+    it('sets the name to osp1', function () {
+      expect($scope.emsCommonModel.name).toEqual(emsCommonFormResponse.name);
+    });
+
+    it('sets the type to kubernetes', function () {
+      expect($scope.emsCommonModel.emstype).toEqual(emsCommonFormResponse.emstype);
+    });
+
+    it('sets the api_version to v2', function () {
+      expect($scope.emsCommonModel.api_version).toEqual('v2');
+    });
+
+    it('sets the provider options to expected value', function () {
+      expect($scope.emsOptionsModel.provider_options_original_values).toEqual(basic_options_example);
+    });
+  });
 
   describe('#updateProviderOptionsOldValues', function () {
     it('sets sourceSection options in destSection', function () {


### PR DESCRIPTION
Per provider options were added in [1][2] to all providers. It is now possible to save values in `ems.options` to use as options.
This PR adds the ability to set options from the UI. To tell which options are supported for each provider type an API request is done [3] which expects the provider to implement the `provider_settings` method, for example [3],[4].
It will look for two sections in the returned value "proxy_settings" and "advanced_settings" and will display them in their own tab. for each section there are expected to be a "label" and "help_text" fields and a "settings" field with all of its options (or sub sections). The options themselves should also have "label" and "help_text" fields and also a "global_default" field that may exist.

![provider_options_new_provider](https://user-images.githubusercontent.com/3123328/31306404-4f2d6590-ab58-11e7-9462-4c51e49664a4.png)

based on:
[1] https://github.com/ManageIQ/manageiq/pull/15398 - merged
[2] https://github.com/ManageIQ/manageiq-schema/pull/23 - merged
[3] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/45 - merged
[4] https://github.com/ManageIQ/manageiq-providers-openshift/pull/32 - merged
[5] https://github.com/ManageIQ/manageiq/pull/15799 - merged
[6] https://github.com/ManageIQ/manageiq-api/pull/3 - merged

This aims to provide solution to a few RFEs:
https://bugzilla.redhat.com/show_bug.cgi?id=1379185
https://bugzilla.redhat.com/show_bug.cgi?id=1459189 (might be a duplicate of the previous one?)
https://bugzilla.redhat.com/show_bug.cgi?id=1459555
https://bugzilla.redhat.com/show_bug.cgi?id=1462835