### PR TITLE
update variable used for header border color

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -4,7 +4,7 @@ $navbar-pf-navbar-navbar-brand-min-width:   270px;
 $navbar-pf-navbar-navbar-brand-padding:     8px 0 2px;
 $dropdown-link-hover-bg:                    #d4edfa;  // sets dropdown link hover
 $link-color:                                #0099d3;  // sets link (also accordion hover, selected table cell) color globally
-$navbar-pf-border-color:                    #063451;  // sets 3px border color at top of screen
+$navbar-pf-vertical-border-color:           #063451;  // sets 3px border color at top of screen
 $navbar-pf-alt-bg-color:                    #0c69a5;  // sets background color of navigation bar
 $nav-pf-vertical-width:                     225px;    // sets width of primary navigation
 $navbar-pf-alt-navbar-toggle-icon-bar-hover-bg: #fff;


### PR DESCRIPTION
This PR updates the variable used for overriding the header border color. (The variable was changed with the introduction of vertical navigation.)

https://bugzilla.redhat.com/show_bug.cgi?id=1467968

Old
<img width="1571" alt="screen shot 2017-07-05 at 12 37 10 pm" src="https://user-images.githubusercontent.com/1287144/27874786-bfff884e-617e-11e7-9d05-52a842974616.png">

New
<img width="1567" alt="screen shot 2017-07-05 at 12 36 34 pm" src="https://user-images.githubusercontent.com/1287144/27874787-c006af16-617e-11e7-8fdf-49e31eaa833f.png">