### PR TITLE
Fix links to objects being tagged on the Job Templates tagging edit

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -132,7 +132,7 @@ class AutomationManagerController < ApplicationController
   def configuration_scripts_tree_rec
     nodes = x_node.split('-')
     case nodes.first
-    when "root", "at"
+    when "root", "at", "cf"
       find_record(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript, params[:id])
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -211,16 +211,16 @@ module ApplicationHelper
   end
 
   MODEL_STRING = {
-    "all_vms"           => VmOrTemplate,
-    "all_miq_templates" => MiqTemplate,
-    "instances"         => Vm,
-    "images"            => MiqTemplate,
-    "groups"            => Account,
-    "users"             => Account,
-    "host_services"     => SystemService,
-    "chargebacks"       => ChargebackRate,
-    "playbooks"         => ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook
-
+    "all_vms"                                => VmOrTemplate,
+    "all_miq_templates"                      => MiqTemplate,
+    "instances"                              => Vm,
+    "images"                                 => MiqTemplate,
+    "groups"                                 => Account,
+    "users"                                  => Account,
+    "host_services"                          => SystemService,
+    "chargebacks"                            => ChargebackRate,
+    "playbooks"                              => ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook,
+    "manageiq/providers/automation_managers" => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
   }.freeze
 
   HAS_ASSOCATION = %w(

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -362,6 +362,22 @@ describe AutomationManagerController do
       expect(view.table.data[1].name).to eq("ConfigScript3")
     end
 
+    it 'renders tree_select for one job template' do
+      record = FactoryGirl.create(:ansible_configuration_script,
+                                  :name        => "ConfigScriptTest1",
+                                  :survey_spec => {'spec' => [{'index' => 0, 'question_description' => 'Survey',
+                                                               'type' => 'text'}]})
+      stub_user(:features => :all)
+      allow(controller).to receive(:x_active_tree).and_return(:configuration_scripts_tree)
+      allow(controller).to receive(:x_active_accord).and_return(:configuration_scripts)
+      controller.instance_variable_set(:@_params, :id => "cf-" + ApplicationRecord.compress_id(record.id))
+      controller.send(:tree_select)
+      show_adv_search = controller.instance_variable_get(:@show_adv_search)
+      title = controller.instance_variable_get(:@right_cell_text)
+      expect(show_adv_search).to eq(false)
+      expect(title).to eq('Job Template (Ansible Tower) "ConfigScriptTest1"')
+    end
+
     it "calls get_view with the associated dbname for the Ansible Tower Providers accordion" do
       stub_user(:features => :all)
       allow(controller).to receive(:x_active_tree).and_return(:automation_manager_providers_tree)


### PR DESCRIPTION
Fix links to objects being tagged on the Job Templates tagging edit

Links

https://bugzilla.redhat.com/show_bug.cgi?id=1454887
