### PR TITLE
Updated Specs for Foreman Provider save and Service Dialog Dropdown Options change

### DIFF
--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -144,7 +144,7 @@ describe ProviderForemanController do
     controller.instance_variable_set(:@provider, provider2)
     allow(controller).to receive(:render_flash)
     controller.save_provider
-    expect(assigns(:flash_array).first[:message]).to include("Name has already been taken")
+    expect(assigns(:flash_array).last[:message]).to include("Name has already been taken")
   end
 
   context "#edit" do

--- a/spec/services/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/services/ansible_tower_job_template_dialog_service_spec.rb
@@ -73,8 +73,8 @@ describe AnsibleTowerJobTemplateDialogService do
     assert_field(fields[1], DialogFieldTextBox,      :name => 'param_param2', :data_type => 'string',    :default_value => "as")
     assert_field(fields[2], DialogFieldTextAreaBox,  :name => 'param_param3', :data_type => 'string',    :default_value => "no\nhello")
     assert_field(fields[3], DialogFieldTextBox,      :name => 'param_param4', :data_type => 'string',    :default_value => "mypassword", :options => {:protected => true})
-    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :default_value => "Peach", :values => [[nil, "<Choose>"], %w(Apple Apple), %w(Banana Banana), %w(Peach Peach)])
-    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :default_value => "opt1",  :values => [%w(222 222), [nil, "<Choose>"], %w(opt1 opt1), %w(opt3 opt3)])
+    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :default_value => "Peach", :values => [%w(Apple Apple), %w(Banana Banana), %w(Peach Peach)])
+    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :default_value => "opt1",  :values => [%w(222 222), %w(opt1 opt1), %w(opt3 opt3)])
     assert_field(fields[6], DialogFieldTextBox,      :name => 'param_param7', :data_type => 'string',    :default_value => "14.5")
   end
 

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -58,7 +58,7 @@ describe OrchestrationTemplateDialogService do
         # Get the dropdown field
         field = dropdown_field(dialog)
         # Ensure the allowed values are properly stored.
-        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [[nil, "<Choose>"], %w(val1 val1), %w(val2 val2)])
+        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [%w(val1 val1), %w(val2 val2)])
       end
     end
 
@@ -124,7 +124,7 @@ describe OrchestrationTemplateDialogService do
     expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
     assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
     assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
-    assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [[nil, "<Choose>"], %w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
+    assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [%w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
     assert_field(fields[3], DialogFieldTextBox,      :name => "stack_timeout",   :data_type => 'integer')
   end
 
@@ -143,8 +143,7 @@ describe OrchestrationTemplateDialogService do
     assert_field(fields[2], DialogFieldDropDownList, :name => "resource_group",     :dynamic => true)
     assert_field(fields[3], DialogFieldTextBox,      :name => "new_resource_group", :validator_rule => '^[A-Za-z][A-Za-z0-9\-_]*$')
 
-    mode_values = [[nil,           "<Choose>"],
-                   ["Complete",    "Complete (Delete other resources in the group)"],
+    mode_values = [["Complete",    "Complete (Delete other resources in the group)"],
                    ["Incremental", "Incremental (Default)"]]
     assert_field(fields[4], DialogFieldDropDownList, :name => "deploy_mode", :values => mode_values)
     expect(fields[4].default_value).to eq("Incremental")
@@ -194,7 +193,7 @@ describe OrchestrationTemplateDialogService do
     expect(fields.size).to eq(3)
 
     assert_field(fields[0], DialogFieldTextBox,      :name => "param_flavor",     :default_value => "m1.small")
-    assert_field(fields[1], DialogFieldDropDownList, :name => "param_image_id",   :default_value => "F18-x86_64-cfntools", :values => [[nil, "<Choose>"], %w(F18-i386-cfntools F18-i386-cfntools), %w(F18-x86_64-cfntools F18-x86_64-cfntools)])
+    assert_field(fields[1], DialogFieldDropDownList, :name => "param_image_id",   :default_value => "F18-x86_64-cfntools", :values => [%w(F18-i386-cfntools F18-i386-cfntools), %w(F18-x86_64-cfntools F18-x86_64-cfntools)])
     assert_field(fields[2], DialogFieldTextBox,      :name => "param_cartridges", :default_value => "cron,diy,haproxy,mysql,nodejs,perl,php,postgresql,python,ruby")
   end
 


### PR DESCRIPTION
Updated Specs for Foreman Provider save and Service Dialog Dropdown Options changes.

UI specs need to be updated to match the changes in the foreman and master repos:

Links 
----------------
https://github.com/ManageIQ/manageiq-providers-foreman/pull/5
https://github.com/ManageIQ/manageiq/pull/15456


