### PR TITLE
Don't x_node_set on a tree which doesn't exist

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -140,7 +140,7 @@ class ReportController < ApplicationController
 
     @widget_nodes ||= []
     @sb[:node_clicked] = false
-    x_node_set("root", :roles_tree) if params[:load_edit_err]
+    x_node_set("root", :roles_tree) if params[:load_edit_err] && tree_exists?(:roles_tree)
     @flash_array = @sb[:flash_msg] unless @sb[:flash_msg].blank?
     get_node_info
     @right_cell_text ||= _("All %{reports}") % {:reports => ui_lookup(:models => "MiqReport")}
@@ -160,7 +160,9 @@ class ReportController < ApplicationController
     if params[:id]
       self.x_active_accord = params[:id].sub(/_accord$/, '')
       self.x_active_tree   = "#{self.x_active_accord}_tree"
-      x_node_set("root", :roles_tree) unless @changed   # reset menu editor to show All Roles if nothing has been changed
+
+      # reset menu editor to show All Roles if nothing has been changed
+      x_node_set("root", :roles_tree) if !@changed && tree_exists?(:roles_tree)
 
       trees_to_replace = []
       trees_to_replace << :widgets if params[:id] == "widgets"


### PR DESCRIPTION
Calling `x_node_set` when a tree doesn't exist works, but actually creates the entry that `tree_exists?` checks to see if such a tree exists.

When the user doesn't have the right to see such a tree, that's problematic, since it breaks the assumption that `tree_exists?` returns true only for trees that were actually initialized.

That leads to calling `lock_tree` on a nonexistent tree, leading to a JS exceptions ("No element has been found").

This makes us actually check if the tree already exists before calling `x_node_set` on it - specifically for `roles_tree` (that's `TreeBuilderReportRoles`).

(I would prefer to fix `x_node_set` instead, but.. this is a bugfix, and I really don't want to introduce more bugs. :))

https://bugzilla.redhat.com/show_bug.cgi?id=1467146