### PR TITLE
Autoload UiConstants so other repos don't need to do this

### DIFF
--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -41,6 +41,11 @@ module ManageIQ
           )
         end
 
+        config.after_initialize do
+          # HACK: Autoload UiConstants so other repos don't need to do this.  This file pollutes the global namespace for legacy bad reasons.
+          UiConstants
+        end
+
         def vmdb_plugin?
           true
         end


### PR DESCRIPTION
This file pollutes the global namespace for legacy bad reasons.

Followup to bundler groups PR:
https://github.com/ManageIQ/manageiq/pull/15459

The autoloading of ui constants in manageiq was reverted back here:
https://github.com/ManageIQ/manageiq/pull/15518