### PR TITLE
[FINE] Fix search on the topology screens

### DIFF
--- a/app/assets/javascripts/controllers/cloud_topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/cloud_topology/cloud_topology_controller.js
@@ -11,6 +11,8 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService,
   var icons = null;
 
   var d3 = window.d3;
+  $scope.d3 = d3;
+
   $scope.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {

--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -11,6 +11,7 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
   var icons = null;
 
   var d3 = window.d3;
+  $scope.d3 = d3;
 
   $scope.refresh = function() {
     var id, type;

--- a/app/assets/javascripts/controllers/infra_topology/infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/infra_topology/infra_topology_controller.js
@@ -11,6 +11,8 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService,
   var icons = null;
 
   var d3 = window.d3;
+  $scope.d3 = d3;
+
   $scope.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {

--- a/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
@@ -7,8 +7,10 @@ MiddlewareTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', '
 function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
   var self = this;
   $scope.vs = null;
-  var d3 = window.d3;
   var icons;
+
+  var d3 = window.d3;
+  $scope.d3 = d3;
 
   $scope.refresh = function() {
     var id;

--- a/app/assets/javascripts/controllers/network_topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/network_topology/network_topology_controller.js
@@ -11,6 +11,8 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
   var icons = null;
 
   var d3 = window.d3;
+  $scope.d3 = d3;
+
   $scope.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {

--- a/app/assets/javascripts/controllers/physical_infra_topology/physical_infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/physical_infra_topology/physical_infra_topology_controller.js
@@ -11,6 +11,8 @@ function physicalInfraTopologyCtrl($scope, $http, $interval, $location, topology
   var icons = null;
 
   var d3 = window.d3;
+  $scope.d3 = d3;
+
   $scope.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -137,7 +137,7 @@ ManageIQ.angular.app.service('topologyService', function() {
 
     $scope.searchNode = function() {
       var svg = topologyService.getSVG($scope.d3);
-      var query = $('input#search_topology')[0].value;
+      var query = $('input#search')[0].value;
 
       $scope.searching = true;
       $scope.notFound = ! topologyService.searchNode(svg, query);
@@ -147,7 +147,7 @@ ManageIQ.angular.app.service('topologyService', function() {
       topologyService.resetSearch($scope.d3);
 
       // Reset the search term in search input
-      $('input#search_topology')[0].value = "";
+      $('input#search')[0].value = "";
 
       $scope.searching = false;
       $scope.notFound = false;


### PR DESCRIPTION
The search mixin introduced in #1277 was depending on #955 that wasn't backported. This broke the search on topology screens in the `fine` release. As #955 is too complex for backporting, I made a set of small fixes that should make the search work again.

@miq-bot add_label bug, fine/yes, topology
@miq-bot assign @himdel 

https://bugzilla.redhat.com/show_bug.cgi?id=1465346