### PR TITLE
[WIP] Use `form-button-component` in a non-component form

### DIFF
--- a/app/assets/javascripts/components/buttons/form-button-component.js
+++ b/app/assets/javascripts/components/buttons/form-button-component.js
@@ -1,0 +1,48 @@
+ManageIQ.angular.app.component('formButtonComponent', {
+  bindings: {
+    angularForm: '=',
+    modelCopy: '=',
+    model: '=',
+    redirectUrl: '@?',
+    newRecord: '<',
+    entity: '@?',
+    entityName: '=?',
+    saveClicked: '&?',
+    addClicked: '&?',
+    resetClicked: '&?',
+    cancelClicked: '&?',
+  },
+  controllerAs: 'vm',
+  controller: formButtonController,
+  templateUrl: '/static/form/form_button_component.html.haml',
+});
+
+formButtonController.$inject = ['miqService'];
+
+function formButtonController(miqService) {
+  var vm = this;
+
+  vm.$onInit = function() {
+    vm.saveable = miqService.saveable;
+
+    if (! angular.isDefined(vm.resetClicked)) {
+      vm.resetClicked = function() {
+        vm.model = angular.copy(vm.modelCopy);
+        vm.angularForm.$setUntouched(true);
+        vm.angularForm.$setPristine(true);
+        miqService.miqFlash('warn', __('All changes have been reset'));
+      };
+    }
+
+    if (! angular.isDefined(vm.cancelClicked)) {
+      vm.cancelClicked = function() {
+        miqService.sparkleOn();
+        if (vm.newRecord) {
+          miqService.redirectBack(sprintf(__('Creation of new %s was canceled by the user.'), vm.entity), 'warning', vm.redirectUrl);
+        } else {
+          miqService.redirectBack(sprintf(__('Edit of %s \"%s\" was canceled by the user.'), vm.entity, vm.entityName), 'warning', vm.redirectUrl);
+        }
+      };
+    }
+  };
+}

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -63,11 +63,6 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
     }
   };
 
-  vm.cancelClicked = function(angularForm) {
-    providerForemanEditButtonClicked('cancel');
-    angularForm.$setPristine(true);
-  };
-
   vm.resetClicked = function(angularForm) {
     $scope.$broadcast ('resetClicked');
     vm.providerForemanModel = angular.copy( vm.modelCopy );

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -1,7 +1,7 @@
 /* global miqAjaxButton miqBuildCalendar miqButtons miqJqueryRequest miqRESTAjaxButton miqSparkleOff miqSparkleOn
 add_flash miqFlashLater miqFlashSaved */
 
-ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', 'API', function($timeout, $document, $q, API) {
+ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', 'API', '$window', function($timeout, $document, $q, API, $window) {
   var miqService = this;
 
   this.storedPasswordPlaceholder = "●●●●●●●●";
@@ -157,5 +157,21 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', 'API'
       callback(data);
       miqService.sparkleOff();
     }
+  };
+
+  this.redirectBack = function(message, flashType, redirectUrl, reload) {
+    var flash = { message: message };
+
+    flash.level = flashType;
+
+    miqFlashLater(flash);
+
+    $timeout(function() {
+      $window.location.href = redirectUrl;
+
+      if(reload) {
+        $window.location.reload(true);
+      }
+    }, 500);
   };
 }]);

--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -95,6 +95,7 @@
                            "new-record"      => "vm.newRecord",
                            "save-clicked"    => "vm.saveClicked(angularForm)",
                            "add-clicked"     => "vm.addClicked(angularForm)",
+                           "reset-clicked"   => "vm.resetClicked(angularForm)",
                            "entity"          => "Provider",
                            "entity-name"     => "vm.providerForemanModel.name"}
     %span{:style => "color:black"}= _("Required. Should have privileged access, such as root or administrator.")

--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -88,7 +88,15 @@
                           :vm_scope          => true,
                           :basic_info_needed => true}
 
-    = render :partial => "layouts/angular/generic_form_buttons"
+    %form-button-component{"angular-form"    => "angularForm",
+                           "model-copy"      => "vm.modelCopy",
+                           "model"           => "vm.providerForemanModel",
+                           "redirect-url"    => "/#{controller_name}/explorer",
+                           "new-record"      => "vm.newRecord",
+                           "save-clicked"    => "vm.saveClicked(angularForm)",
+                           "add-clicked"     => "vm.addClicked(angularForm)",
+                           "entity"          => "Provider",
+                           "entity-name"     => "vm.providerForemanModel.name"}
     %span{:style => "color:black"}= _("Required. Should have privileged access, such as root or administrator.")
 
 :javascript

--- a/app/views/static/form/form_button_component.html.haml
+++ b/app/views/static/form/form_button_component.html.haml
@@ -1,0 +1,27 @@
+.clearfix
+.pull-right.button-group.edit_buttons
+  %miq-button{:name      => t = _("Add"),
+              :title     => t,
+              :alt       => t,
+              'ng-if'    => 'vm.newRecord',
+              :enabled   => "vm.saveable(vm.angularForm)",
+              'on-click' => "vm.addClicked()",
+              :primary   => 'true'}
+  %miq-button{:name      => t = _("Save"),
+              :title     => t,
+              :alt       => t,
+              'ng-if'    => '!vm.newRecord',
+              :enabled   => "vm.saveable(vm.angularForm)",
+              'on-click' => "vm.saveClicked()",
+              :primary   => 'true'}
+  %miq-button{:name      => t = _("Reset"),
+              :title     => t,
+              :alt       => t,
+              'ng-if'    => '!vm.newRecord',
+              :enabled   => "!vm.angularForm.$pristine",
+              'on-click' => "vm.resetClicked()"}
+  %miq-button{:name      => t = _("Cancel"),
+              :title     => t,
+              :alt       => t,
+              :enabled   => "true",
+              'on-click' => "vm.cancelClicked()"}


### PR DESCRIPTION
The PR demonstrates that the new component `form-button-component`  can be used in *any* other form that uses the `form-changed` directive.

This is to address the open issue in this PR https://github.com/ManageIQ/manageiq-ui-classic/pull/1544.
Details are here https://github.com/ManageIQ/manageiq-ui-classic/pull/1544#pullrequestreview-46797703