### PR TITLE
Move SESSION_ constants out of ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1952,7 +1952,7 @@ class ApplicationController < ActionController::Base
     end
 
     if indent.zero?
-      $log.warn("MIQ(#{controller_name}_controller-#{action_name}): ===============BEGIN SESSION DUMMP===============")
+      $log.warn("MIQ(#{controller_name}_controller-#{action_name}): ===============BEGIN SESSION DUMP===============")
     end
 
     if data.kind_of?(Hash)
@@ -1970,7 +1970,7 @@ class ApplicationController < ActionController::Base
     end
 
     if indent.zero?
-      $log.warn("MIQ(#{controller_name}_controller-#{action_name}): ===============END SESSION DUMMP===============")
+      $log.warn("MIQ(#{controller_name}_controller-#{action_name}): ===============END SESSION DUMP===============")
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,7 @@ class ApplicationController < ActionController::Base
   include Mixins::TimeHelper
   include Mixins::MenuSection
   include Mixins::GenericToolbarMixin
+  include Mixins::ControllerConstants
   include Mixins::CustomButtons
   include Mixins::CheckedIdMixin
 

--- a/app/controllers/mixins/controller_constants.rb
+++ b/app/controllers/mixins/controller_constants.rb
@@ -2,10 +2,7 @@ module Mixins
   module ControllerConstants
     # Session data size logging constants
     case Rails.env
-    when "test"
-      SESSION_LOG_THRESHOLD = 50.kilobytes
-      SESSION_ELEMENT_THRESHOLD = 5.kilobytes
-    when "development"
+    when "test", "development"
       SESSION_LOG_THRESHOLD = 50.kilobytes
       SESSION_ELEMENT_THRESHOLD = 5.kilobytes
     else

--- a/app/controllers/mixins/controller_constants.rb
+++ b/app/controllers/mixins/controller_constants.rb
@@ -1,0 +1,16 @@
+module Mixins
+  module ControllerConstants
+    # Session data size logging constants
+    case Rails.env
+    when "test"
+      SESSION_LOG_THRESHOLD = 50.kilobytes
+      SESSION_ELEMENT_THRESHOLD = 5.kilobytes
+    when "development"
+      SESSION_LOG_THRESHOLD = 50.kilobytes
+      SESSION_ELEMENT_THRESHOLD = 5.kilobytes
+    else
+      SESSION_LOG_THRESHOLD = 100.kilobytes
+      SESSION_ELEMENT_THRESHOLD = 10.kilobytes
+    end
+  end
+end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,17 +1,4 @@
 module UiConstants
-  # Session data size logging constants
-  case Rails.env
-  when "test"
-    SESSION_LOG_THRESHOLD = 50.kilobytes
-    SESSION_ELEMENT_THRESHOLD = 5.kilobytes
-  when "development"
-    SESSION_LOG_THRESHOLD = 50.kilobytes
-    SESSION_ELEMENT_THRESHOLD = 5.kilobytes
-  else
-    SESSION_LOG_THRESHOLD = 100.kilobytes
-    SESSION_ELEMENT_THRESHOLD = 10.kilobytes
-  end
-
   # MAX_NAME_LEN = 20      # Default maximum name length
   # MAX_DESC_LEN = 50      # Default maximum description length
   # MAX_HOSTNAME_LEN = 50  # Default maximum host name length


### PR DESCRIPTION
Inspired by this comment: https://github.com/ManageIQ/manageiq-ui-classic/pull/1658#issuecomment-313802335

This is a multi-part effort to "eviscerate" the `UiConstants`, so I started with some low hanging fruit.  This specific PR Just moves the `SESSION_LOG_THRESHOLD` and `SESSION_ELEMENT_THRESHOLD` constants out of the `UiConstants`.

Links
-----
* https://github.com/ManageIQ/manageiq-ui-classic/pull/1658
* Confirmation this is the only place this is used:
  - https://github.com/search?q=org%3AManageIQ+SESSION_LOG_THRESHOLD&type=Code
  - https://github.com/search?q=org%3AManageIQ+SESSION_ELEMENT_THRESHOLD&type=Code

Steps for Testing/QA
--------------------
`app/controller/application_controller.rb:1921` will basically be hit on every request, so to test, you can simply checkout this branch and do the following:

* Using the guide to [attach a local copy of ui-classic to a local `manageiq` repo](https://github.com/ManageIQ/guides/blob/master/developer_setup/plugins.md#dependency-on-a-local-gem), attach this branch into manageiq
* Boot up a server: `bin/rails s`
* Ping the login and confirm nothing breaks:  `$ curl localhost:3000 > /dev/null`