### PR TITLE
ReportController - replace_right_cell - don't rebuild trees which don't exist

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -656,11 +656,20 @@ class ReportController < ApplicationController
 
     trees                = {}
     rebuild              = @in_a_form ? false : rebuild_trees
-    trees[:reports]      = build_reports_tree      if replace_trees.include?(:reports) || rebuild
-    trees[:schedules]    = build_schedules_tree    if replace_trees.include?(:schedules) || rebuild
-    trees[:savedreports] = build_savedreports_tree if replace_trees.include?(:savedreports) || rebuild
-    trees[:db]           = build_db_tree           if replace_trees.include?(:db) || rebuild
-    trees[:widgets]      = build_widgets_tree      if replace_trees.include?(:widgets) || rebuild
+
+    {
+      :reports      => :build_reports_tree,
+      :schedules    => :build_schedules_tree,
+      :savedreports => :build_savedreports_tree,
+      :db           => :build_db_tree,
+      :widgets      => :build_widgets_tree,
+    }.each do |tree, method|
+      next unless tree_exists?(tree)
+
+      if replace_trees.include?(tree) || rebuild
+        trees[tree] = send(method)
+      end
+    end
 
     presenter = ExplorerPresenter.new(
       :active_tree => x_active_tree,

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -664,7 +664,7 @@ class ReportController < ApplicationController
       :db           => :build_db_tree,
       :widgets      => :build_widgets_tree,
     }.each do |tree, method|
-      next unless tree_exists?(tree)
+      next unless tree_exists?(tree.to_s + "_tree")
 
       if replace_trees.include?(tree) || rebuild
         trees[tree] = send(method)


### PR DESCRIPTION
Check if a tree exists before rebuilding it.

(The trees get rebuilt when a new report is generated, but we need to rebuild only the ones that the user can see, not all of them.)

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1468336 (comment #4), and thus a follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/1657 .

Steps to reproduce...
1. log in as a user which can't see all the trees in CI > Reports
1. pick a report - Generate
(before, you'll see an infinite spinner, after, it *should* work :))

Ping @h-kataria :)