### PR TITLE
Expression method ui changes

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -19,13 +19,17 @@ module ApplicationController::AdvancedSearch
       adv_search_clear_default_search_if_cant_be_seen
       @edit.delete(:exp_token)                                          # Remove any existing atom being edited
     else                                                                # Create new exp fields
-      @edit = {}
+      @edit ||= {}
       @edit[@expkey] ||= ApplicationController::Filter::Expression.new
       @edit[@expkey][:expression] = {"???" => "???"}                    # Set as new exp element
       @edit[@expkey][:use_mytags] = true                                # Include mytags in tag search atoms
       @edit[:custom_search] = false                                     # setting default to false
-      @edit[:new] = {}
-      @edit[:new][@expkey] = @edit[@expkey][:expression]                # Copy to new exp
+      @edit[:new] ||= {}
+      if @edit[:new][@expkey]
+        @edit[@expkey][:expression] = @edit[:new][@expkey]                # Copy to new exp
+      else
+        @edit[:new][@expkey] = @edit[@expkey][:expression]                # Copy to new exp
+      end
       @edit[@expkey].history.reset(@edit[@expkey][:expression])
       @edit[:adv_search_open] = false
       @edit[@expkey][:exp_model] = model.to_s

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -53,6 +53,11 @@ module ApplicationController::Filter
         else
           page.replace("exp_editor_div", :partial => "layouts/exp_editor")
         end
+
+        if @edit[:expression_method]
+          page.replace("exp_editor_div", :partial => "layouts/exp_editor")
+        end
+
         if ["not", "discard", "commit", "remove"].include?(params[:pressed])
           page << javascript_hide("exp_buttons_on")
           page << javascript_hide("exp_buttons_not")

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -768,8 +768,6 @@ class MiqAeClassController < ApplicationController
 
   def expression_cleanup
     @edit[:expression_method] = false
-    # @edit[:new][:expression]  = nil
-    # @edit[:expression] = nil
   end
 
   def ae_class_for_instance_or_method(record)

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -725,14 +725,14 @@ class MiqAeClassController < ApplicationController
     @edit[:new][:available_expression_objects] = MiqAeMethod.available_expression_objects.sort
     @edit[:new][:location] = @ae_method.location.nil? ? "inline" : @ae_method.location
     if @edit[:new][:location] == "expression"
-       hash = YAML.load(@ae_method.data)
-       if hash[:db] && hash[:expression]
-         @edit[:new][:expression] = hash[:expression]
-         expression_setup(hash[:db])
-       end
-     else
-       @edit[:new][:data] = @ae_method.data.to_s
-     end
+      expr_hash = YAML.load(@ae_method.data)
+      if expr_hash[:db] && expr_hash[:expression]
+        @edit[:new][:expression] = expr_hash[:expression]
+        expression_setup(expr_hash[:db])
+      end
+    else
+      @edit[:new][:data] = @ae_method.data.to_s
+    end
     @edit[:new][:data] = @ae_method.data.to_s
     if @edit[:new][:location] == "inline" && !@ae_method.data
       @edit[:new][:data] = MiqAeMethod.default_method_text
@@ -761,12 +761,12 @@ class MiqAeClassController < ApplicationController
     @edit[:new][:exp_object] = db
     adv_search_build(db)
   end
- 
+
   def expression_cleanup
     @edit[:expression_method] = false
     # @edit[:new][:expression]  = nil
     # @edit[:expression] = nil
-   end
+  end
 
   def ae_class_for_instance_or_method(record)
     record.id ? record.ae_class : MiqAeClass.find_by_id(from_cid(x_node.split("-").last))
@@ -872,7 +872,7 @@ class MiqAeClassController < ApplicationController
         exp_object = params[:cls_exp_object] || params[:exp_object] || @edit[:new][:exp_object]
         expression_setup(exp_object) if exp_object
       else
-         expression_cleanup
+        expression_cleanup
       end
       if row_selected_in_grid?
         @refresh_div = "class_methods_div"
@@ -2187,7 +2187,7 @@ class MiqAeClassController < ApplicationController
     miqaemethod.data = if @edit[:new][:location] == 'expression'
                          data_for_expression
                        else
-                          @edit[:new][:data]
+                         @edit[:new][:data]
                        end
     miqaemethod.class_id = from_cid(@edit[:ae_class_id])
   end

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -904,7 +904,7 @@ class MiqAeClassController < ApplicationController
       render :update do |page|
         page << javascript_prologue
         page.replace_html('form_div', :partial => 'method_form', :locals => {:prefix => ""}) if @edit[:new][:location] == 'expression'
-        page.replace_html(@refresh_div, :partial => @refresh_partial)  if @refresh_div && (@prev_location != @edit[:new][:location] || params[:exp_object] || params[:cls_exp_object])
+        page.replace_html(@refresh_div, :partial => @refresh_partial) if @refresh_div && (@prev_location != @edit[:new][:location] || params[:exp_object] || params[:cls_exp_object])
         # page.replace_html("hider_1", :partial=>"method_data", :locals=>{:field_name=>@field_name})  if @prev_location != @edit[:new][:location]
         if params[:cls_field_datatype]
           if session[:field_data][:datatype] == "password"

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -759,6 +759,10 @@ class MiqAeClassController < ApplicationController
   def expression_setup(db)
     @edit[:expression_method] = true
     @edit[:new][:exp_object] = db
+    if params[:exp_object] || params[:cls_exp_object]
+      session[:adv_search] = nil
+      @edit[@expkey] = @edit[:new][@expkey] = nil
+    end
     adv_search_build(db)
   end
 
@@ -900,7 +904,7 @@ class MiqAeClassController < ApplicationController
       render :update do |page|
         page << javascript_prologue
         page.replace_html('form_div', :partial => 'method_form', :locals => {:prefix => ""}) if @edit[:new][:location] == 'expression'
-        page.replace_html(@refresh_div, :partial => @refresh_partial)  if @refresh_div && @prev_location != @edit[:new][:location]
+        page.replace_html(@refresh_div, :partial => @refresh_partial)  if @refresh_div && (@prev_location != @edit[:new][:location] || params[:exp_object] || params[:cls_exp_object])
         # page.replace_html("hider_1", :partial=>"method_data", :locals=>{:field_name=>@field_name})  if @prev_location != @edit[:new][:location]
         if params[:cls_field_datatype]
           if session[:field_data][:datatype] == "password"

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1118,6 +1118,10 @@ class MiqAeClassController < ApplicationController
       @in_a_form = false
       replace_right_cell
     when "save"
+      # dont allow save if expression has not been added or existing one has been removed
+      validate_expression("save") if @edit[:new][:location] == 'expression'
+      return if flash_errors?
+
       ae_method = find_record_with_rbac(MiqAeMethod, params[:id])
       set_method_record_vars(ae_method)                     # Set the record variables, but don't save
       begin
@@ -1230,6 +1234,11 @@ class MiqAeClassController < ApplicationController
     when "add"
       return unless load_edit("aemethod_edit__new", "replace_cell__explorer")
       get_method_form_vars
+
+      # dont allow add if expression has not been added or existing one has been removed
+      validate_expression("add") if @edit[:new][:location] == 'expression'
+      return if flash_errors?
+
       add_aemethod = MiqAeMethod.new
       set_method_record_vars(add_aemethod)                        # Set the record variables, but don't save
       begin
@@ -1611,6 +1620,14 @@ class MiqAeClassController < ApplicationController
   end
 
   private
+
+  def validate_expression(task)
+    if @edit[@expkey][:expression]["???"] == "???"
+      add_flash(_("Error during '%{task}': Expression element is required") % {:task => _(task)}, :error)
+      @in_a_form = true
+      javascript_flash
+    end
+  end
 
   def features
     [ApplicationController::Feature.new_with_hash(:role        => "miq_ae_class_explorer",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -915,6 +915,7 @@ module ApplicationHelper
   QS_VALID_USER_INPUT_OPERATORS = ["=", "!=", ">", ">=", "<", "<=", "INCLUDES", "STARTS WITH", "ENDS WITH", "CONTAINS"]
   QS_VALID_FIELD_TYPES = [:string, :boolean, :integer, :float, :percent, :bytes, :megabytes]
   def qs_show_user_input_checkbox?
+    return true if @edit[:expression_method]
     return false unless @edit[:adv_search_open]  # Only allow user input for advanced searches
     return false unless QS_VALID_USER_INPUT_OPERATORS.include?(@edit[@expkey][:exp_key])
     val = (@edit[@expkey][:exp_typ] == "field" && # Field atoms with certain field types return true

--- a/app/views/miq_ae_class/_method_form.html.haml
+++ b/app/views/miq_ae_class/_method_form.html.haml
@@ -65,7 +65,7 @@
       = render :partial => 'layouts/exp_editor'
     - else
       %hr
-      %h3= (@edit[:new][:location] == 'builtin') ? _('Builtin name') : _("Data")
+      %h3= @edit[:new][:location] == 'builtin' ? _('Builtin name') : _("Data")
       = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
       %hr
   %h3= _("Input Parameters")

--- a/app/views/miq_ae_class/_method_form.html.haml
+++ b/app/views/miq_ae_class/_method_form.html.haml
@@ -62,12 +62,15 @@
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent("#{prefix}exp_object", "#{url}",  {beforeSend: true})
-      = render :partial => 'layouts/exp_editor'
     - else
       %hr
       %h3= @edit[:new][:location] == 'builtin' ? _('Builtin name') : _("Data")
       = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
       %hr
+  - if @edit[:new][:location] == 'expression'
+    .div
+      %h3= _("Expression (Choose an element of the expression to edit)")
+      = render :partial => 'layouts/exp_editor'
   %h3= _("Input Parameters")
   %table.table.table-bordered.table-striped
     %thead

--- a/app/views/miq_ae_class/_method_form.html.haml
+++ b/app/views/miq_ae_class/_method_form.html.haml
@@ -42,32 +42,32 @@
           miqInitSelectPicker();
           miqSelectPickerEvent("#{prefix}method_location", "#{url}", {beforeSend: true})
 
-  - if @ae_method.created_on
-    .form-group
-      %label.col-md-2.control-label
-        = _("Created On")
-      .col-md-8
-        = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
+    - if @ae_method.created_on
+      .form-group
+        %label.col-md-2.control-label
+          = _("Created On")
+        .col-md-8
+          = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
 
-  - if @edit[:new][:location] == 'expression'
-    .form-group
-      %label.col-md-2.control-label
-        = _('Expression Object')
-      .col-md-8
-        = select_tag("#{prefix}exp_object",
-                      options_for_select(@edit[:new][:available_expression_objects],
-                      @edit[:new][:exp_object]),
-                      :class    => "selectpicker",
-                      "data-miq_observe" => {:url => url}.to_json)
-        :javascript
-          miqInitSelectPicker();
-          miqSelectPickerEvent("#{prefix}exp_object", "#{url}",  {beforeSend: true})
+    - if @edit[:new][:location] == 'expression'
+      .form-group
+        %label.col-md-2.control-label
+          = _('Expression Object')
+        .col-md-8
+          = select_tag("#{prefix}exp_object",
+                        options_for_select(@edit[:new][:available_expression_objects],
+                        @edit[:new][:exp_object]),
+                        :class    => "selectpicker",
+                        "data-miq_observe" => {:url => url}.to_json)
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent("#{prefix}exp_object", "#{url}",  {beforeSend: true})
       = render :partial => 'layouts/exp_editor'
-  - else
-    %hr
-    %h3= (@edit[:new][:location] == 'builtin') ? _('Builtin name') : _("Data")
-    = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
-  %hr
+    - else
+      %hr
+      %h3= (@edit[:new][:location] == 'builtin') ? _('Builtin name') : _("Data")
+      = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
+      %hr
   %h3= _("Input Parameters")
   %table.table.table-bordered.table-striped
     %thead

--- a/app/views/miq_ae_class/_method_form.html.haml
+++ b/app/views/miq_ae_class/_method_form.html.haml
@@ -28,6 +28,7 @@
                         :maxlength         => ViewHelper::MAX_NAME_LEN,
                         :class => "form-control",
                         "data-miq_observe" => obs)
+
     .form-group
       %label.col-md-2.control-label
         = _('Location')
@@ -39,16 +40,33 @@
                       "data-miq_observe" => {:url => url}.to_json)
         :javascript
           miqInitSelectPicker();
-          miqSelectPickerEvent("#{prefix}method_location", "#{url}")
-    - if @ae_method.created_on
-      .form-group
-        %label.col-md-2.control-label
-          = _("Created On")
-        .col-md-8
-          = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
-  %hr
-  %h3= (@edit[:new][:location] == 'builtin') ? _('Builtin name') : _("Data")
-  = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
+          miqSelectPickerEvent("#{prefix}method_location", "#{url}", {beforeSend: true})
+
+  - if @ae_method.created_on
+    .form-group
+      %label.col-md-2.control-label
+        = _("Created On")
+      .col-md-8
+        = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
+
+  - if @edit[:new][:location] == 'expression'
+    .form-group
+      %label.col-md-2.control-label
+        = _('Expression Object')
+      .col-md-8
+        = select_tag("#{prefix}exp_object",
+                      options_for_select(@edit[:new][:available_expression_objects],
+                      @edit[:new][:exp_object]),
+                      :class    => "selectpicker",
+                      "data-miq_observe" => {:url => url}.to_json)
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("#{prefix}exp_object", "#{url}",  {beforeSend: true})
+      = render :partial => 'layouts/exp_editor'
+  - else
+    %hr
+    %h3= (@edit[:new][:location] == 'builtin') ? _('Builtin name') : _("Data")
+    = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
   %hr
   %h3= _("Input Parameters")
   %table.table.table-bordered.table-striped

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -48,6 +48,8 @@
           :mode                    => "ruby",
           :line_numbers            => true,
           :read_only               => true}
+    - elsif @ae_method.location == 'expression'
+      = @expression
     - else
       = @ae_method.data
     -# show inputs parameters grid if there are any inputs

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2157,7 +2157,8 @@ Rails.application.routes.draw do
         x_button
         x_history
         x_show
-      )
+      ) + adv_search_post +
+        exp_post
     },
     :miq_ae_customization     => {
       :get  => %w(

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -381,6 +381,7 @@ describe MiqAeClassController do
       context "when the record exists" do
         before do
           allow(MiqAeMethod).to receive(:find_by_id).with(123).and_return(miq_ae_method)
+          allow(miq_ae_method).to receive(:location).with(no_args).and_return("inline")
           allow(miq_ae_method).to receive(:ae_class).and_return(miq_ae_class)
           allow(MiqAeMethod).to receive(:get_homonymic_across_domains)
             .with(@user, "fqname").and_return([override, override2])


### PR DESCRIPTION
Expression Method UI changes.

In the location dropdown a new entry has been added called expression.
When you select expression you get 
1. Expression Object: A drop down with the list of objects that can be used to build a MiqExpression
2. The MiqExpression Editor shows up
3. The Ruby code area is not visible
4. When the user saves the expression we display a human readable form of the MiQ expression.

## EDIT VIEW
<img width="895" alt="screen shot 2017-07-11 at 2 55 32 pm" src="https://user-images.githubusercontent.com/6452699/28140242-8b074648-6725-11e7-99b1-025654949719.png">

## DISPLAY
<img width="902" alt="screen shot 2017-07-11 at 2 54 58 pm" src="https://user-images.githubusercontent.com/6452699/28140260-9f466954-6725-11e7-8cae-ea7a70c025d4.png">

