### PR TITLE
Consistent button removal text for all discovered / managed items

### DIFF
--- a/app/helpers/application_helper/toolbar/ansible_credential_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_credential_center.rb
@@ -16,7 +16,7 @@ class ApplicationHelper::Toolbar::AnsibleCredentialCenter < ApplicationHelper::T
         button(
           :embedded_automation_manager_credentials_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Credential'),
+          t = N_('Remove this Credential from Inventory'),
           t,
           :klass => ApplicationHelper::Button::EmbeddedAnsible,
           :url_parms => "&refresh=y",

--- a/app/helpers/application_helper/toolbar/ansible_credentials_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_credentials_center.rb
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::AnsibleCredentialsCenter < ApplicationHelper::
         button(
           :embedded_automation_manager_credentials_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected Credentials'),
+          t = N_('Remove selected Credentials from Inventory'),
           t,
           :klass => ApplicationHelper::Button::EmbeddedAnsible,
           :url_parms => "delete_div",

--- a/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
@@ -46,7 +46,7 @@ class ApplicationHelper::Toolbar::AnsibleRepositoriesCenter < ApplicationHelper:
         button(
           :embedded_configuration_script_source_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected Repositories'),
+          t = N_('Remove selected Repositories from Inventory'),
           t,
           :klass => ApplicationHelper::Button::EmbeddedAnsible,
           :url_parms => "unused_div",

--- a/app/helpers/application_helper/toolbar/ansible_repository_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repository_center.rb
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::AnsibleRepositoryCenter < ApplicationHelper::T
         button(
           :embedded_configuration_script_source_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Repository'),
+          t = N_('Remove this Repository from Inventory'),
           t,
           :klass => ApplicationHelper::Button::EmbeddedAnsible,
           :url_parms => "&refresh=y",

--- a/app/helpers/application_helper/toolbar/auth_key_pair_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/auth_key_pair_cloud_center.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Toolbar::AuthKeyPairCloudCenter < ApplicationHelper::To
         button(
           :auth_key_pair_cloud_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Key Pair'),
+          t = N_('Remove this Key Pair from Inventory'),
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: The selected Key Pair and ALL of its components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb
@@ -16,7 +16,7 @@ class ApplicationHelper::Toolbar::AuthKeyPairCloudsCenter < ApplicationHelper::T
         button(
           :auth_key_pair_cloud_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected Key Pairs'),
+          t = N_('Remove selected Key Pairs from Inventory'),
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Key Pairs and ALL of their components will be permanently removed!"),

--- a/app/helpers/application_helper/toolbar/automation_manager_provider_center.rb
+++ b/app/helpers/application_helper/toolbar/automation_manager_provider_center.rb
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::AutomationManagerProviderCenter < ApplicationH
         button(
           :automation_manager_delete_provider,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Provider'),
+          t = N_('Remove this Provider from Inventory'),
           t,
           :url     => "delete",
           :confirm => N_("Warning: The selected Provider and ALL of their components will be permanently removed!")

--- a/app/helpers/application_helper/toolbar/automation_manager_providers_center.rb
+++ b/app/helpers/application_helper/toolbar/automation_manager_providers_center.rb
@@ -40,7 +40,7 @@ class ApplicationHelper::Toolbar::AutomationManagerProvidersCenter < Application
         button(
           :automation_manager_delete_provider,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items'),
+          t = N_('Remove selected items from Inventory'),
           t,
           :url       => "delete",
           :url_parms => "main_div",

--- a/app/helpers/application_helper/toolbar/cloud_object_store_container_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_object_store_container_center.rb
@@ -22,8 +22,8 @@ class ApplicationHelper::Toolbar::CloudObjectStoreContainerCenter < ApplicationH
           button(
             :cloud_object_store_container_delete,
             'pficon pficon-delete fa-lg',
-            N_('Remove Object Storage Container'),
-            N_('Remove Object Storage Container'),
+            N_('Remove Object Storage Container from Inventory'),
+            N_('Remove Object Storage Container from Inventory'),
             :url_parms => "main_div",
             :confirm   => N_("Warning: The selected Object Storage Container and ALL related Objects will be "\
                              "permanently removed!"),

--- a/app/helpers/application_helper/toolbar/cloud_object_store_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_object_store_containers_center.rb
@@ -31,8 +31,8 @@ class ApplicationHelper::Toolbar::CloudObjectStoreContainersCenter < Application
           button(
             :cloud_object_store_container_delete,
             'pficon pficon-delete fa-lg',
-            N_('Remove selected Object Storage Containers'),
-            N_('Remove Object Storage Containers'),
+            N_('Remove selected Object Storage Containers from Inventory'),
+            N_('Remove Object Storage Containers from Inventory'),
             :url_parms => "main_div",
             :confirm   => N_("Warning: The selected Object Storage Containers and ALL related Objects will be "\
                              "permanently removed!"),

--- a/app/helpers/application_helper/toolbar/cloud_object_store_object_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_object_store_object_center.rb
@@ -11,8 +11,8 @@ class ApplicationHelper::Toolbar::CloudObjectStoreObjectCenter < ApplicationHelp
           button(
             :cloud_object_store_object_delete,
             'pficon pficon-delete fa-lg',
-            N_('Remove Object Storage Object'),
-            N_('Remove Object Storage Object'),
+            N_('Remove Object Storage Object from Inventory'),
+            N_('Remove Object Storage Object from Inventory'),
             :url_parms => "main_div",
             :confirm   => N_("Warning: The selected Object Storage Object will be permanently removed!"),
             :klass     => ApplicationHelper::Button::GenericFeatureButtonWithDisable,

--- a/app/helpers/application_helper/toolbar/cloud_object_store_objects_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_object_store_objects_center.rb
@@ -13,8 +13,8 @@ class ApplicationHelper::Toolbar::CloudObjectStoreObjectsCenter < ApplicationHel
           button(
             :cloud_object_store_object_delete,
             'pficon pficon-delete fa-lg',
-            N_('Remove selected Object Storage Objects'),
-            N_('Remove Object Storage Objects'),
+            N_('Remove selected Object Storage Objects from Inventory'),
+            N_('Remove Object Storage Objects from Inventory'),
             :url_parms => "main_div",
             :confirm   => N_("Warning: The selected Object Storage Object will be permanently removed!"),
             :enabled   => false,

--- a/app/helpers/application_helper/toolbar/configuration_manager_provider_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_manager_provider_center.rb
@@ -24,7 +24,7 @@ class ApplicationHelper::Toolbar::ConfigurationManagerProviderCenter < Applicati
         button(
           :provider_foreman_delete_provider,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Provider'),
+          t = N_('Remove this Provider from Inventory'),
           t,
           :url     => "delete",
           :confirm => N_("Warning: The selected Provider and ALL of their components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/configuration_manager_providers_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_manager_providers_center.rb
@@ -37,7 +37,7 @@ class ApplicationHelper::Toolbar::ConfigurationManagerProvidersCenter < Applicat
         button(
           :provider_foreman_delete_provider,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items'),
+          t = N_('Remove selected items from Inventory'),
           t,
           :url       => "delete",
           :url_parms => "main_div",

--- a/app/helpers/application_helper/toolbar/ems_block_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_block_storages_center.rb
@@ -19,8 +19,8 @@ class ApplicationHelper::Toolbar::EmsBlockStoragesCenter < ApplicationHelper::To
                      button(
                        :ems_storage_delete,
                        'pficon pficon-delete fa-lg',
-                       N_('Remove selected Block Storage Managers'),
-                       N_('Remove Block Storage Managers'),
+                       N_('Remove selected Block Storage Managers from Inventory'),
+                       N_('Remove Block Storage Managers from Inventory'),
                        :url_parms => "main_div",
                        :confirm   => N_("Warning: The selected Block Storage Managers and ALL of their components will be permanently removed!"),
                        :enabled   => false,

--- a/app/helpers/application_helper/toolbar/ems_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cloud_center.rb
@@ -27,7 +27,7 @@ class ApplicationHelper::Toolbar::EmsCloudCenter < ApplicationHelper::Toolbar::B
         button(
           :ems_cloud_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Cloud Provider'),
+          t = N_('Remove this Cloud Provider from Inventory'),
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Cloud Provider and ALL of its components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/ems_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_clouds_center.rb
@@ -42,8 +42,8 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
         button(
           :ems_cloud_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Cloud Providers'),
-          N_('Remove Cloud Providers'),
+          N_('Remove selected Cloud Providers from Inventory'),
+          N_('Remove Cloud Providers from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Cloud Providers and ALL related components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/ems_cluster_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cluster_center.rb
@@ -15,8 +15,8 @@ class ApplicationHelper::Toolbar::EmsClusterCenter < ApplicationHelper::Toolbar:
         button(
           :ems_cluster_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this item'),
-          N_('Remove item'),
+          N_('Remove this item from Inventory'),
+          N_('Remove item from Inventory'),
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This item and ALL of its components will be permanently removed!")),
       ]

--- a/app/helpers/application_helper/toolbar/ems_clusters_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_clusters_center.rb
@@ -29,7 +29,7 @@ class ApplicationHelper::Toolbar::EmsClustersCenter < ApplicationHelper::Toolbar
         button(
           :ems_cluster_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items'),
+          t = N_('Remove selected items from Inventory'),
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!?"),

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
         button(
           :ems_container_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Containers Provider'),
+          t = N_('Remove this Containers Provider from Inventory'),
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Containers Provider and ALL of its components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -41,8 +41,8 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
         button(
           :ems_container_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Containers Providers'),
-          N_('Remove Containers Providers'),
+          N_('Remove selected Containers Providers from Inventory'),
+          N_('Remove Containers Providers from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Containers Providers and ALL of their components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/ems_datawarehouse_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_datawarehouse_center.rb
@@ -21,7 +21,7 @@ class ApplicationHelper::Toolbar::EmsDatawarehouseCenter < ApplicationHelper::To
         button(
           :ems_datawarehouse_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Datawarehouse Provider'),
+          t = N_('Remove this Datawarehouse Provider from Inventory'),
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Datawarehouse Provider and ALL" \

--- a/app/helpers/application_helper/toolbar/ems_datawarehouses_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_datawarehouses_center.rb
@@ -34,8 +34,8 @@ class ApplicationHelper::Toolbar::EmsDatawarehousesCenter < ApplicationHelper::T
         button(
           :ems_datawarehouse_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Datawarehouse Providers'),
-          N_('Remove Datawarehouse Providers'),
+          N_('Remove selected Datawarehouse Providers from Inventory'),
+          N_('Remove Datawarehouse Providers from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Datawarehouse Providers and ALL " \
                            "of their components will be permanently removed!"),

--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -47,7 +47,7 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
         button(
           :ems_infra_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Infrastructure Provider'),
+          t = N_('Remove this Infrastructure Provider from Inventory'),
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Infrastructure Provider and ALL of its components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/ems_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infras_center.rb
@@ -42,8 +42,8 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
         button(
           :ems_infra_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Infrastructure Providers'),
-          N_('Remove Infrastructure Providers'),
+          N_('Remove selected Infrastructure Providers from Inventory'),
+          N_('Remove Infrastructure Providers from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Infrastructure Providers and ALL of their components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/ems_middleware_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_middleware_center.rb
@@ -21,7 +21,7 @@ class ApplicationHelper::Toolbar::EmsMiddlewareCenter < ApplicationHelper::Toolb
         button(
           :ems_middleware_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Middleware Provider'),
+          t = N_('Remove this Middleware Provider from Inventory'),
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Middleware Provider and ALL of its components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/ems_middlewares_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_middlewares_center.rb
@@ -34,8 +34,8 @@ class ApplicationHelper::Toolbar::EmsMiddlewaresCenter < ApplicationHelper::Tool
         button(
           :ems_middleware_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Middleware Providers'),
-          N_('Remove Middleware Providers'),
+          N_('Remove selected Middleware Providers from Inventory'),
+          N_('Remove Middleware Providers from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Middleware Providers and ALL of their components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/ems_network_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_network_center.rb
@@ -27,7 +27,7 @@ class ApplicationHelper::Toolbar::EmsNetworkCenter < ApplicationHelper::Toolbar:
         button(
           :ems_network_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Network Provider'),
+          t = N_('Remove this Network Provider from Inventory'),
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Network Provider and ALL of its components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/ems_networks_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_networks_center.rb
@@ -35,8 +35,8 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
         button(
           :ems_network_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Network Providers'),
-          N_('Remove Network Providers'),
+          N_('Remove selected Network Providers from Inventory'),
+          N_('Remove Network Providers from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Network Providers and ALL of their components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/ems_object_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_object_storages_center.rb
@@ -19,8 +19,8 @@ class ApplicationHelper::Toolbar::EmsObjectStoragesCenter < ApplicationHelper::T
                      button(
                        :ems_storage_delete,
                        'pficon pficon-delete fa-lg',
-                       N_('Remove selected Object Storage Managers'),
-                       N_('Remove Object Storage Managers'),
+                       N_('Remove selected Object Storage Managers from Inventory'),
+                       N_('Remove Object Storage Managers from Inventory'),
                        :url_parms => "main_div",
                        :confirm   => N_("Warning: The selected Object Storage Managers and ALL of their components will be permanently removed!"),
                        :enabled   => false,

--- a/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::EmsPhysicalInfraCenter < ApplicationHelper::To
         button(
           :ems_physical_infra_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Infrastructure Provider'),
+          t = N_('Remove this Infrastructure Provider from Inventory'),
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Infrastructure Provider and ALL of its components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/ems_physical_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_physical_infras_center.rb
@@ -40,8 +40,8 @@ class ApplicationHelper::Toolbar::EmsPhysicalInfrasCenter < ApplicationHelper::T
         button(
           :ems_physical_infra_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Infrastructure Providers'),
-          N_('Remove Infrastructure Providers'),
+          N_('Remove selected Infrastructure Providers from Inventory'),
+          N_('Remove Infrastructure Providers from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Infrastructure Providers and ALL of their components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/ems_storage_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_storage_center.rb
@@ -21,7 +21,7 @@ class ApplicationHelper::Toolbar::EmsStorageCenter < ApplicationHelper::Toolbar:
                      button(
                        :ems_storage_delete,
                        'pficon pficon-delete fa-lg',
-                       t = N_('Remove this Storage Manager'),
+                       t = N_('Remove this Storage Manager from Inventory'),
                        t,
                        :url_parms => "&refresh=y",
                        :confirm   => N_("Warning: This Storage Manager and ALL of its components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/ems_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_storages_center.rb
@@ -19,8 +19,8 @@ class ApplicationHelper::Toolbar::EmsStoragesCenter < ApplicationHelper::Toolbar
                      button(
                        :ems_storage_delete,
                        'pficon pficon-delete fa-lg',
-                       N_('Remove selected Storage Managers'),
-                       N_('Remove Storage Managers'),
+                       N_('Remove selected Storage Managers from Inventory'),
+                       N_('Remove Storage Managers from Inventory'),
                        :url_parms => "main_div",
                        :confirm   => N_("Warning: The selected Storage Managers and ALL of their components will be permanently removed!"),
                        :enabled   => false,

--- a/app/helpers/application_helper/toolbar/host_center.rb
+++ b/app/helpers/application_helper/toolbar/host_center.rb
@@ -58,8 +58,8 @@ class ApplicationHelper::Toolbar::HostCenter < ApplicationHelper::Toolbar::Basic
         button(
           :host_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this item'),
-          N_('Remove item'),
+          N_('Remove this item from Inventory'),
+          N_('Remove item from Inventory'),
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This item and ALL of its components will be permanently removed!?")),
       ]

--- a/app/helpers/application_helper/toolbar/hosts_center.rb
+++ b/app/helpers/application_helper/toolbar/hosts_center.rb
@@ -93,8 +93,8 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
         button(
           :host_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove Selected items'),
-          N_('Remove items'),
+          N_('Remove Selected items from Inventory'),
+          N_('Remove items from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!?"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/inventory_group_center.rb
+++ b/app/helpers/application_helper/toolbar/inventory_group_center.rb
@@ -24,7 +24,7 @@ class ApplicationHelper::Toolbar::InventoryGroupCenter < ApplicationHelper::Tool
         button(
           :automation_manager_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Provider'),
+          t = N_('Remove this Provider from Inventory'),
           t,
           :url     => "delete",
           :confirm => N_("Warning: The selected Provider and ALL of their components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/iso_datastore_center.rb
+++ b/app/helpers/application_helper/toolbar/iso_datastore_center.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Toolbar::IsoDatastoreCenter < ApplicationHelper::Toolba
         button(
           :iso_datastore_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this ISO Datastore'),
+          t = N_('Remove this ISO Datastore from Inventory'),
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This ISO Datastore and ALL of its components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/iso_datastores_center.rb
+++ b/app/helpers/application_helper/toolbar/iso_datastores_center.rb
@@ -15,8 +15,8 @@ class ApplicationHelper::Toolbar::IsoDatastoresCenter < ApplicationHelper::Toolb
         button(
           :iso_datastore_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected ISO Datastores'),
-          N_('Remove ISO Datastores'),
+          N_('Remove selected ISO Datastores from Inventory'),
+          N_('Remove ISO Datastores from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected ISO Datastores and ALL of their components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/middleware_datasource_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_datasource_center.rb
@@ -43,7 +43,7 @@ class ApplicationHelper::Toolbar::MiddlewareDatasourceCenter < ApplicationHelper
           button(
             :middleware_datasource_remove,
             'pficon pficon-delete fa-lg',
-            N_('Remove Middleware Datasource'),
+            N_('Remove Middleware Datasource from Inventory'),
             N_('Remove'),
             :confirm => N_('Do you want to remove this Datasource? Some Applications could be using this '\
  +                             'Datasource and may malfunction if it is deleted.'),

--- a/app/helpers/application_helper/toolbar/middleware_datasources_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_datasources_center.rb
@@ -32,7 +32,7 @@ class ApplicationHelper::Toolbar::MiddlewareDatasourcesCenter < ApplicationHelpe
           button(
             :middleware_datasource_remove,
             'pficon pficon-delete fa-lg',
-            N_('Remove Middleware Datasources'),
+            N_('Remove Middleware Datasources from Inventory'),
             N_('Remove'),
             :url_parms => "main_div",
             :enabled   => false,

--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -34,8 +34,8 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
         button(
           :instance_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Instance'),
-          N_('Remove Instance'),
+          N_('Remove this Instance from Inventory'),
+          N_('Remove Instance from Inventory'),
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Instance and ALL of its components will be permanently removed!")),
         button(

--- a/app/helpers/application_helper/toolbar/orchestration_stack_center.rb
+++ b/app/helpers/application_helper/toolbar/orchestration_stack_center.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Toolbar::OrchestrationStackCenter < ApplicationHelper::
         button(
           :orchestration_stack_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Orchestration Stack'),
+          t = N_('Remove this Orchestration Stack from Inventory'),
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Orchestration Stack and ALL of its components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/orchestration_stacks_center.rb
+++ b/app/helpers/application_helper/toolbar/orchestration_stacks_center.rb
@@ -9,8 +9,8 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
         button(
           :orchestration_stack_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Orchestration Stacks'),
-          N_('Remove Orchestration Stacks'),
+          N_('Remove selected Orchestration Stacks from Inventory'),
+          N_('Remove Orchestration Stacks from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Orchestration Stacks and ALL of their components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/orchestration_template_center.rb
+++ b/app/helpers/application_helper/toolbar/orchestration_template_center.rb
@@ -27,10 +27,10 @@ class ApplicationHelper::Toolbar::OrchestrationTemplateCenter < ApplicationHelpe
         button(
           :orchestration_template_remove,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Orchestration Template'),
+          t = N_('Remove this Orchestration Template from Inventory'),
           t,
           :klass => ApplicationHelper::Button::OrchestrationTemplateEditRemove,
-          :confirm => N_("Remove this Orchestration Template?")),
+          :confirm => N_("Remove this Orchestration Template from Inventory?")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/orchestration_templates_center.rb
+++ b/app/helpers/application_helper/toolbar/orchestration_templates_center.rb
@@ -32,9 +32,9 @@ class ApplicationHelper::Toolbar::OrchestrationTemplatesCenter < ApplicationHelp
         button(
           :orchestration_template_remove,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected Orchestration Templates'),
+          t = N_('Remove selected Orchestration Templates from Inventory'),
           t,
-          :confirm   => N_("Remove selected Orchestration Templates?"),
+          :confirm   => N_("Remove selected Orchestration Templates from Inventory?"),
           :url_parms => "main_div",
           :enabled   => false,
           :onwhen    => "1+"),

--- a/app/helpers/application_helper/toolbar/pxe_server_center.rb
+++ b/app/helpers/application_helper/toolbar/pxe_server_center.rb
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::PxeServerCenter < ApplicationHelper::Toolbar::
         button(
           :pxe_server_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this PXE Server'),
+          t = N_('Remove this PXE Server from Inventory'),
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This PXE Server and ALL of its components will be permanently removed!")),

--- a/app/helpers/application_helper/toolbar/pxe_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/pxe_servers_center.rb
@@ -23,8 +23,8 @@ class ApplicationHelper::Toolbar::PxeServersCenter < ApplicationHelper::Toolbar:
         button(
           :pxe_server_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected PXE Servers'),
-          N_('Remove PXE Servers'),
+          N_('Remove selected PXE Servers from Inventory'),
+          N_('Remove PXE Servers from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected PXE Servers and ALL of their components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/resource_pool_center.rb
+++ b/app/helpers/application_helper/toolbar/resource_pool_center.rb
@@ -9,8 +9,8 @@ class ApplicationHelper::Toolbar::ResourcePoolCenter < ApplicationHelper::Toolba
         button(
           :resource_pool_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Resource Pool'),
-          N_('Remove Resource Pool'),
+          N_('Remove this Resource Pool from Inventory'),
+          N_('Remove Resource Pool from Inventory'),
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Resource Pool and ALL of its components will be permanently removed!")),
       ]

--- a/app/helpers/application_helper/toolbar/resource_pools_center.rb
+++ b/app/helpers/application_helper/toolbar/resource_pools_center.rb
@@ -11,8 +11,8 @@ class ApplicationHelper::Toolbar::ResourcePoolsCenter < ApplicationHelper::Toolb
         button(
           :resource_pool_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Resource Pools'),
-          N_('Remove Resource Pools'),
+          N_('Remove selected Resource Pools from Inventory'),
+          N_('Remove Resource Pools from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Resource Pools and ALL of their components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/storage_center.rb
+++ b/app/helpers/application_helper/toolbar/storage_center.rb
@@ -18,8 +18,8 @@ class ApplicationHelper::Toolbar::StorageCenter < ApplicationHelper::Toolbar::Ba
         button(
           :storage_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Datastore'),
-          N_('Remove Datastore'),
+          N_('Remove this Datastore from Inventory'),
+          N_('Remove Datastore from Inventory'),
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Datastore and ALL of its components will be permanently removed!"),
           :klass     => ApplicationHelper::Button::StorageDelete),

--- a/app/helpers/application_helper/toolbar/storages_center.rb
+++ b/app/helpers/application_helper/toolbar/storages_center.rb
@@ -20,8 +20,8 @@ class ApplicationHelper::Toolbar::StoragesCenter < ApplicationHelper::Toolbar::B
         button(
           :storage_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Datastores'),
-          N_('Remove Datastores'),
+          N_('Remove selected Datastores from Inventory'),
+          N_('Remove Datastores from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Datastores and ALL of their components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/template_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/template_clouds_center.rb
@@ -54,7 +54,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
         button(
           :image_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items'),
+          t = N_('Remove selected items from Inventory'),
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),

--- a/app/helpers/application_helper/toolbar/template_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/template_infras_center.rb
@@ -54,8 +54,8 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
         button(
           :miq_template_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Templates'),
-          N_('Remove Templates'),
+          N_('Remove selected Templates from Inventory'),
+          N_('Remove Templates from Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Templates and ALL of their components will be permanently removed!"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -56,7 +56,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
         button(
           :instance_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items'),
+          t = N_('Remove selected items from Inventory'),
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -64,7 +64,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
         button(
           :vm_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items'),
+          t = N_('Remove selected items from Inventory'),
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),

--- a/app/helpers/application_helper/toolbar/vms_center.rb
+++ b/app/helpers/application_helper/toolbar/vms_center.rb
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
         button(
           :vm_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items'),
+          t = N_('Remove selected items from Inventory'),
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),

--- a/app/helpers/application_helper/toolbar/x_miq_template_center.rb
+++ b/app/helpers/application_helper/toolbar/x_miq_template_center.rb
@@ -34,8 +34,8 @@ class ApplicationHelper::Toolbar::XMiqTemplateCenter < ApplicationHelper::Toolba
         button(
           :miq_template_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Template'),
-          N_('Remove Template'),
+          N_('Remove this Template from Inventory'),
+          N_('Remove Template from Inventory'),
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Template and ALL of its components will be permanently removed!")),
       ]

--- a/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
@@ -35,8 +35,8 @@ class ApplicationHelper::Toolbar::XTemplateCloudCenter < ApplicationHelper::Tool
                      button(
                        :image_delete,
                        'pficon pficon-delete fa-lg',
-                       N_('Remove this Image'),
-                       N_('Remove Image'),
+                       N_('Remove this Image from Inventory'),
+                       N_('Remove Image from Inventory'),
                        :url_parms => "&refresh=y",
                        :confirm   => N_("Warning: This Image and ALL of its components will be permanently removed!")),
                      separator,

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -49,8 +49,8 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
         button(
           :vm_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Virtual machine'),
-          N_('Remove Virtual Machine'),
+          N_('Remove this Virtual machine from Inventory'),
+          N_('Remove Virtual Machine from Inventory'),
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Virtual Machine and ALL of its components will be permanently removed!")),
         button(

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -36,8 +36,8 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
         button(
           :instance_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Instance'),
-          N_('Remove Instance'),
+          N_('Remove this Instance from Inventory'),
+          N_('Remove Instance from Inventory'),
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Instance and ALL of its components will be permanently removed!")),
         button(


### PR DESCRIPTION
For removal of all items in our database that we discover and manage in ManageIQ, we're going to
state (in toolbar button texts) that we're deleting the items from inventory (to avoid confusion).

https://www.pivotaltracker.com/story/show/147302217