### PR TITLE
Fix default option title for select-picker

### DIFF
--- a/spec/javascripts/directives/scheduler/updateDropdownForFilter_spec.js
+++ b/spec/javascripts/directives/scheduler/updateDropdownForFilter_spec.js
@@ -15,8 +15,7 @@ describe('update-drop-down-for-filter initialization', function() {
       '    <option>Relish</option>',
       '  </select>',
       '  ',
-      '  <select id="filter_value" name="filter_value" update-dropdown-for-filter dropdown-model="scheduleModel" dropdown-list="filterList" filter-hide="filterValuesEmpty" ng-model="scheduleModel.filter_value" ng-options="item.text for item in filterList track by item.text">',
-      '    <option disabled="" value="" selected="selected">Choose</option>',
+      '  <select id="filter_value" title="Choose" name="filter_value" update-dropdown-for-filter dropdown-model="scheduleModel" dropdown-list="filterList" filter-hide="filterValuesEmpty" ng-model="scheduleModel.filter_value" ng-options="item.text for item in filterList track by item.text">',
       '  </select>',
       '</form>',
     ].join("\n"));


### PR DESCRIPTION
Bootstrap-select changed from getting option with no value from `<option>...` to having it inside and setting its name via `:title`. 

Before: js specs failing locally. But Trevis not failing.
After: js specs not failing locally. But Trevis maybe failing...

@miq-bot add_label bug/sporadic test failure, wip

@himdel please have a look :)