### PR TITLE
Move monkey patching of fetch_path into AC::Params to ui-classic

### DIFF
--- a/lib/extensions/ac_nested_params.rb
+++ b/lib/extensions/ac_nested_params.rb
@@ -1,0 +1,4 @@
+require 'more_core_extensions/core_ext/hash'
+ActionController::Parameters.class_eval do
+  include MoreCoreExtensions::Shared::Nested
+end

--- a/lib/manageiq/ui/classic.rb
+++ b/lib/manageiq/ui/classic.rb
@@ -1,5 +1,6 @@
 require "manageiq/ui/classic/engine"
 require "manageiq/ui/classic/version"
+require "extensions/ac_nested_params"
 
 module ManageIQ
   module UI

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "coffee-rails"
   s.add_dependency "jquery-hotkeys-rails"
   s.add_dependency "lodash-rails", "~>3.10.0"
+  s.add_dependency "more_core_extensions", "~>3.2"
   s.add_dependency "patternfly-sass", "~> 3.23.1"
   s.add_dependency "sass-rails"
   s.add_dependency "high_voltage", "~> 3.0.0"


### PR DESCRIPTION
Moving from https://github.com/ManageIQ/manageiq/pull/15547

The monkey patching of AC::Params to add fetch_path is only used here so hopefully this looks like a good place to put it.

Note:  I had to add an explicit dependency on more_core_extensions in this repo since it was required before but not actually listed in the gemspec.

cc @martinpovolny 