### PR TITLE
Fix missing constant in application_controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1878,7 +1878,7 @@ class ApplicationController < ActionController::Base
     handle_remember_tab
 
     # Get all of the global variables used by most of the controllers
-    @pp_choices = PPCHOICES
+    @pp_choices = UiConstants::PPCHOICES
     @panels = session[:panels].nil? ? {} : session[:panels]
     @breadcrumbs = session[:breadcrumbs].nil? ? [] : session[:breadcrumbs]
     @panels["icon"] = true if @panels["icon"].nil?                # Default icon panels to be open

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -25,7 +25,7 @@ class MiqTaskController < ApplicationController
   end
 
   def build_jobs_tab
-    @pp_choices = PPCHOICES2  # Get special pp choices for jobs/tasks lists
+    @pp_choices = UiConstants::PPCHOICES2 # Get special pp choices for jobs/tasks lists
     @settings[:perpage][:job_task] ||= 50       # Default to 50 per page until changed
     @tasks_options = HashWithIndifferentAccess.new if @tasks_options.blank?
     @tasks_options[:zones] = Zone.all.collect { |z| z.name unless z.miq_servers.blank? }.compact
@@ -179,7 +179,7 @@ class MiqTaskController < ApplicationController
     end
 
     list_jobs # Get the jobs based on the latest options
-    @pp_choices = PPCHOICES2                             # Get special pp choices for jobs/tasks lists
+    @pp_choices = UiConstants::PPCHOICES2 # Get special pp choices for jobs/tasks lists
 
     render :update do |page|
       page << javascript_prologue


### PR DESCRIPTION
Fix missing constant in application_controller

This is an attempt to fix: https://github.com/ManageIQ/manageiq-ui-classic/issues/1674

My guess it was introduced as part of the attempt to get rid of UiConstants
https://github.com/ManageIQ/manageiq-ui-classic/issues/1661

The app was failing with: 

> [----] F, [2017-07-12T08:51:35.346135 #24205:32a6c20] FATAL -- : Error caught: [NameError] uninitialized constant ApplicationController::PPCHOICES
> ~/git/manageiq/plugins/manageiq-ui-classic/app/controllers/application_controller.rb:1881:in `get_global_session_data'