### PR TITLE
Fix Evacuate form

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/evacuate.rb
+++ b/app/controllers/mixins/actions/vm_actions/evacuate.rb
@@ -4,7 +4,6 @@ module Mixins
       module Evacuate
         def evacuate
           assert_privileges("instance_evacuate")
-          @record ||= find_records_with_rbac(VmOrTemplate, params[:id]).first
           drop_breadcrumb(:name => _("Evacuate Instances"), :url  => "/vm_cloud/evacuate") unless @explorer
           @sb[:explorer] = @explorer
           @in_a_form = true
@@ -20,8 +19,7 @@ module Mixins
 
         def evacuatevms
           assert_privileges("instance_evacuate")
-          recs = checked_or_params
-          session[:evacuate_items] = recs
+          session[:evacuate_items] = checked_or_params
           if @explorer
             evacuate
             @refresh_partial = "vm_common/evacuate"

--- a/app/views/vm_common/_evacuate.html.haml
+++ b/app/views/vm_common/_evacuate.html.haml
@@ -74,6 +74,8 @@
             :title   => t,
             :onclick => "miqAjaxButton('#{url_for_only_path(:action => "evacuate_vm", :button => "cancel")}');")
 
+      = render :partial => "layouts/gtl"
+
 :javascript
   ManageIQ.angular.app.value('vmCloudEvacuateFormId', "#{@evacuate_items.length == 1 ? @evacuate_items[0].id : ''}");
   miq_bootstrap('#form_div');

--- a/app/views/vm_common/_evacuate.html.haml
+++ b/app/views/vm_common/_evacuate.html.haml
@@ -74,8 +74,6 @@
             :title   => t,
             :onclick => "miqAjaxButton('#{url_for_only_path(:action => "evacuate_vm", :button => "cancel")}');")
 
-      = render :partial => "layouts/gtl"
-
 :javascript
   ManageIQ.angular.app.value('vmCloudEvacuateFormId', "#{@evacuate_items.length == 1 ? @evacuate_items[0].id : ''}");
   miq_bootstrap('#form_div');

--- a/app/views/vm_common/_evacuate.html.haml
+++ b/app/views/vm_common/_evacuate.html.haml
@@ -67,12 +67,12 @@
             :class   => "btn btn-primary",
             :alt     => t,
             :title   => t,
-            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "evacuate_vm", :id => "#{@record.id}", :button => "submit")}');")
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "evacuate_vm", :button => "submit")}');")
           = button_tag(t = _('Cancel'),
             :class   => "btn btn-default",
             :alt     => t,
             :title   => t,
-            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "evacuate_vm", :id => "#{@record.id}", :button => "cancel")}');")
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "evacuate_vm", :button => "cancel")}');")
 
 :javascript
   ManageIQ.angular.app.value('vmCloudEvacuateFormId', "#{@evacuate_items.length == 1 ? @evacuate_items[0].id : ''}");


### PR DESCRIPTION
Where:
Compute -> Clouds -> Instances -> click OpenStack one -> Lifecycle -> Evacuate Instance
Compute -> Clouds -> Instances -> check OpenStack one or more -> Lifecycle -> Evacuate Instance
Compute -> Clouds -> Providers -> click OpenStack one -> click Instances-> click one -> Lifecycle -> Evacuate Instance
Compute -> Clouds -> Providers -> click OpenStack one -> click Instances-> check one or more -> Lifecycle -> Evacuate Instance

Before:
Various error message on screen or in log. Like `undefined method 'length' for nil:NilClass [vm/evacuate]` or `Error caught: [RuntimeError] Can't access selected records`. Never displaying Evacuate form.

After:
It works :) With GTL issue that's not related to this PR. User can get to form for Evacuate and can save or cancel it.

Blockes https://github.com/ManageIQ/manageiq-ui-classic/pull/1233

@miq-bot add_label bug

@romanblanco please have a look as it's related to RBAC