### PR TITLE
Update bootstrap-treeview for custom colored node icon support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -45,7 +45,7 @@
     "moment-strftime": "~0.2.0",
     "moment-timezone": "~0.4.1",
     "numeral": "~1.5.5",
-    "patternfly-bootstrap-treeview": "~2.1.1",
+    "patternfly-bootstrap-treeview": "~2.1.5",
     "patternfly-timeline": "~1.0.5",
     "phantomjs-polyfill": "~0.0.2",
     "qs": "~0.3.10",


### PR DESCRIPTION
Custom automate buttons are being displayed in the `ab_tree`. If we want to display the custom fonticons with custom colours in that tree, we need this update.

https://www.pivotaltracker.com/story/show/147779325