### PR TITLE
Move PPCHOICES(2) out of UiConstants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,13 @@ class ApplicationController < ActionController::Base
 
   helper CloudResourceQuotaHelper
 
+  # Expose constants as a helper method in views
+  helper do
+    def pp_choices
+      PPCHOICES
+    end
+  end
+
   include_concern 'Automate'
   include_concern 'CiProcessing'
   include_concern 'Compare'

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -6,6 +6,15 @@ class MiqTaskController < ApplicationController
 
   include Mixins::GenericSessionMixin
 
+  # Per page choices for task/jobs
+  PPCHOICES2 = [
+    [5, 5],
+    [10, 10],
+    [20, 20],
+    [50, 50],
+    [100, 100],
+  ].freeze
+
   def index
     @tabform = nil
     # TODO: remove :feature => "job_my_smartproxy" and  :feature => "job_all_smartproxy" from miq_user_roles.yml

--- a/app/controllers/mixins/controller_constants.rb
+++ b/app/controllers/mixins/controller_constants.rb
@@ -9,5 +9,17 @@ module Mixins
       SESSION_LOG_THRESHOLD = 100.kilobytes
       SESSION_ELEMENT_THRESHOLD = 10.kilobytes
     end
+
+    # Per page choices and default
+    PPCHOICES = [
+      [N_("5"), 5],
+      [N_("10"), 10],
+      [N_("20"), 20],
+      [N_("50"), 50],
+      [N_("100"), 100],
+      [N_("200"), 200],
+      [N_("500"), 500],
+      [N_("1000"), 1000]
+    ].freeze
   end
 end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -38,15 +38,6 @@ module UiConstants
   }
   DEFAULT_PDF_PAGE_SIZE = "US-Letter"
 
-  # Per page choices for task/jobs
-  PPCHOICES2 = [
-    [5, 5],
-    [10, 10],
-    [20, 20],
-    [50, 50],
-    [100, 100],
-  ]
-
   # Setting high number incase we don't want to display paging controls on list views
   ONE_MILLION = 1000000
 

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -38,18 +38,6 @@ module UiConstants
   }
   DEFAULT_PDF_PAGE_SIZE = "US-Letter"
 
-  # Per page choices and default
-  PPCHOICES = [
-    [N_("5"), 5],
-    [N_("10"), 10],
-    [N_("20"), 20],
-    [N_("50"), 50],
-    [N_("100"), 100],
-    [N_("200"), 200],
-    [N_("500"), 500],
-    [N_("1000"), 1000]
-  ]
-
   # Per page choices for task/jobs
   PPCHOICES2 = [
     [5, 5],

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -70,7 +70,7 @@
                 = _(item_per_page[0])
               .col-md-8
                 = select_tag(_(item_per_page[1]),
-                             options_for_select(PPCHOICES, @edit[:new][:perpage][item_per_page[2]]),
+                             options_for_select(pp_choices, @edit[:new][:perpage][item_per_page[2]]),
                            :class    => "selectpicker")
 
             :javascript
@@ -84,7 +84,7 @@
                 = _(item_per_page[0])
               .col-md-8
                 = select_tag(_(item_per_page[1]),
-                             options_for_select([[N_("Unlimited"), 0]].concat(PPCHOICES), @edit[:new][:topology][item_per_page[2]]),
+                             options_for_select([[N_("Unlimited"), 0]].concat(pp_choices), @edit[:new][:topology][item_per_page[2]]),
                              :class    => "selectpicker")
             :javascript
               miqSelectPickerEvent("#{item_per_page[1]}", "#{url}")


### PR DESCRIPTION
Welcome to the next installment of "Killing UiConstants softly" (with @NickLaMuro):  Part Deux, the default pagination epic!

Removes both `PPCHOICES` and `PPCHOICES2` from the `UiConstants` lib, and moves them into properly scoped places.  For `PPCHOICES2`, this was relatively simple since it is only used in the `MiqTaskController`.

For `PPCHOICES`, though, it was not only used to populate the `@pp_choices` variable in the controller, but also called from a view directly (not using the instance variable), so this either needed to be exposed in the view, or a helper method to expose this variable.  I went with the latter to avoid the practice of polluting the global namespace, even in the view, but the way I did it might be controversial.


Links
-----
* Past and similar PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/1662
* Confirmation this is the only place these two constants are called:
  - https://github.com/search?q=org%3AManageIQ+PPCHOICES&type=Code
  - https://github.com/search?q=org%3AManageIQ+PPCHOICES2&type=Code


Steps for Testing/QA
--------------------

PPCHOICES that was called in the view should only be called from the `/configuration/index` page, so you can confirm that works by heading to that page with this change applied.  The page would break trying to populate the "Default Items Per Page" section if things didn't work properly.