### PR TITLE
Fix icon for Ansible credential add button

### DIFF
--- a/app/helpers/application_helper/toolbar/ansible_credentials_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_credentials_center.rb
@@ -8,7 +8,7 @@ class ApplicationHelper::Toolbar::AnsibleCredentialsCenter < ApplicationHelper::
       :items => [
         button(
           :embedded_automation_manager_credentials_add,
-          'pficon pficon-edit fa-lg',
+          'pficon pficon-add-circle-o fa-lg',
           t = N_('Add New Credential'),
           t,
           :klass => ApplicationHelper::Button::EmbeddedAnsible,


### PR DESCRIPTION
Before:
![credentials-before](https://user-images.githubusercontent.com/6648365/28204615-02eda1e8-687f-11e7-838c-d008553fcaf8.jpg)

After:
![credentials-after](https://user-images.githubusercontent.com/6648365/28204620-083bd8b8-687f-11e7-802a-ca67f6eb5fcf.jpg)
