### PR TITLE
Add from_cid to find_record_with_rbac

### DIFF
--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -109,7 +109,7 @@ module Mixins
     #   Instance of selected item
     #
     def find_record_with_rbac(klass, id, options = {})
-      find_records_with_rbac(klass, Array.wrap(id).map! { |record_id| from_cid(record_id) }, options).first
+      find_records_with_rbac(klass, Array.wrap(id).map { |record_id| from_cid(record_id) }, options).first
     end
 
     # Find records by model and id and test it with RBAC

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -109,7 +109,7 @@ module Mixins
     #   Instance of selected item
     #
     def find_record_with_rbac(klass, id, options = {})
-      find_records_with_rbac(klass, Array.wrap(id), options).first
+      find_records_with_rbac(klass, Array.wrap(id).map! { |record_id| from_cid(record_id) }, options).first
     end
 
     # Find records by model and id and test it with RBAC


### PR DESCRIPTION
Prevents failure when id has compressed format.

Networks -> Network Routers -> Configuration -> Add a new Router -> fill and add

Before:
```
F, [2017-07-14T14:56:10.921034 #24986] FATAL -- : Error caught: [RuntimeError] Can't access selected records
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/mixins/checked_id_mixin.rb:127:in `find_records_with_rbac'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/mixins/checked_id_mixin.rb:112:in `find_record_with_rbac'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/network_router_controller.rb:497:in `form_params'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/network_router_controller.rb:116:in `create'
```
After:
It works. 

@miq-bot add_label bug, rbac
@miq-bot assign @romanblanco 