### PR TITLE
Fix for forgotten PPCHOICES

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1879,7 +1879,7 @@ class ApplicationController < ActionController::Base
     handle_remember_tab
 
     # Get all of the global variables used by most of the controllers
-    @pp_choices = UiConstants::PPCHOICES
+    @pp_choices = PPCHOICES
     @panels = session[:panels].nil? ? {} : session[:panels]
     @breadcrumbs = session[:breadcrumbs].nil? ? [] : session[:breadcrumbs]
     @panels["icon"] = true if @panels["icon"].nil?                # Default icon panels to be open


### PR DESCRIPTION
The constant has been moved out of `UiConstants` in 3a3e68c4c0abcf1b03698cd03c46eecb8e56c072

The problem would show during login page rendering.

@NickLaMuro 