### PR TITLE
Hide firmware table if there are no firmware entries

### DIFF
--- a/app/views/physical_server/_textual_firmware_table.html.haml
+++ b/app/views/physical_server/_textual_firmware_table.html.haml
@@ -1,5 +1,5 @@
 - items = expand_textual_group(items)
-- if items.present?
+- if items.present? && items[0][:value].present?
   %table.table.table-bordered.table-striped.table-summary-screen
     %thead
       %tr


### PR DESCRIPTION
Updated the code so that the firmware table on the physical server summary page is only displayed when there are firmware entries. Without this change, only the firmware table's headers are displayed when no firmware entries are present which may be confusing to users.