### PR TITLE
Fix Power actions for Instances in Orchestration Stack page

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -258,7 +258,7 @@ module ApplicationController::CiProcessing
 
     # Either a list or coming from a different controller (e.g. from host screen, go to its vms)
     if @lastaction == "show_list" ||
-       !%w(orchestration_stack service vm_cloud vm_infra vm miq_template vm_or_template).include?(controller_name)
+       !%w(service vm_cloud vm_infra vm miq_template vm_or_template).include?(controller_name)
 
       # FIXME: retrieving vms from DB two times
       items = find_checked_ids_with_rbac(klass, task)
@@ -362,7 +362,7 @@ module ApplicationController::CiProcessing
     when "miq_template"
       MiqTemplate
     when "orchestration_stack"
-      OrchestrationStack
+      params[:display] == "instances" ? VmOrTemplate : OrchestrationStack
     when "service"
       Service
     when "cloud_object_store_container"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1397912

Compute -> Clouds -> Stacks -> click any Stack with Instances -> click Instances -> check one or more Instances -> Power -> choose any action

Before it took Stacks id and klass for Power action instead of selected instance(s).

Before:
<img width="896" alt="screen shot 2017-07-17 at 1 06 02 pm" src="https://user-images.githubusercontent.com/9210860/28265638-125e561c-6af1-11e7-977d-be25e8df3ebd.png">

After:
<img width="899" alt="screen shot 2017-07-17 at 1 08 53 pm" src="https://user-images.githubusercontent.com/9210860/28265648-1cfd8570-6af1-11e7-95ad-3f62293928dd.png">

@miq-bot add_label bug

@h-kataria please review, thanks :)