### PR TITLE
rake update:ui - a wrapper for update:bower & update:yarn

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -10,4 +10,6 @@ namespace :update do
       system("yarn") || abort("\n== yarn failed ==")
     end
   end
+
+  task :ui => ['update:bower', 'update:yarn']
 end


### PR DESCRIPTION
..so that we don't hardocde `update:bower` or `update:yarn` or anything like that in non-ui code

The idea is, right now, we need `bin/update` to update bower & yarn. Later, this will be bower & yarn & webpack, and still later, it will be just yarn & webpack..

There's no point each of those changes should get an manageiq/ PR .. so doing a wrap-all task, so we can call *that* from `bin/update` (and places), and handle the details on the ui-classic side.