### PR TITLE
Fix for Drop Down List Dialog does not keep default value for Integer type

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -511,8 +511,9 @@ module MiqAeCustomizationController::Dialogs
       selected = @edit[:field_default_value]
       page << "$('#field_default_value').selectpicker('destroy');"
       page.replace("field_default_value",
-                   :text => select_tag('field_default_value', options_for_select(values, selected), 'data-miq_observe' => {:interval => '.5', :url => url}.to_json).to_s)
+                   :text => select_tag('field_default_value', options_for_select(values, selected)))
       page << "$('#field_default_value').selectpicker();"
+      page << "miqSelectPickerEvent('field_default_value', '#{url}');"
     end
   end
 


### PR DESCRIPTION
This PR is related to the 5.8 blocker version of the below linked BZ, where it failed QA. The issue stems from the fact that if you're editing drop down values, the controller code replaces the default_value drop down with those updated values. However, it doesn't initialize the select picker to send an ajax transaction like it should when you choose a value from the drop-down.

This will ensure that the updated default_value select picker is properly initialized when it is replaced.

https://bugzilla.redhat.com/show_bug.cgi?id=1463827

@miq-bot add_label bug, fine/yes, blocker

@dclarizio I know adding javascript here in the controller is a horrible idea, but since this is a blocker and this is part of the dialog editor that will (hopefully?) be replaced relatively soon, I figured it wasn't worth the effort to completely refactor this method. Thoughts?

/cc @gmcculloug 