### PR TITLE
Remove MAX_DESC_LEN from UiConstants

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,10 +1,8 @@
 module UiConstants
   # MAX_NAME_LEN = 20      # Default maximum name length
-  # MAX_DESC_LEN = 50      # Default maximum description length
   # MAX_HOSTNAME_LEN = 50  # Default maximum host name length
   # dac - Changed to allow up to 255 characters for all text fields on 1/11/07
   MAX_NAME_LEN = 255        # Default maximum name length
-  MAX_DESC_LEN = 255        # Default maximum description length
   MAX_HOSTNAME_LEN = 255    # Default maximum host name length
 
   MAX_DASHBOARD_COUNT = 10  # Default maximum count of Dashboard per group

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -5,6 +5,8 @@ module ViewHelper
   extend ActionView::Helpers::CaptureHelper
   extend ActionView::Helpers::OutputSafetyHelper
 
+  MAX_DESC_LEN = 255
+
   class << self
     def concat_tag(*args, &block)
       concat content_tag(*args, &block)

--- a/app/views/automation_manager/_form.html.haml
+++ b/app/views/automation_manager/_form.html.haml
@@ -53,7 +53,7 @@
         %input.form-control{:type           => "text",
                             :name           => "url",
                             'ng-model'      => "vm.automationManagerModel.url",
-                            :maxlength      => MAX_DESC_LEN,
+                            :maxlength      => ViewHelper::MAX_DESC_LEN,
                             "id"            => "url",
                             :required       => "",
                             "ng-trim"       => false,

--- a/app/views/layouts/_edit_email.html.haml
+++ b/app/views/layouts/_edit_email.html.haml
@@ -23,7 +23,7 @@
         .col-md-8
           = text_field_tag("from",
                            @edit[:new][:email][:from],
-                           :maxlength         => MAX_DESC_LEN,
+                           :maxlength         => ViewHelper::MAX_DESC_LEN,
                            :class             => "form-control",
                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           = _("(Default: %{email_from})") % {:email_from => ::Settings.smtp.from}

--- a/app/views/layouts/_edit_to_email.html.haml
+++ b/app/views/layouts/_edit_to_email.html.haml
@@ -50,7 +50,7 @@
           .input-group
             = text_field_tag("email",
                              @edit[:email],
-                             :maxlength         => MAX_DESC_LEN,
+                             :maxlength         => ViewHelper::MAX_DESC_LEN,
                              :style             => "float: left; margin-right: 2px",
                              :class             => "form-control",
                              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)

--- a/app/views/miq_ae_customization/_field_value_entry.html.haml
+++ b/app/views/miq_ae_customization/_field_value_entry.html.haml
@@ -8,7 +8,7 @@
       %td
         = text_field("entry", "value", :size => 50, :maxlength => MAX_NAME_LEN)
       %td
-        = text_field("entry", "description", :size => 50, :maxlength => MAX_DESC_LEN)
+        = text_field("entry", "description", :size => 50, :maxlength => ViewHelper::MAX_DESC_LEN)
   - else
     %tr{:id => "#{idx}_tr"}
       %td
@@ -18,7 +18,7 @@
       %td
         = text_field("entry", "value", :size => 50, :maxlength => MAX_NAME_LEN, "value" => entry[0])
       %td
-        = text_field("entry", "description", :size => 50, :maxlength => MAX_DESC_LEN, "value" => entry[1])
+        = text_field("entry", "description", :size => 50, :maxlength => ViewHelper::MAX_DESC_LEN, "value" => entry[1])
         = hidden_field("entry", "id", "value" => h(idx))
 - else
   - if entry == "new"

--- a/app/views/miq_policy/_action_details.html.haml
+++ b/app/views/miq_policy/_action_details.html.haml
@@ -15,7 +15,7 @@
               - if @edit
                 = text_field_tag("description",
                   @edit[:new][:description],
-                  :maxlength         => MAX_DESC_LEN,
+                  :maxlength         => ViewHelper::MAX_DESC_LEN,
                   :class             => "form-control",
                   "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
                 = javascript_tag(javascript_focus('description'))

--- a/app/views/miq_policy/_action_options.html.haml
+++ b/app/views/miq_policy/_action_options.html.haml
@@ -15,7 +15,7 @@
         .col-md-8
           = text_field_tag("from",
             @edit[:new][:options][:from],
-            :maxlength         => MAX_DESC_LEN,
+            :maxlength         => ViewHelper::MAX_DESC_LEN,
             :class             => "form-control",
             "data-miq_observe" => observe_with_interval)
           = _("(Default: %{email_from})") % {:email_from => h(::Settings.smtp.from)}
@@ -25,7 +25,7 @@
         .col-md-8
           = text_field_tag("to",
             @edit[:new][:options][:to],
-            :maxlength         => MAX_DESC_LEN,
+            :maxlength         => ViewHelper::MAX_DESC_LEN,
             :class             => "form-control",
             "data-miq_observe" => observe_with_interval)
   - when "set_custom_attribute"
@@ -38,7 +38,7 @@
         .col-md-8
           = text_field_tag("attribute",
             @edit[:new][:options][:attribute],
-            :maxlength         => MAX_DESC_LEN,
+            :maxlength         => ViewHelper::MAX_DESC_LEN,
             :class             => "form-control",
             "data-miq_observe" => observe_with_interval)
       .form-group
@@ -47,7 +47,7 @@
         .col-md-8
           = text_field_tag("value",
             @edit[:new][:options][:value],
-            :maxlength         => MAX_DESC_LEN,
+            :maxlength         => ViewHelper::MAX_DESC_LEN,
             :class             => "form-control",
             "data-miq_observe" => observe_with_interval)
   - when "tag"
@@ -77,7 +77,7 @@
         .col-md-8
           = text_field_tag("snapshot_name",
             @edit[:new][:options][:name],
-            :maxlength         => MAX_DESC_LEN,
+            :maxlength         => ViewHelper::MAX_DESC_LEN,
             :class             => "form-control",
             "data-miq_observe" => observe_with_interval)
   - when "delete_snapshots_by_age"
@@ -105,7 +105,7 @@
         .col-md-8
           = text_field_tag("memory_value",
             @edit[:new][:options][:value],
-            :maxlength         => MAX_DESC_LEN,
+            :maxlength         => ViewHelper::MAX_DESC_LEN,
             :class             => "form-control",
             "data-miq_observe" => observe_with_interval)
           = _('(Enter the value between 4 - 65636 MB)')
@@ -187,7 +187,7 @@
         .col-md-8
           = text_field_tag("host",
             @edit[:new][:options][:host],
-            :maxlength         => MAX_DESC_LEN,
+            :maxlength         => ViewHelper::MAX_DESC_LEN,
             :class             => "form-control",
             "data-miq_observe" => observe_with_interval)
       .form-group
@@ -209,7 +209,7 @@
         .col-md-8
           = text_field_tag("trap_id",
             @edit[:new][:options][:trap_id],
-            :maxlength         => MAX_DESC_LEN,
+            :maxlength         => ViewHelper::MAX_DESC_LEN,
             :class             => "form-control",
             "data-miq_observe" => observe_with_interval)
     %h3
@@ -356,7 +356,7 @@
               .col-md-8
                 = text_field_tag("hosts",
                   @edit[:new][:options][:hosts],
-                  :maxlength         => MAX_DESC_LEN,
+                  :maxlength         => ViewHelper::MAX_DESC_LEN,
                   :class             => "form-control",
                   "data-miq_observe" => observe_with_interval)
                 = _('Enter a comma separated list of IP or DNS names')

--- a/app/views/miq_policy/_alert_builtin_exp.html.haml
+++ b/app/views/miq_policy/_alert_builtin_exp.html.haml
@@ -108,7 +108,7 @@
         - if @edit[:new][:expression][:options][:trend_direction].to_s.ends_with?("more_than")
           = text_field_tag("trend_steepness",
             @edit[:new][:expression][:options][:trend_steepness],
-            :maxlength         => MAX_DESC_LEN,
+            :maxlength         => ViewHelper::MAX_DESC_LEN,
             :class             => "form-control",
             "data-miq_observe" => observe_with_interval)
           = h(@edit[:perf_column_unit])
@@ -151,7 +151,7 @@
           miqSelectPickerEvent('select_event_log_message_filter_type', '#{url}', {beforeSend: true, complete: true})
         = text_field_tag("event_log_message_filter_value",
           @edit[:new][:expression][:options][:event_log_message_filter_value],
-          :maxlength         => MAX_DESC_LEN,
+          :maxlength         => ViewHelper::MAX_DESC_LEN,
           "data-miq_observe" => observe_with_interval)
       - else
         = h(@alert.expression[:options][:event_log_message_filter_type])
@@ -250,7 +250,7 @@
       - if @edit
         = text_field_tag(option[:name],
           @edit[:new][:expression][:options][option[:name]],
-          :maxlength         => MAX_DESC_LEN,
+          :maxlength         => ViewHelper::MAX_DESC_LEN,
           :class             => "form-control",
           "data-miq_observe" => observe_with_interval)
       - else

--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -17,7 +17,7 @@
             .col-md-8
               = text_field_tag("description",
                 @edit[:new][:description],
-                :maxlength         => MAX_DESC_LEN,
+                :maxlength         => ViewHelper::MAX_DESC_LEN,
                 :class             => "form-control",
                 "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
               = javascript_tag(javascript_focus('description'))

--- a/app/views/miq_policy/_alert_mgmt_event.html.haml
+++ b/app/views/miq_policy/_alert_mgmt_event.html.haml
@@ -18,7 +18,7 @@
             = _('Event Name')
           .col-md-8
             = text_field_tag("event_name", @edit[:new][:event_name],
-              :maxlength => MAX_DESC_LEN,
+              :maxlength => ViewHelper::MAX_DESC_LEN,
               :class     => "form-control",
               "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %hr

--- a/app/views/miq_policy/_alert_profile_details.html.haml
+++ b/app/views/miq_policy/_alert_profile_details.html.haml
@@ -16,7 +16,7 @@
             .col-md-8
               - if @edit
                 = text_field_tag("description", @edit[:new][:description],
-                  :maxlength         => MAX_DESC_LEN,
+                  :maxlength         => ViewHelper::MAX_DESC_LEN,
                   "data-miq_observe" => observe_with_interval,
                   :class             => "form-control",
                   :style             => "overflow-x: scroll;")

--- a/app/views/miq_policy/_alert_snmp.html.haml
+++ b/app/views/miq_policy/_alert_snmp.html.haml
@@ -19,17 +19,17 @@
             = title_for_host
           .col-md-8
             = text_field_tag("host_1", @edit[:new][:snmp][:host][0],
-              :maxlength         => MAX_DESC_LEN,
+              :maxlength         => ViewHelper::MAX_DESC_LEN,
               :class             => "form-control",
               "data-miq_observe" => observe_with_interval)
             %br
             = text_field_tag("host_2", @edit[:new][:snmp][:host][1],
-              :maxlength => MAX_DESC_LEN,
+              :maxlength => ViewHelper::MAX_DESC_LEN,
               :class             => "form-control",
               "data-miq_observe" => observe_with_interval)
             %br
             = text_field_tag("host_3", @edit[:new][:snmp][:host][2],
-              :maxlength => MAX_DESC_LEN,
+              :maxlength => ViewHelper::MAX_DESC_LEN,
               :class             => "form-control",
               "data-miq_observe" => {:interval => '.5',  :url => url}.to_json)
         .form-group
@@ -48,7 +48,7 @@
             = trap_text
           .col-md-8
             = text_field_tag("trap_id", @edit[:new][:snmp][:trap_id],
-              :maxlength         => MAX_DESC_LEN,
+              :maxlength         => ViewHelper::MAX_DESC_LEN,
               :class             => "form-control",
               "data-miq_observe" => observe_with_interval)
   - if @edit[:new][:send_snmp]
@@ -64,7 +64,7 @@
           %tr
             %td
               = text_field_tag("oid__#{i + 1}", @edit[:new][:snmp][:variables][i][:oid],
-                :maxlength         => MAX_DESC_LEN,
+                :maxlength         => ViewHelper::MAX_DESC_LEN,
                 :class             => "form-control",
                 "data-miq_observe" => observe_with_interval)
             %td
@@ -83,7 +83,7 @@
             %td
               = text_field_tag("value__#{i + 1}", @edit[:new][:snmp][:variables][i][:value],
                 :disabled  => val_disabled,
-                :maxlength => MAX_DESC_LEN,
+                :maxlength => ViewHelper::MAX_DESC_LEN,
                 :class             => "form-control",
                 "data-miq_observe" => observe_with_interval)
   %hr

--- a/app/views/miq_policy/_condition_details.html.haml
+++ b/app/views/miq_policy/_condition_details.html.haml
@@ -15,7 +15,7 @@
             .col-md-8
               - if @edit
                 = text_field_tag("description", @edit[:new][:description],
-                  :maxlength         => MAX_DESC_LEN,
+                  :maxlength         => ViewHelper::MAX_DESC_LEN,
                   "data-miq_observe" => observe_with_interval,
                   :class             => "form-control")
                 = javascript_tag(javascript_focus('description'))

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -17,7 +17,7 @@
               - if @edit
                 .col-md-8
                   = text_field_tag("description", @edit[:new][:description],
-                    :maxlength         => MAX_DESC_LEN,
+                    :maxlength         => ViewHelper::MAX_DESC_LEN,
                     :class             => "form-control",
                     "data-miq_observe" => observe_with_interval)
                   = javascript_tag(javascript_focus('description'))

--- a/app/views/miq_policy/_profile_details.html.haml
+++ b/app/views/miq_policy/_profile_details.html.haml
@@ -15,7 +15,7 @@
           - if @edit
             .col-md-8
               = text_field_tag("description", @edit[:new][:description],
-                :maxlength         => MAX_DESC_LEN,
+                :maxlength         => ViewHelper::MAX_DESC_LEN,
                 :class             => "form-control",
                 "data-miq_observe" => observe_with_interval)
             = javascript_tag(javascript_focus('description'))

--- a/app/views/ops/_ap_form.html.haml
+++ b/app/views/ops/_ap_form.html.haml
@@ -22,7 +22,7 @@
         .col-md-8
           = text_field_tag("description",
                             @edit[:new][:description],
-                            :maxlength => MAX_DESC_LEN,
+                            :maxlength => ViewHelper::MAX_DESC_LEN,
                             :class => "form-control",
                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       .form-group

--- a/app/views/ops/_classification_entry.html.haml
+++ b/app/views/ops/_classification_entry.html.haml
@@ -5,7 +5,7 @@
       %td
         = text_field("entry", "name", :maxlength => MAX_NAME_LEN, :style => "width: 100%;")
       %td
-        = text_field("entry", "description", :maxlength => MAX_DESC_LEN, :style => "width: 100%;")
+        = text_field("entry", "description", :maxlength => ViewHelper::MAX_DESC_LEN, :style => "width: 100%;")
       %td.action-cell
         %button.btn.btn-default.btn-block.btn-sm{:title => _("Add this entry"),
           "data-submit"         => 'classification_entries_div',
@@ -23,7 +23,7 @@
           :style     => "width: 100%;")
       %td
         = text_field("entry", "description",
-          :maxlength => MAX_DESC_LEN,
+          :maxlength => ViewHelper::MAX_DESC_LEN,
           "value"    => entry.description,
           :style     => "width: 100%;")
       %td.action-cell

--- a/app/views/ops/_ldap_region_form.html.haml
+++ b/app/views/ops/_ldap_region_form.html.haml
@@ -21,7 +21,7 @@
         .col-md-8
           = text_field_tag("description",
                            @edit[:new][:description],
-                           :maxlength         => MAX_DESC_LEN,
+                           :maxlength         => ViewHelper::MAX_DESC_LEN,
                            :class => "form-control",
                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       .form-group

--- a/app/views/ops/_schedule_form.html.haml
+++ b/app/views/ops/_schedule_form.html.haml
@@ -30,7 +30,7 @@
                                 "id"          => "description",
                                 "name"        => "description",
                                 "ng-model"    => "scheduleModel.description",
-                                "maxlength"   => "#{MAX_DESC_LEN}",
+                                "maxlength"   => "#{ViewHelper::MAX_DESC_LEN}",
                                 "miqrequired" => "",
                                 "checkchange" => ""}
               %span.help-block{"ng-show" => "angularForm.description.$error.miqrequired"}

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -244,7 +244,7 @@
       .col-md-8
         = text_field_tag("smtp_from",
                           @edit[:new][:smtp][:from],
-                          :maxlength => MAX_DESC_LEN,
+                          :maxlength => ViewHelper::MAX_DESC_LEN,
                           :class => "form-control",
                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
     .form-group
@@ -254,7 +254,7 @@
         .input-group
           = text_field_tag("smtp_test_to",
                             @sb[:new_to],
-                            :maxlength => MAX_DESC_LEN,
+                            :maxlength => ViewHelper::MAX_DESC_LEN,
                             :class => "form-control",
                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           %span.input-group-btn
@@ -313,6 +313,6 @@
       .col-md-8
         = text_field_tag("custom_support_url_description",
                           @edit[:new][:server][:custom_support_url_description],
-                          :maxlength => MAX_DESC_LEN,
+                          :maxlength => ViewHelper::MAX_DESC_LEN,
                           :class => "form-control",
                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)

--- a/app/views/ops/_tenant_form.html.haml
+++ b/app/views/ops/_tenant_form.html.haml
@@ -31,7 +31,7 @@
                               "id"          => "tenant_description",
                               "name"        => "description",
                               "ng-model"    => "vm.tenantModel.description",
-                              "maxlength"   => "#{MAX_DESC_LEN}",
+                              "maxlength"   => "#{ViewHelper::MAX_DESC_LEN}",
                               "miqrequired" => ""}
             %span.help-block{"ng-show" => "angularForm.description.$error.miqrequired"}
               = _("Required")

--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -54,7 +54,7 @@
         %input.form-control{:type           => "text",
                             :name           => "url",
                             'ng-model'      => "vm.providerForemanModel.url",
-                            :maxlength      => MAX_DESC_LEN,
+                            :maxlength      => ViewHelper::MAX_DESC_LEN,
                             "id"            => "url",
                             :required       => "",
                             "ng-trim"       => false,

--- a/app/views/report/_schedule_form.html.haml
+++ b/app/views/report/_schedule_form.html.haml
@@ -18,7 +18,7 @@
         = _('Description')
       .col-md-8
         = text_field_tag("description", @edit[:new][:description],
-                         :maxlength         => MAX_DESC_LEN,
+                         :maxlength         => ViewHelper::MAX_DESC_LEN,
                          :class             => "form-control",
                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
     .form-group

--- a/app/views/report/_widget_form.html.haml
+++ b/app/views/report/_widget_form.html.haml
@@ -25,7 +25,7 @@
       .col-md-8
         = text_field_tag("description", @edit[:new][:description],
           :disabled          => @edit[:read_only],
-          :maxlength         => MAX_DESC_LEN,
+          :maxlength         => ViewHelper::MAX_DESC_LEN,
           :class             => "form-control",
           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
     .form-group

--- a/app/views/service/_service_form.html.haml
+++ b/app/views/service/_service_form.html.haml
@@ -34,7 +34,7 @@
                               "id"          => "description",
                               "name"        => "description",
                               "ng-model"    => "vm.serviceModel.description",
-                              "maxlength"   => "#{MAX_DESC_LEN}",
+                              "maxlength"   => "#{ViewHelper::MAX_DESC_LEN}",
                               "required"    => true}
   = render :partial => "layouts/angular/generic_form_buttons"
 


### PR DESCRIPTION
### Issue: #1661 

We have removed `MAX_DESC_LEN` constant from `UiConstants`. `MAX_DESC_LEN` was moved to `ViewHelper` and also added `ViewHelper` prefix for each occurrence of it.