### PR TITLE
[FINE] Display Ansible tower job templates filters

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -747,6 +747,7 @@ module ApplicationHelper
        cloud_tenant
        cloud_volume
        configuration_job
+       configuration_scripts
        container
        container_build
        container_group

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -22,13 +22,33 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    count_only_or_objects(count_only,
-                          Rbac.filtered(ManageIQ::Providers::AnsibleTower::AutomationManager.order("lower(name)"),
-                                        :match_via_descendants => ConfigurationScript), "name")
+    objects = []
+    templates = Rbac.filtered(ManageIQ::Providers::AnsibleTower::AutomationManager.order("lower(name)"), :match_via_descendants => ConfigurationScript)
+
+    templates.each do |temp|
+      objects.push(temp)
+    end
+
+    objects.push(:id          => "global",
+                 :text        => _("Global Filters"),
+                 :icon        => "pficon pficon-folder-close",
+                 :tip         => _("Global Shared Filters"),
+                 :cfmeNoClick => true)
+    objects.push(:id          => "my",
+                 :text        => _("My Filters"),
+                 :icon        => "pficon pficon-folder-close",
+                 :tip         => _("My Personal Filters"),
+                 :cfmeNoClick => true)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_cmat_kids(object, count_only)
     count_only_or_objects(count_only,
                           Rbac.filtered(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.where(:manager_id => object.id)), "name")
+  end
+
+  def x_get_tree_custom_kids(object, count_only, options)
+    objects = MiqSearch.where(:db => options[:leaf]).filters_by_type(object[:id])
+    count_only_or_objects(count_only, objects, 'description')
   end
 end

--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -1,5 +1,5 @@
 #accordion.panel-group
-  - if @accords.length == 1 # there is no need for JavaScript if only one accordion is present
+  - if @accords.present? && @accords.length == 1 # there is no need for JavaScript if only one accordion is present
     .panel.panel-default
       .panel-heading
         %h4.panel-title
@@ -8,7 +8,7 @@
       .panel-collapse.collapse.in
         .panel-body{:id => @accords.first[:container]}
           = render :partial => 'shared/explorer_tree', :locals => {:name => @accords.first[:name]}
-  - elsif @accords.length > 1
+  - elsif @accords.present? && @accords.length > 1
     - accord_names = @accords.map { |accord| accord[:name].to_sym }
     - @accords.each_with_index do |a, i|
       = miq_accordion_panel(a[:title], accord_names.include?(@sb[:active_accord]) ? a[:name].to_sym == @sb[:active_accord] : i == 0, a[:container]) do

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -240,10 +240,14 @@ describe AutomationManagerController do
   end
 
   it "builds ansible tower child tree" do
+    automation_manager1 = ManageIQ::Providers::AnsibleTower::AutomationManager.find_by(:provider_id => automation_provider1.id)
+    automation_manager2 = ManageIQ::Providers::AnsibleTower::AutomationManager.find_by(:provider_id => automation_provider2.id)
+    user = login_as user_with_feature(%w(automation_manager_providers providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
+    allow(User).to receive(:current_user).and_return(user)
     controller.send(:build_automation_manager_tree, :automation_manager_providers, :automation_manager_providers_tree)
     tree_builder = TreeBuilderAutomationManagerProviders.new("root", "", {})
     objects = tree_builder.send(:x_get_tree_roots, false, {})
-    expected_objects = [@automation_manager1, @automation_manager2]
+    expected_objects = [automation_manager1, automation_manager2]
     expect(objects).to match_array(expected_objects)
   end
 
@@ -256,21 +260,24 @@ describe AutomationManagerController do
   end
 
   it "builds ansible tower job templates tree" do
+    user = login_as user_with_feature(%w(automation_manager_providers providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
+    allow(User).to receive(:current_user).and_return(user)
     controller.send(:build_automation_manager_tree, :configuration_scripts, :configuration_scripts_tree)
     tree_builder = TreeBuilderAutomationManagerConfigurationScripts.new("root", "", {})
     objects = tree_builder.send(:x_get_tree_roots, false, {})
-    expected_objects = [@automation_manager1, @automation_manager2]
-    expect(objects).to match_array(expected_objects)
+    expect(objects).to include(@automation_manager1)
+    expect(objects).to include(@automation_manager2)
   end
 
   it "constructs the ansible tower job templates tree node" do
-    login_as user_with_feature(%w(providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
+    user = login_as user_with_feature(%w(providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
+    allow(User).to receive(:current_user).and_return(user)
     controller.send(:build_automation_manager_tree, :configuration_scripts, :configuration_scripts_tree)
     tree_builder = TreeBuilderAutomationManagerConfigurationScripts.new("root", "", {})
-    objects = tree_builder.send(:x_get_tree_roots, false, {})
-    objects = tree_builder.send(:x_get_tree_cmat_kids, objects[0], false)
-    expected_objects = [@ans_job_template1, @ans_job_template3]
-    expect(objects).to match_array(expected_objects)
+    root_objects = tree_builder.send(:x_get_tree_roots, false, {})
+    objects = tree_builder.send(:x_get_tree_cmat_kids, root_objects[1], false)
+    expect(objects).to include(@ans_job_template1)
+    expect(objects).to include(@ans_job_template3)
   end
 
   context "renders tree_select" do


### PR DESCRIPTION
Backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/1082
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1471821

Display Ansible tower job templates filters in accordion
in Automation -> Ansible Tower -> Explorer -> Job Templates.
Correct condition in _explorer.html.haml not to fail if nil.