### PR TITLE
Remove MAX_HOSTNAME_LEN from UiConstants

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,9 +1,7 @@
 module UiConstants
   # MAX_NAME_LEN = 20      # Default maximum name length
-  # MAX_HOSTNAME_LEN = 50  # Default maximum host name length
   # dac - Changed to allow up to 255 characters for all text fields on 1/11/07
   MAX_NAME_LEN = 255        # Default maximum name length
-  MAX_HOSTNAME_LEN = 255    # Default maximum host name length
 
   CHARTS_REPORTS_FOLDER = File.join(Rails.root, "product/charts/miq_reports")
   CHARTS_LAYOUTS_FOLDER = File.join(Rails.root, "product/charts/layouts")

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -6,6 +6,7 @@ module ViewHelper
   extend ActionView::Helpers::OutputSafetyHelper
 
   MAX_DESC_LEN = 255
+  MAX_HOSTNAME_LEN = 255
 
   class << self
     def concat_tag(*args, &block)

--- a/app/views/ems_container/_form_fields.html.haml
+++ b/app/views/ems_container/_form_fields.html.haml
@@ -5,7 +5,7 @@
     .col-md-4
       = text_field_tag("hostname",
         @edit[:new][:hostname],
-        :maxlength         => MAX_HOSTNAME_LEN,
+        :maxlength         => ViewHelper::MAX_HOSTNAME_LEN,
         "class"            => "form-control",
         "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
         :title             => _('Hostname or IPv4/IPv6 address'))

--- a/app/views/ems_datawarehouse/_form_fields.html.haml
+++ b/app/views/ems_datawarehouse/_form_fields.html.haml
@@ -5,7 +5,7 @@
     .col-md-8
       = text_field_tag("hostname",
         @edit[:new][:hostname],
-        :maxlength         => MAX_HOSTNAME_LEN,
+        :maxlength         => ViewHelper::MAX_HOSTNAME_LEN,
         "class"            => "form-control",
         "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
         :title             => _('Hostname or IPv4/IPv6 address'))

--- a/app/views/ems_infra/_form_fields.html.haml
+++ b/app/views/ems_infra/_form_fields.html.haml
@@ -5,7 +5,7 @@
     .col-md-4
       = text_field_tag("hostname",
         @edit[:new][:hostname],
-        :maxlength => MAX_HOSTNAME_LEN,
+        :maxlength => ViewHelper::MAX_HOSTNAME_LEN,
         "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
         :class => "form-control",
         :title => _("Hostname or IPv4/IPv6 address"))

--- a/app/views/ems_middleware/_form_fields.html.haml
+++ b/app/views/ems_middleware/_form_fields.html.haml
@@ -5,7 +5,7 @@
     .col-md-4
       = text_field_tag("hostname",
         @edit[:new][:hostname],
-        :maxlength         => MAX_HOSTNAME_LEN,
+        :maxlength         => ViewHelper::MAX_HOSTNAME_LEN,
         "class"            => "form-control",
         "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
         :title             => _('Hostname or IPv4/IPv6 address'))

--- a/app/views/host/_form.html.haml
+++ b/app/views/host/_form.html.haml
@@ -35,7 +35,7 @@
                                   "id"          => "hostname",
                                   "name"        => "hostname",
                                   "ng-model"    => "hostModel.hostname",
-                                  "maxlength"   => "#{MAX_HOSTNAME_LEN}",
+                                  "maxlength"   => "#{ViewHelper::MAX_HOSTNAME_LEN}",
                                   "miqrequired" => "",
                                   "checkchange" => ""}
               %span.help-block{"ng-show" => "angularForm.hostname.$error.miqrequired"}


### PR DESCRIPTION
### Issue: #1661 

We have removed `MAX_HOSTNAME_LEN` constant from `UiConstants`. `MAX_HOSTNAME_LEN` was moved to `ViewHelper` and also added `ViewHelper` prefix for each occurrence of it.