### PR TITLE
Remove MAX_DASHBOARD_COUNT from UiConstants

### DIFF
--- a/app/helpers/application_helper/button/db_new.rb
+++ b/app/helpers/application_helper/button/db_new.rb
@@ -1,4 +1,7 @@
 class ApplicationHelper::Button::DbNew < ApplicationHelper::Button::ButtonNewDiscover
+
+  MAX_DASHBOARD_COUNT = 10
+
   def disabled?
     if @widgetsets.length >= MAX_DASHBOARD_COUNT
       @error_message = _('Only %{dashboard_count} Dashboards are allowed for a group') %

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -5,7 +5,6 @@ module UiConstants
   # dac - Changed to allow up to 255 characters for all text fields on 1/11/07
   MAX_NAME_LEN = 255        # Default maximum name length
   MAX_DESC_LEN = 255        # Default maximum description length
-  MAX_HOSTNAME_LEN = 255    # Default maximum host name length
 
   MAX_DASHBOARD_COUNT = 10  # Default maximum count of Dashboard per group
 

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -6,8 +6,6 @@ module UiConstants
   MAX_NAME_LEN = 255        # Default maximum name length
   MAX_DESC_LEN = 255        # Default maximum description length
 
-  MAX_DASHBOARD_COUNT = 10  # Default maximum count of Dashboard per group
-
   REPORTS_FOLDER = File.join(Rails.root, "product/reports")
   CHARTS_REPORTS_FOLDER = File.join(Rails.root, "product/charts/miq_reports")
   CHARTS_LAYOUTS_FOLDER = File.join(Rails.root, "product/charts/layouts")

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -5,6 +5,8 @@ module ViewHelper
   extend ActionView::Helpers::CaptureHelper
   extend ActionView::Helpers::OutputSafetyHelper
 
+  MAX_HOSTNAME_LEN = 255
+
   class << self
     def concat_tag(*args, &block)
       concat content_tag(*args, &block)

--- a/app/views/ems_container/_form_fields.html.haml
+++ b/app/views/ems_container/_form_fields.html.haml
@@ -5,7 +5,7 @@
     .col-md-4
       = text_field_tag("hostname",
         @edit[:new][:hostname],
-        :maxlength         => MAX_HOSTNAME_LEN,
+        :maxlength         => ViewHelper::MAX_HOSTNAME_LEN,
         "class"            => "form-control",
         "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
         :title             => _('Hostname or IPv4/IPv6 address'))

--- a/app/views/ems_datawarehouse/_form_fields.html.haml
+++ b/app/views/ems_datawarehouse/_form_fields.html.haml
@@ -5,7 +5,7 @@
     .col-md-8
       = text_field_tag("hostname",
         @edit[:new][:hostname],
-        :maxlength         => MAX_HOSTNAME_LEN,
+        :maxlength         => ViewHelper::MAX_HOSTNAME_LEN,
         "class"            => "form-control",
         "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
         :title             => _('Hostname or IPv4/IPv6 address'))

--- a/app/views/ems_infra/_form_fields.html.haml
+++ b/app/views/ems_infra/_form_fields.html.haml
@@ -5,7 +5,7 @@
     .col-md-4
       = text_field_tag("hostname",
         @edit[:new][:hostname],
-        :maxlength => MAX_HOSTNAME_LEN,
+        :maxlength => ViewHelper::MAX_HOSTNAME_LEN,
         "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
         :class => "form-control",
         :title => _("Hostname or IPv4/IPv6 address"))

--- a/app/views/ems_middleware/_form_fields.html.haml
+++ b/app/views/ems_middleware/_form_fields.html.haml
@@ -5,7 +5,7 @@
     .col-md-4
       = text_field_tag("hostname",
         @edit[:new][:hostname],
-        :maxlength         => MAX_HOSTNAME_LEN,
+        :maxlength         => ViewHelper::MAX_HOSTNAME_LEN,
         "class"            => "form-control",
         "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
         :title             => _('Hostname or IPv4/IPv6 address'))

--- a/app/views/host/_form.html.haml
+++ b/app/views/host/_form.html.haml
@@ -35,7 +35,7 @@
                                   "id"          => "hostname",
                                   "name"        => "hostname",
                                   "ng-model"    => "hostModel.hostname",
-                                  "maxlength"   => "#{MAX_HOSTNAME_LEN}",
+                                  "maxlength"   => "#{ViewHelper::MAX_HOSTNAME_LEN}",
                                   "miqrequired" => "",
                                   "checkchange" => ""}
               %span.help-block{"ng-show" => "angularForm.hostname.$error.miqrequired"}


### PR DESCRIPTION
### Issue: #1661 

We have removed `MAX_DASHBOARD_COUNT` constant from `UiConstants`. `MAX_DASHBOARD_COUNT` was moved to `DbNew` class.