### PR TITLE
Remove MAX_DASHBOARD_COUNT from UiConstants

### DIFF
--- a/app/helpers/application_helper/button/db_new.rb
+++ b/app/helpers/application_helper/button/db_new.rb
@@ -1,4 +1,6 @@
 class ApplicationHelper::Button::DbNew < ApplicationHelper::Button::ButtonNewDiscover
+  MAX_DASHBOARD_COUNT = 10
+
   def disabled?
     if @widgetsets.length >= MAX_DASHBOARD_COUNT
       @error_message = _('Only %{dashboard_count} Dashboards are allowed for a group') %

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -5,8 +5,6 @@ module UiConstants
   MAX_NAME_LEN = 255        # Default maximum name length
   MAX_HOSTNAME_LEN = 255    # Default maximum host name length
 
-  MAX_DASHBOARD_COUNT = 10  # Default maximum count of Dashboard per group
-
   CHARTS_REPORTS_FOLDER = File.join(Rails.root, "product/charts/miq_reports")
   CHARTS_LAYOUTS_FOLDER = File.join(Rails.root, "product/charts/layouts")
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")


### PR DESCRIPTION
### Issue: #1661 

We have removed `MAX_DASHBOARD_COUNT` constant from `UiConstants`. `MAX_DASHBOARD_COUNT` was moved to `DbNew` class.

Cloud Intel -> Reports -> Dashboards -> All Groups -> Cloud-Operators -> Configuration -> Add a new Dashboard

![peek 2017-07-19 15-11aa](https://user-images.githubusercontent.com/22373707/28368454-abd8e0d8-6c94-11e7-966a-b13b408dba36.gif)

