### PR TITLE
[FINE] fixed: allow user on global region to see requests created for remote region

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -415,16 +415,26 @@ class MiqRequestController < ApplicationController
     end
   end
 
+  def remote_and_global_requestors(requestor)
+    condition = []
+    requestors = User.where(:userid => requestor.try(:userid))
+    if requestors.count > 1
+      condition.push("or" => requestors.collect { |user| {"=" => {"value" => user.id, "field" => "MiqRequest-requester_id"}} })
+    else
+      condition.push("=" => {"value" => requestor.try(:id), "field" => "MiqRequest-requester_id"})
+    end
+  end
+
   # Create a condition from the passed in options
   def prov_condition(opts)
     cond = [{"AFTER" => {"value" => "#{opts[:time_period].to_i} Days Ago", "field" => "MiqRequest-created_on"}}]  # Start with setting time
 
     unless is_approver
-      cond.push("=" => {"value" => current_user.try(:id), "field" => "MiqRequest-requester_id"})
+      cond.push(*remote_and_global_requestors(current_user))
     end
 
     if opts[:user_choice] && opts[:user_choice] != "all"
-      cond.push("=" => {"value" => opts[:user_choice], "field" => "MiqRequest-requester_id"})
+      cond.push(*remote_and_global_requestors(User.find_by(:id => opts[:user_choice])))
     end
 
     if (a_s = opts[:applied_states].presence)


### PR DESCRIPTION
When replication set-up we may have 2 users with the same `userid` in global region: one created manually and other created by replication. Requests created  in global region for remote user have remote user's `id` in `requester_id` column.

**Issue**: 
Requests created in global region for remote user were visible for user in remote region but not visible in Global region.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1464610

**Solution**:
Allow all users who have the same `userid` as one assign to request to see this request

**BEFORE:**
![before](https://user-images.githubusercontent.com/6556758/28385767-44e9227c-6c97-11e7-9d7f-aa7aa579093f.gif)


**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/28385156-07d7e4c4-6c95-11e7-9d4a-92aca4e95844.gif)


@miq-bot add-label bug, blocker

\cc @gtanzillo @lpichler 


