### PR TITLE
Modify the API params to support filtering on non-column methods

### DIFF
--- a/app/assets/javascripts/controllers/cloud_object_store_container/cloud_object_store_container_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_object_store_container/cloud_object_store_container_form_controller.js
@@ -20,7 +20,7 @@ ManageIQ.angular.app.controller('cloudObjectStoreContainerFormController', ['miq
     vm.saveable = miqService.saveable;
 
     miqService.sparkleOn();
-    API.get('/api/providers?expand=resources&attributes=id,name&filter[]=supports_cloud_object_store_container_create?=true')
+    API.get('/api/providers?expand=resources&attributes=id,name,supports_cloud_object_store_container_create&filter[]=supports_cloud_object_store_container_create=true')
       .then(getStorageManagers)
       .catch(miqService.handleFailure);
 

--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -21,7 +21,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     vm.newRecord = cloudVolumeFormId === 'new';
 
     miqService.sparkleOn();
-    API.get("/api/providers?expand=resources&attributes=id,name&filter[]=supports_block_storage?=true")
+    API.get("/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true")
       .then(getStorageManagers)
       .catch(miqService.handleFailure);
 


### PR DESCRIPTION
Depends on backend PR: https://github.com/ManageIQ/manageiq/pull/15600

Note that in 5.8, using the API `filter[]` parameter on a non-column attribute results in an error - "Must filter on valid attributes for resource", which will be resolved by the virtual column introduced in the above backend PR.
In master however, there is no error as such, but just an empty list returned by the API.

Before (Storage Manager dropdown empty) :
<img width="1302" alt="screen shot 2017-07-18 at 5 35 56 pm" src="https://user-images.githubusercontent.com/1538216/28345499-a1e5df14-6bdf-11e7-8aa5-9499a9271997.png">


After (Storage Manager dropdown populated) :
<img width="1311" alt="screen shot 2017-07-18 at 5 34 57 pm" src="https://user-images.githubusercontent.com/1538216/28345462-7a1467a8-6bdf-11e7-9352-125efcb5244b.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1471162

