### PR TITLE
Strip html tags before sending error details to flash message

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -66,7 +66,7 @@ module Mixins
       if result
         add_flash(_("Credential validation was successful"))
       else
-        add_flash(_("Credential validation was not successful: %{details}") % {:details => details}, :error)
+        add_flash(_("Credential validation was not successful: %{details}") % {:details => strip_tags(details)}, :error)
       end
 
       render :json => {:message => @flash_array.last(1)[0][:message], :level => @flash_array.last(1)[0][:level]}


### PR DESCRIPTION
**Description**

Sometimes error messages from container validation include html tags. This PR make sure error messages are sanitized before we display them to the user.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1472294

**Screenshots**

Before
![screenshot-localhost 3000-2017-07-19-10-16-22](https://user-images.githubusercontent.com/2181522/28355319-25440480-6c6c-11e7-9882-4d6632b2e66a.png)

After
![screenshot-localhost 3000-2017-07-19-10-17-49](https://user-images.githubusercontent.com/2181522/28355354-480c2cf4-6c6c-11e7-979c-705dfbac53b0.png)

