### PR TITLE
Sort asynchronously arrived notifications by timestamp in the drawer

### DIFF
--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -129,7 +129,7 @@ function eventNotifications($timeout, API) {
     });
     if (group) {
       if (group.notifications) {
-        group.notifications.splice(0, 0, newNotification);
+        group.notifications.splice(_.sortedIndex(group.notifications, newNotification, function (x) { return -x.timeStamp; }), 0, newNotification);
       } else {
         group.notifications = [newNotification];
       }


### PR DESCRIPTION
I'm still not sure if it's a good idea to put the words *asynchronous* and *sort* into the same sentence. The timestamps of a notification aren't the timestamps of arrival, but the creation on the server and as the whole system is asynchronous, **this can cause to have newly arrived notifications appear not on the top of the drawer but somewhere lower**.

@miq-bot add_label bug
@miq-bot assign @himdel 

https://bugzilla.redhat.com/show_bug.cgi?id=1469534