### PR TITLE
Remove REPORTS_FOLDER from UiConstants

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -9,7 +9,6 @@ module UiConstants
 
   MAX_DASHBOARD_COUNT = 10  # Default maximum count of Dashboard per group
 
-  REPORTS_FOLDER = File.join(Rails.root, "product/reports")
   CHARTS_REPORTS_FOLDER = File.join(Rails.root, "product/charts/miq_reports")
   CHARTS_LAYOUTS_FOLDER = File.join(Rails.root, "product/charts/layouts")
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")

--- a/spec/product/reports_spec.rb
+++ b/spec/product/reports_spec.rb
@@ -1,5 +1,5 @@
 describe 'YAML reports' do
-  let(:report_dirs) { [File.join(Rails.root, "product", "reports"), "#{TIMELINES_FOLDER}/miq_reports"] }
+  let(:report_dirs) { [Rails.root.join("product", "reports"), "#{TIMELINES_FOLDER}/miq_reports"] }
   let(:report_yamls) { report_dirs.collect { |dir| Dir.glob(File.join(dir, "**", "*.yaml")) }.flatten }
   let(:chart_dirs) { [CHARTS_REPORTS_FOLDER] }
   let(:chart_yamls) { chart_dirs.collect { |dir| Dir.glob(File.join(dir, "**", "*.yaml")) }.flatten }

--- a/spec/product/reports_spec.rb
+++ b/spec/product/reports_spec.rb
@@ -1,5 +1,5 @@
 describe 'YAML reports' do
-  let(:report_dirs) { [REPORTS_FOLDER, "#{TIMELINES_FOLDER}/miq_reports"] }
+  let(:report_dirs) { [File.join(Rails.root, "product/reports"), "#{TIMELINES_FOLDER}/miq_reports"] }
   let(:report_yamls) { report_dirs.collect { |dir| Dir.glob(File.join(dir, "**", "*.yaml")) }.flatten }
   let(:chart_dirs) { [CHARTS_REPORTS_FOLDER] }
   let(:chart_yamls) { chart_dirs.collect { |dir| Dir.glob(File.join(dir, "**", "*.yaml")) }.flatten }

--- a/spec/product/reports_spec.rb
+++ b/spec/product/reports_spec.rb
@@ -1,5 +1,5 @@
 describe 'YAML reports' do
-  let(:report_dirs) { [File.join(Rails.root, "product/reports"), "#{TIMELINES_FOLDER}/miq_reports"] }
+  let(:report_dirs) { [File.join(Rails.root, "product", "reports"), "#{TIMELINES_FOLDER}/miq_reports"] }
   let(:report_yamls) { report_dirs.collect { |dir| Dir.glob(File.join(dir, "**", "*.yaml")) }.flatten }
   let(:chart_dirs) { [CHARTS_REPORTS_FOLDER] }
   let(:chart_yamls) { chart_dirs.collect { |dir| Dir.glob(File.join(dir, "**", "*.yaml")) }.flatten }


### PR DESCRIPTION
### Issue: #1661 

We have removed `REPORTS_FOLDER` constant from `UiConstants`. One occurrence of constant `REPORTS_FOLDER` was replaced with its value in `manageiq-ui-classic/spec/product/reports_spec.rb`.