### PR TITLE
Broken titles for automate buttons in new and edit dialog

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -636,7 +636,13 @@ module ApplicationController::Buttons
     @layout = "miq_ae_automate_button"
     @sb[:button_groups] = nil
     @sb[:buttons] = nil
-    replace_right_cell(:action => "group_edit")
+
+    # Symbol selection based on active controller
+    if controller_path == 'miq_ae_customization'
+      replace_right_cell(:nodetype => 'group_edit')
+    else
+      replace_right_cell(:action => 'group_edit')
+    end
   end
 
   def button_new_edit(typ)
@@ -657,7 +663,13 @@ module ApplicationController::Buttons
     @layout = "miq_ae_automate_button"
     @sb[:buttons] = nil
     @sb[:button_groups] = nil
-    replace_right_cell(:action => "button_edit")
+
+    # Symbol selection based on active controller
+    if controller_path == 'miq_ae_customization'
+      replace_right_cell(:nodetype => 'button_edit')
+    else
+      replace_right_cell(:action => 'button_edit')
+    end
   end
 
   # Set form variables for button add/edit


### PR DESCRIPTION
This PR fix a broken titles for a new automate buttons and button groups.

based on: https://bugzilla.redhat.com/show_bug.cgi?id=1379348

Automation/Automate/Customization

before:
![before](https://user-images.githubusercontent.com/19405716/28363608-71d6c21e-6c81-11e7-9292-c9598abd88d5.png)

after:
![after](https://user-images.githubusercontent.com/19405716/28363615-77290998-6c81-11e7-8cfe-4550abb84da7.png)

