### PR TITLE
Rename the TreeNode `children` attribute to `nodes` for all nodes

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -649,7 +649,7 @@ function miqInitTree(options, tree) {
   }
 
   if (options.add_nodes) {
-    miqAddNodeChildren(options.tree_name, options.add_node_key, options.select_node, options.children);
+    miqAddNodeChildren(options.tree_name, options.add_node_key, options.select_node, options.nodes);
   }
 
   // Tree state persistence correction after the tree is completely loaded

--- a/app/presenters/full_tree_builder.rb
+++ b/app/presenters/full_tree_builder.rb
@@ -25,16 +25,16 @@ class FullTreeBuilder < TreeBuilder
   # Recursively create the UI tree from a Relationship tree
   #
   # @param rel_tree [Hash] the Hash based Relationship tree to convert, with
-  #   key/value pairs in the form `ActiveRecord::Base (object) => Hash (children)`
+  #   key/value pairs in the form `ActiveRecord::Base (object) => Hash (nodes)`
   # @param parent_ui_tree_id [String] the UI tree id of the parent.  This value
   #   is used in the recursion and should not be passed for the root of the tree.
   # @return [Hash] the UI data as a nested Hash structure
   def convert_to_ui_tree(rel_tree, parent_ui_tree_id = nil)
-    ui_tree = rel_tree.collect do |object, children|
+    ui_tree = rel_tree.collect do |object, nodes|
       ui_node = x_build_single_node(object, parent_ui_tree_id, options)
 
-      unless children.blank?
-        ui_node[:children] = convert_to_ui_tree(children, ui_node[:key])
+      unless nodes.blank?
+        ui_node[:nodes] = convert_to_ui_tree(nodes, ui_node[:key])
       end
 
       ui_node

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -114,6 +114,7 @@ class TreeBuilder
     while stack.any?
       node = stack.pop
       stack += node[:children] if node.key?(:children)
+      stack += node[:nodes] if node.key?(:nodes)
       node[:text] = node.delete(:title) if node.key?(:title)
       node[:nodes] = node.delete(:children) if node.key?(:children)
       node[:lazyLoad] = node.delete(:isLazy) if node.key?(:isLazy)
@@ -206,9 +207,7 @@ class TreeBuilder
   # :full_ids               # stack parent id on top of each node id
   # :lazy                   # set if tree is lazy
   def x_build_tree(options)
-    children = x_get_tree_objects(nil, options, false, [])
-
-    child_nodes = children.map do |child|
+    nodes = x_get_tree_objects(nil, options, false, []).map do |child|
       # already a node? FIXME: make a class for node
       if child.kind_of?(Hash) && child.key?(:text) && child.key?(:key) && child.key?(:image)
         child
@@ -216,8 +215,8 @@ class TreeBuilder
         x_build_node_tree(child, nil, options)
       end
     end
-    return child_nodes unless options[:add_root]
-    [{:key => 'root', :children => child_nodes, :expand => true}]
+    return nodes unless options[:add_root]
+    [{:key => 'root', :nodes => nodes, :expand => true}]
   end
 
   # determine if this is an ancestry node, and return the approperiate object
@@ -275,7 +274,7 @@ class TreeBuilder
       kids = (ancestry_kids || x_get_tree_objects(object, options, false, parents)).map do |o|
         x_build_node(o, node[:key], options)
       end
-      node[:children] = kids unless kids.empty?
+      node[:nodes] = kids unless kids.empty?
     else
       if x_get_tree_objects(object, options, true, parents) > 0
         node[:lazyLoad] = true # set child flag if children exist

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -46,7 +46,7 @@ class TreeBuilderClusters < TreeBuilder
         :icon        => 'pficon pficon-cluster',
         :tip         => node[:name],
         :select      => node[:capture],
-        :children    => @data[node[:id]][:ho_enabled] + @data[node[:id]][:ho_disabled],
+        :nodes       => @data[node[:id]][:ho_enabled] + @data[node[:id]][:ho_disabled],
         :cfmeNoClick => true
       }
     end
@@ -56,7 +56,7 @@ class TreeBuilderClusters < TreeBuilder
               :icon        => 'pficon pficon-screen',
               :tip         => _("Non-clustered Hosts"),
               :select      => non_cluster_selected,
-              :children    => @root[:non_cl_hosts],
+              :nodes       => @root[:non_cl_hosts],
               :cfmeNoClick => true
       }
       nodes.push(node)
@@ -65,7 +65,7 @@ class TreeBuilderClusters < TreeBuilder
   end
 
   def x_get_tree_hash_kids(parent, count_only)
-    hosts = parent[:children]
+    hosts = parent[:nodes]
     nodes = hosts.map do |node|
       if @data[parent[:id].to_i]
         value = @data[parent[:id].to_i][:ho_disabled].include? node
@@ -76,7 +76,7 @@ class TreeBuilderClusters < TreeBuilder
        :icon        => 'pficon pficon-screen',
        :select      => node.kind_of?(Hash) ? node[:capture] : !value,
        :cfmeNoClick => true,
-       :children    => []}
+       :nodes       => []}
     end
     count_only_or_objects(count_only, nodes)
   end

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -49,20 +49,20 @@ class TreeBuilderDatastores < TreeBuilder
         :tip         => "#{node[:name]} [#{node[:location]}]",
         :select      => node[:capture] == true,
         :cfmeNoClick => true,
-        :children    => children }
+        :nodes       => children }
     end
     count_only_or_objects(count_only, nodes)
   end
 
   def x_get_tree_hash_kids(parent, count_only)
-    nodes = parent[:children].map do |node|
+    nodes = parent[:nodes].map do |node|
       { :id           => node[:name],
         :text         => node[:name],
         :icon         => 'pficon pficon-screen',
         :tip          => node[:name],
         :hideCheckbox => true,
         :cfmeNoClick  => true,
-        :children     => [] }
+        :nodes        => [] }
     end
     count_only_or_objects(count_only, nodes)
   end

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -43,7 +43,7 @@ class TreeBuilderMenuRoles < TreeBuilder
   # Typically another method will populate the children of a root object.
   # Since our data is an array of Strings or Arrays, we don't have ids to tie
   # parents to children. Therefore we include the children with the parent.
-  # The :data key was chosen to avoid future conflicts with the :children key.
+  # The :data key was chosen to avoid future conflicts with the :nodes key.
   #
   def x_get_tree_roots(count_only = false, _options)
     branches = menus.map do |i|

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -19,7 +19,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    children = [
+    nodes = [
       {:id    => 'otcfn',
        :tree  => "otcfn_tree",
        :text  => _("CloudFormation Templates"),
@@ -46,7 +46,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
        :icon  => "ff ff-template",
        :tip   => _("vApp Templates")}
     ]
-    count_only_or_objects(count_only, children)
+    count_only_or_objects(count_only, nodes)
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -31,7 +31,7 @@ class TreeBuilderProtect < TreeBuilder
         :icon        => profile.active? ? "fa fa-shield" : "fa fa-inactive fa-shield",
         :tip         => profile.description,
         :select      => @data[:new][profile.id] == @data[:pol_items].length,
-        :children    => profile.members,
+        :nodes       => profile.members,
         :cfmeNoClick => true
       }
     end
@@ -39,7 +39,7 @@ class TreeBuilderProtect < TreeBuilder
   end
 
   def x_get_tree_hash_kids(parent, count_only)
-    nodes = parent[:children].map do |policy|
+    nodes = parent[:nodes].map do |policy|
       icon = case policy.towhat
              when 'Host'
                'pficon pficon-screen'
@@ -64,7 +64,7 @@ class TreeBuilderProtect < TreeBuilder
         :icon         => "#{icon}#{policy.active ? '' : ' fa-inactive'}",
         :tip          => policy.description,
         :hideCheckbox => true,
-        :children     => [],
+        :nodes        => [],
         :cfmeNoClick  => true
       }
     end

--- a/app/presenters/tree_builder_report_export.rb
+++ b/app/presenters/tree_builder_report_export.rb
@@ -24,7 +24,7 @@ class TreeBuilderReportExport < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    export_children = [
+    nodes = [
       {:id    => 'exportcustomreports',
        :text  => _('Custom Reports'),
        :icon  => 'fa fa-file-text-o'},
@@ -32,6 +32,6 @@ class TreeBuilderReportExport < TreeBuilder
        :text  => _('Widgets'),
        :icon  => 'fa fa-file-text-o'}
     ]
-    count_only_or_objects(count_only, export_children)
+    count_only_or_objects(count_only, nodes)
   end
 end

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -39,16 +39,16 @@ class TreeBuilderSections < TreeBuilder
                    :image       => false,
                    :select      => true,
                    :cfmeNoClick => true,
-                   :children    => [section])
+                   :nodes       => [section])
       else
-        nodes.last[:children].push(section)
+        nodes.last[:nodes].push(section)
       end
     end
     nodes.each do |node|
-      checked = node[:children].count { |kid| @data.include[kid[:name]][:checked] } # number of checked kids
+      checked = node[:nodes].count { |kid| @data.include[kid[:name]][:checked] } # number of checked kids
       if checked == 0
         node[:select] = false
-      elsif checked < node[:children].size
+      elsif checked < node[:nodes].size
         node[:select] = 'undefined'
       else
         node[:select] = true
@@ -58,14 +58,14 @@ class TreeBuilderSections < TreeBuilder
   end
 
   def x_get_tree_hash_kids(parent, count_only)
-    nodes = parent[:children].map do |kid|
+    nodes = parent[:nodes].map do |kid|
       {:id          => "group_#{kid[:group]}:#{kid[:name]}",
        :text        => kid[:header],
        :tip         => kid[:header],
        :image       => false,
        :select      => @data.include[kid[:name]][:checked],
        :cfmeNoClick => true,
-       :children    => []
+       :nodes       => []
       }
     end
     count_only_or_objects(count_only, nodes)

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -38,12 +38,12 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
 
   def x_get_server_kids(parent, count_only = false)
     nodes = {'host' => 'pficon pficon-screen', "storage" => 'fa fa-database'}.map do |kid, icon|
-      {:id          => "#{parent.id}__#{kid}",
-       :icon        => icon,
-       :parent      => parent,
-       :text        => Dictionary.gettext(kid.camelcase, :type => :model, :notfound => :titleize, :plural => true),
-       :cfmeNoClick => true,
-       :children    => @data.send(kid.pluralize).sort_by(&:name),
+      {:id              => "#{parent.id}__#{kid}",
+       :icon            => icon,
+       :parent          => parent,
+       :text            => Dictionary.gettext(kid.camelcase, :type => :model, :notfound => :titleize, :plural => true),
+       :cfmeNoClick     => true,
+       :nodes           => @data.send(kid.pluralize).sort_by(&:name),
        :smartproxy_kind => kid}
     end
     count_only_or_objects(count_only, nodes)
@@ -51,13 +51,13 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
 
   def x_get_tree_hash_kids(parent, count_only = false)
     affinities = parent[:parent].send("vm_scan_#{parent[:smartproxy_kind]}_affinity").collect(&:id) if parent[:parent].present?
-    nodes = parent[:children].map do |kid|
-      {:id          => "#{parent[:id]}_#{kid.id}",
-       :icon        => parent[:icon],
-       :text        => kid.name,
-       :select      => affinities.include?(kid.id),
-       :cfmeNoClick => true,
-       :children    => [],
+    nodes = parent[:nodes].map do |kid|
+      {:id              => "#{parent[:id]}_#{kid.id}",
+       :icon            => parent[:icon],
+       :text            => kid.name,
+       :select          => affinities.include?(kid.id),
+       :cfmeNoClick     => true,
+       :nodes           => [],
        :smartproxy_kind => parent[:smartproxy_kind]}
     end
     count_only_or_objects(count_only, nodes)

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -33,11 +33,11 @@ class TreeBuilderVandt < TreeBuilder
 
   private
 
-  def find_child_recursive(children, id)
-    children.each do |t|
-      return t[:children] if t[:key] == id
+  def find_child_recursive(nodes, id)
+    nodes.each do |t|
+      return t[:nodes] if t[:key] == id
 
-      found = find_child_recursive(t[:children], id) if t[:children]
+      found = find_child_recursive(t[:nodes], id) if t[:nodes]
       return found unless found.nil?
     end
     nil

--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -18,7 +18,7 @@
 - tree_id                     ||= "tree_div"
 - tree_name                   ||= "tree"
 - add_node_key                = Hash.new(@add_nodes).fetch(x_active_tree, {}).fetch(:key, nil)
-- children                    = Hash.new(@add_nodes).fetch(x_active_tree, {}).fetch(:children, nil)
+- nodes                    = Hash.new(@add_nodes).fetch(x_active_tree, {}).fetch(:nodes, nil)
 
 - options = {:tree_id            => tree_id,
              :tree_name          => tree_name,
@@ -42,10 +42,10 @@
              :reselect_node      => reselect_node,
              :highlight_changes  => highlight_changes,
              :expand_parent_nodes=> @expand_parent_nodes,
-             :add_nodes          => add_node_key && children && tree_name == x_active_tree.to_s,
+             :add_nodes          => add_node_key && nodes && tree_name == x_active_tree.to_s,
              :active_tree        => x_active_tree,
              :add_node_key       => add_node_key,
-             :children           => children}
+             :nodes              => nodes}
 
 :javascript
   miqInitTree(#{options.to_json.html_safe}, #{bs_tree.html_safe})

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -37,7 +37,7 @@ describe TreeBuilderClusters do
                                         :tip         => "Name",
                                         :select      => 'unsure',
                                         :cfmeNoClick => true,
-                                        :children    => @ho_enabled + @ho_disabled)
+                                        :nodes       => @ho_enabled + @ho_disabled)
       # non-cluster-node
       expect(cluster_nodes.last).to eq(:id          => "NonCluster",
                                        :text        => _("Non-clustered Hosts"),
@@ -45,7 +45,7 @@ describe TreeBuilderClusters do
                                        :tip         => _("Non-clustered Hosts"),
                                        :select      => true,
                                        :cfmeNoClick => true,
-                                       :children    => @non_cluster_hosts)
+                                       :nodes       => @non_cluster_hosts)
     end
 
     it 'sets non-cluster host nodes correctly' do
@@ -57,7 +57,7 @@ describe TreeBuilderClusters do
                                        :icon        => 'pficon pficon-screen',
                                        :select      => true,
                                        :cfmeNoClick => true,
-                                       :children    => []}])
+                                       :nodes       => []}])
     end
 
     it 'sets cluster hosts nodes correctly' do
@@ -70,7 +70,7 @@ describe TreeBuilderClusters do
          :icon        => 'pficon pficon-screen',
          :select      => true,
          :cfmeNoClick => true,
-         :children    => []}
+         :nodes       => []}
       end
       cluster_hosts_expected += @ho_disabled.map do |node|
         {:id          => "#{cluster_nodes.first[:id]}_#{node[:id]}",
@@ -79,7 +79,7 @@ describe TreeBuilderClusters do
          :icon        => 'pficon pficon-screen',
          :select      => false,
          :cfmeNoClick => true,
-         :children    => []}
+         :nodes       => []}
       end
       expect(cluster_hosts).to eq(cluster_hosts_expected)
     end

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -33,7 +33,7 @@ describe TreeBuilderDatastores do
       expect(kids.first[:icon]).to eq('pficon pficon-screen')
       expect(kids.first[:hideCheckbox]).to eq(true)
       expect(kids.first[:cfmeNoClick]).to eq(true)
-      expect(kids.first[:children]).to eq([])
+      expect(kids.first[:nodes]).to eq([])
     end
   end
 end

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -40,7 +40,7 @@ describe TreeBuilderProtect do
         expect(roots[i][:id]).to eq("policy_profile_#{root.id}")
         expect(roots[i][:icon]).to eq(root.active? ? "fa fa-shield" : "fa fa-inactive fa-shield")
         expect(roots[i][:text]).to eq(root.description)
-        expect(roots[i][:children]).to eq(root.members)
+        expect(roots[i][:nodes]).to eq(root.members)
         expect(roots[i][:select]).to eq(@edit[:new].keys.include?(root.id))
       end
       expect(roots.size).to eq(3)
@@ -54,7 +54,7 @@ describe TreeBuilderProtect do
       expect(kids[0][:icon]).to eq("pficon pficon-virtual-machine fa-inactive")
       expect(kids[0][:tip]).to eq(@kids[0].description)
       expect(kids[0][:hideCheckbox]).to eq(true)
-      expect(kids[0][:children]).to eq([])
+      expect(kids[0][:nodes]).to eq([])
     end
   end
 end

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -72,7 +72,7 @@ describe TreeBuilderSections do
                             :image       => false,
                             :select      => true,
                             :cfmeNoClick => true,
-                            :children    => [{:name => :_model_, :header => "Filesystem", :group => "Properties"}]}])
+                            :nodes       => [{:name => :_model_, :header => "Filesystem", :group => "Properties"}]}])
     end
 
     it 'sets children correctly' do
@@ -84,7 +84,7 @@ describe TreeBuilderSections do
                            :image       => false,
                            :cfmeNoClick => true,
                            :select      => true,
-                           :children    => []}])
+                           :nodes       => []}])
     end
   end
 end

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -54,33 +54,33 @@ describe TreeBuilderSmartproxyAffinity do
       kids2 = @smartproxy_affinity_tree.send(:x_get_server_kids, @svr2, false)
       expect(kids1.size).to eq(2)
       expect(kids2.size).to eq(2)
-      expect(kids1.first).to eq(:id          => "#{@svr1[:id]}__host",
-                                :icon        => "pficon pficon-screen",
-                                :parent      => @svr1,
-                                :text        => "Host / Nodes",
-                                :cfmeNoClick => true,
-                                :children    => @selected_zone.send('host'.pluralize).sort_by(&:name),
+      expect(kids1.first).to eq(:id              => "#{@svr1[:id]}__host",
+                                :icon            => "pficon pficon-screen",
+                                :parent          => @svr1,
+                                :text            => "Host / Nodes",
+                                :cfmeNoClick     => true,
+                                :nodes           => @selected_zone.send('host'.pluralize).sort_by(&:name),
                                 :smartproxy_kind => "host")
-      expect(kids2.first).to eq(:id          => "#{@svr2[:id]}__host",
-                                :icon        => "pficon pficon-screen",
-                                :parent      => @svr2,
-                                :text        => "Host / Nodes",
-                                :cfmeNoClick => true,
-                                :children    => @selected_zone.send('host'.pluralize).sort_by(&:name),
+      expect(kids2.first).to eq(:id              => "#{@svr2[:id]}__host",
+                                :icon            => "pficon pficon-screen",
+                                :parent          => @svr2,
+                                :text            => "Host / Nodes",
+                                :cfmeNoClick     => true,
+                                :nodes           => @selected_zone.send('host'.pluralize).sort_by(&:name),
                                 :smartproxy_kind => "host")
-      expect(kids1.last).to eq(:id          => "#{@svr1[:id]}__storage",
-                               :icon        => "fa fa-database",
-                               :parent      => @svr1,
-                               :text        => "Datastores",
-                               :cfmeNoClick => true,
-                               :children    => @selected_zone.send('storage'.pluralize).sort_by(&:name),
+      expect(kids1.last).to eq(:id              => "#{@svr1[:id]}__storage",
+                               :icon            => "fa fa-database",
+                               :parent          => @svr1,
+                               :text            => "Datastores",
+                               :cfmeNoClick     => true,
+                               :nodes           => @selected_zone.send('storage'.pluralize).sort_by(&:name),
                                :smartproxy_kind => "storage")
-      expect(kids2.last).to eq(:id          => "#{@svr2[:id]}__storage",
-                               :icon        => "fa fa-database",
-                               :parent      => @svr2,
-                               :text        => "Datastores",
-                               :cfmeNoClick => true,
-                               :children    => @selected_zone.send('storage'.pluralize).sort_by(&:name),
+      expect(kids2.last).to eq(:id              => "#{@svr2[:id]}__storage",
+                               :icon            => "fa fa-database",
+                               :parent          => @svr2,
+                               :text            => "Datastores",
+                               :cfmeNoClick     => true,
+                               :nodes           => @selected_zone.send('storage'.pluralize).sort_by(&:name),
                                :smartproxy_kind => "storage")
     end
 
@@ -92,11 +92,11 @@ describe TreeBuilderSmartproxyAffinity do
       parents = [parent1, parent2, parent3, parent4]
       parents.each do |parent|
         kids = @smartproxy_affinity_tree.send(:x_get_tree_hash_kids, parent, false)
-        parent[:children].each_with_index do |kid, i|
+        parent[:nodes].each_with_index do |kid, i|
           expect(kids[i][:image]).to eq(parent[:image])
           expect(kids[i][:text]).to eq(kid.name)
           expect(kids[i][:id]).to eq("#{parent[:id]}_#{kid.id}")
-          expect(kids[i][:children]).to eq([])
+          expect(kids[i][:nodes]).to eq([])
           expect(kids[i][:select]).to eq(parent[:parent].send("vm_scan_#{parent[:smartproxy_kind]}_affinity").collect(&:id).include?(kid.id))
         end
       end

--- a/spec/presenters/tree_builder_vms_and_templates_spec.rb
+++ b/spec/presenters/tree_builder_vms_and_templates_spec.rb
@@ -32,17 +32,17 @@ describe TreeBuilderVmsAndTemplates do
 
       tree_v = TreeBuilderVmsAndTemplates.new(ems).tree
       expect(tree_v[:text]).to eq(ems.name)
-      expect(tree_v[:children].size).to eq(1)
+      expect(tree_v[:nodes].size).to eq(1)
 
-      folders_v = tree_v[:children].first
+      folders_v = tree_v[:nodes].first
       expect(folders_v[:text]).to match folder.name
-      expect(folders_v[:children].size).to eq(1)
+      expect(folders_v[:nodes].size).to eq(1)
 
-      subfolders_v = folders_v[:children].detect { |f| f[:text] == subfolder1.name }
+      subfolders_v = folders_v[:nodes].detect { |f| f[:text] == subfolder1.name }
       expect(subfolders_v).to be_present
-      expect(subfolders_v[:children].size).to eq(2)
+      expect(subfolders_v[:nodes].size).to eq(2)
 
-      ems_vs = subfolders_v[:children]
+      ems_vs = subfolders_v[:nodes]
       expect(ems_vs.map { |e| e[:text] }).to match_array(vms.map(&:name))
     end
 
@@ -55,15 +55,15 @@ describe TreeBuilderVmsAndTemplates do
 
       tree_v = TreeBuilderVmsAndTemplates.new(ems).tree
       expect(tree_v[:text]).to eq(ems.name)
-      expect(tree_v[:children].size).to eq(1)
+      expect(tree_v[:nodes].size).to eq(1)
 
-      folders_v = tree_v[:children].first
+      folders_v = tree_v[:nodes].first
       expect(folders_v[:text]).to match folder.name
-      expect(folders_v[:children].size).to eq(1) # would be 3 if we did not prune
+      expect(folders_v[:nodes].size).to eq(1) # would be 3 if we did not prune
 
-      subfolders_v = folders_v[:children].detect { |f| f[:text] == subfolder1.name }
+      subfolders_v = folders_v[:nodes].detect { |f| f[:text] == subfolder1.name }
       expect(subfolders_v).to be_present
-      expect(subfolders_v[:children]).to be_blank # no vms in the tree
+      expect(subfolders_v[:nodes]).to be_blank # no vms in the tree
     end
   end
 end


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/story/show/149153823

@miq-bot add_label trees, refactoring, fine/no
@miq-bot assign @ZitaNemeckova