### PR TITLE
Notifications drawer - add a close button

### DIFF
--- a/app/assets/javascripts/controllers/header/header_controller.js
+++ b/app/assets/javascripts/controllers/header/header_controller.js
@@ -18,6 +18,16 @@ function HeaderCtrl($scope, eventNotifications, $timeout) {
     eventNotifications.setDrawerShown(vm.notificationsDrawerShown);
   };
 
+  ManageIQ.angular.rxSubject.subscribe(function (data) {
+    if (data.controller !== 'HeaderCtrl') {
+      return;
+    }
+
+    if (data.action === 'closeDrawer') {
+      $timeout(vm.toggleNotificationsList);
+    }
+  });
+
   var refresh = function() {
     $timeout(function() {
       vm.newNotifications = eventNotifications.state().unreadNotifications;

--- a/app/assets/javascripts/controllers/notifications/notification-drawer.directive.js
+++ b/app/assets/javascripts/controllers/notifications/notification-drawer.directive.js
@@ -24,6 +24,13 @@ angular.module('miq.notifications').directive('miqNotificationDrawer', ['$window
       }
 
       $scope.limit = { notifications: 100 };
+
+      $scope.closeDrawer = function() {
+        sendDataWithRx({
+          controller: 'HeaderCtrl',
+          action: 'closeDrawer',
+        });
+      };
     }],
     link: function(scope, element) {
       scope.$watch('notificationGroups', function() {

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -132,6 +132,14 @@ div#saml-login hr {
   color: #FFFFFF; margin-left: 1ex;
 }
 
+.miq-drawer-close {
+  color: inherit;
+  cursor: pointer;
+  right: 0;
+  padding: 2px 5px;
+  position: absolute;
+}
+
 /// group switcher styling
 
 .navbar-right .dropdown-submenu > a {

--- a/app/views/static/notification_drawer/notification-drawer.html.haml
+++ b/app/views/static/notification_drawer/notification-drawer.html.haml
@@ -2,6 +2,8 @@
   .drawer-pf-title{'ng-if' => "drawerTitle"}
     %a.drawer-pf-toggle-expand{'ng-if'    => "allowExpand",
                                'ng-click' => "toggleExpandDrawer()"}
+    %a.miq-drawer-close{'ng-click' => "closeDrawer()"}
+      %i.pficon.pficon-close
     %h3.text-center
       {{drawerTitle}}
 


### PR DESCRIPTION
The notification drawer can only be closed from the outside now, by clicking the bell icon.

This adds a close button to the drawer itself, which sends a message to the Header controller to close the drawer.

https://www.pivotaltracker.com/n/projects/1613907/stories/147302039

![drawer-close](https://user-images.githubusercontent.com/289743/28372690-e25137f0-6c8f-11e7-8b36-e5cf0b6500fb.png)
