### PR TITLE
Get tags for switches to display in the summary screen

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -381,6 +381,7 @@ class InfraNetworkingController < ApplicationController
     )
 
     if record_showing
+      get_tagdata(@record)
       presenter.hide(:form_buttons_div)
       presenter.update(:main_div, r[:partial => "layouts/textual_groups_generic"])
     elsif @sb[:action] || params[:display]


### PR DESCRIPTION
Get the tags for the infrastructure switch to display in the summary screen

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1440436

