### PR TITLE
Added a ems_id existence check around VM VNC console button visibility

### DIFF
--- a/app/helpers/application_helper/button/vm_console.rb
+++ b/app/helpers/application_helper/button/vm_console.rb
@@ -7,6 +7,10 @@ class ApplicationHelper::Button::VmConsole < ApplicationHelper::Button::Basic
     @record.vendor == 'vmware'
   end
 
+  def ems?
+    @record.ems_id
+  end
+
   def supported_vendor_api?
     ExtManagementSystem.find(@record.ems_id).api_version.to_f < unsupported_vendor_api_version
   end

--- a/app/helpers/application_helper/button/vm_vnc_console.rb
+++ b/app/helpers/application_helper/button/vm_vnc_console.rb
@@ -2,7 +2,7 @@ class ApplicationHelper::Button::VmVncConsole < ApplicationHelper::Button::VmCon
   needs :@record
 
   def visible?
-    return console_supports_type?('VNC') if vmware?
+    return ems? && console_supports_type?('VNC') if vmware?
     @record.console_supported?('vnc')
   end
 

--- a/spec/helpers/application_helper/buttons/vm_vnc_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_vnc_console_spec.rb
@@ -17,6 +17,11 @@ describe ApplicationHelper::Button::VmVncConsole do
         it_behaves_like 'vm_console_record_types', :vm_amazon => false
       end
     end
+
+    context 'vm console button is not visible' do
+      let(:record) { FactoryGirl.create(:vm_vmware, :ems_id => nil) }
+      it_behaves_like 'vm_console_not_visible?'
+    end
   end
 
   describe '#calculate_properties?' do

--- a/spec/support/examples_group/shared_examples_for_vm_console.rb
+++ b/spec/support/examples_group/shared_examples_for_vm_console.rb
@@ -1,7 +1,9 @@
 shared_examples 'vm_console_record_types' do |supported_records|
   supported_records.each do |type, support|
     context "and record is type of #{type}" do
-      let(:record) { FactoryGirl.create(type) }
+      let(:api_version) { 6.4 }
+      let(:ems) { FactoryGirl.create(:ems_vmware, :api_version => api_version) }
+      let(:record) { FactoryGirl.create(type, :ems_id => ems.id) }
       it { is_expected.to eq(support) }
     end
   end
@@ -31,6 +33,16 @@ shared_examples_for 'vm_console_visible?' do |console_type, records|
   context "when console does not support #{console_type}" do
     let(:remote_console_type) { "NOT_#{console_type}" }
     it { is_expected.to be_falsey }
+  end
+end
+
+shared_examples_for 'vm_console_not_visible?' do |console_type|
+  let(:remote_console_type) { console_type }
+  subject { button.visible? }
+  before { stub_settings(:server => {:remote_console_type => remote_console_type}) }
+
+  context "ems_id is not present" do
+    it { expect(subject).to be_falsey }
   end
 end
 


### PR DESCRIPTION
calling 'api_version' for VM with ems_id as nil was throwing an error when accessing Archived/Orphaned vmware VM summary screen(Need to set Console type support is set to 'VNC')

https://bugzilla.redhat.com/show_bug.cgi?id=1472973

@dclarizio please review/test

VMware VM with VNC console button
![vmware_vm](https://user-images.githubusercontent.com/3450808/28474844-1c229594-6e18-11e7-9284-67f2cbd32028.png)

Orphaned VMware VM with no VNC console button
![orphaned_vm](https://user-images.githubusercontent.com/3450808/28474847-20117e9a-6e18-11e7-8005-0e3f7f5e5544.png)
