### PR TITLE
Drop unnecessary resolutions from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -58,8 +58,6 @@
     "xml_display": "~0.1.1"
   },
   "resolutions": {
-    "patternfly-bootstrap-treeview": "~2.1.1",
-    "moment": ">=2.10.5",
     "d3": "~3.5.0",
     "jquery": "~2.2.4",
     "angular": "~1.6.3",


### PR DESCRIPTION
Drops these lines from the `bin/update` output:
```
bower patternfly-bootstrap-treeview              extra-resolution Unnecessary resolution: patternfly-bootstrap-treeview#~2.1.1
bower moment                                     extra-resolution Unnecessary resolution: moment#>=2.10.5
```

@miq-bot assign @himdel 