### PR TITLE
Add physical infra discovery page

### DIFF
--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -3,6 +3,7 @@ class EmsPhysicalInfraController < ApplicationController
   include Mixins::GenericShowMixin
   include EmsCommon # common methods for EmsInfra/Cloud controllers
   include Mixins::EmsCommonAngular
+  include Mixins::GenericSessionMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/mixins/actions/host_actions/discover.rb
+++ b/app/controllers/mixins/actions/host_actions/discover.rb
@@ -21,16 +21,7 @@ module Mixins
           if session[:type] == "hosts"
             @discover_type = Host.host_discovery_types
           elsif session[:type] == "ems"
-            if request.parameters[:controller] == 'ems_infra'
-              @discover_type = ExtManagementSystem.ems_infra_discovery_types
-            elsif request.parameters[:controller] == 'ems_physical_infra'
-              @discover_type = ExtManagementSystem.ems_physical_infra_discovery_types
-            else
-              @discover_type = ManageIQ::Providers::CloudManager.subclasses.select(&:supports_discovery?).map do |cloud_manager|
-                [cloud_manager.description, cloud_manager.ems_type]
-              end
-              @discover_type_selected = @discover_type.first.try!(:last)
-            end
+            discover_type(request.parameters[:controller])
           else
             @discover_type = ExtManagementSystem.ems_infra_discovery_types
           end
@@ -206,6 +197,21 @@ module Mixins
             elsif @ipmi == false
               page << javascript_hide("discover_credentials")
             end
+          end
+        end
+
+        private
+        
+        def discover_type(controller)
+          if controller == 'ems_infra'
+            @discover_type = ExtManagementSystem.ems_infra_discovery_types
+          elsif controller == 'ems_physical_infra'
+            @discover_type = ExtManagementSystem.ems_physical_infra_discovery_types
+          else
+            @discover_type = ManageIQ::Providers::CloudManager.subclasses.select(&:supports_discovery?).map do |cloud_manager|
+              [cloud_manager.description, cloud_manager.ems_type]
+            end
+            @discover_type_selected = @discover_type.first.try!(:last)
           end
         end
       end

--- a/app/controllers/mixins/actions/host_actions/discover.rb
+++ b/app/controllers/mixins/actions/host_actions/discover.rb
@@ -23,6 +23,8 @@ module Mixins
           elsif session[:type] == "ems"
             if request.parameters[:controller] == 'ems_infra'
               @discover_type = ExtManagementSystem.ems_infra_discovery_types
+            elsif request.parameters[:controller] == 'ems_physical_infra'
+              @discover_type = ExtManagementSystem.ems_physical_infra_discovery_types
             else
               @discover_type = ManageIQ::Providers::CloudManager.subclasses.select(&:supports_discovery?).map do |cloud_manager|
                 [cloud_manager.description, cloud_manager.ems_type]

--- a/app/controllers/mixins/actions/host_actions/discover.rb
+++ b/app/controllers/mixins/actions/host_actions/discover.rb
@@ -201,7 +201,7 @@ module Mixins
         end
 
         private
-        
+
         def discover_type(controller)
           if controller == 'ems_infra'
             @discover_type = ExtManagementSystem.ems_infra_discovery_types

--- a/app/helpers/application_helper/discover.rb
+++ b/app/helpers/application_helper/discover.rb
@@ -13,6 +13,7 @@ module ApplicationHelper
         "scvmm"           => _("Microsoft System Center VMM"),
         "virtualcenter"   => _("VMware vCenter"),
         "vmwareserver"    => _("VMware Server"),
+        "lxca"            => _("Lenovo XClarity Administrator")
       }
 
       if dtypes.key?(dtype)

--- a/app/helpers/application_helper/toolbar/ems_physical_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_physical_infras_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::EmsPhysicalInfrasCenter < ApplicationHelper::T
         button(
           :ems_physical_infra_discover,
           'fa fa-search fa-lg',
-          t = N_('Discover Infrastructure Providers'),
+          t = N_('Discover Physical Infrastructure Providers'),
           t,
           :url       => "/discover",
           :url_parms => "?discover_type=ems"),

--- a/app/views/ems_physical_infra/discover.html.haml
+++ b/app/views/ems_physical_infra/discover.html.haml
@@ -1,9 +1,8 @@
-- url = url_for_only_path :action => 'discover_field_changed'
+- url = url_for_only_path(:action => 'discover_field_changed')
 = render :partial => 'layouts/flash_msg'
-= form_tag({:action => 'discover'},
-           :id     => 'discover_form',
-           :class  => "form-horizontal",
-           :method => :post) do
+= form_tag({:action => 'discover'}, {:id     => 'discover_form',
+                                     :class  => "form-horizontal",
+                                     :method => :post}) do
   %h3
     = _('Discover Type')
   - i = 0
@@ -36,7 +35,7 @@
                          @from[order.to_sym],
                          :size              => "3",
                          :maxlength         => 3,
-                         "data-miq_focus"   => (index == 0),
+                         "data-miq_focus"   => index.zero?,
                          "data-miq_observe" => {:interval => '.5',
                                                 :url      => url}.to_json)
   .form-group

--- a/app/views/ems_physical_infra/discover.html.haml
+++ b/app/views/ems_physical_infra/discover.html.haml
@@ -1,0 +1,71 @@
+- url = url_for_only_path :action => 'discover_field_changed'
+= render :partial => 'layouts/flash_msg'
+= form_tag({:action => 'discover'},
+           :id     => 'discover_form',
+           :class  => "form-horizontal",
+           :method => :post) do
+  %h3
+    = _('Discover Type')
+  - i = 0
+  - while i < @discover_type.length
+    .form-group
+      - if @discover_type.length == 1
+        %label.col-md-2.control-label
+          = check_box_tag("discover_type_#{@discover_type[i]}",
+                          "1",
+                          true,
+                          :id       => "discover_type_#{@discover_type[i]}",
+                          :disabled => "disabled")
+      - else
+        %label.col-md-2.control-label
+          = check_box_tag("discover_type_#{@discover_type[i]}",
+                          "1",
+                          @discover_type_checked.include?(@discover_type[i]),
+                          "data-miq_observe_checkbox" => {:url => url}.to_json)
+      .col-md-8
+        = h(discover_type(@discover_type[i]))
+    - i += 1
+  %h3
+    = _("Subnet Range")
+  .form-group
+    %label.col-md-2.control-label
+      = _("From Address")
+    .col-md-8
+      - %w(first second third fourth).each_with_index do |order, index|
+        = text_field_tag("from_#{order}",
+                         @from[order.to_sym],
+                         :size              => "3",
+                         :maxlength         => 3,
+                         "data-miq_focus"   => (index == 0),
+                         "data-miq_observe" => {:interval => '.5',
+                                                :url      => url}.to_json)
+  .form-group
+    %label.col-md-2.control-label
+      = _("To Address")
+    .col-md-8
+      - %w(first second third).each do |order|
+        = text_field('to', order,
+                     :readonly  => "readonly",
+                     :size      => "3",
+                     :maxlength => 3,
+                     :value     => @to[order.to_sym],
+                     :disabled  => "disabled")
+      = text_field_tag("to_fourth",
+                       @to[:fourth],
+                       :size              => "3",
+                       :maxlength         => 3,
+                       "data-miq_observe" => {:interval => '.5',
+                                              :url      => url}.to_json)
+  .pull-right
+    = button_tag(_("Start"),
+                   :class => "btn btn-primary",
+                   :name  => "start",
+                   :alt   => t = _("Start the %{host} Discovery") % {:host => title_for_host},
+                   :title => t,
+                   :type  => "submit")
+    = button_tag(_("Cancel"),
+                   :class => "btn btn-default",
+                   :name  => "cancel",
+                   :alt   => t = _("Cancel"),
+                   :title => t,
+                   :type  => "submit")


### PR DESCRIPTION
This Pull Request adds a new page for compute/physical-infrastructure label. The discovery page requests the user to input the from address and to addres to make the provider discovery.
![captura de tela de 2017-07-20 10-40-01](https://user-images.githubusercontent.com/17187082/28419982-162e78b0-6d37-11e7-84ba-d8e5dadf107c.png)

Depends On: https://github.com/ManageIQ/manageiq/pull/15607