### PR TITLE
Alter Button Group hover text

### DIFF
--- a/app/views/shared/buttons/_ab_list.html.haml
+++ b/app/views/shared/buttons/_ab_list.html.haml
@@ -69,7 +69,7 @@
     .form-horizontal.static
       .form-group
         %label.control-label.col-md-2
-          = _('Button Text')
+          = _('Button Group Text')
         .col-md-8
           = @record.name.split('|').first
           - display = @record.set_data.key?(:display) ? @record.set_data[:display] : true
@@ -79,11 +79,9 @@
               = check_box_tag(display, true, display, :disabled => true)
               = _('Display on Button')
 
-
-
       .form-group
         %label.control-label.col-md-2
-          = _('Button Hover Text')
+          = _('Button Hover Group Text')
         .col-md-8
           = @record.description
       .form-group


### PR DESCRIPTION
Add 'Group" to the label boxes when displaying (Custom) Button Groups detail page

https://bugzilla.redhat.com/show_bug.cgi?id=1467906

Screen shot after code fix:
![custom button group detail page](https://user-images.githubusercontent.com/552686/28436911-8eac86fe-6d4d-11e7-9fd7-879137feff9c.png)
