### PR TITLE
Introducing some new decorators to remove some old icon helper code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1006,7 +1006,7 @@ class ApplicationController < ActionController::Base
       if has_listicon
         item = listicon_item(view, row['id'])
         icon, icon2, image = listicon_glyphicon(item)
-        image = fileicon(item, view) unless image
+        image = "100/#{(@listicon || view.db).underscore}.png" if icon.nil? && image.nil? # TODO: we want to get rid of this
         icon = nil if %w(pxe).include? params[:controller]
         new_row[:img_url] = ActionController::Base.helpers.image_path(image.to_s)
         new_row[:cells] << {:title => _('View this item'),
@@ -1080,10 +1080,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def calculate_pct_img(val)
-    val == 100 ? 20 : ((val + 2) / 5.25).round # val is the percentage value of free space
-  end
-
   def listicon_item(view, id = nil)
     id = @id if id.nil?
 
@@ -1093,39 +1089,6 @@ class ApplicationController < ActionController::Base
       klass = view.db.constantize
       klass.find(id)    # Read the record from the db
     end
-  end
-
-  # Return the icon classname for the list view icon of a db,id pair
-  # this always supersedes fileicon if not nil
-  def listicon_icon(item)
-    item.decorate.try(:fonticon)
-  end
-
-  # Return the image name for the list view icon of a db,id pair
-  def fileicon(item, view)
-    default = "100/#{(@listicon || view.db).underscore}.png"
-    image = case item
-            when EventLog
-              "100/event_logs.png"
-            when OsProcess
-              "100/processes.png"
-            when Storage
-              "100/piecharts/datastore/#{calculate_pct_img(item.v_free_space_percent_of_total)}.png"
-            when MiqRequest
-              item.decorate.fileicon || "100/#{@listicon.downcase}.png" if @listicon.try(:downcase)
-            when Account
-              "100/#{item.accttype}.png"
-            when SystemService
-              "100/service.png"
-            when ManageIQ::Providers::CloudManager::AuthKeyPair
-              "100/auth_key_pair.png"
-            when MiqWorker
-              "100/processmanager-#{item.normalized_type}.png" if item.try(:normalized_type)
-            else
-              item.decorate.try(:fileicon) if item
-            end
-
-    image || default
   end
 
   def get_host_for_vm(vm)

--- a/app/controllers/ems_datawarehouse_controller.rb
+++ b/app/controllers/ems_datawarehouse_controller.rb
@@ -31,10 +31,6 @@ class EmsDatawarehouseController < ApplicationController
     ems_datawarehouse_path(*args)
   end
 
-  def fileicon(item, _view)
-    item.decorate.try(:fileicon)
-  end
-
   def new_ems_path
     new_ems_datawarehouse_path
   end

--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -30,10 +30,6 @@ class EmsMiddlewareController < ApplicationController
     new_ems_middleware_path
   end
 
-  def fileicon(item, _view)
-    icon = item.decorate.try(:fileicon)
-  end
-
   def restful?
     true
   end

--- a/app/decorators/account_decorator.rb
+++ b/app/decorators/account_decorator.rb
@@ -1,0 +1,9 @@
+class AccountDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-user'
+  end
+
+  def fonticon
+    accttype == 'group' ? 'ff ff-group' : super
+  end
+end

--- a/app/decorators/event_log_decorator.rb
+++ b/app/decorators/event_log_decorator.rb
@@ -1,0 +1,5 @@
+class EventLogDecorator < MiqDecorator
+  def self.fonticon
+    'fa fa-file-text-o'
+  end
+end

--- a/app/decorators/manageiq/providers/cloud_manager/auth_key_pair_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager/auth_key_pair_decorator.rb
@@ -1,0 +1,7 @@
+module ManageIQ::Providers
+  class CloudManager::AuthKeyPairDecorator < MiqDecorator
+    def self.fileicon
+      '100/auth_key_pair.png'
+    end
+  end
+end

--- a/app/decorators/miq_request_decorator.rb
+++ b/app/decorators/miq_request_decorator.rb
@@ -14,8 +14,8 @@ class MiqRequestDecorator < MiqDecorator
       "100/checkmark.png"
     when "error"
       "100/x.png"
-    # else - handled in application controller
-    #  "100/#{@listicon.downcase}.png"
+    else
+      "100/miq_request.png"
     end
   end
 end

--- a/app/decorators/os_process_decorator.rb
+++ b/app/decorators/os_process_decorator.rb
@@ -1,0 +1,5 @@
+class OsProcessDecorator < MiqDecorator
+  def self.fonticon
+    'fa fa-cog'
+  end
+end

--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -2,4 +2,9 @@ class StorageDecorator < MiqDecorator
   def self.fonticon
     'fa fa-database'
   end
+
+  def fileicon
+    percent = v_free_space_percent_of_total == 100 ? 20 : ((v_free_space_percent_of_total + 2) / 5.25).round # val is the percentage value of free space
+    "100/piecharts/datastore/#{percent}.png"
+  end
 end

--- a/app/decorators/system_service_decorator.rb
+++ b/app/decorators/system_service_decorator.rb
@@ -1,0 +1,5 @@
+class SystemServiceDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-service'
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1584,24 +1584,6 @@ module ApplicationHelper
     end
   end
 
-  def listicon_glyphicon_tag(item)
-    item = db.constantize.find(row["id"])
-    glyphicon, glyphicon2 = listicon_glyphicon(item)
-
-    content_tag(:i, nil, :class => glyphicon) do
-      content_tag(:i, nil, :class => glyphicon2) if glyphicon2
-    end
-  end
-
-  def listicon_tag(db, row)
-    item = db.constantize.find(row["id"])
-    if %w(MiqReportResult MiqSchedule MiqUserRole MiqWidget).include?(db)
-      listicon_glyphicon_tag(item)
-    else
-      fileicon_tag(item)
-    end
-  end
-
   # Wrapper around jquery-rjs' remote_function which adds an extra .html_safe()
   # Remove if merged: https://github.com/amatsuda/jquery-rjs/pull/3
   def remote_function(options)


### PR DESCRIPTION
- Created new decorators for classes handled in [fileicon](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...skateman:refactor-icon-tag?expand=1#diff-55c5b7aecfb519d0e4880eaf2788eb6eL1105) and dropped the method
- Removed code that died when @karelhala angularized the GTL

TODO: @epwinchell can you please verify that I used the correct icons?

@himdel, @martinpovolny, @karelhala, @epwinchell please review