### PR TITLE
Pass record to report_data when accessing running processes and event logs

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -355,6 +355,10 @@
 
   ReportDataController.prototype.movePagination = function() {
     this.$timeout(function() {
+      var sortItems = this.$document.getElementsByClassName('miq-sort-items');
+      if (sortItems) {
+        angular.element(sortItems).addClass(this.settings.dropDownClass[0]);
+      }
       $('table td.narrow').addClass('table-view-pf-select').removeClass('narrow');
       var pagination = this.$document.getElementsByClassName('miq-pagination');
       var pagingDiv = this.$document.querySelector('#paging_div');

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -323,9 +323,8 @@ class ApplicationController < ActionController::Base
     if params[:model] == "physical_servers_with_host"
       options.merge!(generate_options)
     end
-
     options[:parent] = options[:parent] || @parent
-    options[:association] = HAS_ASSOCATION[params[:model]] if HAS_ASSOCATION.include? params[:model]
+    options[:association] = HAS_ASSOCATION[params[:model]] if HAS_ASSOCATION.include?(params[:model])
     options[:selected_ids] = params[:records]
     options
   end
@@ -418,6 +417,7 @@ class ApplicationController < ActionController::Base
     bc_text = @record.kind_of?(Vm) ? _("Event Logs") : _("ESX Logs")
     @sb[:action] = params[:action]
     @explorer = true if @record.kind_of?(VmOrTemplate)
+    params[:display] = "event_logs"
     if !params[:show].nil? || !params[:x_show].nil?
       id = params[:show] ? params[:show] : params[:x_show]
       @item = @record.event_logs.find(from_cid(id))
@@ -1106,7 +1106,7 @@ class ApplicationController < ActionController::Base
     default = "100/#{(@listicon || view.db).underscore}.png"
     image = case item
             when EventLog
-              "100/#{@listicon.downcase}.png"
+              "100/event_logs.png"
             when OsProcess
               "100/processes.png"
             when Storage
@@ -1404,9 +1404,6 @@ class ApplicationController < ActionController::Base
       object_ids = @edit[:pol_items] unless @edit[:pol_items].nil?
     end
     object_ids   = params[:records].map(&:to_i) unless params[:records].nil?
-    if !object_ids.nil? && object_ids.length == 1 && !options[:parent].nil? && object_ids.include?(options[:parent].id)
-      object_ids   = nil
-    end
     db           = db.to_s
     dbname       = options[:dbname] || db.gsub('::', '_').downcase # Get db name as text
     db_sym       = (options[:gtl_dbname] || dbname).to_sym # Get db name as symbol

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -325,7 +325,7 @@ class ApplicationController < ActionController::Base
     end
 
     options[:parent] = options[:parent] || @parent
-    options[:association] = params[:model] if HAS_ASSOCATION.include? params[:model]
+    options[:association] = HAS_ASSOCATION[params[:model]] if HAS_ASSOCATION.include? params[:model]
     options[:selected_ids] = params[:records]
     options
   end
@@ -1105,8 +1105,10 @@ class ApplicationController < ActionController::Base
   def fileicon(item, view)
     default = "100/#{(@listicon || view.db).underscore}.png"
     image = case item
-            when EventLog, OsProcess
+            when EventLog
               "100/#{@listicon.downcase}.png"
+            when OsProcess
+              "100/processes.png"
             when Storage
               "100/piecharts/datastore/#{calculate_pct_img(item.v_free_space_percent_of_total)}.png"
             when MiqRequest
@@ -1402,6 +1404,9 @@ class ApplicationController < ActionController::Base
       object_ids = @edit[:pol_items] unless @edit[:pol_items].nil?
     end
     object_ids   = params[:records].map(&:to_i) unless params[:records].nil?
+    if !object_ids.nil? && object_ids.length == 1 && !options[:parent].nil? && object_ids.include?(options[:parent].id)
+      object_ids   = nil
+    end
     db           = db.to_s
     dbname       = options[:dbname] || db.gsub('::', '_').downcase # Get db name as text
     db_sym       = (options[:gtl_dbname] || dbname).to_sym # Get db name as symbol

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -890,6 +890,7 @@ module VmCommon
     end
     @lastaction = "scan_histories"
     @sb[:action] = params[:action]
+    params[:display] = "scan_histories"
     if !params[:show].nil? || !params[:x_show].nil?
       id = params[:show] ? params[:show] : params[:x_show]
       @item = ScanHistory.find(from_cid(id))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -224,10 +224,11 @@ module ApplicationHelper
     "manageiq/providers/automation_managers" => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
   }.freeze
 
-  HAS_ASSOCATION = %w(
-    groups
-    users
-  ).freeze
+  HAS_ASSOCATION = {
+    "groups"    => "groups",
+    "users"     => "users",
+    "OsProcess" => "processes"
+  }.freeze
 
   def model_to_report_data
     current_model = if !@display.nil? && @display != "main"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -225,9 +225,11 @@ module ApplicationHelper
   }.freeze
 
   HAS_ASSOCATION = {
-    "groups"    => "groups",
-    "users"     => "users",
-    "OsProcess" => "processes"
+    "groups"         => "groups",
+    "users"          => "users",
+    "event_logs"     => "event_logs",
+    "OsProcess"      => "processes",
+    "scan_histories" => "scan_histories"
   }.freeze
 
   def model_to_report_data

--- a/app/views/layouts/angular/_gtl.html.haml
+++ b/app/views/layouts/angular/_gtl.html.haml
@@ -5,7 +5,6 @@
 - selected_records = @edit[:object_ids] unless @edit.nil? || @edit[:object_ids].nil?
 - selected_records = @edit[:pol_items] unless @edit.nil? || @edit[:pol_items].nil?
 - selected_records = params[:rec_ids] unless params.nil? || params[:rec_ids].nil?
-- selected_records = [@record] if selected_records.nil? && !@record.nil?
 - selected_records = selected_records.map(&:to_i) if !selected_records.nil? && selected_records.first.kind_of?(String)
 - selected_records = selected_records.map(&:id) if !selected_records.nil? && !selected_records.first.kind_of?(Integer)
 #miq-gtl-view{"ng-controller" => "reportDataController as dataCtrl"}

--- a/app/views/layouts/angular/_gtl.html.haml
+++ b/app/views/layouts/angular/_gtl.html.haml
@@ -5,6 +5,7 @@
 - selected_records = @edit[:object_ids] unless @edit.nil? || @edit[:object_ids].nil?
 - selected_records = @edit[:pol_items] unless @edit.nil? || @edit[:pol_items].nil?
 - selected_records = params[:rec_ids] unless params.nil? || params[:rec_ids].nil?
+- selected_records = [@record] if selected_records.nil? && !@record.nil?
 - selected_records = selected_records.map(&:to_i) if !selected_records.nil? && selected_records.first.kind_of?(String)
 - selected_records = selected_records.map(&:id) if !selected_records.nil? && !selected_records.first.kind_of?(Integer)
 #miq-gtl-view{"ng-controller" => "reportDataController as dataCtrl"}


### PR DESCRIPTION
### Fixes problems with process, event logs and analysis history screens
When accessing these screens all VMs were shown, because currently viewed items were not passed to report_data method.

Steps for Testing/QA
-------------------------------
1) Go to detail of VM
  * Click on Event logs

2) Go to detail of VM
  * Click on Processes

3) Go to detail of VM
  * Click on Analysis history
