### PR TITLE
Optional chargeback allocated calculation 

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -3,6 +3,7 @@ module ReportController::Reports::Editor
 
   included do
     helper_method :cashed_reporting_available_fields, :cashed_reporting_available_fields
+    helper_method :chargeback_allocated_methods, :chargeback_allocated_methods
   end
 
   DEFAULT_PDF_PAGE_SIZE = "US-Letter".freeze
@@ -19,6 +20,10 @@ module ReportController::Reports::Editor
     -vm_guid
     -vm_uid
   ).freeze
+
+  def chargeback_allocated_methods
+    Hash[CHAREGEBACK_ALLOCATED_METHODS.map { |x| _(x) }]
+  end
 
   def miq_report_new
     assert_privileges("miq_report_new")

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -25,6 +25,10 @@ module ReportController::Reports::Editor
     Hash[CHAREGEBACK_ALLOCATED_METHODS.map { |x| _(x) }]
   end
 
+  def default_chargeback_allocated_method
+    chargeback_allocated_methods.keys.first
+  end
+
   def miq_report_new
     assert_privileges("miq_report_new")
     @_params.delete :id # incase add button was pressed from report show screen.
@@ -524,7 +528,7 @@ module ReportController::Reports::Editor
         @edit[:new][:cb_groupby] ||= "date"                     # Default to Date grouping
         @edit[:new][:tz] = session[:user_tz]
         @edit[:new][:cb_include_metrics] = true if @edit[:new][:model] == 'ChargebackVm'
-        @edit[:new][:method_for_allocated_metrics] = DEFAULT_CHARGEBACK_ALLOCATED_METHOD
+        @edit[:new][:method_for_allocated_metrics] = default_chargeback_allocated_method
       end
       reset_report_col_fields
       build_edit_screen
@@ -619,7 +623,7 @@ module ReportController::Reports::Editor
     elsif params.key?(:cb_include_metrics)
       @edit[:new][:cb_include_metrics] = params[:cb_include_metrics] == 'true'
     elsif params.key?(:method_for_allocated_metrics)
-      @edit[:new][:method_for_allocated_metrics] = params[:method_for_allocated_metrics].try(:to_sym) || DEFAULT_CHARGEBACK_ALLOCATED_METHOD
+      @edit[:new][:method_for_allocated_metrics] = params[:method_for_allocated_metrics].try(:to_sym) || default_chargeback_allocated_method
     elsif params.key?(:cb_owner_id)
       @edit[:new][:cb_owner_id] = params[:cb_owner_id].blank? ? nil : params[:cb_owner_id]
     elsif params.key?(:cb_tenant_id)
@@ -1306,7 +1310,7 @@ module ReportController::Reports::Editor
 
       # @edit[:new][:cb_include_metrics] = nil - it means YES (YES is default value for new and legacy reports)
       @edit[:new][:cb_include_metrics] = options[:include_metrics].nil? || options[:include_metrics]
-      @edit[:new][:method_for_allocated_metrics] = options[:method_for_allocated_metrics].try(:to_sym) || DEFAULT_CHARGEBACK_ALLOCATED_METHOD
+      @edit[:new][:method_for_allocated_metrics] = options[:method_for_allocated_metrics].try(:to_sym) || default_chargeback_allocated_method
       @edit[:new][:cb_groupby_tag] = options[:groupby_tag] if options.key?(:groupby_tag)
       @edit[:new][:cb_model] = Chargeback.report_cb_model(@rpt.db)
       @edit[:new][:cb_interval] = options[:interval]

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -519,6 +519,7 @@ module ReportController::Reports::Editor
         @edit[:new][:cb_groupby] ||= "date"                     # Default to Date grouping
         @edit[:new][:tz] = session[:user_tz]
         @edit[:new][:cb_include_metrics] = true if @edit[:new][:model] == 'ChargebackVm'
+        @edit[:new][:method_for_allocated_metrics] = DEFAULT_CHARGEBACK_ALLOCATED_METHOD
       end
       reset_report_col_fields
       build_edit_screen
@@ -612,6 +613,8 @@ module ReportController::Reports::Editor
       end
     elsif params.key?(:cb_include_metrics)
       @edit[:new][:cb_include_metrics] = params[:cb_include_metrics] == 'true'
+    elsif params.key?(:method_for_allocated_metrics)
+      @edit[:new][:method_for_allocated_metrics] = params[:method_for_allocated_metrics].try(:to_sym) || DEFAULT_CHARGEBACK_ALLOCATED_METHOD
     elsif params.key?(:cb_owner_id)
       @edit[:new][:cb_owner_id] = params[:cb_owner_id].blank? ? nil : params[:cb_owner_id]
     elsif params.key?(:cb_tenant_id)
@@ -1013,6 +1016,7 @@ module ReportController::Reports::Editor
         options[:entity_id] = @edit[:new][:cb_entity_id]
       end
 
+      options[:method_for_allocated_metrics] = @edit[:new][:method_for_allocated_metrics]
       options[:include_metrics] = @edit[:new][:cb_include_metrics]
       options[:groupby] = @edit[:new][:cb_groupby]
       options[:groupby_tag] = @edit[:new][:cb_groupby] == 'tag' ? @edit[:new][:cb_groupby_tag] : nil
@@ -1297,6 +1301,7 @@ module ReportController::Reports::Editor
 
       # @edit[:new][:cb_include_metrics] = nil - it means YES (YES is default value for new and legacy reports)
       @edit[:new][:cb_include_metrics] = options[:include_metrics].nil? || options[:include_metrics]
+      @edit[:new][:method_for_allocated_metrics] = options[:method_for_allocated_metrics].try(:to_sym) || DEFAULT_CHARGEBACK_ALLOCATED_METHOD
       @edit[:new][:cb_groupby_tag] = options[:groupby_tag] if options.key?(:groupby_tag)
       @edit[:new][:cb_model] = Chargeback.report_cb_model(@rpt.db)
       @edit[:new][:cb_interval] = options[:interval]

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -499,7 +499,6 @@ module UiConstants
   CHAREGEBACK_ALLOCATED_METHODS = {}
   CHAREGEBACK_ALLOCATED_METHODS[:max] = N_('Maximum')
   CHAREGEBACK_ALLOCATED_METHODS[:avg] = N_('Average')
-  DEFAULT_CHARGEBACK_ALLOCATED_METHOD = CHAREGEBACK_ALLOCATED_METHODS.keys.first
 end
 
 # Make these constants globally available

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -495,6 +495,11 @@ module UiConstants
 
   UTF_16BE_BOM = [254, 255].freeze
   UTF_16LE_BOM = [255, 254].freeze
+
+  CHAREGEBACK_ALLOCATED_METHODS = {}
+  CHAREGEBACK_ALLOCATED_METHODS[:max] = N_('Maximum')
+  CHAREGEBACK_ALLOCATED_METHODS[:avg] = N_('Average')
+  DEFAULT_CHARGEBACK_ALLOCATED_METHOD = CHAREGEBACK_ALLOCATED_METHODS.keys.first
 end
 
 # Make these constants globally available

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -17,7 +17,7 @@
       %label.control-label.col-md-2
         = _('Method for allocated metrics')
       .col-md-8
-        - opts = CHAREGEBACK_ALLOCATED_METHODS.invert.to_a
+        - opts = chargeback_allocated_methods.invert.to_a
         = select_tag("method_for_allocated_metrics",
           options_for_select(opts, @edit[:new][:method_for_allocated_metrics]), :class => "selectpicker")
         :javascript

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -12,6 +12,17 @@
                         :data => {:on_text => _('Yes'), :off_text => _('No')})
       :javascript
         miqInitBootstrapSwitch('cb_include_metrics', "#{url}")
+
+    .form-group
+      %label.control-label.col-md-2
+        = _('Method for allocated metrics')
+      .col-md-8
+        - opts = CHAREGEBACK_ALLOCATED_METHODS.invert.to_a
+        = select_tag("method_for_allocated_metrics",
+          options_for_select(opts, @edit[:new][:method_for_allocated_metrics]), :class => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent('method_for_allocated_metrics', '#{url}', {beforeSend: true, complete: true});
 %h3
   = _('Chargeback Filters')
 .form-horizontal


### PR DESCRIPTION
Adding the parameter to report definition to be able to select another method for chargeback calculation.

![screen shot 2017-07-21 at 15 32 22](https://user-images.githubusercontent.com/14937244/28465741-216dd9a2-6e2a-11e7-8939-94ee419f77c6.png)

Links
----------------
* Backend PR https://github.com/ManageIQ/manageiq/pull/15565
* similar PR (not related just similar as this) https://github.com/ManageIQ/manageiq-ui-classic/pull/366

cc @gtanzillo 
@miq-bot assign @himdel 

@miq_bot add_label enhancement
