### PR TITLE
Added input field for max playbook_ttl value

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -15,7 +15,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       provisioning_machine_credential_id: '',
       provisioning_network_credential_id: '',
       provisioning_cloud_credential_id: '',
-      provisioning_playbook_ttl: '',
+      provisioning_execution_ttl: '',
       provisioning_inventory: 'localhost',
       provisioning_dialog_existing: 'existing',
       provisioning_dialog_id: '',
@@ -31,7 +31,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       retirement_machine_credential_id: '',
       retirement_network_credential_id: '',
       retirement_cloud_credential_id: '',
-      retirement_playbook_ttl: '',
+      retirement_execution_ttl: '',
       retirement_inventory: 'localhost',
       retirement_key: '',
       retirement_value: '',
@@ -125,7 +125,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     vm.catalogItemModel.provisioning_machine_credential_id = configData.provision.credential_id;
     vm.catalogItemModel.provisioning_network_credential_id = configData.provision.network_credential_id;
     vm.catalogItemModel.provisioning_cloud_credential_id = setIfDefined(configData.provision.cloud_credential_id);
-    vm.catalogItemModel.provisioning_playbook_ttl = configData.provision.playbook_ttl;
+    vm.catalogItemModel.provisioning_execution_ttl = configData.provision.execution_ttl;
     vm.catalogItemModel.provisioning_inventory = configData.provision.hosts;
     vm.catalogItemModel.provisioning_dialog_existing = configData.provision.dialog_id ? "existing" : "create";
     vm.catalogItemModel.provisioning_dialog_id = configData.provision.dialog_id;
@@ -167,7 +167,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
 
     vm.catalogItemModel.retirement_network_credential_id = configData.retirement.network_credential_id;
     vm.catalogItemModel.retirement_cloud_credential_id = setIfDefined(configData.retirement.cloud_credential_id);
-    vm.catalogItemModel.retirement_playbook_ttl = configData.retirement.playbook_ttl;
+    vm.catalogItemModel.retirement_execution_ttl = configData.retirement.execution_ttl;
     vm.catalogItemModel.retirement_inventory = configData.retirement.hosts;
     vm.catalogItemModel.retirement_key = '';
     vm.catalogItemModel.retirement_value = '';
@@ -251,8 +251,8 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
         }
       }
     }
-    if (vm.catalogItemModel.provisioning_playbook_ttl !== undefined)
-      catalog_item['config_info']['provision']['playbook_ttl'] = configData.provisioning_playbook_ttl;
+    if (vm.catalogItemModel.provisioning_execution_ttl !== undefined)
+      catalog_item['config_info']['provision']['execution_ttl'] = configData.provisioning_execution_ttl;
     catalog_item['config_info']['provision']['become_enabled'] = configData.provisioning_become_enabled;
     if (configData.provisioning_network_credential_id !== '')
       catalog_item['config_info']['provision']['network_credential_id'] = configData.provisioning_network_credential_id;
@@ -277,8 +277,8 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       retirement['credential_id'] = configData.retirement_machine_credential_id;
     }
     if (vm.catalogItemModel.retirement_playbook_id !== undefined && configData.retirement_playbook_id !== '') {
-      if (vm.catalogItemModel.retirement_playbook_ttl !== undefined)
-        retirement['playbook_ttl'] = configData.retirement_playbook_ttl;
+      if (vm.catalogItemModel.retirement_execution_ttl !== undefined)
+        retirement['execution_ttl'] = configData.retirement_execution_ttl;
       retirement['hosts'] = configData.retirement_inventory;
       retirement['extra_vars'] = formatExtraVars(configData.retirement_variables);
       catalog_item['config_info']['retirement']['become_enabled'] = configData.retirement_become_enabled;
@@ -577,7 +577,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     vm.retirement_cloud_type = vm.provisioning_cloud_type;
     vm._retirement_cloud_type = vm.provisioning_cloud_type;
     vm.catalogItemModel.retirement_cloud_credential_id = vm.catalogItemModel.provisioning_cloud_credential_id;
-    vm.catalogItemModel.retirement_playbook_ttl = vm.catalogItemModel.provisioning_playbook_ttl;
+    vm.catalogItemModel.retirement_execution_ttl = vm.catalogItemModel.provisioning_execution_ttl;
     vm.catalogItemModel.retirement_inventory = vm.catalogItemModel.provisioning_inventory;
     vm.catalogItemModel.retirement_become_enabled = vm.catalogItemModel.provisioning_become_enabled;
     vm.catalogItemModel.retirement_verbosity = vm.catalogItemModel.provisioning_verbosity;

--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -15,6 +15,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       provisioning_machine_credential_id: '',
       provisioning_network_credential_id: '',
       provisioning_cloud_credential_id: '',
+      provisioning_playbook_ttl: '',
       provisioning_inventory: 'localhost',
       provisioning_dialog_existing: 'existing',
       provisioning_dialog_id: '',
@@ -30,6 +31,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       retirement_machine_credential_id: '',
       retirement_network_credential_id: '',
       retirement_cloud_credential_id: '',
+      retirement_playbook_ttl: '',
       retirement_inventory: 'localhost',
       retirement_key: '',
       retirement_value: '',
@@ -123,6 +125,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     vm.catalogItemModel.provisioning_machine_credential_id = configData.provision.credential_id;
     vm.catalogItemModel.provisioning_network_credential_id = configData.provision.network_credential_id;
     vm.catalogItemModel.provisioning_cloud_credential_id = setIfDefined(configData.provision.cloud_credential_id);
+    vm.catalogItemModel.provisioning_playbook_ttl = configData.provision.playbook_ttl;
     vm.catalogItemModel.provisioning_inventory = configData.provision.hosts;
     vm.catalogItemModel.provisioning_dialog_existing = configData.provision.dialog_id ? "existing" : "create";
     vm.catalogItemModel.provisioning_dialog_id = configData.provision.dialog_id;
@@ -164,6 +167,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
 
     vm.catalogItemModel.retirement_network_credential_id = configData.retirement.network_credential_id;
     vm.catalogItemModel.retirement_cloud_credential_id = setIfDefined(configData.retirement.cloud_credential_id);
+    vm.catalogItemModel.retirement_playbook_ttl = configData.retirement.playbook_ttl;
     vm.catalogItemModel.retirement_inventory = configData.retirement.hosts;
     vm.catalogItemModel.retirement_key = '';
     vm.catalogItemModel.retirement_value = '';
@@ -247,6 +251,8 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
         }
       }
     }
+    if (vm.catalogItemModel.provisioning_playbook_ttl !== undefined)
+      catalog_item['config_info']['provision']['playbook_ttl'] = configData.provisioning_playbook_ttl;
     catalog_item['config_info']['provision']['become_enabled'] = configData.provisioning_become_enabled;
     if (configData.provisioning_network_credential_id !== '')
       catalog_item['config_info']['provision']['network_credential_id'] = configData.provisioning_network_credential_id;
@@ -271,6 +277,8 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       retirement['credential_id'] = configData.retirement_machine_credential_id;
     }
     if (vm.catalogItemModel.retirement_playbook_id !== undefined && configData.retirement_playbook_id !== '') {
+      if (vm.catalogItemModel.retirement_playbook_ttl !== undefined)
+        retirement['playbook_ttl'] = configData.retirement_playbook_ttl;
       retirement['hosts'] = configData.retirement_inventory;
       retirement['extra_vars'] = formatExtraVars(configData.retirement_variables);
       catalog_item['config_info']['retirement']['become_enabled'] = configData.retirement_become_enabled;
@@ -569,6 +577,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     vm.retirement_cloud_type = vm.provisioning_cloud_type;
     vm._retirement_cloud_type = vm.provisioning_cloud_type;
     vm.catalogItemModel.retirement_cloud_credential_id = vm.catalogItemModel.provisioning_cloud_credential_id;
+    vm.catalogItemModel.retirement_playbook_ttl = vm.catalogItemModel.provisioning_playbook_ttl;
     vm.catalogItemModel.retirement_inventory = vm.catalogItemModel.provisioning_inventory;
     vm.catalogItemModel.retirement_become_enabled = vm.catalogItemModel.provisioning_become_enabled;
     vm.catalogItemModel.retirement_verbosity = vm.catalogItemModel.provisioning_verbosity;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1860,6 +1860,7 @@ class CatalogController < ApplicationController
     playbook_details[:provisioning][:network_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential, provision[:network_credential_id]) if provision[:network_credential_id]
     playbook_details[:provisioning][:cloud_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential, provision[:cloud_credential_id]) if provision[:cloud_credential_id]
     fetch_dialog(playbook_details, provision[:dialog_id], :provisioning)
+    playbook_details[:provisioning][:playbook_ttl] = provision[:playbook_ttl]
     playbook_details[:provisioning][:verbosity] = provision[:verbosity]
     playbook_details[:provisioning][:become_enabled] = provision[:become_enabled] == true ? _('Yes') : _('No')
 
@@ -1874,6 +1875,7 @@ class CatalogController < ApplicationController
         playbook_details[:retirement][:network_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential, retirement[:network_credential_id]) if retirement[:network_credential_id]
         playbook_details[:retirement][:cloud_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential, retirement[:cloud_credential_id]) if retirement[:cloud_credential_id]
       end
+      playbook_details[:retirement][:playbook_ttl] = retirement[:playbook_ttl]
       playbook_details[:retirement][:verbosity] = retirement[:verbosity]
       playbook_details[:retirement][:become_enabled] = retirement[:become_enabled] == true ? _('Yes') : _('No')
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1860,7 +1860,7 @@ class CatalogController < ApplicationController
     playbook_details[:provisioning][:network_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential, provision[:network_credential_id]) if provision[:network_credential_id]
     playbook_details[:provisioning][:cloud_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential, provision[:cloud_credential_id]) if provision[:cloud_credential_id]
     fetch_dialog(playbook_details, provision[:dialog_id], :provisioning)
-    playbook_details[:provisioning][:playbook_ttl] = provision[:playbook_ttl]
+    playbook_details[:provisioning][:execution_ttl] = provision[:execution_ttl]
     playbook_details[:provisioning][:verbosity] = provision[:verbosity]
     playbook_details[:provisioning][:become_enabled] = provision[:become_enabled] == true ? _('Yes') : _('No')
 
@@ -1875,7 +1875,7 @@ class CatalogController < ApplicationController
         playbook_details[:retirement][:network_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential, retirement[:network_credential_id]) if retirement[:network_credential_id]
         playbook_details[:retirement][:cloud_credential] = fetch_name_from_object(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential, retirement[:cloud_credential_id]) if retirement[:cloud_credential_id]
       end
-      playbook_details[:retirement][:playbook_ttl] = retirement[:playbook_ttl]
+      playbook_details[:retirement][:execution_ttl] = retirement[:execution_ttl]
       playbook_details[:retirement][:verbosity] = retirement[:verbosity]
       playbook_details[:retirement][:become_enabled] = retirement[:become_enabled] == true ? _('Yes') : _('No')
     end

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -239,6 +239,11 @@
                 = h(provisioning[:cloud_credential])
             .form-group
               %label.col-md-3.control-label
+                = _('Max TTL (mins)')
+              .col-md-9
+                = h(@record.config_info[:provision][:playbook_ttl])
+            .form-group
+              %label.col-md-3.control-label
                 = _('Hosts')
               .col-md-9
                 = h(@record.config_info[:provision][:hosts])
@@ -316,6 +321,11 @@
                   = _('Cloud Credential')
                 .col-md-9
                   = h(retirement[:cloud_credential])
+              .form-group
+                %label.col-md-3.control-label
+                  = _('Max TTL (mins)')
+                .col-md-9
+                  = h(@record.config_info[:retirement][:playbook_ttl])
               .form-group
                 %label.col-md-3.control-label
                   = _('Hosts')

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -241,7 +241,7 @@
               %label.col-md-3.control-label
                 = _('Max TTL (mins)')
               .col-md-9
-                = h(@record.config_info[:provision][:playbook_ttl])
+                = h(@record.config_info[:provision][:execution_ttl])
             .form-group
               %label.col-md-3.control-label
                 = _('Hosts')
@@ -325,7 +325,7 @@
                 %label.col-md-3.control-label
                   = _('Max TTL (mins)')
                 .col-md-9
-                  = h(@record.config_info[:retirement][:playbook_ttl])
+                  = h(@record.config_info[:retirement][:execution_ttl])
               .form-group
                 %label.col-md-3.control-label
                   = _('Hosts')

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -108,17 +108,17 @@
           %span.help-block{"ng-show" => "angularForm.#{prefix}_inventory.$error.miqrequired"}
             = _("Required")
 
-    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_playbook_ttl.$invalid}"}
-      %label.col-md-3.control-label{"for" => "#{prefix}_playbook_ttl"}
+    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_execution_ttl.$invalid}"}
+      %label.col-md-3.control-label{"for" => "#{prefix}_execution_ttl"}
         = _("Max TTL (mins)")
       .col-md-9
         %input.form-control{:type         => "text",
-                            'ng-model'    => "#{ng_model}.#{prefix}_playbook_ttl",
-                            :name         => "#{prefix}_playbook_ttl",
+                            'ng-model'    => "#{ng_model}.#{prefix}_execution_ttl",
+                            :name         => "#{prefix}_execution_ttl",
                             :maxlength    => 50,
                             "ng-pattern"  => "/^\s*$|^[-+]?[0-9]+$/",
                             "checkchange" => true}
-        %span{"style"=>"color:red", "ng-show" => "angularForm.#{prefix}_playbook_ttl.$invalid"}
+        %span{"style"=>"color:red", "ng-show" => "angularForm.#{prefix}_execution_ttl.$invalid"}
           = _("Max TTL value must be numeric")
 
     #escalate_privilege{"ng-if" => "vm.retirement_playbook_selected('#{prefix}')"}

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -107,6 +107,20 @@
                             "checkchange" => true}
           %span.help-block{"ng-show" => "angularForm.#{prefix}_inventory.$error.miqrequired"}
             = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_playbook_ttl.$invalid}"}
+      %label.col-md-3.control-label{"for" => "#{prefix}_playbook_ttl"}
+        = _("Max TTL (mins)")
+      .col-md-9
+        %input.form-control{:type         => "text",
+                            'ng-model'    => "#{ng_model}.#{prefix}_playbook_ttl",
+                            :name         => "#{prefix}_playbook_ttl",
+                            :maxlength    => 50,
+                            "ng-pattern"  => "/^\s*$|^[-+]?[0-9]+$/",
+                            "checkchange" => true}
+        %span{"style"=>"color:red", "ng-show" => "angularForm.#{prefix}_playbook_ttl.$invalid"}
+          = _("Max TTL value must be numeric")
+
     #escalate_privilege{"ng-if" => "vm.retirement_playbook_selected('#{prefix}')"}
       .form-group
         %label.col-md-3.control-label

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -768,7 +768,7 @@ describe CatalogController do
             :repository_id   => repository.id,
             :playbook_id     => playbook.id,
             :dialog_id       => dialog.id,
-            :playbook_ttl    => nil,
+            :execution_ttl   => nil,
             :verbosity       => 4
           },
           :retirement => {
@@ -777,7 +777,7 @@ describe CatalogController do
             :credential_id   => auth.id,
             :repository_id   => repository.id,
             :playbook_id     => playbook.id,
-            :playbook_ttl    => nil,
+            :execution_ttl   => nil,
             :verbosity       => 0
           }
         }
@@ -793,7 +793,7 @@ describe CatalogController do
           :dialog             => "Some Label",
           :dialog_id          => dialog.id,
           :become_enabled     => "No",
-          :playbook_ttl       => nil,
+          :execution_ttl      => nil,
           :verbosity          => 4
         },
         :retirement   => {
@@ -802,7 +802,7 @@ describe CatalogController do
           :playbook           => playbook.name,
           :machine_credential => auth.name,
           :become_enabled     => "No",
-          :playbook_ttl       => nil,
+          :execution_ttl      => nil,
           :verbosity          => 0
         }
       }
@@ -822,7 +822,7 @@ describe CatalogController do
             :repository_id   => 1,
             :playbook_id     => playbook.id,
             :dialog_id       => 2,
-            :playbook_ttl    => nil,
+            :execution_ttl   => nil,
             :verbosity       => 4
           },
           :retirement => {
@@ -831,7 +831,7 @@ describe CatalogController do
             :credential_id   => auth.id,
             :repository_id   => repository.id,
             :playbook_id     => 2,
-            :playbook_ttl    => nil,
+            :execution_ttl   => nil,
             :verbosity       => 0
           }
         }
@@ -845,7 +845,7 @@ describe CatalogController do
           :playbook           => playbook.name,
           :machine_credential => auth.name,
           :become_enabled     => "No",
-          :playbook_ttl       => nil,
+          :execution_ttl      => nil,
           :verbosity          => 4
         },
         :retirement   => {
@@ -854,7 +854,7 @@ describe CatalogController do
           :playbook           => nil,
           :machine_credential => auth.name,
           :become_enabled     => "No",
-          :playbook_ttl       => nil,
+          :execution_ttl      => nil,
           :verbosity          => 0
         }
       }

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -768,6 +768,7 @@ describe CatalogController do
             :repository_id   => repository.id,
             :playbook_id     => playbook.id,
             :dialog_id       => dialog.id,
+            :playbook_ttl    => nil,
             :verbosity       => 4
           },
           :retirement => {
@@ -776,6 +777,7 @@ describe CatalogController do
             :credential_id   => auth.id,
             :repository_id   => repository.id,
             :playbook_id     => playbook.id,
+            :playbook_ttl    => nil,
             :verbosity       => 0
           }
         }
@@ -791,6 +793,7 @@ describe CatalogController do
           :dialog             => "Some Label",
           :dialog_id          => dialog.id,
           :become_enabled     => "No",
+          :playbook_ttl       => nil,
           :verbosity          => 4
         },
         :retirement   => {
@@ -799,6 +802,7 @@ describe CatalogController do
           :playbook           => playbook.name,
           :machine_credential => auth.name,
           :become_enabled     => "No",
+          :playbook_ttl       => nil,
           :verbosity          => 0
         }
       }
@@ -818,6 +822,7 @@ describe CatalogController do
             :repository_id   => 1,
             :playbook_id     => playbook.id,
             :dialog_id       => 2,
+            :playbook_ttl    => nil,
             :verbosity       => 4
           },
           :retirement => {
@@ -826,6 +831,7 @@ describe CatalogController do
             :credential_id   => auth.id,
             :repository_id   => repository.id,
             :playbook_id     => 2,
+            :playbook_ttl    => nil,
             :verbosity       => 0
           }
         }
@@ -839,6 +845,7 @@ describe CatalogController do
           :playbook           => playbook.name,
           :machine_credential => auth.name,
           :become_enabled     => "No",
+          :playbook_ttl       => nil,
           :verbosity          => 4
         },
         :retirement   => {
@@ -847,6 +854,7 @@ describe CatalogController do
           :playbook           => nil,
           :machine_credential => auth.name,
           :become_enabled     => "No",
+          :playbook_ttl       => nil,
           :verbosity          => 0
         }
       }

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -28,7 +28,7 @@ describe('catalogItemFormController', function() {
           repository_id: undefined,
           playbook_id:          10000000000493,
           credential_id:        10000000000090,
-          playbook_ttl:         100,
+          execution_ttl:         100,
           hosts:                'localhost',
           verbosity:            '0',
           extra_vars:           {

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -28,6 +28,7 @@ describe('catalogItemFormController', function() {
           repository_id: undefined,
           playbook_id:          10000000000493,
           credential_id:        10000000000090,
+          playbook_ttl:         100,
           hosts:                'localhost',
           verbosity:            '0',
           extra_vars:           {


### PR DESCRIPTION
Added new input field on both Provisioning & retirement tabs to allow user to enter maximum playbook_ttl numeric value.

https://www.pivotaltracker.com/story/show/147956383

screenshots:
![max_ttl_numeric_value](https://user-images.githubusercontent.com/3450808/28532742-ad77aa8c-7068-11e7-87ad-08d392baaf91.png)

![max_ttl_validation](https://user-images.githubusercontent.com/3450808/28532931-5bc16218-7069-11e7-8428-fb250e472f24.png)

![catalog_item_summary](https://user-images.githubusercontent.com/3450808/28533279-832db29c-706a-11e7-9452-30de2e7a5d27.png)

@tinaafitz please test.