### PR TITLE
Display checkable folders in the Alert Profile Assignment tree for `ems_folder`

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -192,10 +192,9 @@ module MiqPolicyController::AlertProfiles
                                          :hac,
                                          @sb,
                                          true,
-                                         :edit     => @edit,
-                                         :filters  => @filters,
-                                         :group    => @group,
-                                         :selected => @assign[:new][:objects].collect { |f| "ResourcePool_#{f}" })
+                                         :assign_to => @assign[:new][:assign_to],
+                                         :cat       => @assign[:new][:cat],
+                                         :selected  => @assign[:new][:objects].collect { |f| "ResourcePool_#{f}" })
     else
       tree = TreeBuilderAlertProfileObj.new(:object_tree,
                                             :object,

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -180,7 +180,7 @@ module MiqPolicyController::AlertProfiles
     tree = nil
     return nil if alert_profile_get_assign_to_objects_empty?
     if @assign[:new][:assign_to] == "ems_folder"
-      tree = TreeBuilderBelongsToHac.new(:vat_tree,
+      tree = TreeBuilderBelongsToVat.new(:vat_tree,
                                          :vat,
                                          @sb,
                                          true,

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -184,10 +184,9 @@ module MiqPolicyController::AlertProfiles
                                          :vat,
                                          @sb,
                                          true,
-                                         :edit     => @edit,
-                                         :filters  => @filters,
-                                         :group    => @group,
-                                         :selected => @assign[:new][:objects].collect { |f| "EmsFolder_#{f}" })
+                                         :assign_to => @assign[:new][:assign_to],
+                                         :cat       => @assign[:new][:cat],
+                                         :selected  => @assign[:new][:objects].collect { |f| "EmsFolder_#{f}" })
     elsif @assign[:new][:assign_to] == "resource_pool"
       tree = TreeBuilderBelongsToHac.new(:hac_tree,
                                          :hac,

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -180,31 +180,32 @@ module MiqPolicyController::AlertProfiles
     tree = nil
     return nil if alert_profile_get_assign_to_objects_empty?
     if @assign[:new][:assign_to] == "ems_folder"
-      tree = TreeBuilderBelongsToVat.new(:vat_tree,
-                                         :vat,
-                                         @sb,
-                                         true,
-                                         :assign_to => @assign[:new][:assign_to],
-                                         :cat       => @assign[:new][:cat],
-                                         :selected  => @assign[:new][:objects].collect { |f| "EmsFolder_#{f}" })
+      tree = instantiate_tree("TreeBuilderBelongsToVat",
+                              :vat_tree,
+                              :vat,
+                              @assign[:new][:objects].collect { |f| "EmsFolder_#{f}" })
     elsif @assign[:new][:assign_to] == "resource_pool"
-      tree = TreeBuilderBelongsToHac.new(:hac_tree,
-                                         :hac,
-                                         @sb,
-                                         true,
-                                         :assign_to => @assign[:new][:assign_to],
-                                         :cat       => @assign[:new][:cat],
-                                         :selected  => @assign[:new][:objects].collect { |f| "ResourcePool_#{f}" })
+      tree = instantiate_tree("TreeBuilderBelongsToHac",
+                              :hac_tree,
+                              :hac,
+                              @assign[:new][:objects].collect { |f| "ResourcePool_#{f}" })
     else
-      tree = TreeBuilderAlertProfileObj.new(:object_tree,
-                                            :object,
-                                            @sb,
-                                            true,
-                                            :assign_to => @assign[:new][:assign_to],
-                                            :cat       => @assign[:new][:cat],
-                                            :selected  => @assign[:new][:objects])
+      tree = instantiate_tree("TreeBuilderAlertProfileObj",
+                              :object_tree,
+                              :object,
+                              @assign[:new][:objects])
     end
     tree
+  end
+
+  def instantiate_tree(tree_class, tree_name, type, selected)
+    tree_class.constantize.new(tree_name,
+                               type,
+                               @sb,
+                               true,
+                               :assign_to => @assign[:new][:assign_to],
+                               :cat       => @assign[:new][:cat],
+                               :selected  => selected)
   end
 
   def alert_profile_build_edit_screen

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -7,7 +7,11 @@ class TreeBuilderBelongsToHac < TreeBuilder
 
   def override(node, object, _pid, options)
     if [ExtManagementSystem, EmsCluster, Datacenter, EmsFolder, ResourcePool].any? { |klass| object.kind_of?(klass) }
-      node[:select] = options.key?(:selected) && options[:selected].include?("#{object.class.name}_#{object[:id]}")
+      node[:select] = if @assign_to
+                        options.key?(:selected) && options[:selected].include?("ResourcePool_#{object[:id]}")
+                      else
+                        options.key?(:selected) && options[:selected].include?("#{object.class.name}_#{object[:id]}")
+                      end
     end
     node[:hideCheckbox] = true if object.kind_of?(Host) && object.ems_cluster_id.present?
     node[:cfmeNoClick] = true

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -18,6 +18,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     @edit = params[:edit]
     @group = params[:group]
     @selected = params[:selected]
+    @assign_to = params[:assign_to]
     # need to remove tree info
     TreeState.new(sandbox).remove_tree(name)
     super(name, type, sandbox, build)
@@ -29,16 +30,25 @@ class TreeBuilderBelongsToHac < TreeBuilder
     {:full_ids             => true,
      :add_root             => false,
      :lazy                 => false,
-     :checkable_checkboxes => @edit.present?,
+     :checkable_checkboxes => @edit.present? || @assign_to.present?,
      :selected             => @selected}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{group_id}___",
-                  :oncheck           => @edit ? "miqOnCheckUserFilters" : nil,
+
+    oncheck, check_url = if @assign_to
+                           ["miqOnCheckHandler", "/miq_policy/alert_profile_assign_changed/"]
+                         elsif @edit
+                           ["miqOnCheckUserFilters", "/ops/rbac_group_field_changed/#{group_id}___"]
+                         else
+                           [nil, "/ops/rbac_group_field_changed/#{group_id}___"]
+                         end
+
+    locals.merge!(:oncheck           => oncheck,
+                  :check_url         => check_url,
+                  :highlight_changes => @assign_to ? false : true,
                   :checkboxes        => true,
-                  :highlight_changes => true,
                   :onclick           => false)
   end
 


### PR DESCRIPTION
Fixed the Alert Profiles Assignment tree to display correct nodes when `Selected Folders` is selected and ensured that the folders are checkable.

Before (Displays wrong nodes + uncheckable nodes)
<img width="1437" alt="screen shot 2017-07-24 at 3 43 10 pm" src="https://user-images.githubusercontent.com/1538216/28551258-e132de72-709b-11e7-850d-f72e9ae4707b.png">

After (Displays correct nodes (folders) that are checkable)
<img width="1433" alt="screen shot 2017-07-24 at 6 11 05 pm" src="https://user-images.githubusercontent.com/1538216/28551317-17b4866c-709c-11e7-88fd-0fa80de73402.png">




https://bugzilla.redhat.com/show_bug.cgi?id=1473321