### PR TITLE
Corrected flash message of datastore domain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2170,7 +2170,7 @@ class ApplicationController < ActionController::Base
 
   def get_record_display_name(record)
     return record.label                      if record.respond_to?("label")
-    return record.description                if record.respond_to?("description") && !record.description.nil?
+    return record.description                if record.respond_to?("description") && record.description.nil?
     return record.ext_management_system.name if record.respond_to?("ems_id")
     return record.title                      if record.respond_to?("title")
     return record.name                       if record.respond_to?("name")


### PR DESCRIPTION
After deletion of datastore domain from automation explorer, flash message showing 'description' deleted instead of 'domain name'

https://bugzilla.redhat.com/show_bug.cgi?id=1474693

Steps to Reproduce:
1. Navigate to Automation -> Automate -> Explorer
2. Add new domain under datastore, put name of domain as a 'Jon_Snow' and description as a 'King', Save it
3. Now, click on 'Jon_Snow' and remove domain