### PR TITLE
Report data api

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -90,7 +90,10 @@
 
       if (event.controller === COTNROLLER_NAME && this.apiFunctions && this.apiFunctions[event.action]) {
         var actionCallback = this.apiFunctions[event.action];
-        actionCallback.apply(this, event.data);
+        var resultData = actionCallback.apply(this, event.data);
+        if (event.eventCallback) {
+          event.eventCallback(resultData);
+        }
       }
     }.bind(this),
     function(err) {

--- a/app/assets/javascripts/miq_qe.js
+++ b/app/assets/javascripts/miq_qe.js
@@ -86,55 +86,52 @@ ManageIQ.qe.inFlight = function() {
 ManageIQ.qe.gtl = {
   actionsToFunction: function() {
     var startEnd = function(pageNumber) {
-      var start = (pageNumber - 1) * this.settings.perpage;
-      var end = start + this.settings.perPage;
-      return {
-        start: start,
-        end: end,
-      };
+    var start = (pageNumber - 1) * this.settings.perpage;
+    var end = start + this.settings.perPage;
+    return {
+      start: start,
+      end: end,
+    };
     }.bind(this);
     var goToPage = function(pageNumber) {
       var pageItems = startEnd(pageNumber);
       this.onLoadNext(pageItems.start, pageItems.end);
     }.bind(this);
-    if (this.constructor.name === 'ReportDataController') {
-      return {
-        'select_item': function(id, isSelected) {
-          var item = this.gtlData.rows.filter(function(currItem) {
-            return currItem.id === id;
-          });
-          this.onItemSelect(item[0], isSelected);
-          this.$scope.$digest();
-        },
-        'click_item': function(id) {
-          var item = this.gtlData.rows.filter(function(currItem) {
-            return currItem.id === id;
-          });
-          this.onItemClicked(item[0], document.createEvent('Event'));
-        },
-        'select_all': function(isSelected) {
-          this.gtlData.rows.forEach(function(item) {
-            this.onItemSelect(item, isSelected);
-          }.bind(this));
-          this.$scope.$digest();
-        },
-        'go_to_page': function(pageNumber) {
-          goToPage(pageNumber);
-        },
-        'last_page': function() {
-          goToPage(this.settings.total);
-        },
-        'first_page': function() {
-          goToPage(1);
-        },
-        'perevious_page': function() {
-          goToPage(this.settings.current - 1);
-        },
-        'next_page': function() {
-          goToPage(this.settings.current + 1);
-        },
-      };
-    }
-    return {};
+    return {
+      'select_item': function(id, isSelected) {
+        var item = this.gtlData.rows.filter(function(currItem) {
+          return currItem.id === id;
+        });
+        this.onItemSelect(item[0], isSelected);
+        this.$scope.$digest();
+      },
+      'click_item': function(id) {
+        var item = this.gtlData.rows.filter(function(currItem) {
+          return currItem.id === id;
+        });
+        this.onItemClicked(item[0], document.createEvent('Event'));
+      },
+      'select_all': function(isSelected) {
+        this.gtlData.rows.forEach(function(item) {
+          this.onItemSelect(item, isSelected);
+        }.bind(this));
+        this.$scope.$digest();
+      },
+      'go_to_page': function(pageNumber) {
+        goToPage(pageNumber);
+      },
+      'last_page': function() {
+        goToPage(this.settings.total);
+      },
+      'first_page': function() {
+        goToPage(1);
+      },
+      'perevious_page': function() {
+        goToPage(this.settings.current - 1);
+      },
+      'next_page': function() {
+        goToPage(this.settings.current + 1);
+      },
+    };
   },
 };


### PR DESCRIPTION
This is improvement for QE report data (GTL) API, which allows more easily query data on screen and control GTLs more programmatically.

### New methods:
1) (stores) `sendDataWithRx({controller: 'reportDataController', action: 'get_current_page'})`
Will store current page number.
2) (stores) `sendDataWithRx({controller: 'reportDataController', action: 'get_pages_amount'})`
Will store number of all items.
3) (stores) `sendDataWithRx({controller: 'reportDataController', action: 'get_items_per_page'})`
Will store number of shown items per page.
4) `sendDataWithRx({controller: 'reportDataController', action: 'set_items_per_page', data: [5]})`
Will change number of records per page, data is array with number of records per page.
5) `sendDataWithRx({controller: 'reportDataController', action: 'set_sorting', data: [{sortBy: 2, isAscending: true}]})`
Will change sort based on given data. `sortBy` ID of column to sort by, `isAscending` true|false direction.
6) `(stores) sendDataWithRx({controller: 'reportDataController', action: 'get_sorting'})`
Will store sorting object. `sortBy` column which is sorted by, `sortDir` is either `ASC` or `DESC`
7) (stores) `sendDataWithRx({controller: 'reportDataController', action: 'get_all_items'})`
Will store all items on screen in given format including helpful methods.
8) (stores) `sendDataWithRx({controller: 'reportDataController', action: 'get_item', data: ['name_or_id']})` data `name_or_id` can be number or string, since simple comparison (`==`) is used.
Will query for item based on name or it's ID property. If record doesn't have name column set it will try to look up based on ID. This item will be stored in given format including helpful methods.

### Store result in global scope
If we want to get some information from screen we can call method which will store this result (methods marked as stores) in global scope. We can then access it by calling `ManageIQ.qe.gtl.result`. Example: 
`endDataWithRx({controller: 'reportDataController', action: 'get_item', data: ['name_of_record']})` will store found item in `ManageIQ.qe.gtl.result` and calling `ManageIQ.qe.gtl.result.click()` will click on such item.

### New callback function
If we want to check or play around with stored data we can now pass callback function. Example: `sendDataWithRx({controller: 'reportDataController', action: 'get_item', data: ['name_of_record'], eventCallback: function(data) {data.click();}})` this will query GTL to find item with name `name_of_record` and once data are returned it will click on such item.

### Item querying
It is possible to query for all items or to select one item (shown in 7) and 8) point), result will contain not only item, but couple of helpful methods, the result is:
```javascript
{
  select: function(){},
  unselect: function(){},
  is_selected: function(){},
  click: function(){},
  item: {...}
}
```