### PR TITLE
Added flash_msg div to display errors in the Dialog Editor

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -105,7 +105,10 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
   }
 
   function saveFailure() {
-    miqService.miqFlash('error', __('There was an error editing this dialog.'));
+    miqService.miqFlash(
+      'error',
+      __('There was an error editing this dialog: ') + arguments[0].error.message
+    );
   }
 
   // FIXME: @himdel: method copied from other place -> maybe extract somewhere?

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -1,5 +1,6 @@
 .col-md-12.ss-details-wrapper{'ng-controller' => 'dialogEditorController as vm'}
   .row{'ng-if' => 'vm.dialog'}
+    = render :partial => "layouts/flash_msg"
     .col-md-6
       %h2= _("Dialog Content")
       %dialog-editor-tabs


### PR DESCRIPTION
Fixing issue with missing flash message described in https://github.com/ManageIQ/manageiq-ui-classic/pull/1398#issuecomment-316457874.

Flash message was there, just wasn't rendered, because of missing `flash_msg` div:
https://github.com/ManageIQ/manageiq-ui-classic/blob/6978bb3c881ab74d9ce5a83f618c6365841cd19c/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js#L108

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/pull/1398#issuecomment-316457874.
* related to https://www.pivotaltracker.com/n/projects/1613907/stories/144481043/comments/177154253

Steps for Testing/QA
-------------------------------

After the change, the flash is displayed:

![screenshot from 2017-07-25 15-18-02](https://user-images.githubusercontent.com/1187051/28576817-3a40860e-7155-11e7-9fcf-4ccdf1d4a21c.png)

/cc @martinpovolny 