### PR TITLE
Allow MIQ defined Users to belong to multiple Groups

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -835,7 +835,12 @@ module OpsController::OpsRbac
           page.replace(@refresh_div, :partial => @refresh_partial)
         end
         bad = false
-      elsif x_node.split("-").first == "g" || x_node == "xx-g"
+      else
+        # only do following if groups of a user change (adding/editing a user)
+        if x_node.split("-").first == "u" || x_node == "xx-u"
+          page.replace("group_selected",
+                       :partial => "ops/rbac_group_selected")
+        end
         # only do following for groups
         page.replace(@refresh_div,
                      :partial => @refresh_partial,

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -997,13 +997,14 @@ module OpsController::OpsRbac
     copy = @sb[:typ] == "copy"
     # save a shadow copy of the record if record is being copied
     @user = copy ? @record.dup : @record
+    @user.miq_groups = @record.miq_groups if copy
     @edit = {:new => {}, :current => {}}
     @edit[:user_id] = @record.id unless copy
     @edit[:key] = "rbac_user_edit__#{@edit[:user_id] || "new"}"
     # prefill form fields for edit and copy action
     @edit[:new].merge!(:name  => @user.name,
                        :email => @user.email,
-                       :group => @user.current_group ? @user.current_group.id : nil)
+                       :group => @user.miq_groups ? @user.miq_groups.map(&:id) : nil)
     unless copy
       @edit[:new].merge!(:userid   => @user.userid,
                          :password => @user.password,

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -75,16 +75,19 @@
         %label.col-md-2.control-label
           = _("Users in this Group")
         .col-md-8
-          - @group.users.sort_by { |a| a.name.downcase }.each do |u|
-            - if role_allows?(:feature => "rbac_user_show")
-              - params = {:class   => "pointer",
-                          :onclick => "miqTreeActivateNode('rbac_tree', 'u-#{to_cid(u.id)}');",
-                          :title   => _("View this User")}
-            - else
-              - params = {}
-            %i.pficon.pficon-user{params}
-            = h(u.name)
-            %br
+          - if role_allows?(:feature => "rbac_user_show")
+            - @group.users.sort_by { |a| a.name.downcase }.each do |u|
+              - params = {:class => "pointer",
+                          :onclick => "miqOnClickSelectRbacTreeNode('u-#{to_cid(u.id)}');",
+                          :title => _("View this User")}
+              %i.pficon.pficon-user{params}
+              = link_to(u.name, "#", params)
+              %br
+          - else
+            - @group.users.sort_by { |a| a.name.downcase }.each do |u|
+              %i.pficon.pficon-user
+              = link_to(u.name, "#")
+              %br
     - unless @edit
       = render :partial => "rbac_tag_box"
     - if @edit

--- a/app/views/ops/_rbac_group_selected.html.haml
+++ b/app/views/ops/_rbac_group_selected.html.haml
@@ -1,0 +1,8 @@
+#group_selected
+  - if @edit[:new][:group].present? && @edit[:new][:group] != 'null'
+    - selected_group_ids = @edit[:new][:group].split(',').delete_if(&:blank?)
+    - selected_groups = Rbac.filtered(MiqGroup.find(selected_group_ids)).map(&:description)
+    - selected_groups.each do |g|
+      %i.ff.ff-group
+      = g
+      %br

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -52,6 +52,7 @@
                   - params = {}
                 %i.ff.ff-group{params}
                 = link_to(g.description, "#", params)
+                %br
     .col-md-12.col-lg-6
       %hr
       - if @edit

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -89,29 +89,60 @@
                            :maxlength         => 50,
                            :class => "form-control",
                            "data-miq_observe" => observe_url_json)
-    .form-group
-      %label.col-md-2.control-label
-        = _("Group")
-      .col-md-8
-        - if !@edit
+    - unless @edit
+      .form-group
+        %label.col-md-2.control-label
+          = _("Current Group")
+        .col-md-8
           - params = {}
           - if @user.current_group
             - if role_allows?(:feature => "rbac_group_show")
-              - params = {:class => "pointer", :onclick => "miqOnClickSelectRbacTreeNode('g-#{to_cid(@user.current_group.id)}');", :title => _("View this Group")}
+              - params = {:class => "pointer",
+                          :onclick => "miqOnClickSelectRbacTreeNode('g-#{to_cid(@user.current_group.id)}');",
+                          :title => _("View this Group")}
             %i.ff.ff-group{params}
             = link_to(@user.current_group.description, "#", params)
+    .form-group
+      %label.col-md-2.control-label
+        - if !@edit
+          = _("Groups")
+        - else
+          = _("Available Groups")
+      .col-md-5
+        - groups = @user.present? && @user.miq_groups.present? ? @user.miq_groups.order(:description) : []
+        - if groups.present? && @edit.blank?
+          - if role_allows?(:feature => "rbac_group_show")
+            - groups.each do |group|
+              - params = {:class => "pointer",
+                          :onclick => "miqOnClickSelectRbacTreeNode('g-#{to_cid(group.id)}');",
+                          :title => _("View this Group")}
+              %i.ff.ff-group{params}
+              = link_to(group.description, "#", params)
+              %br
+          - else
+            - groups.each do |group|
+              %i.ff.ff-group
+              = link_to(group.description, "#")
+              %br
         - else
           - if disabled
             %p.form-control-static
-              = h(@user.current_group.description)
+              - groups.each do |group|
+                = h(group.description)
+                %br
           - else
-            - options = (@edit[:new][:group] ? [] : [[_("<Choose a Group>"), nil]]) + @edit[:groups]
+            - options = (@edit[:new][:group].present? ? [] : [[_("<Choose a Group>"), nil]]) + @edit[:groups]
             = select_tag('chosen_group',
                          options_for_select(options, @edit[:new][:group]),
-                         :class    => "selectpicker")
-          :javascript
-            miqInitSelectPicker();
-            miqSelectPickerEvent('chosen_group', "#{url}")
+                         :class    => "selectpicker",
+                         :multiple => true,
+                         :style    => "overflow-x: scroll;")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('chosen_group', "#{url}")
+      - if @edit
+        %label.col-md-2
+          = _("Selected Groups")
     - unless @edit
       .form-group
         %label.col-md-2.control-label
@@ -119,7 +150,9 @@
         .col-md-8
           - if @user.current_group && @user.current_group.miq_user_role
             - if role_allows?(:feature => "rbac_user_show")
-              - params = {:class => "pointer", :onclick => "miqOnClickSelectRbacTreeNode('ur-#{to_cid(@user.current_group.miq_user_role.id)}');", :title => _("View this Role")}
+              - params = {:class => "pointer",
+                          :onclick => "miqOnClickSelectRbacTreeNode('ur-#{to_cid(@user.current_group.miq_user_role.id)}');",
+                          :title => _("View this Role")}
             - else
               - params = {}
             %i.ff.ff-user-role{params}

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -144,6 +144,7 @@
       - if @edit
         %label.col-md-2
           = _("Selected Groups")
+          = render :partial => "ops/rbac_group_selected"
     - unless @edit
       .form-group
         %label.col-md-2.control-label

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -132,8 +132,9 @@
                 %br
           - else
             - options = (@edit[:new][:group].present? ? [] : [[_("<Choose a Group>"), nil]]) + @edit[:groups]
+            - select_groups = @edit[:new][:userid].blank? ? @edit[:new][:group] : groups.map(&:id)
             = select_tag('chosen_group',
-                         options_for_select(options, @edit[:new][:group]),
+                         options_for_select(options, select_groups),
                          :class    => "selectpicker",
                          :multiple => true,
                          :style    => "overflow-x: scroll;")

--- a/product/views/User.yaml
+++ b/product/views/User.yaml
@@ -45,7 +45,7 @@ headers:
 - Full Name
 - Username
 - E-mail
-- Group
+- Current Group
 - Role
 - Last Logon
 - Last Logoff

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -78,12 +78,11 @@ describe OpsController do
           :name     => 'test7',
           :userid   => 'test7',
           :email    => 'test7@foo.bar',
-          :group    => group.id,
+          :group    => group.id.to_s,
           :password => 'test7',
           :verify   => 'test7',
         }
       }
-
       expect(controller).to receive(:replace_right_cell)
       get :rbac_user_edit, :params => { :button => 'add' }
     end
@@ -95,7 +94,7 @@ describe OpsController do
           :name     => 'test7',
           :userid   => 'test7',
           :email    => 'test7@foo.bar',
-          :group    => group.id,
+          :group    => group.id.to_s,
           :password => 'test7',
           :verify   => 'test8',
         }


### PR DESCRIPTION
Allow MIQ defined Users to belong to multiple Groups
without using external authentication
in Configuration -> Access Control -> Users.

## Links
https://www.pivotaltracker.com/story/show/147303377

## Screenshots
Before:
![groups1](https://user-images.githubusercontent.com/13417815/28580281-4f318450-715f-11e7-8bd8-583ef79274b3.png)

After:
![user4](https://user-images.githubusercontent.com/13417815/29515698-b9676664-866d-11e7-9144-17b5ccdcefa8.png)
![user2](https://user-images.githubusercontent.com/13417815/29274093-e39ccabc-8106-11e7-8da8-ca30279b51de.png)
![user3](https://user-images.githubusercontent.com/13417815/29274220-61a574cc-8107-11e7-8395-50ff691fbef4.png)
