### PR TITLE
HAWKULAR-1164 - Stop an EAP domain

### DIFF
--- a/app/controllers/middleware_domain_controller.rb
+++ b/app/controllers/middleware_domain_controller.rb
@@ -9,12 +9,23 @@ class MiddlewareDomainController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  OPERATIONS = {
+    :middleware_domain_stop => {:op   => :stop_middleware_server,
+                                :skip => true,
+                                :hawk => N_('stopping'),
+                                :msg  => N_('Stopping selected domain(s)')}
+  }.freeze
+
   def self.display_methods
     %w(middleware_server_groups)
   end
 
   def self.default_show_template
     "#{model.name.underscore}/show"
+  end
+
+  def self.operations
+    OPERATIONS
   end
 
   menu_section :mdl

--- a/app/helpers/application_helper/toolbar/middleware_domain_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_domain_center.rb
@@ -26,10 +26,10 @@ class ApplicationHelper::Toolbar::MiddlewareDomainCenter < ApplicationHelper::To
                      button(
                        :middleware_domain_stop,
                        nil,
-                       N_('Stop this Domain'),
-                       N_('Stop Domain'),
+                       N_('Shutdown this Domain'),
+                       N_('Shutdown Domain'),
                        :image   => 'power_off',
-                       :confirm => N_('Do you want to stop this domain?')
+                       :confirm => N_('This operation will shutdown the entire domain, including all EAP instances that are serving user requests. Are you sure you want to proceed?')
                      )
                    ]
                  ),

--- a/app/helpers/application_helper/toolbar/middleware_domain_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_domain_center.rb
@@ -16,4 +16,22 @@ class ApplicationHelper::Toolbar::MiddlewareDomainCenter < ApplicationHelper::To
                    ]
                  ),
                ])
+  button_group('middleware_domain_operations', [
+                 select(
+                   :middleware_server_power_choice,
+                   'fa fa-power-off fa-lg',
+                   t = N_('Power'),
+                   t,
+                   :items => [
+                     button(
+                       :middleware_domain_stop,
+                       nil,
+                       N_('Stop this Domain'),
+                       N_('Stop Domain'),
+                       :image   => 'power_off',
+                       :confirm => N_('Do you want to stop this domain?')
+                     )
+                   ]
+                 ),
+               ])
 end


### PR DESCRIPTION
Adds operation to shutdown EAP domains.


![screenshot from 2017-08-16 11-42-18](https://user-images.githubusercontent.com/3845764/29374887-a45a5612-8278-11e7-94df-873220420014.png)

alert on chrome
![screenshot from 2017-08-16 11-44-40](https://user-images.githubusercontent.com/3845764/29374890-a7b01630-8278-11e7-9a81-4a81754c8a5c.png)

alert on firefox
![screenshot from 2017-08-17 14-04-30](https://user-images.githubusercontent.com/3845764/29429101-0b7b3384-8355-11e7-9f8f-af50ad7cdf84.png)
