### PR TITLE
Remove TOP_TABLES_BY_ROWS_COUNT from UiConstants

### DIFF
--- a/app/helpers/ops_helper/textual_summary.rb
+++ b/app/helpers/ops_helper/textual_summary.rb
@@ -107,7 +107,7 @@ module OpsHelper::TextualSummary
       :title     => _("Tables with the Most Rows"),
       :headers   => [_("Name"), _("Rows")],
       :col_order => %w(name value),
-      :value     => vmdb_table_top_rows(:rows, TOP_TABLES_BY_ROWS_COUNT)
+      :value     => vmdb_table_top_rows(:rows, 5)
     }
   end
 

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -6,7 +6,6 @@ module UiConstants
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
 
-  TOP_TABLES_BY_ROWS_COUNT = 5
   TOP_TABLES_BY_WASTED_SPACE_COUNT = 5
   GIGABYTE = 1024 * 1024 * 1024
 


### PR DESCRIPTION
### Issue: #1661 

We have removed `TOP_TABLES_BY_ROWS_COUNT` constant from `UiConstants`. One occurrence of constant `TOP_TABLES_BY_ROWS_COUNT` was replaced with its value in `manageiq-ui-classic/app/helpers/ops_helper/textual_summary.rb`.