### PR TITLE
Remove TOP_TABLES_BY_WASTED_SPACE_COUNT from UiConstants

### DIFF
--- a/app/helpers/ops_helper/textual_summary.rb
+++ b/app/helpers/ops_helper/textual_summary.rb
@@ -125,7 +125,7 @@ module OpsHelper::TextualSummary
       :title     => _("Tables with Most Wasted Space"),
       :headers   => [_("Name"), _("Wasted")],
       :col_order => %w(name value),
-      :value     => vmdb_table_top_rows(:wasted_bytes, TOP_TABLES_BY_WASTED_SPACE_COUNT)
+      :value     => vmdb_table_top_rows(:wasted_bytes, 5)
     }
   end
 

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -6,8 +6,6 @@ module UiConstants
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
 
-  TOP_TABLES_BY_WASTED_SPACE_COUNT = 5
-
   # PDF page sizes
   PDF_PAGE_SIZES = {
     "a0"            => N_("A0 - 841mm x 1189mm"),


### PR DESCRIPTION
### Issue: #1661 

We have removed `TOP_TABLES_BY_WASTED_SPACE_COUNT` constant from `UiConstants`. One occurrence of constant `TOP_TABLES_BY_WASTED_SPACE_COUNT` was replaced with its value in `manageiq-ui-classic/app/helpers/ops_helper/textual_summary.rb`.