### PR TITLE
Allow copying/focusing in disabled codemirror editor

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1171,7 +1171,7 @@ function miqInitCodemirror(options) {
     lineNumbers: options.line_numbers,
     matchBrackets: true,
     theme: 'eclipse',
-    readOnly: options.read_only ? 'nocursor' : false,
+    readOnly: options.read_only,
     viewportMargin: Infinity,
   });
 


### PR DESCRIPTION
This way it's possible to copy the automate methods even if not editing them.

FYI @loicavenel