### PR TITLE
Remove GIGABYTE from UiConstants

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -7,7 +7,6 @@ module UiConstants
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
 
   TOP_TABLES_BY_WASTED_SPACE_COUNT = 5
-  GIGABYTE = 1024 * 1024 * 1024
 
   # PDF page sizes
   PDF_PAGE_SIZES = {

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -8,7 +8,7 @@ describe OpsController do
       stub_user(:features => :all)
     end
 
-    let(:four_terabytes) {4096 * 1024 * 1024 * 1024}
+    let(:four_terabytes) { 4096 * 1024 * 1024 * 1024 }
 
     context "#tree_select" do
       it "renders rbac_details tab when rbac_tree root node is selected" do

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -8,6 +8,8 @@ describe OpsController do
       stub_user(:features => :all)
     end
 
+    let(:four_terabytes) {4096 * 1024 * 1024 * 1024}
+
     context "#tree_select" do
       it "renders rbac_details tab when rbac_tree root node is selected" do
         session[:sandboxes] = {"ops" => {:active_tree => :rbac_tree}}
@@ -42,7 +44,7 @@ describe OpsController do
         tenant = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
         tenant.set_quotas(:cpu_allocated => {:value => 1024},
                           :vms_allocated => {:value => 27},
-                          :mem_allocated => {:value => 4096 * GIGABYTE})
+                          :mem_allocated => {:value => four_terabytes})
 
         session[:sandboxes] = {"ops" => {:active_tree => :rbac_tree}}
         post :tree_select, :params => { :id => "tn-#{controller.to_cid(tenant.id)}", :format => :js }


### PR DESCRIPTION
### Issue: #1661 

We have removed `GIGABYTE` constant from `UiConstants`. One occurrence of constant `GIGABYTE` was replaced by its value and the new composite value was saved into new variable.