### PR TITLE
Fix travis - ContainerDefinition no longer exists

### DIFF
--- a/app/helpers/container_helper/textual_summary.rb
+++ b/app/helpers/container_helper/textual_summary.rb
@@ -70,35 +70,35 @@ module ContainerHelper::TextualSummary
   end
 
   def textual_command
-    {:label => _("Command"), :value => @record.container_definition.command} if @record.container_definition.command
+    {:label => _("Command"), :value => @record.command} if @record.command
   end
 
   def textual_capabilities_add
-    if @record.container_definition.capabilities_add.present?
+    if @record.capabilities_add.present?
       {
         :label => _("Add Capabilities"),
-        :value => @record.container_definition.capabilities_add
+        :value => @record.capabilities_add
       }
     end
   end
 
   def textual_capabilities_drop
-    if @record.container_definition.capabilities_drop.present?
+    if @record.capabilities_drop.present?
       {
         :label => _("Drop Capabilities"),
-        :value => @record.container_definition.capabilities_drop
+        :value => @record.capabilities_drop
       }
     end
   end
 
   def textual_privileged
     {:label => _("Privileged"),
-     :value => @record.container_definition.privileged} unless @record.container_definition.privileged.nil?
+     :value => @record.privileged} unless @record.privileged.nil?
   end
 
   def textual_run_as_user
     {:label => _("Run As User"),
-     :value => @record.container_definition.run_as_user} if @record.container_definition.run_as_user
+     :value => @record.run_as_user} if @record.run_as_user
   end
 
   def textual_se_linux_user
@@ -123,7 +123,7 @@ module ContainerHelper::TextualSummary
 
   def textual_run_as_non_root
     {:label => _("Run As Non Root"),
-     :value => @record.container_definition.run_as_non_root} unless @record.container_definition.run_as_non_root.nil?
+     :value => @record.run_as_non_root} unless @record.run_as_non_root.nil?
   end
 
   def textual_group_env
@@ -136,7 +136,7 @@ module ContainerHelper::TextualSummary
   end
 
   def collect_env_variables
-    @record.container_definition.container_env_vars.collect do |var|
+    @record.container_env_vars.collect do |var|
       [var.name, var.value, var.field_path]
     end
   end

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -1,7 +1,6 @@
 describe ContainerTopologyService do
 
   let(:container_topology_service) { described_class.new(nil) }
-  let(:long_id) { "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest" }
 
   describe "#build_topology" do
     subject { container_topology_service.build_topology }
@@ -10,9 +9,8 @@ describe ContainerTopologyService do
       expect(subject.keys).to match_array([:items, :kinds, :relations, :icons])
     end
 
-    let(:container) { Container.create(:name => "ruby-example", :ems_ref => long_id, :state => 'running') }
+    let(:container) { Container.create(:name => "ruby-example", :state => 'running') }
     let(:container_condition) { ContainerCondition.create(:name => 'Ready', :status => 'True') }
-    let(:container_def) { ContainerDefinition.create(:name => "ruby-example", :ems_ref => 'b6976f84-5184-11e5-950e-001a4a231290_ruby-helloworld_172.30.194.30:5000/test/origin-ruby-sample@sha256:0cd076c9beedb3b1f5cf3ba43da6b749038ae03f5886b10438556e36ec2a0dd9', :container => container) }
     let(:container_node) { ContainerNode.create(:ext_management_system => ems_kube, :name => "127.0.0.1", :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb", :container_conditions => [container_condition], :lives_on => vm_rhev) }
     let(:ems_kube) { FactoryGirl.create(:ems_kubernetes_with_authentication_err) }
     let(:ems_openshift) { FactoryGirl.create(:ems_openshift) }
@@ -51,7 +49,7 @@ describe ContainerTopologyService do
       container_group = ContainerGroup.create(:ext_management_system => ems_kube,
                                               :container_node        => container_node, :container_replicator => container_replicator,
                                               :name                  => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
-                                              :phase                 => "Running", :container_definitions => [container_def])
+                                              :phase                 => "Running", :containers => [container])
       container_service = ContainerService.create(:ext_management_system => ems_kube, :container_groups => [container_group],
                                                   :ems_ref               => "95e49048-3e00-11e5-a0d2-18037327aaeb",
                                                   :name                  => "service1", :container_routes => [container_route])
@@ -134,7 +132,7 @@ describe ContainerTopologyService do
       container_topology_service.instance_variable_set(:@entity, ems_kube)
       container_group = ContainerGroup.create(:ext_management_system => ems_kube, :container_node => container_node,
                                               :name => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
-                                              :phase => "Running", :container_definitions => [container_def])
+                                              :phase => "Running", :containers => [container])
       container_service = ContainerService.create(:ext_management_system => ems_kube, :container_groups => [container_group],
                                                   :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
                                                   :name => "service1")


### PR DESCRIPTION
removed in https://github.com/ManageIQ/manageiq/pull/15393
and https://github.com/ManageIQ/manageiq-schema/pull/24

travis https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/257611343

```
  1) ContainerTopologyService#build_topology topology contains the expected structure when vm is off
     Failure/Error: let(:container_def) { ContainerDefinition.create(:name => "ruby-example", :ems_ref => 'b6976f84-5184-11e5-950e-001a4a231290_ruby-helloworld_172.30.194.30:5000/test/origin-ruby-sample@sha256:0cd076c9beedb3b1f5cf3ba43da6b749038ae03f5886b10438556e36ec2a0dd9', :container => container) }
     NameError:
       uninitialized constant ContainerDefinition
     # ./spec/services/container_topology_service_spec.rb:15:in `block (3 levels) in <top (required)>'
     # ./spec/services/container_topology_service_spec.rb:137:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:75:in `block (3 levels) in <top (required)>'
     # ./spec/manageiq/spec/support/evm_spec_helper.rb:35:in `clear_caches'
     # ./spec/spec_helper.rb:75:in `block (2 levels) in <top (required)>'
```

ContainerDefinition no longer exists, updating the spec to put the container in the group directly.

Cc @zeari 