### PR TITLE
Convert timeline_options_controller to controllerAs

### DIFF
--- a/app/assets/javascripts/controllers/timeline/timeline_options_controller.js
+++ b/app/assets/javascripts/controllers/timeline/timeline_options_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('timelineOptionsController', ['$http', '$scope', 'miqService', 'url', 'categories', function($http, $scope, miqService, url, categories) {
+ManageIQ.angular.app.controller('timelineOptionsController', ['$http', 'miqService', 'url', 'categories', function($http, miqService, url, categories) {
     var vm = this;
     var init = function() {
         vm.reportModel = {
@@ -26,7 +26,7 @@ ManageIQ.angular.app.controller('timelineOptionsController', ['$http', '$scope',
     };
 
     vm.countDecrement = function() {
-        if(vm.reportModel.tl_range_count > 1) {
+        if (vm.reportModel.tl_range_count > 1) {
             vm.reportModel.tl_range_count--;
         }
     };

--- a/app/assets/javascripts/controllers/timeline/timeline_options_controller.js
+++ b/app/assets/javascripts/controllers/timeline/timeline_options_controller.js
@@ -1,6 +1,7 @@
 ManageIQ.angular.app.controller('timelineOptionsController', ['$http', '$scope', 'miqService', 'url', 'categories', function($http, $scope, miqService, url, categories) {
+    var vm = this;
     var init = function() {
-        $scope.reportModel = {
+        vm.reportModel = {
             tl_show: 'timeline',
             tl_categories: ['Power Activity'],
             tl_timerange: 'weeks',
@@ -10,76 +11,76 @@ ManageIQ.angular.app.controller('timelineOptionsController', ['$http', '$scope',
             tl_date: new Date(ManageIQ.calendar.calDateTo)
         };
 
-        $scope.afterGet  = true;
-        $scope.dateOptions = {
+        vm.afterGet  = true;
+        vm.dateOptions = {
             autoclose: true,
             todayHighlight: true,
             orientation: 'bottom'
         };
-        ManageIQ.angular.scope = $scope;
-        $scope.availableCategories = categories;
+        ManageIQ.angular.scope = vm;
+        vm.availableCategories = categories;
     };
 
-    $scope.eventTypeUpdated = function() {
-        $scope.reportModel.tl_categories = [];
+    vm.eventTypeUpdated = function() {
+        vm.reportModel.tl_categories = [];
     };
 
-    $scope.countDecrement = function() {
-        if($scope.reportModel.tl_range_count > 1) {
-            $scope.reportModel.tl_range_count--;
+    vm.countDecrement = function() {
+        if(vm.reportModel.tl_range_count > 1) {
+            vm.reportModel.tl_range_count--;
         }
     };
 
-    $scope.countIncrement = function() {
-        $scope.reportModel.tl_range_count++;
+    vm.countIncrement = function() {
+        vm.reportModel.tl_range_count++;
     };
 
-    $scope.applyButtonClicked = function() {
-        if($scope.reportModel.tl_categories.length === 0) {
+    vm.applyButtonClicked = function() {
+        if(vm.reportModel.tl_categories.length === 0) {
             return;
         }
-        
+
         // process selections
-        if($scope.reportModel.tl_timerange === 'days') {
-            $scope.reportModel.tl_typ = 'Hourly';
-            $scope.reportModel.tl_days = $scope.reportModel.tl_range_count;
+        if(vm.reportModel.tl_timerange === 'days') {
+            vm.reportModel.tl_typ = 'Hourly';
+            vm.reportModel.tl_days = vm.reportModel.tl_range_count;
         } else {
-            $scope.reportModel.tl_typ = 'Daily';
-            if($scope.reportModel.tl_timerange === 'weeks') {
-                $scope.reportModel.tl_days = $scope.reportModel.tl_range_count * 7;
+            vm.reportModel.tl_typ = 'Daily';
+            if(vm.reportModel.tl_timerange === 'weeks') {
+                vm.reportModel.tl_days = vm.reportModel.tl_range_count * 7;
             } else {
-                $scope.reportModel.tl_days = $scope.reportModel.tl_range_count * 30;
+                vm.reportModel.tl_days = vm.reportModel.tl_range_count * 30;
             }
         }
 
-        var selectedDay = moment($scope.reportModel.tl_date),
+        var selectedDay = moment(vm.reportModel.tl_date),
             startDay = selectedDay.clone(),
             endDay = selectedDay.clone();
 
-        if($scope.reportModel.tl_timepivot === "starting") {
-            endDay.add($scope.reportModel.tl_days, 'days').toDate();
-            $scope.reportModel.miq_date = endDay.format('MM/DD/YYYY');
-        } else if($scope.reportModel.tl_timepivot === "centered") {
-            var enddays = Math.ceil($scope.reportModel.tl_days/2);
+        if(vm.reportModel.tl_timepivot === "starting") {
+            endDay.add(vm.reportModel.tl_days, 'days').toDate();
+            vm.reportModel.miq_date = endDay.format('MM/DD/YYYY');
+        } else if(vm.reportModel.tl_timepivot === "centered") {
+            var enddays = Math.ceil(vm.reportModel.tl_days/2);
             startDay.subtract(enddays, 'days').toDate();
             endDay.add(enddays, 'days').toDate();
-            $scope.reportModel.miq_date = endDay.format('MM/DD/YYYY');
+            vm.reportModel.miq_date = endDay.format('MM/DD/YYYY');
 
-        }  else if($scope.reportModel.tl_timepivot === "ending") {
-            startDay.subtract($scope.reportModel.tl_days, 'days');
-            $scope.reportModel.miq_date = endDay.format('MM/DD/YYYY');
+        }  else if(vm.reportModel.tl_timepivot === "ending") {
+            startDay.subtract(vm.reportModel.tl_days, 'days');
+            vm.reportModel.miq_date = endDay.format('MM/DD/YYYY');
         }
         ManageIQ.calendar.calDateFrom = startDay.toDate();
         ManageIQ.calendar.calDateTo = endDay.toDate();
-        if($scope.reportModel.tl_show === 'timeline') {
-            if($scope.reportModel.showDetailedEvents) {
-                $scope.reportModel.tl_fl_typ = 'detail';
+        if(vm.reportModel.tl_show === 'timeline') {
+            if(vm.reportModel.showDetailedEvents) {
+                vm.reportModel.tl_fl_typ = 'detail';
             } else {
-                $scope.reportModel.tl_fl_typ = 'critical';
+                vm.reportModel.tl_fl_typ = 'critical';
             }
         }
         miqService.sparkleOn();
-        miqService.miqAsyncAjaxButton(url, miqService.serializeModel($scope.reportModel));
+        miqService.miqAsyncAjaxButton(url, miqService.serializeModel(vm.reportModel));
     };
 
     init();

--- a/app/assets/javascripts/controllers/timeline/timeline_options_controller.js
+++ b/app/assets/javascripts/controllers/timeline/timeline_options_controller.js
@@ -1,87 +1,87 @@
 ManageIQ.angular.app.controller('timelineOptionsController', ['$http', 'miqService', 'url', 'categories', function($http, miqService, url, categories) {
-    var vm = this;
-    var init = function() {
-        vm.reportModel = {
-            tl_show: 'timeline',
-            tl_categories: ['Power Activity'],
-            tl_timerange: 'weeks',
-            tl_timepivot: 'ending',
-            tl_result: 'success',
-            tl_range_count: 1,
-            tl_date: new Date(ManageIQ.calendar.calDateTo)
-        };
-
-        vm.afterGet  = true;
-        vm.dateOptions = {
-            autoclose: true,
-            todayHighlight: true,
-            orientation: 'bottom'
-        };
-        ManageIQ.angular.scope = vm;
-        vm.availableCategories = categories;
+  var vm = this;
+  var init = function() {
+    vm.reportModel = {
+      tl_show: 'timeline',
+      tl_categories: ['Power Activity'],
+      tl_timerange: 'weeks',
+      tl_timepivot: 'ending',
+      tl_result: 'success',
+      tl_range_count: 1,
+      tl_date: new Date(ManageIQ.calendar.calDateTo)
     };
 
-    vm.eventTypeUpdated = function() {
-        vm.reportModel.tl_categories = [];
+    vm.afterGet  = true;
+    vm.dateOptions = {
+      autoclose: true,
+      todayHighlight: true,
+      orientation: 'bottom'
     };
+    ManageIQ.angular.scope = vm;
+    vm.availableCategories = categories;
+  };
 
-    vm.countDecrement = function() {
-        if (vm.reportModel.tl_range_count > 1) {
-            vm.reportModel.tl_range_count--;
-        }
-    };
+  vm.eventTypeUpdated = function() {
+    vm.reportModel.tl_categories = [];
+  };
 
-    vm.countIncrement = function() {
-        vm.reportModel.tl_range_count++;
-    };
+  vm.countDecrement = function() {
+    if (vm.reportModel.tl_range_count > 1) {
+      vm.reportModel.tl_range_count--;
+    }
+  };
 
-    vm.applyButtonClicked = function() {
-        if(vm.reportModel.tl_categories.length === 0) {
-            return;
-        }
+  vm.countIncrement = function() {
+    vm.reportModel.tl_range_count++;
+  };
 
-        // process selections
-        if(vm.reportModel.tl_timerange === 'days') {
-            vm.reportModel.tl_typ = 'Hourly';
-            vm.reportModel.tl_days = vm.reportModel.tl_range_count;
-        } else {
-            vm.reportModel.tl_typ = 'Daily';
-            if(vm.reportModel.tl_timerange === 'weeks') {
-                vm.reportModel.tl_days = vm.reportModel.tl_range_count * 7;
-            } else {
-                vm.reportModel.tl_days = vm.reportModel.tl_range_count * 30;
-            }
-        }
+  vm.applyButtonClicked = function() {
+    if (vm.reportModel.tl_categories.length === 0) {
+      return;
+    }
 
-        var selectedDay = moment(vm.reportModel.tl_date),
-            startDay = selectedDay.clone(),
-            endDay = selectedDay.clone();
+    // process selections
+    if (vm.reportModel.tl_timerange === 'days') {
+      vm.reportModel.tl_typ = 'Hourly';
+      vm.reportModel.tl_days = vm.reportModel.tl_range_count;
+    } else {
+      vm.reportModel.tl_typ = 'Daily';
+      if (vm.reportModel.tl_timerange === 'weeks') {
+        vm.reportModel.tl_days = vm.reportModel.tl_range_count * 7;
+      } else {
+        vm.reportModel.tl_days = vm.reportModel.tl_range_count * 30;
+      }
+    }
 
-        if(vm.reportModel.tl_timepivot === "starting") {
-            endDay.add(vm.reportModel.tl_days, 'days').toDate();
-            vm.reportModel.miq_date = endDay.format('MM/DD/YYYY');
-        } else if(vm.reportModel.tl_timepivot === "centered") {
-            var enddays = Math.ceil(vm.reportModel.tl_days/2);
-            startDay.subtract(enddays, 'days').toDate();
-            endDay.add(enddays, 'days').toDate();
-            vm.reportModel.miq_date = endDay.format('MM/DD/YYYY');
+    var selectedDay = moment(vm.reportModel.tl_date),
+      startDay = selectedDay.clone(),
+      endDay = selectedDay.clone();
 
-        }  else if(vm.reportModel.tl_timepivot === "ending") {
-            startDay.subtract(vm.reportModel.tl_days, 'days');
-            vm.reportModel.miq_date = endDay.format('MM/DD/YYYY');
-        }
-        ManageIQ.calendar.calDateFrom = startDay.toDate();
-        ManageIQ.calendar.calDateTo = endDay.toDate();
-        if(vm.reportModel.tl_show === 'timeline') {
-            if(vm.reportModel.showDetailedEvents) {
-                vm.reportModel.tl_fl_typ = 'detail';
-            } else {
-                vm.reportModel.tl_fl_typ = 'critical';
-            }
-        }
-        miqService.sparkleOn();
-        miqService.miqAsyncAjaxButton(url, miqService.serializeModel(vm.reportModel));
-    };
+    if (vm.reportModel.tl_timepivot === "starting") {
+      endDay.add(vm.reportModel.tl_days, 'days').toDate();
+      vm.reportModel.miq_date = endDay.format('MM/DD/YYYY');
+    } else if (vm.reportModel.tl_timepivot === "centered") {
+      var enddays = Math.ceil(vm.reportModel.tl_days/2);
+      startDay.subtract(enddays, 'days').toDate();
+      endDay.add(enddays, 'days').toDate();
+      vm.reportModel.miq_date = endDay.format('MM/DD/YYYY');
 
-    init();
+    }  else if (vm.reportModel.tl_timepivot === "ending") {
+      startDay.subtract(vm.reportModel.tl_days, 'days');
+      vm.reportModel.miq_date = endDay.format('MM/DD/YYYY');
+    }
+    ManageIQ.calendar.calDateFrom = startDay.toDate();
+    ManageIQ.calendar.calDateTo = endDay.toDate();
+    if (vm.reportModel.tl_show === 'timeline') {
+      if (vm.reportModel.showDetailedEvents) {
+        vm.reportModel.tl_fl_typ = 'detail';
+      } else {
+        vm.reportModel.tl_fl_typ = 'critical';
+      }
+    }
+    miqService.sparkleOn();
+    miqService.miqAsyncAjaxButton(url, miqService.serializeModel(vm.reportModel));
+  };
+
+  init();
 }]);

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -2,7 +2,7 @@
 
 #tl_options_div
   %form#form_div{:name           => 'angularForm',
-                 'ng-controller' => 'timelineOptionsController',
+                 'ng-controller' => 'timelineOptionsController as vm',
                  'ng-show'       => 'vm.afterGet',
                  :novalidate     => true}
     - if @timeline

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -4,6 +4,7 @@
   %form#form_div{:name           => 'angularForm',
                  'ng-controller' => 'timelineOptionsController',
                  'ng-show'       => 'vm.afterGet',
+                 'miq-form'      => true,
                  :novalidate     => true}
     - if @timeline
       %h3

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -3,7 +3,7 @@
 #tl_options_div
   %form#form_div{:name           => 'angularForm',
                  'ng-controller' => 'timelineOptionsController',
-                 'ng-show'       => 'afterGet',
+                 'ng-show'       => 'vm.afterGet',
                  :novalidate     => true}
     - if @timeline
       %h3
@@ -18,14 +18,14 @@
               %div{'class' => 'timeline-filterbar'}
                 = select_tag("tl_show",
                   options_for_select(accessible_select_event_types, nil),
-                  'ng-model'                    => 'reportModel.tl_show',
+                  'ng-model'                    => 'vm.reportModel.tl_show',
                   "selectpicker-for-select-tag" => '',
                   :class                        => 'selectpicker',
-                  'ng-change'                   => 'eventTypeUpdated()')
+                  'ng-change'                   => 'vm.eventTypeUpdated()')
                 %span{'ng-if' => 'reportModel.tl_show === "timeline"'}
                   = select_tag("tl_category_management",
                     options_for_select(@tl_options.management.events.keys.sort, nil),
-                    'ng-model'                    => 'reportModel.tl_categories',
+                    'ng-model'                    => 'vm.reportModel.tl_categories',
                     "selectpicker-for-select-tag" => '',
                     'data-live-search'            => 'true',
                     'data-actions-box'            => 'true',
@@ -36,7 +36,7 @@
                 %span{'ng-if' => 'reportModel.tl_show !== "timeline"'}
                   = select_tag("tl_category_policy",
                     options_for_select(@tl_options.policy.events.keys.sort, nil),
-                    'ng-model'                    => 'reportModel.tl_categories',
+                    'ng-model'                    => 'vm.reportModel.tl_categories',
                     "selectpicker-for-select-tag" => '',
                     'data-live-search'            => 'true',
                     'data-actions-box'            => 'true',
@@ -50,25 +50,25 @@
                             :name         => 'showDetailedEvents',
                             'ng-model'    => 'reportModel.showDetailedEvents'}
                     = _("Show Detailed Events")
-                %span{'ng-if' => 'reportModel.tl_show !== "timeline"', 'class' => 'timeline-option'}
+                %span{'ng-if' => 'vm.reportModel.tl_show !== "timeline"', 'class' => 'timeline-option'}
                   %label.radio
-                    %input{"ng-model" => "reportModel.tl_result", :type => "radio", :value => "success"}
+                    %input{"ng-model" => "vm.reportModel.tl_result", :type => "radio", :value => "success"}
                     = _("Successful Events")
                   %label.radio
-                    %input{"ng-model" => "reportModel.tl_result", :type => "radio", :value => "failure"}
+                    %input{"ng-model" => "vm.reportModel.tl_result", :type => "radio", :value => "failure"}
                     = _("Failed Events")
                   %label.radio
-                    %input{"ng-model" => "reportModel.tl_result", :type => "radio", :value => "both"}
+                    %input{"ng-model" => "vm.reportModel.tl_result", :type => "radio", :value => "both"}
                     = _("Both")
               %div{'class' => 'timeline-date-box'}
                 .input-group.bootstrap-touchspin.timeline-stepper.pull-left
                   %span.input-group-btn
-                    %button.btn.btn-default.bootstrap-touchspin-down{"ng-click" => "countDecrement()", :type => "button"} -
-                  %input.timeline-range-input.bootstrap-touchspin.form-control{"ng-model" => "reportModel.tl_range_count",
+                    %button.btn.btn-default.bootstrap-touchspin-down{"ng-click" => "vm.countDecrement()", :type => "button"} -
+                  %input.timeline-range-input.bootstrap-touchspin.form-control{"ng-model" => "vm.reportModel.tl_range_count",
                                                                                 :readonly => "readonly",
                                                                                 :type     => "text"}
                   %span.input-group-btn
-                    %button.btn.btn-default.bootstrap-touchspin-up{"ng-click" => "countIncrement()", :type => "button"} +
+                    %button.btn.btn-default.bootstrap-touchspin-up{"ng-click" => "vm.countIncrement()", :type => "button"} +
                 = select_tag("tl_range",
                   options_for_select([[_("Days"), "days"],
                                       [_("Weeks"), "weeks"],
@@ -80,7 +80,7 @@
                   options_for_select([[_("centered"), "centered"],
                                       [_("starting"), "starting"],
                                       [_("ending"), "ending"]], nil),
-                  'ng-model'                    => 'reportModel.tl_timepivot',
+                  'ng-model'                    => 'vm.reportModel.tl_timepivot',
                   "selectpicker-for-select-tag" => '',
                   :class                        => 'selectpicker pull-left timeline-pivot-input')
                 %input{'pf-datepicker' => '',
@@ -88,8 +88,8 @@
                       'date'    => 'reportModel.tl_date',
                       'class'   => 'pull-righto timeline-date-input'}
             %div
-              .btn.btn-default{'ng-click'    => 'applyButtonClicked()',
-                              'ng-disabled' => 'reportModel.tl_categories.length === 0',
+              .btn.btn-default{'ng-click'    => 'vm.applyButtonClicked()',
+                              'ng-disabled' => 'vm.reportModel.tl_categories.length === 0',
                               'class'       => 'timeline-apply'}
                 = _("Apply")
             = hidden_field_tag(:ignore_form_changes)

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -25,7 +25,7 @@
                   "selectpicker-for-select-tag" => '',
                   :class                        => 'selectpicker',
                   'ng-change'                   => 'vm.eventTypeUpdated()')
-                %span{'ng-if' => 'reportModel.tl_show === "timeline"'}
+                %span{'ng-if' => 'vm.reportModel.tl_show === "timeline"'}
                   = select_tag("tl_category_management",
                     options_for_select(@tl_options.management.events.keys.sort, nil),
                     'ng-model'                    => 'vm.reportModel.tl_categories',
@@ -36,7 +36,7 @@
                     'data-deselect-all-text'      => _('Deselect All'),
                     'multiple'                    => '',
                     :class                        => 'selectpicker category-selector')
-                %span{'ng-if' => 'reportModel.tl_show !== "timeline"'}
+                %span{'ng-if' => 'vm.reportModel.tl_show !== "timeline"'}
                   = select_tag("tl_category_policy",
                     options_for_select(@tl_options.policy.events.keys.sort, nil),
                     'ng-model'                    => 'vm.reportModel.tl_categories',
@@ -47,11 +47,11 @@
                     'data-deselect-all-text'      => _('Deselect All'),
                     'multiple'                    => '',
                     :class                        => 'selectpicker category-selector')
-                %span{'ng-if' => 'reportModel.tl_show === "timeline"', 'class' => 'timeline-option'}
+                %span{'ng-if' => 'vm.reportModel.tl_show === "timeline"', 'class' => 'timeline-option'}
                   %label
                     %input{:type         => 'checkbox',
-                            :name         => 'showDetailedEvents',
-                            'ng-model'    => 'reportModel.showDetailedEvents'}
+                           :name         => 'showDetailedEvents',
+                           'ng-model'    => 'vm.reportModel.showDetailedEvents'}
                     = _("Show Detailed Events")
                 %span{'ng-if' => 'vm.reportModel.tl_show !== "timeline"', 'class' => 'timeline-option'}
                   %label.radio
@@ -76,7 +76,7 @@
                   options_for_select([[_("Days"), "days"],
                                       [_("Weeks"), "weeks"],
                                       [_("Months"), "months"]], nil),
-                  'ng-model'                    => 'reportModel.tl_timerange',
+                  'ng-model'                    => 'vm.reportModel.tl_timerange',
                   "selectpicker-for-select-tag" => '',
                   :class                        => 'selectpicker pull-left')
                 = select_tag("tl_timepivot",
@@ -87,13 +87,13 @@
                   "selectpicker-for-select-tag" => '',
                   :class                        => 'selectpicker pull-left timeline-pivot-input')
                 %input{'pf-datepicker' => '',
-                      'options' => 'dateOptions',
-                      'date'    => 'reportModel.tl_date',
-                      'class'   => 'pull-righto timeline-date-input'}
+                       'options'       => 'vm.dateOptions',
+                       'date'          => 'vm.reportModel.tl_date',
+                       'class'         => 'pull-righto timeline-date-input'}
             %div
               .btn.btn-default{'ng-click'    => 'vm.applyButtonClicked()',
-                              'ng-disabled' => 'vm.reportModel.tl_categories.length === 0',
-                              'class'       => 'timeline-apply'}
+                               'ng-disabled' => 'vm.reportModel.tl_categories.length === 0',
+                               'class'       => 'timeline-apply'}
                 = _("Apply")
             = hidden_field_tag(:ignore_form_changes)
 

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -4,6 +4,9 @@
   %form#form_div{:name           => 'angularForm',
                  'ng-controller' => 'timelineOptionsController as vm',
                  'ng-show'       => 'vm.afterGet',
+                 'miq-form'      => true,
+                 'model'         => 'vm.reportModel',
+                 'model-copy'    => 'vm.modelCopy',
                  :novalidate     => true}
     - if @timeline
       %h3

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -4,7 +4,6 @@
   %form#form_div{:name           => 'angularForm',
                  'ng-controller' => 'timelineOptionsController',
                  'ng-show'       => 'vm.afterGet',
-                 'miq-form'      => true,
                  :novalidate     => true}
     - if @timeline
       %h3

--- a/spec/javascripts/controllers/timeline/timeline_options_controller_spec.js
+++ b/spec/javascripts/controllers/timeline/timeline_options_controller_spec.js
@@ -30,49 +30,48 @@ describe('timelineOptionsController', function() {
 
     describe('count increment', function() {
         it('should increment the count', function() {
-            $scope.countIncrement();
-            expect($scope.reportModel.tl_range_count).toBe(2);
+            $controller.countIncrement();
+            expect($controller.reportModel.tl_range_count).toBe(2);
         });
 
         it('should decrement the count', function() {
-            $scope.reportModel.tl_range_count = 10;
-            $scope.countDecrement();
-            expect($scope.reportModel.tl_range_count).toBe(9);
+            $controller.reportModel.tl_range_count = 10;
+            $controller.countDecrement();
+            expect($controller.reportModel.tl_range_count).toBe(9);
         });
     });
 
     describe('options update', function() {
         it('should update the type to be hourly', function() {
-            $scope.reportModel.tl_timerange = 'days';
-            $scope.applyButtonClicked();
-            expect($scope.reportModel.tl_typ).toBe('Hourly');
+            $controller.reportModel.tl_timerange = 'days';
+            $controller.applyButtonClicked();
+            expect($controller.reportModel.tl_typ).toBe('Hourly');
         });
 
         it('should update the type to be daily', function() {
-            $scope.reportModel.tl_timerange = 'weeks';
-            $scope.applyButtonClicked();
-            expect($scope.reportModel.tl_typ).toBe('Daily');
+            $controller.reportModel.tl_timerange = 'weeks';
+            $controller.applyButtonClicked();
+            expect($controller.reportModel.tl_typ).toBe('Daily');
         });
 
         it('should update the miq_date correctly', function() {
-            $scope.reportModel.tl_timerange = 'days';
-            $scope.reportModel.tl_range_count = 10;
+            $controller.reportModel.tl_timerange = 'days';
+            $controller.reportModel.tl_range_count = 10;
             var timeLineDate = new Date('2016-04-01')
-            $scope.reportModel.tl_date = new Date(timeLineDate.getTime() + (timeLineDate.getTimezoneOffset() * 60000));
-            $scope.reportModel.tl_timepivot = 'starting';
-            $scope.applyButtonClicked();
-            expect($scope.reportModel.miq_date).toBe('04/11/2016');
+            $controller.reportModel.tl_date = new Date(timeLineDate.getTime() + (timeLineDate.getTimezoneOffset() * 60000));
+            $controller.reportModel.tl_timepivot = 'starting';
+            $controller.applyButtonClicked();
+            expect($controller.reportModel.miq_date).toBe('04/11/2016');
         });
 
         it('should update the miq_date correctly based on centered', function() {
-            $scope.reportModel.tl_timerange = 'days';
-            $scope.reportModel.tl_range_count = 10;
+            $controller.reportModel.tl_timerange = 'days';
+            $controller.reportModel.tl_range_count = 10;
             var timeLineDate = new Date('2016-04-01')
-            $scope.reportModel.tl_date = new Date(timeLineDate.getTime() + (timeLineDate.getTimezoneOffset() * 60000));
-            $scope.reportModel.tl_timepivot = 'centered';
-            $scope.applyButtonClicked();
-            expect($scope.reportModel.miq_date).toBe('04/06/2016');
+            $controller.reportModel.tl_date = new Date(timeLineDate.getTime() + (timeLineDate.getTimezoneOffset() * 60000));
+            $controller.reportModel.tl_timepivot = 'centered';
+            $controller.applyButtonClicked();
+            expect($controller.reportModel.miq_date).toBe('04/06/2016');
         });
     });
 });
-


### PR DESCRIPTION
Convert timeline_options_controller to controllerAs


- [x] uses as vm
- [x] ManageIQ.angular.scope points to vm - neeeded by QE
- [x] does not inject $scope unless needed for a $watch or events, or angularForm
- [ ] ~~using a common button partial~~ (not really sure, but I think no need for it)
- [x] uses miq-form
- [ ] ~~uses form-changed, no checkchange~~ (no checkchange to begin with)
- [x] no separate edit & new, use the same partial
- [x] specs
- [x] no copying values one by one - use Object.assign (No need for it)
- [x] no miqAjaxButton(url, true) - always submit the actual model, don't rely on magic form serialization
- [x] no extra $setPristine etc. where it doesn't make sense (form submit, form reset..)
- [x] no if (condition) return true; else return false;
- [x] no miqrequired, use required or ng-required