### PR TITLE
Generic Object Instances UI - `show_list` and `show`

### DIFF
--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -1,0 +1,25 @@
+class GenericObjectController < ApplicationController
+  before_action :check_privileges
+  before_action :get_session_data
+
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  include Mixins::GenericListMixin
+  include Mixins::GenericSessionMixin
+  include Mixins::GenericShowMixin
+
+  menu_section :automate
+
+  def self.model
+    GenericObject
+  end
+
+  private
+
+  def textual_group_list
+    []
+  end
+
+  helper_method :textual_group_list
+end

--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -18,7 +18,7 @@ class GenericObjectController < ApplicationController
   private
 
   def textual_group_list
-    []
+    [%i(properties attribute_details_list)]
   end
 
   helper_method :textual_group_list

--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -15,6 +15,10 @@ class GenericObjectDefinitionController < ApplicationController
     %w(generic_objects)
   end
 
+  def display_generic_objects
+    nested_list("generic_object", GenericObject)
+  end
+
   def self.model
     GenericObjectDefinition
   end

--- a/app/decorators/generic_object_decorator.rb
+++ b/app/decorators/generic_object_decorator.rb
@@ -1,0 +1,5 @@
+class GenericObjectDecorator < MiqDecorator
+  def self.fonticon
+    'ff ff-generic-object'
+  end
+end

--- a/app/helpers/generic_object_helper.rb
+++ b/app/helpers/generic_object_helper.rb
@@ -1,0 +1,3 @@
+module GenericObjectHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -10,27 +10,17 @@ module GenericObjectHelper::TextualSummary
   end
 
   def textual_group_attribute_details_list
-    TextualListview.new_from_hash(textual_attribute_details_list)
-  end
-
-  def textual_attribute_details_list
-    {
-      :title     => _("Attributes (#{@record.property_attributes.count})"),
-      :headers   => [_("Name"), _("Value")],
-      :col_order => %w(name value),
-      :value     => attributes_array
-    }
+    TextualMultilabel.new(
+      _("Attributes (#{@record.property_attributes.count})"),
+      :additional_table_class => "table-fixed",
+      :labels                 => [_("Name"), _("Value")],
+      :values                 => attributes_array
+    )
   end
 
   def attributes_array
-    attributes = []
-    @record.property_attributes.each do |row|
-      attributes.push({
-        :title    => row[0],
-        :name     => row[0],
-        :value    => row[1],
-      })
+    @record.property_attributes.each do |var|
+      [var[0], var[1]]
     end
-    attributes
   end
 end

--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -1,0 +1,36 @@
+module GenericObjectHelper::TextualSummary
+  include TextualMixins::TextualName
+
+  def textual_group_properties
+    TextualGroup.new(_("Properties"), %i(name))
+  end
+
+  def textual_name
+    {:label => _("Name"), :value => @record.name}
+  end
+
+  def textual_group_attribute_details_list
+    TextualListview.new_from_hash(textual_attribute_details_list)
+  end
+
+  def textual_attribute_details_list
+    {
+      :title     => _("Attributes (#{@record.property_attributes.count})"),
+      :headers   => [_("Name"), _("Value")],
+      :col_order => %w(name value),
+      :value     => attributes_array
+    }
+  end
+
+  def attributes_array
+    attributes = []
+    @record.property_attributes.each do |row|
+      attributes.push({
+        :title    => row[0],
+        :name     => row[0],
+        :value    => row[1],
+      })
+    end
+    attributes
+  end
+end

--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -2,11 +2,19 @@ module GenericObjectHelper::TextualSummary
   include TextualMixins::TextualName
 
   def textual_group_properties
-    TextualGroup.new(_("Properties"), %i(name))
+    TextualGroup.new(_("Properties"), %i(name created updated))
   end
 
   def textual_name
     {:label => _("Name"), :value => @record.name}
+  end
+
+  def textual_created
+    {:label => _("Created"), :value => format_timezone(@record.created_at)}
+  end
+
+  def textual_updated
+    {:label => _("Updated"), :value => format_timezone(@record.updated_at)}
   end
 
   def textual_group_attribute_details_list

--- a/app/views/generic_object/show.html.haml
+++ b/app/views/generic_object/show.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => 'layouts/textual_groups_generic'

--- a/app/views/generic_object/show_list.html.haml
+++ b/app/views/generic_object/show_list.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => 'layouts/gtl'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2043,6 +2043,14 @@ Rails.application.routes.draw do
         x_post
     },
 
+    :generic_object => {
+      :get => %w(
+        show_list
+      ),
+      :post => %w(
+      )
+    },
+
     :generic_object_definition => {
       :get => %w(
         show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2045,6 +2045,7 @@ Rails.application.routes.draw do
 
     :generic_object => {
       :get => %w(
+        show
         show_list
       ),
       :post => %w(

--- a/product/views/GenericObject.yaml
+++ b/product/views/GenericObject.yaml
@@ -1,0 +1,73 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Generic Objects
+
+# Menu name
+name: GenericObject
+
+# Main DB table report is based on
+db: GenericObject
+
+# Columns to fetch from the main table
+cols:
+- name
+- created_at
+- updated_at
+
+# Included tables (joined, has_one, has_many) and columns
+
+# Included tables and columns for query performance
+include_for_find:
+
+# Order of columns (from all tables)
+col_order:
+- name
+- created_at
+- updated_at
+
+# Column titles, in order
+headers:
+- Name
+- Created
+- Updated
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+- created_at
+- updated_at
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/spec/controllers/generic_object_controller_spec.rb
+++ b/spec/controllers/generic_object_controller_spec.rb
@@ -1,0 +1,26 @@
+describe GenericObjectController do
+  include CompressedIds
+
+  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+  let(:zone) { FactoryGirl.build(:zone) }
+
+  describe "#show" do
+    render_views
+    before(:each) do
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as FactoryGirl.create(:user)
+      generic_obj = FactoryGirl.create(:generic_object)
+      get :show, :params => {:id => generic_obj.id}
+    end
+    it { expect(response.status).to eq(200) }
+  end
+
+  describe "#show_list" do
+    before(:each) do
+      stub_user(:features => :all)
+      FactoryGirl.create(:generic_object)
+      get :show_list
+    end
+    it { expect(response.status).to eq(200) }
+  end
+end


### PR DESCRIPTION
UI for Generic Object Instances

Accessible from the Generic Object Classes Summary screen shown below -
<img width="1426" alt="screen shot 2017-07-26 at 3 41 21 pm" src="https://user-images.githubusercontent.com/1538216/28646894-edf67aa0-7218-11e7-8d3a-6cfa6b841866.png">

----------------------
`show_list` for Generic Object Instances
<img width="1429" alt="screen shot 2017-07-28 at 4 22 56 pm" src="https://user-images.githubusercontent.com/1538216/28739604-18ab8c4c-73b1-11e7-9b2b-71828d0f7890.png">


----------------
`show` for Generic Object Instance
(Displays `Name` and `Attributes`)
<img width="1430" alt="screen shot 2017-07-26 at 4 40 41 pm" src="https://user-images.githubusercontent.com/1538216/28648236-399f369c-7221-11e7-8762-aa4175b10ce9.png">



