### PR TITLE
Same value was replaced with new constant

### DIFF
--- a/app/helpers/ops_helper/textual_summary.rb
+++ b/app/helpers/ops_helper/textual_summary.rb
@@ -3,6 +3,8 @@ module OpsHelper::TextualSummary
   # Groups
   #
 
+  TOP_TABLES_BY_COUNT = 5
+
   def textual_group_vmdb_connection_properties
     TextualGroup.new(
       _("Properties"),
@@ -107,7 +109,7 @@ module OpsHelper::TextualSummary
       :title     => _("Tables with the Most Rows"),
       :headers   => [_("Name"), _("Rows")],
       :col_order => %w(name value),
-      :value     => vmdb_table_top_rows(:rows, 5)
+      :value     => vmdb_table_top_rows(:rows, TOP_TABLES_BY_COUNT)
     }
   end
 
@@ -116,7 +118,7 @@ module OpsHelper::TextualSummary
       :title     => _("Largest Tables"),
       :headers   => [_("Name"), _("Size")],
       :col_order => %w(name value),
-      :value     => vmdb_table_top_rows(:size, 5)
+      :value     => vmdb_table_top_rows(:size, TOP_TABLES_BY_COUNT)
     }
   end
 
@@ -125,7 +127,7 @@ module OpsHelper::TextualSummary
       :title     => _("Tables with Most Wasted Space"),
       :headers   => [_("Name"), _("Wasted")],
       :col_order => %w(name value),
-      :value     => vmdb_table_top_rows(:wasted_bytes, 5)
+      :value     => vmdb_table_top_rows(:wasted_bytes, TOP_TABLES_BY_COUNT)
     }
   end
 


### PR DESCRIPTION
### Issue: #1661 
---
### Issue in pull request: https://github.com/ManageIQ/manageiq-ui-classic/pull/1757
Three same values are replaced with constant `TOP_TABLES_BY_COUNT` in `manageiq-ui-classic/app/helpers/ops_helper/textual_summary.rb`.
