### PR TITLE
Remove PDF_PAGE_SIZES from UiConstants

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -6,23 +6,6 @@ module UiConstants
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
 
-  # PDF page sizes
-  PDF_PAGE_SIZES = {
-    "a0"            => N_("A0 - 841mm x 1189mm"),
-    "a1"            => N_("A1 - 594mm x 841mm"),
-    "a2"            => N_("A2 - 420mm x 594mm"),
-    "a3"            => N_("A3 - 297mm x 420mm"),
-    "a4"            => N_("A4 - 210mm x 297mm (default)"),
-    "US-Letter"     => N_("US Letter - 8.5in x 11.0in"),
-    "US-Legal"      => N_("US Legal - 8.5in x 14.0in"),
-    "US-Executive"  => N_("US Executive - 7.25in x 10.5in"),
-    "US-Ledger"     => N_("US Ledger - 17.0in x 11.0in"),
-    "US-Tabloid"    => N_("US Tabloid - 11.0in x 17.0in"),
-    "US-Government" => N_("US Government - 8.0in x 11.0in"),
-    "US-Statement"  => N_("US Statement - 5.5in x 8.5in"),
-    "US-Folio"      => N_("US Folio - 8.5in x 13.0in")
-  }
-
   # RSS Feeds
   RSS_FEEDS = {
     "Microsoft Security"         => "http://www.microsoft.com/protect/rss/rssfeed.aspx",

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -9,6 +9,23 @@ module ViewHelper
   MAX_DESC_LEN = 255
   MAX_HOSTNAME_LEN = 255
 
+  # PDF page sizes
+  PDF_PAGE_SIZES = {
+    "a0"            => N_("A0 - 841mm x 1189mm"),
+    "a1"            => N_("A1 - 594mm x 841mm"),
+    "a2"            => N_("A2 - 420mm x 594mm"),
+    "a3"            => N_("A3 - 297mm x 420mm"),
+    "a4"            => N_("A4 - 210mm x 297mm (default)"),
+    "US-Letter"     => N_("US Letter - 8.5in x 11.0in"),
+    "US-Legal"      => N_("US Legal - 8.5in x 14.0in"),
+    "US-Executive"  => N_("US Executive - 7.25in x 10.5in"),
+    "US-Ledger"     => N_("US Ledger - 17.0in x 11.0in"),
+    "US-Tabloid"    => N_("US Tabloid - 11.0in x 17.0in"),
+    "US-Government" => N_("US Government - 8.0in x 11.0in"),
+    "US-Statement"  => N_("US Statement - 5.5in x 8.5in"),
+    "US-Folio"      => N_("US Folio - 8.5in x 13.0in")
+  }
+
   class << self
     def concat_tag(*args, &block)
       concat content_tag(*args, &block)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -24,7 +24,7 @@ module ViewHelper
     "US-Government" => N_("US Government - 8.0in x 11.0in"),
     "US-Statement"  => N_("US Statement - 5.5in x 8.5in"),
     "US-Folio"      => N_("US Folio - 8.5in x 13.0in")
-  }
+  }.freeze
 
   class << self
     def concat_tag(*args, &block)

--- a/app/views/report/_form_formatting.html.haml
+++ b/app/views/report/_form_formatting.html.haml
@@ -8,7 +8,7 @@
         = _('Page Size')
       .col-md-8
         = select_tag('pdf_page_size',
-          options_for_select(PDF_PAGE_SIZES.map { |k, v| [_(v), v] }.sort, @edit[:new][:pdf_page_size]),
+          options_for_select(ViewHelper::PDF_PAGE_SIZES.map { |k, v| [_(v), v] }.sort, @edit[:new][:pdf_page_size]),
           :multiple             => false,
           :class                => "selectpicker")
         :javascript


### PR DESCRIPTION
### Issue: #1661 

We have removed `PDF_PAGE_SIZES` constant from `UiConstants`. `PDF_PAGE_SIZES` was moved to `ViewHelper` and also added `ViewHelper` prefix to `PDF_PAGE_SIZES` in `manageiq-ui-classic/app/views/report/_form_formatting.html.haml`.