### PR TITLE
Add ui_select dep. to match new ui-components.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -83,3 +83,4 @@
 //= require manageiq-ui-components/dist/js/ui-components
 //= require rx-angular/dist/rx.angular
 //= require patternfly-timeline/dist/timeline
+//= require ui-select/dist/select

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -1,4 +1,5 @@
 ManageIQ.angular.app = angular.module('ManageIQ', [
+  'ui.select',
   'ui.bootstrap',
   'ui.codemirror',
   'patternfly',

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -27,4 +27,5 @@
  *= require xml_display
  *= require patternfly-timeline/dist/timeline
  *= require manageiq-ui-components/dist/css/ui-components
+ *= require ui-select/dist/select
 */

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "eslint-plugin-react": "^5.1.1",
     "eslint-plugin-standard": "^2.0.1"
   },
+  "dependencies": {
+    "ui-select": "0.19.8"
+  },
   "engines": {
     "node": ">= 6.9.1",
     "npm": ">= 3.10.3"


### PR DESCRIPTION
https://github.com/ManageIQ/ui-components/pull/82 was merged in ui-components adding a new dependancy

we need to add that to manageiq-ui-classic too

now the new dialog component is available in the OPS UI and can be used to replace the old code