### PR TITLE
use ViewHelper prefix module for constant

### DIFF
--- a/app/views/static/ops/tenant/tenant.html.haml
+++ b/app/views/static/ops/tenant/tenant.html.haml
@@ -14,7 +14,7 @@
                           "name"        => "name",
                           "ng-model"    => "vm.tenantModel.name",
                           "ng-disabled" => "vm.tenantModel.default && vm.tenantModel.use_config_for_attributes",
-                          "maxlength"   => "#{MAX_NAME_LEN}",
+                          "maxlength"   => ViewHelper::MAX_NAME_LEN,
                           "required"    => "",
                           "auto-focus"  => ""}
       %span.help-block{"ng-show" => "angularForm.name.$error.required"}


### PR DESCRIPTION
the constant has been moved to ViewHelper but it was accessed without module prefix.

## Test scenario
Add child tenant to an any tenant 

@miq-bot add_label bug
cc @europ 

@miq-bot assign @himdel 