### PR TITLE
Remove DEFAULT_PDF_PAGE_SIZE from UiConstants

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -5,7 +5,7 @@ module ReportController::Reports::Editor
     helper_method :cashed_reporting_available_fields, :cashed_reporting_available_fields
   end
 
-  DEFAULT_PDF_PAGE_SIZE = "US-Letter"
+  DEFAULT_PDF_PAGE_SIZE = "US-Letter".freeze
 
   CHARGEBACK_ALLOWED_FIELD_SUFFIXES = %w(
     _cost

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -5,6 +5,8 @@ module ReportController::Reports::Editor
     helper_method :cashed_reporting_available_fields, :cashed_reporting_available_fields
   end
 
+  DEFAULT_PDF_PAGE_SIZE = "US-Letter"
+
   CHARGEBACK_ALLOWED_FIELD_SUFFIXES = %w(
     _cost
     -owner_name

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -22,7 +22,6 @@ module UiConstants
     "US-Statement"  => N_("US Statement - 5.5in x 8.5in"),
     "US-Folio"      => N_("US Folio - 8.5in x 13.0in")
   }
-  DEFAULT_PDF_PAGE_SIZE = "US-Letter"
 
   # Setting high number incase we don't want to display paging controls on list views
   ONE_MILLION = 1000000


### PR DESCRIPTION
### Issue: #1661 

We have removed `DEFAULT_PDF_PAGE_SIZE` constant from `UiConstants`. Definition of `DEFAULT_PDF_PAGE_SIZE` constant was moved to `Editor`.