### PR TITLE
Remove ONE_MILLION from UiConstants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,7 +76,7 @@ class ApplicationController < ActionController::Base
   before_action :allow_websocket
   after_action :set_global_session_data, :except => [:resize_layout]
 
-  ONE_MILLION = 1000000 # Setting high number incase we don't want to display paging controls on list views
+  ONE_MILLION = 1_000_000 # Setting high number incase we don't want to display paging controls on list views
 
   def local_request?
     Rails.env.development? || Rails.env.test?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,6 +76,8 @@ class ApplicationController < ActionController::Base
   before_action :allow_websocket
   after_action :set_global_session_data, :except => [:resize_layout]
 
+  ONE_MILLION = 1000000 # Setting high number incase we don't want to display paging controls on list views
+
   def local_request?
     Rails.env.development? || Rails.env.test?
   end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -24,9 +24,6 @@ module UiConstants
   }
   DEFAULT_PDF_PAGE_SIZE = "US-Letter"
 
-  # Setting high number incase we don't want to display paging controls on list views
-  ONE_MILLION = 1000000
-
   # RSS Feeds
   RSS_FEEDS = {
     "Microsoft Security"         => "http://www.microsoft.com/protect/rss/rssfeed.aspx",


### PR DESCRIPTION
### Issue: #1661 

We have removed `ONE_MILLION` constant from `UiConstants`. Definition of `ONE_MILLION` constant was moved to `ApplicationController`.