### PR TITLE
Correct label text wording for Custom Button Group summary page.

### DIFF
--- a/app/views/shared/buttons/_ab_list.html.haml
+++ b/app/views/shared/buttons/_ab_list.html.haml
@@ -81,7 +81,7 @@
 
       .form-group
         %label.control-label.col-md-2
-          = _('Button Hover Group Text')
+          = _('Button Group Hover Text')
         .col-md-8
           = @record.description
       .form-group


### PR DESCRIPTION
Change label wording to Group Hover Text.

https://bugzilla.redhat.com/show_bug.cgi?id=1467906

Screen shot prior to change:
![custom group buttons hover text prior to code change](https://user-images.githubusercontent.com/552686/28687302-f159d57a-72c2-11e7-8981-b8bc56f5b16a.png)

Screen shot post code change:
![custom group buttons hover text post code change](https://user-images.githubusercontent.com/552686/28687367-0090fd3e-72c3-11e7-9bfc-32ae76d9a2b2.png)




