### PR TITLE
Redundant wording for Custom Button Group and Button.

### DIFF
--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -22,7 +22,7 @@
   .form-horizontal
     .form-group
       %label.control-label.col-md-2
-        = _('Button Text')
+        = _('Text')
       .col-md-8
         .input-group
           = text_field_tag("name", @edit[:new][:name],
@@ -38,7 +38,7 @@
         = javascript_tag(javascript_focus('name'))
     .form-group
       %label.control-label.col-md-2
-        = _('Button Hover Text')
+        = _('Hover Text')
       .col-md-8
         = text_field_tag("description", @edit[:new][:description],
                           :maxlength         => 50,
@@ -46,7 +46,7 @@
                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
     .form-group
       %label.control-label.col-md-2
-        = _('Button Image')
+        = _('Image')
       .col-md-8
         = select_tag('button_image',
                         options_for_select([[_("No Image"), nil]] + @edit[:new][:button_images], @edit[:new][:button_image].to_s),

--- a/app/views/shared/buttons/_ab_list.html.haml
+++ b/app/views/shared/buttons/_ab_list.html.haml
@@ -69,7 +69,7 @@
     .form-horizontal.static
       .form-group
         %label.control-label.col-md-2
-          = _('Button Group Text')
+          = _('Text')
         .col-md-8
           = @record.name.split('|').first
           - display = @record.set_data.key?(:display) ? @record.set_data[:display] : true
@@ -81,7 +81,7 @@
 
       .form-group
         %label.control-label.col-md-2
-          = _('Button Group Hover Text')
+          = _('Hover Text')
         .col-md-8
           = @record.description
       .form-group

--- a/app/views/shared/buttons/_ab_show.html.haml
+++ b/app/views/shared/buttons/_ab_show.html.haml
@@ -5,7 +5,7 @@
 .form-horizontal.static
   .form-group
     %label.control-label.col-md-2
-      = _('Button Text')
+      = _('Text')
     .col-md-8
       = @custom_button.name
       - display = @custom_button.options.key?(:display) ? @custom_button.options[:display] : true
@@ -17,7 +17,7 @@
 
   .form-group
     %label.control-label.col-md-2
-      = _('Button Hover Text')
+      = _('Hover Text')
     .col-md-8
       = @custom_button.description
   .form-group

--- a/app/views/shared/buttons/_group_form.html.haml
+++ b/app/views/shared/buttons/_group_form.html.haml
@@ -6,7 +6,7 @@
   .form-horizontal
     .form-group
       %label.control-label.col-md-2
-        = _('Button Group Text')
+        = _('Text')
       .col-md-8
         .input-group
           = text_field_tag("name", @edit[:new][:name],
@@ -22,7 +22,7 @@
               = javascript_tag(javascript_focus('name'))
     .form-group
       %label.control-label.col-md-2
-        = _('Button Group Hover Text')
+        = _('Hover Text')
       .col-md-8
         = text_field_tag("description", @edit[:new][:description],
                         :maxlength         => 30,
@@ -30,7 +30,7 @@
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
     .form-group
       %label.control-label.col-md-2
-        = _('Button Group Image')
+        = _('Image')
       .col-md-8
         #form-group
         = select_tag('button_image',


### PR DESCRIPTION
Delete redundant wording already displayed in form title, both for Custom Button Group and individual Button.

Screen shots prior to code fixes:
![custom button display text prior to fix](https://user-images.githubusercontent.com/552686/28693524-f03063fa-72d9-11e7-8e94-f436cbff101e.png)

![custom button edit page display text prior to code fix](https://user-images.githubusercontent.com/552686/28693901-dd1addca-72db-11e7-8a9d-1f1849526284.png)

![custom group buttons hover text post code change](https://user-images.githubusercontent.com/552686/28693573-2fe12f2a-72da-11e7-9585-34567dda7cb6.png)

Screen shots post code fix:
![custom button group hover text post code change](https://user-images.githubusercontent.com/552686/28693705-f8eff9fa-72da-11e7-9039-6325bce87943.png)

![custom button display text post fix](https://user-images.githubusercontent.com/552686/28693552-12df5b9a-72da-11e7-8532-c59494ddcfb6.png)

![custom button edit page display text post fix](https://user-images.githubusercontent.com/552686/28733336-715e5c46-7390-11e7-8095-268d8e5b5879.png)
