### PR TITLE
undefined method `split' when checking request view

### DIFF
--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -10,7 +10,7 @@ module ApplicationHelper::Dialogs
   end
 
   def dialog_dropdown_selected_value(field)
-    if !field.values || field.values.empty?
+    if !field.values || field.values.empty? || filed.value.kind_of?(Numeric)
       return field.value
     end
     if field.value.kind_of?(String) && field.value.include?(',')


### PR DESCRIPTION
When checking finished requests we see in the logs:

[ActionView::Template::Error] undefined method `split' for 16384:Fixnum
/opt/rh/cfme-gemset/bundler/gems/manageiq-ui-classic-1048ffdbd63f/app/helpers/application_helper/dialogs.rb:18:in `dialog_dropdown_selected_value'

this PR fixes the issue by returning value when field.value is a Numeric value.

Bug-Url:
https://bugzilla.redhat.com/1464170