### PR TITLE
Fix HAML indentation for Report Widget fragment

### DIFF
--- a/app/views/dashboard/_widget_report.html.haml
+++ b/app/views/dashboard/_widget_report.html.haml
@@ -3,10 +3,10 @@
     widget -- MiqWidget object
 .mc{:id => "dd_w#{widget.id}_box",
 :style => @sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display: none;' : ''}
-- if widget.contents_for_user(current_user).contents.blank?
-  .blank-slate-pf{:style => "padding: 10px"}
-    .blank-slate-pf-icon
-      %i.fa.fa-cog
-      %h1= _('No report data found.')
-- else
-  = widget.contents_for_user(current_user).contents.html_safe
+  - if widget.contents_for_user(current_user).contents.blank?
+    .blank-slate-pf{:style => "padding: 10px"}
+      .blank-slate-pf-icon
+        %i.fa.fa-cog
+        %h1= _('No report data found.')
+  - else
+    = widget.contents_for_user(current_user).contents.html_safe


### PR DESCRIPTION
Missing indentation caused the widget content being outside of the div.mc which handles minimizing, therefore minimizing and maximizing of the widget did not work.

https://bugzilla.redhat.com/show_bug.cgi?id=1476305