### PR TITLE
Fixed save of RH satellite 6 subscription

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -32,6 +32,7 @@ module OpsController::Settings::Common
       else
         @refresh_div = nil
       end
+      @changed = false unless rhn_save_enabled?
     when 'settings_workers'
       @changed = (@edit[:new].config != @edit[:current].config)
       if @edit[:new].config[:workers][:worker_base][:ui_worker][:count] != @edit[:current].config[:workers][:worker_base][:ui_worker][:count]

--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -269,9 +269,11 @@ module OpsController::Settings::RHN
     # rhn_fire_available_organizations is async, if wait_for_task is completed, render the results
     if params[:task_id]
       render :update do |page|
+        @changed = (@edit[:new] != @edit[:current])
         page << javascript_prologue
         if 'rhn_satellite6' == @edit[:new][:register_to]
           page.replace_html('settings_rhn', :partial => 'settings_rhn_edit_tab')
+          page << javascript_for_miq_button_visibility(@changed) unless flash_errors?
         else
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
@@ -350,6 +352,12 @@ module OpsController::Settings::RHN
   end
 
   private
+
+  def rhn_save_enabled?
+    return @changed if @edit[:new][:register_to] != 'rhn_satellite6'
+    # @edit[:organizations] gets set when validate button is pressed
+    @edit[:new][:register_to] == 'rhn_satellite6' && @edit[:organizations]
+  end
 
   def reset_repo_name_from_default
     MiqDatabase.registration_default_value_for_update_repo_name

--- a/app/views/layouts/_auth_credentials2.html.haml
+++ b/app/views/layouts/_auth_credentials2.html.haml
@@ -11,6 +11,7 @@
                     :password => _('Change Password / Confirm Password'),
                     :title    => _('Validate the credentials')}
 - labels = defined?(labels) && labels.present? ? default_labels.update(labels) : default_labels
+- validate_note ||= nil
 - observe_url_json = {:interval => '.5', :url => change_url}.to_json
 
 .form-group
@@ -51,4 +52,7 @@
                 :remote               => true,
                 "data-method"         => :post,
                 'data-miq_sparkle_on' => true)
+      - if validate_note
+        .note
+          %b= validate_note
 -# Note that we do not turn off the sparkle. We expect async handling here.

--- a/app/views/ops/_settings_rhn_edit_tab.html.haml
+++ b/app/views/ops/_settings_rhn_edit_tab.html.haml
@@ -84,6 +84,7 @@
                           :record_id    => 'new',
                           :change_url   => url,
                           :validate_url => 'rhn_validate',
+                          :validate_note => @edit[:new][:register_to] == 'rhn_satellite6' && @edit[:organizations].nil? ? _("Note: Validation required") : nil,
                           :validate     => true}
 
     - if 'rhn_satellite6' == @edit[:new][:register_to] && !@edit[:organizations].blank?


### PR DESCRIPTION
Changed code to force user to validate credentials if user has selected to Register to Satellite 6, `@edit[:organizations] ` gets set only when validate button is pressed, `@edit[:organizations]` is required to be set for satellite 6 to save registration_organization_display_name for MiqDatabase record.
Added a note under "Validate" button to force user to validate when selecting Satellite 6 in the drop down and disabled "Save" button if validation is not done yet.

https://bugzilla.redhat.com/show_bug.cgi?id=1463389

@carbonin can you help with testing of this fix, i don't have environment setup to be able to fully test the fix.

screenshots:

![rh_satellite6_validation](https://user-images.githubusercontent.com/3450808/28725067-424363ee-738a-11e7-8419-f9e6f445a27f.png)

![rh_subscription_manager](https://user-images.githubusercontent.com/3450808/28725070-44426974-738a-11e7-98d6-0dd10db585b7.png)
