### PR TITLE
Removing redundant code moving work to db

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -860,19 +860,12 @@ class ApplicationController < ActionController::Base
     folders = []
     user = current_user
     @sb[:grp_title] = reports_group_title
-    @data = []
+    data = []
     if !group.settings || group.settings[:report_menus].blank? || mode == "default"
       # array of all reports if menu not configured
-      @rep = MiqReport.for_user(current_user).sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
-      if tree_type == "timeline"
-        @data = @rep.reject { |r| r.timeline.nil? }
-      else
-        @data = @rep.select do |r|
-          r.template_type == "report" && !r.template_type.blank?
-        end
-      end
-      @data.each do |r|
-        next if r.template_type != "report" && !r.template_type.blank?
+      data = MiqReport.for_user(current_user).where(:template_type => "report").order(:rpt_type, :filename, :name)
+      data.where.not(:timeline => nil) if tree_type == "timeline"
+      data.each do |r|
         r_group = r.rpt_group == "Custom" ? "#{@sb[:grp_title]} - Custom" : r.rpt_group # Get the report group
         title = r_group.split('-').collect(&:strip)
         if @temp_title != title[0]


### PR DESCRIPTION
The `get_reports_menu` method filtered a lot of data after selecting it from the DB.  This PR removes some of that post filtering.

Previously, *all* MiqReports were pulled from the DB for the current user.  Then, the controller would select and reject records based on criteria that could be in queries.

Additionally, a check was in place to limit the rows to report templates conditional on whether the `tree_type` was timeline or not.  However, immediately after, all non report templates are skipped in processing.  Instead, this will only select report templates from the DB.

This also removes the `@data` and `@rep` instance variables from the controller scope.
