### PR TITLE
Generic Object Classes Listview - bells and whistles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1408,6 +1408,7 @@ module ApplicationHelper
           ems_storage
           flavor
           floating_ip
+          generic_object_definition
           host
           load_balancer
           middleware_datasource
@@ -1478,6 +1479,7 @@ module ApplicationHelper
              ems_storage
              flavor
              floating_ip
+             generic_object_definition
              host
              host_aggregate
              load_balancer

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -877,6 +877,7 @@ module ApplicationHelper
        ems_storage
        flavor
        floating_ip
+       generic_object_definition
        host
        host_aggregate
        load_balancer
@@ -1303,6 +1304,7 @@ module ApplicationHelper
                         event
                         flavor
                         floating_ip
+                        generic_object_definition
                         host
                         host_aggregate
                         load_balancer

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -178,6 +178,7 @@ module ApplicationHelper::PageLayouts
       ems_storage
       flavor
       floating_ip
+      generic_object_definition
       host
       host_aggregate
       load_balancer

--- a/app/views/layouts/listnav/_generic_object_definition.html.haml
+++ b/app/views/layouts/listnav/_generic_object_definition.html.haml
@@ -1,0 +1,13 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(_("Properties"), false, "god_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to(_('Summary'), {:action => 'show', :id => @record, :display => 'main'}, {:title => _("Show Summary")})
+    = miq_accordion_panel(_("Relationships"), false, "god_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = li_link(:count => @record.number_of(:generic_objects),
+            :tables        => 'instances',
+            :record        => @record,
+            :display       => 'generic_objects')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2050,11 +2050,23 @@ Rails.application.routes.draw do
 
     :generic_object_definition => {
       :get => %w(
+        download_data
+        download_summary_pdf
         show
         show_list
       ),
       :post => %w(
-      )
+        create_del
+        exp_button
+        exp_changed
+        exp_token_pressed
+        listnav_search_selected
+        update_del
+        quick_search
+        show_list
+      ) +
+        adv_search_post +
+        save_post
     },
 
     :ansible_credential => {


### PR DESCRIPTION
Added support for the following in the `Generic Object Classes` Listview

- Quick search
- Advanced search
- Download data 
- GTL

------------------

Displays Quick search,  GTL :
<img width="1435" alt="screen shot 2017-07-28 at 4 07 16 pm" src="https://user-images.githubusercontent.com/1538216/28739325-eeb8058e-73ae-11e7-9f80-c106440f1911.png">

-------------------
Displays Advanced Search:
<img width="1428" alt="screen shot 2017-07-28 at 4 07 36 pm" src="https://user-images.githubusercontent.com/1538216/28739326-f2008626-73ae-11e7-8ccd-5dfd3b08b39c.png">

-------------
Listnav to save custom filters
<img width="1340" alt="screen shot 2017-08-01 at 3 15 17 pm" src="https://user-images.githubusercontent.com/1538216/28849610-a72d3880-76cc-11e7-860b-fc3b3f61d39d.png">

------------------
Listnav in the Generic Object Class Summary Page
<img width="1343" alt="screen shot 2017-08-01 at 4 02 04 pm" src="https://user-images.githubusercontent.com/1538216/28850663-e3e49bf0-76d2-11e7-9377-b351a3f2b0a5.png">



