### PR TITLE
Convert network_topology_controller to controllerAs

### DIFF
--- a/app/assets/javascripts/controllers/topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/network_topology_controller.js
@@ -2,16 +2,16 @@ angular.module('ManageIQ').controller('networkTopologyController', NetworkTopolo
 NetworkTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
 
 function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
-  ManageIQ.angular.scope = $scope;
+  var vm = this;
+  ManageIQ.angular.scope = vm;
   miqHideSearchClearButton();
-  var self = this;
-  $scope.vs = null;
+  vm.vs = null;
   var icons = null;
 
   var d3 = window.d3;
-  $scope.d3 = d3;
+  vm.d3 = d3;
 
-  topologyService.mixinContextMenu(this, $scope);
+  topologyService.mixinContextMenu(this, vm);
 
   ManageIQ.angular.rxSubject.subscribe(function(event) {
     if (event.name === 'refreshTopology') {
@@ -19,7 +19,8 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
     }
   });
 
-  $scope.refresh = function() {
+
+  vm.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
       id = '';
@@ -34,15 +35,15 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
       .catch(miqService.handleFailure);
   };
 
-  $scope.checkboxModel = {
+  vm.checkboxModel = {
     value: false
   };
 
-  $scope.legendTooltip = __("Click here to show/hide entities of this type");
+  vm.legendTooltip = __("Click here to show/hide entities of this type");
 
-  $('input#box_display_names').click(topologyService.showHideNames($scope));
-  $scope.refresh();
-  var promise = $interval($scope.refresh, 1000 * 60 * 3);
+  $('input#box_display_names').click(topologyService.showHideNames(vm));
+  vm.refresh();
+  var promise = $interval(vm.refresh, 1000 * 60 * 3);
 
   $scope.$on('$destroy', function() {
     $interval.cancel(promise);
@@ -61,24 +62,24 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
 
     added.append("circle")
       .attr("r", function(d) {
-        return self.getDimensions(d).r;
+        return vm.getDimensions(d).r;
       })
       .attr('class', function(d) {
         return topologyService.getItemStatusClass(d);
       })
       .on("contextmenu", function(d) {
-        self.contextMenu(this, d);
+        vm.contextMenu(this, d);
       });
 
     added.append("title");
 
     added.on("dblclick", function(d) {
-      return self.dblclick(d);
+      return vm.dblclick(d);
     });
 
     added.append("image")
       .attr("xlink:href", function (d) {
-        var iconInfo = self.getIcon(d);
+        var iconInfo = vm.getIcon(d);
         switch(iconInfo.type) {
           case 'image':
             return iconInfo.icon;
@@ -87,32 +88,32 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
         }
       })
       .attr("height", function(d) {
-        var iconInfo = self.getIcon(d);
+        var iconInfo = vm.getIcon(d);
         if (iconInfo.type != 'image') {
           return 0;
         }
         return 40;
       })
       .attr("width", function(d) {
-        var iconInfo = self.getIcon(d);
+        var iconInfo = vm.getIcon(d);
         if (iconInfo.type != 'image') {
           return 0;
         }
         return 40;
       })
       .attr("y", function(d) {
-        return self.getDimensions(d).y;
+        return vm.getDimensions(d).y;
       })
       .attr("x", function(d) {
-        return self.getDimensions(d).x;
+        return vm.getDimensions(d).x;
       })
       .on("contextmenu", function(d) {
-        self.contextMenu(this, d);
+        vm.contextMenu(this, d);
       });
 
     added.append("text")
       .each(function(d) {
-        var iconInfo = self.getIcon(d);
+        var iconInfo = vm.getIcon(d);
         if (iconInfo.type != 'glyph')
           return;
 
@@ -124,13 +125,13 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
       })
 
       .attr("y", function(d) {
-        return self.getDimensions(d).y;
+        return vm.getDimensions(d).y;
       })
       .attr("x", function(d) {
-        return self.getDimensions(d).x;
+        return vm.getDimensions(d).x;
       })
       .on("contextmenu", function(d) {
-        self.contextMenu(this, d);
+        vm.contextMenu(this, d);
       });
 
     added.append("text")
@@ -141,7 +142,7 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
       })
       .attr('class', function() {
          var class_name = "attached-label";
-         if ($scope.checkboxModel.value) {
+         if (vm.checkboxModel.value) {
            return class_name + ' visible';
          } else {
            return class_name;
@@ -152,7 +153,7 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
       return topologyService.tooltip(d).join("\n");
     });
 
-    $scope.vs = vertices;
+    vm.vs = vertices;
 
     /* Don't do default rendering */
     ev.preventDefault();
@@ -189,16 +190,16 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
   function getNetworkTopologyData(response) {
     var data = response.data;
 
-    var currentSelectedKinds = $scope.kinds;
-    $scope.items = data.data.items;
-    $scope.relations = data.data.relations;
-    $scope.kinds = data.data.kinds;
+    var currentSelectedKinds = vm.kinds;
+    vm.items = data.data.items;
+    vm.relations = data.data.relations;
+    vm.kinds = data.data.kinds;
     icons = data.data.icons;
 
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys($scope.kinds).length)) {
-      $scope.kinds = currentSelectedKinds;
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys(vm.kinds).length)) {
+      vm.kinds = currentSelectedKinds;
     }
   }
 
-  topologyService.mixinSearch($scope);
+  topologyService.mixinSearch(vm);
 }

--- a/app/assets/javascripts/controllers/topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/network_topology_controller.js
@@ -15,7 +15,7 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
 
   ManageIQ.angular.rxSubject.subscribe(function(event) {
     if (event.name === 'refreshTopology') {
-      $scope.refresh();
+      vm.refresh();
     }
   });
 

--- a/app/assets/javascripts/controllers/topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/network_topology_controller.js
@@ -3,7 +3,7 @@ NetworkTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'top
 
 function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
   var vm = this;
-  ManageIQ.angular.scope = vm;
+  ManageIQ.angular.scope = $scope;
   miqHideSearchClearButton();
   vm.vs = null;
   var icons = null;

--- a/app/assets/javascripts/controllers/topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/network_topology_controller.js
@@ -193,7 +193,7 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
     var currentSelectedKinds = vm.kinds;
     vm.items = data.data.items;
     vm.relations = data.data.relations;
-    vm.kinds = data.data.kinds;
+    vm.kinds = $scope.kinds = data.data.kinds;
     icons = data.data.icons;
 
     if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys(vm.kinds).length)) {

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -1,4 +1,4 @@
-- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}",'miq-form' => true }
+- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
 .topology{'ng-controller' => "networkTopologyController as vm"}
   .legend
     %label#selected

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -1,5 +1,5 @@
-- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
-.topology{'ng-controller' => "networkTopologyController"}
+- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}",'miq-form' => true }
+.topology{'ng-controller' => "networkTopologyController as vm"}
   .legend
     %label#selected
     %div{'ng-if' => "kinds"}
@@ -53,7 +53,7 @@
 
   = render :partial => "shared/topology/not_found"
 
-  %kubernetes-topology-graph{:items => "items", :relations => "relations", :kinds => "kinds"}
+  %kubernetes-topology-graph{:items => "vm.items", :relations => "vm.relations", :kinds => "vm.kinds"}
 
 :javascript
   miq_bootstrap('.topology');

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -51,7 +51,7 @@
     %strong
       = _("Click on the legend to show/hide entities, and double click/right click the entities in the graph to navigate to their summary pages.")
 
-  = render :partial => "shared/topology/not_found"
+  = render :partial => "shared/topology/not_found_vm"
 
   %kubernetes-topology-graph{:items => "vm.items", :relations => "vm.relations", :kinds => "vm.kinds"}
 

--- a/spec/javascripts/controllers/network/network_topology_controller_spec.js
+++ b/spec/javascripts/controllers/network/network_topology_controller_spec.js
@@ -24,21 +24,21 @@ describe('networkTopologyController', function() {
 
     describe('data loads successfully', function() {
       it('in all main objects', function() {
-        expect(scope.items).toBeDefined();
-        expect(scope.relations).toBeDefined();
-        expect(scope.kinds).toBeDefined();
+        expect($controller.items).toBeDefined();
+        expect($controller.relations).toBeDefined();
+        expect($controller.kinds).toBeDefined();
       });
     });
 
     describe('kinds contain all expected kinds', function() {
       it('in all main objects', function() {
-        expect(Object.keys(scope.kinds).length).toBeGreaterThan(7);
-        expect(scope.kinds["CloudSubnet"]).toBeDefined();
-        expect(scope.kinds["NetworkRouter"]).toBeDefined();
-        expect(scope.kinds["FloatingIp"]).toBeDefined();
-        expect(scope.kinds["Vm"]).toBeDefined();
-        expect(scope.kinds["SecurityGroup"]).toBeDefined();
-        expect(scope.kinds["CloudTenant"]).toBeDefined();
+        expect(Object.keys(($controller.kinds).length).toBeGreaterThan(7);
+        expect(($controller.kinds["CloudSubnet"]).toBeDefined();
+        expect(($controller.kinds["NetworkRouter"]).toBeDefined();
+        expect(($controller.kinds["FloatingIp"]).toBeDefined();
+        expect(($controller.kinds["Vm"]).toBeDefined();
+        expect(($controller.kinds["SecurityGroup"]).toBeDefined();
+        expect(($controller.kinds["CloudTenant"]).toBeDefined();
       });
     });
 

--- a/spec/javascripts/controllers/network/network_topology_controller_spec.js
+++ b/spec/javascripts/controllers/network/network_topology_controller_spec.js
@@ -32,13 +32,13 @@ describe('networkTopologyController', function() {
 
     describe('kinds contain all expected kinds', function() {
       it('in all main objects', function() {
-        expect(Object.keys(($controller.kinds).length).toBeGreaterThan(7);
-        expect(($controller.kinds["CloudSubnet"]).toBeDefined();
-        expect(($controller.kinds["NetworkRouter"]).toBeDefined();
-        expect(($controller.kinds["FloatingIp"]).toBeDefined();
-        expect(($controller.kinds["Vm"]).toBeDefined();
-        expect(($controller.kinds["SecurityGroup"]).toBeDefined();
-        expect(($controller.kinds["CloudTenant"]).toBeDefined();
+        expect(Object.keys($controller.kinds).length).toBeGreaterThan(7);
+        expect($controller.kinds["CloudSubnet"]).toBeDefined();
+        expect($controller.kinds["NetworkRouter"]).toBeDefined();
+        expect($controller.kinds["FloatingIp"]).toBeDefined();
+        expect($controller.kinds["Vm"]).toBeDefined();
+        expect($controller.kinds["SecurityGroup"]).toBeDefined();
+        expect($controller.kinds["CloudTenant"]).toBeDefined();
       });
     });
 


### PR DESCRIPTION
Convert network_topology_controller to controllerAs


- [x] uses as vm
- [x] ManageIQ.angular.scope points to vm - neeeded by QE
- [x] does not inject $scope unless needed for a $watch or events, or angularForm
- [x] using a common button partial (No need)
- [x] uses miq-form (not a form)
- [x] uses form-changed, no checkchange (No need)
- [x] no separate edit & new, use the same partial
- [x] specs
- [x] no copying values one by one - use Object.assign (No need)
- [x] no miqAjaxButton(url, true) - always submit the actual model, don't rely on magic form serialization
- [x] no extra $setPristine etc. where it doesn't make sense (form submit, form reset..)
- [x] no if (condition) return true; else return false;
- [x] no miqrequired, use required or ng-required