### PR TITLE
Adding an Automate Task schedule: remove time_zone as the last Attribute/Value pair

### DIFF
--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -154,7 +154,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         // should ignore list of targets as this list can be really long no need to send that up to server
         var moreUrlParams = $.param(miqService.serializeModelWithIgnoredFields($scope.scheduleModel, ["targets", "time_zone"]));
         if (moreUrlParams) {
-          url += '&' + decodeURIComponent(moreUrlParams) + encodeURIComponent($scope.scheduleModel.time_zone);
+          url += '&' + decodeURIComponent(moreUrlParams) + '&' + encodeURIComponent($scope.scheduleModel.time_zone);
         }
       }
       miqService.miqAjaxButton(url, serializeFields);


### PR DESCRIPTION
The encoded `time_zone` parameter was being sent over without an `&` separator which caused it to be included in the key value pairs returned

https://bugzilla.redhat.com/show_bug.cgi?id=1466032
