### PR TITLE
[WIP] Corrected flash message inconsistency between creating vs. deleting automate object

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2165,10 +2165,10 @@ class ApplicationController < ActionController::Base
 
   def get_record_display_name(record)
     return record.label                      if record.respond_to?("label")
-    return record.description                if record.respond_to?("description") && !record.description.nil?
     return record.ext_management_system.name if record.respond_to?("ems_id")
     return record.title                      if record.respond_to?("title")
     return record.name                       if record.respond_to?("name")
+    return record.description                if record.respond_to?("description") && !record.description.nil?
     "<Record ID #{record.id}>"
   end
 


### PR DESCRIPTION
This PR is for following BZ issue,
https://bugzilla.redhat.com/show_bug.cgi?id=1477037

Description: Earlier inconsistent flash message was showing description obj deleted instead of domain-name obj in automation explorer, this PR can correct that issue.

Fix: I have changed order here and this works fine for me
