### PR TITLE
Remove RSS_FEEDS from UiConstants

### DIFF
--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -1,6 +1,22 @@
 module ReportController::Widgets
   extend ActiveSupport::Concern
 
+  # RSS Feeds
+  RSS_FEEDS = {
+    "Microsoft Security"         => "http://www.microsoft.com/protect/rss/rssfeed.aspx",
+    "CNN Top Stories"            => "http://rss.cnn.com/rss/cnn_topstories.rss",
+    "Gartner Latest Research"    => "http://www.gartner.com/it/rss/leaders/latest_research_itoperations.jsp#",
+    "Google News"                => "http://news.google.com/?output=rss",
+    "SlashDot"                   => "http://slashdot.org/index.rdf",
+    "VM Etc."                    => "http://feeds.feedburner.com/vmetc?format=xml",
+    "Virtualization Pro"         => "http://itknowledgeexchange.techtarget.com/virtualization-pro/feed/",
+    "Virtualization Information" => "http://virtualizationinformation.com/?feed=rss2",
+    "Vmware Tips & Tricks"       => "http://rss.techtarget.com/840.xml",
+    "DABCC - News & Support"     => "http://feeds.dabcc.com/AllArticles",
+    "VmwareWolf"                 => "http://feeds.feedburner.com/vmwarewolf",
+    "Vmware RSS Feeds"           => "http://vmware.simplefeed.net/rss?f=995b0290-01dc-11dc-3032-0019bbc54f6f"
+  }.freeze
+
   def widget_refresh
     assert_privileges("widget_refresh")
     replace_right_cell
@@ -420,7 +436,7 @@ module ReportController::Widgets
       end
       @edit[:new][:feed_type] = @widget.options && @widget.options[:url] ? "external" : "internal"
       if @widget.options && @widget.options[:url]
-        RSS_FEEDS.each do |r|
+        self.class::RSS_FEEDS.each do |r|
           if r[1] == @widget.options[:url]
             @edit[:new][:url] = @widget.options[:url]
           end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -6,22 +6,6 @@ module UiConstants
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
 
-  # RSS Feeds
-  RSS_FEEDS = {
-    "Microsoft Security"         => "http://www.microsoft.com/protect/rss/rssfeed.aspx",
-    "CNN Top Stories"            => "http://rss.cnn.com/rss/cnn_topstories.rss",
-    "Gartner Latest Research"    => "http://www.gartner.com/it/rss/leaders/latest_research_itoperations.jsp#",
-    "Google News"                => "http://news.google.com/?output=rss",
-    "SlashDot"                   => "http://slashdot.org/index.rdf",
-    "VM Etc."                    => "http://feeds.feedburner.com/vmetc?format=xml",
-    "Virtualization Pro"         => "http://itknowledgeexchange.techtarget.com/virtualization-pro/feed/",
-    "Virtualization Information" => "http://virtualizationinformation.com/?feed=rss2",
-    "Vmware Tips & Tricks"       => "http://rss.techtarget.com/840.xml",
-    "DABCC - News & Support"     => "http://feeds.dabcc.com/AllArticles",
-    "VmwareWolf"                 => "http://feeds.feedburner.com/vmwarewolf",
-    "Vmware RSS Feeds"           => "http://vmware.simplefeed.net/rss?f=995b0290-01dc-11dc-3032-0019bbc54f6f"
-  }
-
   # Screen background color choices
   BG_COLORS = [
     "#c00",      # First entry is the default

--- a/app/views/report/_widget_form_rss.html.haml
+++ b/app/views/report/_widget_form_rss.html.haml
@@ -37,7 +37,7 @@
         = _('External RSS Feed/URL')
       .col-md-8
         = select_tag("rss_url",
-          options_for_select([["<#{_('Enter URL Manually')}>", nil]] + RSS_FEEDS.sort, @edit[:new][:url]),
+          options_for_select([["<#{_('Enter URL Manually')}>", nil]] + ReportController::RSS_FEEDS.sort, @edit[:new][:url]),
           :disabled => @edit[:read_only],
           :class    => "selectpicker")
         :javascript


### PR DESCRIPTION
### Issue: #1661 

We have removed `RSS_FEEDS` constant from `UiConstants`. `RSS_FEEDS` was moved to `Widgets` and also added prefix for every  `RSS_FEEDS` occurrence.

Cloud Intel -> Reports -> Dashboard Widgets -> All Widgets -> Reports -> "`Amazon - Active VMs`" -> Configuration -> Edit this Widget

![widgets](https://user-images.githubusercontent.com/22373707/28816632-c635cd9a-76a5-11e7-84e0-8f2bdf8f47a8.gif)
