### PR TITLE
Remove THEMES from UiConstants

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,6 +2,17 @@ class DashboardController < ApplicationController
   include DashboardHelper
   include StartUrl
 
+  # UI Themes
+  THEMES = [
+    [_("Red"), "red"],
+    [_("Orange"), "orange"],
+    [_("Yellow"), "yellow"],
+    [_("Green"), "green"],
+    [_("Blue"), "blue"],
+    [_("ManageIQ-Blue"), "manageiq-blue"],
+    [_("Black"), "black"]
+  ].freeze
+
   menu_section :vi
 
   @@items_per_page = 8

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -39,17 +39,6 @@ module UiConstants
     "Vmware RSS Feeds"           => "http://vmware.simplefeed.net/rss?f=995b0290-01dc-11dc-3032-0019bbc54f6f"
   }
 
-  # UI Themes
-  THEMES =  [
-    [_("Red"), "red"],
-    [_("Orange"), "orange"],
-    [_("Yellow"), "yellow"],
-    [_("Green"), "green"],
-    [_("Blue"), "blue"],
-    [_("ManageIQ-Blue"), "manageiq-blue"],
-    [_("Black"), "black"]
-  ]
-
   # Screen background color choices
   BG_COLORS = [
     "#c00",      # First entry is the default


### PR DESCRIPTION
### Issue: #1661 

We have removed `THEMES` constant from `UiConstants`. Definition of constant `THEMES` was moved to `DashboardController`.