### PR TITLE
Fix a syntax error in miq_qe.js

### DIFF
--- a/app/assets/javascripts/miq_qe.js
+++ b/app/assets/javascripts/miq_qe.js
@@ -116,7 +116,7 @@ ManageIQ.qe.gtl = {
           this.onItemClicked(item, document.createEvent('Event'));
           this.$scope.$digest();
         }.bind(this),
-        item,
+        item: item,
       };
     }.bind(this);
     return {


### PR DESCRIPTION
Before this fix I was getting the following when compiling assets during the container build:

```plain
rake aborted!
ExecJS::RuntimeError: SyntaxError: Unexpected token punc «,», expected punc «:» (line: 151371, col: 12, pos: 9599562)

Error
    at new JS_Parse_Error (/tmp/execjs20170801-15221-1azzdltjs:3623:11948)
    at js_error (/tmp/execjs20170801-15221-1azzdltjs:3623:12167)
    at croak (/tmp/execjs20170801-15221-1azzdltjs:3623:22038)
    at token_error (/tmp/execjs20170801-15221-1azzdltjs:3623:22175)
    at expect_token (/tmp/execjs20170801-15221-1azzdltjs:3623:22411)
    at expect (/tmp/execjs20170801-15221-1azzdltjs:3623:22562)
    at /tmp/execjs20170801-15221-1azzdltjs:3624:215
    at /tmp/execjs20170801-15221-1azzdltjs:3623:22954
    at expr_atom (/tmp/execjs20170801-15221-1azzdltjs:3623:30987)
    at maybe_unary (/tmp/execjs20170801-15221-1azzdltjs:3624:1752)
    at expr_ops (/tmp/execjs20170801-15221-1azzdltjs:3624:2523)
    at maybe_conditional (/tmp/execjs20170801-15221-1azzdltjs:3624:2615)
    at maybe_assign (/tmp/execjs20170801-15221-1azzdltjs:3624:3058)
    at expression (/tmp/execjs20170801-15221-1azzdltjs:3624:3384)
new JS_Parse_Error ((execjs):3623:11948)
js_error ((execjs):3623:12167)
croak ((execjs):3623:22038)
token_error ((execjs):3623:22175)
expect_token ((execjs):3623:22411)
expect ((execjs):3623:22562)
(execjs):3624:215
(execjs):3623:22954
expr_atom ((execjs):3623:30987)
maybe_unary ((execjs):3624:1752)
expr_ops ((execjs):3624:2523)
maybe_conditional ((execjs):3624:2615)
maybe_assign ((execjs):3624:3058)
expression ((execjs):3624:3384)
/var/www/miq/vmdb/lib/tasks/evm.rake:77:in `block (4 levels) in <top (required)>'
/var/www/miq/vmdb/lib/tasks/evm_rake_helper.rb:7:in `with_dummy_database_url_configuration'
/var/www/miq/vmdb/lib/tasks/evm.rake:75:in `block (3 levels) in <top (required)>'
Tasks: TOP => assets:precompile
(See full trace by running task with --trace)
```