### PR TITLE
Add more details in Generic Object Class Summary screen

### DIFF
--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -22,7 +22,7 @@ class GenericObjectDefinitionController < ApplicationController
   private
 
   def textual_group_list
-    [%i(relationships)]
+    [%i(properties relationships attribute_details_list association_details_list method_details_list)]
   end
 
   helper_method :textual_group_list

--- a/app/helpers/generic_object_definition_helper/textual_summary.rb
+++ b/app/helpers/generic_object_definition_helper/textual_summary.rb
@@ -1,6 +1,22 @@
 module GenericObjectDefinitionHelper::TextualSummary
   include TextualMixins::TextualName
 
+  def textual_group_properties
+    TextualGroup.new(_("Properties"), %i(name created updated))
+  end
+
+  def textual_name
+    {:label => _("Name"), :value => @record.name}
+  end
+
+  def textual_created
+    {:label => _("Created"), :value => format_timezone(@record.created_at)}
+  end
+
+  def textual_updated
+    {:label => _("Updated"), :value => format_timezone(@record.updated_at)}
+  end
+
   def textual_group_relationships
     TextualGroup.new(_("Relationships"), %i(generic_objects))
   end
@@ -13,5 +29,44 @@ module GenericObjectDefinitionHelper::TextualSummary
                :title => _('Show all Instances'))
     end
     h
+  end
+
+  def textual_group_attribute_details_list
+    TextualMultilabel.new(
+      _("Attributes (#{@record.property_attributes.count})"),
+      :additional_table_class => "table-fixed",
+      :labels                 => [_("Name"), _("Type")],
+      :values                 => record_properties(:property_attributes)
+    )
+  end
+
+  def textual_group_association_details_list
+    TextualMultilabel.new(
+      _("Associations (#{@record.property_associations.count})"),
+      :additional_table_class => "table-fixed",
+      :labels                 => [_("Name"), _("Class")],
+      :values                 => record_properties(:property_associations)
+    )
+  end
+
+  def textual_group_method_details_list
+    TextualMultilabel.new(
+      _("Methods (#{@record.property_methods.count})"),
+      :additional_table_class => "table-fixed",
+      :labels                 => [_("Name")],
+      :values                 => methods_array
+    )
+  end
+
+  def record_properties(property)
+    @record.send(property).each do |var|
+      [var[0], var[1]]
+    end
+  end
+
+  def methods_array
+    @record.property_methods.collect do |var|
+      [var]
+    end
   end
 end

--- a/app/helpers/generic_object_definition_helper/textual_summary.rb
+++ b/app/helpers/generic_object_definition_helper/textual_summary.rb
@@ -32,20 +32,23 @@ module GenericObjectDefinitionHelper::TextualSummary
   end
 
   def textual_group_attribute_details_list
-    TextualMultilabel.new(
-      _("Attributes (#{@record.property_attributes.count})"),
-      :additional_table_class => "table-fixed",
-      :labels                 => [_("Name"), _("Type")],
-      :values                 => record_properties(:property_attributes)
-    )
+    record_properties_list(_("Attributes (#{@record.property_attributes.count})"),
+                           :property_attributes,
+                           [_("Name"), _("Type")])
   end
 
   def textual_group_association_details_list
+    record_properties_list(_("Associations (#{@record.property_associations.count})"),
+                           :property_associations,
+                           [_("Name"), _("Class")])
+  end
+
+  def record_properties_list(type_and_count, type, labels)
     TextualMultilabel.new(
-      _("Associations (#{@record.property_associations.count})"),
+      type_and_count,
       :additional_table_class => "table-fixed",
-      :labels                 => [_("Name"), _("Class")],
-      :values                 => record_properties(:property_associations)
+      :labels                 => labels,
+      :values                 => record_properties(type)
     )
   end
 


### PR DESCRIPTION
Added some properties and key attributes in the Generic Object Class Summary screen such as - `Attributes`, `Associations` and `Methods` -- basically, the attributes that define the Generic Object Class

<img width="1341" alt="screen shot 2017-08-01 at 2 19 41 pm" src="https://user-images.githubusercontent.com/1538216/28847547-80866a42-76c4-11e7-8590-e120b6a97a0d.png">
