### PR TITLE
Removed unnecessary BG_COLORS and bg_color_changed 

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -130,19 +130,6 @@ class ConfigurationController < ApplicationController
     end
   end
 
-  # AJAX driven routine for background color selection
-  def bg_color_changed
-    # ui1 bgcolor changed
-    @edit = session[:edit]
-    @edit[:new][:display][:bg_color] = params[:bg_color]      # Capture the new setting
-    session[:changed] = (@edit[:new] != @edit[:current])
-    @changed = session[:changed]
-    render :update do |page|
-      page << javascript_prologue
-      page.replace 'tab_div', :partial => "ui_1"
-    end
-  end
-
   def update
     if params["save"]
       get_form_vars if @tabform != "ui_3"

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -6,16 +6,6 @@ module UiConstants
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
 
-  # Screen background color choices
-  BG_COLORS = [
-    "#c00",      # First entry is the default
-    "#ff8a00",
-    "#ffe400",
-    "#6b9130",
-    "#0c7ad7",
-    "#000"
-  ]
-
   # Theme settings - each subitem will be set in @settings[:css][:<subitem>] based on the selected theme
   THEME_CSS_SETTINGS = {
     "red"           => {
@@ -158,7 +148,6 @@ module UiConstants
       :reporttheme   => "MIQ",
       :quad_truncate => "m",
       :theme         => "red",            # Luminescent Blue
-      :bg_color      => BG_COLORS.first,  # Background color
       :taskbartext   => true,             # Show button text on taskbar
       :vmcompare     => "Compressed",     # Start VM compare and drift in compressed mode
       :hostcompare   => "Compressed",     # Start Host compare in compressed mode


### PR DESCRIPTION
### Issue: #1661 

Constant `BG_COLORS` has been removed from `UiConstants`.
Method `bg_color_changed` has been removed from `ConfigurationController`.