### PR TITLE
Removed unnecessary NAV_STYLES and nav_style_changed

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -130,18 +130,6 @@ class ConfigurationController < ApplicationController
     end
   end
 
-  # AJAX driven routine for nav style selection
-  def nav_style_changed
-    @edit = session[:edit]
-    @edit[:new][:display][:nav_style] = params[:nav_style]    # Capture the new setting
-    session[:changed] = (@edit[:new] != @edit[:current])
-    @changed = session[:changed]
-    render :update do |page|
-      page << javascript_prologue
-      page.replace 'tab_div', :partial => "ui_1"
-    end
-  end
-
   # AJAX driven routine for background color selection
   def bg_color_changed
     # ui1 bgcolor changed

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -32,12 +32,6 @@ module UiConstants
     "#000"
   ]
 
-  # Navigation Styles
-  NAV_STYLES = [
-    "vertical",     # First entry is the default
-    "wedged"
-  ]
-
   # Theme settings - each subitem will be set in @settings[:css][:<subitem>] based on the selected theme
   THEME_CSS_SETTINGS = {
     "red"           => {
@@ -184,7 +178,6 @@ module UiConstants
       :taskbartext   => true,             # Show button text on taskbar
       :vmcompare     => "Compressed",     # Start VM compare and drift in compressed mode
       :hostcompare   => "Compressed",     # Start Host compare in compressed mode
-      :nav_style     => NAV_STYLES.first,  # Navigation style
       :timezone      => nil,               # This will be set when the user logs in
       :display_vms   => false # don't display vms by default
     },


### PR DESCRIPTION
### Issue: #1661 

Constant `NAV_STYLES` has been removed from `UiConstants`.
Method `nav_style_changed` has been removed from `ConfigurationController`.