### PR TITLE
Showing network list of a specific network manager

### DIFF
--- a/app/controllers/ems_network_controller.rb
+++ b/app/controllers/ems_network_controller.rb
@@ -18,6 +18,10 @@ class EmsNetworkController < ApplicationController
     @table_name ||= "ems_network"
   end
 
+  def rbac_params
+    {:match_via_descendants => ManageIQ::Providers::NetworkManager}
+  end
+
   def ems_path(*args)
     path_hash = {:action => 'show', :id => args[0].id.to_s }
     path_hash.merge(args[1])


### PR DESCRIPTION
Showing the cloud network list via the context of a specific network manager
led to 'undefined method `rbac_params' for EmsNetworkController' error.
This patch fixes it.