### PR TITLE
Redirecting to 'show list' after deleting a 'cloud network'

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -138,6 +138,8 @@ class CloudNetworkController < ApplicationController
       if @flash_array.nil?
         add_flash(_("The selected Cloud Network was deleted"))
       end
+      session[:flash_msgs] = @flash_array.dup if @flash_array
+      javascript_redirect(previous_breadcrumb_url)
     end
   end
 


### PR DESCRIPTION
Currently it stays in the deleted network form. It is not standard. For example, when 'cloud subnet' is deleted it is redirected to the subnets list.