### PR TITLE
According to Neutron API, subnet's gateway field is named 'gateway_ip'

### DIFF
--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -223,7 +223,7 @@ class CloudSubnetController < ApplicationController
     options[:cidr] = params[:cidr] if params[:cidr]
     # An address is automatically assigned by Openstack when gateway is null
     if params[:gateway]
-      options[:gateway] = params[:gateway].blank? ? nil : params[:gateway]
+      options[:gateway_ip] = params[:gateway].blank? ? nil : params[:gateway]
     end
     options[:ip_version] = params[:network_protocol]
     options[:cloud_tenant] = find_record_with_rbac(CloudTenant, params[:cloud_tenant_id]) if params[:cloud_tenant_id]


### PR DESCRIPTION
According to Neutron API, subnet's gateway field is named 'gateway_ip' and not 'gateway'.
Only the 'new' flow had to be fixed, the 'update' flow already used the
correct name.

Reference to Neutron API -
https://developer.openstack.org/api-ref/networking/v2/?expanded=update-subnet-detail