### PR TITLE
'subnet_form.network_protocol' actually represents 'subnet.ip_version'

### DIFF
--- a/app/assets/javascripts/controllers/cloud_subnet/cloud_subnet_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_subnet/cloud_subnet_form_controller.js
@@ -20,7 +20,7 @@ ManageIQ.angular.app.controller('cloudSubnetFormController', ['$scope', 'cloudSu
       $scope.cloudSubnetModel.dhcp_enabled = data.dhcp_enabled;
       $scope.cloudSubnetModel.cidr = data.cidr;
       $scope.cloudSubnetModel.gateway = data.gateway;
-      $scope.cloudSubnetModel.network_protocol = data.network_protocol;
+      $scope.cloudSubnetModel.network_protocol = data.extra_attributes.ip_version;
       $scope.modelCopy = angular.copy( $scope.cloudSubnetModel );
       miqService.sparkleOff();
     }).catch(miqService.handleFailure);


### PR DESCRIPTION
The field called 'network_protocol' in the cloud subnet form actually
expects to get the 'subnet.ip_version' value.
It is derived from some facts-
* Currently, in case of new, the 'subnet.ip_version' is taken from
'form.network_protocol' field.
* The default value of the 'form.network_protocol' field is '4'
('subnet.network_protocol' looks like this 'ipv4').
* The maximum size of 'form.network_protocol' is 2. Which caused an
exception in the line fixed in this patch.