### PR TITLE
Corrected duplicate flash message of reset button in priority order

### DIFF
--- a/app/views/miq_ae_class/_domains_priority_form.html.haml
+++ b/app/views/miq_ae_class/_domains_priority_form.html.haml
@@ -1,4 +1,3 @@
-= render :partial => "layouts/flash_msg"
 #domains_list
   .row
     .col-md-7.col-sm-10.col-xs-10


### PR DESCRIPTION
This PR is for following BZ,
https://bugzilla.redhat.com/show_bug.cgi?id=1477554

Their were two flash messages rendering before change,
![Before](http://i.imgur.com/CcqvbKk.png)

After change,
![After](http://i.imgur.com/XRYtdo9.png)

Need your thoughts,
Thanks !