### PR TITLE
Remove PERPAGE_TYPES from UiConstants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -78,6 +78,8 @@ class ApplicationController < ActionController::Base
 
   ONE_MILLION = 1_000_000 # Setting high number incase we don't want to display paging controls on list views
 
+  PERPAGE_TYPES = %w(grid tile list reports).each_with_object({}) { |value, acc| acc[value] = value.to_sym }.freeze
+
   def local_request?
     Rails.env.development? || Rails.env.test?
   end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -48,8 +48,6 @@ module UiConstants
     }
   }
 
-  PERPAGE_TYPES = %w(grid tile list reports).each_with_object({}) { |value, acc| acc[value] = value.to_sym }.freeze
-
   # Default UI settings
   DEFAULT_SETTINGS = {
     :quadicons => { # Show quad icons, by resource type


### PR DESCRIPTION
### Issue: #1661 

Constant `PERPAGE_TYPES` has been removed from `UiConstants`. Definition of constant `PERPAGE_TYPES` was moved to `ApplicationController`.