### PR TITLE
Remove the tree_state parameter from trees as it is always set to true

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -613,10 +613,10 @@ function miqInitTree(options, tree) {
       miqTreeOnNodeChecked(options, node);
     },
     onNodeExpanded:       function (event, node) {
-      if (options.tree_state) miqTreeState(options.cookie_id, node.key, true);
+      miqTreeState(options.cookie_id, node.key, true);
     },
     onNodeCollapsed:      function (event, node) {
-      if (options.tree_state) miqTreeState(options.cookie_id, node.key, false);
+      miqTreeState(options.cookie_id, node.key, false);
     },
     lazyLoad:             function (node, display) {
       if (options.autoload) {
@@ -653,11 +653,9 @@ function miqInitTree(options, tree) {
   }
 
   // Tree state persistence correction after the tree is completely loaded
-  if (options.tree_state) {
-    miqTreeObject(options.tree_name).getNodes().forEach(function (node) {
-      if (miqTreeState(options.cookie_id, node.key) === !node.state.expanded) {
-        miqTreeObject(options.tree_name).toggleNodeExpanded(node);
-      }
-    });
-  }
+  miqTreeObject(options.tree_name).getNodes().forEach(function (node) {
+    if (miqTreeState(options.cookie_id, node.key) === !node.state.expanded) {
+      miqTreeObject(options.tree_name).toggleNodeExpanded(node);
+    }
+  });
 }

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -193,7 +193,6 @@ class TreeBuilder
       :tree_name  => @name.to_s,
       :bs_tree    => @bs_tree,
       :onclick    => "miqOnClickSelectTreeNode",
-      :tree_state => true,
       :checkboxes => false
     }
   end

--- a/app/presenters/tree_builder_timelines.rb
+++ b/app/presenters/tree_builder_timelines.rb
@@ -38,10 +38,9 @@ class TreeBuilderTimelines < TreeBuilder
 
   def set_locals_for_render
     super.merge!(
-      :id_prefix  => 'timelines_',
-      :onclick    => "miqOnClickTimelineSelection",
-      :click_url  => "/dashboard/show_timeline/",
-      :tree_state => true
+      :id_prefix => 'timelines_',
+      :onclick   => "miqOnClickTimelineSelection",
+      :click_url => "/dashboard/show_timeline/"
     )
   end
 

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -13,9 +13,7 @@ class TreeBuilderUtilization < TreeBuilderRegion
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:onclick     => "miqOnClickSelectOptimizeTreeNode",
-                  :select_node => @selected_node.to_s,
-                  :tree_state  => true)
+    locals.merge!(:onclick => "miqOnClickSelectOptimizeTreeNode", :select_node => @selected_node.to_s)
   end
 
   def root_options

--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -4,7 +4,6 @@
 - select_node                 ||= false
 - checkboxes                  ||= false
 - three_checks                ||= false
-- tree_state                  ||= false
 - onclick                     ||= false
 - onselect                    ||= false
 - oncheck                     ||= false
@@ -27,7 +26,6 @@
              :min_expand_level   => min_expand_level ? min_expand_level : 1,
              :checkboxes         => checkboxes,
              :hierarchical_check => three_checks,
-             :tree_state         => tree_state,
              :onclick            => onclick,
              :oncheck            => oncheck,
              :click_url          => click_url,

--- a/app/views/miq_ae_customization/_dialog_edit_tree.html.haml
+++ b/app/views/miq_ae_customization/_dialog_edit_tree.html.haml
@@ -15,5 +15,4 @@
               :bs_tree                    => @dialog_edit_tree,
               :onclick                    => "miqOnClickSelectDlgEditTreeNode",
               :select_node                => x_node(:dialog_edit_tree).to_s,
-              :tree_state                 => true,
               :cookie_prefix              => "edit_"})

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -302,8 +302,7 @@
                                :oncheck       => "miqOnCheckProvTags",
                                :check_url     => "/miq_request/prov_field_changed/#{check}",
                                :checkboxes    => true,
-                               :cookie_prefix => "prov_trees",
-                               :tree_state    => true})
+                               :cookie_prefix => "prov_trees"})
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]

--- a/spec/javascripts/miq_tree_spec.js
+++ b/spec/javascripts/miq_tree_spec.js
@@ -4,7 +4,7 @@ describe('miq_tree', function() {
       it('checks child nodes', function () {
         $('body').append($('<div id="testbox">'));
 
-        miqInitTree({tree_id: "testbox", post_check: true, hierarchical_check: true}, [
+        miqInitTree({tree_name: "test", tree_id: "testbox", post_check: true, hierarchical_check: true}, [
           {
             key: "1",
             text: "Parent unset, children partial",

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -78,7 +78,6 @@ describe TreeBuilderBelongsToHac do
   describe '#set_locals_for_render' do
     it 'sets locals correctly' do
       expect(subject.send(:set_locals_for_render)).to include(:onclick           => false,
-                                                              :tree_state        => true,
                                                               :checkboxes        => true,
                                                               :check_url         => "/ops/rbac_group_field_changed/new___",
                                                               :oncheck           => nil,

--- a/spec/presenters/tree_builder_timelines_spec.rb
+++ b/spec/presenters/tree_builder_timelines_spec.rb
@@ -20,10 +20,9 @@ describe TreeBuilderTimelines do
   describe '#set_locals_for_render' do
     it 'set locals correctly' do
       locals = subject.send(:set_locals_for_render)
-      expect(locals).to include(:id_prefix  => 'timelines_',
-                                :onclick    => "miqOnClickTimelineSelection",
-                                :click_url  => "/dashboard/show_timeline/",
-                                :tree_state => true)
+      expect(locals).to include(:id_prefix => 'timelines_',
+                                :onclick   => "miqOnClickTimelineSelection",
+                                :click_url => "/dashboard/show_timeline/")
     end
   end
 


### PR DESCRIPTION
This parameter is `true` by default in each tree built by `TreeBuilder` and all the two remaining trees have it explicitly.

@miq-bot add_label technical debt, trees, fine/no
