### PR TITLE
Remove TIMER_DAYS,TIMER_HOURS,TIMER_WEEKS,TIMER_MONTHS from UiConstants

### DIFF
--- a/app/helpers/report_helper/timer.rb
+++ b/app/helpers/report_helper/timer.rb
@@ -1,4 +1,40 @@
 module ReportHelper
+
+  TIMER_DAYS = [
+    [N_("Day"), "1"],
+    [N_("2 Days"), "2"],
+    [N_("3 Days"), "3"],
+    [N_("4 Days"), "4"],
+    [N_("5 Days"), "5"],
+    [N_("6 Days"), "6"],
+  ].freeze
+
+  TIMER_HOURS = [
+    [N_("Hour"), "1"],
+    [N_("2 Hours"), "2"],
+    [N_("3 Hours"), "3"],
+    [N_("4 Hours"), "4"],
+    [N_("6 Hours"), "6"],
+    [N_("8 Hours"), "8"],
+    [N_("12 Hours"), "12"],
+  ].freeze
+
+  TIMER_WEEKS = [
+    [N_("Week"), "1"],
+    [N_("2 Weeks"), "2"],
+    [N_("3 Weeks"), "3"],
+    [N_("4 Weeks"), "4"],
+  ].freeze
+
+  TIMER_MONTHS = [
+    [N_("Month"), "1"],
+    [N_("2 Months"), "2"],
+    [N_("3 Months"), "3"],
+    [N_("4 Months"), "4"],
+    [N_("5 Months"), "5"],
+    [N_("6 Months"), "6"],
+  ].freeze
+  
   Timer = Struct.new(
     :typ,
     :months,

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -133,38 +133,6 @@ module UiConstants
 
   VIEW_RESOURCES = DEFAULT_SETTINGS[:views].keys.each_with_object({}) { |value, acc| acc[value.to_s] = value }.freeze
 
-  TIMER_DAYS = [
-    [N_("Day"), "1"],
-    [N_("2 Days"), "2"],
-    [N_("3 Days"), "3"],
-    [N_("4 Days"), "4"],
-    [N_("5 Days"), "5"],
-    [N_("6 Days"), "6"],
-  ]
-  TIMER_HOURS = [
-    [N_("Hour"), "1"],
-    [N_("2 Hours"), "2"],
-    [N_("3 Hours"), "3"],
-    [N_("4 Hours"), "4"],
-    [N_("6 Hours"), "6"],
-    [N_("8 Hours"), "8"],
-    [N_("12 Hours"), "12"],
-  ]
-  TIMER_WEEKS = [
-    [N_("Week"), "1"],
-    [N_("2 Weeks"), "2"],
-    [N_("3 Weeks"), "3"],
-    [N_("4 Weeks"), "4"],
-  ]
-  TIMER_MONTHS = [
-    [N_("Month"), "1"],
-    [N_("2 Months"), "2"],
-    [N_("3 Months"), "3"],
-    [N_("4 Months"), "4"],
-    [N_("5 Months"), "5"],
-    [N_("6 Months"), "6"],
-  ]
-
   # Maximum fields to show for automation engine resolution screens
   AE_MAX_RESOLUTION_FIELDS = 5
 

--- a/app/views/report/_schedule_form_timer.html.haml
+++ b/app/views/report/_schedule_form_timer.html.haml
@@ -18,7 +18,7 @@
         = hidden_span_if(@edit[:new][:timer].typ.downcase != "daily", :id => "daily_span") do
           = _("every")
           = select_tag("timer_days",
-            options_for_select(TIMER_DAYS.map { |x, y| [_(x), y] }, @edit[:new][:timer].days),
+            options_for_select(ReportHelper::TIMER_DAYS.map { |x, y| [_(x), y] }, @edit[:new][:timer].days),
             :class => "selectpicker")
           :javascript
             miqInitSelectPicker();
@@ -26,7 +26,7 @@
         = hidden_span_if(@edit[:new][:timer].typ.downcase != "hourly", :id => "hourly_span") do
           = _("every")
           = select_tag("timer_hours",
-            options_for_select(TIMER_HOURS.map { |x, y| [_(x), y] }, @edit[:new][:timer].hours),
+            options_for_select(ReportHelper::TIMER_HOURS.map { |x, y| [_(x), y] }, @edit[:new][:timer].hours),
             :class => "selectpicker")
           :javascript
             miqInitSelectPicker();
@@ -34,7 +34,7 @@
         = hidden_span_if(@edit[:new][:timer].typ.downcase != "weekly", :id => "weekly_span") do
           = _("every")
           = select_tag("timer_weeks",
-            options_for_select(TIMER_WEEKS.map { |x, y| [_(x), y] }, @edit[:new][:timer].weeks),
+            options_for_select(ReportHelper::TIMER_WEEKS.map { |x, y| [_(x), y] }, @edit[:new][:timer].weeks),
             :class => "selectpicker")
           :javascript
             miqInitSelectPicker();
@@ -42,7 +42,7 @@
         = hidden_span_if(@edit[:new][:timer].typ.downcase != "monthly", :id => "monthly_span") do
           = _("every")
           = select_tag("timer_months",
-            options_for_select(TIMER_MONTHS.map { |x, y| [_(x), y] }, @edit[:new][:timer].months),
+            options_for_select(ReportHelper::TIMER_MONTHS.map { |x, y| [_(x), y] }, @edit[:new][:timer].months),
             :class => "selectpicker")
           :javascript
             miqInitSelectPicker();


### PR DESCRIPTION
### Issue: #1661 

Constants `TIMER_DAYS,TIMER_HOURS,TIMER_WEEKS,TIMER_MONTHS` have been removed from `UiConstants`. Definitions of constants `TIMER_DAYS,TIMER_HOURS,TIMER_WEEKS,TIMER_MONTHS` were moved to `ReportHelper`. Prefix `ReportHelper::` was added to every occurrence of these constants.

Cloud Intel -> Reports -> Schedules -> Copy of ChargeBack by Project -> Configuration -> Edit this Schedule

![image](https://user-images.githubusercontent.com/22373707/28924788-2b86afb6-7863-11e7-9c6f-04c148552a93.gif)
