### PR TITLE
Filter custom buttons according to visibility expressions

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -340,6 +340,8 @@ class ApplicationHelper::ToolbarBuilder
 
   def get_custom_buttons(model, record, toolbar_result)
     cbses = CustomButtonSet.find_all_by_class_name(button_class_name(model), service_template_id(record))
+    cbses = CustomButtonSet.filter_with_visibility_expression(cbses, record)
+
     cbses.sort_by { |cbs| cbs.set_data[:group_index] }.collect do |cbs|
       group = {
         :id           => cbs.id,

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -31,11 +31,18 @@ describe ApplicationHelper, "::ToolbarBuilder" do
     end
 
     shared_examples "with custom buttons" do
+      def add_button_to_set(button_set, button)
+        button_set.add_member(button)
+        button_set.set_data[:button_order] ||= []
+        button_set.set_data[:button_order].push(button.id)
+        button_set.save
+      end
+
       before do
         @button_set = FactoryGirl.create(:custom_button_set, :set_data => {:applies_to_class => applies_to_class, :button_icon => 'fa fa-cogs'})
         login_as user
         @button1 = FactoryGirl.create(:custom_button, :applies_to_class => applies_to_class, :visibility => {:roles => ["_ALL_"]}, :options => {:button_icon => 'fa fa-star'})
-        @button_set.add_member @button1
+        add_button_to_set(@button_set, @button1)
       end
 
       it "#get_custom_buttons" do
@@ -60,6 +67,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :text_display => @button_set.set_data.key?(:display) ? @button_set.set_data[:display] : true,
           :buttons      => [expected_button1]
         }
+
         expect(toolbar_builder.get_custom_buttons(subject.class, subject, Mixins::CustomButtons::Result.new(:single))).to eq([expected_button_set])
       end
 


### PR DESCRIPTION
- works for lists and for summary screens
## behaviors
### summary screens
- if visibility expression is not set it means that button will be displayed
- if visibility expression set then it is evaluated for the object(Vm,...) of the summary page

### lists
- if **all** visibility expressions are not set in custom buttons then buttons are displayed
- if **any** visibility expression is set in custom buttons then all buttons are not displayed

## Links
backend pending: https://github.com/ManageIQ/manageiq/pull/15725
first part of https://www.pivotaltracker.com/story/show/147780767 - visibility of custom buttons


