### PR TITLE
Fixed issue with downloading report

### DIFF
--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -79,7 +79,7 @@ module ApplicationController::ReportDownloads
   # Send rendered report data
   def send_report_data
     if @sb[:render_rr_id]
-      rr = MiqReportResult.for_user(current_user).find(@sb[:render_rr_id])
+      rr = MiqReportResult.find(@sb[:render_rr_id])
       filename = filename_timestamp(rr.report.title, 'export_filename')
       disable_client_cache
       generated_result = rr.get_generated_result(@sb[:render_type])


### PR DESCRIPTION
**Issue:** Connecting as admin user and executing download will set userid column in `miq_report_result` table to 'admin|2d7db0c5addb0eb91de3541c811ea02e|download'. As result record is not found for `current_user`.

https://bugzilla.redhat.com/show_bug.cgi?id=1471014

**Solution:** Do not check if `curent_user` can access data for downloading. We can remove this check since download button available only when specific report selected and visibility restriction was already applied to list of reports.

**BEFORE:**
![before](https://user-images.githubusercontent.com/6556758/28969168-722009c0-78f1-11e7-8525-9ca9505317d5.gif)


**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/28969174-7719d74e-78f1-11e7-940d-d7b3b75db8e2.gif)


@miq-bot add-label bug, fine/yes, euwe/yes

\cc @gtanzillo 