### PR TITLE
Add evaluation of enablement expression and displayed text to custom button

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -267,6 +267,8 @@ class ApplicationHelper::ToolbarBuilder
       :image         => cb.options[:button_icon],
       :color         => cb.options[:button_color],
       :text_display  => cb.options.key?(:display) ? cb.options[:display] : true,
+      :enabled       => cb.evaluate_enablement_expression_for(record),
+      :disabled_text => cb.disabled_text,
       :target_object => record_id
     }
   end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -274,14 +274,16 @@ class ApplicationHelper::ToolbarBuilder
 
   def custom_button_selects(model, record, toolbar_result)
     get_custom_buttons(model, record, toolbar_result).collect do |group|
+      buttons = group[:buttons].collect { |b| create_custom_button(b, model, record) }
+
       props = {
         :id      => "custom_#{group[:id]}",
         :type    => :buttonSelect,
         :icon    => "#{group[:image]} fa-lg",
         :color   => group[:color],
         :title   => group[:description],
-        :enabled => true,
-        :items   => group[:buttons].collect { |b| create_custom_button(b, model, record) }
+        :enabled => record ? true : buttons.all?{ |button| button[:enabled]},
+        :items   => buttons
       }
       props[:text] = group[:text] if group[:text_display]
 

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -237,8 +237,7 @@ class ApplicationHelper::ToolbarBuilder
            x_edit_view_tb history_main ems_container_dashboard ems_infra_dashboard).include?(name)
   end
 
-  def create_custom_button(input, model, record, options = {})
-    options[:enabled] = true unless options.key?(:enabled)
+  def create_custom_button(input, model, record)
     button_id = input[:id]
     button_name = input[:name].to_s
     record_id = record.present? ? record.id : 'LIST'
@@ -311,7 +310,7 @@ class ApplicationHelper::ToolbarBuilder
     if record.present?
       service_buttons = record_to_service_buttons(record)
       unless service_buttons.empty?
-        buttons = service_buttons.collect { |b| create_custom_button(b, model, record, :enabled => nil) }
+        buttons = service_buttons.collect { |b| create_custom_button(b, model, record) }
         toolbar.button_group("custom_buttons_", buttons)
       end
     end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -246,7 +246,7 @@ class ApplicationHelper::ToolbarBuilder
       :type      => :button,
       :icon      => "#{input[:image]} fa-lg",
       :color     => input[:color],
-      :title     => input[:description].to_s,
+      :title     => !input[:enabled] && input[:disabled_text] ? input[:disabled_text] : input[:description].to_s,
       :enabled   => input[:enabled],
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "button",

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -247,7 +247,7 @@ class ApplicationHelper::ToolbarBuilder
       :icon      => "#{input[:image]} fa-lg",
       :color     => input[:color],
       :title     => input[:description].to_s,
-      :enabled   => options[:enabled],
+      :enabled   => input[:enabled],
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "button",
       :url_parms => "?id=#{record_id}&button_id=#{button_id}&cls=#{model}&pressed=custom_button&desc=#{button_name}"

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -47,6 +47,8 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :image         => @button1.options[:button_icon],
           :color         => nil,
           :text_display  => @button1.options.key?(:display) ? @button1.options[:display] : true,
+          :enabled       => true,
+          :disabled_text => nil,
           :target_object => subject.id
         }
         expected_button_set = {
@@ -58,7 +60,6 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :text_display => @button_set.set_data.key?(:display) ? @button_set.set_data[:display] : true,
           :buttons      => [expected_button1]
         }
-
         expect(toolbar_builder.get_custom_buttons(subject.class, subject, Mixins::CustomButtons::Result.new(:single))).to eq([expected_button_set])
       end
 


### PR DESCRIPTION
enable custom buttons according to the evaluation of enablement expression and display disabled_text if the button is  a disabled
disabled button:
![enabled custom button](https://user-images.githubusercontent.com/14937244/28959713-ee5f9352-78fb-11e7-9dbb-114d9e99dfe5.png)

on the list:
- if all enablement expressions are not set then custom buttons are enabled (as it was before)
- if any enablement expression is evaluated to false then whole group button is disabled



## Links
backend https://github.com/ManageIQ/manageiq/pull/15729


@miq-bot assign @martinpovolny 
