### PR TITLE
Jasmine: Serve /static from app/views/static, same as runtime

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ class StaticOrHaml
 
   def call(env)
     path = Pathname.new(@dir).join(env["PATH_INFO"].sub(/^\/+/, ''))
-    return [404, {}, []] unless File.exists?(path)
+    return [404, {}, []] unless File.exist?(path)
 
     return @rack_file.call(env) unless path.to_s.ends_with?('.haml')
 
@@ -57,7 +57,7 @@ module Jasmine
 
     def initialize_config
       old_initialize_config
-      @config.add_rack_path('/static', lambda { StaticOrHaml.new })
+      @config.add_rack_path('/static', -> { StaticOrHaml.new })
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,17 @@ if ENV["BUNDLE_GEMFILE"].nil? || ENV["BUNDLE_GEMFILE"] == File.expand_path("../G
   load 'jasmine/tasks/jasmine.rake'
 end
 
+module Jasmine
+  class << self
+    alias old_initialize_config initialize_config
+
+    def initialize_config
+      old_initialize_config
+      @config.add_rack_path('/static', lambda { Rack::File.new('app/views/static') })
+    end
+  end
+end
+
 namespace :spec do
   namespace :javascript do
     desc "Setup environment for javascript specs"

--- a/spec/javascripts/static_spec.js
+++ b/spec/javascripts/static_spec.js
@@ -1,0 +1,27 @@
+// this is the JS counterpart to spec/requests/static_spec.rb
+// here we're testing if the jasmine integration works
+
+describe('/static/* in jasmine', function() {
+  it("returns test template", function(done) {
+    Promise.resolve($.get("/static/test.html"))
+      .then(function(data) {
+        expect(data).toMatch(/^<!--/);
+      })
+      .catch(function() {
+        expect("Error").toEqual(null);
+      })
+      .then(done);
+  });
+
+  it("renders haml template", function(done) {
+    Promise.resolve($.get("/static/test_haml.html.haml"))
+      .then(function(data) {
+        expect(data).toMatch(/<div class=['"]testclass['"]>/);
+        expect(data).not.toMatch(/\.testclass/);
+      })
+      .catch(function() {
+        expect("Error").toEqual(null);
+      })
+      .then(done);
+  });
+});

--- a/spec/requests/static_spec.rb
+++ b/spec/requests/static_spec.rb
@@ -1,16 +1,17 @@
-describe "/static/*" do
-  context "foo" do
-    it "returns test template" do
-      get "/static/test"
-      expect(response.status).to eq(200)
-      expect(response.body).to start_with('<!--')
-    end
+# this is the Ruby counterpart to spec/javascripts/static_spec.js
+# here we're testing the /static controller works
 
-    it "renders haml template" do
-      get "/static/test_haml"
-      expect(response.status).to eq(200)
-      expect(response.body).to match(/<div class=['"]testclass['"]>/)
-      expect(response.body).not_to include(".testclass")
-    end
+describe "/static/*" do
+  it "returns test template" do
+    get "/static/test"
+    expect(response.status).to eq(200)
+    expect(response.body).to start_with('<!--')
+  end
+
+  it "renders haml template" do
+    get "/static/test_haml"
+    expect(response.status).to eq(200)
+    expect(response.body).to match(/<div class=['"]testclass['"]>/)
+    expect(response.body).not_to include(".testclass")
   end
 end


### PR DESCRIPTION
In JS specs, we currently have no way of getting any html views. Thus, any tests that check for html changes need to provide their own html.

That's... moslty good enough, until we start using (and testing) components, where we either need to always mock the template in the spec, or write the component with an inline html-in-a-js-string template, which is sub-optimal for non-trivial components.

So.. this is to enable our js components to read their own template on Jasmine, the same way as during actual runtime - a http request to /static/* serves a template from app/views/static/*.

This is not strictly equivalent to what `StaticController` does, only static files and HAML are supported here, and no magic is done to the filename (`/static/test` will 404, not equal to `/static/test.html` as in `StaticController`), but it does let us test our components in a sane way.

Not sure if Rakefile is quite the place, but not sure where else to put this either, since this is the only place where we reference (and indeed, load) Jasmine.