### PR TITLE
Reverse-merge tree params if the tree is already in the sandbox

### DIFF
--- a/app/presenters/tree_state.rb
+++ b/app/presenters/tree_state.rb
@@ -7,7 +7,7 @@ class TreeState
 
   def add_tree(tree_params)
     name = tree_params[:tree]
-    return false if @sb.has_key_path?(:trees, name)
+    tree_params = @sb[:trees][name].reverse_merge(tree_params) if @sb.has_key_path?(:trees, name)
     @sb.store_path(:trees, name, tree_params)
   end
 

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -116,7 +116,7 @@ describe ReportController do
                                       )
       TreeBuilderReportWidgets.new('widgets_tree', 'widgets', {})
       nodes = controller.send(:tree_add_child_nodes, 'xx-r')
-      expected = [{:key        => "-#{controller.to_cid(widget.id)}",
+      expected = [{:key        => "xx-r_-#{controller.to_cid(widget.id)}",
                    :text       => "Foo",
                    :icon       => 'fa fa-file-text-o',
                    :tooltip    => "Foo",


### PR DESCRIPTION
If the tree was already in the sandbox, the updated params were simply ignored. This causes issues when loading an explorer screen with a tree. The reverse-merging doesn't change the already set values for a tree, just adds the new ones that will fix the issue.

**Steps to reproduce:**
1. Make sure you have a clean browser session
1. Go to the summary screen of a Provider/VM/Host
1. Navigate to a related Datastore
1. The tree on the left side is broken

![screenshot from 2017-08-04 12-27-28](https://user-images.githubusercontent.com/649130/28965231-590bc5cc-7910-11e7-85a5-4b43e01f0eb0.png)

**After this fix:**
![screenshot from 2017-08-04 12-31-17](https://user-images.githubusercontent.com/649130/28965336-d8b322f2-7910-11e7-8cec-77fdf0126286.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1478355