### PR TITLE
Delete the @reselect_node and its JS counterpart as it is dead

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -640,10 +640,6 @@ function miqInitTree(options, tree) {
     miqTreeActivateNodeSilently(options.tree_name, options.select_node);
   }
 
-  if (options.reselect_node) {
-    miqTreeActivateNodeSilently(options.tree_name, options.reselect_node);
-  }
-
   if (options.expand_parent_nodes) {
     miqExpandParentNodes(options.tree_name, options.select_node);
   }

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -132,11 +132,6 @@ class InfraNetworkingController < ApplicationController
     session.delete(:exp_parms)
     @in_a_form = false
 
-    if params[:id]
-      nodetype, id = params[:id].split("-")
-      @reselect_node = self.x_node = "#{nodetype}-#{to_cid(id)}"
-      get_node_info(x_node)
-    end
     render :layout => "application"
   end
 

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -108,13 +108,6 @@ module Mixins
       session.delete(:exp_parms)
       @in_a_form = false
 
-      if params[:id] # If a tree node id came in, show in one of the trees
-        nodetype, id = params[:id].split("-")
-        # treebuilder initializes x_node to root first time in locals_for_render,
-        # need to set this here to force & activate node when link is clicked outside of explorer.
-        @reselect_node = self.x_node = "#{nodetype}-#{to_cid(id)}"
-        get_node_info(x_node)
-      end
       render :layout => "application"
     end
 

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -340,7 +340,7 @@ class StorageController < ApplicationController
       # treebuilder initializes x_node to root first time in locals_for_render,
       # need to set this here to force & activate node when link is clicked outside of explorer.
       self.x_active_tree = :storage_tree
-      self.x_node = @reselect_node = "#{nodetype}-#{to_cid(id)}"
+      self.x_node = "#{nodetype}-#{to_cid(id)}"
     end
 
     build_accordions_and_trees

--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -12,7 +12,6 @@
 - allow_reselect              ||= false
 - highlight_changes           ||= false
 - post_check                  ||= false
-- reselect_node               ||= @reselect_node
 - bs_tree                     ||= '{}'
 - min_expand_level            ||= 1
 - tree_id                     ||= "tree_div"
@@ -39,7 +38,6 @@
              :controller         => j(request.parameters[:controller]),
              :silent_activate    => @explorer && tree_name == x_active_tree.to_s,
              :select_node        => select_node,
-             :reselect_node      => reselect_node,
              :highlight_changes  => highlight_changes,
              :expand_parent_nodes=> @expand_parent_nodes,
              :add_nodes          => add_node_key && nodes && tree_name == x_active_tree.to_s,


### PR DESCRIPTION
This instance variable has been used to force-select a node in a tree after navigating there from an other screen, usually relationships like VMs to Hosts. A lof of these relationship-navigation workflows have been refactored, probably while @martinpovolny created the mixins for textual summaries.

I found only two places where this variable is still being set and all of them looked obsolete to me. The `ManagerControllerMixin` seems like it was copy-pasted from controllers and I haven't found any way to display relationships to the screens where it's being used. The last person made modifications in the area was @lgalis, so she might tell us more about this feature.

Also there are no datastore treenodes displayed on the datastores explorer screen that could be selected when navigating to a datastore from a Provider/Host/VM. Note that there is a [bug](https://github.com/ManageIQ/manageiq-ui-classic/pull/1830) that corrupts the rendered tree when accessing it from a relationship screen, but it's not related to this PR at all.

@miq-bot add_label technical debt, fine/no, trees