### PR TITLE
Change GET to POST route report data

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3300,7 +3300,11 @@ Rails.application.routes.draw do
     end
 
     default_routes.each do |action_name|
+      # TODO GET will be removed, now is it just for compatibility with ui-components
       get "#{controller_name}/#{action_name}(/:id)",
+          :action     => action_name,
+          :controller => controller_name
+      post "#{controller_name}/#{action_name}(/:id)",
           :action     => action_name,
           :controller => controller_name
     end


### PR DESCRIPTION
when set ownership screen is opened from the list then there is an array pass to request
`/report_data?..` and when we exceed the length of url it will lead to 400 http status.


## Links
related BZ for https://bugzilla.redhat.com/show_bug.cgi?id=1461534 but this VZ is for older versions like (POST )
related UI components PR :https://github.com/ManageIQ/ui-components/issues/110

cc @himdel @karelhala 
