### PR TITLE
Remove get route for report data

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3321,10 +3321,6 @@ Rails.application.routes.draw do
     end
 
     default_routes.each do |action_name|
-      # TODO GET will be removed, now is it just for compatibility with ui-components
-      get "#{controller_name}/#{action_name}(/:id)",
-          :action     => action_name,
-          :controller => controller_name
       post "#{controller_name}/#{action_name}(/:id)",
           :action     => action_name,
           :controller => controller_name


### PR DESCRIPTION
GET was replaced to POST(in https://github.com/ManageIQ/manageiq-ui-classic/pull/1833), so now this GET routes is useless

## Links
~~WIP: this need to be merged first https://github.com/ManageIQ/manageiq-ui-classic/pull/1833 (it is based in its branch)~~

@miq-bot assign @himdel 

cc @karelhala 