### PR TITLE
miqFormatNotification - don't throw when missing text

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1646,6 +1646,11 @@ function miqUncompressedId(id) {
 function queryParam(name) { return QS(window.location.href).get(name); }
 
 function miqFormatNotification(text, bindings) {
+  if (!text) {
+    // prevent Jed exceptions when a notification has missing text (__(undefined))
+    return "";
+  }
+
   var str = __(text);
   _.each(bindings, function (value, key) {
     str = str.replace(new RegExp('%{' + key + '}', 'g'), value.text);


### PR DESCRIPTION
This prevents..

```
Error: No translation key found.
at Jed.dcnpgettext (jed.self-41628f2….js?body=1:256)
at Jed.gettext (jed.self-41628f2….js?body=1:168)
at window.__ (all.self-1d305bc….js?body=1:42)
at miqFormatNotification (miq_application.self-72b21e7….js?body=1:1650)
at event_notifications_service.self-163eceb….j…:74
at Array.forEach (<anonymous>)
at event_notifications_service.self-163eceb….j…:73
at processQueue (angular.self-6b939a3….js?body=1:17001)
at angular.self-6b939a3….js?body=1:17045
at Scope.$digest (angular.self-6b939a3….js?body=1:18183) "Possibly unhandled rejection: {}"
```

in browser console when rendering notifications (so, every page).

The underlying issue is notifications with `NULL` `options` in the DB => the API returns `details` with just `{seen: false}`, no `text`, causing `miqFormatNotification` to call `__(undefined)`, which throws.