### PR TITLE
Drop the min_expand_level parameter from trees as it's always 1

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -583,7 +583,7 @@ function miqInitTree(options, tree) {
     showCheckbox:         options.checkboxes,
     hierarchicalCheck:    options.hierarchical_check,
     highlightChanges:     options.highlight_changes,
-    levels:               options.min_expand_level,
+    levels:               1,
     allowReselect:        options.allow_reselect,
     expandIcon:           'fa fa-fw fa-angle-right',
     collapseIcon:         'fa fa-fw fa-angle-down',

--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -14,7 +14,6 @@
 - post_check                  ||= false
 - reselect_node               ||= @reselect_node
 - bs_tree                     ||= '{}'
-- min_expand_level            ||= 1
 - tree_id                     ||= "tree_div"
 - tree_name                   ||= "tree"
 - add_node_key                = Hash.new(@add_nodes).fetch(x_active_tree, {}).fetch(:key, nil)
@@ -24,7 +23,6 @@
              :tree_name          => tree_name,
              :group_changed      => session[:group_changed],
              :cookie_id          => "#{cookie_prefix}#{tree_name}",
-             :min_expand_level   => min_expand_level ? min_expand_level : 1,
              :checkboxes         => checkboxes,
              :hierarchical_check => three_checks,
              :tree_state         => tree_state,


### PR DESCRIPTION
Safe to remove, but probably hakiri will complain about the false-positive issue.