### PR TITLE
$validators return true/false

### DIFF
--- a/app/assets/javascripts/directives/url_validation.js
+++ b/app/assets/javascripts/directives/url_validation.js
@@ -6,7 +6,7 @@ ManageIQ.angular.app.directive('urlValidation', function() {
         if (!viewValue) {
           return true;
         }
-        return validUrl(viewValue);
+        return !!validUrl(viewValue);
       };
 
       var validUrl = function(s) {


### PR DESCRIPTION
`.match` returns `null`. Depending on version of Angular `$validators` may return `null` as `false`. This forces `null` to be return as `false` always.

Automation -> Ansible -> Repositories -> Add/Edit Repository -> type anything (but URL or SSH)

https://bugzilla.redhat.com/show_bug.cgi?id=1471883

This bug is showing only in Fine. 

Before: It's valid. And `Add` or `Save` button is enabled.
After: `Warning URL must include a protocol (http:// or https://) or be a valid SSH path (user@server:path)` is displayed. And `Add` or `Save` button is disabled.

@miq-bot add_label bug, automation/ansible, fine/yes