### PR TITLE
Set correct db value for Provider Foreman case

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -285,6 +285,8 @@ module ApplicationHelper
             "ansible_credential"
           elsif record.kind_of?(ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource)
             "ansible_repository"
+          elsif record.kind_of?(ManageIQ::Providers::Foreman::ConfigurationManager)
+            "provider_foreman"
           elsif record.class.respond_to?(:db_name)
             record.class.db_name
           else


### PR DESCRIPTION
Fix for the error below on a Provider Foreman page -

```
F, [2017-08-07T12:14:07.262478 #36969] FATAL -- : Error caught: [ActionController::UrlGenerationError] No route matches {:action=>"show", :controller=>"ems_configuration", :id=>"29"}
~/.rvm/gems/ruby-2.4.1/gems/actionpack-5.0.5/lib/action_dispatch/journey/formatter.rb:51:in `generate'
~/.rvm/gems/ruby-2.4.1/gems/actionpack-5.0.5/lib/action_dispatch/routing/route_set.rb:631:in `generate'
~/.rvm/gems/ruby-2.4.1/gems/actionpack-5.0.5/lib/action_dispatch/routing/route_set.rb:662:in `generate'
~/.rvm/gems/ruby-2.4.1/gems/actionpack-5.0.5/lib/action_dispatch/routing/route_set.rb:709:in `url_for'
~/.rvm/gems/ruby-2.4.1/gems/actionpack-5.0.5/lib/action_dispatch/routing/url_for.rb:172:in `url_for'
~/.rvm/gems/ruby-2.4.1/gems/actionview-5.0.5/lib/action_view/routing_url_for.rb:90:in `url_for'
~/manageiq/plugins/manageiq-ui-classic/app/helpers/application_helper.rb:17:in `url_for_only_path'
~/manageiq/plugins/manageiq-ui-classic/app/helpers/application_helper.rb:313:in `url_for_db'
~/manageiq/plugins/manageiq-ui-classic/app/helpers/application_helper.rb:293:in `url_for_record'
~/manageiq/plugins/manageiq-ui-classic/app/helpers/quadicon_helper.rb:643:in `render_non_listicon_single_quadicon'
~/manageiq/plugins/manageiq-ui-classic/app/helpers/quadicon_helper.rb:693:in `render_single_quad_quadicon'
~/manageiq/plugins/manageiq-ui-classic/app/helpers/quadicon_helper.rb:163:in `quadicon_builder_factory'
~/manageiq/plugins/manageiq-ui-classic/app/helpers/quadicon_helper.rb:150:in `block in render_quadicon'
```

Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/1858