### PR TITLE
Drop the add_nodes from treeview as it's never actually used

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -610,10 +610,6 @@ function miqInitTree(options, tree) {
     miqTreeActivateNodeSilently(options.tree_name, options.select_node);
   }
 
-  if (options.add_nodes) {
-    miqAddNodeChildren(options.tree_name, options.add_node_key, options.select_node, options.nodes);
-  }
-
   // Tree state persistence correction after the tree is completely loaded
   miqTreeObject(options.tree_name).getNodes().forEach(function (node) {
     if (miqTreeState(options.cookie_id, node.key) === !node.state.expanded) {

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -209,9 +209,6 @@ class CatalogController < ApplicationController
       self.x_active_accord = 'sandt'
       st = ServiceTemplate.find_by_id(from_cid(params[:id].split("-").last))
       prefix = st.service_template_catalog_id ? "stc-#{to_cid(st.service_template_catalog_id)}_st-" : "-Unassigned_st-"
-      add_nodes = open_parent_nodes(st)
-      @add_nodes = {}
-      @add_nodes[:sandt_tree] = add_nodes if add_nodes  # Set nodes that need to be added, if any
       self.x_node = "#{prefix}#{to_cid(id)}"
       get_node_info(x_node)
     else

--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -78,15 +78,9 @@ module VmShowMixin
     get_node_info(x_node_right_cell)
   end
 
-  def set_active_elements_authorized_user(tree_name, accord_name, add_nodes, klass, id)
+  def set_active_elements_authorized_user(tree_name, accord_name, klass, id)
     self.x_active_tree   = tree_name
     self.x_active_accord = accord_name
-    if add_nodes
-      nodes = open_parent_nodes(klass.find_by_id(id))
-      # Create the hash so the view knows to highlight the selected node
-      @add_nodes = {}
-      @add_nodes[tree_name.to_sym] = nodes if nodes # Set nodes that need to be added, if any
-    end
   end
 
   def show_record(id = nil)

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -232,11 +232,11 @@ class VmCloudController < ApplicationController
 
     # Position in tree that matches selected record
     if role_allows?(:feature => "instances_accord") && prefix == "instances"
-      set_active_elements_authorized_user('instances_tree', 'instances', true, ManageIQ::Providers::CloudManager::Vm, id)
+      set_active_elements_authorized_user('instances_tree', 'instances', ManageIQ::Providers::CloudManager::Vm, id)
     elsif role_allows?(:feature => "images_accord") && prefix == "images"
-      set_active_elements_authorized_user('images_tree', 'images', true, ManageIQ::Providers::CloudManager::Template, id)
+      set_active_elements_authorized_user('images_tree', 'images', ManageIQ::Providers::CloudManager::Template, id)
     elsif role_allows?(:feature => "#{prefix}_filter_accord")
-      set_active_elements_authorized_user("#{prefix}_filter_tree", "#{prefix}_filter", false, nil, nil)
+      set_active_elements_authorized_user("#{prefix}_filter_tree", "#{prefix}_filter", nil, nil)
     else
       if (prefix == "vms" && role_allows?(:feature => "vms_instances_filter_accord")) ||
          (prefix == "templates" && role_allows?(:feature => "templates_images_filter_accord"))

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -47,9 +47,9 @@ class VmInfraController < ApplicationController
 
     # Position in tree that matches selected record
     if role_allows?(:feature => "vandt_accord")
-      set_active_elements_authorized_user('vandt_tree', 'vandt', true, VmOrTemplate, id)
+      set_active_elements_authorized_user('vandt_tree', 'vandt', VmOrTemplate, id)
     elsif role_allows?(:feature => "#{prefix}_filter_accord")
-      set_active_elements_authorized_user("#{prefix}_filter_tree", "#{prefix}_filter", false, nil, id)
+      set_active_elements_authorized_user("#{prefix}_filter_tree", "#{prefix}_filter", nil, id)
     else
       if (prefix == "vms" && role_allows?(:feature => "vms_instances_filter_accord")) ||
          (prefix == "templates" && role_allows?(:feature => "templates_images_filter_accord"))

--- a/app/controllers/vm_or_template_controller.rb
+++ b/app/controllers/vm_or_template_controller.rb
@@ -37,7 +37,7 @@ class VmOrTemplateController < ApplicationController
 
     # Position in tree that matches selected record
     if role_allows?(:feature => "#{prefix}_filter_accord")
-      set_active_elements_authorized_user("#{prefix}_filter_tree", "#{prefix}_filter", false, nil, nil)
+      set_active_elements_authorized_user("#{prefix}_filter_tree", "#{prefix}_filter", nil, nil)
     else
       redirect_to(:controller => 'dashboard', :action => "auth_error")
       return true

--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -14,8 +14,6 @@
 - bs_tree                     ||= '{}'
 - tree_id                     ||= "tree_div"
 - tree_name                   ||= "tree"
-- add_node_key                = Hash.new(@add_nodes).fetch(x_active_tree, {}).fetch(:key, nil)
-- nodes                    = Hash.new(@add_nodes).fetch(x_active_tree, {}).fetch(:nodes, nil)
 
 - options = {:tree_id            => tree_id,
              :tree_name          => tree_name,
@@ -35,10 +33,7 @@
              :silent_activate    => @explorer && tree_name == x_active_tree.to_s,
              :select_node        => select_node,
              :highlight_changes  => highlight_changes,
-             :add_nodes          => add_node_key && nodes && tree_name == x_active_tree.to_s,
-             :active_tree        => x_active_tree,
-             :add_node_key       => add_node_key,
-             :nodes              => nodes}
+             :active_tree        => x_active_tree}
 
 :javascript
   miqInitTree(#{options.to_json.html_safe}, #{bs_tree.html_safe})


### PR DESCRIPTION
This is basically dead code:
```ruby
Hash.new(:foo).fetch(:bar, {}) # => {}
Hash.new({:a => :b}).fetch(:bar, {}) # => {}
```

@miq-bot add_label trees, technical debt, fine/no