### PR TITLE
Webpacker - temporarily use a branch

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -30,7 +30,8 @@ Gem::Specification.new do |s|
   s.add_dependency "patternfly-sass", "~> 3.23.1"
   s.add_dependency "sass-rails"
   s.add_dependency "uglifier", "~>3.0.0"
-  s.add_dependency "webpacker", "~>2.0.0"
+  #FIXME: temporarily including a branch instead, in manageiq/Gemfile
+  #s.add_dependency "webpacker", "~>2.0.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "guard-rspec", '~> 4.7.3'


### PR DESCRIPTION
webpacker 2.0 enhances assets:precompile, which doesn't work because webpacker:compile can't be run from manageiq, only ui-components.

Merge together with https://github.com/ManageIQ/manageiq/pull/15766 please. ...details in that PR.