### PR TITLE
Un-enhance assets:precompile and assets:clobber

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -39,10 +39,22 @@ if Rake::Task.task_defined?("assets:precompile")
   Rake::Task["assets:precompile"].enhance do
     Rake::Task["webpack:compile"].invoke
   end
+
+  Rake::Task["assets:precompile"].actions.each do |action|
+    if action.source_location[0].include?(File.join("lib", "tasks", "webpacker"))
+      Rake::Task["assets:precompile"].actions.delete(action)
+    end
+  end
 end
 if Rake::Task.task_defined?("assets:clobber")
   Rake::Task["assets:clobber"].enhance do
     Rake::Task["webpack:clobber"].invoke
+  end
+
+  Rake::Task["assets:clobber"].actions.each do |action|
+    if action.source_location[0].include?(File.join("lib", "tasks", "webpacker"))
+      Rake::Task["assets:clobber"].actions.delete(action)
+    end
   end
 end
 


### PR DESCRIPTION
Removes any additions added to `assets:precompile` and `assets:clobber` by `webpacker`, and allows the additions by `manageiq-ui-classic` to do that heavy lifting.

About the change
----------------

[`Rake::Task[].enhance`](http://ruby-doc.org/stdlib-2.0.0/libdoc/rake/rdoc/Rake/Task.html#method-i-enhance) does the following two things:

* Adds any prerequisites to the task (provided as arguments)
* Adds an action to the task via a block

The addition that was made by the `webpacker` gem was via a block, and not a prerequisite, as shown below (from the `manageiq` dir):

```console
$ irb
irb> load "Rakefile"
irb> Rake::Task["assets:precompile"].prerequisites
=> ["environment"]
irb> Rake::Task["assets:precompile"].actions
=> [#<Proc:0x007fb01d120028@//sprockets-rails-3.2.0/lib/sprockets/rails/task.rb:66>, #<Proc:0x007fb018a75808@/webpacker-2.0/lib/tasks/webpacker/compile.rake:29>, #<Proc:0x007fb01ab4ea20@/manageiq-ui-classic/lib/tasks/manageiq/ui_tasks.rake:39>]
```

(note:  directories shown have been truncated a bit)

So, to remove the addition, we can simply do an `Array#delete(action)` to the action based on it's `source_location`, and only remove the one that includes `lib/tasks/webpacker`.

Of note, the `source_location` of the proc is given as a two element array, with the file name as the first element, and the line number as the second.

```console
irb> action.source_location
=> ["/webpacker-2.0/lib/tasks/webpacker/compile.rake", 29]
```


Links
-----

* https://github.com/ManageIQ/manageiq/issues/15748
* Followup to https://github.com/ManageIQ/manageiq-ui-classic/pull/1849
* Other approaches:
    - https://github.com/ManageIQ/manageiq-ui-classic/pull/1859 and https://github.com/ManageIQ/manageiq/pull/15766
    - https://github.com/rails/webpacker/pull/622


Steps for Testing/QA
--------------------

With this branch changed out in `manageiq-ui-classic`, and `manageiq` hooked up to use the this local copy of `manageiq-ui-classic`, make sure the `rake assets:precompile` and `rake assets:clobber` tasks function properly.