### PR TITLE
Network provider fields

### DIFF
--- a/app/assets/javascripts/controllers/cloud_network/cloud_network_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_network/cloud_network_form_controller.js
@@ -4,6 +4,7 @@ ManageIQ.angular.app.controller('cloudNetworkFormController', ['cloudNetworkForm
   var init = function() {
     vm.afterGet = false;
     vm.cloudNetworkModel = { name: '', ems_id: '', cloud_tenant_id: '' };
+    vm.network_type_pattern = /vlan|vxlan|gre/;
     vm.formId = cloudNetworkFormId;
     vm.model = "cloudNetworkModel";
     vm.newRecord = cloudNetworkFormId === "new";
@@ -21,16 +22,9 @@ ManageIQ.angular.app.controller('cloudNetworkFormController', ['cloudNetworkForm
     } else {
       miqService.sparkleOn();
       API.get("/api/cloud_networks/" + cloudNetworkFormId + "?attributes=cloud_tenant,ext_management_system.name").then(function(data) {
-        vm.cloudNetworkModel.name = data.name;
+        Object.assign(vm.cloudNetworkModel, data);
         vm.cloudNetworkModel.ems_name = data.ext_management_system.name;
         vm.cloudNetworkModel.cloud_tenant_name = data.cloud_tenant.name;
-        vm.cloudNetworkModel.enabled = data.enabled;
-        vm.cloudNetworkModel.external_facing = data.external_facing;
-        vm.cloudNetworkModel.port_security_enabled = data.port_security_enabled;
-        vm.cloudNetworkModel.provider_network_type = data.provider_network_type;
-        vm.cloudNetworkModel.qos_policy_id = data.qos_policy_id;
-        vm.cloudNetworkModel.shared = data.shared;
-        vm.cloudNetworkModel.vlan_transparent = data.vlan_transparent;
         vm.afterGet = true;
         vm.modelCopy = angular.copy( vm.cloudNetworkModel );
         miqService.sparkleOff();

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -226,16 +226,13 @@ class CloudNetworkController < ApplicationController
     options = {}
     # True by default
     params[:enabled] = false unless params[:enabled]
-    # TODO: uncomment once form contains this field
-    # params[:port_security_enabled] = false unless params[:port_security_enabled]
-    params[:qos_policy_id] = nil if params[:qos_policy_id] && params[:qos_policy_id].empty?
-
     options[:name] = params[:name] if params[:name] unless @network.name == params[:name]
     options[:admin_state_up] = switch_to_bol(params[:enabled]) unless @network.enabled == switch_to_bol(params[:enabled])
     options[:shared] = switch_to_bol(params[:shared]) unless @network.shared == switch_to_bol(params[:shared])
     unless @network.external_facing == switch_to_bol(params[:external_facing])
       options[:external_facing] = switch_to_bol(params[:external_facing])
     end
+
     # TODO: uncomment once form contains this field
     # options[:port_security_enabled] = switch_to_bol(params[:port_security_enabled]) unless @network.port_security_enabled == switch_to_bol(params[:port_security_enabled])
     options[:qos_policy_id] = params[:qos_policy_id] unless @network.qos_policy_id == params[:qos_policy_id]
@@ -256,6 +253,8 @@ class CloudNetworkController < ApplicationController
     # options[:port_security_enabled] = params[:port_security_enabled] if params[:port_security_enabled]
     options[:qos_policy_id] = params[:qos_policy_id] if params[:qos_policy_id]
     options[:provider_network_type] = params[:provider_network_type] if params[:provider_network_type]
+    options[:provider_physical_network] = params[:provider_physical_network] if params[:provider_physical_network]
+    options[:provider_segmentation_id] = params[:provider_segmentation_id] if params[:provider_segmentation_id]
     options[:cloud_tenant] = find_record_with_rbac(CloudTenant, params[:cloud_tenant_id]) if params[:cloud_tenant_id]
     options
   end

--- a/app/views/cloud_network/new.html.haml
+++ b/app/views/cloud_network/new.html.haml
@@ -45,7 +45,7 @@
   .form-horizontal{"ng-if" => "vm.cloudNetworkModel.cloud_tenant_id"}
     %h3
       = _('Network Provider Information')
-    .form-group{"ng-class" => "{'has-error': angularForm.provider_network_type.$invalid}"}
+    .form-group
       %label.col-md-2.control-label
         = _('Provider Network Type')
       .col-md-8
@@ -53,10 +53,23 @@
                       options_for_select([["<#{_('Choose')}>", nil]] + @network_provider_network_type_choices.sort),
                       "ng-model"                    => "vm.cloudNetworkModel.provider_network_type",
                       "pf-select"                   => true,
-                      "required"                    => "",
                       "selectpicker-for-select-tag" => "")
-        %span.help-block{"ng-show" => "angularForm.provider_network_type.$error.required"}
-          = _("Required")
+    .form-group{"ng-if" => "vm.cloudNetworkModel.provider_network_type"}
+      %label.control-label.col-md-2
+        = _('Physical Network')
+      .col-md-8
+        %input.form-control{"type"         => "text",
+                            "name"         => "provider_physical_network",
+                            "ng-model"     => "vm.cloudNetworkModel.provider_physical_network",
+                            'ng-maxlength' => 128}
+    .form-group{"ng-if" => "vm.network_type_pattern.test(vm.cloudNetworkModel.provider_network_type)"}
+      %label.control-label.col-md-2
+        = _('Segmentation ID')
+      .col-md-8
+        %input.form-control{"type"         => "text",
+                            "name"         => "provider_segmentation_id",
+                            "ng-model"     => "vm.cloudNetworkModel.provider_segmentation_id",
+                            'ng-maxlength' => 128}
 
   = render :partial => "common_new_edit"
   = render :partial => "layouts/angular/generic_form_buttons"


### PR DESCRIPTION
Adds physical and segmentation id fields to support creation a network provider.
Makes provider_network_type not required, because the network to use default backend anyway.
Also re-factors using `Object.assign`

![networ-providers](https://user-images.githubusercontent.com/1901741/29312564-55b9dc0a-81f9-11e7-9a28-6e2c58ee7d5d.png)
