### PR TITLE
Report data api per page

### DIFF
--- a/app/assets/javascripts/miq_qe.js
+++ b/app/assets/javascripts/miq_qe.js
@@ -101,17 +101,31 @@ ManageIQ.qe.gtl = {
 
     var queryItem = function(identificator) {
       var foundItem;
-        var nameColumn = this.gtlData.cols.filter(function(data) {return data.text === 'Name';});
-        if (nameColumn) {
-          var index = this.gtlData.cols.indexOf(nameColumn[0]);
-          foundItem = this.gtlData.rows.filter(function(oneRow) {
-            return oneRow.cells[index].text === identificator;
-          });
+      var result = {};
+      var nameColumn = this.gtlData.cols.filter(function(data) {return data.text === 'Name';});
+      if (nameColumn) {
+        var index = this.gtlData.cols.indexOf(nameColumn[0]);
+        foundItem = this.gtlData.rows.filter(function(oneRow) {
+          return oneRow.cells[index].text === identificator;
+        });
+      }
+      if (foundItem.length === 0) {
+        foundItem = this.gtlData.rows.filter(function(oneRow) {return oneRow.id == identificator;});
+      }
+      if (foundItem.length === 1) {
+        result = {
+          cells: foundItem[0].cells.reduce(function(acc, value, index){
+            var colName = this.gtlData.cols[index].text || index;
+            acc[colName] = value.text;
+            return acc;
+          }.bind(this), {}),
+          id: foundItem[0].id,
+          long_id: foundItem[0].long_id,
+          quadicon: foundItem[0].quadicon,
+          img_url: foundItem[0].img_url
         }
-        if (foundItem.length === 0) {
-          foundItem = this.gtlData.rows.filter(function(oneRow) {return oneRow.id == identificator;});
-        }
-        return foundItem.length === 1 ? foundItem[0] : {};
+      }
+      return result;
     }.bind(this);
 
     var getItem = function(item) {
@@ -194,6 +208,13 @@ ManageIQ.qe.gtl = {
         return result;
       },
       'set_sorting': function(sortBy) {
+        if (sortBy.columnName) {
+          sortBy.columnId = this.gtlData.cols.indexOf(
+            this.gtlData.cols.filter(function(item) {
+              return item.text === sortBy.columnName;
+            })[0]
+          );
+        }
         this.onSort(sortBy.columnId, sortBy.isAscending);
       },
       'get_all_items': function() {
@@ -217,7 +238,7 @@ ManageIQ.qe.gtl = {
       'is_displayed': function(identificator) {
         var foundItem = queryItem(identificator);
         ManageIQ.qe.gtl.result = foundItem.id ? true : false;
-        return foundItem;
+        return foundItem.id ? true : false;
       },
     };
   },

--- a/app/assets/javascripts/miq_qe.js
+++ b/app/assets/javascripts/miq_qe.js
@@ -101,7 +101,6 @@ ManageIQ.qe.gtl = {
 
     var queryItem = function(identificator) {
       var foundItem;
-      var result = {};
       var nameColumn = this.gtlData.cols.filter(function(data) {return data.text === 'Name';});
       if (nameColumn) {
         var index = this.gtlData.cols.indexOf(nameColumn[0]);
@@ -112,20 +111,21 @@ ManageIQ.qe.gtl = {
       if (foundItem.length === 0) {
         foundItem = this.gtlData.rows.filter(function(oneRow) {return oneRow.id == identificator;});
       }
-      if (foundItem.length === 1) {
-        result = {
-          cells: foundItem[0].cells.reduce(function(acc, value, index){
-            var colName = this.gtlData.cols[index].text || index;
-            acc[colName] = value.text;
-            return acc;
-          }.bind(this), {}),
-          id: foundItem[0].id,
-          long_id: foundItem[0].long_id,
-          quadicon: foundItem[0].quadicon,
-          img_url: foundItem[0].img_url
-        }
+      return foundItem.length === 1 ? foundItem[0] : {};
+    }.bind(this);
+
+    var processItem = function(item) {
+      return {
+        cells: item.cells.reduce(function(acc, value, index){
+          var colName = this.gtlData.cols[index].text || index;
+          acc[colName] = value.text;
+          return acc;
+        }.bind(this), {}),
+        id: item.id,
+        long_id: item.long_id,
+        quadicon: item.quadicon,
+        img_url: item.img_url
       }
-      return result;
     }.bind(this);
 
     var getItem = function(item) {
@@ -145,7 +145,7 @@ ManageIQ.qe.gtl = {
           this.onItemClicked(item, document.createEvent('Event'));
           this.$scope.$digest();
         }.bind(this),
-        item: item,
+        item: processItem(item),
       };
     }.bind(this);
     return {

--- a/app/assets/javascripts/miq_qe.js
+++ b/app/assets/javascripts/miq_qe.js
@@ -87,7 +87,7 @@ ManageIQ.qe.gtl = {
   actionsToFunction: function() {
     var startEnd = function(pageNumber) {
       var start = (pageNumber - 1) * this.settings.perpage;
-      var end = start + this.settings.perPage;
+      var end = start + this.settings.perpage;
       return {
         start: start,
         end: end,
@@ -96,7 +96,22 @@ ManageIQ.qe.gtl = {
 
     var goToPage = function(pageNumber) {
       var pageItems = startEnd(pageNumber);
-      this.onLoadNext(pageItems.start, pageItems.end);
+      this.onLoadNext(pageItems.start, this.settings.perpage);
+    }.bind(this);
+
+    var queryItem = function(identificator) {
+      var foundItem;
+        var nameColumn = this.gtlData.cols.filter(function(data) {return data.text === 'Name';});
+        if (nameColumn) {
+          var index = this.gtlData.cols.indexOf(nameColumn[0]);
+          foundItem = this.gtlData.rows.filter(function(oneRow) {
+            return oneRow.cells[index].text === identificator;
+          });
+        }
+        if (foundItem.length === 0) {
+          foundItem = this.gtlData.rows.filter(function(oneRow) {return oneRow.id == identificator;});
+        }
+        return foundItem.length === 1 ? foundItem[0] : {};
     }.bind(this);
 
     var getItem = function(item) {
@@ -148,7 +163,7 @@ ManageIQ.qe.gtl = {
       'first_page': function() {
         goToPage(1);
       },
-      'perevious_page': function() {
+      'previous_page': function() {
         goToPage(this.settings.current - 1);
       },
       'next_page': function() {
@@ -167,7 +182,7 @@ ManageIQ.qe.gtl = {
         return this.settings.perpage;
       },
       'set_items_per_page': function(itemsPerPage) {
-        this.settings.perPage = itemsPerPage;
+        this.settings.perpage = itemsPerPage;
         goToPage(this.settings.current);
       },
       'get_sorting': function() {
@@ -190,23 +205,19 @@ ManageIQ.qe.gtl = {
         return responseData;
       },
       'get_item': function(identificator) {
-        var foundItem;
-        var nameColumn = this.gtlData.cols.filter(function(data) {return data.text === 'Name';});
-        if (nameColumn) {
-          var index = this.gtlData.cols.indexOf(nameColumn[0]);
-          foundItem = this.gtlData.rows.filter(function(oneRow) {
-            return oneRow.cells[index].text === identificator;
-          });
-        }
-        if (foundItem.length === 0) {
-          foundItem = this.gtlData.rows.filter(function(oneRow) {return oneRow.id == identificator;});
-        }
-        if (foundItem.length === 1) {
-          var responseData = getItem(foundItem[0]);
+        var foundItem = queryItem(identificator);
+        if (foundItem.id) {
+          var responseData = getItem(foundItem);
           ManageIQ.qe.gtl.result = responseData;
           return responseData;
         }
-        return {};
+        ManageIQ.qe.gtl.result = foundItem;
+        return foundItem;
+      },
+      'is_displayed': function(identificator) {
+        var foundItem = queryItem(identificator);
+        ManageIQ.qe.gtl.result = foundItem.id ? true : false;
+        return foundItem;
       },
     };
   },


### PR DESCRIPTION
This is improvement for QE report data (GTL) API, new method, bug fixes and improvements.

### New method:
* (stores) `sendDataWithRx({controller: 'reportDataController', action: 'is_displayed', data: ['name_or_id']})` data `name_or_id` can be number or string, since simple comparison (`==`) is used.
Will query for item based on name or it's ID property. It will store either true or false in result object.

### Bug fixes:
1) perevious_page - typo [FIXED]
2) set_sorting takes number not name - [FIXED], new set_sorting: `sendDataWithRx({controller: 'reportDataController', action: 'set_sorting', data: [{columnName: 'Name', isAscending: true}]})`
3) set_sorting doesn't change sorting - [FIXED] wit previous point
4) check/uncheck all work not thru pagination pane (pagination page checkbox isn't updated) - desired behavior
5) set_items_per_page sets incorrect value when it is called not on first page - [FIXED]
6) first/next/previous/last/go_to_page don't work - [FIXED]

### Improvements
If someone will call for `get_item` or `get_all_items` result item will now have cells as object with key and value, instead of array of object's value.
```javascript
{
  item: {
    "cells":{  
         "Name":"dell-r420-01.cloudforms.lab.eng.rdu2.redhat.com",
         "IP Addres": "0.0.0.0",
         "Cluster":"Default",
         "Total VMs":"1",
         "Total Templates":"0",
         "Platform":"rhel",
         "Version":"",
      },
      id:"12",
      long_id:12,
      img_url: "some/path",
      quadicon: "htmlObject"
  }
}
```