### PR TITLE
Fix wrong breadcrumb link when click on Service Catalog

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -203,7 +203,7 @@ module ApplicationController::CiProcessing
       bc_name = breadcrumb_name(model)
       bc_name += " - " + session["#{self.class.session_key_prefix}_type".to_sym].titleize if session["#{self.class.session_key_prefix}_type".to_sym]
       bc_name += " (filtered)" if @filters && (!@filters[:tags].blank? || !@filters[:cats].blank?)
-      action = %w(service vm_cloud vm_infra vm_or_template storage).include?(self.class.table_name) ? "explorer" : "show_list"
+      action = %w(service vm_cloud vm_infra vm_or_template storage service_template).include?(self.class.table_name) ? "explorer" : "show_list"
       @breadcrumbs.clear
       drop_breadcrumb(:name => bc_name, :url => "/#{controller_name}/#{action}")
     end


### PR DESCRIPTION
Fix wrong breadcrumb link when click on Service Catalog 

Steps to Reproduce:
1. Create a service of type orchestration. 
2. Do some operations(click here and there) on Service- catalog items 
3. Now go to MyService click on that service . On service detail page , click on stack . Stack page will be shown with "Service catalog item" link at the top.
4. Click on "Service Catalog Item " Page does not exist

https://bugzilla.redhat.com/show_bug.cgi?id=1469820

