### PR TITLE
Don't include webpack dependencies in the test environment

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -31,7 +31,8 @@
         = stylesheet_link_tag 'miq_debug'
       = csrf_meta_tag
       = render :partial => 'layouts/i18n_js'
-      = javascript_pack_tag 'application'
+      -# FIXME: the conditional below is a temporary fix for a webpacker issue, remove when it's resolved
+      = javascript_pack_tag 'application' unless Rails.env.test?
 
       :javascript
         ManageIQ.charts.provider = "#{Charting.backend}";


### PR DESCRIPTION
When running specs locally the `javascript_pack_tag` causes frozen array errors. As this method is owned by the `webpacker` gem, the issue should be probably fixed there. This is just a temporary fix until we get the final one into the upstream.

@miq-bot add_label test, fine/no, developer
@miq-bot assign @himdel 