### PR TITLE
Ansible Repository - remove remaining $scope

### DIFF
--- a/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
@@ -1,6 +1,6 @@
 /* global miqFlashLater */
 
-ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'repositoryId', 'miqService', 'API', function($scope, repositoryId,  miqService, API) {
+ManageIQ.angular.app.controller('repositoryFormController', ['repositoryId', 'miqService', 'API', function(repositoryId, miqService, API) {
   var vm = this;
 
   var init = function() {
@@ -23,7 +23,8 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
 
     ManageIQ.angular.scope = vm;
 
-    $scope.newRecord = repositoryId === 'new';
+    vm.saveable = miqService.saveable;
+    vm.newRecord = repositoryId === 'new';
 
     vm.scm_credentials = [{name: __('Select credentials'), value: null}];
     API.get('/api/authentications?collection_class=ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential&expand=resources&sort_by=name&sort_order=ascending')
@@ -41,9 +42,9 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
     }
   };
 
-  $scope.cancelClicked = function() {
+  vm.cancelClicked = function() {
     miqService.sparkleOn();
-    var message = $scope.newRecord ? __('Add of Repository cancelled by user.') : sprintf(__('Edit of Repository \"%s\" cancelled by user.'), vm.repositoryModel.name);
+    var message = vm.newRecord ? __('Add of Repository cancelled by user.') : sprintf(__('Edit of Repository \"%s\" cancelled by user.'), vm.repositoryModel.name);
     var url = '/ansible_repository/show_list';
     miqFlashLater({
       message: message,
@@ -52,20 +53,20 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$scope', 'reposito
     window.location.href = url;
   };
 
-  $scope.resetClicked = function() {
+  vm.resetClicked = function(angularForm) {
     vm.repositoryModel = angular.copy( vm.modelCopy );
-    $scope.angularForm.$setPristine(true);
+    angularForm.$setPristine(true);
     miqService.miqFlash('warn', __('All changes have been reset'));
   };
 
-  $scope.saveClicked = function() {
+  vm.saveClicked = function() {
     miqService.sparkleOn();
     API.put('/api/configuration_script_sources/' + repositoryId, vm.repositoryModel)
       .then(vm.getBack)
       .catch(miqService.handleFailure);
   };
 
-  $scope.addClicked = function() {
+  vm.addClicked = function() {
     miqService.sparkleOn();
     API.post('/api/configuration_script_sources/', vm.repositoryModel)
       .then(vm.getBack)

--- a/app/views/ansible_repository/_repository_form.html.haml
+++ b/app/views/ansible_repository/_repository_form.html.haml
@@ -86,7 +86,7 @@
           %label
             = check_box_tag("scm_update_on_launch", "1", false, 'ng-model' => 'vm.repositoryModel.scm_update_on_launch')
             = _('Update on Launch')
-    = render :partial => "layouts/angular/x_edit_buttons_angular"
+    = render :partial => 'layouts/angular/generic_form_buttons'
 :javascript
   ManageIQ.angular.app.value('repositoryId', '#{@id}');
   miq_bootstrap('#form_div');

--- a/spec/javascripts/controllers/ansible_repository/ansible_repository_form_controller_spec.js
+++ b/spec/javascripts/controllers/ansible_repository/ansible_repository_form_controller_spec.js
@@ -104,7 +104,7 @@ describe('repositoryFormController', function() {
       });
       $scope.vm.modelCopy = angular.copy($scope.vm.repositoryModel); //set modelCopy to default value
       $scope.vm.repositoryModel.description = 'value changed'; //values changed
-      $scope.resetClicked();
+      $scope.vm.resetClicked($scope.angularForm);
     });
 
     it('sets values to original', function(done) {
@@ -129,7 +129,7 @@ describe('repositoryFormController', function() {
       });
       spyOn(controller, 'getBack').and.callFake(function(){ return true;});
 
-      $scope.saveClicked();
+      $scope.vm.saveClicked();
     });
 
     it('calls API', function(done) {


### PR DESCRIPTION
Replace buttons with buttons that support controllerAs.

Automation -> Ansible -> Repositories -> Add/Edit

Before/After: Same

@miq-bot add_label technical debt, automation/ansible
