### PR TITLE
Menu: Don't remember iframes.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1791,7 +1791,7 @@ class ApplicationController < ActionController::Base
     return if request.xml_http_request? || !request.get? || request.format != Mime[:html] ||
       request.headers['X-Angular-Request'].present?
 
-    return if controller_name == 'dashboard' && action_name == 'maintab'
+    return if controller_name == 'dashboard' && %(iframe maintab).include?(action_name)
 
     remember_tab
   end


### PR DESCRIPTION
Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1465943

Fixes:
```
undefined method `href' for nil:NilClass [dashboard/iframe]
```

Steps to Reproduce:
1. Log in
2. Go to 'Red Hat Insights' tab
3. Go back to 'Cloud Intel' tab

