### PR TITLE
Delete dupe warning message in Optimize Bottlenecks

### DIFF
--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -718,6 +718,7 @@ class MiqCapacityController < ApplicationController
   def bottleneck_tl_to_xml
     @timeline = true
     if @sb[:bottlenecks][:report].table.data.length == 0
+      @flash_array = nil
       add_flash(_("No records found for this timeline"), :warning)
     else
       tz = @sb[:bottlenecks][:report].tz ? @sb[:bottlenecks][:report].tz : Time.zone


### PR DESCRIPTION
Ensure we do not generate duplicate warning message on an previously generated and empty Bottlenecks Timeline report.

https://bugzilla.redhat.com/show_bug.cgi?id=1479411

Screen shot prior to fix:

![bz1479411_bottlenecks duplicate messages](https://user-images.githubusercontent.com/552686/29195763-0210aba0-7de5-11e7-82bc-668bf9acddd8.png)

=================
Screen shot post fix:

![bz1479411_bottlenecks display post fix](https://user-images.githubusercontent.com/552686/29195766-0a2d57e8-7de5-11e7-9d3a-2e8cd22912b6.png)
