### PR TITLE
Use class variable gtl_type to check type of report, this way we will receive correct report type

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -980,7 +980,7 @@ class ApplicationController < ActionController::Base
     view_context.instance_variable_set(:@explorer, @explorer)
     table.data.each do |row|
       target = @targets_hash[row.id] unless row['id'].nil?
-      if @in_report_data && get_view_calculate_gtl_type(view.db) != "list"
+      if @in_report_data && defined?(@gtl_type) && @gtl_type != "list"
         quadicon = view_context.render_quadicon(target) if !target.nil? && type_has_quadicon(target.class.name)
       end
       new_row = {


### PR DESCRIPTION
### Fixes #1885
In previous PR https://github.com/ManageIQ/manageiq-ui-classic/pull/1867 there was a mistake where we checked GTL type by calling `get_view_calculate_gtl_type`, however this function will return always `list` when called later on. However we have class variable which is called `gtl_type` this variable stores correct type.