### PR TITLE
[FINE] Display checkable folders in the Alert Profile Assignment tree for `ems_folder`

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -152,10 +152,10 @@ module MiqPolicyController::AlertProfiles
     end
     if params.key?(:id)
       if params[:check] == "1"
-        @assign[:new][:objects].push(params[:id].split("_").last.to_i)
+        @assign[:new][:objects].push(from_cid(params[:id].split("-").last))
         @assign[:new][:objects].sort!
       else
-        @assign[:new][:objects].delete(params[:id].split("_").last.to_i)
+        @assign[:new][:objects].delete(from_cid(params[:id].split("-").last))
       end
     end
 
@@ -194,10 +194,9 @@ module MiqPolicyController::AlertProfiles
                                            :vat,
                                            @sb,
                                            true,
-                                           :edit     => @edit,
-                                           :filters  => @filters,
-                                           :group    => @group,
-                                           :selected => @assign[:new][:objects].collect { |f| "EmsFolder_#{f}" })
+                                           :assign_to => @assign[:new][:assign_to],
+                                           :cat       => @assign[:new][:cat],
+                                           :selected  => @assign[:new][:objects].collect { |f| "EmsFolder_#{f}" })
       elsif @assign[:new][:assign_to] == "resource_pool"
         tree = TreeBuilderBelongsToHac.new(:hac_tree,
                                            :hac,

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -190,7 +190,7 @@ module MiqPolicyController::AlertProfiles
     tree = nil
     unless @objects.empty?               # Build object tree
       if @assign[:new][:assign_to] == "ems_folder"
-        tree = TreeBuilderBelongsToHac.new(:vat_tree,
+        tree = TreeBuilderBelongsToVat.new(:vat_tree,
                                            :vat,
                                            @sb,
                                            true,

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -202,9 +202,8 @@ module MiqPolicyController::AlertProfiles
                                            :hac,
                                            @sb,
                                            true,
-                                           :edit     => @edit,
-                                           :filters  => @filters,
-                                           :group    => @group,
+                                           :assign_to => @assign[:new][:assign_to],
+                                           :cat       => @assign[:new][:cat],
                                            :selected => @assign[:new][:objects].collect { |f| "ResourcePool_#{f}" })
       else
         root_node = TreeNodeBuilder.generic_tree_node(

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -7,7 +7,11 @@ class TreeBuilderBelongsToHac < TreeBuilder
 
   def override(node, object, _pid, options)
     if [ExtManagementSystem, EmsCluster, Datacenter, EmsFolder, ResourcePool].any? { |klass| object.kind_of?(klass) }
-      node[:select] = options.key?(:selected) && options[:selected].include?("#{object.class.name}_#{object[:id]}")
+      node[:select] = if @assign_to
+                        options.key?(:selected) && options[:selected].include?("ResourcePool_#{object[:id]}")
+                      else
+                        options.key?(:selected) && options[:selected].include?("#{object.class.name}_#{object[:id]}")
+                      end
     end
     node[:hideCheckbox] = true if object.kind_of?(Host) && object.ems_cluster_id.present?
     node[:cfmeNoClick] = true

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -18,6 +18,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     @edit = params[:edit]
     @group = params[:group]
     @selected = params[:selected]
+    @assign_to = params[:assign_to]
     # need to remove tree info
     TreeState.new(sandbox).remove_tree(name)
     super(name, type, sandbox, build)
@@ -29,17 +30,26 @@ class TreeBuilderBelongsToHac < TreeBuilder
     {:full_ids             => true,
      :add_root             => false,
      :lazy                 => false,
-     :checkable_checkboxes => @edit.present?,
+     :checkable_checkboxes => @edit.present? || @assign_to.present?,
      :selected             => @selected}
   end
 
   def set_locals_for_render
     locals = super
+
+    oncheck, check_url = if @assign_to
+                           ["miqOnCheckHandler", "/miq_policy/alert_profile_assign_changed/"]
+                         elsif @edit
+                           ["miqOnCheckUserFilters", "/ops/rbac_group_field_changed/#{group_id}___"]
+                         else
+                           [nil, "/ops/rbac_group_field_changed/#{group_id}___"]
+                         end
+
     locals.merge!(:id_prefix         => 'hac_',
-                  :check_url         => "/ops/rbac_group_field_changed/#{group_id}___",
-                  :oncheck           => @edit ? "miqOnCheckUserFilters" : nil,
+                  :check_url         => check_url,
+                  :oncheck           => oncheck,
                   :checkboxes        => true,
-                  :highlight_changes => true,
+                  :highlight_changes => @assign_to ? false : true,
                   :onclick           => false)
   end
 

--- a/app/views/miq_policy/_alert_profile_assign.html.haml
+++ b/app/views/miq_policy/_alert_profile_assign.html.haml
@@ -35,11 +35,4 @@
     %h3
       = _('Selections')
     - if @assign[:obj_tree]
-      #obj_treebox.treeview-pf-hover.treeview-pf-select{:style => "width: 100%; color: #000;"}
-      = render(:partial => "layouts/tree",
-        :locals         => {:tree_id    => "obj_treebox",
-          :tree_name                    => "obj_tree",
-          :bs_tree                      => @assign[:obj_tree],
-          :oncheck                      => "miqOnCheckHandler",
-          :check_url                    => "alert_profile_assign_changed/",
-          :checkboxes                   => true})
+      = render(:partial => 'shared/tree', :locals => {:tree => @assign[:obj_tree], :name => @assign[:obj_tree].name})


### PR DESCRIPTION
Fine equivalent of https://github.com/ManageIQ/manageiq-ui-classic/pull/1747

https://bugzilla.redhat.com/show_bug.cgi?id=1479944