### PR TITLE
Created additional decorators replacing icons set through @listicon

### DIFF
--- a/app/decorators/advanced_setting_decorator.rb
+++ b/app/decorators/advanced_setting_decorator.rb
@@ -1,0 +1,5 @@
+class AdvancedSettingDecorator < MiqDecorator
+  def self.fonticon
+    'fa fa-wrench'
+  end
+end

--- a/app/decorators/cloud_service_decorator.rb
+++ b/app/decorators/cloud_service_decorator.rb
@@ -1,0 +1,5 @@
+class CloudServiceDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-service'
+  end
+end

--- a/app/decorators/firewall_rule_decorator.rb
+++ b/app/decorators/firewall_rule_decorator.rb
@@ -1,0 +1,5 @@
+class FirewallRuleDecorator < MiqDecorator
+  def self.fonticon
+    'ff ff-firewall'
+  end
+end

--- a/app/decorators/guest_application_decorator.rb
+++ b/app/decorators/guest_application_decorator.rb
@@ -1,0 +1,5 @@
+class GuestApplicationDecorator < MiqDecorator
+  def self.fonticon
+    'ff ff-software-package'
+  end
+end

--- a/app/decorators/openscap_rule_result_decorator.rb
+++ b/app/decorators/openscap_rule_result_decorator.rb
@@ -1,0 +1,5 @@
+class OpenscapRuleResultDecorator < MiqDecorator
+  def self.fonticon
+    'fa fa-shield'
+  end
+end

--- a/app/decorators/orchestration_stack_output_decorator.rb
+++ b/app/decorators/orchestration_stack_output_decorator.rb
@@ -1,0 +1,5 @@
+class OrchestrationStackOutputDecorator < MiqDecorator
+  def self.fonticon
+    'ff ff-file-output-o'
+  end
+end

--- a/app/decorators/orchestration_stack_parameter_decorator.rb
+++ b/app/decorators/orchestration_stack_parameter_decorator.rb
@@ -1,0 +1,5 @@
+class OrchestrationStackParameterDecorator < MiqDecorator
+  def self.fonticon
+    'ff ff-parameter'
+  end
+end

--- a/app/decorators/orchestration_stack_resource_decorator.rb
+++ b/app/decorators/orchestration_stack_resource_decorator.rb
@@ -1,0 +1,5 @@
+class OrchestrationStackResourceDecorator < MiqDecorator
+  def self.fonticon
+    'ff ff-resource'
+  end
+end

--- a/app/decorators/patch_decorator.rb
+++ b/app/decorators/patch_decorator.rb
@@ -1,0 +1,5 @@
+class PatchDecorator < MiqDecorator
+  def self.fonticon
+    'fa fa-shield'
+  end
+end

--- a/app/decorators/scan_history_decorator.rb
+++ b/app/decorators/scan_history_decorator.rb
@@ -1,0 +1,5 @@
+class ScanHistoryDecorator < MiqDecorator
+  def self.fonticon
+    'fa fa-search'
+  end
+end

--- a/app/decorators/storage_file_decorator.rb
+++ b/app/decorators/storage_file_decorator.rb
@@ -1,0 +1,5 @@
+class StorageFileDecorator < MiqDecorator
+  def self.fonticon
+    'fa fa-file-o'
+  end
+end


### PR DESCRIPTION
We're still setting icons using the `@listicon` instance variable instead of using decorators. I searched for all the places where the `@listicon` is set and created decorators for the related models.