### PR TITLE
Clear Search box text

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1478,7 +1478,7 @@ function miqInitMainContent() {
   $('#main-content').css('height', 'calc(100% - ' + height + 'px)')
 }
 
-function miqHideSearchClearButton() {
+function miqHideSearchClearButton(explorer) {
   // Hide the clear button if the search input is empty
   $(".search-pf .has-clear .clear").each(function() {
     if (!$(this).prev('.form-control').val()) {
@@ -1494,6 +1494,9 @@ function miqHideSearchClearButton() {
   $(".search-pf .has-clear .clear").click(function () {
     $(this).prev('.form-control').val('').focus();
     $(this).hide();
+    // Clear Search text values as well
+    var url = "/" + ManageIQ.controller + "/adv_search_text_clear" + "?in_explorer=" + explorer;
+    miqJqueryRequest(url);
   });
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -531,6 +531,13 @@ class ApplicationController < ActionController::Base
     send_data fs.contents, :filename => fs.name
   end
 
+  def adv_search_text_clear
+    if params[:in_explorer] == "true"
+      @search_text = @sb[:search_text] = nil
+      reload
+    end
+  end
+
   protected
 
   def render_flash(add_flash_text = nil, severity = nil)

--- a/app/views/layouts/_searchbar.html.haml
+++ b/app/views/layouts/_searchbar.html.haml
@@ -39,7 +39,7 @@
 :javascript
   $(function($) {
     $(document).ready(function() {
-      miqHideSearchClearButton()
+      miqHideSearchClearButton("#{@explorer}");
     });
     $("button[data-target='#advsearchModal']").click(function(){
       miqJqueryRequest("adv_search_toggle", {beforeSend: true});

--- a/app/views/layouts/_x_adv_searchbox.html.haml
+++ b/app/views/layouts/_x_adv_searchbox.html.haml
@@ -49,7 +49,7 @@
       ManageIQ.explorer.clearSearchToggle(#{clear_search_status});
       $(function() {
         $(document).ready(function() {
-          miqHideSearchClearButton();
+          miqHideSearchClearButton("#{@explorer}");
         });
         $("button[data-target='#advsearchModal']").click(function(){
           miqJqueryRequest("adv_search_toggle", {beforeSend: true});

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     adv_search_load_choice
     adv_search_name_typed
     adv_search_toggle
+    adv_search_text_clear
   )
 
   button_post = %w(


### PR DESCRIPTION
Added code to clear out Search box text, fixes 2 BZs. Keeps Search text while navigating through accordions on a page, but clears out Search text when button is clicked and renders unfiltered data display.
 
https://bugzilla.redhat.com/show_bug.cgi?id=1346996

https://bugzilla.redhat.com/show_bug.cgi?id=1462638

============================
Screen shots post code fix:

Unfiltered data display:
![search clearance initial display vms and templates](https://user-images.githubusercontent.com/552686/29475559-1dfeaef8-8415-11e7-9488-f4c8de03287a.png)

Search text is cleared, unfiltered data rendered:
![search clearance vms and templates after clear button click](https://user-images.githubusercontent.com/552686/29475575-35d6b458-8415-11e7-8ace-84bcc6d64fd8.png)

Search text has no data match:
![search clearance vms and templates filter not found](https://user-images.githubusercontent.com/552686/29475600-53fab506-8415-11e7-8c5f-ab92541086da.png)

