### PR TITLE
When showing dashboard widget in full screen do not try to show MiqReport for user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -201,7 +201,7 @@ class ApplicationController < ActionController::Base
       rpt.generate_table(:userid => session[:userid])
     else
       rpt = if session[:report_result_id]
-              MiqReportResult.for_user(current_user).find(session[:report_result_id]).report_results
+              MiqReportResult.find(session[:report_result_id]).report_results
             elsif session[:rpt_task_id].present?
               MiqTask.find(session[:rpt_task_id]).task_results
             else
@@ -447,7 +447,7 @@ class ApplicationController < ActionController::Base
     end
     # Dashboard widget will send in report result id else, find report result in the sandbox
     search_id = params[:rr_id] ? params[:rr_id].to_i : @sb[:pages][:rr_id]
-    rr = MiqReportResult.for_user(current_user).find(search_id)
+    rr = MiqReportResult.find(search_id)
 
     session[:report_result_id] = rr.id  # Save report result id for chart rendering
     session[:rpt_task_id]      = nil    # Clear out report task id, using a saved report


### PR DESCRIPTION
### Closes #1853
Querying MiqReport for current user will try to fetch item with miq_group_id not NIL, but no record with miq_group_id set exists.