### PR TITLE
Remove expandParentNodes as its never being used in any tree

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -640,10 +640,6 @@ function miqInitTree(options, tree) {
     miqTreeActivateNodeSilently(options.tree_name, options.select_node);
   }
 
-  if (options.expand_parent_nodes) {
-    miqExpandParentNodes(options.tree_name, options.select_node);
-  }
-
   if (options.add_nodes) {
     miqAddNodeChildren(options.tree_name, options.add_node_key, options.select_node, options.nodes);
   }

--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -35,7 +35,6 @@
              :silent_activate    => @explorer && tree_name == x_active_tree.to_s,
              :select_node        => select_node,
              :highlight_changes  => highlight_changes,
-             :expand_parent_nodes=> @expand_parent_nodes,
              :add_nodes          => add_node_key && nodes && tree_name == x_active_tree.to_s,
              :active_tree        => x_active_tree,
              :add_node_key       => add_node_key,


### PR DESCRIPTION
:scissors: :scissors: :toilet: :scissors: :toilet: :tada: 
@miq-bot add_label technical debt, trees, fine/no