### PR TITLE
Remove 'miqSetAETreeNodeSelectionClass' from the tree safe eval list

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -458,7 +458,6 @@ function miqTreeEventSafeEval(func) {
     'miqOnClickSnapshotTree',
     'miqOnClickTagCat',
     'miqOnClickTimelineSelection',
-    'miqSetAETreeNodeSelectionClass',
   ];
 
   if (whitelist.includes(func)) {


### PR DESCRIPTION
Dead code, all references removed by @ZitaNemeckova in a0bc4d48f0fc3899d144e9e05b70bed0a7ec0334 :scissors: :skull: 

@miq-bot add_label technical debt, trees, fine/no