### PR TITLE
Cloud topology controller as vm

### DIFF
--- a/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
@@ -2,20 +2,22 @@ angular.module('ManageIQ').controller('cloudTopologyController', CloudTopologyCt
 CloudTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
 
 function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
+  var vm = this;
+
   ManageIQ.angular.scope = $scope;
   miqHideSearchClearButton();
-  var self = this;
-  $scope.vs = null;
+  vm.vs = null;
   var icons = null;
 
   var d3 = window.d3;
-  $scope.d3 = d3;
+  // NOTE: for search
+  vm.d3 = d3;
 
-  topologyService.mixinContextMenu(this, $scope);
+  topologyService.mixinContextMenu(vm, vm);
 
   $scope.refresh = function() {
     var id;
-    if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
+    if ($location.absUrl().match('show/$') || $location.absUrl().match('show$')) {
       id = '';
     } else {
       id = '/' + (/cloud_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
@@ -31,144 +33,147 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService,
   function getCloudTopologyFormDataComplete(response) {
     var data = response.data;
 
-    var currentSelectedKinds = $scope.kinds;
+    var currentSelectedKinds = vm.kinds;
 
-    $scope.items = data.data.items;
-    $scope.relations = data.data.relations;
-    $scope.kinds = data.data.kinds;
+    vm.items = data.data.items;
+    vm.relations = $scope.relations = data.data.relations;
+    // NOTE: $scope.kind is required by kubernetes-topology-icon
+    vm.kinds = $scope.kinds = data.data.kinds;
     icons = data.data.icons;
 
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys($scope.kinds).length)) {
-      $scope.kinds = currentSelectedKinds;
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys(vm.kinds).length)) {
+      vm.kinds = vm.kinds = currentSelectedKinds;
     }
   }
 
-  $scope.checkboxModel = {
-    value: false
+  vm.checkboxModel = {
+    value: false,
   };
 
-  $scope.legendTooltip = __("Click here to show/hide entities of this type");
+  vm.legendTooltip = __('Click here to show/hide entities of this type');
 
-  $('input#box_display_names').click(topologyService.showHideNames($scope));
+  $('input#box_display_names').click(topologyService.showHideNames(vm));
   $scope.refresh();
   var promise = $interval($scope.refresh, 1000 * 60 * 3);
-
+// NOTE: cannot move $on events to scope until angular2
   $scope.$on('$destroy', function() {
     $interval.cancel(promise);
   });
 
-  $scope.$on("render", function(ev, vertices, added) {
+  $scope.$on('render', function(ev, vertices, added) {
     /*
      * We are passed two selections of <g> elements:
      * vertices: All the elements
      * added: Just the ones that were added
      */
 
-    added.attr("class", function(d) {
+    added.attr('class', function(d) {
       return d.item.kind;
     });
 
-    added.append("circle")
-      .attr("r", function(d) {
-        return self.getDimensions(d).r;
+    added.append('circle')
+      .attr('r', function(d) {
+        return vm.getDimensions(d).r;
       })
       .attr('class', function(d) {
         return topologyService.getItemStatusClass(d);
       })
-      .on("contextmenu", function(d) {
-        self.contextMenu(this, d);
+      .on('contextmenu', function(d) {
+        vm.contextMenu(this, d);
+        vm.contextMenu(this, d);
       });
 
-    added.append("title");
+    added.append('title');
 
-    added.on("dblclick", function(d) {
-      return self.dblclick(d);
+    added.on('dblclick', function(d) {
+      return vm.dblclick(d);
     });
 
-    added.append("image")
-      .attr("xlink:href", function (d) {
-        var iconInfo = self.getIcon(d);
-        switch(iconInfo.type) {
+    added.append('image')
+      .attr('xlink:href', function(d) {
+        var iconInfo = vm.getIcon(d);
+        switch (iconInfo.type) {
           case 'image':
             return iconInfo.icon;
-          case "glyph":
+          case 'glyph':
+            return null;
+          default:
             return null;
         }
       })
-      .attr("height", function(d) {
-        var iconInfo = self.getIcon(d);
-        if (iconInfo.type != 'image') {
+      .attr('height', function(d) {
+        var iconInfo = vm.getIcon(d);
+        if (iconInfo.type !== 'image') {
           return 0;
         }
         return 40;
       })
-      .attr("width", function(d) {
-        var iconInfo = self.getIcon(d);
-        if (iconInfo.type != 'image') {
+      .attr('width', function(d) {
+        var iconInfo = vm.getIcon(d);
+        if (iconInfo.type !== 'image') {
           return 0;
         }
         return 40;
       })
-      .attr("y", function(d) {
-        return self.getDimensions(d).y;
+      .attr('y', function(d) {
+        return vm.getDimensions(d).y;
       })
-      .attr("x", function(d) {
-        return self.getDimensions(d).x;
+      .attr('x', function(d) {
+        return vm.getDimensions(d).x;
       })
-      .on("contextmenu", function(d) {
-        self.contextMenu(this, d);
+      .on('contextmenu', function(d) {
+        vm.contextMenu(this, d);
       });
 
-    added.append("text")
+    added.append('text')
       .each(function(d) {
-        var iconInfo = self.getIcon(d);
-        if (iconInfo.type != 'glyph')
+        var iconInfo = vm.getIcon(d);
+        if (iconInfo.type !== 'glyph') {
           return;
-
+        }
         /* global fontIconChar */
         var fonticon = fontIconChar(iconInfo.class);
         $(this).text(fonticon.char)
-          .attr("class", "glyph")
+          .attr('class', 'glyph')
           .attr('font-family', fonticon.font);
       })
 
-      .attr("y", function(d) {
-        return self.getDimensions(d).y;
+      .attr('y', function(d) {
+        return vm.getDimensions(d).y;
       })
-      .attr("x", function(d) {
-        return self.getDimensions(d).x;
+      .attr('x', function(d) {
+        return vm.getDimensions(d).x;
       })
-      .on("contextmenu", function(d) {
-        self.contextMenu(this, d);
+      .on('contextmenu', function(d) {
+        vm.contextMenu(this, d);
       });
 
-    added.append("text")
-      .attr("x", 26)
-      .attr("y", 24)
+    added.append('text')
+      .attr('x', 26)
+      .attr('y', 24)
       .text(function(d) {
         return d.item.name;
       })
       .attr('class', function() {
-         var class_name = "attached-label";
-         if ($scope.checkboxModel.value) {
-           return class_name + ' visible';
-         } else {
-           return class_name;
-         }
+        var className = 'attached-label';
+        if (vm.checkboxModel.value) {
+          return className + ' visible';
+        }
+        return className;
       });
 
-    added.selectAll("title").text(function(d) {
-      return topologyService.tooltip(d).join("\n");
+    added.selectAll('title').text(function(d) {
+      return topologyService.tooltip(d).join('\n');
     });
 
-    $scope.vs = vertices;
+    vm.vs = vertices;
 
     /* Don't do default rendering */
     ev.preventDefault();
   });
 
-  this.getIcon = function getIcon(d) {
-    switch(d.item.kind) {
+  vm.getIcon = function getIcon(d) {
+    switch (d.item.kind) {
       case 'CloudManager':
         return icons[d.item.display_kind];
       default:
@@ -176,22 +181,25 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService,
     }
   };
 
-  this.getDimensions = function getDimensions(d) {
+  vm.getDimensions = function getDimensions(d) {
     var defaultDimensions = topologyService.defaultElementDimensions();
     switch (d.item.kind) {
-      case "CloudManager":
+      case 'CloudManager':
         return { x: -20, y: -20, r: 28 };
-      case "AvailabilityZone":
-      case "Tag":
+      case 'AvailabilityZone':
+      case 'Tag':
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: 13 };
-      case "CloudTenant":
+      case 'CloudTenant':
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: 19 };
-      case "Vm":
+      case 'Vm':
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: 21 };
       default:
         return defaultDimensions;
     }
   };
 
-  topologyService.mixinSearch($scope);
+  topologyService.mixinSearch(vm);
+  // NOTE: need for searching in miq-toolbar
+  $scope.searchNode = vm.searchNode;
+  $scope.resetSearch = vm.resetSearch;
 }

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -13,6 +13,7 @@ ManageIQ.angular.app.service('topologyService', function() {
     return status;
   };
 
+
   this.showHideNames = function($scope) {
     return function() {
       $scope.checkboxModel.value = $('input#box_display_names')[0].checked;
@@ -216,24 +217,27 @@ ManageIQ.angular.app.service('topologyService', function() {
   // this injects some common code in the controller - temporary pending a proper merge
   this.mixinSearch = function($scope) {
     var topologyService = this;
-
     $scope.searching = false;
     $scope.notFound = false;
-
-    $scope.searchNode = function() {
-      var svg = topologyService.getSVG($scope.d3);
-      var query = $('input#search_topology')[0].value;
-
-      $scope.searching = true;
-      $scope.notFound = ! topologyService.searchNode(svg, query);
-    };
-
+      // NOTE: listener on search
+    ManageIQ.angular.rxSubject.subscribe(function(event) {
+      if (event.service === 'topologyService') {
+        if (event.name === 'searchNode') {
+          $scope.searching = true;
+          var svg = topologyService.getSVG($scope.d3);
+          var query = $('input#search_topology')[0].value;
+          $scope.notFound = ! topologyService.searchNode(svg, query);
+        } else if (event.name === 'resetSearch') {
+          topologyService.resetSearch($scope.d3);
+          $('input#search_topology')[0].value = '';
+          $scope.searching = false;
+          $scope.notFound = false;
+        }
+      }
+    });
     $scope.resetSearch = function() {
       topologyService.resetSearch($scope.d3);
-
-      // Reset the search term in search input
       $('input#search_topology')[0].value = '';
-
       $scope.searching = false;
       $scope.notFound = false;
     };

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -55,7 +55,7 @@ ManageIQ.angular.app.service('topologyService', function() {
             .style('top', mousePosition[1] + 'px');
         popup.append('h5').text('Actions on ' + data.item.display_kind);
 
-        if (data.item.kind != 'Tag') {
+        if (data.item.kind !== 'Tag') {
           popup.append('p').text(__('Go to summary page')).on('click', function() {
             self.dblclick(data);
           });
@@ -85,7 +85,7 @@ ManageIQ.angular.app.service('topologyService', function() {
     };
 
     self.dblclick = function dblclick(d) {
-      if (d.item.kind == 'Tag') {
+      if (d.item.kind === 'Tag') {
         return false;
       }
       window.location.assign(topologyService.geturl(d));
@@ -205,7 +205,7 @@ ManageIQ.angular.app.service('topologyService', function() {
     while ((tmp_list.length > size_limit) && kind_index < remove_hierarchy.length) {
       var kind_to_hide = remove_hierarchy[kind_index];
       tmp_list = tmp_list.filter(function(item) {
-        return item.kind != kind_to_hide;
+        return item.kind !== kind_to_hide;
       });
       kind_index++;
       delete kinds[kind_to_hide];
@@ -216,6 +216,12 @@ ManageIQ.angular.app.service('topologyService', function() {
   // this injects some common code in the controller - temporary pending a proper merge
   this.mixinSearch = function($scope) {
     var topologyService = this;
+    var resetEvent = function() {
+      topologyService.resetSearch($scope.d3);
+      $('input#search_topology')[0].value = '';
+      $scope.searching = false;
+      $scope.notFound = false;
+    };
     $scope.searching = false;
     $scope.notFound = false;
       // NOTE: listener on search
@@ -227,18 +233,10 @@ ManageIQ.angular.app.service('topologyService', function() {
           var query = $('input#search_topology')[0].value;
           $scope.notFound = ! topologyService.searchNode(svg, query);
         } else if (event.name === 'resetSearch') {
-          topologyService.resetSearch($scope.d3);
-          $('input#search_topology')[0].value = '';
-          $scope.searching = false;
-          $scope.notFound = false;
+          resetEvent();
         }
       }
     });
-    $scope.resetSearch = function() {
-      topologyService.resetSearch($scope.d3);
-      $('input#search_topology')[0].value = '';
-      $scope.searching = false;
-      $scope.notFound = false;
-    };
+    $scope.resetSearch = resetEvent;
   };
 });

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -103,8 +103,7 @@ ManageIQ.angular.app.service('topologyService', function() {
     nodes.style('opacity', '1');
 
     var found = true;
-
-    if (query != '') {
+    if (query !== '') {
       var selected = nodes.filter(function(d) {
         return d.item.name.indexOf(query) === -1;
       });

--- a/app/views/cloud_topology/show.html.haml
+++ b/app/views/cloud_topology/show.html.haml
@@ -27,7 +27,7 @@
     %strong
       = _("Click on the legend to show/hide entities, and double click/right click the entities in the graph to navigate to their summary pages.")
 
-  = render :partial => "shared/topology/not_found"
+  = render :partial => "shared/topology/not_found_vm"
 
   %kubernetes-topology-graph{:items => "vm.items", :relations => "vm.relations", :kinds => "vm.kinds"}
 

--- a/app/views/cloud_topology/show.html.haml
+++ b/app/views/cloud_topology/show.html.haml
@@ -1,8 +1,10 @@
-- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
-.topology{'ng-controller' => "cloudTopologyController"}
+- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{vm.legendTooltip}}"}
+.topology{'ng-controller' => "cloudTopologyController as vm"}
   .legend
     %label#selected
-    %div{'ng-if' => "kinds"}
+    %label
+      test
+    %div{'ng-if' => "vm.kinds"}
       %kubernetes-topology-icon{tooltipOptions, :kind => "Vm"}
         %label
           %i.pficon.pficon-virtual-machine
@@ -29,7 +31,7 @@
 
   = render :partial => "shared/topology/not_found"
 
-  %kubernetes-topology-graph{:items => "items", :relations => "relations", :kinds => "kinds"}
+  %kubernetes-topology-graph{:items => "vm.items", :relations => "vm.relations", :kinds => "vm.kinds"}
 
 :javascript
   miq_bootstrap('.topology');

--- a/app/views/cloud_topology/show.html.haml
+++ b/app/views/cloud_topology/show.html.haml
@@ -1,23 +1,21 @@
-- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{vm.legendTooltip}}"}
+- tooltip_options = {"tooltip-placement" => "bottom", "tooltip" => "{{vm.legendTooltip}}"}
 .topology{'ng-controller' => "cloudTopologyController as vm"}
   .legend
     %label#selected
-    %label
-      test
     %div{'ng-if' => "vm.kinds"}
-      %kubernetes-topology-icon{tooltipOptions, :kind => "Vm"}
+      %kubernetes-topology-icon{tooltip_options, :kind => "Vm"}
         %label
           %i.pficon.pficon-virtual-machine
           = _("VMs")
-      %kubernetes-topology-icon{tooltipOptions, :kind => "AvailabilityZone"}
+      %kubernetes-topology-icon{tooltip_options, :kind => "AvailabilityZone"}
         %label
           %i.pficon.pficon-zone
           = _("Availability Zones")
-      %kubernetes-topology-icon{tooltipOptions, :kind => "CloudTenant"}
+      %kubernetes-topology-icon{tooltip_options, :kind => "CloudTenant"}
         %label
           %i.pficon.pficon-cloud-tenant
           = _("Cloud Tenants")
-      %kubernetes-topology-icon{tooltipOptions, :kind => "Tag"}
+      %kubernetes-topology-icon{tooltip_options, :kind => "Tag"}
         %label
           %i.fa.fa-tag
           = _("Tags")

--- a/app/views/shared/_topology_header_toolbar.html.haml
+++ b/app/views/shared/_topology_header_toolbar.html.haml
@@ -4,14 +4,13 @@
     = _("Display Names")
 
 .form-group
-  %button.btn.btn-default{'data-function'      => 'miqCallAngular',
-                          'data-function-data' => {:name => 'refresh',
-                                                   :args => []}.to_json}
+  %button.btn.btn-default{'data-function'      => 'sendDataWithRx',
+                          'data-function-data' => {:controller => 'cloudTopologyController',
+                                                   :name => 'refresh'}.to_json}
     %i.fa.fa-refresh.fa-lg
     = _("Refresh")
-
 %form.search-pf.topology-search{:role     => 'form',
-                                :onsubmit => 'miqCallAngular({ name: "searchNode", args: [] }); return false'}
+                                :onsubmit => 'sendDataWithRx({service: "topologyService", name: "searchNode", args: [] }); return false'}
   .form-group.has-clear
     .search-pf-input-group
       %label.sr-only{:for => 'search'}
@@ -23,18 +22,18 @@
       -# this hidden button is a workaround
       -# pressing enter in ^input triggers a *click* event on the next button
       -# without this, that button is resetSearch, which ..is undesirable :)
-      %button.hidden{'data-function'      => 'miqCallAngular',
-                     'data-function-data' => {:name => 'searchNode',
-                                              :args => []}.to_json}
+      %button.hidden{'data-function'      => 'sendDataWithRx',
+                     'data-function-data' => {:service => 'topologyService',
+                                              :name => 'searchNode'}.to_json}
 
       %button.clear{'aria-hidden'        => 'true',
-                    'data-function'      => 'miqCallAngular',
-                    'data-function-data' => {:name => 'resetSearch',
-                                             :args => []}.to_json}
+                    'data-function'      => 'sendDataWithRx',
+                    'data-function-data' => {:service => 'topologyService',
+                                             :name => 'resetSearch'}.to_json}
         %span.pficon.pficon-close
 
   .form-group.search-button
-    %button.btn.btn-default.search-topology-button{'data-function'      => 'miqCallAngular',
-                                                   'data-function-data' => {:name => 'searchNode',
-                                                                            :args => []}.to_json}
+    %button.btn.btn-default.search-topology-button{'data-function'      => 'sendDataWithRx',
+                                                   'data-function-data' => {:service => 'topologyService',
+                                                                            :name => 'searchNode'}.to_json}
       %span.fa.fa-search

--- a/spec/javascripts/controllers/cloud/cloud_topology_controller_spec.js
+++ b/spec/javascripts/controllers/cloud/cloud_topology_controller_spec.js
@@ -1,64 +1,65 @@
 describe('cloudTopologyController', function() {
-    var scope, $controller, $httpBackend;
-    var mock_data =  getJSONFixture('cloud_topology_response.json');
-    var cloud_tenant = { id:"396086e5-7b0d-11e5-8286-18037327aaeb",  item:{display_kind:"CloudTenant", name:"admin", kind:"CloudTenant", id:"396086e5-7b0d-11e5-8286-18037327aaeb", miq_id:"100012"}};
-    var cloud_provider = { id:"4",  item:{display_kind:"Openstack", name:"myProvider", kind:"CloudManager", id:"2", miq_id:"2"}};
+  var scope;
+  var $httpBackend;
+  var vm;
+  var mockData =  getJSONFixture('cloud_topology_response.json');
+  var cloudTenant = { id: '396086e5-7b0d-11e5-8286-18037327aaeb',  item: {display_kind: 'CloudTenant', name: 'admin', kind: 'CloudTenant', id: '396086e5-7b0d-11e5-8286-18037327aaeb', miq_id: '100012'}};
+  var cloudProvider = { id: '4',  item: {display_kind: 'Openstack', name: 'myProvider', kind: 'CloudManager', id: '2', miq_id: '2'}};
 
-    beforeEach(module('ManageIQ'));
+  beforeEach(module('ManageIQ'));
 
-    beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, $location) {
-      spyOn($location, 'absUrl').and.returnValue('/network_topology/show');
-      scope = $rootScope.$new();
+  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, $location) {
+    spyOn($location, 'absUrl').and.returnValue('/network_topology/show');
+    scope = $rootScope.$new();
 
-      $httpBackend = _$httpBackend_;
-      $httpBackend.when('GET','/cloud_topology/data').respond(mock_data);
-      $controller = _$controller_('cloudTopologyController',
+    $httpBackend = _$httpBackend_;
+    $httpBackend.when('GET', '/cloud_topology/data').respond(mockData);
+    vm = _$controller_('cloudTopologyController',
           {$scope: scope});
-      $httpBackend.flush();
-    }));
+    $httpBackend.flush();
+  }));
 
-    afterEach(function() {
-      $httpBackend.verifyNoOutstandingExpectation();
-      $httpBackend.verifyNoOutstandingRequest();
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('data loads successfully', function() {
+    it('in all main objects', function() {
+      expect(vm.items).toBeDefined();
+      expect(vm.relations).toBeDefined();
+      expect(vm.kinds).toBeDefined();
     });
+  });
 
-    describe('data loads successfully', function() {
-      it('in all main objects', function() {
-        expect(scope.items).toBeDefined();
-        expect(scope.relations).toBeDefined();
-        expect(scope.kinds).toBeDefined();
-      });
+  describe('kinds contain all expected kinds', function() {
+    it('in all main objects', function() {
+      expect(Object.keys(scope.kinds).length).toBeGreaterThan(4);
+      expect(scope.kinds.AvailabilityZone).toBeDefined();
+      expect(scope.kinds.Vm).toBeDefined();
+      expect(scope.kinds.CloudTenant).toBeDefined();
     });
+  });
 
-    describe('kinds contain all expected kinds', function() {
-      it('in all main objects', function() {
-        expect(Object.keys(scope.kinds).length).toBeGreaterThan(4);
-        expect(scope.kinds["AvailabilityZone"]).toBeDefined();
-        expect(scope.kinds["Vm"]).toBeDefined();
-        expect(scope.kinds["CloudTenant"]).toBeDefined();
-      });
+  describe('the topology gets correct icons', function() {
+    it('in graph elements', function() {
+      var d = { id: '2',  item: {display_kind: 'Openstack', kind: 'CloudManager', id: '2'}};
+      expect(vm.getIcon(d)).toMatch(/openstack/);
+      expect(vm.getIcon(cloudProvider)).toMatch(/openstack/);
+      d = { id: '4',  item: {display_kind: 'VM', kind: 'Vm', id: '4'}};
+      expect(vm.getIcon(d)).toEqual('\uE90f');
+      expect(vm.getIcon(cloudTenant)).toEqual('\uE904');
     });
+  });
 
-    describe('the topology gets correct icons', function() {
-      it('in graph elements', function() {
-        var d = { id:"2",  item:{display_kind:"Openstack", kind:"CloudManager", id:"2"}};
-        expect($controller.getIcon(d)).toMatch(/openstack/);
-        expect($controller.getIcon(cloud_provider)).toMatch(/openstack/);
-        d = { id:"4",  item:{display_kind:"VM", kind:"Vm", id:"4"}};
-        expect($controller.getIcon(d)).toEqual("\uE90f");
-        expect($controller.getIcon(cloud_tenant)).toEqual("\uE904");
-      });
+  describe('dimensions are returned correctly', function() {
+    it('of all objects', function() {
+      var d = { id: '2',  item: {display_kind: 'Openstack', kind: 'CloudManager', id: '2', miq_id: '37'}};
+      expect(vm.getDimensions(d)).toEqual({ x: -20, y: -20, r: 28 });
+      expect(vm.getDimensions(cloudProvider)).toEqual({ x: -20, y: -20, r: 28 });
+      d = { id: '4',  item: {display_kind: 'VM', kind: 'Vm', id: '4', miq_id: '25'}};
+      expect(vm.getDimensions(d)).toEqual({ x: 0, y: 9, r: 21 });
+      expect(vm.getDimensions(cloudTenant)).toEqual({ x: 0, y: 9, r: 19 });
     });
-
-    describe('dimensions are returned correctly', function() {
-      it('of all objects', function() {
-        var d = { id:"2",  item:{display_kind:"Openstack", kind:"CloudManager", id:"2", miq_id:"37"}};
-        expect($controller.getDimensions(d)).toEqual({ x: -20, y: -20, r: 28 });
-        expect($controller.getDimensions(cloud_provider)).toEqual({ x: -20, y: -20, r: 28 });
-        d = { id:"4",  item:{display_kind:"VM", kind:"Vm", id:"4", miq_id:"25"}};
-        expect($controller.getDimensions(d)).toEqual({ x: 0, y: 9, r: 21 });
-        expect($controller.getDimensions(cloud_tenant)).toEqual({ x: 0, y: 9, r: 19 });
-      });
-    });
-
+  });
 });

--- a/spec/javascripts/controllers/cloud/cloud_topology_controller_spec.js
+++ b/spec/javascripts/controllers/cloud/cloud_topology_controller_spec.js
@@ -3,11 +3,27 @@ describe('cloudTopologyController', function() {
   var $httpBackend;
   var vm;
   var mockData =  getJSONFixture('cloud_topology_response.json');
-  var cloudTenant = { id: '396086e5-7b0d-11e5-8286-18037327aaeb',  item: {display_kind: 'CloudTenant', name: 'admin', kind: 'CloudTenant', id: '396086e5-7b0d-11e5-8286-18037327aaeb', miq_id: '100012'}};
-  var cloudProvider = { id: '4',  item: {display_kind: 'Openstack', name: 'myProvider', kind: 'CloudManager', id: '2', miq_id: '2'}};
-
+  var cloudTenant = {
+    id: '396086e5-7b0d-11e5-8286-18037327aaeb',
+    item: {
+      display_kind: 'CloudTenant',
+      name: 'admin',
+      kind: 'CloudTenant',
+      id: '396086e5-7b0d-11e5-8286-18037327aaeb',
+      miq_id: '100012',
+    },
+  };
+  var cloudProvider = {
+    id: '4',
+    item: {
+      display_kind: 'Openstack',
+      name: 'myProvider',
+      kind: 'CloudManager',
+      id: '2',
+      miq_id: '2',
+    },
+  };
   beforeEach(module('ManageIQ'));
-
   beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, $location) {
     spyOn($location, 'absUrl').and.returnValue('/network_topology/show');
     scope = $rootScope.$new();
@@ -43,10 +59,24 @@ describe('cloudTopologyController', function() {
 
   describe('the topology gets correct icons', function() {
     it('in graph elements', function() {
-      var d = { id: '2',  item: {display_kind: 'Openstack', kind: 'CloudManager', id: '2'}};
+      var d = {
+        id: '2',
+        item: {
+          display_kind: 'Openstack',
+          kind: 'CloudManager',
+          id: '2',
+        },
+      };
       expect(vm.getIcon(d)).toMatch(/openstack/);
       expect(vm.getIcon(cloudProvider)).toMatch(/openstack/);
-      d = { id: '4',  item: {display_kind: 'VM', kind: 'Vm', id: '4'}};
+      d = {
+        id: '4',
+        item: {
+          display_kind: 'VM',
+          kind: 'Vm',
+          id: '4',
+        },
+      };
       expect(vm.getIcon(d)).toEqual('\uE90f');
       expect(vm.getIcon(cloudTenant)).toEqual('\uE904');
     });
@@ -54,10 +84,26 @@ describe('cloudTopologyController', function() {
 
   describe('dimensions are returned correctly', function() {
     it('of all objects', function() {
-      var d = { id: '2',  item: {display_kind: 'Openstack', kind: 'CloudManager', id: '2', miq_id: '37'}};
+      var d = {
+        id: '2',
+        item: {
+          display_kind: 'Openstack',
+          kind: 'CloudManager',
+          id: '2',
+          miq_id: '37',
+        },
+      };
       expect(vm.getDimensions(d)).toEqual({ x: -20, y: -20, r: 28 });
       expect(vm.getDimensions(cloudProvider)).toEqual({ x: -20, y: -20, r: 28 });
-      d = { id: '4',  item: {display_kind: 'VM', kind: 'Vm', id: '4', miq_id: '25'}};
+      d = {
+        id: '4',
+        item: {
+          display_kind: 'VM',
+          kind: 'Vm',
+          id: '4',
+          miq_id: '25',
+        },
+      };
       expect(vm.getDimensions(d)).toEqual({ x: 0, y: 9, r: 21 });
       expect(vm.getDimensions(cloudTenant)).toEqual({ x: 0, y: 9, r: 19 });
     });


### PR DESCRIPTION
Refactoring CloudTopologyController as vm
events like `$scope.$(on, 'render', ...)` have to stay on `$scope` for now.
Also [topology_header_toolbar.html.haml](https://github.com/Hyperkid123/manageiq-ui-classic/blob/628a69e62d1b7f27c55703d04a1760eeef30e742/app/views/cloud_topology/show.html.haml) now sends data with `sendDataWithRx` instead of to miqCallAngular, so that **search** and **reset** methods can be removed from $scope