### PR TITLE
Remove AE_MAX_RESOLUTION_FIELDS from UiConstants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -197,6 +197,8 @@ class ApplicationController < ActionController::Base
     },
   }
 
+  AE_MAX_RESOLUTION_FIELDS = 5 # Maximum fields to show for automation engine resolution screens
+
   def local_request?
     Rails.env.development? || Rails.env.test?
   end

--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -54,7 +54,7 @@ module ApplicationController::Automate
     @edit[:new][:attrs]          = @resolve[:new][:attrs]
     @edit[:new][:target_class]   = @resolve[:target_class] = Hash[*@resolve[:target_classes].flatten.reverse][@resolve[:new][:target_class]]
     @edit[:uri] = @resolve[:uri]
-    (AE_MAX_RESOLUTION_FIELDS - @resolve[:new][:attrs].length).times { @edit[:new][:attrs].push([]) }
+    (ApplicationController::AE_MAX_RESOLUTION_FIELDS - @resolve[:new][:attrs].length).times { @edit[:new][:attrs].push([]) }
     @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
@@ -74,7 +74,7 @@ module ApplicationController::Automate
         @resolve[:new][:attrs].push(attr) unless @resolve[:new][:attrs].include?(attr)
       end
     end
-    (AE_MAX_RESOLUTION_FIELDS - @resolve[:new][:attrs].length).times { @resolve[:new][:attrs].push([]) }
+    (ApplicationController::AE_MAX_RESOLUTION_FIELDS - @resolve[:new][:attrs].length).times { @resolve[:new][:attrs].push([]) }
     if @edit[:new][:instance_name] && @edit[:instance_names].include?(@edit[:new][:instance_name])
       @resolve[:new][:instance_name] = @edit[:new][:instance_name]
     else

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -96,7 +96,7 @@ module ApplicationController::Buttons
       @edit[:new][:other_name] = params[:other_name] if params[:other_name]
       @edit[:new][:object_message] = params[:object_message] if params[:object_message]
       @edit[:new][:object_request] = params[:object_request] if params[:object_request]
-      AE_MAX_RESOLUTION_FIELDS.times do |i|
+      ApplicationController::AE_MAX_RESOLUTION_FIELDS.times do |i|
         f = ("attribute_" + (i + 1).to_s)
         v = ("value_" + (i + 1).to_s)
         @edit[:new][:attrs][i][0] = params[f] if params[f.to_sym]
@@ -948,9 +948,9 @@ module ApplicationController::Buttons
         end
       end
     end
-    # AE_MAX_RESOLUTION_FIELDS.times{@edit[:new][:attrs].push(Array.new)} if @edit[:new][:attrs].empty?
-    # num = AE_MAX_RESOLUTION_FIELDS - @edit[:new][:attrs].length
-    (AE_MAX_RESOLUTION_FIELDS - @edit[:new][:attrs].length).times { @edit[:new][:attrs].push([]) }
+    # ApplicationController::AE_MAX_RESOLUTION_FIELDS.times{@edit[:new][:attrs].push(Array.new)} if @edit[:new][:attrs].empty?
+    # num = ApplicationController::AE_MAX_RESOLUTION_FIELDS - @edit[:new][:attrs].length
+    (ApplicationController::AE_MAX_RESOLUTION_FIELDS - @edit[:new][:attrs].length).times { @edit[:new][:attrs].push([]) }
     @edit[:new][:starting_object] ||= "SYSTEM/PROCESS"
     @edit[:new][:instance_name] ||= "Request"
 
@@ -1128,10 +1128,10 @@ module ApplicationController::Buttons
       @resolve[:target_classes] = Array(@resolve[:target_classes].invert).sort
       @resolve[:new][:attrs] ||= []
       if @resolve[:new][:attrs].empty?
-        AE_MAX_RESOLUTION_FIELDS.times { @resolve[:new][:attrs].push([]) }
+        ApplicationController::AE_MAX_RESOLUTION_FIELDS.times { @resolve[:new][:attrs].push([]) }
       else
-        # add empty array if @resolve[:new][:attrs] length is less than AE_MAX_RESOLUTION_FIELDS
-        AE_MAX_RESOLUTION_FIELDS.times { @resolve[:new][:attrs].push([]) if @resolve[:new][:attrs].length < AE_MAX_RESOLUTION_FIELDS }
+        # add empty array if @resolve[:new][:attrs] length is less than ApplicationController::AE_MAX_RESOLUTION_FIELDS
+        ApplicationController::AE_MAX_RESOLUTION_FIELDS.times { @resolve[:new][:attrs].push([]) if @resolve[:new][:attrs].length < ApplicationController::AE_MAX_RESOLUTION_FIELDS }
       end
       @resolve[:throw_ready] = ready_to_throw
     else

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -407,7 +407,7 @@ Methods updated/added: %{method_stats}") % stat_options)
       add_flash(_("Starting Process is required"), :error)
     end
     add_flash(_("Request is required"), :error) if @resolve[:new][:object_request].blank?
-    AE_MAX_RESOLUTION_FIELDS.times do |i|
+    ApplicationController::AE_MAX_RESOLUTION_FIELDS.times do |i|
       f = ("attribute_" + (i + 1).to_s)
       v = ("value_" + (i + 1).to_s)
       add_flash(_("%{val} missing for %{field}") % {:val => f.titleize, :field => v.titleize}, :error) if @resolve[:new][:attrs][i][0].blank? && !@resolve[:new][:attrs][i][1].blank?
@@ -428,7 +428,7 @@ Methods updated/added: %{method_stats}") % stat_options)
     @resolve[:new][:other_name] = params[:other_name] if params.key?(:other_name)
     @resolve[:new][:object_message] = params[:object_message] if params.key?(:object_message)
     @resolve[:new][:object_request] = params[:object_request] if params.key?(:object_request)
-    AE_MAX_RESOLUTION_FIELDS.times do |i|
+    ApplicationController::AE_MAX_RESOLUTION_FIELDS.times do |i|
       f = ("attribute_" + (i + 1).to_s)
       v = ("value_" + (i + 1).to_s)
       @resolve[:new][:attrs][i][0] = params[f] if params[f.to_sym]

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -102,7 +102,7 @@ module MiqPolicyController::MiqActions
     params.each do |var, val|
       vars = var.split("_")
       if (vars[0] == "attribute" || vars[0] == "value") && !val.blank?
-        AE_MAX_RESOLUTION_FIELDS.times do |i|
+        ApplicationController::AE_MAX_RESOLUTION_FIELDS.times do |i|
           f = ("attribute_" + (i + 1).to_s)
           v = ("value_" + (i + 1).to_s)
           @edit[:new][:attrs][i][0] = params[f] if params[f.to_sym]
@@ -256,7 +256,7 @@ module MiqPolicyController::MiqActions
     @edit[:new][:object_message] = @edit[:new][:options][:ae_message] unless @edit[:new][:options][:ae_message].nil?
     @edit[:new][:object_request] = @edit[:new][:options][:ae_request] unless @edit[:new][:options][:ae_request].nil?
     @edit[:new][:attrs] ||= []
-    AE_MAX_RESOLUTION_FIELDS.times { @edit[:new][:attrs].push([]) }
+    ApplicationController::AE_MAX_RESOLUTION_FIELDS.times { @edit[:new][:attrs].push([]) }
     unless @edit[:new][:options][:ae_hash].nil?
       @edit[:new][:options][:ae_hash].each_with_index do |kv, i|
         @edit[:new][:attrs][i][0] = kv[0]

--- a/app/controllers/ops_controller/settings/automate_schedules.rb
+++ b/app/controllers/ops_controller/settings/automate_schedules.rb
@@ -54,11 +54,11 @@ module OpsController::Settings::AutomateSchedules
     automate_request[:ui_attrs]       = filter[:ui][:ui_attrs] || []
 
     if automate_request[:ui_attrs].empty?
-      AE_MAX_RESOLUTION_FIELDS.times { automate_request[:ui_attrs].push([]) }
+      ApplicationController::AE_MAX_RESOLUTION_FIELDS.times { automate_request[:ui_attrs].push([]) }
     else
-      # add empty array if @resolve[:new][:attrs] length is less than AE_MAX_RESOLUTION_FIELDS
+      # add empty array if @resolve[:new][:attrs] length is less than ApplicationController::AE_MAX_RESOLUTION_FIELDS
       len = automate_request[:ui_attrs].length
-      AE_MAX_RESOLUTION_FIELDS.times { automate_request[:ui_attrs].push([]) if len < AE_MAX_RESOLUTION_FIELDS }
+      ApplicationController::AE_MAX_RESOLUTION_FIELDS.times { automate_request[:ui_attrs].push([]) if len < ApplicationController::AE_MAX_RESOLUTION_FIELDS }
     end
     automate_request
   end

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -492,7 +492,7 @@ module OpsController::Settings::Schedules
       schedule.verify_file_depot(uri_settings)
     elsif params[:action_typ] == "automation_request"
       ui_attrs = []
-      AE_MAX_RESOLUTION_FIELDS.times do |i|
+      ApplicationController::AE_MAX_RESOLUTION_FIELDS.times do |i|
         next unless params[:ui_attrs] && params[:ui_attrs][i.to_s]
         ui_attrs[i] = []
         ui_attrs[i][0] = params[:ui_attrs][i.to_s][0]

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -6,9 +6,6 @@ module UiConstants
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
 
-  # Maximum fields to show for automation engine resolution screens
-  AE_MAX_RESOLUTION_FIELDS = 5
-
   DRIFT_TIME_COLUMNS = [
     "last_scan_on",
     "boot_time",

--- a/app/views/layouts/_ae_resolve_options.html.haml
+++ b/app/views/layouts/_ae_resolve_options.html.haml
@@ -102,7 +102,7 @@
 %h3
   = _("Attribute/Value Pairs")
 .form-horizontal
-  - AE_MAX_RESOLUTION_FIELDS.times do |i|
+  - ApplicationController::AE_MAX_RESOLUTION_FIELDS.times do |i|
     - f = "attribute_" + (i + 1).to_s
     - v = "value_" + (i + 1).to_s
     .form-group


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `AE_MAX_RESOLUTION_FIELDS` was removed from `UiConstants` and moved to `ApplicationController`. Prefix `ApplicationController::` was added to every occurrence of this constant.