### PR TITLE
[FINE] Revert "Disable the v2v button"

### DIFF
--- a/app/helpers/application_helper/button/transform_vm_button.rb
+++ b/app/helpers/application_helper/button/transform_vm_button.rb
@@ -2,7 +2,7 @@ class ApplicationHelper::Button::TransformVmButton < ApplicationHelper::Button::
   needs :@record
 
   def visible?
-    false
+    @record.vendor == "vmware"
   end
 
   def disabled?


### PR DESCRIPTION
This reverts commit db821571ae59ce3c2cf6a666dbeb93087242dd26.

Re-enabling the "Transform VM" button after the main functional blockers have been fixed.