### PR TITLE
Use the common JS method for handling timeline tree onclicks

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -217,16 +217,6 @@ function miqOnClickHostNet(id) {
   }
 }
 
-// OnClick handler for Timeline Tree
-function miqOnClickTimelineSelection(id) {
-  var allIds = id.split('rep-');
-  // Valid id should be something like xx-first_xx-second_rep-1r215, so it should return two 'ids' if split by rep- identifier
-  if (allIds.length === 2) {
-    var rep_id = allIds[allIds.length - 1];
-    miqJqueryRequest(ManageIQ.tree.clickUrl + '?id=' + rep_id, {beforeSend: true, complete: true});
-  }
-}
-
 // OnCheck handler for the belongs to drift/compare sections tree
 function miqOnCheckSections(_tree_name, key, checked, all_checked) {
   var url = ManageIQ.tree.checkUrl + '?id=' + encodeURIComponent(key) + '&check=' + checked;
@@ -457,7 +447,6 @@ function miqTreeEventSafeEval(func) {
     'miqOnClickSmartProxyAffinityCheck',
     'miqOnClickSnapshotTree',
     'miqOnClickTagCat',
-    'miqOnClickTimelineSelection',
   ];
 
   if (whitelist.includes(func)) {

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -532,10 +532,11 @@ class DashboardController < ApplicationController
     build_timeline_listnav
   end
 
-  def show_timeline
+  def tree_select # timeline tree
     @breadcrumbs = []
     @layout      = "timeline"
     if params[:id]
+      _, params[:id] = parse_nodetype_and_id(params[:id])
       build_timeline
       render :update do |page|
         page << javascript_prologue

--- a/app/presenters/tree_builder_timelines.rb
+++ b/app/presenters/tree_builder_timelines.rb
@@ -36,17 +36,8 @@ class TreeBuilderTimelines < TreeBuilder
 
   private
 
-  def set_locals_for_render
-    super.merge!(
-      :id_prefix => 'timelines_',
-      :onclick   => "miqOnClickTimelineSelection",
-      :click_url => "/dashboard/show_timeline/"
-    )
-  end
-
   def tree_init_options(_tree_name)
     {
-      :full_ids => true,
       :lazy     => false,
       :add_root => false
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1100,8 +1100,8 @@ Rails.application.routes.draw do
         login_retry
         reset_widgets
         resize_layout
-        show_timeline
         tl_generate
+        tree_select
         wait_for_task
         widget_add
         widget_close

--- a/spec/presenters/tree_builder_timelines_spec.rb
+++ b/spec/presenters/tree_builder_timelines_spec.rb
@@ -13,16 +13,7 @@ describe TreeBuilderTimelines do
   describe '#tree_init_options' do
     it 'sets init options correctly' do
       tree_options = subject.send(:tree_init_options, :timelines)
-      expect(tree_options).to eq(:full_ids => true, :lazy => false, :add_root => false)
-    end
-  end
-
-  describe '#set_locals_for_render' do
-    it 'set locals correctly' do
-      locals = subject.send(:set_locals_for_render)
-      expect(locals).to include(:id_prefix => 'timelines_',
-                                :onclick   => "miqOnClickTimelineSelection",
-                                :click_url => "/dashboard/show_timeline/")
+      expect(tree_options).to eq(:lazy => false, :add_root => false)
     end
   end
 

--- a/spec/routing/dashboard_routing_spec.rb
+++ b/spec/routing/dashboard_routing_spec.rb
@@ -129,9 +129,9 @@ describe 'routes for DashboardController' do
     end
   end
 
-  describe "#show_timeline" do
+  describe "#tree_select" do
     it "routes with POST" do
-      expect(post("/dashboard/show_timeline")).to route_to("dashboard#show_timeline")
+      expect(post("/dashboard/tree_select")).to route_to("dashboard#tree_select")
     end
   end
 


### PR DESCRIPTION
Making the timeline tree more similar to the trees on explorer screens.
Parent issue: #1871 

@miq-bot add_label trees, refactoring, fine/no
@miq-bot assign @martinpovolny 