### PR TITLE
Replace calls of miqCallAngular with sendDataWithRx

### DIFF
--- a/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
@@ -1,6 +1,6 @@
 miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 'patternfly', 'miq.dialogs', 'miq.wizard', 'ManageIQ', 'miq.api'])).controller('containers.deployProviderController',
-  ['$rootScope', '$scope', 'miqService', 'API',
-  function($rootScope, $scope, miqService, API) {
+  ['$rootScope', '$scope', 'miqService', 'API', '$timeout',
+  function($rootScope, $scope, miqService, API, $timeout) {
     'use strict';
 
     $scope.showDeploymentWizard = false;
@@ -244,5 +244,17 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
       $scope.showDeploymentWizard = false;
       return true;
     };
+
+    ManageIQ.rxSubject.subscribe(function(event) {
+      if (event.controller !== 'containers.deployProviderController') {
+        return;
+      }
+
+      $timeout(function() {
+        if (event.name === 'showListener') {
+          $scope.showListener();
+        }
+      });
+    });
   }
 ]);

--- a/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
+++ b/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
@@ -1,13 +1,10 @@
 ManageIQ.angular.app.controller('mwServerController', MwServerController);
 ManageIQ.angular.app.controller('mwServerGroupController', MwServerGroupController);
 
-MwServerController.$inject = ['$scope', 'miqService', 'mwAddDatasourceService'];
-MwServerGroupController.$inject = ['$scope', 'miqService' ];
-
 /**
  * MwServerController - since there can be only one controller per page due to:
  * 'ManageIQ.angular.scope = $scope;'
- * We are now using Rx.js Observables instead of miqCallAngular, for sending configurable
+ * We are now using Rx.js Observables, for sending configurable
  * data from miq buttons.
  * This is the parent controller for the page that is bootstrapped,
  * interacting with the page via $scope and then 'sendDataWithRx' events down to the sub
@@ -28,21 +25,23 @@ MwServerGroupController.$inject = ['$scope', 'miqService' ];
  * @param {MwAddDatasourceService} mwAddDatasourceService - Datasource services
  * @constructor
  */
-function MwServerController($scope, miqService, mwAddDatasourceService) {
-  return MwServerControllerFactory($scope, miqService, mwAddDatasourceService, false);
+MwServerController.$inject = ['$scope', 'miqService', 'mwAddDatasourceService', '$timeout'];
+function MwServerController($scope, miqService, mwAddDatasourceService, $timeout) {
+  return MwServerControllerFactory($scope, miqService, mwAddDatasourceService, false, $timeout);
 }
 
-function MwServerGroupController($scope, miqService, mwAddDatasourceService) {
-  return MwServerControllerFactory($scope, miqService, mwAddDatasourceService, true);
+MwServerGroupController.$inject = ['$scope', 'miqService', 'mwAddDatasourceService', '$timeout'];
+function MwServerGroupController($scope, miqService, mwAddDatasourceService, $timeout) {
+  return MwServerControllerFactory($scope, miqService, mwAddDatasourceService, true, $timeout);
 }
 
-function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, isGroupDeployment) {
+function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, isGroupDeployment, $timeout) {
   ManageIQ.angular.scope = $scope;
 
   ManageIQ.angular.rxSubject.subscribe(function(event) {
     var eventType = event.type;
-    var  operation = event.operation;
-    var  timeout = event.timeout;
+    var operation = event.operation;
+    var timeout = event.timeout;
 
     $scope.paramsModel = $scope.paramsModel || {};
     if (eventType === 'mwServerOps'  && operation) {
@@ -57,6 +56,20 @@ function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, i
     if (eventType === 'mwReloadDeployDialog') {
       $scope.warnMsg = event.msg;
       $scope.$apply();
+    }
+
+    if (event.controller === 'middlewareServerController') {
+      $timeout(function() {
+        if (event.name === 'showDeployListener') {
+          $scope.showDeployListener();
+        }
+        if (event.name === 'showDatasourceListener') {
+          $scope.showDatasourceListener();
+        }
+        if (event.name === 'showDeployListener') {
+          $scope.showDeployListener();
+        }
+      });
     }
   });
 

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -28,7 +28,7 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Create Containers Provider'),
           t,
-          :data   => {'function' => 'miqCallAngular', 'function-data' => '{ "name": "showListener", "args": [] }'},
+          :data   => {'function' => 'sendDataWithRx', 'function-data' => '{ "name": "showListener", "controller": "containers.deployProviderController" }'},
           :hidden => ContainerDeploymentService.hide_deployment_wizard?),
         button(
           :ems_container_edit,

--- a/app/helpers/application_helper/toolbar/middleware_server_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_server_center.rb
@@ -144,8 +144,8 @@ class ApplicationHelper::Toolbar::MiddlewareServerCenter < ApplicationHelper::To
           N_('Add Deployment'),
           :data => {'toggle'        => 'modal',
                     'target'        => '#modal_d_div',
-                    'function'      => 'miqCallAngular',
-                    'function-data' => '{"name": "showDeployListener", "args": []}'},
+                    'function'      => 'sendDataWithRx',
+                    'function-data' => '{"name": "showDeployListener", "controller": "middlewareServerController"}'},
           :klass => ApplicationHelper::Button::MiddlewareStandaloneServerAction)
       ]
     ),
@@ -164,8 +164,8 @@ class ApplicationHelper::Toolbar::MiddlewareServerCenter < ApplicationHelper::To
           N_('Add JDBC Driver'),
           :data => {'toggle'        => 'modal',
                     'target'        => '#modal_jdbc_div',
-                    'function'      => 'miqCallAngular',
-                    'function-data' => '{"name": "showJdbcDriverListener", "args": []}'},
+                    'function'      => 'sendDataWithRx',
+                    'function-data' => '{"name": "showJdbcDriverListener", "controller": "middlewareServerController"}'},
           :klass => ApplicationHelper::Button::MiddlewareStandaloneServerAction)
       ]
     ),
@@ -184,8 +184,8 @@ class ApplicationHelper::Toolbar::MiddlewareServerCenter < ApplicationHelper::To
           N_('Add Datasource'),
           :data => {'toggle'        => 'modal',
                     'target'        => '#modal_ds_div',
-                    'function'      => 'miqCallAngular',
-                    'function-data' => '{"name": "showDatasourceListener", "args": []}'},
+                    'function'      => 'sendDataWithRx',
+                    'function-data' => '{"name": "showDatasourceListener", "controller": "middlewareServerController"}'},
           :klass => ApplicationHelper::Button::MiddlewareStandaloneServerAction)
       ]
     ),

--- a/app/helpers/application_helper/toolbar/middleware_server_group_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_server_group_center.rb
@@ -95,8 +95,8 @@ class ApplicationHelper::Toolbar::MiddlewareServerGroupCenter < ApplicationHelpe
                        N_('Add Deployment'),
                        :data => {'toggle'        => 'modal',
                                  'target'        => '#modal_d_div',
-                                 'function'      => 'miqCallAngular',
-                                 'function-data' => '{"name": "showDeployListener", "args": []}'}
+                                 'function'      => 'sendDataWithRx',
+                                 'function-data' => '{"name": "showDeployListener", "controller": "middlewareServerController"}'}
                      )
                    ]
                  ),


### PR DESCRIPTION
`miqCallAngular` was created before we were using RxJs for messages.

Furthermore, it relies on the `ManageIQ.angular.scope` global to talk to the right controller, and breaks if that is not the scope (so, always when converted to controllerAs).

=> Removing all but the topology related calls, which are being taken care of by @Hyperkid123 .

Cc @mtho11 