### PR TITLE
Skip calling Rbac on a null or nil target_class

### DIFF
--- a/app/controllers/ops_controller/settings/automate_schedules.rb
+++ b/app/controllers/ops_controller/settings/automate_schedules.rb
@@ -18,14 +18,15 @@ module OpsController::Settings::AutomateSchedules
   end
 
   def fetch_target_ids
-    targets = Rbac.filtered(params[:target_class]).select(:id, :name)
-    unless targets.nil?
-      targets = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
-      target_id = ""
+    if params[:target_class] && params[:target_class] != 'null'
+      targets = Rbac.filtered(params[:target_class]).select(:id, :name)
+      unless targets.nil?
+        targets = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
+      end
     end
 
     render :json => {
-      :target_id => target_id,
+      :target_id => '',
       :targets   => targets
     }
   end

--- a/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
@@ -61,6 +61,24 @@ describe OpsController do
     end
   end
 
+  describe "#fetch_target_ids" do
+    include OpsController::Settings::AutomateSchedules
+    let(:ops) { OpsController.new }
+
+    before do
+      ops.instance_variable_set(:@params, {})
+    end
+
+    [nil, 'null'].each do |target|
+      it "skips Rbac if :target_class is #{target}" do
+        ops.params = {:target_class => target }
+        expect(ops).to receive(:render).once
+        expect(Rbac).to receive(:filtered).never
+        ops.fetch_target_ids
+      end
+    end
+  end
+
   describe "#fetch_automate_request_vars" do
     include OpsController::Settings::AutomateSchedules
     let(:ops) { OpsController.new }


### PR DESCRIPTION
When calling `fetch_target_ids` we were always running `Rbac` regardless if the parameter `:target_class` was populated or not.

In some cases, when the empty option was selected, a 'null' was getting sent over and forcing `Rbac` as well.

This fixes both cases.

https://bugzilla.redhat.com/show_bug.cgi?id=1479570
