### PR TITLE
[FINE] Fix links to objects being tagged on the Job Templates tagging edit 

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -134,7 +134,7 @@ class AutomationManagerController < ApplicationController
   def configuration_scripts_tree_rec
     nodes = x_node.split('-')
     case nodes.first
-    when "root", "at"
+    when "root", "at", "cf"
       find_record(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript, params[:id])
     end
   end

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -375,6 +375,22 @@ describe AutomationManagerController do
       controller.send(:accordion_select)
     end
 
+    it 'renders tree_select for one job template' do
+      record = FactoryGirl.create(:ansible_configuration_script,
+                                  :name        => "ConfigScriptTest1",
+                                  :survey_spec => {'spec' => [{'index' => 0, 'question_description' => 'Survey',
+                                                               'type' => 'text'}]})
+      stub_user(:features => :all)
+      allow(controller).to receive(:x_active_tree).and_return(:configuration_scripts_tree)
+      allow(controller).to receive(:x_active_accord).and_return(:configuration_scripts)
+      controller.instance_variable_set(:@_params, :id => "cf-" + ApplicationRecord.compress_id(record.id))
+      controller.send(:tree_select)
+      show_adv_search = controller.instance_variable_get(:@show_adv_search)
+      title = controller.instance_variable_get(:@right_cell_text)
+      expect(show_adv_search).to eq(false)
+      expect(title).to eq('Job Template (Ansible Tower) "ConfigScriptTest1"')
+    end
+
     it "calls get_view with the associated dbname for the Configured Systems accordion" do
       stub_user(:features => :all)
       allow(controller).to receive(:x_node).and_return("root")


### PR DESCRIPTION
Handle cf type for job templates tree node
FINE branch for upstream PR https://github.com/ManageIQ/manageiq-ui-classic/pull/1655

Links
----------------
https://github.com/ManageIQ/manageiq-ui-classic/pull/1655
https://bugzilla.redhat.com/show_bug.cgi?id=1478529