### PR TITLE
Specify correct features names in Block/Object Storage toolbar button actions

### DIFF
--- a/app/helpers/application_helper/toolbar/ems_block_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_block_storages_center.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Toolbar::EmsBlockStoragesCenter < ApplicationHelper::To
                    t,
                    :items => [
                      button(
-                       :ems_storage_refresh,
+                       :ems_block_storage_refresh,
                        'fa fa-refresh fa-lg',
                        N_('Refresh relationships and power states for all items related to the selected Block Storage Managers'),
                        N_('Refresh Relationships and Power States'),
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::EmsBlockStoragesCenter < ApplicationHelper::To
                        :onwhen    => "1+"),
                      separator,
                      button(
-                       :ems_storage_delete,
+                       :ems_block_storage_delete,
                        'pficon pficon-delete fa-lg',
                        N_('Remove selected Block Storage Managers from Inventory'),
                        N_('Remove Block Storage Managers from Inventory'),

--- a/app/helpers/application_helper/toolbar/ems_object_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_object_storages_center.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Toolbar::EmsObjectStoragesCenter < ApplicationHelper::T
                    t,
                    :items => [
                      button(
-                       :ems_storage_refresh,
+                       :ems_object_storage_refresh,
                        'fa fa-refresh fa-lg',
                        N_('Refresh relationships and power states for all items related to the selected Object Storage Managers'),
                        N_('Refresh Relationships and Power States'),
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::EmsObjectStoragesCenter < ApplicationHelper::T
                        :onwhen    => "1+"),
                      separator,
                      button(
-                       :ems_storage_delete,
+                       :ems_object_storage_delete,
                        'pficon pficon-delete fa-lg',
                        N_('Remove selected Object Storage Managers from Inventory'),
                        N_('Remove Object Storage Managers from Inventory'),


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/15812

In the ems code, the `delete` and `refresh` operations are invoked based on the following condition -
```ruby
deleteemss if params[:pressed] == "#{table_name}_delete"
refreshemss if params[:pressed] == "#{table_name}_refresh"
```

Therefore, feature names for `delete` and `refresh` must be based off the current `table name`

For e.g. `ems_block_storage_refresh` should be specified in the toolbar button action as opposed to `ems_storage_refresh` in order for the button action to execute.

Before:
<img width="1375" alt="screen shot 2017-08-14 at 2 49 48 pm" src="https://user-images.githubusercontent.com/1538216/29293405-e1bd4462-80ff-11e7-95d6-77c2816c4fa7.png">


After:
<img width="1373" alt="screen shot 2017-08-14 at 2 48 22 pm" src="https://user-images.githubusercontent.com/1538216/29293372-c049d926-80ff-11e7-8c7d-3c6fe216ae0f.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1440114