### PR TITLE
Hide History toolbar when in Reports Import/Export tree

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -687,7 +687,7 @@ class ReportController < ApplicationController
     partial = options[:partial] ? options[:partial] : set_partial_name
     unless @in_a_form
       c_tb = build_toolbar(center_toolbar_filename)
-      h_tb = build_toolbar("x_history_tb")
+      h_tb = build_toolbar("x_history_tb") unless x_active_tree == :export_tree
       v_tb = build_toolbar("report_view_tb") if @report && [:reports_tree, :savedreports_tree].include?(x_active_tree)
     end
 


### PR DESCRIPTION
Do not display History Toolbar when in Reports => Import / Export tree, no history to be available/selected.

https://bugzilla.redhat.com/show_bug.cgi?id=1393193

Screen shot prior to fix:
![bz1393193_reports import export history dropdown prior to code fix](https://user-images.githubusercontent.com/552686/29299384-203c16b4-8123-11e7-82c6-b29329691843.png)

===================
Screen shots post fix:

![bz1393193_reports export hide historytoolbar post fix](https://user-images.githubusercontent.com/552686/29299397-2ec3a6ac-8123-11e7-8e69-f4613b6ee3eb.png)

![bz1393193_reports export hide historytoolbar custom rpts node post fix](https://user-images.githubusercontent.com/552686/29299404-3a8d6e00-8123-11e7-9975-76993d3df046.png)

