### PR TITLE
Remove DRIFT_TIME_COLUMNS from UiConstants

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -1,6 +1,12 @@
 module ApplicationController::Compare
   extend ActiveSupport::Concern
 
+  DRIFT_TIME_COLUMNS = [
+    "last_scan_on",
+    "boot_time",
+    "last_logon"
+  ].freeze
+
   def get_compare_report(model)
     db = model.kind_of?(String) ? model.constantize : model
     MiqReport.find_by(:filename => "#{db.table_name}.yaml", :template_type => "compare")

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -6,11 +6,6 @@ module UiConstants
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
 
-  DRIFT_TIME_COLUMNS = [
-    "last_scan_on",
-    "boot_time",
-    "last_logon"
-  ]
   # START of TIMELINE TIMEZONE Code
   TIMELINE_TIME_COLUMNS = [
     "created_on",


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `DRIFT_TIME_COLUMNS` was removed from `UiConstants` and moved to module `ApplicationController::Compare`.

`Compute` -> `Infrastructure` -> `Virtual Machines` -> Choose 2 from `All VMs & Templates`  -> `Compare Selected items` 