### PR TITLE
Rerganize treeview handlers for onClick and onCheck

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -240,7 +240,7 @@ function miqOnClickSmartProxyAffinityCheck(node) {
   miqJqueryRequest(ManageIQ.tree.checkUrl + node.key + '?check=' + checked);
 }
 
-function miqGetChecked(node, treename) {
+function miqOnCheckGenealogy(node, treename) {
   var count = 0;
   var tree = miqTreeObject(treename);
   // Map the selected nodes into an array of keys
@@ -429,9 +429,9 @@ function miqSquashToggle(treeName) {
 
 function miqTreeEventSafeEval(func) {
   var whitelist = [
-    'miqGetChecked',
     'miqMenuEditor',
     'miqOnCheckCUFilters',
+    'miqOnCheckGenealogy',
     'miqOnCheckHandler',
     'miqOnCheckProtect',
     'miqOnCheckProvTags',

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -23,6 +23,11 @@ function miqOnCheckGeneric(node) {
   miqJqueryRequest(url);
 }
 
+// Generic OnClick handler for selecting nodes in tree
+function miqOnClickGeneric(id) {
+  miqJqueryRequest(ManageIQ.tree.clickUrl + id, {beforeSend: true, complete: true});
+}
+
 function miqAddNodeChildren(treename, key, selected_node, children) {
   var node = miqTreeFindNodeByKey(treename, key);
   if (node.lazyLoad) {
@@ -224,16 +229,6 @@ function miqOnCheckSections(_tree_name, key, checked, all_checked) {
   return true;
 }
 
-// OnClick handler for catgories Tree
-function miqOnClickTagCat(id) {
-  miqJqueryRequest(ManageIQ.tree.clickUrl + '?id=' + id, {beforeSend: true, complete: true});
-}
-
-// OnClick handler for Genealogy Tree
-function miqOnClickGenealogyTree(id) {
-  miqJqueryRequest(ManageIQ.tree.clickUrl + id, {beforeSend: true, complete: true});
-}
-
 function miqOnCheckGenealogy(node, treename) {
   var count = 0;
   var tree = miqTreeObject(treename);
@@ -431,7 +426,7 @@ function miqTreeEventSafeEval(func) {
     'miqOnCheckProvTags',
     'miqOnCheckSections',
     'miqOnCheckUserFilters',
-    'miqOnClickGenealogyTree',
+    'miqOnClickGeneric',
     'miqOnClickHostNet',
     'miqOnClickAutomate',
     'miqOnClickSelectDlgEditTreeNode',
@@ -439,7 +434,6 @@ function miqTreeEventSafeEval(func) {
     'miqOnClickSelectTreeNode',
     'miqOnClickServerRoles',
     'miqOnClickSnapshots',
-    'miqOnClickTagCat',
   ];
 
   if (whitelist.includes(func)) {

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -143,7 +143,7 @@ function miqTreeScrollToNode(tree, id) {
   parentPanelBody.animate({scrollTop: (parentPanelBody.position().top + node.$el.position().top)});
 }
 
-function miqOnClickSelectAETreeNode(id) {
+function miqOnClickAutomate(id) {
   miqTreeExpandNode('automate_tree', id);
   miqJqueryRequest('/' + ManageIQ.controller + '/ae_tree_select/?id=' + id + '&tree=automate_tree');
 }
@@ -433,7 +433,7 @@ function miqTreeEventSafeEval(func) {
     'miqOnCheckUserFilters',
     'miqOnClickGenealogyTree',
     'miqOnClickHostNet',
-    'miqOnClickSelectAETreeNode',
+    'miqOnClickAutomate',
     'miqOnClickSelectDlgEditTreeNode',
     'miqOnClickUtilization',
     'miqOnClickSelectTreeNode',

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -189,7 +189,7 @@ function miqOnCheckProtect(node, _treename) {
 }
 
 // OnClick handler for the VM Snapshot Tree
-function miqOnClickSnapshotTree(id) {
+function miqOnClickSnapshots(id) {
   var pieces = id.split(/-/);
   var shortId = pieces[pieces.length - 1]
   miqJqueryRequest('/' + ManageIQ.controller + '/snap_pressed/' + shortId, {beforeSend: true, complete: true});
@@ -438,7 +438,7 @@ function miqTreeEventSafeEval(func) {
     'miqOnClickSelectOptimizeTreeNode',
     'miqOnClickSelectTreeNode',
     'miqOnClickServerRoles',
-    'miqOnClickSnapshotTree',
+    'miqOnClickSnapshots',
     'miqOnClickTagCat',
   ];
 

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -53,7 +53,7 @@ function miqRemoveNodeChildren(treename, key) {
   }
 }
 
-function miqMenuEditor(id) {
+function miqOnCheckMenuRoles(id) {
   var nid = id.split('__');
   if (nid[0] != 'r') {
     var url = ManageIQ.tree.clickUrl + '?node_id=' + encodeURIComponent(id) + '&node_clicked=1';
@@ -429,10 +429,10 @@ function miqSquashToggle(treeName) {
 
 function miqTreeEventSafeEval(func) {
   var whitelist = [
-    'miqMenuEditor',
     'miqOnCheckCUFilters',
     'miqOnCheckGenealogy',
     'miqOnCheckHandler',
+    'miqOnCheckMenuRoles',
     'miqOnCheckProtect',
     'miqOnCheckProvTags',
     'miqOnCheckSections',

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -17,8 +17,8 @@ function miqTreeFindNodeByKey(tree, key) {
   });
 }
 
-// OnCheck handler for the checkboxes in tree
-function miqOnCheckHandler(node) {
+// Generic OnCheck handler for the checkboxes in tree
+function miqOnCheckGeneric(node) {
   var url = ManageIQ.tree.checkUrl + node.key + '?check=' + (node.state.checked ? '1' : '0');
   miqJqueryRequest(url);
 }
@@ -234,12 +234,6 @@ function miqOnClickGenealogyTree(id) {
   miqJqueryRequest(ManageIQ.tree.clickUrl + id, {beforeSend: true, complete: true});
 }
 
-// OnCheck handler for the SmartProxy Affinity tree
-function miqOnClickSmartProxyAffinityCheck(node) {
-  var checked = node.state.checked ? '1' : '0';
-  miqJqueryRequest(ManageIQ.tree.checkUrl + node.key + '?check=' + checked);
-}
-
 function miqOnCheckGenealogy(node, treename) {
   var count = 0;
   var tree = miqTreeObject(treename);
@@ -431,7 +425,7 @@ function miqTreeEventSafeEval(func) {
   var whitelist = [
     'miqOnCheckCUFilters',
     'miqOnCheckGenealogy',
-    'miqOnCheckHandler',
+    'miqOnCheckGeneric',
     'miqOnCheckMenuRoles',
     'miqOnCheckProtect',
     'miqOnCheckProvTags',
@@ -444,7 +438,6 @@ function miqTreeEventSafeEval(func) {
     'miqOnClickSelectOptimizeTreeNode',
     'miqOnClickSelectTreeNode',
     'miqOnClickServerRoles',
-    'miqOnClickSmartProxyAffinityCheck',
     'miqOnClickSnapshotTree',
     'miqOnClickTagCat',
   ];

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -152,7 +152,7 @@ function miqOnClickIncludeDomainPrefix() {
   miqJqueryRequest('/' + ManageIQ.controller + '/ae_tree_select_toggle?button=domain');
 }
 
-function miqOnClickSelectOptimizeTreeNode(id) {
+function miqOnClickUtilization(id) {
   var tree;
   if (miqDomElementExists('utilization_accord')) {
     tree = "utilization_tree";
@@ -435,7 +435,7 @@ function miqTreeEventSafeEval(func) {
     'miqOnClickHostNet',
     'miqOnClickSelectAETreeNode',
     'miqOnClickSelectDlgEditTreeNode',
-    'miqOnClickSelectOptimizeTreeNode',
+    'miqOnClickUtilization',
     'miqOnClickSelectTreeNode',
     'miqOnClickServerRoles',
     'miqOnClickSnapshots',

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -426,14 +426,14 @@ function miqTreeEventSafeEval(func) {
     'miqOnCheckProvTags',
     'miqOnCheckSections',
     'miqOnCheckUserFilters',
+    'miqOnClickAutomate',
+    'miqOnClickDiagnostics',
     'miqOnClickGeneric',
     'miqOnClickHostNet',
-    'miqOnClickAutomate',
     'miqOnClickSelectDlgEditTreeNode',
-    'miqOnClickUtilization',
     'miqOnClickSelectTreeNode',
-    'miqOnClickDiagnostics',
     'miqOnClickSnapshots',
+    'miqOnClickUtilization',
   ];
 
   if (whitelist.includes(func)) {

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -285,7 +285,7 @@ function miqTreeExpandRecursive(treeId, fullNodeId) {
 }
 
 // OnClick handler for Server Roles Tree
-function miqOnClickServerRoles(id) {
+function miqOnClickDiagnostics(id) {
   var typ = id.split('-')[0]; // Break apart the node ids
   switch (typ) {
     case 'svr':
@@ -432,7 +432,7 @@ function miqTreeEventSafeEval(func) {
     'miqOnClickSelectDlgEditTreeNode',
     'miqOnClickUtilization',
     'miqOnClickSelectTreeNode',
-    'miqOnClickServerRoles',
+    'miqOnClickDiagnostics',
     'miqOnClickSnapshots',
   ];
 

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -21,7 +21,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
 
   def set_locals_for_render
     super.merge!(
-      :oncheck    => "miqOnCheckHandler",
+      :oncheck    => "miqOnCheckGeneric",
       :check_url  => "/miq_policy/alert_profile_assign_changed/",
       :checkboxes => true,
       :selectable => false,

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -28,7 +28,7 @@ class TreeBuilderAutomate < TreeBuilderAeClass
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:onclick      => "miqOnClickSelectAETreeNode",
+    locals.merge!(:onclick      => "miqOnClickAutomate",
                   :exp_tree     => false,
                   :autoload     => true,
                   :base_id      => "root",

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -42,7 +42,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     locals = super
 
     oncheck, check_url = if @assign_to
-                           ["miqOnCheckHandler", "/miq_policy/alert_profile_assign_changed/"]
+                           ["miqOnCheckGeneric", "/miq_policy/alert_profile_assign_changed/"]
                          elsif @edit
                            ["miqOnCheckUserFilters", "/ops/rbac_group_field_changed/#{group_id}___"]
                          else

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -18,7 +18,7 @@ class TreeBuilderDiagnostics < TreeBuilder
     locals = super
     locals.merge!(:autoload  => false,
                   :click_url => "/ops/diagnostics_tree_select/",
-                  :onclick   => "miqOnClickServerRoles")
+                  :onclick   => "miqOnClickDiagnostics")
   end
 
   def x_build_single_node(object, pid, options)

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -29,7 +29,7 @@ class TreeBuilderGenealogy < TreeBuilder
       :click_url  => "/vm/genealogy_tree_selected/",
       :onclick    => "miqOnClickGenealogyTree",
       :checkboxes => true,
-      :oncheck    => "miqGetChecked",
+      :oncheck    => "miqOnCheckGenealogy",
       :check_url  => "/vm/set_checked_items/"
     )
   end

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -27,7 +27,7 @@ class TreeBuilderGenealogy < TreeBuilder
   def set_locals_for_render
     super.merge!(
       :click_url  => "/vm/genealogy_tree_selected/",
-      :onclick    => "miqOnClickGenealogyTree",
+      :onclick    => "miqOnClickGeneric",
       :checkboxes => true,
       :oncheck    => "miqOnCheckGenealogy",
       :check_url  => "/vm/set_checked_items/"

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -22,7 +22,7 @@ class TreeBuilderMenuRoles < TreeBuilder
   def set_locals_for_render
     locals = {
       :click_url => "/report/menu_editor/",
-      :onclick   => "miqMenuEditor"
+      :onclick   => "miqOnCheckMenuRoles"
     }
 
     super.merge!(locals)

--- a/app/presenters/tree_builder_miq_action_category.rb
+++ b/app/presenters/tree_builder_miq_action_category.rb
@@ -26,7 +26,7 @@ class TreeBuilderMiqActionCategory < TreeBuilder
     locals = super
     locals.merge!(
       :click_url => "/miq_policy/action_tag_pressed/",
-      :onclick   => "miqOnClickTagCat"
+      :onclick   => "miqOnClickGeneric"
     )
   end
 

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -27,7 +27,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
       :post_check   => true
     }
 
-    locals[:oncheck] = "miqOnCheckHandler" if @editable
+    locals[:oncheck] = "miqOnCheckGeneric" if @editable
 
     super.merge!(locals)
   end

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -23,7 +23,7 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
                   :onclick      => false,
                   :three_checks => true,
                   :post_check   => true,
-                  :oncheck      => 'miqOnClickSmartProxyAffinityCheck',
+                  :oncheck      => 'miqOnCheckGeneric',
                   :check_url    => '/ops/smartproxy_affinity_field_changed/')
   end
 

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -23,7 +23,7 @@ class TreeBuilderSnapshots < TreeBuilder
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true, :onclick => 'miqOnClickSnapshotTree',)
+    locals.merge!(:autoload => true, :onclick => 'miqOnClickSnapshots',)
   end
 
   def root_options

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -13,7 +13,7 @@ class TreeBuilderUtilization < TreeBuilderRegion
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:onclick => "miqOnClickSelectOptimizeTreeNode", :select_node => @selected_node.to_s)
+    locals.merge!(:onclick => "miqOnClickUtilization", :select_node => @selected_node.to_s)
   end
 
   def root_options

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -38,7 +38,7 @@ describe TreeBuilderAlertProfileObj do
       it 'sets locals for render correctly' do
         locals = subject.send(:set_locals_for_render)
         expect(locals[:check_url]).to eq("/miq_policy/alert_profile_assign_changed/")
-        expect(locals[:oncheck]).to eq("miqOnCheckHandler")
+        expect(locals[:oncheck]).to eq("miqOnCheckGeneric")
         expect(locals[:checkboxes]).to be_truthy
         expect(locals[:selectable]).to be_falsey
         expect(locals[:onclick]).to be_falsey

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -28,7 +28,7 @@ describe TreeBuilderGenealogy do
       expect(subject.send(:set_locals_for_render)).to include(:click_url  => "/vm/genealogy_tree_selected/",
                                                               :onclick    => "miqOnClickGenealogyTree",
                                                               :checkboxes => true,
-                                                              :oncheck    => "miqGetChecked",
+                                                              :oncheck    => "miqOnCheckGenealogy",
                                                               :check_url  => "/vm/set_checked_items/")
     end
   end

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -26,7 +26,7 @@ describe TreeBuilderGenealogy do
   describe '#set_locals_for_render' do
     it 'sets locals for render correctly' do
       expect(subject.send(:set_locals_for_render)).to include(:click_url  => "/vm/genealogy_tree_selected/",
-                                                              :onclick    => "miqOnClickGenealogyTree",
+                                                              :onclick    => "miqOnClickGeneric",
                                                               :checkboxes => true,
                                                               :oncheck    => "miqOnCheckGenealogy",
                                                               :check_url  => "/vm/set_checked_items/")

--- a/spec/presenters/tree_builder_menu_roles_spec.rb
+++ b/spec/presenters/tree_builder_menu_roles_spec.rb
@@ -96,8 +96,8 @@ describe TreeBuilderMenuRoles do
       expect(subject[:click_url]).to eq "/report/menu_editor/"
     end
 
-    it 'uses miqMenuEditor to handle clicks' do
-      expect(subject[:onclick]).to eq "miqMenuEditor"
+    it 'uses miqOnCheckMenuRoles to handle clicks' do
+      expect(subject[:onclick]).to eq "miqOnCheckMenuRoles"
     end
   end
 end

--- a/spec/presenters/tree_builder_miq_action_category_spec.rb
+++ b/spec/presenters/tree_builder_miq_action_category_spec.rb
@@ -34,7 +34,7 @@ describe TreeBuilderMiqActionCategory do
     it 'set locals for render correctly' do
       locals = subject.send(:set_locals_for_render)
       expect(locals[:click_url]).to eq("/miq_policy/action_tag_pressed/")
-      expect(locals[:onclick]).to eq("miqOnClickTagCat")
+      expect(locals[:onclick]).to eq("miqOnClickGeneric")
     end
   end
 

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -42,7 +42,7 @@ describe TreeBuilderSmartproxyAffinity do
       expect(locals[:checkboxes]).to eq(true)
       expect(locals[:check_url]).to eq('/ops/smartproxy_affinity_field_changed/')
       expect(locals[:onclick]).to eq(false)
-      expect(locals[:oncheck]).to eq('miqOnClickSmartProxyAffinityCheck')
+      expect(locals[:oncheck]).to eq('miqOnCheckGeneric')
       expect(locals[:three_checks]).to eq(true)
     end
     it 'sets roots correctly' do


### PR DESCRIPTION
I intentionally left out the handler used in the dialog editor. Also there will be more unification after I removed the `ManageIQ.tree.checkUrl` and `ManageIQ.tree.clickUrl` global variables.
Parent issue: #1871

@miq-bot add_label trees, refactoring, fine/no
@miq-bot assign @martinpovolny