### PR TITLE
Add custom buttons

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -245,7 +245,11 @@ module ApplicationController::Buttons
   private
 
   BASE_MODEL_EXPLORER_CLASSES = [Vm, MiqTemplate, Service].freeze
-  APPLIES_TO_CLASS_BASE_MODELS = %w(CloudTenant EmsCluster ExtManagementSystem Host MiqTemplate Service ServiceTemplate Storage Vm).freeze
+  APPLIES_TO_CLASS_BASE_MODELS = %w(AvailabilityZone CloudNetwork CloudObjectStoreContainer CloudSubnet CloudTenant
+                                    CloudVolume ContainerGroup ContainerImage ContainerProject ContainerTemplate
+                                    ContainerVolume EmsCluster ExtManagementSystem Host LoadBalancer MiqTemplate
+                                    NetworkRouter OrchestrationStack SecurityGroup Service ServiceTemplate Storage
+                                    Switch Vm).freeze
   def applies_to_class_model(applies_to_class)
     # TODO: Give a better name for this concept, including ServiceTemplate using Service
     # This should probably live in the model once this concept is defined.

--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -22,4 +22,6 @@ class AvailabilityZoneController < ApplicationController
   helper_method :textual_group_list
 
   menu_section :clo
+
+  has_custom_buttons
 end

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -34,6 +34,9 @@ class CloudNetworkController < ApplicationController
       javascript_redirect :action => "edit", :id => checked_item_id
     when "cloud_network_new"
       javascript_redirect :action => "new"
+    when "custom_button"
+      custom_buttons
+      return
     else
       if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div
@@ -275,4 +278,6 @@ class CloudNetworkController < ApplicationController
   end
 
   menu_section :net
+
+  has_custom_buttons
 end

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -21,6 +21,9 @@ class CloudObjectStoreContainerController < ApplicationController
     case params[:pressed]
     when "cloud_object_store_container_new"
       return javascript_redirect(:action => "new")
+    when "custom_button"
+      custom_buttons
+      return
     else
       process_cloud_object_storage_buttons(params[:pressed])
     end
@@ -129,4 +132,6 @@ class CloudObjectStoreContainerController < ApplicationController
   helper_method :textual_group_list
 
   menu_section :ost
+
+  has_custom_buttons
 end

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -28,6 +28,9 @@ class CloudSubnetController < ApplicationController
       delete_subnets
     when "cloud_subnet_edit"
       javascript_redirect :action => "edit", :id => checked_item_id
+    when params[:pressed] == "custom_button"
+      custom_buttons
+      return
     else
       if params[:pressed] == "cloud_subnet_new"
         javascript_redirect :action => "new"
@@ -275,4 +278,6 @@ class CloudSubnetController < ApplicationController
   end
 
   menu_section :net
+
+  has_custom_buttons
 end

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -19,6 +19,11 @@ class CloudVolumeController < ApplicationController
     params[:display] = @display if %w(instances).include?(@display)
     params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
 
+    if params[:pressed] == "custom_button"
+      custom_buttons
+      return
+    end
+
     if params[:pressed].starts_with?("instance_") # support for instance_ buttons
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       process_vm_buttons(pfx)
@@ -686,4 +691,6 @@ class CloudVolumeController < ApplicationController
   end
 
   menu_section :bst
+
+  has_custom_buttons
 end

--- a/app/controllers/container_group_controller.rb
+++ b/app/controllers/container_group_controller.rb
@@ -25,4 +25,6 @@ class ContainerGroupController < ApplicationController
   end
 
   menu_section :cnt
+
+  has_custom_buttons
 end

--- a/app/controllers/container_image_controller.rb
+++ b/app/controllers/container_image_controller.rb
@@ -35,4 +35,6 @@ class ContainerImageController < ApplicationController
   end
 
   menu_section :cnt
+
+  has_custom_buttons
 end

--- a/app/controllers/container_project_controller.rb
+++ b/app/controllers/container_project_controller.rb
@@ -18,4 +18,6 @@ class ContainerProjectController < ApplicationController
   helper_method :textual_group_list
 
   menu_section :cnt
+
+  has_custom_buttons
 end

--- a/app/controllers/container_template_controller.rb
+++ b/app/controllers/container_template_controller.rb
@@ -14,4 +14,6 @@ class ContainerTemplateController < ApplicationController
   helper_method :textual_group_list
 
   menu_section :cnt
+
+  has_custom_buttons
 end

--- a/app/controllers/ems_block_storage_controller.rb
+++ b/app/controllers/ems_block_storage_controller.rb
@@ -44,4 +44,6 @@ class EmsBlockStorageController < ApplicationController
   end
 
   menu_section :bst
+
+  has_custom_buttons
 end

--- a/app/controllers/ems_object_storage_controller.rb
+++ b/app/controllers/ems_object_storage_controller.rb
@@ -43,4 +43,6 @@ class EmsObjectStorageController < ApplicationController
   end
 
   menu_section :ost
+
+  has_custom_buttons
 end

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -638,4 +638,6 @@ class InfraNetworkingController < ApplicationController
   end
 
   menu_section :inf
+
+  has_custom_buttons
 end

--- a/app/controllers/load_balancer_controller.rb
+++ b/app/controllers/load_balancer_controller.rb
@@ -21,4 +21,6 @@ class LoadBalancerController < ApplicationController
   helper_method :textual_group_list
 
   menu_section :net
+
+  has_custom_buttons
 end

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -7,6 +7,11 @@ module ContainersCommonMixin
     params[:display] = @display if ["#{params[:controller]}s"].include?(@display)  # displaying container_*
     params[:page] = @current_page if @current_page.nil?   # Save current page for list refresh
 
+    if params[:pressed] == "custom_button"
+      custom_buttons
+      return
+    end
+
     # Handle Toolbar Policy Tag Button
     @refresh_div = "main_div" # Default div for button.rjs to refresh
     model = self.class.model

--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -44,6 +44,11 @@ module Mixins
       params[:display] = @display if %w(vms images instances).include?(@display)
       params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
 
+      if params[:pressed] == "custom_button"
+        custom_buttons
+        return
+      end
+
       handle_status = :not_started
       # Handle vm-style buttons if included in the controller
       if respond_to?(:process_vm_buttons, true)

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -532,4 +532,6 @@ class NetworkRouterController < ApplicationController
       false
     end
   end
+
+  has_custom_buttons
 end

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -53,6 +53,11 @@ class OrchestrationStackController < ApplicationController
     params[:display] = @display if ["instances"].include?(@display)  # Were we displaying vms/hosts/storages
     params[:page] = @current_page if @current_page.nil?   # Save current page for list refresh
 
+    if params[:pressed] == "custom_button"
+      custom_buttons
+      return
+    end
+
     if params[:pressed].starts_with?("instance_")        # Handle buttons from sub-items screen
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       process_vm_buttons(pfx)
@@ -91,6 +96,9 @@ class OrchestrationStackController < ApplicationController
         orchestration_stack_retire_now
       when "orchestration_stack_tag"
         tag(OrchestrationStack)
+      when params[:pressed] == "custom_button"
+        custom_buttons
+        return
       end
       return if %w(orchestration_stack_retire orchestration_stack_tag).include?(params[:pressed]) &&
                 @flash_array.nil? # Tag screen showing, so return
@@ -242,4 +250,6 @@ class OrchestrationStackController < ApplicationController
   end
 
   menu_section :clo
+
+  has_custom_buttons
 end

--- a/app/controllers/persistent_volume_controller.rb
+++ b/app/controllers/persistent_volume_controller.rb
@@ -18,4 +18,6 @@ class PersistentVolumeController < ApplicationController
   end
 
   menu_section :cnt
+
+  has_custom_buttons
 end

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -29,6 +29,9 @@ class SecurityGroupController < ApplicationController
       delete_security_groups
     when "security_group_edit"
       javascript_redirect :action => "edit", :id => checked_item_id(params)
+    when params[:pressed] == "custom_button"
+      custom_buttons
+      return
     else
       if params[:pressed] == "security_group_new"
         javascript_redirect :action => "new"
@@ -322,4 +325,6 @@ class SecurityGroupController < ApplicationController
                    security_groups.length) % {:number => security_groups.length})
     end
   end
+
+  has_custom_buttons
 end

--- a/app/decorators/container_volume_decorator.rb
+++ b/app/decorators/container_volume_decorator.rb
@@ -1,0 +1,5 @@
+class ContainerVolumeDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-volume'
+  end
+end

--- a/app/decorators/orchestration_stack_decorator.rb
+++ b/app/decorators/orchestration_stack_decorator.rb
@@ -1,0 +1,5 @@
+class OrchestrationStackDecorator < MiqDecorator
+  def self.fonticon
+    'ff ff-stack'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,7 @@ Rails.application.routes.draw do
 
     :availability_zone        => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         index
@@ -400,6 +401,7 @@ Rails.application.routes.draw do
 
     :cloud_object_store_container => {
       :get => %w(
+        dialog_load
         download_data
         download_summary_pdf
         index
@@ -484,6 +486,7 @@ Rails.application.routes.draw do
 
     :cloud_volume             => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         attach
@@ -635,6 +638,7 @@ Rails.application.routes.draw do
 
     :container_group          => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         edit
@@ -751,6 +755,7 @@ Rails.application.routes.draw do
 
     :container_image          => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         edit
@@ -849,6 +854,7 @@ Rails.application.routes.draw do
 
     :container_project        => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         edit
@@ -912,6 +918,7 @@ Rails.application.routes.draw do
 
     :persistent_volume        => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         edit
@@ -968,6 +975,7 @@ Rails.application.routes.draw do
 
     :container_template          => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         index
@@ -1674,6 +1682,7 @@ Rails.application.routes.draw do
 
     :security_group           => {
       :get  => %w(
+        dialog_load
         edit
         download_data
         download_summary_pdf
@@ -1739,6 +1748,7 @@ Rails.application.routes.draw do
 
     :cloud_subnet             => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         cloud_subnet_form_fields
@@ -1774,6 +1784,7 @@ Rails.application.routes.draw do
 
     :cloud_network             => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         edit
@@ -1837,6 +1848,7 @@ Rails.application.routes.draw do
     :network_router           => {
       :get  => %w(
         add_interface_select
+        dialog_load
         download_data
         download_summary_pdf
         edit
@@ -1877,6 +1889,7 @@ Rails.application.routes.draw do
 
     :load_balancer             => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         index
@@ -2007,6 +2020,7 @@ Rails.application.routes.draw do
 
     :infra_networking         => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         explorer
@@ -2654,6 +2668,7 @@ Rails.application.routes.draw do
     :orchestration_stack      => {
       :get  => %w(
         cloud_networks
+        dialog_load
         download_data
         download_summary_pdf
         retirement_info


### PR DESCRIPTION
Add `has_custom_buttons` to controllers, add new classes mapping to icon in `tree_builder_buttons`, add classes to `APPLIES_TO_CLASS_BASE_MODELS`. 

Set custom buttons:
Automation -> Automate -> Customization -> Buttons

Custom buttons added to: 
Compute -> Cloud -> Availability Zone
Compute -> Cloud -> Stacks
Compute -> Infrastructure -> Networking
Compute -> Containers -> Project
Compute -> Containers -> Pod
Compute -> Containers -> Images
Compute -> Containers -> Volumes
Compute -> Containers -> Template
Networks -> Networks
Networks -> Subnets
Networks -> Network Routers
Networks -> Load Balancers
Networks -> Security Groups
Storage -> Block Storage -> Managers
Storage -> Block Storage -> Volumes
Storage -> Object Storage -> Managers
Storage -> Object Storage -> Object Store Containers

<img width="288" alt="screen shot 2017-08-21 at 10 31 58 am" src="https://user-images.githubusercontent.com/9210860/29510445-0b5bf834-865c-11e7-8931-76a781bb611c.png">


https://www.pivotaltracker.com/story/show/147778977

@miq-bot add_label wip, enhancement, euwe/no, automation/automate