### PR TITLE
Remove TIMELINE_TIME_COLUMNS from UiConstants 

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -6,13 +6,6 @@ module UiConstants
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
 
-  # START of TIMELINE TIMEZONE Code
-  TIMELINE_TIME_COLUMNS = [
-    "created_on",
-    "timestamp"
-  ]
-  # END of TIMELINE TIMEZONE Code
-
   # Choices for trend and C&U days back pulldowns
   WEEK_CHOICES = {
     7  => N_("1 Week"),

--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -2,6 +2,8 @@ module ReportFormatter
   class TimelineMessage
     include CompressedIds
 
+    TIMELINE_TIME_COLUMNS = %w(created_on timestamp).freeze
+
     def initialize(row, event, flags, db)
       @row, @event, @flags, @db = row, event, flags, db
     end


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `TIMELINE_TIME_COLUMNS` was removed from `UiConstants` and moved to `TimelineMessage` class.