### PR TITLE
Remove CHARTS_REPORTS_FOLDER, CHARTS_LAYOUTS_FOLDER, TIMELINES_FOLDER, TOOLBARS_FOLDER from UiConstants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,6 +77,8 @@ class ApplicationController < ActionController::Base
   before_action :allow_websocket
   after_action :set_global_session_data, :except => [:resize_layout]
 
+  TIMELINES_FOLDER = Rails.root.join("product", "timelines")
+
   ONE_MILLION = 1_000_000 # Setting high number incase we don't want to display paging controls on list views
 
   PERPAGE_TYPES = %w(grid tile list reports).each_with_object({}) { |value, acc| acc[value] = value.to_sym }.freeze

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -1,6 +1,8 @@
 module ApplicationController::Performance
   extend ActiveSupport::Concern
 
+  CHARTS_REPORTS_FOLDER = Rails.root.join("product", "charts", "miq_reports")
+
   # Process changes to performance charts
   def perf_chart_chooser
     assert_privileges("perf_reload")

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -2,6 +2,7 @@ module ApplicationController::Performance
   extend ActiveSupport::Concern
 
   CHARTS_REPORTS_FOLDER = Rails.root.join("product", "charts", "miq_reports")
+  CHARTS_LAYOUTS_FOLDER = Rails.root.join("product", "charts", "layouts")
 
   # Process changes to performance charts
   def perf_chart_chooser

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -42,7 +42,7 @@ module ApplicationController::Timelines
   private ############################
 
   def tl_get_rpt(timeline)
-    MiqReport.new(YAML.load(File.open("#{TIMELINES_FOLDER}/miq_reports/#{timeline}.yaml")))
+    MiqReport.new(YAML.load(File.open("#{ApplicationController::TIMELINES_FOLDER}/miq_reports/#{timeline}.yaml")))
   end
 
   def tl_build_init_options(refresh = nil)

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -669,7 +669,7 @@ class MiqCapacityController < ApplicationController
       @title = @sb[:bottlenecks][:report].title
       bottleneck_tl_to_xml
     else
-      @sb[:bottlenecks][:report] = MiqReport.new(YAML.load(File.open("#{TIMELINES_FOLDER}/miq_reports/tl_bottleneck_events.yaml")))
+      @sb[:bottlenecks][:report] = MiqReport.new(YAML.load(File.open("#{ApplicationController::TIMELINES_FOLDER}/miq_reports/tl_bottleneck_events.yaml")))
       @sb[:bottlenecks][:report].headers.map! { |header| _(header) }
       @sb[:bottlenecks][:report].tz = @sb[:bottlenecks][:tl_options][:tz] # Set the new timezone
       @title = @sb[:bottlenecks][:report].title

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,7 +1,6 @@
 module UiConstants
   # dac - Changed to allow up to 255 characters for all text fields on 1/11/07
 
-  CHARTS_LAYOUTS_FOLDER = File.join(Rails.root, "product/charts/layouts")
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
 

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,7 +1,6 @@
 module UiConstants
   # dac - Changed to allow up to 255 characters for all text fields on 1/11/07
 
-  CHARTS_REPORTS_FOLDER = File.join(Rails.root, "product/charts/miq_reports")
   CHARTS_LAYOUTS_FOLDER = File.join(Rails.root, "product/charts/layouts")
   TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,7 +1,6 @@
 module UiConstants
   # dac - Changed to allow up to 255 characters for all text fields on 1/11/07
 
-  TIMELINES_FOLDER = File.join(Rails.root, "product/timelines")
   TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
 
   # Choices for trend and C&U days back pulldowns

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,8 +1,6 @@
 module UiConstants
   # dac - Changed to allow up to 255 characters for all text fields on 1/11/07
 
-  TOOLBARS_FOLDER = File.join(Rails.root, "product/toolbars")
-
   # Choices for trend and C&U days back pulldowns
   WEEK_CHOICES = {
     7  => N_("1 Week"),

--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -10,7 +10,7 @@
         :javascript
            miqInitSelectPicker();
         - if @perf_options[:index] && %w(host vm).include?(request.parameters["controller"])
-          - rt_chart = YAML.load(File.open("#{CHARTS_LAYOUTS_FOLDER}/realtime_perf_charts/#{@perf_options[:model]}.yaml"))
+          - rt_chart = YAML.load(File.open("#{ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER}/realtime_perf_charts/#{@perf_options[:model]}.yaml"))
           - @rt_hide = rt_chart[@perf_options[:index].to_i][:type] == "None"
         - if request.parameters["controller"] == "storage" && @perf_options[:cat]
           = select("perf", "typ", [[_("Hourly"), "Hourly"], [_("Daily"), "Daily"]], {:selected => @perf_options[:typ]},

--- a/spec/product/reports_spec.rb
+++ b/spec/product/reports_spec.rb
@@ -1,5 +1,5 @@
 describe 'YAML reports' do
-  let(:report_dirs) { [Rails.root.join("product", "reports"), "#{TIMELINES_FOLDER}/miq_reports"] }
+  let(:report_dirs) { [Rails.root.join("product", "reports"), "#{ApplicationController::TIMELINES_FOLDER}/miq_reports"] }
   let(:report_yamls) { report_dirs.collect { |dir| Dir.glob(File.join(dir, "**", "*.yaml")) }.flatten }
   let(:chart_dirs) { [ApplicationController::Performance::CHARTS_REPORTS_FOLDER] }
   let(:chart_yamls) { chart_dirs.collect { |dir| Dir.glob(File.join(dir, "**", "*.yaml")) }.flatten }

--- a/spec/product/reports_spec.rb
+++ b/spec/product/reports_spec.rb
@@ -1,7 +1,7 @@
 describe 'YAML reports' do
   let(:report_dirs) { [Rails.root.join("product", "reports"), "#{TIMELINES_FOLDER}/miq_reports"] }
   let(:report_yamls) { report_dirs.collect { |dir| Dir.glob(File.join(dir, "**", "*.yaml")) }.flatten }
-  let(:chart_dirs) { [CHARTS_REPORTS_FOLDER] }
+  let(:chart_dirs) { [ApplicationController::Performance::CHARTS_REPORTS_FOLDER] }
   let(:chart_yamls) { chart_dirs.collect { |dir| Dir.glob(File.join(dir, "**", "*.yaml")) }.flatten }
   let!(:user) { FactoryGirl.create(:user_with_group) }
 
@@ -15,7 +15,7 @@ describe 'YAML reports' do
   end
 
   it 'can be build even though without data' do
-    # TODO: CHARTS_REPORTS_FOLDER
+    # TODO: ApplicationController::Performance::CHARTS_REPORTS_FOLDER
     report_yamls.each do |yaml|
       report_data = YAML.load(File.open(yaml))
       report_data.delete('menu_name')

--- a/spec/services/charts_layout_service_spec.rb
+++ b/spec/services/charts_layout_service_spec.rb
@@ -3,28 +3,28 @@ describe ChartsLayoutService do
   let(:host_redhat) { FactoryGirl.create(:host_redhat) }
   let(:vm_openstack) { FactoryGirl.create(:vm_openstack) }
   let(:host_openstack_infra_chart) do
-    YAML.load(File.open(File.join(UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'ManageIQ_Providers_Openstack_InfraManager_Host') + '.yaml'))
+    YAML.load(File.open(File.join(ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'ManageIQ_Providers_Openstack_InfraManager_Host') + '.yaml'))
   end
   let(:host_chart) do
-    YAML.load(File.open(File.join(UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host') + '.yaml'))
+    YAML.load(File.open(File.join(ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host') + '.yaml'))
   end
   let(:layout_chart) do
-    YAML.load(File.open(File.join(UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_util_charts') + '.yaml'))
+    YAML.load(File.open(File.join(ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER, 'daily_util_charts') + '.yaml'))
   end
 
   describe "#layout" do
     it "returns layout for specific class if exists" do
-      chart = ChartsLayoutService.layout(host_openstack_infra,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host')
+      chart = ChartsLayoutService.layout(host_openstack_infra, ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host')
       expect(chart).to eq(host_openstack_infra_chart)
     end
 
     it "returns layout for fname if specific class does not exist" do
-      chart = ChartsLayoutService.layout(host_redhat,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host')
+      chart = ChartsLayoutService.layout(host_redhat, ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host')
       expect(chart).to eq(host_chart)
     end
 
     it "returns base layout if fname is missing" do
-      chart = ChartsLayoutService.layout(host_openstack_infra,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_util_charts')
+      chart = ChartsLayoutService.layout(host_openstack_infra, ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER, 'daily_util_charts')
       expect(chart).to eq(layout_chart)
     end
   end
@@ -32,7 +32,7 @@ describe ChartsLayoutService do
   describe "#layout applies_to_method functionality" do
     it "shows CPU (%) by default for VmOpenstack" do
       # By default percent is visible and mhz not
-      chart = ChartsLayoutService.layout(vm_openstack,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
+      chart = ChartsLayoutService.layout(vm_openstack, ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
       expect(chart.count { |x| x[:title] == "CPU (%)" }).to equal 1
       expect(chart.count { |x| x[:title] == "CPU (Mhz)" }).to equal 0
     end
@@ -41,7 +41,7 @@ describe ChartsLayoutService do
       # Stub it so mhz is visible and percent not
       allow(vm_openstack).to receive(:cpu_percent_available?).and_return(false)
       allow(vm_openstack).to receive(:cpu_mhz_available?).and_return(true)
-      chart = ChartsLayoutService.layout(vm_openstack,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
+      chart = ChartsLayoutService.layout(vm_openstack, ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
       expect(chart.count { |x| x[:title] == "CPU (%)" }).to equal 0
       expect(chart.count { |x| x[:title] == "CPU (Mhz)" }).to equal 1
     end
@@ -50,7 +50,7 @@ describe ChartsLayoutService do
       ems_azure = FactoryGirl.create(:ems_azure)
       host = FactoryGirl.create(:host, :ext_management_system => ems_azure)
       vm_azure =  FactoryGirl.create(:vm_azure, :ext_management_system => ems_azure, :host => host)
-      chart = ChartsLayoutService.layout(vm_azure,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
+      chart = ChartsLayoutService.layout(vm_azure, ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
       expect(chart.count { |x| x[:title] == "Memory (MB)" }).to equal 1
     end
   end


### PR DESCRIPTION
### Issue: #1661 

Constants `CHARTS_REPORTS_FOLDER, CHARTS_LAYOUTS_FOLDER, TIMELINES_FOLDER, TOOLBARS_FOLDER` have been removed from `UiConstants`.

Definitions of constants `CHARTS_REPORTS_FOLDER, CHARTS_LAYOUTS_FOLDER` were moved to `ApplicationController::Performance`.
Definition of constant `TIMELINES_FOLDER` was moved to `ApplicationController`.
Constant `TOOLBARS_FOLDER` was removed permanently.

Prefix `ReportHelper::` was added to every occurrence of these constants.

Appertaining prefix was added to these constants except `TOOLBARS_FOLDER` .


