### PR TITLE
Change webpacker to store plugin javascript in corespoding folder

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,7 +32,7 @@
       = csrf_meta_tag
       = render :partial => 'layouts/i18n_js'
       -# FIXME: the conditional below is a temporary fix for a webpacker issue, remove when it's resolved
-      = javascript_pack_tag 'application' unless Rails.env.test?
+      = javascript_pack_tag 'manageiq-ui-classic/application' unless Rails.env.test?
 
       :javascript
         ManageIQ.charts.provider = "#{Charting.backend}";

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -26,10 +26,10 @@ Object.keys(engines).forEach(function(k) {
 module.exports = {
   entry: packPaths.reduce(
     (map, entry) => {
-      const localMap = map
-      const namespace = relative(join(entryPath), dirname(entry))
-      localMap[join(namespace, basename(entry, extname(entry)))] = resolve(entry)
-      return localMap
+      const pluginName = dirname(entry).substring(0, dirname(entry).length - join(entryPath).length)
+      const prefix = basename(entry, extname(entry)) === 'application' ? '' : basename(pluginName) + '/'
+      map[prefix + basename(entry, extname(entry))] = resolve(entry)
+      return map
     }, {}
   ),
 

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -27,8 +27,7 @@ module.exports = {
   entry: packPaths.reduce(
     (map, entry) => {
       const pluginName = dirname(entry).substring(0, dirname(entry).length - join(entryPath).length)
-      const prefix = basename(entry, extname(entry)) === 'application' ? '' : basename(pluginName) + '/'
-      map[prefix + basename(entry, extname(entry))] = resolve(entry)
+      map[join(basename(pluginName), basename(entry, extname(entry)))] = resolve(entry)
       return map
     }, {}
   ),


### PR DESCRIPTION
when webpacker loads files it will store them in plugin's folder in public/packs folder.

### Before
Folder structure of public packs was
```bash
public/packs/hello_angular.js
public/packs/application.js
public/packs/manifest.json
```

Usage in haml file:
```diff
+%hello-angular
+  Loading...
+= javascript_pack_tag 'hello_angular'
```

### After
Folder structure of public packs
```bash
public/packs/manageiq-ui-classic/hello_angular.js
public/packs/manageiq-ui-classic/application.js
public/packs/manifest.json
```

Usage in haml file:
```diff
+%hello-angular
+  Loading...
+= javascript_pack_tag 'manageiq-ui-classic/hello_angular'
```

### Fixes plugin's javascripts
If we were to add another plugin with `app/javascript/packs/example.js` the chunk name was broken `../../plugin_example/app/javascript/packs/example`, this file was later on not accessible and threw 404. This PR changes it that any JS packs will be copied over to parent manageIq core `public/packs` folder and will be placed within folder of plugin's name. (for example)
```bash
plugin_example/example.js
```

Usage of such JS is (can be used across whole MiQ app, not just in plugin):
```diff
+= javascript_pack_tag 'plugin_example/example'
```
