### PR TITLE
Block unsupported VMs reset

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -235,6 +235,14 @@ module ApplicationController::CiProcessing
     true
   end
 
+  def check_reset_requirements(selected_items)
+    if VmOrTemplate.find(selected_items).any? { |vm| !vm.supports_reset? }
+      javascript_flash(:text => _("Reset does not apply to at least one of the selected items"), :severity => :error, :scroll_top => true)
+      return false
+    end
+    true
+  end
+
   def check_non_empty(items, display_name)
     if items.blank?
       add_flash(_("No items were selected for %{task}") % {:task => display_name}, :error)
@@ -246,6 +254,7 @@ module ApplicationController::CiProcessing
   def vm_button_operation_internal(items, task, display_name)
     return false if task == 'retire_now' && !check_retire_requirements(items)
     return false if task == 'scan' && !check_scan_requirements(items)
+    return false if task == 'reset' && !check_reset_requirements(items)
     return false unless check_non_empty(items, display_name)
 
     process_objects(items, task, display_name)

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -264,6 +264,17 @@ describe VmInfraController do
     expect(response.status).to eq(200)
   end
 
+  it 'can reset selected items' do
+    get :show, :params => { :id => vm_vmware.id }
+    expect(response).to redirect_to(:action => 'explorer')
+
+    post :explorer
+    expect(response.status).to eq(200)
+
+    post :x_button, :params => { :pressed => 'vm_reset', :id => vm_vmware.id }
+    expect(response.status).to eq(200)
+  end
+
   it 'can migrate selected items' do
     get :show, :params => { :id => vm_vmware.id }
     expect(response).to redirect_to(:action => 'explorer')
@@ -339,6 +350,10 @@ describe VmInfraController do
   end
 
   it 'can Reset VM' do
+    expect(vm_vmware).to receive(:supports_control?).and_return(true)
+    expect(vm_vmware).to receive(:current_state).and_return("on")
+    expect(VmOrTemplate).to receive(:find).with([vm_vmware.id.to_s]).and_return([vm_vmware])
+
     post :x_button, :params => { :pressed => 'vm_reset', :id => vm_vmware.id }
     expect(response.status).to eq(200)
 


### PR DESCRIPTION
When selecting VMs to be reset via the VMs center dialog, no validation
is done for the selected VMs. Therefore VMs which doesn't meet the
criteria and would block such action if applied on a VM specific, can be
selected and later on failed.

A pre-check is added to make sure VMs which doesn't meet the expected
terms for reset are prevented from being reset.

https://bugzilla.redhat.com/show_bug.cgi?id=1476592