### PR TITLE
Display Associations in Generic Object Summary

### DIFF
--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -15,6 +15,16 @@ class GenericObjectController < ApplicationController
     GenericObject
   end
 
+  def self.populate_display_methods(record)
+    define_singleton_method("display_methods") do
+      associations = %w()
+      record.property_associations.each do |key, _value|
+        associations.push(key)
+      end
+      associations
+    end
+  end
+
   private
 
   def textual_group_list

--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -18,7 +18,7 @@ class GenericObjectController < ApplicationController
   private
 
   def textual_group_list
-    [%i(properties attribute_details_list)]
+    [%i(properties attribute_details_list associations)]
   end
 
   helper_method :textual_group_list

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -5,6 +5,8 @@ module Mixins
       return unless init_show
       @center_toolbar = self.class.toolbar_singular if self.class.toolbar_singular
 
+      self.class.populate_display_methods(@record) if self.class.respond_to?(:populate_display_methods)
+
       case @display
       # these methods are defined right in GenericShowMixin
       when "summary_only"

--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -26,6 +26,22 @@ module GenericObjectHelper::TextualSummary
     )
   end
 
+  def textual_group_associations
+    associations = %i()
+    @record.property_associations.each do |key, _value|
+      associations.push(key.to_sym)
+      define_singleton_method("textual_#{key}") do
+        num = @record.send(key).count
+        h = {:label => _("%{label}") % {:label => key.capitalize}, :value => num}
+        if role_allows?(:feature => "generic_object_view") && num > 0
+          h.update(:link  => url_for_only_path(:action => 'show', :id => @record, :display => key),
+                   :title => _('Show all %{associated_models}') % {:associated_models => key.capitalize})
+        end
+      end
+    end
+    TextualGroup.new(_("Associations"), associations)
+  end
+
   def attributes_array
     @record.property_attributes.each do |var|
       [var[0], var[1]]

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -155,7 +155,7 @@ module QuadiconHelper
   def quadicon_builder_factory(item, options)
     case quadicon_builder_name_from(item)
     when 'service', 'service_template', 'service_ansible_tower', 'service_template_ansible_tower'
-      render_service_quadicon(item, options)
+      render_service_quadicon(item, options.merge!(:url => "/service/explorer/s-#{item.id}"))
     when 'resource_pool'         then render_resource_pool_quadicon(item, options)
     when 'host'                  then render_host_quadicon(item, options)
     when 'ext_management_system' then render_ext_management_system_quadicon(item, options)
@@ -457,7 +457,7 @@ module QuadiconHelper
     link_opts = {}
 
     if quadicon_show_links?
-      url = quadicon_url_to_xshow_from_cid(item)
+      url = options[:url] || quadicon_url_to_xshow_from_cid(item, options)
       link_opts = {:sparkle => true, :remote => true}
     end
 

--- a/app/views/generic_object/show.html.haml
+++ b/app/views/generic_object/show.html.haml
@@ -1,2 +1,5 @@
 #main_div
-  = render :partial => 'layouts/textual_groups_generic'
+  - if @record.property_associations.keys.include?(@display)
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  - else
+    = render :partial => 'layouts/textual_groups_generic'

--- a/spec/controllers/generic_object_controller_spec.rb
+++ b/spec/controllers/generic_object_controller_spec.rb
@@ -9,7 +9,8 @@ describe GenericObjectController do
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)
-      generic_obj = FactoryGirl.create(:generic_object)
+      generic_obj_defn = FactoryGirl.create(:generic_object_definition)
+      generic_obj = FactoryGirl.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
       get :show, :params => {:id => generic_obj.id}
     end
     it { expect(response.status).to eq(200) }


### PR DESCRIPTION
Generic Objects can pretty much be associated with **any** reportable model.

Therefore the `display` list cannot be predetermined and has to be created on-the-fly, along with the `display_*` methods -- that's what is unique about this PR, unique as in, not implemented before in Textual Summaries.

<img width="1367" alt="screen shot 2017-08-15 at 4 53 17 pm" src="https://user-images.githubusercontent.com/1538216/29342951-c7d758ce-81e2-11e7-9ae7-4f067950ddb3.png">

<img width="1367" alt="screen shot 2017-08-15 at 4 54 04 pm" src="https://user-images.githubusercontent.com/1538216/29342970-e2f8b2ec-81e2-11e7-9caf-7095687dde62.png">

<img width="1365" alt="screen shot 2017-08-15 at 4 53 45 pm" src="https://user-images.githubusercontent.com/1538216/29342978-f9888de8-81e2-11e7-8521-84bfcfa931cd.png">

