### PR TITLE
Remove WEEK_CHOICES from UiConstants

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,17 +1,6 @@
 module UiConstants
   # dac - Changed to allow up to 255 characters for all text fields on 1/11/07
 
-  # Choices for trend and C&U days back pulldowns
-  WEEK_CHOICES = {
-    7  => N_("1 Week"),
-    14 => N_("2 Weeks"),
-    21 => N_("3 Weeks"),
-    28 => N_("4 Weeks")
-    # 60 => "2 Months",   # Removed longer times when on demand daily rollups was added in sprint 59 due to performance
-    # 90 => "3 Months",
-    # 180 => "6 Months"
-  }
-
   # Choices for Target options show pulldown
   TARGET_TYPE_CHOICES = {
     "EmsCluster" => N_("Clusters"),

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -35,6 +35,14 @@ module ViewHelper
     1.hour     => N_("1 Hour")
   }.freeze
 
+  # Choices for trend and C&U days back pulldowns
+  WEEK_CHOICES = {
+    7  => N_("1 Week"),
+    14 => N_("2 Weeks"),
+    21 => N_("3 Weeks"),
+    28 => N_("4 Weeks")
+  }.freeze
+
   class << self
     def concat_tag(*args, &block)
       concat content_tag(*args, &block)

--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -62,7 +62,7 @@
             = _("Show")
           %dd
             = select_tag("perf_days",
-                          options_for_select(WEEK_CHOICES.map { |k, v| [_(v), k] }.sort,
+                          options_for_select(ViewHelper::WEEK_CHOICES.map { |k, v| [_(v), k] }.sort,
                             @perf_options[:days].to_i),
                           "data-miq_sparkle_on" => true,
                           :class    => "selectpicker")

--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -268,7 +268,7 @@
         = _('Trends for past')
       .col-md-8
         = select_tag("trend_days",
-                      options_for_select(WEEK_CHOICES.invert.sort_by(&:last), @sb[:planning][:options][:days].to_i),
+                      options_for_select(ViewHelper::WEEK_CHOICES.invert.sort_by(&:last), @sb[:planning][:options][:days].to_i),
                       "class"                => "selectpicker",
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true)

--- a/app/views/miq_capacity/_planning_report.html.haml
+++ b/app/views/miq_capacity/_planning_report.html.haml
@@ -11,6 +11,7 @@
     - if @sb[:planning][:rpt].extras[:vm_profile]
       = render :partial => "planning_vm_profile"
   - if @perf_record
-    %p= _("* Information shown is based on available trend data going back %{weeks}.") % {:weeks => _(WEEK_CHOICES[@sb[:planning][:options][:days]])}
+    %p
+      = _("* Information shown is based on available trend data going back %{weeks}.") % {:weeks => _(ViewHelper::WEEK_CHOICES[@sb[:planning][:options][:days]])}
   - else
     = render :partial => "planning_instructions"

--- a/app/views/miq_capacity/_planning_summary.html.haml
+++ b/app/views/miq_capacity/_planning_summary.html.haml
@@ -43,6 +43,7 @@
         = render :partial => "planning_vm_profile"
 
   - if @perf_record
-    %p= _("* Information shown is based on available trend data going back %{weeks}.") % {:weeks => _(WEEK_CHOICES[@sb[:planning][:options][:days]])}
+    %p
+      = _("* Information shown is based on available trend data going back %{weeks}.") % {:weeks => _(ViewHelper::WEEK_CHOICES[@sb[:planning][:options][:days]])}
   - else
     = render :partial => "planning_instructions"

--- a/app/views/miq_capacity/_planning_vm_profile.html.haml
+++ b/app/views/miq_capacity/_planning_vm_profile.html.haml
@@ -57,7 +57,7 @@
 %dl.dl-horizontal
   %dt= _('Trend for Past')
   %dd
-    = h(_(WEEK_CHOICES[@sb[:planning][:options][:days].to_i]))
+    = h(_(ViewHelper::WEEK_CHOICES[@sb[:planning][:options][:days].to_i]))
   %dt= _('Time Profile')
   %dd
     - if @sb[:planning][:options][:time_profile].nil?

--- a/app/views/miq_capacity/_utilization_options.html.haml
+++ b/app/views/miq_capacity/_utilization_options.html.haml
@@ -9,7 +9,7 @@
         = _('Trends for past')
       .col-md-10
         = select_tag("#{cap_type}_days",
-          options_for_select(WEEK_CHOICES.map {|k, v| [_(v), k]}.sort, @sb[:util][:options][:days].to_i),
+          options_for_select(ViewHelper::WEEK_CHOICES.map {|k, v| [_(v), k]}.sort, @sb[:util][:options][:days].to_i),
           "class"               => "selectpicker")
         :javascript
           miqInitSelectPicker();


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `WEEK_CHOICES` was removed from `UiConstants` and moved to `ViewHelper`. Prefix `ViewHelper::` was added to every occurrence of this constants.