### PR TITLE
Remove REALTIME_CHOICES from UiConstants

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -17,15 +17,6 @@ module UiConstants
     # 180 => "6 Months"
   }
 
-  # Choices for C&U last hour real time minutes back pulldown
-  REALTIME_CHOICES = {
-    10.minutes => N_("10 Minutes"),
-    15.minutes => N_("15 Minutes"),
-    30.minutes => N_("30 Minutes"),
-    45.minutes => N_("45 Minutes"),
-    1.hour     => N_("1 Hour")
-  }
-
   # Choices for Target options show pulldown
   TARGET_TYPE_CHOICES = {
     "EmsCluster" => N_("Clusters"),

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -26,6 +26,15 @@ module ViewHelper
     "US-Folio"      => N_("US Folio - 8.5in x 13.0in")
   }.freeze
 
+  # Choices for C&U last hour real time minutes back pulldown
+  REALTIME_CHOICES = {
+    10.minutes => N_("10 Minutes"),
+    15.minutes => N_("15 Minutes"),
+    30.minutes => N_("30 Minutes"),
+    45.minutes => N_("45 Minutes"),
+    1.hour     => N_("1 Hour")
+  }
+
   class << self
     def concat_tag(*args, &block)
       concat content_tag(*args, &block)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -33,7 +33,7 @@ module ViewHelper
     30.minutes => N_("30 Minutes"),
     45.minutes => N_("45 Minutes"),
     1.hour     => N_("1 Hour")
-  }
+  }.freeze
 
   class << self
     def concat_tag(*args, &block)

--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -35,7 +35,7 @@
           = _("Show")
         %dd
           = select_tag("perf_minutes",
-                       options_for_select(REALTIME_CHOICES.map { |k, v| [_(v), k] }.sort_by(&:last),
+                       options_for_select(ViewHelper::REALTIME_CHOICES.map { |k, v| [_(v), k] }.sort_by(&:last),
                        @perf_options[:rt_minutes]),
                        "data-miq_sparkle_on" => true,
                        :class    => "selectpicker")


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `REALTIME_CHOICES` was removed from `UiConstants` and moved to `ViewHelper`. Prefix `ViewHelper::` was added to this constants.