### PR TITLE
Remove TREND_LIMIT_PERCENTS from UiConstants

### DIFF
--- a/app/helpers/planning_helper.rb
+++ b/app/helpers/planning_helper.rb
@@ -1,9 +1,11 @@
 module PlanningHelper
+
   # Choices for Target options show pulldown
   TARGET_TYPE_CHOICES = {
     "EmsCluster" => N_("Clusters"),
     "Host"       => N_("Hosts")
   }.freeze
+
   # Source pulldown in VM Options
   PLANNING_VM_MODES = {
     :allocated => N_("Allocation"),
@@ -11,4 +13,30 @@ module PlanningHelper
     :used      => N_("Usage"),
     :manual    => N_("Manual Input")
   }.freeze
+
+  # Choices for the trend limit percent pulldowns
+  TREND_LIMIT_PERCENTS = {
+    "200%" => 200,
+    "190%" => 190,
+    "180%" => 180,
+    "170%" => 170,
+    "160%" => 160,
+    "150%" => 150,
+    "140%" => 140,
+    "130%" => 130,
+    "120%" => 120,
+    "110%" => 110,
+    "100%" => 100,
+    "95%"  => 95,
+    "90%"  => 90,
+    "85%"  => 85,
+    "80%"  => 80,
+    "75%"  => 75,
+    "70%"  => 70,
+    "65%"  => 65,
+    "60%"  => 60,
+    "55%"  => 55,
+    "50%"  => 50,
+  }.freeze
+
 end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,31 +1,6 @@
 module UiConstants
   # dac - Changed to allow up to 255 characters for all text fields on 1/11/07
 
-  # Choices for the trend limit percent pulldowns
-  TREND_LIMIT_PERCENTS = {
-    "200%" => 200,
-    "190%" => 190,
-    "180%" => 180,
-    "170%" => 170,
-    "160%" => 160,
-    "150%" => 150,
-    "140%" => 140,
-    "130%" => 130,
-    "120%" => 120,
-    "110%" => 110,
-    "100%" => 100,
-    "95%"  => 95,
-    "90%"  => 90,
-    "85%"  => 85,
-    "80%"  => 80,
-    "75%"  => 75,
-    "70%"  => 70,
-    "65%"  => 65,
-    "60%"  => 60,
-    "55%"  => 55,
-    "50%"  => 50,
-  }
-
   # Report Controller constants
   NOTHING_STRING = "<<< Nothing >>>"
   GRAPH_MAX_COUNT = 10

--- a/app/views/planning/_planning_options.html.haml
+++ b/app/views/planning/_planning_options.html.haml
@@ -210,7 +210,7 @@
           = _('CPU Speed')
         .col-md-8
           = select_tag("limit_cpu",
-                        options_for_select(TREND_LIMIT_PERCENTS, @sb[:options][:limit_cpu]),
+                        options_for_select(PlanningHelper::TREND_LIMIT_PERCENTS, @sb[:options][:limit_cpu]),
                         :disabled              => !@sb[:options][:trend_cpu],
                         "class"                => "selectpicker",
                         "data-miq_sparkle_on"  => true,
@@ -238,7 +238,7 @@
           = _('Memory Size')
         .col-md-8
           = select_tag("limit_memory",
-                        options_for_select(TREND_LIMIT_PERCENTS, @sb[:options][:limit_memory]),
+                        options_for_select(PlanningHelper::TREND_LIMIT_PERCENTS, @sb[:options][:limit_memory]),
                         :disabled              => !@sb[:options][:trend_memory],
                         "class"                => "selectpicker",
                         "data-miq_sparkle_on"  => true,
@@ -252,7 +252,7 @@
           = _('Datastore Space')
         .col-md-8
           = select_tag("limit_storage",
-                        options_for_select(TREND_LIMIT_PERCENTS, @sb[:options][:limit_storage]),
+                        options_for_select(PlanningHelper::TREND_LIMIT_PERCENTS, @sb[:options][:limit_storage]),
                         :disabled => !@sb[:options][:trend_storage],
                         "class"                => "selectpicker",
                         "data-miq_sparkle_on"  => true,
@@ -269,7 +269,7 @@
         = _('Trends for past')
       .col-md-8
         = select_tag("trend_days",
-                      options_for_select(ViewHelper::WEEK_CHOICES.invert.sort_by(&:last), @sb[:options][:days].to_i),
+                      options_for_select(PlanningHelper::WEEK_CHOICES.invert.sort_by(&:last), @sb[:options][:days].to_i),
                       "class"                => "selectpicker",
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true)


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `TREND_LIMIT_PERCENTS` was removed from `UiConstants` and moved to `ViewHelper`. Prefix `ViewHelper::` was added to every occurrence of this constants (only in one file).