### PR TITLE
Use the generic onCheck handler in the default filters tree

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -91,7 +91,7 @@ class ConfigurationController < ApplicationController
   def filters_field_changed
     return unless load_edit("config_edit__ui3", "configuration")
     id = params[:id].split('-').last.to_i
-    @edit[:new].find { |x| x[:id] == id }[:search_key] = params[:check] == 'true' ? nil : '_hidden_'
+    @edit[:new].find { |x| x[:id] == id }[:search_key] = params[:check] == '1' ? nil : '_hidden_'
     @edit[:current].each_with_index do |arr, i|          # needed to compare each array element's attributes to find out if something has changed
       if @edit[:new][i][:search_key] != arr[:search_key]
         @changed = true

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -40,7 +40,7 @@ class TreeBuilderDefaultFilters < TreeBuilder
   def set_locals_for_render
     locals = super
     locals.merge!(:check_url         => "/configuration/filters_field_changed/",
-                  :onselect          => "miqOnCheckSections",
+                  :oncheck           => "miqOnCheckGeneric",
                   :checkboxes        => true,
                   :highlight_changes => true)
   end


### PR DESCRIPTION
Making this tree more similar to the others. Parent issue: #1871
@miq-bot add_label trees, refactoring, fine/no