### PR TITLE
Set the selectable to false in C&U trees rather than handle it in JS

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -164,15 +164,10 @@ function miqOnClickUtilization(id) {
   } else if (miqDomElementExists('bottlenecks_accord')) {
     tree = "bottlenecks_tree";
   }
-  if (id.split('-')[1].split('_')[0] == 'folder' ) {
-    miqTreeActivateNodeSilently(tree, id);
-    return;
-  } else {
-    var rep_id = id.split('__');
-    miqTreeActivateNodeSilently(tree, rep_id);
-    var url = "/miq_capacity/optimize_tree_select/?id=" + rep_id[0];
-    miqJqueryRequest(url, {beforeSend: true});
-  }
+  var rep_id = id.split('__');
+  miqTreeActivateNodeSilently(tree, rep_id);
+  var url = "/miq_capacity/optimize_tree_select/?id=" + rep_id[0];
+  miqJqueryRequest(url, {beforeSend: true});
 }
 
 // delete specific tree cookies

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -11,6 +11,10 @@ class TreeBuilderUtilization < TreeBuilderRegion
 
   private
 
+  def override(node, _object, _pid, _options)
+    node[:selectable] = node[:key].split('-')[1].split('_')[0] != 'folder'
+  end
+
   def set_locals_for_render
     locals = super
     locals.merge!(:onclick => "miqOnClickUtilization", :select_node => @selected_node.to_s)


### PR DESCRIPTION
This looks like something ancient, we have the `selectable` (formerly `cfmeNoClick`) parameter that allows us to make nodes expandable but not selectable. The JS I'm removing is basically doing the same...

Parent issue: #1871
@miq-bot add_label trees, fine/no, refactoring