### PR TITLE
Fix pdf download for configuration profiles

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -91,13 +91,6 @@ class AutomationManagerController < ApplicationController
     generic_x_show
   end
 
-  def identify_record(id, klass = self.class.model)
-    type, _id = parse_nodetype_and_id(x_node)
-    klass = TreeBuilder.get_model_for_prefix(type).constantize if type
-    record = super(id, klass)
-    record
-  end
-
   def tree_record
     @record =
       case x_active_tree

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -121,6 +121,13 @@ module Mixins
       render :layout => "application"
     end
 
+    def identify_record(id, klass = self.class.model)
+      type, _id = parse_nodetype_and_id(x_node)
+      klass = TreeBuilder.get_model_for_prefix(type).constantize if type
+      record = super(id, klass)
+      record
+    end
+
     def tree_autoload
       @view ||= session[:view]
       super

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -613,6 +613,29 @@ describe ProviderForemanController do
     end
   end
 
+  context 'download pdf file' do
+    let(:pdf_options) { controller.instance_variable_get(:@options) }
+
+    before :each do
+      @record = @config_profile
+      allow(PdfGenerator).to receive(:pdf_from_string).and_return("")
+      allow(controller).to receive(:tagdata).and_return(nil)
+      allow(controller).to receive(:x_node).and_return(config_profile_key(@config_profile))
+      login_as FactoryGirl.create(:user_admin)
+      stub_user(:features => :all)
+    end
+
+    it 'request returns 200' do
+      get :download_summary_pdf, :params => {:id => @record.id}
+      expect(response.status).to eq(200)
+    end
+
+    it 'title is set correctly' do
+      get :download_summary_pdf, :params => {:id => @record.id}
+      expect(pdf_options[:title]).to eq("#{ui_lookup(:model => @record.class.name)} \"#{@record.name}\"")
+    end
+  end
+
   def user_with_feature(features)
     features = EvmSpecHelper.specific_product_features(*features)
     FactoryGirl.create(:user, :features => features)


### PR DESCRIPTION
Move the identify_record to the manager_mixin to be used for the foreman provider to identify the record based on the tree object

Links 
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1471393

To Test : - try to download the pdf for a configuration profile

