### PR TITLE
Changed label "Location" to "Type", made field read-only after selection

### DIFF
--- a/app/views/miq_ae_class/_method_form.html.haml
+++ b/app/views/miq_ae_class/_method_form.html.haml
@@ -31,16 +31,20 @@
 
     .form-group
       %label.col-md-2.control-label
-        = _('Location')
+        = _('Type')
       .col-md-8
-        = select_tag("#{prefix}method_location",
-                      options_for_select(@edit[:new][:available_locations].sort,
-                      @edit[:new][:location]),
-                      :class    => "selectpicker",
-                      "data-miq_observe" => {:url => url}.to_json)
-        :javascript
-          miqInitSelectPicker();
-          miqSelectPickerEvent("#{prefix}method_location", "#{url}", {beforeSend: true})
+        - if @edit[:new][:location]
+          %p.form-control-static
+            = @edit[:new][:location]
+        - else
+          = select_tag("#{prefix}method_location",
+                        options_for_select([[_("<Choose>"), nil]] + @edit[:new][:available_locations].sort,
+                        @edit[:new][:location]),
+                        :class    => "selectpicker",
+                        "data-miq_observe" => {:url => url}.to_json)
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent("#{prefix}method_location", "#{url}", {beforeSend: true})
 
     - if @ae_method.created_on
       .form-group
@@ -48,25 +52,25 @@
           = _("Created On")
         .col-md-8
           = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
-
-    - if @edit[:new][:location] == 'expression'
-      .form-group
-        %label.col-md-2.control-label
-          = _('Expression Object')
-        .col-md-8
-          = select_tag("#{prefix}exp_object",
-                        options_for_select(@edit[:new][:available_expression_objects],
-                        @edit[:new][:exp_object]),
-                        :class    => "selectpicker",
-                        "data-miq_observe" => {:url => url}.to_json)
-          :javascript
-            miqInitSelectPicker();
-            miqSelectPickerEvent("#{prefix}exp_object", "#{url}",  {beforeSend: true})
-    - else
-      %hr
-      %h3= @edit[:new][:location] == 'builtin' ? _('Builtin name') : _("Data")
-      = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
-      %hr
+    - if @edit[:new][:location]
+      - if @edit[:new][:location] == 'expression'
+        .form-group
+          %label.col-md-2.control-label
+            = _('Expression Object')
+          .col-md-8
+            = select_tag("#{prefix}exp_object",
+                          options_for_select(@edit[:new][:available_expression_objects],
+                          @edit[:new][:exp_object]),
+                          :class    => "selectpicker",
+                          "data-miq_observe" => {:url => url}.to_json)
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent("#{prefix}exp_object", "#{url}",  {beforeSend: true})
+      - else
+        %hr
+        %h3= @edit[:new][:location] == 'builtin' ? _('Builtin name') : _("Data")
+        = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
+        %hr
   - if @edit[:new][:location] == 'expression'
     .div
       %h3= _("Expression (Choose an element of the expression to edit)")

--- a/app/views/miq_ae_class/_method_form.html.haml
+++ b/app/views/miq_ae_class/_method_form.html.haml
@@ -4,39 +4,11 @@
   %h3
     = _('Main Info')
   .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
-        = Dictionary.gettext('fqname', :type => :column, :notfound => :titleize)
-      .col-md-8
-        %p.form-control-static
-          = h(@sb[:namespace_path])
-    .form-group
-      %label.col-md-2.control-label
-        = _('Name')
-      .col-md-8
-        = text_field_tag("#{prefix}method_name",
-                        @edit[:new][:name],
-                        :maxlength         => ViewHelper::MAX_NAME_LEN,
-                        :class => "form-control",
-                        "data-miq_observe" => obs)
-    .form-group
-      %label.col-md-2.control-label
-        = _('Display Name')
-      .col-md-8
-        = text_field_tag("#{prefix}method_display_name",
-                        @edit[:new][:display_name],
-                        :maxlength         => ViewHelper::MAX_NAME_LEN,
-                        :class => "form-control",
-                        "data-miq_observe" => obs)
-
-    .form-group
-      %label.col-md-2.control-label
-        = _('Type')
-      .col-md-8
-        - if @edit[:new][:location]
-          %p.form-control-static
-            = @edit[:new][:location]
-        - else
+    - unless @edit[:new][:location]
+      .form-group
+        %label.col-md-2.control-label
+          = _('Type')
+        .col-md-8
           = select_tag("#{prefix}method_location",
                         options_for_select([[_("<Choose>"), nil]] + @edit[:new][:available_locations].sort,
                         @edit[:new][:location]),
@@ -45,48 +17,82 @@
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent("#{prefix}method_location", "#{url}", {beforeSend: true})
-
-    - if @ae_method.created_on
+    - else
       .form-group
         %label.col-md-2.control-label
-          = _("Created On")
+          = _('Type')
         .col-md-8
-          = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
-    - if @edit[:new][:location]
-      - if @edit[:new][:location] == 'expression'
+          %p.form-control-static
+            = @edit[:new][:location]
+      .form-group
+        %label.col-md-2.control-label
+          = Dictionary.gettext('fqname', :type => :column, :notfound => :titleize)
+        .col-md-8
+          %p.form-control-static
+            = h(@sb[:namespace_path])
+      .form-group
+        %label.col-md-2.control-label
+          = _('Name')
+        .col-md-8
+          = text_field_tag("#{prefix}method_name",
+                          @edit[:new][:name],
+                          :maxlength         => ViewHelper::MAX_NAME_LEN,
+                          :class => "form-control",
+                          "data-miq_observe" => obs)
+      .form-group
+        %label.col-md-2.control-label
+          = _('Display Name')
+        .col-md-8
+          = text_field_tag("#{prefix}method_display_name",
+                          @edit[:new][:display_name],
+                          :maxlength         => ViewHelper::MAX_NAME_LEN,
+                          :class => "form-control",
+                          "data-miq_observe" => obs)
+
+      - if @ae_method.created_on
         .form-group
           %label.col-md-2.control-label
-            = _('Expression Object')
+            = _("Created On")
           .col-md-8
-            = select_tag("#{prefix}exp_object",
-                          options_for_select(@edit[:new][:available_expression_objects],
-                          @edit[:new][:exp_object]),
-                          :class    => "selectpicker",
-                          "data-miq_observe" => {:url => url}.to_json)
-            :javascript
-              miqInitSelectPicker();
-              miqSelectPickerEvent("#{prefix}exp_object", "#{url}",  {beforeSend: true})
-      - else
-        %hr
-        %h3= @edit[:new][:location] == 'builtin' ? _('Builtin name') : _("Data")
-        = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
-        %hr
-  - if @edit[:new][:location] == 'expression'
-    .div
-      %h3= _("Expression (Choose an element of the expression to edit)")
-      = render :partial => 'layouts/exp_editor'
-  %h3= _("Input Parameters")
-  %table.table.table-bordered.table-striped
-    %thead
-      %tr
-        %th
-          - icon = @sb[:squash_state] ? "down" : "up"
-          - url2 = url_for_only_path(:action => 'expand_toggle', :id => "exp_collapse")
-          %button.btn.btn-default{:title => (@sb[:squash_state] ? _("Show Input Parameters") : _("Hide Input Parameters")),
-                  "data-miq_sparkle_on" => true,
-                  :remote               => true,
-                  "data-method"         => :post,
-                  :id                   => 'exp_collapse_img',
-                  'data-click_url'      => {:url => url2}.to_json}
-            %i{:class => "fa fa-angle-#{icon} fa-lg"}
-  = render :partial => "inputs"
+            = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
+      - if @edit[:new][:location]
+        - if @edit[:new][:location] == 'expression'
+          .form-group
+            %label.col-md-2.control-label
+              = _('Expression Object')
+            .col-md-8
+              = select_tag("#{prefix}exp_object",
+                            options_for_select(@edit[:new][:available_expression_objects],
+                            @edit[:new][:exp_object]),
+                            :class    => "selectpicker",
+                            "data-miq_observe" => {:url => url}.to_json)
+              :javascript
+                miqInitSelectPicker();
+                miqSelectPickerEvent("#{prefix}exp_object", "#{url}",  {beforeSend: true})
+        - else
+          %hr
+          %h3= @edit[:new][:location] == 'builtin' ? _('Builtin name') : _("Data")
+          = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
+          %hr
+    - if @edit[:new][:location] == 'expression'
+      .div
+        %h3= _("Expression (Choose an element of the expression to edit)")
+        = render :partial => 'layouts/exp_editor'
+
+    - if @edit[:new][:location]
+      %h3= _("Input Parameters")
+      %table.table.table-bordered.table-striped
+        %thead
+          %tr
+            %th
+              - icon = @sb[:squash_state] ? "down" : "up"
+              - url2 = url_for_only_path(:action => 'expand_toggle', :id => "exp_collapse")
+              %button.btn.btn-default{:title => (@sb[:squash_state] ? _("Show Input Parameters") : _("Hide Input Parameters")),
+                      "data-miq_sparkle_on" => true,
+                      :remote               => true,
+                      "data-method"         => :post,
+                      :id                   => 'exp_collapse_img',
+                      'data-click_url'      => {:url => url2}.to_json}
+                %i{:class => "fa fa-angle-#{icon} fa-lg"}
+
+      = render :partial => "inputs"

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -23,7 +23,7 @@
             = @ae_method.display_name
       .form-group
         %label.col-md-2.control-label
-          = _('Location')
+          = _('Type')
         .col-md-8
           %p.form-control-static
             = @ae_method.location

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -5,6 +5,12 @@
     .form-horizontal.static
       .form-group
         %label.col-md-2.control-label
+          = _('Type')
+        .col-md-8
+          %p.form-control-static
+            = @ae_method.location
+      .form-group
+        %label.col-md-2.control-label
           = Dictionary.gettext('fqname', :type => :column, :notfound => :titleize)
         .col-md-8
           %p.form-control-static
@@ -21,12 +27,6 @@
         .col-md-8
           %p.form-control-static
             = @ae_method.display_name
-      .form-group
-        %label.col-md-2.control-label
-          = _('Type')
-        .col-md-8
-          %p.form-control-static
-            = @ae_method.location
       .form-group
         %label.col-md-2.control-label
           = _('Created On')


### PR DESCRIPTION
Changed code to make Type as read only field once user selects the type of Add new method screen. Type field will be read only field on Edit Method screen.

https://www.pivotaltracker.com/story/show/149747321

@dclarizio please review.

before:
![add_method_before](https://user-images.githubusercontent.com/3450808/29372509-5b487084-8279-11e7-89d6-923f6a54c430.png)

![edit_method_before](https://user-images.githubusercontent.com/3450808/29372513-5ec47690-8279-11e7-8fa4-c8dd1585047e.png)

![method_summary_before](https://user-images.githubusercontent.com/3450808/29425742-5e114672-8352-11e7-9022-8edc7047b873.png)


after:
![add_method_after1](https://user-images.githubusercontent.com/3450808/29421931-94ce2c38-8344-11e7-8016-2e06af71822a.png)

![add_method_after](https://user-images.githubusercontent.com/3450808/29425663-1aee0470-8352-11e7-9c3f-45c33582a8fd.png)

![edit_method_after](https://user-images.githubusercontent.com/3450808/29425667-1e662ea2-8352-11e7-8a88-1c9a4ee33982.png)

![method_summary](https://user-images.githubusercontent.com/3450808/29425679-22055eac-8352-11e7-859f-428d0e69b69b.png)
