### PR TITLE
Restyle Button Edit Screen

### DIFF
--- a/app/views/layouts/_ae_resolve_options.html.haml
+++ b/app/views/layouts/_ae_resolve_options.html.haml
@@ -9,7 +9,7 @@
     %h3
       = _("Object Details")
     .form-group
-      %label.col-md-3.control-label
+      %label.col-md-2.control-label
         = _("System/Process")
       .col-md-8
         = select_tag('instance_name',
@@ -22,7 +22,7 @@
           miqInitSelectPicker();
           miqSelectPickerEvent('instance_name', "#{url}")
   .form-group
-    %label.col-md-3.control-label
+    %label.col-md-2.control-label
       = _("Message")
     .col-md-8
       = text_field_tag("object_message",
@@ -34,7 +34,7 @@
       - unless is_browser_ie?
         = javascript_tag("if (!$('#description').length) #{javascript_focus('object_message')}")
   .form-group
-    %label.col-md-3.control-label
+    %label.col-md-2.control-label
       = _("Request")
     .col-md-8
       = text_field_tag("object_request",
@@ -49,7 +49,7 @@
       = _("Object Attribute")
     .form-horizontal
       .form-group
-        %label.col-md-3.control-label
+        %label.col-md-2.control-label
           = _("Type")
         .col-md-8
           = ui_lookup(:model => @resolve[:target_class])
@@ -59,7 +59,7 @@
       = _("Object Attribute")
     .form-horizontal
       .form-group
-        %label.col-md-3.control-label
+        %label.col-md-2.control-label
           = _("Type")
         .col-md-8
           = select_tag('target_class',
@@ -73,7 +73,7 @@
             miqSelectPickerEvent('target_class', "#{url}")
       - if resolve[:new][:target_class] && !resolve[:new][:target_class].blank? && resolve[:targets]
         .form-group
-          %label.col-md-3.control-label
+          %label.col-md-2.control-label
             = _("Selection")
           .col-md-8
             = select_tag('target_id',
@@ -91,7 +91,7 @@
     = _("Simulation Parameters")
   .form-horizontal
     .form-group
-      %label.col-md-3.control-label
+      %label.col-md-2.control-label
         = _("Execute Methods")
       .col-md-8
         = check_box_tag("readonly",
@@ -106,7 +106,7 @@
     - f = "attribute_" + (i + 1).to_s
     - v = "value_" + (i + 1).to_s
     .form-group
-      %label.col-md-3.control-label
+      %label.col-md-2.control-label
         = (i + 1).to_s
       .col-md-4
         = text_field_tag(f,

--- a/app/views/layouts/_custom_button_expression.html.haml
+++ b/app/views/layouts/_custom_button_expression.html.haml
@@ -1,25 +1,37 @@
--# expression_type 
+-# expression_type
 - table_key = "#{expression_type}_table".to_sym
 
-.div{:id => "form_#{expression_type}_div"}
+.form-horizontal{:id => "form_#{expression_type}_div"}
   - if @expkey == expression_type
-    %h3= title + _("(Choose an element of the expression to edit)")
-    = render :partial => 'layouts/exp_editor'
+    .form-group
+      %label.control-label.col-md-2
+        = title
+      .col-md-8
+        =_("Choose an element of the expression to edit")
+        = render :partial => 'layouts/exp_editor'
   - else
-    %h3= title + _('(Press the "Edit" button to edit the expression)')
-    = link_to(image_tag('toolbars/edit.png', :border => "0", :alt => (t = _("Edit this Expression"))),
-      {:action => 'button_update', :button => expression_type},
-      {"data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :remote => true, "data-method" => :post, :title => t})
-    %br
-    - if @edit[table_key].nil?
-      = render :partial => 'layouts/info_msg',
-               :locals  => {:message => _("No enablement expression defined.")}
-    - else
-      - @edit[table_key].each do |token|
-        - if !["AND", "OR", "(", ")"].include?([token].flatten.first)
-          = h([token].flatten.first)
-        - else
-          %font{:color => "black"}
-            %b
-              = h([token].flatten.first)
+    .form-group
+      %label.control-label.col-md-2
+        = title
+      .col-md-8
+        = link_to({:action => "button_update",
+                      :button => expression_type},
+                      "data-miq_sparkle_on" => true,
+                      "data-miq_sparkle_off" => true,
+                      :remote => true,
+                      "data-method" => :post) do
+          %button.btn.btn-default
+            - if @edit[table_key].nil?
+              = _("Define Expression")
+            - else
+              = _("Edit Expression")
 
+        - unless @edit[table_key].nil?
+          .spacer
+          - @edit[table_key].each do |token|
+            - if !["AND", "OR", "(", ")"].include?([token].flatten.first)
+              = h([token].flatten.first)
+            - else
+              %font{:color => "black"}
+                %b
+                  = h([token].flatten.first)

--- a/app/views/layouts/_exp_editor.html.haml
+++ b/app/views/layouts/_exp_editor.html.haml
@@ -9,7 +9,7 @@
 #exp_editor_div
   = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'exp_editor_flash'}
   %fieldset
-    .toolbar-pf-actions
+    .toolbar-pf-actions{:style => "margin-left: 20px"}
       .form-group
         - if @edit[@expkey].history.idx > 0
           - t = _('Undo the last change')

--- a/app/views/layouts/_role_enablement_expression.html.haml
+++ b/app/views/layouts/_role_enablement_expression.html.haml
@@ -1,3 +1,3 @@
 = render :partial => 'layouts/custom_button_expression', 
          :locals => {:expression_type => :enablement_expression,
-                     :title => _('Enablement Expression')}
+                     :title => _('Expression')}

--- a/app/views/layouts/_role_visibility.html.haml
+++ b/app/views/layouts/_role_visibility.html.haml
@@ -2,7 +2,7 @@
 #form_role_visibility
   %hr
   %h3
-    = _("Visibility")
+    = _("Role Access")
   .form-horizontal
     .form-group
       %label.control-label.col-md-2

--- a/app/views/layouts/_role_visibility_expression.html.haml
+++ b/app/views/layouts/_role_visibility_expression.html.haml
@@ -1,3 +1,3 @@
 = render :partial => 'layouts/custom_button_expression',
          :locals => {:expression_type => :visibility_expression,
-                     :title => _('Visibility Expression')}
+                     :title => _('Expression')}

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -21,7 +21,7 @@
       - exptypes -= [[_(EXP_FIND_TYPE[0]), EXP_FIND_TYPE[1]]]
   #exp_atom_editor_div
     %fieldset
-      .toolbar-pf-actions
+      .toolbar-pf-actions{:style => "margin-left: 20px"}
         .form-group
           - t = _('Commit expression element changes')
           %button.btn.btn-default{"data-method" => :post,

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -18,7 +18,7 @@
         :title => _("Paste is not available, no object information has been copied from the Simulation screen"))
   = render :partial => "layouts/flash_msg"
   %h3
-    = _('Action')
+    = _('Options')
   .form-horizontal
     .form-group
       %label.control-label.col-md-2
@@ -90,17 +90,27 @@
                      options_for_select([[_('Submit all'), 'all'], [_('One by one'), 'one']], @edit[:new][:submit_how]),
                      "data-miq_sparkle_on" => true,
                     )
-  = render(:partial => "layouts/role_enablement_expression",
+    %hr
+    %h3
+      = _('Enablement')
+    = render(:partial => "layouts/role_enablement_expression",
            :locals  => {:rec_id => @custom_button ? @custom_button.id : 'new', :action => "automate_button_field_changed"})
-%h3
-  = _('Disabled Button Text')
-  .form-horizontal.static
-    = text_field_tag("disabled_text", @edit[:new][:disabled_text],
-                          :maxlength         => 50,
-                          :class             => "form-control",
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+
+    .form-group
+      %label.control-label.col-md-2
+        = _('Disabled Button Text')
+      .col-md-8
+        = text_field_tag("disabled_text", @edit[:new][:disabled_text],
+                              :maxlength         => 50,
+                              :class             => "form-control",
+                              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %hr
+  %h3
+    = _('Visibility')
   = render(:partial => "layouts/role_visibility_expression",
            :locals  => {:rec_id => @custom_button ? @custom_button.id : 'new', :action => "automate_button_field_changed"})
+
+
   = render(:partial => "layouts/ae_resolve_options",
     :locals         => {:resolve => @edit,
       :form_action               => "ae_resolve",

--- a/app/views/shared/buttons/_ab_show.html.haml
+++ b/app/views/shared/buttons/_ab_show.html.haml
@@ -83,20 +83,20 @@
         = _('Selection')
       .col-md-8
         = h(@resolve[:new][:target_id])
-%hr
 
-%h3
-  = _("Enablement Expression")
-.form-horizontal.static
-  - if @custom_button && !@custom_button.enablement_expression.nil? && @custom_button.enablement_expression.kind_of?(MiqExpression)
-    = h(@custom_button.enablement_expression.to_human)
-  - else
-    = render :partial => 'layouts/info_msg', :locals => {:message => _("No Enablement Expression defined, this button will be always enabled")}
-%hr
-%h3
-  = _('Disabled Button Text')
-.form-horizontal.static
-  = h(@custom_button.disabled_text)
+  .form-group
+    %label.control-label.col-md-2
+      = _("Enablement Expression")
+    .col-md-8
+      - if @custom_button && !@custom_button.enablement_expression.nil? && @custom_button.enablement_expression.kind_of?(MiqExpression)
+        = h(@custom_button.enablement_expression.to_human)
+      - else
+        = render :partial => 'layouts/info_msg', :locals => {:message => _("No Enablement Expression defined, this button will be always enabled")}
+  .form-group
+    %label.control-label.col-md-2
+      = _('Disabled Button Text')
+    .col-md-8
+      = h(@custom_button.disabled_text)
 
 %hr
 


### PR DESCRIPTION
This PR is a first pass at cleaning up the styling of the Button Edit Screen. It standardizes all items into the form-horizontal layout and relabels items for clarity.

Follow-up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/1792

Before
<img width="1030" alt="screen shot 2017-08-16 at 1 18 03 pm" src="https://user-images.githubusercontent.com/1287144/29376093-66d23d20-8285-11e7-9589-d75d0c2f3783.png">
<img width="1023" alt="screen shot 2017-08-16 at 1 18 10 pm" src="https://user-images.githubusercontent.com/1287144/29376092-66c7d718-8285-11e7-9b41-b0acb0b19e00.png">



After
<img width="1105" alt="screen shot 2017-08-17 at 12 21 00 pm" src="https://user-images.githubusercontent.com/1287144/29422652-e21a5c08-8346-11e7-9299-fd0dc9ea06bb.png">
<img width="1109" alt="screen shot 2017-08-17 at 12 21 10 pm" src="https://user-images.githubusercontent.com/1287144/29422651-e21a2ba2-8346-11e7-9450-0278ce18e053.png">
