### PR TITLE
Use decorators to determine root node icons in custom buttons tree

### DIFF
--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -1,5 +1,9 @@
 class ExtManagementSystemDecorator < MiqDecorator
   def self.fonticon
+    'pficon pficon-server'
+  end
+
+  def fonticon
     nil
   end
 

--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -1,0 +1,5 @@
+class MiqTemplateDecorator < MiqDecorator
+  def self.fonticon
+    'ff ff-template'
+  end
+end

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -1,5 +1,9 @@
 class VmOrTemplateDecorator < MiqDecorator
   def self.fonticon
+    'pficon pficon-virtual-machine'
+  end
+
+  def fonticon
     nil
   end
 

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -17,13 +17,21 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(_count_only, _options)
-    resolve = {}
-    CustomButton.button_classes.each { |db| resolve[db] = ui_lookup(:model => db) }
-    @sb[:target_classes] = resolve.invert
-    resolve = Array(resolve.invert).sort
-    resolve.collect do |typ|
-      {:id => "ab_#{typ[1]}", :text => typ[0], :tip => typ[0]}.merge(buttons_node_image(typ[1]))
+    @sb[:target_classes] = {}
+    buttons = CustomButton.button_classes.map do |klass|
+      name = ui_lookup(:model => klass)
+      # FIXME: This is probably a session backed caching of a small hash and it should be removed
+      @sb[:target_classes][name] = klass
+
+      {
+        :id   => "ab_#{klass}",
+        :text => name,
+        :tip  => name,
+        :icon => klass.safe_constantize.try(:decorate).try(:fonticon)
+      }
     end
+
+    buttons.sort_by { |button| button[:text] }
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
@@ -34,19 +42,5 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
       CustomButtonSet.new(:name => "[Unassigned Buttons]|ub-#{nodes[1]}", :description => "[Unassigned Buttons]")
     )
     count_only_or_objects(count_only, objects)
-  end
-
-  def buttons_node_image(node)
-    case node
-    when 'ExtManagementSystem' then {:icon  => 'pficon pficon-server'}
-    when 'CloudTenant'         then {:icon  => 'pficon-cloud-tenant'}
-    when 'EmsCluster'          then {:icon  => 'pficon pficon-cluster'}
-    when 'Host'                then {:icon  => 'pficon pficon-screen'}
-    when 'MiqTemplate'         then {:icon  => 'ff ff-template'}
-    when 'Service'             then {:icon  => 'pficon pficon-service'}
-    when 'Storage'             then {:icon  => 'fa fa-database'}
-    when 'Vm'                  then {:icon  => 'pficon pficon-virtual-machine'}
-    when 'PhysicalServer'      then {:icon  => 'pficon pficon-enterprise'}
-    end
   end
 end


### PR DESCRIPTION
Automation -> Automate -> Customization -> Buttons

One more place to remove :scissors: :toilet: static fonticon definitions :scissors: :toilet:  from. The `x_get_tree_roots` method was iterating too many times and in a not very functional way so I also refactored it. 

Two `self.fonticon` definitions were intentionally missing as we prefer SVG icons on them. I sorted it out by setting their `fonticon` to `nil`. This way it allows us to:
```ruby
Vm.decorate.fonticon
=> "pficon pficon-virtual-machine"

Vm.first.decorate.fonticon
=> nil
```

The `@sb[:target_classes]` classes is probably a session-backed caching and it should be removed in a future PR as we can always re-generate the hash fast and easy.

@miq-bot add_label trees, technical debt, fine/no
@miq-bot assign @ZitaNemeckova, @himdel, @epwinchell 