### PR TITLE
Container list - fix Cannot read property subscribe of undefined

### DIFF
--- a/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
@@ -245,7 +245,7 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
       return true;
     };
 
-    ManageIQ.rxSubject.subscribe(function(event) {
+    ManageIQ.angular.rxSubject.subscribe(function(event) {
       if (event.controller !== 'containers.deployProviderController') {
         return;
       }


### PR DESCRIPTION
Introduced in #1903.

Go to Compute > Containers > Providers

```
TypeError: Cannot read property 'subscribe' of undefined
   at new <anonymous> (deploy-provider-controller.self-d357ab1….js:248)
```

(in browser console)

Adding that missing `.angular`

Cc @mzazrivec 