### PR TITLE
Introducing a controller that returns automate entry point tree JSON

### DIFF
--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -1,0 +1,16 @@
+# This is a highly experimental implementation of something that we would like to have probably in an UI-API
+# It is definitely not a good example and it SHOULD NOT BE COPY-PASTED in any case
+class TreeController < ApplicationController
+  before_action :check_privileges
+
+  def automate_entrypoint
+    tree = TreeBuilderAutomateEntrypoint.new(:automate_entrypoint, :automate_entrypoint_tree, {})
+    json = if params[:id]
+             TreeBuilder.convert_bs_tree(tree.x_get_child_nodes(params[:id])).to_json
+           else
+             tree.instance_variable_get(:@bs_tree)
+           end
+
+    render :body => json, :content_type => 'application/json'
+  end
+end

--- a/app/presenters/tree_builder_automate_entrypoint.rb
+++ b/app/presenters/tree_builder_automate_entrypoint.rb
@@ -1,0 +1,12 @@
+class TreeBuilderAutomateEntrypoint < TreeBuilderAutomate
+  def override(node, object, _pid, _options)
+    node.delete(:selectable)
+    node[:dataAttr] = {:fqname => object.fqname} if object.try(:fqname)
+  end
+
+  def root_options
+    root = super
+    root.delete(:selectable)
+    root
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3348,6 +3348,9 @@ Rails.application.routes.draw do
     end
   end
 
+  # API-like JSON trees
+  get '/tree/automate_entrypoint', :to => 'tree#automate_entrypoint'
+
   # pure-angular templates
   get '/static/*id' => 'static#show', :format => false
 


### PR DESCRIPTION
:fire: :fire:  Dialog editor calls for aid! And TreeBuilderAutomateEntrypoint will answer! :trumpet: :trumpet: 

The dialog editor component needs a way to fetch the automate tree in JSON form. The data format is given and it won't change, but the way how I implemented this is not final and this piece of code should not be used as an example in any case. 

If you send a GET request to `/tree/automate_entrypoint`, it sends back the collapsed root node(s) with `isLazy` set to `true`. If you send a POST request with a lazy node's key as an `id` attribute, it will return the node expanded with its children. The routes aren't final, I'd like to ask @martinpovolny's help for GET vs POST vs CSRF security.

**EDIT: Using GET for both lazy and root node requests, so no CSRF issues**

We can't move this to the API as we're using TreeBuilders that are living in the UI repo. However, in the future I'd like to see these things fully API-driven.


