### PR TITLE
Quad icons for containers providers

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -383,7 +383,7 @@ table.table.table-summary-screen tbody td img {
 }
 
 .flobj { position: absolute;z-index: auto;width: 72px;}
-.flobj p { margin: 5px 0 0 0;padding: 0;color: #e3e4e4;vertical-align: middle;text-align:center;text-transform: none;text-shadow: 0 0 3px #000;font: normal 16px OpenSansSemibold,Arial,Helvetica,sans-serif !important;}
+.flobj p { margin: 5px 0 0 0;padding: 0;color: #e3e4e4;vertical-align: middle;text-align:center;text-transform: none;text-shadow: 0 0 3px #000;font: normal 16px OpenSansSemibold,Arial,Helvetica,sans-serif;}
 .a72 { padding: 3px  0 0 5px; width: 28px; height: 28px;font-size: 1.3em;line-height: 1.8em;}
 .b72 { padding: 3px 0 0 37px; font-size: 1.3em;line-height: 1.8em;}
 .c72 { padding: 38px 0 0 5px; width: 31px; height: 31px;font-size: 1.3em;line-height: 1.7em;}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -93,7 +93,8 @@ class ApplicationController < ActionController::Base
       :miq_template    => true,
       :physical_server => true,
       :storage         => true,
-      :vm              => true
+      :vm              => true,
+      :ems_container   => true
     },
     :views     => { # List view setting, by resource type
       :authkeypaircloud                         => "list",

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -547,6 +547,7 @@ class ConfigurationController < ApplicationController
     when "ui_1"                                               # Visual Settings tab
       @edit[:new][:quadicons][:ems] = params[:quadicons_ems] == "true" if params[:quadicons_ems]
       @edit[:new][:quadicons][:ems_cloud] = params[:quadicons_ems_cloud] == "true" if params[:quadicons_ems_cloud]
+      @edit[:new][:quadicons][:ems_container] = params[:quadicons_ems_container] == "true" if params[:quadicons_ems_container]
       @edit[:new][:quadicons][:host] = params[:quadicons_host] == "true" if params[:quadicons_host]
       @edit[:new][:quadicons][:vm] = params[:quadicons_vm] == "true" if params[:quadicons_vm]
       @edit[:new][:quadicons][:physical_server] = params[:quadicons_physical_server] == "true" if params[:quadicons_physical_server]

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -441,9 +441,9 @@ module QuadiconHelper
     flobj_img_simple(image, cls, 64)
   end
 
-  def flobj_p_simple(cls, text)
+  def flobj_p_simple(cls, text, test_style = nil)
     content_tag(:div, :class => "flobj #{cls}") do
-      content_tag(:p, text)
+      content_tag(:p, text, :style => test_style)
     end
   end
 
@@ -558,11 +558,14 @@ module QuadiconHelper
       item_count = case item
                    when EmsPhysicalInfra then item.physical_servers.size
                    when EmsCloud         then item.total_vms
+                   when ::ManageIQ::Providers::ContainerManager then item.container_nodes.size
                    else
                      item.hosts.size
                    end
-      output << flobj_p_simple("a72", item_count)
+      # reduce font-size of the item_count so it will fit in its quadrant
+      output << flobj_p_simple("a72", item_count, item_count.to_s.size > 2 ? "font-size: 12px;" : "")
       output << flobj_p_simple("b72", item.total_miq_templates) if item.kind_of?(EmsCloud)
+      output << currentstate_icon(item.enabled? ? "on" : "paused") if item.kind_of?(::ManageIQ::Providers::ContainerManager)
       output << flobj_img_simple("svg/vendor-#{h(item.image_name)}.svg", "c72")
       output << flobj_img_simple(img_for_auth_status(item), "d72")
       output << flobj_img_simple('100/shield.png', "g72") unless item.get_policies.empty?

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -15,6 +15,7 @@
           -# Host Item is commented (condition set as false) until we have host item quads
           - [[role_allows?(:feature => "ems_infra_show_list"), ui_lookup(:table => "ems_infra"),          "ems"],
              [role_allows?(:feature => "ems_cloud_show_list"), ui_lookup(:table => "ems_cloud"),          "ems_cloud"],
+             [role_allows?(:feature => "ems_container_show_list"), ui_lookup(:table => "ems_container"),  "ems_container"],
              [role_allows?(:feature => "host_show_list"),      _("Host"),                                 "host"],
              [role_allows?(:feature => "storage_show_list"),   ui_lookup(:table => "storages"),           "storage"],
              [true,                                           _("VM"),                                   "vm"],


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1484770
Followup for #1663 
Add quadicons for containers providers 
![screencapture-localhost-3000-ems_container-show_list-1502983563166 1](https://user-images.githubusercontent.com/11256940/29420088-aab476ee-8379-11e7-8a16-c318c19df131.png)

@himdel @serenamarie125 @simon3z Please review

