### PR TITLE
Added missing routes for expression editor.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -327,6 +327,7 @@ Rails.application.routes.draw do
         x_show
       ) +
                button_post +
+               exp_post +
                dialog_runner_post
     },
 


### PR DESCRIPTION
After Expressions were added to custom buttons, needed to add expression editor related routes to catalog explorer section as custom buttons can be added from Catalogs explorer as well.

Fixes error when trying to Add a Custom button for a selected Catalog Item in Catalogs Explorer.
F, [2017-08-17T13:54:44.149991 #15450] FATAL -- : Error caught: [ActionView::Template::Error] No route matches {:action=>"exp_button", :controller=>"catalog", :id=>"10000000000018", :pressed=>"and"}

@lgalis please review.
