### PR TITLE
Adds rails-controller-testing to ui-classic

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "guard-rspec", '~> 4.7.3'
+  s.add_development_dependency "rails-controller-testing", '~> 1.0.2'
   s.add_development_dependency "simplecov"
 
   # core because jasmine has < 3.0, not < 2.6


### PR DESCRIPTION
This should be the only repo that needs this when running tests, so maintaining this here means that only this repo requires it as a dependency, not every repo that uses `ManageIQ/manageiq` in it for testing.

Related to https://github.com/ManageIQ/manageiq/pull/15852 and arguably should be merged after that PR has been merged (so we can confirm this one works).  That said, this will cause master for this repo to fail for a bit, so something to consider.


Links
-----

* https://github.com/ManageIQ/manageiq/pull/15852


Steps for Testing/QA
--------------------

Confirm the test suite passes after https://github.com/ManageIQ/manageiq/pull/15852 has been merged.