### PR TITLE
controller name adjustment no longer needed for `provider_foreman`

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -285,8 +285,6 @@ module ApplicationHelper
             "ansible_credential"
           elsif record.kind_of?(ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource)
             "ansible_repository"
-          elsif record.kind_of?(ManageIQ::Providers::Foreman::ConfigurationManager)
-            "provider_foreman"
           elsif record.class.respond_to?(:db_name)
             record.class.db_name
           else


### PR DESCRIPTION
The PR is basically a revert of 1f6221d7ad1f5fc330d5c9b8725c510946b538cb (https://github.com/ManageIQ/manageiq-ui-classic/pull/1847)

@himdel @karelhala Like I had indicated in https://github.com/ManageIQ/manageiq-ui-classic/pull/1847, we never really needed this `controller name` adjustment for `provider_foreman` before. 
Something changed last week which caused the below error -
```
-07T12:14:07.262478 #36969] FATAL -- : Error caught: [ActionController::UrlGenerationError] No route matches {:action=>"show", :controller=>"ems_configuration", :id=>"29"}

```
but now, the issue seems to have fixed itself, just like that, and we do not need the https://github.com/ManageIQ/manageiq-ui-classic/pull/1847 fix anymore.

What broke it, and what fixed it, remains a mystery.
(My hunch is webpack related changes had something to do with it)

So let's remove those lines since they are not needed anymore.
Let's get a better handle on the issue if it resurfaces. Thanks.