### PR TITLE
Remove dead method buttons_node_image

### DIFF
--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -3,17 +3,6 @@ module MiqAeCustomizationController::CustomButtons
 
   private
 
-  def buttons_node_image(node)
-    case node
-    when "ExtManagementSystem"
-      return "ext_management_system"
-    when "MiqTemplate"
-      return "vm"
-    else
-      return node.downcase
-    end
-  end
-
   def ab_get_node_info(node)
     @nodetype = node.split("_")
     nodeid = node.split("-")


### PR DESCRIPTION
There is a [single mention](https://github.com/ManageIQ/manageiq-ui-classic/blob/fcc58051e2667ad53848698e0e43caf45914122a/app/presenters/tree_builder_buttons.rb#L25) of this method, but it's a call for a [different method](https://github.com/ManageIQ/manageiq-ui-classic/blob/fcc58051e2667ad53848698e0e43caf45914122a/app/presenters/tree_builder_buttons.rb#L39) with the same name that will be [removed anyway](https://github.com/ManageIQ/manageiq-ui-classic/pull/1942).

@miq-bot add_label technical debt, fine/no
@miq-bot assign @mzazrivec 