### PR TITLE
get_db_view - remove all_vms_and_templates association for infra vms as well

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1650,9 +1650,13 @@ class ApplicationController < ActionController::Base
   end
 
   def get_db_view(db, options = {})
-    if db == "ManageIQ_Providers_InfraManager_Template" && options[:association] == "all_vms_and_templates"
+    if %w(
+         ManageIQ_Providers_InfraManager_Template
+         ManageIQ_Providers_InfraManager_Vm
+       ).include?(db) && options[:association] == "all_vms_and_templates"
       options[:association] = nil
     end
+
     MiqReport.load_from_view_options(db, current_user, options, db_view_yaml_cache)
   end
 


### PR DESCRIPTION
Closes ManageIQ/manageiq#15846

In Compute > Infra > Vms .. go to Vms accordion, go to a Vm detail, toolbar Policy > Edit tags.
`no implicit conversion of nil into String` happens when trying to load the list of vms to tag.

That's because `get_db_view` is only looking for `ManageIQ_Providers_InfraManager_Vm-all_vms_and_templates.yaml`, which doesn't exist. `ManageIQ_Providers_InfraManager_Vm.yml`, which does, is never looked for when the association is set.

This is the missing half of https://github.com/ManageIQ/manageiq-ui-classic/pull/1290 which fixed the same problem for templates but not vms.

This happens only in infra, not cloud. (For cloud, the product views exist *with* the association in the name.)