### PR TITLE
Removed Waiting_to_start from the list of possible states for MiqTask

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -74,7 +74,7 @@ module UiConstants
     5 => N_("5 Days Ago"),
     6 => N_("6 Days Ago")
   }
-  TASK_STATES = [[N_("Initializing"), "initializing"], [N_("Waiting to Start"), "Waiting_to_start"],
+  TASK_STATES = [[N_("Initializing"), "initializing"],
                  [N_("Cancelling"), "Cancelling"], [N_("Aborting"), "Aborting"], [N_("Finished"), "Finished"],
                  [N_("Snapshot Create"), "Snapshot_create"], [N_("Scanning"), "Scanning"],
                  [N_("Snapshot Delete"), "Snapshot_delete"], [N_("Synchronizing"), "Synchronizing"],


### PR DESCRIPTION
After merging https://github.com/ManageIQ/manageiq/pull/14679 task can not have 'Waiting_to_start' state.

@miq-bot add-label core
\cc @gtanzillo @dclarizio
