### PR TITLE
Use to_s instead of message

### DIFF
--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -78,7 +78,7 @@ class HawkularProxyService
   rescue StandardError => e
     {
       :parameters => params,
-      :error      => ActionView::Base.full_sanitizer.sanitize(e.message) + " " + _("(Please check your Hawkular server)")
+      :error      => ActionView::Base.full_sanitizer.sanitize(e.to_s) + " " + _("(Please check your Hawkular server)")
     }
   end
 


### PR DESCRIPTION
**Description**
Some errors from the Hawkular client do not supply a string `#message` method. Using `#to_s` instead of `#message` is safe here, it falles back to `#message` if we have one, and supply sane string if `#message` is not a string.

**Screenshots**
Problem:
( e.message retruns another `Hawkular::ConnectionException` object )
![screenshot-localhost 3000-2017-08-20-11-52-24](https://user-images.githubusercontent.com/2181522/29493590-fc68216e-85a1-11e7-9d24-e955a611cb7a.png)

Fix:
![screenshot-localhost 3000-2017-08-20-12-16-47](https://user-images.githubusercontent.com/2181522/29493589-fc66a49c-85a1-11e7-8eb5-bdd8f3410f19.png)

