### PR TITLE
CloudTenant uses GenericButtonMixin for tagging

### DIFF
--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -24,7 +24,7 @@ class CloudTenantController < ApplicationController
       custom_buttons
     else
       editable_objects = CloudTenantController.display_methods.map(&:singularize) - %w(instance image) # handled in super
-      if params[:pressed].starts_with?(*editable_objects)
+      if params[:pressed].starts_with?(*editable_objects) && !params[:pressed].ends_with?('_tag')
         target_controller = editable_objects.find { |n| params[:pressed].starts_with?(n) }
         action = params[:pressed].sub("#{target_controller}_", '')
         action = "#{action}_#{target_controller.sub('cloud_','').pluralize}" if action == 'delete'


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1383197

Steps to Reproduce:
1. Navigate to Compute -> Cloud-> Tenants
2. On tenant summary page click on anything for ex:cloud subnets
3. Select a one or more in list view and  perform actions (delete/Edit tags)

Before: `No route matches {:action=>"tag", :controller=>"cloud_volume", :id=>"10000000000004", :miq_grid_checks=>"10r30"} [cloud_tenant/button]`
After: It works.

@miq-bot add_label bug, euwe/yes, fine/yes