### PR TITLE
Allow to see saved chargeback report after linked MiqTask deleted

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -353,7 +353,7 @@ class ChargebackController < ApplicationController
     else
       @report_result_id = session[:report_result_id] = rr.id
       session[:report_result_runtime]  = rr.last_run_on
-      if MiqTask.state_finished(rr.miq_task_id)
+      if rr.status.downcase == "complete"
         @report = rr.report_results
         session[:rpt_task_id] = nil
         if @report.blank?


### PR DESCRIPTION
**Resolving Issue:** Existing chargeback report would not be shown if linked `MiqTask` deleted

This PR is follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/1488

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1450272

@miq-bot add-label bug, reporting

\cc @lpichler 