### PR TITLE
Show card only for single provider

### DIFF
--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -2,7 +2,7 @@
   = render :partial => "layouts/flash_msg"
   .row.row-tile-pf
     .col-xs-12.col-sm-12.col-md-2
-      .card-pf.card-pf-accented.card-pf-aggregate-status.provider-status-card
+      .card-pf.card-pf-accented.card-pf-aggregate-status.provider-status-card{"ng-if" => "isSingleProvider"}
         %h2.card-pf-title
           %img.provider-icon-small{"ng-src" =>"{{providerTypeIconImage}}"}
           {{providerTypeName}}


### PR DESCRIPTION
**Description**

The card for showing one provider data is shown on the multi provider dashboard.
This PR adds a check to prevent it from showing on multi provider dashboard.

Affected page:
compute -> containers -> overview

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1464924

**Screenshots**

Problem
![screenshot-localhost 3000-2017-08-22-09-26-20](https://user-images.githubusercontent.com/2181522/29551584-058ba970-871c-11e7-81e0-4a05dc640af9.png)

Fix
![screenshot-localhost 3000-2017-08-22-09-25-07](https://user-images.githubusercontent.com/2181522/29551585-058da54a-871c-11e7-9352-00d564daa12d.png)

