### PR TITLE
Remove MAX_REPORT_COLUMNS, SHOWALL_STRING from UiConstants 

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -21,6 +21,8 @@ module ReportController::Reports::Editor
     -vm_uid
   ).freeze
 
+  MAX_REPORT_COLUMNS = 100 # Default maximum number of columns in a report
+
   def chargeback_allocated_methods
     Hash[CHAREGEBACK_ALLOCATED_METHODS.map { |x| _(x) }]
   end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -34,7 +34,6 @@ module UiConstants
 
   # Report Controller constants
   NOTHING_STRING = "<<< Nothing >>>"
-  SHOWALL_STRING = "<<< Show All >>>"
   MAX_REPORT_COLUMNS = 100      # Default maximum number of columns in a report
   GRAPH_MAX_COUNT = 10
 

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -34,7 +34,6 @@ module UiConstants
 
   # Report Controller constants
   NOTHING_STRING = "<<< Nothing >>>"
-  MAX_REPORT_COLUMNS = 100      # Default maximum number of columns in a report
   GRAPH_MAX_COUNT = 10
 
   TREND_MODEL = "VimPerformanceTrend"   # Performance trend model name requiring special processing


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `MAX_REPORT_COLUMNS` was removed from `UiConstants` and moved to `ReportController::Reports::Editor` module.
Useless constant `SHOWALL_STRING` was permanently removed from `UiConstants`.