### PR TITLE
Add Ansible Playbook custom button

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -925,7 +925,7 @@ module ApplicationController::Buttons
   end
 
   def button_set_playbook_form_vars
-    @edit[:ansible_playbooks] = ServiceTemplateAnsiblePlaybook.order(:name).pluck(:name, :id) || {}
+    @edit[:ansible_playbooks] = ServiceTemplateAnsiblePlaybook.order(:name).pluck(:name, :id) || []
     @edit[:new][:service_template_id] = ServiceTemplate.find_by(:name => @custom_button.uri_attributes[:service_template_name]).try(:id)
     @edit[:new][:inventory_type] = if @custom_button.uri_attributes[:hosts].blank?
                                      'localhost'

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -107,9 +107,13 @@ module ApplicationController::Buttons
       @edit[:new][:open_url] = params[:open_url] == "1" if params[:open_url]
       copy_params_if_set(@edit[:new], params, %i(name target_attr_name display_for submit_how description button_icon button_color dialog_id disabled_text button_type inventory_type))
       visibility_box_edit
-      clear_playbook_variables if params[:button_type] == 'default'
+
+      if params[:button_type] == 'default'
+        clear_playbook_variables
+      end
       if params[:button_type] == 'ansible_playbook'
-        initialize_playbook_variables if params[:button_type] == 'ansible_playbook'
+        initialize_playbook_variables
+        @edit[:new][:dialog_id] = nil
         @edit[:new][:object_request] = CustomButton::PLAYBOOK_METHOD
       end
     end

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -105,7 +105,7 @@ module ApplicationController::Buttons
       end
       @edit[:new][:display] = params[:display] == "1" if params[:display]
       @edit[:new][:open_url] = params[:open_url] == "1" if params[:open_url]
-      copy_params_if_set(@edit[:new], params, %i(name target_attr_name display_for submit_how description button_icon button_color dialog_id disabled_text))
+      copy_params_if_set(@edit[:new], params, %i(name target_attr_name display_for submit_how description button_icon button_color dialog_id disabled_text button_type inventory_type))
       visibility_box_edit
       clear_playbook_variables if params[:button_type] == 'default'
       if params[:button_type] == 'ansible_playbook'

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -108,7 +108,7 @@ module ApplicationController::Buttons
 
     render :update do |page|
       page << javascript_prologue
-      if params.key?(:instance_name) || params.key?(:other_name) || params.key?(:target_class)
+      if [:instance_name, :other_name, :target_class, :button_type].any? { |k| params.key?(k) }
         page.replace("ab_form", :partial => "shared/buttons/ab_form")
       end
       if params[:visibility_typ]
@@ -120,11 +120,11 @@ module ApplicationController::Buttons
       end
       if @edit[:new][:button_type] == 'ansible_playbook'
         page << javascript_show('playbook_div')
-        if @edit[:new][:inventory_type] == "manual"
-          page << javascript_show('manual_inventory_div')
-        else
-          page << javascript_hide('manual_inventory_div')
-        end
+        page << if @edit[:new][:inventory_type] == "manual"
+                  javascript_show('manual_inventory_div')
+                else
+                  javascript_hide('manual_inventory_div')
+                end
       else
         page << javascript_hide('playbook_div')
       end
@@ -853,7 +853,7 @@ module ApplicationController::Buttons
   end
 
   def validate_playbook_button(button_hash)
-    add_flash(_("An Ansible Playbook must be selected"), :error) if button_hahs[:service_template_id].blank?
+    add_flash(_("An Ansible Playbook must be selected"), :error) if button_hash[:service_template_id].blank?
     if button_hash[:inventory_type] == 'manual' && button_hash[:hosts].blank?
       add_flash(_("At least one host must be specified for manual mode"), :error)
     end
@@ -938,7 +938,6 @@ module ApplicationController::Buttons
   end
 
   def button_set_playbook_record(button)
-    #TO DO - save playbook variables if button type is ansible playbook
     if @edit[:new][:button_type] == 'ansible_playbook'
       target = case @edit[:new][:inventory_type]
                when "event_target"
@@ -960,13 +959,13 @@ module ApplicationController::Buttons
                                      'localhost'
                                    else
                                      case @custom_button.uri_attributes[:hosts]
-                                       when 'vmdb_object'
-                                         "event_target"
-                                       when 'localhost'
-                                         "localhost"
-                                       else
-                                         @edit[:new][:hosts] = @custom_button.uri_attributes[:hosts]
-                                         "manual"
+                                     when 'vmdb_object'
+                                       "event_target"
+                                     when 'localhost'
+                                       "localhost"
+                                     else
+                                       @edit[:new][:hosts] = @custom_button.uri_attributes[:hosts]
+                                       "manual"
                                      end
                                    end
   end

--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -62,9 +62,12 @@ module MiqAeCustomizationController::CustomButtons
       @record = @custom_button = CustomButton.find(from_cid(nodeid.last))
       build_resolve_screen
       @resolve[:new][:attrs] = []
-      default_attributes = %w(request service_template_name hosts) if @custom_button[:options][:button_type] == 'ansible_playbook'
-
       if @custom_button.uri_attributes
+        default_attributes = if @custom_button[:options].try(:[], :button_type)
+                               %w(request service_template_name hosts)
+                             else
+                               %w(request)
+                             end
         @custom_button.uri_attributes.each do |attr|
           if attr[0] != "object_name" && attr[0] != "request" && !default_attributes.include?(attr[0].to_s)
             @resolve[:new][:attrs].push(attr) unless @resolve[:new][:attrs].include?(attr)

--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -62,9 +62,11 @@ module MiqAeCustomizationController::CustomButtons
       @record = @custom_button = CustomButton.find(from_cid(nodeid.last))
       build_resolve_screen
       @resolve[:new][:attrs] = []
+      default_attributes = %w(request service_template_name hosts) if @custom_button[:options][:button_type] == 'ansible_playbook'
+
       if @custom_button.uri_attributes
         @custom_button.uri_attributes.each do |attr|
-          if attr[0] != "object_name" && attr[0] != "request"
+          if attr[0] != "object_name" && attr[0] != "request" && !default_attributes.include?(attr[0].to_s)
             @resolve[:new][:attrs].push(attr) unless @resolve[:new][:attrs].include?(attr)
           end
         end

--- a/app/controllers/mixins/playbook_options.rb
+++ b/app/controllers/mixins/playbook_options.rb
@@ -26,7 +26,7 @@ module Mixins
     end
 
     def dialog_for_service_template(service_template)
-        service_template.resource_actions.each do |ra|
+      service_template.resource_actions.each do |ra|
         d = Dialog.where(:id => ra.dialog_id).first
         @edit[:new][:dialog_id] = d.id if d
       end

--- a/app/controllers/mixins/playbook_options.rb
+++ b/app/controllers/mixins/playbook_options.rb
@@ -1,0 +1,55 @@
+module Mixins
+  module PlaybookOptions
+    def playbook_options_field_changed
+      @edit = session[:edit]
+      @edit[:new][:inventory_type] = params[:inventory_type] if params[:inventory_type]
+      playbook_box_edit
+
+      render :update do |page|
+        page << javascript_prologue
+        if @edit[:new][:button_type] == 'ansible_playbook'
+          page << javascript_show('playbook_div')
+          page << if @edit[:new][:inventory_type] == "manual"
+                    javascript_show('manual_inventory_div')
+                  else
+                    javascript_hide('manual_inventory_div')
+                  end
+        else
+          page << javascript_hide('playbook_div')
+        end
+
+        @changed = session[:changed] = (@edit[:new] != @edit[:current])
+        page << javascript_for_miq_button_visibility(@changed)
+
+        page << "miqSparkle(false);"
+      end
+    end
+
+    def playbook_box_edit
+      if params[:inventory_manual] || params[:inventory_localhost] || params[:inventory_event_target]
+        update_playbook_variables(params)
+      end
+      @edit[:new][:service_template_id] = params[:service_template_id].to_i if params[:service_template_id]
+      @edit[:new][:hosts] = params[:hosts] if params[:hosts]
+    end
+
+    def update_playbook_variables(params)
+      @edit[:new][:inventory_type] = params[:inventory_manual] if params[:inventory_manual]
+      @edit[:new][:inventory_type] = params[:inventory_localhost] if params[:inventory_localhost]
+      @edit[:new][:inventory_type] = params[:inventory_event_target] if params[:inventory_event_target]
+      @edit[:new][:hosts] = '' if params[:inventory_localhost] || params[:inventory_event_target]
+    end
+
+    def clear_playbook_variables
+      @edit[:new][:service_template_id] = nil
+      @edit[:new][:inventory_type] = 'localhost'
+      @edit[:new][:hosts] = ''
+    end
+
+    def initialize_playbook_variables
+      @edit[:new][:service_template_id] = nil
+      @edit[:new][:inventory_type] = "localhost"
+      @edit[:new][:hosts] = ''
+    end
+  end
+end

--- a/app/controllers/mixins/playbook_options.rb
+++ b/app/controllers/mixins/playbook_options.rb
@@ -25,11 +25,23 @@ module Mixins
       end
     end
 
+    def dialog_for_service_template(service_template)
+        service_template.resource_actions.each do |ra|
+        d = Dialog.where(:id => ra.dialog_id).first
+        @edit[:new][:dialog_id] = d.id if d
+      end
+    end
+
     def playbook_box_edit
       if params[:inventory_manual] || params[:inventory_localhost] || params[:inventory_event_target]
         update_playbook_variables(params)
       end
-      @edit[:new][:service_template_id] = params[:service_template_id].to_i if params[:service_template_id]
+      if params[:service_template_id]
+        @edit[:new][:service_template_id] = params[:service_template_id].to_i
+        service_template = ServiceTemplate.find_by(:id => @edit[:new][:service_template_id])
+        dialog_for_service_template(service_template) if service_template
+      end
+
       @edit[:new][:hosts] = params[:hosts] if params[:hosts]
     end
 

--- a/app/views/layouts/_ae_resolve_options.html.haml
+++ b/app/views/layouts/_ae_resolve_options.html.haml
@@ -1,10 +1,11 @@
 - field_changed_url ||= "form_field_changed"
 - ae_sim_form       ||= false
 - ae_custom_button  ||= false
+- ae_ansible_custom_button ||= false
 - rec_id = @edit && @edit[:action_id].present? ? @edit[:action_id] : "new"
 - url    = url_for_only_path(:action => field_changed_url, :id => rec_id)
 .form-horizontal
-  - if form_action == "ae_resolve"
+  - if form_action == "ae_resolve" && !ae_ansible_custom_button
     %hr
     %h3
       = _("Object Details")
@@ -21,27 +22,28 @@
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('instance_name', "#{url}")
-  .form-group
-    %label.col-md-2.control-label
-      = _("Message")
-    .col-md-8
-      = text_field_tag("object_message",
-                       resolve[:new][:object_message],
-                       :maxlength         => ViewHelper::MAX_NAME_LEN,
-                       :class             => "form-control",
-                       "data-miq_observe" => {:interval => '.5',
-                                              :url      => url}.to_json)
-      - unless is_browser_ie?
-        = javascript_tag("if (!$('#description').length) #{javascript_focus('object_message')}")
-  .form-group
-    %label.col-md-2.control-label
-      = _("Request")
-    .col-md-8
-      = text_field_tag("object_request",
-                       resolve[:new][:object_request],
-                       :maxlength         => ViewHelper::MAX_NAME_LEN,
-                       :class            => "form-control",
-                       "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  - if !ae_ansible_custom_button
+    .form-group
+      %label.col-md-2.control-label
+        = _("Message")
+      .col-md-8
+        = text_field_tag("object_message",
+                         resolve[:new][:object_message],
+                         :maxlength         => ViewHelper::MAX_NAME_LEN,
+                         :class             => "form-control",
+                         "data-miq_observe" => {:interval => '.5',
+                                                :url      => url}.to_json)
+        - unless is_browser_ie?
+          = javascript_tag("if (!$('#description').length) #{javascript_focus('object_message')}")
+    .form-group
+      %label.col-md-2.control-label
+        = _("Request")
+      .col-md-8
+        = text_field_tag("object_request",
+                         resolve[:new][:object_request],
+                         :maxlength         => ViewHelper::MAX_NAME_LEN,
+                         :class            => "form-control",
+                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
 - if form_action != "miq_action"
   - if ae_custom_button
     %hr

--- a/app/views/layouts/_ae_resolve_options.html.haml
+++ b/app/views/layouts/_ae_resolve_options.html.haml
@@ -22,7 +22,7 @@
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('instance_name', "#{url}")
-  - if !ae_ansible_custom_button
+  - unless ae_ansible_custom_button
     .form-group
       %label.col-md-2.control-label
         = _("Message")

--- a/app/views/shared/_playbook_options.html.haml
+++ b/app/views/shared/_playbook_options.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'playbook_options_field_changed', :id => (@custom_button.id || 'new'))
+- url = url_for_only_path(:action => 'playbook_options_field_changed', :id => (@custom_button.try(:id) || 'new'))
 - observe_with_interval = {:interval => '.5', :url => url}.to_json
 #form_playbook_options
 .form-group

--- a/app/views/shared/_playbook_options.html.haml
+++ b/app/views/shared/_playbook_options.html.haml
@@ -1,0 +1,43 @@
+- url = url_for_only_path(:action => 'automate_button_field_changed', :id => (@custom_button.id || 'new'))
+- observe_with_interval = {:interval => '.5', :url => url}.to_json
+#form_playbook_options
+.form-group
+  %label.control-label.col-md-2
+    = _("Playbook Catalog Item")
+  .col-md-8
+    = select_tag('service_template_id',
+    options_for_select([["<#{_('Choose')}>", nil]] + @edit[:ansible_playbooks],
+    @edit[:new][:service_template_id]),
+    "style"            => "width:150px",
+    "data-live-search" => "true",
+    "class"            => "selectpicker")
+    :javascript
+      miqInitSelectPicker();
+      miqSelectPickerEvent('service_template_id', '#{url}')
+.form-group
+  %label.control-label.col-md-2
+    = _("Inventory")
+  .col-md-8
+    = radio_button_tag('inventory', "localhost", !!(@edit[:new][:inventory_type] == "localhost"),
+      "title"            => _('Run on localhost'),
+      "data-miq_observe" => {:url => url}.to_json)
+    = label_tag('inventory_localhost', _("Localhost"), "title" => _('Run on localhost'))
+    %br
+    = radio_button_tag('inventory', "event_target", !!(@edit[:new][:inventory_type] == "event_target"),
+      "title"            => _('Run on the target of the Policy Event'),
+      "data-miq_observe" => {:url => url}.to_json)
+    = label_tag('inventory_event_target', _("Target Machine"), "title" => _('Run on the target of the Policy Event'))
+    %br
+    = radio_button_tag('inventory', "manual", !!(@edit[:new][:inventory_type] == "manual"),
+      "title" => _('Enter a comma separated list of IP or DNS names'),
+      "data-miq_observe" => {:url => url}.to_json)
+    = label_tag('inventory_manual', _("Specific Hosts"), "title" => _('Enter a comma separated list of IP or DNS names'))
+    #manual_inventory_div{:style => @edit[:new][:inventory_type] == "manual" ? "" : "display:none"}
+      .form-group
+        .col-md-8
+          = text_field_tag("hosts",
+            @edit[:new][:hosts],
+            :maxlength         => ViewHelper::MAX_DESC_LEN,
+            :class             => "form-control",
+            "data-miq_observe" => observe_with_interval)
+          = _('Enter a comma separated list of IP or DNS names')

--- a/app/views/shared/_playbook_options.html.haml
+++ b/app/views/shared/_playbook_options.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'automate_button_field_changed', :id => (@custom_button.id || 'new'))
+- url = url_for_only_path(:action => 'playbook_options_field_changed', :id => (@custom_button.id || 'new'))
 - observe_with_interval = {:interval => '.5', :url => url}.to_json
 #form_playbook_options
 .form-group

--- a/app/views/shared/_playbook_options.html.haml
+++ b/app/views/shared/_playbook_options.html.haml
@@ -18,17 +18,17 @@
   %label.control-label.col-md-2
     = _("Inventory")
   .col-md-8
-    = radio_button_tag('inventory', "localhost", !!(@edit[:new][:inventory_type] == "localhost"),
+    = radio_button_tag('inventory', "localhost", @edit[:new][:inventory_type] == "localhost",
       "title"            => _('Run on localhost'),
       "data-miq_observe" => {:url => url}.to_json)
     = label_tag('inventory_localhost', _("Localhost"), "title" => _('Run on localhost'))
     %br
-    = radio_button_tag('inventory', "event_target", !!(@edit[:new][:inventory_type] == "event_target"),
+    = radio_button_tag('inventory', "event_target", @edit[:new][:inventory_type] == "event_target",
       "title"            => _('Run on the target of the Policy Event'),
       "data-miq_observe" => {:url => url}.to_json)
     = label_tag('inventory_event_target', _("Target Machine"), "title" => _('Run on the target of the Policy Event'))
     %br
-    = radio_button_tag('inventory', "manual", !!(@edit[:new][:inventory_type] == "manual"),
+    = radio_button_tag('inventory', "manual", @edit[:new][:inventory_type] == "manual",
       "title" => _('Enter a comma separated list of IP or DNS names'),
       "data-miq_observe" => {:url => url}.to_json)
     = label_tag('inventory_manual', _("Specific Hosts"), "title" => _('Enter a comma separated list of IP or DNS names'))

--- a/app/views/shared/buttons/_ab_advanced_form.html.haml
+++ b/app/views/shared/buttons/_ab_advanced_form.html.haml
@@ -1,0 +1,50 @@
+- url = url_for_only_path(:action => 'automate_button_field_changed')
+#ab_form
+  #policy_bar
+    - if @resolve[:uri] && Hash[*@resolve[:target_classes].flatten].invert[@resolve[:new][:target_class]] == @edit[:new][:target_class]
+
+      %li
+        - t = _("Paste object details for use in a Button.")
+        = link_to(image_tag(image_path('toolbars/paste.png'), :border => "0", :class  => "", :alt => t),
+          {:action => "resolve", :button => "paste"},
+          "data-miq_sparkle_on"  => true,
+          "data-miq_sparkle_off" => true,
+          :remote                => true,
+          "data-method"          => :post,
+          :title                 => t)
+    - else
+      = image_tag(image_path('toolbars/paste.png'),
+        :class => "dimmed",
+        :title => _("Paste is not available, no object information has been copied from the Simulation screen"))
+  = render :partial => "layouts/flash_msg"
+  %h3
+    = _('Advanced Options')
+  .form-horizontal
+    %h3
+      = _('Enablement')
+    = render(:partial => "layouts/role_enablement_expression",
+           :locals  => {:rec_id => @custom_button ? @custom_button.id : 'new', :action => "automate_button_field_changed"})
+
+    .form-group
+      %label.control-label.col-md-2
+        = _('Disabled Button Text')
+      .col-md-8
+        = text_field_tag("disabled_text", @edit[:new][:disabled_text],
+                              :maxlength         => 50,
+                              :class             => "form-control",
+                              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %hr
+  %h3
+    = _('Visibility')
+  = render(:partial => "layouts/role_visibility_expression",
+           :locals  => {:rec_id => @custom_button ? @custom_button.id : 'new', :action => "automate_button_field_changed"})
+
+
+  = render(:partial => "layouts/ae_resolve_options",
+    :locals         => {:resolve => @edit,
+      :form_action               => "ae_resolve",
+      :ae_custom_button          => true,
+      :ae_ansible_custom_button  => @edit[:new][:button_type] == "ansible_playbook",
+      :field_changed_url         => "automate_button_field_changed"})
+  = render(:partial => "layouts/role_visibility",
+           :locals  => {:rec_id => @custom_button ? @custom_button.id : 'new', :action => "automate_button_field_changed"})

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -1,4 +1,3 @@
-- url = url_for_only_path(:action => 'automate_button_field_changed')
 #ab_form
   #policy_bar
     - if @resolve[:uri] && Hash[*@resolve[:target_classes].flatten].invert[@resolve[:new][:target_class]] == @edit[:new][:target_class]
@@ -17,139 +16,18 @@
         :class => "dimmed",
         :title => _("Paste is not available, no object information has been copied from the Simulation screen"))
   = render :partial => "layouts/flash_msg"
-  %h3
-    = _('Options')
-  .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
-        = _('Button Type')
-      .col-md-8
-        - if @edit
-          = select_tag('button_type',
-                options_for_select(CustomButton::TYPES.invert, @edit[:new][:button_type]),
-                :class => "selectpicker")
-          :javascript
-                miqInitSelectPicker();
-                miqSelectPickerEvent('button_type', '#{url}', {beforeSend: true, complete: true})
-        - else
-          = h(@edit[:new][:button_type] == "default" ? "Default" : CustomButton::TYPES[[:button_type]])
-        - display = @edit[:new][:button_type] == "ansible_playbook" ? "" : "display:none"
-    #playbook_div{:style => display}
-      = render :partial => "shared/playbook_options"
-    .form-group
-      %label.control-label.col-md-2
-        = _('Text')
-      .col-md-8
-        .input-group
-          = text_field_tag("name", @edit[:new][:name],
-                          :maxlength         => 30,
-                          :class             => "form-control",
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          .input-group-addon
-            %label.checkbox-inline
-              = check_box_tag("display", "1", @edit[:new][:display],
-                               "data-miq_observe_checkbox" => {:interval => '.5', :url => url}.to_json)
-              = _('Display on Button')
-      - unless is_browser_ie?
-        = javascript_tag(javascript_focus('name'))
-    .form-group
-      %label.control-label.col-md-2
-        = _('Hover Text')
-      .col-md-8
-        = text_field_tag("description", @edit[:new][:description],
-                          :maxlength         => 50,
-                          :class             => "form-control",
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-    .form-group
-      %label.control-label.col-md-2
-        = _('Icon')
-      .col-md-8#button-icon-picker{'ng-controller' => 'fonticonPickerController as vm'}
-        %miq-fonticon-picker{'input-name' => 'button_icon', :selected => @edit[:new][:button_icon], 'icon-changed' => 'vm.select(selected);'}
-          %miq-fonticon-family{:selector => 'ff', :title => 'Font Fabulous'}
-          %miq-fonticon-family{:selector => 'pficon', :title => 'PatternFly'}
-          %miq-fonticon-family{:selector => 'fa', :title => 'Font Awesome'}
-    .form-group
-      %label.control-label.col-md-2
-        = _('Icon Color')
-      .col-md-8
-        -# Remove the default #4d5258 value when using a color picker with nil support
-        = color_field_tag("button_color", @edit[:new][:button_color] || '#4d5258',
-                          :maxlength         => 30,
-                          :class             => "form-control",
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-    - if @edit[:new][:button_type] != "ansible_playbook"
-      .form-group
-        %label.control-label.col-md-2
-          = _('Dialog')
-        .col-md-8
-          = select_tag('dialog_id',
-                        options_for_select([[_("<None>"), nil]] + Array(@edit[:new][:available_dialogs].invert).sort_by { |a| a.first.downcase }, @edit[:new][:dialog_id]),
-                        "data-miq_sparkle_on" => true,
-                        :class => "selectpicker")
-    .form-group
-      %label.control-label.col-md-2
-        = _('Open URL')
-      .col-md-8
-        = check_box_tag("open_url", "1", @edit[:new][:open_url], "data-miq_observe_checkbox" => {:interval => '.5', :url => url}.to_json)
 
-    .form-group
-      %label.control-label.col-md-2
-        = _('Display for')
-      .col-md-8
-        = select_tag("display_for",
-                     options_for_select([[_('Single entity'), 'single'], [_('List'), 'list'], [_('Single and list'), 'both']], @edit[:new][:display_for]),
-                     "data-miq_sparkle_on" => true)
-    .form-group
-      %label.control-label.col-md-2
-        = _('Submit')
-      .col-md-8
-        = select_tag("submit_how",
-                     options_for_select([[_('Submit all'), 'all'], [_('One by one'), 'one']], @edit[:new][:submit_how]),
-                     "data-miq_sparkle_on" => true,
-                    )
-    %hr
-    %h3
-      = _('Enablement')
-    = render(:partial => "layouts/role_enablement_expression",
-           :locals  => {:rec_id => @custom_button ? @custom_button.id : 'new', :action => "automate_button_field_changed"})
+  #custom_button_tabs
+    %ul.nav.nav-tabs
+      = miq_tab_header('ab_options_tab') do
+        = _('Options')
+      = miq_tab_header('ab_advanced_tab') do
+        = _('Advanced')
+    .tab-content
+      = miq_tab_content('ab_options_tab') do
+        = render :partial => "shared/buttons/ab_options_form"
+      = miq_tab_content('ab_advanced_tab') do
+        = render :partial => "shared/buttons/ab_advanced_form"
 
-    .form-group
-      %label.control-label.col-md-2
-        = _('Disabled Button Text')
-      .col-md-8
-        = text_field_tag("disabled_text", @edit[:new][:disabled_text],
-                              :maxlength         => 50,
-                              :class             => "form-control",
-                              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  %hr
-  %h3
-    = _('Visibility')
-  = render(:partial => "layouts/role_visibility_expression",
-           :locals  => {:rec_id => @custom_button ? @custom_button.id : 'new', :action => "automate_button_field_changed"})
-
-
-  = render(:partial => "layouts/ae_resolve_options",
-    :locals         => {:resolve => @edit,
-      :form_action               => "ae_resolve",
-      :ae_custom_button          => true,
-      :ae_ansible_custom_button  => @edit[:new][:button_type] == "ansible_playbook",
-      :field_changed_url         => "automate_button_field_changed"})
-  = render(:partial => "layouts/role_visibility",
-           :locals  => {:rec_id => @custom_button ? @custom_button.id : 'new', :action => "automate_button_field_changed"})
-:javascript
-  miqInitSelectPicker();
-  miqSelectPickerEvent('dialog_id', '#{url}');
-  miqSelectPickerEvent('display_for', '#{url}');
-  miqSelectPickerEvent('submit_how', '#{url}');
-  miq_bootstrap('#button-icon-picker', 'ManageIQ.fonticonPicker');
-
-  // This is an ugly hack to be able to use this component in a non-angular context with miq-observe
-  // FIXME: Remove this when the form is converted to angular
-  $(function() {
-    $('#button-icon-picker input[type="hidden"]').on('change', _.debounce(function() {
-      miqObserveRequest('#{url}', {
-        no_encoding: true,
-        data: 'button_icon' + '=' + $(this).val(),
-      });
-    }, 700, {leading: true, trailing: true}));
-  });
+  :javascript
+    miq_tabs_init('#custom_button_tabs');

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -21,6 +21,22 @@
     = _('Options')
   .form-horizontal
     .form-group
+      %label.col-md-2.control-label
+        = _('Button Type')
+      .col-md-8
+        - if @edit
+          = select_tag('button_type',
+                options_for_select(CustomButton::TYPES.invert, @edit[:new][:button_type]),
+                :class => "selectpicker")
+          :javascript
+                miqInitSelectPicker();
+                miqSelectPickerEvent('button_type', '#{url}', {beforeSend: true, complete: true})
+        - else
+          = h(@edit[:new][:button_type] == "default" ? "Default" : CustomButton::TYPES[[:button_type]])
+        - display = @edit[:new][:button_type] == "ansible_playbook" ? "" : "display:none"
+    #playbook_div{:style => display}
+      = render :partial => "shared/playbook_options"
+    .form-group
       %label.control-label.col-md-2
         = _('Text')
       .col-md-8

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -77,14 +77,15 @@
                           :maxlength         => 30,
                           :class             => "form-control",
                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-    .form-group
-      %label.control-label.col-md-2
-        = _('Dialog')
-      .col-md-8
-        = select_tag('dialog_id',
-                      options_for_select([[_("<None>"), nil]] + Array(@edit[:new][:available_dialogs].invert).sort_by { |a| a.first.downcase }, @edit[:new][:dialog_id]),
-                      "data-miq_sparkle_on" => true,
-                      :class => "selectpicker")
+    - if @edit[:new][:button_type] != "ansible_playbook"
+      .form-group
+        %label.control-label.col-md-2
+          = _('Dialog')
+        .col-md-8
+          = select_tag('dialog_id',
+                        options_for_select([[_("<None>"), nil]] + Array(@edit[:new][:available_dialogs].invert).sort_by { |a| a.first.downcase }, @edit[:new][:dialog_id]),
+                        "data-miq_sparkle_on" => true,
+                        :class => "selectpicker")
     .form-group
       %label.control-label.col-md-2
         = _('Open URL')

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -131,6 +131,7 @@
     :locals         => {:resolve => @edit,
       :form_action               => "ae_resolve",
       :ae_custom_button          => true,
+      :ae_ansible_custom_button  => @edit[:new][:button_type] == "ansible_playbook",
       :field_changed_url         => "automate_button_field_changed"})
   = render(:partial => "layouts/role_visibility",
            :locals  => {:rec_id => @custom_button ? @custom_button.id : 'new', :action => "automate_button_field_changed"})

--- a/app/views/shared/buttons/_ab_options_form.html.haml
+++ b/app/views/shared/buttons/_ab_options_form.html.haml
@@ -1,0 +1,108 @@
+- url = url_for_only_path(:action => 'automate_button_field_changed')
+#ab_options_form
+  %h3
+    = _('Options')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Button Type')
+      .col-md-8
+        - if @edit
+          = select_tag('button_type',
+                options_for_select(CustomButton::TYPES.invert, @edit[:new][:button_type]),
+                :class => "selectpicker")
+          :javascript
+                miqInitSelectPicker();
+                miqSelectPickerEvent('button_type', '#{url}', {beforeSend: true, complete: true})
+        - else
+          = h(@edit[:new][:button_type] == "default" ? "Default" : CustomButton::TYPES[[:button_type]])
+        - display = @edit[:new][:button_type] == "ansible_playbook" ? "" : "display:none"
+    #playbook_div{:style => display}
+      = render :partial => "shared/playbook_options"
+    .form-group
+      %label.control-label.col-md-2
+        = _('Text')
+      .col-md-8
+        .input-group
+          = text_field_tag("name", @edit[:new][:name],
+                          :maxlength         => 30,
+                          :class             => "form-control",
+                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+          .input-group-addon
+            %label.checkbox-inline
+              = check_box_tag("display", "1", @edit[:new][:display],
+                               "data-miq_observe_checkbox" => {:interval => '.5', :url => url}.to_json)
+              = _('Display on Button')
+      - unless is_browser_ie?
+        = javascript_tag(javascript_focus('name'))
+    .form-group
+      %label.control-label.col-md-2
+        = _('Hover Text')
+      .col-md-8
+        = text_field_tag("description", @edit[:new][:description],
+                          :maxlength         => 50,
+                          :class             => "form-control",
+                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+    .form-group
+      %label.control-label.col-md-2
+        = _('Icon')
+      .col-md-8#button-icon-picker{'ng-controller' => 'fonticonPickerController as vm'}
+        %miq-fonticon-picker{'input-name' => 'button_icon', :selected => @edit[:new][:button_icon], 'icon-changed' => 'vm.select(selected);'}
+          %miq-fonticon-family{:selector => 'ff', :title => 'Font Fabulous'}
+          %miq-fonticon-family{:selector => 'pficon', :title => 'PatternFly'}
+          %miq-fonticon-family{:selector => 'fa', :title => 'Font Awesome'}
+    .form-group
+      %label.control-label.col-md-2
+        = _('Icon Color')
+      .col-md-8
+        -# Remove the default #4d5258 value when using a color picker with nil support
+        = color_field_tag("button_color", @edit[:new][:button_color] || '#4d5258',
+                          :maxlength         => 30,
+                          :class             => "form-control",
+                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+    - if @edit[:new][:button_type] != "ansible_playbook"
+      .form-group
+        %label.control-label.col-md-2
+          = _('Dialog')
+        .col-md-8
+          = select_tag('dialog_id',
+                        options_for_select([[_("<None>"), nil]] + Array(@edit[:new][:available_dialogs].invert).sort_by { |a| a.first.downcase }, @edit[:new][:dialog_id]),
+                        "data-miq_sparkle_on" => true,
+                        :class => "selectpicker")
+    .form-group
+      %label.control-label.col-md-2
+        = _('Open URL')
+      .col-md-8
+        = check_box_tag("open_url", "1", @edit[:new][:open_url], "data-miq_observe_checkbox" => {:interval => '.5', :url => url}.to_json)
+
+    .form-group
+      %label.control-label.col-md-2
+        = _('Display for')
+      .col-md-8
+        = select_tag("display_for",
+                     options_for_select([[_('Single entity'), 'single'], [_('List'), 'list'], [_('Single and list'), 'both']], @edit[:new][:display_for]),
+                     "data-miq_sparkle_on" => true)
+    .form-group
+      %label.control-label.col-md-2
+        = _('Submit')
+      .col-md-8
+        = select_tag("submit_how",
+                     options_for_select([[_('Submit all'), 'all'], [_('One by one'), 'one']], @edit[:new][:submit_how]),
+                     "data-miq_sparkle_on" => true)
+:javascript
+  miqInitSelectPicker();
+  miqSelectPickerEvent('dialog_id', '#{url}');
+  miqSelectPickerEvent('display_for', '#{url}');
+  miqSelectPickerEvent('submit_how', '#{url}');
+  miq_bootstrap('#button-icon-picker', 'ManageIQ.fonticonPicker');
+
+  // This is an ugly hack to be able to use this component in a non-angular context with miq-observe
+  // FIXME: Remove this when the form is converted to angular
+  $(function() {
+    $('#button-icon-picker input[type="hidden"]').on('change', _.debounce(function() {
+      miqObserveRequest('#{url}', {
+        no_encoding: true,
+        data: 'button_icon' + '=' + $(this).val(),
+      });
+    }, 700, {leading: true, trailing: true}));
+  });

--- a/app/views/shared/buttons/_ab_show.html.haml
+++ b/app/views/shared/buttons/_ab_show.html.haml
@@ -5,6 +5,23 @@
 .form-horizontal.static
   .form-group
     %label.control-label.col-md-2
+      = _('Button Type')
+    .col-md-8
+      = h(CustomButton::TYPES[@custom_button.options[:button_type]] || 'Default')
+  - display = @custom_button.options[:button_type] == "ansible_playbook" ? "" : "display:none"
+  #playbook_div{:style => display}
+    .form-group
+      %label.control-label.col-md-2
+        = _('Ansible Playbook')
+      .col-md-8
+        = @custom_button.uri_attributes[:service_template_name]
+    .form-group
+      %label.control-label.col-md-2
+        = _('Target')
+      .col-md-8
+        = @custom_button.uri_attributes[:hosts]
+  .form-group
+    %label.control-label.col-md-2
       = _('Text')
     .col-md-8
       = @custom_button.name
@@ -14,7 +31,6 @@
         %label{:style => "font-weight: normal"}
           = check_box_tag(display, true, display, :disabled => true)
           = _('Display on Button')
-
   .form-group
     %label.control-label.col-md-2
       = _('Hover Text')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,6 +284,7 @@ Rails.application.routes.draw do
         atomic_form_field_changed
         atomic_st_edit
         automate_button_field_changed
+        playbook_options_field_changed
         explorer
         get_ae_tree_edit_key
         group_create
@@ -2202,6 +2203,7 @@ Rails.application.routes.draw do
         ae_tree_select_toggle
         accordion_select
         automate_button_field_changed
+        playbook_options_field_changed
         cancel_import
         change_tab
         dialog_edit

--- a/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
@@ -26,13 +26,14 @@ describe MiqAeCustomizationController do
       controller.instance_variable_set(:@breadcrumbs, [])
 
       edit = {
-        :new              => {:available_dialogs => {:id => '01', :name => '02'},
-                  :instance_name => 'CustomButton_1',
-                  :attrs => [%w(Attr1 01), %w(Attr2 02), %w(Attr3 03), %w(Attr4 04), %w(Attr5 05)],
-                  :visibility_typ => 'Type1'},
-        :instance_names   => %w(CustomButton_1 CustomButton_2),
-        :visibility_types => %w(Type1 Type2),
-        :current          => {}
+        :new               => {:available_dialogs => {:id => '01', :name => '02'},
+                               :instance_name     => 'CustomButton_1',
+                               :attrs             => [%w(Attr1 01), %w(Attr2 02), %w(Attr3 03), %w(Attr4 04), %w(Attr5 05)],
+                               :visibility_typ    => 'Type1'},
+        :instance_names    => %w(CustomButton_1 CustomButton_2),
+        :visibility_types  => %w(Type1 Type2),
+        :ansible_playbooks => [],
+        :current           => {}
       }
       controller.instance_variable_set(:@edit, edit)
       session[:edit] = edit
@@ -61,6 +62,7 @@ describe MiqAeCustomizationController do
               :visibility_expression => v_expression.exp,
               :enablement_expression => e_expression.exp,
               :visibility_types      => %w(Type1 Type2),
+              :ansible_playbooks     => [],
               :current               => {}}
       controller.instance_variable_set(:@edit, edit)
       session[:edit] = edit


### PR DESCRIPTION
Adds an option for the user to create an Ansible Playbook type of custom button, that allows the selection of a playbook to run as well as an inventory target, This makes use of the Order_Ansible_Playbook method introduced here: https://github.com/ManageIQ/manageiq-content/pull/113

Depends on https://github.com/ManageIQ/manageiq/pull/15874

Links 
---------

https://www.pivotaltracker.com/story/show/148248347

![screenshot from 2017-09-06 15-44-12](https://user-images.githubusercontent.com/12769982/30131731-d9cca8c8-931b-11e7-91c8-864f3250da7e.png)
![screenshot from 2017-09-06 15-44-21](https://user-images.githubusercontent.com/12769982/30131732-d9cfa3b6-931b-11e7-8628-dd53e4c90a6b.png)
![screenshot from 2017-09-06 15-45-01](https://user-images.githubusercontent.com/12769982/30131733-d9d1a22e-931b-11e7-8a34-4058a6749914.png)

