### PR TITLE
Remove NOTHING_STRING from UiConstants & added missing gettext call

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -74,7 +74,7 @@ module ReportController::Reports::Editor
         replace_right_cell
         return
       end
-      if @edit[:new][:graph_type] && (@edit[:new][:sortby1].blank? || @edit[:new][:sortby1] == NOTHING_STRING)
+      if @edit[:new][:graph_type] && (@edit[:new][:sortby1].blank? || @edit[:new][:sortby1] == ReportHelper::NOTHING_STRING)
         add_flash(_("Report can not be saved unless sort field has been configured for Charts"), :error)
         @sb[:miq_tab] = "edit_4"
         build_edit_screen
@@ -150,7 +150,7 @@ module ReportController::Reports::Editor
       page << "miqSparkle(false);"
       page << javascript_for_miq_button_visibility_changed(@changed)
       if @tl_changed  # Reload the screen if the timeline data was changed
-        page.replace_html("tl_sample_div", :partial => "form_tl_sample") if @tl_field != NOTHING_STRING
+        page.replace_html("tl_sample_div", :partial => "form_tl_sample") if @tl_field != ReportHelper::NOTHING_STRING
       elsif @formatting_changed   # Reload the screen if the formatting pulldowns need to be reset
         page.replace_html("formatting_div", :partial => "form_formatting")
       elsif @tl_repaint
@@ -271,7 +271,7 @@ module ReportController::Reports::Editor
       else
         @position_time = format_timezone(Time.now - 1.year, "UTC", nil)
       end
-      @timeline = true if @tl_field != NOTHING_STRING
+      @timeline = true if @tl_field != ReportHelper::NOTHING_STRING
       @tl_json = sample_timeline
     when "7"  # Preview
       # generate preview report when
@@ -306,15 +306,15 @@ module ReportController::Reports::Editor
 
   # Reset report column fields if model or interval was changed
   def reset_report_col_fields
-    @edit[:new][:fields]          = []                    # Clear fields array
-    @edit[:new][:headers]         = {}                  # Clear headers hash
+    @edit[:new][:fields]          = [] # Clear fields array
+    @edit[:new][:headers]         = {} # Clear headers hash
     @edit[:new][:pivot]           = ReportController::PivotOptions.new
-    @edit[:new][:sortby1]         = NOTHING_STRING      # Clear sort fields
-    @edit[:new][:sortby2]         = NOTHING_STRING
+    @edit[:new][:sortby1]         = ReportHelper::NOTHING_STRING # Clear sort fields
+    @edit[:new][:sortby2]         = ReportHelper::NOTHING_STRING
     @edit[:new][:filter_operator] = nil
     @edit[:new][:filter_string]   = nil
     @edit[:new][:categories]      = []
-    @edit[:new][:graph_type]      = nil             # Clear graph field
+    @edit[:new][:graph_type]      = nil # Clear graph field
     @edit[:new][:chart_mode]      = nil
     @edit[:new][:chart_column]    = nil
     @edit[:new][:perf_trend_col]  = nil
@@ -324,8 +324,8 @@ module ReportController::Reports::Editor
     @edit[:new][:perf_trend_pct3] = nil
     @edit[:new][:perf_limit_col]  = nil
     @edit[:new][:perf_limit_val]  = nil
-    @edit[:new][:record_filter]   = nil           # Clear record filter
-    @edit[:new][:display_filter]  = nil         # Clear display filter
+    @edit[:new][:record_filter]   = nil # Clear record filter
+    @edit[:new][:display_filter]  = nil # Clear display filter
     @edit[:miq_exp]               = true
   end
 
@@ -709,7 +709,7 @@ module ReportController::Reports::Editor
     @edit[:new][:pivot] ||= ReportController::PivotOptions.new
     @edit[:new][:pivot].update(params)
     if params[:chosen_pivot1] || params[:chosen_pivot2] || params[:chosen_pivot3]
-      if @edit[:new][:pivot].by1 == NOTHING_STRING
+      if @edit[:new][:pivot].by1 == ReportHelper::NOTHING_STRING
         @edit[:pivot_cols] = {}                       # Clear pivot_cols if no pivot grouping fields selected
       else
         @edit[:pivot_cols].delete(@edit[:new][:pivot].by1)   # Remove any pivot grouping fields from pivot cols
@@ -738,7 +738,7 @@ module ReportController::Reports::Editor
       # Remove any col options for any existing sort + suffix
       @edit[:new][:col_options].delete(@edit[:new][:sortby1].split("-").last) if @edit[:new][:sortby1].split("__")[1]
       @edit[:new][:sortby1] = params[:chosen_sort1]
-      @edit[:new][:sortby2] = NOTHING_STRING if params[:chosen_sort1] == NOTHING_STRING || params[:chosen_sort1] == @edit[:new][:sortby2].split("__").first
+      @edit[:new][:sortby2] = ReportHelper::NOTHING_STRING if params[:chosen_sort1] == ReportHelper::NOTHING_STRING || params[:chosen_sort1] == @edit[:new][:sortby2].split("__").first
       @refresh_div = "sort_div"
       @refresh_partial = "form_sort"
     elsif params[:chosen_sort2] && params[:chosen_sort2] != @edit[:new][:sortby2].split("__").first
@@ -804,7 +804,7 @@ module ReportController::Reports::Editor
 
   def gfv_timeline
     if params[:chosen_tl] && params[:chosen_tl] != @edit[:new][:tl_field]
-      if @edit[:new][:tl_field] == NOTHING_STRING || params[:chosen_tl] == NOTHING_STRING
+      if @edit[:new][:tl_field] == ReportHelper::NOTHING_STRING || params[:chosen_tl] == ReportHelper::NOTHING_STRING
         @refresh_div = "tl_settings_div"
         @refresh_partial = "form_tl_settings"
         @tl_changed = true
@@ -886,11 +886,11 @@ module ReportController::Reports::Editor
                 @edit[:new][:col_options].delete(co_key) if co_val.empty? # Remove the col, if empty
               end
             end
-            @edit[:new][:sortby1] = NOTHING_STRING
-            @edit[:new][:sortby2] = NOTHING_STRING
+            @edit[:new][:sortby1] = ReportHelper::NOTHING_STRING
+            @edit[:new][:sortby2] = ReportHelper::NOTHING_STRING
           end
           if @edit[:new][:sortby1] && nf.last == @edit[:new][:sortby2].split("__").first  # If deleting the second sort field
-            @edit[:new][:sortby2] = NOTHING_STRING
+            @edit[:new][:sortby2] = ReportHelper::NOTHING_STRING
           end
 
           # Clear out selected chart data column
@@ -950,14 +950,14 @@ module ReportController::Reports::Editor
     rpt.order = @edit[:new][:sortby1].nil? ? nil : @edit[:new][:order]
 
     # Set the graph fields
-    if @edit[:new][:sortby1] == NOTHING_STRING || @edit[:new][:graph_type].nil?
+    if @edit[:new][:sortby1] == ReportHelper::NOTHING_STRING || @edit[:new][:graph_type].nil?
       rpt.dims  = nil
       rpt.graph = nil
     else
       if @edit[:new][:graph_type] =~ /^(Pie|Donut)/ # Pie and Donut charts must be set to 1 dimension
         rpt.dims = 1
       else
-        rpt.dims = @edit[:new][:sortby2] == NOTHING_STRING ? 1 : 2  # Set dims to 1 or 2 based on presence of sortby2
+        rpt.dims = @edit[:new][:sortby2] == ReportHelper::NOTHING_STRING ? 1 : 2 # Set dims to 1 or 2 based on presence of sortby2
       end
       if @edit[:new][:chart_mode] == 'values' && @edit[:new][:chart_column].blank?
         options = chart_fields_options
@@ -1040,7 +1040,7 @@ module ReportController::Reports::Editor
     end
 
     # Set the timeline field
-    if @edit[:new][:tl_field] == NOTHING_STRING
+    if @edit[:new][:tl_field] == ReportHelper::NOTHING_STRING
       rpt.timeline = nil
     else
       rpt.timeline = Hash.new
@@ -1049,7 +1049,7 @@ module ReportController::Reports::Editor
     end
 
     # Set the line break group field
-    if @edit[:new][:sortby1] == NOTHING_STRING  # If no sort fields
+    if @edit[:new][:sortby1] == ReportHelper::NOTHING_STRING # If no sort fields
       rpt.group = nil               # Clear line break group
     else                            # Otherwise, check the setting
       case @edit[:new][:group]
@@ -1071,7 +1071,7 @@ module ReportController::Reports::Editor
     rpt.col_formats = []
     rpt.headers = []
     rpt.include = Hash.new
-    rpt.sortby = @edit[:new][:sortby1] == NOTHING_STRING ? nil : []  # Clear sortby if sortby1 not present, else set up array
+    rpt.sortby = @edit[:new][:sortby1] == ReportHelper::NOTHING_STRING ? nil : [] # Clear sortby if sortby1 not present, else set up array
 
     # Add in the chargeback static fields
     if Chargeback.db_is_chargeback?(rpt.db) # For chargeback, add in specific chargeback report options
@@ -1091,7 +1091,7 @@ module ReportController::Reports::Editor
     @edit[:new][:fields].each do |field_entry|          # Go thru all of the fields
       field = field_entry[1]                            # Get the encoded fully qualified field name
 
-      if @edit[:new][:pivot].by1 != NOTHING_STRING && # If we are doing pivoting and
+      if @edit[:new][:pivot].by1 != ReportHelper::NOTHING_STRING && # If we are doing pivoting and
          @edit[:pivot_cols].key?(field)              # this is a pivot calc column
         @edit[:pivot_cols][field].each do |calc_typ|    # Add header/format/col_order for each calc type
           rpt.headers.push(@edit[:new][:headers][field + "__#{calc_typ}"])
@@ -1363,7 +1363,7 @@ module ReportController::Reports::Editor
     @edit[:new][:display_filter] = @edit[expkey][:expression] if @edit[:new][:display_filter].nil?              # Copy to new exp
 
     # Get timeline fields
-    @edit[:new][:tl_field]     = NOTHING_STRING
+    @edit[:new][:tl_field]     = ReportHelper::NOTHING_STRING
     @edit[:new][:tl_position]  = "Last"
     if @rpt.timeline.kind_of?(Hash)    # Timeline has any data
       @edit[:new][:tl_field]     = @rpt.timeline[:field]     unless @rpt.timeline[:field].blank?
@@ -1402,8 +1402,8 @@ module ReportController::Reports::Editor
     end
 
     # build selected fields array from the report record
-    @edit[:new][:sortby1]  = NOTHING_STRING # Initialize sortby fields to nothing
-    @edit[:new][:sortby2]  = NOTHING_STRING
+    @edit[:new][:sortby1]  = ReportHelper::NOTHING_STRING # Initialize sortby fields to nothing
+    @edit[:new][:sortby2]  = ReportHelper::NOTHING_STRING
     @edit[:new][:pivot] = ReportController::PivotOptions.new
     if params[:pressed] == "miq_report_new"
       @edit[:new][:fields]      = []
@@ -1560,7 +1560,7 @@ module ReportController::Reports::Editor
   def build_field_order
     @edit[:new][:field_order] = []
     @edit[:new][:fields].each do |f|
-      if @edit[:new][:pivot] && @edit[:new][:pivot].by1 != NOTHING_STRING && # If we are doing pivoting and
+      if @edit[:new][:pivot] && @edit[:new][:pivot].by1 != ReportHelper::NOTHING_STRING && # If we are doing pivoting and
          @edit[:pivot_cols].key?(f.last)             # this is a pivot calc column
         MiqReport::PIVOTS.each do |c|
           calc_typ = c.first
@@ -1766,7 +1766,7 @@ module ReportController::Reports::Editor
     when '5'
       if @edit[:new][:fields].empty?
         add_flash(_('Charts tab is not available until at least 1 field has been selected'), :error)
-      elsif @edit[:new][:sortby1].blank? || @edit[:new][:sortby1] == NOTHING_STRING
+      elsif @edit[:new][:sortby1].blank? || @edit[:new][:sortby1] == ReportHelper::NOTHING_STRING
         add_flash(_('Charts tab is not available unless a sort field has been selected'), :error)
         active_tab = 'edit_4'
       end

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -601,10 +601,10 @@ module ReportController::Widgets
     end
     widget.options[:col_order] = [] if @edit[:new][:pivot]
     @edit[:new][:pivot] ||= ReportController::PivotOptions.new
-    widget.options[:col_order].push(@edit[:new][:pivot].by1) if !@edit[:new][:pivot].by1.blank? && @edit[:new][:pivot].by1 != NOTHING_STRING
-    widget.options[:col_order].push(@edit[:new][:pivot].by2) if !@edit[:new][:pivot].by2.blank? && @edit[:new][:pivot].by2 != NOTHING_STRING
-    widget.options[:col_order].push(@edit[:new][:pivot].by3) if !@edit[:new][:pivot].by3.blank? && @edit[:new][:pivot].by3 != NOTHING_STRING
-    widget.options[:col_order].push(@edit[:new][:pivot].by4) if !@edit[:new][:pivot].by4.blank? && @edit[:new][:pivot].by4 != NOTHING_STRING
+    widget.options[:col_order].push(@edit[:new][:pivot].by1) if !@edit[:new][:pivot].by1.blank? && @edit[:new][:pivot].by1 != ReportHelper::NOTHING_STRING
+    widget.options[:col_order].push(@edit[:new][:pivot].by2) if !@edit[:new][:pivot].by2.blank? && @edit[:new][:pivot].by2 != ReportHelper::NOTHING_STRING
+    widget.options[:col_order].push(@edit[:new][:pivot].by3) if !@edit[:new][:pivot].by3.blank? && @edit[:new][:pivot].by3 != ReportHelper::NOTHING_STRING
+    widget.options[:col_order].push(@edit[:new][:pivot].by4) if !@edit[:new][:pivot].by4.blank? && @edit[:new][:pivot].by4 != ReportHelper::NOTHING_STRING
     widget.content_type = WIDGET_CONTENT_TYPE[@sb[:wtype]]
     widget.visibility ||= {}
     if @edit[:new][:visibility_typ] == "group"
@@ -649,7 +649,7 @@ module ReportController::Widgets
         add_flash(_("A %{type} must be selected") % {:type => typ.titleize}, :error)
       end
     end
-    if @sb[:wtype] == "r" && @edit[:new][:pivot].by1 == NOTHING_STRING
+    if @sb[:wtype] == "r" && @edit[:new][:pivot].by1 == ReportHelper::NOTHING_STRING
       add_flash(_("At least one Column must be selected"), :error)
     end
     if @sb[:wtype] == "m"

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -18,7 +18,7 @@ module ReportHelper
     :miq_rpt_gray_bg     => _("Gray Background")
   }
 
-  NOTHING_STRING = "<<< Nothing >>>".freeze
+  NOTHING_STRING = "<<< #{_('Nothing')} >>>".freeze
 
   def visibility_options(widget)
     typ = widget.visibility.keys.first

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -18,6 +18,8 @@ module ReportHelper
     :miq_rpt_gray_bg     => _("Gray Background")
   }
 
+  NOTHING_STRING = "<<< Nothing >>>".freeze
+
   def visibility_options(widget)
     typ = widget.visibility.keys.first
     values = widget.visibility.values.flatten

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -27,7 +27,6 @@ module UiConstants
   }
 
   # Report Controller constants
-  NOTHING_STRING = "<<< Nothing >>>"
   GRAPH_MAX_COUNT = 10
 
   TREND_MODEL = "VimPerformanceTrend"   # Performance trend model name requiring special processing

--- a/app/views/report/_form_consolidate.html.haml
+++ b/app/views/report/_form_consolidate.html.haml
@@ -8,31 +8,31 @@
         = _('Column 1')
       .col-md-8
         = select_tag('chosen_pivot1',
-          options_for_select([NOTHING_STRING] + @pivot.options1, @pivot.by1),
+          options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options1, @pivot.by1),
           :multiple             => false,
           :class                => "selectpicker")
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('chosen_pivot1', '#{url}', {beforeSend: true, complete: true});
-    - if @pivot.by1 != NOTHING_STRING
+    - if @pivot.by1 != ReportHelper::NOTHING_STRING
       .form-group
         %label.control-label.col-md-2
           = _('Column 2')
         .col-md-8
           = select_tag('chosen_pivot2',
-            options_for_select([NOTHING_STRING] + @pivot.options2, @pivot.by2),
+            options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options2, @pivot.by2),
             :multiple             => false,
             :class                => "selectpicker")
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent('chosen_pivot2', '#{url}', {beforeSend: true});
-      - if @pivot.by2 != NOTHING_STRING
+      - if @pivot.by2 != ReportHelper::NOTHING_STRING
         .form-group
           %label.control-label.col-md-2
             = _('Column 3')
           .col-md-8
             = select_tag('chosen_pivot3',
-              options_for_select([NOTHING_STRING] + @pivot.options3, @pivot.by3),
+              options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options3, @pivot.by3),
               :multiple             => false,
               :class                => "selectpicker")
             :javascript
@@ -43,7 +43,7 @@
     = _('Note:')
   = _('Consolidating records will not show detail records in the report.')
   %hr
-  - if @pivot.by1 != NOTHING_STRING
+  - if @pivot.by1 != ReportHelper::NOTHING_STRING
     %h3
       = _('Specify Calculations of Numeric Values for Grouped Records')
     %table.table.table-striped.table-bordered

--- a/app/views/report/_form_sort.html.haml
+++ b/app/views/report/_form_sort.html.haml
@@ -12,7 +12,7 @@
         - else
           - sortby1 = @sortby1
         = select_tag('chosen_sort1',
-          options_for_select([NOTHING_STRING] + @sort1, sortby1),
+          options_for_select([ReportHelper::NOTHING_STRING] + @sort1, sortby1),
           :multiple              => false,
           :class                 => "selectpicker")
         :javascript
@@ -27,7 +27,7 @@
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent('sort1_suffix', '#{url}', {beforeSend: true, complete: true});
-    - if @sortby1 != NOTHING_STRING
+    - if @sortby1 != ReportHelper::NOTHING_STRING
       .form-group
         %label.control-label.col-md-2
           = _('Sort Order')
@@ -75,7 +75,7 @@
               :javascript
                 miqInitSelectPicker();
                 miqSelectPickerEvent('break_format', '#{url}', {beforeSend: true, complete: true});
-  - if @sortby1 != NOTHING_STRING
+  - if @sortby1 != ReportHelper::NOTHING_STRING
     %br
     .form-horizontal
       .form-group
@@ -87,7 +87,7 @@
           - else
             - sortby2 = @sortby2
           = select_tag('chosen_sort2',
-            options_for_select([NOTHING_STRING] + @sort2, sortby2),
+            options_for_select([ReportHelper::NOTHING_STRING] + @sort2, sortby2),
             :multiple              => false,
             :class                 => "selectpicker")
           :javascript
@@ -117,7 +117,7 @@
               miqSelectPickerEvent('row_limit', '#{url}', {beforeSend: true, complete: true});
           - else
             = _('All')
-  - unless @sortby1 == NOTHING_STRING || @edit[:new][:group] == "No"
+  - unless @sortby1 == ReportHelper::NOTHING_STRING || @edit[:new][:group] == "No"
     %hr
     %h3
       = _("Specify Calculations for Summary Rows")

--- a/app/views/report/_form_tl_sample.html.haml
+++ b/app/views/report/_form_tl_sample.html.haml
@@ -1,5 +1,5 @@
 #tl_sample_div
-  - if @tl_field != NOTHING_STRING
+  - if @tl_field != ReportHelper::NOTHING_STRING
     %hr
     %h3
       = _('Sample Timeline')

--- a/app/views/report/_form_tl_settings.html.haml
+++ b/app/views/report/_form_tl_settings.html.haml
@@ -10,14 +10,14 @@
             = _('Base Timeline on')
           .col-md-8
             = select_tag('chosen_tl',
-              options_for_select([NOTHING_STRING] + @tl_fields, @tl_field),
+              options_for_select([ReportHelper::NOTHING_STRING] + @tl_fields, @tl_field),
               :multiple              => false,
               :class                 => "selectpicker")
             :javascript
               miqInitSelectPicker();
               miqSelectPickerEvent('chosen_tl', '#{url}', {beforeSend: true, complete: true});
     .col-md-12.col-lg-6
-      - if @tl_field != NOTHING_STRING
+      - if @tl_field != ReportHelper::NOTHING_STRING
         .form-horizontal
           .form-group
             %label.control-label.col-md-2

--- a/app/views/report/_widget_columns.html.haml
+++ b/app/views/report/_widget_columns.html.haml
@@ -5,49 +5,49 @@
       *
     = _('Column 1')
   .col-md-8
-    = select_tag("chosen_pivot1", options_for_select([NOTHING_STRING] + @pivot.options1, @pivot.by1),
+    = select_tag("chosen_pivot1", options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options1, @pivot.by1),
       :multiple             => false,
       :class                => "selectpicker",
       :disabled             => @edit[:read_only])
     :javascript
       miqInitSelectPicker();
       miqSelectPickerEvent('chosen_pivot1', '#{url}', {beforeSend: true})
-- if @pivot.by1 != NOTHING_STRING && @pivot.options2.present?
+- if @pivot.by1 != ReportHelper::NOTHING_STRING && @pivot.options2.present?
   .form-group
     %label.control-label.col-md-2
       - if @edit[:read_only]
         *
       = _('Column 2')
     .col-md-8
-      = select_tag("chosen_pivot2", options_for_select([NOTHING_STRING] + @pivot.options2, @pivot.by2),
+      = select_tag("chosen_pivot2", options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options2, @pivot.by2),
         :multiple             => false,
         :class                => "selectpicker",
         :disabled             => @edit[:read_only])
       :javascript
         miqInitSelectPicker();
         miqSelectPickerEvent('chosen_pivot2', '#{url}', {beforeSend: true});
-  - if @pivot.by2 != NOTHING_STRING && @pivot.options3.present?
+  - if @pivot.by2 != ReportHelper::NOTHING_STRING && @pivot.options3.present?
     .form-group
       %label.control-label.col-md-2
         - if @edit[:read_only]
           *
         = _('Column 3')
       .col-md-8
-        = select_tag("chosen_pivot3", options_for_select([NOTHING_STRING] + @pivot.options3, @pivot.by3),
+        = select_tag("chosen_pivot3", options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options3, @pivot.by3),
           :multiple             => false,
           :class                => "selectpicker",
           :disabled             => @edit[:read_only])
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('chosen_pivot3', '#{url}', {beforeSend: true});
-  - if @pivot.by3 != NOTHING_STRING && @edit[:new][:pivot].options4.present?
+  - if @pivot.by3 != ReportHelper::NOTHING_STRING && @edit[:new][:pivot].options4.present?
     .form-group
       %label.control-label.col-md-2
         - if @edit[:read_only]
           *
         = _('Column 4')
       .col-md-8
-        = select_tag("chosen_pivot4", options_for_select([NOTHING_STRING] + @pivot.options4, @pivot.by4),
+        = select_tag("chosen_pivot4", options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options4, @pivot.by4),
           :multiple             => false,
           :class                => "selectpicker",
           :disabled             => @edit[:read_only],

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -494,12 +494,12 @@ describe ReportController do
           edit = assigns(:edit)
           edit[:new][:pivot] = ReportController::PivotOptions.new(P1, P2, P3)
           controller.instance_variable_set(:@edit, edit)
-          controller.instance_variable_set(:@_params, :chosen_pivot1 => NOTHING_STRING)
+          controller.instance_variable_set(:@_params, :chosen_pivot1 => ReportHelper::NOTHING_STRING)
           controller.send(:gfv_pivots)
           edit_new = assigns(:edit)[:new]
-          expect(edit_new[:pivot].by1).to eq(NOTHING_STRING)
-          expect(edit_new[:pivot].by2).to eq(NOTHING_STRING)
-          expect(edit_new[:pivot].by3).to eq(NOTHING_STRING)
+          expect(edit_new[:pivot].by1).to eq(ReportHelper::NOTHING_STRING)
+          expect(edit_new[:pivot].by2).to eq(ReportHelper::NOTHING_STRING)
+          expect(edit_new[:pivot].by3).to eq(ReportHelper::NOTHING_STRING)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
           expect(assigns(:refresh_partial)).to eq("form_consolidate")
         end
@@ -508,12 +508,12 @@ describe ReportController do
           edit = assigns(:edit)
           edit[:new][:pivot] = ReportController::PivotOptions.new(P1, P2, P3)
           controller.instance_variable_set(:@edit, edit)
-          controller.instance_variable_set(:@_params, :chosen_pivot2 => NOTHING_STRING)
+          controller.instance_variable_set(:@_params, :chosen_pivot2 => ReportHelper::NOTHING_STRING)
           controller.send(:gfv_pivots)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:pivot].by1).to eq(P1)
-          expect(edit_new[:pivot].by2).to eq(NOTHING_STRING)
-          expect(edit_new[:pivot].by3).to eq(NOTHING_STRING)
+          expect(edit_new[:pivot].by2).to eq(ReportHelper::NOTHING_STRING)
+          expect(edit_new[:pivot].by3).to eq(ReportHelper::NOTHING_STRING)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
           expect(assigns(:refresh_partial)).to eq("form_consolidate")
         end
@@ -527,7 +527,7 @@ describe ReportController do
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:pivot].by1).to eq(P2)
           expect(edit_new[:pivot].by2).to eq(P3)
-          expect(edit_new[:pivot].by3).to eq(NOTHING_STRING)
+          expect(edit_new[:pivot].by3).to eq(ReportHelper::NOTHING_STRING)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
           expect(assigns(:refresh_partial)).to eq("form_consolidate")
         end
@@ -541,7 +541,7 @@ describe ReportController do
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:pivot].by1).to eq(P1)
           expect(edit_new[:pivot].by2).to eq(P3)
-          expect(edit_new[:pivot].by3).to eq(NOTHING_STRING)
+          expect(edit_new[:pivot].by3).to eq(ReportHelper::NOTHING_STRING)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
           expect(assigns(:refresh_partial)).to eq("form_consolidate")
         end
@@ -576,17 +576,17 @@ describe ReportController do
           controller.send(:gfv_sort)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:sortby1]).to eq(S2)
-          expect(edit_new[:sortby2]).to eq(NOTHING_STRING)
+          expect(edit_new[:sortby2]).to eq(ReportHelper::NOTHING_STRING)
           expect(assigns(:refresh_div)).to eq("sort_div")
           expect(assigns(:refresh_partial)).to eq("form_sort")
         end
 
         it "clearing first sort col clears both sort cols" do
-          controller.instance_variable_set(:@_params, :chosen_sort1 => NOTHING_STRING)
+          controller.instance_variable_set(:@_params, :chosen_sort1 => ReportHelper::NOTHING_STRING)
           controller.send(:gfv_sort)
           edit_new = assigns(:edit)[:new]
-          expect(edit_new[:sortby1]).to eq(NOTHING_STRING)
-          expect(edit_new[:sortby2]).to eq(NOTHING_STRING)
+          expect(edit_new[:sortby1]).to eq(ReportHelper::NOTHING_STRING)
+          expect(edit_new[:sortby2]).to eq(ReportHelper::NOTHING_STRING)
           expect(assigns(:refresh_div)).to eq("sort_div")
           expect(assigns(:refresh_partial)).to eq("form_sort")
         end
@@ -646,11 +646,11 @@ describe ReportController do
         end
 
         it "clearing second sort col" do
-          controller.instance_variable_set(:@_params, :chosen_sort2 => NOTHING_STRING)
+          controller.instance_variable_set(:@_params, :chosen_sort2 => ReportHelper::NOTHING_STRING)
           controller.send(:gfv_sort)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:sortby1]).to eq(S1)
-          expect(edit_new[:sortby2]).to eq(NOTHING_STRING)
+          expect(edit_new[:sortby2]).to eq(ReportHelper::NOTHING_STRING)
         end
 
         it "sets second sort col suffix" do
@@ -694,10 +694,10 @@ describe ReportController do
         end
 
         it "clears timeline col" do
-          controller.instance_variable_set(:@_params, :chosen_tl => NOTHING_STRING)
+          controller.instance_variable_set(:@_params, :chosen_tl => ReportHelper::NOTHING_STRING)
           controller.send(:gfv_timeline)
           edit = assigns(:edit)
-          expect(edit[:new][:tl_field]).to eq(NOTHING_STRING)
+          expect(edit[:new][:tl_field]).to eq(ReportHelper::NOTHING_STRING)
         end
 
         it "sets event to position at" do


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `NOTHING_STRING` was removed from `UiConstants` and moved to `ReportHelper`.
Prefix `ReportHelper::` was added to some occurrences of this constant or `include ReportHelper`.

Added missing gettext call around `Nothing` string.


**Calling `_form_consolidate.html.haml`**:
`Cloud Intel` -> `Reports` -> `Reports` -> `Virtual Machines` -> `Configuration` ->` Add new Report` -> `Consolidation`

**Calling `_form_sort.html.haml`**:
`Cloud Intel` -> `Reports` -> `Reports` -> `Virtual Machines` -> `Configuration` ->` Add new Report` -> `Summary`

**Calling `_form_tl_sample.html.haml` or `_form_tl_settings.html.haml`**:
`Cloud Intel` -> `Reports` -> `Reports` -> `Virtual Machines` -> `Configuration` ->` Add new Report` -> `Timeline`

**Calling `_widget_columns.html.haml`**:
`Cloud Intel` -> `Reports` -> `Reports` -> `Virtual Machines` -> `Configuration` ->` Add new Report` -> ` `