### PR TITLE
Use the error modal for API errors as well

### DIFF
--- a/app/assets/javascripts/controllers/error_modal_controller.js
+++ b/app/assets/javascripts/controllers/error_modal_controller.js
@@ -8,18 +8,19 @@ function ErrorModalController($timeout) {
   ManageIQ.angular.rxSubject.subscribe(function(event) {
     if ('serverError' in event) {
       $timeout(function() {
-        $ctrl.show(event.serverError);
+        $ctrl.show(event.serverError, event.source);
       });
     }
   });
 
-  $ctrl.show = function(err) {
+  $ctrl.show = function(err, source) {
     if (!err || !_.isObject(err)) {
       return;
     }
 
     $ctrl.data = err.data;
     $ctrl.error = err;
+    $ctrl.source = source;
     $ctrl.isHtml = err.headers && err.headers('content-type') && err.headers('content-type').match('text/html');
 
     // special handling for our error screen
@@ -54,7 +55,7 @@ angular.module('miq.error', [])
       '            </span>',
       '          </button>',
       '          <h4 class="modal-title">',
-      '            Server Error',
+      '            Server Error {{$ctrl.source && "(" + $ctrl.source + ")"}}',
       '          </h4>',
       '        </div>',
       '        <div class="modal-body">',

--- a/app/assets/javascripts/controllers/error_modal_controller.js
+++ b/app/assets/javascripts/controllers/error_modal_controller.js
@@ -13,6 +13,23 @@ function ErrorModalController($timeout) {
     }
   });
 
+  function findError(data) {
+    // find the exception in our miq rails error screen
+    var m = data.match(/<h2>\s*Error text:\s*<\/h2>\s*<br>\s*<h3>\s*(.*?)\s*<\/h3>/);
+    if (m) {
+      return m[1];
+    }
+
+    // the same in JS-encoded form
+    m = data.match(/\\u003ch2\\u003e\\nError text:\\n\\u003c\/h2\\u003e\\n\\u003cbr\\u003e\\n\\u003ch3\\u003e\\n(.*?)\\n\\u003c\/h3\\u003e/);
+    if (m) {
+      return m[1];
+    }
+
+    // no luck
+    return data;
+  }
+
   $ctrl.show = function(err, source) {
     if (!err || !_.isObject(err)) {
       return;
@@ -33,10 +50,7 @@ function ErrorModalController($timeout) {
 
     // special handling for our error screen
     if ($ctrl.isHtml && $ctrl.data) {
-      var m = $ctrl.data.match(/<h2>\s*Error text:\s*<\/h2>\s*<br>\s*<h3>\s*(.*?)\s*<\/h3>/);
-      if (m) {
-        $ctrl.data = m[1];
-      }
+      $ctrl.data = findError($ctrl.data);
     }
 
     $ctrl.status = (err.status !== -1) ? err.status + " " + err.statusText : "Server not responding";

--- a/app/assets/javascripts/controllers/error_modal_controller.js
+++ b/app/assets/javascripts/controllers/error_modal_controller.js
@@ -20,8 +20,10 @@ function ErrorModalController($timeout) {
 
     if (source === 'API') {
       $ctrl.contentType = err.headers.get("content-type");
+      $ctrl.url = err.url;
     } else if (source === '$http') {
       $ctrl.contentType = err.headers('content-type');
+      $ctrl.url = err.config.url;
     }
 
     $ctrl.error = err;
@@ -69,6 +71,12 @@ angular.module('miq.error', [])
       '            <i class="error-icon pficon-error-circle-o"></i>',
       '          </div>',
       '          <div class="col-xs-12 col-md-10">',
+      '            <p ng-if="$ctrl.url">',
+      '              <strong>',
+      '                URL',
+      '              </strong>',
+      '              {{$ctrl.url}}',
+      '            </p>',
       '            <p>',
       '              <strong>',
       '                Status',

--- a/app/assets/javascripts/controllers/error_modal_controller.js
+++ b/app/assets/javascripts/controllers/error_modal_controller.js
@@ -18,10 +18,16 @@ function ErrorModalController($timeout) {
       return;
     }
 
-    $ctrl.data = err.data;
+    if (source === 'API') {
+      $ctrl.contentType = err.headers.get("content-type");
+    } else if (source === '$http') {
+      $ctrl.contentType = err.headers('content-type');
+    }
+
     $ctrl.error = err;
     $ctrl.source = source;
-    $ctrl.isHtml = err.headers && err.headers('content-type') && err.headers('content-type').match('text/html');
+    $ctrl.data = err.data;
+    $ctrl.isHtml = ($ctrl.contentType || "").match('text/html');
 
     // special handling for our error screen
     if ($ctrl.isHtml && $ctrl.data) {
@@ -73,7 +79,7 @@ angular.module('miq.error', [])
       '              <strong>',
       '                Content-Type',
       '              </strong>',
-      '              {{$ctrl.error.headers("content-type")}}',
+      '              {{$ctrl.contentType}}',
       '            </p>',
       '            <p>',
       '              <strong>',

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -39,9 +39,10 @@ function miqHttpInject(angular_app) {
         responseError: function(err) {
           sendDataWithRx({
             serverError: err,
+            source: '$http',
           });
 
-          console.error('Server returned a non-200 response:', err.status, err.statusText, err);
+          console.error('$http: Server returned a non-200 response:', err.status, err.statusText, err);
           return $q.reject(err);
         },
       };

--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -115,6 +115,23 @@
     });
   };
 
+  // default to using the error modal on error
+  ["get", "post", "put", "delete", "options", "patch"].forEach(function(name) {
+    var orig = API[name];
+
+    API[name] = function() {
+      return orig.apply(this, arguments)
+        .catch(function(err) {
+          sendDataWithRx({
+            serverError: err,
+          });
+
+          console.error('Server returned a non-200 response:', err.status, err.statusText, err);
+          throw err;
+        });
+    };
+  });
+
   window.vanillaJsAPI = API;
 
 

--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -115,7 +115,7 @@
     });
   };
 
-  // default to using the error modal on error
+  // default to using the error modal on error, skip by using API.get.noErrorModal instead
   ["get", "post", "put", "delete", "options", "patch"].forEach(function(name) {
     var orig = API[name];
 
@@ -131,6 +131,8 @@
           throw err;
         });
     };
+
+    API[name].noErrorModal = orig;
   });
 
   window.vanillaJsAPI = API;
@@ -195,9 +197,15 @@
 angular.module('miq.api', [])
 .factory('API', ['$q', function($q) {
   var angularify = function(what) {
-    return function() {
+    var ret = function() {
       return $q.when(what.apply(vanillaJsAPI, arguments));
     };
+
+    if (what.noErrorModal) {
+      ret.noErrorModal = angularify(what.noErrorModal);
+    }
+
+    return ret;
   };
 
   return {

--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -124,9 +124,10 @@
         .catch(function(err) {
           sendDataWithRx({
             serverError: err,
+            source: 'API',
           });
 
-          console.error('Server returned a non-200 response:', err.status, err.statusText, err);
+          console.error('API: Server returned a non-200 response:', err.status, err.statusText, err);
           throw err;
         });
     };


### PR DESCRIPTION
Right now, we have an error modal component, which we trigger when an angular ajax request fails - but only for requests made via angular's $http.

Now that we're moving to use the API more and more, we also need to see those errors if they're coming from the API.

Thus, this enhances the error modal to:

   * work for all API requests, unless called with `noErrorModal`
   * show the request type in the header (`API` vs `$http`)
   * show the request URL


To prevent the error modal on API request when such is not desired (for example, when a 404 is a valid response that the client code can handle), this makes it possible to call those methods as `API.get.noErrorModal(url)` instead of `API.get(url)` and not see the error. (This works for all the request methods, not just get.)

---

An API request failing (this is new):

![api_error](https://user-images.githubusercontent.com/289743/29574780-15c77b58-8752-11e7-8242-f4b8494a102c.png)

A `$http` request failing (this worked before, but didn't show the url (or the type)):

![http_error](https://user-images.githubusercontent.com/289743/29574800-2a89ee7c-8752-11e7-8b5c-bc782fee1db5.png)
