### PR TITLE
Refactoring the utilization, planning and bottlenecks controllers

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -1089,28 +1089,28 @@ module ApplicationController::Performance
     @perf_record = MiqEnterprise.first
 
     unless params[:task_id] || params[:display_vms]     # First time thru, generate report async
-      unless (refresh == "n" || params[:refresh] == "n") && @sb[:planning][:options] && @sb[:planning][:options][:model] == @perf_record.class.base_class.to_s
-        @sb[:planning][:options] ||= {}
-        @sb[:planning][:options][:typ] = "Daily"
-        @sb[:planning][:options][:days] ||= "30"
-        @sb[:planning][:options][:model] = "VimPerformancePlanning"
-        @sb[:planning][:options][:record_id] = @perf_record.id
+      unless (refresh == "n" || params[:refresh] == "n") && @sb[:options] && @sb[:options][:model] == @perf_record.class.base_class.to_s
+        @sb[:options] ||= {}
+        @sb[:options][:typ] = "Daily"
+        @sb[:options][:days] ||= "30"
+        @sb[:options][:model] = "VimPerformancePlanning"
+        @sb[:options][:record_id] = @perf_record.id
       end
-      @sb[:planning][:options][:trend_end] = perf_planning_end_date
-      @sb[:planning][:options][:days] ||= "30"
-      @sb[:planning][:options][:ght_type] ||= "hybrid"
-      @sb[:planning][:options][:chart_type] = :summary
-      @sb[:planning][:rpt] = nil                  # Clear existing planning report
+      @sb[:options][:trend_end] = perf_planning_end_date
+      @sb[:options][:days] ||= "30"
+      @sb[:options][:ght_type] ||= "hybrid"
+      @sb[:options][:chart_type] = :summary
+      @sb[:rpt] = nil                  # Clear existing planning report
       rpt = perf_get_chart_rpt("vim_perf_planning")
 
-      rpt.headers[0] = "#{ui_lookup(:model => @sb[:planning][:options][:target_typ])} Name"
+      rpt.headers[0] = "#{ui_lookup(:model => @sb[:options][:target_typ])} Name"
       rpt.db_options = Hash.new
       rpt.db_options[:rpt_type] = "planning"
       # Set the default planning options
-      rpt.db_options[:options] = {:vm_options => VimPerformancePlanning.vm_default_options(@sb[:planning][:options][:vm_mode])}
+      rpt.db_options[:options] = {:vm_options => VimPerformancePlanning.vm_default_options(@sb[:options][:vm_mode])}
 
-      if @sb[:planning][:options][:vm_mode] == :manual  # Set the manually entered values
-        @sb[:planning][:options][:values].each do |k, v|
+      if @sb[:options][:vm_mode] == :manual  # Set the manually entered values
+        @sb[:options][:values].each do |k, v|
           if k.to_sym == :storage
             rpt.db_options[:options][:vm_options][k.to_sym][:value] = v * 1.gigabyte
           else
@@ -1119,54 +1119,54 @@ module ApplicationController::Performance
         end
       end
 
-      rpt.db_options[:options][:vm] = @sb[:planning][:options][:chosen_vm] ? @sb[:planning][:options][:chosen_vm].to_i : nil
+      rpt.db_options[:options][:vm] = @sb[:options][:chosen_vm] ? @sb[:options][:chosen_vm].to_i : nil
 
       rpt.db_options[:options][:range] = {
-        :days     => @sb[:planning][:options][:days],
-        :end_date => @sb[:planning][:options][:trend_end]
+        :days     => @sb[:options][:days],
+        :end_date => @sb[:options][:trend_end]
       }
 
-      rpt.db_options[:options][:target_tags] = {:compute_type => @sb[:planning][:options][:target_typ].to_sym}
-      rpt.db_options[:options][:target_tags][:compute_filter] = @sb[:planning][:options][:target_filter] if @sb[:planning][:options][:target_filter]
+      rpt.db_options[:options][:target_tags] = {:compute_type => @sb[:options][:target_typ].to_sym}
+      rpt.db_options[:options][:target_tags][:compute_filter] = @sb[:options][:target_filter] if @sb[:options][:target_filter]
 
       rpt.db_options[:options][:target_options] = {}
-      if @sb[:planning][:options][:trend_cpu]
+      if @sb[:options][:trend_cpu]
         rpt.db_options[:options][:target_options][:cpu] = {
           :mode      => :perf_trend,
           :metric    => :max_cpu_usagemhz_rate_average,
           :limit_col => :derived_cpu_available,
-          :limit_pct => @sb[:planning][:options][:limit_cpu]
+          :limit_pct => @sb[:options][:limit_cpu]
         }
       end
-      if @sb[:planning][:options][:trend_memory]
+      if @sb[:options][:trend_memory]
         rpt.db_options[:options][:target_options][:memory] = {
           :mode      => :perf_trend,
           :metric    => :max_derived_memory_used,
           :limit_col => :derived_memory_available,
-          :limit_pct => @sb[:planning][:options][:limit_memory]
+          :limit_pct => @sb[:options][:limit_memory]
         }
       end
-      if @sb[:planning][:options][:trend_storage]
+      if @sb[:options][:trend_storage]
         rpt.db_options[:options][:target_options][:storage] = {
           :mode      => :current,
           :metric    => :used_space,
           :limit_col => :total_space,
-          :limit_pct => @sb[:planning][:options][:limit_storage]
+          :limit_pct => @sb[:options][:limit_storage]
         }
       end
-      if @sb[:planning][:options][:trend_vcpus]
+      if @sb[:options][:trend_vcpus]
         rpt.db_options[:options][:target_options][:vcpus] = {
           :mode        => :current,
           :limit_col   => :total_vcpus, # not sure of name, but should be # vcpus/core times # of cores
-          :limit_ratio => @sb[:planning][:options][:limit_vcpus]
+          :limit_ratio => @sb[:options][:limit_vcpus]
         }
       end
-      rpt.tz = @sb[:planning][:options][:tz]
-      rpt.time_profile_id = @sb[:planning][:options][:time_profile]
+      rpt.tz = @sb[:options][:tz]
+      rpt.time_profile_id = @sb[:options][:time_profile]
 
       # Remove columns not checked in options
       [:cpu, :vcpus, :memory, :storage].each do |k|
-        if @sb[:planning][:vm_opts][k].nil? || !@sb[:planning][:options]["trend_#{k}".to_sym]
+        if @sb[:vm_opts][k].nil? || !@sb[:options]["trend_#{k}".to_sym]
           i = rpt.col_order.index("#{k}_vm_count")
           rpt.col_order.delete_at(i)
           rpt.headers.delete_at(i)
@@ -1186,23 +1186,23 @@ module ApplicationController::Performance
 
     # Remove columns not checked in options
     [:cpu, :vcpus, :memory, :storage].each do |k|
-      if @sb[:planning][:vm_opts][k].nil? || !@sb[:planning][:options]["trend_#{k == :storage ? "disk" : k.to_s}".to_sym]
+      if @sb[:vm_opts][k].nil? || !@sb[:options]["trend_#{k == :storage ? "disk" : k.to_s}".to_sym]
         chart_layouts[:VimPerformancePlanning].first[:columns].delete_if { |col| col == "#{k}_vm_count" }
       end
     end
 
     if params.key?(:display_vms)                # Only changed date for the timestamp charts, no need to rebuild the report object
-      rpt = @sb[:planning][:rpt]
+      rpt = @sb[:rpt]
     elsif params[:task_id]                          # Came in after async report generation
       miq_task = MiqTask.find(params[:task_id])     # Not first time, read the task record
       rpt = miq_task.miq_report_result.report_results # Grab the report object from the blob
       miq_task.destroy                              # Get rid of the task and results
     end
-    @sb[:planning][:options][:index] = nil
-    unless @sb[:planning][:options][:index]
-      chart_layouts[@sb[:planning][:options][:model].to_sym].each_with_index do |chart, _idx|
+    @sb[:options][:index] = nil
+    unless @sb[:options][:index]
+      chart_layouts[@sb[:options][:model].to_sym].each_with_index do |chart, _idx|
         if chart[:type] == "None" || # No chart is available for this slot
-           (@sb[:planning][:options][:tag] && chart[:allowed_child_tag] && !@sb[:planning][:options][:tag].starts_with?(chart[:allowed_child_tag]))  # Tag not allowed
+           (@sb[:options][:tag] && chart[:allowed_child_tag] && !@sb[:options][:tag].starts_with?(chart[:allowed_child_tag]))  # Tag not allowed
           chart_data.push(nil)              # Push a placeholder onto the chart data array
         else
           options = chart
@@ -1210,36 +1210,36 @@ module ApplicationController::Performance
             trendcol = perf_get_chart_trendcol(chart)
           end
           options[:chart_type] = chart[:chart_type].to_sym if chart[:chart_type]  # Override :summary chart type if specified in chart definition
-          options[:max_value] = @sb[:planning][:options][:display_vms] if @sb[:planning][:options][:display_vms]
+          options[:max_value] = @sb[:options][:display_vms] if @sb[:options][:display_vms]
           chart_data.push(perf_gen_chart(rpt, options).merge(:menu => chart[:menu]))
           chart[:title] = rpt.title           # Grab title from chart in case formatting added units
         end
         charts.push(chart)
       end
     else
-      chart = chart_layouts[@sb[:planning][:options][:model].to_sym][@sb[:planning][:options][:index].to_i]
+      chart = chart_layouts[@sb[:options][:model].to_sym][@sb[:options][:index].to_i]
       perf_remove_chart_cols(chart)
       options = chart.merge(:width => 1000, :height => 700)
       if chart[:trends]
         trendcol = perf_get_chart_trendcol(chart)
       end
       options[:chart_type] = chart[:chart_type].to_sym if chart[:chart_type]  # Override :summary chart type if specified in chart definition
-      options[:max_value] = @sb[:planning][:options][:display_vms] if @sb[:planning][:options][:display_vms]
+      options[:max_value] = @sb[:options][:display_vms] if @sb[:options][:display_vms]
       chart_data.push(perf_gen_chart(rpt, options).merge(:menu => chart[:menu]))
       chart[:title] = rpt.title                 # Grab title from chart in case formatting added units
       charts.push(chart)
     end
-    @sb[:planning][:rpt] = rpt                  # Hang on to the report data for the trend charts
-    @sb[:planning][:charts] = charts
-    @sb[:planning][:chart_data] = {}
-    @sb[:planning][:chart_data]["planning"] = chart_data
+    @sb[:rpt] = rpt                  # Hang on to the report data for the trend charts
+    @sb[:charts] = charts
+    @sb[:chart_data] = {}
+    @sb[:chart_data]["planning"] = chart_data
   end
 
   # Get the ending trend date for planning trend lookups
   def perf_planning_end_date
     s, e = MiqEnterprise.first.first_and_last_capture
     return if s.nil?                                      # Nothing to do if no util data
-    tz = @sb[:planning][:options][:time_profile_tz] || @sb[:planning][:options][:tz]  # Use tz in time profile or chosen tz, if no profile tz
+    tz = @sb[:options][:time_profile_tz] || @sb[:options][:tz]  # Use tz in time profile or chosen tz, if no profile tz
     edate = e.in_time_zone(tz)
     edate = edate.hour < 23 ? edate - 1.day : edate # Eliminate partial end days
     create_time_in_tz([edate.month, edate.day, edate.year].join("/") + " 23", tz)

--- a/app/controllers/bottlenecks_controller.rb
+++ b/app/controllers/bottlenecks_controller.rb
@@ -9,7 +9,6 @@ class BottlenecksController < ApplicationController
   def index
     @explorer = true
     @trees = [] # TODO: TreeBuilder
-    @breadcrumbs = []
     @explorer = true
     @layout = "miq_capacity_bottlenecks"
     self.x_active_tree = 'bottlenecks_tree'
@@ -128,7 +127,6 @@ class BottlenecksController < ApplicationController
     end
     @sb[:active_tab] = "summary" # reset tab back to first tab when node is changed in the tree
     show_timeline(refresh) # Create the timeline report
-    drop_breadcrumb(:name => _("Activity"), :url => "/bottlenecks/?refresh=n")
   end
 
   def show_timeline(refresh = nil)

--- a/app/controllers/bottlenecks_controller.rb
+++ b/app/controllers/bottlenecks_controller.rb
@@ -1,8 +1,6 @@
 class BottlenecksController < ApplicationController
   before_action :check_privileges
   before_action :get_session_data
-  after_action :cleanup_action
-  after_action :set_session_data
 
   menu_section(:opt)
 
@@ -88,17 +86,8 @@ class BottlenecksController < ApplicationController
   private
 
   def get_session_data
-    @title        = _("Bottlenecks")
-    @layout     ||= "miq_capacity_bottlenecks"
-    @lastaction   = session[:miq_capacity_lastaction]
-    @display      = session[:miq_capacity_display]
-    @current_page = session[:miq_capacity_current_page]
-  end
-
-  def set_session_data
-    session[:miq_capacity_lastaction]   = @lastaction
-    session[:miq_capacity_current_page] = @current_page
-    session[:miq_capacity_display]      = @display unless @display.nil?
+    @title = _("Bottlenecks")
+    @layout ||= "miq_capacity_bottlenecks"
   end
 
   def replace_right_cell

--- a/app/controllers/bottlenecks_controller.rb
+++ b/app/controllers/bottlenecks_controller.rb
@@ -8,30 +8,14 @@ class BottlenecksController < ApplicationController
 
   def index
     @explorer = true
-    @trees = [] # TODO: TreeBuilder
-    @explorer = true
-    @layout = "miq_capacity_bottlenecks"
-    self.x_active_tree = 'bottlenecks_tree'
-
-    @accords = [{
-      :name      => "bottlenecks",
-      :title     => _("Bottlenecks"),
-      :container => "bottlenecks_accord",
-      :image     => "enterprise"
-    }]
-
-    @trees << TreeBuilderUtilization.new(
-      :bottlenecks_tree, :bottlenecks, @sb, true, :selected_node => x_node(:bottlenecks_tree)
-    )
     @right_cell_text = _("Bottlenecks Summary")
-
     @sb[:active_tab] = "summary"
-    self.x_node ||= ""
     @timeline = true
-    if @sb[:report]
-      tl_to_xml # Use existing report to generate timeline
-    end
-    get_node_info(x_node)  if x_node != "" # Get the bottleneck info for the tree node
+
+    tl_to_xml if @sb[:report] # Use existing report to generate timeline
+
+    build_accordions_and_trees
+
     render :layout => "application"
   end
 
@@ -82,6 +66,17 @@ class BottlenecksController < ApplicationController
   end
 
   private
+
+  def features
+    [
+      {:role     => "bottlenecks",
+       :role_any => true,
+       :name     => :utilization,
+       :title    => _("Bottlenecks")}
+    ].map do |hsh|
+      ApplicationController::Feature.new_with_hash(hsh)
+    end
+  end
 
   def get_session_data
     @title = _("Bottlenecks")

--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -116,6 +116,7 @@ module Sandbox
     automation_manager_providers
     automation_manager_cs_filter
     automation_manager_configuration_scripts
+    bottlenecks
     cb_assignments
     cb_rates
     cb_reports
@@ -159,6 +160,7 @@ module Sandbox
     templates_filter
     templates_images_filter
     templates_images_filter
+    utilization
     vandt
     vmdb
     vms_filter

--- a/app/controllers/planning_controller.rb
+++ b/app/controllers/planning_controller.rb
@@ -5,7 +5,6 @@ class PlanningController < ApplicationController
   menu_section(:opt)
 
   def index
-    @breadcrumbs = []
     @explorer = true
     @accords = [{:name => "planning", :title => _("Planning Options"), :container => "planning_options_accord"}]
 
@@ -18,7 +17,6 @@ class PlanningController < ApplicationController
   end
 
   def plan
-    @breadcrumbs = []
     @explorer = true
     @accords = [{:name => "planning", :title => _("Planning Options"), :container => "planning_options_accord"}]
 
@@ -172,7 +170,6 @@ class PlanningController < ApplicationController
   end
 
   def reset
-    @breadcrumbs = []
     @explorer = true
     @accords = [{:name => "planning", :title => _("Planning Options"), :container => "planning_options_accord"}]
 
@@ -210,7 +207,6 @@ class PlanningController < ApplicationController
   end
 
   def build_options
-    @breadcrumbs = []
     @sb[:planning] ||= {} # Leave existing values
     @sb[:planning] = {} if params[:button] == "reset" # Clear everything on reset
     @sb[:planning][:options] ||= {} # Leave existing values

--- a/app/controllers/planning_controller.rb
+++ b/app/controllers/planning_controller.rb
@@ -24,16 +24,16 @@ class PlanningController < ApplicationController
     @sb[:active_tab] = "summary"
     @layout = "miq_capacity_planning"
 
-    vm_opts = VimPerformancePlanning.vm_default_options(@sb[:planning][:options][:vm_mode])
-    if (vm_opts[:cpu] && @sb[:planning][:options][:trend_cpu]) || # Check that at least one required metric is checked
-       (vm_opts[:vcpus] && @sb[:planning][:options][:trend_vcpus]) ||
-       (vm_opts[:memory] && @sb[:planning][:options][:trend_memory]) ||
-       (vm_opts[:storage] && @sb[:planning][:options][:trend_storage])
+    vm_opts = VimPerformancePlanning.vm_default_options(@sb[:options][:vm_mode])
+    if (vm_opts[:cpu] && @sb[:options][:trend_cpu]) || # Check that at least one required metric is checked
+       (vm_opts[:vcpus] && @sb[:options][:trend_vcpus]) ||
+       (vm_opts[:memory] && @sb[:options][:trend_memory]) ||
+       (vm_opts[:storage] && @sb[:options][:trend_storage])
       perf_planning_gen_data
-      @sb[:planning][:options][:submitted_vm_mode] = @sb[:planning][:options][:vm_mode] # Save for display
-      if @sb[:planning][:rpt]
+      @sb[:options][:submitted_vm_mode] = @sb[:options][:vm_mode] # Save for display
+      if @sb[:rpt]
         replace_right_cell
-      elsif @sb[:planning][:no_data] # to prevent double render error, making sure it's not wait_for_task transaction
+      elsif @sb[:no_data] # to prevent double render error, making sure it's not wait_for_task transaction
         add_flash(_("No Utilization data available to generate planning results"), :warning)
         render :update do |page|
           page << javascript_prologue
@@ -55,47 +55,47 @@ class PlanningController < ApplicationController
     if params[:filter_typ].present?
       filter_typ = params[:filter_typ] == "<Choose>" ? nil : params[:filter_typ]
 
-      @sb[:planning][:options][:filter_typ] = filter_typ
-      @sb[:planning][:vms] = wizard_get_vms('all', nil) if filter_typ == 'all'
+      @sb[:options][:filter_typ] = filter_typ
+      @sb[:vms] = wizard_get_vms('all', nil) if filter_typ == 'all'
     end
 
     if params[:filter_value].present?
       filter_value = params[:filter_value] == "<Choose>" ? nil : params[:filter_value]
 
-      @sb[:planning][:options][:filter_value] = filter_value
-      @sb[:planning][:vms] = wizard_get_vms(@sb[:planning][:options][:filter_typ], filter_value)
+      @sb[:options][:filter_value] = filter_value
+      @sb[:vms] = wizard_get_vms(@sb[:options][:filter_typ], filter_value)
     end
 
-    @sb[:planning][:options][:chosen_vm] = params[:chosen_vm] == "<Choose>" ? nil : params[:chosen_vm] if params[:chosen_vm]
-    @sb[:planning][:options][:days] = params[:trend_days].to_i if params[:trend_days]
-    @sb[:planning][:options][:vm_mode] = _(VALID_PLANNING_VM_MODES[params[:vm_mode]]) if params[:vm_mode]
-    @sb[:planning][:options][:trend_cpu] = (params[:trend_cpu] == "1") if params[:trend_cpu]
-    @sb[:planning][:options][:trend_vcpus] = (params[:trend_vcpus] == "1") if params[:trend_vcpus]
-    @sb[:planning][:options][:trend_memory] = (params[:trend_memory] == "1") if params[:trend_memory]
-    @sb[:planning][:options][:trend_storage] = (params[:trend_storage] == "1") if params[:trend_storage]
-    @sb[:planning][:options][:tz] = params[:planning_tz] if params[:planning_tz]
+    @sb[:options][:chosen_vm] = params[:chosen_vm] == "<Choose>" ? nil : params[:chosen_vm] if params[:chosen_vm]
+    @sb[:options][:days] = params[:trend_days].to_i if params[:trend_days]
+    @sb[:options][:vm_mode] = _(VALID_PLANNING_VM_MODES[params[:vm_mode]]) if params[:vm_mode]
+    @sb[:options][:trend_cpu] = (params[:trend_cpu] == "1") if params[:trend_cpu]
+    @sb[:options][:trend_vcpus] = (params[:trend_vcpus] == "1") if params[:trend_vcpus]
+    @sb[:options][:trend_memory] = (params[:trend_memory] == "1") if params[:trend_memory]
+    @sb[:options][:trend_storage] = (params[:trend_storage] == "1") if params[:trend_storage]
+    @sb[:options][:tz] = params[:planning_tz] if params[:planning_tz]
     if params.key?(:time_profile)
       tp = TimeProfile.find(params[:time_profile]) unless params[:time_profile].blank?
-      @sb[:planning][:options][:time_profile] = params[:time_profile].blank? ? nil : params[:time_profile].to_i
-      @sb[:planning][:options][:time_profile_tz] = params[:time_profile].blank? ? nil : tp.tz
-      @sb[:planning][:options][:time_profile_days] = params[:time_profile].blank? ? nil : tp.days
+      @sb[:options][:time_profile] = params[:time_profile].blank? ? nil : params[:time_profile].to_i
+      @sb[:options][:time_profile_tz] = params[:time_profile].blank? ? nil : tp.tz
+      @sb[:options][:time_profile_days] = params[:time_profile].blank? ? nil : tp.days
     end
     if params[:target_typ]
-      @sb[:planning][:options][:target_typ] = params[:target_typ]
-      @sb[:planning][:options][:target_filters] = MiqSearch.where(:id => params[:target_typ]).descriptions
-      @sb[:planning][:options][:target_filter] = nil
+      @sb[:options][:target_typ] = params[:target_typ]
+      @sb[:options][:target_filters] = MiqSearch.where(:id => params[:target_typ]).descriptions
+      @sb[:options][:target_filter] = nil
     end
-    @sb[:planning][:options][:target_filter] = params[:target_filter].blank? ? nil : params[:target_filter] if params.key?(:target_filter)
-    @sb[:planning][:options][:limit_cpu] = params[:limit_cpu].to_i if params[:limit_cpu]
-    @sb[:planning][:options][:limit_vcpus] = params[:limit_vcpus].to_i if params[:limit_vcpus]
-    @sb[:planning][:options][:limit_memory] = params[:limit_memory].to_i if params[:limit_memory]
-    @sb[:planning][:options][:limit_storage] = params[:limit_storage].to_i if params[:limit_storage]
-    @sb[:planning][:options][:display_vms] = params[:display_vms].blank? ? nil : params[:display_vms].to_i if params.key?(:display_vms)
+    @sb[:options][:target_filter] = params[:target_filter].blank? ? nil : params[:target_filter] if params.key?(:target_filter)
+    @sb[:options][:limit_cpu] = params[:limit_cpu].to_i if params[:limit_cpu]
+    @sb[:options][:limit_vcpus] = params[:limit_vcpus].to_i if params[:limit_vcpus]
+    @sb[:options][:limit_memory] = params[:limit_memory].to_i if params[:limit_memory]
+    @sb[:options][:limit_storage] = params[:limit_storage].to_i if params[:limit_storage]
+    @sb[:options][:display_vms] = params[:display_vms].blank? ? nil : params[:display_vms].to_i if params.key?(:display_vms)
 
-    @sb[:planning][:options][:values][:cpu] = params[:trend_cpu_val].to_i if params[:trend_cpu_val]
-    @sb[:planning][:options][:values][:vcpus] = params[:trend_vcpus_val].to_i if params[:trend_vcpus_val]
-    @sb[:planning][:options][:values][:memory] = params[:trend_memory_val].to_i if params[:trend_memory_val]
-    @sb[:planning][:options][:values][:storage] = params[:trend_storage_val].to_i if params[:trend_storage_val]
+    @sb[:options][:values][:cpu] = params[:trend_cpu_val].to_i if params[:trend_cpu_val]
+    @sb[:options][:values][:vcpus] = params[:trend_vcpus_val].to_i if params[:trend_vcpus_val]
+    @sb[:options][:values][:memory] = params[:trend_memory_val].to_i if params[:trend_memory_val]
+    @sb[:options][:values][:storage] = params[:trend_storage_val].to_i if params[:trend_storage_val]
 
     get_vm_values if params[:chosen_vm] || # Refetch the VM values if any of these options change
                      params[:vm_mode] ||
@@ -103,16 +103,16 @@ class PlanningController < ApplicationController
                      params[:tz] ||
                      params[:time_profile]
 
-    @sb[:planning][:vm_opts] = VimPerformancePlanning.vm_default_options(@sb[:planning][:options][:vm_mode])
-    unless (@sb[:planning][:vm_opts][:cpu] && @sb[:planning][:options][:trend_cpu]) || # Check that at least one required metric is checked
-           (@sb[:planning][:vm_opts][:vcpus] && @sb[:planning][:options][:trend_vcpus]) ||
-           (@sb[:planning][:vm_opts][:memory] && @sb[:planning][:options][:trend_memory]) ||
-           (@sb[:planning][:vm_opts][:storage] && @sb[:planning][:options][:trend_storage])
+    @sb[:vm_opts] = VimPerformancePlanning.vm_default_options(@sb[:options][:vm_mode])
+    unless (@sb[:vm_opts][:cpu] && @sb[:options][:trend_cpu]) || # Check that at least one required metric is checked
+           (@sb[:vm_opts][:vcpus] && @sb[:options][:trend_vcpus]) ||
+           (@sb[:vm_opts][:memory] && @sb[:options][:trend_memory]) ||
+           (@sb[:vm_opts][:storage] && @sb[:options][:trend_storage])
       add_flash(_("At least one VM Option must be selected"), :error)
-      @sb[:planning][:options][:trend_cpu] = true if params[:trend_cpu]
-      @sb[:planning][:options][:trend_vcpus] = true if params[:trend_vcpus]
-      @sb[:planning][:options][:trend_memory] = true if params[:trend_memory]
-      @sb[:planning][:options][:trend_storage] = true if params[:trend_storage]
+      @sb[:options][:trend_cpu] = true if params[:trend_cpu]
+      @sb[:options][:trend_vcpus] = true if params[:trend_vcpus]
+      @sb[:options][:trend_memory] = true if params[:trend_memory]
+      @sb[:options][:trend_storage] = true if params[:trend_storage]
     end
     if params.key?(:display_vms)
       perf_planning_gen_data
@@ -126,7 +126,7 @@ class PlanningController < ApplicationController
                params[:trend_storage_val]
           page.replace("planning_options_div", :partial => "planning_options")
         end
-        session[:changed] = @sb[:planning][:options][:chosen_vm] || @sb[:planning][:options][:vm_mode] == :manual
+        session[:changed] = @sb[:options][:chosen_vm] || @sb[:options][:vm_mode] == :manual
         page << javascript_for_miq_button_visibility(session[:changed])
       end
     end
@@ -151,21 +151,21 @@ class PlanningController < ApplicationController
   # Send the current planning report data in text, CSV, or PDF
   def report_download
     profile = []
-    profile.push("CPU #{@sb[:planning][:rpt].extras[:vm_profile][:cpu]}") if @sb[:planning][:rpt].extras[:vm_profile][:cpu]
-    profile.push("RAM #{@sb[:planning][:rpt].extras[:vm_profile][:memory]}") if @sb[:planning][:rpt].extras[:vm_profile][:memory]
-    profile.push("Disk #{@sb[:planning][:rpt].extras[:vm_profile][:storage]}") if @sb[:planning][:rpt].extras[:vm_profile][:storage]
-    @sb[:planning][:rpt].title = _("Counts of VMs (%{profile})") % {:profile => profile.join(", ")}
-    filename = "VM Counts per #{ui_lookup(:model => @sb[:planning][:options][:target_typ])}"
+    profile.push("CPU #{@sb[:rpt].extras[:vm_profile][:cpu]}") if @sb[:rpt].extras[:vm_profile][:cpu]
+    profile.push("RAM #{@sb[:rpt].extras[:vm_profile][:memory]}") if @sb[:rpt].extras[:vm_profile][:memory]
+    profile.push("Disk #{@sb[:rpt].extras[:vm_profile][:storage]}") if @sb[:rpt].extras[:vm_profile][:storage]
+    @sb[:rpt].title = _("Counts of VMs (%{profile})") % {:profile => profile.join(", ")}
+    filename = "VM Counts per #{ui_lookup(:model => @sb[:options][:target_typ])}"
     disable_client_cache
     case params[:typ]
     when "txt"
-      send_data(@sb[:planning][:rpt].to_text,
+      send_data(@sb[:rpt].to_text,
                 :filename => "#{filename}.txt")
     when "csv"
-      send_data(@sb[:planning][:rpt].to_csv,
+      send_data(@sb[:rpt].to_csv,
                 :filename => "#{filename}.csv")
     when "pdf"
-      render_pdf(@sb[:planning][:rpt])
+      render_pdf(@sb[:rpt])
     end
   end
 
@@ -176,6 +176,8 @@ class PlanningController < ApplicationController
     self.x_active_tree = nil
     @sb[:active_tab] = "summary"
     @layout = "miq_capacity_planning"
+
+    @sb = {}
 
     planning_build_options
   end
@@ -207,45 +209,43 @@ class PlanningController < ApplicationController
   end
 
   def build_options
-    @sb[:planning] ||= {} # Leave existing values
-    @sb[:planning] = {} if params[:button] == "reset" # Clear everything on reset
-    @sb[:planning][:options] ||= {} # Leave existing values
-    @sb[:planning][:options][:days] ||= 7
-    @sb[:planning][:options][:vm_mode] ||= :allocated
-    @sb[:planning][:options][:trend_cpu] = true if @sb[:planning][:options][:trend_cpu].nil?
-    @sb[:planning][:options][:trend_vcpus] = true if @sb[:planning][:options][:trend_vcpus].nil?
-    @sb[:planning][:options][:trend_memory] = true if @sb[:planning][:options][:trend_memory].nil?
-    @sb[:planning][:options][:trend_storage] = true if @sb[:planning][:options][:trend_storage].nil?
-    @sb[:planning][:options][:tz] ||= session[:user_tz]
-    @sb[:planning][:options][:values] ||= {}
+    @sb[:options] ||= {} # Leave existing values
+    @sb[:options][:days] ||= 7
+    @sb[:options][:vm_mode] ||= :allocated
+    @sb[:options][:trend_cpu] = true if @sb[:options][:trend_cpu].nil?
+    @sb[:options][:trend_vcpus] = true if @sb[:options][:trend_vcpus].nil?
+    @sb[:options][:trend_memory] = true if @sb[:options][:trend_memory].nil?
+    @sb[:options][:trend_storage] = true if @sb[:options][:trend_storage].nil?
+    @sb[:options][:tz] ||= session[:user_tz]
+    @sb[:options][:values] ||= {}
     get_vm_values
     get_time_profiles # Get time profiles list (global and user specific)
 
     # Get the time zone from the time profile, if one is in use
-    if @sb[:planning][:options][:time_profile]
-      tp = TimeProfile.find_by(:id => @sb[:planning][:options][:time_profile])
-      set_time_profile_vars(tp, @sb[:planning][:options])
+    if @sb[:options][:time_profile]
+      tp = TimeProfile.find_by(:id => @sb[:options][:time_profile])
+      set_time_profile_vars(tp, @sb[:options])
     else
-      set_time_profile_vars(selected_time_profile_for_pull_down, @sb[:planning][:options])
+      set_time_profile_vars(selected_time_profile_for_pull_down, @sb[:options])
     end
 
-    @sb[:planning][:options][:target_typ] ||= "EmsCluster"
-    @sb[:planning][:options][:target_filters] = MiqSearch.where(:db => @sb[:planning][:options][:target_typ]).descriptions
-    @sb[:planning][:options][:limit_cpu] ||= 90
-    @sb[:planning][:options][:limit_vcpus] ||= 10
-    @sb[:planning][:options][:limit_memory] ||= 90
-    @sb[:planning][:options][:limit_storage] ||= 90
-    @sb[:planning][:options][:display_vms] ||= 100
+    @sb[:options][:target_typ] ||= "EmsCluster"
+    @sb[:options][:target_filters] = MiqSearch.where(:db => @sb[:options][:target_typ]).descriptions
+    @sb[:options][:limit_cpu] ||= 90
+    @sb[:options][:limit_vcpus] ||= 10
+    @sb[:options][:limit_memory] ||= 90
+    @sb[:options][:limit_storage] ||= 90
+    @sb[:options][:display_vms] ||= 100
 
-    @sb[:planning][:emss] = {}
-    find_filtered(ExtManagementSystem).each { |e| @sb[:planning][:emss][e.id.to_s] = e.name }
-    @sb[:planning][:clusters] = {}
-    find_filtered(EmsCluster).each { |e| @sb[:planning][:clusters][e.id.to_s] = e.name }
-    @sb[:planning][:hosts] = {}
-    find_filtered(Host).each { |e| @sb[:planning][:hosts][e.id.to_s] = e.name }
-    @sb[:planning][:datastores] = {}
-    find_filtered(Storage).each { |e| @sb[:planning][:datastores][e.id.to_s] = e.name }
-    @sb[:planning][:vm_filters] = MiqSearch.where(:db => "Vm").descriptions
+    @sb[:emss] = {}
+    find_filtered(ExtManagementSystem).each { |e| @sb[:emss][e.id.to_s] = e.name }
+    @sb[:clusters] = {}
+    find_filtered(EmsCluster).each { |e| @sb[:clusters][e.id.to_s] = e.name }
+    @sb[:hosts] = {}
+    find_filtered(Host).each { |e| @sb[:hosts][e.id.to_s] = e.name }
+    @sb[:datastores] = {}
+    find_filtered(Storage).each { |e| @sb[:datastores][e.id.to_s] = e.name }
+    @sb[:vm_filters] = MiqSearch.where(:db => "Vm").descriptions
     @right_cell_text = _("Planning Summary")
     if params[:button] == "reset"
       session[:changed] = false
@@ -261,28 +261,28 @@ class PlanningController < ApplicationController
         page.replace_html("main_div", :partial => "planning_tabs")
       end
     end
-    if @sb[:planning] && @sb[:planning][:chart_data] # If planning charts already exist
+    if @sb[:chart_data] # If planning charts already exist
       @perf_record = MiqEnterprise.first
     end
   end
 
   # Get the metric values for the selected VM based on the mode
   def get_vm_values
-    return if @sb[:planning][:options][:vm_mode] == :manual
-    if @sb[:planning][:options][:chosen_vm]
-      @sb[:planning][:options][:values] = {}
-      vm_options = VimPerformancePlanning.vm_default_options(@sb[:planning][:options][:vm_mode])
-      VimPerformancePlanning.vm_metric_values(Vm.find(@sb[:planning][:options][:chosen_vm]),
+    return if @sb[:options][:vm_mode] == :manual
+    if @sb[:options][:chosen_vm]
+      @sb[:options][:values] = {}
+      vm_options = VimPerformancePlanning.vm_default_options(@sb[:options][:vm_mode])
+      VimPerformancePlanning.vm_metric_values(Vm.find(@sb[:options][:chosen_vm]),
                                               :vm_options      => vm_options,
                                               :range           => {
-                                                :days     => @sb[:planning][:options][:days],
+                                                :days     => @sb[:options][:days],
                                                 :end_date => perf_planning_end_date
                                               },
-                                              :tz              => @sb[:planning][:options][:tz],
-                                              :time_profile_id => @sb[:planning][:options][:time_profile])
+                                              :tz              => @sb[:options][:tz],
+                                              :time_profile_id => @sb[:options][:time_profile])
       vm_options.each do |k, v|
         next if v.nil?
-        @sb[:planning][:options][:values][k] = if k == :storage
+        @sb[:options][:values][k] = if k == :storage
                                                  (v[:value].to_i / 1.gigabyte).round
                                                else
                                                  v[:value].to_i.round
@@ -295,13 +295,13 @@ class PlanningController < ApplicationController
     v_tb = build_toolbar("miq_capacity_view_tb")
     presenter = ExplorerPresenter.new(:active_tree => @sb[:active_tree])
 
-    presenter.load_chart(@sb[:planning][:chart_data])
+    presenter.load_chart(@sb[:chart_data])
 
     presenter.reload_toolbars(:view => v_tb)
     presenter.set_visibility(@sb[:active_tab] == 'report', :toolbar)
 
     presenter.update(:main_div, r[:partial => 'planning_tabs'])
-    presenter[:replace_cell_text] = if @sb[:planning][:options][:target_typ] == 'Host'
+    presenter[:replace_cell_text] = if @sb[:options][:target_typ] == 'Host'
                                       _("Best Fit Hosts")
                                     else
                                       _("Best Fit Clusters")

--- a/app/controllers/planning_controller.rb
+++ b/app/controllers/planning_controller.rb
@@ -1,8 +1,6 @@
 class PlanningController < ApplicationController
   before_action :check_privileges
   before_action :get_session_data
-  after_action :cleanup_action
-  after_action :set_session_data
 
   menu_section(:opt)
 
@@ -188,17 +186,8 @@ class PlanningController < ApplicationController
   private
 
   def get_session_data
-    @title        = _("Planning")
-    @layout     ||= "miq_capacity_planning"
-    @lastaction   = session[:miq_capacity_lastaction]
-    @display      = session[:miq_capacity_display]
-    @current_page = session[:miq_capacity_current_page]
-  end
-
-  def set_session_data
-    session[:miq_capacity_lastaction]   = @lastaction
-    session[:miq_capacity_current_page] = @current_page
-    session[:miq_capacity_display]      = @display unless @display.nil?
+    @title = _("Planning")
+    @layout ||= "miq_capacity_planning"
   end
 
   def wizard_get_vms_records(filter_type, filter_value)

--- a/app/controllers/utilization_controller.rb
+++ b/app/controllers/utilization_controller.rb
@@ -1,8 +1,6 @@
 class UtilizationController < ApplicationController
   before_action :check_privileges
   before_action :get_session_data
-  after_action :cleanup_action
-  after_action :set_session_data
 
   menu_section(:opt)
 
@@ -128,17 +126,8 @@ class UtilizationController < ApplicationController
   private
 
   def get_session_data
-    @title        = _("Utilization")
-    @layout     ||= "miq_capacity_utilization"
-    @lastaction   = session[:miq_capacity_lastaction]
-    @display      = session[:miq_capacity_display]
-    @current_page = session[:miq_capacity_current_page]
-  end
-
-  def set_session_data
-    session[:miq_capacity_lastaction]   = @lastaction
-    session[:miq_capacity_current_page] = @current_page
-    session[:miq_capacity_display]      = @display unless @display.nil?
+    @title = _("Utilization")
+    @layout ||= "miq_capacity_utilization"
   end
 
   # Get all info for the node about to be displayed

--- a/app/controllers/utilization_controller.rb
+++ b/app/controllers/utilization_controller.rb
@@ -25,16 +25,15 @@ class UtilizationController < ApplicationController
 
     @sb[:active_tab] = "summary"
     self.x_node ||= ""
-    @sb[:util] = {}            # reset existing values
-    @sb[:util][:options] = {}  # reset existing values
+    @sb[:options] = {}  # reset existing values
     get_time_profiles # Get time profiles list (global and user specific)
 
     # Get the time zone from the time profile, if one is in use
-    if @sb[:util][:options][:time_profile]
-      tp = TimeProfile.find_by(:id => @sb[:util][:options][:time_profile])
-      set_time_profile_vars(tp, @sb[:util][:options])
+    if @sb[:options][:time_profile]
+      tp = TimeProfile.find_by(:id => @sb[:options][:time_profile])
+      set_time_profile_vars(tp, @sb[:options])
     else
-      set_time_profile_vars(selected_time_profile_for_pull_down, @sb[:util][:options])
+      set_time_profile_vars(selected_time_profile_for_pull_down, @sb[:options])
     end
 
     @ajax_action = "chart_chooser"
@@ -44,25 +43,25 @@ class UtilizationController < ApplicationController
   # Process changes to capacity charts
   def chart_chooser
     unless params[:task_id] # Only do this first time thru
-      @sb[:util][:options][:chart_date] = params[:miq_date_1] if params[:miq_date_1]
-      @sb[:util][:options][:chart_date] = params[:miq_date_2] if params[:miq_date_2]
-      @sb[:util][:options][:days] = params[:details_days] if params[:details_days]
-      @sb[:util][:options][:days] = params[:report_days] if params[:report_days]
-      @sb[:util][:options][:days] = params[:summ_days] if params[:summ_days]
-      @sb[:util][:options][:tz] = params[:details_tz] if params[:details_tz]
-      @sb[:util][:options][:tz] = params[:report_tz] if params[:report_tz]
-      @sb[:util][:options][:tz] = params[:summ_tz] if params[:summ_tz]
-      @sb[:util][:options][:tag] = params[:details_tag] == "<None>" ? nil : params[:details_tag] if params[:details_tag]
-      @sb[:util][:options][:tag] = params[:report_tag] == "<None>" ? nil : params[:report_tag] if params[:report_tag]
-      @sb[:util][:options][:tag] = params[:summ_tag] == "<None>" ? nil : params[:summ_tag] if params[:summ_tag]
-      @sb[:util][:options][:index] = params[:chart_idx] == "clear" ? nil : params[:chart_idx] if params[:chart_idx]
+      @sb[:options][:chart_date] = params[:miq_date_1] if params[:miq_date_1]
+      @sb[:options][:chart_date] = params[:miq_date_2] if params[:miq_date_2]
+      @sb[:options][:days] = params[:details_days] if params[:details_days]
+      @sb[:options][:days] = params[:report_days] if params[:report_days]
+      @sb[:options][:days] = params[:summ_days] if params[:summ_days]
+      @sb[:options][:tz] = params[:details_tz] if params[:details_tz]
+      @sb[:options][:tz] = params[:report_tz] if params[:report_tz]
+      @sb[:options][:tz] = params[:summ_tz] if params[:summ_tz]
+      @sb[:options][:tag] = params[:details_tag] == "<None>" ? nil : params[:details_tag] if params[:details_tag]
+      @sb[:options][:tag] = params[:report_tag] == "<None>" ? nil : params[:report_tag] if params[:report_tag]
+      @sb[:options][:tag] = params[:summ_tag] == "<None>" ? nil : params[:summ_tag] if params[:summ_tag]
+      @sb[:options][:index] = params[:chart_idx] == "clear" ? nil : params[:chart_idx] if params[:chart_idx]
       if params.key?(:details_time_profile) || params.key?(:report_time_profile) || params.key?(:summ_time_profile)
-        @sb[:util][:options][:time_profile] = params[:details_time_profile].blank? ? nil : params[:details_time_profile].to_i if params.key?(:details_time_profile)
-        @sb[:util][:options][:time_profile] = params[:report_time_profile].blank? ? nil : params[:report_time_profile].to_i if params.key?(:report_time_profile)
-        @sb[:util][:options][:time_profile] = params[:summ_time_profile].blank? ? nil : params[:summ_time_profile].to_i if params.key?(:summ_time_profile)
-        tp = TimeProfile.find(@sb[:util][:options][:time_profile]) unless @sb[:util][:options][:time_profile].blank?
-        @sb[:util][:options][:time_profile_tz] = @sb[:util][:options][:time_profile].blank? ? nil : tp.tz
-        @sb[:util][:options][:time_profile_days] = @sb[:util][:options][:time_profile].blank? ? nil : tp.days
+        @sb[:options][:time_profile] = params[:details_time_profile].blank? ? nil : params[:details_time_profile].to_i if params.key?(:details_time_profile)
+        @sb[:options][:time_profile] = params[:report_time_profile].blank? ? nil : params[:report_time_profile].to_i if params.key?(:report_time_profile)
+        @sb[:options][:time_profile] = params[:summ_time_profile].blank? ? nil : params[:summ_time_profile].to_i if params.key?(:summ_time_profile)
+        tp = TimeProfile.find(@sb[:options][:time_profile]) unless @sb[:options][:time_profile].blank?
+        @sb[:options][:time_profile_tz] = @sb[:options][:time_profile].blank? ? nil : tp.tz
+        @sb[:options][:time_profile_days] = @sb[:options][:time_profile].blank? ? nil : tp.days
       end
     end
     if x_node != ""
@@ -75,7 +74,7 @@ class UtilizationController < ApplicationController
 
   # Send the current utilization report data in text, CSV, or PDF
   def report_download
-    report = MiqReport.new(:title     => @sb[:util][:title],
+    report = MiqReport.new(:title     => @sb[:title],
                            :cols      => cols = %w(section item value),
                            :col_order => cols,
                            :headers   => [_("Section"), _("Item"), _("Value")],
@@ -104,7 +103,7 @@ class UtilizationController < ApplicationController
       self.x_node = params[:id]
     end
 
-    @sb[:util][:options][:tag] = nil # Reset any tag
+    @sb[:options][:tag] = nil # Reset any tag
     get_node_info(x_node)
     perf_util_daily_gen_data
     replace_right_cell(@nodetype) unless @waiting # Draw right side if task is done
@@ -139,13 +138,13 @@ class UtilizationController < ApplicationController
                          _("%{model} \"%{name}\" Utilization Trend Summary") %
                            {:model => ui_lookup(:model => @record.class.base_class.to_s), :name => @record.name}
                        end
-    @sb[:util][:title] = @right_cell_text
-    unless @sb[:util][:options].nil? || @sb[:util][:options][:tag].blank?
-      @right_cell_text += _(" - Filtered by %{filter}") % {:filter => @sb[:util][:tags][@sb[:util][:options][:tag]]}
+    @sb[:title] = @right_cell_text
+    unless @sb[:options].nil? || @sb[:options][:tag].blank?
+      @right_cell_text += _(" - Filtered by %{filter}") % {:filter => @sb[:tags][@sb[:options][:tag]]}
     end
 
     # Get start/end dates in selected timezone
-    tz = @sb[:util][:options][:time_profile_tz] || @sb[:util][:options][:tz] # Use time profile tz or chosen tz, if no profile tz
+    tz = @sb[:options][:time_profile_tz] || @sb[:options][:tz] # Use time profile tz or chosen tz, if no profile tz
     s, e = @record.first_and_last_capture
     return if s.nil?
     s = s.in_time_zone(tz)
@@ -157,58 +156,58 @@ class UtilizationController < ApplicationController
     sdate = create_time_in_tz("#{s.year}-#{s.month}-#{s.day} 00", tz) # Start at midnight of start date
     edate = create_time_in_tz("#{e.year}-#{e.month}-#{e.day} 23", tz) # End at 11pm of start date
 
-    unless (refresh == "n" || params[:refresh] == "n") && @sb[:util][:options] && @sb[:util][:options][:model] == @record.class.base_class.to_s
-      @sb[:util][:options] ||= {}
-      @sb[:util][:options][:typ] = "Daily"
-      @sb[:util][:options][:days] ||= "7"
-      @sb[:util][:options][:model] = @record.class.base_class.to_s
-      @sb[:util][:options][:record_id] = @record.id
+    unless (refresh == "n" || params[:refresh] == "n") && @sb[:options] && @sb[:options][:model] == @record.class.base_class.to_s
+      @sb[:options] ||= {}
+      @sb[:options][:typ] = "Daily"
+      @sb[:options][:days] ||= "7"
+      @sb[:options][:model] = @record.class.base_class.to_s
+      @sb[:options][:record_id] = @record.id
     end
-    trenddate = edate - @sb[:util][:options][:days].to_i.days + 1.hour # Get trend starting date
+    trenddate = edate - @sb[:options][:days].to_i.days + 1.hour # Get trend starting date
     sdate = sdate > trenddate ? sdate : trenddate                   # Use trend date, unless earlier than first date
-    if @sb[:util][:options][:chart_date]                            # Clear chosen chart date if out of trend range
-      cdate = create_time_in_tz(@sb[:util][:options][:chart_date], tz) # Get chart date at midnight in time zone
+    if @sb[:options][:chart_date]                            # Clear chosen chart date if out of trend range
+      cdate = create_time_in_tz(@sb[:options][:chart_date], tz) # Get chart date at midnight in time zone
       if (cdate < sdate || cdate > edate) || # Reset if chart date is before start date or after end date
-         (@sb[:util][:options][:time_profile] && !@sb[:util][:options][:time_profile_days].include?(cdate.wday))
-        @sb[:util][:options][:chart_date] = nil
+         (@sb[:options][:time_profile] && !@sb[:options][:time_profile_days].include?(cdate.wday))
+        @sb[:options][:chart_date] = nil
       end
     end
-    @sb[:util][:options][:trend_start] = sdate
-    @sb[:util][:options][:trend_end] = edate
-    @sb[:util][:options][:sdate] = sdate # Start and end dates for calendar control
-    @sb[:util][:options][:edate] = edate
-    @sb[:util][:options][:chart_date] ||= [edate.month, edate.day, edate.year].join("/")
+    @sb[:options][:trend_start] = sdate
+    @sb[:options][:trend_end] = edate
+    @sb[:options][:sdate] = sdate # Start and end dates for calendar control
+    @sb[:options][:edate] = edate
+    @sb[:options][:chart_date] ||= [edate.month, edate.day, edate.year].join("/")
 
-    if @sb[:util][:options][:time_profile]                              # If profile in effect, set date to a valid day in the profile
-      @sb[:util][:options][:skip_days] = skip_days_from_time_profile(@sb[:util][:options][:time_profile_days])
+    if @sb[:options][:time_profile]                              # If profile in effect, set date to a valid day in the profile
+      @sb[:options][:skip_days] = skip_days_from_time_profile(@sb[:options][:time_profile_days])
 
-      cdate = @sb[:util][:options][:chart_date].to_date                 # Start at the currently set date
+      cdate = @sb[:options][:chart_date].to_date                 # Start at the currently set date
       6.times do                                                        # Go back up to 6 days (try each weekday)
-        break if @sb[:util][:options][:time_profile_days].include?(cdate.wday) # If weekday is in the profile, use it
+        break if @sb[:options][:time_profile_days].include?(cdate.wday) # If weekday is in the profile, use it
         cdate -= 1.day # Drop back 1 day and try again
       end
-      @sb[:util][:options][:chart_date] = [cdate.month, cdate.day, cdate.year].join("/") # Set the new date
+      @sb[:options][:chart_date] = [cdate.month, cdate.day, cdate.year].join("/") # Set the new date
     else
-      @sb[:util][:options][:skip_days] = nil
+      @sb[:options][:skip_days] = nil
     end
 
-    @sb[:util][:options][:days] ||= "7"
-    @sb[:util][:options][:ght_type] ||= "hybrid"
-    @sb[:util][:options][:chart_type] = :summary
+    @sb[:options][:days] ||= "7"
+    @sb[:options][:ght_type] ||= "hybrid"
+    @sb[:options][:chart_type] = :summary
   end
 
   def replace_right_cell(_nodetype) # replace_trees can be an array of tree symbols to be replaced
     # Get the tags for this node for the Classification pulldown
-    @sb[:util][:tags] = nil unless params[:miq_date_1] || params[:miq_date_2] # Clear tags unless just changing date
+    @sb[:tags] = nil unless params[:miq_date_1] || params[:miq_date_2] # Clear tags unless just changing date
     unless @nodetype == "h" || @nodetype == "s" || params[:miq_date_1] || params[:miq_date_2] # Get the tags for the pulldown, unless host, storage, or just changing the date
-      if @sb[:util][:options][:chart_date]
-        mm, dd, yy = @sb[:util][:options][:chart_date].split("/")
+      if @sb[:options][:chart_date]
+        mm, dd, yy = @sb[:options][:chart_date].split("/")
         end_date = Time.utc(yy, mm, dd, 23, 59, 59)
-        @sb[:util][:tags] = VimPerformanceAnalysis.child_tags_over_time_period(
+        @sb[:tags] = VimPerformanceAnalysis.child_tags_over_time_period(
           @record, 'daily',
-          :end_date => end_date, :days => @sb[:util][:options][:days].to_i,
-           :ext_options => {:tz           => @sb[:util][:trend_rpt].tz, # Add ext_options for tz from rpt object
-                            :time_profile => @sb[:util][:trend_rpt].time_profile}
+          :end_date => end_date, :days => @sb[:options][:days].to_i,
+           :ext_options => {:tz           => @sb[:trend_rpt].tz, # Add ext_options for tz from rpt object
+                            :time_profile => @sb[:trend_rpt].time_profile}
         )
       end
     end
@@ -216,7 +215,7 @@ class UtilizationController < ApplicationController
     v_tb = build_toolbar("miq_capacity_view_tb")
     presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
 
-    presenter.load_chart(@sb[:util][:chart_data])
+    presenter.load_chart(@sb[:chart_data])
 
     # clearing out any selection in tree if active node has been reset to "" upon returning to screen or when first time in
     presenter[:clear_selection] = x_node == ''
@@ -227,9 +226,9 @@ class UtilizationController < ApplicationController
     presenter.update(:main_div, r[:partial => 'utilization_tabs'])
     presenter[:right_cell_text] = @right_cell_text
     presenter[:build_calendar] = {
-      :date_from => @sb[:util][:options][:sdate],
-      :date_to   => @sb[:util][:options][:edate],
-      :skip_days => @sb[:util][:options][:skip_days],
+      :date_from => @sb[:options][:sdate],
+      :date_to   => @sb[:options][:edate],
+      :skip_days => @sb[:options][:skip_days],
     }
 
     render :json => presenter.for_render
@@ -238,10 +237,10 @@ class UtilizationController < ApplicationController
   # Create an array of hashes from the Utilization summary report tab information
   def summ_hashes
     a = []
-    @sb[:util][:summary][:info].each { |r| a.push("section" => _("Basic Info"), "item" => r[0], "value" => r[1]) } if @sb[:util][:summary][:info]
-    @sb[:util][:summary][:cpu].each { |r| a.push("section" => _("CPU"), "item" => r[0], "value" => r[1]) } if @sb[:util][:summary][:cpu]
-    @sb[:util][:summary][:memory].each { |r| a.push("section" => _("Memory"), "item" => r[0], "value" => r[1]) } if @sb[:util][:summary][:memory]
-    @sb[:util][:summary][:storage].each { |r| a.push("section" => _("Disk"), "item" => r[0], "value" => r[1]) } if @sb[:util][:summary][:storage]
+    @sb[:summary][:info].each { |r| a.push("section" => _("Basic Info"), "item" => r[0], "value" => r[1]) } if @sb[:summary][:info]
+    @sb[:summary][:cpu].each { |r| a.push("section" => _("CPU"), "item" => r[0], "value" => r[1]) } if @sb[:summary][:cpu]
+    @sb[:summary][:memory].each { |r| a.push("section" => _("Memory"), "item" => r[0], "value" => r[1]) } if @sb[:summary][:memory]
+    @sb[:summary][:storage].each { |r| a.push("section" => _("Disk"), "item" => r[0], "value" => r[1]) } if @sb[:summary][:storage]
     a
   end
 end

--- a/app/controllers/utilization_controller.rb
+++ b/app/controllers/utilization_controller.rb
@@ -9,7 +9,6 @@ class UtilizationController < ApplicationController
   def index
     @explorer = true
     @trees = [] # TODO: TreeBuilder
-    @breadcrumbs = []
     self.x_active_tree = 'utilization_tree'
 
     @accords = [{

--- a/app/controllers/utilization_controller.rb
+++ b/app/controllers/utilization_controller.rb
@@ -8,24 +8,12 @@ class UtilizationController < ApplicationController
 
   def index
     @explorer = true
-    @trees = [] # TODO: TreeBuilder
-    self.x_active_tree = 'utilization_tree'
-
-    @accords = [{
-      :name      => "enterprise",
-      :title     => _("Utilization"),
-      :container => "utilization_accord",
-      :image     => "enterprise"
-    }]
-
     @right_cell_text = _("Utilization Summary")
-    @trees << TreeBuilderUtilization.new(
-      :utilization_tree, :utilization, @sb, true, :selected_node => x_node(:utilization_tree)
-    )
-
     @sb[:active_tab] = "summary"
-    self.x_node ||= ""
-    @sb[:options] = {}  # reset existing values
+    @sb[:options] = {} # reset existing values
+
+    build_accordions_and_trees
+
     get_time_profiles # Get time profiles list (global and user specific)
 
     # Get the time zone from the time profile, if one is in use
@@ -122,6 +110,17 @@ class UtilizationController < ApplicationController
   end
 
   private
+
+  def features
+    [
+      {:role     => "utilization",
+       :role_any => true,
+       :name     => :utilization,
+       :title    => _("Utilization")}
+    ].map do |hsh|
+      ApplicationController::Feature.new_with_hash(hsh)
+    end
+  end
 
   def get_session_data
     @title = _("Utilization")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -703,10 +703,6 @@ module ApplicationHelper
       miq_ae_class
       miq_ae_export
       miq_ae_tools
-      miq_capacity_bottlenecks
-      miq_capacity_planning
-      miq_capacity_utilization
-      miq_capacity_waste
       miq_policy
       miq_policy_export
       miq_policy_rsop

--- a/app/helpers/application_helper/button/utilization_download.rb
+++ b/app/helpers/application_helper/button/utilization_download.rb
@@ -4,7 +4,7 @@ class ApplicationHelper::Button::UtilizationDownload < ApplicationHelper::Button
     # a) either have no active tree item (meaning we are in "Planning") and
     #    have planning report data
     return false if @view_context.x_active_tree.nil? &&
-                    @sb.fetch_path(:planning, :rpt) && !@sb[:planning][:rpt].table.data.empty?
+                    @sb.fetch_path(:planning, :rpt) && !@sb[:rpt].table.data.empty?
 
     # b) we are in the "Utilization" and have trend report and summary
     return false if @sb.fetch_path(:util, :trend_rpt) && @sb.fetch_path(:util, :summary)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -496,7 +496,9 @@ class TreeBuilder
     # Optimize
     ## Utilization
     ### Utilization (TODO)
+    :utilization                     => "TreeBuilderUtilization",
     ### Bottlenecks (TODO)
+    :bottlenecks                     => "TreeBuilderUtilization",
 
     # OPS (Configuration)
     ## Settings

--- a/app/views/bottlenecks/_bottlenecks_options.html.haml
+++ b/app/views/bottlenecks/_bottlenecks_options.html.haml
@@ -8,7 +8,7 @@
         = _('Event Groups')
       .col-md-10
         = select_tag("tl_#{typ}_fl_grp1",
-          options_for_select([["<#{_('ALL')}> ", ""]] + @sb[:bottlenecks][:groups].sort, @sb[:bottlenecks][:tl_options][:filter1]),
+          options_for_select([["<#{_('ALL')}> ", ""]] + @sb[:groups].sort, @sb[:tl_options][:filter1]),
           "class" => "selectpicker",
           "data-miq_sparkle_on"  => true,
           "data-miq_sparkle_off" => true)
@@ -20,7 +20,7 @@
         %label.control-label.col-md-2
           = _('Show Host Events')
         .col-md-10
-          = check_box_tag("tl_#{typ}_hosts", "1", @sb[:bottlenecks][:tl_options][:hosts],
+          = check_box_tag("tl_#{typ}_hosts", "1", @sb[:tl_options][:hosts],
             "data-miq_sparkle_on"       => true,
             "data-miq_sparkle_off"      => true,
             "data-miq_observe_checkbox" => {:url => url}.to_json)
@@ -30,7 +30,7 @@
       .col-md-10
         = select_tag("tl_#{typ}_tz",
           options_for_select(ALL_TIMEZONES,
-          @sb[:bottlenecks][:tl_options][:tz]),
+          @sb[:tl_options][:tz]),
           "data-live-search" => "true",
           "class" => "selectpicker",
           "data-miq_sparkle_on"  => true,

--- a/app/views/bottlenecks/_bottlenecks_report.html.haml
+++ b/app/views/bottlenecks/_bottlenecks_report.html.haml
@@ -4,7 +4,7 @@
   - else
     = render :partial => "layouts/flash_msg"
     = render :partial => 'bottlenecks_options', :locals  => {:typ => "report"}
-    - if @sb[:bottlenecks] && @sb[:bottlenecks][:report]
+    - if @sb[:report]
       %hr
       %h3= _('Bottleneck Event Details')
-      = @sb[:bottlenecks][:report].to_html.html_safe
+      = @sb[:report].to_html.html_safe

--- a/app/views/bottlenecks/_bottlenecks_tl_detail.html.haml
+++ b/app/views/bottlenecks/_bottlenecks_tl_detail.html.haml
@@ -1,13 +1,13 @@
 #tl_div
-  - if @sb[:bottlenecks] && @sb[:bottlenecks][:report] && @sb[:bottlenecks][:report].table && @sb[:bottlenecks][:report].table.data.blank?
-  - elsif @sb[:bottlenecks][:report]
+  - if @sb[:report] && @sb[:report].table && @sb[:report].table.data.blank?
+  - elsif @sb[:report]
     #chart_placeholder{:style => 'position: relative'}
     = render(:partial => "layouts/timeline",
              :locals  => {:tl_json       => @tl_json,
                           :position_time => session[:tl_position]})
-    - if @sb[:bottlenecks][:report].filter_summary
-      = @sb[:bottlenecks][:report].filter_summary
-  - elsif @sb[:bottlenecks][:tl_options] && @sb[:bottlenecks][:tl_options][:sdate].nil? && @sb[:bottlenecks][:tl_options][:edate].nil?
+    - if @sb[:report].filter_summary
+      = @sb[:report].filter_summary
+  - elsif @sb[:tl_options] && @sb[:tl_options][:sdate].nil? && @sb[:tl_options][:edate].nil?
     = render :partial => 'layouts/info_msg', :locals => {:message => _("No events available for this timeline.")}
   - else
     - unless x_node == ""

--- a/app/views/planning/_planning_options.html.haml
+++ b/app/views/planning/_planning_options.html.haml
@@ -13,8 +13,8 @@
         [_("By Filter"), "filter"],
         [_("All VMs/Instances"), "all"],]
       = select_tag("filter_typ",
-                    options_for_select(options, @sb[:planning][:options][:filter_typ]),
-                    :disabled              => @sb[:planning][:options][:vm_mode] == :manual,
+                    options_for_select(options, @sb[:options][:filter_typ]),
+                    :disabled              => @sb[:options][:vm_mode] == :manual,
                     "class"                => "selectpicker",
                     'data-live-search'     => true,
                     "data-miq_sparkle_on"  => true,
@@ -23,42 +23,42 @@
         miqInitSelectPicker();
         miqSelectPickerEvent("filter_typ", "#{url}");
     .form-group
-      - if @sb[:planning][:options][:filter_typ] == "host"
-        - options = [["<#{_('Choose a %{host}') % {:host => title_for_host}}>", "<Choose>"]] + Array(@sb[:planning][:hosts].invert).sort_by { |a| a.first.downcase }
+      - if @sb[:options][:filter_typ] == "host"
+        - options = [["<#{_('Choose a %{host}') % {:host => title_for_host}}>", "<Choose>"]] + Array(@sb[:hosts].invert).sort_by { |a| a.first.downcase }
         = select_tag("filter_value",
-                      options_for_select(options, @sb[:planning][:options][:filter_value]),
-                      :disabled              => @sb[:planning][:options][:vm_mode] == :manual,
+                      options_for_select(options, @sb[:options][:filter_value]),
+                      :disabled              => @sb[:options][:vm_mode] == :manual,
                       "data-live-search"     => "true",
                       "class"                => "selectpicker",
                       'data-live-search'     => true,
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true,
                       "data-miq_observe"     => {:url => url}.to_json)
-      - elsif @sb[:planning][:options][:filter_typ] == "cluster"
-        - options = [["<#{_('Choose a %{cluster}')}>" % {:cluster => title_for_cluster}, "<Choose>"]] + Array(@sb[:planning][:clusters].invert).sort_by { |a| a.first.downcase }
+      - elsif @sb[:options][:filter_typ] == "cluster"
+        - options = [["<#{_('Choose a %{cluster}')}>" % {:cluster => title_for_cluster}, "<Choose>"]] + Array(@sb[:clusters].invert).sort_by { |a| a.first.downcase }
         = select_tag("filter_value",
-                      options_for_select(options, @sb[:planning][:options][:filter_value]),
-                      :disabled              => @sb[:planning][:options][:vm_mode] == :manual,
+                      options_for_select(options, @sb[:options][:filter_value]),
+                      :disabled              => @sb[:options][:vm_mode] == :manual,
                       "class"                => "selectpicker",
                       'data-live-search'     => true,
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true,
                       "data-miq_observe"     => {:url => url}.to_json)
-      - elsif @sb[:planning][:options][:filter_typ] == "ems"
-        - options = [["<#{_('Choose a %{provider}')}>" % {:provider => ui_lookup(:table => "ext_management_systems")}, "<Choose>"]] + Array(@sb[:planning][:emss].invert).sort_by { |a| a.first.downcase }
+      - elsif @sb[:options][:filter_typ] == "ems"
+        - options = [["<#{_('Choose a %{provider}')}>" % {:provider => ui_lookup(:table => "ext_management_systems")}, "<Choose>"]] + Array(@sb[:emss].invert).sort_by { |a| a.first.downcase }
         = select_tag("filter_value",
-                      options_for_select(options, @sb[:planning][:options][:filter_value]),
-                      :disabled              => @sb[:planning][:options][:vm_mode] == :manual,
+                      options_for_select(options, @sb[:options][:filter_value]),
+                      :disabled              => @sb[:options][:vm_mode] == :manual,
                       "class"                => "selectpicker",
                       'data-live-search'     => true,
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true,
                       "data-miq_observe"     => {:url => url}.to_json)
-      - elsif @sb[:planning][:options][:filter_typ] == "filter"
-        - options = [["<#{_('Choose a Filter')}>", "<Choose>"]] + Array(@sb[:planning][:vm_filters].invert).sort_by { |a| a.first.downcase }
+      - elsif @sb[:options][:filter_typ] == "filter"
+        - options = [["<#{_('Choose a Filter')}>", "<Choose>"]] + Array(@sb[:vm_filters].invert).sort_by { |a| a.first.downcase }
         = select_tag("filter_value",
-                      options_for_select(options, @sb[:planning][:options][:filter_value]),
-                      :disabled              => @sb[:planning][:options][:vm_mode] == :manual,
+                      options_for_select(options, @sb[:options][:filter_value]),
+                      :disabled              => @sb[:options][:vm_mode] == :manual,
                       "class"                => "selectpicker",
                       'data-live-search'     => true,
                       "data-miq_sparkle_on"  => true,
@@ -66,15 +66,15 @@
       :javascript
         miqInitSelectPicker();
         miqSelectPickerEvent("filter_value", "#{url}");
-      - if @sb[:planning][:vms]
-        - if @sb[:planning][:vms].empty?
+      - if @sb[:vms]
+        - if @sb[:vms].empty?
           &nbsp;
           = _('No VMs found')
         - else
-          - options = [["<#{_('Choose a VM')}>", "<Choose>"]] + Array(@sb[:planning][:vms].invert).sort_by { |a| a.first.downcase }
+          - options = [["<#{_('Choose a VM')}>", "<Choose>"]] + Array(@sb[:vms].invert).sort_by { |a| a.first.downcase }
           = select_tag("chosen_vm",
-                        options_for_select(options, @sb[:planning][:options][:chosen_vm]),
-                        :disabled              => @sb[:planning][:options][:vm_mode] == :manual,
+                        options_for_select(options, @sb[:options][:chosen_vm]),
+                        :disabled              => @sb[:options][:vm_mode] == :manual,
                         "data-live-search"     => "true",
                         "class"                => "selectpicker",
                         'data-live-search'     => true,
@@ -92,84 +92,84 @@
         = _('Source')
       .col-md-8
         = select_tag("vm_mode",
-                      options_for_select(PLANNING_VM_MODES.map { |k, v| [_(v), k] }.sort, @sb[:planning][:options][:vm_mode]),
+                      options_for_select(PLANNING_VM_MODES.map { |k, v| [_(v), k] }.sort, @sb[:options][:vm_mode]),
                       "class"                => "selectpicker",
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true)
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent("vm_mode", "#{url}");
-    - vm_opts = VimPerformancePlanning.vm_default_options(@sb[:planning][:options][:vm_mode])
+    - vm_opts = VimPerformancePlanning.vm_default_options(@sb[:options][:vm_mode])
     - if vm_opts[:cpu]
       .form-group
         %label.control-label.col-md-4
           = _('CPU Speed')
         .col-md-8
-          = check_box_tag("trend_cpu", "1", @sb[:planning][:options][:trend_cpu],
+          = check_box_tag("trend_cpu", "1", @sb[:options][:trend_cpu],
                           "data-miq_sparkle_on"       => true,
                           "data-miq_sparkle_off"      => true,
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
-          - if @sb[:planning][:options][:vm_mode] == :manual
+          - if @sb[:options][:vm_mode] == :manual
             = text_field_tag("trend_cpu_val",
-                              @sb[:planning][:options][:values][:cpu],
+                              @sb[:options][:values][:cpu],
                               :maxlength         => 15,
-                              :disabled          => !@sb[:planning][:options][:trend_cpu],
+                              :disabled          => !@sb[:options][:trend_cpu],
                               "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           - else
-            = @sb[:planning][:options][:values][:cpu]
+            = @sb[:options][:values][:cpu]
           = _('MHz')
     - if vm_opts[:vcpus]
       .form-group
         %label.control-label.col-md-4
           = _('vCPU Count')
         .col-md-8
-          = check_box_tag("trend_vcpus", "1", @sb[:planning][:options][:trend_vcpus],
+          = check_box_tag("trend_vcpus", "1", @sb[:options][:trend_vcpus],
                           "data-miq_sparkle_on"       => true,
                           "data-miq_sparkle_off"      => true,
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
-          - if @sb[:planning][:options][:vm_mode] == :manual
+          - if @sb[:options][:vm_mode] == :manual
             = text_field_tag("trend_vcpus_val",
-                              @sb[:planning][:options][:values][:vcpus],
+                              @sb[:options][:values][:vcpus],
                               :maxlength         => 15,
-                              :disabled          => !@sb[:planning][:options][:trend_vcpus],
+                              :disabled          => !@sb[:options][:trend_vcpus],
                               "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           - else
-            = @sb[:planning][:options][:values][:vcpus]
+            = @sb[:options][:values][:vcpus]
     - if vm_opts[:memory]
       .form-group
         %label.control-label.col-md-4
           = _('Memory Size')
         .col-md-8
-          = check_box_tag("trend_memory", "1", @sb[:planning][:options][:trend_memory],
+          = check_box_tag("trend_memory", "1", @sb[:options][:trend_memory],
                           "data-miq_sparkle_on"       => true,
                           "data-miq_sparkle_off"      => true,
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
-          - if @sb[:planning][:options][:vm_mode] == :manual
+          - if @sb[:options][:vm_mode] == :manual
             = text_field_tag("trend_memory_val",
-                              @sb[:planning][:options][:values][:memory],
+                              @sb[:options][:values][:memory],
                               :maxlength         => 15,
-                              :disabled          => !@sb[:planning][:options][:trend_memory],
+                              :disabled          => !@sb[:options][:trend_memory],
                               "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           - else
-            = @sb[:planning][:options][:values][:memory]
+            = @sb[:options][:values][:memory]
           = _('MB')
     - if vm_opts[:storage]
       .form-group
         %label.control-label.col-md-4
           = _('Disk Space')
         .col-md-8
-          = check_box_tag("trend_storage", "1", @sb[:planning][:options][:trend_storage],
+          = check_box_tag("trend_storage", "1", @sb[:options][:trend_storage],
                           "data-miq_sparkle_on"       => true,
                           "data-miq_sparkle_off"      => true,
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
-          - if @sb[:planning][:options][:vm_mode] == :manual
+          - if @sb[:options][:vm_mode] == :manual
             = text_field_tag("trend_storage_val",
-                              @sb[:planning][:options][:values][:storage],
+                              @sb[:options][:values][:storage],
                               :maxlength         => 15,
-                              :disabled          => !@sb[:planning][:options][:trend_storage],
+                              :disabled          => !@sb[:options][:trend_storage],
                               "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           - else
-            = @sb[:planning][:options][:values][:storage]
+            = @sb[:options][:values][:storage]
           = _('GB')
           %br{:clear => "all"}
           = _('* Disk space not supported for OpenStack providers')
@@ -182,21 +182,21 @@
         = _('Show')
       .col-md-8
         = select_tag("target_typ",
-                      options_for_select(TARGET_TYPE_CHOICES.map { |k, v| [_(v), k] }.sort_by(&:last), @sb[:planning][:options][:target_typ]),
+                      options_for_select(TARGET_TYPE_CHOICES.map { |k, v| [_(v), k] }.sort_by(&:last), @sb[:options][:target_typ]),
                       "class"                => "selectpicker",
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true)
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent("target_typ", "#{url}");
-    - unless @sb[:planning][:options][:target_filters].blank?
+    - unless @sb[:options][:target_filters].blank?
       .form-group
         %label.control-label.col-md-4
           = _('Filter')
         .col-md-8
-          - options = [["<#{_('All')}>", nil]] + Array(@sb[:planning][:options][:target_filters].invert).sort_by { |a| a.first.downcase }
+          - options = [["<#{_('All')}>", nil]] + Array(@sb[:options][:target_filters].invert).sort_by { |a| a.first.downcase }
           = select_tag("target_filter",
-                        options_for_select(options, @sb[:planning][:options][:target_filter]),
+                        options_for_select(options, @sb[:options][:target_filter]),
                         "class"                => "selectpicker",
                         "data-miq_sparkle_on"  => true,
                         "data-miq_sparkle_off" => true)
@@ -209,8 +209,8 @@
           = _('CPU Speed')
         .col-md-8
           = select_tag("limit_cpu",
-                        options_for_select(TREND_LIMIT_PERCENTS, @sb[:planning][:options][:limit_cpu]),
-                        :disabled              => !@sb[:planning][:options][:trend_cpu],
+                        options_for_select(TREND_LIMIT_PERCENTS, @sb[:options][:limit_cpu]),
+                        :disabled              => !@sb[:options][:trend_cpu],
                         "class"                => "selectpicker",
                         "data-miq_sparkle_on"  => true,
                         "data-miq_sparkle_off" => true)
@@ -223,8 +223,8 @@
           = _('vCPUs per Core')
         .col-md-8
           = select_tag("limit_vcpus",
-                        options_for_select((1..25).to_a.reverse, @sb[:planning][:options][:limit_vcpus]),
-                        :disabled => !@sb[:planning][:options][:trend_vcpus],
+                        options_for_select((1..25).to_a.reverse, @sb[:options][:limit_vcpus]),
+                        :disabled => !@sb[:options][:trend_vcpus],
                         "class"                => "selectpicker",
                         "data-miq_sparkle_on"  => true,
                         "data-miq_sparkle_off" => true)
@@ -237,8 +237,8 @@
           = _('Memory Size')
         .col-md-8
           = select_tag("limit_memory",
-                        options_for_select(TREND_LIMIT_PERCENTS, @sb[:planning][:options][:limit_memory]),
-                        :disabled              => !@sb[:planning][:options][:trend_memory],
+                        options_for_select(TREND_LIMIT_PERCENTS, @sb[:options][:limit_memory]),
+                        :disabled              => !@sb[:options][:trend_memory],
                         "class"                => "selectpicker",
                         "data-miq_sparkle_on"  => true,
                         "data-miq_sparkle_off" => true)
@@ -251,8 +251,8 @@
           = _('Datastore Space')
         .col-md-8
           = select_tag("limit_storage",
-                        options_for_select(TREND_LIMIT_PERCENTS, @sb[:planning][:options][:limit_storage]),
-                        :disabled => !@sb[:planning][:options][:trend_storage],
+                        options_for_select(TREND_LIMIT_PERCENTS, @sb[:options][:limit_storage]),
+                        :disabled => !@sb[:options][:trend_storage],
                         "class"                => "selectpicker",
                         "data-miq_sparkle_on"  => true,
                         "data-miq_sparkle_off" => true)
@@ -268,7 +268,7 @@
         = _('Trends for past')
       .col-md-8
         = select_tag("trend_days",
-                      options_for_select(ViewHelper::WEEK_CHOICES.invert.sort_by(&:last), @sb[:planning][:options][:days].to_i),
+                      options_for_select(ViewHelper::WEEK_CHOICES.invert.sort_by(&:last), @sb[:options][:days].to_i),
                       "class"                => "selectpicker",
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true)
@@ -283,10 +283,10 @@
           = _('No Time Profiles found')
         - elsif session[:time_profiles].length == 1
           -# Only 1 choice, show the value
-          = session[:time_profiles][@sb[:planning][:options][:time_profile].to_i]
+          = session[:time_profiles][@sb[:options][:time_profile].to_i]
         - else
           = select_tag("time_profile",
-                        options_for_select(session[:time_profiles].invert.sort_by(&:first), @sb[:planning][:options][:time_profile]),
+                        options_for_select(session[:time_profiles].invert.sort_by(&:first), @sb[:options][:time_profile]),
                         "class"                => "selectpicker",
                         "data-miq_sparkle_on"  => true,
                         "data-miq_sparkle_off" => true)

--- a/app/views/planning/_planning_report.html.haml
+++ b/app/views/planning/_planning_report.html.haml
@@ -1,17 +1,17 @@
 #planning_report_div
   = render :partial => "layouts/flash_msg"
 
-  - if @perf_record && @sb[:planning] && @sb[:planning][:rpt]
+  - if @perf_record && @sb[:rpt]
 
-    %h3= _("VM Counts per %{model}") % {:model => ui_lookup(:model => @sb[:planning][:options][:target_typ])}
-    = @sb[:planning][:rpt].to_html.html_safe
+    %h3= _("VM Counts per %{model}") % {:model => ui_lookup(:model => @sb[:options][:target_typ])}
+    = @sb[:rpt].to_html.html_safe
     - tvms = 0
-    - @sb[:planning][:rpt].table.data.each { |r| tvms += r["total_vm_count"].to_i }
-    = _('Total number of VMs that can fit on all of the above %{models}: %{count}') % {:models => ui_lookup(:models => @sb[:planning][:options][:target_typ]), :count => tvms}
-    - if @sb[:planning][:rpt].extras[:vm_profile]
+    - @sb[:rpt].table.data.each { |r| tvms += r["total_vm_count"].to_i }
+    = _('Total number of VMs that can fit on all of the above %{models}: %{count}') % {:models => ui_lookup(:models => @sb[:options][:target_typ]), :count => tvms}
+    - if @sb[:rpt].extras[:vm_profile]
       = render :partial => "planning_vm_profile"
   - if @perf_record
     %p
-      = _("* Information shown is based on available trend data going back %{weeks}.") % {:weeks => _(ViewHelper::WEEK_CHOICES[@sb[:planning][:options][:days]])}
+      = _("* Information shown is based on available trend data going back %{weeks}.") % {:weeks => _(ViewHelper::WEEK_CHOICES[@sb[:options][:days]])}
   - else
     = render :partial => "planning_instructions"

--- a/app/views/planning/_planning_summary.html.haml
+++ b/app/views/planning/_planning_summary.html.haml
@@ -7,23 +7,23 @@
       %dt= _('Limit Chart to')
       %dd
         = select_tag("display_vms",
-          options_for_select(10.step(100, 10).to_a, @sb[:planning][:options][:display_vms]),
+          options_for_select(10.step(100, 10).to_a, @sb[:options][:display_vms]),
           "data-miq_sparkle_on" => true,
           "data-miq_observe"    => {:url => url}.to_json)
         = _('VMs')
     %hr
-    - if @sb[:planning] && @sb[:planning][:chart_data] && @sb[:planning][:chart_data]["planning"]
+    - if @sb[:chart_data] && @sb[:chart_data]["planning"]
       = render(:partial => "layouts/perf_charts",
-        :locals         => {:charts => @sb[:planning][:charts],
+        :locals         => {:charts => @sb[:charts],
           :chart_set                => "planning",
-          :chart_data               => @sb[:planning][:chart_data]["planning"],
-          :perf_options             => @sb[:planning][:options]})
+          :chart_data               => @sb[:chart_data]["planning"],
+          :perf_options             => @sb[:options]})
     - else
       = render :partial => 'layouts/info_msg', :locals => {:message => _("No planning data is available for the selected item.")}
     %br{:clear => "all"}
     %hr
-    - if @sb[:planning][:chart_data] && @sb[:planning][:chart_data]["planning"]
-      %h3= _("Eligible %{type} ") % {:type => ui_lookup(:models => @sb[:planning][:options][:target_typ])}
+    - if @sb[:chart_data] && @sb[:chart_data]["planning"]
+      %h3= _("Eligible %{type} ") % {:type => ui_lookup(:models => @sb[:options][:target_typ])}
       %table.table.table-bordered.table-striped
         %thead
           %tr
@@ -31,19 +31,19 @@
             %th= _('Name')
             %th= _('Max VMs')
         %tbody
-          - if @sb[:planning][:rpt]
-            - @sb[:planning][:rpt].table.data.each_with_index do |r, r_idx|
+          - if @sb[:rpt]
+            - @sb[:rpt].table.data.each_with_index do |r, r_idx|
               - break if r_idx > 9 || r[1].to_i == 0
               %tr
                 %td= (r_idx + 1).ordinalize
                 %td= r["name"]
                 %td= r["total_vm_count"]
 
-      - if @sb[:planning][:rpt] && @sb[:planning][:rpt].extras[:vm_profile]
+      - if @sb[:rpt] && @sb[:rpt].extras[:vm_profile]
         = render :partial => "planning_vm_profile"
 
   - if @perf_record
     %p
-      = _("* Information shown is based on available trend data going back %{weeks}.") % {:weeks => _(ViewHelper::WEEK_CHOICES[@sb[:planning][:options][:days]])}
+      = _("* Information shown is based on available trend data going back %{weeks}.") % {:weeks => _(ViewHelper::WEEK_CHOICES[@sb[:options][:days]])}
   - else
     = render :partial => "planning_instructions"

--- a/app/views/planning/_planning_vm_profile.html.haml
+++ b/app/views/planning/_planning_vm_profile.html.haml
@@ -3,75 +3,75 @@
 %dl.dl-horizontal
   %dt= _('Source')
   %dd
-    = h(_(PLANNING_VM_MODES[@sb[:planning][:options][:submitted_vm_mode]]))
+    = h(_(PLANNING_VM_MODES[@sb[:options][:submitted_vm_mode]]))
 
-  - if @sb[:planning][:vm_opts][:cpu] && @sb[:planning][:options][:trend_cpu] && @sb[:planning][:rpt].extras[:vm_profile][:cpu]
+  - if @sb[:vm_opts][:cpu] && @sb[:options][:trend_cpu] && @sb[:rpt].extras[:vm_profile][:cpu]
     %dt= _('CPU Speed')
     %dd
-      = h(@sb[:planning][:rpt].extras[:vm_profile][:cpu])
+      = h(@sb[:rpt].extras[:vm_profile][:cpu])
 
-  - if @sb[:planning][:vm_opts][:vcpus] && @sb[:planning][:options][:trend_vcpus] && @sb[:planning][:rpt].extras[:vm_profile][:vcpus]
+  - if @sb[:vm_opts][:vcpus] && @sb[:options][:trend_vcpus] && @sb[:rpt].extras[:vm_profile][:vcpus]
     %dt= _('vCPU Count')
     %dd
-      = h(@sb[:planning][:rpt].extras[:vm_profile][:vcpus])
+      = h(@sb[:rpt].extras[:vm_profile][:vcpus])
 
-  - if @sb[:planning][:vm_opts][:memory] && @sb[:planning][:options][:trend_memory] && @sb[:planning][:rpt].extras[:vm_profile][:memory]
+  - if @sb[:vm_opts][:memory] && @sb[:options][:trend_memory] && @sb[:rpt].extras[:vm_profile][:memory]
     %dt= _('Memory Size')
     %dd
-      = h(@sb[:planning][:rpt].extras[:vm_profile][:memory])
+      = h(@sb[:rpt].extras[:vm_profile][:memory])
 
-  - if @sb[:planning][:vm_opts][:storage] && @sb[:planning][:options][:trend_storage] && @sb[:planning][:rpt].extras[:vm_profile][:storage]
+  - if @sb[:vm_opts][:storage] && @sb[:options][:trend_storage] && @sb[:rpt].extras[:vm_profile][:storage]
     %dt= _('Disk Space')
     %dd
-      = h(@sb[:planning][:rpt].extras[:vm_profile][:storage])
+      = h(@sb[:rpt].extras[:vm_profile][:storage])
 
 %hr
 %h3= _('Target Options/Limits')
 %dl.dl-horizontal
   %dt= _('Show')
   %dd
-    = h(_(TARGET_TYPE_CHOICES[@sb[:planning][:options][:target_typ]]))
+    = h(_(TARGET_TYPE_CHOICES[@sb[:options][:target_typ]]))
 
-  - if @sb[:planning][:vm_opts][:cpu] && @sb[:planning][:options][:trend_cpu] && @sb[:planning][:rpt].extras[:vm_profile][:cpu]
+  - if @sb[:vm_opts][:cpu] && @sb[:options][:trend_cpu] && @sb[:rpt].extras[:vm_profile][:cpu]
     %dt= _('CPU Speed')
     %dd
-      = "#{h(@sb[:planning][:options][:limit_cpu])}%"
+      = "#{h(@sb[:options][:limit_cpu])}%"
 
-  - if @sb[:planning][:vm_opts][:vcpus] && @sb[:planning][:options][:trend_vcpus] && @sb[:planning][:rpt].extras[:vm_profile][:vcpus]
+  - if @sb[:vm_opts][:vcpus] && @sb[:options][:trend_vcpus] && @sb[:rpt].extras[:vm_profile][:vcpus]
     %dt= _('vCPU per Core')
     %dd
-      = h(@sb[:planning][:options][:limit_vcpus])
+      = h(@sb[:options][:limit_vcpus])
 
-  - if @sb[:planning][:vm_opts][:memory] && @sb[:planning][:options][:trend_memory] && @sb[:planning][:rpt].extras[:vm_profile][:memory]
+  - if @sb[:vm_opts][:memory] && @sb[:options][:trend_memory] && @sb[:rpt].extras[:vm_profile][:memory]
     %dt= _('Memory Size')
     %dd
-      = "#{h(@sb[:planning][:options][:limit_memory])}%"
+      = "#{h(@sb[:options][:limit_memory])}%"
 
-  - if @sb[:planning][:vm_opts][:storage] && @sb[:planning][:options][:trend_storage] && @sb[:planning][:rpt].extras[:vm_profile][:storage]
+  - if @sb[:vm_opts][:storage] && @sb[:options][:trend_storage] && @sb[:rpt].extras[:vm_profile][:storage]
     %dt= _('Datastore Space')
     %dd
-      = "#{h(@sb[:planning][:options][:limit_storage])}%"
+      = "#{h(@sb[:options][:limit_storage])}%"
 
 %hr
 %h3= _('Trend Options')
 %dl.dl-horizontal
   %dt= _('Trend for Past')
   %dd
-    = h(_(ViewHelper::WEEK_CHOICES[@sb[:planning][:options][:days].to_i]))
+    = h(_(ViewHelper::WEEK_CHOICES[@sb[:options][:days].to_i]))
   %dt= _('Time Profile')
   %dd
-    - if @sb[:planning][:options][:time_profile].nil?
+    - if @sb[:options][:time_profile].nil?
       = _('No Time Profile Selected')
     - else
-      = h(session[:time_profiles][@sb[:planning][:options][:time_profile]])
+      = h(session[:time_profiles][@sb[:options][:time_profile]])
 
   %dt= _('Time Zone')
   %dd
-    - if @sb[:planning][:options][:time_profile_tz]
-      = @sb[:planning][:options][:time_profile_tz]
+    - if @sb[:options][:time_profile_tz]
+      = @sb[:options][:time_profile_tz]
       &nbsp;&nbsp;&nbsp;
       = _('* Set in Time Profile')
     - else
       - ALL_TIMEZONES.each do |tz|
-        - if tz[1] == @sb[:planning][:options][:tz]
+        - if tz[1] == @sb[:options][:tz]
           = h(tz[0])

--- a/app/views/utilization/_utilization_details.html.haml
+++ b/app/views/utilization/_utilization_details.html.haml
@@ -1,21 +1,21 @@
 #utilization_details_div
   = render :partial => "layouts/flash_msg"
-  - if @sb[:util] && @sb[:util][:trend_rpt] && @sb[:util][:summary]
+  - if @sb[:trend_rpt] && @sb[:summary]
     = render :partial => "utilization_options", :locals  => {:cap_type => "details"}
     = render(:partial => "layouts/perf_charts",
-      :locals         => {:charts => @sb[:util][:trend_charts],
+      :locals         => {:charts => @sb[:trend_charts],
         :chart_set                => "utiltrend",
-        :chart_data               => @sb[:util][:chart_data]["utiltrend"],
-        :perf_options             => @sb[:util][:options]})
+        :chart_data               => @sb[:chart_data]["utiltrend"],
+        :perf_options             => @sb[:options]})
   - else
     - if x_node == ""
       - msg = _("Select a node on the left to view Utilization information.")
     - else
       - msg = _("No performance data is available for the selected item.")
     = render :partial => 'layouts/info_msg', :locals => {:message => msg}
-  - if @sb[:util] && @sb[:util][:trend_rpt]
+  - if @sb[:trend_rpt]
     %br{:clear => "all"}
     %hr
-    = _('* Information shown is based on available trend data from %{start_time} to %{end_time} in the %{timezone} time zone.') % {:start_time => format_timezone(@sb[:util][:options][:trend_start], @sb[:util][:options][:tz], "date"), :end_time => format_timezone(@sb[:util][:options][:trend_end], @sb[:util][:options][:tz], "date"), :timezone => @sb[:util][:options][:time_profile_tz] || @sb[:util][:options][:tz]}
+    = _('* Information shown is based on available trend data from %{start_time} to %{end_time} in the %{timezone} time zone.') % {:start_time => format_timezone(@sb[:options][:trend_start], @sb[:options][:tz], "date"), :end_time => format_timezone(@sb[:options][:trend_end], @sb[:options][:tz], "date"), :timezone => @sb[:options][:time_profile_tz] || @sb[:options][:tz]}
     %p
     %br

--- a/app/views/utilization/_utilization_options.html.haml
+++ b/app/views/utilization/_utilization_options.html.haml
@@ -9,7 +9,7 @@
         = _('Trends for past')
       .col-md-10
         = select_tag("#{cap_type}_days",
-          options_for_select(ViewHelper::WEEK_CHOICES.map {|k, v| [_(v), k]}.sort, @sb[:util][:options][:days].to_i),
+          options_for_select(ViewHelper::WEEK_CHOICES.map {|k, v| [_(v), k]}.sort, @sb[:options][:days].to_i),
           "class"               => "selectpicker")
         :javascript
           miqInitSelectPicker();
@@ -20,9 +20,9 @@
       %label.control-label.col-md-2
         = _('Classification')
       .col-md-10
-        - options = [["<#{_('None')}>", "<None>"]] + (@sb[:util][:tags] ? @sb[:util][:tags].invert.sort : [])
+        - options = [["<#{_('None')}>", "<None>"]] + (@sb[:tags] ? @sb[:tags].invert.sort : [])
         = select_tag("#{cap_type}_tag",
-          options_for_select(options, @sb[:util][:options][:tag]),
+          options_for_select(options, @sb[:options][:tag]),
           "class"               => "selectpicker")
         :javascript
           miqInitSelectPicker();
@@ -37,11 +37,11 @@
           = _('No Time Profiles found')
         - elsif session[:time_profiles].length == 1
           -# Only 1 choice, show the value
-          = session[:time_profiles][@sb[:util][:options][:time_profile].to_i]
+          = session[:time_profiles][@sb[:options][:time_profile].to_i]
         - else
           = select_tag("#{cap_type}_time_profile",
             options_for_select(Array(session[:time_profiles].invert).sort_by(&:first),
-            @sb[:util][:options][:time_profile]),
+            @sb[:options][:time_profile]),
             "class"               => "selectpicker")
           :javascript
             miqInitSelectPicker();
@@ -53,7 +53,7 @@
           = _('Selected Day')
         .col-md-10
           = datepicker_input_tag("miq_date_#{date_id}",
-            @sb[:util][:options][:chart_date],
+            @sb[:options][:chart_date],
             :readonly               => "true",
             "data-miq_sparkle_on"   => true,
             "data-miq_observe_date" => {:url => url}.to_json)

--- a/app/views/utilization/_utilization_report.html.haml
+++ b/app/views/utilization/_utilization_report.html.haml
@@ -1,11 +1,11 @@
 #utilization_report_div
   = render :partial => "layouts/flash_msg"
-  - if @sb[:util] && @sb[:util][:trend_rpt] && @sb[:util][:summary]
+  - if @sb[:trend_rpt] && @sb[:summary]
     = render :partial => "utilization_options", :locals => {:cap_type => "report"}
     %hr
     %h3= _('Basic Information')
     %dl.dl-horizontal
-      - @sb[:util][:summary][:info].each do |si|
+      - @sb[:summary][:info].each do |si|
         %dt
           = si.first
         %dd
@@ -16,9 +16,9 @@
     - else
       - msg = _("No performance data is available for the selected item.")
     = render :partial => 'layouts/info_msg', :locals => {:message => msg}
-  - if @sb[:util] && @sb[:util][:summary]
+  - if @sb[:summary]
     - {:cpu => _('CPU'), :memory => _('Memory'), :storage => _('Disk')}.each do |k, v|
-      - if @sb[:util][:summary][k] && !@sb[:util][:summary][k].empty?
+      - if @sb[:summary][k] && !@sb[:summary][k].empty?
         %hr
         %table.table.table-bordered.table-striped
           %thead
@@ -26,12 +26,12 @@
               %th{:colspan => 2, :align => "left"}
                 = v
           %tbody
-            - @sb[:util][:summary][k].each do |c|
+            - @sb[:summary][k].each do |c|
               %tr
                 %td
                   = c.first
                 %td
                   = c.last
-  - if @sb[:util] && @sb[:util][:trend_rpt]
+  - if @sb[:trend_rpt]
     %hr
-    = _('* Information shown is based on available trend data from %{start_time} to %{end_time} in the %{timezone} time zone.') % {:start_time => format_timezone(@sb[:util][:options][:trend_start], @sb[:util][:options][:tz], "date"), :end_time => format_timezone(@sb[:util][:options][:trend_end], @sb[:util][:options][:tz], "date"), :timezone => @sb[:util][:options][:time_profile_tz] || @sb[:util][:options][:tz]}
+    = _('* Information shown is based on available trend data from %{start_time} to %{end_time} in the %{timezone} time zone.') % {:start_time => format_timezone(@sb[:options][:trend_start], @sb[:options][:tz], "date"), :end_time => format_timezone(@sb[:options][:trend_end], @sb[:options][:tz], "date"), :timezone => @sb[:options][:time_profile_tz] || @sb[:options][:tz]}

--- a/app/views/utilization/_utilization_summary.html.haml
+++ b/app/views/utilization/_utilization_summary.html.haml
@@ -1,25 +1,25 @@
 #utilization_summary_div
   = render :partial => "layouts/flash_msg"
-  - if @sb[:util] && @sb[:util][:trend_rpt] && @sb[:util][:summary]
+  - if @sb[:trend_rpt] && @sb[:summary]
     = render :partial => "utilization_options", :locals  => {:cap_type => "summ"}
     = render(:partial => "layouts/perf_charts",
-      :locals         => {:charts => @sb[:util][:ts_charts],
+      :locals         => {:charts => @sb[:ts_charts],
         :chart_set                => "utilts",
-        :chart_data               => @sb[:util][:chart_data]["utilts"],
-        :perf_options             => @sb[:util][:options]})
+        :chart_data               => @sb[:chart_data]["utilts"],
+        :perf_options             => @sb[:options]})
     %br{:clear => "all"}
     %hr
     - {:cpu => _('CPU'), :memory => _('Memory'), :storage => _('Disk')}.each do |k, v|
       - if k != :cpu
         %hr
-      - if @sb[:util][:summary][k] && !@sb[:util][:summary][k].empty?
+      - if @sb[:summary][k] && !@sb[:summary][k].empty?
         %table.table.table-bordered.table-striped
           %thead
             %th{:colspan => 2}
               = v
           %tbody
-            - @sb[:util][:summary][k].each do |c|
-              - if (c.first.include?("Trend:") && c.first.include?("Max")) || (c.first.include?("Available") && @sb[:util][:options][:model] != "Host") || c.first.include?("Total")
+            - @sb[:summary][k].each do |c|
+              - if (c.first.include?("Trend:") && c.first.include?("Max")) || (c.first.include?("Available") && @sb[:options][:model] != "Host") || c.first.include?("Total")
                 %tr
                   %td
                     = c.first
@@ -31,8 +31,8 @@
     - else
       - msg = _("No performance data is available for the selected item.")
     = render :partial => 'layouts/info_msg', :locals => {:message => msg}
-  - if @sb[:util] && @sb[:util][:trend_rpt]
+  - if @sb[:trend_rpt]
     %hr
-    = _('* Information shown is based on available trend data from %{start_time} to %{end_time} in the %{timezone} time zone.') % {:start_time => format_timezone(@sb[:util][:options][:trend_start], @sb[:util][:options][:tz], "date"), :end_time => format_timezone(@sb[:util][:options][:trend_end], @sb[:util][:options][:tz], "date"), :timezone => @sb[:util][:options][:time_profile_tz] || @sb[:util][:options][:tz]}
+    = _('* Information shown is based on available trend data from %{start_time} to %{end_time} in the %{timezone} time zone.') % {:start_time => format_timezone(@sb[:options][:trend_start], @sb[:options][:tz], "date"), :end_time => format_timezone(@sb[:options][:trend_end], @sb[:options][:tz], "date"), :timezone => @sb[:options][:time_profile_tz] || @sb[:options][:tz]}
     %p
     %br

--- a/spec/controllers/application_controller/performance_spec.rb
+++ b/spec/controllers/application_controller/performance_spec.rb
@@ -3,8 +3,7 @@ describe ApplicationController do
     it "should not get nil error when submitting up Manual Input data" do
       enterprise = FactoryGirl.create(:miq_enterprise)
       allow(MiqServer).to receive(:my_zone).and_return("default")
-      sb = HashWithIndifferentAccess.new
-      sb[:planning] = {
+      sb = {
         :options => {
           :target_typ => "EmsCluster",
           :vm_mode    => :manual,
@@ -15,7 +14,7 @@ describe ApplicationController do
         :vm_opts => {
           :cpu => 2
         }
-      }
+      }.with_indifferent_access
       controller.instance_variable_set(:@sb, sb)
       allow(controller).to receive(:initiate_wait_for_task)
       controller.send(:perf_planning_gen_data)

--- a/spec/controllers/bottlenecks_controller_spec.rb
+++ b/spec/controllers/bottlenecks_controller_spec.rb
@@ -10,6 +10,7 @@ describe BottlenecksController do
     describe '#index' do
       it 'renders the page' do
         seed_session_trees('miq_capacity', :bottlenecks_tree, 'foobar')
+        controller.instance_variable_set(:@sb, {})
         expect(controller).to receive(:get_node_info)
         # render fails but it's not needed for this test
         expect(controller).to receive(:render)

--- a/spec/controllers/bottlenecks_controller_spec.rb
+++ b/spec/controllers/bottlenecks_controller_spec.rb
@@ -8,7 +8,7 @@ describe BottlenecksController do
     end
 
     describe '#index' do
-      it 'sets breadcrumb' do
+      it 'renders the page' do
         seed_session_trees('miq_capacity', :bottlenecks_tree, 'foobar')
         expect(controller).to receive(:get_node_info)
         # render fails but it's not needed for this test
@@ -51,7 +51,6 @@ describe BottlenecksController do
                                 :title_prefix => "Datastore",
                                 :title        => ds.name}}
       tree_nodes.each do |_key, node|
-        controller.instance_variable_set(:@breadcrumbs, [])
         controller.instance_variable_set(:@sb, :trees       => {
                                            :bottlenecks_tree => {:active_node => node[:active_node]}
                                          },

--- a/spec/controllers/bottlenecks_controller_spec.rb
+++ b/spec/controllers/bottlenecks_controller_spec.rb
@@ -55,7 +55,7 @@ describe BottlenecksController do
                                            :bottlenecks_tree => {:active_node => node[:active_node]}
                                          },
                                                :active_tree => :bottlenecks_tree,
-                                               :bottlenecks => {:options => {}},)
+                                               :options     => {},)
         expect(controller).not_to receive(:render)
         controller.send(:get_node_info, node[:active_node])
         expect(assigns(:right_cell_text)).to eq("#{node[:title_prefix]} \"#{node[:title]}\" #{title_suffix}")

--- a/spec/controllers/planning_controller_spec.rb
+++ b/spec/controllers/planning_controller_spec.rb
@@ -15,38 +15,38 @@ describe PlanningController do
 
     it 'displays all Vms' do
       allow(controller).to receive(:render)
-      controller.instance_variable_set(:@sb, :planning => {:vms => {}, :options => {}})
+      controller.instance_variable_set(:@sb, :vms => {}, :options => {})
       controller.instance_variable_set(:@_params, :filter_typ => "all")
       controller.send(:option_changed)
       sb = controller.instance_variable_get(:@sb)
-      expect(sb[:planning][:vms]).to eq(@vm1.id.to_s => @vm1.name,
-                                        @vm2.id.to_s => @vm2.name,
-                                        @vm3.id.to_s => @vm3.name,
-                                        @vm4.id.to_s => @vm4.name)
+      expect(sb[:vms]).to eq(@vm1.id.to_s => @vm1.name,
+                             @vm2.id.to_s => @vm2.name,
+                             @vm3.id.to_s => @vm3.name,
+                             @vm4.id.to_s => @vm4.name)
     end
 
     it 'displays Vms with the same name' do
       ems = FactoryGirl.create(:ems_vmware, :name => "ProviderName")
       vm5 = FactoryGirl.create(:vm_vmware,  :name => 'Name1', :host => @host2, :ext_management_system => ems)
       allow(controller).to receive(:render)
-      controller.instance_variable_set(:@sb, :planning => {:vms => {}, :options => {}})
+      controller.instance_variable_set(:@sb, :vms => {}, :options => {})
       controller.instance_variable_set(:@_params, :filter_typ => "all")
       controller.send(:option_changed)
       sb = controller.instance_variable_get(:@sb)
-      expect(sb[:planning][:vms]).to eq(@vm1.id.to_s => @vm1.name,
-                                        vm5.id.to_s  => "#{ems.name}:#{vm5.name}",
-                                        @vm2.id.to_s => @vm2.name,
-                                        @vm3.id.to_s => @vm3.name,
-                                        @vm4.id.to_s => @vm4.name)
+      expect(sb[:vms]).to eq(@vm1.id.to_s => @vm1.name,
+                             vm5.id.to_s  => "#{ems.name}:#{vm5.name}",
+                             @vm2.id.to_s => @vm2.name,
+                             @vm3.id.to_s => @vm3.name,
+                             @vm4.id.to_s => @vm4.name)
     end
 
     it 'displays Vms filtered by host' do
       allow(controller).to receive(:render)
-      controller.instance_variable_set(:@sb, :planning => {:vms => {}, :options => {}})
+      controller.instance_variable_set(:@sb, :vms => {}, :options => {})
       controller.instance_variable_set(:@_params, :filter_typ => "host", :filter_value => @host1.id)
       controller.send(:option_changed)
       sb = controller.instance_variable_get(:@sb)
-      expect(sb[:planning][:vms]).to eq(@vm1.id.to_s => @vm1.name, @vm3.id.to_s => @vm3.name, @vm4.id.to_s => @vm4.name)
+      expect(sb[:vms]).to eq(@vm1.id.to_s => @vm1.name, @vm3.id.to_s => @vm3.name, @vm4.id.to_s => @vm4.name)
     end
   end
 end

--- a/spec/controllers/utilization_controller_spec.rb
+++ b/spec/controllers/utilization_controller_spec.rb
@@ -27,7 +27,7 @@ describe UtilizationController do
                                            :utilization_tree => {:active_node => node[:active_node]},
                                          },
                                                :active_tree => :utilization_tree,
-                                               :util        => {:options => {}})
+                                               :options     => {})
         expect(controller).not_to receive(:render)
         controller.send(:get_node_info, node[:active_node])
         expect(assigns(:right_cell_text)).to eq("#{node[:title_prefix]} \"#{node[:title]}\" #{title_suffix}")

--- a/spec/controllers/utilization_controller_spec.rb
+++ b/spec/controllers/utilization_controller_spec.rb
@@ -23,7 +23,6 @@ describe UtilizationController do
                                 :title_prefix => "Datastore",
                                 :title        => ds.name}}
       tree_nodes.each do |_key, node|
-        controller.instance_variable_set(:@breadcrumbs, [])
         controller.instance_variable_set(:@sb, :trees       => {
                                            :utilization_tree => {:active_node => node[:active_node]},
                                          },

--- a/spec/views/bottlenecks/_bottlenecks_options.html.haml_spec.rb
+++ b/spec/views/bottlenecks/_bottlenecks_options.html.haml_spec.rb
@@ -1,8 +1,8 @@
 describe 'bottlenecks/_bottlenecks_options.html.haml' do
   before :each do
     set_controller_for_view('bottlenecks')
-    assign(:sb, :bottlenecks => {:groups     => %w(Capacity Utilization),
-                                 :tl_options => {:filter1 => 'ALL'}})
+    assign(:sb, :groups     => %w(Capacity Utilization),
+                :tl_options => {:filter1 => 'ALL'})
   end
 
   it 'does render Show Host Events checkbox under Datastores' do

--- a/spec/views/utilization/_utilization_options.html.haml_spec.rb
+++ b/spec/views/utilization/_utilization_options.html.haml_spec.rb
@@ -2,13 +2,10 @@ describe "utilization/_utilization_options.html.haml" do
   before :each do
     set_controller_for_view("utilization")
     assign(:record, Struct.new(:id).new(2))
-    assign(:sb, :util => {:options => {:days         => 2,
-                                       :time_profile => "1",
-                                       :chart_date   => "asdf"
-                                       },
-                          :tags    => {:asdf => "fdsa"}
-                          }
-          )
+    assign(:sb, :options => {:days         => 2,
+                             :time_profile => "1",
+                             :chart_date   => "asdf"},
+                :tags    => {:asdf => "fdsa"})
   end
   it "check if correct fields are being displayed if cap_type is not set" do
     # render with default cap_type variable value


### PR DESCRIPTION
This is a followup PR of #1966 and also the part of #1871. There were some unnecessary dead parts (breadcrumbs, session stuff) of the code that have been removed. I also de-namespaced the `@sb` hashes as they're now living in their separate controllers.

The most important part is that we're finally using the `build_accordions_and_trees` method as in every other explorer screen.

@miq-bot add_label refactoring, trees, explorers, fine/no
@miq-bot assign @h-kataria 