### PR TITLE
Build the policy trees the same way as any other explorer tree

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -226,8 +226,7 @@ class MiqPolicyController < ApplicationController
     self.x_active_tree ||= 'policy_profile_tree'
     self.x_active_accord ||= 'policy_profile'
 
-    trees = features.collect { |feature| [feature.tree_name, feature.build_tree(@sb)] }
-    @trees = Hash[* trees.flatten] # trees.to_h in Ruby 2.2
+    @trees = features.map { |feature| feature.build_tree(@sb) }
     @accords = features.map(&:accord_hash)
 
     if params[:profile].present?  # If profile record id passed in, position on that node

--- a/app/views/shared/_explorer_tree.html.haml
+++ b/app/views/shared/_explorer_tree.html.haml
@@ -4,10 +4,5 @@
 -# Used instance variables:
 -#   @trees - all the available trees generated with TreeBuilder
 
-- case controller.controller_name
-- when 'miq_policy'
-  - tree = @trees["#{name}_tree".to_sym]
-  = render :partial => "shared/tree", :locals => {:tree => tree, :name => tree.name.to_s}
-- else
-  - tree = @trees.length == 1 ? @trees.first : @trees.detect { |t| t.type == name.to_sym }
-  = render :partial => 'shared/tree', :locals  => {:tree => tree, :name => tree.name.to_s}
+- tree = @trees.length == 1 ? @trees.first : @trees.detect { |t| t.type == name.to_sym }
+= render :partial => 'shared/tree', :locals  => {:tree => tree, :name => tree.name.to_s}


### PR DESCRIPTION
This is the last left side explorer tree that is different from the others. It still should be rewritten to use the `build_accordions_and_trees` as the others, but that's not important from the [tree componentization perspective](https://github.com/ManageIQ/manageiq-ui-classic/issues/1871).

@miq-bot add_label trees, fine/no, refactoring