### PR TITLE
Remove PLANNING_VM_MODES from UiConstants

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,7 @@ module ApplicationHelper
   include StiRoutingHelper
   include ToolbarHelper
   include TextualSummaryHelper
+  include PlanningHelper
   include NumberHelper
   include Title
 

--- a/app/helpers/planning_helper.rb
+++ b/app/helpers/planning_helper.rb
@@ -1,0 +1,9 @@
+module PlanningHelper
+  # Source pulldown in VM Options
+  PLANNING_VM_MODES = {
+    :allocated => N_("Allocation"),
+    :reserved  => N_("Reservation"),
+    :used      => N_("Usage"),
+    :manual    => N_("Manual Input")
+  }.freeze
+end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -40,14 +40,7 @@ module UiConstants
 
   TREND_MODEL = "VimPerformanceTrend"   # Performance trend model name requiring special processing
 
-  # Source pulldown in VM Options
-  PLANNING_VM_MODES = {
-    :allocated => N_("Allocation"),
-    :reserved  => N_("Reservation"),
-    :used      => N_("Usage"),
-    :manual    => N_("Manual Input")
-  }
-  VALID_PLANNING_VM_MODES = PLANNING_VM_MODES.keys.index_by(&:to_s)
+  VALID_PLANNING_VM_MODES = PlanningHelper::PLANNING_VM_MODES.keys.index_by(&:to_s)
 
   TASK_TIME_PERIODS = {
     0 => N_("Today"),

--- a/app/views/planning/_planning_options.html.haml
+++ b/app/views/planning/_planning_options.html.haml
@@ -92,7 +92,7 @@
         = _('Source')
       .col-md-8
         = select_tag("vm_mode",
-                      options_for_select(PLANNING_VM_MODES.map { |k, v| [_(v), k] }.sort, @sb[:options][:vm_mode]),
+                      options_for_select(PlanningHelper::PLANNING_VM_MODES.map { |k, v| [_(v), k] }.sort, @sb[:options][:vm_mode]),
                       "class"                => "selectpicker",
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true)

--- a/app/views/planning/_planning_vm_profile.html.haml
+++ b/app/views/planning/_planning_vm_profile.html.haml
@@ -3,7 +3,7 @@
 %dl.dl-horizontal
   %dt= _('Source')
   %dd
-    = h(_(PLANNING_VM_MODES[@sb[:options][:submitted_vm_mode]]))
+    = h(_(PlanningHelper::PLANNING_VM_MODES[@sb[:options][:submitted_vm_mode]]))
 
   - if @sb[:vm_opts][:cpu] && @sb[:options][:trend_cpu] && @sb[:rpt].extras[:vm_profile][:cpu]
     %dt= _('CPU Speed')


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `PLANNING_VM_MODES` was removed from `UiConstants` and moved to `PlanningHelper`. Prefix `PlanningHelper::` was added to some occurrence of this constants.