### PR TITLE
Add 'submit' and 'cancel' buttons to service dialogs by default

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -68,6 +68,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
       dialogData = {
         description: DialogEditor.getDialogDescription(),
         label: DialogEditor.getDialogLabel(),
+        buttons: 'submit, cancel',
         dialog_tabs: [],
       };
       dialogData.dialog_tabs = _.cloneDeep(DialogEditor.getDialogTabs(), customizer);


### PR DESCRIPTION
This change adds buttons 'submit' and 'cancel' to service provisioning dialogs by default.

Links
----------------

https://www.pivotaltracker.com/n/projects/1613907/stories/144481043/comments/176976267

Steps for Testing/QA
-------------------------------
- create a new service dialog (Automation -> Automate -> Customization -> Service Dialogs -> Add a new dialog with a Dialog Editor)
- assign the dialog to a catalog item (Services -> Catalogs -> Catalog Items accordion -> edit catalog item and assign the created dialog
- order a catalog item (Services -> Catalogs -> Service Catalogs accordion -> Order)

![screenshot from 2017-08-24 11-48-17](https://user-images.githubusercontent.com/1187051/29660657-27d5f510-88c2-11e7-8c05-7a071580a140.png)
