### PR TITLE
Not found partial for topology controllersAs vm

### DIFF
--- a/app/views/shared/topology/_not_found_vm.html.haml
+++ b/app/views/shared/topology/_not_found_vm.html.haml
@@ -1,0 +1,5 @@
+.floating-not-found{'ng-show' => 'vm.searching && vm.notFound'}
+  = _("No results match the search criteria")
+  %br
+  %a.btn.btn-link{:href => "", 'ng-click' => "vm.resetSearch()"}
+    = _("Clear Search")


### PR DESCRIPTION
This is just a small change to help refactoring topology controllers as vm ([like this one](https://github.com/ManageIQ/manageiq-ui-classic/pull/1898)).

Partial uses vm prefix instead of scope

eventually should replace the [old partial](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/shared/topology/_not_found.html.haml)

## Files
app/views/shared/topology/_not_found_vm.html.haml
