### PR TITLE
Angularize left-side trees on all explorer screens

### DIFF
--- a/app/assets/javascripts/angular_modules/module_tree_view.js
+++ b/app/assets/javascripts/angular_modules/module_tree_view.js
@@ -1,0 +1,4 @@
+/* global miqHttpInject */
+miqHttpInject(
+  angular.module('ManageIQ.treeView', ['miqStaticAssets.treeView'])
+);

--- a/app/assets/javascripts/controllers/tree_view_controller.js
+++ b/app/assets/javascripts/controllers/tree_view_controller.js
@@ -1,0 +1,35 @@
+/* global miqJqueryRequest */
+(function() {
+  var CONTROLLER_NAME = 'treeViewController';
+
+  var TreeViewController = function($http) {
+    var vm = this;
+    vm.$http = $http;
+    vm.selectedNodes = {};
+  };
+
+  TreeViewController.prototype.initSelected = function(tree, node) {
+    this.selectedNodes[tree] = this.selectedNodes[tree] || { key: node };
+  };
+
+  TreeViewController.prototype.lazyLoad = function(node, name, url) {
+    var vm = this;
+    return new Promise(function(resolve) {
+      vm.$http.post(url, {
+        id: node.key,
+        tree: name,
+        mode: 'all',
+      }).then(function(response) {
+        resolve(response.data);
+      });
+    });
+  };
+
+  TreeViewController.prototype.nodeSelect = function(node, path) {
+    var url = path + '?id=' + encodeURIComponent(node.key.split('__')[0]);
+    miqJqueryRequest(url, {beforeSend: true});
+  };
+
+  TreeViewController.$inject = ['$http'];
+  window.miqHttpInject(angular.module('ManageIQ.treeView')).controller(CONTROLLER_NAME, TreeViewController);
+})();

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -1,7 +1,7 @@
 /* global DoNav miqClearTreeState miqDomElementExists miqJqueryRequest miqSetButtons miqSparkle */
 
 function miqTreeObject(tree) {
-  return $('#' + tree + 'box').treeview(true);
+  return $('miq-tree-view[name="' + tree + '"] > .treeview').treeview(true);
 }
 
 function miqTreeFindNodeByKey(tree, key) {

--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -1,12 +1,17 @@
 - if @accords
-  #accordion.panel-group
+  #accordion.panel-group{'ng-controller' => 'treeViewController as vm'}
     -# Set the first accordion as selected if there is no active_accord in the sandbox
     - selected = @accords.find(-> { @accords.first }) { |accord| accord[:name].to_sym == @sb[:active_accord] }
     - @accords.each do |accord|
       = miq_accordion_panel(accord[:title], selected == accord, accord[:container]) do
         -# Set the first tree to be rendered if there is a mismatch with the name/type
         - tree = @trees.find(-> { @trees.first }) { |t| t.type == accord[:name].to_sym  }
-        = render :partial => 'shared/tree', :locals  => {:tree => tree, :name => tree.name.to_s}
-
-    :javascript
-      $('#accordion').on('show.bs.collapse', miqAccordSelect);
+        %miq-tree-view{:name       => tree.name,
+                       :data       => tree.locals_for_render[:bs_tree],
+                       "ng-init"   => "vm.initSelected('#{tree.name}', '#{tree.locals_for_render[:select_node]}')",
+                       'on-select' => "vm.nodeSelect(node, '/#{request.parameters[:controller]}/tree_select')",
+                       'selected'  => "vm.selectedNodes['#{tree.name}']",
+                       'lazy-load' => "(vm.lazyLoad(node, '#{tree.name}', '/#{request.parameters[:controller]}/tree_autoload'))"}
+  :javascript
+    miq_bootstrap('#accordion', 'ManageIQ.treeView');
+    $('#accordion').on('show.bs.collapse', miqAccordSelect);

--- a/spec/javascripts/miq_tree_spec.js
+++ b/spec/javascripts/miq_tree_spec.js
@@ -2,7 +2,7 @@ describe('miq_tree', function() {
   describe('miqInitTree', function () {
     describe('post_check', function () {
       it('checks child nodes', function () {
-        $('body').append($('<div id="testbox">'));
+        $('body').append($('<miq-tree-view name="test"><div id="testbox" class="treeview"/></miq-tree-view>'));
 
         miqInitTree({tree_name: "test", tree_id: "testbox", post_check: true, hierarchical_check: true}, [
           {


### PR DESCRIPTION
Now all our explorer listnavs are using a single partial that makes easier to use the `TreeView` component for rendering the trees. There are a few glitches that should be sorted out and probably more will come while we're testing this.

I'm using a single controller for all trees in a screen but I'm not sure if this is *The Right Way&trade;* so @himdel or @karelhala correct me if this approach is wrong.

* [x] Displaying the tree
* [x] Lazy-loading elements on expand
* [x] Selecting nodes from the outside https://github.com/ManageIQ/ui-components/pull/129
* [x] Displaying SVG/PNG images as node icons https://github.com/ManageIQ/ui-components/pull/132

Parent issue: #1871 
Pivotal story: https://www.pivotaltracker.com/story/show/150541878

@miq-bot add_label trees, explorers, refactoring, fine/no