### PR TITLE
Fix filter tab for chargeback report for all providers

### DIFF
--- a/app/helpers/report_helper/editor.rb
+++ b/app/helpers/report_helper/editor.rb
@@ -1,6 +1,6 @@
 module ReportHelper::Editor
   def cb_entities_by_provider_id(provider_id, entity_type)
-    provider = ManageIQ::Providers::ContainerManager.find(provider_id)
+    provider = ManageIQ::Providers::ContainerManager.find_by(:id => provider_id)
     return [] if provider.nil?
     case entity_type.underscore.to_sym
     when :container_project

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -109,7 +109,7 @@
           :javascript
              miqInitSelectPicker();
              miqSelectPickerEvent('cb_provider_id', '#{url}', {beforeSend: true, complete: true});
-      - if @edit[:new][:cb_provider_id].present?
+      - if @edit[:new][:cb_provider_id].present? && @edit[:new][:cb_provider_id].try(:to_sym) != :all
         .form-group
           %label.control-label.col-md-2
             = ui_lookup(:model => @edit[:new][:cb_model])


### PR DESCRIPTION
scenario:
http://g.recordit.co/JOKxoTDcTq.gif

Note: after creating the report, the error message is also thrown as well as on clicking on tab filter after re-editing.


error message
```

F, [2017-08-25T11:07:47.212860 #28711] FATAL -- : Error caught: [ActionView::Template::Error] Couldn't find ManageIQ::Providers::ContainerManager with 'id'=0 [WHERE "ext_management_systems"."type" IN ('ManageIQ::Providers::ContainerManager', 'ManageIQ::Providers::Kubernetes::ContainerManager', 'ManageIQ::Providers::Openshift::ContainerManager')]
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activerecord-5.0.5/lib/active_record/relation/finder_methods.rb:353:in `raise_record_not_found_exception!'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activerecord-5.0.5/lib/active_record/relation/finder_methods.rb:479:in `find_one'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activerecord-5.0.5/lib/active_record/relation/finder_methods.rb:458:in `find_with_ids'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activerecord-5.0.5/lib/active_record/relation/finder_methods.rb:66:in `find'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activerecord-5.0.5/lib/active_record/querying.rb:3:in `find'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activerecord-5.0.5/lib/active_record/core.rb:151:in `find'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/helpers/report_helper/editor.rb:3:in `cb_entities_by_provider_id'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/views/report/_form_filter_chargeback.html.haml:119:in `___sers_liborpichler_manageiq_manageiq_ui_classic_app_views_report__form_filter_chargeback_html_haml___1162561060062711179_70220969285480'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.5/lib/action_view/template.rb:159:in `block in render'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionview-5.0.5/lib/action_view/template.rb:354:in `instrument'

```


@miq-bot assign @martinpovolny 
cc @gtanzillo 
can you review please  @zeari ?


