### PR TITLE
Replace lock trees in explorer with a more generic lock sidebar

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -22,17 +22,8 @@ ManageIQ.explorer.buildCalendar = function(options) {
   miqBuildCalendar();
 };
 
-ManageIQ.explorer.lock_tree = function(tree_name, lock) {
-  var tree = miqTreeObject(tree_name);
-  if (!tree || "length" in tree) {
-    // "length" in tree - because miqTreeObject returns a jquery array when the element doesn't exist
-    // https://github.com/patternfly/patternfly-bootstrap-treeview/issues/16
-    console.warn("Attempting to lock_tree a tree which doesn't exist", tree_name, lock);
-    return;
-  }
-
-  lock ? tree.disableAll({silent: true, keepState: true}) : tree.enableAll();
-  miqDimDiv('#' + tree_name + '_div', lock);
+ManageIQ.explorer.lockSidebar = function(lock) {
+  $('.sidebar-pf-left').toggleClass('sidebar-disabled', lock);
 };
 
 ManageIQ.explorer.clearSearchToggle = function(show) {
@@ -256,12 +247,6 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
     miqTreeActivateNodeSilently(data.activateNode.activeTree, data.activateNode.osf);
   }
 
-  if (_.isObject(data.lockTrees)) {
-    _.forEach(data.lockTrees, function (lock, tree) {
-      ManageIQ.explorer.lock_tree(tree, lock);
-    });
-  }
-
   if (_.isObject(data.chartData)) {
     ManageIQ.charts.chartData = data.chartData;
     load_c3_charts();
@@ -282,6 +267,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
 
   if (data.hideModal) { $('#quicksearchbox').modal('hide'); }
   if (data.initAccords) { miqInitAccordions(); }
+  if (data.lockSidebar !== undefined) { ManageIQ.explorer.lockSidebar(data.lockSidebar); }
 
   if (_.isString(data.ajaxUrl)) {
     miqAsyncAjax(data.ajaxUrl);

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -874,6 +874,11 @@ img.tiny { margin: 0; padding: 0;width:20px;height:20px; border: 0; vertical-ali
 
 #spinner_div { margin-top: -45px; margin-left: -35px; width:180px; height: 180px; border-radius: 8px; background: image-url('layout/overlay_dark.png');}
 
+.sidebar-disabled {
+  pointer-events: none;
+  opacity: 0.4;
+}
+
 /// ===================================================================
 /// end misc styling
 /// ===================================================================

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2099,7 +2099,7 @@ class CatalogController < ApplicationController
     presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.present?, :toolbar)
 
     presenter[:record_id] = determine_record_id_for_presenter
-    presenter.lock_tree(x_active_tree, @edit && @edit[:current])
+    presenter[:lock_sidebar] = @edit && @edit[:current]
     presenter[:osf_node] = x_node
     presenter.reset_changes
     presenter.reset_one_trans

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -913,7 +913,7 @@ class ChargebackController < ApplicationController
 
     presenter[:right_cell_text]     = @right_cell_text
     unless x_active_tree == :cb_assignments_tree
-      presenter.lock_tree(x_active_tree, @in_a_form && @edit)
+      presenter[:lock_sidebar] = @in_a_form && @edit
     end
 
     render :json => presenter.for_render

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -590,7 +590,7 @@ class InfraNetworkingController < ApplicationController
     presenter.hide(:quicksearchbox)
     presenter[:hide_modal] = true
 
-    presenter.lock_tree(x_active_tree, @in_a_form)
+    presenter[:lock_sidebar] = @in_a_form
   end
 
   def display_adv_searchbox

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -320,7 +320,7 @@ class MiqAeClassController < ApplicationController
       presenter.hide(:paging_div, :form_buttons_div)
     end
 
-    presenter.lock_tree(x_active_tree, @in_a_form && @edit)
+    presenter[:lock_sidebar] = @in_a_form && @edit
 
     if @record.kind_of?(MiqAeMethod) && !@in_a_form
       presenter.set_visibility(!@record.inputs.blank?, :params_div)

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -429,7 +429,7 @@ class MiqAeCustomizationController < ApplicationController
 
     # Replace right side with based on selected tree node type
     presenter.update(:main_div, render_proc[:partial => "shared/buttons/ab_list"])
-    presenter.lock_tree(:ab_tree, @edit)
+    presenter[:lock_sidebar] = @edit
   end
 
   def setup_presenter_for_dialog_edit_tree(presenter)

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -691,15 +691,7 @@ class MiqPolicyController < ApplicationController
 
     presenter[:record_id] = @record.try(:id)
 
-    # Lock current tree if in edit or assign, else unlock all trees
-    if (@edit || @assign) && params[:action] != "x_search_by_name"
-      presenter.lock_tree(x_active_tree)
-    else
-      [:policy_profile_tree, :policy_tree, :condition_tree,
-       :action_tree, :alert_profile_tree, :alert_tree].each do |tree|
-        presenter.lock_tree(tree, false)
-      end
-    end
+    presenter[:lock_sidebar] = (@edit || @assign) && params[:action] != "x_search_by_name"
 
     render :json => presenter.for_render
   end

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -480,7 +480,7 @@ module Mixins
       presenter.hide(:quicksearchbox)
       presenter[:hide_modal] = true
 
-      presenter.lock_tree(x_active_tree, @in_a_form)
+      presenter[:lock_sidebar] = @in_a_form
     end
 
     def construct_edit_for_audit

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -244,7 +244,7 @@ class PxeController < ApplicationController
 
     # Save open nodes, if any were added
     presenter[:osf_node] = x_node
-    presenter.lock_tree(x_active_tree, @in_a_form && @edit)
+    presenter[:lock_sidebar] = @in_a_form && @edit
 
     render :json => presenter.for_render
   end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -890,16 +890,7 @@ class ReportController < ApplicationController
     presenter[:record_id] = (locals && locals[:record_id]) || determine_record_id_for_presenter
 
     # Lock current tree if in edit or assign, else unlock all trees
-    if @edit && @edit[:current]
-      presenter.lock_tree(x_active_tree)
-      # lock schedules tree when jumping from reports to add a schedule for a report
-      presenter.lock_tree(:schedules_tree) if params[:pressed] == 'miq_report_schedules'
-    else
-      presenter.lock_tree(x_active_tree, false)
-      [:db_tree, :reports_tree, :savedreports_tree, :schedules_tree, :widgets_tree, :roles_tree].each do |tree|
-        presenter.lock_tree(tree, false) if tree_exists?(tree)
-      end
-    end
+    presenter[:lock_sidebar] = @edit && @edit[:current]
 
     render :json => presenter.for_render
   end

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -41,7 +41,6 @@ module ReportController::Dashboards
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      @lock_tree = true
       session[:changed] = @changed = false
       replace_right_cell
     end
@@ -101,7 +100,6 @@ module ReportController::Dashboards
       db_set_form_vars
       session[:changed] = false
       @in_a_form = true
-      @lock_tree = true
       replace_right_cell
     end
   end

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -38,7 +38,6 @@ module ReportController::Menus
 
     @breadcrumbs = []
     drop_breadcrumb(:name => "Edit Report menus for '#{session[:role_choice]}'")
-    @lock_tree = true
     if session[:node_selected].index(':').nil? || params[:button] == "reset"
       edit_folder
       replace_right_cell if params[:node_clicked]
@@ -198,7 +197,6 @@ module ReportController::Menus
       session[:role_choice]     = nil
       @new_menu_node            = "roleroot"
       @menu_roles_tree = nil
-      @lock_tree                = false
       @edit = session[:edit]    = nil
       @changed                  = session[:changed] = false
       self.x_node = "root"
@@ -241,7 +239,6 @@ module ReportController::Menus
         session[:role_choice]     = nil
         @new_menu_node            = "roleroot"
         @menu_roles_tree = nil
-        @lock_tree                = false
         @changed                  = session[:changed] = false
         @edit = session[:edit]    = nil
         self.x_node = "root"

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -49,7 +49,7 @@ module ReportController::Reports::Editor
       set_form_vars
     end
     build_edit_screen
-    @ina_form = @lock_tree = true
+    @ina_form = true
     replace_right_cell
   end
 
@@ -131,7 +131,6 @@ module ReportController::Reports::Editor
       build_edit_screen
       @changed          = (@edit[:new] != @edit[:current])
       session[:changed] = @changed
-      @lock_tree        = true
       replace_right_cell
     end
   end

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -49,7 +49,6 @@ module ReportController::Reports::Editor
       set_form_vars
     end
     build_edit_screen
-    @ina_form = true
     replace_right_cell
   end
 

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -267,7 +267,6 @@ module ReportController::Schedules
       end
       schedule_set_form_vars
       schedule_build_edit_screen
-      @lock_tree = true
       replace_right_cell
     end
   end

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -46,7 +46,6 @@ module ReportController::Widgets
 
     widget_set_form_vars
     session[:changed] = false
-    @lock_tree = true
     replace_right_cell
   end
 
@@ -101,7 +100,6 @@ module ReportController::Widgets
       widget_set_form_vars
       session[:changed] = false
       @in_a_form = true
-      @lock_tree = true
       replace_right_cell
     end
   end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -389,7 +389,7 @@ class ServiceController < ApplicationController
 
     presenter[:record_id] = determine_record_id_for_presenter
 
-    presenter.lock_tree(x_active_tree, @edit && @edit[:current])
+    presenter[:lock_sidebar] = @edit && @edit[:current]
     presenter[:osf_node] = x_node
     # unset variable that was set in form_field_changed to prompt for changes when leaving the screen
     presenter.reset_changes

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -535,7 +535,7 @@ class StorageController < ApplicationController
     presenter.hide(:quicksearchbox)
     presenter[:hide_modal] = true
 
-    presenter.lock_tree(x_active_tree, @in_a_form)
+    presenter[:lock_sidebar] = @in_a_form
   end
 
   def display_adv_searchbox

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1367,7 +1367,7 @@ module VmCommon
 
     presenter.hide(:blocker_div) unless @edit && @edit[:adv_search_open]
     presenter[:hide_modal] = true
-    presenter.lock_tree(x_active_tree, @in_a_form && @edit)
+    presenter[:lock_sidebar] = @in_a_form && @edit
 
     render :json => presenter.for_render
   end

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -34,9 +34,9 @@ class ExplorerPresenter
   #   open_accord                      -- accordion to open
   #   exp                              -- data for the expression editor
   #   active_tree                      -- x_active_tree view state from controller
+  #   lock_sidebar                     -- enable or disable the sidebar
   #
   # Following options are hashes:
-  #   lock_unlock_trees         -- trees to lock/unlock
   #   update_partials           -- partials to update contents
   #   replace_partials          -- partials to replace (also wrapping tag)
   #   element_updates           -- update DOM element content or title FIXME: content can be
@@ -63,7 +63,6 @@ class ExplorerPresenter
 
   def initialize(options = {})
     @options = {
-      :lock_unlock_trees    => {},
       :set_visible_elements => {},
       :update_partials      => {},
       :element_updates      => {},
@@ -124,11 +123,6 @@ class ExplorerPresenter
 
   def set_visibility(value, *elements)
     elements.each { |el| @options[:set_visible_elements][el] = value }
-    self
-  end
-
-  def lock_tree(tree, lock = true)
-    @options[:lock_unlock_trees][tree] = !!lock
     self
   end
 
@@ -276,7 +270,7 @@ class ExplorerPresenter
       }
     end
 
-    data[:lockTrees] = @options[:lock_unlock_trees]
+    data[:lockSidebar] = !!@options[:lock_sidebar]
     data[:chartData] = @options[:load_chart]
     data[:resetChanges] = !!@options[:reset_changes]
     data[:resetOneTrans] = !!@options[:reset_one_trans]


### PR DESCRIPTION
While [converting](https://github.com/ManageIQ/manageiq-ui-classic/pull/1989) left side trees to angular I had some issues with locking trees. We had a discussion with @martinpovolny that it's more logical if we lock the whole left sidebar instead of locking trees one by one.

@miq-bot add_label fine/no, explorers, trees, refactoring