### PR TITLE
Remove old RBAC-related dead code from OPS screen

### DIFF
--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -9,16 +9,6 @@ module JsHelper
     'miqSparkleOff();'
   end
 
-  # replacement for app/views/shared/ajax/_tree_lock_unlock.js.erb
-  def tree_lock(tree_var, lock = true)
-    bool_str = (!!lock).to_s
-    element = "#{tree_var}_div"
-    "
-      miqTreeObject('#{j_str(tree_var)}').#{lock ? 'disable' : 'enable'}All({silent: true, keepState: true});
-      #{javascript_dim(element, bool_str)}
-    ".html_safe
-  end
-
   # safe variant of j/escape_javascript that calls .to_s to work with non-string values
   def j_str(value)
     j(value.to_s)
@@ -34,10 +24,6 @@ module JsHelper
 
   def javascript_highlight(element, status)
     "miqHighlight('##{j_str(element)}', #{j_str(status)});".html_safe
-  end
-
-  def javascript_dim(element, status)
-    "miqDimDiv('##{j_str(element)}', #{j_str(status)});".html_safe
   end
 
   def javascript_disable_field(element)

--- a/app/views/ops/explorer.html.haml
+++ b/app/views/ops/explorer.html.haml
@@ -8,10 +8,6 @@
   ManageIQ.calendar.calDateTo = null
 
   function miqOpsAfterOnload() {
-  = javascript_dim("settings_tree_div", false) if role_allows?(:feature => "ops_settings")
-  = javascript_dim("diagnostics_tree_div", false) if role_allows?(:feature => "ops_diagnostics")
-  = javascript_dim("vmdb_tree_div", false) if role_allows?(:feature => "ops_db")
-  = javascript_dim("rbac_tree_div", false) if role_allows?(:feature => "ops_rbac", :any => true)
   - if @sb[:active_tab] == "db_utilization"
     miqAsyncAjax('#{url_for_only_path(:action => @ajax_action, :id => @record)}');
   };

--- a/spec/helpers/js_helper_spec.rb
+++ b/spec/helpers/js_helper_spec.rb
@@ -15,22 +15,6 @@ describe JsHelper do
     end
   end
 
-  context '#tree_lock' do
-    it 'returns js to lock tree' do
-      expect(tree_lock('bar', true).gsub(/^\s+/, '')).to eq(<<-JS.strip_heredoc)
-        miqTreeObject('bar').disableAll({silent: true, keepState: true});
-        miqDimDiv('\#bar_div', true);
-      JS
-    end
-
-    it 'returns js to unlock tree' do
-      expect(tree_lock('bar', false).gsub(/^\s+/, '')).to eq(<<-JS.strip_heredoc)
-        miqTreeObject('bar').enableAll({silent: true, keepState: true});
-        miqDimDiv('\#bar_div', false);
-      JS
-    end
-  end
-
   context '#javascript_focus' do
     it 'returns js to focus on an element' do
       expect(javascript_focus('foo')).to eq("$('#foo').focus();")
@@ -41,13 +25,6 @@ describe JsHelper do
     it 'returns js to to add or remove the active class on the element' do
       expect(javascript_highlight('foo', true)).to eq("miqHighlight('\#foo', true);")
       expect(javascript_highlight('foo', false)).to eq("miqHighlight('\#foo', false);")
-    end
-  end
-
-  context '#javascript_dim' do
-    it 'returns js to to add or remove the dimmed class on the element' do
-      expect(javascript_dim('foo', true)).to eq("miqDimDiv('\#foo', true);")
-      expect(javascript_dim('foo', false)).to eq("miqDimDiv('\#foo', false);")
     end
   end
 


### PR DESCRIPTION
Currently we're using the `features` hash for hiding/displaying accordions and trees in explorer screens. This makes the `javascript_dim` calls obsolete in the OPS area and so we can remove some dead code.

@miq-bot add_label technical debt, explorers, fine/no