### PR TITLE
[WIP] Fix Tagging Reset button click

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -13,6 +13,10 @@ module ApplicationController::Tags
       tagging_edit_tags_save
     when "reset", nil # Reset or first time in
       @tagging = session[:tag_db] = params[:db] ? params[:db] : db if params[:db] || db
+      # NOTE: For Tagging Reset button click make sure @tagging is properly set,
+      # seems to be set to nil interim and before right cell is rendered
+      @tagging ||= controller_to_model
+      @sb[:action] ||= "tag"
       tagging_edit_tags_reset
     end
   end


### PR DESCRIPTION
Clicking Reset button when in Tagging page resulted in a log error messages that a) were not visible to users and b) resulted in reset action not taking place.

https://bugzilla.redhat.com/show_bug.cgi?id=1470636

Screen shots post code fix:

<img width="1673" alt="tagging select value post fix" src="https://user-images.githubusercontent.com/552686/29736046-96974756-89b2-11e7-8843-3ac5bfda66d0.png">

<img width="1676" alt="tagging click reset button with flash message" src="https://user-images.githubusercontent.com/552686/29736049-9dfca464-89b2-11e7-9db7-1c2f7719060d.png">
