### PR TITLE
Remove TREND_MODEL from UiConstants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,6 +84,8 @@ class ApplicationController < ActionController::Base
 
   PERPAGE_TYPES = %w(grid tile list reports).each_with_object({}) { |value, acc| acc[value] = value.to_sym }.freeze
 
+  TREND_MODEL = "VimPerformanceTrend".freeze # Performance trend model name requiring special processing
+
   # Default UI settings
   DEFAULT_SETTINGS = {
     :quadicons => { # Show quad icons, by resource type

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -331,7 +331,7 @@ module ReportController::Reports::Editor
 
   def build_tabs
     req = "edit"
-    if @edit[:new][:model] == TREND_MODEL
+    if @edit[:new][:model] == ApplicationController::TREND_MODEL
       @tabs = [
         ["#{req}_1", _("Columns")],
         ["#{req}_3", _("Filter")],
@@ -1081,7 +1081,7 @@ module ReportController::Reports::Editor
     end
 
     # Remove when we support user sorting of trend reports
-    if rpt.db == TREND_MODEL
+    if rpt.db == ApplicationController::TREND_MODEL
       rpt.sortby = ["resource_name"]
       rpt.order = "Ascending"
     end
@@ -1428,7 +1428,7 @@ module ReportController::Reports::Editor
     @edit[:new][:name] = "Copy of #{@rpt.name}" if params[:pressed] == "miq_report_copy"
 
     # For trend reports, check for percent field chosen
-    if @rpt.db && @rpt.db == TREND_MODEL &&
+    if @rpt.db && @rpt.db == ApplicationController::TREND_MODEL &&
        MiqExpression.reporting_available_fields(@edit[:new][:model], @edit[:new][:perf_interval]).find do|af|
          af.last ==
          @edit[:new][:perf_trend_db] + "-" + @edit[:new][:perf_trend_col]
@@ -1623,7 +1623,7 @@ module ReportController::Reports::Editor
 
   def valid_report?(rpt)
     active_tab = 'edit_1'
-    if @edit[:new][:model] == TREND_MODEL
+    if @edit[:new][:model] == ApplicationController::TREND_MODEL
       unless @edit[:new][:perf_trend_col]
         add_flash(_('Trending for is required'), :error)
       end
@@ -1746,7 +1746,7 @@ module ReportController::Reports::Editor
         add_flash(_('Formatting tab is not available until at least 1 field has been selected'), :error)
       end
     when '3'
-      if @edit[:new][:model] == TREND_MODEL
+      if @edit[:new][:model] == ApplicationController::TREND_MODEL
         unless @edit[:new][:perf_trend_col]
           add_flash(_('Filter tab is not available until Trending for field has been selected'), :error)
         end
@@ -1786,7 +1786,7 @@ module ReportController::Reports::Editor
         end
       end
     when '7'
-      if @edit[:new][:model] == TREND_MODEL
+      if @edit[:new][:model] == ApplicationController::TREND_MODEL
         unless @edit[:new][:perf_trend_col]
           add_flash(_('Preview tab is not available until Trending for field has been selected'), :error)
         end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -675,7 +675,7 @@ module ApplicationHelper
     if model
       if model.ends_with?("Performance", "MetricsRollup")
         return :performance
-      elsif model == UiConstants::TREND_MODEL
+      elsif model == ApplicationController::TREND_MODEL
         return :trend
       elsif model.starts_with?("Chargeback")
         return model.downcase.to_sym

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -30,8 +30,6 @@ module UiConstants
   NOTHING_STRING = "<<< Nothing >>>"
   GRAPH_MAX_COUNT = 10
 
-  TREND_MODEL = "VimPerformanceTrend"   # Performance trend model name requiring special processing
-
   VALID_PLANNING_VM_MODES = PlanningHelper::PLANNING_VM_MODES.keys.index_by(&:to_s)
 
   TASK_TIME_PERIODS = {

--- a/app/views/report/_form_filter.html.haml
+++ b/app/views/report/_form_filter.html.haml
@@ -1,7 +1,7 @@
 #filter_div
   - if @edit[:new][:perf_interval]
     = render :partial => "form_filter_performance"
-  - if @edit[:new][:model] == TREND_MODEL
+  - if @edit[:new][:model] == ApplicationController::TREND_MODEL
     -# No additional filters for trend reports
   - elsif Chargeback.db_is_chargeback?(@edit[:new][:model])
     = render :partial => "form_filter_chargeback"


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `TREND_MODEL` was removed from `UiConstants` and moved to `ApplicationController`. Prefix `ApplicationController::` was added to every occurrence of `TREND_MODEL`.



