### PR TITLE
Remove FROM_HOURS from UiConstants

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -564,8 +564,8 @@ module ApplicationController::Filter
     end
 
     def self.through_choices(from_choice) # Return the through_choices pulldown array for FROM datetime/date operators
-      tc = if FROM_HOURS.include?(from_choice)
-             FROM_HOURS
+      tc = if ViewHelper::FROM_HOURS.include?(from_choice)
+             ViewHelper::FROM_HOURS
            elsif FROM_DAYS.include?(from_choice)
              FROM_DAYS
            elsif FROM_WEEKS.include?(from_choice)

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -122,33 +122,6 @@ module UiConstants
   EXP_FROM = "FROM"
   EXP_IS = "IS"
 
-  # FROM Date/Time expression atom selectors
-  FROM_HOURS = [
-    N_('This Hour'),
-    N_('Last Hour'),
-    N_('2 Hours Ago'),
-    N_('3 Hours Ago'),
-    N_('4 Hours Ago'),
-    N_('5 Hours Ago'),
-    N_('6 Hours Ago'),
-    N_('7 Hours Ago'),
-    N_('8 Hours Ago'),
-    N_('9 Hours Ago'),
-    N_('10 Hours Ago'),
-    N_('11 Hours Ago'),
-    N_('12 Hours Ago'),
-    N_('13 Hours Ago'),
-    N_('14 Hours Ago'),
-    N_('15 Hours Ago'),
-    N_('16 Hours Ago'),
-    N_('17 Hours Ago'),
-    N_('18 Hours Ago'),
-    N_('19 Hours Ago'),
-    N_('20 Hours Ago'),
-    N_('21 Hours Ago'),
-    N_('22 Hours Ago'),
-    N_('23 Hours Ago')
-  ]
   FROM_DAYS = [
     N_('Today'),
     N_('Yesterday'),

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -51,6 +51,34 @@ module ViewHelper
     N_('4 Years Ago')
   ].freeze
 
+  # FROM Date/Time expression atom selectors
+  FROM_HOURS = [
+    N_('This Hour'),
+    N_('Last Hour'),
+    N_('2 Hours Ago'),
+    N_('3 Hours Ago'),
+    N_('4 Hours Ago'),
+    N_('5 Hours Ago'),
+    N_('6 Hours Ago'),
+    N_('7 Hours Ago'),
+    N_('8 Hours Ago'),
+    N_('9 Hours Ago'),
+    N_('10 Hours Ago'),
+    N_('11 Hours Ago'),
+    N_('12 Hours Ago'),
+    N_('13 Hours Ago'),
+    N_('14 Hours Ago'),
+    N_('15 Hours Ago'),
+    N_('16 Hours Ago'),
+    N_('17 Hours Ago'),
+    N_('18 Hours Ago'),
+    N_('19 Hours Ago'),
+    N_('20 Hours Ago'),
+    N_('21 Hours Ago'),
+    N_('22 Hours Ago'),
+    N_('23 Hours Ago')
+  ].freeze
+
   class << self
     def concat_tag(*args, &block)
       concat content_tag(*args, &block)

--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -74,7 +74,7 @@
               "data-miq_sparkle_on"  => true,
               "data-miq_sparkle_off" => true)
         - else
-          - opts = (@edit[@expkey][:val1][:type] == :datetime ? FROM_HOURS : [])
+          - opts = (@edit[@expkey][:val1][:type] == :datetime ? ViewHelper::FROM_HOURS : [])
           - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
           = select_tag('chosen_from_1',
             options_for_select(Hash[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),

--- a/app/views/layouts/exp_atom/_edit_find.html.haml
+++ b/app/views/layouts/exp_atom/_edit_find.html.haml
@@ -60,7 +60,7 @@
               "data-miq_sparkle_on"  => true,
               "data-miq_sparkle_off" => true)
         - else
-          - opts = (@edit[@expkey][:val1][:type] == :datetime ? FROM_HOURS : [])
+          - opts = (@edit[@expkey][:val1][:type] == :datetime ? ViewHelper::FROM_HOURS : [])
           - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
           = select_tag('chosen_from_1',
             options_for_select(Hash[opts.map{|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),
@@ -175,7 +175,7 @@
                   "data-miq_sparkle_on"  => true,
                   "data-miq_sparkle_off" => true)
             - else
-              - opts = (@edit[@expkey][:val2][:type] == :datetime ? FROM_HOURS : [])
+              - opts = (@edit[@expkey][:val2][:type] == :datetime ? ViewHelper::FROM_HOURS : [])
               - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
               = select_tag('chosen_from_2',
                 options_for_select(Hash[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_cvalue][0]),

--- a/app/views/report/_form_styling.html.haml
+++ b/app/views/report/_form_styling.html.haml
@@ -57,7 +57,7 @@
                       "data-miq_sparkle_off" => true,
                       "data-miq_observe"     => {:url => url}.to_json)
                   - elsif [:datetime, :date].include?(field_type)
-                    - opts = (field_type == :datetime ? FROM_HOURS : []) + FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
+                    - opts = (field_type == :datetime ? ViewHelper::FROM_HOURS : []) + FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
                     = select_tag("styleval_#{f_idx}_#{s_idx}",
                       options_for_select(Hash[opts.map {|x| [_(x), x]}], styles[s_idx][:value]),
                       :multiple              => false,


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `FROM_HOURS` was removed from `UiConstants` and moved to `ViewHelper`. Prefix `ViewHelper::` was added to every occurrence of `FROM_HOURS`.


`Cloud Intel` -> `Reports` -> `Reports` -> `Virtual Machines` -> `Configuration` ->` Add new Report` -> `Styling`