### PR TITLE
Remove FROM_DAYS from UiConstants

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -566,8 +566,8 @@ module ApplicationController::Filter
     def self.through_choices(from_choice) # Return the through_choices pulldown array for FROM datetime/date operators
       tc = if ViewHelper::FROM_HOURS.include?(from_choice)
              ViewHelper::FROM_HOURS
-           elsif FROM_DAYS.include?(from_choice)
-             FROM_DAYS
+           elsif ViewHelper::FROM_DAYS.include?(from_choice)
+             ViewHelper::FROM_DAYS
            elsif FROM_WEEKS.include?(from_choice)
              FROM_WEEKS
            elsif FROM_MONTHS.include?(from_choice)

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -122,17 +122,6 @@ module UiConstants
   EXP_FROM = "FROM"
   EXP_IS = "IS"
 
-  FROM_DAYS = [
-    N_('Today'),
-    N_('Yesterday'),
-    N_('2 Days Ago'),
-    N_('3 Days Ago'),
-    N_('4 Days Ago'),
-    N_('5 Days Ago'),
-    N_('6 Days Ago'),
-    N_('7 Days Ago'),
-    N_('14 Days Ago')
-  ]
   FROM_WEEKS = [
     N_('This Week'),
     N_('Last Week'),

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -79,6 +79,18 @@ module ViewHelper
     N_('23 Hours Ago')
   ].freeze
 
+  FROM_DAYS = [
+    N_('Today'),
+    N_('Yesterday'),
+    N_('2 Days Ago'),
+    N_('3 Days Ago'),
+    N_('4 Days Ago'),
+    N_('5 Days Ago'),
+    N_('6 Days Ago'),
+    N_('7 Days Ago'),
+    N_('14 Days Ago')
+  ].freeze
+
   class << self
     def concat_tag(*args, &block)
       concat content_tag(*args, &block)

--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -75,7 +75,7 @@
               "data-miq_sparkle_off" => true)
         - else
           - opts = (@edit[@expkey][:val1][:type] == :datetime ? ViewHelper::FROM_HOURS : [])
-          - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
+          - opts += ViewHelper::FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
           = select_tag('chosen_from_1',
             options_for_select(Hash[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),
             :class                => 'selectpicker',

--- a/app/views/layouts/exp_atom/_edit_find.html.haml
+++ b/app/views/layouts/exp_atom/_edit_find.html.haml
@@ -61,7 +61,7 @@
               "data-miq_sparkle_off" => true)
         - else
           - opts = (@edit[@expkey][:val1][:type] == :datetime ? ViewHelper::FROM_HOURS : [])
-          - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
+          - opts += ViewHelper::FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
           = select_tag('chosen_from_1',
             options_for_select(Hash[opts.map{|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),
             :multiple              => false,
@@ -176,7 +176,7 @@
                   "data-miq_sparkle_off" => true)
             - else
               - opts = (@edit[@expkey][:val2][:type] == :datetime ? ViewHelper::FROM_HOURS : [])
-              - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
+              - opts += ViewHelper::FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
               = select_tag('chosen_from_2',
                 options_for_select(Hash[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_cvalue][0]),
                 :multiple              => false,

--- a/app/views/report/_form_styling.html.haml
+++ b/app/views/report/_form_styling.html.haml
@@ -57,7 +57,9 @@
                       "data-miq_sparkle_off" => true,
                       "data-miq_observe"     => {:url => url}.to_json)
                   - elsif [:datetime, :date].include?(field_type)
-                    - opts = (field_type == :datetime ? ViewHelper::FROM_HOURS : []) + FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
+                    - opts = h((field_type == :datetime ? ViewHelper::FROM_HOURS : []) + |
+                               ViewHelper::FROM_DAYS + FROM_WEEKS + FROM_MONTHS +        |
+                               FROM_QUARTERS + ViewHelper::FROM_YEARS)                   |
                     = select_tag("styleval_#{f_idx}_#{s_idx}",
                       options_for_select(Hash[opts.map {|x| [_(x), x]}], styles[s_idx][:value]),
                       :multiple              => false,


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `FROM_DAYS` was removed from `UiConstants` and moved to `ViewHelper`. Prefix `ViewHelper::` was added to every occurrence of `FROM_DAYS`.


`Cloud Intel` -> `Reports` -> `Reports` -> `Virtual Machines` -> `Configuration` ->` Add new Report` -> `Styling`