### PR TITLE
Remove FROM_QUARTERS from UiConstants

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -572,8 +572,8 @@ module ApplicationController::Filter
              ViewHelper::FROM_WEEKS
            elsif ViewHelper::FROM_MONTHS.include?(from_choice)
              ViewHelper::FROM_MONTHS
-           elsif FROM_QUARTERS.include?(from_choice)
-             FROM_QUARTERS
+           elsif ViewHelper::FROM_QUARTERS.include?(from_choice)
+             ViewHelper::FROM_QUARTERS
            elsif ViewHelper::FROM_YEARS.include?(from_choice)
              ViewHelper::FROM_YEARS
            end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -121,14 +121,6 @@ module UiConstants
   EXP_FROM = "FROM"
   EXP_IS = "IS"
 
-  FROM_QUARTERS = [
-    N_('This Quarter'),
-    N_('Last Quarter'),
-    N_('2 Quarters Ago'),
-    N_('3 Quarters Ago'),
-    N_('4 Quarters Ago')
-  ]
-
   # Need this for mapping with MiqWidget record content_type field
   WIDGET_CONTENT_TYPE = {
     "r"  => "report",

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -100,6 +100,14 @@ module ViewHelper
     N_('6 Months Ago')
   ].freeze
 
+  FROM_QUARTERS = [
+    N_('This Quarter'),
+    N_('Last Quarter'),
+    N_('2 Quarters Ago'),
+    N_('3 Quarters Ago'),
+    N_('4 Quarters Ago')
+  ].freeze
+
   FROM_YEARS = [
     N_('This Year'),
     N_('Last Year'),

--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -75,7 +75,7 @@
               "data-miq_sparkle_off" => true)
         - else
           - opts = (@edit[@expkey][:val1][:type] == :datetime ? ViewHelper::FROM_HOURS : [])
-          - opts += ViewHelper::FROM_DAYS + ViewHelper::FROM_WEEKS + ViewHelper::FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
+          - opts += ViewHelper::FROM_DAYS + ViewHelper::FROM_WEEKS + ViewHelper::FROM_MONTHS + ViewHelper::FROM_QUARTERS + ViewHelper::FROM_YEARS
           = select_tag('chosen_from_1',
             options_for_select(Hash[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),
             :class                => 'selectpicker',

--- a/app/views/layouts/exp_atom/_edit_find.html.haml
+++ b/app/views/layouts/exp_atom/_edit_find.html.haml
@@ -61,7 +61,7 @@
               "data-miq_sparkle_off" => true)
         - else
           - opts = (@edit[@expkey][:val1][:type] == :datetime ? ViewHelper::FROM_HOURS : [])
-          - opts += ViewHelper::FROM_DAYS + ViewHelper::FROM_WEEKS + ViewHelper::FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
+          - opts += ViewHelper::FROM_DAYS + ViewHelper::FROM_WEEKS + ViewHelper::FROM_MONTHS + ViewHelper::FROM_QUARTERS + ViewHelper::FROM_YEARS
           = select_tag('chosen_from_1',
             options_for_select(Hash[opts.map{|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),
             :multiple              => false,
@@ -176,7 +176,7 @@
                   "data-miq_sparkle_off" => true)
             - else
               - opts = (@edit[@expkey][:val2][:type] == :datetime ? ViewHelper::FROM_HOURS : [])
-              - opts += ViewHelper::FROM_DAYS + ViewHelper::FROM_WEEKS + ViewHelper::FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
+              - opts += ViewHelper::FROM_DAYS + ViewHelper::FROM_WEEKS + ViewHelper::FROM_MONTHS + ViewHelper::FROM_QUARTERS + ViewHelper::FROM_YEARS
               = select_tag('chosen_from_2',
                 options_for_select(Hash[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_cvalue][0]),
                 :multiple              => false,

--- a/app/views/report/_form_styling.html.haml
+++ b/app/views/report/_form_styling.html.haml
@@ -59,7 +59,7 @@
                   - elsif [:datetime, :date].include?(field_type)
                     - opts = h((field_type == :datetime ? ViewHelper::FROM_HOURS : []) +                  |
                                ViewHelper::FROM_DAYS + ViewHelper::FROM_WEEKS + ViewHelper::FROM_MONTHS + |
-                               FROM_QUARTERS + ViewHelper::FROM_YEARS)                                    |
+                               ViewHelper::FROM_QUARTERS + ViewHelper::FROM_YEARS)                        |
                     = select_tag("styleval_#{f_idx}_#{s_idx}",
                       options_for_select(Hash[opts.map {|x| [_(x), x]}], styles[s_idx][:value]),
                       :multiple              => false,


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `FROM_QUARTERS` was removed from `UiConstants` and moved to `ViewHelper`. Prefix `ViewHelper::` was added to every occurrence of `FROM_QUARTERS`.


`Cloud Intel` -> `Reports` -> `Reports` -> `Virtual Machines` -> `Configuration` ->` Add new Report` -> `Styling`