### PR TITLE
Remove FROM_YEARS from UiConstants

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -574,8 +574,8 @@ module ApplicationController::Filter
              FROM_MONTHS
            elsif FROM_QUARTERS.include?(from_choice)
              FROM_QUARTERS
-           elsif FROM_YEARS.include?(from_choice)
-             FROM_YEARS
+           elsif ViewHelper::FROM_YEARS.include?(from_choice)
+             ViewHelper::FROM_YEARS
            end
       # Return the THROUGH choices based on the FROM choice
       tc[0..tc.index(from_choice)]

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -182,13 +182,6 @@ module UiConstants
     N_('3 Quarters Ago'),
     N_('4 Quarters Ago')
   ]
-  FROM_YEARS = [
-    N_('This Year'),
-    N_('Last Year'),
-    N_('2 Years Ago'),
-    N_('3 Years Ago'),
-    N_('4 Years Ago')
-  ]
 
   # Need this for display purpose to map with id
   WIDGET_TYPES = {

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -43,6 +43,14 @@ module ViewHelper
     28 => N_("4 Weeks")
   }.freeze
 
+  FROM_YEARS = [
+    N_('This Year'),
+    N_('Last Year'),
+    N_('2 Years Ago'),
+    N_('3 Years Ago'),
+    N_('4 Years Ago')
+  ].freeze
+
   class << self
     def concat_tag(*args, &block)
       concat content_tag(*args, &block)

--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -75,7 +75,7 @@
               "data-miq_sparkle_off" => true)
         - else
           - opts = (@edit[@expkey][:val1][:type] == :datetime ? FROM_HOURS : [])
-          - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + FROM_YEARS
+          - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
           = select_tag('chosen_from_1',
             options_for_select(Hash[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),
             :class                => 'selectpicker',

--- a/app/views/layouts/exp_atom/_edit_find.html.haml
+++ b/app/views/layouts/exp_atom/_edit_find.html.haml
@@ -61,7 +61,7 @@
               "data-miq_sparkle_off" => true)
         - else
           - opts = (@edit[@expkey][:val1][:type] == :datetime ? FROM_HOURS : [])
-          - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + FROM_YEARS
+          - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
           = select_tag('chosen_from_1',
             options_for_select(Hash[opts.map{|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),
             :multiple              => false,
@@ -176,7 +176,7 @@
                   "data-miq_sparkle_off" => true)
             - else
               - opts = (@edit[@expkey][:val2][:type] == :datetime ? FROM_HOURS : [])
-              - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + FROM_YEARS
+              - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
               = select_tag('chosen_from_2',
                 options_for_select(Hash[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_cvalue][0]),
                 :multiple              => false,

--- a/app/views/report/_form_styling.html.haml
+++ b/app/views/report/_form_styling.html.haml
@@ -57,7 +57,7 @@
                       "data-miq_sparkle_off" => true,
                       "data-miq_observe"     => {:url => url}.to_json)
                   - elsif [:datetime, :date].include?(field_type)
-                    - opts = (field_type == :datetime ? FROM_HOURS : []) + FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + FROM_YEARS
+                    - opts = (field_type == :datetime ? FROM_HOURS : []) + FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + ViewHelper::FROM_YEARS
                     = select_tag("styleval_#{f_idx}_#{s_idx}",
                       options_for_select(Hash[opts.map {|x| [_(x), x]}], styles[s_idx][:value]),
                       :multiple              => false,


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `FROM_YEARS` was removed from `UiConstants` and moved to `ViewHelper`. Prefix `ViewHelper::` was added to every occurrence of `FROM_YEARS`.


`Cloud Intel` -> `Reports` -> `Reports` -> `Virtual Machines` -> `Configuration` ->` Add new Report` -> `Styling`