### PR TITLE
Chart widget has three states - no data, valid/invalid data

### DIFF
--- a/app/assets/javascripts/components/widget-chart.js
+++ b/app/assets/javascripts/components/widget-chart.js
@@ -5,7 +5,7 @@ ManageIQ.angular.app.component('widgetChart', {
   controllerAs: 'vm',
   controller: ['$http', 'miqService', '$sce', function($http, miqService, $sce) {
     var vm = this;
-    vm.widgetChartModel = {valid: false};
+    vm.widgetChartModel = {};
 
     this.$onInit = function() {
       $http.get('/dashboard/widget_chart_data/' + vm.id)
@@ -15,21 +15,15 @@ ManageIQ.angular.app.component('widgetChart', {
     };
 
     vm.getData = function(response) {
-      vm.widgetChartModel.content = $sce.trustAsHtml(response.data.content);
-      vm.widgetChartModel.valid = response.data.valid;
-    };
-
-    vm.contentPresent = function() {
-      return vm.widgetChartModel.content !== undefined;
-    };
-
-    vm.contentValid = function() {
-      return vm.widgetChartModel.valid;
+      vm.widgetChartModel.state = response.data.state;
+      if (response.data.content !== null) {
+        vm.widgetChartModel.content = $sce.trustAsHtml(response.data.content);
+      }
     };
   }],
   template: [
     '<div class="mc" id="{{vm.div_id}}" ng-class="{ hidden: vm.widgetChartModel.minimized }">',
-    '  <div class="blank-slate-pf " style="padding: 10px" ng-if="!vm.contentPresent() && vm.contentValid()">',
+    '  <div class="blank-slate-pf " style="padding: 10px" ng-if="vm.widgetChartModel.state === \'no_data\'">',
     '    <div class="blank-slate-pf-icon">',
     '      <i class="fa fa-cog">',
     '      </i>',
@@ -38,7 +32,7 @@ ManageIQ.angular.app.component('widgetChart', {
     __('No chart data found.'),
     '    </h1>',
     '  </div>',
-    '  <div class="blank-slate-pf " style="padding: 10px" ng-if="vm.contentPresent() && !vm.contentValid()">',
+    '  <div class="blank-slate-pf " style="padding: 10px" ng-if="vm.widgetChartModel.state === \'invalid\'">',
     '    <div class="blank-slate-pf-icon">',
     '      <i class="fa fa-cog">',
     '      </i>',
@@ -50,7 +44,7 @@ ManageIQ.angular.app.component('widgetChart', {
     __('Invalid chart data. Try regenerating the widgets.'),
     '    </p>',
     '  </div>',
-    '  <div ng-if="vm.contentPresent() && vm.contentValid()">',
+    '  <div ng-if="vm.widgetChartModel.state === \'valid\'">',
     '    <div ng-bind-html="vm.widgetChartModel.content">',
     '    </div>',
     '  </div>',

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -119,16 +119,18 @@ class DashboardController < ApplicationController
   def widget_chart_data
     widget = find_record_with_rbac(MiqWidget, params[:id])
     datum = widget.contents_for_user(current_user).contents
-    if Charting.data_ok?(datum)
+    content = nil
+    if datum.blank?
+      state = 'no_data'
+    elsif Charting.data_ok?(datum)
       content = r[:partial => "widget_chart", :locals => {:widget => widget}].html_safe
-      valid = true
+      state = 'valid'
     else
-      content = {}
-      valid = false
+      state = 'invalid'
     end
     render :json => {:content   => content,
                      :minimized => @sb[:dashboards][@sb[:active_db]][:minimized].include?(params[:id]),
-                     :valid     => valid}
+                     :state     => state}
   end
 
   def widget_menu_data


### PR DESCRIPTION
Fix bug introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/1832

Before: 
`[$sce:itype] Attempted to trust a non-string value in a content requiring a string: Context: html http://errors.angularjs.org/1.6.6/$sce/itype?p0=html`
After:
No data
<img width="391" alt="screen shot 2017-08-28 at 4 48 28 pm" src="https://user-images.githubusercontent.com/9210860/29778981-6e1ccf42-8c11-11e7-8a78-367e9c1ba528.png">

Invalid data
<img width="389" alt="screen shot 2017-08-28 at 4 48 36 pm" src="https://user-images.githubusercontent.com/9210860/29778974-6a95b3a2-8c11-11e7-8f76-9f803c95014b.png">

@miq-bot add_label dashboards, fine/no