### PR TITLE
Remove WIDGET_TYPES, SINGULAR_WIDGET_TYPES from UiConstants

### DIFF
--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -17,6 +17,13 @@ module ReportController::Widgets
     "Vmware RSS Feeds"           => "http://vmware.simplefeed.net/rss?f=995b0290-01dc-11dc-3032-0019bbc54f6f"
   }.freeze
 
+  SINGULAR_WIDGET_TYPES = {
+    "r"  => N_('Report'),
+    "c"  => N_('Chart'),
+    "rf" => N_('RSS Feed'),
+    "m"  => N_('Menu')
+  }.freeze
+
   def widget_refresh
     assert_privileges("widget_refresh")
     replace_right_cell

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -190,14 +190,6 @@ module UiConstants
     N_('4 Years Ago')
   ]
 
-  # Need this for display purpose to map with id
-  WIDGET_TYPES = {
-    "r"  => N_('Reports'),
-    "c"  => N_('Charts'),
-    "rf" => N_('RSS Feeds'),
-    "m"  => N_('Menus')
-  }
-
   SINGULAR_WIDGET_TYPES = {
     "r"  => N_('Report'),
     "c"  => N_('Chart'),

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -190,12 +190,6 @@ module UiConstants
     N_('4 Years Ago')
   ]
 
-  SINGULAR_WIDGET_TYPES = {
-    "r"  => N_('Report'),
-    "c"  => N_('Chart'),
-    "rf" => N_('RSS Feed'),
-    "m"  => N_('Menu')
-  }
   # Need this for mapping with MiqWidget record content_type field
   WIDGET_CONTENT_TYPE = {
     "r"  => "report",

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -1,4 +1,12 @@
 class TreeBuilderReportWidgets < TreeBuilder
+  # Need this for display purpose to map with id
+  WIDGET_TYPES = {
+    "r"  => N_('Reports'),
+    "c"  => N_('Charts'),
+    "rf" => N_('RSS Feeds'),
+    "m"  => N_('Menus')
+  }.freeze
+
   private
 
   def tree_init_options(tree_name)


### PR DESCRIPTION
### Issue: #1661 

Constant `SINGULAR_WIDGET_TYPES` was replaced with same constant `WIDGET_TYPES`. Definition of constant `SINGULAR_WIDGET_TYPES` was removed from `UiConstants`.

Definition of constant `WIDGET_TYPES` was removed from `UiConstants` and moved to `ReportController`. Prefix `ReportController::` was added to every occurrence of `WIDGET_TYPES`.
