### PR TITLE
Fix custom Provisioning dialogs confirmation flash messages

### DIFF
--- a/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -231,7 +231,7 @@ module MiqAeCustomizationController::OldDialogs
       if !@dialog || @dialog.id.blank?
         add_flash(_("Add of new %{record} was cancelled by the user") % {:record => ui_lookup(:model => "MiqDialog")})
       else
-        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqDialog"), :name => @dialog.name})
+        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqDialog"), :name => get_record_display_name(@dialog)})
       end
       get_node_info
       replace_right_cell(:nodetype => x_node)
@@ -267,9 +267,9 @@ module MiqAeCustomizationController::OldDialogs
         javascript_flash
       else
         if params[:button] == "add"
-          add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqDialog"), :name => dialog.name})
+          add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqDialog"), :name => get_record_display_name(dialog)})
         else
-          add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "MiqDialog"), :name => dialog.name})
+          add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "MiqDialog"), :name => get_record_display_name(dialog)})
         end
         AuditEvent.success(build_saved_audit(dialog, @edit))
         @edit = session[:edit] = nil  # clean out the saved info


### PR DESCRIPTION
Refactor messages for consistency and clarity. Display Custom Provisioning dialog description in both, accordion tree node and flash message, when doing Add/Edit/Cancel(Edit)/Delete. 

Custom dialog names have a chance to be too brief/short when referring to them in display, thus dialog description is preferred.

https://bugzilla.redhat.com/show_bug.cgi?id=1481637

Screen shot prior to code refactoring/fix:

<img width="1674" alt="bz1481637_add provisioning dialog prior to code fix" src="https://user-images.githubusercontent.com/552686/29791210-07d675e6-8bf1-11e7-897e-e9ae8ab17d0d.png">

<img width="1674" alt="bz1481637_add provisioning dialog flash msg prior to code fix" src="https://user-images.githubusercontent.com/552686/29791225-0f0fdc30-8bf1-11e7-8a20-87603ea7a615.png">

=====================================
Scree shots post code refactoring/fix:

<img width="1672" alt="bz1481637_add provisioning dialog post fix" src="https://user-images.githubusercontent.com/552686/29791254-24177494-8bf1-11e7-8ad7-a02651743b21.png">

<img width="1674" alt="bz1481637_add provisioning dialog saved msg post fix" src="https://user-images.githubusercontent.com/552686/29791262-2d3324ba-8bf1-11e7-9779-f6d93bc48209.png">

<img width="1676" alt="bz1481637_add provisioning dialog edit cancel msg post fix" src="https://user-images.githubusercontent.com/552686/29791289-3f7f12a0-8bf1-11e7-84e0-8eeebd6d3056.png">

<img width="1676" alt="bz1481637_add provisioning dialog delete msg post fix" src="https://user-images.githubusercontent.com/552686/29791298-46dd4d3c-8bf1-11e7-9ec7-feb391154ffa.png">



