### PR TITLE
Fix breakage to MW Add JDBC Driver

### DIFF
--- a/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
+++ b/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
@@ -66,8 +66,8 @@ function MwServerControllerFactory($scope, miqService, mwAddDatasourceService, i
         if (event.name === 'showDatasourceListener') {
           $scope.showDatasourceListener();
         }
-        if (event.name === 'showDeployListener') {
-          $scope.showDeployListener();
+        if (event.name === 'showJdbcDriverListener') {
+          $scope.showJdbcDriverListener();
         }
       });
     }


### PR DESCRIPTION
This is a fix for a breakage in the Middleware JDBC Add JDBC Driver Dialogs from the middleware server page as identified by MW QE issue: 
https://github.com/ManageIQ/manageiq-providers-hawkular/issues/33

This page just recently started producing the following:
<img width="601" alt="add-jdbc-driver-bug" src="https://user-images.githubusercontent.com/1312165/29797034-7fead7a8-8c09-11e7-8929-46b740f7ad59.png">

Here is the page restored to it's original condition:
<img width="594" alt="add-jdbc-good" src="https://user-images.githubusercontent.com/1312165/29797099-1c91a3fc-8c0a-11e7-9170-7b0c03af6c32.png">

Looks like original cause is cut-n-paste error in: https://github.com/ManageIQ/manageiq-ui-classic/pull/1903

cc @himdel 
