### PR TITLE
[FINE] Fix routing error for image policy simulation

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2994,6 +2994,7 @@ Rails.application.routes.draw do
         reconfigure_form_fields
         launch_html5_console
         perf_chart_chooser
+        policies
         protect
         retire
         show


### PR DESCRIPTION
How to reproduce

1. Compute -> Cloud -> Cloud Provides -> List of Images  
2. Select image(s) from list
3. Policy -> Policy simulation

This is a fix for fine only. As things are in master, now we use angular to render quadicons
and the fix / problem does not apply there. 

https://bugzilla.redhat.com/show_bug.cgi?id=1482458