### PR TITLE
Fix policy simulation screen for images & templates

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -84,6 +84,7 @@ module ApplicationController::PolicySupport
     drop_breadcrumb(:name => _("Policy Simulation"),
                     :url  => "/#{request.parameters["controller"]}/policy_sim?continue=true")
     session[:policies] = {} unless params[:continue]  # Clear current policies, unless continuing previous simulation
+    records = session[:tag_items] if records.empty? && session[:tag_items].present?
     policy_sim_build_screen(records)
 
     if @explorer

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -223,7 +223,8 @@ module ApplicationHelper
     "chargebacks"                            => ChargebackRate,
     "playbooks"                              => ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook,
     "physical_servers_with_host"             => PhysicalServer,
-    "manageiq/providers/automation_managers" => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
+    "manageiq/providers/automation_managers" => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript,
+    "vms"                                    => VmOrTemplate
   }.freeze
 
   HAS_ASSOCATION = {


### PR DESCRIPTION
Steps to reproduce:
1. Cloud / Infra provider -> Its Images / Templates -> Select one or more images (templates)
2. Policy -> Simulation

Before:
![simulation-before](https://user-images.githubusercontent.com/6648365/29818489-d1000470-8cbc-11e7-9ea0-2d59b5eb4227.jpg)

After:
![simulation-after](https://user-images.githubusercontent.com/6648365/29818491-d6fe979c-8cbc-11e7-9192-0d869052936d.jpg)


The fix is to correctly identify model for generating reports (for angular) for images & templates.
