### PR TITLE
Notification drawer - close button on the right even when expanded

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -140,6 +140,12 @@ div#saml-login hr {
   position: absolute;
 }
 
+.drawer-pf-expanded .drawer-pf-title {
+  width: auto;
+  left: 0;
+  right: 0;
+}
+
 /// group switcher styling
 
 .navbar-right .dropdown-submenu > a {


### PR DESCRIPTION
In #1720, we introduced a close button to the notification drawer, but it would be positioned wrong when that drawer was expanded (to full width).

This fixed the positioning so that the area title is 100% wide and thus the button is on the right side.

Before:

![drawer-master-large](https://user-images.githubusercontent.com/289743/29819224-403c8326-8caf-11e7-850d-f20cbae3765f.png)


Now:

![drawer-fix-large](https://user-images.githubusercontent.com/289743/29819228-45840ec6-8caf-11e7-8cd6-1b0054298c4b.png)


(Unexpanded - identical in both:

![drawer-master-small](https://user-images.githubusercontent.com/289743/29819219-39332724-8caf-11e7-8b2a-af910fd69ce5.png)

)