### PR TITLE
Codeclimate: increase ruby mass.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -37,8 +37,9 @@ engines:
     config:
       concurrency: 1
       languages:
-      - ruby
-      - javascript
+        ruby:
+          mass_threshold: 30
+        javascript:
   eslint:
     enabled: true
     channel: "eslint-3"


### PR DESCRIPTION
Trying to adjust the code mass for ruby.

I guess this will help us focus on the more important issues by lowering the noice.

We might want to lower the threshold back later on.
