### PR TITLE
TextualSummary: Fix a typo.

### DIFF
--- a/app/views/shared/summary/_textual_multilabel.html.haml
+++ b/app/views/shared/summary/_textual_multilabel.html.haml
@@ -10,7 +10,7 @@
           - if (label.kind_of? Hash) && label[:sortable]
             .pull-left
               = label[:value]
-            .pull-rigt
+            .pull-right
               %i{:class => label[:sortable] == :asc ? "fa-sort-asc" : "fa-sort-desc"}
           - else
             = label


### PR DESCRIPTION
Fix a typo found here:

https://github.com/ManageIQ/manageiq-ui-classic/pull/1654

Actually I don't understand why noone fixed it given so many people knew about the typo :-(