### PR TITLE
Remove TASK_TIME_PERIODS from UiConstants

### DIFF
--- a/app/helpers/miq_task_helper.rb
+++ b/app/helpers/miq_task_helper.rb
@@ -1,0 +1,11 @@
+module MiqTaskHelper
+  TASK_TIME_PERIODS = {
+    0 => N_("Today"),
+    1 => N_("1 Day Ago"),
+    2 => N_("2 Days Ago"),
+    3 => N_("3 Days Ago"),
+    4 => N_("4 Days Ago"),
+    5 => N_("5 Days Ago"),
+    6 => N_("6 Days Ago")
+  }.freeze
+end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -5,16 +5,6 @@ module UiConstants
 
   VALID_PLANNING_VM_MODES = PlanningHelper::PLANNING_VM_MODES.keys.index_by(&:to_s)
 
-  TASK_TIME_PERIODS = {
-    0 => N_("Today"),
-    1 => N_("1 Day Ago"),
-    2 => N_("2 Days Ago"),
-    3 => N_("3 Days Ago"),
-    4 => N_("4 Days Ago"),
-    5 => N_("5 Days Ago"),
-    6 => N_("6 Days Ago")
-  }
-
   PROV_TIME_PERIODS = {
     1  => N_("Last 24 Hours"),
     7  => N_("Last 7 Days"),

--- a/app/views/miq_task/_tasks_options.html.haml
+++ b/app/views/miq_task/_tasks_options.html.haml
@@ -32,7 +32,7 @@
         = _("24 Hour Time Period")
       .col-md-8
         = select_tag("time_period",
-          options_for_select(Array(TASK_TIME_PERIODS.invert).sort_by(&:last).map{|x| [_(x[0]), x[1]]}, @tasks_options[@tabform][:time_period]),
+          options_for_select(Array(MiqTaskHelper::TASK_TIME_PERIODS.invert).sort_by(&:last).map{|x| [_(x[0]), x[1]]}, @tasks_options[@tabform][:time_period]),
           :class => "selectpicker")
         :javascript
           miqInitSelectPicker();


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `TASK_TIME_PERIODS` was removed from `UiConstants` and moved to new module `MiqTaskHelper`. Prefix `MiqTaskHelper::` was added to `TASK_TIME_PERIODS`.