### PR TITLE
Remove TASK_STATES from UiConstants

### DIFF
--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -15,6 +15,21 @@ class MiqTaskController < ApplicationController
     [100, 100],
   ].freeze
 
+  TASK_STATES = [
+    [N_("Initializing"), "initializing"],
+    [N_("Cancelling"), "Cancelling"],
+    [N_("Aborting"), "Aborting"],
+    [N_("Finished"), "Finished"],
+    [N_("Snapshot Create"), "Snapshot_create"],
+    [N_("Scanning"), "Scanning"],
+    [N_("Snapshot Delete"), "Snapshot_delete"],
+    [N_("Synchronizing"), "Synchronizing"],
+    [N_("Deploy Smartproxy"), "Deploy_smartproxy"],
+    [N_("Initialized"), "Initialized"],
+    [N_("Queued"), "Queued"],
+    [N_("Active"), "Active"]
+  ].freeze
+
   def index
     @tabform = nil
     # TODO: remove :feature => "job_my_smartproxy" and  :feature => "job_all_smartproxy" from miq_user_roles.yml
@@ -224,7 +239,7 @@ class MiqTaskController < ApplicationController
       :error        => true,
       :warn         => true,
       :running      => true,
-      :states       => UiConstants::TASK_STATES,
+      :states       => TASK_STATES,
       :state_choice => "all",
       :time_period  => 0,
     }

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -14,12 +14,6 @@ module UiConstants
     5 => N_("5 Days Ago"),
     6 => N_("6 Days Ago")
   }
-  TASK_STATES = [[N_("Initializing"), "initializing"],
-                 [N_("Cancelling"), "Cancelling"], [N_("Aborting"), "Aborting"], [N_("Finished"), "Finished"],
-                 [N_("Snapshot Create"), "Snapshot_create"], [N_("Scanning"), "Scanning"],
-                 [N_("Snapshot Delete"), "Snapshot_delete"], [N_("Synchronizing"), "Synchronizing"],
-                 [N_("Deploy Smartproxy"), "Deploy_smartproxy"],
-                 [N_("Initialized"), "Initialized"], [N_("Queued"), "Queued"], [N_("Active"), "Active"]].freeze
 
   PROV_STATES = {
     "pending_approval" => N_("Pending Approval"),

--- a/spec/controllers/miq_task_controller_spec.rb
+++ b/spec/controllers/miq_task_controller_spec.rb
@@ -18,7 +18,7 @@ describe MiqTaskController do
                  :running      => true,
                  :state_choice => "all",
                  :time_period  => 0,
-                 :states       => UiConstants::TASK_STATES}
+                 :states       => MiqTaskController::TASK_STATES}
       end
 
       it "all defaults" do
@@ -225,7 +225,7 @@ describe MiqTaskController do
                  :running      => true,
                  :state_choice => "all",
                  :time_period  => 0,
-                 :states       => UiConstants::TASK_STATES}
+                 :states       => MiqTaskController::TASK_STATES}
       end
 
       it "all defaults" do
@@ -455,7 +455,7 @@ describe MiqTaskController do
                  :zone         => "<all>",
                  :user_choice  => "all",
                  :time_period  => 0,
-                 :states       => UiConstants::TASK_STATES}
+                 :states       => MiqTaskController::TASK_STATES}
       end
 
       it "all defaults" do
@@ -649,7 +649,7 @@ describe MiqTaskController do
                  :state_choice => "all",
                  :user_choice  => "all",
                  :time_period  => 0,
-                 :states       => UiConstants::TASK_STATES}
+                 :states       => MiqTaskController::TASK_STATES}
       end
 
       it "all defaults" do


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `TASK_STATES` was removed from `UiConstants` and moved to `MiqTaskController`. Prefix `MiqTaskController::` was added to `TASK_STATES` only in one file `miq_task_controller_spec.rb`.