### PR TITLE
Remove PROV_STATES from UiConstants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -205,6 +205,12 @@ class ApplicationController < ActionController::Base
 
   AE_MAX_RESOLUTION_FIELDS = 5 # Maximum fields to show for automation engine resolution screens
 
+  PROV_STATES = {
+    "pending_approval" => N_("Pending Approval"),
+    "approved"         => N_("Approved"),
+    "denied"           => N_("Denied")
+  }.freeze
+
   def local_request?
     Rails.env.development? || Rails.env.test?
   end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -21,11 +21,6 @@ module UiConstants
                  [N_("Deploy Smartproxy"), "Deploy_smartproxy"],
                  [N_("Initialized"), "Initialized"], [N_("Queued"), "Queued"], [N_("Active"), "Active"]].freeze
 
-  PROV_STATES = {
-    "pending_approval" => N_("Pending Approval"),
-    "approved"         => N_("Approved"),
-    "denied"           => N_("Denied")
-  }
   PROV_TIME_PERIODS = {
     1  => N_("Last 24 Hours"),
     7  => N_("Last 7 Days"),


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `PROV_STATES` was removed from `UiConstants` and moved to `ApplicationController`.