### PR TITLE
Remove PROV_TIME_PERIODS from UiConstants

### DIFF
--- a/app/helpers/miq_request_helper.rb
+++ b/app/helpers/miq_request_helper.rb
@@ -1,0 +1,7 @@
+module MiqRequestHelper
+  PROV_TIME_PERIODS = {
+    1  => N_("Last 24 Hours"),
+    7  => N_("Last 7 Days"),
+    30 => N_("Last 30 Days")
+  }.freeze
+end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -5,12 +5,6 @@ module UiConstants
 
   VALID_PLANNING_VM_MODES = PlanningHelper::PLANNING_VM_MODES.keys.index_by(&:to_s)
 
-  PROV_TIME_PERIODS = {
-    1  => N_("Last 24 Hours"),
-    7  => N_("Last 7 Days"),
-    30 => N_("Last 30 Days")
-  }
-
   ALL_TIMEZONES = ActiveSupport::TimeZone.all.collect { |tz| ["(GMT#{tz.formatted_offset}) #{tz.name}", tz.name] }
   # Following line does not include timezones with partial hour offsets
   # ALL_TIMEZONES = ActiveSupport::TimeZone.all.collect{|tz| tz.utc_offset % 3600 == 0 ? ["(GMT#{tz.formatted_offset}) #{tz.name}",tz.name] : nil}.compact

--- a/app/views/miq_request/_prov_options.html.haml
+++ b/app/views/miq_request/_prov_options.html.haml
@@ -45,7 +45,7 @@
         = _("Request Date:")
       .col-md-8
         = select_tag("time_period",
-                      options_for_select(PROV_TIME_PERIODS.map { |k, v| [_(v), k] }.sort_by(&:last), res_type[:time_period]),
+                      options_for_select(MiqRequestHelper::PROV_TIME_PERIODS.map { |k, v| [_(v), k] }.sort_by(&:last), res_type[:time_period]),
                       :class    => "selectpicker")
         :javascript
           miqInitSelectPicker();


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `PROV_TIME_PERIODS` was removed from `UiConstants` and moved to new module `MiqRequestHelper`. Prefix `MiqRequestHelper::` was added to `TASK_STATES` only in one file `_prov_options.html.haml`.