### PR TITLE
Adding dialog validations in Dialog Editor

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -31,6 +31,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
 
   vm.saveDialogDetails = saveDialogDetails;
   vm.dismissChanges = dismissChanges;
+  vm.dialogIsValid = dialogIsValid;
 
   var beingCloned = null; // hack that solves recursion problem for cloneDeep
   function customizer(value) {
@@ -98,6 +99,73 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
       + dialogId,
       {action: action, resource: dialogData}
     ).then(saveSuccess, saveFailure);
+  }
+
+  function dialogHasName() {
+    return !_.isEmpty(DialogEditor.getDialogLabel());
+  }
+
+  function dialogHasTab() {
+    return DialogEditor.data.content[0].dialog_tabs.length > 0;
+  }
+
+  function dialogTabsHaveName() {
+    return _.every(
+      DialogEditor.data.content[0].dialog_tabs,
+      tab => !_.isEmpty(tab.label)
+    );
+  }
+
+  function dialogTabsHaveBox() {
+    return _.every(
+      DialogEditor.data.content[0].dialog_tabs,
+      tab => tab.dialog_groups.length > 0
+    );
+  }
+
+  function dialogBoxesHaveName() {
+    return _.every(
+      DialogEditor.data.content[0].dialog_tabs,
+      tab => _.every(
+        tab.dialog_groups,
+        group => !_.isEmpty(group.label)
+      )
+    );
+  }
+
+  function dialogBoxesHaveElement() {
+    return _.every(
+      DialogEditor.data.content[0].dialog_tabs,
+      tab => _.every(
+        tab.dialog_groups,
+        group => group.dialog_fields.length > 0
+      )
+    );
+  }
+
+  function dialogElementsHaveName() {
+    return _.every(
+      DialogEditor.data.content[0].dialog_tabs,
+      tab => _.every(
+        tab.dialog_groups,
+        group => _.every(
+          group.dialog_fields,
+          field => !(_.isEmpty(field.name) || _.isEmpty(field.label))
+        )
+      )
+    );
+  }
+
+  function dialogIsValid() {
+    return (
+      dialogHasName() &&
+      dialogHasTab() &&
+      dialogTabsHaveName() &&
+      dialogTabsHaveBox() &&
+      dialogBoxesHaveName() &&
+      dialogBoxesHaveElement() &&
+      dialogElementsHaveName()
+    );
   }
 
   function dismissChanges() {

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -104,60 +104,28 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
   function dialogIsValid() {
     var validators = {
       dialog: [
-        function (dialog) {
-          return {
-            status: ! _.isEmpty(dialog.label),
-            errorMessage: __('Dialog needs to have a label')
-          }
-        },
-        function (dialog) {
-          return {
-            status: dialog.dialog_tabs.length > 0,
-            errorMessage: __('Dialog needs to have at least one tab')
-          }
-        }
+        dialog => ({ status: ! _.isEmpty(dialog.label),
+                     errorMessage: __('Dialog needs to have a label') }),
+        dialog => ({ status: dialog.dialog_tabs.length > 0,
+                     errorMessage: __('Dialog needs to have at least one tab') })
       ],
       tabs: [
-        function (tab) {
-          return {
-            status: ! _.isEmpty(tab.label),
-            errorMessage: __('Dialog tab needs to have a name')
-          }
-        },
-        function (tab) {
-          return {
-            status: tab.dialog_groups.length > 0,
-            errorMessage: __('Dialog tab needs to have at least one box')
-          }
-        }
+        tab => ({ status: ! _.isEmpty(tab.label),
+                  errorMessage: __('Dialog tab needs to have a name') }),
+        tab => ({ status: tab.dialog_groups.length > 0,
+                  errorMessage: __('Dialog tab needs to have at least one box') })
       ],
       groups: [
-        function (group) {
-          return {
-            status: ! _.isEmpty(group.label),
-            errorMessage: __('Dialog box needs to have a name')
-          }
-        },
-        function (group) {
-          return {
-            status: group.dialog_fields.length > 0,
-            errorMessage: __('Dialog box needs to have at least one element')
-          }
-        }
+        group => ({ status: ! _.isEmpty(group.label),
+                    errorMessage: __('Dialog box needs to have a name') }),
+        group => ({ status: group.dialog_fields.length > 0,
+                    errorMessage: __('Dialog box needs to have at least one element') })
       ],
       fields: [
-        function (field) {
-          return {
-            status: ! _.isEmpty(field.name),
-            errorMessage: __('Dialog element needs to have a name')
-          }
-        },
-        function (field) {
-          return {
-            status: ! _.isEmpty(field.label),
-            errorMessage: __('Dialog element needs to have a label')
-          }
-        }
+        field => ({ status: ! _.isEmpty(field.name),
+                    errorMessage: __('Dialog element needs to have a name') }),
+        field => ({ status: ! _.isEmpty(field.label),
+                    errorMessage: __('Dialog element needs to have a label') })
       ]
     };
 
@@ -170,21 +138,17 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
       return validation.status;
     };
 
-    return _.every(DialogEditor.data.content, (dialog) => {
-      let u = _.every(validators.dialog, (f) => validate(f, dialog));
-      let v = _.every(dialog.dialog_tabs, (tab) => {
-        let w = _.every(validators.tabs, (f) => validate(f, tab));
-        let x = _.every(tab.dialog_groups, (group) => {
-          let y = _.every(validators.groups, (f) => validate(f, group));
-          let z = _.every(group.dialog_fields, (field) => {
-            return _.every(validators.fields, (f) => validate(f, field));
-          });
-          return y && z;
-        });
-        return w && x;
-      });
-      return u && v;
-    });
+    return _.every(DialogEditor.data.content, dialog =>
+      _.every(validators.dialog, f => validate(f, dialog)) &&
+      _.every(dialog.dialog_tabs, tab =>
+        _.every(validators.tabs, f => validate(f, tab)) &&
+        _.every(tab.dialog_groups, group =>
+          _.every(validators.groups, f => validate(f, group)) &&
+          _.every(group.dialog_fields, field =>
+            _.every(validators.fields, f => validate(f, field)))
+        )
+      )
+    );
   }
 
   function dismissChanges() {

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -28,6 +28,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
     DialogEditor.setData(dialog);
     vm.dialog = dialog;
     vm.DialogValidation = DialogValidation;
+    vm.DialogEditor = DialogEditor;
   }
 
   vm.saveDialogDetails = saveDialogDetails;

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'miqService', 'DialogEditor', 'dialogId', function($window, API, miqService, DialogEditor, dialogId) {
+ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'miqService', 'DialogEditor', 'DialogValidation', 'dialogId', function($window, API, miqService, DialogEditor, DialogValidation, dialogId) {
   var vm = this;
 
   if (dialogId === 'new') {
@@ -27,11 +27,11 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
   function init(dialog) {
     DialogEditor.setData(dialog);
     vm.dialog = dialog;
+    vm.DialogValidation = DialogValidation;
   }
 
   vm.saveDialogDetails = saveDialogDetails;
   vm.dismissChanges = dismissChanges;
-  vm.dialogIsValid = dialogIsValid;
 
   var beingCloned = null; // hack that solves recursion problem for cloneDeep
   function customizer(value) {
@@ -99,56 +99,6 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
       + dialogId,
       {action: action, resource: dialogData}
     ).then(saveSuccess, saveFailure);
-  }
-
-  function dialogIsValid() {
-    var validators = {
-      dialog: [
-        dialog => ({ status: ! _.isEmpty(dialog.label),
-                     errorMessage: __('Dialog needs to have a label') }),
-        dialog => ({ status: dialog.dialog_tabs.length > 0,
-                     errorMessage: __('Dialog needs to have at least one tab') })
-      ],
-      tabs: [
-        tab => ({ status: ! _.isEmpty(tab.label),
-                  errorMessage: __('Dialog tab needs to have a name') }),
-        tab => ({ status: tab.dialog_groups.length > 0,
-                  errorMessage: __('Dialog tab needs to have at least one box') })
-      ],
-      groups: [
-        group => ({ status: ! _.isEmpty(group.label),
-                    errorMessage: __('Dialog box needs to have a name') }),
-        group => ({ status: group.dialog_fields.length > 0,
-                    errorMessage: __('Dialog box needs to have at least one element') })
-      ],
-      fields: [
-        field => ({ status: ! _.isEmpty(field.name),
-                    errorMessage: __('Dialog element needs to have a name') }),
-        field => ({ status: ! _.isEmpty(field.label),
-                    errorMessage: __('Dialog element needs to have a label') })
-      ]
-    };
-
-    let invalid = [];
-    let validate = function (f, item) {
-      let validation = f(item);
-      if (!validation.status) {
-        invalid.push({ message: validation.errorMessage, item: item });
-      }
-      return validation.status;
-    };
-
-    return _.every(DialogEditor.data.content, dialog =>
-      _.every(validators.dialog, f => validate(f, dialog)) &&
-      _.every(dialog.dialog_tabs, tab =>
-        _.every(validators.tabs, f => validate(f, tab)) &&
-        _.every(tab.dialog_groups, group =>
-          _.every(validators.groups, f => validate(f, group)) &&
-          _.every(group.dialog_fields, field =>
-            _.every(validators.fields, f => validate(f, field)))
-        )
-      )
-    );
   }
 
   function dismissChanges() {

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -18,8 +18,11 @@
       .draggable
         %dialog-editor-field-static
   .pull-right
-    %button.btn.btn-default{"ng-click" => "vm.dismissChanges()", :type => "button"}= _("Cancel")
-    %button.btn.btn-primary{"ng-click" => "vm.saveDialogDetails()", "ng-disabled" => "vm.dialogUnchanged()", :type => "button"}= _("Save")
+    %button.btn.btn-default{"ng-click" => "vm.dismissChanges()",
+                            :type => "button"}= _("Cancel")
+    %button.btn.btn-primary{"ng-click" => "vm.saveDialogDetails()",
+                            "ng-disabled" => "!vm.dialogIsValid()",
+                            :type => "button"}= _("Save")
   = render :partial => "layouts/x_edit_buttons"
 
 :javascript

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -21,7 +21,8 @@
     %button.btn.btn-default{"ng-click" => "vm.dismissChanges()",
                             :type => "button"}= _("Cancel")
     %button.btn.btn-primary{"ng-click" => "vm.saveDialogDetails()",
-                            "ng-disabled" => "!vm.dialogIsValid()",
+                            "ng-disabled" => "!vm.DialogValidation.dialogIsValid()",
+                            "ng-attr-title" => "{{vm.DialogValidation.invalid.message}}",
                             :type => "button"}= _("Save")
   = render :partial => "layouts/x_edit_buttons"
 

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -21,7 +21,7 @@
     %button.btn.btn-default{"ng-click" => "vm.dismissChanges()",
                             :type => "button"}= _("Cancel")
     %button.btn.btn-primary{"ng-click" => "vm.saveDialogDetails()",
-                            "ng-disabled" => "!vm.DialogValidation.dialogIsValid()",
+                            "ng-disabled" => "!vm.DialogValidation.dialogIsValid(vm.DialogEditor.data.content)",
                             "ng-attr-title" => "{{vm.DialogValidation.invalid.message}}",
                             :type => "button"}= _("Save")
   = render :partial => "layouts/x_edit_buttons"


### PR DESCRIPTION
After these changes, it won't be possible to submit invalid dialog.
The methods are testing that

- dialog has a name
- dialog has at least one tab
- every dialog tab have a name
- every dialog tab has at least one box
- every dialog box has a name
- every dialog box has at least one element
- every element has a name

if one test fails, the `Save` buttons becomes disabled.

Links
----------------
* https://www.pivotaltracker.com/story/show/144481043

Steps for Testing/QA
-------------------------------

Automation -> Automate -> Customization -> Edit this / Add a new dialog in the Dialog Editor -> [see the screencast]

![screencast from 2017-08-30 16-21-22](https://user-images.githubusercontent.com/1187051/29877333-97ef6886-8d9f-11e7-9adf-c05b5a5c5790.gif)

/cc @d-m-u @skateman @himdel @karelhala 