### PR TITLE
Adds error on dialog field association circular reference catch

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -1,4 +1,5 @@
 class MiqAeCustomizationController < ApplicationController
+  require "English"
   include_concern 'CustomButtons'
   include_concern 'OldDialogs'
   include_concern 'Dialogs'
@@ -57,7 +58,7 @@ class MiqAeCustomizationController < ApplicationController
       rescue DialogImportValidator::ParsedNonDialogYamlError
         add_flash(_("Error during upload: incorrect Dialog format, only service dialogs can be imported"), :error)
       rescue DialogImportValidator::DialogFieldAssociationCircularReferenceError
-        add_flash(_("Error during upload: the dialog fields to be imported contain circular association references"), :error)
+        add_flash(_("Error during upload: the following dialog fields to be imported contain circular association references: #{$ERROR_INFO}"), :error)
       rescue DialogImportValidator::InvalidDialogFieldTypeError
         add_flash(_("Error during upload: one of the DialogField types is not supported"), :error)
       end

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -56,6 +56,8 @@ class MiqAeCustomizationController < ApplicationController
         add_flash(_("Error: the file uploaded is not of the supported format"), :error)
       rescue DialogImportValidator::ParsedNonDialogYamlError
         add_flash(_("Error during upload: incorrect Dialog format, only service dialogs can be imported"), :error)
+      rescue DialogImportValidator::DialogFieldAssociationCircularReferenceError
+        add_flash(_("Error during upload: the dialog fields to be imported contain circular association references"), :error)
       rescue DialogImportValidator::InvalidDialogFieldTypeError
         add_flash(_("Error during upload: one of the DialogField types is not supported"), :error)
       end

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -331,6 +331,20 @@ describe MiqAeCustomizationController do
         end
       end
 
+      context "when the dialog importer raises a circular reference error" do
+        before do
+          allow(dialog_import_service).to receive(:store_for_import)
+            .and_raise(DialogImportValidator::DialogFieldAssociationCircularReferenceError)
+        end
+
+        it "redirects with an error message" do
+          post :upload_import_file, :params => params, :xhr => true
+          expect(controller.instance_variable_get(:@flash_array))
+            .to include(:message => "Error during upload: the following dialog fields to be imported contain circular association references: DialogImportValidator::DialogFieldAssociationCircularReferenceError",
+                        :level   => :error)
+        end
+      end
+
       context "when the dialog importer raises a parse non dialog yaml error" do
         before do
           allow(dialog_import_service).to receive(:store_for_import)


### PR DESCRIPTION
Shows UI error for importing a dialog whose references are circular. 

**Links**
    Depends on: https://github.com/ManageIQ/manageiq/pull/15909
