### PR TITLE
Deduplicate tree building.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2262,7 +2262,7 @@ class ApplicationController < ActionController::Base
   end
 
   def reload_trees_by_presenter(presenter, trees)
-    trees.each_pair do |_, tree|
+    trees.each do |tree|
       next unless tree.present?
       presenter.reload_tree(tree.name, tree.locals_for_render[:bs_tree])
     end

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -12,7 +12,10 @@ module ApplicationController::Explorer
   def try_build_tree(tree_symbol)
     method_name = "build_#{tree_symbol}_tree"
     return unless respond_to?(method_name, true)
-    method(method_name).call(tree_symbol)
+    build_method = method(method_name)
+    # FIXME: This is temporary, we actually need to remove all the build_*_tree methods and
+    # use the Feature::build_tree instead.
+    build_method.arity == 1 ? build_method.call(tree_symbol) : build_method.call
   end
 
   # Historical tree item selected

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -2,6 +2,19 @@
 module ApplicationController::Explorer
   extend ActiveSupport::Concern
 
+  def build_replaced_trees(replace_trees, valid_values)
+    return [] unless replace_trees
+    valid_values.find_all { |tree| replace_trees.include?(tree) }
+                .collect { |tree| try_build_tree(tree) }
+                .compact
+  end
+
+  def try_build_tree(tree_symbol)
+    method_name = "build_#{tree_symbol}_tree"
+    return unless respond_to?(method_name, true)
+    method(method_name).call(tree_symbol)
+  end
+
   # Historical tree item selected
   def x_history
     @hist = x_tree_history[params[:item].to_i]  # Set instance var so we know hist button was pressed

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -343,22 +343,7 @@ class AutomationManagerController < ApplicationController
   end
 
   def rebuild_trees(replace_trees)
-    trees = {}
-    if replace_trees
-      if replace_trees.include?(:automation_manager_providers)
-        trees[:automation_manager_providers] = build_automation_manager_tree(:automation_manager_providers,
-                                                                             :automation_manager_providers_tree)
-      end
-      if replace_trees.include?(:automation_manager_cs_filter)
-        trees[:automation_manager_cs_filter] = build_automation_manager_tree(:automation_manager_cs_filter,
-                                                                             :automation_manager_cs_filter_tree)
-      end
-      if replace_trees.include?(:configuration_scripts)
-        trees[:configuration_scripts] = build_automation_manager_tree(:configuration_scripts,
-                                                                      :configuration_scripts_tree)
-      end
-    end
-    trees
+    build_replaced_trees(replace_trees, %i(automation_manager_providers automation_manager_cs_filter configuration_scripts))
   end
 
   def leaf_record

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1914,14 +1914,10 @@ class CatalogController < ApplicationController
     replace_trees   = @replace_trees   if @replace_trees    # get_node_info might set this
     right_cell_text = @right_cell_text if @right_cell_text  # get_node_info might set this too
 
+    trees = build_replaced_trees(replace_trees, %i(sandt svccat stcat ot))
+
     type, _id = parse_nodetype_and_id(x_node)
-    trees = {}
-    if replace_trees
-      trees[:sandt]  = build_st_tree        if replace_trees.include?(:sandt)
-      trees[:svccat] = build_svccat_tree    if replace_trees.include?(:svccat)
-      trees[:stcat]  = build_stcat_tree     if replace_trees.include?(:stcat)
-      trees[:ot]     = build_orch_tmpl_tree if replace_trees.include?(:ot)
-    end
+
     allowed_records = %w(MiqTemplate OrchestrationTemplate Service ServiceTemplate ServiceTemplateCatalog)
     record_showing = (type && allowed_records.include?(TreeBuilder.get_model_for_prefix(type)) && !@view) ||
                      params[:action] == "x_show"
@@ -2092,7 +2088,7 @@ class CatalogController < ApplicationController
   end
 
   # Build a Catalog Items explorer tree
-  def build_st_tree
+  def build_sandt_tree
     TreeBuilderCatalogItems.new('sandt_tree', 'sandt', @sb)
   end
 
@@ -2107,7 +2103,7 @@ class CatalogController < ApplicationController
   end
 
   # Build a Orchestration Templates explorer tree
-  def build_orch_tmpl_tree
+  def build_ot_tree
     TreeBuilderOrchestrationTemplates.new('ot_tree', 'ot', @sb)
   end
 

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -835,7 +835,7 @@ class ChargebackController < ApplicationController
 
     # Build a presenter to render the JS
     presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
-    reload_trees_by_presenter(presenter, :cb_rates => cb_rates_build_tree) if replace_trees.include?(:cb_rates)
+    reload_trees_by_presenter(presenter, [cb_rates_build_tree]) if replace_trees.include?(:cb_rates)
 
     # FIXME
     #  if params[:action].ends_with?("_delete")

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -834,9 +834,7 @@ class ChargebackController < ApplicationController
     c_tb = build_toolbar(center_toolbar_filename)
 
     # Build a presenter to render the JS
-    presenter = ExplorerPresenter.new(
-      :active_tree => x_active_tree,
-    )
+    presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
     reload_trees_by_presenter(presenter, :cb_rates => cb_rates_build_tree) if replace_trees.include?(:cb_rates)
 
     # FIXME

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -501,10 +501,6 @@ class MiqAeCustomizationController < ApplicationController
     TreeBuilderButtons.new("ab_tree", "ab", @sb)
   end
 
-  def build_dialog_edit_tree
-    dialog_edit_build_tree
-  end
-
   def dialog_import_export_build_tree
     TreeBuilderAeCustomization.new("dialog_import_export_tree", "dialog_import_export", @sb)
   end

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -237,13 +237,7 @@ class MiqAeCustomizationController < ApplicationController
     nodetype, replace_trees = options.values_at(:nodetype, :replace_trees)
     # fixme, don't call all the time
     build_ae_tree(:automate, :automate_tree) # Build Catalog Items tree
-    trees = {}
-    if replace_trees
-      trees[:ab]           = ab_build_tree                if replace_trees.include?(:ab)
-      trees[:old_dialogs]  = old_dialogs_build_tree       if replace_trees.include?(:old_dialogs)
-      trees[:dialogs]      = dialog_build_tree            if replace_trees.include?(:dialogs)
-      trees[:dialog_edit]  = dialog_edit_build_tree       if replace_trees.include?(:dialog_edit)
-    end
+    trees = build_replaced_trees(replace_trees, %i(ab old_dialogs dialogs dialog_edit))
 
     @explorer = true
     presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
@@ -495,16 +489,20 @@ class MiqAeCustomizationController < ApplicationController
     end
   end
 
-  def old_dialogs_build_tree
+  def build_old_dialogs_tree
     TreeBuilderProvisioningDialogs.new("old_dialogs_tree", "old_dialogs", @sb)
   end
 
-  def dialog_build_tree
+  def build_dialogs_tree
     TreeBuilderServiceDialogs.new("dialogs_tree", "dialogs", @sb)
   end
 
-  def ab_build_tree
+  def build_ab_tree
     TreeBuilderButtons.new("ab_tree", "ab", @sb)
+  end
+
+  def build_dialog_edit_tree
+    dialog_edit_build_tree
   end
 
   def dialog_import_export_build_tree

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -20,7 +20,7 @@ module MiqAeCustomizationController::Dialogs
     dialog_get_form_vars
 
     # dialog_edit_set_form_vars
-    dialog_edit_build_tree
+    build_dialog_edit_tree
     dialog_sort_values if (params[:field_data_typ] || params[:field_sort_by] ||
         params[:field_sort_order]) && @edit[:field_sort_by].to_s != "none"
     @_params[:typ] = ""
@@ -296,7 +296,7 @@ module MiqAeCustomizationController::Dialogs
         self.x_node = "#{nodes[0]}_#{nodes[1]}_#{nodes[2]}"
       end
     end
-    dialog_edit_build_tree
+    build_dialog_edit_tree
     @sb[:edit_typ] = nil
     replace_right_cell(:nodetype => x_node, :replace_trees => [:dialog_edit])
   end
@@ -418,7 +418,7 @@ module MiqAeCustomizationController::Dialogs
 
     parent[name] = temp
 
-    dialog_edit_build_tree
+    build_dialog_edit_tree
     render :update do |page|
       page << javascript_prologue
       session[:changed] = changed = (@edit[:new] != @edit[:current])
@@ -750,7 +750,7 @@ module MiqAeCustomizationController::Dialogs
   end
 
   # Build a Dialogs tree
-  def dialog_edit_build_tree
+  def build_dialog_edit_tree
     x_tree_init(:dialog_edit_tree, :dialog_edit, nil)
     # building tab nodes under a dialog
     tab_nodes = []
@@ -1135,7 +1135,7 @@ module MiqAeCustomizationController::Dialogs
 
       @sb[:node_typ] = "element" if params[:action] != "dialog_form_field_changed"
     end
-    dialog_edit_build_tree
+    build_dialog_edit_tree
     session[:changed] = (@edit[:new] != @edit[:current])
     session[:edit] = @edit
   end
@@ -1282,7 +1282,7 @@ module MiqAeCustomizationController::Dialogs
     end
 
     @edit[:current] = copy_hash(@edit[:new])
-    dialog_edit_build_tree
+    build_dialog_edit_tree
     x_node_set("root", :dialog_edit_tree)     # always set it to root for edit tree
 
     session[:edit] = @edit

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -522,7 +522,7 @@ class MiqPolicyController < ApplicationController
         raise _("unknown tree in replace_trees: %{name}") % {name => name}
       end
     end
-    reload_trees_by_presenter(presenter, trees)
+    reload_trees_by_presenter(presenter, trees.values)
 
     if params[:action].ends_with?('_delete') &&
        !x_node.starts_with?('p') &&

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -767,13 +767,7 @@ class OpsController < ApplicationController
 
   def replace_explorer_trees(replace_trees, presenter)
     # Build hash of trees to replace and optional new node to be selected
-    trees = {}
-    if replace_trees
-      trees[:settings]    = settings_build_tree     if replace_trees.include?(:settings)
-      trees[:rbac]        = rbac_build_tree         if replace_trees.include?(:rbac)
-      trees[:diagnostics] = diagnostics_build_tree  if replace_trees.include?(:diagnostics)
-      trees[:vmdb]        = db_build_tree           if replace_trees.include?(:vmdb)
-    end
+    trees = build_replaced_trees(replace_trees, %i(settings rbac diagnostics vmdb))
     reload_trees_by_presenter(presenter, trees)
   end
 

--- a/app/controllers/ops_controller/db.rb
+++ b/app/controllers/ops_controller/db.rb
@@ -86,7 +86,7 @@ module OpsController::Db
   private #######################
 
   # Build a VMDB tree for Database accordion
-  def vmdb_build_tree
+  def build_vmdb_tree
     TreeBuilderOpsVmdb.new("vmdb_tree", "vmdb", @sb)
   end
 

--- a/app/controllers/ops_controller/db.rb
+++ b/app/controllers/ops_controller/db.rb
@@ -86,7 +86,7 @@ module OpsController::Db
   private #######################
 
   # Build a VMDB tree for Database accordion
-  def db_build_tree
+  def vmdb_build_tree
     TreeBuilderOpsVmdb.new("vmdb_tree", "vmdb", @sb)
   end
 

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -666,8 +666,8 @@ module OpsController::Diagnostics
     @explorer = true
     if params[:pressed] == "delete_server" || params[:pressed] == "zone_delete_server"
       @sb[:diag_selected_id] = nil
-      settings_build_tree
-      diagnostics_build_tree
+      build_settings_tree
+      build_diagnostics_tree
     end
     if x_node == "root"
       parent = MiqRegion.my_region
@@ -893,7 +893,7 @@ module OpsController::Diagnostics
     end
   end
 
-  def diagnostics_build_tree
+  def build_diagnostics_tree
     TreeBuilderOpsDiagnostics.new("diagnostics_tree", "diagnostics", @sb)
   end
 

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -874,7 +874,7 @@ module OpsController::OpsRbac
   end
 
   # Build the main Access Control tree
-  def rbac_build_tree
+  def build_rbac_tree
     TreeBuilderOpsRbac.new("rbac_tree", "rbac", @sb)
   end
 

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1192,7 +1192,7 @@ module OpsController::Settings::Common
   end
 
   # Build the main Settings tree
-  def settings_build_tree
+  def build_settings_tree
     TreeBuilderOpsSettings.new("settings_tree", "settings", @sb)
   end
 

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -217,15 +217,12 @@ class ProviderForemanController < ApplicationController
     end
   end
 
-  def build_configuration_manager_tree(type, name)
-    tree = case name
-           when :configuration_manager_providers_tree
-             TreeBuilderConfigurationManager.new(name, type, @sb)
-           when :configuration_manager_cs_filter_tree
-             TreeBuilderConfigurationManagerConfiguredSystems.new(name, type, @sb)
-           end
-    instance_variable_set :"@#{name}", tree.tree_nodes
-    tree
+  def build_configuration_manager_providers_tree(_type)
+    TreeBuilderConfigurationManager.new(:configuration_manager_providers, :configuration_manager_providers_tree, @sb)
+  end
+
+  def build_configuration_manager_cs_filter_tree(_type)
+    TreeBuilderConfigurationManagerConfiguredSystems.new(:configuration_manager_cs_filter, :configuration_manager_cs_filter_tree, @sb)
   end
 
   def get_node_info(treenodeid, show_list = true)
@@ -334,13 +331,7 @@ class ProviderForemanController < ApplicationController
   end
 
   def rebuild_trees(replace_trees)
-    trees = {}
-    if replace_trees
-      trees[:configuration_manager_providers] = build_configuration_manager_tree(:configuration_manager_providers,
-                                                                                 :configuration_manager_providers_tree) if replace_trees.include?(:configuration_manager_providers)
-      trees[:configuration_manager_cs_filter] = build_configuration_manager_tree(:configuration_manager_cs_filter, :configuration_manager_cs_filter_tree) if replace_trees.include?(:configuration_manager_cs_filter)
-    end
-    trees
+    build_replaced_trees(replace_trees, %i(configuration_manager_providers configuration_manager_cs_filter))
   end
 
   def leaf_record

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -102,17 +102,9 @@ class PxeController < ApplicationController
 
     @explorer = true
 
-    trees = {}
-    if replace_trees
-      trees[:pxe_servers]             = pxe_server_build_tree               if replace_trees.include?(:pxe_servers)
-      trees[:pxe_image_types]         = pxe_image_type_build_tree           if replace_trees.include?(:pxe_image_types)
-      trees[:customization_templates] = customization_template_build_tree   if replace_trees.include?(:customization_templates)
-      trees[:iso_datastores]          = iso_datastore_build_tree            if replace_trees.include?(:iso_datastores)
-    end
+    trees = build_replaced_trees(replace_trees, %i(pxe_servers pxe_image_types customization_templates iso_datastores))
 
-    presenter = ExplorerPresenter.new(
-      :active_tree => x_active_tree,
-    )
+    presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
 
     c_tb = build_toolbar(center_toolbar_filename) unless @in_a_form
     h_tb = build_toolbar('x_history_tb')

--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -290,7 +290,7 @@ module PxeController::IsoDatastores
   end
 
   # Get information for an event
-  def build_iso_datastore_tree
+  def build_iso_datastores_tree
     TreeBuilderIsoDatastores.new("iso_datastores_tree", "iso_datastores", @sb)
   end
 

--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -290,7 +290,7 @@ module PxeController::IsoDatastores
   end
 
   # Get information for an event
-  def iso_datastore_build_tree
+  def build_iso_datastore_tree
     TreeBuilderIsoDatastores.new("iso_datastores_tree", "iso_datastores", @sb)
   end
 

--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -257,7 +257,7 @@ module PxeController::PxeCustomizationTemplates
   end
 
   # Get information for an event
-  def build_customization_template_tree
+  def build_customization_templates_tree
     TreeBuilderPxeCustomizationTemplates.new("customization_templates_tree", "customization_templates", @sb)
   end
 end

--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -257,7 +257,7 @@ module PxeController::PxeCustomizationTemplates
   end
 
   # Get information for an event
-  def customization_template_build_tree
+  def build_customization_template_tree
     TreeBuilderPxeCustomizationTemplates.new("customization_templates_tree", "customization_templates", @sb)
   end
 end

--- a/app/controllers/pxe_controller/pxe_image_types.rb
+++ b/app/controllers/pxe_controller/pxe_image_types.rb
@@ -188,7 +188,7 @@ module PxeController::PxeImageTypes
   end
 
   # Get information for an event
-  def build_pxe_image_type_tree
+  def build_pxe_image_types_tree
     TreeBuilderPxeImageTypes.new("pxe_image_types_tree", "pxe_image_types", @sb)
   end
 

--- a/app/controllers/pxe_controller/pxe_image_types.rb
+++ b/app/controllers/pxe_controller/pxe_image_types.rb
@@ -188,7 +188,7 @@ module PxeController::PxeImageTypes
   end
 
   # Get information for an event
-  def pxe_image_type_build_tree
+  def build_pxe_image_type_tree
     TreeBuilderPxeImageTypes.new("pxe_image_types_tree", "pxe_image_types", @sb)
   end
 

--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -449,7 +449,7 @@ module PxeController::PxeServers
   end
 
   # Get information for an event
-  def pxe_server_build_tree
+  def build_pxe_server_tree
     TreeBuilderPxeServers.new("pxe_servers_tree", "pxe_servers", @sb)
   end
 

--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -449,7 +449,7 @@ module PxeController::PxeServers
   end
 
   # Get information for an event
-  def build_pxe_server_tree
+  def build_pxe_servers_tree
     TreeBuilderPxeServers.new("pxe_servers_tree", "pxe_servers", @sb)
   end
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -653,26 +653,14 @@ class ReportController < ApplicationController
     @sb[:active_tab] = params[:tab_id] ? params[:tab_id] : "report_info" if x_active_tree == :reports_tree &&
                                                                             params[:action] != "reload" && !["miq_report_run", "saved_report_delete"].include?(params[:pressed]) # do not reset if reload saved reports buttons is pressed
 
-    trees                = {}
-    rebuild              = @in_a_form ? false : rebuild_trees
-
-    {
-      :reports      => :build_reports_tree,
-      :schedules    => :build_schedules_tree,
-      :savedreports => :build_savedreports_tree,
-      :db           => :build_db_tree,
-      :widgets      => :build_widgets_tree,
-    }.each do |tree, method|
-      next unless tree_exists?(tree.to_s + "_tree")
-
-      if replace_trees.include?(tree) || rebuild
-        trees[tree] = send(method)
-      end
+    rebuild = @in_a_form ? false : rebuild_trees
+    valid_trees = %i(reports schedules savedreports db widgets).find_all do |tree|
+      tree_exists?(tree.to_s + "_tree")
     end
+    trees = build_replaced_trees(rebuild ? valid_trees : replace_trees, valid_trees)
 
-    presenter = ExplorerPresenter.new(
-      :active_tree => x_active_tree,
-    )
+    presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
+
     # Clicked on right cell record, open the tree enough to show the node, if not already showing
     # Open the parent nodes of selected record, if not open
     # Showing a report

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -344,9 +344,7 @@ class ServiceController < ApplicationController
       :right_cell_text => @right_cell_text
     )
 
-    if Array(replace_trees).include?(:svcs)
-      reload_trees_by_presenter(presenter, :svcs => build_svcs_tree)
-    end
+    reload_trees_by_presenter(presenter, build_replaced_trees(replace_trees, %i(svcs)))
 
     # Replace right cell divs
     presenter.update(:main_div,

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -387,11 +387,8 @@ class StorageController < ApplicationController
     return if @in_a_form
     record_showing = leaf_record
 
-    trees = {}
-    if replace_trees
-      trees[:storage]     = storage_build_tree     if replace_trees.include?(:storage)
-      trees[:storage_pod] = storage_pod_build_tree if replace_trees.include?(:storage_pod)
-    end
+    trees = build_replaced_trees(replace_trees, %i(storage storage_pod))
+
     presenter = rendering_objects
     update_partials(record_showing, presenter)
     replace_search_box(presenter)

--- a/app/controllers/storage_controller/storage_d.rb
+++ b/app/controllers/storage_controller/storage_d.rb
@@ -31,7 +31,7 @@ module StorageController::StorageD
   private #######################
 
   # Get information for an event
-  def storage_build_tree
+  def build_storage_tree
     TreeBuilderStorage.new("storage_tree", "storage", @sb)
   end
 

--- a/app/controllers/storage_controller/storage_pod.rb
+++ b/app/controllers/storage_controller/storage_pod.rb
@@ -49,7 +49,7 @@ module StorageController::StoragePod
 
 
   # Get information for an event
-  def storage_pod_build_tree
+  def build_storage_pod_tree
     TreeBuilderStoragePod.new("storage_pod_tree", "storage_pod", @sb)
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -300,10 +300,10 @@ describe ApplicationController do
     end
   end
 
-  describe "#reload_trees_by_presenter" do
-    let(:tree_1) { double(:name => 'tree_1') }
-    let(:tree_2) { double(:name => 'tree_2') }
-    let(:trees) { {'tree_1' => tree_1, 'tree_2' => tree_2, 'tree_3' => nil} }
+  describe "#replace_trees_by_presenter" do
+    let(:tree_1) { double(:name => 'tree_1', :type => 'tree_1') }
+    let(:tree_2) { double(:name => 'tree_2', :type => 'tree_2') }
+    let(:trees) { [tree_1, tree_2, nil] }
     let(:presenter) { double(:presenter) }
 
     it "calls render and passes data to presenter for each pair w/ value" do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -95,6 +95,16 @@ describe CatalogController do
     end
   end
 
+  describe 'replace_right_cell' do
+    it "Can build all the trees" do
+      seed_session_trees('catalog', :sandt_tree, '-Unassigned')
+      session_to_sb
+
+      allow(controller).to receive(:render)
+      controller.send(:replace_right_cell, :replace_trees => %i(stcat sandt svccat))
+    end
+  end
+
   context "#atomic_st_edit" do
     it "Atomic Service Template and its valid Resource Actions are saved" do
       controller.instance_variable_set(:@sb, {})
@@ -149,7 +159,6 @@ describe CatalogController do
       }
       controller.instance_variable_set(:@edit, edit)
       session[:edit] = edit
-      allow(controller).to receive(:replace_right_cell)
       controller.send(:atomic_st_edit)
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
@@ -584,6 +593,7 @@ describe CatalogController do
     it "Renders list of orchestration templates using correct GTL type" do
       %w(root xx-otcfn xx-othot xx-otazu).each do |id|
         post :tree_select, :params => { :id => id, :format => :js }
+        expect(response).to have_http_status 200
         expect(response).to render_template('layouts/angular/_gtl')
       end
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -100,7 +100,15 @@ describe CatalogController do
       seed_session_trees('catalog', :sandt_tree, '-Unassigned')
       session_to_sb
 
-      allow(controller).to receive(:render)
+      expect(controller).to receive(:reload_trees_by_presenter).with(
+        instance_of(ExplorerPresenter),
+        array_including(
+          instance_of(TreeBuilderCatalogs),
+          instance_of(TreeBuilderCatalogItems),
+          instance_of(TreeBuilderServiceCatalog),
+        )
+      )
+      expect(controller).to receive(:render)
       controller.send(:replace_right_cell, :replace_trees => %i(stcat sandt svccat))
     end
   end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -594,4 +594,20 @@ describe ChargebackController do
       expect(fetched_report).to eq(chargeback_report)
     end
   end
+
+  context "#replace_right_cell" do
+    it "Can build the :cb_rates tree" do
+      seed_session_trees('chargeback', :cb_rates, 'root')
+      session_to_sb
+
+      expect(controller).to receive(:render)
+      expect(controller).to receive(:reload_trees_by_presenter).with(
+        instance_of(ExplorerPresenter),
+        array_including(
+          instance_of(TreeBuilderChargebackRates),
+        )
+      )
+      controller.send(:replace_right_cell, :replace_trees => %i(cb_rates))
+    end
+  end
 end

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -535,4 +535,27 @@ describe MiqAeCustomizationController do
       expect(response.body).to include("main_div")
     end
   end
+
+  describe 'replace_right_cell' do
+    it "Can build all the trees" do
+      seed_session_trees('miq_ae_customization', :ab, 'root')
+      session_to_sb
+      controller.instance_variable_set(:@edit, :new => {})
+
+      expect(controller).to receive(:reload_trees_by_presenter).with(
+        instance_of(ExplorerPresenter),
+        array_including(
+          instance_of(TreeBuilderButtons),
+          instance_of(TreeBuilderProvisioningDialogs),
+          instance_of(TreeBuilderServiceDialogs),
+        )
+      )
+
+      # FIXME: this tree is an exceptional one, it's going to be removed when we replace the
+      # dialog editor.
+      expect(controller).to receive(:build_dialog_edit_tree)
+      expect(controller).to receive(:render)
+      controller.send(:replace_right_cell, :replace_trees => %i(ab old_dialogs dialogs dialog_edit))
+    end
+  end
 end

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -273,8 +273,18 @@ describe OpsController do
     it "build trees that are passed in and met other conditions" do
       controller.instance_variable_set(:@sb, {})
       allow(controller).to receive(:x_build_dyna_tree)
-      replace_trees = [:settings, :diagnostics]
+      allow(VmdbDatabase).to receive_message_chain(:my_database, :evm_tables) {[]}
+      replace_trees = %i(settings diagnostics rbac vmdb)
       presenter = ExplorerPresenter.new
+      expect(controller).to receive(:reload_trees_by_presenter).with(
+        instance_of(ExplorerPresenter),
+        array_including(
+          instance_of(TreeBuilderOpsSettings),
+          instance_of(TreeBuilderOpsDiagnostics),
+          instance_of(TreeBuilderOpsRbac),
+          instance_of(TreeBuilderOpsVmdb),
+        )
+      )
       controller.send(:replace_explorer_trees, replace_trees, presenter)
       expect(response.status).to eq(200)
     end

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -14,13 +14,13 @@ describe OpsController do
       OpsController::OPS_X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, method|
         it "calls the appropriate method: '#{method}' for action '#{action_name}'" do
           expect(controller).to receive(method)
-          get :x_button, :params => { :pressed => action_name }
+          get :x_button, :params => {:pressed => action_name}
         end
       end
     end
 
     it 'exception is raised for unknown action' do
-      get :x_button, :params => { :pressed => 'random_dude', :format => :html }
+      get :x_button, :params => {:pressed => 'random_dude', :format => :html}
       expect(response).to render_template('layouts/exception')
     end
 
@@ -37,7 +37,7 @@ describe OpsController do
 
       it 'rbac role add' do
         MiqProductFeature.seed
-        session[:sandboxes] = { "ops" => { :trees => {} } }
+        session[:sandboxes] = {"ops" => {:trees => {}}}
         post :x_button, :params => {:pressed => 'rbac_role_add'}
         expect(response.status).to eq(200)
       end
@@ -50,7 +50,7 @@ describe OpsController do
     session[:sandboxes] = {"ops" => {:active_tree => :vmdb_tree,
                                      :active_tab  => 'db_settings',
                                      :trees       => {:vmdb_tree => {:active_node => 'root'}}}}
-    post :change_tab, :params => { :tab_id => 'db_settings', :format => :json }
+    post :change_tab, :params => {:tab_id => 'db_settings', :format => :json}
   end
 
   it 'can view the db_connections tab' do
@@ -60,7 +60,7 @@ describe OpsController do
                                      :active_tab  => 'db_connections',
                                      :trees       => {:vmdb_tree => {:active_node => 'root'}}}}
     expect(controller).to receive(:head)
-    post :change_tab, :params => { :tab_id => 'db_connections', :format => :json }
+    post :change_tab, :params => {:tab_id => 'db_connections', :format => :json}
     expect(response.status).to eq(200)
   end
 
@@ -84,7 +84,7 @@ describe OpsController do
         }
       }
       expect(controller).to receive(:replace_right_cell)
-      get :rbac_user_edit, :params => { :button => 'add' }
+      get :rbac_user_edit, :params => {:button => 'add'}
     end
 
     it 'cannot add a user w/o matching passwords' do
@@ -101,7 +101,7 @@ describe OpsController do
       }
 
       expect(controller).to receive(:render_flash)
-      get :rbac_user_edit, :params => { :button => 'add' }
+      get :rbac_user_edit, :params => {:button => 'add'}
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to eq("Password/Verify Password do not match")
       expect(flash_messages.first[:level]).to eq(:error)
@@ -121,7 +121,7 @@ describe OpsController do
       }
 
       expect(controller).to receive(:render_flash)
-      get :rbac_user_edit, :params => { :button => 'add' }
+      get :rbac_user_edit, :params => {:button => 'add'}
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to eq("A User must be assigned to a Group")
       expect(flash_messages.first[:level]).to eq(:error)
@@ -138,8 +138,7 @@ describe OpsController do
                                         :towhat      => "DatabaseBackup",
                                         :run_at      => {:start_time => "2015-04-19 00:00:00 UTC",
                                                          :tz         => "UTC",
-                                                         :interval   => {:unit => "once", :value => ""}
-                                                        })
+                                                         :interval   => {:unit => "once", :value => ""}})
       post :db_backup, :params => {
         :backup_schedule => miq_schedule.id,
         :uri             => "nfs://test_location",
@@ -273,7 +272,7 @@ describe OpsController do
     it "build trees that are passed in and met other conditions" do
       controller.instance_variable_set(:@sb, {})
       allow(controller).to receive(:x_build_dyna_tree)
-      allow(VmdbDatabase).to receive_message_chain(:my_database, :evm_tables) {[]}
+      allow(VmdbDatabase).to receive_message_chain(:my_database, :evm_tables) { [] }
       replace_trees = %i(settings diagnostics rbac vmdb)
       presenter = ExplorerPresenter.new
       expect(controller).to receive(:reload_trees_by_presenter).with(
@@ -296,24 +295,25 @@ describe OpsController do
       allow(controller).to receive(:check_privileges).and_return(true)
       allow(controller).to receive(:assert_privileges).and_return(true)
       seed_session_trees('ops', :diagnostics_tree, "z-#{ApplicationRecord.compress_id(@zone.id)}")
-      post :change_tab, :params => { :tab_id => "diagnostics_collect_logs" }
+      post :change_tab, :params => {:tab_id => "diagnostics_collect_logs"}
     end
+
     it "does not render toolbar buttons when edit is clicked" do
-      post :x_button, :params => { :id => @miq_server.id, :pressed => 'log_depot_edit', :format => :js }
+      post :x_button, :params => {:id => @miq_server.id, :pressed => 'log_depot_edit', :format => :js}
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)['reloadToolbars']).to match([nil])
     end
 
     it "renders toolbar buttons when cancel is clicked" do
       allow(controller).to receive(:diagnostics_set_form_vars)
-      post :x_button, :params => { :id => @miq_server.id, :pressed => 'log_depot_edit', :button => "cancel", :format => :js }
+      post :x_button, :params => {:id => @miq_server.id, :pressed => 'log_depot_edit', :button => "cancel", :format => :js}
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)['reloadToolbars'].length).to eq(1)
     end
 
     it "renders toolbar buttons when save is clicked" do
       allow(controller).to receive(:diagnostics_set_form_vars)
-      post :x_button, :params => { :id => @miq_server.id, :pressed => 'log_depot_edit', :button => "save", :format => :js }
+      post :x_button, :params => {:id => @miq_server.id, :pressed => 'log_depot_edit', :button => "save", :format => :js}
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)['reloadToolbars'].length).to eq(1)
     end

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -82,4 +82,24 @@ describe PxeController do
     render_views
     it { is_expected.to have_http_status 200 }
   end
+
+  describe 'replace_right_cell' do
+    it "Can build all the trees" do
+      seed_session_trees('pxe', :pxe_tree, 'root')
+      session_to_sb
+
+      expect(controller).to receive(:reload_trees_by_presenter).with(
+        instance_of(ExplorerPresenter),
+        array_including(
+          instance_of(TreeBuilderPxeServers),
+          instance_of(TreeBuilderPxeImageTypes),
+          instance_of(TreeBuilderPxeImageTypes),
+          instance_of(TreeBuilderPxeCustomizationTemplates),
+          instance_of(TreeBuilderIsoDatastores)
+        )
+      )
+      expect(controller).to receive(:render)
+      controller.send(:replace_right_cell, :replace_trees => %i(pxe_servers pxe_image_types customization_templates iso_datastores))
+    end
+  end
 end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1103,7 +1103,8 @@ describe ReportController do
                                        :trees => {'reports_tree'      => {:active_node => "root"},
                                                   'savedreports_tree' => {:active_node => "root"},
                                                   'widgets_tree'      => {:active_node => "root"},
-                                                  'db_tree'           => {:active_node => "root"}},
+                                                  'db_tree'           => {:active_node => "root"},
+                                                  'schedules_tree'    => {:active_node => "root"}},
                                        :active_tree => :reports_tree)
 
       allow(controller).to receive(:x_node) { 'root' }
@@ -1170,6 +1171,25 @@ describe ReportController do
       expect(controller).not_to receive(:build_widgets_tree)
 
       controller.send(:replace_right_cell, :replace_trees => [:reports])
+    end
+
+    it "Can build all the trees" do
+      allow(User).to receive(:server_timezone).and_return("UTC")
+      sb[:rep_tree_build_time] = Time.now.utc
+      MiqWidgetSet.seed
+      @rpt = create_and_generate_report_for_user("Vendor and Guest OS", "User2")
+
+      expect(controller).to receive(:reload_trees_by_presenter).with(
+        instance_of(ExplorerPresenter),
+        array_including(
+          instance_of(TreeBuilderReportReports),
+          instance_of(TreeBuilderReportSavedReports),
+          instance_of(TreeBuilderReportSchedules),
+          instance_of(TreeBuilderReportWidgets),
+          instance_of(TreeBuilderReportDashboards)
+        )
+      )
+      controller.send(:replace_right_cell, :replace_trees => %i(reports schedules savedreports db widgets))
     end
   end
 

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -34,6 +34,11 @@ module Spec
         session[:sandboxes][a_controller][:trees][active_tree][:active_node] = node unless node.nil?
       end
 
+      def session_to_sb(a_controller = nil)
+        a_controller ||= controller.controller_name
+        controller.instance_variable_set(:@sb, session[:sandboxes][a_controller])
+      end
+
       def assert_nested_list(parent, children, relation, label, child_path: nil, gtl_types: nil)
         gtl_types    ||= [:list, :tile, :grid]
         child_path   ||= relation.singularize


### PR DESCRIPTION
deduplicate tree building, unifying some differences

next step should be removing all the `build_*_tree` methods and calling the `TreeBuilder` subclass directly