### PR TITLE
Jasmine - expose public/packs under /packs/

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,12 @@ module Jasmine
 
     def initialize_config
       old_initialize_config
+
+      # serve haml templates from app/views/static/ on /static/
       @config.add_rack_path('/static', -> { StaticOrHaml.new })
+
+      # serve weback-compiled packs from public/packs/ on /packs/
+      @config.add_rack_path('/packs', -> { Rack::File.new(Rails.root.join('public', 'packs')) })
     end
   end
 end

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -17,6 +17,7 @@ src_files:
   - assets/jasmine-jquery
   - assets/angular-mocks
   - __spec__/helpers/fixtures-fix.js
+  - packs/manageiq-ui-classic/application-common.js
 
 # stylesheets
 #


### PR DESCRIPTION
..so that we can test webpack-compiled JS as well :).

The `jasmine.yml` change is a quick fix to at least include the one pack we're using right now, but in the future, this will need to read all the `*-common.js` packs.

Cc @mzazrivec , this is a follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/1829, this time, to expose `/packs` :).