### PR TITLE
Replace all dialog logic with dialogUser from ui-components repository

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -25,6 +25,34 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
   }
 
   function init(dialog) {
+    function translateResponderNamesToIds(dialog) {
+      var dynamicFields = [];
+      var allFields = [];
+
+      _.forEach(dialog.dialog_tabs, function(tab) {
+        _.forEach(tab.dialog_groups, function(group) {
+          _.forEach(group.dialog_fields, function(field) {
+            if (field.dynamic === true) {
+              dynamicFields.push(field);
+            }
+
+            allFields.push(field);
+          });
+        });
+      });
+
+      _.forEach(allFields, function(field) {
+        _.forEach(field.dialog_field_responders, function(responder, index) {
+          _.forEach(dynamicFields, function(dynamicField) {
+            if (responder === dynamicField.name) {
+              field.dialog_field_responders[index] = dynamicField.id;
+            }
+          });
+        });
+      });
+    }
+
+    translateResponderNamesToIds(dialog.content[0]);
     DialogEditor.setData(dialog);
     vm.dialog = dialog;
     vm.DialogValidation = DialogValidation;

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -46,6 +46,6 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
   }
 
   function saveable() {
-    return !dialogFieldRefreshService.areFieldsBeingRefreshed;
+    return ! dialogFieldRefreshService.areFieldsBeingRefreshed;
   }
 }]);

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'serviceTemplateId', 'serviceTemplateCatalogId', function(API, dialogFieldRefreshService, serviceTemplateId, serviceTemplateCatalogId) {
+ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'serviceTemplateId', 'serviceTemplateCatalogId', function(API, dialogFieldRefreshService, miqService, serviceTemplateId, serviceTemplateCatalogId) {
   var vm = this;
 
   vm.$onInit = function() {
@@ -15,11 +15,37 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
   vm.setDialogData = setDialogData;
   vm.refreshUrl = '/api/service_catalogs/' + serviceTemplateCatalogId + '/service_templates/';
 
+  vm.submitButtonClicked = submitButtonClicked;
+  vm.cancelClicked = cancelClicked;
+  vm.saveable = saveable;
+
   function refreshField(field) {
     return dialogFieldRefreshService.refreshField(vm.dialogData, [field.name], vm.refreshUrl, serviceTemplateId);
   }
 
   function setDialogData(data) {
     vm.dialogData = data.data;
+  }
+
+  function submitButtonClicked() {
+    var url = '/api/service_catalogs/' + serviceTemplateCatalogId + '/service_templates/' + serviceTemplateId;
+    vm.dialogData.action = 'order';
+    miqService.sparkleOn();
+    API.post(url, vm.dialogData).then(function() {
+      miqService.redirectBack(__('Service ordered successfully!'), 'info', '/miq_request?typ=service');
+    }).catch(function(err) {
+      miqService.sparkleOff();
+      add_flash(__('Error requesting data from server'), 'error');
+      console.log(err);
+      return Promise.reject(err);
+    });
+  }
+
+  function cancelClicked(_event) {
+    miqService.miqAjaxButton('/catalog/explorer');
+  }
+
+  function saveable() {
+    return !dialogFieldRefreshService.areFieldsBeingRefreshed;
   }
 }]);

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -1,0 +1,25 @@
+ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'serviceTemplateId', 'serviceTemplateCatalogId', function(API, dialogFieldRefreshService, serviceTemplateId, serviceTemplateCatalogId) {
+  var vm = this;
+
+  vm.$onInit = function() {
+    return new Promise(function(resolve) {
+      resolve(API.get('/api/service_templates/' + serviceTemplateId + '/service_dialogs?expand=resources&attributes=content').then(init));
+    });
+  };
+
+  function init(dialog) {
+    vm.dialog = dialog.resources[0].content[0];
+  }
+
+  vm.refreshField = refreshField;
+  vm.setDialogData = setDialogData;
+  vm.refreshUrl = '/api/service_catalogs/' + serviceTemplateCatalogId + '/service_templates/';
+
+  function refreshField(field) {
+    return dialogFieldRefreshService.refreshField(vm.dialogData, [field.name], vm.refreshUrl, serviceTemplateId);
+  }
+
+  function setDialogData(data) {
+    vm.dialogData = data.data;
+  }
+}]);

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -1,26 +1,26 @@
-ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'serviceTemplateId', 'serviceTemplateCatalogId', function(API, dialogFieldRefreshService, miqService, serviceTemplateId, serviceTemplateCatalogId) {
+ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'cancelEndpoint', function(API, dialogFieldRefreshService, miqService, dialogId, apiSubmitEndpoint, apiAction, cancelEndpoint) {
   var vm = this;
 
   vm.$onInit = function() {
     return new Promise(function(resolve) {
-      resolve(API.get('/api/service_templates/' + serviceTemplateId + '/service_dialogs?expand=resources&attributes=content').then(init));
+      resolve(API.get('/api/service_dialogs/' + dialogId, {expand: 'resources', attributes: 'content'}).then(init));
     });
   };
 
   function init(dialog) {
-    vm.dialog = dialog.resources[0].content[0];
+    vm.dialog = dialog.content[0];
   }
 
   vm.refreshField = refreshField;
   vm.setDialogData = setDialogData;
-  vm.refreshUrl = '/api/service_catalogs/' + serviceTemplateCatalogId + '/service_templates/';
+  vm.refreshUrl = '/api/service_dialogs/';
 
   vm.submitButtonClicked = submitButtonClicked;
   vm.cancelClicked = cancelClicked;
   vm.saveable = saveable;
 
   function refreshField(field) {
-    return dialogFieldRefreshService.refreshField(vm.dialogData, [field.name], vm.refreshUrl, serviceTemplateId);
+    return dialogFieldRefreshService.refreshField(vm.dialogData, [field.name], vm.refreshUrl, dialogId);
   }
 
   function setDialogData(data) {
@@ -28,10 +28,9 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
   }
 
   function submitButtonClicked() {
-    var url = '/api/service_catalogs/' + serviceTemplateCatalogId + '/service_templates/' + serviceTemplateId;
-    vm.dialogData.action = 'order';
+    vm.dialogData.action = apiAction;
     miqService.sparkleOn();
-    API.post(url, vm.dialogData).then(function() {
+    API.post(apiSubmitEndpoint, vm.dialogData).then(function() {
       miqService.redirectBack(__('Service ordered successfully!'), 'info', '/miq_request?typ=service');
     }).catch(function(err) {
       miqService.sparkleOff();
@@ -42,7 +41,7 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
   }
 
   function cancelClicked(_event) {
-    miqService.miqAjaxButton('/catalog/explorer');
+    miqService.miqAjaxButton(cancelEndpoint);
   }
 
   function saveable() {

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -12,6 +12,7 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'miq.util',
   'kubernetesUI',
   'miqStaticAssets.dialogEditor',
+  'miqStaticAssets.dialogUser',
 ]);
 miqHttpInject(ManageIQ.angular.app);
 

--- a/app/assets/javascripts/services/dialog_field_refresh_service.js
+++ b/app/assets/javascripts/services/dialog_field_refresh_service.js
@@ -1,0 +1,17 @@
+ManageIQ.angular.app.service('dialogFieldRefreshService', ['miqService', function(miqService) {
+  this.refreshField = function(dialogData, dialogField, url, resourceId) {
+    var data = angular.toJson({
+      action: 'refresh_dialog_fields',
+      resource: {
+        dialog_fields: dialogData,
+        fields: dialogField,
+      },
+    });
+
+    return new Promise(function(resolve) {
+      miqService.jqueryRequest(url + resourceId, {data: data, dataType: 'json'}).then(function(response) {
+        resolve(response.result[dialogField]);
+      });
+    });
+  };
+}]);

--- a/app/assets/javascripts/services/dialog_field_refresh_service.js
+++ b/app/assets/javascripts/services/dialog_field_refresh_service.js
@@ -1,5 +1,8 @@
 ManageIQ.angular.app.service('dialogFieldRefreshService', ['miqService', function(miqService) {
+  this.areFieldsBeingRefreshed = false;
+
   this.refreshField = function(dialogData, dialogField, url, resourceId) {
+    this.areFieldsBeingRefreshed = true;
     var data = angular.toJson({
       action: 'refresh_dialog_fields',
       resource: {
@@ -11,7 +14,10 @@ ManageIQ.angular.app.service('dialogFieldRefreshService', ['miqService', functio
     return new Promise(function(resolve) {
       miqService.jqueryRequest(url + resourceId, {data: data, dataType: 'json'}).then(function(response) {
         resolve(response.result[dialogField]);
-      });
-    });
+        if ($.active < 1) {
+          this.areFieldsBeingRefreshed = false;
+        }
+      }.bind(this));
+    }.bind(this));
   };
 }]);

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -33,7 +33,7 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', 'API'
   };
 
   this.jqueryRequest = function(url, options) {
-    miqJqueryRequest(url, options);
+    return miqJqueryRequest(url, options);
   };
 
   this.sparkleOn = function() {

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -155,7 +155,7 @@ module ApplicationController::DialogRunner
     @in_a_form = true
     @changed = session[:changed] = true
     if @edit[:explorer]
-      replace_right_cell(:action => "dialog_provision")
+      replace_right_cell(:action => "dialog_provision", :dialog_locals => options[:dialog_locals])
     else
       javascript_redirect :action => 'dialog_load'
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -541,6 +541,11 @@ class CatalogController < ApplicationController
       options[:header] = @right_cell_text
       options[:target_id] = st.id
       options[:target_kls] = st.class.name
+      options[:dialog_locals] = {
+        :api_submit_endpoint => "/api/service_catalogs/#{st.service_template_catalog_id}/service_templates/#{st.id}",
+        :api_action          => "order",
+        :cancel_endpoint     => "/catalog/explorer"
+      }
       dialog_initialize(ra, options)
     else
       # if catalog item has no dialog and provision button was pressed from list view
@@ -1977,7 +1982,7 @@ class CatalogController < ApplicationController
       elsif action && ["st_catalog_new", "st_catalog_edit"].include?(action)
         r[:partial => "stcat_form"]
       elsif action == "dialog_provision"
-        r[:partial => "shared/dialogs/dialog_provision"]
+        r[:partial => "shared/dialogs/dialog_provision", :locals => options[:dialog_locals]]
       elsif %w(ot_add ot_copy ot_edit service_dialog_from_ot).include?(action)
         r[:partial => action]
       elsif record_showing
@@ -2050,7 +2055,7 @@ class CatalogController < ApplicationController
             }
           end
         end
-        unless Settings.product.new_dialog_user_ui && action_name == "svc_catalog_provision"
+        if Settings.product.old_dialog_user_ui || action_name != "svc_catalog_provision"
           presenter.update(
             :form_buttons_div,
             r[

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2050,7 +2050,18 @@ class CatalogController < ApplicationController
             }
           end
         end
-        presenter.update(:form_buttons_div, r[:partial => "layouts/x_dialog_buttons", :locals => {:action_url => "dialog_form_button_pressed", :record_id => @edit[:rec_id]}])
+        unless Settings.product.new_dialog_user_ui && action_name == "svc_catalog_provision"
+          presenter.update(
+            :form_buttons_div,
+            r[
+              :partial => "layouts/x_dialog_buttons",
+              :locals  => {
+                :action_url => "dialog_form_button_pressed",
+                :record_id  => @edit[:rec_id]
+              }
+            ]
+          )
+        end
       elsif %w(ot_edit ot_copy ot_add service_dialog_from_ot).include?(action)
         presenter.hide(:toolbar).show(:paging_div, :form_buttons_div).hide(:pc_div_1)
         locals = {:record_id  => @edit[:rec_id],

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -1,10 +1,7 @@
 - wf = @edit[:wf] if @edit && @edit[:wf]
 = render :partial => "layouts/flash_msg"
 
-- if Settings.product.new_dialog_user_ui && action_name == "svc_catalog_provision"
-  = render :partial => "shared/dialogs/dialog_user", :locals => {:wf => wf}
-
-- else
+- if Settings.product.old_dialog_user_ui || action_name != "svc_catalog_provision"
   :javascript
     dialogFieldRefresh.unbindAllPreviousListeners();
 
@@ -31,3 +28,6 @@
                             :record_id  => @edit[:rec_id]}
   :javascript
     miq_tabs_init('#dialog_tabs')
+
+- else
+  = render :partial => "shared/dialogs/dialog_user", :locals => {:wf => wf}

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -1,7 +1,7 @@
 - wf = @edit[:wf] if @edit && @edit[:wf]
 = render :partial => "layouts/flash_msg"
 
-- if Settings.product.new_dialog_user_ui
+- if Settings.product.new_dialog_user_ui && action_name == "svc_catalog_provision"
   = render :partial => "shared/dialogs/dialog_user", :locals => {:wf => wf}
 
 - else

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -1,29 +1,33 @@
 - wf = @edit[:wf] if @edit && @edit[:wf]
 = render :partial => "layouts/flash_msg"
 
-:javascript
-  dialogFieldRefresh.unbindAllPreviousListeners();
+- if Settings.product.new_dialog_user_ui
+  = render :partial => "shared/dialogs/dialog_user", :locals => {:wf => wf}
 
-.row
-  .col-md-12.col-lg-12
-    #dialog_tabs
-      - auto_refreshable_field_indicies = build_auto_refreshable_field_indicies(wf)
+- else
+  :javascript
+    dialogFieldRefresh.unbindAllPreviousListeners();
 
-      %ul.nav.nav-tabs
-        - wf.dialog.dialog_tabs.each do |tab|
-          = miq_tab_header(tab.id) do
-            = tab.label
-      .tab-content
-        - wf.dialog.dialog_tabs.each_with_index do |tab, tab_index|
-          = miq_tab_content(tab.id) do
-            - locals = {:wf                              => wf,
-                        :tab                             => tab,
-                        :tab_index                       => tab_index,
-                        :auto_refreshable_field_indicies => auto_refreshable_field_indicies}
-            = render :partial => "shared/dialogs/dialog_tab", :locals => locals
-  - if @edit && !@edit[:explorer] && @record.respond_to?(:buttons)
-    = render :partial => "layouts/x_dialog_buttons",
-             :locals  => {:action_url => 'dialog_form_button_pressed',
-                          :record_id  => @edit[:rec_id]}
-:javascript
-  miq_tabs_init('#dialog_tabs')
+  .row
+    .col-md-12.col-lg-12
+      #dialog_tabs
+        - auto_refreshable_field_indicies = build_auto_refreshable_field_indicies(wf)
+
+        %ul.nav.nav-tabs
+          - wf.dialog.dialog_tabs.each do |tab|
+            = miq_tab_header(tab.id) do
+              = tab.label
+        .tab-content
+          - wf.dialog.dialog_tabs.each_with_index do |tab, tab_index|
+            = miq_tab_content(tab.id) do
+              - locals = {:wf                              => wf,
+                          :tab                             => tab,
+                          :tab_index                       => tab_index,
+                          :auto_refreshable_field_indicies => auto_refreshable_field_indicies}
+              = render :partial => "shared/dialogs/dialog_tab", :locals => locals
+    - if @edit && !@edit[:explorer] && @record.respond_to?(:buttons)
+      = render :partial => "layouts/x_dialog_buttons",
+               :locals  => {:action_url => 'dialog_form_button_pressed',
+                            :record_id  => @edit[:rec_id]}
+  :javascript
+    miq_tabs_init('#dialog_tabs')

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -30,4 +30,8 @@
     miq_tabs_init('#dialog_tabs')
 
 - else
-  = render :partial => "shared/dialogs/dialog_user", :locals => {:wf => wf}
+  = render :partial => "shared/dialogs/dialog_user",
+    :locals => {:wf                  => wf,
+                :api_submit_endpoint => api_submit_endpoint,
+                :api_action          => api_action,
+                :cancel_endpoint     => cancel_endpoint}

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -1,0 +1,8 @@
+.row.wrapper{"ng-controller" => "dialogUserController as vm"}
+  .col-md-12.col-lg-12{'ng-if' => 'vm.dialog'}
+    %dialog-user{"dialog" =>"vm.dialog", "refresh-field" => "vm.refreshField(field)", "on-update" => "vm.setDialogData(data)"}
+
+:javascript
+  ManageIQ.angular.app.value('serviceTemplateId', '#{wf.target.compressed_id}');
+  ManageIQ.angular.app.value('serviceTemplateCatalogId', '#{wf.target.service_template_catalog.compressed_id}');
+  miq_bootstrap('.wrapper');

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -17,6 +17,8 @@
                 'on-click' => "vm.cancelClicked($event)"}
 
 :javascript
-  ManageIQ.angular.app.value('serviceTemplateId', '#{wf.target.id}');
-  ManageIQ.angular.app.value('serviceTemplateCatalogId', '#{wf.target.service_template_catalog.id}');
+  ManageIQ.angular.app.value('dialogId', '#{wf.dialog.id}');
+  ManageIQ.angular.app.value('apiSubmitEndpoint', '#{api_submit_endpoint}');
+  ManageIQ.angular.app.value('apiAction', '#{api_action}');
+  ManageIQ.angular.app.value('cancelEndpoint', '#{cancel_endpoint}');
   miq_bootstrap('.wrapper');

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -2,6 +2,20 @@
   .col-md-12.col-lg-12{'ng-if' => 'vm.dialog'}
     %dialog-user{"dialog" =>"vm.dialog", "refresh-field" => "vm.refreshField(field)", "on-update" => "vm.setDialogData(data)"}
 
+  .clearfix
+  .pull-right.button-group
+    %miq-button{:name      => t = _("Submit"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => 'vm.saveable()',
+                'on-click' => "vm.submitButtonClicked()",
+                :primary   => 'true'}
+    %miq-button{:name      => t = _("Cancel"),
+                :title     => t,
+                :alt       => t,
+                :enabled   => 'true',
+                'on-click' => "vm.cancelClicked($event)"}
+
 :javascript
   ManageIQ.angular.app.value('serviceTemplateId', '#{wf.target.id}');
   ManageIQ.angular.app.value('serviceTemplateCatalogId', '#{wf.target.service_template_catalog.id}');

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -3,6 +3,6 @@
     %dialog-user{"dialog" =>"vm.dialog", "refresh-field" => "vm.refreshField(field)", "on-update" => "vm.setDialogData(data)"}
 
 :javascript
-  ManageIQ.angular.app.value('serviceTemplateId', '#{wf.target.compressed_id}');
-  ManageIQ.angular.app.value('serviceTemplateCatalogId', '#{wf.target.service_template_catalog.compressed_id}');
+  ManageIQ.angular.app.value('serviceTemplateId', '#{wf.target.id}');
+  ManageIQ.angular.app.value('serviceTemplateCatalogId', '#{wf.target.service_template_catalog.id}');
   miq_bootstrap('.wrapper');

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -1,5 +1,5 @@
 describe('dialogUserController', function() {
-  var $controller, API, dialogFieldRefreshService, miqService, serviceTemplateId, serviceTemplateCatalogId;
+  var $controller, API, dialogFieldRefreshService, miqService;
 
   beforeEach(module('ManageIQ'));
 
@@ -8,11 +8,7 @@ describe('dialogUserController', function() {
     dialogFieldRefreshService = _dialogFieldRefreshService_;
     miqService = _miqService_;
 
-    var responseResult = {
-      resources: [{
-        content: ['the dialog']
-      }]
-    };
+    var responseResult = {content: ['the dialog']};
 
     spyOn(API, 'get').and.callFake(function() {
       return {then: function(response) { response(responseResult); }};
@@ -28,8 +24,10 @@ describe('dialogUserController', function() {
       API: API,
       dialogFieldRefreshService: dialogFieldRefreshService,
       miqService: miqService,
-      serviceTemplateId: '123',
-      serviceTemplateCatalogId: '321'
+      dialogId: '1234',
+      apiSubmitEndpoint: 'submit endpoint',
+      apiAction: 'order',
+      cancelEndpoint: 'cancel endpoint',
     });
   }));
 
@@ -39,7 +37,7 @@ describe('dialogUserController', function() {
     });
 
     it('requests the current dialog based on the service template', function() {
-      expect(API.get).toHaveBeenCalledWith('/api/service_templates/123/service_dialogs?expand=resources&attributes=content');
+      expect(API.get).toHaveBeenCalledWith('/api/service_dialogs/1234', {expand: 'resources', attributes: 'content'});
     });
 
     it('resolves the request and stores the information in the dialog property', function() {
@@ -47,7 +45,7 @@ describe('dialogUserController', function() {
     });
 
     it('sets the refreshUrl', function() {
-      expect($controller.refreshUrl).toEqual('/api/service_catalogs/321/service_templates/');
+      expect($controller.refreshUrl).toEqual('/api/service_dialogs/');
     });
   });
 
@@ -59,8 +57,8 @@ describe('dialogUserController', function() {
       expect(dialogFieldRefreshService.refreshField).toHaveBeenCalledWith(
         'dialogData',
         ['dialogName'],
-        '/api/service_catalogs/321/service_templates/',
-        '123'
+        '/api/service_dialogs/',
+        '1234'
       );
     });
   });
@@ -98,7 +96,7 @@ describe('dialogUserController', function() {
         $controller.submitButtonClicked();
 
         setTimeout(function() {
-          expect(API.post).toHaveBeenCalledWith('/api/service_catalogs/321/service_templates/123', {
+          expect(API.post).toHaveBeenCalledWith('submit endpoint', {
             action: 'order',
             field1: 'field1'
           });
@@ -143,7 +141,7 @@ describe('dialogUserController', function() {
   describe('cancelClicked', function() {
     it('uses the miqService to make a call to catalog/explorer', function() {
       $controller.cancelClicked('event');
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/catalog/explorer');
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('cancel endpoint');
     });
   });
 

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -1,0 +1,70 @@
+describe('dialogUserController', function() {
+  var $controller, API, dialogFieldRefreshService, serviceTemplateId, serviceTemplateCatalogId;
+
+  beforeEach(module('ManageIQ'));
+
+  beforeEach(inject(function(_$controller_, _API_, _dialogFieldRefreshService_) {
+    API = _API_;
+    dialogFieldRefreshService = _dialogFieldRefreshService_;
+
+    var responseResult = {
+      resources: [{
+        content: ['the dialog']
+      }]
+    };
+
+    spyOn(API, 'get').and.callFake(function() {
+      return {then: function(response) { response(responseResult); }};
+    });
+    spyOn(dialogFieldRefreshService, 'refreshField');
+
+    $controller = _$controller_('dialogUserController', {
+      API: API,
+      dialogFieldRefreshService: dialogFieldRefreshService,
+      serviceTemplateId: '123',
+      serviceTemplateCatalogId: '321'
+    });
+  }));
+
+  describe('$onInit', function() {
+    beforeEach(function() {
+      $controller.$onInit();
+    });
+
+    it('requests the current dialog based on the service template', function() {
+      expect(API.get).toHaveBeenCalledWith('/api/service_templates/123/service_dialogs?expand=resources&attributes=content');
+    });
+
+    it('resolves the request and stores the information in the dialog property', function() {
+      expect($controller.dialog).toEqual('the dialog');
+    });
+
+    it('sets the refreshUrl', function() {
+      expect($controller.refreshUrl).toEqual('/api/service_catalogs/321/service_templates/');
+    });
+  });
+
+  describe('refreshField', function() {
+    it('delegates to the dialogFieldRefreshService', function() {
+      $controller.dialogData = 'dialogData';
+
+      $controller.refreshField({name: 'dialogName'});
+      expect(dialogFieldRefreshService.refreshField).toHaveBeenCalledWith(
+        'dialogData',
+        ['dialogName'],
+        '/api/service_catalogs/321/service_templates/',
+        '123'
+      );
+    });
+  });
+
+  describe('setDialogData', function() {
+    it('sets the data attribute of the data passed in to dialogData', function() {
+      expect($controller.dialogData).toEqual(undefined);
+
+      $controller.setDialogData({data: 'newData'});
+
+      expect($controller.dialogData).toEqual('newData');
+    });
+  });
+});

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -1,11 +1,12 @@
 describe('dialogUserController', function() {
-  var $controller, API, dialogFieldRefreshService, serviceTemplateId, serviceTemplateCatalogId;
+  var $controller, API, dialogFieldRefreshService, miqService, serviceTemplateId, serviceTemplateCatalogId;
 
   beforeEach(module('ManageIQ'));
 
-  beforeEach(inject(function(_$controller_, _API_, _dialogFieldRefreshService_) {
+  beforeEach(inject(function(_$controller_, _API_, _dialogFieldRefreshService_, _miqService_) {
     API = _API_;
     dialogFieldRefreshService = _dialogFieldRefreshService_;
+    miqService = _miqService_;
 
     var responseResult = {
       resources: [{
@@ -16,11 +17,17 @@ describe('dialogUserController', function() {
     spyOn(API, 'get').and.callFake(function() {
       return {then: function(response) { response(responseResult); }};
     });
+
     spyOn(dialogFieldRefreshService, 'refreshField');
+    spyOn(miqService, 'miqAjaxButton');
+    spyOn(miqService, 'redirectBack');
+    spyOn(miqService, 'sparkleOn');
+    spyOn(miqService, 'sparkleOff');
 
     $controller = _$controller_('dialogUserController', {
       API: API,
       dialogFieldRefreshService: dialogFieldRefreshService,
+      miqService: miqService,
       serviceTemplateId: '123',
       serviceTemplateCatalogId: '321'
     });
@@ -65,6 +72,100 @@ describe('dialogUserController', function() {
       $controller.setDialogData({data: 'newData'});
 
       expect($controller.dialogData).toEqual('newData');
+    });
+  });
+
+  describe('submitButtonClicked', function() {
+    beforeEach(function() {
+      $controller.setDialogData({data: {field1: 'field1'}});
+    });
+
+    context('when the API call succeeds', function() {
+      beforeEach(function() {
+        spyOn(API, 'post').and.returnValue(Promise.resolve('awesome'));
+      });
+
+      it('starts the sparkle', function(done) {
+        $controller.submitButtonClicked();
+
+        setTimeout(function() {
+          expect(miqService.sparkleOn).toHaveBeenCalled();
+          done();
+        });
+      });
+
+      it('posts to the API using the correct url and data', function(done) {
+        $controller.submitButtonClicked();
+
+        setTimeout(function() {
+          expect(API.post).toHaveBeenCalledWith('/api/service_catalogs/321/service_templates/123', {
+            action: 'order',
+            field1: 'field1'
+          });
+          done();
+        });
+      });
+
+      it('redirects to the miq_request screen', function(done) {
+        $controller.submitButtonClicked();
+        setTimeout(function() {
+          expect(miqService.redirectBack).toHaveBeenCalledWith('Service ordered successfully!', 'info', '/miq_request?typ=service');
+          done();
+        });
+      });
+    });
+
+    context('when the API call fails', function() {
+      beforeEach(function() {
+        spyOn(API, 'post').and.returnValue(Promise.reject('not awesome'));
+        spyOn(window, 'add_flash');
+      });
+
+      it('turns off the sparkle', function(done) {
+        $controller.submitButtonClicked();
+        setTimeout(function() {
+          expect(miqService.sparkleOff).toHaveBeenCalled();
+          done();
+        });
+      });
+
+      it('adds a flash message', function(done) {
+        $controller.submitButtonClicked();
+
+        setTimeout(function() {
+          expect(window.add_flash).toHaveBeenCalledWith('Error requesting data from server', 'error');
+          done();
+        });
+      });
+    });
+  });
+
+  describe('cancelClicked', function() {
+    it('uses the miqService to make a call to catalog/explorer', function() {
+      $controller.cancelClicked('event');
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/catalog/explorer');
+    });
+  });
+
+  describe('saveable', function() {
+    context('when fields are being refreshed', function() {
+      beforeEach(function() {
+        dialogFieldRefreshService.areFieldsBeingRefreshed = true;
+      });
+
+      it('returns false', function() {
+        expect($controller.saveable()).toBe(false);
+      });
+    });
+
+    context('when fields are not being refrshed', function() {
+      beforeEach(function() {
+        dialogFieldRefreshService.areFieldsBeingRefreshed = false;
+      });
+
+      it('returns true', function() {
+        expect($controller.saveable()).toBe(true);
+      });
     });
   });
 });

--- a/spec/javascripts/services/dialog_field_refresh_service_spec.js
+++ b/spec/javascripts/services/dialog_field_refresh_service_spec.js
@@ -1,0 +1,62 @@
+describe('dialogFieldRefreshService', function() {
+  var testDialogFieldRefreshService, miqService;
+
+  beforeEach(module('ManageIQ'));
+
+  beforeEach(inject(function(dialogFieldRefreshService, _miqService_) {
+    testDialogFieldRefreshService = dialogFieldRefreshService;
+    miqService = _miqService_;
+
+    var responseResult = {
+      result: {
+        'the field': 'the results'
+      }
+    };
+
+    spyOn(miqService, 'jqueryRequest').and.callFake(function() {
+      return {then: function(response) { response(responseResult); }};
+    });
+  }));
+
+  describe('#refreshField', function() {
+    var data = 'the data';
+    var field = 'the field';
+    var url = 'url';
+    var resourceId = '123';
+
+    var refreshPromise;
+    var resolvedValue;
+
+    beforeEach(function(done) {
+      refreshPromise = testDialogFieldRefreshService.refreshField(data, field, url, resourceId);
+
+      refreshPromise.then(function(value) {
+        resolvedValue = value;
+        done();
+      });
+    });
+
+    it('returns a promise', function() {
+      expect(refreshPromise instanceof Promise).toBe(true);
+    });
+
+    it('uses a jqueryRequest', function() {
+      var requestData = {
+        action: 'refresh_dialog_fields',
+        resource: {
+          dialog_fields: 'the data',
+          fields: 'the field'
+        }
+      };
+
+      expect(miqService.jqueryRequest).toHaveBeenCalledWith('url123', {
+        data: JSON.stringify(requestData),
+        dataType: 'json'
+      });
+    });
+
+    it('resolves the promise with the results', function() {
+      expect(resolvedValue).toEqual('the results');
+    });
+  });
+});


### PR DESCRIPTION
This will finally let us get away from storing the dialog objects in the session when doing anything related to running them, and puts all of the logic into the javascript from the ui-components to handle things like auto-refreshes.

~~It will also need [this small PR](https://github.com/ManageIQ/manageiq/pull/15916) from the main repo in order to access the `.target` attribute on the `ResourceActionWorkflow` in the view.~~

https://www.pivotaltracker.com/story/show/150645792

@himdel Please review and/or tag others for review as well.
/cc @gmcculloug 

Note that in order to use this feature, the `product:new_dialog_user_ui` setting must be `true` in the advanced configuration.