### PR TITLE
[WIP] Fix widget maximize operation by checking other condition in addition to linked MiqGroup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -578,7 +578,12 @@ class ApplicationController < ActionController::Base
     end
     # Dashboard widget will send in report result id else, find report result in the sandbox
     search_id = params[:rr_id] ? params[:rr_id].to_i : @sb[:pages][:rr_id]
-    rr = MiqReportResult.for_user(current_user).find(search_id)
+    rr = MiqReportResult.find(search_id)
+    unless rr.available_to_user?(current_user)
+      add_flash(_("Current user does not permission to view report data id: #{search_id}"), :error)
+      render :partial => "layouts/flash_msg"
+      return
+    end
 
     session[:report_result_id] = rr.id  # Save report result id for chart rendering
     session[:rpt_task_id]      = nil    # Clear out report task id, using a saved report

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -332,7 +332,7 @@ class ApplicationController < ActionController::Base
       rpt.generate_table(:userid => session[:userid])
     else
       rpt = if session[:report_result_id]
-              MiqReportResult.for_user(current_user).find(session[:report_result_id]).report_results
+              MiqReportResult.find(session[:report_result_id]).report_results
             elsif session[:rpt_task_id].present?
               MiqTask.find(session[:rpt_task_id]).task_results
             else

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -30,7 +30,7 @@ module ApplicationController::ReportDownloads
     # Use rr frorm paging, if present
     rr ||= MiqReportResult.for_user(current_user).find(@sb[:pages][:rr_id]) if @sb[:pages]
     # Use report_result_id in session, if present
-    rr ||= MiqReportResult.for_user(current_user).find(session[:report_result_id]) if session[:report_result_id]
+    rr ||= MiqReportResult.find(session[:report_result_id]) if session[:report_result_id]
 
     filename = filename_timestamp(rr.report.title)
     disable_client_cache
@@ -51,7 +51,7 @@ module ApplicationController::ReportDownloads
     unless params[:task_id] # First time thru, kick off the report generate task
       if render_type
         @sb[:render_type] = render_type
-        rr = MiqReportResult.for_user(current_user).find(session[:report_result_id]) # Get report task id from the session
+        rr = MiqReportResult.find(session[:report_result_id]) # Get report task id from the session
         task_id = rr.async_generate_result(@sb[:render_type], :userid     => session[:userid],
                                                               :session_id => request.session_options[:id])
         initiate_wait_for_task(:task_id => task_id)
@@ -134,7 +134,7 @@ module ApplicationController::ReportDownloads
       miq_task = MiqTask.find(session[:rpt_task_id])
       miq_task.task_results
     elsif session[:report_result_id]
-      rr = MiqReportResult.for_user(current_user).find(session[:report_result_id])
+      rr = MiqReportResult.find(session[:report_result_id])
       report = rr.report_results
       report.report_run_time = rr.last_run_on
       report


### PR DESCRIPTION
This PR is follow-up to ManageIQ/manageiq-ui-classic#1627, ManageIQ/manageiq-ui-classic#1827

blocked by:
- [ ] https://github.com/ManageIQ/manageiq/pull/15920 -added `MiqReportResult#available_to_user?`

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1492174

**Issue**: `Full Screen`, `PDF Download`, and `Zoom in` operations on widget in Dashboard throw error. Reason for error - miq_group_id column which driving access in `MiqReportResult.for_user(user)` was not set 

**Solution**:  Check other access rules in addition to linked group

**Before:** 
![before](https://user-images.githubusercontent.com/6556758/30446040-01718ae8-9956-11e7-86f8-8e2ae19be02d.gif)

**After:**
![after](https://user-images.githubusercontent.com/6556758/30446055-0a5c5a0c-9956-11e7-822d-9c5ce492167f.gif)

\cc @gtanzillo 