### PR TITLE
Added lines of code that set label for legend/data points

### DIFF
--- a/lib/report_formatter/chart_common.rb
+++ b/lib/report_formatter/chart_common.rb
@@ -439,6 +439,7 @@ module ReportFormatter
       selected_groups = sorted_sums.reverse.take(keep)
 
       cathegory_texts = selected_groups.collect do |key, _|
+        label = key
         label = _('no value') if label.blank?
         label
       end
@@ -466,7 +467,7 @@ module ReportFormatter
 
         series.push(:value   => other[val2],
                     :tooltip => "Other / #{val2}: #{other[val2]}") if show_other
-
+        label = val2 if val2.kind_of?(String)
         label = label.to_s.gsub(/\\/, ' \ ')
         label = _('no value') if label.blank?
         add_series(label, series)


### PR DESCRIPTION
This code was initially added in https://github.com/h-kataria/manageiq/commit/571509efba2abc147d5b199f81bf5af68ef3f0ce#diff-1b496ab3b832aea7df191c3838c63414R465 and https://github.com/h-kataria/manageiq/commit/571509efba2abc147d5b199f81bf5af68ef3f0ce#diff-1b496ab3b832aea7df191c3838c63414R498 but was removed somehow. Adding missing lines of code back

https://bugzilla.redhat.com/show_bug.cgi?id=1487397

@martinpovolny please review/test. 

before:
![before_fix](https://user-images.githubusercontent.com/3450808/29947321-f2c874e6-8e76-11e7-921a-aa42659be61f.png)

after:
![after](https://user-images.githubusercontent.com/3450808/29947285-d2c5feca-8e76-11e7-9a86-6d5df0395b40.png)

Reports used to recreate the issue
[Reports_20170829_130449.zip](https://github.com/ManageIQ/manageiq-ui-classic/files/1268635/Reports_20170829_130449.zip)

