### PR TITLE
Dupe message when trying to Remove Default Chargeback Rate

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -209,7 +209,6 @@ class ChargebackController < ApplicationController
         render_flash(_("No %{records} were selected for deletion") %
           {:records => ui_lookup(:models => "ChargebackRate")}, :error)
       end
-      process_cb_rates(rates, "destroy")  unless rates.empty?
     else # showing 1 rate, delete it
       cb_rate = ChargebackRate.find_by_id(params[:id])
       if cb_rate.nil?


### PR DESCRIPTION
UI displays duplicate message when attempting to remove Default Chargeback Rate from the list.

https://bugzilla.redhat.com/show_bug.cgi?id=1486651

Screen shot prior to code fix:
![delete default chargeback rate 2 messages prior to fix](https://user-images.githubusercontent.com/552686/29949012-d4bc59a0-8e66-11e7-99f6-c2076eb41e1a.png)

===========================
Screen shot post code fix:

![delete default chargeback rate 1 message post fix](https://user-images.githubusercontent.com/552686/29949026-e4806a52-8e66-11e7-99a3-4d467ecfae91.png)


