### PR TITLE
Hide the form_buttons_div when not required on CustomButtons screen

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -330,7 +330,7 @@ class MiqAeCustomizationController < ApplicationController
       end
       presenter.show(:paging_div)
     else
-      presenter.hide(:paging_div)
+      presenter.hide(:paging_div).hide(:form_buttons_div)
     end
   end
 


### PR DESCRIPTION
We split up the paging bar and the bottom form buttons into separate divs, so we need to hide them separately. This place was probably missed when we were doing the split.

**Before:**
![screenshot from 2017-09-01 09-51-55](https://user-images.githubusercontent.com/649130/29960291-5e776d08-8efb-11e7-90d7-eef8f9028995.png)

**After:**
![screenshot from 2017-09-01 09-51-24](https://user-images.githubusercontent.com/649130/29960299-63f8a102-8efb-11e7-8e76-318bb72499bf.png)

**Steps to reproduce:**
* Automation -> Automate -> Customization -> Custom Buttons
* Add a new button to an existing button group
* Cancel or save the button

https://bugzilla.redhat.com/show_bug.cgi?id=1486677