### PR TITLE
Fix miqTreeObject to work again with non-angularized trees

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -1,7 +1,14 @@
 /* global DoNav miqClearTreeState miqDomElementExists miqJqueryRequest miqSetButtons miqSparkle */
 
 function miqTreeObject(tree) {
-  return $('miq-tree-view[name="' + tree + '"] > .treeview').treeview(true);
+  var obj;
+  try {
+    obj = $('#' + tree + 'box').treeview(true);
+  } catch (_ex) {
+    obj = $('miq-tree-view[name="' + tree + '"] > .treeview').treeview(true);
+  } finally {
+    return obj;
+  }
 }
 
 function miqTreeFindNodeByKey(tree, key) {


### PR DESCRIPTION
The angularization of explorer trees in #1989 caused the `miqTreeObject` to stop working for all non-explorer trees. This try-catch block fixes the issue and makes them work again.