### PR TITLE
Fix bad use of constant in planning

### DIFF
--- a/app/views/planning/_planning_options.html.haml
+++ b/app/views/planning/_planning_options.html.haml
@@ -269,7 +269,7 @@
         = _('Trends for past')
       .col-md-8
         = select_tag("trend_days",
-                      options_for_select(PlanningHelper::WEEK_CHOICES.invert.sort_by(&:last), @sb[:options][:days].to_i),
+                      options_for_select(ViewHelper::WEEK_CHOICES.invert.sort_by(&:last), @sb[:options][:days].to_i),
                       "class"                => "selectpicker",
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true)

--- a/app/views/planning/_planning_options.html.haml
+++ b/app/views/planning/_planning_options.html.haml
@@ -181,7 +181,7 @@
       %label.control-label.col-md-4
         = _('Show')
       .col-md-8
-        - options = TARGET_TYPE_CHOICES.map { |k, v| [_(v), k] }.sort_by(&:last)
+        - options = PlanningHelper::TARGET_TYPE_CHOICES.map { |k, v| [_(v), k] }.sort_by(&:last)
         = select_tag("target_typ",
                       options_for_select(options, @sb[:options][:target_typ]),
                       "class"                => "selectpicker",

--- a/app/views/planning/_planning_vm_profile.html.haml
+++ b/app/views/planning/_planning_vm_profile.html.haml
@@ -30,7 +30,7 @@
 %dl.dl-horizontal
   %dt= _('Show')
   %dd
-    = h(_(TARGET_TYPE_CHOICES[@sb[:options][:target_typ]]))
+    = h(_(PlanningHelper::TARGET_TYPE_CHOICES[@sb[:options][:target_typ]]))
 
   - if @sb[:vm_opts][:cpu] && @sb[:options][:trend_cpu] && @sb[:rpt].extras[:vm_profile][:cpu]
     %dt= _('CPU Speed')


### PR DESCRIPTION
TARGET_TYPE_CHOICES and WEEK_CHOICES are badly used.

Before;
![screencapture-localhost-3000-planning-1504256118461](https://user-images.githubusercontent.com/9535558/29962798-16102796-8f0d-11e7-9eef-cee93862625a.png)

After:
![Uploading screencapture-localhost-3000-planning-1504256646970.png…]()
