### PR TITLE
Dialog editor - don't show error modal when validation failed

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -93,11 +93,12 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
       dialogId = '/' + DialogEditor.getDialogId();
     }
 
-    API.post(
-      '/api/service_dialogs'
-      + dialogId,
-      {action: action, resource: dialogData}
-    ).then(saveSuccess, saveFailure);
+    API.post('/api/service_dialogs' + dialogId, {
+      action: action,
+      resource: dialogData,
+    }, { // options - don't show the error modal on validation errors
+      skipErrors: [400],
+    }).then(saveSuccess, saveFailure);
   }
 
   function dismissChanges() {

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -109,10 +109,10 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
     getBack(vm.dialog.content[0].label + __(' was saved'), false, false);
   }
 
-  function saveFailure() {
+  function saveFailure(response) {
     miqService.miqFlash(
       'error',
-      __('There was an error editing this dialog: ') + arguments[0].error.message
+      __('There was an error editing this dialog: ') + response.data.error.message
     );
   }
 

--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -21,50 +21,31 @@
   function API() {
   }
 
-  API.get = function(url, options) {
-    return fetch(url, _.extend({
-      method: 'GET',
-    }, process_options(options)))
-    .then(responseAndError(options));
+  var urlOnly = function(method) {
+    return function(url, options) {
+      return fetch(url, _.extend({
+        method: method,
+      }, process_options(options)))
+      .then(responseAndError(options));
+    };
   };
 
-  API.options = function(url, options) {
-    return fetch(url, _.extend({
-      method: 'OPTIONS',
-    }, process_options(options)))
-    .then(responseAndError(options));
+  var withData = function(method) {
+    return function(url, data, options) {
+      return fetch(url, _.extend({
+        method: method,
+        body: process_data(data),
+      }, process_options(options)))
+      .then(responseAndError(options));
+    };
   };
 
-  API.post = function(url, data, options) {
-    return fetch(url, _.extend({
-      method: 'POST',
-      body: process_data(data),
-    }, process_options(options)))
-    .then(responseAndError(options));
-  };
-
-  API.delete = function(url, options) {
-    return fetch(url, _.extend({
-      method: 'DELETE',
-    }, process_options(options)))
-    .then(responseAndError(options));
-  };
-
-  API.put = function(url, data, options) {
-    return fetch(url, _.extend({
-      method: 'PUT',
-      body: process_data(data),
-    }, process_options(options)))
-    .then(responseAndError(options));
-  };
-
-  API.patch = function(url, data, options) {
-    return fetch(url, _.extend({
-      method: 'PATCH',
-      body: process_data(data),
-    }, process_options(options)))
-    .then(responseAndError(options));
-  };
+  API.delete = urlOnly('DELETE');
+  API.get = urlOnly('GET');
+  API.options = urlOnly('OPTIONS');
+  API.patch = withData('PATCH');
+  API.post = withData('POST');
+  API.put = withData('PUT');
 
   var base64encode = window.btoa; // browser api
 


### PR DESCRIPTION
In https://github.com/ManageIQ/manageiq-ui-classic/pull/1976, we enabled the error modal for API use.

This is one of the places where an error from the API was already being handled by the code, and should not have an error modal.

https://bugzilla.redhat.com/show_bug.cgi?id=1486688

---

This also changes the API error modal opt-out mechanism:


before:

`API.get('/foo')` - shows error modal on any 4** and 5** response
~~`API.get.noErrorModal('/foo')` - never shows error modal~~

now:

`API.get('/foo')` - shows error modal on any 4** and 5** response
`API.get('/foo', { skipErrors: true })` - never shows error modal
`API.get('/foo', { skipErrors: [400, 404] })` - show error modal an all 4** and 5**, except for 400 and 404

(for methods taking data (put, post), options is the third argument)