### PR TITLE
Support oVirt network provider

### DIFF
--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -607,9 +607,15 @@ describe EmsInfraController do
     before do
       allow(controller).to receive(:check_privileges).and_return(true)
       allow(controller).to receive(:assert_privileges).and_return(true)
-      login_as FactoryGirl.create(:user, :features => "ems_infra_new")
+      ems = FactoryGirl.build(:user, :features => "ems_infra_new")
+      login_as ems
       allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager)
         .to receive(:supported_api_versions).and_return([3, 4])
+      ovirt_service = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4
+      allow_any_instance_of(ovirt_service)
+        .to receive(:collect_external_network_providers).and_return([])
+      ems.save
+
     end
 
     render_views


### PR DESCRIPTION
The PR includes- 
- Adding ovirt's 'network manager' to the 'cloud network' 'provider choices'
- Adding ovirt's 'network manager' to the 'cloud subnet' 'provider choices'
- Icon to oVirt's network manager
- Tests for Redhat network provider