### PR TITLE
In summary endpoints, use endpoint's name instead of role

### DIFF
--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -107,11 +107,36 @@ module EmsContainerHelper::TextualSummary
     endpoints = @record.endpoints.where.not(:role => 'default')
     return if endpoints.nil?
 
+    endpoints_types = {
+      :hawkular          => {
+        :name => _("Metrics"),
+        :type => _("Hakular"),
+      },
+      :prometheus        => {
+        :name => _("Metrics"),
+        :type => _("prometheus"),
+      },
+      :prometheus_alerts => {
+        :name => _("Alerts"),
+        :type => _("prometheus"),
+      }
+    }
+
     endpoint_groups = endpoints.map do |e|
-      [
-        {:label => _("%{role} Host Name") % {:role => e.role.capitalize}, :value => e.hostname},
-        {:label => _("%{role} API Port") % {:role => e.role.capitalize}, :value => e.port}
-      ]
+      type = endpoints_types[e.role.to_sym]
+
+      if type
+        [
+          {:label => _("%{name} Host Name") % {:name => type[:name]}, :value => e.hostname},
+          {:label => _("%{name} API Port") % {:name => type[:name]}, :value => e.port},
+          {:label => _("%{name} Type") % {:name => type[:name]}, :value => type[:type]}
+        ]
+      else
+        [
+          {:label => _("%{name} Host Name") % {:name => e.role.capitalize}, :value => e.hostname},
+          {:label => _("%{name} API Port") % {:name => e.role.capitalize}, :value => e.port}
+        ]
+      end
     end
 
     TextualGroup.new(_("Endpoints"), endpoint_groups.flatten)


### PR DESCRIPTION
**Description**

In providers summary page, rename endpoints by what they do and not my their internal role name in the data base.

For example:

|  before  | after |
|-----------|--------|
| Prometheus Host Name | Metrics Host Name [ with type "Prometheus" ]  |
| Prometheus_alerts Host Name | Alerts Host Name  [ with type "Prometheus" ]  |
| Hawkular Host Name | Metrics Host Name  [ with type "Hawkular" ]  |

**Screenshots**

After:
![screenshot-5b7fd941-f833-4da3-bedb-5e20f2fd793d-2017-09-03-15-01-45](https://user-images.githubusercontent.com/2181522/30002706-0dec1b9e-90b9-11e7-844c-57f3e4db767a.png)

Before:
![screenshot-5b7fd941-f833-4da3-bedb-5e20f2fd793d-2017-09-03-15-01-35](https://user-images.githubusercontent.com/2181522/30002705-0deb7dc4-90b9-11e7-99e0-83a42b8c4f3e.png)
