### PR TITLE
Remove CHAREGEBACK_ALLOCATED_METHODS from UiConstants

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -23,6 +23,11 @@ module ReportController::Reports::Editor
 
   MAX_REPORT_COLUMNS = 100 # Default maximum number of columns in a report
 
+  CHAREGEBACK_ALLOCATED_METHODS = {
+    :max => N_('Maximum'),
+    :avg => N_('Average')
+  }.freeze
+
   def chargeback_allocated_methods
     Hash[CHAREGEBACK_ALLOCATED_METHODS.map { |x| _(x) }]
   end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -112,9 +112,6 @@ module UiConstants
   UTF_16BE_BOM = [254, 255].freeze
   UTF_16LE_BOM = [255, 254].freeze
 
-  CHAREGEBACK_ALLOCATED_METHODS = {}
-  CHAREGEBACK_ALLOCATED_METHODS[:max] = N_('Maximum')
-  CHAREGEBACK_ALLOCATED_METHODS[:avg] = N_('Average')
 end
 
 # Make these constants globally available


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `CHAREGEBACK_ALLOCATED_METHODS` was removed from `UiConstants`. It was moved to `ReportController::Reports::Editor`.

`Cloud Intel` -> `Reports`