### PR TITLE
Remove ASSIGN_TOS from UiConstants

### DIFF
--- a/app/helpers/term_of_service_helper.rb
+++ b/app/helpers/term_of_service_helper.rb
@@ -1,0 +1,54 @@
+module TermOfServiceHelper
+  ASSIGN_TOS = {
+    # This set of assignments was created for miq_alerts
+    "ExtManagementSystem" => {
+      "enterprise"                 => N_("The Enterprise"),
+      "ext_management_system"      => N_("Selected Providers"),
+      "ext_management_system-tags" => N_("Tagged Providers"),
+      "EmsCluster" => {
+        "ems_cluster"      => N_("Selected Cluster / Deployment Roles"),
+        "ems_cluster-tags" => N_("Tagged Cluster / Deployment Roles"),
+        "Host" => {
+          "host"      => N_("Selected Host / Nodes"),
+          "host-tags" => N_("Tagged Host / Nodes"),
+          "Vm" => {
+            "ems_folder"         => N_("Selected Folders"),
+            "resource_pool"      => N_("Selected Resource Pools"),
+            "resource_pool-tags" => N_("Tagged Resource Pools"),
+            "vm-tags"            => N_("Tagged VMs and Instances")
+          }
+        }
+      }
+    },
+    "Storage" => {
+      "enterprise"   => N_("The Enterprise"),
+      "storage"      => N_("Selected Datastores"),
+      "storage-tags" => N_("Tagged Datastores"),
+      "tenant"       => N_("Tenants")
+    },
+    "MiqServer" => {
+      "miq_server" => N_("Selected Servers"),
+    },
+    "MiddlewareServer"    => {
+      "enterprise"        => N_("The Enterprise"),
+      "middleware_server" => N_("Selected Middleware Servers")
+    },
+    "ContainerNode" => {
+      "enterprise" => N_("The Enterprise"),
+    },
+    # This set of assignments was created for chargeback_rates
+    :chargeback_compute => {
+      "enterprise"             => N_("The Enterprise"),
+      "ext_management_system"  => N_("Selected Providers"),
+      "ems_cluster"            => N_("Selected Cluster / Deployment Roles"),
+      "ems_container"          => N_("Selected Containers Providers"),
+      "vm-tags"                => N_("Tagged VMs and Instances"),
+      "container_image-tags"   => N_("Tagged Container Images"),
+      "container_image-labels" => N_("Labeled Container Images"),
+      "tenant"                 => N_("Tenants")
+    }
+  }
+
+  ASSIGN_TOS[:chargeback_storage] = ASSIGN_TOS["Storage"]
+  ASSIGN_TOS.freeze
+end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -9,60 +9,6 @@ module UiConstants
   # Following line does not include timezones with partial hour offsets
   # ALL_TIMEZONES = ActiveSupport::TimeZone.all.collect{|tz| tz.utc_offset % 3600 == 0 ? ["(GMT#{tz.formatted_offset}) #{tz.name}",tz.name] : nil}.compact
 
-  # Assignment choices
-  ASSIGN_TOS = {}
-
-  # This set of assignments was created for miq_alerts
-  ASSIGN_TOS["ExtManagementSystem"] = {
-    "enterprise"                 => N_("The Enterprise"),
-    "ext_management_system"      => N_("Selected Providers"),
-    "ext_management_system-tags" => N_("Tagged Providers")
-  }
-  ASSIGN_TOS["EmsCluster"] = {
-    "ems_cluster"      => N_("Selected Cluster / Deployment Roles"),
-    "ems_cluster-tags" => N_("Tagged Cluster / Deployment Roles"),
-  }.merge(ASSIGN_TOS["ExtManagementSystem"])
-  ASSIGN_TOS["Host"] = {
-    "host"      => N_("Selected Host / Nodes"),
-    "host-tags" => N_("Tagged Host / Nodes")
-  }.merge(ASSIGN_TOS["EmsCluster"])
-  ASSIGN_TOS["Vm"] = {
-    "ems_folder"         => N_("Selected Folders"),
-    "resource_pool"      => N_("Selected Resource Pools"),
-    "resource_pool-tags" => N_("Tagged Resource Pools"),
-    "vm-tags"            => N_("Tagged VMs and Instances")
-  }.merge(ASSIGN_TOS["Host"])
-  ASSIGN_TOS["Storage"] = {
-    "enterprise"   => N_("The Enterprise"),
-    "storage"      => N_("Selected Datastores"),
-    "storage-tags" => N_("Tagged Datastores"),
-    "tenant"       => N_("Tenants")
-  }
-  ASSIGN_TOS["MiqServer"] = {
-    "miq_server" => N_("Selected Servers"),
-  }
-  ASSIGN_TOS["MiddlewareServer"] = {
-    "enterprise"        => N_("The Enterprise"),
-    "middleware_server" => N_("Selected Middleware Servers")
-  }
-  ASSIGN_TOS["ContainerNode"] = {
-    "enterprise" => N_("The Enterprise"),
-  }
-
-
-  # This set of assignments was created for chargeback_rates
-  ASSIGN_TOS[:chargeback_storage] = ASSIGN_TOS["Storage"]
-  ASSIGN_TOS[:chargeback_compute] = {
-    "enterprise"             => N_("The Enterprise"),
-    "ext_management_system"  => N_("Selected Providers"),
-    "ems_cluster"            => N_("Selected Cluster / Deployment Roles"),
-    "ems_container"          => N_("Selected Containers Providers"),
-    "vm-tags"                => N_("Tagged VMs and Instances"),
-    "container_image-tags"   => N_("Tagged Container Images"),
-    "container_image-labels" => N_("Labeled Container Images"),
-    "tenant"                 => N_("Tenants")
-  }
-
   # Snapshot ages for delete_snapshots_by_age action type
   SNAPSHOT_AGES = {}
   (1..23).each { |a| SNAPSHOT_AGES[a.hours.to_i] = (a.to_s + (a < 2 ? _(" Hour") : _(" Hours"))) }

--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -9,7 +9,7 @@
       %label.col-md-2.control-label
         = _('Assign To')
       .col-md-8
-        - options = ASSIGN_TOS[x_node.split('-').last == "Compute" ? "chargeback_compute".to_sym : "chargeback_storage".to_sym].map do |k, v|
+        - options = TermOfServiceHelper::ASSIGN_TOS[x_node.split('-').last == "Compute" ? "chargeback_compute".to_sym : "chargeback_storage".to_sym].map do |k, v|
           - [_(v), k]
         = select_tag("cbshow_typ", options_for_select([[nothing, "nil"]] + options, @edit[:new][:cbshow_typ]),
                     "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")

--- a/app/views/miq_policy/_alert_profile_assign.html.haml
+++ b/app/views/miq_policy/_alert_profile_assign.html.haml
@@ -14,7 +14,7 @@
         = _('Assign To')
       .col-md-8
         = select_tag('chosen_assign_to',
-          options_for_select([["<#{_('Nothing')}>", nil]] + ASSIGN_TOS[@alert_profile.mode].map { |k, v| [_(v).to_s, k.to_s] }.sort, @assign[:new][:assign_to]),
+          options_for_select([["<#{_('Nothing')}>", nil]] + TermOfServiceHelper::ASSIGN_TOS[@alert_profile.mode].map { |k, v| [_(v).to_s, k.to_s] }.sort, @assign[:new][:assign_to]),
           :class => "selectpicker")
         :javascript
           miqInitSelectPicker();


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `ASSIGN_TOS` was removed from `UiConstants`. It was moved to `ViewHelper`.

`Compute` -> `Clouds` -> `Providers`