### PR TITLE
Consider archived nodes for single provider dashboard

### DIFF
--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -243,4 +243,13 @@ class ContainerDashboardService
   def image_metrics
     daily_image_metrics || hourly_image_metrics
   end
+
+  # ems has no realtime metrics but its nodes do.
+  def realtime_metrics
+    current_user = @controller.current_user
+    tp = TimeProfile.profile_for_user_tz(current_user.id, current_user.get_timezone) || TimeProfile.default_time_profile
+    Metric::Helper.find_for_interval_name('realtime', tp)
+                  .where(:resource => @ems.try(:all_container_nodes) || ContainerNode.all)
+                  .where('timestamp > ?', REALTIME_TIME_RANGE.minutes.ago.utc).order('timestamp')
+  end
 end

--- a/app/services/container_service_mixin.rb
+++ b/app/services/container_service_mixin.rb
@@ -203,14 +203,6 @@ module ContainerServiceMixin
     end
   end
 
-  def realtime_metrics
-    current_user = @controller.current_user
-    tp = TimeProfile.profile_for_user_tz(current_user.id, current_user.get_timezone) || TimeProfile.default_time_profile
-    Metric::Helper.find_for_interval_name('realtime', tp)
-                  .where(:resource => @resource)
-                  .where('timestamp > ?', REALTIME_TIME_RANGE.minutes.ago.utc).order('timestamp')
-  end
-
   def hourly_metrics
     MetricRollup.with_interval_and_time_range("hourly", (1.day.ago.beginning_of_hour.utc)..(Time.now.utc))
                 .where(:resource => @resource)


### PR DESCRIPTION
restore `realtime_metrics` to `container_dashboard_service.rb` with correct metrics thats include archived nodes. Container projects do not have realtime metrics (like ems, they only have rollups) so the projects dashboard should not be affected.

@zakiva Please review
cc @simon3z 

@miq-bot add_label compute/containers