### PR TITLE
Fix custom button dialog list check

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -822,12 +822,19 @@ module ApplicationController::Buttons
       add_flash(_("At least one Role must be selected"), :error)
     end
 
-    if button_hash[:open_url] == true && button_hash[:display_for] != 'single'
-      add_flash(_('URL can be opened only by buttons for a single entity'), :error)
-    end
+    # Check values that should not be present when not having a single entity
+    unless button_hash[:display_for] == 'single'
+      # URL should not be present
+      if button_hash[:open_url] == true
+        add_flash(_('URL can be opened only by buttons for a single entity'), :error)
+      end
 
-    if !button_hash[:dialog_id].blank? && button_hash[:display_for] != 'single'
-      add_flash(_('Dialog can be opened only by buttons for a single entity'), :error)
+      # Dialog should not be present
+      # Checking for zero, since some code further above does .to_i
+      # TODO: What exact values can come here?
+      unless [nil, 0, '', '0'].include?(button_hash[:dialog_id])
+        add_flash(_('Dialog can be opened only by buttons for a single entity'), :error)
+      end
     end
 
     !flash_errors?


### PR DESCRIPTION
There was a wrong condition which lead the validator into assumption that a dialog is selected, when in fact it was not.

Looks like nil gets converted to 0 at some point, which no longer is `.blank?`.

Fixes #2083 (an attempt to do so)