### PR TITLE
Remove UTF_16BE_BOM, UTF_16LE_BOM from UiConstants

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -109,9 +109,6 @@ module UiConstants
 
   MIQ_AE_COPY_ACTIONS = %w(miq_ae_class_copy miq_ae_instance_copy miq_ae_method_copy)
 
-  UTF_16BE_BOM = [254, 255].freeze
-  UTF_16LE_BOM = [255, 254].freeze
-
 end
 
 # Make these constants globally available


### PR DESCRIPTION
### Issue: #1661 

#### Needs to be merged together with https://github.com/ManageIQ/manageiq/pull/15931

Definitions of constants `UTF_16BE_BOM` and `UTF_16LE_BOM` were removed from `UiConstants` - `manageiq-ui-classic/app/helpers/ui_constants.rb`. They were moved to `Filesystem` - `manageiq/app/models/filesystem.rb`.

/cc @martinpovolny @mzazrivec @romanblanco 

@miq-bot add_label pending core