### PR TITLE
Remove EXP_COUNT_TYPE, EXP_FIND_TYPE, EXP_TYPES, VM_EXP_TYPES from UiCon…

### DIFF
--- a/app/helpers/exp_atom_helper.rb
+++ b/app/helpers/exp_atom_helper.rb
@@ -1,0 +1,20 @@
+module ExpAtomHelper
+  # Selection for count based filters
+  EXP_COUNT_TYPE = [N_("Count of"), "count"].freeze
+
+  # Selection for find/check filters
+  EXP_FIND_TYPE = [N_("Find"), "find"].freeze
+
+  # All normal filters
+  EXP_TYPES = [
+    [N_("Field"), "field"],
+    EXP_COUNT_TYPE,
+    [N_("Tag"), "tag"],
+    EXP_FIND_TYPE
+  ].freeze
+
+  # Special VM registry filter
+  VM_EXP_TYPES = [
+    [N_("Registry"), "regkey"]
+  ].freeze
+end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -71,18 +71,6 @@ module UiConstants
     "tenant"                 => N_("Tenants")
   }
 
-  EXP_COUNT_TYPE = [N_("Count of"), "count"].freeze  # Selection for count based filters
-  EXP_FIND_TYPE = [N_("Find"), "find"].freeze        # Selection for find/check filters
-  EXP_TYPES = [                           # All normal filters
-    [N_("Field"), "field"],
-    EXP_COUNT_TYPE,
-    [N_("Tag"), "tag"],
-    EXP_FIND_TYPE
-  ]
-  VM_EXP_TYPES = [                        # Special VM registry filter
-    [N_("Registry"), "regkey"]
-  ]
-
   # Snapshot ages for delete_snapshots_by_age action type
   SNAPSHOT_AGES = {}
   (1..23).each { |a| SNAPSHOT_AGES[a.hours.to_i] = (a.to_s + (a < 2 ? _(" Hour") : _(" Hours"))) }

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -14,11 +14,11 @@
   -# Get all of the expression types, then remove the count and/or find based ones if model has none
   - unless exp_model == "_display_filter_"
     -# Not valid for secondary display filter
-    - exptypes = EXP_TYPES.map { |x| [_(x[0]), x[1]] }
+    - exptypes = ExpAtomHelper::EXP_TYPES.map { |x| [_(x[0]), x[1]] }
     - unless MiqExpression.miq_adv_search_lists(exp_model, :exp_available_counts).length > 0
-      - exptypes -= [[_(EXP_COUNT_TYPE[0]), EXP_COUNT_TYPE[1]]]
+      - exptypes -= [[_(ExpAtomHelper::EXP_COUNT_TYPE[0]), ExpAtomHelper::EXP_COUNT_TYPE[1]]]
     - unless MiqExpression.miq_adv_search_lists(exp_model, :exp_available_finds).length > 0
-      - exptypes -= [[_(EXP_FIND_TYPE[0]), EXP_FIND_TYPE[1]]]
+      - exptypes -= [[_(ExpAtomHelper::EXP_FIND_TYPE[0]), ExpAtomHelper::EXP_FIND_TYPE[1]]]
   #exp_atom_editor_div
     %fieldset
       .toolbar-pf-actions{:style => "margin-left: 20px"}
@@ -45,7 +45,7 @@
         - opts = ["<#{_('Choose')}>"]
         - case exp_model
         - when 'Vm'
-          - opts += exptypes + VM_EXP_TYPES.map { |x| [_(x[0]), x[1]] }
+          - opts += exptypes + ExpAtomHelper::VM_EXP_TYPES.map { |x| [_(x[0]), x[1]] }
         - when 'AuditEvent'
           - opts += [[_('Field'), 'field']]
         - when '_display_filter_'


### PR DESCRIPTION
### Issue: #1661 

Definitions of constants `EXP_COUNT_TYPE`, `EXP_FIND_TYPE`, `EXP_TYPES` and `VM_EXP_TYPES` were removed from `UiConstants`. They were moved to new module `ExpAtomHelper`.
