### PR TITLE
Remove CATEGORY_CHOICES from UiConstants

### DIFF
--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -1,6 +1,14 @@
 module OpsController::Settings::AnalysisProfiles
   extend ActiveSupport::Concern
 
+  CATEGORY_CHOICES = {
+    "system"   => N_("System"),
+    "services" => N_("Services"),
+    "software" => N_("Software"),
+    "accounts" => N_("User Accounts"),
+    "vmconfig" => N_("VM Configuration")
+  }.freeze
+
   # Show scanitemset list view
   def aps_list
     ap_build_list

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -9,14 +9,6 @@ module UiConstants
   # Following line does not include timezones with partial hour offsets
   # ALL_TIMEZONES = ActiveSupport::TimeZone.all.collect{|tz| tz.utc_offset % 3600 == 0 ? ["(GMT#{tz.formatted_offset}) #{tz.name}",tz.name] : nil}.compact
 
-  CATEGORY_CHOICES = {}
-  CATEGORY_CHOICES["services"] = N_("Services")
-  CATEGORY_CHOICES["software"] = N_("Software")
-  CATEGORY_CHOICES["system"] = N_("System")
-  CATEGORY_CHOICES["accounts"] = N_("User Accounts")
-  CATEGORY_CHOICES["vmconfig"] = N_("VM Configuration")
-  # CATEGORY_CHOICES["vmevents"] = "VM Events"
-
   # Assignment choices
   ASSIGN_TOS = {}
 

--- a/app/views/ops/_ap_form_set.html.haml
+++ b/app/views/ops/_ap_form_set.html.haml
@@ -9,7 +9,7 @@
           - @selected = Array.new
           - @edit[:new]["category"][:definition]["content"].each do |a|
             - @selected.push(a["target"])
-        - CATEGORY_CHOICES.each_slice(3) do |keyvalue|
+        - OpsController::Settings::AnalysisProfiles::CATEGORY_CHOICES.each_slice(3) do |keyvalue|
           .form-group
             - keyvalue.each do |k, v|
               - checked = @selected.include? k if @selected


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `CATEGORY_CHOICES` was removed from `UiConstants`. It was moved to `OpsController::Settings::AnalysisProfiles`.