### PR TITLE
Use quota_display in Container Project summary screen

### DIFF
--- a/app/helpers/container_project_helper/textual_summary.rb
+++ b/app/helpers/container_project_helper/textual_summary.rb
@@ -35,9 +35,9 @@ module ContainerProjectHelper::TextualSummary
       rows << [
         item.container_quota.name,
         item.resource,
-        item.quota_desired,
-        item.quota_enforced,
-        item.quota_observed,
+        item.quota_desired_display,
+        item.quota_enforced_display,
+        item.quota_observed_display,
       ]
     end
     rows


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/15639

Use the new `quota_*_display` virtual columns where the float values are converted to strings with rounding for integers. 

Before:
![quotabefore](https://user-images.githubusercontent.com/11769555/31053316-7d675c9a-a6a3-11e7-8326-1898dbf2a5a0.png)


After:
![quotaadter](https://user-images.githubusercontent.com/11769555/31053317-81279818-a6a3-11e7-921e-bc7dc92e0eb3.png)
