### PR TITLE
[WIP] Use TreeSelectorComponent for selecting the entry points on the new catalog screens

### DIFF
--- a/app/assets/javascripts/angular_modules/module_entrypoint_selector.js
+++ b/app/assets/javascripts/angular_modules/module_entrypoint_selector.js
@@ -1,9 +1,9 @@
 /* global miqHttpInject */
 miqHttpInject(
-  angular.module('ManageIQ.treeSelector', [
+  angular.module('ManageIQ.entrypointSelector', [
     'miqStaticAssets.treeSelector',
     'miqStaticAssets.treeView',
     'ui.bootstrap',
-    'frapontillo.bootstrap-switch'
+    'frapontillo.bootstrap-switch',
   ])
 );

--- a/app/assets/javascripts/angular_modules/module_tree_selector.js
+++ b/app/assets/javascripts/angular_modules/module_tree_selector.js
@@ -1,0 +1,4 @@
+/* global miqHttpInject */
+miqHttpInject(
+  angular.module('ManageIQ.treeSelector', ['miqStaticAssets.treeSelector', 'miqStaticAssets.treeView', 'ui.bootstrap'])
+);

--- a/app/assets/javascripts/angular_modules/module_tree_selector.js
+++ b/app/assets/javascripts/angular_modules/module_tree_selector.js
@@ -1,4 +1,9 @@
 /* global miqHttpInject */
 miqHttpInject(
-  angular.module('ManageIQ.treeSelector', ['miqStaticAssets.treeSelector', 'miqStaticAssets.treeView', 'ui.bootstrap'])
+  angular.module('ManageIQ.treeSelector', [
+    'miqStaticAssets.treeSelector',
+    'miqStaticAssets.treeView',
+    'ui.bootstrap',
+    'frapontillo.bootstrap-switch'
+  ])
 );

--- a/app/assets/javascripts/controllers/entrypoint_selection_controller.js
+++ b/app/assets/javascripts/controllers/entrypoint_selection_controller.js
@@ -1,0 +1,69 @@
+/* global miqJqueryRequest */
+
+(function() {
+  var CONTROLLER_NAME = 'entrypointSelectionController';
+
+  var EntrypointSelectionController = function($http, $uibModal) {
+    var vm = this;
+    vm.$http = $http;
+    vm.$uibModal = $uibModal;
+
+    vm.$http.get('/tree/automate_entrypoint').then(function(response) {
+      vm.data = response.data;
+    });
+
+    vm.lazyLoad = function(node) {
+      return new Promise(function(resolve) {
+        vm.$http.get('/tree/automate_entrypoint?id=' + encodeURIComponent(node.key)).then(function(response) {
+          resolve(response.data);
+        });
+      });
+    };
+
+    vm.openModal = function(field) {
+      vm.field = field;
+      if (vm[vm.field]) {
+        var items = vm[vm.field].split('/');
+        var selected = items.map(function(_item, index) {
+          return {
+            fqname: items.slice(0, index + 1).join('/'),
+          };
+        });
+        selected.shift();
+        vm.selected = selected;
+      }
+      vm.modal = vm.$uibModal.open({
+        templateUrl: '/static/entrypoint-modal.html',
+        windowClass: 'entrypoint-modal',
+        keyboard: false,
+        size: 'lg',
+        controllerAs: '$ctrl',
+        controller: ['parent', function(parent) { this.parent = parent; }], // this this is not the this you would want as vm
+        resolve: {
+          parent: function() {
+            return vm;
+          },
+        },
+      });
+    };
+
+    vm.closeModal = function() {
+      delete vm.field;
+      vm.modal.close();
+    };
+
+    vm.onSelect = function(node) {
+      vm[vm.field] = node.fqname;
+      angular.element('#' + vm.field).trigger('change');
+      vm.closeModal();
+    };
+
+    vm.resetField = function(field) {
+      angular.element('#' + field).trigger('change');
+      delete vm[field];
+    };
+  };
+
+  EntrypointSelectionController.$inject = ['$http', '$uibModal'];
+  window.miqHttpInject(angular.module('ManageIQ.treeSelector')).controller(CONTROLLER_NAME, EntrypointSelectionController);
+})();

--- a/app/assets/javascripts/controllers/entrypoint_selection_controller.js
+++ b/app/assets/javascripts/controllers/entrypoint_selection_controller.js
@@ -100,5 +100,5 @@
   };
 
   EntrypointSelectionController.$inject = ['$http', '$uibModal'];
-  window.miqHttpInject(angular.module('ManageIQ.treeSelector')).controller(CONTROLLER_NAME, EntrypointSelectionController);
+  window.miqHttpInject(angular.module('ManageIQ.entrypointSelector')).controller(CONTROLLER_NAME, EntrypointSelectionController);
 })();

--- a/app/assets/javascripts/controllers/entrypoint_selection_controller.js
+++ b/app/assets/javascripts/controllers/entrypoint_selection_controller.js
@@ -20,8 +20,11 @@
       });
     };
 
-    vm.openModal = function(field) {
+    vm.openModal = function(field, showInclude, includeDomain) {
       vm.field = field;
+      vm.showInclude = showInclude;
+      vm.includeDomain = includeDomain;
+
       if (vm[vm.field]) {
         var items = vm[vm.field].split('/');
         var selected = items.map(function(_item, index) {
@@ -53,7 +56,11 @@
     };
 
     vm.onSelect = function(node) {
-      vm[vm.field] = node.fqname;
+      var fqname = node.fqname.split('/');
+      if (vm.includeDomain === false) {
+        fqname.splice(1, 1);
+      }
+      vm[vm.field] = fqname.join('/');
       angular.element('#' + vm.field).trigger('change');
       vm.closeModal();
     };

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -127,8 +127,6 @@ class CatalogController < ApplicationController
     return unless load_edit("prov_edit__#{id}", "replace_cell__explorer")
     get_form_vars
     changed = (@edit[:new] != @edit[:current])
-    # Build Catalog Items tree unless @edit[:ae_tree_select]
-    build_ae_tree(:catalog, :automate_tree) if params[:display] || params[:template_id] || params[:manager_id]
     if params[:st_prov_type] # build request screen for selected item type
       @_params[:org_controller] = "service_template"
       if ansible_playbook?
@@ -361,7 +359,6 @@ class CatalogController < ApplicationController
     default_entry_point("generic", "composite") if params[:display]
     st_get_form_vars
     changed = (@edit[:new] != @edit[:current])
-    build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree
     render :update do |page|
       page << javascript_prologue
       page.replace("basic_info_div", :partial => "form_basic_info") if params[:resource_id] || params[:display]
@@ -433,7 +430,6 @@ class CatalogController < ApplicationController
 
     # if resource has been deleted from group, rearrange groups incase group is now empty.
     rearrange_groups_array
-    build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree
     changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
@@ -472,56 +468,10 @@ class CatalogController < ApplicationController
     end
   end
 
-  def get_ae_tree_edit_key(type)
-    case type
-    when 'provision'   then :fqname
-    when 'retire'      then :retire_fqname
-    when 'reconfigure' then :reconfigure_fqname
-    end
-  end
-  private :get_ae_tree_edit_key
-
   def need_prov_dialogs?(type)
     !type.starts_with?('generic')
   end
   helper_method :need_prov_dialogs?
-
-  def ae_tree_select_toggle
-    @edit = session[:edit]
-    self.x_active_tree = :sandt_tree
-    at_tree_select_toggle(get_ae_tree_edit_key(@edit[:ae_field_typ]))
-    x_node_set(@edit[:active_id], :automate_tree) if params[:button] == 'submit'
-    session[:edit] = @edit
-  end
-
-  def ae_tree_select_discard
-    ae_tree_key = get_ae_tree_edit_key(params[:typ])
-    @edit = session[:edit]
-    @edit[:new][params[:typ]] = nil
-    @edit[:new][ae_tree_key] = ''
-    # build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree unless @edit[:ae_tree_select]
-    render :update do |page|
-      page << javascript_prologue
-      @changed = (@edit[:new] != @edit[:current])
-      x_node_set(@edit[:active_id], :automate_tree)
-      page << javascript_hide("ae_tree_select_div")
-      page << javascript_hide("blocker_div")
-      page << javascript_hide("#{ae_tree_key}_div")
-      page << "$('##{ae_tree_key}').val('#{@edit[:new][ae_tree_key]}');"
-      page << "$('##{ae_tree_key}').prop('title', '#{@edit[:new][ae_tree_key]}');"
-      @edit[:ae_tree_select] = false
-      page << javascript_for_miq_button_visibility(@changed)
-      page << "miqTreeActivateNodeSilently('automate_tree', 'root');"
-      page << "miqSparkle(false);"
-    end
-    session[:edit] = @edit
-  end
-
-  def ae_tree_select
-    @edit = session[:edit]
-    at_tree_select(get_ae_tree_edit_key(@edit[:ae_field_typ]))
-    session[:edit] = @edit
-  end
 
   def svc_catalog_provision
     assert_privileges("svc_catalog_provision")
@@ -1342,7 +1292,6 @@ class CatalogController < ApplicationController
     else
       @right_cell_text = _("Editing %{model} \"%{name}\"") % {:name => @record.name, :model => ui_lookup(:model => "ServiceTemplate")}
     end
-    build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree
   end
 
   def st_set_form_vars

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1457,6 +1457,8 @@ class CatalogController < ApplicationController
     @edit[:st_prov_type] = @edit[:new][:st_prov_type] = params[:st_prov_type] if params[:st_prov_type]
     @edit[:new][:long_description] = @edit[:new][:long_description].to_s + "..." if params[:transOne]
 
+    copy_params_if_set(@edit[:new], params, %i(fqname reconfigure_fqname retire_fqname))
+
     get_form_vars_orchestration if @edit[:new][:st_prov_type] == 'generic_orchestration'
     fetch_form_vars_ansible_or_ct if %w(generic_ansible_tower generic_container_template).include?(@edit[:new][:st_prov_type])
   end

--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -1,6 +1,7 @@
 # This is a highly experimental implementation of something that we would like to have probably in an UI-API
 # It is definitely not a good example and it SHOULD NOT BE COPY-PASTED in any case
 class TreeController < ApplicationController
+  skip_after_action :set_global_session_data
   before_action :check_privileges
 
   def automate_entrypoint

--- a/app/presenters/tree_builder_automate_entrypoint.rb
+++ b/app/presenters/tree_builder_automate_entrypoint.rb
@@ -1,7 +1,7 @@
 class TreeBuilderAutomateEntrypoint < TreeBuilderAutomate
   def override(node, object, _pid, _options)
     node.delete(:selectable)
-    node[:dataAttr] = {:fqname => object.fqname} if object.try(:fqname)
+    node[:fqname] = object.fqname if object.try(:fqname)
   end
 
   def root_options

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -2,8 +2,6 @@
   :action => @edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed")
 
 #basic_info_div
-  = hidden_div_if(@edit && @edit[:ae_tree_select] != true, :id => "ae_tree_select_div") do
-    = render(:partial => 'layouts/ae_tree_select')
   .form-horizontal
     .form-group
       %label.col-md-2.control-label
@@ -116,72 +114,61 @@
                           :class                => "selectpicker")
             :javascript
               miqSelectPickerEvent('template_id', '#{url}')
-    .form-group
-      %label.col-md-2.control-label{:title => _("Provisioning Entry Point (NameSpace/Class/Instance)")}
-        = _('Provisioning Entry Point')
-      .col-md-8{:title => @edit[:new][:fqname]}
-        .input-group
-          = text_field_tag("fqname",
-                           @edit[:new][:fqname],
-                           :class   => "form-control",
-                           :onFocus => 'miqShowAE_Tree("provision");miqButtons("hide", "automate");')
-          %span.input-group-btn
-            #fqname_div{:style => @edit[:new][:fqname] != "" ? "" : "display:none"}
-              = link_to({:action => 'ae_tree_select_discard',
-                         :typ => "provision"},
-                        "data-miq_sparkle_on"  => true,
-                        "data-miq_sparkle_off" => true,
-                        "data-confirm"         => _("Are you sure you want to remove this Provisioning Entry Point?"),
-                        "data-method"          => :post,
-                        :remote                => true,
-                        :class                 => "btn btn-default",
-                        :title                 => _("Remove this Provisioning Entry Point")) do
-                %i.pficon.pficon-close
-          %span.input-group-addon{:style => "visibility:hidden"}
-    - unless @edit[:new][:st_prov_type] == 'generic_container_template'
+    #entrypoint-selection{'ng-controller' => 'entrypointSelectionController as vm'}
       .form-group
-        %label.col-md-2.control-label{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
-          = _('Reconfigure Entry Point')
-        .col-md-8{:title => @edit[:new][:reconfigure_fqname]}
+        %label.col-md-2.control-label{:title => _("Provisioning Entry Point (NameSpace/Class/Instance)")}
+          = _('Provisioning Entry Point')
+        .col-md-8{:title => @edit[:new][:fqname]}
           .input-group
-            = text_field_tag("reconfigure_fqname",
-                             @edit[:new][:reconfigure_fqname],
-                             :class             => "form-control",
-                             :onFocus           => 'miqShowAE_Tree("reconfigure");miqButtons("hide", "automate");',
-                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+            = text_field_tag("fqname", nil,
+              :class     => 'form-control',
+              'ng-value' => 'vm.fqname',
+              'ng-init'  => "vm.fqname = '#{@edit[:new][:fqname]}'")
             %span.input-group-btn
-              #reconfigure_fqname_div{:style => @edit[:new][:reconfigure_fqname] != "" ? "" : "display:none"}
-                = link_to({:action => 'ae_tree_select_discard',
-                           :typ => "reconfigure"},
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          "data-confirm"         => _("Are you sure you want to remove this Reconfigure Entry Point?"),
-                          "data-method"          => :post,
-                          :remote                => true,
-                          :class                 => "btn btn-default",
-                          :title                 => _("Remove this Reconfigure Entry Point")) do
-                  %i.pficon.pficon-close
-            %span.input-group-addon{:style => "visibility:hidden"}
+              %button.btn.btn-default{'ng-click' => "vm.openModal('fqname');"}
+                %i.ff.ff-load-balancer
+              %button.btn.btn-default{'ng-click' => "vm.resetField('fqname');"}
+                %i.fa.fa-close
 
-      .form-group
-        %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
-          = _('Retirement Entry Point')
-        .col-md-8{:title => @edit[:new][:retire_fqname]}
-          .input-group
-            = text_field_tag("retire_fqname",
-                             @edit[:new][:retire_fqname],
-                             :class   => "form-control",
-                             :onFocus => 'miqShowAE_Tree("retire");miqButtons("hide", "automate");')
-            %span.input-group-btn
-              #retire_fqname_div{:style => @edit[:new][:retire_fqname] != "" ? "" : "display:none"}
-                = link_to({:action => 'ae_tree_select_discard',
-                           :typ => "retire"},
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          "data-confirm"         => _("Are you sure you want to remove this Retirement Entry Point?"),
-                          "data-method"          => :post,
-                          :remote                => true,
-                          :class                 => "btn btn-default",
-                          :title                 => _("Remove this Retirement Entry Point")) do
-                  %i.pficon.pficon-close
-            %span.input-group-addon{:style => "visibility:hidden"}
+      - unless @edit[:new][:st_prov_type] == 'generic_container_template'
+        .form-group
+          %label.col-md-2.control-label{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
+            = _('Reconfigure Entry Point')
+          .col-md-8{:title => @edit[:new][:reconfigure_fqname]}
+            .input-group
+              = text_field_tag("reconfigure_fqname", nil,
+                :class     => 'form-control',
+                'ng-value' => 'vm.reconfigure_fqname',
+                'ng-init'  => "vm.reconfigure_fqname = '#{@edit[:new][:reconfigure_fqname]}'")
+              %span.input-group-btn
+                %button.btn.btn-default{'ng-click' => "vm.openModal('reconfigure_fqname');"}
+                  %i.ff.ff-load-balancer
+                %button.btn.btn-default{'ng-click' => "vm.resetField('reconfigure_fqname');"}
+                  %i.fa.fa-close
+
+        .form-group
+          %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
+            = _('Retirement Entry Point')
+          .col-md-8{:title => @edit[:new][:retire_fqname]}
+            .input-group
+              = text_field_tag("retire_fqname", nil,
+                :class     => 'form-control',
+                'ng-value' => 'vm.retire_fqname',
+                'ng-init'  => "vm.retire_fqname = '#{@edit[:new][:retire_fqname]}'")
+              %span.input-group-btn
+                %button.btn.btn-default{'ng-click' => "vm.openModal('retire_fqname');"}
+                  %i.ff.ff-load-balancer
+                %button.btn.btn-default{'ng-click' => "vm.resetField('retire_fqname');"}
+                  %i.fa.fa-close
+
+    :javascript
+      miq_bootstrap('#entrypoint-selection', 'ManageIQ.treeSelector');
+      // FIXME: drop this while angularizing as it is a bad practice
+      $(function() {
+        $('#entrypoint-selection input[type="text"]').on('change', _.debounce(function() {
+          miqObserveRequest('#{url}', {
+            no_encoding: true,
+            data: this.id + '=' + this.value,
+          });
+        }, 700, {leading: true, trailing: true}));
+      });

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -125,7 +125,7 @@
               'ng-value' => 'vm.fqname',
               'ng-init'  => "vm.fqname = '#{@edit[:new][:fqname]}'")
             %span.input-group-btn
-              %button.btn.btn-default{'ng-click' => "vm.openModal('fqname');"}
+              %button.btn.btn-default{'ng-click' => "vm.openModal('fqname', true, false);"}
                 %i.ff.ff-load-balancer
               %button.btn.btn-default{'ng-click' => "vm.resetField('fqname');"}
                 %i.fa.fa-close
@@ -141,7 +141,7 @@
                 'ng-value' => 'vm.reconfigure_fqname',
                 'ng-init'  => "vm.reconfigure_fqname = '#{@edit[:new][:reconfigure_fqname]}'")
               %span.input-group-btn
-                %button.btn.btn-default{'ng-click' => "vm.openModal('reconfigure_fqname');"}
+                %button.btn.btn-default{'ng-click' => "vm.openModal('reconfigure_fqname', true, false);"}
                   %i.ff.ff-load-balancer
                 %button.btn.btn-default{'ng-click' => "vm.resetField('reconfigure_fqname');"}
                   %i.fa.fa-close
@@ -156,7 +156,7 @@
                 'ng-value' => 'vm.retire_fqname',
                 'ng-init'  => "vm.retire_fqname = '#{@edit[:new][:retire_fqname]}'")
               %span.input-group-btn
-                %button.btn.btn-default{'ng-click' => "vm.openModal('retire_fqname');"}
+                %button.btn.btn-default{'ng-click' => "vm.openModal('retire_fqname', true, false);"}
                   %i.ff.ff-load-balancer
                 %button.btn.btn-default{'ng-click' => "vm.resetField('retire_fqname');"}
                   %i.fa.fa-close

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -162,7 +162,7 @@
                   %i.fa.fa-close
 
     :javascript
-      miq_bootstrap('#entrypoint-selection', 'ManageIQ.treeSelector');
+      miq_bootstrap('#entrypoint-selection', 'ManageIQ.entrypointSelector');
       // FIXME: drop this while angularizing as it is a bad practice
       $(function() {
         $('#entrypoint-selection input[type="text"]').on('change', _.debounce(function() {

--- a/app/views/static/entrypoint-modal.html
+++ b/app/views/static/entrypoint-modal.html
@@ -2,14 +2,21 @@
   <h4 class="modal-title" translate>Select Entry Point Instance</h4>
 </div>
 <div class="modal-body">
-  <miq-tree-selector
-    name="entrypoint_selection"
-    selected="$ctrl.parent.selected"
-    selectable="{key: '^aei-'}"
-    data="$ctrl.parent.data"
-    lazy-load="$ctrl.parent.lazyLoad(node)"
-    on-select="$ctrl.parent.onSelect(node)"
-  ></miq-tree-selector>
+  <div class="pull-left">
+    <miq-tree-selector
+      name="entrypoint_selection"
+      selected="$ctrl.parent.selected"
+      selectable="{key: '^aei-'}"
+      data="$ctrl.parent.data"
+      lazy-load="$ctrl.parent.lazyLoad(node)"
+      on-select="$ctrl.parent.onSelect(node)"
+    ></miq-tree-selector>
+  </div>
+  <div class="form-group pull-right">
+    <label class="control-label" translate>Include domain prefix in the path:</label>
+    <input bs-switch type="checkbox" ng-model="$ctrl.parent.includeDomain" ng-show="$ctrl.parent.showInclude"/>
+  </div>
+  <div class="clearfix"></div>
 </div>
 <div class="modal-footer">
   <button class="btn btn-default" ng-click="$ctrl.parent.closeModal(false);" translate>Close</button>

--- a/app/views/static/entrypoint-modal.html
+++ b/app/views/static/entrypoint-modal.html
@@ -1,0 +1,16 @@
+<div class="modal-header">
+  <h4 class="modal-title" translate>Select Entry Point Instance</h4>
+</div>
+<div class="modal-body">
+  <miq-tree-selector
+    name="entrypoint_selection"
+    selected="$ctrl.parent.selected"
+    selectable="{key: '^aei-'}"
+    data="$ctrl.parent.data"
+    lazy-load="$ctrl.parent.lazyLoad(node)"
+    on-select="$ctrl.parent.onSelect(node)"
+  ></miq-tree-selector>
+</div>
+<div class="modal-footer">
+  <button class="btn btn-default" ng-click="$ctrl.parent.closeModal(false);" translate>Close</button>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,15 +278,11 @@ Rails.application.routes.draw do
       :post => %w(
         ab_group_reorder
         accordion_select
-        ae_tree_select
-        ae_tree_select_discard
-        ae_tree_select_toggle
         atomic_form_field_changed
         atomic_st_edit
         automate_button_field_changed
         playbook_options_field_changed
         explorer
-        get_ae_tree_edit_key
         group_create
         group_form_field_changed
         group_reorder_field_changed

--- a/spec/routing/catalog_routing_spec.rb
+++ b/spec/routing/catalog_routing_spec.rb
@@ -22,16 +22,12 @@ describe 'routes for CatalogController' do
   %w(
     ab_group_reorder
     accordion_select
-    ae_tree_select
-    ae_tree_select_discard
-    ae_tree_select_toggle
     atomic_form_field_changed
     atomic_st_edit
     automate_button_field_changed
     button_create
     button_update
     explorer
-    get_ae_tree_edit_key
     group_create
     group_form_field_changed
     group_reorder_field_changed


### PR DESCRIPTION
The entry point selection when creating/editing a catalog item was kinda complicated. Using the new `TreeSelectorComponent` this has been simplified a lot. The tree is now loaded through an API-like controller and there is no server roundtrip necessary to determine which node is selectable. I still don't like that the modal gets reloaded each time it is opened as it also reloads the tree data, but I will think about a better solution in a future PR. The linking between the angular controller and the old-style form is kinda ugly, but it will be cleaned up during the angularization of the whole form.

![screenshot from 2017-09-04 20-29-40](https://user-images.githubusercontent.com/649130/30036760-573b5834-91b6-11e7-994a-4aae829fb56c.png)


Depends on https://github.com/ManageIQ/ui-components/pull/133 and https://github.com/ManageIQ/ui-components/pull/143.

@miq-bot add_label trees, fine/no, refactoring