### PR TITLE
Jasmine - fix travis for packs by using the default pack path even in test env

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -33,7 +33,5 @@ development:
 test:
   <<: *default
 
-  public_output_path: packs-test
-
 production:
   <<: *default


### PR DESCRIPTION
Webpacker defaults to using a different output dir in test environment - `packs-test`.
But our tests assume this will be `packs`, the same as when running those tests locally.

=> Changing to use `packs`, so that the tests can actually find the assets.

Cc @mzazrivec because you already know about https://github.com/ManageIQ/manageiq-ui-classic/pull/2061

Cc @Hyperkid123 maybe this time :)