### PR TITLE
API.login - don't show error modal on login error

### DIFF
--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -75,6 +75,7 @@
       headers: {
         'Authorization': 'Basic ' + base64encode([login, password].join(':')),
       },
+      skipErrors: [401],
     })
     .then(function(response) {
       sessionStorage.miq_token = response.auth_token;


### PR DESCRIPTION
In #1976, we enabled the error modal for API use.

This is one of the places where an error from the API was already being handled by the code, and should not have an error modal.

..because when trying to login, we already show a flash on failure.

(depends on changes in fcc6248, #2075)

https://bugzilla.redhat.com/show_bug.cgi?id=1486616