### PR TITLE
Remove WIDGET_CONTENT_TYPE from UiConstants

### DIFF
--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -24,6 +24,14 @@ module ReportController::Widgets
     "m"  => N_('Menu')
   }.freeze
 
+  # Need this for mapping with MiqWidget record content_type field
+  WIDGET_CONTENT_TYPE = {
+    "r"  => "report",
+    "c"  => "chart",
+    "rf" => "rss",
+    "m"  => "menu"
+  }.freeze
+
   def widget_refresh
     assert_privileges("widget_refresh")
     replace_right_cell

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -86,14 +86,6 @@ module UiConstants
   EXP_FROM = "FROM"
   EXP_IS = "IS"
 
-  # Need this for mapping with MiqWidget record content_type field
-  WIDGET_CONTENT_TYPE = {
-    "r"  => "report",
-    "c"  => "chart",
-    "rf" => "rss",
-    "m"  => "menu"
-  }
-
   VALID_PERF_PARENTS = {
     "EmsCluster" => :ems_cluster,
     "Host"       => :host

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -31,7 +31,7 @@ class TreeBuilderReportWidgets < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
-    widgets = MiqWidget.where(:content_type => WIDGET_CONTENT_TYPE[object[:id].split('-').last])
+    widgets = MiqWidget.where(:content_type => ReportController::Widgets::WIDGET_CONTENT_TYPE[object[:id].split('-').last])
     count_only_or_objects(count_only, widgets, 'title')
   end
 end

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -140,7 +140,7 @@
               - elsif x_active_tree == :reports_tree
                 - click = "miqTreeActivateNode('reports_tree', '#{x_node}_rr-#{to_cid(row['id'])}');"
             - when "MiqWidget"
-              - typ = WIDGET_CONTENT_TYPE.invert[row['content_type']]
+              - typ = ReportController::Widgets::WIDGET_CONTENT_TYPE.invert[row['content_type']]
               - click = "miqTreeActivateNode('widgets_tree', 'xx-#{typ}_-#{to_cid(row['id'])}');"
             - when "IsoDatastore"
               - click = "miqTreeActivateNode('iso_datastores_tree', 'isd-#{to_cid(row['id'])}');"
@@ -234,7 +234,7 @@
                     - elsif x_active_tree == :reports_tree
                       - click = "miqTreeActivateNode('reports_tree', '#{x_node}_rr-#{to_cid(row['id'])}');"
                   - when "MiqWidget"
-                    - typ = WIDGET_CONTENT_TYPE.invert[row['content_type']]
+                    - typ = ReportController::Widgets::WIDGET_CONTENT_TYPE.invert[row['content_type']]
                     - click = remote_function(:loading  => "miqSparkle(true);",
                                               :complete => "miqSparkle(false);",
                                               :url      => {:action => 'x_show', :id => "xx-#{typ}_-#{to_cid(row['id'])}"})

--- a/app/views/report/_db_widget.html.haml
+++ b/app/views/report/_db_widget.html.haml
@@ -4,7 +4,7 @@
 - if @edit && @edit[:current]
   - params = {:id => "w_#{widget.id}", :title => _("Drag/drop Widget \"%{widget_title}\"") % {:widget_title => widget.title}}
 - else
-  - url = "/report/x_show/xx-#{WIDGET_CONTENT_TYPE.invert[widget.content_type]}_-#{to_cid(widget.id)}?accord=widgets"
+  - url = "/report/x_show/xx-#{ReportController::Widgets::WIDGET_CONTENT_TYPE.invert[widget.content_type]}_-#{to_cid(widget.id)}?accord=widgets"
   - params = {:onclick => remote_function(:url => url), :id => widget.id, :title => _("View this Widget")}
 / .pointer{params}
 .panel.panel-default{params}

--- a/app/views/report/_report_info.html.haml
+++ b/app/views/report/_report_info.html.haml
@@ -120,7 +120,7 @@
         - @widget_nodes.each do |w|
           - if role_allows?(:feature => "miq_report_widget_editor")
             - params = {:title => _("Click to view selected widget"),
-              :onclick => remote_function(:url => "/report/x_show/xx-#{WIDGET_CONTENT_TYPE.invert[w.content_type]}_-#{to_cid(w.id)}?accord=widgets")}
+              :onclick => remote_function(:url => "/report/x_show/xx-#{ReportController::Widgets::WIDGET_CONTENT_TYPE.invert[w.content_type]}_-#{to_cid(w.id)}?accord=widgets")}
           - else
             - params = {}
           %tr{params}

--- a/app/views/report/_widget_form_filter.html.haml
+++ b/app/views/report/_widget_form_filter.html.haml
@@ -1,2 +1,2 @@
 #form_filter_div
-  = render :partial => "widget_form_#{WIDGET_CONTENT_TYPE[@sb[:wtype]]}", :locals => {:read_only => @edit[:read_only]}
+  = render :partial => "widget_form_#{ReportController::Widgets::WIDGET_CONTENT_TYPE[@sb[:wtype]]}", :locals => {:read_only => @edit[:read_only]}


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `WIDGET_CONTENT_TYPE` was removed from `UiConstants`. It was moved to `ReportController::Widgets`.