### PR TITLE
Remove VALID_PERF_PARENTS from UiConstants

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -687,7 +687,7 @@ module ApplicationController::Performance
     if perf_parent?                               # Build the parent report, if asked for
       p_rpt = Marshal.load(Marshal.dump(rpt))    # Deep clone the main report
       p_rpt.where_clause[1] = @perf_options[:parent]
-      p_rpt.where_clause[2] = @perf_record.send(VALID_PERF_PARENTS[@perf_options[:parent]]).id
+      p_rpt.where_clause[2] = @perf_record.send(ApplicationHelper::VALID_PERF_PARENTS[@perf_options[:parent]]).id
       rpts.push(p_rpt)
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,11 @@ module ApplicationHelper
   include PlanningHelper
   include Title
 
+  VALID_PERF_PARENTS = {
+    "EmsCluster" => :ems_cluster,
+    "Host"       => :host
+  }
+
   # Need to generate paths w/o hostname by default to make proxying work.
   #
   def url_for_only_path(args)

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -86,11 +86,6 @@ module UiConstants
   EXP_FROM = "FROM"
   EXP_IS = "IS"
 
-  VALID_PERF_PARENTS = {
-    "EmsCluster" => :ems_cluster,
-    "Host"       => :host
-  }
-
   MIQ_AE_COPY_ACTIONS = %w(miq_ae_class_copy miq_ae_instance_copy miq_ae_method_copy)
 
 end


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `VALID_PERF_PARENTS` was removed from `UiConstants`. It was moved to `ApplicationHelper`.