### PR TITLE
Reload listnav explorer trees from explorers using RxJS

### DIFF
--- a/app/assets/javascripts/controllers/tree_view_controller.js
+++ b/app/assets/javascripts/controllers/tree_view_controller.js
@@ -2,11 +2,21 @@
 (function() {
   var CONTROLLER_NAME = 'treeViewController';
 
-  var TreeViewController = function($http) {
+  var TreeViewController = function($http, $scope) {
     var vm = this;
     vm.$http = $http;
+    vm.$scope = $scope;
     vm.selectedNodes = {};
     vm.data = {};
+
+    ManageIQ.angular.rxSubject.subscribe(function(payload) {
+      if (payload.reloadTrees && _.isObject(payload.reloadTrees) && Object.keys(payload.reloadTrees).length > 0) {
+        _.forEach(payload.reloadTrees, function(value, key) {
+          vm.data[key] = value;
+        });
+        vm.$scope.$apply();
+      }
+    });
 
     vm.initSelected = function(tree, node) {
       vm.selectedNodes[tree] = vm.selectedNodes[tree] || { key: node };
@@ -35,6 +45,6 @@
     };
   };
 
-  TreeViewController.$inject = ['$http'];
+  TreeViewController.$inject = ['$http', '$scope'];
   window.miqHttpInject(angular.module('ManageIQ.treeView')).controller(CONTROLLER_NAME, TreeViewController);
 })();

--- a/app/assets/javascripts/controllers/tree_view_controller.js
+++ b/app/assets/javascripts/controllers/tree_view_controller.js
@@ -6,28 +6,33 @@
     var vm = this;
     vm.$http = $http;
     vm.selectedNodes = {};
-  };
+    vm.data = {};
 
-  TreeViewController.prototype.initSelected = function(tree, node) {
-    this.selectedNodes[tree] = this.selectedNodes[tree] || { key: node };
-  };
+    vm.initSelected = function(tree, node) {
+      vm.selectedNodes[tree] = vm.selectedNodes[tree] || { key: node };
+    };
 
-  TreeViewController.prototype.lazyLoad = function(node, name, url) {
-    var vm = this;
-    return new Promise(function(resolve) {
-      vm.$http.post(url, {
-        id: node.key,
-        tree: name,
-        mode: 'all',
-      }).then(function(response) {
-        resolve(response.data);
+    vm.initData = function(tree, data, selected) {
+      vm.data[tree] = vm.data[tree] || data;
+      vm.selectedNodes[tree] = vm.selectedNodes[tree] || { key: selected };
+    };
+
+    vm.lazyLoad = function(node, name, url) {
+      return new Promise(function(resolve) {
+        vm.$http.post(url, {
+          id: node.key,
+          tree: name,
+          mode: 'all',
+        }).then(function(response) {
+          resolve(response.data);
+        });
       });
-    });
-  };
+    };
 
-  TreeViewController.prototype.nodeSelect = function(node, path) {
-    var url = path + '?id=' + encodeURIComponent(node.key.split('__')[0]);
-    miqJqueryRequest(url, {beforeSend: true});
+    vm.nodeSelect = function(node, path) {
+      var url = path + '?id=' + encodeURIComponent(node.key.split('__')[0]);
+      miqJqueryRequest(url, {beforeSend: true});
+    };
   };
 
   TreeViewController.$inject = ['$http'];

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -107,6 +107,12 @@ ManageIQ.explorer.updatePartials = function(data) {
   }
 };
 
+ManageIQ.explorer.reloadTrees = function(data) {
+  if (_.isObject(data.reloadTrees)) {
+    sendDataWithRx({reloadTrees: data.reloadTrees});
+  }
+};
+
 ManageIQ.explorer.spinnerOff = function(data) {
   if (data.spinnerOff) {
     miqSparkle(false);
@@ -196,6 +202,8 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
   }
 
   ManageIQ.explorer.replacePartials(data);
+
+  ManageIQ.explorer.reloadTrees(data);
 
   if (_.isObject(data.buildCalendar)) { ManageIQ.explorer.buildCalendar(data.buildCalendar); }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2220,10 +2220,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def replace_trees_by_presenter(presenter, trees)
-    trees.each_pair do |name, tree|
+  def reload_trees_by_presenter(presenter, trees)
+    trees.each_pair do |_, tree|
       next unless tree.present?
-      presenter.reload_tree(name, tree)
+      presenter.reload_tree(tree.name, tree.locals_for_render[:bs_tree])
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2223,17 +2223,7 @@ class ApplicationController < ActionController::Base
   def replace_trees_by_presenter(presenter, trees)
     trees.each_pair do |name, tree|
       next unless tree.present?
-
-      presenter.replace(
-        "#{name}_tree_div",
-        render_to_string(
-          :partial => 'shared/tree',
-          :locals  => {
-            :tree => tree,
-            :name => tree.name.to_s
-          }
-        )
-      )
+      presenter.reload_tree(name, tree)
     end
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1967,7 +1967,7 @@ class CatalogController < ApplicationController
       :active_tree => x_active_tree,
       :add_nodes   => add_nodes
     )
-    replace_trees_by_presenter(presenter, trees)
+    reload_trees_by_presenter(presenter, trees)
 
     if @sb[:buttons_node]
       if action == "group_reorder"

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -838,7 +838,7 @@ class ChargebackController < ApplicationController
     presenter = ExplorerPresenter.new(
       :active_tree => x_active_tree,
     )
-    replace_trees_by_presenter(presenter, :cb_rates => cb_rates_build_tree) if replace_trees.include?(:cb_rates)
+    reload_trees_by_presenter(presenter, :cb_rates => cb_rates_build_tree) if replace_trees.include?(:cb_rates)
 
     # FIXME
     #  if params[:action].ends_with?("_delete")

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -280,7 +280,7 @@ class MiqAeClassController < ApplicationController
       :add_nodes       => add_nodes,
     )
 
-    replace_trees_by_presenter(presenter, :ae => build_ae_tree) unless replace_trees.blank?
+    reload_trees_by_presenter(presenter, :ae => build_ae_tree) unless replace_trees.blank?
 
     if @sb[:action] == "miq_ae_field_seq"
       presenter.update(:class_fields_div, r[:partial => "fields_seq_form"])

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -248,7 +248,7 @@ class MiqAeCustomizationController < ApplicationController
     @explorer = true
     presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
 
-    replace_trees_by_presenter(presenter, trees)
+    reload_trees_by_presenter(presenter, trees)
     presenter[:osf_node] = x_node unless @in_a_form
 
     if ['dialog_edit', 'dialog_copy'].include?(params[:pressed])

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -522,7 +522,7 @@ class MiqPolicyController < ApplicationController
         raise _("unknown tree in replace_trees: %{name}") % {name => name}
       end
     end
-    replace_trees_by_presenter(presenter, trees)
+    reload_trees_by_presenter(presenter, trees)
 
     if params[:action].ends_with?('_delete') &&
        !x_node.starts_with?('p') &&

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -310,7 +310,7 @@ module Mixins
       update_partials(record_showing, presenter)
       replace_search_box(presenter)
       handle_bottom_cell(presenter)
-      replace_trees_by_presenter(presenter, trees)
+      reload_trees_by_presenter(presenter, trees)
       rebuild_toolbars(record_showing, presenter)
       presenter[:right_cell_text] = @right_cell_text
       presenter[:osf_node] = x_node # Open, select, and focus on this node

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -774,7 +774,7 @@ class OpsController < ApplicationController
       trees[:diagnostics] = diagnostics_build_tree  if replace_trees.include?(:diagnostics)
       trees[:vmdb]        = db_build_tree           if replace_trees.include?(:vmdb)
     end
-    replace_trees_by_presenter(presenter, trees)
+    reload_trees_by_presenter(presenter, trees)
   end
 
   # Build the audit object when a profile is saved

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -117,7 +117,7 @@ class PxeController < ApplicationController
     c_tb = build_toolbar(center_toolbar_filename) unless @in_a_form
     h_tb = build_toolbar('x_history_tb')
 
-    replace_trees_by_presenter(presenter, trees)
+    reload_trees_by_presenter(presenter, trees)
 
     # Rebuild the toolbars
     presenter.reload_toolbars(:history => h_tb)

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -690,7 +690,7 @@ class ReportController < ApplicationController
       v_tb = build_toolbar("report_view_tb") if @report && [:reports_tree, :savedreports_tree].include?(x_active_tree)
     end
 
-    replace_trees_by_presenter(presenter, trees)
+    reload_trees_by_presenter(presenter, trees)
     presenter[:osf_node] = x_node  # Open, select, and focus on this node
 
     session[:changed] = (@edit[:new] != @edit[:current]) if @edit && @edit[:current] # to get save/reset buttons to highlight when something is changed

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -326,7 +326,7 @@ class ServiceController < ApplicationController
     )
 
     if Array(replace_trees).include?(:svcs)
-      replace_trees_by_presenter(presenter, :svcs => build_svcs_tree)
+      reload_trees_by_presenter(presenter, :svcs => build_svcs_tree)
     end
 
     # Replace right cell divs

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -396,7 +396,7 @@ class StorageController < ApplicationController
     update_partials(record_showing, presenter)
     replace_search_box(presenter)
     handle_bottom_cell(presenter)
-    replace_trees_by_presenter(presenter, trees)
+    reload_trees_by_presenter(presenter, trees)
     rebuild_toolbars(record_showing, presenter)
     case x_active_tree
     when :storage_tree

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -142,8 +142,8 @@ class ExplorerPresenter
     self
   end
 
-  def reload_tree(_name, tree)
-    @options[:reload_trees][tree.name] = tree.locals_for_render[:bs_tree]
+  def reload_tree(name, data)
+    @options[:reload_trees][name] = data
   end
 
   def replace(div_name, content)

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -68,6 +68,7 @@ class ExplorerPresenter
       :element_updates      => {},
       :replace_partials     => {},
       :reload_toolbars      => {},
+      :reload_trees         => {},
       :exp                  => {},
       :osf_node             => '',
       :show_miq_buttons     => false,
@@ -139,6 +140,10 @@ class ExplorerPresenter
       @options[:reload_toolbars][div_name] = toolbar_data
     end
     self
+  end
+
+  def reload_tree(_name, tree)
+    @options[:reload_trees][tree.name] = tree.locals_for_render[:bs_tree]
   end
 
   def replace(div_name, content)
@@ -246,6 +251,7 @@ class ExplorerPresenter
     data[:updatePartials] = @options[:update_partials] # Replace content of given DOM element (element stays).
     data[:updateElements] = @options[:element_updates] # Update element in the DOM with given options
     data[:replacePartials] = @options[:replace_partials] # Replace given DOM element (and it's children) (element goes away).
+    data[:reloadTrees] = @options[:reload_trees] # Replace the data attribute of the given TreeViewComponent
     data[:buildCalendar] = format_calendar_dates(@options[:build_calendar])
     data[:initDashboard] = !! @options[:init_dashboard]
     data[:ajaxUrl] = ajax_action_url(@options[:ajax_action]) if @options[:ajax_action]

--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -7,9 +7,9 @@
         -# Set the first tree to be rendered if there is a mismatch with the name/type
         - tree = @trees.find(-> { @trees.first }) { |t| t.type == accord[:name].to_sym  }
         %miq-tree-view{:name       => tree.name,
-                       :data       => tree.locals_for_render[:bs_tree],
+                       :data       => "vm.data['#{tree.name}']",
                        :reselect   => tree.locals_for_render[:allow_reselect],
-                       "ng-init"   => "vm.initSelected('#{tree.name}', '#{tree.locals_for_render[:select_node]}')",
+                       "ng-init"   => "vm.initData('#{tree.name}', '#{tree.locals_for_render[:bs_tree]}', '#{tree.locals_for_render[:select_node]}')",
                        'on-select' => "vm.nodeSelect(node, '/#{request.parameters[:controller]}/tree_select')",
                        'selected'  => "vm.selectedNodes['#{tree.name}']",
                        'lazy-load' => "(vm.lazyLoad(node, '#{tree.name}', '/#{request.parameters[:controller]}/tree_autoload'))"}

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -300,7 +300,7 @@ describe ApplicationController do
     end
   end
 
-  describe "#replace_trees_by_presenter" do
+  describe "#reload_trees_by_presenter" do
     let(:tree_1) { double(:name => 'tree_1') }
     let(:tree_2) { double(:name => 'tree_2') }
     let(:trees) { {'tree_1' => tree_1, 'tree_2' => tree_2, 'tree_3' => nil} }
@@ -310,7 +310,7 @@ describe ApplicationController do
       allow(tree_1).to receive(:locals_for_render).and_return(:bs_tree => {})
       allow(tree_2).to receive(:locals_for_render).and_return(:bs_tree => {})
       expect(presenter).to receive(:reload_tree).with(any_args).twice
-      controller.send(:replace_trees_by_presenter, presenter, trees)
+      controller.send(:reload_trees_by_presenter, presenter, trees)
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -307,8 +307,9 @@ describe ApplicationController do
     let(:presenter) { double(:presenter) }
 
     it "calls render and passes data to presenter for each pair w/ value" do
-      expect(controller).to receive(:render_to_string).with(any_args).twice
-      expect(presenter).to receive(:replace).with(any_args).twice
+      allow(tree_1).to receive(:locals_for_render).and_return(:bs_tree => {})
+      allow(tree_2).to receive(:locals_for_render).and_return(:bs_tree => {})
+      expect(presenter).to receive(:reload_tree).with(any_args).twice
       controller.send(:replace_trees_by_presenter, presenter, trees)
     end
   end

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -97,7 +97,7 @@ describe MiqAeClassController do
                                        :trees       => {:ae_tree => {:active_node => node}})
       controller.instance_variable_set(:@_params, :button => "reset", :id => cls1.id)
       allow(controller).to receive(:open_parent_nodes)
-      expect(controller).to_not receive(:replace_trees_by_presenter)
+      expect(controller).to_not receive(:reload_trees_by_presenter)
       expect(controller).to receive(:render)
       controller.send(:copy_objects)
       expect(controller.send(:flash_errors?)).not_to be_truthy

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -200,14 +200,14 @@ describe MiqPolicyController do
   end
 
   describe '#replace_right_cell' do
-    it 'should replace policy_tree_div when replace_trees contains :policy' do
+    it 'should reload policy tree when reload_trees contains :policy_tree' do
       allow(controller).to receive(:params).and_return(:action => 'whatever')
       controller.instance_eval { @sb = {:active_tree => :policy_tree} }
       allow(controller).to receive(:render).and_return(nil)
       presenter = ExplorerPresenter.new(:active_tree => :policy_tree)
 
       controller.send(:replace_right_cell, :nodetype => 'root', :replace_trees => [:policy], :presenter => presenter)
-      expect(presenter[:replace_partials]).to have_key('policy_tree_div')
+      expect(presenter[:reload_trees]).to have_key(:policy_tree)
     end
 
     it 'should not hide center toolbar while doing searches' do


### PR DESCRIPTION
When creating/editing/deleting an item on an explorer screen, we're reloading the trees using `replacePartial`. After the [angularization of explorer listnav trees](https://github.com/ManageIQ/manageiq-ui-classic/pull/1989) this became a bug as these trees are no longer accessible using old CSS selectors.

Instead of replacing the whole partial I created an RxJS subscription in the `TreeViewController` that expects the updated tree JSON. The data is being sent by the `ManageIQ.explorer` as `reloadTrees` that goes way up to the `ApplicationController` where the `replace_trees_by_presenter` has been renamed to `reload_trees_by_presenter`.

Depends on: https://github.com/ManageIQ/ui-components/pull/145
Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/1871