### PR TITLE
Set the metrics auth status to the metrics tab

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -304,7 +304,8 @@ module Mixins
                          :service_account           => service_account ? service_account : "",
                          :bearer_token_exists       => @ems.authentication_token(:bearer).nil? ? false : true,
                          :ems_controller            => controller_name,
-                         :default_auth_status       => default_auth_status}
+                         :default_auth_status       => default_auth_status,
+                         :metrics_auth_status       => metrics_auth_status.nil? ? false : metrics_auth_status}
       end
 
       if controller_name == "ems_middleware"


### PR DESCRIPTION
**Description**

We forgot to set the `metrics_auth_status` :-( and the tab gets "not valid" sign, even if it is valid.

p.s.
We also forgot to set the actual validation :-) this PR set the validation in the backend:
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/109

**Screenshots**
Before
![screenshot-5b7fd941-f833-4da3-bedb-5e20f2fd793d-2017-09-05-14-26-41](https://user-images.githubusercontent.com/2181522/30059074-4570d4e0-9246-11e7-8baf-875232a503df.png)

After
![screenshot-5b7fd941-f833-4da3-bedb-5e20f2fd793d-2017-09-05-14-26-23](https://user-images.githubusercontent.com/2181522/30059075-45724d16-9246-11e7-98c0-c79b36bb99fa.png)
