### PR TITLE
[WIP] travis cache delete

### DIFF
--- a/tools/ci/setup_js_env.sh
+++ b/tools/ci/setup_js_env.sh
@@ -26,3 +26,7 @@ yarn
 
 # compile webpacker assets
 bundle exec rake webpack:compile
+
+
+
+travis cache --delete


### PR DESCRIPTION
Specs are broken now, because of old ui-components in travis cache.

Trying to drop the whole thing.

(Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/2062)