### PR TITLE
Container Provider: change authentication status labels

### DIFF
--- a/app/helpers/textual_mixins/textual_authentications_status.rb
+++ b/app/helpers/textual_mixins/textual_authentications_status.rb
@@ -25,8 +25,14 @@ module TextualMixins::TextualAuthenticationsStatus
   end
 
   def map_authentications(authentications)
+    type = {
+      :hawkular          => _("Metrics"),
+      :prometheus        => _("Metrics"),
+      :prometheus_alerts => _("Alerts")
+    }
+
     authentications.map do |auth|
-      { :label => _("%{label} Authentication") % { :label => auth.authtype.to_s.titleize },
+      { :label => _("%{label} Authentication") % { :label => type[auth.authtype.to_sym] || auth.authtype.to_s.titleize },
         :value => textual_authentication_value(auth.status, auth.updated_on),
         :title => textual_authentication_title(auth.status, auth.updated_on, auth.last_valid_on) }
     end


### PR DESCRIPTION
Setting the authentication labels in the status table to "Alerts" or "Metrics" instead of "Prometheus" or "Hawkular": 

![status](https://user-images.githubusercontent.com/11769555/30061520-595d2526-9250-11e7-9223-f6532d10fbc1.png)


Before:

![statubfefore](https://user-images.githubusercontent.com/11769555/30061676-f55ebffc-9250-11e7-8d6d-aeabf364a6b7.png)
