### PR TITLE
Fix saving filter in Advanced search

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -215,7 +215,7 @@ module ApplicationController::AdvancedSearch
     @edit[:custom_search] = false
 
     case params[:button]
-    when "saveit"
+    when "save", "saveit"
       if adv_search_button_saveid
         adv_search_redraw_left_div
       else

--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -246,7 +246,7 @@ module ApplicationController::AdvancedSearch
     when "cancel"
       @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression]) # Rebuild the existing expression table
       @edit[@expkey].prefill_val_types
-      adv_search_button_redraw_search_partials
+      adv_search_redraw_search_partials
 
     end
   end


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1486622

Fix saving a new expression created in Advanced search
when clicking on Save button. Fix error when clicking on
Cancel button when canceling saving of a new filter.

The real problem was not related to Apply button or choosing 'Tag'
when creating search expression or providers as mentioned in the
BZ but saving the expression (there was no flash message after
clicking on Save button, no new filter in accordion, no form to write
down the name of a new filter, and also it does not make sense to
click on Save and then to click on Apply button as mentioned in steps
to reproduce the bug). Now the filter is successfully saved and it
appears in accordion, it can be applied, deleted an also canceling
saving of a new filter works fine. The flash message about successful
saving of a new filter still does not appear (there is also problem with
displaying any flash messages in Advanced search) and you have to
close the window manually to see the filter in accordion and to use it 
from there. I am not sure if it is on purpose or not but from my point
of view it looks like it is another issue/bug which should be fixed
(probably in another PR).
