### PR TITLE
bower.json - invalidate travis cache by updating to newer angular

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,13 +17,13 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.6.3",
-    "angular-animate": "~1.6.3",
+    "angular": "~1.6.6",
+    "angular-animate": "~1.6.6",
     "angular-bootstrap-switch": "~0.5.1",
     "angular-dragdrop": "~1.0.13",
-    "angular-mocks": "~1.6.3",
+    "angular-mocks": "~1.6.6",
     "angular-patternfly-sass": "~3.23.1",
-    "angular-sanitize": "~1.6.3",
+    "angular-sanitize": "~1.6.6",
     "angular-ui-codemirror": "~0.3.0",
     "angular-ui-sortable": "~0.16.1",
     "angular.validators": "~4.4.2",
@@ -60,8 +60,8 @@
   "resolutions": {
     "d3": "~3.5.0",
     "jquery": "~2.2.4",
-    "angular": "~1.6.3",
-    "angular-sanitize": "~1.6.3",
-    "angular-animate": "~1.6.3"
+    "angular": "~1.6.6",
+    "angular-sanitize": "~1.6.6",
+    "angular-animate": "~1.6.6"
   }
 }


### PR DESCRIPTION
Travis is currently broken because it uses an old version of ui-components from cache.

We need to bust the cache - and the simplest way is to change `bower.json` => updating angular to 1.6.6.