### PR TITLE
miq-tree-view - provide missing reselect - the tree already has that info

### DIFF
--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -8,6 +8,7 @@
         - tree = @trees.find(-> { @trees.first }) { |t| t.type == accord[:name].to_sym  }
         %miq-tree-view{:name       => tree.name,
                        :data       => tree.locals_for_render[:bs_tree],
+                       :reselect   => tree.locals_for_render[:allow_reselect],
                        "ng-init"   => "vm.initSelected('#{tree.name}', '#{tree.locals_for_render[:select_node]}')",
                        'on-select' => "vm.nodeSelect(node, '/#{request.parameters[:controller]}/tree_select')",
                        'selected'  => "vm.selectedNodes['#{tree.name}']",


### PR DESCRIPTION
Apparently forgotten in https://github.com/ManageIQ/manageiq-ui-classic/pull/1989.

Cc @skateman 