### PR TITLE
Fix focus in policy tree after adding condition

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -507,7 +507,7 @@ class MiqPolicyController < ApplicationController
       when :policy_profile
         self.x_node = @new_profile_node if @new_profile_node
       when :policy
-        nil
+        self.x_node = @new_policy_node if @new_policy_node
       when :event
         nil
       when :condition


### PR DESCRIPTION
Control -> Explorer -> Policies -> select any Policy node -> Configuration -> Create a new Condition assigned to this Policy -> fill a form -> click Add

Before:
<img width="1211" alt="screen shot 2017-09-05 at 3 30 01 pm" src="https://user-images.githubusercontent.com/9210860/30063693-cf5d450e-924f-11e7-90d2-8faa37250fb0.png">

After:
<img width="1213" alt="screen shot 2017-09-05 at 3 28 09 pm" src="https://user-images.githubusercontent.com/9210860/30063697-d370b126-924f-11e7-94ab-f356c8da948e.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1424267

@miq-bot add_label bug, euwe/yes, fine/yes, trees