### PR TITLE
Container summary screen: Check if role_allows? Environment Variables

### DIFF
--- a/app/helpers/container_helper/textual_summary.rb
+++ b/app/helpers/container_helper/textual_summary.rb
@@ -127,6 +127,7 @@ module ContainerHelper::TextualSummary
   end
 
   def textual_group_env
+    return nil unless role_allows?(:feature => "container_env_vars")
     TextualMultilabel.new(
       _("Environment variables"),
       :additional_table_class => "table-fixed",


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1422206
Depends on: https://github.com/ManageIQ/manageiq/pull/15935

Hiding Container Environment variables table unless `role_allows?` it. 