### PR TITLE
fix limit and request labels for containers

### DIFF
--- a/app/helpers/container_helper/textual_summary.rb
+++ b/app/helpers/container_helper/textual_summary.rb
@@ -146,8 +146,8 @@ module ContainerHelper::TextualSummary
       _("Request and Limits"),
       :labels => [_("Resource"), _("Value")],
       :values => [[_("Limit CPU cores"), @record.limit_cpu_cores],
-                  [_("Limit CPU cores"), @record.limit_memory_bytes],
+                  [_("Limit Memory bytes"), @record.limit_memory_bytes],
                   [_("Request CPU cores"), @record.request_cpu_cores],
-                  [_("Request Memory"), @record.request_memory_bytes]])
+                  [_("Request Memory bytes"), @record.request_memory_bytes]])
   end
 end


### PR DESCRIPTION
Before:
![before-limit](https://user-images.githubusercontent.com/11256940/30067013-4713c5a2-9262-11e7-9b9e-1151c270a2a3.png)

After:
![after-limit](https://user-images.githubusercontent.com/11256940/30067019-48da1cec-9262-11e7-870d-83cbacac0d4b.png)

@martinpovolny @himdel Please review
cc @simon3z

@miq-bot add_label compute/containers, bug 