### PR TITLE
Exclude a new dynamicFieldList key from dialogField properties on dialogEditorController

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -31,7 +31,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
 
   var beingCloned = null; // hack that solves recursion problem for cloneDeep
   function customizer(value) {
-    var keysToDelete = ['active', '$$hashKey', 'href'];
+    var keysToDelete = ['active', '$$hashKey', 'href', 'dynamicFieldList'];
     var useCustomizer =
       (value !== beingCloned) &&
       _.isObject(value) &&


### PR DESCRIPTION
This is in preparation for https://github.com/ManageIQ/ui-components/pull/138, since the ui-components piece will build a list of the dynamic fields in order to send through the associations. Without deleting this key on the incoming API transaction, it will crash trying to set the `.dynamicFieldList` property, which does not exist.

https://www.pivotaltracker.com/story/show/148013513