### PR TITLE
Fix chart layout when single chart displayed

### DIFF
--- a/app/views/layouts/_perf_charts.html.haml
+++ b/app/views/layouts/_perf_charts.html.haml
@@ -1,7 +1,7 @@
 %div{:id => "#{chart_set}_charts_div", :onmousedown => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
   - if @charts || @perf_options[:chart_type] != :performance
     - perf_options ||= @perf_options
-    - detailed_view = !!perf_options[:index]
+    - single_chart_view = !!perf_options[:index] || chart_data.count == 1
     - charts ||= @charts
     - if chart_data
       - if !perf_parent?
@@ -15,7 +15,7 @@
                                                      :chart_set   => chart_set,
                                                      :chart_index => c})
 
-                - if detailed_view
+                - if single_chart_view
                   .col-md-12
                     = chart_render
                 - else


### PR DESCRIPTION
When there is only single chart displayed, sometimes we also use same layout as for multiple charts. 

Before:
![screencapture-localhost-3000-utilization-1504697215390](https://user-images.githubusercontent.com/9535558/30109676-ef2ea09c-930f-11e7-896b-88db31e8177c.png)

After:
![screencapture-localhost-3000-utilization-1504697154869](https://user-images.githubusercontent.com/9535558/30109677-f1a0c9ea-930f-11e7-81e9-50a2092b6d85.png)
