### PR TITLE
Fix margin of expanded alerts

### DIFF
--- a/app/assets/stylesheets/alerts.scss
+++ b/app/assets/stylesheets/alerts.scss
@@ -58,6 +58,7 @@
     }
     .list-group-item-container {
       margin-right: -14px;
+      margin-top: 5px;
       [class^="col-"] {
         padding-left: 20px;
         padding-right: 20px;


### PR DESCRIPTION
The provider of the alert ('EngLab Prometheus' here) is too close to the upper margin of the expanded content

before:
![before](https://user-images.githubusercontent.com/3010449/30113698-465eee90-931e-11e7-82a4-ce55ab29fe3f.png)

after:
![after](https://user-images.githubusercontent.com/3010449/30113706-4a792a04-931e-11e7-9f35-b27db5d730c4.png)
