### PR TITLE
Delete unused tree methods

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -135,12 +135,6 @@ class InfraNetworkingController < ApplicationController
     render :layout => "application"
   end
 
-  def tree_autoload_dynatree
-    @view ||= session[:view]
-    x_tree_init(:infra_networking_tree, :infra_networking, Switch)
-    super
-  end
-
   def tagging
     assert_privileges("infra_networking_tag")
     tagging_edit('Switch', false)

--- a/app/controllers/mixins/explorer_presenter_mixin.rb
+++ b/app/controllers/mixins/explorer_presenter_mixin.rb
@@ -1,18 +1,5 @@
 module Mixins
   module ExplorerPresenterMixin
-    def update_tree_and_render_list(replace_trees)
-      @explorer = true
-      get_node_info(x_node)
-      presenter = rendering_objects
-      replace_explorer_trees(replace_trees, presenter)
-
-      presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
-      rebuild_toolbars(false, presenter)
-      handle_bottom_cell(presenter)
-
-      render :json => presenter.for_render
-    end
-
     def rendering_objects
       ExplorerPresenter.new(
         :active_tree => x_active_tree,

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -660,11 +660,6 @@ module ReportController::Menus
     @right_cell_text = _("Editing %{model} \"%{name}\"") % {:name => session[:role_choice], :model => ui_lookup(:model => "MiqGroup")}
   end
 
-  # Build the main roles/menu editor tree
-  def build_roles_tree
-    TreeBuilderReportRoles.new('roles_tree', 'roles', @sb)
-  end
-
   def get_group_roles
     if super_admin_user?
       roles = MiqGroup.non_tenant_groups

--- a/app/controllers/storage_controller/storage_d.rb
+++ b/app/controllers/storage_controller/storage_d.rb
@@ -2,12 +2,6 @@
 module StorageController::StorageD
   extend ActiveSupport::Concern
 
-  def storage_tree_select
-    @lastaction = "explorer"
-    _typ, id = params[:id].split("_")
-    @record = Storage.find(from_cid(id))
-  end
-
   def storage_list
     @lastaction = "storage_list"
     @force_no_grid_xml   = true

--- a/app/controllers/storage_controller/storage_pod.rb
+++ b/app/controllers/storage_controller/storage_pod.rb
@@ -2,12 +2,6 @@
 module StorageController::StoragePod
   extend ActiveSupport::Concern
 
-  def storage_pod_tree_select
-    @lastaction = "explorer"
-    _typ, id = params[:id].split("_")
-    @record = Storage.find(from_cid(id))
-  end
-
   def storage_pod_list
     @lastaction = "storage_pod_list"
     @force_no_grid_xml   = true


### PR DESCRIPTION
`tree_autoload_dynatree` 
Never called. `super` doesn't exist.
`update_tree_and_render_list(replace_trees)`
Never called.
`build_roles_tree`
Never called.
`storage(_pod)_tree_select`
Never called. Trees in that controller have set `tree_select` instead of those two.

@miq-bot add_label technical debt, trees, fine/no