### PR TITLE
Edit divs for Available and Selected Groups

### DIFF
--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -108,7 +108,7 @@
           = _("Groups")
         - else
           = _("Available Groups")
-      .col-md-5
+      .col-md-2
         - groups = @user.present? && @user.miq_groups.present? ? @user.miq_groups.order(:description) : []
         - if groups.present? && @edit.blank?
           - if role_allows?(:feature => "rbac_group_show")
@@ -142,8 +142,9 @@
               miqInitSelectPicker();
               miqSelectPickerEvent('chosen_group', "#{url}")
       - if @edit
-        %label.col-md-2
+        %label.col-md-2.control-label
           = _("Selected Groups")
+        .col-md-3
           = render :partial => "ops/rbac_group_selected"
     - unless @edit
       .form-group


### PR DESCRIPTION
Edit drop down div for **Available Groups** under _Configuration
-> Access Control -> Users_ and also div for **Selected Groups**
when creating a new User so **Selected Groups** are next to
**Available Groups** and the whole name of a selected group
is in the one line, easily readable.

This PR is related to feature implemented in https://github.com/ManageIQ/manageiq-ui-classic/pull/1752

Before:
![3](https://user-images.githubusercontent.com/13417815/30114602-a05ff246-9318-11e7-8588-92098d1949fe.png)

After:
![1](https://user-images.githubusercontent.com/13417815/30114411-0dbecf02-9318-11e7-8b6c-346854229b2d.png)
![2](https://user-images.githubusercontent.com/13417815/30114422-11bf516c-9318-11e7-8292-45fe1d9f09ac.png)
