### PR TITLE
Fixed VM Policy Edit Cancel Button

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -25,7 +25,7 @@ module ApplicationController::AdvancedSearch
       @edit[@expkey][:use_mytags] = true                                # Include mytags in tag search atoms
       @edit[:custom_search] = false                                     # setting default to false
       @edit[:new] ||= {}
-      if @edit[:new][@expkey]
+      if !@edit[:new].empty? && @edit[:new][@expkey]
         @edit[@expkey][:expression] = @edit[:new][@expkey]                # Copy to new exp
       else
         @edit[:new][@expkey] = @edit[@expkey][:expression]                # Copy to new exp

--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -25,7 +25,7 @@ module ApplicationController::AdvancedSearch
       @edit[@expkey][:use_mytags] = true                                # Include mytags in tag search atoms
       @edit[:custom_search] = false                                     # setting default to false
       @edit[:new] ||= {}
-      if !@edit[:new].empty? && @edit[:new][@expkey]
+      if !@edit[:new][@expkey].nil? && @edit[:new][@expkey] != 0
         @edit[@expkey][:expression] = @edit[:new][@expkey]                # Copy to new exp
       else
         @edit[:new][@expkey] = @edit[@expkey][:expression]                # Copy to new exp

--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -58,7 +58,7 @@ module ApplicationController::PolicySupport
         @sb[:action] = nil
       end
       if @edit[:explorer]
-        @edit = nil if params[:button] == "cancel" || params[:button] == "save"
+        @edit = nil if %w(cancel save).include?(params[:button])
         replace_right_cell
       else
         @edit = nil                                       # Clear out the session :edit hash

--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -58,7 +58,7 @@ module ApplicationController::PolicySupport
         @sb[:action] = nil
       end
       if @edit[:explorer]
-        @edit = nil if params[:button] == "cancel"
+        @edit = nil if params[:button] == "cancel" || params[:button] == "save"
         replace_right_cell
       else
         @edit = nil                                       # Clear out the session :edit hash

--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -57,8 +57,8 @@ module ApplicationController::PolicySupport
         add_flash(_("Policy assignments successfully changed"))
         @sb[:action] = nil
       end
-      session[:flash_msgs] = @flash_array
       if @edit[:explorer]
+        @edit = nil if params[:button] == "cancel"
         replace_right_cell
       else
         @edit = nil                                       # Clear out the session :edit hash

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -162,6 +162,19 @@ describe VmInfraController do
     expect(response.status).to eq(200)
   end
 
+  it 'can cancel Manage Policies' do
+    post :explorer
+    expect(response.status).to eq(200)
+
+    post :x_button, :params => { :pressed => 'vm_protect', :id => vm_vmware.id }
+    expect(response.status).to eq(200)
+
+    controller.instance_variable_set(:@in_a_form, nil)
+    post :protect, :params => { :button => 'cancel' }
+
+    expect(response.body).to include("Edit policy assignments was cancelled by the user")
+  end
+
   it 'can open Policies Simulation' do
     vm = FactoryGirl.create(:vm_vmware,
                             :host     => host_1x1,


### PR DESCRIPTION
Fixed the crash that occurs when pressing the Cancel button on the VM Policy Edit page.
Also fix the double flash message for the same event.

Links 
----------
https://bugzilla.redhat.com/show_bug.cgi?id=1484312


Steps for Testing/QA 
-------------------------------

