### PR TITLE
Refactoring middleware topology controller as vm

### DIFF
--- a/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
@@ -32,7 +32,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
 
   $('input#box_display_names').click(topologyService.showHideNames(vm));
   vm.refresh();
-  var promise = $interval($scope.refresh, 1000 * 60 * 3);
+  var promise = $interval(vm.refresh, 1000 * 60 * 3);
 
   $scope.$on('$destroy', function() {
     $interval.cancel(promise);
@@ -49,38 +49,38 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     });
     added.append('circle')
       .attr('r', function(d) {
-        return self.getCircleDimensions(d).r;
+        return vm.getCircleDimensions(d).r;
       })
       .attr('class', function(d) {
         return topologyService.getItemStatusClass(d);
       })
       .on('contextmenu', function(d) {
-        self.contextMenu(this, d);
+        vm.contextMenu(this, d);
       });
     added.append('title');
     added.on('dblclick', function(d) {
-      return self.dblclick(d);
+      return vm.dblclick(d);
     });
 
     added.append('image')
       .attr('xlink:href', function(d) {
-        var iconInfo = self.getIcon(d);
+        var iconInfo = vm.getIcon(d);
         return (iconInfo.type == 'glyph' ? null : iconInfo.icon);
       })
       .attr('y', function(d) {
-        return self.getCircleDimensions(d).y;
+        return vm.getCircleDimensions(d).y;
       })
       .attr('x', function(d) {
-        return self.getCircleDimensions(d).x;
+        return vm.getCircleDimensions(d).x;
       })
       .attr('height', function(d) {
-        return self.getCircleDimensions(d).height;
+        return vm.getCircleDimensions(d).height;
       })
       .attr('width', function(d) {
-        return self.getCircleDimensions(d).width;
+        return vm.getCircleDimensions(d).width;
       })
       .on('contextmenu', function(d) {
-        self.contextMenu(this, d);
+        vm.contextMenu(this, d);
       });
 
     // attached labels
@@ -95,7 +95,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     // possible glyphs
     added.append('text')
       .each(function(d) {
-        var iconInfo = self.getIcon(d);
+        var iconInfo = vm.getIcon(d);
         if (iconInfo.type != 'glyph') {
           return;
         }
@@ -116,7 +116,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
         }
       })
       .on('contextmenu', function(d) {
-        self.contextMenu(this, d);
+        vm.contextMenu(this, d);
       });
 
     added.selectAll('title').text(function(d) {
@@ -128,7 +128,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     ev.preventDefault();
   });
 
-  self.getIcon = function getIcon(d) {
+  vm.getIcon = function getIcon(d) {
     if (d.item.icon) {
       return {
         'type': 'image',
@@ -139,7 +139,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     return icons[d.item.display_kind];
   };
 
-  self.getCircleDimensions = function getCircleDimensions(d) {
+  vm.getCircleDimensions = function getCircleDimensions(d) {
     var defaultDimensions = topologyService.defaultElementDimensions();
     switch (d.item.kind) {
       case 'MiddlewareManager':
@@ -179,8 +179,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
 
   function getMiddlewareTopologyData(response) {
     var data = response.data;
-
-    var currentSelectedKinds = $scope.kinds;
+    var currentSelectedKinds = vm.kinds;
 
     vm.items = data.data.items;
     vm.relations = data.data.relations;

--- a/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
@@ -65,7 +65,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     added.append('image')
       .attr('xlink:href', function(d) {
         var iconInfo = vm.getIcon(d);
-        return (iconInfo.type == 'glyph' ? null : iconInfo.icon);
+        return (iconInfo.type === 'glyph' ? null : iconInfo.icon);
       })
       .attr('y', function(d) {
         return vm.getCircleDimensions(d).y;

--- a/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
@@ -4,15 +4,15 @@ MiddlewareTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', '
 function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
   ManageIQ.angular.scope = $scope;
   miqHideSearchClearButton();
-  var self = this;
-  $scope.vs = null;
+  var vm = this;
+  vm.vs = null;
   var d3 = window.d3;
-  $scope.d3 = d3;
+  vm.d3 = d3;
   var icons;
 
-  topologyService.mixinContextMenu(this, $scope);
+  topologyService.mixinContextMenu(vm, vm);
 
-  $scope.refresh = function() {
+  vm.refresh = function() {
     var id;
     if ($location.absUrl().match('show/$') || $location.absUrl().match('show$')) {
       id = '';
@@ -25,13 +25,13 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
       .catch(miqService.handleFailure);
   };
 
-  $scope.checkboxModel = {
+  vm.checkboxModel = {
     value: false,
   };
-  $scope.legendTooltip = 'Click here to show/hide entities of this type';
+  vm.legendTooltip = 'Click here to show/hide entities of this type';
 
-  $('input#box_display_names').click(topologyService.showHideNames($scope));
-  $scope.refresh();
+  $('input#box_display_names').click(topologyService.showHideNames(vm));
+  vm.refresh();
   var promise = $interval($scope.refresh, 1000 * 60 * 3);
 
   $scope.$on('$destroy', function() {
@@ -90,7 +90,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
       .text(function(d) {
         return d.item.name;
       })
-      .attr('class', 'attached-label' + ($scope.checkboxModel.value ? ' visible' : ''));
+      .attr('class', 'attached-label' + (vm.checkboxModel.value ? ' visible' : ''));
 
     // possible glyphs
     added.append('text')
@@ -122,7 +122,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     added.selectAll('title').text(function(d) {
       return topologyService.tooltip(d).join('\n');
     });
-    $scope.vs = vertices;
+    vm.vs = vertices;
 
     /* Don't do default rendering */
     ev.preventDefault();
@@ -182,14 +182,14 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
 
     var currentSelectedKinds = $scope.kinds;
 
-    $scope.items = data.data.items;
-    $scope.relations = data.data.relations;
-    $scope.kinds = data.data.kinds;
+    vm.items = data.data.items;
+    vm.relations = data.data.relations;
+    vm.kinds = $scope.kinds = data.data.kinds;
     icons = data.data.icons;
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys($scope.kinds).length)) {
-      $scope.kinds = currentSelectedKinds;
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys(vm.kinds).length)) {
+      vm.kinds = currentSelectedKinds;
     }
   }
 
-  topologyService.mixinSearch($scope);
+  topologyService.mixinSearch(vm);
 }

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -101,11 +101,10 @@ ManageIQ.angular.app.service('topologyService', function() {
   this.searchNode = function(svg, query) {
     var nodes = svg.selectAll('g');
     nodes.style('opacity', '1');
-
     var found = true;
     if (query !== '') {
       var selected = nodes.filter(function(d) {
-        return d.item.name.indexOf(query) === -1;
+        return d.item.name.toLowerCase().indexOf(query.toLowerCase()) === -1;
       });
       selected.style('opacity', '0.2');
 

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -1,8 +1,8 @@
 - tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
-.topology{'ng-controller' => "middlewareTopologyController"}
+.topology{'ng-controller' => "middlewareTopologyController as vm"}
   .legend.middleware
     %label#selected
-    %div{'ng-if' => "kinds"}
+    %div{'ng-if' => "vm.kinds"}
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareServer"}
         %label
           %img{:src => image_path('svg/vendor-wildfly.svg'), :width => 18, :height => 18}
@@ -43,9 +43,9 @@
     %strong
       = _("Click on the legend to show/hide entities, and double click on the entities in the graph to navigate to their summary pages.")
 
-  = render :partial => "shared/topology/not_found"
+  = render :partial => "shared/topology/not_found_vm"
 
-  %kubernetes-topology-graph.middleware{:items => "items", :relations => "relations", :kinds => "kinds"}
+  %kubernetes-topology-graph.middleware{:items => "vm.items", :relations => "vm.relations", :kinds => "vm.kinds"}
 
 :javascript
   miq_bootstrap('.topology');

--- a/spec/javascripts/controllers/middleware/middleware_topology_controller_spec.js
+++ b/spec/javascripts/controllers/middleware/middleware_topology_controller_spec.js
@@ -1,5 +1,9 @@
 describe('middlewareTopologyController', function () {
-  var scope, $controller, $httpBackend, topologyService;
+  var scope;
+  var $controller;
+  var $httpBackend;
+  var topologyService;
+  var ctrl;
   var mock_data = getJSONFixture('middleware_topology_response.json');
 
   var mw_manager = {
@@ -137,7 +141,7 @@ describe('middlewareTopologyController', function () {
 
     $httpBackend = _$httpBackend_;
     $httpBackend.when('GET', '/middleware_topology/data').respond(mock_data);
-    $controller = _$controller_('middlewareTopologyController',
+    ctrl = _$controller_('middlewareTopologyController',
       {$scope: scope, topologyService: _topologyService_});
     $httpBackend.flush();
   }));
@@ -149,9 +153,9 @@ describe('middlewareTopologyController', function () {
 
   describe('mw topology data loads successfully', function () {
     it('in all main objects', function () {
-      expect(scope.items).toBeDefined();
-      expect(scope.relations).toBeDefined();
-      expect(scope.kinds).toBeDefined();
+      expect(ctrl.items).toBeDefined();
+      expect(ctrl.relations).toBeDefined();
+      expect(ctrl.kinds).toBeDefined();
     });
   });
 
@@ -159,54 +163,54 @@ describe('middlewareTopologyController', function () {
   describe('kinds contains all expected mw kinds', function () {
     it('in all main objects', function () {
       expect(Object.keys(scope.kinds).length).toBe(8);
-      expect(scope.kinds["MiddlewareManager"]).toBeDefined();
-      expect(scope.kinds["MiddlewareServer"]).toBeDefined();
-      expect(scope.kinds["MiddlewareDeployment"]).toBeDefined();
-      expect(scope.kinds["MiddlewareDatasource"]).toBeDefined();
-      expect(scope.kinds["Vm"]).toBeDefined();
-      expect(scope.kinds["MiddlewareDomain"]).toBeDefined();
-      expect(scope.kinds["MiddlewareServerGroup"]).toBeDefined();
-      expect(scope.kinds["MiddlewareMessaging"]).toBeDefined();
+      expect(ctrl.kinds["MiddlewareManager"]).toBeDefined();
+      expect(ctrl.kinds["MiddlewareServer"]).toBeDefined();
+      expect(ctrl.kinds["MiddlewareDeployment"]).toBeDefined();
+      expect(ctrl.kinds["MiddlewareDatasource"]).toBeDefined();
+      expect(ctrl.kinds["Vm"]).toBeDefined();
+      expect(ctrl.kinds["MiddlewareDomain"]).toBeDefined();
+      expect(ctrl.kinds["MiddlewareServerGroup"]).toBeDefined();
+      expect(ctrl.kinds["MiddlewareMessaging"]).toBeDefined();
     });
   });
 
 
   describe('the mw topology gets correct icons', function () {
     it('in graph elements', function () {
-      expect($controller.getIcon(mw_manager).icon).toContain("vendor-hawkular");
-      expect($controller.getIcon(mw_server).icon).toContain("vendor-wildfly");
-      expect($controller.getIcon(mw_deployment).fontfamily).toEqual("font-fabulous");
-      expect($controller.getIcon(mw_datasource).fontfamily).toEqual("FontAwesome");
-      expect($controller.getIcon(vm).fontfamily).toEqual("PatternFlyIcons-webfont");
-      expect($controller.getIcon(mw_domain).fontfamily).toEqual("FontAwesome");
-      expect($controller.getIcon(mw_server_group).fontfamily).toEqual("FontAwesome");
-      expect($controller.getIcon(mw_messaging).fontfamily).toEqual("FontAwesome");
+      expect(ctrl.getIcon(mw_manager).icon).toContain("vendor-hawkular");
+      expect(ctrl.getIcon(mw_server).icon).toContain("vendor-wildfly");
+      expect(ctrl.getIcon(mw_deployment).fontfamily).toEqual("font-fabulous");
+      expect(ctrl.getIcon(mw_datasource).fontfamily).toEqual("FontAwesome");
+      expect(ctrl.getIcon(vm).fontfamily).toEqual("PatternFlyIcons-webfont");
+      expect(ctrl.getIcon(mw_domain).fontfamily).toEqual("FontAwesome");
+      expect(ctrl.getIcon(mw_server_group).fontfamily).toEqual("FontAwesome");
+      expect(ctrl.getIcon(mw_messaging).fontfamily).toEqual("FontAwesome");
     });
   });
 
   describe('dimensions are returned correctly', function () {
     it('for all objects', function () {
-      expect($controller.getCircleDimensions(mw_manager)).toEqual({x: -20, y: -20, height: 40, width: 40, r: 28});
-      expect($controller.getCircleDimensions(mw_server)).toEqual({x: -12, y: -12, height: 23, width: 23, r: 19});
-      expect($controller.getCircleDimensions(mw_deployment)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
-      expect($controller.getCircleDimensions(mw_datasource)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
-      expect($controller.getCircleDimensions(vm)).toEqual({ x: 0, y: 9, height: 40, width: 40, r: 21 });
-      expect($controller.getCircleDimensions(mw_domain)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
-      expect($controller.getCircleDimensions(mw_server_group)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
-      expect($controller.getCircleDimensions(mw_messaging)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
+      expect(ctrl.getCircleDimensions(mw_manager)).toEqual({x: -20, y: -20, height: 40, width: 40, r: 28});
+      expect(ctrl.getCircleDimensions(mw_server)).toEqual({x: -12, y: -12, height: 23, width: 23, r: 19});
+      expect(ctrl.getCircleDimensions(mw_deployment)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
+      expect(ctrl.getCircleDimensions(mw_datasource)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
+      expect(ctrl.getCircleDimensions(vm)).toEqual({ x: 0, y: 9, height: 40, width: 40, r: 21 });
+      expect(ctrl.getCircleDimensions(mw_domain)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
+      expect(ctrl.getCircleDimensions(mw_server_group)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
+      expect(ctrl.getCircleDimensions(mw_messaging)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
     });
   });
 
   describe('icon types are returned correctly', function () {
     it('for all objects', function () {
-      expect($controller.getIcon(mw_manager).type).toEqual("image");
-      expect($controller.getIcon(mw_server).type).toEqual("image");
-      expect($controller.getIcon(mw_deployment).type).toEqual("glyph");
-      expect($controller.getIcon(mw_datasource).type).toEqual("glyph");
-      expect($controller.getIcon(vm).type).toEqual("glyph");
-      expect($controller.getIcon(mw_domain).type).toEqual("glyph");
-      expect($controller.getIcon(mw_server_group).type).toEqual("glyph");
-      expect($controller.getIcon(mw_messaging).type).toEqual("glyph");
+      expect(ctrl.getIcon(mw_manager).type).toEqual("image");
+      expect(ctrl.getIcon(mw_server).type).toEqual("image");
+      expect(ctrl.getIcon(mw_deployment).type).toEqual("glyph");
+      expect(ctrl.getIcon(mw_datasource).type).toEqual("glyph");
+      expect(ctrl.getIcon(vm).type).toEqual("glyph");
+      expect(ctrl.getIcon(mw_domain).type).toEqual("glyph");
+      expect(ctrl.getIcon(mw_server_group).type).toEqual("glyph");
+      expect(ctrl.getIcon(mw_messaging).type).toEqual("glyph");
     });
   });
 


### PR DESCRIPTION
Continuing with refactoring remaining topology controllers (as in [#1898](https://github.com/ManageIQ/manageiq-ui-classic/pull/1898))