### PR TITLE
Add missing kubernetes icon to alert screens

### DIFF
--- a/app/controllers/alerts_list_controller.rb
+++ b/app/controllers/alerts_list_controller.rb
@@ -19,6 +19,7 @@ class AlertsListController < ApplicationController
   def class_icons
     res = {}
     [
+      'ManageIQ::Providers::Kubernetes::ContainerManager',
       'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
       'ManageIQ::Providers::Openshift::ContainerManager',
     ].each do |klass|


### PR DESCRIPTION
Before change:
![01](https://user-images.githubusercontent.com/3010449/30165265-193c60bc-93e8-11e7-83fd-da74f536ad20.png)

After change:
![after](https://user-images.githubusercontent.com/3010449/30165279-28bf116a-93e8-11e7-9ad1-6026509de112.png)
