### PR TITLE
Added missing gettext to Dialog Editor labels

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -5,10 +5,10 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
     var dialogInitContent = {
       'content': [{
         'dialog_tabs': [{
-          'label': 'New tab',
+          'label': __('New tab'),
           'position': 0,
           'dialog_groups': [{
-            'label': 'New box',
+            'label': __('New section'),
             'position': 0,
             'dialog_fields': []
           }],


### PR DESCRIPTION
Added missing gettext + renamed 'box' to 'section' to be consistent after changes in https://github.com/ManageIQ/ui-components/pull/139