### PR TITLE
Fix typo page heading when Adding Button Group

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -422,7 +422,7 @@ class MiqAeCustomizationController < ApplicationController
       @right_cell_text = right_cell_text_for_node(@custom_button, "CustomButton")
       presenter.update(:main_div, render_proc[:partial => "shared/buttons/ab_form"])
     when 'group_edit'
-      @right_cell_text = right_cell_text_for_node(@custom_button_set, "CustomButonSet")
+      @right_cell_text = right_cell_text_for_node(@custom_button_set, "CustomButtonSet")
     when 'group_reorder'
       @right_cell_text = _("%{models} Group Reorder") % {:models => ui_lookup(:models => "CustomButton")}
     end


### PR DESCRIPTION
Fixed typo page header text when adding Customization Button Group. Page header now properly displays proper name when prior to fix misspelled name was not matched/recognized by gettext() call and simply returned as string to plug into header.

https://bugzilla.redhat.com/show_bug.cgi?id=1486691

Screen shot prior to fix:
![bz1486691_adding a new buttons group prior to fix](https://user-images.githubusercontent.com/552686/30182230-f2993fec-93ca-11e7-81b4-34ee3c204628.png)

=======================
Screen shot post fix:
<img width="1677" alt="bz1486691_adding a new buttons group post fix" src="https://user-images.githubusercontent.com/552686/30182341-5bc2d992-93cb-11e7-9479-80c9ca81db0c.png">

