### PR TITLE
Remove GRAPH_MAX_COUNT from UiConstants

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -22,6 +22,7 @@ module ReportController::Reports::Editor
   ).freeze
 
   MAX_REPORT_COLUMNS = 100 # Default maximum number of columns in a report
+  GRAPH_MAX_COUNT = 10
 
   CHAREGEBACK_ALLOCATED_METHODS = {
     :max => N_('Maximum'),

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,8 +1,5 @@
 module UiConstants
 
-  # Report Controller constants
-  GRAPH_MAX_COUNT = 10
-
   VALID_PLANNING_VM_MODES = PlanningHelper::PLANNING_VM_MODES.keys.index_by(&:to_s)
 
   ALL_TIMEZONES = ActiveSupport::TimeZone.all.collect { |tz| ["(GMT#{tz.formatted_offset}) #{tz.name}", tz.name] }

--- a/app/views/report/_form_chart.html.haml
+++ b/app/views/report/_form_chart.html.haml
@@ -47,7 +47,7 @@
           = _('Top values to show')
         .col-md-8
           = select_tag('chosen_count',
-            options_for_select(3..GRAPH_MAX_COUNT, @edit[:new][:graph_count].to_i),
+            options_for_select(3..ReportController::Reports::Editor::GRAPH_MAX_COUNT, @edit[:new][:graph_count].to_i),
             :multiple              => false,
             :class                 => "selectpicker")
           :javascript

--- a/lib/report_formatter/chart_common.rb
+++ b/lib/report_formatter/chart_common.rb
@@ -251,7 +251,7 @@ module ReportFormatter
 
     def keep_and_show_other
       # Show other sum value by default
-      mri.graph.kind_of?(Hash) ? [mri.graph[:count].to_i, mri.graph[:other]] : [GRAPH_MAX_COUNT, true]
+      mri.graph.kind_of?(Hash) ? [mri.graph[:count].to_i, mri.graph[:other]] : [ReportController::Reports::Editor::GRAPH_MAX_COUNT, true]
     end
 
     def build_reporting_chart_dim2

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -416,7 +416,7 @@ describe ReportController do
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:graph_type]).to eq(chosen_graph)
           expect(edit_new[:graph_other]).to be_truthy
-          expect(edit_new[:graph_count]).to eq(GRAPH_MAX_COUNT)
+          expect(edit_new[:graph_count]).to eq(ReportController::Reports::Editor::GRAPH_MAX_COUNT)
           expect(assigns(:refresh_div)).to eq("chart_div")
           expect(assigns(:refresh_partial)).to eq("form_chart")
         end
@@ -425,13 +425,13 @@ describe ReportController do
           chosen_graph = "<No chart>"
           controller.instance_variable_set(:@_params, :chosen_graph => chosen_graph)
           edit = assigns(:edit)
-          edit[:current] = {:graph_count => GRAPH_MAX_COUNT, :graph_other => true}
+          edit[:current] = {:graph_count => ReportController::Reports::Editor::GRAPH_MAX_COUNT, :graph_other => true}
           controller.instance_variable_set(:@edit, edit)
           controller.send(:gfv_charts)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:graph_type]).to be_nil
           expect(edit_new[:graph_other]).to be_truthy
-          expect(edit_new[:graph_count]).to eq(GRAPH_MAX_COUNT)
+          expect(edit_new[:graph_count]).to eq(ReportController::Reports::Editor::GRAPH_MAX_COUNT)
           expect(assigns(:refresh_div)).to eq("chart_div")
           expect(assigns(:refresh_partial)).to eq("form_chart")
         end


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `GRAPH_MAX_COUNT` was removed from `UiConstants`. It was moved to `ReportController::Reports::Editor`.