### PR TITLE
Remove VALID_PLANNING_VM_MODES from UiConstants

### DIFF
--- a/app/controllers/planning_controller.rb
+++ b/app/controllers/planning_controller.rb
@@ -4,6 +4,8 @@ class PlanningController < ApplicationController
 
   menu_section(:opt)
 
+  VALID_PLANNING_VM_MODES = PlanningHelper::PLANNING_VM_MODES.keys.index_by(&:to_s)
+
   def index
     @explorer = true
     @accords = [{:name => "planning", :title => _("Planning Options"), :container => "planning_options_accord"}]

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,7 +1,5 @@
 module UiConstants
 
-  VALID_PLANNING_VM_MODES = PlanningHelper::PLANNING_VM_MODES.keys.index_by(&:to_s)
-
   # Snapshot ages for delete_snapshots_by_age action type
   SNAPSHOT_AGES = {}
   (1..23).each { |a| SNAPSHOT_AGES[a.hours.to_i] = (a.to_s + (a < 2 ? _(" Hour") : _(" Hours"))) }


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `VALID_PLANNING_VM_MODES` was removed from `UiConstants`. It was moved to `PlanningController`.