### PR TITLE
Remove ALL_TIMEZONES from UiConstants

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -5,10 +5,6 @@ module UiConstants
 
   VALID_PLANNING_VM_MODES = PlanningHelper::PLANNING_VM_MODES.keys.index_by(&:to_s)
 
-  ALL_TIMEZONES = ActiveSupport::TimeZone.all.collect { |tz| ["(GMT#{tz.formatted_offset}) #{tz.name}", tz.name] }
-  # Following line does not include timezones with partial hour offsets
-  # ALL_TIMEZONES = ActiveSupport::TimeZone.all.collect{|tz| tz.utc_offset % 3600 == 0 ? ["(GMT#{tz.formatted_offset}) #{tz.name}",tz.name] : nil}.compact
-
   # Snapshot ages for delete_snapshots_by_age action type
   SNAPSHOT_AGES = {}
   (1..23).each { |a| SNAPSHOT_AGES[a.hours.to_i] = (a.to_s + (a < 2 ? _(" Hour") : _(" Hours"))) }

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -9,6 +9,8 @@ module ViewHelper
   MAX_DESC_LEN = 255
   MAX_HOSTNAME_LEN = 255
 
+  ALL_TIMEZONES = ActiveSupport::TimeZone.all.collect { |tz| ["(GMT#{tz.formatted_offset}) #{tz.name}", tz.name] }.freeze
+
   # PDF page sizes
   PDF_PAGE_SIZES = {
     "a0"            => N_("A0 - 841mm x 1189mm"),

--- a/app/views/bottlenecks/_bottlenecks_options.html.haml
+++ b/app/views/bottlenecks/_bottlenecks_options.html.haml
@@ -29,7 +29,7 @@
         = _('Time Zone')
       .col-md-10
         = select_tag("tl_#{typ}_tz",
-          options_for_select(ALL_TIMEZONES,
+          options_for_select(ViewHelper::ALL_TIMEZONES,
           @sb[:tl_options][:tz]),
           "data-live-search" => "true",
           "class" => "selectpicker",

--- a/app/views/configuration/_timeprofile_form.html.haml
+++ b/app/views/configuration/_timeprofile_form.html.haml
@@ -176,7 +176,7 @@
           = _('Timezone')
         .col-md-8
           = select_tag('profile_tz',
-                       options_for_select([["<#{_('Determine at Run Time')}>", nil]] + ALL_TIMEZONES),
+                       options_for_select([["<#{_('Determine at Run Time')}>", nil]] + ViewHelper::ALL_TIMEZONES),
                        "ng-model"                    => "vm.timeProfileModel.profile_tz",
                        'ng-disabled'                 => "vm.timeProfileModel.restricted_time_profile",
                        "selectpicker-for-select-tag" => "",

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -93,7 +93,7 @@
           %h3
             = _('Display Settings')
           - [[_("Chart Theme"), "display_reporttheme", Charting.chart_themes_for_select, :reporttheme, false],
-             [_("Time Zone"),   "display_timezone",    ALL_TIMEZONES,                    :timezone, true],
+             [_("Time Zone"), "display_timezone", ViewHelper::ALL_TIMEZONES, :timezone, true],
              [_("Locale"), "display_locale",      [[_("Global Default"), "default"]] + FastGettext.human_available_locales, :locale, false]].each do |display_settings|
             .form-group
               %label.col-md-3.control-label

--- a/app/views/ops/_diagnostics_cu_repair_tab.html.haml
+++ b/app/views/ops/_diagnostics_cu_repair_tab.html.haml
@@ -13,9 +13,9 @@
       %label.col-md-2.control-label
         = _("Timezone")
       .col-md-8
-        = select_tag('cu_repair_tz',                                            |
-                    options_for_select(ALL_TIMEZONES, @edit[:new][:timezone]),  |
-                    :class    => "selectpicker")                                |
+        = select_tag('cu_repair_tz',                                                       |
+                    options_for_select(ViewHelper::ALL_TIMEZONES, @edit[:new][:timezone]), |
+                    :class    => "selectpicker")                                           |
       :javascript
         miqInitSelectPicker();
         miqSelectPickerEvent('cu_repair_tz', "#{url}")

--- a/app/views/ops/_schedule_form_timer.html.haml
+++ b/app/views/ops/_schedule_form_timer.html.haml
@@ -26,7 +26,7 @@
           = _("Time Zone")
         .col-md-10
           = select_tag("time_zone",
-                       options_for_select(ALL_TIMEZONES),
+                       options_for_select(ViewHelper::ALL_TIMEZONES),
                        "ng-model"    => "scheduleModel.time_zone",
                        "checkchange" => "",
                        "data-live-search"            => "true",

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -69,7 +69,7 @@
         = _("Appliance Time Zone")
       .col-md-8
         = select_tag('server_timezone',
-                      options_for_select(ALL_TIMEZONES, @edit[:new][:server][:timezone]),
+                      options_for_select(ViewHelper::ALL_TIMEZONES, @edit[:new][:server][:timezone]),
                       "data-live-search" => "true",
                       :class             => "selectpicker")
     :javascript

--- a/app/views/planning/_planning_vm_profile.html.haml
+++ b/app/views/planning/_planning_vm_profile.html.haml
@@ -72,6 +72,6 @@
       &nbsp;&nbsp;&nbsp;
       = _('* Set in Time Profile')
     - else
-      - ALL_TIMEZONES.each do |tz|
+      - ViewHelper::ALL_TIMEZONES.each do |tz|
         - if tz[1] == @sb[:options][:tz]
           = h(tz[0])

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -204,7 +204,7 @@
       = _('Time Zone')
     .col-md-8
       = select_tag('chosen_tz',
-        options_for_select(ALL_TIMEZONES, @edit[:new][:tz]),
+        options_for_select(ViewHelper::ALL_TIMEZONES, @edit[:new][:tz]),
         :class => "selectpicker")
       :javascript
         miqInitSelectPicker();

--- a/app/views/report/_schedule_form_timer.html.haml
+++ b/app/views/report/_schedule_form_timer.html.haml
@@ -52,7 +52,7 @@
         = _('Time Zone')
       .col-md-8
         = select_tag("time_zone",
-          options_for_select(ALL_TIMEZONES, @edit[:tz]),
+          options_for_select(ViewHelper::ALL_TIMEZONES, @edit[:tz]),
           "data-live-search" => "true",
           :class             => "selectpicker")
         :javascript


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `ALL_TIMEZONES` was removed from `UiConstants`. It was moved to `ViewHelper`. `ViewHelper::` prefix was added to every occurrence of this constant.

**Calling `app/views/report/_schedule_form_timer.html.haml`**:
`Cloud Intel` -> `Reports` -> `Schedules` -> `Copy of ChargeBack by Project` -> `Configuration` -> `Edit this Schedule`

**Calling `app/views/report/_form_filter_chargeback.html.haml`**:
`Cloud Intel` -> `Reports` -> `Reports` -> `Configuration`