### PR TITLE
Remove SNAPSHOT_AGES from UiConstants

### DIFF
--- a/app/helpers/miq_policy_helper.rb
+++ b/app/helpers/miq_policy_helper.rb
@@ -1,0 +1,8 @@
+module MiqPolicyHelper
+  # Snapshot ages for delete_snapshots_by_age action type
+  SNAPSHOT_AGES = {}
+  (1..23).each { |a| SNAPSHOT_AGES[a.hours.to_i] = (a.to_s + (a < 2 ? _(" Hour") : _(" Hours"))) }
+  (1..6).each { |a| SNAPSHOT_AGES[a.days.to_i] = (a.to_s + (a < 2 ? _(" Day") : _(" Days"))) }
+  (1..4).each { |a| SNAPSHOT_AGES[a.weeks.to_i] = (a.to_s + (a < 2 ? _(" Week") : _(" Weeks"))) }
+  SNAPSHOT_AGES.freeze
+end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -1,11 +1,4 @@
 module UiConstants
-
-  # Snapshot ages for delete_snapshots_by_age action type
-  SNAPSHOT_AGES = {}
-  (1..23).each { |a| SNAPSHOT_AGES[a.hours.to_i] = (a.to_s + (a < 2 ? _(" Hour") : _(" Hours"))) }
-  (1..6).each { |a| SNAPSHOT_AGES[a.days.to_i] = (a.to_s + (a < 2 ? _(" Day") : _(" Days"))) }
-  (1..4).each { |a| SNAPSHOT_AGES[a.weeks.to_i] = (a.to_s + (a < 2 ? _(" Week") : _(" Weeks"))) }
-
 end
 
 # Make these constants globally available

--- a/app/views/miq_policy/_action_details.html.haml
+++ b/app/views/miq_policy/_action_details.html.haml
@@ -55,7 +55,7 @@
             .form-group
               %label.control-label.col-md-2= _('Delete if older than')
               .col-md-8
-                %p.form-control-static= h(SNAPSHOT_AGES[@action.options[:age]])
+                %p.form-control-static= h(MiqPolicyHelper::SNAPSHOT_AGES[@action.options[:age]])
 
           %hr
         - when "custom_automation"

--- a/app/views/miq_policy/_action_options.html.haml
+++ b/app/views/miq_policy/_action_options.html.haml
@@ -89,7 +89,7 @@
           = _("Delete if Older than")
         .col-md-8
           = select_tag('snapshot_age',
-            options_for_select([["<#{_('Choose')}>", nil]] + SNAPSHOT_AGES.invert.to_a.sort_by(&:last),
+            options_for_select([["<#{_('Choose')}>", nil]] + MiqPolicyHelper::SNAPSHOT_AGES.invert.to_a.sort_by(&:last),
             @edit[:new][:options][:age]),
             :class             => "selectpicker")
           :javascript


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `SNAPSHOT_AGES` was removed from `UiConstants`. It was moved to new module`MiqPolicyHelper`.