### PR TITLE
Store the expanded state of the explorer trees locally

### DIFF
--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -12,6 +12,7 @@
                        "ng-init"   => "vm.initSelected('#{tree.name}', '#{tree.locals_for_render[:select_node]}')",
                        'on-select' => "vm.nodeSelect(node, '/#{request.parameters[:controller]}/tree_select')",
                        'selected'  => "vm.selectedNodes['#{tree.name}']",
+                       'persist'   => 'key',
                        'lazy-load' => "(vm.lazyLoad(node, '#{tree.name}', '/#{request.parameters[:controller]}/tree_autoload'))"}
   :javascript
     miq_bootstrap('#accordion', 'ManageIQ.treeView');


### PR DESCRIPTION
As we're already storing the state on the server side and sending the tree already expanded when necessary, this doesn't do very much but it's a good start for the API-backed tree builders.

@martinpovolny @himdel 