### PR TITLE
Remove MIQ_AE_COPY_ACTIONS from UiConstants

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -9,6 +9,8 @@ class MiqAeClassController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  MIQ_AE_COPY_ACTIONS = %w(miq_ae_class_copy miq_ae_instance_copy miq_ae_method_copy).freeze
+
   # GET /automation_classes
   # GET /automation_classes.xml
   def index

--- a/app/helpers/application_helper/button/miq_ae.rb
+++ b/app/helpers/application_helper/button/miq_ae.rb
@@ -19,7 +19,7 @@ class ApplicationHelper::Button::MiqAe < ApplicationHelper::Button::Basic
   private
 
   def edit_possible?
-    MIQ_AE_COPY_ACTIONS.include?(self[:child_id]) &&
+    MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(self[:child_id]) &&
       User.current_tenant.any_editable_domains? &&
       MiqAeDomain.any_unlocked?
   end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -20,8 +20,6 @@ module UiConstants
   EXP_FROM = "FROM"
   EXP_IS = "IS"
 
-  MIQ_AE_COPY_ACTIONS = %w(miq_ae_class_copy miq_ae_instance_copy miq_ae_method_copy)
-
 end
 
 # Make these constants globally available

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -22,7 +22,7 @@ class TreeBuilderAeClass < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    objects = if MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
+    objects = if MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
                 [MiqAeDomain.find_by_id(@sb[:domain_id])] # GIT support can't use where
               else
                 filter_ae_objects(User.current_tenant.visible_domains)
@@ -54,7 +54,7 @@ class TreeBuilderAeClass < TreeBuilder
       end
     end
     objects = filter_ae_objects(object.ae_namespaces)
-    unless MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
+    unless MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
       ns_classes = filter_ae_objects(object.ae_classes)
       objects += ns_classes unless ns_classes.blank?
     end


### PR DESCRIPTION
### Issue: #1661 

Definition of constant `MIQ_AE_COPY_ACTIONS` was removed from `UiConstants`. It was moved to `MiqAeClassController` class.