### PR TITLE
Remove EXP_TODAY, EXP_FROM, EXP_IS from UiConstants

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -2,6 +2,7 @@ module ApplicationController::Filter
 
   EXP_TODAY = "Today"
   EXP_FROM = "FROM"
+  EXP_IS = "IS"
 
   Expression = Struct.new(
     :alias,

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -1,6 +1,7 @@
 module ApplicationController::Filter
 
   EXP_TODAY = "Today"
+  EXP_FROM = "FROM"
 
   Expression = Struct.new(
     :alias,

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -1,8 +1,7 @@
 module ApplicationController::Filter
-
-  EXP_TODAY = "Today"
-  EXP_FROM = "FROM"
-  EXP_IS = "IS"
+  EXP_TODAY = "Today".freeze
+  EXP_FROM = "FROM".freeze
+  EXP_IS = "IS".freeze
 
   Expression = Struct.new(
     :alias,

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -1,4 +1,7 @@
 module ApplicationController::Filter
+
+  EXP_TODAY = "Today"
+
   Expression = Struct.new(
     :alias,
     :expression,

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -476,7 +476,7 @@ module ReportController::Reports::Editor
       elsif value.include?("NIL") || value.include?("EMPTY")
         @edit[:new][:col_options][field_name][:style][s_idx].delete(:value) # Remove value key
       elsif [:datetime, :date].include?(field_data_type)
-        @edit[:new][:col_options][field_name][:style][s_idx][:value] = EXP_TODAY  # Set default date value
+        @edit[:new][:col_options][field_name][:style][s_idx][:value] = ApplicationController::Filter::EXP_TODAY  # Set default date value
       elsif [:boolean].include?(field_data_type)
         @edit[:new][:col_options][field_name][:style][s_idx][:value] = true       # Set default boolean value
       else

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -476,7 +476,7 @@ module ReportController::Reports::Editor
       elsif value.include?("NIL") || value.include?("EMPTY")
         @edit[:new][:col_options][field_name][:style][s_idx].delete(:value) # Remove value key
       elsif [:datetime, :date].include?(field_data_type)
-        @edit[:new][:col_options][field_name][:style][s_idx][:value] = ApplicationController::Filter::EXP_TODAY  # Set default date value
+        @edit[:new][:col_options][field_name][:style][s_idx][:value] = ApplicationController::Filter::EXP_TODAY # Set default date value
       elsif [:boolean].include?(field_data_type)
         @edit[:new][:col_options][field_name][:style][s_idx][:value] = true       # Set default boolean value
       else

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -8,9 +8,6 @@ module UiConstants
   (1..6).each { |a| SNAPSHOT_AGES[a.days.to_i] = (a.to_s + (a < 2 ? _(" Day") : _(" Days"))) }
   (1..4).each { |a| SNAPSHOT_AGES[a.weeks.to_i] = (a.to_s + (a < 2 ? _(" Week") : _(" Weeks"))) }
 
-  # Expression constants
-  EXP_IS = "IS"
-
 end
 
 # Make these constants globally available

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -9,7 +9,6 @@ module UiConstants
   (1..4).each { |a| SNAPSHOT_AGES[a.weeks.to_i] = (a.to_s + (a < 2 ? _(" Week") : _(" Weeks"))) }
 
   # Expression constants
-  EXP_TODAY = "Today"
   EXP_FROM = "FROM"
   EXP_IS = "IS"
 

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -9,7 +9,6 @@ module UiConstants
   (1..4).each { |a| SNAPSHOT_AGES[a.weeks.to_i] = (a.to_s + (a < 2 ? _(" Week") : _(" Weeks"))) }
 
   # Expression constants
-  EXP_FROM = "FROM"
   EXP_IS = "IS"
 
 end

--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -83,7 +83,7 @@
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true)
 
-        - if @edit[@expkey][:exp_key] == EXP_FROM && @edit[@expkey][:exp_value][0]
+        - if @edit[@expkey][:exp_key] == ApplicationController::Filter::EXP_FROM && @edit[@expkey][:exp_value][0]
           %br
           = _('THROUGH')
           %br

--- a/app/views/layouts/exp_atom/_edit_find.html.haml
+++ b/app/views/layouts/exp_atom/_edit_find.html.haml
@@ -69,7 +69,7 @@
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true)
 
-        - if @edit[@expkey][:exp_skey] == EXP_FROM && @edit[@expkey][:exp_value][0]
+        - if @edit[@expkey][:exp_skey] == ApplicationController::Filter::EXP_FROM && @edit[@expkey][:exp_value][0]
           = ('THROUGH')
           - if @edit[@expkey][:val1][:date_format] == 's'
             = datepicker_input_tag("miq_date_1_1",
@@ -184,7 +184,7 @@
                 "data-miq_sparkle_on"  => true,
                 "data-miq_sparkle_off" => true)
 
-            - if @edit[@expkey][:exp_ckey] == EXP_FROM && @edit[@expkey][:exp_cvalue][0]
+            - if @edit[@expkey][:exp_ckey] == ApplicationController::Filter::EXP_FROM && @edit[@expkey][:exp_cvalue][0]
               = _('THROUGH')
               - if @edit[@expkey][:val2][:date_format] == 's'
                 - val = @edit[@expkey][:exp_cvalue][1] ? @edit[@expkey][:exp_cvalue][1].split(" ").first : ""


### PR DESCRIPTION
### Issue: #1661 

Definitions of constants `EXP_TODAY`, `EXP_FROM`, `EXP_IS` were removed from `UiConstants`. They were moved to `ApplicationController::Filter`.