### PR TITLE
Fix selection of configured system

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -97,7 +97,7 @@ class ProviderForemanController < ApplicationController
           self.x_node = params[:id]
           quick_search_show
         end
-      elsif x_active_tree == :configuration_manager_cs_filter_tree && params[:button] != 'saveit'
+      elsif x_active_tree == :configuration_manager_cs_filter_tree && params[:button].present? && params[:button] != 'saveit'
         listnav_search_selected(from_cid(id))
       end
     end


### PR DESCRIPTION
Steps to reproduce:
1. Configuration -> Management -> Configured Systems -> Foreman Configured Systems
2. Click any system on the right
3. Error bellow:

```
FATAL -- : Error caught: [ActiveRecord::RecordNotFound] Couldn't find MiqSearch with 'id'=1000000000248
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/core.rb:173:in `find'
manageiq-ui-classic/app/controllers/application_controller/filter.rb:223:in `load_selected_search'
manageiq-ui-classic/app/controllers/application_controller/filter.rb:188:in `listnav_search_selected'
manageiq-ui-classic/app/controllers/provider_foreman_controller.rb:101:in `load_or_clear_adv_search'
manageiq-ui-classic/app/controllers/mixins/manager_controller_mixin.rb:175:in `tree_select'
manageiq-ui-classic/app/controllers/application_controller/explorer.rb:195:in `block (2 levels) in generic_x_show'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/mime_responds.rb:201:in `respond_to'
manageiq-ui-classic/app/controllers/application_controller/explorer.rb:188:in `generic_x_show'
manageiq-ui-classic/app/controllers/provider_foreman_controller.rb:114:in `x_show'
```