### PR TITLE
Check hosts when rendering EMS quadicon

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -562,7 +562,7 @@ module QuadiconHelper
                    when EmsCloud         then item.total_vms
                    when ::ManageIQ::Providers::ContainerManager then item.container_nodes.size
                    else
-                     item.hosts.size
+                     item.hosts ? item.hosts.size : 0
                    end
       # reduce font-size of the item_count so it will fit in its quadrant
       output << flobj_p_simple("a72", item_count, item_count.to_s.size > 2 ? "font-size: 12px;" : "")


### PR DESCRIPTION
In case of the Nuage network provider, this patch resolves an issue of not being able to render the main provider view because there are no hosts associated with the EMS. Prior to this patch the following error was observed: `Error caught: [ActionView::Template::Error] undefined method `size' for nil:NilClass`

