### PR TITLE
Load font-fabulous from Rubygems instead of GitHub

### DIFF
--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -12,10 +12,12 @@ require 'sprockets/railtie'
 if ENV["RAILS_ENV"] != "production" || defined?(Rake)
   require 'sass-rails'
   require 'coffee-rails'
+  require 'font-fabulous'
   require 'patternfly-sass'
 else
   require 'bootstrap-sass/engine'
   require 'font_awesome/sass/rails/engine'
+  require 'font-fabulous/engine'
   require 'patternfly-sass/engine'
 end
 

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 5.0.0", ">= 5.0.0.1"
 
   s.add_dependency "coffee-rails"
+  s.add_dependency "font-fabulous", "~> 1.0.0"
   s.add_dependency "high_voltage", "~> 3.0.0"
   s.add_dependency "jquery-hotkeys-rails"
   s.add_dependency "lodash-rails", "~>3.10.0"


### PR DESCRIPTION
Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/2168
Depends on: https://github.com/ManageIQ/manageiq/pull/15966

@miq-bot add_label technical debt, pending core