### PR TITLE
Jasmine /static - render hamls with helpers available

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,11 @@ class StaticOrHaml
     return @rack_file.call(env) unless path.to_s.ends_with?('.haml')
 
     raw = File.read(path)
-    compiled = Haml::Engine.new(raw).render
+    scope = ActionView::Base.new
+    scope.controller = ActionController::Base.new
+    scope.view_paths << File.expand_path("../app/views", __FILE__)
+
+    compiled = Haml::Engine.new(raw).render(scope)
 
     [200, {"Content-Type" => "text/html"}, [compiled]]
   end


### PR DESCRIPTION
A follow-up to #1829.

Before, the /static template were rendered in an empty context - no Rails helpers were available.

Now, at least the basic rails helpers (like `render` or `options_for_select`) should be available when rendering a static template from jasmine specs.

---

Testing:

```
cat '= render :partial => "layouts/flash_msg"' > app/views/static/foo.html.haml
be rake environment jasmine
$BROWSER localhost:8888/static/foo.html.haml
```

before - an exception, now, it renders the partial


Cc @mzazrivec 