### PR TITLE
Fix pdf summary download in config management

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -192,6 +192,17 @@ class ProviderForemanController < ApplicationController
     true
   end
 
+  def download_summary_pdf
+    nodetype, id = parse_nodetype_and_id(valid_active_node(x_node))
+    klass = TreeBuilder.get_model_for_prefix(nodetype)
+    klass = TreeBuilder.get_model_for_prefix(id) if klass == "Hash"
+
+    super do
+      @flash_array = []
+      @record = identify_record(params[:id], klass.constantize)
+    end
+  end
+
   private
 
   def textual_group_list


### PR DESCRIPTION
In provider foreman controller, we're dealing with multiple models (provider, system, profile), so we need
to override the `download_summary_pdf` method to reflect this.

Steps to reproduce problem:
1. Configuration -> Management
2. Click on leaf nodes in the rendered trees (all accordions)
3. Click on download summary pdf icon (when it's available)

https://bugzilla.redhat.com/show_bug.cgi?id=1474819