### PR TITLE
[FINE] Fix the tree rendering for Server Alert Profiles

### DIFF
--- a/app/views/miq_policy/_alert_profile_assign.html.haml
+++ b/app/views/miq_policy/_alert_profile_assign.html.haml
@@ -35,4 +35,14 @@
     %h3
       = _('Selections')
     - if @assign[:obj_tree]
-      = render(:partial => 'shared/tree', :locals => {:tree => @assign[:obj_tree], :name => @assign[:obj_tree].name})
+      - if @assign[:obj_tree].respond_to?(:name)
+        = render(:partial => 'shared/tree', :locals => {:tree => @assign[:obj_tree], :name => @assign[:obj_tree].name})
+      - else
+        #obj_treebox.treeview-pf-hover.treeview-pf-select{:style => "width: 100%; color: #000;"}
+        = render(:partial => "layouts/tree",
+          :locals         => {:tree_id    => "obj_treebox",
+                              :tree_name  => "obj_tree",
+                              :bs_tree    => @assign[:obj_tree],
+                              :oncheck    => "miqOnCheckHandler",
+                              :check_url  => "alert_profile_assign_changed/",
+                              :checkboxes => true})


### PR DESCRIPTION
The tree rendered under Server Alert Profiles uses `TreeNodeBuilder.generic_tree_node`, which creates a tree that does not have a `name` method (and was the reason for the crash - `undefined method 'name' `)

To fix the tree rendering under Server Alert Profiles, use the `"layouts/tree"` partial with `tree_name`  passed in the `locals` hash instead, to render the tree successfully.

https://bugzilla.redhat.com/show_bug.cgi?id=1489697