### PR TITLE
Only count unresolved alerts

### DIFF
--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -101,7 +101,7 @@ class ContainerDashboardService
   def alerts
     provider_ids = ManageIQ::Providers::ContainerManager.all.pluck(:id)
     relation = @ems ? @ems.miq_alert_statuses : MiqAlertStatus.where(:ems_id => provider_ids)
-    alerts_status = relation.present? ? relation.group(:severity).count.values_at('error', 'warning') : [nil, nil]
+    alerts_status = relation.present? ? relation.where(:resolved => [false, nil]).group(:severity).count.values_at('error', 'warning') : [nil, nil]
 
     errors = alerts_status[0] || 0
     warnings = alerts_status[1] || 0


### PR DESCRIPTION
**Description**

`MiqAlertStatus` can be `resolved` or not resolved, users are interested only in the none resolved alerts count.

**Screenshot**
Before fix:
```
ExtManagementSystem.first.miq_alert_statuses.count
2
```
![screenshot-localhost 3000-2017-09-14-13-43-04](https://user-images.githubusercontent.com/2181522/30444989-acccb29a-9952-11e7-8980-b2e88d69cd2f.png)

After fix:
```
ExtManagementSystem.first.miq_alert_statuses.where(:resolved => [false,nil]).count
1
```
![screenshot-localhost 3000-2017-09-14-13-32-03](https://user-images.githubusercontent.com/2181522/30444479-250a4aee-9951-11e7-9dd3-569421d59b60.png)