### PR TITLE
monitoring styling cleanup

### DIFF
--- a/app/assets/stylesheets/alerts.scss
+++ b/app/assets/stylesheets/alerts.scss
@@ -27,13 +27,10 @@
     }
   }
   .list-view-pf-view {
-    margin-top: -1px;
+    margin-top: 0;
   }
   .list-view-container, .row-tile-pf {
-    height: calc(100vh - 196px);
-    overflow-y: auto;
-    position: static;
-    top: 98px;
+    padding: 0;
   }
   .list-view-pf {
     .list-view-pf-body > .row {
@@ -52,10 +49,8 @@
     }
   }
   .list-group-item.list-view-pf-expand-active {
+    margin-top: -1px;
     padding-bottom: 0;
-    .list-group-item-header {
-      padding-bottom: 7px;
-    }
     .list-group-item-container {
       margin-right: -14px;
       margin-top: 5px;
@@ -108,7 +103,6 @@
   .list-group-item {
     &.alert {
       padding-left: 15px;
-      margin-bottom: -1px;
       &.alert-danger {
         background-color: $alert-danger-bg;
       }

--- a/app/views/shared/views/_show_alerts_list.html.haml
+++ b/app/views/shared/views/_show_alerts_list.html.haml
@@ -11,7 +11,7 @@
             = _("All Alerts")
     .row.init-hidden{"ng-class" => "{'initialized': vm.loadingDone}"}
       %div{"pf-toolbar" => "", "config" => "vm.toolbarConfig"}
-      = render :partial => "shared/views/alerts_list"
+    = render :partial => "shared/views/alerts_list"
 
 :javascript
   miq_bootstrap('.miq-alerts-center', 'alertsCenter');

--- a/app/views/shared/views/_show_alerts_most_recent.html.haml
+++ b/app/views/shared/views/_show_alerts_most_recent.html.haml
@@ -20,7 +20,7 @@
                   "ng-change" => "vm.filterChange()"}
           %span
             = _("alerts")
-      = render :partial => "shared/views/alerts_list"
+    = render :partial => "shared/views/alerts_list"
 
 :javascript
   miq_bootstrap('.miq-alerts-center', 'alertsCenter');


### PR DESCRIPTION
This PR refactors some of the styling of the monitor alerts screen and eliminates an unnecessary horizontal scrollbar by outdenting rows that had been nested.

Follow-up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/2117

Old

<img width="654" alt="screen shot 2017-09-15 at 4 07 06 pm" src="https://user-images.githubusercontent.com/1287144/30501313-fe63d2e0-9a2f-11e7-919a-c482e95d68dc.png">

New

<img width="978" alt="screen shot 2017-09-15 at 4 04 09 pm" src="https://user-images.githubusercontent.com/1287144/30501223-975ea160-9a2f-11e7-9531-3bfde3468f23.png">

<img width="980" alt="screen shot 2017-09-15 at 4 04 21 pm" src="https://user-images.githubusercontent.com/1287144/30501224-975f2cca-9a2f-11e7-80ce-5bec89e37b19.png">
