### PR TITLE
fix toolbar height

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -453,12 +453,17 @@ table.table.table-summary-screen tbody td img {
 
 /// begin toolbar styling
 
+.toolbar-pf .toolbar-pf-actions { /* sets margin to zero to compensate for margin added to form groups (for proper spacing when wrapped) */
+  margin-bottom: 0px;
+}
+
 .toolbar-pf .form-group { /*compensates for filter-pf not being implemented */
   padding-left: 0;
 }
 
 .toolbar-pf .toolbar-pf-actions .form-group { /* adds padding between buttons when they wrap */
   margin-bottom: 10px;
+  white-space: nowrap;
 }
 
 /// end toolbar styling


### PR DESCRIPTION
This PR corrects the height of the toolbars, by adjusting the toolbar bottom margin, compensating for padding that was added to properly space  form groups when they wrap. This issue appeared on master only.

Old
<img width="834" alt="screen shot 2017-09-18 at 3 21 40 pm" src="https://user-images.githubusercontent.com/1287144/30560227-3618a20e-9c85-11e7-9987-8f4c50c16c01.png">

New
<img width="949" alt="screen shot 2017-09-18 at 3 20 24 pm" src="https://user-images.githubusercontent.com/1287144/30560226-36183094-9c85-11e7-984a-c29676767398.png">

<img width="543" alt="screen shot 2017-09-18 at 3 20 44 pm" src="https://user-images.githubusercontent.com/1287144/30560532-360bcbf0-9c86-11e7-908f-80c90a0c60ca.png">

