### PR TITLE
Ensure the 'required' property gets saved for dynamic drop down fields

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -1340,6 +1340,7 @@ module MiqAeCustomizationController::Dialogs
                     fld[:load_values_on_init] = field[:load_on_init]
                     fld[:show_refresh_button] = field[:show_refresh_button]
                     fld[:auto_refresh]        = field[:auto_refresh]
+                    fld[:required]            = field[:required]
                   end
 
                   if field[:typ] == "DialogFieldCheckBox"

--- a/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
@@ -59,9 +59,8 @@
   .form-group
     %label.col-md-2.control-label= _('Required')
     .col-md-8
-      = check_box_tag('field_required', 'true',
-                      @edit[:field_required],
-                        "data-miq_observe_checkbox" => {:url => url}.to_json)
+      = check_box_tag('field_required', 'true', @edit[:field_required],
+                      "data-miq_observe_checkbox" => {:url => url}.to_json)
 - if %w(DialogFieldTextBox DialogFieldTextAreaBox).include?(@edit[:field_typ])
   .form-group
     %label.col-md-2.control-label
@@ -91,12 +90,8 @@
     %label.col-md-2.control-label
       = _('Required')
     .col-md-8
-      = select_tag('field_required',
-                  options_for_select([[_("True"), true], [_("False"), false]], @edit[:field_required].to_s),
-                  "data-miq_sparkle_on" => true,
-                  :class    => "selectpicker")
-      :javascript
-        miqSelectPickerEvent('field_required', "#{url}")
+      = check_box_tag('field_required', 'true', @edit[:field_required],
+                      "data-miq_observe_checkbox" => {:url => url}.to_json)
   .form-group
     %label.col-md-2.control-label
       = _('Value Type')

--- a/app/views/miq_ae_customization/_dialog_field_form_non_dynamic_options.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form_non_dynamic_options.html.haml
@@ -60,8 +60,7 @@
   .form-group
     %label.col-md-2.control-label= _('Required')
     .col-md-8
-      = check_box_tag('field_required', 'true',
-                      @edit[:field_required],
+      = check_box_tag('field_required', 'true', @edit[:field_required],
                       "data-miq_observe_checkbox" => {:url => url}.to_json)
 
   - if %w(DialogFieldTextBox DialogFieldTextAreaBox).include?(@edit[:field_typ])
@@ -103,12 +102,8 @@
     %label.col-md-2.control-label
       = _('Required')
     .col-md-8
-      = select_tag('field_required',
-                  options_for_select([[_("True"), true], [_("False"), false]], @edit[:field_required].to_s),
-                  "data-miq_sparkle_on" => true,
-                  :class    => "selectpicker")
-      :javascript
-        miqSelectPickerEvent('field_required', "#{url}")
+      = check_box_tag('field_required', 'true', @edit[:field_required],
+                      "data-miq_observe_checkbox" => {:url => url}.to_json)
 
   .form-group
     %label.col-md-2.control-label


### PR DESCRIPTION
The `required` property wasn't being saved for dynamic drop down dialog fields. The user is able to manually change this value in the automate method, but since the option exists in the UI, they should be able to set it there as well, so this PR fixes that issue.

Ultimately, in the new dialog editor, this will be obsolete and the new editor does not have this issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1492150

/cc @gmcculloug 
@miq-bot add_label euwe/yes, fine/yes, bug
@miq-bot assign @h-kataria 

@h-kataria If you think someone else should be assigned, please re-assign, thanks!