### PR TITLE
Introduce UI for Nuage events

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -394,6 +394,10 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       if ($scope.emsCommonModel.emstype === 'openstack') {
         $scope.emsCommonModel.tenant_mapping_enabled = false;
       }
+    } else if ($scope.emsCommonModel.emstype === 'nuage_network') {
+      $scope.emsCommonModel.default_api_port = $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
+      $scope.emsCommonModel.event_stream_selection = 'none';
+      $scope.emsCommonModel.amqp_security_protocol = 'non-ssl';
     } else if ($scope.emsCommonModel.emstype === 'scvmm') {
       $scope.emsCommonModel.default_security_protocol = 'ssl';
     } else if ($scope.emsCommonModel.emstype === 'rhevm') {

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -482,7 +482,7 @@ module EmsCommon
   end
 
   def retrieve_nuage_api_versions
-    [['Version 3.2', 'v3_2'], ['Version 4.0', 'v4_0']]
+    [['Version 3.2', 'v3_2'], ['Version 4.0', 'v4_0'], ['Version 5.0', 'v5.0']]
   end
 
   def retrieve_security_protocols

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -537,6 +537,7 @@ module Mixins
 
       if ems.kind_of?(ManageIQ::Providers::Nuage::NetworkManager)
         default_endpoint = {:role => :default, :hostname => hostname, :port => port, :security_protocol => ems.security_protocol}
+        amqp_endpoint = {:role => :amqp, :hostname => amqp_hostname, :port => amqp_port, :security_protocol => amqp_security_protocol}
       end
 
       if ems.kind_of?(ManageIQ::Providers::Lenovo::PhysicalInfraManager)

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -28,8 +28,9 @@
                        "prefix"                      => prefix.to_s,
                        "reset-validation-status"     => "#{prefix}_auth_status")
     .col-md-8{"ng-if" => "emsCommonModel.emstype == 'nuage_network'"}
+      - prefix == "amqp" ? security_protocols = @amqp_security_protocols : security_protocols = @nuage_security_protocols
       = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose')}>", nil]] + @nuage_security_protocols, :disabled => ["<#{_('Choose')}>", nil]),
+                       options_for_select([["<#{_('Choose')}>", nil]] + security_protocols, :disabled => ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "required"                    => defined?(security_protocol_not_required) ? false : true,

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -33,6 +33,10 @@
         = _("Web Services")
       = miq_tab_header('ipmi', nil, {'ng-click' => "changeAuthTab('ipmi')"}) do
         = _("IPMI")
+    - elsif %w(ems_network).include?(controller_name)
+      = miq_tab_header('amqp', nil, {'ng-click' => "changeAuthTab('amqp')"}) do
+        %i{"error-on-tab" => "amqp", :style => "color:#cc0000"}
+        = _("Events")
 
   .tab-content
     = miq_tab_content('default', 'default') do
@@ -141,7 +145,7 @@
           %span{:style => "color:black"}
             = _("Required. Used to gather Utilization data.")
 
-    - if %w(ems_cloud ems_infra).include?(params[:controller])
+    - if %w(ems_cloud ems_infra ems_network).include?(params[:controller])
       = miq_tab_content('metrics', 'default') do
         .form-group
           .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'rhevm'"}
@@ -171,8 +175,8 @@
               = _("Used to gather Capacity & Utilization metrics.")
       = miq_tab_content('amqp', 'default') do
         .form-group
-          .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'openstack_infra' || #{ng_model}.emstype == 'vmware_cloud'"}
-            %label.radio-inline.control-label{"for" => "none_radio", "ng-show" => "#{ng_model}.emstype == 'vmware_cloud'"}
+          .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'openstack_infra' || #{ng_model}.emstype == 'vmware_cloud' || #{ng_model}.emstype == 'nuage_network'"}
+            %label.radio-inline.control-label{"for" => "none_radio", "ng-show" => "#{ng_model}.emstype == 'vmware_cloud' || #{ng_model}.emstype == 'nuage_network'"}
               %input{:type         => "radio",
                      :name         => "event_stream_selection",
                      :id           => "none_radio",
@@ -228,6 +232,12 @@
             %span{:style => "color:black"}
               %div{"ng-if" => "emsCommonModel.event_stream_selection == 'amqp'"}
                 = _("Enable event monitoring. Used to automatically resync state when changes are performed on VMware vCloud Director directly.")
+              %div{"ng-if" => "emsCommonModel.event_stream_selection == 'none'"}
+                = _("Disable event monitoring.")
+          .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'nuage_network'"}
+            %span{:style => "color:black"}
+              %div{"ng-if" => "emsCommonModel.event_stream_selection == 'amqp'"}
+                = _("Used to authenticate with Nuage AMQP Messaging Bus for event handling.")
               %div{"ng-if" => "emsCommonModel.event_stream_selection == 'none'"}
                 = _("Disable event monitoring.")
       = miq_tab_content('ssh_keypair', 'default') do
@@ -408,6 +418,8 @@
     $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.emstype == 'nuage_network'"}
   :javascript
+    miq_tabs_show_hide("#amqp_tab", true);
+    miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.ems_controller == 'ems_container'"}


### PR DESCRIPTION
With the introduction of Nuage event catcher, users need to be able to configure the AMQP connection for their Nuage network manager. This patch adds a secondary tab for the Events allowing users to opt-in and create authentication for the AMQP. Complete validation of all credentials is supported.

This PR is based on a contribution from @VojkoR in [this commit](https://github.com/VojkoR/manageiq-ui-classic/commit/b94dac073963daf0b12d9ccc0ba59671270575e7). It adds additional logic to configure the endpoint and authentications.

Links [Optional]
----------------

* [video](https://youtu.be/jJHbaHcd1oY): shows validation of credentials, both default and amqp for Nuage network manager
* depends on [this Nuage PR](https://github.com/ManageIQ/manageiq-providers-nuage/pull/9)

