### PR TITLE
Add initial codeowners file for trees, styling and images

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+app/presenters/tree_node/     @skateman
+app/presenters/tree_builder_* @skateman
+app/assets/stylesheets/       @epwinchell
+app/assets/images/            @epwinchell


### PR DESCRIPTION
We talked about this with @martinpovolny and the conclusion was to only use [this feature](https://github.com/blog/2392-introducing-code-owners) for notifying developers that something has been changed in the area they are/were responsible for. It is possible to [block PR merges](https://help.github.com/articles/about-protected-branches/) before a code owner approves it, however, **we don't want to enable this**.

Initially I marked my tree-related files and the things @epwinchell is working on, like styling and images. I assume others want to mark their stuff too, feel free to do so. We could mark the `CODEOWNERS` file itself with a larger audience (i.e. all UI mergers), but it might be too much spamming.