### PR TITLE
Display Generic Object instances in Service summary

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -173,7 +173,7 @@ class ServiceController < ApplicationController
     if @record.type == "ServiceAnsiblePlaybook"
       [%i(properties), %i(lifecycle tags)]
     else
-      [%i(properties lifecycle relationships miq_custom_attributes), %i(vm_totals tags)]
+      [%i(properties lifecycle relationships generic_objects miq_custom_attributes), %i(vm_totals tags)]
     end
   end
   helper_method :textual_group_list

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -33,8 +33,12 @@ class ServiceController < ApplicationController
   # Service show selected, redirect to proper controller
   def show
     @record = Service.find(from_cid(params[:id]))
-    @display = params[:display]
-    if @display
+
+    @gtl_url = "/show"
+    @display = params[:display] if params[:display]
+
+    if self.class.display_methods.include?(@display)
+      params[:display] = @display
       display_nested_list(@display)
       return
     end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -1,5 +1,6 @@
 class ServiceController < ApplicationController
   include Mixins::GenericSessionMixin
+  include Mixins::GenericShowMixin
 
   before_action :check_privileges
   before_action :get_session_data
@@ -31,15 +32,21 @@ class ServiceController < ApplicationController
 
   # Service show selected, redirect to proper controller
   def show
-    record = Service.find_by_id(from_cid(params[:id]))
+    @record = Service.find_by_id(from_cid(params[:id]))
+    @display = params[:display]
+    if @display
+      display_nested_list(@display)
+      return
+    end
+
     unless @explorer
-      tree_node_id = TreeBuilder.build_node_id(record)
+      tree_node_id = TreeBuilder.build_node_id(@record)
       redirect_to :controller => "service",
                   :action     => "explorer",
                   :id         => tree_node_id
       return
     end
-    redirect_to :action => 'show', :controller => record.class.base_model.to_s.underscore, :id => record.id
+    redirect_to :action => 'show', :controller => @record.class.base_model.to_s.underscore, :id => @record.id
   end
 
   def show_list
@@ -137,6 +144,14 @@ class ServiceController < ApplicationController
       :name        => service.name,
       :description => service.description
     }
+  end
+
+  def self.display_methods
+    %w(generic_objects)
+  end
+
+  def display_generic_objects
+    nested_list("generic_object", GenericObject)
   end
 
   private

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -32,7 +32,7 @@ class ServiceController < ApplicationController
 
   # Service show selected, redirect to proper controller
   def show
-    @record = Service.find_by_id(from_cid(params[:id]))
+    @record = Service.find(from_cid(params[:id]))
     @display = params[:display]
     if @display
       display_nested_list(@display)
@@ -46,7 +46,7 @@ class ServiceController < ApplicationController
                   :id         => tree_node_id
       return
     end
-    redirect_to :action => 'show', :controller => @record.class.base_model.to_s.underscore, :id => @record.id
+    redirect_to(:action => 'show', :controller => @record.class.base_model.to_s.underscore, :id => @record.id)
   end
 
   def show_list

--- a/app/decorators/generic_object_decorator.rb
+++ b/app/decorators/generic_object_decorator.rb
@@ -3,7 +3,7 @@ class GenericObjectDecorator < MiqDecorator
     'ff ff-generic-object'
   end
 
-  def self.fileicon
-    '100/generic_object.png'
+  def fileicon
+    try(:picture) ? "/pictures/#{picture.basename}" : "100/generic_object.png"
   end
 end

--- a/app/decorators/generic_object_definition_decorator.rb
+++ b/app/decorators/generic_object_definition_decorator.rb
@@ -3,7 +3,7 @@ class GenericObjectDefinitionDecorator < MiqDecorator
     'fa fa-file-text-o'
   end
 
-  def self.fileicon
-    '100/generic_object_definition.png'
+  def fileicon
+    try(:picture) ? "/pictures/#{picture.basename}" : "100/generic_object_definition.png"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1360,7 +1360,7 @@ module ApplicationHelper
                         retired
                         scan_profile
                         security_group
-                        service
+                        services
                         storage
                         templates
                       )

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -74,7 +74,7 @@ module ServiceHelper::TextualSummary
   end
 
   def textual_group_generic_objects
-    TextualGroup.new(_("Generic Object"), %i(generic_object_instances))
+    TextualGroup.new(_("Generic Objects"), %i(generic_object_instances))
   end
 
   #

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -251,7 +251,7 @@ module ServiceHelper::TextualSummary
     num = @record.number_of(:generic_objects)
     h = {:label => _("Instances"), :value => num}
     if role_allows?(:feature => "generic_object_view") && num > 0
-      h.update(:link  => url_for_only_path(:action => 'show', :id => @record, :display => 'generic_objects'),
+      h.update(:link  => url_for_only_path(:action => 'show', :id => @record, :display => 'generic_objects', :type => 'tile'),
                :title => _('Show Generic Object Instances for this Service'))
     end
     h

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -73,6 +73,10 @@ module ServiceHelper::TextualSummary
     TextualGroup.new(_("Custom Attributes"), textual_miq_custom_attributes)
   end
 
+  def textual_group_generic_objects
+    TextualGroup.new(_("Generic Object"), %i(generic_object_instances))
+  end
+
   #
   # Items
   #
@@ -241,6 +245,16 @@ module ServiceHelper::TextualSummary
      :value => credential.name,
      :title => _('VMware Credential'),
      :link  => url_for_only_path(:action => 'show', :id => credential.id, :controller => 'ansible_credential')}
+  end
+
+  def textual_generic_object_instances
+    num = @record.number_of(:generic_objects)
+    h = {:label => _("Instances"), :value => num}
+    if role_allows?(:feature => "generic_object_view") && num > 0
+      h.update(:link  => url_for_only_path(:action => 'show', :id => @record, :display => 'generic_objects'),
+               :title => _('Show Generic Object Instances for this Service'))
+    end
+    h
   end
 
   def credential(credential, label)

--- a/app/views/service/show.html.haml
+++ b/app/views/service/show.html.haml
@@ -1,0 +1,5 @@
+#main_div
+  - if %w(generic_objects).include?(@display)
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  - else
+    = render :partial => 'layouts/textual_groups_generic'

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -77,6 +77,26 @@ describe ServiceController do
       expect(response.status).to eq(200)
       expect(response.body).to include('Smart Management')
     end
+
+    it 'displays generic objects as a nested list' do
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as FactoryGirl.create(:user)
+      controller.instance_variable_set(:@breadcrumbs, [])
+      service = FactoryGirl.create(:service, :name => "Abc")
+      definition = FactoryGirl.create(:generic_object_definition,
+                                      :properties => {:associations => {"vms" => "Vm", "services" => "Service"}})
+      go = FactoryGirl.create(
+        :generic_object,
+        :generic_object_definition => definition,
+        :name                      => 'go_assoc',
+        :services                  => [service]
+      )
+      service.add_resource(go)
+
+      get :show, :params => { :id => service.id, :display => 'generic_objects'}
+      expect(response.status).to eq(200)
+      expect(assigns(:breadcrumbs)).to eq([{:name => "Abc (All Generic Objects)", :url => "/service/show/#{service.id}?display=generic_objects"}])
+    end
   end
 
   context "#sanitize_output" do


### PR DESCRIPTION
Generic Object instances in the Service Detail Page -
<img width="1361" alt="screen shot 2017-09-19 at 12 02 51 pm" src="https://user-images.githubusercontent.com/1538216/30610364-c771ced0-9d32-11e7-9374-5d5342033159.png">

<img width="446" alt="screen shot 2017-09-19 at 12 03 13 pm" src="https://user-images.githubusercontent.com/1538216/30610351-c02c6e28-9d32-11e7-9570-868c04f1a3ce.png">

Drilling down in the GO instances -
(Tile View displays `Definition` (Generic Object Class)
<img width="1354" alt="screen shot 2017-09-27 at 3 18 11 pm" src="https://user-images.githubusercontent.com/1538216/30940807-503372d6-a397-11e7-9182-16ff73441db4.png">

(List View displays `Definition` (Generic Object Class) column
<img width="1357" alt="screen shot 2017-09-27 at 3 18 25 pm" src="https://user-images.githubusercontent.com/1538216/30940868-90cb80ea-a397-11e7-95c4-b22a8f47e2f2.png">




<img width="1350" alt="screen shot 2017-09-19 at 12 17 10 pm" src="https://user-images.githubusercontent.com/1538216/30610879-8143ac60-9d34-11e7-979d-8e2e3c1afadc.png">



https://www.pivotaltracker.com/n/projects/1613907/stories/148040727