### PR TITLE
[WIP] Convert deploy_provider_controller to controllerAs

### DIFF
--- a/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
@@ -22,7 +22,7 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
     vm.deploymentDetailsGeneralComplete = false;
     vm.nextButtonTitle = __("Next >");
 
-    var initializeDeploymentWizard = function () {
+    var initializeDeploymentWizard = vm.initializeDeploymentWizard = function () {
       vm.data = {
         providerName: '',
         providerType: 'openshiftEnterprise',
@@ -42,7 +42,7 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
       vm.deployProviderReady = true;
     };
 
-    var create_auth_object = function () {
+    var create_auth_object = vm.create_auth_object = function () {
       var auth = {};
       switch (vm.data.authentication.mode) {
         case 'all':
@@ -53,8 +53,8 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
           auth.htpassd_users = vm.data.authentication.htPassword.users;
           break;
         case 'ldap':
-          auth.type = 'AuthenticationLdap';
           Object.assign(auth, vm.data.authentication.ldap);
+          auth.type = 'AuthenticationLdap';
           auth.bind_dn = vm.data.authentication.ldap.bindDN;
           auth.password = vm.data.authentication.ldap.bindPassword;
           auth.certificate_authority = vm.data.authentication.ldap.ca;
@@ -92,7 +92,7 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
       return auth;
     };
 
-    var create_nodes_object = function() {
+    var create_nodes_object = vm.create_nodes_object = function() {
       var nodes = [];
       vm.nodeData.allNodes.forEach(function(item) {
         var name = "";
@@ -168,7 +168,7 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
     vm.deployComplete = false;
     vm.deployInProgress = false;
 
-    var startDeploy = function () {
+    var startDeploy = vm.startDeploy = function () {
       vm.deployInProgress = true;
       vm.deployComplete = false;
       vm.deploySuccess = false;

--- a/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
@@ -54,15 +54,13 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
           break;
         case 'ldap':
           auth.type = 'AuthenticationLdap';
-          auth.id = vm.data.authentication.ldap.id;
-          auth.email = vm.data.authentication.ldap.email;
-          auth.name = vm.data.authentication.ldap.name;
-          auth.username = vm.data.authentication.ldap.username;
+          Object.assign(auth, vm.data.authentication.ldap);
           auth.bind_dn = vm.data.authentication.ldap.bindDN;
           auth.password = vm.data.authentication.ldap.bindPassword;
           auth.certificate_authority = vm.data.authentication.ldap.ca;
-          auth.insecure = vm.data.authentication.ldap.insecure;
-          auth.url = vm.data.authentication.ldap.url;
+          delete auth.bindDN;
+          delete auth.bindPassword;
+          delete auth.ca;
           break;
         case 'requestHeader':
           auth.type = 'AuthenticationRequestHeader';

--- a/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
@@ -2,11 +2,11 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
   ['$rootScope', '$scope', 'miqService', 'API', '$timeout',
   function($rootScope, $scope, miqService, API, $timeout) {
     'use strict';
-
-    $scope.showDeploymentWizard = false;
-    ManageIQ.angular.scope = $scope;
-    $scope.data = {};
-    $scope.nodeData = {
+    var vm = this;
+    vm.showDeploymentWizard = false;
+    ManageIQ.angular.scope = vm;
+    vm.data = {};
+    vm.nodeData = {
       allNodes: [],
       filteredNodes: [],
       providerVMs: [],
@@ -14,16 +14,16 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
       userDefinedVMs: []
     };
 
-    $scope.deployProviderReady = false;
-    $scope.deployComplete = false;
-    $scope.deployInProgress = false;
-    $scope.deploySuccess = false;
-    $scope.deployFailed = false;
-    $scope.deploymentDetailsGeneralComplete = false;
-    $scope.nextButtonTitle = __("Next >");
+    vm.deployProviderReady = false;
+    vm.deployComplete = false;
+    vm.deployInProgress = false;
+    vm.deploySuccess = false;
+    vm.deployFailed = false;
+    vm.deploymentDetailsGeneralComplete = false;
+    vm.nextButtonTitle = __("Next >");
 
     var initializeDeploymentWizard = function () {
-      $scope.data = {
+      vm.data = {
         providerName: '',
         providerType: 'openshiftEnterprise',
         provisionOn: 'existingVms',
@@ -36,59 +36,59 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
         }
       };
 
-      $scope.data.existingProviders = $scope.deploymentData.providers;
-      $scope.data.newVmProviders = $scope.deploymentData.provision;
-      $scope.originAvailable = $scope.deploymentData.deployment_types.includes("origin");
-      $scope.deployProviderReady = true;
+      vm.data.existingProviders = vm.deploymentData.providers;
+      vm.data.newVmProviders = vm.deploymentData.provision;
+      vm.originAvailable = vm.deploymentData.deployment_types.includes("origin");
+      vm.deployProviderReady = true;
     };
 
     var create_auth_object = function () {
       var auth = {};
-      switch ($scope.data.authentication.mode) {
+      switch (vm.data.authentication.mode) {
         case 'all':
           auth.type = "AuthenticationAllowAll";
           break;
         case 'htPassword':
           auth.type = 'AuthenticationHtpasswd';
-          auth.htpassd_users = $scope.data.authentication.htPassword.users;
+          auth.htpassd_users = vm.data.authentication.htPassword.users;
           break;
         case 'ldap':
           auth.type = 'AuthenticationLdap';
-          auth.id = $scope.data.authentication.ldap.id;
-          auth.email = $scope.data.authentication.ldap.email;
-          auth.name = $scope.data.authentication.ldap.name;
-          auth.username = $scope.data.authentication.ldap.username;
-          auth.bind_dn = $scope.data.authentication.ldap.bindDN;
-          auth.password = $scope.data.authentication.ldap.bindPassword;
-          auth.certificate_authority = $scope.data.authentication.ldap.ca;
-          auth.insecure = $scope.data.authentication.ldap.insecure;
-          auth.url = $scope.data.authentication.ldap.url;
+          auth.id = vm.data.authentication.ldap.id;
+          auth.email = vm.data.authentication.ldap.email;
+          auth.name = vm.data.authentication.ldap.name;
+          auth.username = vm.data.authentication.ldap.username;
+          auth.bind_dn = vm.data.authentication.ldap.bindDN;
+          auth.password = vm.data.authentication.ldap.bindPassword;
+          auth.certificate_authority = vm.data.authentication.ldap.ca;
+          auth.insecure = vm.data.authentication.ldap.insecure;
+          auth.url = vm.data.authentication.ldap.url;
           break;
         case 'requestHeader':
           auth.type = 'AuthenticationRequestHeader';
-          auth.request_header_challenge_url = $scope.data.authentication.requestHeader.challengeUrl;
-          auth.request_header_login_url = $scope.data.authentication.requestHeader.loginUrl;
-          auth.certificate_authority = $scope.data.authentication.requestHeader.clientCA;
-          auth.request_header_headers = $scope.data.authentication.requestHeader.headers;
+          auth.request_header_challenge_url = vm.data.authentication.requestHeader.challengeUrl;
+          auth.request_header_login_url = vm.data.authentication.requestHeader.loginUrl;
+          auth.certificate_authority = vm.data.authentication.requestHeader.clientCA;
+          auth.request_header_headers = vm.data.authentication.requestHeader.headers;
           break;
         case 'openId':
           auth.type = 'AuthenticationOpenId';
-          auth.userid = $scope.data.authentication.openId.clientId;
-          auth.password = $scope.data.authentication.openId.clientSecret;
-          auth.open_id_sub_claim = $scope.data.authentication.openId.subClaim;
-          auth.open_id_authorization_endpoint = $scope.data.authentication.openId.authEndpoint;
-          auth.open_id_token_endpoint = $scope.data.authentication.openId.tokenEndpoint;
+          auth.userid = vm.data.authentication.openId.clientId;
+          auth.password = vm.data.authentication.openId.clientSecret;
+          auth.open_id_sub_claim = vm.data.authentication.openId.subClaim;
+          auth.open_id_authorization_endpoint = vm.data.authentication.openId.authEndpoint;
+          auth.open_id_token_endpoint = vm.data.authentication.openId.tokenEndpoint;
           break;
         case 'google':
           auth.type = 'AuthenticationGoogle';
-          auth.userid = $scope.data.authentication.google.clientId;
-          auth.password = $scope.data.authentication.google.clientSecret;
-          auth.google_hosted_domain = $scope.data.authentication.google.hostedDomain;
+          auth.userid = vm.data.authentication.google.clientId;
+          auth.password = vm.data.authentication.google.clientSecret;
+          auth.google_hosted_domain = vm.data.authentication.google.hostedDomain;
           break;
         case 'github':
           auth.type = 'AuthenticationGithub';
-          auth.userid = $scope.data.authentication.github.clientId;
-          auth.password = $scope.data.authentication.github.clientSecret;
+          auth.userid = vm.data.authentication.github.clientId;
+          auth.password = vm.data.authentication.github.clientSecret;
           break;
       }
       return auth;
@@ -96,13 +96,13 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
 
     var create_nodes_object = function() {
       var nodes = [];
-      $scope.nodeData.allNodes.forEach(function(item) {
+      vm.nodeData.allNodes.forEach(function(item) {
         var name = "";
-        if ($scope.data.provisionOn == 'existingVms') {
+        if (vm.data.provisionOn == 'existingVms') {
           var id = item.id;
           name = item.name;
         }
-        else if ($scope.data.provisionOn == 'noProvider') {
+        else if (vm.data.provisionOn == 'noProvider') {
           name = item.vmName;
           var publicName = item.publicName;
         }
@@ -135,113 +135,113 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
       };
 
       var resource = {
-        provider_name: $scope.data.providerName,
-        provider_type: $scope.data.providerType,
-        method_type: method_types[$scope.data.provisionOn],
+        provider_name: vm.data.providerName,
+        provider_type: vm.data.providerType,
+        method_type: method_types[vm.data.provisionOn],
         rhsm_authentication: {
-          userid: $scope.data.rhnUsername,
-          password: $scope.data.rhnPassword,
-          rhsm_sku: $scope.data.rhnSKU,
-          rhsm_server: $scope.data.rhnSatelliteUrl
+          userid: vm.data.rhnUsername,
+          password: vm.data.rhnPassword,
+          rhsm_sku: vm.data.rhnSKU,
+          rhsm_server: vm.data.rhnSatelliteUrl
         },
         ssh_authentication: {
-          userid: $scope.data.deploymentUsername,
-          auth_key: $scope.data.deploymentKey
+          userid: vm.data.deploymentUsername,
+          auth_key: vm.data.deploymentKey
         },
         nodes: create_nodes_object(),
         identity_authentication: create_auth_object()
       };
 
-      if ($scope.data.provisionOn == 'existingVms') {
-        resource.underline_provider_id = $scope.data.existingProviderId;
-      } else if ($scope.data.provisionOn == 'newVms') {
-        resource.underline_provider_id = $scope.data.newVmProviderId;
-        resource.masters_creation_template_id = $scope.data.masterCreationTemplateId;
-        resource.nodes_creation_template_id = $scope.data.nodeCreationTemplateId;
-        resource.master_base_name = $scope.data.createMasterBaseName;
-        resource.node_base_name = $scope.data.createNodesBaseName;
+      if (vm.data.provisionOn == 'existingVms') {
+        resource.underline_provider_id = vm.data.existingProviderId;
+      } else if (vm.data.provisionOn == 'newVms') {
+        resource.underline_provider_id = vm.data.newVmProviderId;
+        resource.masters_creation_template_id = vm.data.masterCreationTemplateId;
+        resource.nodes_creation_template_id = vm.data.nodeCreationTemplateId;
+        resource.master_base_name = vm.data.createMasterBaseName;
+        resource.node_base_name = vm.data.createNodesBaseName;
       }
       return resource;
     };
 
-    $scope.ready = false;
+    vm.ready = false;
 
-    $scope.data = {};
-    $scope.deployComplete = false;
-    $scope.deployInProgress = false;
+    vm.data = {};
+    vm.deployComplete = false;
+    vm.deployInProgress = false;
 
     var startDeploy = function () {
-      $scope.deployInProgress = true;
-      $scope.deployComplete = false;
-      $scope.deploySuccess = false;
-      $scope.deployFailed = false;
+      vm.deployInProgress = true;
+      vm.deployComplete = false;
+      vm.deploySuccess = false;
+      vm.deployFailed = false;
 
       var url = '/api/container_deployments';
       var resource = create_deployment_resource();
       API.post(url, {"action" : "create", "resource" : resource}).then(function (response) {
         'use strict';
-        $scope.deployInProgress = false;
-        $scope.deployComplete = true;
-        $scope.deployFailed = response.error !== undefined;
+        vm.deployInProgress = false;
+        vm.deployComplete = true;
+        vm.deployFailed = response.error !== undefined;
         if (response.error) {
           if (response.error.message) {
-            $scope.deployFailureMessage = response.error.message;
+            vm.deployFailureMessage = response.error.message;
           }
           else {
-            $scope.deployFailureMessage = __("An unknown error has occurred.");
+            vm.deployFailureMessage = __("An unknown error has occurred.");
           }
         }
       });
     };
 
-    $scope.nextCallback = function(step) {
+    vm.nextCallback = function(step) {
       if (step.stepId === 'review-summary') {
         startDeploy();
       }
       return true;
     };
-    $scope.backCallback = function(step) {
+    vm.backCallback = function(step) {
       return true;
     };
 
     $scope.$on("wizard:stepChanged", function(e, parameters) {
       if (parameters.step.stepId == 'review-summary') {
-        $scope.nextButtonTitle = __("Deploy");
+        vm.nextButtonTitle = __("Deploy");
       } else if (parameters.step.stepId == 'review-progress') {
-        $scope.nextButtonTitle = __("Close");
+        vm.nextButtonTitle = __("Close");
       } else {
-        $scope.nextButtonTitle = __("Next >");
+        vm.nextButtonTitle = __("Next >");
       }
     });
 
-    $scope.showDeploymentWizard = false;
-    $scope.showListener = function() {
-      if (!$scope.showDeploymentWizard) {
+    vm.showDeploymentWizard = false;
+    vm.showListener = function() {
+      if (!vm.showDeploymentWizard) {
         var url = '/api/container_deployments';
         API.options(url).then(function (response) {
           'use strict';
-          $scope.deploymentData = response.data;
+          vm.deploymentData = response.data;
           initializeDeploymentWizard();
-          $scope.ready = true;
+          vm.ready = true;
         });
-        $scope.showDeploymentWizard = true;
+        vm.showDeploymentWizard = true;
       }
     };
 
-    $scope.cancelDeploymentWizard = function () {
-      if (!$scope.deployInProgress) {
-        $scope.showDeploymentWizard = false;
+    vm.cancelDeploymentWizard = function () {
+      if (!vm.deployInProgress) {
+        vm.showDeploymentWizard = false;
       }
     };
 
-    $scope.cancelWizard = function () {
-      $scope.showDeploymentWizard = false;
+    vm.cancelWizard = function () {
+      vm.showDeploymentWizard = false;
       return true;
     };
 
-    $scope.finishedWizard = function () {
+    vm.finishedWizard = function () {
       $rootScope.$emit('deployProvider.finished');
-      $scope.showDeploymentWizard = false;
+      vm.showDeploymentWizard = false;
       return true;
     };
 
@@ -252,7 +252,7 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
 
       $timeout(function() {
         if (event.name === 'showListener') {
-          $scope.showListener();
+          vm.showListener();
         }
       });
     });

--- a/spec/javascripts/controllers/containers/deploy_provider_controller_spec.js
+++ b/spec/javascripts/controllers/containers/deploy_provider_controller_spec.js
@@ -1,0 +1,107 @@
+describe('containers.deployProviderController', function() {
+    var $scope, vm, $controller, $httpBackend, miqService;
+
+    beforeEach(module('miq.containers.providersModule'));
+
+    beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _miqService_) {
+        miqService = _miqService_;
+        spyOn(miqService, 'showButtons');
+        spyOn(miqService, 'hideButtons');
+        spyOn(miqService, 'miqAjaxButton');
+        spyOn(miqService, 'sparkleOn');
+        spyOn(miqService, 'sparkleOff');
+        $scope = $rootScope.$new();
+        spyOn($scope, '$broadcast');
+        $httpBackend = _$httpBackend_;
+        $controller = _$controller_('containers.deployProviderController as vm', {
+            $scope: $scope,
+            keyPairFormId: 'new',
+            url: '/ems_container/show_list',
+            categories: [],
+            miqService: miqService
+        });
+    }));
+
+    afterEach(function() {
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    describe('create authentication object', function() {
+        it('should create authentication object with default options', function() {
+            $controller.deploymentData = { 'providers' : ['bla'], 'provision' : 'prov', 'deployment_types' : 'origin' };
+            $controller.initializeDeploymentWizard();
+            auth = $controller.create_auth_object();
+            expect(auth.type).toBe('AuthenticationAllowAll');
+
+        });
+
+        it('should create authentication object with custom options', function() {
+            $controller.deploymentData = { 'providers' : ['bla'], 'provision' : 'prov', 'deployment_types' : 'origin' };
+            $controller.initializeDeploymentWizard();
+            [{ 'input' : { 'mode': 'htPassword', 'htPassword' : {'users' : ['user']} }, 'expectedResult' : {'type' : 'AuthenticationHtpasswd', 'htpassd_users' : ['user']}},
+             { 'input' : { 'mode': 'ldap', 'ldap' : {'bindDN' : 'dn', 'bindPassword' : 'bp', 'ca' : 'ca', 'others' : 'something'} },
+               'expectedResult' : {'type' : 'AuthenticationLdap', 'bind_dn' : 'dn', 'password' : 'bp', 'certificate_authority' : 'ca', 'others' : 'something' }},
+             { 'input' : { 'mode': 'requestHeader', 'requestHeader' : {'challengeUrl' : 'url1', 'loginUrl' : 'url2', 'clientCA' : 'ca', 'headers' : ['h']} },
+                'expectedResult' : {'type' : 'AuthenticationRequestHeader', 'request_header_challenge_url' : 'url1', 'request_header_login_url' : 'url2', 'certificate_authority' : 'ca',
+                                    'request_header_headers' : ['h']}},
+             { 'input' : { 'mode': 'openId', 'openId' : {'clientId' : 'ci', 'clientSecret' : 'cs', 'subClaim' : 'sc', 'authEndpoint' : 'ae', 'tokenEndpoint' : 'te'} },
+                'expectedResult' : {'type' : 'AuthenticationOpenId', 'userid' : 'ci', 'password' : 'cs', 'open_id_sub_claim' : 'sc',
+                                    'open_id_authorization_endpoint' : 'ae', 'open_id_token_endpoint' : 'te'} },
+             { 'input' : { 'mode': 'google', 'google' : {'clientId' : 'ci', 'clientSecret' : 'cs', 'hostedDomain' : 'hd'} },
+                'expectedResult' : {'type' : 'AuthenticationGoogle', 'userid' : 'ci', 'password' : 'cs', 'google_hosted_domain' : 'hd'} },
+             { 'input' : { 'mode': 'github', 'github' : {'clientId' : 'ci', 'clientSecret' : 'cs'} },
+                'expectedResult' : {'type' : 'AuthenticationGithub', 'userid' : 'ci', 'password' : 'cs'} }
+            ].forEach(function(e) {
+                $controller.data.authentication = e.input;
+                auth = $controller.create_auth_object();
+                expect(auth).toEqual(e.expectedResult);
+            });
+
+        });
+    });
+
+    describe('create nodes object', function() {
+        it('should create empty nodes object', function() {
+            nodes = $controller.create_nodes_object();
+            expect(nodes).toEqual([]);
+        });
+
+        it('should create nodes object with no Provider', function() {
+            $controller.data.provisionOn = 'noProvider';
+            $controller.nodeData.allNodes = [{ 'master' : 'm', 'node' : 'n', 'storage' : 's', 'loadBalancer' : 'lb', 'vmName' : 'Knedlik',
+                                               'dns' : 'dns', 'etcd' :'etcd', 'infrastructure' : 'in',  'publicName' : 'publicKnedlik' }];
+            nodes = $controller.create_nodes_object();
+            expect(nodes).toEqual([{ 'name' : 'Knedlik', 'id' : undefined, 'public_name' : 'publicKnedlik', 'roles' : {'master' : 'm', 'node' : 'n', 'storage' : 's', 'master_lb' : 'lb',
+                                               'dns' : 'dns', 'etcd' :'etcd', 'infrastructure' : 'in' }}]);
+        });
+
+        it('should create nodes object with existing VMs', function() {
+            $controller.data.provisionOn = 'existingVms';
+            $controller.nodeData.allNodes = [{ 'master' : 'm', 'id' : 1, 'node' : 'n', 'storage' : 's', 'loadBalancer' : 'lb', 'vmName' : 'Knedlik',
+                                               'dns' : 'dns', 'etcd' :'etcd', 'infrastructure' : 'in' }];
+            nodes = $controller.create_nodes_object();
+            expect(nodes).toEqual([{ 'name' : 'Knedlik', 'id' : 1, 'roles' : {'master' : 'm', 'node' : 'n', 'storage' : 's', 'master_lb' : 'lb',
+                                               'dns' : 'dns', 'etcd' :'etcd', 'infrastructure' : 'in' }}]);
+        });
+
+        it('should filter nodes without master/node/storage', function() {
+            $controller.data.provisionOn = 'existingVms';
+            $controller.nodeData.allNodes = [{ 'id' : 1, 'loadBalancer' : 'lb', 'vmName' : 'Knedlik',
+                                               'dns' : 'dns', 'etcd' :'etcd', 'infrastructure' : 'in' }];
+            nodes = $controller.create_nodes_object();
+            expect(nodes).toEqual([]);
+        });
+    });
+
+    describe('starts deploy', function() {
+        it('should deploy', function() {
+            $controller.deploymentData = { 'providers' : ['bla'], 'provision' : 'prov', 'deployment_types' : 'origin' };
+            $controller.initializeDeploymentWizard();
+            $controller.startDeploy();
+            expect($controller.deployFailed).toBe(false);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Convert deploy_provider_controller to controllerAs


- [x] uses as vm
- [x] ManageIQ.angular.scope points to vm - neeeded by QE
- [x] does not inject $scope unless needed for a $watch or events, or angularForm
- [x] using a common button partial (No need)
- [x] uses miq-form (not a form)
- [x] uses form-changed, no checkchange (No need)
- [x] no separate edit & new, use the same partial
- [x] specs
- [x] no copying values one by one - use Object.assign
- [x] no miqAjaxButton(url, true) - always submit the actual model, don't rely on magic form serialization
- [x] no extra $setPristine etc. where it doesn't make sense (form submit, form reset..)
- [x] no if (condition) return true; else return false;
- [x] no miqrequired, use required or ng-required