### PR TITLE
[WIP] Dupe flash message when clicking Reset in Storage Manager Policy edit

### DIFF
--- a/app/views/layouts/angular/_gtl.html.haml
+++ b/app/views/layouts/angular/_gtl.html.haml
@@ -1,5 +1,5 @@
 - current_model = model_to_report_data
-- no_flash_div ||= false
+- no_flash_div ||= @embedded
 - gtl_type_string = j_str(@gtl_type)
 - active_tree = x_active_tree unless params[:display] || @use_action
 - selected_records = @edit[:object_ids] unless @edit.nil? || @edit[:object_ids].nil?


### PR DESCRIPTION
Added early setting for no_flash_div as well as check for `@embedded` setting, to determine page mode display, gtl or not.  

https://bugzilla.redhat.com/show_bug.cgi?id=1486699

https://bugzilla.redhat.com/show_bug.cgi?id=1486674

Code fix references prior refactoring in this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/592

https://github.com/ManageIQ/manageiq-ui-classic/pull/592/files#diff-d0ae3f05218e9a339d54872f322a6c42L19

View code used to check setting of "@embedded" when determining display mode of the page content and whether to display flash message (in gtl mode).  

Screen shot post code fix, confirmation flash message is only displayed once at top of the page:
