### PR TITLE
Using isolate scope in validationStatus directive

### DIFF
--- a/app/assets/javascripts/directives/validation/validation_status.js
+++ b/app/assets/javascripts/directives/validation/validation_status.js
@@ -1,16 +1,19 @@
 ManageIQ.angular.app.directive('validationStatus', ['$rootScope', function($rootScope) {
   return {
     require: 'ngModel',
-    link: function (scope, elem, attrs, ctrl) {
-      ctrl.$validators.validationRequired = function (modelValue, viewValue) {
-        if (viewValue !== undefined && viewValue === true) {
-          _.get(scope, attrs.mainScope).postValidationModelRegistry(attrs.prefix);
+    scope: {
+      postValidationModelRegistry: '<?',
+      prefix: '@?',
+    },
+    link: function(scope, _elem, _attrs, ctrl) {
+      ctrl.$validators.validationRequired = function(_modelValue, viewValue) {
+        if (viewValue) {
+          scope.postValidationModelRegistry(scope.prefix);
           return true;
-        } else {
-          $rootScope.$broadcast('setErrorOnTab', {tab: attrs.prefix});
-          return false;
         }
+        $rootScope.$broadcast('setErrorOnTab', {tab: scope.prefix});
+        return false;
       };
-    }
-  }
+    },
+  };
 }]);

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -21,14 +21,15 @@
   %div{"ng-if" => "#{main_scope}.checkAuthentication"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{valtype}_auth_status.$error.validationRequired}"}
       .col-md-8
-        %input.form-control{"type"                => "checkbox",
-                            "id"                  => "#{valtype}_auth_status",
-                            "name"                => "#{valtype}_auth_status",
-                            "ng-model"            => "$parent.#{main_scope}.#{ng_model}.#{valtype}_auth_status",
-                            "prefix"              => "#{valtype}",
-                            "main-scope"          => "$parent.#{main_scope}",
-                            "validation-status"   => "",
-                            "adjust-error-on-tab" => "$parent.#{main_scope}.#{ng_model}.#{valtype}_auth_status",
-                            "ng-show"             => false}
+        %input.form-control{"type"                           => "checkbox",
+                            "id"                             => "#{valtype}_auth_status",
+                            "name"                           => "#{valtype}_auth_status",
+                            "ng-model"                       => "$parent.#{main_scope}.#{ng_model}.#{valtype}_auth_status",
+                            "prefix"                         => "#{valtype}",
+                            "main-scope"                     => "$parent.#{main_scope}",
+                            "validation-status"              => "",
+                            "adjust-error-on-tab"            => "$parent.#{main_scope}.#{ng_model}.#{valtype}_auth_status",
+                            "ng-show"                        => false,
+                            "post-validation-model-registry" => "$parent.#{main_scope}.postValidationModelRegistry"}
         %span.help-block{"ng-if" => "angularForm.#{valtype}_auth_status.$error.validationRequired"}
           = _("Validation Required")

--- a/spec/javascripts/directives/validation/validation_status_spec.js
+++ b/spec/javascripts/directives/validation/validation_status_spec.js
@@ -1,35 +1,35 @@
 describe('validationStatus initialization', function() {
-  var $scope, $parentScope, form;
+  var $scope;
+  var elem;
+  var angularForm;
   beforeEach(module('ManageIQ'));
   beforeEach(inject(function($compile, $rootScope) {
     $scope = $rootScope.$new();
-    $parentScope = $rootScope.$new();
-    $scope.$parent = $parentScope;
-    $parentScope.model = "emsCommonModel";
+    $scope.postValidationModelRegistry = jasmine.createSpy('postValidationModelRegistry');
     var element = angular.element(
       '<form name="angularForm">' +
       '<input type="text" error-on-tab="default"/>' +
-      '<input type="checkbox" main-scope="$parent" validation-status="" prefix="default" ng-model="emsCommonModel.default_auth_status" name="default_auth_status"/>' +
+      '<input type="checkbox" validation-status="" prefix="default"' +
+        'ng-model="emsCommonModel.default_auth_status"' +
+        'name="default_auth_status"' +
+        'post-validation-model-registry="postValidationModelRegistry"/>' +
       '</form>'
     );
-    $compile(element)($scope);
-    $scope.$digest();
-    elem = $compile(element)($rootScope);
+    elem = $compile(element)($scope);
+    elem.scope().$digest();
     angularForm = $scope.angularForm;
   }));
 
   describe('validation-status', function() {
     it('builds post Validation Model when validation status is valid', function() {
-      $parentScope.postValidationModelRegistry = function() {};
-      spyOn($parentScope, 'postValidationModelRegistry');
       angularForm.default_auth_status.$setViewValue(true);
-      expect($parentScope.postValidationModelRegistry).toHaveBeenCalled();
+      expect($scope.postValidationModelRegistry).toHaveBeenCalled();
     });
 
-    it('sets error icon on html element when validation status is invalid', inject(function($rootScope, $timeout) {
+    it('sets error icon on html element when validation status is invalid', inject(function($timeout) {
       angularForm.default_auth_status.$setViewValue(false);
       $timeout.flush();
-      expect(elem[0][0].className).toEqual("fa fa-exclamation-circle");
+      expect(elem[0][0].className).toEqual('fa fa-exclamation-circle');
     }));
   });
 });


### PR DESCRIPTION
Removed scope spaghetti dependencies in validation_status directive. Now it uses isolate scope, and required attributes are passed as parameters to isolate scope.

This enables further refactoring of all controllers with credentials partial and replace them with [authCredentialsComponent from #2063](https://github.com/ManageIQ/manageiq-ui-classic/pull/2063).

this change should affect:
* [automationManagerFormControoler](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/assets/javascripts/controllers/automation_manager/automation_manager_form_controller.js)
* [providerForemanFormControoler](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js)
* [emsCommonFormController](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js)