### PR TITLE
Fix for Infra Cloud Instance Tag button

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -234,7 +234,7 @@ module EmsCommon
       when "security_group_tag"               then tag(SecurityGroup)
       end
 
-      return if params[:pressed].include?("tag") && !%w(host_tag vm_tag miq_template_tag).include?(params[:pressed])
+      return if params[:pressed].include?("tag") && !%w(host_tag vm_tag miq_template_tag instance_tag).include?(params[:pressed])
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       # Handle Host power buttons
       if host_power_button?(params[:pressed])

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -48,6 +48,17 @@ describe EmsCloudController do
         expect(response.body).to include('orchestration_stack/retire')
       end
 
+      it "when the Tagging Button is pressed for a Cloud provider Instance" do
+        allow(controller).to receive(:role_allows?).and_return(true)
+        ems = FactoryGirl.create("ems_vmware")
+        vm = FactoryGirl.create(:vm_vmware,
+                                :ext_management_system => ems,
+                                :storage               => FactoryGirl.create(:storage))
+        post :button, :params => { :pressed => "instance_tag", "check_#{vm.id}" => "1", :format => :js, :id => ems.id, :display => 'instances' }
+        expect(response.status).to eq 200
+        expect(response.body).to include('ems_cloud/tagging_edit')
+      end
+
       it "when Delete Button is pressed for CloudObjectStoreContainer" do
         expect(controller).to receive(:process_cloud_object_storage_buttons)
         post :button, :params => { :pressed => "cloud_object_store_container_delete" }


### PR DESCRIPTION
Fix for Infra Cloud Instance Tag button

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1486764

Steps to reproduce
-------------------------
1. Navigate to Compute -> Cloud -> Provider 
2. Select any 'cloud provider' (aws ec2 recommended)
3. On summery page, click on 'Instances'
4. Now, select instances and try edit tags from policy
