### PR TITLE
Include current value of system default in report time selection test

### DIFF
--- a/app/views/report/_form_columns.html.haml
+++ b/app/views/report/_form_columns.html.haml
@@ -34,7 +34,7 @@
           %label.control-label.col-md-2
             = _('Cancel after')
           .col-md-8
-            - opts = [["<#{_('System Default')}>", nil]] + (1..6).map { |i| [n_('%{number} Hour', '%{number} Hours', i) % {:number => i}, i.hours] }
+            - opts = [["<#{_('System Default')} (#{MiqReport.default_queue_timeout} seconds)>", nil]] + (1..6).map { |i| [n_('%{number} Hour', '%{number} Hours', i) % {:number => i}, i.hours] }
             = select_tag('chosen_queue_timeout',
               options_for_select(opts, @edit[:new][:queue_timeout]),
               :multiple              => false,

--- a/app/views/report/_form_columns.html.haml
+++ b/app/views/report/_form_columns.html.haml
@@ -34,7 +34,7 @@
           %label.control-label.col-md-2
             = _('Cancel after')
           .col-md-8
-            - opts = [["<#{_('System Default')} (#{MiqReport.default_queue_timeout} seconds)>", nil]] + (1..6).map { |i| [n_('%{number} Hour', '%{number} Hours', i) % {:number => i}, i.hours] }
+            - opts = [["<#{_('System Default')} (#{distance_of_time_in_words(MiqReport.default_queue_timeout)})>", nil]] + (1..6).map { |i| [n_('%{number} Hour', '%{number} Hours', i) % {:number => i}, i.hours] }
             = select_tag('chosen_queue_timeout',
               options_for_select(opts, @edit[:new][:queue_timeout]),
               :multiple              => false,


### PR DESCRIPTION
This is a small change for an RFE requesting that the actual default reporting queue timeout be displayed with the selection <System Default>

I'm not sure if there is a nicer way to display this, I'm open to suggestions.

https://bugzilla.redhat.com/show_bug.cgi?id=1393038
