### PR TITLE
Add Generic Object Definition Name and Generic Object Instances count to the GO reports

### DIFF
--- a/product/views/GenericObject.yaml
+++ b/product/views/GenericObject.yaml
@@ -20,6 +20,7 @@ db: GenericObject
 # Columns to fetch from the main table
 cols:
 - name
+- generic_object_definition_name
 - created_at
 - updated_at
 
@@ -31,12 +32,14 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- generic_object_definition_name
 - created_at
 - updated_at
 
 # Column titles, in order
 headers:
 - Name
+- Definition
 - Created
 - Updated
 
@@ -49,6 +52,7 @@ order: Ascending
 # Columns to sort the report on, in order
 sortby:
 - name
+- generic_object_definition_name
 - created_at
 - updated_at
 

--- a/product/views/GenericObjectDefinition.yaml
+++ b/product/views/GenericObjectDefinition.yaml
@@ -21,6 +21,7 @@ db: GenericObjectDefinition
 cols:
 - name
 - description
+- generic_objects_count
 - created_at
 - updated_at
 
@@ -33,6 +34,7 @@ include_for_find:
 col_order:
 - name
 - description
+- generic_objects_count
 - created_at
 - updated_at
 
@@ -40,6 +42,7 @@ col_order:
 headers:
 - Name
 - Description
+- Instances
 - Created
 - Updated
 
@@ -53,6 +56,7 @@ order: Ascending
 sortby:
 - name
 - description
+- generic_objects_count
 - created_at
 - updated_at
 


### PR DESCRIPTION
Requires - https://github.com/ManageIQ/manageiq/pull/16007

Instances count column added -
<img width="1361" alt="screen shot 2017-09-21 at 9 43 43 am" src="https://user-images.githubusercontent.com/1538216/30707808-7f503e86-9eb1-11e7-9ccb-d88e54d0b9fe.png">

Generic Object Definition Name column added -
<img width="1368" alt="screen shot 2017-09-21 at 9 44 24 am" src="https://user-images.githubusercontent.com/1538216/30707847-a14193fa-9eb1-11e7-9fa6-86d7eb61d717.png">
