### PR TITLE
Corrects typo after refactor of copy_params_if_set

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -617,7 +617,7 @@ class CloudVolumeController < ApplicationController
   helper_method :textual_group_list
 
   def form_params
-    options = copy_param_if_set({}, params, %i(name size cloud_tenant_id vm_id device_path))
+    options = copy_params_if_set({}, params, %i(name size cloud_tenant_id vm_id device_path))
     options[:volume_type] = params[:aws_volume_type] if params[:aws_volume_type]
     # Only set IOPS if io1 (provisioned IOPS) and IOPS available
     options[:iops] = params[:aws_iops] if options[:volume_type] == 'io1' && params[:aws_iops]


### PR DESCRIPTION
Recent refactor created new
methods copy_param_if_set and copy_params_if_set.
Original code copied many keys of param hash to options.
Refactor introduced a typo when controller called copy_param_if_set instead of
copy_params_if_set method.
This corrects it.

Links
----------------

* typo introduced in https://github.com/ManageIQ/manageiq-ui-classic/commit/ab1acca5e08c5e672f5a47f1dab2c28621302e6a#diff-aeeacbaf8c05f0fb259fb2e622dc6628

Steps for Testing/QA
-------------------------------

Have a Cloud Volume attached to a VM and try to detach it from UI.
