### PR TITLE
Enabling JDR generation for MW Manager.

### DIFF
--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -29,7 +29,7 @@ class MiddlewareServerController < ApplicationController
                                    :msg  => N_('Resume')
     },
     :middleware_dr_generate    => {:op   => :generate_diagnostic_report,
-                                   :skip => true,
+                                   :skip => false,
                                    :hawk => N_('generating JDR report'),
                                    :msg  => N_('Generate JDR report')}
   }.freeze


### PR DESCRIPTION
Fixes ManageIQ/manageiq-providers-hawkular#50.

JDR can be generated for MW Manager, but UI was denying it.


