### PR TITLE
Fixed code to render custom buttons toolbar on provider dashboard view

### DIFF
--- a/app/controllers/mixins/custom_buttons.rb
+++ b/app/controllers/mixins/custom_buttons.rb
@@ -20,7 +20,7 @@ module Mixins::CustomButtons
   end
 
   def custom_toolbar_simple
-    if @record && @lastaction == "show" && @display == "main"
+    if @record && %w(show show_dashboard).include?(@lastaction) && %w(dashboard main).include?(@display)
       Mixins::CustomButtons::Result.new(:single)
     elsif @lastaction == "show_list"
       Mixins::CustomButtons::Result.new(:list)


### PR DESCRIPTION
Fixed code to render custom buttons toolbar when switching Textual summary to Dashboard view for a selected Provider

https://bugzilla.redhat.com/show_bug.cgi?id=1492361

@dclarizio please review.
@lgalis please review/test

before:
![before](https://user-images.githubusercontent.com/3450808/30716305-8c2c9b8c-9ee7-11e7-8cd5-a14848e6dacc.png)

after:
![after](https://user-images.githubusercontent.com/3450808/30716311-9303262e-9ee7-11e7-98c9-2f049d539f90.png)

