### PR TITLE
Restore the Delete button for servers in a zone

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -705,7 +705,7 @@ module OpsController::Diagnostics
   def diagnostics_set_form_vars
     active_node = x_node
     if active_node && active_node.split('-').first == "z"
-      @record = @selected_zone = @selected_server = Zone.find_by_id(active_node.split('-').last)
+      @record = @selected_server = Zone.find_by(:id => active_node.split('-').last)
       @sb[:selected_server_id] = @selected_server.id
       @sb[:selected_typ] = "zone"
       if @selected_server.miq_servers.length >= 1 &&

--- a/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
@@ -17,19 +17,19 @@ class ApplicationHelper::Toolbar::DiagnosticsZoneCenter < ApplicationHelper::Too
       t,
       :items => [
         button(
-          :zone_delete,
+          :zone_delete_server,
           'pficon pficon-delete fa-lg',
           t = proc do
-            _('Delete Zone %{server_name} [%{server_id}]') % {:server_name => @selected_zone.name, :server_id => @selected_zone.id}
+            _('Delete Server %{server_name} [%{server_id}]') % {:server_name => @record.name, :server_id => @record.id}
           end,
           t,
           :confirm => proc do
-                        _("Do you want to delete Zone %{server_name} [%{server_id}]?") % {
-                          :server_name => @selected_zone.name,
-                          :server_id   => @selected_zone.id
+                        _("Do you want to delete Server %{server_name} [%{server_id}]?") % {
+                          :server_name => @record.name,
+                          :server_id   => @record.id
                         }
                       end,
-          :klass => ApplicationHelper::Button::ZoneDelete
+          :klass   => ApplicationHelper::Button::ZoneDeleteServer
         ),
         button(
           :zone_role_start,

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -147,6 +147,7 @@ class TreeBuilder
   # Subclass this method if active node on initial load is different than root node.
   def active_node_set(tree_nodes)
     @tree_state.x_node_set(tree_nodes.first[:key], @name) unless @tree_state.x_node(@name)
+    @tree_state.x_node(@name)
   end
 
   def set_nodes(nodes)

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -7,6 +7,12 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
     x_get_tree_miq_servers
   end
 
+  def override(node, _object, _pid, _options)
+    if @sb[:diag_selected_id] && node[:key] == "svr-#{@sb[:diag_selected_id]}"
+      node[:highlighted] = true
+    end
+  end
+
   def x_get_tree_miq_servers
     @root.miq_servers.sort_by { |s| s.name.to_s }.each_with_object([]) do |server, objects|
       unless @sb[:diag_selected_id] # Set default selected record vars

--- a/spec/helpers/application_helper/toolbar/diagnostics_zone_center_spec.rb
+++ b/spec/helpers/application_helper/toolbar/diagnostics_zone_center_spec.rb
@@ -1,0 +1,13 @@
+describe ApplicationHelper::Toolbar::MiqAeDomainCenter do
+  describe "definition of class" do
+    it "contains the server delete button" do
+      diagnostics_zone_center = Kernel.const_get("ApplicationHelper::Toolbar::DiagnosticsZoneCenter")
+      buttons = diagnostics_zone_center.definition["ldap_domain_vmdb"].buttons
+      button_names = []
+      buttons.each do |button|
+        button_names += button[:items].pluck(:id) if button[:items]
+      end
+      expect(button_names).to include("zone_delete_server")
+    end
+  end
+end

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -69,7 +69,7 @@ describe TreeBuilderRolesByServer do
                                   'state'      => {'expanded' => true},
                                   'selectable' => true,
                                   'class'      => ''},],
-                'state'      => {'expanded' => true},
+                'state'      => {'expanded' => true, 'selected' => true},
                 'class'      => ''}]
       expect(JSON.parse(@server_tree.locals_for_render[:bs_tree])).to eq(nodes)
     end


### PR DESCRIPTION
Restore the Delete button for servers in a zone, selected from the right-side "Roles By Servers" tab


Links 
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1492216

-----

Before:
![screenshot from 2018-02-07 21-58-06](https://user-images.githubusercontent.com/12769982/35953437-a1ba3f3a-0c52-11e8-875b-cd6e00101deb.png)

After:
![screenshot from 2018-03-14 15-04-08](https://user-images.githubusercontent.com/12769982/37425242-08443c4a-2799-11e8-95e5-675a62e8c074.png)
