### PR TITLE
Fix custom button validation for display = list and no dialog selected

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -802,7 +802,7 @@ module ApplicationController::Buttons
       add_flash(_('URL can be opened only by buttons for a single entity'), :error)
     end
 
-    if !button_hash[:dialog_id].blank? && button_hash[:display_for] != 'single'
+    if (!button_hash[:dialog_id].blank? && !button_hash[:dialog_id].zero?) && button_hash[:display_for] != 'single'
       add_flash(_('Dialog can be opened only by buttons for a single entity'), :error)
     end
 

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -203,5 +203,22 @@ describe ApplicationController do
       ]
       expect(assigns(:flash_array)).to eq(flash_messages)
     end
+
+    it "display appropriate error messages for display = list" do
+      edit = {
+        :new => {:name           => 'testCB',
+                 :description    => 'testCB',
+                 :button_icon    => 'img',
+                 :object_request => 'request',
+                 :dialog_id      => 0,
+                 :open_url       => true,
+                 :display_for    => :list}
+      }
+      flash_errors = [{:message => "Starting Process is required", :level => :error},
+                      {:message => 'URL can be opened only by buttons for a single entity', :level => :error}]
+
+      controller.send(:button_valid?, edit[:new])
+      expect(assigns(:flash_array)).to match(flash_errors)
+    end
   end
 end


### PR DESCRIPTION
#Check for zero or blank for dialog_id on custom button to be displayed for lists

Steps for Testing/QA 
-------------------------------
1. go to Automate -> add a new custom button
2. From the 'Display' dropdown, select 'List'
3. Leave 'Dialog' as <None>, click 'Add'
without the fix, this error message will be displayed: 'Dialog can be opened only by buttons for a single entity'

