### PR TITLE
Wait for task in JS

### DIFF
--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -1,3 +1,5 @@
+/* global miqDeferred */
+
 /* functions to use the API from our JS/Angular:
  *
  * API.get(url, options) - use API.get('/api'), returns a Promise
@@ -98,11 +100,7 @@
   };
 
   API.wait_for_task = function(task_id) {
-    var deferred = {};
-    deferred.promise = new Promise(function(resolve, reject) {
-      deferred.resolve = resolve;
-      deferred.reject = reject;
-    });
+    var deferred = miqDeferred();
 
     var retry = function() {
       API.get('/api/tasks/' + task_id + '?attributes=task_results')

--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -99,11 +99,11 @@
     });
   };
 
-  API.wait_for_task = function(task_id) {
+  API.wait_for_task = function(taskId) {
     var deferred = miqDeferred();
 
     var retry = function() {
-      API.get('/api/tasks/' + task_id + '?attributes=task_results')
+      API.get('/api/tasks/' + taskId + '?attributes=task_results')
         .then(function(result) {
           if (result.state === 'Finished') {  // MiqTask::STATE_FINISHED
             deferred.resolve(result);

--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -119,7 +119,7 @@
     };
 
     var failOnBadStatus = function(result) {
-      if (! result.status || ['Error', 'Timeout', 'Expired'].includes(result.status)) {
+      if (result.status !== 'Ok') {
         return Promise.reject(result);
       }
 

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1065,15 +1065,22 @@ function miqProcessObserveQueue() {
   });
 }
 
-function miqObserveRequest(url, options) {
-  options = _.cloneDeep(options || {});
-  options.observe = true;
-
+function miqDeferred() {
   var deferred = {};
+
   deferred.promise = new Promise(function(resolve, reject) {
     deferred.resolve = resolve;
     deferred.reject = reject;
   });
+
+  return deferred;
+}
+
+function miqObserveRequest(url, options) {
+  options = _.cloneDeep(options || {});
+  options.observe = true;
+
+  var deferred = miqDeferred();
 
   ManageIQ.observe.queue.push({
     url: url,

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -53,6 +53,9 @@ ManageIQ.explorer.process = function(data) {
     case 'window':
       ManageIQ.explorer.processWindow(data);
       break;
+    case 'rx':
+      ManageIQ.explorer.processRx(data);
+      break;
     default:
   }
 };
@@ -81,6 +84,10 @@ ManageIQ.explorer.processFlash = function(data) {
   if (! _.isUndefined(data.activateNode)) {
     miqTreeActivateNode(data.activateNode.tree, data.activateNode.node);
   }
+};
+
+ManageIQ.explorer.processRx = function(data) {
+  ManageIQ.explorer.rx(data);
 };
 
 ManageIQ.explorer.replacePartials = function(data) {
@@ -119,6 +126,11 @@ ManageIQ.explorer.spinnerOff = function(data) {
   }
 };
 
+ManageIQ.explorer.rx = function(data) {
+  if (data.rx) {
+    sendDataWithRx(data.rx);
+  }
+};
 
 ManageIQ.explorer.scrollTop = function(data) {
   if (data.scrollTop) {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,10 +52,10 @@ class ApplicationController < ActionController::Base
 
   include_concern 'AdvancedSearch'
   include_concern 'Automate'
+  include_concern 'Buttons'
   include_concern 'CiProcessing'
   include_concern 'Compare'
   include_concern 'CurrentUser'
-  include_concern 'Buttons'
   include_concern 'DialogRunner'
   include_concern 'Explorer'
   include_concern 'Filter'
@@ -71,6 +71,7 @@ class ApplicationController < ActionController::Base
   include_concern 'Timelines'
   include_concern 'Timezone'
   include_concern 'TreeSupport'
+  include_concern 'WaitForTask'
 
   before_action :reset_toolbar
   before_action :set_session_tenant
@@ -351,59 +352,6 @@ class ApplicationController < ActionController::Base
     rpt.to_chart(settings(:display, :reporttheme), true, MiqReport.graph_options)
     render Charting.render_format => rpt.chart
   end
-
-  ###########################################################################
-  # Use ajax to retry until the passed in task is complete, then rerun the original action
-  # This action can be called directly or via URL
-  # If called directly, options will have the task_id
-  # Otherwise, task_id will be in the params
-  ###########################################################################
-  def wait_for_task
-    @edit = session[:edit]  # If in edit, need to preserve @edit object
-    raise Forbidden, _('Invalid input for "wait_for_task".') unless params[:task_id]
-
-    @edit = session[:edit]  # If in edit, need to preserve @edit object
-    session[:async] ||= {}
-    session[:async][:interval] ||= 1000 # Default interval to 1 second
-    session[:async][:params] ||= {}
-
-    if MiqTask.find(params[:task_id].to_i).state != "Finished" # Task not done --> retry
-      browser_refresh_task(params[:task_id])
-    else # Task done
-      @_params.instance_variable_get(:@parameters).merge!(session[:async][:params]) # Merge in the original parms and
-      send(session.fetch_path(:async, :params, :action)) # call the orig. method
-    end
-  end
-
-  def browser_refresh_task(task_id)
-    session[:async][:interval] += 250 if session[:async][:interval] < 5000 # Slowly move up to 5 second retries
-    render :update do |page|
-      page << javascript_prologue
-      ajax_call = remote_function(:url => {:action => 'wait_for_task', :task_id => task_id})
-      page << "setTimeout(\"#{ajax_call}\", #{session[:async][:interval]});"
-    end
-  end
-  private :browser_refresh_task
-
-  #
-  # :task_id => id of task to wait for
-  # :action  => 'action_to_call' -- action to be called when the task finishes
-  #
-  def initiate_wait_for_task(options = {})
-    task_id = options[:task_id]
-    session[:async] ||= {}
-    session[:async][:interval] ||= 1000 # Default interval to 1 second
-    session[:async][:params] ||= {}
-
-    session[:async][:params] = params.deep_dup # Save the incoming parms
-    session[:async][:params][:task_id] = task_id
-
-    # override method to be called, when the task is done
-    session[:async][:params][:action] = options[:action] if options.key?(:action)
-
-    browser_refresh_task(task_id)
-  end
-  private :initiate_wait_for_task
 
   # Method for creating object with data for report.
   # Report is either grid/table or list.

--- a/app/controllers/application_controller/wait_for_task.rb
+++ b/app/controllers/application_controller/wait_for_task.rb
@@ -37,6 +37,7 @@ module ApplicationController::WaitForTask
   #
   # :task_id => id of task to wait for
   # :action  => 'action_to_call' -- action to be called when the task finishes
+  # :rx_action => 'method_to_call' -- a method to create a RxJs message
   #
   def initiate_wait_for_task(options = {})
     task_id = options[:task_id]
@@ -50,7 +51,31 @@ module ApplicationController::WaitForTask
     # override method to be called, when the task is done
     session[:async][:params][:action] = options[:action] if options.key?(:action)
 
+    if options.key?(:rx_action)
+      raise "Unsupported combination" if options.key?(:action)
+
+      session[:async][:params][:action] = 'wait_for_task_rx'
+      session[:async][:params][:rx_action] = options[:rx_action]
+    end
+
     browser_refresh_task(task_id)
   end
   private :initiate_wait_for_task
+
+  # used for any task with rx_action
+  def wait_for_task_rx
+    task_id = params[:task_id]
+    rx_action = session[:async][:params][:rx_action]
+
+    task = MiqTask.find(task_id)
+    result = send(rx_action, task)
+    raise "Non-hash rx_action return" unless result.kind_of?(Hash)
+
+    # FIXME: move this to ExplorerPresenter
+    render :update do |page|
+      page << javascript_prologue
+      page << "sendDataWithRx(#{result.to_json});"
+    end
+  end
+  private :wait_for_task_rx
 end

--- a/app/controllers/application_controller/wait_for_task.rb
+++ b/app/controllers/application_controller/wait_for_task.rb
@@ -1,0 +1,56 @@
+module ApplicationController::WaitForTask
+  extend ActiveSupport::Concern
+
+  ###########################################################################
+  # Use ajax to retry until the passed in task is complete, then rerun the original action
+  # This action can be called directly or via URL
+  # If called directly, options will have the task_id
+  # Otherwise, task_id will be in the params
+  ###########################################################################
+  def wait_for_task
+    @edit = session[:edit]  # If in edit, need to preserve @edit object
+    raise Forbidden, _('Invalid input for "wait_for_task".') unless params[:task_id]
+
+    @edit = session[:edit]  # If in edit, need to preserve @edit object
+    session[:async] ||= {}
+    session[:async][:interval] ||= 1000 # Default interval to 1 second
+    session[:async][:params] ||= {}
+
+    if MiqTask.find(params[:task_id].to_i).state != "Finished" # Task not done --> retry
+      browser_refresh_task(params[:task_id])
+    else # Task done
+      @_params.instance_variable_get(:@parameters).merge!(session[:async][:params]) # Merge in the original parms and
+      send(session.fetch_path(:async, :params, :action)) # call the orig. method
+    end
+  end
+
+  def browser_refresh_task(task_id)
+    session[:async][:interval] += 250 if session[:async][:interval] < 5000 # Slowly move up to 5 second retries
+    render :update do |page|
+      page << javascript_prologue
+      ajax_call = remote_function(:url => {:action => 'wait_for_task', :task_id => task_id})
+      page << "setTimeout(\"#{ajax_call}\", #{session[:async][:interval]});"
+    end
+  end
+  private :browser_refresh_task
+
+  #
+  # :task_id => id of task to wait for
+  # :action  => 'action_to_call' -- action to be called when the task finishes
+  #
+  def initiate_wait_for_task(options = {})
+    task_id = options[:task_id]
+    session[:async] ||= {}
+    session[:async][:interval] ||= 1000 # Default interval to 1 second
+    session[:async][:params] ||= {}
+
+    session[:async][:params] = params.deep_dup # Save the incoming parms
+    session[:async][:params][:task_id] = task_id
+
+    # override method to be called, when the task is done
+    session[:async][:params][:action] = options[:action] if options.key?(:action)
+
+    browser_refresh_task(task_id)
+  end
+  private :initiate_wait_for_task
+end

--- a/app/controllers/application_controller/wait_for_task.rb
+++ b/app/controllers/application_controller/wait_for_task.rb
@@ -71,11 +71,8 @@ module ApplicationController::WaitForTask
     result = send(rx_action, task)
     raise "Non-hash rx_action return" unless result.kind_of?(Hash)
 
-    # FIXME: move this to ExplorerPresenter
-    render :update do |page|
-      page << javascript_prologue
-      page << "sendDataWithRx(#{result.to_json});"
-    end
+    presenter = ExplorerPresenter.rx(:rx => result)
+    render :json => presenter.for_render
   end
   private :wait_for_task_rx
 end

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -53,6 +53,10 @@ class ExplorerPresenter
     new(args.update(:mode => 'flash'))
   end
 
+  def self.rx(args = {})
+    new(args.update(:mode => 'rx'))
+  end
+
   def self.main_div(args = {})
     new(args.update(:mode => 'main_div'))
   end
@@ -74,6 +78,7 @@ class ExplorerPresenter
       :show_miq_buttons     => false,
       :load_chart           => nil,
       :open_window          => nil,
+      :rx                   => nil,
     }.update(options)
   end
 
@@ -160,6 +165,11 @@ class ExplorerPresenter
     @options[:report_data] = report_data
   end
 
+  def rx(data)
+    @options[:rx] = data
+    self
+  end
+
   def self.open_window(url)
     new(:mode => 'window', :open_url => url)
   end
@@ -178,6 +188,7 @@ class ExplorerPresenter
     when 'flash'    then for_render_flash
     when 'buttons'  then for_render_buttons
     when 'window'   then for_render_window
+    when 'rx'       then for_render_rx
     else for_render_default
     end
   end
@@ -198,6 +209,12 @@ class ExplorerPresenter
     data = {:explorer => 'window'}
     data[:openUrl] = @options[:open_url]
     data[:spinnerOff] = true if @options[:spinner_off]
+    data
+  end
+
+  def for_render_rx
+    data = {:explorer => 'rx'}
+    data[:rx] = @options[:rx]
     data
   end
 


### PR DESCRIPTION
This:

  * [x] moves the `wait_for_task` related code to `ApplicationController::WaitForTask`
  * [x] adds support to `initiate_wait_for_task` to send an RxJs message instead of a server-side action
  * [x] adds an `API.wait_for_task(task_id) => Promise` method to achieve the same via the API
  * [ ] TODO make @skateman write a websocket push mechanism to replace the API poll :)
  * [ ] TODO document this in a guides PR (work, work :))


Currently all the waits are initiated from rails side, typically by creating a task, and calling something like `initiate_wait_for_task(:task_id => task_id, :action => "create_finished")` (other code omits the action, defaulting to the current one).

This should make it possible to replace:

```ruby
def long_task
  task_id = create_task
  initiate_wait_for_task(:task_id => task_id, :action => "task_done")
end

def task_done
  task = MiqTask.find(params[:task_id])
  render_task_result(task)
end
```

with something like

```ruby
def long_task
  task_id = create_task
  initiate_wait_for_task(:task_id    => task_id,
                         :rx_action => "rx_done")
end

def rx_done(task)
  return {:message => "taskError", :data => task} unless task.status_ok?
  {:message => "taskSuccess", :data => task}
end
```

and get a Rx message client-side.

It should also make it easy for client code to achieve the same (except for actually creating a task) by doing..

```js
API.wait_for_task(task_id)
  .then((task) => sendDataWithRx({ message: "taskSuccess", data: task }))
  .catch((task) => sendDataWithRx({ message: "taskError", data: task }));
```

Cc @skateman, @martinpovolny 