### PR TITLE
Fix nesting of hashes in TermOfServiceHelper::ASSIGN_TOS

### DIFF
--- a/app/helpers/term_of_service_helper.rb
+++ b/app/helpers/term_of_service_helper.rb
@@ -4,21 +4,21 @@ module TermOfServiceHelper
     "ExtManagementSystem" => {
       "enterprise"                 => N_("The Enterprise"),
       "ext_management_system"      => N_("Selected Providers"),
-      "ext_management_system-tags" => N_("Tagged Providers"),
-      "EmsCluster" => {
-        "ems_cluster"      => N_("Selected Cluster / Deployment Roles"),
-        "ems_cluster-tags" => N_("Tagged Cluster / Deployment Roles"),
-        "Host" => {
-          "host"      => N_("Selected Host / Nodes"),
-          "host-tags" => N_("Tagged Host / Nodes"),
-          "Vm" => {
-            "ems_folder"         => N_("Selected Folders"),
-            "resource_pool"      => N_("Selected Resource Pools"),
-            "resource_pool-tags" => N_("Tagged Resource Pools"),
-            "vm-tags"            => N_("Tagged VMs and Instances")
-          }
-        }
-      }
+      "ext_management_system-tags" => N_("Tagged Providers")
+    },
+    "EmsCluster" => {
+      "ems_cluster"      => N_("Selected Cluster / Deployment Roles"),
+      "ems_cluster-tags" => N_("Tagged Cluster / Deployment Roles")
+    },
+    "Host" => {
+      "host"      => N_("Selected Host / Nodes"),
+      "host-tags" => N_("Tagged Host / Nodes")
+    },
+    "Vm" => {
+      "ems_folder"         => N_("Selected Folders"),
+      "resource_pool"      => N_("Selected Resource Pools"),
+      "resource_pool-tags" => N_("Tagged Resource Pools"),
+      "vm-tags"            => N_("Tagged VMs and Instances")
     },
     "Storage" => {
       "enterprise"   => N_("The Enterprise"),


### PR DESCRIPTION
The structure of the hash seems to have been inadvertently changes if commit 3c3b18f87f11f9ed8c4cff420c7acafa830c342b in PR #2082

The issue was discover while attempting to assign an alert profile. It failed with the error -

```
[----] F, [2017-09-22T14:37:47.305082 #68404:3fc8f2ef62f8] FATAL -- : Error caught: [ActionView::Template::Error] undefined method `map' for nil:NilClass
Did you mean?  tap
/Users/gtanzill/work/rh/manageiq-ui-classic/app/views/miq_policy/_alert_profile_assign.html.haml:16:in `___sers_gtanzill_work_rh_manageiq_ui_classic_app_views_miq_policy__alert_profile_assign_html_haml__3366413194070634160_70132305363060'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/actionview-5.0.6/lib/action_view/template.rb:159:in `block in render'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/activesupport-5.0.6/lib/active_support/notifications.rb:166:in `instrument'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/actionview-5.0.6/lib/action_view/template.rb:354:in `instrument'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/actionview-5.0.6/lib/action_view/template.rb:157:in `render'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/actionview-5.0.6/lib/action_view/renderer/partial_renderer.rb:343:in `render_partial'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/actionview-5.0.6/lib/action_view/renderer/partial_renderer.rb:311:in `block in render'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/actionview-5.0.6/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/activesupport-5.0.6/lib/active_support/notifications.rb:164:in `block in instrument'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/activesupport-5.0.6/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/activesupport-5.0.6/lib/active_support/notifications.rb:164:in `instrument'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/actionview-5.0.6/lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/actionview-5.0.6/lib/action_view/renderer/partial_renderer.rb:310:in `render'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/actionview-5.0.6/lib/action_view/renderer/renderer.rb:47:in `render_partial'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/actionview-5.0.6/lib/action_view/renderer/renderer.rb:21:in `render'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/actionview-5.0.6/lib/action_view/helpers/rendering_helper.rb:32:in `render'
/Users/gtanzill/.rvm/gems/ruby-2.3.1@vmdb_5_7/gems/haml-4.0.7/lib/haml/helpers/action_view_mods.rb:12:in `render_with_haml'
/Users/gtanzill/work/rh/manageiq-ui-classic/app/views/miq_policy/_alert_profile_details.html.haml:6:in `___sers_gtanzill_work_rh_manageiq_ui_classic_app_views_miq_policy__alert_profile_details_html_haml___2248326320704882584_70132260365840'
```