### PR TITLE
Catalog: fix duplicate DOM IDs.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -162,7 +162,7 @@ class CatalogController < ApplicationController
         # when display in catalog is checked, replace div so tabs can be redrawn
         page.replace("form_div", :partial => "st_form") if params[:st_prov_type] ||
           (params[:display] && @edit[:new][:st_prov_type].starts_with?("generic"))
-        page.replace_html("basic_info_div", :partial => "form_basic_info") if params[:display] ||
+        page.replace("basic_info_div", :partial => "form_basic_info") if params[:display] ||
           params[:template_id] || params[:manager_id]
         if params[:display]
           page << "miq_tabs_show_hide('#details_tab', '#{(params[:display] == "1")}')"
@@ -364,8 +364,8 @@ class CatalogController < ApplicationController
     build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree
     render :update do |page|
       page << javascript_prologue
-      page.replace_html("basic_info_div", :partial => "form_basic_info") if params[:resource_id] || params[:display]
-      page.replace_html("resources_info_div", :partial => "form_resources_info") if params[:resource_id] || @group_idx
+      page.replace("basic_info_div", :partial => "form_basic_info") if params[:resource_id] || params[:display]
+      page.replace("resources_info_div", :partial => "form_resources_info") if params[:resource_id] || @group_idx
       if params[:display]
         page << "miq_tabs_show_hide('#details_tab', '#{(params[:display] == "1")}')"
       end
@@ -437,8 +437,8 @@ class CatalogController < ApplicationController
     changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
-      page.replace_html("basic_info_div", :partial => "form_basic_info")
-      page.replace_html("resources_info_div", :partial => "form_resources_info")
+      page.replace("basic_info_div", :partial => "form_basic_info")
+      page.replace("resources_info_div", :partial => "form_resources_info")
       if changed != session[:changed]
         session[:changed] = changed
         page << "ManageIQ.changes = true;"


### PR DESCRIPTION
Both `form_basic_info` and `form_resources_info` contain the corresponding `basic_info_div` and `resources_info_div` divs.

Therefor we need to call `replace` which replaces also the wrapping `div` element unlike `replace_html` that replaces the INNER html creating duplicate DOM IDs (and elements) on each click.

Ping @mzazrivec, @h-kataria 