### PR TITLE
Add prometheus route detection

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -284,10 +284,10 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.isDetectionEnabled = function() {
-    return ($scope.emsCommonModel.ems_controller == "ems_container") &&
-      ($scope.emsCommonModel.emstype == "openshift") &&
+    return ($scope.emsCommonModel.ems_controller === "ems_container") &&
+      ($scope.emsCommonModel.emstype === "openshift") &&
       ($scope.emsCommonModel.default_hostname && $scope.emsCommonModel.default_api_port) &&
-      ($scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid);
+      ($scope.emsCommonModel.default_password !== '' && $scope.angularForm.default_password.$valid);
   };
 
   var emsCommonEditButtonClicked = function(buttonName, _serializeFields, $event) {

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -284,7 +284,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.isDetectionEnabled = function() {
-    return ($scope.emsCommonModel.metrics_selection == "hawkular" && $scope.emsCommonModel.ems_controller == "ems_container") &&
+    return ($scope.emsCommonModel.ems_controller == "ems_container") &&
       ($scope.emsCommonModel.emstype == "openshift") &&
       ($scope.emsCommonModel.default_hostname && $scope.emsCommonModel.default_api_port) &&
       ($scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid);

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -16,6 +16,7 @@ class EmsContainerController < ApplicationController
     "hawkular"   => %w(hawkular-metrics openshift-infra),
     "prometheus" => %w(prometheus prometheus)
   }.freeze
+  OPENSHIFT_DEFAULT_ROUTE = %w(hawkular-metrics openshift-infra).freeze
 
   def self.model
     ManageIQ::Providers::ContainerManager
@@ -66,7 +67,7 @@ class EmsContainerController < ApplicationController
   end
 
   def update_ems_button_detect(verify_ems = nil)
-    route, project = OPENSHIFT_ROUTES.fetch(params[:metrics_selection], [nil, nil])
+    route, project = OPENSHIFT_ROUTES.fetch(params[:metrics_selection], OPENSHIFT_DEFAULT_ROUTE)
     verify_ems ||= find_record_with_rbac(model, params[:id])
     set_ems_record_vars(verify_ems, :validate)
     @in_a_form = true

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -12,6 +12,11 @@ class EmsContainerController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  OPENSHIFT_ROUTES = {
+    "hawkular"   => %w(hawkular-metrics openshift-infra),
+    "prometheus" => %w(prometheus prometheus)
+  }.freeze
+
   def self.model
     ManageIQ::Providers::ContainerManager
   end
@@ -61,15 +66,16 @@ class EmsContainerController < ApplicationController
   end
 
   def update_ems_button_detect(verify_ems = nil)
+    route, project = OPENSHIFT_ROUTES.fetch(params[:metrics_selection], [nil, nil])
     verify_ems ||= find_record_with_rbac(model, params[:id])
     set_ems_record_vars(verify_ems, :validate)
     @in_a_form = true
 
-    result, details = get_hostname_from_routes(verify_ems)
+    result, details = get_hostname_from_routes(verify_ems, route, project)
     if result
-      add_flash(_("Hawkular Route Detection: success"))
+      add_flash(_("Route Detection: success"))
     else
-      add_flash(_("Hawkular Route Detection: failure [%{details}]") % {:details => details}, :error)
+      add_flash(_("Route Detection: failure [%{details}]") % {:details => details}, :error)
     end
 
     render :json => {
@@ -80,10 +86,10 @@ class EmsContainerController < ApplicationController
   end
 
   # TODO: move to backend
-  def get_hostname_from_routes(ems)
+  def get_hostname_from_routes(ems, route, project)
     return nil, "Route detection not applicable for provider type" unless ems.class.respond_to?(:openshift_connect)
     [
-      ems.connect(:service => :openshift).get_route('hawkular-metrics', 'openshift-infra').try(:spec).try(:host),
+      ems.connect(:service => :openshift).get_route(route, project).try(:spec).try(:host),
       nil
     ]
   rescue StandardError => e

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -468,10 +468,6 @@ module Mixins
         default_endpoint = {:role => :default, :hostname => hostname, :port => port}
         default_endpoint.merge!(endpoint_security_options(ems.security_protocol, default_tls_ca_certs))
         if params[:metrics_selection] == 'hawkular'
-          if metrics_hostname.blank?
-            default_key = params[:default_password] || ems.authentication_key
-            metrics_hostname = get_hostname_from_routes(ems, default_endpoint, default_key)
-          end
           params[:cred_type] = "hawkular"
           hawkular_endpoint = {:role => :hawkular, :hostname => metrics_hostname, :port => metrics_port}
           hawkular_endpoint.merge!(endpoint_security_options(metrics_security_protocol, metrics_tls_ca_certs))

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -285,7 +285,8 @@
                                                 :id                     => record.id,
                                                 :ng_reqd_hostname       => "true",
                                                 :ng_reqd_api_port       => "true",
-                                                :prefix                 => "metrics"}
+                                                :prefix                 => "metrics",
+                                                :detection              => true}
               = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                          :locals  => {:ng_show           => true,
                                       :ng_model          => ng_model.to_s,

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -71,7 +71,7 @@ describe EmsContainerController do
 
       expect(controller.send(:flash_errors?)).to be_truthy
       expect(assigns(:flash_array).first[:message]).to eq(
-        'Hawkular Route Detection: failure [Route detection not applicable for provider type]'
+        'Route Detection: failure [Route detection not applicable for provider type]'
       )
     end
 
@@ -87,7 +87,7 @@ describe EmsContainerController do
       controller.send(:update_ems_button_detect)
 
       expect(controller.send(:flash_errors?)).to be_falsey
-      expect(assigns(:flash_array).first[:message]).to eq('Hawkular Route Detection: success')
+      expect(assigns(:flash_array).first[:message]).to eq('Route Detection: success')
     end
 
     it "tolerates detection exceptions" do
@@ -103,7 +103,7 @@ describe EmsContainerController do
 
       expect(controller.send(:flash_errors?)).to be_truthy
       expect(assigns(:flash_array).first[:message]).to include(
-        'Hawkular Route Detection: failure [message]'
+        'Route Detection: failure [message]'
       )
     end
   end


### PR DESCRIPTION
**Description**
We need the "Detect" button (the one currently works for Hawkular) to work for Prometheus Metrics and Alerts.

Alerts route detection need more invasive changes, out of scope for this PR.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1461970

**Screenshots**
![gifrecord_2017-09-24_163951](https://user-images.githubusercontent.com/2181522/30783181-404d6f9a-a147-11e7-8f78-892447478750.gif)


