### PR TITLE
Adding status field in Domain's Summary page's properties section.

### DIFF
--- a/app/helpers/middleware_domain_helper/textual_summary.rb
+++ b/app/helpers/middleware_domain_helper/textual_summary.rb
@@ -3,6 +3,10 @@ module MiddlewareDomainHelper::TextualSummary
     TextualGroup.new(_("Properties"), %i(name nativeid state))
   end
 
+  def textual_state
+    _(@record.properties['Availability'])
+  end
+
   def textual_group_relationships
     # Order of items should be from parent to child
     TextualGroup.new(_("Relationships"), %i(ems middleware_server_groups))

--- a/app/helpers/middleware_domain_helper/textual_summary.rb
+++ b/app/helpers/middleware_domain_helper/textual_summary.rb
@@ -1,6 +1,6 @@
 module MiddlewareDomainHelper::TextualSummary
   def textual_group_properties
-    TextualGroup.new(_("Properties"), %i(name nativeid status))
+    TextualGroup.new(_("Properties"), %i(name nativeid state))
   end
 
   def textual_group_relationships

--- a/app/helpers/middleware_domain_helper/textual_summary.rb
+++ b/app/helpers/middleware_domain_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module MiddlewareDomainHelper::TextualSummary
   end
 
   def textual_state
-    _(@record.properties['Availability'])
+    @record.properties['Availability']
   end
 
   def textual_group_relationships

--- a/app/helpers/middleware_domain_helper/textual_summary.rb
+++ b/app/helpers/middleware_domain_helper/textual_summary.rb
@@ -1,6 +1,6 @@
 module MiddlewareDomainHelper::TextualSummary
   def textual_group_properties
-    TextualGroup.new(_("Properties"), %i(name nativeid))
+    TextualGroup.new(_("Properties"), %i(name nativeid status))
   end
 
   def textual_group_relationships

--- a/app/helpers/middleware_summary_helper.rb
+++ b/app/helpers/middleware_summary_helper.rb
@@ -9,8 +9,8 @@ module MiddlewareSummaryHelper
     @record.nativeid
   end
 
-  def textual_status
-    @record.status
+  def textual_state
+    @record.properties['Availability']
   end
 
   def textual_group_smart_management

--- a/app/helpers/middleware_summary_helper.rb
+++ b/app/helpers/middleware_summary_helper.rb
@@ -9,10 +9,6 @@ module MiddlewareSummaryHelper
     @record.nativeid
   end
 
-  def textual_state
-    _(@record.properties['Availability'])
-  end
-
   def textual_group_smart_management
     TextualTags.new(_("Smart Management"), %i(tags))
   end

--- a/app/helpers/middleware_summary_helper.rb
+++ b/app/helpers/middleware_summary_helper.rb
@@ -9,6 +9,10 @@ module MiddlewareSummaryHelper
     @record.nativeid
   end
 
+  def textual_status
+    @record.status
+  end
+
   def textual_group_smart_management
     TextualTags.new(_("Smart Management"), %i(tags))
   end

--- a/app/helpers/middleware_summary_helper.rb
+++ b/app/helpers/middleware_summary_helper.rb
@@ -10,7 +10,7 @@ module MiddlewareSummaryHelper
   end
 
   def textual_state
-    @record.properties['Availability']
+    _(@record.properties['Availability'])
   end
 
   def textual_group_smart_management


### PR DESCRIPTION
This PR is related to [#44](https://github.com/ManageIQ/manageiq-providers-hawkular/issues/44). It only adds a new property field into Domain's summary page. 

Domain's summary page:
![adding-status-domain](https://user-images.githubusercontent.com/613814/30863777-2b03a00a-a2d2-11e7-9460-562f9ea2607a.png)

Here the addition:
![domain-properties-table](https://user-images.githubusercontent.com/613814/30864099-00a30d90-a2d3-11e7-80c6-2ff76fb57584.png)

