### PR TITLE
Move back the sidebar resizer to its original location

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -46,7 +46,7 @@
 }
 .resizer-box {
   position: absolute;
-  bottom: 50px;
+  bottom: 100px;
   left: -18px;
   width: 38px
 }


### PR DESCRIPTION
The changes around the GTL and the search/paginator footer have caused the resizer to move lower than it should be.

**Before:**
![screenshot from 2017-09-25 14-44-34](https://user-images.githubusercontent.com/649130/30808868-167ad8b0-a200-11e7-8ba5-260858ecaa11.png)

**After:**
![screenshot from 2017-09-25 14-45-18](https://user-images.githubusercontent.com/649130/30808891-2d530878-a200-11e7-8c30-f60fac045661.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1486650

@miq-bot assign @epwinchell 
@miq-bot add_label bug
