### PR TITLE
Add search to Services list view

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -295,14 +295,15 @@ module ApplicationController::AdvancedSearch
     respond_to do |format|
       format.js do
         @explorer = true
-        if x_active_tree.to_s =~ /_filter_tree$/ &&
+        if (x_active_tree.to_s =~ /_filter_tree$/ || x_active_tree.to_s == "svcs_tree") &&
            !%w(Vm MiqTemplate).include?(TreeBuilder.get_model_for_prefix(@nodetype))
           search_id = 0
           adv_search_build(model_from_active_tree(x_active_tree))
           session[:edit] = @edit # Set because next method will restore @edit from session
         end
         listnav_search_selected(search_id) # Clear or set the adv search filter
-        self.x_node = "root"
+        # no root node for My Services
+        self.x_node = x_active_tree.to_s == "svcs_tree" ? "xx-asrv" : "root"
         replace_right_cell
       end
       format.html do

--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -185,7 +185,7 @@ module ApplicationController::AdvancedSearch
       build_configuration_manager_tree(:configuration_manager_cs_filter, x_active_tree)
       build_accordions_and_trees
       load_or_clear_adv_search
-    elsif @edit[:in_explorer] || %w(storage_tree configuration_scripts_tree).include?(x_active_tree.to_s)
+    elsif @edit[:in_explorer] || %w(storage_tree configuration_scripts_tree svcs_tree).include?(x_active_tree.to_s)
       tree_type = x_active_tree.to_s.sub(/_tree/, '').to_sym
       builder = TreeBuilder.class_for_type(tree_type)
       tree = builder.new(x_active_tree, tree_type, @sb)

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -183,6 +183,7 @@ module ApplicationController::Filter
     @edit = session[:edit]
     @edit[:selected] = true # Set a flag, this is checked whether to load initial default or clear was clicked
     if id.to_i.zero?
+      @edit[:selected] = false
       clear_selected_search
     else
       load_selected_search(id)

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -59,8 +59,7 @@ class ServiceController < ApplicationController
   end
 
   def explorer
-    @explorer   = true
-    @lastaction = "explorer"
+    @explorer = true
 
     # if AJAX request, replace right cell, and return
     if request.xml_http_request?

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -357,7 +357,7 @@ class ServiceController < ApplicationController
     action, replace_trees = options.values_at(:action, :replace_trees)
     @explorer = true
     partial, action_url, @right_cell_text = set_right_cell_vars(action) if action # Set partial name, action and cell header
-    get_node_info(x_node) if !@edit && !@in_a_form && !params[:display]
+    get_node_info(x_node) if !action && !@in_a_form && !params[:display]
     replace_trees = @replace_trees if @replace_trees  # get_node_info might set this
     type, = parse_nodetype_and_id(x_node)
     record_showing = type && ["Service"].include?(TreeBuilder.get_model_for_prefix(type))
@@ -441,6 +441,11 @@ class ServiceController < ApplicationController
 
     presenter[:lock_sidebar] = @edit && @edit[:current]
     presenter[:osf_node] = x_node
+
+    # Hide/show searchbox depending on if a list is showing
+    presenter.set_visibility(!(@record || @in_a_form), :adv_searchbox_div)
+    presenter[:clear_search_toggle] = clear_search_status
+
     # unset variable that was set in form_field_changed to prompt for changes when leaving the screen
     presenter.reset_changes
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -993,6 +993,8 @@ module ApplicationHelper
       "ManageIQ::Providers::CloudManager::Vm"
     when :images_filter_tree
       "ManageIQ::Providers::CloudManager::Template"
+    when :svcs_tree
+      "Service"
     when :vms_filter_tree
       "ManageIQ::Providers::InfraManager::Vm"
     when :templates_filter_tree

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -904,6 +904,7 @@ module ApplicationHelper
        retired
        security_group
        service
+       services
        storage
        templates
        vm
@@ -1577,6 +1578,7 @@ module ApplicationHelper
        instances_filter
        providers
        storage
+       svcs
        templates_filter
        templates_images_filter
        vandt

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -282,7 +282,7 @@ class ExplorerPresenter
     data[:resetOneTrans] = !!@options[:reset_one_trans]
     data[:oneTransIE] = !!@options[:one_trans_ie]
     data[:focus] = @options[:focus]
-    data[:clearSearch] = @options[:clear_search_toggle] if @options[:clear_search_toggle]
+    data[:clearSearch] = @options[:clear_search_toggle] if @options.key?(:clear_search_toggle)
     data[:hideModal] if @options[:hide_modal]
     data[:initAccords] if @options[:init_accords]
     data[:reportData] = @options[:report_data] if @options[:report_data]

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -7,6 +7,7 @@ class TreeBuilderDefaultFilters < TreeBuilder
     :containerservice                              => %w(Containers Services),
     :host                                          => %w(Infrastructure Hosts),
     :miqtemplate                                   => %w(Services Workloads Templates\ &\ Images),
+    :service                                       => %w(Services My\ Services),
     :storage                                       => %w(Infrastructure Datastores),
     :vm                                            => %w(Services Workloads VMs\ &\ Instances),
     :"manageiq::providers::cloudmanager::template" => %w(Cloud Instances Images),

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -32,6 +32,16 @@ class TreeBuilderServices < TreeBuilder
                  :icon          => "pficon pficon-folder-close",
                  :load_children => true,
                  :tip           => _("Retired Services"))
+    objects.push(:id         => "global",
+                 :text       => _("Global Filters"),
+                 :icon       => "pficon pficon-folder-close",
+                 :selectable => false,
+                 :tip        => _("Global Shared Filters"))
+    objects.push(:id         => "my",
+                 :text       => _("My Filters"),
+                 :icon       => "pficon pficon-folder-close",
+                 :selectable => false,
+                 :tip        => _("My Personal Filters"))
     count_only_or_objects(count_only, objects)
   end
 

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -47,11 +47,31 @@ class TreeBuilderServices < TreeBuilder
 
   def x_get_tree_custom_kids(object, count_only, _options)
     services = Rbac.filtered(Service.where(:retired => object[:id] != 'asrv', :display => true))
-    if count_only
+    if %w(global my).include?(object[:id]) # Get My Filters and Global Filters
+      count_only_or_objects(count_only, x_get_search_results(object, _options[:leaf]))
+    elsif count_only
       services.size
     else
       MiqPreloader.preload(services.to_a, :picture)
       Service.arrange_nodes(services.sort_by { |n| [n.ancestry.to_s, n.name.downcase] })
     end
+  end
+
+  def x_get_search_results(object, leaf)
+    case object[:id]
+    when "global" # Global filters
+      x_get_global_filter_search_results(leaf)
+    when "my"     # My filters
+      x_get_my_filter_search_results(leaf)
+    end
+  end
+
+  def x_get_global_filter_search_results(leaf)
+    MiqSearch.where(:db => leaf).visible_to_all.sort_by { |a| a.description.downcase }
+  end
+
+  def x_get_my_filter_search_results(leaf)
+    MiqSearch.where(:db => leaf, :search_type => "user", :search_key => User.current_user.userid)
+             .sort_by { |a| a.description.downcase }
   end
 end

--- a/app/views/service/explorer.html.haml
+++ b/app/views/service/explorer.html.haml
@@ -1,3 +1,6 @@
+- content_for :search do
+  = render(:partial => "layouts/x_adv_searchbox")
+  = render(:partial => 'layouts/quick_search')
 - if TreeBuilder.get_model_for_prefix(@nodetype) == "Service"
   -# Showing a specific Service
   #main_div

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2967,12 +2967,16 @@ Rails.application.routes.draw do
       :post => %w(
         button
         explorer
+        listnav_search_selected
         ownership_field_changed
         ownership_update
+        quick_search
         reload
         retire
         service_edit
         service_tag
+        show
+        show_list
         tag_edit_form_field_changed
         tagging_edit
         tree_autoload
@@ -2982,7 +2986,11 @@ Rails.application.routes.draw do
         x_show
         ownership_form_fields
       ) +
-               dialog_runner_post
+               dialog_runner_post +
+               adv_search_post +
+               exp_post +
+               save_post +
+               x_post
     },
 
     :storage                  => {

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -2,9 +2,11 @@ describe TreeBuilderServices do
   let(:builder) { TreeBuilderServices.new("x", "y", {}) }
 
   it "generates tree" do
+    User.current_user = FactoryGirl.create(:user)
+    allow(User).to receive(:server_timezone).and_return("UTC")
     create_deep_tree
 
-    expect(root_nodes.size).to eq(2)
+    expect(root_nodes.size).to eq(4)
     active_nodes = kid_nodes(root_nodes[0])
     retired_nodes = kid_nodes(root_nodes[1])
     expect(active_nodes).to eq(


### PR DESCRIPTION
This PR adds Search and Advanced search to Services list view
(Services -> My Services) with all of their functionality.

Done:
- Display Global Filters and My Filters in accordion in Services -> My Services
  (My Services list view screen)
- Display saved filters in the tree, under Global or My Filters in accordion
- Make filters work properly when clicking on an existing filter from accordion
- Add search form to My Services list view screen
- Make Search form work properly
- Add Advanced search bar to My Services list view screen
- Make loading a filter in Adv search work properly
- Make applying a filter in Adv search work properly
- Make saving and deleting a filter in Adv search work properly
- Appear "clear" link in My Services screen at the end of the title right after applying
  a filter in Advanced search to be able to clear selected filter/search;
  update title of the screen properly after clearing selected search.
- Global Filters of My Services should be displayed in in My Settings -> Default Filters
  -> Services, to be able to be visible or not
- Add few OOTB Services filters in core repo, such as Environment/Dev, Environment/Prod etc.

## Links
https://www.pivotaltracker.com/story/show/150614745
https://bugzilla.redhat.com/show_bug.cgi?id=1500608

## Screenshots
Before:
![services1](https://user-images.githubusercontent.com/13417815/31230826-71e5d5dc-a9e5-11e7-87bd-daab1c3771d7.png)

After:
![services2](https://user-images.githubusercontent.com/13417815/31230759-487f7112-a9e5-11e7-90e6-7741cb09ad7d.png)
![service3](https://user-images.githubusercontent.com/13417815/31444444-887a4948-ae9c-11e7-8db1-6dc19b9534a8.png)

