### PR TITLE
Toolbar styling and markup cleanup

### DIFF
--- a/app/assets/stylesheets/alerts.scss
+++ b/app/assets/stylesheets/alerts.scss
@@ -14,18 +14,6 @@
       display: block;
     }
   }
-  .toolbar-pf .form-group {
-    padding-left: 25px;
-    .btn {
-      margin-left: 0;
-    }
-    .btn.btn-link {
-      margin-left: 10px;
-    }
-    .btn-group {
-      margin-left: 0;
-    }
-  }
   .list-view-pf-view {
     margin-top: 0;
   }

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -451,23 +451,6 @@ table.table.table-summary-screen tbody td img {
   }
 }
 
-/// begin toolbar styling
-
-.toolbar-pf .toolbar-pf-actions { /* sets margin to zero to compensate for margin added to form groups (for proper spacing when wrapped) */
-  margin-bottom: 0px;
-}
-
-.toolbar-pf .form-group { /*compensates for filter-pf not being implemented */
-  padding-left: 0;
-}
-
-.toolbar-pf .toolbar-pf-actions .form-group { /* adds padding between buttons when they wrap */
-  margin-bottom: 10px;
-  white-space: nowrap;
-}
-
-/// end toolbar styling
-
 /// begin paginator styling
 
 @media (min-width: $screen-sm) {

--- a/app/views/layouts/_center_div_dashboard_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_dashboard_no_listnav.html.haml
@@ -1,7 +1,7 @@
 = render :partial => "layouts/vertical_navbar"
 .container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus{:style => "overflow: hidden; height: 100%;"}
   .row.toolbar-pf#toolbar
-    .col-md-12
+    .col-sm-12
       - if @widgets_menu
         = render :partial => "layouts/angular/toolbar"
   .row#main-content.miq-body

--- a/app/views/layouts/_center_div_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_no_listnav.html.haml
@@ -4,7 +4,7 @@
     .col-md-12.max-height
       - if !@in_a_form && taskbar_in_header?
         .row.toolbar-pf#toolbar
-          .col-md-12
+          .col-sm-12
             = render :partial => "layouts/angular/toolbar"
       .row#main-content
         .col-md-12

--- a/app/views/layouts/_center_div_with_listnav.html.haml
+++ b/app/views/layouts/_center_div_with_listnav.html.haml
@@ -2,11 +2,10 @@
 .container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus.max-height{:style => "overflow: hidden !important"}
   - if !@in_a_form && taskbar_in_header?
     .row.toolbar-pf#toolbar.miq-toolbar-menu
-      .col-md-12
-        .toolbar-pf-actions
-          - if @layout == "dashboard"
-            = render :partial => "/layouts/tabs"
-          = render :partial => "layouts/angular/toolbar"
+      .col-sm-12
+        - if @layout == "dashboard"
+          = render :partial => "/layouts/tabs"
+        = render :partial => "layouts/angular/toolbar"
   .row.max-height
     .col-sm-10.col-md-9.col-sm-push-2.col-md-push-3.max-height
       #main-content.row

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -13,7 +13,7 @@
 
   .container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus.resizable-sidebar.max-height{:style => "overflow: hidden !important"}
     .row.toolbar-pf#toolbar.miq-toolbar-menu
-      .col-md-12
+      .col-sm-12
         = render :partial => "layouts/angular/toolbar"
     .row.max-height
       #right_div.resizable.max-height{:class => "col-md-#{maindiv} col-md-push-#{sidewidth}"}


### PR DESCRIPTION
This PR cleans up the markup, corrects some styling issues, and removes all styling from the repo.

Depends on: https://github.com/ManageIQ/ui-components/pull/165

Old
<img width="983" alt="screen shot 2017-09-25 at 12 47 14 pm" src="https://user-images.githubusercontent.com/1287144/30820458-fa2a65aa-a1ef-11e7-9839-8d8a1d8f3e60.png">
<img width="988" alt="screen shot 2017-09-25 at 12 48 46 pm" src="https://user-images.githubusercontent.com/1287144/30820457-fa2593f4-a1ef-11e7-928f-dcab4364bdb9.png">
<img width="983" alt="screen shot 2017-09-25 at 12 49 06 pm" src="https://user-images.githubusercontent.com/1287144/30820456-fa1c99ca-a1ef-11e7-838a-9a3ffae3f3c5.png">

New
<img width="984" alt="screen shot 2017-09-25 at 12 37 28 pm" src="https://user-images.githubusercontent.com/1287144/30820225-4c0fc46a-a1ef-11e7-9ece-5323898c140c.png">
<img width="982" alt="screen shot 2017-09-25 at 12 43 49 pm" src="https://user-images.githubusercontent.com/1287144/30820224-4c0ed2da-a1ef-11e7-8501-5425854afe87.png">
<img width="983" alt="screen shot 2017-09-25 at 12 44 12 pm" src="https://user-images.githubusercontent.com/1287144/30820223-4c041034-a1ef-11e7-8e72-92376817d5a9.png">