### PR TITLE
Add optional flag to check for expected class

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -73,7 +73,11 @@ class ReportController < ApplicationController
     if params[:upload] && params[:upload][:file] && params[:upload][:file].respond_to?(:read)
       @sb[:overwrite] = !params[:overwrite].nil?
       begin
-        reps, mri = MiqReport.import(params[:upload][:file], :save => true, :overwrite => @sb[:overwrite], :userid => session[:userid])
+        reps, mri = MiqReport.import(params[:upload][:file],
+                                     :save           => true,
+                                     :overwrite      => @sb[:overwrite],
+                                     :userid         => session[:userid],
+                                     :expected_class => 'MiqReport')
       rescue => bang
         add_flash(_("Error during 'upload': %{message}") % {:message => bang.message}, :error)
         @sb[:flash_msg] = @flash_array


### PR DESCRIPTION
This needs to be tested with https://github.com/ManageIQ/manageiq/pull/16034.

This provides an optional parameter that can be tested against to make sure a user doesn't try to import a Widget via the Custom Report form.

@miq-bot add_labels bug, cloud intel/report, pending core

https://bugzilla.redhat.com/show_bug.cgi?id=1442728