### PR TITLE
Fixed Custom Reports node text when there is "-" present in tenant name

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1012,7 +1012,7 @@ class ApplicationController < ActionController::Base
       data.where.not(:timeline => nil) if tree_type == "timeline"
       data.each do |r|
         r_group = r.rpt_group == "Custom" ? "#{@sb[:grp_title]} - Custom" : r.rpt_group # Get the report group
-        title = r_group.split('-').collect(&:strip)
+        title = r_group.reverse.split('-', 2).collect(&:reverse).collect(&:strip).reverse
         if @temp_title != title[0]
           @temp_title = title[0]
           reports = []

--- a/spec/controllers/miq_report_controller/menus_spec.rb
+++ b/spec/controllers/miq_report_controller/menus_spec.rb
@@ -1,30 +1,22 @@
 describe ReportController do
   describe "#menu_update" do
-    let(:rpt_menu) do
-      [
-        [
-          "Configuration Management", [
-            ["Virtual Machines", ["VMs with Free Space > 50% by Department"]],
-          ]
-        ]
-      ]
-    end
-
     before do
       controller.instance_variable_set(:@edit, :new => {})
       controller.instance_variable_set(:@sb, :new => {})
       controller.instance_variable_set(:@_params, :button => "default")
-
+      tenant = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant, :name => "foo - bar", :subdomain => "foo - bar")
+      user = FactoryGirl.create(:user, :tenant => tenant)
+      @report = FactoryGirl.create(:miq_report, :rpt_type => "Custom", :miq_group => user.current_group)
       @user = stub_user(:features => :all)
     end
 
-    it "set menus to default" do
+    it "set menus to default and sets correct title for custom reports" do
       expect(controller).to receive(:menu_get_form_vars)
       expect(controller).to receive(:get_tree_data)
       expect(controller).to receive(:replace_right_cell)
-      expect(controller).to receive(:get_reports_menu).with(@user.current_group, "reports", "default").and_return(rpt_menu)
 
       controller.menu_update
+      expect(assigns(:edit)[:new]).to eq([["foo - bar (EVM Group): #{@user.current_group.description}", [["Custom", [@report.name]]]]])
       expect(assigns(:flash_array).first[:message]).to include("default")
     end
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1489821

before:
![before](https://user-images.githubusercontent.com/3450808/30827526-691ac528-a208-11e7-8231-a63feb692ba0.png)

after:
with "-" in company name
![screenshot from 2017-09-25 15-41-54](https://user-images.githubusercontent.com/3450808/30827531-6be22184-a208-11e7-8e3a-9cc27627d33e.png)

without "-" in company name
![screenshot from 2017-09-25 15-45-25](https://user-images.githubusercontent.com/3450808/30827572-90f4fb40-a208-11e7-93b9-7871d67cbe96.png)

@dclarizio please review