### PR TITLE
Fix error when deleting already removed JDR reports

### DIFF
--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -193,16 +193,18 @@ class MiddlewareServerController < ApplicationController
                    else
                      [from_cid(params['mw_dr_selected'])]
                    end
-    reports = mw_server.middleware_diagnostic_reports.find(selected_drs)
-    mw_server.middleware_diagnostic_reports.destroy(reports)
-
-    flash_msg = n_('Deletion of one JDR report succeeded.',
+    begin
+      reports = mw_server.middleware_diagnostic_reports.find(selected_drs)
+    rescue ActiveRecord::RecordNotFound
+      add_flash(_("Unable to locate all reports in database, please try again."), :error)
+    else
+      mw_server.middleware_diagnostic_reports.destroy(reports)
+      add_flash(n_('Deletion of one JDR report succeeded.',
                    "Deletion of %{count} JDR reports succeeded.",
-                   reports.count) % {:count => reports.count}
-
-    redirect_to(:action    => 'show',
-                :id        => to_cid(mw_server.id),
-                :flash_msg => flash_msg)
+                   reports.count) % {:count => reports.count})
+    end
+    session[:flash_msgs] = @flash_array
+    redirect_to(:action => 'show', :id => to_cid(mw_server.id))
   end
 
   def dr_report_download

--- a/spec/controllers/middleware_server_controller_spec.rb
+++ b/spec/controllers/middleware_server_controller_spec.rb
@@ -137,7 +137,7 @@ describe MiddlewareServerController do
       expect { mw_dr.reload }.to raise_exception(ActiveRecord::RecordNotFound)
       expect(mw_dr_erred.reload).to be_truthy
       expect(action).to redirect_to(:action => 'show', :id => mw_server.compressed_id)
-      expect(assigns(:flash_array).first[:message]).to include (
+      expect(assigns(:flash_array).first[:message]).to include(
         _('Deletion of one JDR report succeeded.')
       )
     end
@@ -151,7 +151,7 @@ describe MiddlewareServerController do
       expect { mw_dr.reload }.to raise_exception(ActiveRecord::RecordNotFound)
       expect { mw_dr_erred.reload }.to raise_exception(ActiveRecord::RecordNotFound)
       expect(action).to redirect_to(:action => 'show', :id => mw_server.compressed_id)
-      expect(assigns(:flash_array).first[:message]).to include (
+      expect(assigns(:flash_array).first[:message]).to include(
         _('Deletion of 2 JDR reports succeeded.')
       )
     end

--- a/spec/controllers/middleware_server_controller_spec.rb
+++ b/spec/controllers/middleware_server_controller_spec.rb
@@ -119,6 +119,9 @@ describe MiddlewareServerController do
       report.save!
       report
     end
+    let!(:mw_dr_missing) do
+      FactoryGirl.build(:hawkular_jdr_report, :middleware_server => mw_server)
+    end
 
     it 'should stream diagnostic report file to client for download' do
       get :dr_download, :params => {:id => mw_server.compressed_id, :key => mw_dr.compressed_id }
@@ -133,10 +136,9 @@ describe MiddlewareServerController do
 
       expect { mw_dr.reload }.to raise_exception(ActiveRecord::RecordNotFound)
       expect(mw_dr_erred.reload).to be_truthy
-      expect(action).to redirect_to(
-        :action    => 'show',
-        :id        => mw_server.compressed_id,
-        :flash_msg => _('Deletion of one JDR report succeeded.')
+      expect(action).to redirect_to(:action => 'show', :id => mw_server.compressed_id)
+      expect(assigns(:flash_array).first[:message]).to include (
+        _('Deletion of one JDR report succeeded.')
       )
     end
 
@@ -148,10 +150,23 @@ describe MiddlewareServerController do
 
       expect { mw_dr.reload }.to raise_exception(ActiveRecord::RecordNotFound)
       expect { mw_dr_erred.reload }.to raise_exception(ActiveRecord::RecordNotFound)
-      expect(action).to redirect_to(
-        :action    => 'show',
-        :id        => mw_server.compressed_id,
-        :flash_msg => _('Deletion of 2 JDR reports succeeded.')
+      expect(action).to redirect_to(:action => 'show', :id => mw_server.compressed_id)
+      expect(assigns(:flash_array).first[:message]).to include (
+        _('Deletion of 2 JDR reports succeeded.')
+      )
+    end
+
+    it 'should not delete a nonexistent report if requested' do
+      action = post :dr_delete, :params => {
+        :id             => mw_server.compressed_id,
+        :mw_dr_selected => mw_dr_missing.compressed_id
+      }
+
+      expect(mw_dr.reload).to be_truthy
+      expect(mw_dr_erred.reload).to be_truthy
+      expect(action).to redirect_to(:action => 'show', :id => mw_server.compressed_id)
+      expect(assigns(:flash_array)).to eq(
+        [{:message => "Unable to locate all reports in database, please try again.", :level => :error}]
       )
     end
   end


### PR DESCRIPTION
Catch ActiveRecord::RecordNotFound and display an error flash message
instead. Then refreshes the 'show' page, so the list of JDR reports is
rebuilt.

Changes the way how flash messages are forwarded to client (using `add_flash` instead of in-lining in `redirect_to`).

Fixes https://github.com/ManageIQ/manageiq-providers-hawkular/issues/58