### PR TITLE
Add tagging button for cloud object store containers.

### DIFF
--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -22,18 +22,19 @@ module Mixins
 
     def handle_tag_buttons(pressed)
       case pressed
-      when "#{self.class.table_name}_tag"  then tag(self.class.model)
-      when 'cloud_network_tag'             then tag(CloudNetwork)
-      when 'cloud_object_store_object_tag' then tag(CloudObjectStoreObject)
-      when 'cloud_subnet_tag'              then tag(CloudSubnet)
-      when 'cloud_tenant_tag'              then tag(CloudTenant)
-      when 'cloud_volume_snapshot_tag'     then tag(CloudVolumeSnapshot)
-      when 'cloud_volume_tag'              then tag(CloudVolume)
-      when 'floating_ip_tag'               then tag(FloatingIp)
-      when 'load_balancer_tag'             then tag(LoadBalancer)
-      when 'network_port_tag'              then tag(NetworkPort)
-      when 'network_router_tag'            then tag(NetworkRouter)
-      when 'security_group_tag'            then tag(SecurityGroup)
+      when "#{self.class.table_name}_tag"     then tag(self.class.model)
+      when 'cloud_network_tag'                then tag(CloudNetwork)
+      when 'cloud_object_store_container_tag' then tag(CloudObjectStoreContainer)
+      when 'cloud_object_store_object_tag'    then tag(CloudObjectStoreObject)
+      when 'cloud_subnet_tag'                 then tag(CloudSubnet)
+      when 'cloud_tenant_tag'                 then tag(CloudTenant)
+      when 'cloud_volume_snapshot_tag'        then tag(CloudVolumeSnapshot)
+      when 'cloud_volume_tag'                 then tag(CloudVolume)
+      when 'floating_ip_tag'                  then tag(FloatingIp)
+      when 'load_balancer_tag'                then tag(LoadBalancer)
+      when 'network_port_tag'                 then tag(NetworkPort)
+      when 'network_router_tag'               then tag(NetworkRouter)
+      when 'security_group_tag'               then tag(SecurityGroup)
       end
 
       @flash_array.nil? ? :finished : :continue


### PR DESCRIPTION
Fix "Tag" button for Object store container.

https://bugzilla.redhat.com/show_bug.cgi?id=1494344

Steps to Reproduce:
 1. Add cloud provider first (Openstack RHOS7-GA recommended)
 2. Navigate to Compute -> Cloud -> Tenants
 3. Click on 'admin' from 'Cloud Tenants' table
 4. Click on 'Cloud Object Store Containers' from 'Relationship' table 
 5. Click on one 'Cloud Object Store Containers' from 'All Images' table
 6. From 'Policy' select 'Edit tag'

ping @tzumainn, @petrblaho, @aufi : please, review.