### PR TITLE
Allow override of the help menu items using the settings.yml

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -277,9 +277,24 @@ module Menu
 
       def help_menu_section
         Menu::Section.new(:help, N_('Help'), 'pficon pficon-help', [
-          Menu::Item.new('documentation', N_('Documentation'), 'documentation',  {:feature => 'documentation'}, '/support/index?support_tab=about'),
-          Menu::Item.new('product',       N_('ManageIQ.org'),  'product',        {:feature => 'product'},       I18n.t("product.support_website").html_safe, :new_window),
-          Menu::Item.new('about',         N_('About'),         'about',          {:feature => 'about'},         '#aboutModal', :modal)
+          Menu::Item.new('documentation',
+                         Settings.help_menu.try(:documentation).try(:title) || N_('Documentation'),
+                         'documentation',
+                         {:feature => 'documentation'},
+                         Settings.help_menu.try(:documentation).try(:link) || '/support/index?support_tab=about',
+                         Settings.help_menu.try(:documentation).try(:type)),
+          Menu::Item.new('product',
+                         Settings.help_menu.try(:product).try(:title) || N_('ManageIQ.org'),
+                         'product',
+                         {:feature => 'product'},
+                         Settings.help_menu.try(:product).try(:link) || I18n.t("product.support_website").html_safe,
+                         Settings.help_menu.try(:product).try(:type) || :new_window),
+          Menu::Item.new('about',
+                         Settings.help_menu.try(:about).try(:title) || N_('About'),
+                         'about',
+                         {:feature => 'about'},
+                         Settings.help_menu.try(:about).try(:link) || '#aboutModal',
+                         Settings.help_menu.try(:about).try(:type) || :modal)
         ], :help)
       end
 


### PR DESCRIPTION
This PR allows to override the three items in the help menu with custom title/link/type settings. If something is not set explicitly, the default value from the `default_menu` will be used. The `type` attribute is a special setting that can be set to `new_window` or `modal` and trivially it can open a new window or a modal instead of the default link behavior.

To test it, use this diff or create your own:
```diff
diff --git a/config/settings.yml b/config/settings.yml
index 66f0007e0f..b41edbffd3 100644
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -802,6 +802,18 @@
     - MoveIntoResourcePool
     :VmSuspendedEvent:
     - SuspendVM_Task
+:help_menu:
+  :documentation:
+    :title: Mystery Link
+    :link: http://weirdorconfusing.com
+  :product:
+    :title: Awesome Product
+    :link: http://www.manageiq.org
+    :type: :new_window
+  :about:
+    :title: About
+    :link: "#aboutModal"
+    :type: :modal
 :host_delete:
   :queue_timeout: 20.minutes
 :host_introspect:
```

Pivotal story: https://www.pivotaltracker.com/story/show/150933794

@miq-bot add_label enhancement
@miq-bot assign @martinpovolny 