### PR TITLE
Angular - move the translate filter to a new miq.compat module

### DIFF
--- a/app/assets/javascripts/angular_modules/module_compat.js
+++ b/app/assets/javascripts/angular_modules/module_compat.js
@@ -1,0 +1,4 @@
+/* global miqHttpInject */
+miqHttpInject(
+  angular.module('miq.compat', [])
+);

--- a/app/assets/javascripts/directives/translate.js
+++ b/app/assets/javascripts/directives/translate.js
@@ -1,0 +1,10 @@
+// this is for compatibility with angular-translate used in Service UI
+// we currently don't support extracting such strings in ui-classic
+// hence miq.compat, so that it needs to be explicitly required when needed
+
+angular.module('miq.compat')
+  .filter('translate', function() {
+    return function(val) {
+      return __(val);
+    };
+  });

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -8,6 +8,7 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'angular.validators',
   'miq.api',
   'miq.card',
+  'miq.compat',
   'miq.util',
   'kubernetesUI',
   'miqStaticAssets.dialogEditor',
@@ -19,13 +20,6 @@ ManageIQ.angular.rxSubject = new Rx.Subject();
 ManageIQ.constants = {
   reportData: 'report_data',
 };
-
-// FIXME: temporary workaround for gettext in UI components code
-ManageIQ.angular.app.filter('translate', function() {
-  return function(val) {
-    return __(val);
-  };
-});
 
 function miqHttpInject(angular_app) {
   angular_app.config(['$httpProvider', function($httpProvider) {


### PR DESCRIPTION
The filter is only for compatibility with SUI, and code moved from SUI to ui-components.

We do not use `translate` for extracting in ui-classic, but we don't want the code to die while trying to translate something.

We will probably need to also implement the translate directive at some point, or move to a different angular i18n system in ui-components (Cc @mzazrivec).

But for now.. this should make it easier to use this even in per-feature modules, and not only with `ManageIQ.angular.app` ... Cc @skateman (you'll need to add `miq.compat`)