### PR TITLE
Adding miq_date parameter when setting hourly and daily vars

### DIFF
--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -12,8 +12,8 @@ module ApplicationController::Timelines
     def update_from_params(params)
       self.typ = params[:tl_typ] if params[:tl_typ]
       self.days = params[:tl_days] if params[:tl_days]
-      self.hourly = params[:miq_date_1] if params[:miq_date_1] && typ == 'Hourly'
-      self.daily = params[:miq_date_1] if params[:miq_date_1] && typ == 'Daily'
+      self.hourly = params[:miq_date_1] || params[:miq_date] if (params[:miq_date_1] || params[:miq_date]) && typ == 'Hourly'
+      self.daily = params[:miq_date_1] || params[:miq_date] if (params[:miq_date_1] || params[:miq_date]) && typ == 'Daily'
     end
 
     def update_start_end(sdate, edate)


### PR DESCRIPTION
Middleware timeline uses `miq_date` to send the chosen date to the UI backend, thus was being ignored.
Changing update_from_params to read miq_date if received, but giving priority to miq_date_1.

This PR is part of a collection of PRs solving ManageIQ/manageiq#15756.

![screenshot from 2017-09-28 12-45-07](https://user-images.githubusercontent.com/23639005/30982106-14d2fe04-a44c-11e7-9350-97d8f4a23060.png)
