### PR TITLE
When we have records selected use grid as GTL type.

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -6,6 +6,7 @@
   var TREES_WITHOUT_PARENT = ['pxe', 'ops'];
   var TREE_TABS_WITHOUT_PARENT = ['action_tree', 'alert_tree', 'schedules_tree'];
   var USE_TREE_ID = ['automation_manager'];
+  var DEFAULT_VIEW = 'grid';
 
   function isAllowedParent(initObject) {
     return TREES_WITHOUT_PARENT.indexOf(ManageIQ.controller) === -1 &&
@@ -259,7 +260,7 @@
     } else if (this.initObject.showUrl === 'false') {
       this.initObject.showUrl = false;
     }
-    this.gtlType = initObject.gtlType || 'grid';
+    this.gtlType = initObject.gtlType || DEFAULT_VIEW;
     this.settings.isLoading = true;
     ManageIQ.gridChecks = [];
     this.$window.sendDataWithRx({setCount: 0});

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1454,6 +1454,7 @@ class ApplicationController < ActionController::Base
   def get_view_calculate_gtl_type(db_sym)
     gtl_type = settings(:views, db_sym) unless %w(scanitemset miqschedule pxeserver customizationtemplate).include?(db_sym.to_s)
     gtl_type = 'grid' if ['vm'].include?(db_sym.to_s) && request.parameters[:controller] == 'service'
+    gtl_type = 'grid' if params[:records] && params[:records].kind_of?(Array)
     gtl_type ||= 'list' # return a sane default
     gtl_type
   end


### PR DESCRIPTION
This fixes problem with missing quadicons if we are in property settings pages (tagging, simulate...)
### Before:
![screenshot from 2017-09-27 10-37-18](https://user-images.githubusercontent.com/3439771/30903683-dc17554c-a36f-11e7-97da-71e15badb4f4.png)

### After:
![screenshot from 2017-09-27 10-45-39](https://user-images.githubusercontent.com/3439771/30904045-07272676-a371-11e7-93e2-13fcd07d3e8f.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1487116