### PR TITLE
Extended service, vm, instance & orch. stack retirement functionality

### DIFF
--- a/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
+++ b/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
@@ -31,7 +31,7 @@ ManageIQ.angular.app.controller('retirementFormController', ['$http', 'objectIds
     var data = response.data;
 
     if (data.retirement_date != null) {
-      vm.retirementInfo.retirementDate = moment.utc(data.retirement_date, 'MM-DD-YYYY').toDate();
+      vm.retirementInfo.retirementDate = moment.utc(data.retirement_date).toDate();
     }
     vm.retirementInfo.retirementWarning = data.retirement_warning || '';
     vm.modelCopy = _.extend({}, vm.retirementInfo);

--- a/app/assets/javascripts/directives/datetimepicker.js
+++ b/app/assets/javascripts/directives/datetimepicker.js
@@ -1,0 +1,60 @@
+/*
+ * The datetimepicker directive takes care of data conversion (String <-> Date)
+ * between datetimepicker input and model. For the data conversion to work
+ * correctly, the directive requires a date/time format to be supplied in
+ * datetime-format attribute:
+ *
+ * <input type="text" datetimepicker="true" datetime-format="MM/DD/YYYY HH:mm" ... />
+ *
+ * Optionally, it's possible to set the following attributes via the directive:
+ *
+ * - datetime-locale: locale to use
+ * - start-date: starting date for the datetime picker
+ */
+
+ManageIQ.angular.app.directive('datetimepicker', function() {
+  return {
+    require: 'ngModel',
+    link: function(scope, elem, attr, ctrl) {
+      elem.datetimepicker({showClear: true, showClose: true});
+
+      // datetime picker uses its own event for change
+      elem.on('dp.change', function(event) {
+        elem.trigger('change', event);
+      });
+
+      // date & time format
+      if (attr.datetimeFormat) {
+        elem.data('DateTimePicker').format(attr.datetimeFormat);
+      }
+
+      // date & time locale
+      if (attr.datetimeLocale) {
+        elem.data('DateTimePicker').locale(attr.datetimeLocale);
+      }
+
+      // start date
+      if (attr.startDate) {
+        scope.$watch(attr.startDate, function(value) {
+          elem.data('DateTimePicker').minDate(value);
+        });
+      }
+
+      // formatter
+      ctrl.$formatters.push(function(value) {
+        if (value) {
+          return moment(value).utc().format(attr.datetimeFormat);
+        }
+      });
+
+      // parser
+      ctrl.$parsers.push(function(value) {
+        if (value) {
+          return moment.utc(value, attr.datetimeFormat).toDate();
+        }
+
+        return null;
+      });
+    },
+  };
+});

--- a/app/controllers/mixins/actions/vm_actions/retire.rb
+++ b/app/controllers/mixins/actions/vm_actions/retire.rb
@@ -59,7 +59,7 @@ module Mixins
           end
           obj = kls.find_by(:id => params[:id])
           render :json => {
-            :retirement_date    => obj.retires_on.try(:strftime, '%m/%d/%Y'),
+            :retirement_date    => obj.retires_on,
             :retirement_warning => obj.retirement_warn
           }
         end

--- a/app/helpers/application_helper/form_tags.rb
+++ b/app/helpers/application_helper/form_tags.rb
@@ -10,5 +10,18 @@ module ApplicationHelper
       }
       text_field_tag(name, value, options.merge!(datepicker_options))
     end
+
+    def datetimepicker_input_tag(name, value = nil, options = {})
+      datepicker_options = {
+        "datetimepicker"  => true,
+        # FIXME: currently, not all locales (e.g. Japanese) are supported
+        # by the datepicker widget and would throw an ugly javascript error
+        # "datetime-locale" => FastGettext.locale,
+        # FIXME: in the future, this should honor l10n preferences. Here we need
+        # to supply a format that moment.js understands.
+        "datetime-format" => 'MM/DD/YYYY HH:mm'
+      }
+      text_field_tag(name, value, options.merge!(datepicker_options))
+    end
   end
 end

--- a/app/views/shared/views/_retire.html.haml
+++ b/app/views/shared/views/_retire.html.haml
@@ -4,25 +4,21 @@
                                "ng-controller" => "retirementFormController as vm",
                                "miq-form"      => true,
                                "model"         => "vm.retirementInfo",
-                               "model-copy"    => "vm.modelCopy" }
+                               "model-copy"    => "vm.modelCopy",
+                               "form-changed"  => true }
   %h3
     = _('Set/Remove Retirement Date')
   %tbody
     .form-group
       %label.col-md-2.control-label
-        = _('Retirement Date')
-      .col-md-8#retirement_date_div
-        = datepicker_input_tag("retirementDate", nil,
-                                :id                  => "retirement_date",
-                                :class               => "css1",
-                                "ng-model"           => "vm.retirementInfo.retirementDate",
-                                "miq-calendar"       => true,
-                                "miq-cal-date-from"  => "vm.datepickerStartDate",
-                                "checkchange"        => true)
-        %a{'href'              => '#',
-           'ng-click'          => 'vm.retirementInfo.retirementDate = null; vm.retirementInfo.retirementWarning = ""',
-           'ng-hide'           => '!vm.retirementInfo.retirementDate'}
-          = image_tag(image_path('16/clear.png'), :border => "0", :alt => _("Set to blank"))
+        = _('Retirement Date and Time')
+      .col-md-4#retirement_date_div
+        .form-group
+          = datetimepicker_input_tag('retirement_date', nil,
+                                     'id'         => 'retirement_date',
+                                     'class'      => 'form-control',
+                                     'ng-model'   => 'vm.retirementInfo.retirementDate',
+                                     'start-date' => 'vm.datepickerStartDate')
     .form-group
       %label.col-md-2.control-label
         = _('Retirement Warning')
@@ -36,7 +32,6 @@
                      "ng-options"  => "item.value as item.label for item in #{select_options.to_json.gsub('"', '\'')}",
                      "ng-model"    => "vm.retirementInfo.retirementWarning",
                      "ng-disabled" => "!vm.retirementInfo.retirementDate",
-                     "checkchange" => true,
                      "pf-select"   => true)
         :javascript
           miqInitSelectPicker();

--- a/spec/helpers/application_helper/form_tags_spec.rb
+++ b/spec/helpers/application_helper/form_tags_spec.rb
@@ -8,4 +8,12 @@ describe ApplicationHelper::FormTags do
     expect(input).to include('data-date-format=')
     expect(input).to include('data-date-language=')
   end
+
+  it "#datetimepicker_input_tag sets correct date / time, datetime-format" do
+    input = helper.datetimepicker_input_tag('id01', Time.at(1_170_361_845).utc)
+
+    expect(input).to include('datetimepicker="true"')
+    expect(input).to include('datetime-format=')
+    expect(input).to include('value="2007-02-01 20:30:45 UTC"')
+  end
 end

--- a/spec/javascripts/directives/datetimepicker_spec.js
+++ b/spec/javascripts/directives/datetimepicker_spec.js
@@ -1,0 +1,30 @@
+describe('datetimepicker test', function() {
+  var scope, form, element, compile;
+  beforeEach(module('ManageIQ'));
+  beforeEach(inject(function($compile, $rootScope) {
+    scope = $rootScope;
+    compile = $compile;
+    element = angular.element('<form name="angularForm">' +
+      '<input type="text" datetimepicker="true" ng-model="testModel.test_date" name="test_date" ' +
+      'start-date="testModel.start_date" datetime-format="MM/DD/YYYY HH:mm" ' +
+      '/></form>');
+    scope.testModel = {
+      test_date : new Date(Date.UTC(2015, 7, 30, 13, 45)),
+      start_date: new Date(Date.UTC(1970, 0, 1)),
+    };
+    compile(element)(scope);
+    scope.$digest();
+    form = scope.angularForm;
+  }));
+
+  describe('datetimepicker formatter and parser', function() {
+    it('should format a date value from model into string value for output', function() {
+      expect(form.test_date.$viewValue).toBe('08/30/2015 13:45');
+    });
+
+    it('should parse a value from input into model value', function() {
+      form.test_date.$setViewValue('12/31/1980 15:22');
+      expect(scope.testModel.test_date).toEqual(new Date(Date.UTC(1980, 11, 31, 15, 22)));
+    });
+  });
+});


### PR DESCRIPTION
This change allows for setting retirement date & time for services, virtual machines and orchestration templates. In the past, the form would only allow to select retirement date. From now on, we're able
to select the time to retire as well (all in UTC time zone).

This change also introduces date & time picker from Patternfly. For it to work nicely with our application
and angular, we're using a new angular directive `datetimepicker`.

https://www.pivotaltracker.com/story/show/150934417

What won't currently work:
* translated month names: with some locales (e.g. Japanese) the widget would throw an ugly
javascript error. This would have to be addressed on the datepicker upstream side.
* localized date formats: for this to work, we'd need to supply a date format that moment.js would understand. For now, we're using `MM/DD/YYYY HH:mm`.

Initial retirement screen:
![retirement01](https://user-images.githubusercontent.com/6648365/30962252-53bb7202-a449-11e7-933f-ecfb8f81d26b.jpg)

Date / time picker, the date selection part:
![retirement02](https://user-images.githubusercontent.com/6648365/30962268-5fdf349c-a449-11e7-9b7f-1eb31ebb4537.jpg)

Date / time picker, the time selection part:
![retirement03](https://user-images.githubusercontent.com/6648365/30962279-6906c62a-a449-11e7-9d13-e7592744b210.jpg)

The retirement date & time has been set:
![retirement04](https://user-images.githubusercontent.com/6648365/30962300-83f3d220-a449-11e7-843b-b9ed90cef63d.jpg)


