### PR TITLE
 Update pre_prov view to support Volumes and Snapshots

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1607,7 +1607,7 @@ class ApplicationController < ActionController::Base
       :page                      => options[:all_pages] ? 1 : @current_page,
       :per_page                  => options[:all_pages] ? ONE_MILLION : @items_per_page,
       :where_clause              => get_view_where_clause(options[:where_clause]),
-      :named_scope               => options[:named_scope] || (:without_volume_templates if db == "MiqTemplate"),
+      :named_scope               => options[:named_scope],
       :display_filter_hash       => options[:display_filter_hash],
       :userid                    => session[:userid],
       :selected_ids              => object_ids,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1607,7 +1607,7 @@ class ApplicationController < ActionController::Base
       :page                      => options[:all_pages] ? 1 : @current_page,
       :per_page                  => options[:all_pages] ? ONE_MILLION : @items_per_page,
       :where_clause              => get_view_where_clause(options[:where_clause]),
-      :named_scope               => options[:named_scope],
+      :named_scope               => options[:named_scope] || (:without_volume_templates if db == "MiqTemplate"),
       :display_filter_hash       => options[:display_filter_hash],
       :userid                    => session[:userid],
       :selected_ids              => object_ids,

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -164,7 +164,7 @@ module Mixins
     end
 
     def display_images
-      nested_list("template_cloud", ManageIQ::Providers::CloudManager::Template)
+      nested_list("template_cloud", ManageIQ::Providers::CloudManager::Template, :named_scope => :without_volume_templates)
     end
 
     # options:

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -184,6 +184,7 @@ module Mixins
       view_options[:association] = options[:association] if options.key?(:association)
       view_options[:parent_method] = options[:parent_method] if options.key?(:parent_method)
       view_options[:where_clause] = options[:where_clause] if options.key?(:where_clause)
+      view_options[:named_scope] = options[:named_scope] if options.key?(:named_scope)
 
       @view, @pages = get_view(model, view_options)
       @showtype = @display

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1089,6 +1089,9 @@ module VmCommon
       end
     else      # Get list of child VMs of this node
       options = {:model => model}
+      if model == "ManageIQ::Providers::CloudManager::Template"
+        options[:named_scope] = [:without_volume_templates]
+      end
       if x_node == "root"
         if x_active_tree == :vandt_tree
           klass = ManageIQ::Providers::InfraManager::VmOrTemplate

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -36,18 +36,36 @@
             = h(row.name)
           - if @edit[:vm_headers].include?("image?")
             %td.text-nowrap
-              - if row.respond_to?(:image?)
+              - if row.respond_to?(:volume_template?)
+                = h(_("Volume"))
+              - elsif row.respond_to?(:image?)
                 = h(row.image? ? _("Image") : _("Snapshot"))
+
           %td
-            = h(row.operating_system.try(:product_name))
+            - if row.respond_to?(:volume_template?)
+              = h(_("N/A"))
+            - else
+              = h(row.operating_system.try(:product_name))
           %td
-            = h(row.platform)
+            - if row.respond_to?(:volume_template?)
+              = h(_("N/A"))
+            - else
+              = h(row.platform)
           %td
-            = h(row.cpu_total_cores)
+            - if row.respond_to?(:volume_template?)
+              = h(_("N/A"))
+            - else
+              = h(row.cpu_total_cores)
           %td
-            = h(number_to_human_size(row.mem_cpu.to_i * 1024 * 1024))
+            - if row.respond_to?(:volume_template?)
+              = h(_("N/A"))
+            - else
+              = h(number_to_human_size(row.mem_cpu.to_i * 1024 * 1024))
           %td
-            = h(number_to_human_size(row.allocated_disk_storage))
+            - if row.respond_to?(:volume_template?)
+              = h(_("N/A"))
+            - else
+              = h(number_to_human_size(row.allocated_disk_storage))
           %td
             = h(row.deprecated ? _("true") : _("false"))
           %td

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -38,31 +38,33 @@
             %td.text-nowrap
               - if row.respond_to?(:volume_template?)
                 = h(_("Volume"))
+              - elsif row.respond_to?(:volume_snapshot_template?)
+                = h(_("Volume Snapshot"))
               - elsif row.respond_to?(:image?)
                 = h(row.image? ? _("Image") : _("Snapshot"))
 
           %td
-            - if row.respond_to?(:volume_template?)
+            - if row.respond_to?(:volume_template?) || row.respond_to?(:volume_snapshot_template?)
               = h(_("N/A"))
             - else
               = h(row.operating_system.try(:product_name))
           %td
-            - if row.respond_to?(:volume_template?)
+            - if row.respond_to?(:volume_template?) || row.respond_to?(:volume_snapshot_template?)
               = h(_("N/A"))
             - else
               = h(row.platform)
           %td
-            - if row.respond_to?(:volume_template?)
+            - if row.respond_to?(:volume_template?) || row.respond_to?(:volume_snapshot_template?)
               = h(_("N/A"))
             - else
-              = h(row.cpu_total_cores)
+              = h(row.cpu_total_cores) || row.respond_to?(:volume_snapshot_template?)
           %td
-            - if row.respond_to?(:volume_template?)
+            - if row.respond_to?(:volume_template?) || row.respond_to?(:volume_snapshot_template?)
               = h(_("N/A"))
             - else
               = h(number_to_human_size(row.mem_cpu.to_i * 1024 * 1024))
           %td
-            - if row.respond_to?(:volume_template?)
+            - if row.respond_to?(:volume_template?) || row.respond_to?(:volume_snapshot_template?)
               = h(_("N/A"))
             - else
               = h(number_to_human_size(row.allocated_disk_storage))

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -29,53 +29,7 @@
                 %img{:src => image_path("16/sort_#{@edit[:vm_sortdir] == 'ASC' ? 'up' : 'down'}.png")}
     %tbody
       - @vms.each do |row|
-        - @id = row.id
-        - cls =  @edit[:src_vm_id] && @edit[:src_vm_id] == @id ? "selected" : ""
-        %tr{:class => cls, :onclick => "miqAjax('/miq_request/pre_prov/?sel_id=#{@id}');", :id => "row_#{@id}"}
-          %td.text-nowrap
-            = h(row.name)
-          - if @edit[:vm_headers].include?("image?")
-            %td.text-nowrap
-              - if row.respond_to?(:volume_template?)
-                = h(_("Volume"))
-              - elsif row.respond_to?(:volume_snapshot_template?)
-                = h(_("Volume Snapshot"))
-              - elsif row.respond_to?(:image?)
-                = h(row.image? ? _("Image") : _("Snapshot"))
-
-          %td
-            - if row.respond_to?(:volume_template?) || row.respond_to?(:volume_snapshot_template?)
-              = h(_("N/A"))
-            - else
-              = h(row.operating_system.try(:product_name))
-          %td
-            - if row.respond_to?(:volume_template?) || row.respond_to?(:volume_snapshot_template?)
-              = h(_("N/A"))
-            - else
-              = h(row.platform)
-          %td
-            - if row.respond_to?(:volume_template?) || row.respond_to?(:volume_snapshot_template?)
-              = h(_("N/A"))
-            - else
-              = h(row.cpu_total_cores) || row.respond_to?(:volume_snapshot_template?)
-          %td
-            - if row.respond_to?(:volume_template?) || row.respond_to?(:volume_snapshot_template?)
-              = h(_("N/A"))
-            - else
-              = h(number_to_human_size(row.mem_cpu.to_i * 1024 * 1024))
-          %td
-            - if row.respond_to?(:volume_template?) || row.respond_to?(:volume_snapshot_template?)
-              = h(_("N/A"))
-            - else
-              = h(number_to_human_size(row.allocated_disk_storage))
-          %td
-            = h(row.deprecated ? _("true") : _("false"))
-          %td
-            - if row.ext_management_system
-              = h(row.ext_management_system.name)
-          %td
-            = h(row.v_total_snapshots)
-          - if @edit[:vm_headers].include?("cloud_tenant")
-            %td
-              - if row.respond_to?(:cloud_tenant)
-                = h(row.cloud_tenant.try(:name))
+        - if row.respond_to?(:volume_template?) || row.respond_to?(:volume_snapshot_template?)
+          = render :partial => "miq_request/pre_prov_volumes_snapshots", :locals => {:row => row}
+        - else
+          = render :partial => "miq_request/pre_prov_images", :locals => {:row => row}

--- a/app/views/miq_request/_pre_prov_images.html.haml
+++ b/app/views/miq_request/_pre_prov_images.html.haml
@@ -1,0 +1,30 @@
+- @id = row.id
+- cls =  @edit[:src_vm_id] && @edit[:src_vm_id] == @id ? "selected" : ""
+%tr{:class => cls, :onclick => "miqAjax('/miq_request/pre_prov/?sel_id=#{@id}');", :id => "row_#{@id}"}
+  %td.text-nowrap
+    = h(row.name)
+  - if @edit[:vm_headers].include?("image?")
+    %td.text-nowrap
+      - if row.respond_to?(:image?)
+        = h(row.image? ? _("Image") : _("Snapshot"))
+  %td
+    = h(row.operating_system.try(:product_name))
+  %td
+    = h(row.platform)
+  %td
+    = h(row.cpu_total_cores) || row.respond_to?(:volume_snapshot_template?)
+  %td
+    = h(number_to_human_size(row.mem_cpu.to_i * 1024 * 1024))
+  %td
+    = h(number_to_human_size(row.allocated_disk_storage))
+  %td
+    = h(row.deprecated ? _("true") : _("false"))
+  %td
+    - if row.ext_management_system
+      = h(row.ext_management_system.name)
+  %td
+    = h(row.v_total_snapshots)
+  - if @edit[:vm_headers].include?("cloud_tenant")
+    %td
+      - if row.respond_to?(:cloud_tenant)
+        = h(row.cloud_tenant.try(:name))

--- a/app/views/miq_request/_pre_prov_volumes_snapshots.html.haml
+++ b/app/views/miq_request/_pre_prov_volumes_snapshots.html.haml
@@ -1,0 +1,32 @@
+- @id = row.id
+- cls =  @edit[:src_vm_id] && @edit[:src_vm_id] == @id ? "selected" : ""
+%tr{:class => cls, :onclick => "miqAjax('/miq_request/pre_prov/?sel_id=#{@id}');", :id => "row_#{@id}"}
+  %td.text-nowrap
+    = h(row.name)
+  - if @edit[:vm_headers].include?("image?")
+    %td.text-nowrap
+      - if row.respond_to?(:volume_template?)
+        = h(_("Volume"))
+      - elsif row.respond_to?(:volume_snapshot_template?)
+        = h(_("Volume Snapshot"))
+  %td
+    = h(_("N/A"))
+  %td
+    = h(_("N/A"))
+  %td
+    = h(_("N/A"))
+  %td
+    = h(_("N/A"))
+  %td
+    = h(_("N/A"))
+  %td
+    = h(_("N/A"))
+  %td
+    - if row.ext_management_system
+      = h(row.ext_management_system.name)
+  %td
+    = h(_("N/A"))
+  - if @edit[:vm_headers].include?("cloud_tenant")
+    %td
+      - if row.respond_to?(:cloud_tenant)
+        = h(row.cloud_tenant.try(:name))


### PR DESCRIPTION
This pull request allows Volumes and Snapshots to appear nicely in the pre-provisioning source selection screen. It also filters VolumeTemplates and VolumeSnapshotTemplates out of other Image reports via a named scope.

Disclaimer: I know this isn't the right way to use the named scope, but some times the easiest way to get help is to do it wrong first. ;) 

Depends on https://github.com/ManageIQ/manageiq/pull/16066
See also:
https://github.com/ManageIQ/manageiq-providers-openstack/pull/104
