### PR TITLE
Enables physical infra menu by default

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -6,7 +6,7 @@ module Menu
         Menu::Section.new(:compute, N_("Compute"), 'pficon pficon-cpu', [
           clouds_menu_section,
           infrastructure_menu_section,
-          ::Settings.product.physical_infrastructure ? physical_infrastructure_menu_section : nil,
+          physical_infrastructure_menu_section,
           container_menu_section
         ].compact)
       end


### PR DESCRIPTION
The physical infrastructure menu was in Technical Preview for the Fine release. During TP, the menu item for Physical Infrastructure was hidden by default.    This PR re-enables this menu by default in preparation for the  next downstream release

The menu items below should appear by default when this PR is merged.
![manageiq_ dashboard - google chrome 9_28_2017 1_32_23 pm](https://user-images.githubusercontent.com/6444418/30981493-8be472a6-a452-11e7-9d05-602b099706c4.png)

