### PR TITLE
Fix exception when submitting Reconfigure request

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -254,8 +254,8 @@ module Mixins
           if params[:cb_cpu] == 'true'
             options[:cores_per_socket]  = params[:cores_per_socket_count].nil? ? 1 : params[:cores_per_socket_count].to_i
             options[:number_of_sockets] = params[:socket_count].nil? ? 1 : params[:socket_count].to_i
-            vccores = params[:cores_per_socket_count].zero? ? 1 : params[:cores_per_socket_count].to_i
-            vsockets = params[:socket_count].zero? ? 1 : params[:socket_count].to_i
+            vccores = params[:cores_per_socket_count].to_i.zero? ? 1 : params[:cores_per_socket_count].to_i
+            vsockets = params[:socket_count].to_i.zero? ? 1 : params[:socket_count].to_i
             options[:number_of_cpus] = vccores * vsockets
           end
 


### PR DESCRIPTION
`.zero?` was being called on a String.  Added missing `.to_i` to resolve.

https://bugzilla.redhat.com/show_bug.cgi?id=1489090
