### PR TITLE
set default port based on emstype

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -378,7 +378,11 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
   $scope.providerTypeChanged = function() {
     if ($scope.emsCommonModel.ems_controller === 'ems_container') {
-      $scope.emsCommonModel.default_api_port = "8443"; // TODO: correct per-type port
+      if ($scope.emsCommonModel.emstype === 'kubernetes') {
+        $scope.emsCommonModel.default_api_port = "6443";
+      } else {
+        $scope.emsCommonModel.default_api_port = "8443";
+      }
       return;
     }
     $scope.emsCommonModel.default_api_port = "";


### PR DESCRIPTION
This PR will cause the default value for `API Port` to change when 'Kubernetes' or 'Openshift' are selected from the EMS Type is selected in the Add New Containers Provider window. Values: 6443 for Kubernetes, 8443 for Openshift