### PR TITLE
Saved report pagination fix

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -454,32 +454,21 @@ table.table.table-summary-screen tbody td img {
 /// begin paginator styling
 
 @media (min-width: $screen-sm) {
-  .toolbar-pf#paging_div { /* sets paging_div at bottom of screen and styles */
-    bottom: 0;
-    border-top: 1px solid #c7c7c7;
-    height: 44px;
-    background-image: linear-gradient(to bottom, #FAFAFA 0%, #EDEDED 100%);
-  }
   #paging_div { /* sets paging_div at bottom of screen and styles */
-    height: 40px;
+    border-top: 1px solid #d1d1d1;
     margin-top: 0;
     top:0;
     .col-md-12 {
       padding: 0;
     }
     .content-view-pf-pagination {
+      border: 0;
+      height: 44px;
       margin: 0;
-      padding: 0;
+      padding: 3px 0 0 0;
     }
   }
 }
-
-#paging_div {
-  border-top: 1px solid #c7c7c7;
-  background-image: linear-gradient(to bottom, #FAFAFA 0%, #EDEDED 100%);
-}
-
-
 
 /// end paginator styling
 

--- a/app/controllers/mixins/controller_constants.rb
+++ b/app/controllers/mixins/controller_constants.rb
@@ -2,14 +2,14 @@ module Mixins
   module ControllerConstants
     # Per page choices and default
     PPCHOICES = [
-      [N_("5"), 5],
-      [N_("10"), 10],
-      [N_("20"), 20],
-      [N_("50"), 50],
-      [N_("100"), 100],
-      [N_("200"), 200],
-      [N_("500"), 500],
-      [N_("1000"), 1000]
+      [N_("5 Items"), 5],
+      [N_("10 Items"), 10],
+      [N_("20 Items"), 20],
+      [N_("50 Items"), 50],
+      [N_("100 Items"), 100],
+      [N_("200 Items"), 200],
+      [N_("500 Items"), 500],
+      [N_("1000 Items"), 1000]
     ].freeze
   end
 end

--- a/app/views/layouts/_paging_bar.html.haml
+++ b/app/views/layouts/_paging_bar.html.haml
@@ -1,4 +1,4 @@
-.form-group.pull-right{:style => "border-right: 0"}
+%span
   %ul.pagination
     %li.first
       / first button

--- a/app/views/layouts/_saved_report_paging_bar.html.haml
+++ b/app/views/layouts/_saved_report_paging_bar.html.haml
@@ -1,5 +1,5 @@
 .col-md-12
-  .toolbar-pf-actions
+  .pagination.content-view-pf-pagination
     - action_url = "saved_report_paging"
     - url = url_for_only_path(:action => action_url)
     - @pb_occ ||= 0
@@ -8,17 +8,16 @@
                 :current => 1,
                 :total   => @sb[:pages][:total],
                 :items   => @sb[:pages][:items]}
+    .form-group
+    .form-group{:id => "rpb_div_#{@pb_occ}", :style => "justify-content: flex-end;"}
+      = select_tag("ppsetting",
+                  options_for_select(@pp_choices, pages[:perpage]),
+                  "data-width" => "auto",
+                  :class       => "selectpicker dropup")
 
-    %div{:id => "rpb_div_#{@pb_occ}"}
+      :javascript
+        miqSelectPickerEvent("ppsetting", "#{url}", {beforeSend: true, complete: true})
       = render :partial => '/layouts/paging_bar',
                :locals => {:pages => pages, :action_url => action_url, :action_id => ''}
-      .form-group.pull-right
-        = _('Items per page:')
-        = select_tag("ppsetting",
-                    options_for_select(@pp_choices, pages[:perpage]),
-                    "data-width" => "auto",
-                    :class       => "selectpicker dropup")
-        :javascript
-          miqSelectPickerEvent("ppsetting", "#{url}", {beforeSend: true, complete: true})
     :javascript
       miqInitSelectPicker();


### PR DESCRIPTION
This PR aligns the styling of the "saved reports" pagination bar with the standard ui-components based pagination bar. It also removes extraneous borders from all the pagination bars.

https://bugzilla.redhat.com/show_bug.cgi?id=1489136

Old
<img width="896" alt="screen shot 2017-09-28 at 3 32 26 pm" src="https://user-images.githubusercontent.com/1287144/30986690-4bdeb710-a462-11e7-94bc-dd296b1c6376.png">

New
<img width="906" alt="screen shot 2017-09-28 at 3 31 07 pm" src="https://user-images.githubusercontent.com/1287144/30986691-4bf1a942-a462-11e7-915f-dfa632f40320.png">