### PR TITLE
Adds server count to phyinfra list page

### DIFF
--- a/product/views/ManageIQ_Providers_PhysicalInfraManager.yaml
+++ b/product/views/ManageIQ_Providers_PhysicalInfraManager.yaml
@@ -21,8 +21,8 @@ cols:
 - ipaddress
 - emstype_description
 - port
+- total_physical_servers
 - total_hosts
-- total_storages
 - total_vms
 - total_miq_templates
 - region_description
@@ -42,8 +42,8 @@ col_order:
 - ipaddress
 - emstype_description
 - zone.name
+- total_physical_servers
 - total_hosts
-- total_storages
 - total_vms
 - total_miq_templates
 - region_description
@@ -54,8 +54,8 @@ headers:
 - Discovered IP Address
 - Type
 - EVM Zone
+- Physical Servers
 - Hosts
-- Datastores
 - VMs
 - Templates
 - Region


### PR DESCRIPTION
Adds the count of servers that each provider is managing to the Physical Infrastructure provider list page and removes the datastore column as it is not directly relevant to the physical infrastructure provider.

![manageiq_ ems physical infras - google chrome 9_28_2017 4_24_53 pm](https://user-images.githubusercontent.com/6444418/30989326-4fcac0e0-a46b-11e7-9a9d-10800f8d7a5a.png)


