### PR TITLE
Add tag expression to the group editor

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -69,9 +69,9 @@ module OpsController::OpsRbac
   def rbac_group_edit
     assert_privileges("rbac_group_edit")
     case params[:button]
-    when 'cancel'      then rbac_edit_cancel('group')
-    when 'save', 'add' then rbac_edit_save_or_add('group')
-    when 'reset', nil  then rbac_edit_reset(params[:typ], 'group', MiqGroup) # Reset or first time in
+    when 'cancel'            then rbac_edit_cancel('group')
+    when 'save', 'add'       then rbac_edit_save_or_add('group')
+    when 'reset', nil        then rbac_edit_reset(params[:typ], 'group', MiqGroup) # Reset or first time in
     end
   end
 
@@ -442,6 +442,15 @@ module OpsController::OpsRbac
     end
   end
 
+  def rbac_group_filter_expression
+    rbac_group_set_form_vars
+    @changed = session[:changed] = (@edit[:new] != @edit[:current])
+    @expkey = params[:button].to_sym
+    @edit[:filter_expression_table] = exp_build_table_or_nil(@edit[:new][:filter_expression])
+    @in_a_form = true
+    replace_right_cell(:nodetype => x_node)
+  end
+
   def rbac_group_seq_edit_screen
     @edit = {}
     @edit[:new] = {}
@@ -459,6 +468,7 @@ module OpsController::OpsRbac
     session[:edit] = @edit
     session[:changed] = false
   end
+
 
   def move_cols_up
     return unless load_edit("rbac_group_edit__seq", "replace_cell__explorer")
@@ -815,7 +825,7 @@ module OpsController::OpsRbac
   # AJAX driven routine to check for changes in ANY field on the form
   def rbac_field_changed(rec_type)
     id = params[:id].split('__').first # Get the record id
-    id = from_cid(id) unless id == "new" || id == "seq" # Decompress id if not "new"
+    id = from_cid(id) unless id == "new" || id == "seq" || !cid?(id) # Decompress id if not "new"
     return unless load_edit("rbac_#{rec_type}_edit__#{id}", "replace_cell__explorer")
 
     case rec_type
@@ -848,6 +858,8 @@ module OpsController::OpsRbac
         page.replace(@refresh_div,
                      :partial => @refresh_partial,
                      :locals  => {:type => "classifications", :action_url => 'rbac_group_field_changed'}) if @refresh_div
+
+        page.replace("customer_tags_div", :partial => "ops/rbac_group/customer_tags") if params[:use_filter_expression].present?
 
         # Only update description field value if ldap group user field was selected
         page << "$('#description').val('#{j_str(@edit[:new][:ldap_groups_user])}');" if params[:ldap_groups_user]
@@ -906,7 +918,7 @@ module OpsController::OpsRbac
       @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "User"), :name => User.find(from_cid(id)).name}
       rbac_user_get_details(id)
     when "g"
-      @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqGroup"), :name => MiqGroup.find(from_cid(id)).description}
+      @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqGroup"), :name => MiqGroup.find(cid?(id) ? from_cid(id) : id).description}
       @edit = nil
       rbac_group_get_details(id)
     when "ur"
@@ -939,11 +951,14 @@ module OpsController::OpsRbac
   end
 
   def rbac_group_get_details(id)
-    @record = @group = MiqGroup.find_by(:id => from_cid(id))
+    @record = @group = MiqGroup.find_by(:id => cid?(id) ? from_cid(id) : id)
     @belongsto = {}
     @filters = {}
+    @filter_expression = []
+    @use_filter_expression = false
     if @record.present?
       get_tagdata(@group)
+      @use_filter_expression = @group.entitlement[:filter_expression].kind_of?(MiqExpression)
       # Build the belongsto filters hash
       @group.get_belongsto_filters.each do |b| # Go thru the belongsto tags
         bobj = MiqFilter.belongsto2object(b) # Convert to an object
@@ -1143,6 +1158,16 @@ module OpsController::OpsRbac
       end
     end
 
+    if params[:use_filter_expression]
+      @edit[:new][:use_filter_expression] = params[:use_filter_expression]
+      if params[:use_filter_expression] == 'false'
+        @edit[:new][:use_filter_expression] = false
+        rbac_group_right_tree(@edit[:new][:belongsto].keys)
+      elsif params[:use_filter_expression] == 'true'
+        @edit[:use_filter_expression] = true
+      end
+    end
+
     params[:tree_typ] ? params[:tree_typ] + "_tree" : nil
   end
 
@@ -1153,6 +1178,7 @@ module OpsController::OpsRbac
     @edit = {
       :new => {
         :filters     => {},
+        :filter_expression => {},
         :belongsto   => {},
         :description => @group.description,
       },
@@ -1195,9 +1221,31 @@ module OpsController::OpsRbac
     @edit[:projects_tenants].push(["Tenants", all_tenants]) unless all_tenants.blank?
     @edit[:new][:group_tenant] = @group.tenant_id
 
+    rbac_group_filter_expression_vars(:filter_expression, :filter_expression_table)
     @edit[:current] = copy_hash(@edit[:new])
 
     rbac_group_right_tree(@edit[:new][:belongsto].keys)
+  end
+
+  def rbac_group_filter_expression_vars(field_expression, field_expression_table)
+    @edit[:new][field_expression] = @group.entitlement[field_expression].kind_of?(MiqExpression) ?  @group.entitlement[field_expression].exp : nil if @group
+    @edit[:new][:use_filter_expression] = true
+    # Populate exp editor fields for the expression column
+    @edit[field_expression] ||= ApplicationController::Filter::Expression.new
+    @edit[field_expression][:expression] = [] # Store exps in an array
+    if @edit[:new][field_expression].blank?
+      @edit[:new][:use_filter_expression] = false
+      @edit[field_expression][:expression] = {"???" => "???"} # Set as new exp element
+      @edit[:new][field_expression] = copy_hash(@edit[field_expression][:expression]) # Copy to new exp
+    else
+      @edit[field_expression][:expression] = copy_hash(@edit[:new][field_expression])
+    end
+    @edit[field_expression_table] = exp_build_table_or_nil(@edit[field_expression][:expression])
+
+    @expkey = field_expression # Set expression key to expression
+    @edit[field_expression].history.reset(@edit[field_expression][:expression])
+    @edit[field_expression][:exp_table] = exp_build_table(@edit[field_expression][:expression])
+    @edit[field_expression][:exp_model] = @group.class # Set model for the exp editor
   end
 
   # Set group record variables to new values
@@ -1207,6 +1255,8 @@ module OpsController::OpsRbac
     group.miq_user_role = role
     group.tenant = Tenant.find(@edit[:new][:group_tenant]) if @edit[:new][:group_tenant]
     rbac_group_set_filters(group) # Go set the filters for the group
+    rbac_group_set_filter_expression(group) # Go set the filters for the group
+
   end
 
   # Set filters in the group record from the @edit[:new] hash values
@@ -1219,6 +1269,13 @@ module OpsController::OpsRbac
     group.entitlement ||= Entitlement.new
     group.entitlement.set_managed_filters(@set_filter_values)
     group.entitlement.set_belongsto_filters(@edit[:new][:belongsto].values) # Set belongs to to hash values
+  end
+
+  def rbac_group_set_filter_expression(group)
+    group.entitlement ||= Entitlement.new
+    exp_remove_tokens(@edit[:new][:filter_expression])
+    group.entitlement.filter_expression = @edit[:new][:filter_expression]["???"] ? nil : MiqExpression.new(@edit[:new][:filter_expression])
+    #group.save
   end
 
   # Need to make arrays by category containing arrays of items so the filtering logic can apply
@@ -1240,7 +1297,8 @@ module OpsController::OpsRbac
     vmr = @record.settings.fetch_path(:restrictions, :vms) if @record.settings
     @edit[:new][:vm_restriction] = vmr || :none
     @edit[:new][:features] = rbac_expand_features(@record.feature_identifiers).sort
-
+    @expkey = :filter_expression
+    @edit[:filter_expression_table] = exp_build_table_or_nil(@edit[:new][:filter_expression])
     @edit[:current] = copy_hash(@edit[:new])
 
     @role_features = @record.feature_identifiers.sort
@@ -1364,6 +1422,7 @@ module OpsController::OpsRbac
   # Validate some of the role fields
   def rbac_group_validate?
     @assigned_filters = [] if @edit[:new][:filters].empty?
+    @filter_expression = [] if @edit[:new][:filter_expression].empty?
     if @edit[:new][:role].nil? || @edit[:new][:role] == ""
       add_flash(_("A User Group must be assigned a Role"), :error)
       return false

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1245,7 +1245,7 @@ module OpsController::OpsRbac
     @expkey = field_expression # Set expression key to expression
     @edit[field_expression].history.reset(@edit[field_expression][:expression])
     @edit[field_expression][:exp_table] = exp_build_table(@edit[field_expression][:expression])
-    @edit[field_expression][:exp_model] = @group.class # Set model for the exp editor
+    @edit[field_expression][:exp_model] = @group.class.to_s # Set model for the exp editor
   end
 
   # Set group record variables to new values

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -824,7 +824,7 @@ module OpsController::OpsRbac
   # AJAX driven routine to check for changes in ANY field on the form
   def rbac_field_changed(rec_type)
     id = params[:id].split('__').first # Get the record id
-    id = from_cid(id) unless id == "new" || id == "seq" || !cid?(id) # Decompress id if not "new"
+    id = from_cid(id) unless %w(new seq).include?(id) || !cid?(id)
     return unless load_edit("rbac_#{rec_type}_edit__#{id}", "replace_cell__explorer")
 
     case rec_type

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -824,7 +824,7 @@ module OpsController::OpsRbac
   # AJAX driven routine to check for changes in ANY field on the form
   def rbac_field_changed(rec_type)
     id = params[:id].split('__').first # Get the record id
-    id = from_cid(id) unless %w(new seq).include?(id) || !cid?(id)
+    id = from_cid(id) unless %w(new seq).include?(id)
     return unless load_edit("rbac_#{rec_type}_edit__#{id}", "replace_cell__explorer")
 
     case rec_type
@@ -917,7 +917,7 @@ module OpsController::OpsRbac
       @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "User"), :name => User.find(from_cid(id)).name}
       rbac_user_get_details(id)
     when "g"
-      @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqGroup"), :name => MiqGroup.find(cid?(id) ? from_cid(id) : id).description}
+      @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqGroup"), :name => MiqGroup.find(from_cid(id)).description}
       @edit = nil
       rbac_group_get_details(id)
     when "ur"
@@ -950,7 +950,7 @@ module OpsController::OpsRbac
   end
 
   def rbac_group_get_details(id)
-    @record = @group = MiqGroup.find_by(:id => cid?(id) ? from_cid(id) : id)
+    @record = @group = MiqGroup.find_by(:id => from_cid(id))
     @belongsto = {}
     @filters = {}
     @filter_expression = []

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1228,11 +1228,11 @@ module OpsController::OpsRbac
   end
 
   def rbac_group_filter_expression_vars(field_expression, field_expression_table)
-    @edit[:new][field_expression] = if @group && @group.entitlement && @group.entitlement[field_expression].kind_of?(MiqExpression)
-                                      @group.entitlement[field_expression].exp
-                                    else
-                                      nil
-                                    end
+    if @group && @group.entitlement && @group.entitlement[field_expression].kind_of?(MiqExpression)
+      @edit[:new][field_expression] = @group.entitlement[field_expression].exp
+    else
+      @edit[:new][field_expression] = nil
+    end
     @edit[:new][:use_filter_expression] = true
     # Populate exp editor fields for the expression column
     @edit[field_expression] ||= ApplicationController::Filter::Expression.new

--- a/app/views/layouts/_custom_button_expression.html.haml
+++ b/app/views/layouts/_custom_button_expression.html.haml
@@ -14,12 +14,13 @@
       %label.control-label.col-md-2
         = title
       .col-md-8
-        = link_to({:action => "button_update",
-                      :button => expression_type},
-                      "data-miq_sparkle_on" => true,
-                      "data-miq_sparkle_off" => true,
-                      :remote => true,
-                      "data-method" => :post) do
+        = link_to({:action => action,
+                   :id => id,
+                   :button => expression_type},
+                   "data-miq_sparkle_on" => true,
+                   "data-miq_sparkle_off" => true,
+                   :remote => true,
+                   "data-method" => :post) do
           %button.btn.btn-default
             - if @edit[table_key].nil?
               = _("Define Expression")

--- a/app/views/layouts/_filter_expression.html.haml
+++ b/app/views/layouts/_filter_expression.html.haml
@@ -7,7 +7,7 @@
       %label.control-label.col-md-2
         = title
       .col-md-8
-        =_("Choose an element of the expression to edit")
+        = _("Choose an element of the expression to edit")
         = render :partial => 'layouts/exp_editor'
   - else
     .form-group
@@ -15,7 +15,6 @@
         = title
       .col-md-8
         = link_to({:action => action,
-                   :id => id,
                    :button => expression_type},
                    "data-miq_sparkle_on" => true,
                    "data-miq_sparkle_off" => true,

--- a/app/views/layouts/_group_filter_expression.html.haml
+++ b/app/views/layouts/_group_filter_expression.html.haml
@@ -7,7 +7,7 @@
     - else
       = render :partial => 'layouts/info_msg', :locals => {:message => _("No Filter Expression defined")}
 - else
-  = render :partial => 'layouts/custom_button_expression',
+  = render :partial => 'layouts/filter_expression',
            :locals => {:expression_type => :filter_expression,
                        :action          => "rbac_group_edit",
                        :id              => @edit[:group_id] || 'new',

--- a/app/views/layouts/_group_filter_expression.html.haml
+++ b/app/views/layouts/_group_filter_expression.html.haml
@@ -1,0 +1,14 @@
+- if @edit.nil?
+  %h3
+    = _('Filter Expression')
+  .form-horizontal.static
+    - if @group && @group.entitlement && @group.entitlement.filter_expression && @group.entitlement.filter_expression.kind_of?(MiqExpression)
+      = h(@group.entitlement.filter_expression.to_human)
+    - else
+      = render :partial => 'layouts/info_msg', :locals => {:message => _("No Filter Expression defined")}
+- else
+  = render :partial => 'layouts/custom_button_expression',
+           :locals => {:expression_type => :filter_expression,
+                       :action          => "rbac_group_edit",
+                       :id              => @edit[:group_id] || 'new',
+                       :title           => _('Expression')}

--- a/app/views/layouts/_role_enablement_expression.html.haml
+++ b/app/views/layouts/_role_enablement_expression.html.haml
@@ -1,4 +1,4 @@
-= render :partial => 'layouts/custom_button_expression',
+= render :partial => 'layouts/filter_expression',
          :locals => {:expression_type => :enablement_expression,
                      :action          => "button_update",
                      :title           => _('Expression')}

--- a/app/views/layouts/_role_enablement_expression.html.haml
+++ b/app/views/layouts/_role_enablement_expression.html.haml
@@ -1,3 +1,4 @@
-= render :partial => 'layouts/custom_button_expression', 
+= render :partial => 'layouts/custom_button_expression',
          :locals => {:expression_type => :enablement_expression,
-                     :title => _('Expression')}
+                     :action          => "button_update",
+                     :title           => _('Expression')}

--- a/app/views/layouts/_role_visibility_expression.html.haml
+++ b/app/views/layouts/_role_visibility_expression.html.haml
@@ -1,4 +1,4 @@
-= render :partial => 'layouts/custom_button_expression',
+= render :partial => 'layouts/filter_expression',
          :locals => {:expression_type => :visibility_expression,
                      :action          => "button_update",
                      :title           => _('Expression')}

--- a/app/views/layouts/_role_visibility_expression.html.haml
+++ b/app/views/layouts/_role_visibility_expression.html.haml
@@ -1,3 +1,4 @@
 = render :partial => 'layouts/custom_button_expression',
          :locals => {:expression_type => :visibility_expression,
-                     :title => _('Expression')}
+                     :action          => "button_update",
+                     :title           => _('Expression')}

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -53,6 +53,8 @@
             - opts.push([_('Field'), 'field'])
           - unless @edit[@expkey].tags_for_display_filters.empty?
             - opts.push([_('Tag'), 'tag'])
+        - when 'MiqGroup'
+          - opts += [[_('Tag'), 'tag']]
         - else
           - opts += exptypes
 

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -3,17 +3,20 @@
     - rec_id = @edit && @edit[:group_id] ? @edit[:group_id] : "new"
     - url = url_for(:action => 'rbac_group_field_changed', :id => rec_id)
     %br
-    = _("This user is limited to items with the selected tags.")
-    %br
-    %br
     .form-horizontal
       .form-group
-        .col-md-4
-          .col-md-8
-            - if @edit
-              = check_box_tag("use_filter_expression", true, @edit[:new][:use_filter_expression], :data => {:on_text => _('Yes'), :off_text => _('No')})
+        %label.col-md-2.control-label
+          = _("This user is limited to ")
+        .col-md-8
+          - if @edit
+            = select_tag('use_filter_expression',
+                      options_for_select([[_("Specific Tags"), false],
+                                          [_("Tags Based On Expression"), true]],
+                      @edit[:new][:use_filter_expression]),
+                      :class    => "selectpicker")
             :javascript
-              miqInitBootstrapSwitch('use_filter_expression', "#{url}")
+               miqInitSelectPicker();
+               miqSelectPickerEvent('use_filter_expression', "#{url}")
     - if @edit[:new][:use_filter_expression]
       = render(:partial => "layouts/group_filter_expression")
     - else
@@ -21,4 +24,7 @@
   - elsif @use_filter_expression
     = render(:partial => "layouts/group_filter_expression")
   - else
+    = _("This user is limited to items with the selected tags.")
+    %br
+    %br
     = render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -1,5 +1,19 @@
-%br
-= _("This user is limited to items with the selected tags.")
-%br
-%br
-= render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})
+#customer_tags_div
+  - url = url_for(:action => 'rbac_group_field_changed', :id => @edit && @edit[:group_id] ? @edit[:group_id] : @record.try(:id) || "new")
+  %br
+  = _("This user is limited to items with the selected tags.")
+  %br
+  %br
+  .form-horizontal
+    .form-group
+      .col-md-4
+        .col-md-8
+          - if @edit
+            = check_box_tag("use_filter_expression", true, @edit[:new][:use_filter_expression], :data => {:on_text => _('Yes'), :off_text => _('No')})
+          :javascript
+            miqInitBootstrapSwitch('use_filter_expression', "#{url}")
+  - if @edit && @edit[:new][:use_filter_expression]
+    = render(:partial => "layouts/group_filter_expression",
+             :locals  => {:id => @edit[:group_id] || "new"})
+  - else
+    = render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -18,5 +18,7 @@
       = render(:partial => "layouts/group_filter_expression")
     - else
       = render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})
+  - elsif @use_filter_expression
+    = render(:partial => "layouts/group_filter_expression")
   - else
     = render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -1,19 +1,22 @@
 #customer_tags_div
-  - url = url_for(:action => 'rbac_group_field_changed', :id => @edit && @edit[:group_id] ? @edit[:group_id] : @record.try(:id) || "new")
-  %br
-  = _("This user is limited to items with the selected tags.")
-  %br
-  %br
-  .form-horizontal
-    .form-group
-      .col-md-4
-        .col-md-8
-          - if @edit
-            = check_box_tag("use_filter_expression", true, @edit[:new][:use_filter_expression], :data => {:on_text => _('Yes'), :off_text => _('No')})
-          :javascript
-            miqInitBootstrapSwitch('use_filter_expression', "#{url}")
-  - if @edit && @edit[:new][:use_filter_expression]
-    = render(:partial => "layouts/group_filter_expression",
-             :locals  => {:id => @edit[:group_id] || "new"})
+  - if @edit
+    - rec_id = @edit && @edit[:group_id] ? @edit[:group_id] : "new"
+    - url = url_for(:action => 'rbac_group_field_changed', :id => rec_id)
+    %br
+    = _("This user is limited to items with the selected tags.")
+    %br
+    %br
+    .form-horizontal
+      .form-group
+        .col-md-4
+          .col-md-8
+            - if @edit
+              = check_box_tag("use_filter_expression", true, @edit[:new][:use_filter_expression], :data => {:on_text => _('Yes'), :off_text => _('No')})
+            :javascript
+              miqInitBootstrapSwitch('use_filter_expression', "#{url}")
+    - if @edit[:new][:use_filter_expression]
+      = render(:partial => "layouts/group_filter_expression")
+    - else
+      = render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})
   - else
     = render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2704,7 +2704,8 @@ Rails.application.routes.draw do
         ls_select
         ldap_entry_changed
         ls_delete
-      )
+      ) +
+        exp_post
     },
 
     :orchestration_stack      => {

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -392,7 +392,7 @@ describe OpsController do
 
       stub_user(:features => :all)
       @group = FactoryGirl.create(:miq_group)
-      @role = MiqUserRole.find_by(:name, "EvmRole-operator")
+      @role = MiqUserRole.find_by(:name => "EvmRole-operator")
       @exp = MiqExpression.new("=" => {:field => "name", :value => "Test"}, :token => 1)
     end
 

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -392,32 +392,32 @@ describe OpsController do
 
       stub_user(:features => :all)
       @group = FactoryGirl.create(:miq_group)
-      @role = MiqUserRole.find_by_name("EvmRole-operator")
+      @role = MiqUserRole.find_by(:name, "EvmRole-operator")
       @exp = MiqExpression.new("=" => {:field => "name", :value => "Test"}, :token => 1)
     end
 
     it "saves the filters when use_filter_expression is false" do
       @group.entitlement = Entitlement.create!
-      controller.instance_variable_set(:@edit, {:new => {:use_filter_expression => false,
-                                                         :name                  => 'Name',
-                                                         :description           => "Test",
-                                                         :role                  => @role.id,
-                                                         :filter_expression     => @exp.exp,
-                                                         :belongsto             => {},
-                                                         :filters               => {'managed/application/abrt' => '/managed/application/abrt'}}})
+      controller.instance_variable_set(:@edit, :new => {:use_filter_expression => false,
+                                                        :name                  => 'Name',
+                                                        :description           => "Test",
+                                                        :role                  => @role.id,
+                                                        :filter_expression     => @exp.exp,
+                                                        :belongsto             => {},
+                                                        :filters               => {'managed/application/abrt' => '/managed/application/abrt'}})
       controller.send(:rbac_group_set_record_vars, @group)
       expect(@group.entitlement.filter_expression).to be_nil
       expect(@group.entitlement.get_managed_filters).to match([["/managed/application/abrt"]])
     end
 
     it "saves the filter_expression when use_filter_expression true" do
-      controller.instance_variable_set(:@edit, {:new => {:use_filter_expression => true,
-                                                         :name                  => 'Name',
-                                                         :description           => "Test",
-                                                         :role                  => @role.id,
-                                                         :filter_expression     => @exp.exp,
-                                                         :belongsto             => {},
-                                                         :filters               => {'managed/application/abrt' => '/managed/application/abrt'}}})
+      controller.instance_variable_set(:@edit, :new => {:use_filter_expression => true,
+                                                        :name                  => 'Name',
+                                                        :description           => "Test",
+                                                        :role                  => @role.id,
+                                                        :filter_expression     => @exp.exp,
+                                                        :belongsto             => {},
+                                                        :filters               => {'managed/application/abrt' => '/managed/application/abrt'}})
       controller.send(:rbac_group_set_record_vars, @group)
       expect(@group.entitlement.get_managed_filters).to eq([])
       expect(@group.entitlement.filter_expression.exp).to match(@exp.exp)


### PR DESCRIPTION
In the Group editor, add a choice to either select the tags manually or create a tag (only) based expression, with ANDs and ORs allowed.  A check box  with "Use a Tag based expression" allows a user to switch between the tree view selection of tags or an expression editor.

Links
---------
https://www.pivotaltracker.com/story/show/150242459


Steps for Testing/QA 
-------------------------------
![screenshot from 2017-10-09 13-02-48](https://user-images.githubusercontent.com/12769982/31349697-3ece15be-acf2-11e7-9175-285d456a5069.png)
![screenshot from 2017-10-09 13-03-05](https://user-images.githubusercontent.com/12769982/31349699-3ed43cbe-acf2-11e7-864e-dd9c232194d9.png)
![screenshot from 2017-10-09 13-12-40](https://user-images.githubusercontent.com/12769982/31350059-b033c234-acf3-11e7-8122-49273caa0a10.png)


