### PR TITLE
Added support to delete Generic Object Definitions using REST API DELETE

### DIFF
--- a/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
@@ -1,0 +1,45 @@
+ManageIQ.angular.app.component('genericObjectDefinitionToolbar', {
+  bindings: {
+    genericObjectDefinitionId: '=?',
+    redirectUrl: '@?',
+  },
+  controllerAs: 'toolbar',
+  controller: genericObjectDefinitionToolbarController,
+});
+
+genericObjectDefinitionToolbarController.$inject = ['API', 'miqService'];
+
+function genericObjectDefinitionToolbarController(API, miqService) {
+  var toolbar = this;
+
+  ManageIQ.angular.rxSubject.subscribe(function(event) {
+    toolbar.action = event.type;
+
+    if (toolbar.action) {
+      if (toolbar.genericObjectDefinitionId) {
+        toolbar.genericObjectDefinitions = _.union(toolbar.genericObjectDefinitions, [toolbar.genericObjectDefinitionId]);
+      } else {
+        toolbar.genericObjectDefinitions = ManageIQ.gridChecks;
+      }
+      postGenericObjectDefinitionAction();
+    }
+  });
+
+  // private functions
+  function postGenericObjectDefinitionAction() {
+    if (toolbar.action === 'delete' && toolbar.genericObjectDefinitionId) {
+      deleteWithAPI(toolbar.genericObjectDefinitionId);
+    }
+  }
+
+  function deleteWithAPI(id) {
+    API.post('/api/generic_object_definitions/' + id, { action: 'delete' })
+      .then(postAction)
+      .catch(miqService.handleFailure);
+  }
+
+  function postAction(response) {
+    var saveMsg = sprintf(__('Generic Object Class:"%s" was successfully deleted'), response.name);
+    miqService.redirectBack(saveMsg, 'success', toolbar.redirectUrl);
+  }
+}

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
@@ -7,9 +7,9 @@ ManageIQ.angular.app.component('genericObjectDefinitionToolbar', {
   controller: genericObjectDefinitionToolbarController,
 });
 
-genericObjectDefinitionToolbarController.$inject = ['API', 'miqService'];
+genericObjectDefinitionToolbarController.$inject = ['API', 'miqService', '$window'];
 
-function genericObjectDefinitionToolbarController(API, miqService) {
+function genericObjectDefinitionToolbarController(API, miqService, $window) {
   var toolbar = this;
 
   ManageIQ.angular.rxSubject.subscribe(function(event) {
@@ -45,7 +45,7 @@ function genericObjectDefinitionToolbarController(API, miqService) {
       miqService.miqFlashLater(
         { message: sprintf(__('Generic Object Class "%s" with %s instances cannot be deleted'), response.name, response.generic_objects_count),
           level: 'warning'});
-      miqService.miqFlashSaved();
+      $window.location.reload(true);
     }
   }
 
@@ -61,7 +61,7 @@ function genericObjectDefinitionToolbarController(API, miqService) {
       miqService.redirectBack(saveMsg, 'success', toolbar.redirectUrl);
     } else {
       miqService.miqFlashLater({message: saveMsg});
-      miqService.miqFlashSaved();
+      $window.location.reload(true);
     }
   }
 }

--- a/app/helpers/application_helper/button/generic_object_definition_delete_button.rb
+++ b/app/helpers/application_helper/button/generic_object_definition_delete_button.rb
@@ -1,0 +1,17 @@
+class ApplicationHelper::Button::GenericObjectDefinitionDeleteButton < ApplicationHelper::Button::Basic
+  def visible?
+    if @display == 'generic_objects'
+      false
+    else
+      true
+    end
+  end
+
+  def disabled?
+    if @record.generic_objects.count > 0
+      true
+    else
+      false
+    end
+  end
+end

--- a/app/helpers/application_helper/button/generic_object_definition_delete_button.rb
+++ b/app/helpers/application_helper/button/generic_object_definition_delete_button.rb
@@ -1,17 +1,9 @@
 class ApplicationHelper::Button::GenericObjectDefinitionDeleteButton < ApplicationHelper::Button::Basic
   def visible?
-    if @display == 'generic_objects'
-      false
-    else
-      true
-    end
+    @display != 'generic_objects'
   end
 
   def disabled?
-    if @record.generic_objects.count > 0
-      true
-    else
-      false
-    end
+    !@record.generic_objects.count.zero?
   end
 end

--- a/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
@@ -18,6 +18,8 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionCenter < ApplicationHel
           'pficon pficon-delete fa-lg',
           t = N_('Remove this Generic Object Classes from Inventory'),
           t,
+          :data    => {'function'      => 'sendDataWithRx',
+                       'function-data' => '{"type": "delete", "controller": "genericObjectDefinitionToolbarController"}'},
           :klass => ApplicationHelper::Button::GenericObjectDefinitionDeleteButton,
           :confirm => N_("Warning: This Generic Object Class will be permanently removed!"),
         )

--- a/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
@@ -20,7 +20,7 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionCenter < ApplicationHel
           t,
           :data    => {'function'      => 'sendDataWithRx',
                        'function-data' => '{"type": "delete", "controller": "genericObjectDefinitionToolbarController"}'},
-          :klass => ApplicationHelper::Button::GenericObjectDefinitionDeleteButton,
+          :klass   => ApplicationHelper::Button::GenericObjectDefinitionDeleteButton,
           :confirm => N_("Warning: This Generic Object Class will be permanently removed!"),
         )
       ]

--- a/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionCenter < ApplicationHel
           'pficon pficon-delete fa-lg',
           t = N_('Remove this Generic Object Classes from Inventory'),
           t,
-          :klass => ApplicationHelper::Button::GenericObjectDefinition,
+          :klass => ApplicationHelper::Button::GenericObjectDefinitionDeleteButton,
           :confirm => N_("Warning: This Generic Object Class will be permanently removed!"),
         )
       ]

--- a/app/helpers/application_helper/toolbar/generic_object_definitions_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definitions_center.rb
@@ -24,6 +24,8 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionsCenter < ApplicationHe
           'pficon pficon-delete fa-lg',
           t = N_('Remove selected Generic Object Classes from Inventory'),
           t,
+          :data    => {'function'      => 'sendDataWithRx',
+                       'function-data' => '{"type": "delete", "controller": "genericObjectDefinitionToolbarController"}'},
           :enabled   => false,
           :onwhen => "1+",
           :confirm   => N_("Warning: The selected Generic Object Classes will be permanently removed!")),

--- a/app/views/generic_object_definition/show.html.haml
+++ b/app/views/generic_object_definition/show.html.haml
@@ -3,3 +3,9 @@
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
     = render :partial => 'layouts/textual_groups_generic'
+
+  %generic-object-definition-toolbar#generic_object_definition_show_form{'generic-object-definition-id' => @record.id,
+                                                                         'redirect-url'                 => "/#{controller_name}/show_list",}
+:javascript
+  miq_bootstrap('#generic_object_definition_show_form');
+

--- a/app/views/generic_object_definition/show_list.html.haml
+++ b/app/views/generic_object_definition/show_list.html.haml
@@ -1,2 +1,8 @@
 #main_div
   = render :partial => 'layouts/gtl'
+
+  %generic-object-definition-toolbar#generic_object_definition_show_list_form
+
+:javascript
+  miq_bootstrap('#generic_object_definition_show_list_form');
+

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -499,6 +499,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
 
       before do
         allow(Rbac).to receive(:role_allows?).and_return(true)
+        allow(@record).to receive(:generic_objects).and_return([])
       end
 
       it "includes the button group" do


### PR DESCRIPTION
The C-R-U for `Generic Object Definitions` was implemented in https://github.com/ManageIQ/manageiq-ui-classic/pull/2137.

This PR implements the D (Delete) using REST API.

https://www.pivotaltracker.com/n/projects/1613907/stories/147627789

<img width="1353" alt="screen shot 2017-09-28 at 3 52 53 pm" src="https://user-images.githubusercontent.com/1538216/30993935-1fb7c768-a466-11e7-8a71-39426178fd6d.png">


<img width="1355" alt="screen shot 2017-09-28 at 3 53 23 pm" src="https://user-images.githubusercontent.com/1538216/30993919-0bf531b6-a466-11e7-8a9d-ce05a4fd7e66.png">
