### PR TITLE
Fix adding Clould Network, Security Group, ...

### DIFF
--- a/app/controllers/application_controller/network.rb
+++ b/app/controllers/application_controller/network.rb
@@ -2,6 +2,6 @@ module ApplicationController::Network
   extend ActiveSupport::Concern
 
   def network_managers
-    Rbac::Filterer.filtered(ManageIQ::Providers::Openstack::NetworkManager).select(:id, :name)
+    Rbac::Filterer.filtered(ManageIQ::Providers::Openstack::NetworkManager).select(:id, :name, :parent_ems_id)
   end
 end


### PR DESCRIPTION
Network manager is deriving name from parent manager now
and it needs parent_ems_id as well in
https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/network_manager.rb#L87

caused by https://github.com/ManageIQ/manageiq/pull/16067

### Test scenario
![inwdobmbad](https://user-images.githubusercontent.com/14937244/31064723-5ab6129e-a73f-11e7-9fd2-ce19b04c7f41.gif)


bug is also present on(based on occurence of usage https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/network.rb#L4﻿):
**Network -> Security Group > Add new**
**Network -> Network Router > Add new**
**Network -> Floating IPs > Add new**
@miq-bot assign @martinpovolny 


### Error log (security group)
```
D, [2017-10-02T07:04:16.889213 #62147] DEBUG -- :   ManageIQ::Providers::Openstack::NetworkManager Inst Including Associations (0.2ms - 2rows)
D, [2017-10-02T07:04:16.900205 #62147] DEBUG -- :   MiqUserRole Inst Including Associations (0.1ms - 1rows)
F, [2017-10-02T07:04:16.900769 #62147] FATAL -- : Error caught: [ActiveModel::MissingAttributeError] missing attribute: parent_ems_id
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/attribute_methods/read.rb:66:in `block in _read_attribute'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/attribute_set.rb:44:in `block in fetch_value'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/attribute.rb:196:in `value'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/attribute_set.rb:44:in `fetch_value'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/attribute_methods/read.rb:66:in `_read_attribute'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/associations/belongs_to_association.rb:103:in `stale_state'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/associations/association.rb:65:in `loaded!'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/associations/association.rb:150:in `load_target'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/associations/association.rb:53:in `reload'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/associations/singular_association.rb:14:in `reader'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/associations/builder/association.rb:111:in `parent_manager'
/Users/liborpichler/manageiq/manageiq/app/models/manageiq/providers/network_manager.rb:87:in `name'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/security_group_controller.rb:163:in `block in new'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/relation/delegation.rb:38:in `each'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/relation/delegation.rb:38:in `each'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/security_group_controller.rb:162:in `new'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/abstract_controller/base.rb:188:in `process_action'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/rendering.rb:30:in `process_action'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.6/lib/active_support/callbacks.rb:126:in `call'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.6/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.6/lib/active_support/callbacks.rb:455:in `call'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.6/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.6/lib/active_support/callbacks.rb:750:in `_run_process_action_callbacks'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.6/lib/active_support/callbacks.rb:90:in `run_callbacks'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/abstract_controller/callbacks.rb:19:in `process_action'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/rescue.rb:20:in `process_action'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.6/lib/active_support/notifications.rb:164:in `block in instrument'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.6/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.6/lib/active_support/notifications.rb:164:in `instrument'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/params_wrapper.rb:248:in `process_action'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.6/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/abstract_controller/base.rb:126:in `process'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.6/lib/action_view/rendering.rb:30:in `process'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal.rb:190:in `dispatch'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal.rb:262:in `dispatch'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_dispatch/routing/route_set.rb:32:in `serve'
/usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_dispatch/journey/router.rb:39:in `block in serve'
/usr/local/opt/rbenv/version
```
