### PR TITLE
Remove rbac_params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -422,10 +422,6 @@ class ApplicationController < ActionController::Base
     }
   end
 
-  def rbac_params
-    {:match_via_descendants => ManageIQ::Providers::NetworkManager}
-  end
-
   # Private method for processing params.
   # params can contain these options:
   # @param params parameters object.
@@ -454,8 +450,6 @@ class ApplicationController < ActionController::Base
                   page_params
                 when 'miq_tasks'
                   jobs_info
-                when 'cloud_networks'
-                  rbac_params
                 when 'physical_servers_with_host'
                   options.merge!(generate_options)
                 else

--- a/app/controllers/ems_network_controller.rb
+++ b/app/controllers/ems_network_controller.rb
@@ -18,10 +18,6 @@ class EmsNetworkController < ApplicationController
     @table_name ||= "ems_network"
   end
 
-  def rbac_params
-    {:match_via_descendants => ManageIQ::Providers::NetworkManager}
-  end
-
   def ems_path(*args)
     path_hash = {:action => 'show', :id => args[0].id.to_s }
     path_hash.merge(args[1])


### PR DESCRIPTION
This feature is provided by internal rule in RBAC
https://github.com/ManageIQ/manageiq/pull/16063 - this PR need to be merged first for keeping functionality
@miq-bot  assign @martinpovolny 
@martinpovolny  I went thru cases in https://github.com/ManageIQ/manageiq-ui-classic/pull/2236
let me know if you are aware of any other cases.

cc @gtanzillo 