### PR TITLE
Fix adding new Group

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -934,7 +934,7 @@ module OpsController::OpsRbac
   end
 
   def rbac_group_get_details(id)
-    @record = @group = MiqGroup.find(from_cid(id))
+    @record = @group = MiqGroup.find_by(:id => from_cid(id))
     @belongsto = {}
     @filters = {}
     if @record.present?


### PR DESCRIPTION
Configuration -> Access Control -> Groups -> Configuration -> Add a new Group
Click any tab in Assign Filters

https://bugzilla.redhat.com/show_bug.cgi?id=1497269

Before:
`Error caught: [ActiveRecord::RecordNotFound] Couldn't find MiqGroup with 'id'=0`
<img width="882" alt="screen shot 2017-10-02 at 10 10 38 am" src="https://user-images.githubusercontent.com/9210860/31068886-45b59b74-a75a-11e7-94b3-05b58c7032ab.png">

After:
<img width="743" alt="screen shot 2017-10-02 at 10 14 54 am" src="https://user-images.githubusercontent.com/9210860/31068949-8c8ca84e-a75a-11e7-9b17-2931d6ca8b06.png">

Introduced by #2077 (fine/no)

@miq-bot add_label fine/no, bug