### PR TITLE
Change name of Foreman Tag Edit button

### DIFF
--- a/app/helpers/application_helper/toolbar/x_foreman_configured_system_center.rb
+++ b/app/helpers/application_helper/toolbar/x_foreman_configured_system_center.rb
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::XForemanConfiguredSystemCenter < ApplicationHe
       :enabled => true,
       :items   => [
         button(
-          :provider_foreman_configured_system_tag,
+          :configured_system_tag,
           'pficon pficon-edit fa-lg',
           N_('Edit Tags for this Configured System'),
           N_('Edit Tags'),

--- a/app/helpers/application_helper/toolbar/x_provider_foreman_foreman_configured_system_center.rb
+++ b/app/helpers/application_helper/toolbar/x_provider_foreman_foreman_configured_system_center.rb
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::XProviderForemanForemanConfiguredSystemCenter 
       :enabled => true,
       :items   => [
         button(
-          :provider_foreman_configured_system_tag,
+          :configured_system_tag,
           'pficon pficon-edit fa-lg',
           N_('Edit Tags for this Configured System'),
           N_('Edit Tags'),


### PR DESCRIPTION
Change name of Edit Tags buttons, to feature which already exist in `miq_feature.yml` and according to my opinion represent same thing. This feature isn't used in any buttons, which also might indicate, that should be used here

Issue
----------------
https://github.com/ManageIQ/manageiq-ui-classic/issues/2208

