### PR TITLE
miq.notifications - update accordion sizing when opening/closing an accordion

### DIFF
--- a/app/assets/javascripts/controllers/notifications/notification-drawer.directive.js
+++ b/app/assets/javascripts/controllers/notifications/notification-drawer.directive.js
@@ -46,11 +46,13 @@ angular.module('miq.notifications').directive('miqNotificationDrawer', ['$window
         });
       });
 
-      scope.$watch('drawerHidden', function() {
+      scope.$watch('drawerHidden', updateAccordionSizing);
+
+      function updateAccordionSizing() {
         $timeout(function() {
           angular.element($window).triggerHandler('resize');
         }, 100);
-      });
+      }
 
       scope.toggleCollapse = function(selectedGroup) {
         if (selectedGroup.open) {
@@ -61,6 +63,8 @@ angular.module('miq.notifications').directive('miqNotificationDrawer', ['$window
           });
           selectedGroup.open = true;
         }
+
+        updateAccordionSizing();
       };
 
       scope.toggleExpandDrawer = function() {


### PR DESCRIPTION
Opening/closing notifications triggers a resize which causes the styling to update correctly..
but expanding/closing a notification group does **not** do the same.

Thus, the styling only fits until one expands an accordion.


This makes notifications trigger a `resize` event every time a notification group is collapsed or expanded -> the scrollbar should always appear now.

This pretty much fits what the current version in angular-patternfly [does](https://github.com/patternfly/angular-patternfly/blob/master/src/notification/notification-drawer.component.js#L55-L69).


https://bugzilla.redhat.com/show_bug.cgi?id=1445762
https://bugzilla.redhat.com/show_bug.cgi?id=1445689