### PR TITLE
Add timeline to physical server

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -1,6 +1,8 @@
 class PhysicalServerController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
+  include Mixins::GenericSessionMixin
+  include Mixins::MoreShowActions
 
   before_action :check_privileges
   before_action :session_data
@@ -45,5 +47,10 @@ class PhysicalServerController < ApplicationController
 
     return if %w(physical_server_protect physical_server_tag).include?(params[:pressed]) &&
               @flash_array.nil? # Some other screen is showing, so return
+    if params[:pressed] == "physical_server_timeline"
+      @record = find_record_with_rbac(ManageIQ::Providers::PhysicalInfraManager::PhysicalServer, params[:id])
+      show_timeline
+      javascript_redirect(:action => 'show', :id => @record.id, :display => 'timeline')
+    end
   end
 end

--- a/app/helpers/application_helper/button/physical_server_timeline.rb
+++ b/app/helpers/application_helper/button/physical_server_timeline.rb
@@ -1,0 +1,17 @@
+class ApplicationHelper::Button::PhysicalServerTimeline < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    self[:hidden] = true unless visible?
+  end
+
+  def visible?
+    @record.supports_timeline?
+  end
+
+  def disabled?
+    unless @record.has_events?
+      @error_message = _('No Timeline data has been collected for this Physical Server')
+    end
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/toolbar/physical_server_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_server_center.rb
@@ -115,4 +115,22 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
       ),
     ]
   )
+
+   button_group('physical_server_monitoring', [
+    select(
+      :physical_server_monitoring_choice,
+      'ff ff-monitoring fa-lg',
+      t = N_('Monitoring'),
+      t,
+      :items => [
+        button(
+          :ems_physical_infra_timeline,
+          'ff ff-timeline fa-lg',
+          N_('Show Timelines for this Physical Server'),
+          N_('Timelines'),
+          :klass     => ApplicationHelper::Button::PhysicalServerTimeline,
+          :url_parms => "?display=timeline"),
+      ]
+    ),
+  ])
 end

--- a/app/helpers/application_helper/toolbar/physical_server_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_server_center.rb
@@ -116,21 +116,25 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
     ]
   )
 
-   button_group('physical_server_monitoring', [
-    select(
-      :physical_server_monitoring_choice,
-      'ff ff-monitoring fa-lg',
-      t = N_('Monitoring'),
-      t,
-      :items => [
-        button(
-          :ems_physical_infra_timeline,
-          'ff ff-timeline fa-lg',
-          N_('Show Timelines for this Physical Server'),
-          N_('Timelines'),
-          :klass     => ApplicationHelper::Button::PhysicalServerTimeline,
-          :url_parms => "?display=timeline"),
-      ]
-    ),
-  ])
+  button_group(
+    'physical_server_monitoring',
+    [
+      select(
+        :physical_server_monitoring_choice,
+        'ff ff-monitoring fa-lg',
+        t = N_('Monitoring'),
+        t,
+        :items => [
+          button(
+            :physical_server_timeline,
+            'ff ff-timeline fa-lg',
+            N_('Show Timelines for this Physical Server'),
+            N_('Timelines'),
+            :klass     => ApplicationHelper::Button::PhysicalServerTimeline,
+            :url_parms => "?display=timeline"
+          )
+        ]
+      )
+    ]
+  )
 end

--- a/app/views/physical_server/show.html.haml
+++ b/app/views/physical_server/show.html.haml
@@ -2,7 +2,12 @@
   - if %w(physical_servers).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
-    = render :partial => 'layouts/textual_groups_generic'
+    - case @showtype
+    - when "main"
+      = render :partial => 'layouts/textual_groups_generic'
+    - when "timeline"
+      = render :partial => "layouts/tl_show_async"
+
 
   %physical-server-toolbar#physical_server_show_form{'physical-server-id' => @record.id}
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1324,6 +1324,8 @@ Rails.application.routes.draw do
         update
         update_del
         quick_search
+        tl_chooser
+        wait_for_task
       ) +
           adv_search_post +
           exp_post +

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -1,33 +1,77 @@
 describe PhysicalServerController do
   include CompressedIds
 
+  render_views
+
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
   let(:zone) { FactoryGirl.build(:zone) }
 
-  describe "#show" do
-    render_views
-    before(:each) do
-      EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      ems = FactoryGirl.create(:ems_physical_infra)
-      asset_details = FactoryGirl.create(:asset_details)
-      computer_system = FactoryGirl.create(:computer_system, :hardware => FactoryGirl.create(:hardware))
-      physical_server = FactoryGirl.create(:physical_server,
-                                           :asset_details   => asset_details,
-                                           :computer_system => computer_system,
-                                           :ems_id          => ems.id)
-      get :show, :params => {:id => physical_server.id}
-    end
-    it { expect(response.status).to eq(200) }
+  before(:each) do
+    stub_user(:features => :all)
+    EvmSpecHelper.create_guid_miq_server_zone
+    login_as FactoryGirl.create(:user)
+    ems = FactoryGirl.create(:ems_physical_infra)
+    asset_details = FactoryGirl.create(:asset_details)
+    computer_system = FactoryGirl.create(:computer_system, :hardware => FactoryGirl.create(:hardware))
+    @physical_server = FactoryGirl.create(:physical_server,
+                                          :asset_details   => asset_details,
+                                          :computer_system => computer_system,
+                                          :ems_id          => ems.id,
+                                          :id              => 1)
   end
 
   describe "#show_list" do
     before(:each) do
-      stub_user(:features => :all)
       FactoryGirl.create(:physical_server)
-      get :show_list
     end
-    it { expect(response.status).to eq(200) }
+
+    subject { get :show_list }
+
+    it do
+      is_expected.to have_http_status 200
+      is_expected.to render_template(:partial => "layouts/_gtl")
+    end
+  end
+
+  describe "#show" do
+    context "with valid id" do
+      subject { get :show, :params => {:id => @physical_server.id} }
+
+      it "should respond to show" do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/_textual_groups_generic")
+      end
+    end
+
+    context "with invalid id" do
+      subject { get :show, :params => {:id => 2 } }
+
+      it "should redirect to #show_list" do
+        is_expected.to have_http_status 302
+        is_expected.to redirect_to(:action => :show_list)
+
+        flash_messages = assigns(:flash_array)
+        expect(flash_messages.first[:message]).to include("Can't access selected records")
+      end
+    end
+
+    context "display=timeline" do
+      it do
+        post :show, :params => {:id => @physical_server.id, :display => "timeline"}
+        expect(response.status).to eq 200
+        is_expected.to render_template(:partial => "layouts/_tl_show_async")
+        expect(controller.send(:flash_errors?)).to be_falsey
+      end
+    end
+  end
+
+  describe "#button" do
+    subject { post :button, :params => { :id => @physical_server.id, :pressed => "physical_server_timeline", :format => :js } }
+
+    it "when timelines button is pressed" do
+      is_expected.to have_http_status 200
+      expect(response.body).to include(%(window.location.href = "/physical_server/show/#{@physical_server.id}?display=timeline"))
+    end
   end
 
   context "#button" do


### PR DESCRIPTION
This PR consists in adding the monitoring button group with timelines button to the physical server page and making the timeline page available when this button is clicked.

![Physical server page with monitoring button group](https://user-images.githubusercontent.com/18252261/31092752-c6a5a474-a785-11e7-8734-b7ff20361c68.png)
Physical server page with monitoring button group

![Disabled when there are no events for the physical server](https://user-images.githubusercontent.com/18252261/31092786-dcd9e39a-a785-11e7-83ca-a69881b9690d.png)
Disabled when there are no events for the physical server

![Enabled when there are events for the physical server](https://user-images.githubusercontent.com/18252261/31092805-eebb0c88-a785-11e7-8249-54549526ffed.png)
Enabled when there are events for the physical server

![Timeline page before filtering](https://user-images.githubusercontent.com/18252261/31093026-c3eebbfc-a786-11e7-8238-28e5746a7228.png)
Timeline page before filtering

![Timeline page after filtering](https://user-images.githubusercontent.com/18252261/31093020-beaa96ca-a786-11e7-8b59-a42a519e9c52.png)
Timeline page after filtering

[This PR depends on core PR 16084.](https://github.com/ManageIQ/manageiq/pull/16084)


