### PR TITLE
Support for timeline events for MW Server power operations

### DIFF
--- a/app/controllers/middleware_domain_controller.rb
+++ b/app/controllers/middleware_domain_controller.rb
@@ -10,10 +10,13 @@ class MiddlewareDomainController < ApplicationController
   after_action :set_session_data
 
   OPERATIONS = {
-    :middleware_domain_stop => {:op   => :stop_middleware_server,
-                                :skip => true,
-                                :hawk => N_('stopping'),
-                                :msg  => N_('Stopping selected domain(s)')}
+    :middleware_domain_stop => {
+      :op           => :stop_middleware_server,
+      :log_timeline => 'MwDomain.Stop.UserRequest',
+      :skip         => true,
+      :hawk         => N_('stopping'),
+      :msg          => N_('Stopping selected domain(s)')
+    }
   }.freeze
 
   def self.display_methods

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -12,84 +12,109 @@ class MiddlewareServerController < ApplicationController
   after_action :set_session_data
 
   COMMON_OPERATIONS = {
-    :middleware_server_reload  => {:op   => :reload_middleware_server,
-                                   :skip => true,
-                                   :hawk => N_('reloading'),
-                                   :msg  => N_('Reload')
+    :middleware_server_reload  => {
+      :op           => :reload_middleware_server,
+      :log_timeline => 'MwServer.Reload.UserRequest',
+      :skip         => true,
+      :hawk         => N_('reloading'),
+      :msg          => N_('Reload')
     },
-    :middleware_server_suspend => {:op    => :suspend_middleware_server,
-                                   :skip  => true,
-                                   :hawk  => N_('suspending'),
-                                   :msg   => N_('Suspend'),
-                                   :param => :timeout
+    :middleware_server_suspend => {
+      :op           => :suspend_middleware_server,
+      :log_timeline => 'MwServer.Suspend.UserRequest',
+      :skip         => true,
+      :hawk         => N_('suspending'),
+      :msg          => N_('Suspend'),
+      :param        => :timeout
     },
-    :middleware_server_resume  => {:op   => :resume_middleware_server,
-                                   :skip => true,
-                                   :hawk => N_('resuming'),
-                                   :msg  => N_('Resume')
+    :middleware_server_resume  => {
+      :op           => :resume_middleware_server,
+      :log_timeline => 'MwServer.Resume.UserRequest',
+      :skip         => true,
+      :hawk         => N_('resuming'),
+      :msg          => N_('Resume')
     },
-    :middleware_dr_generate    => {:op   => :generate_diagnostic_report,
-                                   :skip => false,
-                                   :hawk => N_('generating JDR report'),
-                                   :msg  => N_('Generate JDR report')}
+    :middleware_dr_generate    => {
+      :op   => :generate_diagnostic_report,
+      :skip => false,
+      :hawk => N_('generating JDR report'),
+      :msg  => N_('Generate JDR report')
+    }
   }.freeze
 
   STANDALONE_ONLY = {
-    :middleware_server_stop     => {:op   => :stop_middleware_server,
-                                    :skip => true,
-                                    :hawk => N_('stopping'),
-                                    :msg  => N_('Stop')
+    :middleware_server_stop     => {
+      :op           => :stop_middleware_server,
+      :log_timeline => 'MwServer.Shutdown.UserRequest',
+      :skip         => true,
+      :hawk         => N_('stopping'),
+      :msg          => N_('Stop')
     },
-    :middleware_server_shutdown => {:op    => :shutdown_middleware_server,
-                                    :skip  => true,
-                                    :hawk  => N_('shutting down'),
-                                    :msg   => N_('Shutdown'),
-                                    :param => :timeout
+    :middleware_server_shutdown => {
+      :op           => :shutdown_middleware_server,
+      :log_timeline => 'MwServer.Shutdown.UserRequest',
+      :skip         => true,
+      :hawk         => N_('shutting down'),
+      :msg          => N_('Shutdown'),
+      :param        => :timeout
     },
-    :middleware_server_restart  => {:op   => :restart_middleware_server,
-                                    :skip => true,
-                                    :hawk => N_('restarting'),
-                                    :msg  => N_('Restart')
+    :middleware_server_restart  => {
+      :op           => :restart_middleware_server,
+      :log_timeline => 'MwServer.Restart.UserRequest',
+      :skip         => true,
+      :hawk         => N_('restarting'),
+      :msg          => N_('Restart')
     },
-    :middleware_add_deployment  => {:op    => :add_middleware_deployment,
-                                    :skip  => false,
-                                    :hawk  => N_('Not deploying to Hawkular server'),
-                                    :msg   => N_('Deployment initiated for selected server(s)'),
-                                    :param => :file
+    :middleware_add_deployment  => {
+      :op    => :add_middleware_deployment,
+      :skip  => false,
+      :hawk  => N_('Not deploying to Hawkular server'),
+      :msg   => N_('Deployment initiated for selected server(s)'),
+      :param => :file
     },
-    :middleware_add_jdbc_driver => {:op    => :add_middleware_jdbc_driver,
-                                    :skip  => false,
-                                    :msg   => N_('JDBC Driver installation'),
-                                    :param => :driver
+    :middleware_add_jdbc_driver => {
+      :op    => :add_middleware_jdbc_driver,
+      :skip  => false,
+      :msg   => N_('JDBC Driver installation'),
+      :param => :driver
     },
-    :middleware_add_datasource  => {:op    => :add_middleware_datasource,
-                                    :skip  => false,
-                                    :hawk  => N_('Not adding new datasource to Hawkular server'),
-                                    :msg   => N_('New datasource initiated for selected server(s)'),
-                                    :param => :datasource
+    :middleware_add_datasource  => {
+      :op    => :add_middleware_datasource,
+      :skip  => false,
+      :hawk  => N_('Not adding new datasource to Hawkular server'),
+      :msg   => N_('New datasource initiated for selected server(s)'),
+      :param => :datasource
     }
   }.freeze
 
   DOMAIN_ONLY = {
-    :middleware_domain_server_start   => {:op   => :start_middleware_domain_server,
-                                          :skip => true,
-                                          :hawk => N_('starting'),
-                                          :msg  => N_('Start')
+    :middleware_domain_server_start   => {
+      :op           => :start_middleware_domain_server,
+      :log_timeline => 'MwServer.Start.UserRequest',
+      :skip         => true,
+      :hawk         => N_('starting'),
+      :msg          => N_('Start')
     },
-    :middleware_domain_server_stop    => {:op   => :stop_middleware_domain_server,
-                                          :skip => true,
-                                          :hawk => N_('stopping'),
-                                          :msg  => N_('Stop')
+    :middleware_domain_server_stop    => {
+      :op           => :stop_middleware_domain_server,
+      :log_timeline => 'MwServer.Stop.UserRequest',
+      :skip         => true,
+      :hawk         => N_('stopping'),
+      :msg          => N_('Stop')
     },
-    :middleware_domain_server_restart => {:op   => :restart_middleware_domain_server,
-                                          :skip => true,
-                                          :hawk => N_('restarting'),
-                                          :msg  => N_('Restart')
+    :middleware_domain_server_restart => {
+      :op           => :restart_middleware_domain_server,
+      :log_timeline => 'MwServer.Restart.UserRequest',
+      :skip         => true,
+      :hawk         => N_('restarting'),
+      :msg          => N_('Restart')
     },
-    :middleware_domain_server_kill    => {:op   => :kill_middleware_domain_server,
-                                          :skip => true,
-                                          :hawk => N_('killing'),
-                                          :msg  => N_('Kill')
+    :middleware_domain_server_kill    => {
+      :op           => :kill_middleware_domain_server,
+      :log_timeline => 'MwServer.Kill.UserRequest',
+      :skip         => true,
+      :hawk         => N_('killing'),
+      :msg          => N_('Kill')
     },
   }.freeze
 
@@ -295,6 +320,7 @@ class MiddlewareServerController < ApplicationController
         render :json => {:status => :ok, :msg => skip_message}
       else
         operation_triggered = trigger_param_operation(operation_info, mw_server, :param)
+        log_operation_in_timeline(operation_info, mw_server)
       end
       if operation_triggered
         initiated_msg = _("%{operation} initiated for selected server(s)") % {:operation => operation_info.fetch(:msg)}
@@ -332,6 +358,7 @@ class MiddlewareServerController < ApplicationController
           run_operation_on_record(operation_info, mw_server)
         end
         operation_triggered = true
+        log_operation_in_timeline(operation_info, mw_server)
       end
     end
     add_flash(_("%{operation} initiated for selected server(s)") % {:operation => operation_info.fetch(:msg)}) if operation_triggered
@@ -339,21 +366,38 @@ class MiddlewareServerController < ApplicationController
 
   def trigger_mw_operation(operation, mw_server, params = nil)
     mw_manager = mw_server.ext_management_system
-    path = mw_server.ems_ref
 
-    # in domain mode case we want to run the operation on the server-config DMR resource
-    if mw_server.respond_to?(:in_domain?) && mw_server.in_domain?
-      path = path.sub(/%2Fserver%3D/, '%2Fserver-config%3D')
-    end
-
-    args = [operation, path]
+    args = [operation, mw_server.ems_ref]
     if mw_server.instance_of?(MiddlewareDeployment)
       args << mw_server.name
     elsif params
       args << params
     end
 
+    # in domain mode case we want to run the operation on the server-config DMR resource
+    if mw_server.respond_to?(:in_domain?) && mw_server.in_domain?
+      args << {:original_resource_path => args[1]}
+      args[1] = args[1].sub(/%2Fserver%3D/, '%2Fserver-config%3D')
+    end
+
     mw_manager.public_send(*args)
+  end
+
+  def log_operation_in_timeline(operation_info, mw_server)
+    if operation_info.fetch(:log_timeline, false)
+      EmsEvent.add_queue(
+        'add', mw_server.ext_management_system.id,
+        :ems_id          => mw_server.ext_management_system.id,
+        :source          => 'EVM',
+        :timestamp       => Time.zone.now,
+        :event_type      => operation_info.fetch(:log_timeline),
+        :message         => _('%{operation} requested for server %{server}') %
+          {:operation => operation_info.fetch(:msg), :server => mw_server.name},
+        :middleware_ref  => mw_server.ems_ref,
+        :middleware_type => 'MiddlewareServer',
+        :username        => current_userid
+      )
+    end
   end
 
   menu_section :mdl

--- a/spec/controllers/middleware_server_controller_spec.rb
+++ b/spec/controllers/middleware_server_controller_spec.rb
@@ -181,56 +181,55 @@ describe MiddlewareServerController do
   end
 
   describe('Standalone server operations:') do
-    def expected_event_hash(operation_info, mw_server)
-      {
-        :ems_id          => ems.id,
-        :source          => 'EVM',
-        :event_type      => operation_info.fetch(:log_timeline),
-        :message         => _('%{operation} requested for server %{server}') %
-          {:operation => operation_info.fetch(:msg), :server => mw_server.name},
-        :middleware_ref  => mw_server.ems_ref,
-        :middleware_type => 'MiddlewareServer',
-        :username        => user.userid
-      }
+    def timeline_event_expectations(event, operation_info, mw_server)
+      expect(event.ems_id).to eq(ems.id)
+      expect(event.source).to eq('EVM')
+      expect(event.event_type).to eq(operation_info.fetch(:log_timeline))
+      expect(event.message).to eq(_('%{server} will be %{operation} per user request') %
+                                    {:operation => operation_info.fetch(:hawk), :server => mw_server.name})
+      expect(event.middleware_server_id).to eq(mw_server.id)
+      expect(event.middleware_server_name).to eq(mw_server.name)
+      expect(event.username).to eq(user.userid)
     end
 
     let(:ems) { FactoryGirl.create(:ems_middleware) }
-    let(:mw_server) { FactoryGirl.create(:hawkular_middleware_server, :ext_management_system => ems) }
+    let(:mw_server) do
+      FactoryGirl.create(:hawkular_middleware_server,
+                         :ext_management_system => ems,
+                         :ems_ref               => '/f;f1/r;server')
+    end
 
     before(:each) do
+      EvmSpecHelper.create_guid_miq_server_zone
       allow(controller).to receive(:trigger_mw_operation)
     end
 
     %w(reload suspend resume stop shutdown restart).each do |operation|
-      it("#{operation} button operation should queue creation of timeline event") do
+      it("#{operation} button operation should create timeline event") do
         op_name = "middleware_server_#{operation}"
         operation_info = described_class::ALL_OPERATIONS.fetch(op_name.to_sym)
-
-        expect(EmsEvent).to receive(:add_queue).with(
-          'add', ems.id,
-          hash_including(expected_event_hash(operation_info, mw_server))
-        )
 
         post :button, :params => {
           :id      => mw_server.id,
           :pressed => op_name,
           :timeout => 10
         }
+
+        MiqQueue.last.deliver
+        timeline_event_expectations(EmsEvent.last, operation_info, mw_server)
       end
 
-      it("#{operation} dialog operation should queue creation of timeline event") do
+      it("#{operation} dialog operation should create timeline event") do
         operation_info = described_class::ALL_OPERATIONS.fetch("middleware_server_#{operation}".to_sym)
-
-        expect(EmsEvent).to receive(:add_queue).with(
-          'add', ems.id,
-          hash_including(expected_event_hash(operation_info, mw_server))
-        )
 
         post :run_operation, :params => {
           :id        => mw_server.id,
           :operation => operation,
           :timeout   => 10
         }
+
+        MiqQueue.last.deliver
+        timeline_event_expectations(EmsEvent.last, operation_info, mw_server)
       end
     end
   end


### PR DESCRIPTION
When user requests an operation in a server, an event in
the timeline logged.

Jira: https://issues.jboss.org/browse/HAWKULAR-1249

Must be merged first:
* ManageIQ/manageiq-providers-hawkular#61
* ManageIQ/manageiq-schema#86

![screenshot from 2017-10-04 12-42-09](https://user-images.githubusercontent.com/23639005/31190814-d92dc6e4-a901-11e7-96d2-bc6c41676f2c.png)
