### PR TITLE
Accordion styling tweak

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -13,6 +13,11 @@
     padding: 0px;
     overflow: hidden;
   }
+
+  #listnav_div .panel:first-child { /* hides panel top border to prevent double border with toolbar  */
+    border-top: 0;
+  }
+
   #main-content { /* inserts height calculation for scrollable area */
     overflow: auto;
   }


### PR DESCRIPTION
This PR hides the top border of the first accordion panel (toolbar  already has a border) in desktop mode.

Old
<img width="569" alt="screen shot 2017-10-02 at 4 06 16 pm" src="https://user-images.githubusercontent.com/1287144/31096956-b814f288-a78b-11e7-940a-f550aad51cb1.png">

New
<img width="567" alt="screen shot 2017-10-02 at 4 45 47 pm" src="https://user-images.githubusercontent.com/1287144/31098606-309551a8-a791-11e7-8ee3-b7106a1a3806.png">

