### PR TITLE
Allow 'assign to containers provider' in chargeback storage assignments

### DIFF
--- a/app/helpers/term_of_service_helper.rb
+++ b/app/helpers/term_of_service_helper.rb
@@ -21,10 +21,11 @@ module TermOfServiceHelper
       "vm-tags"            => N_("Tagged VMs and Instances")
     },
     "Storage" => {
-      "enterprise"   => N_("The Enterprise"),
-      "storage"      => N_("Selected Datastores"),
-      "storage-tags" => N_("Tagged Datastores"),
-      "tenant"       => N_("Tenants")
+      "enterprise"    => N_("The Enterprise"),
+      "storage"       => N_("Selected Datastores"),
+      "storage-tags"  => N_("Tagged Datastores"),
+      "ems_container" => N_("Selected Containers Providers"),
+      "tenant"        => N_("Tenants")
     },
     "MiqServer" => {
       "miq_server" => N_("Selected Servers"),


### PR DESCRIPTION
Goes together with:
* https://github.com/ManageIQ/manageiq/pull/16095 
* https://github.com/ManageIQ/manageiq/pull/10470

Needed for adding storage columns to containers chargeback
![screencapture-localhost-3000-chargeback-explorer-1507020120437](https://user-images.githubusercontent.com/11256940/31116738-e3fcaae0-a82f-11e7-8cff-069e33c58d20.png)


cc @simon3z 

@miq-bot add_label compute/containers