### PR TITLE
Group by docker label in ChargebackContainerImage

### DIFF
--- a/app/helpers/report_helper/editor.rb
+++ b/app/helpers/report_helper/editor.rb
@@ -9,4 +9,8 @@ module ReportHelper::Editor
       provider.container_images.order(:name).pluck(:name, :id)
     end
   end
+
+  def cb_image_labels
+    CustomAttribute.where(:section => "docker_labels").distinct('name').pluck(:name).each_with_object({}) { |l, h| h[l] = l }
+  end
 end

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -135,7 +135,7 @@
     .col-md-8
       - opts = [["#{_('Date')}", "date"], ["#{_(@edit[:new][:cb_model])}", "vm"]]
       - opts += [["#{_('Tag')}", "tag"]] unless @edit[:new][:model] == "ChargebackContainerImage"
-      - opts += [["#{_('Project')}", "project"]] if @edit[:new][:model] == "ChargebackContainerImage"
+      - opts += [["#{_('Project')}", "project"], [_('Label'), 'label']] if @edit[:new][:model] == "ChargebackContainerImage"
       = select_tag("cb_groupby",
         options_for_select(opts, @edit[:new][:cb_groupby]),
         :class                 => "selectpicker")
@@ -154,6 +154,18 @@
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('cb_groupby_tag', '#{url}', {beforeSend: true, complete: true});
+  - if @edit[:new][:cb_groupby] == "label"
+    .form-group
+      %label.control-label.col-md-2
+        = _('Group by Label')
+      .col-md-8
+        - opts = [["<#{_('Choose a Label')}>", nil]] + Array(cb_image_labels.invert).sort_by { |a| a.first.downcase }
+        = select_tag("cb_groupby_label",
+          options_for_select(opts, @edit[:new][:cb_groupby_label]),
+          :class                 => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent('cb_groupby_label', '#{url}', {beforeSend: true, complete: true});
 
 %h3
   = _('Chargeback Interval')


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1497663
Depends on: https://github.com/ManageIQ/manageiq/pull/16097
Allows to group by docker label in Chargeback for Containers Images reports
![screencapture-localhost-3000-report-explorer-1507020536717](https://user-images.githubusercontent.com/11256940/31117009-dbc70dce-a830-11e7-9c9b-963387ae83db.png)
 
cc @simon3z 
@miq-bot add_label compute/containers