### PR TITLE
Add severity to Alerts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1168,7 +1168,7 @@ class ApplicationController < ActionController::Base
         when "result"
           new_row[:cells] << {:span => result_span_class(row[col]), :text => row[col].titleize}
         when "severity"
-          value = row[col].nil? ? ' ' : row[col]
+          value = row[col] || ' '
           new_row[:cells] << {:span => severity_span_class(value), :text => severity_title(value)}
         when 'state'
           celltext = row[col].titleize
@@ -1222,7 +1222,7 @@ class ApplicationController < ActionController::Base
   end
 
   def severity_title(value)
-    if self.class == MiqPolicyController
+    if self.class.instance_of?(MiqPolicyController)
       self.class::SEVERITIES[value]
     else
       value.titleize

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1169,7 +1169,7 @@ class ApplicationController < ActionController::Base
           new_row[:cells] << {:span => result_span_class(row[col]), :text => row[col].titleize}
         when "severity"
           value = row[col].nil? ? ' ' : row[col]
-          new_row[:cells] << {:span => severity_span_class(value), :text => value.titleize}
+          new_row[:cells] << {:span => severity_span_class(value), :text => severity_title(value)}
         when 'state'
           celltext = row[col].titleize
         when 'hardware.bitness'
@@ -1218,6 +1218,14 @@ class ApplicationController < ActionController::Base
       "label label-warning center-block"
     else
       "label label-low-severity center-block"
+    end
+  end
+
+  def severity_title(value)
+    if self.class == MiqPolicyController
+      self.class::SEVERITIES[value]
+    else
+      value.titleize
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1168,7 +1168,8 @@ class ApplicationController < ActionController::Base
         when "result"
           new_row[:cells] << {:span => result_span_class(row[col]), :text => row[col].titleize}
         when "severity"
-          new_row[:cells] << {:span => severity_span_class(row[col]), :text => row[col].titleize}
+          value = row[col].nil? ? ' ' : row[col]
+          new_row[:cells] << {:span => severity_span_class(value), :text => value.titleize}
         when 'state'
           celltext = row[col].titleize
         when 'hardware.bitness'

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -1,7 +1,7 @@
 module MiqPolicyController::Alerts
   extend ActiveSupport::Concern
 
-  SEVERITIES = {"info" => _('Info'), "warning" => _('Warninig'), "error" => _('Error')}.freeze
+  SEVERITIES = {"info" => _('Info'), "warning" => _('Warning'), "error" => _('Error')}.freeze
 
   def alert_edit_cancel
     @edit = nil

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -1,6 +1,8 @@
 module MiqPolicyController::Alerts
   extend ActiveSupport::Concern
 
+  SEVERITIES = {nil => '', "info" => _('Info'), "warning" => _('Warninig'), "error" => _('Error')}.freeze
+
   def alert_edit_cancel
     @edit = nil
     @alert = session[:edit][:alert_id] ? MiqAlert.find(session[:edit][:alert_id]) : MiqAlert.new

--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -32,6 +32,16 @@
             .col-md-8
               %p.form-control-static
                 = @alert.enabled ? _("Yes") : _("No")
+        .form-group
+          %label.control-label.col-md-2
+            = _("Severity")
+          - if @edit
+            .col-md-8
+              = check_box_tag("enabled_cb", "1", @edit[:new][:enabled], "data-miq_observe_checkbox" => observe)
+          - else
+            .col-md-8
+              %p.form-control-static
+                = controller.class::SEVERITIES[@alert.severity]
         -# Based on (model)
         .form-group
           %label.control-label.col-md-2

--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -37,7 +37,14 @@
             = _("Severity")
           - if @edit
             .col-md-8
-              = check_box_tag("enabled_cb", "1", @edit[:new][:enabled], "data-miq_observe_checkbox" => observe)
+              - options = [[_("<Choose>"), nil]]
+              - controller.class::SEVERITIES.each { |key, value| options.push([value, key]) }
+              = select_tag('miq_alert_severity',
+                options_for_select(options, @edit[:new][:severity]),
+                :class => "selectpicker")
+              :javascript
+                miqInitSelectPicker();
+                miqSelectPickerEvent('miq_alert_severity', '#{url}', {beforeSend: true, complete: true})
           - else
             .col-md-8
               %p.form-control-static

--- a/product/views/MiqAlert.yaml
+++ b/product/views/MiqAlert.yaml
@@ -27,6 +27,7 @@ cols:
 - notify_snmp
 - notify_evm_event
 - notify_automate
+- severity
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -41,6 +42,7 @@ col_order:
 - notify_snmp
 - notify_evm_event
 - notify_automate
+- severity
 
 # Column titles, in order
 headers:
@@ -52,6 +54,7 @@ headers:
 - SNMP
 - Event on Timeline
 - Management Event Raised
+- Severity
 
 # Condition(s) string for the SQL query
 conditions:

--- a/spec/views/miq_policy/_alert_details.html.haml_spec.rb
+++ b/spec/views/miq_policy/_alert_details.html.haml_spec.rb
@@ -1,7 +1,7 @@
 describe "miq_policy/_alert_details.html.haml" do
   before do
     @alert = FactoryGirl.create(:miq_alert)
-    SEVERITIES = {"info" => _('Info'), "warning" => _('Warninig'), "error" => _('Error')}.freeze
+    SEVERITIES = MiqPolicyController::Alerts::SEVERITIES
     exp = {:eval_method => 'nothing', :mode => 'internal', :options => {}}
     allow(@alert).to receive(:expression).and_return(exp)
     set_controller_for_view("miq_policy")

--- a/spec/views/miq_policy/_alert_details.html.haml_spec.rb
+++ b/spec/views/miq_policy/_alert_details.html.haml_spec.rb
@@ -1,6 +1,7 @@
 describe "miq_policy/_alert_details.html.haml" do
   before do
     @alert = FactoryGirl.create(:miq_alert)
+    SEVERITIES = {"info" => _('Info'), "warning" => _('Warninig'), "error" => _('Error')}.freeze
     exp = {:eval_method => 'nothing', :mode => 'internal', :options => {}}
     allow(@alert).to receive(:expression).and_return(exp)
     set_controller_for_view("miq_policy")


### PR DESCRIPTION
Control -> Explorer -> Alerts
https://www.pivotaltracker.com/story/show/151340254

Depends on https://github.com/ManageIQ/manageiq/pull/16040 (Merged)

TODO:
- [x]  Severity shows in list view with i18n
- [x]  Severity shows in detail page with i18n
- [x]  Add/Edit Severity dropbox after Active checkbox
- [x] Severity is required

After:
<img width="897" alt="screen shot 2017-10-03 at 4 13 19 pm" src="https://user-images.githubusercontent.com/9210860/31129780-e0164a5a-a855-11e7-8586-ca4014e781e8.png">

<img width="452" alt="screen shot 2017-10-04 at 11 02 00 am" src="https://user-images.githubusercontent.com/9210860/31167768-7e3f4ffe-a8f3-11e7-9a99-a7b338ca75bb.png">

<img width="769" alt="screen shot 2017-10-04 at 2 29 31 pm" src="https://user-images.githubusercontent.com/9210860/31175733-7ab35a20-a910-11e7-9069-ef7645858b58.png">

Fix for select picker is out of scope of this PR.

@miq-bot add_label wip, pending core