### PR TITLE
Fix clipped topology tooltip

### DIFF
--- a/app/assets/stylesheets/container_topology.css
+++ b/app/assets/stylesheets/container_topology.css
@@ -5,7 +5,7 @@
 }
 
 .topology .legend { /* prevents tooltip from conflicting with the nav bar*/
-  margin-left: 40px;
+  margin-left: 55px;
 }
 
 .kube-topology g text.glyph {


### PR DESCRIPTION
This PR adjusted the topology legend to prevent tooltips from being hidden behind the vertical navigation.

https://bugzilla.redhat.com/show_bug.cgi?id=1486660

Old
<img width="756" alt="screen shot 2017-10-03 at 1 11 15 pm" src="https://user-images.githubusercontent.com/1287144/31138624-1eba1a16-a83d-11e7-96eb-0444b52dc2b5.png">

New
<img width="774" alt="screen shot 2017-10-03 at 1 12 20 pm" src="https://user-images.githubusercontent.com/1287144/31138623-1eb839b2-a83d-11e7-8e85-c2514ed6ddd3.png">

