### PR TITLE
Delay based retirement

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -50,6 +50,7 @@
 //= require bootstrap-select
 //= require bootstrap-hover-dropdown
 //= require bootstrap-switch
+//= require bootstrap-touchspin
 //= require angular-bootstrap-switch
 //= require angular-ui-codemirror
 //= require patternfly-bootstrap-treeview

--- a/app/assets/javascripts/components/datetime-delay-picker.js
+++ b/app/assets/javascripts/components/datetime-delay-picker.js
@@ -1,0 +1,61 @@
+ManageIQ.angular.app.component('datetimeDelayPicker', {
+  bindings: {
+    model: '=',
+    start_date: '<',
+  },
+
+  controllerAs: 'vm',
+
+  controller: ['$scope', '$element', function($scope, $element) {
+    $scope.__ = __;
+
+    this.months = 0;
+    this.weeks = 0;
+    this.days = 0;
+    this.hours = 0;
+
+    this.setRetirementDate = function() {
+      this.model = moment.utc(this.start_date)
+        .add(this.months, 'month')
+        .add(this.weeks, 'week')
+        .add(this.days, 'day')
+        .add(this.hours, 'hour')
+        .toDate();
+    };
+
+    this.$onInit = function() {
+      if (! this.start_date) {
+        this.start_date = new Date();
+      }
+    };
+
+    this.$postLink = function() {
+      var commonAttrs = {min: 0, verticalbuttons: true, buttondown_class: "btn btn-link", buttonup_class: "btn btn-link"};
+      var attrs = {months: __('Months'), weeks: __('Weeks'), days: __('Days'), hours: __('Hours')};
+
+      for (var key in attrs) {
+        if (attrs.hasOwnProperty(key)) {
+          $element.find('input[name=' + key + ']').TouchSpin(Object.assign({}, commonAttrs, {'prefix': attrs[key]}));
+        }
+      }
+    };
+  }],
+
+  template: [
+    '<div class="form-group">',
+    '  <label class="control-label col-md-3">{{ __("Time Delay:") }}</label>',
+    '  <div class="col-md-2">',
+    '    <input class="form-control" name="months" type="text" ng-model="vm.months" ng-change="vm.setRetirementDate()">',
+    '  </div>',
+    '  <div class="col-md-2">',
+    '    <input class="form-control" name="weeks" type="text" ng-model="vm.weeks" ng-change="vm.setRetirementDate()">',
+    '  </div>',
+    '  <div class="col-md-2">',
+    '    <input class="form-control" name="days" type="text" ng-model="vm.days" ng-change="vm.setRetirementDate()">',
+    '  </div>',
+    '  <div class="col-md-2">',
+    '    <input class="form-control" name="hours" type="text" ng-model="vm.hours" ng-change="vm.setRetirementDate()">',
+    '  </div>',
+    '</div>',
+  ].join('\n'),
+});

--- a/app/views/shared/views/_retire.html.haml
+++ b/app/views/shared/views/_retire.html.haml
@@ -10,16 +10,31 @@
     = _('Set/Remove Retirement Date')
   %tbody
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-3.control-label
+        = _('Enter Retirement Date as')
+      .col-md-4{"ng-init" => "formMode = 'date'"}
+        = select_tag("formMode",
+                     options_for_select(_("Specific Date and Time") => 'date', _("Time Delay from Now") => 'delay'),
+                     "ng-model"  => "formMode",
+                     "pf-select" => true)
+    .form-group{"ng-if" => "formMode == 'date'"}
+      %label.col-md-3.control-label
         = _('Retirement Date and Time')
       .col-md-4#retirement_date_div
-        = datetimepicker_input_tag('retirement_date', nil,
-                                   'id'         => 'retirement_date',
+        = datetimepicker_input_tag('retirement_date_datepicker', nil,
                                    'class'      => 'form-control',
                                    'ng-model'   => 'vm.retirementInfo.retirementDate',
                                    'start-date' => 'vm.datepickerStartDate')
+    %datetime-delay-picker{'ng-if'      => "formMode == 'delay'",
+                           'model'      => 'vm.retirementInfo.retirementDate',
+                           'start-date' => 'vm.datepickerStartDate'}
+    .form-group{"ng-if" => "formMode == 'delay'"}
+      %label.col-md-3.control-label
+        = _('Retirement Date and Time')
+      .col-md-4#retirement_date_result_div
+        %input.form-control#retirement_date{'readonly' => true, 'ng-model' => 'vm.retirementInfo.retirementDate'}
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-3.control-label
         = _('Retirement Warning')
       .col-md-8
         - select_options = [{:value => "", :label => _("None")},
@@ -34,7 +49,8 @@
                      "pf-select"   => true)
         :javascript
           miqInitSelectPicker();
-  = _('* Saving a blank date will remove all retirement dates')
+  %div{"ng-if" => "formMode == 'date'"}
+    = _('* Saving a blank date will remove all retirement dates')
 
   %hr
   %h3


### PR DESCRIPTION
This enhancement allows for selecting service / vm / orchestration stack retirement date as
a time delay from now (implemented as an angular directive `datetime-delay-picker`).

Initial landing screen for service / vm / orchestration stack retirement, it shows standard datetime picker
widget allowing to select specific date & time for retirement:
![delay-retirement-03](https://user-images.githubusercontent.com/6648365/31179683-e1149d5e-a91c-11e7-90b9-2d676d18225b.jpg)

New functionality allows for entering the retirement date & time as a delay from now. After selecting
the option in the new dropdown menu, the following screen is shown:
![delay-retirement-04](https://user-images.githubusercontent.com/6648365/31179695-e9c3e694-a91c-11e7-93ed-c68df8d8a9ae.jpg)

The screen contains inputs for months, weeks, days and hours from now, when the item in question
would be retired. Additionally, the screen also renders the supposed retirement date.
