### PR TITLE
Fixed VM visibility fieldset alignment.

### DIFF
--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -62,21 +62,21 @@
                   = ui_lookup(:tables => table_view_name)
                 .col-md-8
                   %ul.list-inline= render_view_buttons(resource, @edit[:new][:views][resource])
-          %fieldset
-            %h3
-              = _('VM Visibility')
-            .form-group
-              %label.col-md-3.control-label
-                = _("Show VMs in Explorer tree.")
-              .col-md-6
-                = check_box_tag("display_vms",
-                                 '1',
-                                 @edit[:new][:display][:display_vms],
-                                 :data => {:on_text => _('Yes'), :off_text => _('No')})
-                .note
-                  = _("Warning: Enabling this option may cause performance issues in large environments (i.e. thousands of VMs)")
-                :javascript
-                  miqInitBootstrapSwitch("display_vms", "#{url}")
+        %fieldset
+          %h3
+            = _('VM Visibility')
+          .form-group
+            %label.col-md-3.control-label
+              = _("Show VMs in Explorer tree.")
+            .col-md-6
+              = check_box_tag("display_vms",
+                               '1',
+                               @edit[:new][:display][:display_vms],
+                               :data => {:on_text => _('Yes'), :off_text => _('No')})
+              .note
+                = _("Warning: Enabling this option may cause performance issues in large environments (i.e. thousands of VMs)")
+              :javascript
+                miqInitBootstrapSwitch("display_vms", "#{url}")
       .col-md-12.col-lg-6
         - if has_any_role?(%w(ems_middleware_show_list middleware_server_show_list middleware_deployment_show_list middleware_datasource_show_list middleware_domain_show_list middleware_server_group_show_list middleware_messaging_show_list))
           %fieldset


### PR DESCRIPTION
VM Visibility switch was inside an incorrect if block, moved it out of the if block

https://bugzilla.redhat.com/show_bug.cgi?id=1465465

@dclarizio please review/merge

before:
![before](https://user-images.githubusercontent.com/3450808/31142338-09a55c02-a848-11e7-80ab-9d58a93d6e32.png)

after:
![after](https://user-images.githubusercontent.com/3450808/31142345-0d03de3c-a848-11e7-9dd1-65bf33a6cf7c.png)
