### PR TITLE
Add policy buttons to physical servers page

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -34,11 +34,16 @@ class PhysicalServerController < ApplicationController
 
   def textual_group_list
     [
-      %i(properties networks relationships power_management assets firmware_details network_adapters),
+      %i(properties networks relationships power_management assets firmware_details network_adapters smart_management),
     ]
   end
   helper_method :textual_group_list
 
   def button
+    assign_policies(PhysicalServer) if params[:pressed] == "physical_server_protect"
+    tag(PhysicalServer) if params[:pressed] == "physical_server_tag"
+
+    return if %w(physical_server_protect physical_server_tag).include?(params[:pressed]) &&
+              @flash_array.nil? # Some other screen is showing, so return
   end
 end

--- a/app/helpers/application_helper/button/physical_server_policy_simulation.rb
+++ b/app/helpers/application_helper/button/physical_server_policy_simulation.rb
@@ -1,5 +1,0 @@
-class ApplicationHelper::Button::PhysicalServerPolicySimulation < ApplicationHelper::Button::Basic
-  def disabled?
-    true # TODO: Physical Server policy simulation
-  end
-end

--- a/app/helpers/application_helper/button/physical_server_policy_simulation.rb
+++ b/app/helpers/application_helper/button/physical_server_policy_simulation.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::PhysicalServerPolicySimulation < ApplicationHelper::Button::Basic
+  def disabled?
+    true # TODO: Physical Server policy simulation
+  end
+end

--- a/app/helpers/application_helper/toolbar/physical_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_servers_center.rb
@@ -118,16 +118,6 @@ class ApplicationHelper::Toolbar::PhysicalServersCenter < ApplicationHelper::Too
             :onwhen    => "1+"
           ),
           button(
-            :physical_server_policy_sim,
-            'fa fa-play-circle-o fa-lg',
-            N_('View Policy Simulation for the selected items'),
-            N_('Policy Simulation'),
-            :url_parms => "main_div",
-            :enabled   => false,
-            :onwhen    => "1+",
-            :klass     => ApplicationHelper::Button::PhysicalServerPolicySimulation
-          ),
-          button(
             :physical_server_tag,
             'pficon pficon-edit fa-lg',
             N_('Edit tags for the selected items'),

--- a/app/helpers/application_helper/toolbar/physical_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_servers_center.rb
@@ -98,4 +98,46 @@ class ApplicationHelper::Toolbar::PhysicalServersCenter < ApplicationHelper::Too
       ),
     ]
   )
+  button_group(
+    'physical_server_policy',
+    [
+      select(
+        :physical_server_policy_choice,
+        'fa fa-shield fa-lg',
+        N_('Policy'),
+        :enabled => false,
+        :onwhen  => "1+",
+        :items   => [
+          button(
+            :physical_server_protect,
+            'pficon pficon-edit fa-lg',
+            N_('Manage Policies for the selected items'),
+            N_('Manage Policies'),
+            :url_parms => "main_div",
+            :enabled   => false,
+            :onwhen    => "1+"
+          ),
+          button(
+            :physical_server_policy_sim,
+            'fa fa-play-circle-o fa-lg',
+            N_('View Policy Simulation for the selected items'),
+            N_('Policy Simulation'),
+            :url_parms => "main_div",
+            :enabled   => false,
+            :onwhen    => "1+",
+            :klass     => ApplicationHelper::Button::PhysicalServerPolicySimulation
+          ),
+          button(
+            :physical_server_tag,
+            'pficon pficon-edit fa-lg',
+            N_('Edit tags for the selected items'),
+            N_('Edit Tags'),
+            :url_parms => "main_div",
+            :enabled   => false,
+            :onwhen    => "1+"
+          ),
+        ]
+      ),
+    ]
+  )
 end

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -50,6 +50,10 @@ module PhysicalServerHelper::TextualSummary
     )
   end
 
+  def textual_group_smart_management
+    TextualTags.new(_("Smart Management"), %i(tags))
+  end
+
   def textual_host
     {:label => _("Host"), :value => @record.host.try(:name), :icon => "pficon pficon-virtual-machine", :link => url_for(:controller => 'host', :action => 'show', :id => @record.host.try(:id))}
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1309,6 +1309,7 @@ Rails.application.routes.draw do
         protect
         show_list
         show
+        tagging_edit
       ) + compare_get,
 
       :post   =>  %w(
@@ -1317,6 +1318,9 @@ Rails.application.routes.draw do
         create
         create_del
         listnav_search_selected
+        protect
+        tagging_edit
+        tag_edit_form_field_changed
         update
         update_del
         quick_search

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -29,4 +29,20 @@ describe PhysicalServerController do
     end
     it { expect(response.status).to eq(200) }
   end
+
+  context "#button" do
+    it "when Physical Server Manage Policies is pressed" do
+      controller.instance_variable_set(:@_params, :pressed => "physical_server_protect")
+      expect(controller).to receive(:assign_policies).with(PhysicalServer)
+      controller.button
+      expect(controller.send(:flash_errors?)).not_to be_truthy
+    end
+
+    it "when Physical Server Tag is pressed" do
+      controller.instance_variable_set(:@_params, :pressed => "physical_server_tag")
+      expect(controller).to receive(:tag).with(PhysicalServer)
+      controller.button
+      expect(controller.send(:flash_errors?)).not_to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This PR contains:
- Policy buttons for Physical Server page;
        - Manage Policies
        - Policy Simulation 
        - Edit tags

![image](https://user-images.githubusercontent.com/5839808/31391164-2a6cd258-adac-11e7-8d60-8f87c9ea6d97.png)


![image](https://user-images.githubusercontent.com/5839808/31387009-42af5f3c-ad9f-11e7-8f8a-65da21164d96.png)

![image](https://user-images.githubusercontent.com/5839808/31387058-688b2e52-ad9f-11e7-8992-adb7b451098f.png)

depends on #[16104](https://github.com/ManageIQ/manageiq/pull/16104)
depends on #[16110](https://github.com/ManageIQ/manageiq/pull/16110)