### PR TITLE
Add tagging for generic object instances

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2264,6 +2264,8 @@ class ApplicationController < ActionController::Base
       "automation_manager_provider"
     when 'provider_foreman'
       "configuration_manager_provider"
+    when "generic_object_definition" # tagging for nested list on the generic object class
+      "generic_object"
     else
       controller_name
     end

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -39,7 +39,6 @@ module ApplicationController::Tags
   alias_method :miq_template_tag, :tagging_edit
   alias_method :storage_tag, :tagging_edit
   alias_method :infra_networking_tag, :tagging_edit
-  alias_method :generic_object_tag, :tagging_edit
 
   # Handle tag edit field changes
   def tag_edit_form_field_changed

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -39,6 +39,7 @@ module ApplicationController::Tags
   alias_method :miq_template_tag, :tagging_edit
   alias_method :storage_tag, :tagging_edit
   alias_method :infra_networking_tag, :tagging_edit
+  alias_method :generic_object_tag, :tagging_edit
 
   # Handle tag edit field changes
   def tag_edit_form_field_changed

--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -8,6 +8,7 @@ class GenericObjectController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
+  include Mixins::GenericButtonMixin
 
   menu_section :automate
   toolbar :generic_object

--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -10,6 +10,7 @@ class GenericObjectController < ApplicationController
   include Mixins::GenericShowMixin
 
   menu_section :automate
+  toolbar :generic_object
 
   def self.model
     GenericObject

--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -10,7 +10,10 @@ class GenericObjectDefinitionController < ApplicationController
   include Mixins::GenericShowMixin
 
   menu_section :automate
-  toolbar :generic_object_definition
+
+  def toolbar_singular
+    @display == 'generic_objects' ? :generic_objects : :generic_object_definition
+  end
 
   def self.display_methods
     %w(generic_objects)
@@ -31,6 +34,8 @@ class GenericObjectDefinitionController < ApplicationController
         { :action => 'new' }
       when 'generic_object_definition_edit'
         { :action => 'edit', :id => from_cid(params[:id] || params[:miq_grid_checks]) }
+      when 'generic_object_tag'
+        { :controller => 'generic_object', :action => 'tag', :id => params[:miq_grid_checks]}
       end
     )
   end
@@ -48,6 +53,9 @@ class GenericObjectDefinitionController < ApplicationController
     @in_a_form = true
   end
 
+  def default_show_template
+    "generic_object_definition/show"
+  end
   private
 
   def textual_group_list

--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -11,31 +11,21 @@ class GenericObjectDefinitionController < ApplicationController
 
   menu_section :automate
 
-  def toolbar_singular
-    @display == 'generic_objects' ? :generic_objects : :generic_object_definition
-  end
-
-  def self.display_methods
-    %w(generic_objects)
-  end
-
-  def display_generic_objects
-    nested_list("generic_object", GenericObject)
-  end
-
   def self.model
     GenericObjectDefinition
   end
 
   def button
+    if @display == 'generic_objects' && params[:pressed] == 'generic_object_tag'
+      tag(GenericObject)
+      return
+    end
     javascript_redirect(
       case params[:pressed]
       when 'generic_object_definition_new'
         { :action => 'new' }
       when 'generic_object_definition_edit'
         { :action => 'edit', :id => from_cid(params[:id] || params[:miq_grid_checks]) }
-      when 'generic_object_tag'
-        { :controller => 'generic_object', :action => 'tag', :id => params[:miq_grid_checks]}
       end
     )
   end
@@ -53,9 +43,14 @@ class GenericObjectDefinitionController < ApplicationController
     @in_a_form = true
   end
 
+  def self.display_methods
+    %w(generic_objects)
+  end
+
   def default_show_template
     "generic_object_definition/show"
   end
+
   private
 
   def textual_group_list

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -20,8 +20,7 @@ class ServiceController < ApplicationController
   def button
     custom_buttons if params[:pressed] == "custom_button"
     return if ["custom_button"].include?(params[:pressed])    # custom button screen, so return, let custom_buttons method handle everything
-
-    tag(GenericObject) if @display == 'generic_objects' && params[:pressed] == 'generic_object_tag' 
+    tag(GenericObject) if @display == 'generic_objects' && params[:pressed] == 'generic_object_tag'
   end
 
   def x_button

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -20,6 +20,8 @@ class ServiceController < ApplicationController
   def button
     custom_buttons if params[:pressed] == "custom_button"
     return if ["custom_button"].include?(params[:pressed])    # custom button screen, so return, let custom_buttons method handle everything
+
+    tag(GenericObject) if @display == 'generic_objects' && params[:pressed] == 'generic_object_tag' 
   end
 
   def x_button

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1327,6 +1327,7 @@ module ApplicationHelper
                         event
                         flavor
                         floating_ip
+                        generic_object
                         generic_object_definition
                         host
                         host_aggregate

--- a/app/helpers/application_helper/button/mixins/sub_list_view_screen_mixin.rb
+++ b/app/helpers/application_helper/button/mixins/sub_list_view_screen_mixin.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper::Button::Mixins::SubListViewScreenMixin
   def sub_list_view_screen?
-    @lastaction == 'show' && !@display.in?(%w(main vms instances all_vms cloud_volumes))
+    @lastaction == 'show' && !@display.in?(%w(main vms instances all_vms cloud_volumes generic_objects))
   end
 end

--- a/app/helpers/application_helper/toolbar/generic_object_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_center.rb
@@ -1,0 +1,17 @@
+class ApplicationHelper::Toolbar::GenericObjectCenter < ApplicationHelper::Toolbar::Basic
+  button_group('generic_object_policy', [
+    select(
+      :generic_object_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :items => [
+        button(
+          :generic_object_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for this Generic Object Instance'),
+          N_('Edit Tags')),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar/generic_objects_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_objects_center.rb
@@ -1,0 +1,22 @@
+class ApplicationHelper::Toolbar::GenericObjectsCenter < ApplicationHelper::Toolbar::Basic
+  button_group('generic_object_policy', [
+    select(
+      :generic_object_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :generic_object_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for the selected Generic Object Instances'),
+          N_('Edit Tags'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -535,7 +535,7 @@ class ApplicationHelper::ToolbarChooser
               ems_object_storage
               timeline
               usage
-              generic_object).include?(@layout)
+              generic_object_definition).include?(@layout)
           if ["show_list"].include?(@lastaction)
             return "#{@layout.pluralize}_center_tb"
           else

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -447,7 +447,7 @@ class ApplicationHelper::ToolbarChooser
                     load_balancers network_ports network_routers orchestration_stacks resource_pools
                     security_groups storages middleware_deployments middleware_datasources
                     middleware_messagings middleware_servers)
-    to_display_center = %w(stack_orchestration_template topology cloud_object_store_objects)
+    to_display_center = %w(stack_orchestration_template topology cloud_object_store_objects generic_objects)
     if @lastaction == 'show' && (@view || @display != 'main') && !@layout.starts_with?("miq_request")
       if @display == "vms" || @display == "all_vms"
         return "vm_infras_center_tb"
@@ -534,7 +534,8 @@ class ApplicationHelper::ToolbarChooser
               ems_block_storage
               ems_object_storage
               timeline
-              usage).include?(@layout)
+              usage
+              generic_object).include?(@layout)
           if ["show_list"].include?(@lastaction)
             return "#{@layout.pluralize}_center_tb"
           else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2109,6 +2109,7 @@ Rails.application.routes.draw do
         update_del
         quick_search
         show_list
+        tag_edit_form_field_changed
         tagging_edit
       ) +
         adv_search_post +

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2944,6 +2944,7 @@ Rails.application.routes.draw do
         retire
         service_form_fields
         show
+        tagging_edit
       ),
       :post => %w(
         button
@@ -2955,6 +2956,7 @@ Rails.application.routes.draw do
         service_edit
         service_tag
         tag_edit_form_field_changed
+        tagging_edit
         tree_autoload
         tree_select
         x_button

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2078,8 +2078,12 @@ Rails.application.routes.draw do
       :get => %w(
         show
         show_list
+        tagging_edit
       ),
       :post => %w(
+        button
+        tag_edit_form_field_changed
+        tagging_edit
       )
     },
 
@@ -2091,6 +2095,7 @@ Rails.application.routes.draw do
         new
         show
         show_list
+        tagging_edit
       ),
       :post => %w(
         button
@@ -2104,6 +2109,7 @@ Rails.application.routes.draw do
         update_del
         quick_search
         show_list
+        tagging_edit
       ) +
         adv_search_post +
         save_post

--- a/spec/controllers/generic_object_controller_spec.rb
+++ b/spec/controllers/generic_object_controller_spec.rb
@@ -45,11 +45,11 @@ describe GenericObjectController do
       session[:tag_db] = "GenericObject"
       session[:tag_items] = "GenericObject"
       session[:assigned_filters] = []
-      edit = { :key        => "GenericObject_edit_tags__#{@gobj.id}",
-               :tagging    => "GenericObject",
-               :tag_items  => [@gobj.id],
-               :current    => {:assignments => []},
-               :new        => {:assignments => [@tag1.id, @tag2.id]}}
+      edit = { :key       => "GenericObject_edit_tags__#{@gobj.id}",
+               :tagging   => "GenericObject",
+               :tag_items => [@gobj.id],
+               :current   => {:assignments => []},
+               :new       => {:assignments => [@tag1.id, @tag2.id]}}
       session[:edit] = edit
       controller.instance_variable_set(:@settings, {})
       allow(controller).to receive(:fetch_path)

--- a/spec/controllers/generic_object_controller_spec.rb
+++ b/spec/controllers/generic_object_controller_spec.rb
@@ -25,4 +25,57 @@ describe GenericObjectController do
     end
     it { expect(response.status).to eq(200) }
   end
+
+  describe "#tags_edit" do
+    before(:each) do
+      EvmSpecHelper.create_guid_miq_server_zone
+      user = FactoryGirl.create(:user_with_group)
+      stub_user(:features => :all)
+      generic_obj_defn = FactoryGirl.create(:generic_object_definition)
+      @gobj = FactoryGirl.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
+      allow(@gobj).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryGirl.create(:classification_tag,
+                                 :name   => "tag_1",
+                                 :parent => classification)
+      @tag2 = FactoryGirl.create(:classification_tag,
+                                 :name   => "tag_2",
+                                 :parent => classification)
+      allow(Classification).to receive(:find_assigned_entries).with(@gobj).and_return([@tag1, @tag2])
+      session[:tag_db] = "GenericObject"
+      session[:tag_items] = "GenericObject"
+      session[:assigned_filters] = []
+      edit = { :key        => "GenericObject_edit_tags__#{@gobj.id}",
+               :tagging    => "GenericObject",
+               :tag_items  => [@gobj.id],
+               :current    => {:assignments => []},
+               :new        => {:assignments => [@tag1.id, @tag2.id]}}
+      session[:edit] = edit
+      controller.instance_variable_set(:@settings, {})
+      allow(controller).to receive(:fetch_path)
+    end
+
+    after(:each) do
+      expect(response.status).to eq(200)
+    end
+
+    it "builds tagging screen" do
+      post :button, :params => { :pressed => "generic_object_tag", :format => :js, :id => @gobj.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    it "cancels tags edit" do
+      session[:breadcrumbs] = [{:url => "generic_object/show/#{@gobj.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @gobj.id }
+      expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
+      expect(assigns(:edit)).to be_nil
+    end
+
+    it "save tags" do
+      session[:breadcrumbs] = [{:url => "generic_object/show/#{@gobj.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @gobj.id }
+      expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
+      expect(assigns(:edit)).to be_nil
+    end
+  end
 end

--- a/spec/controllers/generic_object_definition_controller_spec.rb
+++ b/spec/controllers/generic_object_definition_controller_spec.rb
@@ -37,7 +37,7 @@ describe GenericObjectDefinitionController do
       definition = FactoryGirl.create(:generic_object_definition)
       go = FactoryGirl.create(:generic_object, :generic_object_definition_id => definition.id)
       get :show, :params => {:id => definition.id, :display => 'generic_objects'}
-      post :button, :params => {:pressed => "generic_object_tag", "check_#{go.id}" => "1", :id => definition.id, :display => 'generic_objects',  :format => :js}
+      post :button, :params => {:pressed => "generic_object_tag", "check_#{go.id}" => "1", :id => definition.id, :display => 'generic_objects', :format => :js}
       expect(response.status).to eq(200)
       expect(response.body).to include('generic_object_definition/tagging_edit')
     end

--- a/spec/controllers/generic_object_definition_controller_spec.rb
+++ b/spec/controllers/generic_object_definition_controller_spec.rb
@@ -23,4 +23,23 @@ describe GenericObjectDefinitionController do
     end
     it { expect(response.status).to eq(200) }
   end
+
+  context "#button" do
+    render_views
+
+    before(:each) do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+      ApplicationController.handle_exceptions = true
+    end
+
+    it "when Generic Object Tag is pressed for the generic object nested list" do
+      definition = FactoryGirl.create(:generic_object_definition)
+      go = FactoryGirl.create(:generic_object, :generic_object_definition_id => definition.id)
+      get :show, :params => {:id => definition.id, :display => 'generic_objects'}
+      post :button, :params => {:pressed => "generic_object_tag", "check_#{go.id}" => "1", :id => definition.id, :display => 'generic_objects',  :format => :js}
+      expect(response.status).to eq(200)
+      expect(response.body).to include('generic_object_definition/tagging_edit')
+    end
+  end
 end


### PR DESCRIPTION
Allow tagging of Generic Object instances from the details page, initially when they are shown under a GO Class (in automate) or Service.

Links 
---------

https://www.pivotaltracker.com/story/show/151174596
https://bugzilla.redhat.com/show_bug.cgi?id=1497692

![screenshot from 2017-10-13 17-22-15](https://user-images.githubusercontent.com/12769982/31595590-df214910-b20a-11e7-9eea-2913ce896a37.png)
![screenshot from 2017-10-16 00-38-29](https://user-images.githubusercontent.com/12769982/31595591-df3da984-b20a-11e7-9f7b-8dc18df02da1.png)
![screenshot from 2017-10-16 00-40-56](https://user-images.githubusercontent.com/12769982/31595592-df60a7ea-b20a-11e7-9972-7fc2c7658e32.png)
![screenshot from 2017-10-16 00-41-38](https://user-images.githubusercontent.com/12769982/31595594-dfb81ff2-b20a-11e7-88ad-0235736eafa0.png)

