### PR TITLE
Show 'no data' under container dashboard alerts 

### DIFF
--- a/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
@@ -88,6 +88,7 @@
           }
         }
 
+        $scope.hasAlerts = data.alerts.dataAvailable;
         dashboardUtilsFactory.updateAlertsStatus($scope.objectStatus.alerts, data.alerts);
         dashboardUtilsFactory.updateStatus($scope.objectStatus.nodes, data.status.nodes);
         dashboardUtilsFactory.updateStatus($scope.objectStatus.containers, data.status.containers);

--- a/app/assets/stylesheets/container_providers_dashboard.scss
+++ b/app/assets/stylesheets/container_providers_dashboard.scss
@@ -49,6 +49,15 @@
     padding-left: 0px;
 }
 
+.alerts-card-no-data .card-pf, .provider-card .card-pf {
+  min-height: 132px;
+  text-align: center;
+}
+
+.alerts-no-data-title {
+  padding-bottom: 14px;
+}
+
 .provider-card {
     min-height: 140px;
     padding-left: 0px;

--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -16,7 +16,15 @@
       .alerts-card{:layout                     => "tall",
                   "pf-aggregate-status-card"  => "",
                   "show-top-border"           => "true",
-                  :status                     => "objectStatus.alerts"}
+                  :status                     => "objectStatus.alerts",
+                  "ng-if"                     => "hasAlerts"}
+      .alerts-card-no-data{"show-top-border"           => "true",
+                           "pf-card"      => "",
+                           "ng-if"                     => "!hasAlerts",
+                           :layout                     => "tall"}
+        .alerts-no-data-title
+          = _("Alerts")
+        %div{"pf-empty-chart" => ""}
     .col-xs-12.col-sm-12.col-md-8
       .row
         .col-xs-6.col-sm-6.col-md-3


### PR DESCRIPTION
Show no data under container dashboard alerts when no prometheus endpoint available.

before:
![before](https://user-images.githubusercontent.com/11256940/31152591-881fb246-a8a5-11e7-8b35-09f5fded7bc0.png)

after:
![after](https://user-images.githubusercontent.com/11256940/31152544-547fcc82-a8a5-11e7-9efc-cc83d8f234c4.png)

@simon3z @yaacov @moolitayer please review

@miq-bot add_label compute/containers