### PR TITLE
formChanged - handle form elements which do not change model

### DIFF
--- a/app/assets/javascripts/directives/form_changed.js
+++ b/app/assets/javascripts/directives/form_changed.js
@@ -1,7 +1,7 @@
 ManageIQ.angular.app.directive('formChanged', function() {
   return {
     require: 'form',
-    link: function(scope, _elem, _attr, ctrl) {
+    link: function(scope, _elem, attr, ctrl) {
       var model = function() {
         return scope.$eval(ctrl.model || scope.model);
       };
@@ -32,14 +32,18 @@ ManageIQ.angular.app.directive('formChanged', function() {
         return undefined;
       };
 
-      scope.$watchCollection(ctrl.model || scope.model, function() {
+      var updateDirty = function() {
         // TODO in lodash 4 it's _.isEqualWith
         if (_.isEqual(model(), modelCopy(), compare)) {
           ctrl.$setPristine();
         } else {
           ctrl.$setDirty();
         }
-      });
+      };
+
+      scope.$watchCollection(ctrl.model || scope.model, updateDirty);
+      // for form elements which do not change the model (but do make the form dirty)
+      scope.$watch(attr.name + '.$dirty', updateDirty);
     },
   };
 });


### PR DESCRIPTION
Without this, an input which does not change the model will make the form dirty on use, and form-change won't notice because it only watches for model changes.

This makes `form-changed` also watch for the form becoming `$dirty` and run the comparison then as well.

Cc @ZitaNemeckova 

Needed by https://github.com/ManageIQ/manageiq-ui-classic/pull/2282, Cc @mzazrivec 