### PR TITLE
Chart data returns empty chart for unknown chart types

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1535,13 +1535,19 @@ function rbacGroupLoadTab(id) {
 }
 
 function chartData(type, data, data2) {
+  var empty = {
+    data: {
+      columns: [],
+    },
+  };
+
   if (type === undefined) {
-    return {data :{columns: []}};
+    return empty;
   }
 
   var config = _.cloneDeep(ManageIQ.charts.c3config[type]);
   if (config === undefined) {
-    return {data :{columns: []}};
+    return empty;
   }
 
   if (_.isObject(data.miq)) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1536,7 +1536,12 @@ function rbacGroupLoadTab(id) {
 
 function chartData(type, data, data2) {
   if (type === undefined) {
-    return;
+    return {data :{columns: []}};
+  }
+
+  var config = _.cloneDeep(ManageIQ.charts.c3config[type]);
+  if (config === undefined) {
+    return {data :{columns: []}};
   }
 
   if (_.isObject(data.miq)) {
@@ -1607,7 +1612,7 @@ function chartData(type, data, data2) {
     };
   }
 
-  var config = _.cloneDeep(ManageIQ.charts.c3config[type]);
+
   // some PatternFly default configs define contents function, but it breaks formatting
   if (_.isObject(config.tooltip)) {
     config.tooltip.contents = undefined;


### PR DESCRIPTION
Fixes issues when infinite spinner was present in report edit/copy form, because of unknown chart type. 


Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1491629
https://github.com/ManageIQ/manageiq/pull/16117
Each one of PRs should be enough to fix it.
