### PR TITLE
Workaround RipperRubyParser error

### DIFF
--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -280,7 +280,7 @@ module Mixins
       assert_privileges("#{privilege_prefix}_edit_provider")
       # set value of read only zone text box, when there is only single zone
       if params[:id] == "new"
-        return render :json => {:zone => Zone.in_my_region.size >= 1 ? Zone.in_my_region.first.name : nil}
+        return render(:json => {:zone => Zone.in_my_region.size >= 1 ? Zone.in_my_region.first.name : nil})
       end
 
       manager = find_record(concrete_model, params[:id])


### PR DESCRIPTION
See https://github.com/mvz/ripper_ruby_parser/issues/5 for more info

```
Error parsing classes in /home/bdunne/.gem/ruby/2.3.3/bundler/gems/manageiq-ui-classic-e15d14cbf240/app/controllers/mixins/manager_controller_mixin.rb:
RuntimeError: type should be a Symbol, not: s(:command, s(:@ident, "render", s(283, 15)), s(:args_add_block, s(s(:bare_assoc_hash, s(s(:assoc_new, s(:symbol_literal, s(:symbol, s(:@ident, "json", s(283, 23)))), s(:hash, s(:assoclist_from_args, s(s(:assoc_new, s(:symbol_literal, s(:symbol, s(:@ident, "zone", s(283, 33)))), s(:ifop, s(:binary, s(:call, s(:call, s(:var_ref, s(:@const, "Zone", s(283, 41))), :".", s(:@ident, "in_my_region", s(283, 46))), :".", s(:@ident, "size", s(283, 59))), :>=, s(:@int, "1", s(283, 67))), s(:call, s(:call, s(:call, s(:var_ref, s(:@const, "Zone", s(283, 71))), :".", s(:@ident, "in_my_region", s(283, 76))), :".", s(:@ident, "first", s(283, 89))), :".", s(:@ident, "name", s(283, 95))), s(:var_ref, s(:@kw, "nil", s(283, 102)))))))))))), false))

rake aborted!
type should be a Symbol, not: s(:command, s(:@ident, "render", s(283, 15)), s(:args_add_block, s(s(:bare_assoc_hash, s(s(:assoc_new, s(:symbol_literal, s(:symbol, s(:@ident, "json", s(283, 23)))), s(:hash, s(:assoclist_from_args, s(s(:assoc_new, s(:symbol_literal, s(:symbol, s(:@ident, "zone", s(283, 33)))), s(:ifop, s(:binary, s(:call, s(:call, s(:var_ref, s(:@const, "Zone", s(283, 41))), :".", s(:@ident, "in_my_region", s(283, 46))), :".", s(:@ident, "size", s(283, 59))), :>=, s(:@int, "1", s(283, 67))), s(:call, s(:call, s(:call, s(:var_ref, s(:@const, "Zone", s(283, 71))), :".", s(:@ident, "in_my_region", s(283, 76))), :".", s(:@ident, "first", s(283, 89))), :".", s(:@ident, "name", s(283, 95))), s(:var_ref, s(:@kw, "nil", s(283, 102)))))))))))), false))
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:242:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:95:in `handle_return_argument_list'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/methods.rb:24:in `process_return'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:68:in `block in map_body'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp.rb:65:in `map'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp.rb:65:in `map'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:68:in `map_body'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb:8:in `process_if'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:68:in `block in map_body'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp.rb:65:in `map'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp.rb:65:in `map'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:68:in `map_body'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/blocks.rb:87:in `process_bodystmt'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/methods.rb:79:in `block in method_body'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/methods.rb:69:in `in_method'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/methods.rb:79:in `method_body'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/methods.rb:9:in `process_def'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:125:in `process_comment'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:68:in `block in map_body'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp.rb:65:in `map'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp.rb:65:in `map'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:68:in `map_body'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/blocks.rb:87:in `process_bodystmt'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:219:in `class_or_module_body'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:57:in `process_module'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:125:in `process_comment'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:68:in `block in map_body'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp.rb:65:in `map'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp.rb:65:in `map'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:68:in `map_body'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_handlers/blocks.rb:87:in `process_bodystmt'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:219:in `class_or_module_body'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:57:in `process_module'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:125:in `process_comment'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:49:in `block in process_program'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp.rb:65:in `map'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp.rb:65:in `map'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:49:in `process_program'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:269:in `block (2 levels) in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:324:in `error_handler'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:268:in `block in process'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:388:in `in_context'
/home/bdunne/.gem/ruby/2.3.3/gems/sexp_processor-4.10.0/lib/sexp_processor.rb:245:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/sexp_processor.rb:39:in `process'
/home/bdunne/.gem/ruby/2.3.3/gems/ripper_ruby_parser-1.1.1/lib/ripper_ruby_parser/parser.rb:21:in `parse'
/home/bdunne/projects/redhat/manageiq/lib/extensions/descendant_loader.rb:75:in `classes_in'
/home/bdunne/projects/redhat/manageiq/lib/extensions/descendant_loader.rb:193:in `classes_in'
/home/bdunne/projects/redhat/manageiq/lib/extensions/descendant_loader.rb:209:in `block in class_inheritance_relationships'
/home/bdunne/projects/redhat/manageiq/lib/extensions/descendant_loader.rb:208:in `glob'
/home/bdunne/projects/redhat/manageiq/lib/extensions/descendant_loader.rb:208:in `class_inheritance_relationships'
/home/bdunne/projects/redhat/manageiq/lib/tasks/evm.rake:102:in `block (3 levels) in <top (required)>'
/home/bdunne/projects/redhat/manageiq/lib/tasks/evm_rake_helper.rb:7:in `with_dummy_database_url_configuration'
/home/bdunne/projects/redhat/manageiq/lib/tasks/evm.rake:100:in `block (2 levels) in <top (required)>'
/home/bdunne/projects/redhat/manageiq/lib/tasks/test_vmdb.rake:32:in `block (2 levels) in <top (required)>'
/home/bdunne/.gem/ruby/2.3.3/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/lib/bundler/cli/exec.rb:74:in `load'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/lib/bundler/cli/exec.rb:74:in `kernel_load'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/lib/bundler/cli/exec.rb:27:in `run'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/lib/bundler/cli.rb:362:in `exec'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/lib/bundler/cli.rb:22:in `dispatch'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/lib/bundler/cli.rb:13:in `start'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/exe/bundle:30:in `block in <top (required)>'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.15.4/exe/bundle:22:in `<top (required)>'
/home/bdunne/.gem/ruby/2.3.3/bin/bundle:22:in `load'
/home/bdunne/.gem/ruby/2.3.3/bin/bundle:22:in `<main>'
Tasks: TOP => test:vmdb_sequential => evm:compile_sti_loader
(See full trace by running task with --trace)
```