### PR TITLE
Change Discovery button logic for Cloud

### DIFF
--- a/app/helpers/application_helper/button/button_new_discover_cloud.rb
+++ b/app/helpers/application_helper/button/button_new_discover_cloud.rb
@@ -1,0 +1,11 @@
+class ApplicationHelper::Button::ButtonNewDiscoverCloud < ApplicationHelper::Button::Basic
+  include ApplicationHelper::Button::Mixins::SubListViewScreenMixin
+
+  def visible?
+    !sub_list_view_screen?
+  end
+
+  def disabled?
+    ManageIQ::Providers::CloudManager.subclasses.select(&:supports_discovery?).count.zero?
+  end
+end

--- a/app/helpers/application_helper/toolbar/ems_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_clouds_center.rb
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
           t,
           :url       => "/discover",
           :url_parms => "?discover_type=ems",
-          :klass     => ApplicationHelper::Button::ButtonNewDiscover),
+          :klass     => ApplicationHelper::Button::ButtonNewDiscoverCloud),
         separator,
         button(
           :ems_cloud_new,


### PR DESCRIPTION
We are disabling discovery for Cloud providers, currently the only two that we support anyway are Azure and Amazon.

By not having any Cloud providers discoverable the Discovery page fails.

I propose we change the button (and the page if someone types the url directly) logic that it detects if the number of discoverable providers is more than zero.