### PR TITLE
Fix spec failing on CloudObjectStoreObject#delete - stub support to true

### DIFF
--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -348,6 +348,7 @@ describe ApplicationController do
     end
 
     it "invokes delete for a selected CloudObjectStoreObject" do
+      allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(true)
       controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
       expect(assigns(:flash_array).first[:message]).to include(
                                                          "Delete initiated for 1 Cloud Object Store Object from the ManageIQ Database"


### PR DESCRIPTION
apparently (according to https://github.com/ManageIQ/manageiq/pull/16111), some CloudObjectStoreObjects do support deletion and some don't.

We're testing both behaviours, but stubbing `supports` only to false for the latter.
This also stubs `supports` to true for the first case.

An alternative would be to have an amazon cloud object store object factory and use that one instead.

@h-kataria WDYT?