### PR TITLE
Value Threshold for Middleware Alerts

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -175,6 +175,9 @@ module MiqPolicyController::Alerts
     if params[:value_mw_garbage_collector]
       @edit[:new][:expression][:options][:value_mw_garbage_collector] = params[:value_mw_garbage_collector]
     end
+    if params[:value_mw_threshold]
+      @edit[:new][:expression][:options][:value_mw_threshold] = params[:value_mw_threshold]
+    end
     if params[:select_mw_operator]
       @edit[:new][:expression][:options][:mw_operator] = params[:select_mw_operator]
     end
@@ -613,6 +616,12 @@ module MiqPolicyController::Alerts
       value_mw_garbage_collector = @edit.fetch_path(:new, :expression, :options, :value_mw_garbage_collector)
       unless value_mw_garbage_collector && is_integer?(value_mw_garbage_collector)
         add_flash(_("Duration Per Minute must be an integer"), :error)
+      end
+    end
+    if %w(mw_tx_committed mw_tx_timeout mw_tx_heuristics mw_tx_application_rollbacks mw_tx_resource_rollbacks mw_tx_aborted).include?(@edit.fetch_path(:new, :expression, :eval_method))
+      value_mw_threshold = @edit.fetch_path(:new, :expression, :options, :value_mw_threshold)
+      unless value_mw_threshold && is_integer?(value_mw_threshold)
+        add_flash(_("Number must be an integer"), :error)
       end
     end
     unless alert.options[:notifications][:email] ||

--- a/app/views/miq_policy/_alert_builtin_exp.html.haml
+++ b/app/views/miq_policy/_alert_builtin_exp.html.haml
@@ -223,6 +223,25 @@
           = h(@alert.expression[:options][:ems_alarm_name])
   - when :mw_operator
     -# Skip this, handled by value_mw_garbage_collector
+  - when :value_mw_threshold
+    %label.control-label.col-md-2
+      = h(option[:description])
+    .col-md-8
+      - if @edit
+        = select_tag('select_mw_operator',
+          options_for_select(@edit[:operators], @edit[:new][:expression][:options][:mw_operator]),
+          :class => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent('select_mw_operator', '#{url}', {beforeSend: true, complete: true})
+        = text_field_tag("value_mw_threshold",
+          @edit[:new][:expression][:options][:value_mw_threshold],
+          :maxlength         => ViewHelper::MAX_NAME_LEN,
+          :class             => "form-control",
+          "data-miq_observe" => observe_with_interval)
+      - else
+        = h(@alert.expression[:options][:mw_operator])
+        = h(@alert.expression[:options][:value_mw_threshold])
   - when :value_mw_garbage_collector
     %label.control-label.col-md-2
       = h(option[:description])


### PR DESCRIPTION
We are working in https://issues.jboss.org/browse/HAWKULAR-1255 and we need a new field called value_mw_threshold with operator for this kind of alerts.

https://github.com/ManageIQ/manageiq/pull/16125 **merged**
https://github.com/ManageIQ/manageiq-providers-hawkular/pull/68 **merged**

![screenshot from 2017-10-05 17-42-04](https://user-images.githubusercontent.com/3019213/31236511-8aa9b566-a9f4-11e7-9573-fb71d88fcc12.png)
