### PR TITLE
Floating IP controller/views should use address instead of name

### DIFF
--- a/app/assets/javascripts/controllers/floating_ip/floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/floating_ip/floating_ip_form_controller.js
@@ -1,6 +1,6 @@
 ManageIQ.angular.app.controller('floatingIpFormController', ['$http', '$scope', 'floatingIpFormId', 'miqService', function($http, $scope, floatingIpFormId, miqService) {
   var vm = this;
-  vm.floatingIpModel = { name: '' };
+  vm.floatingIpModel = { floating_ip_address: '' };
   vm.formId = floatingIpFormId;
   vm.afterGet = false;
   vm.modelCopy = angular.copy( vm.floatingIpModel );
@@ -10,7 +10,7 @@ ManageIQ.angular.app.controller('floatingIpFormController', ['$http', '$scope', 
   vm.saveable = miqService.saveable;
 
   if (floatingIpFormId == 'new') {
-    vm.floatingIpModel.name = "";
+    vm.floatingIpModel.floating_ip_address = "";
     vm.floatingIpModel.description = "";
     vm.newRecord = true;
   } else {

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -76,14 +76,14 @@ class FloatingIpController < ApplicationController
 
   def create_finished
     task_id = session[:async][:params][:task_id]
-    floating_ip_name = session[:async][:params][:name]
+    floating_ip_address = session[:async][:params][:floating_ip_address]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
-      add_flash(_("Floating IP \"%{name}\" created") % { :name  => floating_ip_name })
+      add_flash(_("Floating IP \"%{address}\" created") % { :address => floating_ip_address })
     else
       add_flash(
-        _("Unable to create Floating IP \"%{name}\": %{details}") % { :name    => floating_ip_name,
-                                                                      :details => task.message }, :error)
+        _("Unable to create Floating IP \"%{address}\": %{details}") % { :address => floating_ip_address,
+                                                                         :details => task.message }, :error)
     end
 
     @breadcrumbs.pop if @breadcrumbs
@@ -126,7 +126,7 @@ class FloatingIpController < ApplicationController
     @floating_ip = find_record_with_rbac(FloatingIp, params[:id])
     @in_a_form = true
     drop_breadcrumb(
-      :name => _("Associate Floating IP \"%{name}\"") % { :name  => @floating_ip.name },
+      :name => _("Associate Floating IP \"%{address}\"") % { :address => @floating_ip.address },
       :url  => "/floating_ip/edit/#{@floating_ip.id}")
   end
 
@@ -181,7 +181,7 @@ class FloatingIpController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Edit of Floating IP \"%{name}\" was cancelled by the user") % { :name  => @floating_ip.name })
+      cancel_action(_("Edit of Floating IP \"%{address}\" was cancelled by the user") % { :name => @floating_ip.address })
 
     when "save"
       if @floating_ip.supports_update?
@@ -200,8 +200,8 @@ class FloatingIpController < ApplicationController
           initiate_wait_for_task(:task_id => task_id, :action => "update_finished")
         end
       else
-        add_flash(_("Couldn't initiate update of Floating IP \"%{name}\": %{details}") % {
-          :name    => @floating_ip.name,
+        add_flash(_("Couldn't initiate update of Floating IP \"%{address}\": %{details}") % {
+          :address => @floating_ip.address,
           :details => @floating_ip.unsupported_reason(:update)
         }, :error)
       end
@@ -211,13 +211,13 @@ class FloatingIpController < ApplicationController
   def update_finished
     task_id = session[:async][:params][:task_id]
     floating_ip_id = session[:async][:params][:id]
-    floating_ip_name = session[:async][:params][:name]
+    floating_ip_address = session[:async][:params][:floating_ip_address]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
-      add_flash(_("Floating IP \"%{name}\" updated") % { :name  => floating_ip_name })
+      add_flash(_("Floating IP \"%{address}\" updated") % { :address => floating_ip_address })
     else
-      add_flash(_("Unable to update Floating IP \"%{name}\": %{details}") % {
-        :name    => floating_ip_name,
+      add_flash(_("Unable to update Floating IP \"%{address}\": %{details}") % {
+        :address => floating_ip_address,
         :details => task.message }, :error)
     end
 
@@ -254,7 +254,7 @@ class FloatingIpController < ApplicationController
       floating_ips.each do |floating_ip|
         audit = {
           :event        => "floating_ip_record_delete_initiated",
-          :message      => "[#{floating_ip.name}] Record delete initiated",
+          :message      => "[#{floating_ip.address}] Record delete initiated",
           :target_id    => floating_ip.id,
           :target_class => "FloatingIp",
           :userid       => session[:userid]

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -181,7 +181,7 @@ class FloatingIpController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Edit of Floating IP \"%{address}\" was cancelled by the user") % { :name => @floating_ip.address })
+      cancel_action(_("Edit of Floating IP \"%{address}\" was cancelled by the user") % { :address => @floating_ip.address })
 
     when "save"
       if @floating_ip.supports_update?

--- a/app/views/floating_ip/new.html.haml
+++ b/app/views/floating_ip/new.html.haml
@@ -52,8 +52,8 @@
         = _('Floating IP Address (optional)')
       .col-md-8
         %input.form-control{:type          => "text",
-                            :name          => "name",
-                            'ng-model'     => "vm.floatingIpModel.name",
+                            :name          => "floating_ip_address",
+                            'ng-model'     => "vm.floatingIpModel.floating_ip_address",
                             'ng-maxlength' => 40,
                             :checkchange   => true}
     .form-group


### PR DESCRIPTION
Replaces use of "name" in Floating IP controller and view code with "floating_ip_address" or "address" where appropriate.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1490918
