### PR TITLE
Allow required flag to be set/unset for all dialog field types

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -965,6 +965,11 @@ module MiqAeCustomizationController::Dialogs
     # element type was NOT changed and is present
     elsif !@edit[:field_typ].blank?
       @edit[:field_visible] = key[:visible]
+
+      if params[:field_required]
+        @edit[:field_required] = key[:required] = (params[:field_required] == "true")
+      end
+
       # set default_value - checkbox
       if @edit[:field_typ] =~ /Check/
         if params[:field_default_value]
@@ -986,10 +991,6 @@ module MiqAeCustomizationController::Dialogs
         else
           @edit[:field_default_value] ||= ""
           key[:default_value] ||= ""
-        end
-
-        if params[:field_required]
-          @edit[:field_required] = key[:required] = (params[:field_required] == "true")
         end
       end
 
@@ -1028,10 +1029,6 @@ module MiqAeCustomizationController::Dialogs
 
         if params[:field_single_value]
           @edit[:field_single_value] = key[:single_value] = (params[:field_single_value] == "true")
-        end
-
-        if params[:field_required]
-          @edit[:field_required] = key[:required] = (params[:field_required] == "true")
         end
 
         @edit[:field_sort_by]    = key[:sort_by]    = params[:field_sort_by]  if params[:field_sort_by]


### PR DESCRIPTION
As an add-on to https://github.com/ManageIQ/manageiq-ui-classic/pull/2185 discovered in the 5.8 clone: https://bugzilla.redhat.com/show_bug.cgi?id=1496946

#2185 fixed the ability to set the required property for dynamic drop down fields, but for some reason the required property was never included in the `dialog_get_form_vars_field` method for drop downs (as well as checkboxes).

This PR refactors the line for checking the required parameter that gets passed in when you click the checkbox in the UI, and ensures that it saves.

Note that again, the new dialog editor does not have this problem.

Original related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1492150

/cc @gmcculloug
@miq-bot add_label euwe/yes, fine/yes, bug
@miq-bot assign @h-kataria
