### PR TITLE
Fixed path to jquery and jquery-ui in the asset pipeline

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,7 +2,7 @@
 //= require es6-shim
 //= require array-includes
 //= require fetch
-//= require jquery
+//= require jquery/dist/jquery.js
 //= require jquery_overrides
 //= require i18n
 //= require patternfly
@@ -42,7 +42,7 @@
 //= require automate_import_export
 //= require dialog_field_refresh
 //= require miq_c3_config
-//= require jquery-ui
+//= require jquery-ui/jquery-ui.js
 //= require bootstrap
 //= require bootstrap-datepicker
 //= require eonasdan-bootstrap-datetimepicker

--- a/app/views/layouts/remote_console.html.haml
+++ b/app/views/layouts/remote_console.html.haml
@@ -6,7 +6,7 @@
     = favicon_link_tag
     = stylesheet_link_tag 'application'
     -# Load the required JS based on the console type
-    = javascript_include_tag 'jquery', "remote_consoles/#{@console[:type]}"
+    = javascript_include_tag 'jquery/dist/jquery.js', "remote_consoles/#{@console[:type]}"
     -# Css for the unified look & feel
     :css
       #remote-console {

--- a/app/views/vm_common/console_vmrc.html.haml
+++ b/app/views/vm_common/console_vmrc.html.haml
@@ -2,7 +2,7 @@
 %html{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
     = favicon_link_tag
-    = javascript_include_tag 'jquery'
+    = javascript_include_tag 'jquery/dist/jquery.js'
     :javascript
       // INITIALIZE
       $(document).ready(function(){

--- a/app/views/vm_common/console_webmks.html.haml
+++ b/app/views/vm_common/console_webmks.html.haml
@@ -5,7 +5,7 @@
       = _('%{product_name} WebMKS Remote Console') % {:product_name => I18n.t('product.name')}
     = favicon_link_tag
     = stylesheet_link_tag 'webmks'
-    = javascript_include_tag 'jquery', 'jquery-ui', 'webmks'
+    = javascript_include_tag 'jquery/dist/jquery.js', 'jquery-ui/jquery-ui.js', 'webmks'
     :javascript
       $(function () {
         var wmks = WMKS.createWMKS('wmksContainer', {}).register(WMKS.CONST.Events.CONNECTION_STATE_CHANGE, function (event,data) {


### PR DESCRIPTION
Somehow the path to the `jquery` and `jquery-ui` bower packages is not always interpolated properly in production. Found this issue while debugging some WebMKS issues in the latest upstream build. Setting the paths properly makes both issues disappear...

https://bugzilla.redhat.com/show_bug.cgi?id=1496850
https://bugzilla.redhat.com/show_bug.cgi?id=1497830

@miq-bot add_label bug, consoles