### PR TITLE
Translating availabilities/status for Domains/Servers/Deploys

### DIFF
--- a/app/helpers/middleware_deployment_helper/textual_summary.rb
+++ b/app/helpers/middleware_deployment_helper/textual_summary.rb
@@ -1,4 +1,6 @@
 module MiddlewareDeploymentHelper::TextualSummary
+  include TextualMixins::TextualAvailability
+
   #
   # Groups
   #
@@ -13,6 +15,6 @@ module MiddlewareDeploymentHelper::TextualSummary
   end
 
   def textual_status
-    @record.status
+    translated_status(@record.status)
   end
 end

--- a/app/helpers/middleware_domain_helper/textual_summary.rb
+++ b/app/helpers/middleware_domain_helper/textual_summary.rb
@@ -1,10 +1,12 @@
 module MiddlewareDomainHelper::TextualSummary
+  include TextualMixins::TextualAvailability
+
   def textual_group_properties
     TextualGroup.new(_("Properties"), %i(name nativeid state))
   end
 
   def textual_state
-    @record.properties['Availability']
+    translated_status(@record.properties['Availability'])
   end
 
   def textual_group_relationships

--- a/app/helpers/middleware_server_helper/textual_summary.rb
+++ b/app/helpers/middleware_server_helper/textual_summary.rb
@@ -1,4 +1,6 @@
 module MiddlewareServerHelper::TextualSummary
+  include TextualMixins::TextualAvailability
+
   #
   # Groups
   #
@@ -45,7 +47,7 @@ module MiddlewareServerHelper::TextualSummary
   def textual_server_state
     {
       :label => _('Server State'),
-      :value => (@record.properties['Calculated Server State'] || @record.properties['Server State']).to_s.capitalize
+      :value => translated_status(@record.properties['Calculated Server State'] || @record.properties['Server State'])
     }
   end
 

--- a/app/helpers/textual_mixins/textual_availability.rb
+++ b/app/helpers/textual_mixins/textual_availability.rb
@@ -1,0 +1,16 @@
+module TextualMixins::TextualAvailability
+  STATUS_TRANSLATIONS = {
+    'enabled'  => N_('Enabled'),
+    'disabled' => N_('Disabled'),
+    'running'  => N_('Running'),
+    'up'       => N_('Running'),
+    'stopped'  => N_('Stopped'),
+    'down'     => N_('Stopped'),
+    'unknown'  => N_('Unknown')
+  }.freeze
+
+  def translated_status(status)
+    status ||= 'unknown'
+    STATUS_TRANSLATIONS.key?(status.downcase) ? _(STATUS_TRANSLATIONS[status.downcase]) : status
+  end
+end

--- a/spec/helpers/textual_mixins/textual_availability_spec.rb
+++ b/spec/helpers/textual_mixins/textual_availability_spec.rb
@@ -1,0 +1,22 @@
+describe TextualMixins::TextualAvailability do
+  describe '#translated_status' do
+    subject { helper.translated_status(status) }
+
+    before do
+      stub_const("TextualMixins::TextualAvailability::STATUS_TRANSLATIONS",
+                 'running' => N_('Translation'))
+    end
+
+    context 'when status is in the translation key' do
+      let(:status) { 'Running' }
+
+      it { is_expected.to eq 'Translation' }
+    end
+
+    context 'when status is not in the translation key' do
+      let(:status) { 'Untranslated' }
+
+      it { is_expected.to eq 'Untranslated' }
+    end
+  end
+end


### PR DESCRIPTION
Status literals of Domain/Server/Deployment translated and `titleized`.

Deployment status:
![translate-deployment](https://user-images.githubusercontent.com/613814/31330651-8d47f074-acdf-11e7-9449-0f3007b4c2c3.png)

Domain state:
![translate-domain](https://user-images.githubusercontent.com/613814/31330649-8d3c5304-acdf-11e7-80d4-a2404df9ab7f.png)

Server state:
![translate-server](https://user-images.githubusercontent.com/613814/31330650-8d3cbbb4-acdf-11e7-86e8-bbced03c3aed.png)
