### PR TITLE
Make the dragdrop placeholder in the main dashboard visible

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -784,17 +784,35 @@ function miqClearLoginFields() {
 // Initialize dashboard column jQuery sortables
 function miqInitDashboardCols() {
   if (miqDomElementExists('col1')) {
-    $('#col1').sortable({connectWith: '#col2, #col3', handle: '.sortable-handle'});
+    $('#col1').sortable({
+      connectWith: '#col2, #col3',
+      handle: '.sortable-handle',
+      helper: 'clone',
+      placeholder: 'sortable-placeholder',
+      forcePlaceholderSize: true,
+    });
     $('#col1').off('sortupdate');
     $('#col1').on('sortupdate', miqDropComplete);
   }
   if (miqDomElementExists('col2')) {
-    $('#col2').sortable({connectWith: '#col1, #col3', handle: '.sortable-handle'});
+    $('#col2').sortable({
+      connectWith: '#col1, #col3',
+      handle: '.sortable-handle',
+      helper: 'clone',
+      placeholder: 'sortable-placeholder',
+      forcePlaceholderSize: true,
+    });
     $('#col2').off('sortupdate');
     $('#col2').on('sortupdate', miqDropComplete);
   }
   if (miqDomElementExists('col3')) {
-    $('#col3').sortable({connectWith: '#col1, #col2', handle: '.sortable-handle'});
+    $('#col3').sortable({
+      connectWith: '#col1, #col2',
+      handle: '.sortable-handle',
+      helper: 'clone',
+      placeholder: 'sortable-placeholder',
+      forcePlaceholderSize: true,
+    });
     $('#col3').off('sortupdate');
     $('#col3').on('sortupdate', miqDropComplete);
   }

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -896,6 +896,12 @@ img.tiny { margin: 0; padding: 0;width:20px;height:20px; border: 0; vertical-ali
   border: none !important;
 }
 
+.sortable-placeholder {
+  background-color: rgba(255, 255, 255, 0.8);
+  border: 2px dashed #ddd;
+}
+
 /// ===================================================================
 /// end misc styling
 /// ===================================================================
+


### PR DESCRIPTION
The `sortable` module in `jquery-ui` is not sensitive enough when moving a dashboard widget to the bottom of the page. I was trying to add some temporary extra padding when moving a widget, but that was not working. But as we're moving towards angular we'll drop all the `jquery` code and so the issue will disappear. Until then I'm adding this placeholder feature to help the drag & drop process to be more understandable for the user.

![screenshot from 2017-10-09 10-52-08](https://user-images.githubusercontent.com/649130/31330780-0e223678-ace0-11e7-8a37-aede8e74c2f0.png)

@epwinchell can you please review the styling of the placeholder box? I'm pretty sure I did it wrong :wink: 

https://bugzilla.redhat.com/show_bug.cgi?id=1485637