### PR TITLE
Fix selection of Hosts in HAC tree

### DIFF
--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -6,7 +6,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
   has_kids_for ResourcePool, [:x_get_resource_pool_kids]
 
   def override(node, object, _pid, options)
-    if [ExtManagementSystem, EmsCluster, Datacenter, EmsFolder, ResourcePool].any? { |klass| object.kind_of?(klass) }
+    if [ExtManagementSystem, EmsCluster, Datacenter, EmsFolder, ResourcePool, Host].any? { |klass| object.kind_of?(klass) }
       node[:select] = if @assign_to
                         options.key?(:selected) && options[:selected].include?("ResourcePool_#{object[:id]}")
                       else


### PR DESCRIPTION
Configuration -> Access Control -> Group -> select any group -> select Hosts/Nodes & Clusters/Deployment Roles

Edit selected group to have one or more Hosts. See tree after save.

Before:
<img width="414" alt="screen shot 2017-10-09 at 11 12 43 am" src="https://user-images.githubusercontent.com/9210860/31331623-64dbf956-ace3-11e7-8670-d412e720f541.png">

After:
<img width="345" alt="screen shot 2017-10-09 at 11 10 45 am" src="https://user-images.githubusercontent.com/9210860/31331619-61e8acd0-ace3-11e7-90c6-79c0cfd723ab.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1464960

@miq-bot add_label fine/yes, trees, bug