### PR TITLE
Setup data for modal component

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -68,13 +68,13 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
       tab: '<dialog-editor-modal-tab></dialog-editor-modal-tab>',
       box: '<dialog-editor-modal-box></dialog-editor-modal-box>',
       field: '<dialog-editor-modal-field></dialog-editor-modal-field>',
-    }
+    };
     vm.modalOptions = {
       template: templates[type],
       size: 'lg',
     };
-    vm.elementData = { type: type, tabId: tab, boxId: box, fieldId: field, }
-    vm.visible = true
+    vm.elementData = { type: type, tabId: tab, boxId: box, fieldId: field };
+    vm.visible = true;
   }
 
   var beingCloned = null; // hack that solves recursion problem for cloneDeep

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -73,7 +73,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
       template: templates[type],
       size: 'lg',
     };
-    vm.elementData = { type: type, tabId: tab, boxId: box, fieldId: field };
+    vm.elementInfo = { type: type, tabId: tab, boxId: box, fieldId: field };
     vm.visible = true;
   }
 

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -64,13 +64,13 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
   vm.setupModalOptions = setupModalOptions;
 
   function setupModalOptions(type, tab, box, field) {
-    var templates = {
-      tab: '<dialog-editor-modal-tab></dialog-editor-modal-tab>',
-      box: '<dialog-editor-modal-box></dialog-editor-modal-box>',
-      field: '<dialog-editor-modal-field></dialog-editor-modal-field>',
-    };
+    var components = {
+      tab: 'dialog-editor-modal-tab',
+      box: 'dialog-editor-modal-box',
+      field: 'dialog-editor-modal-field'
+    }
     vm.modalOptions = {
-      template: templates[type],
+      component: components[type],
       size: 'lg',
     };
     vm.elementInfo = { type: type, tabId: tab, boxId: box, fieldId: field };

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -61,6 +61,21 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
 
   vm.saveDialogDetails = saveDialogDetails;
   vm.dismissChanges = dismissChanges;
+  vm.setupModalOptions = setupModalOptions;
+
+  function setupModalOptions(type, tab, box, field) {
+    var templates = {
+      tab: '<dialog-editor-modal-tab></dialog-editor-modal-tab>',
+      box: '<dialog-editor-modal-box></dialog-editor-modal-box>',
+      field: '<dialog-editor-modal-field></dialog-editor-modal-field>',
+    }
+    vm.modalOptions = {
+      template: templates[type],
+      size: 'lg',
+    };
+    vm.elementData = { type: type, tabId: tab, boxId: box, fieldId: field, }
+    vm.visible = true
+  }
 
   var beingCloned = null; // hack that solves recursion problem for cloneDeep
   function customizer(value) {

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -68,7 +68,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
       tab: 'dialog-editor-modal-tab',
       box: 'dialog-editor-modal-box',
       field: 'dialog-editor-modal-field'
-    }
+    };
     vm.modalOptions = {
       component: components[type],
       size: 'lg',

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -17,7 +17,7 @@
               {{ vm.dialog.content[0].description }}
     .dialog-designer-container
       %dialog-editor-modal{"modal-options" => "vm.modalOptions",
-                           "dialog-data" => "vm.dialogData",
+                           "element-info" => "vm.elementInfo",
                            :visible => "vm.modalVisible"}
       .toolbox-container
         #toolbox.static-field-container

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -24,8 +24,8 @@
           .draggable
             %dialog-editor-field-static
         .editable-fields-container
-          %dialog-editor-tabs
-          %dialog-editor-boxes
+          %dialog-editor-tabs{"setup-modal-options" => "vm.setupModalOptions(type, tab, box, field)"}
+          %dialog-editor-boxes{"setup-modal-options" => "vm.setupModalOptions(type, tab, box, field)"}
 
     .pull-right
       %button.btn.btn-default{"ng-click" => "vm.dismissChanges()",

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -16,6 +16,9 @@
               :title => _("Dialog's description")}
               {{ vm.dialog.content[0].description }}
     .dialog-designer-container
+      %dialog-editor-modal{"modal-options" => "vm.modalOptions",
+                           "dialog-data" => "vm.dialogData",
+                           :visible => "vm.modalVisible"}
       .toolbox-container
         #toolbox.static-field-container
           .draggable


### PR DESCRIPTION
## Description

After this changes, the modal component added in https://github.com/ManageIQ/ui-components/pull/177 will be used.

This change is done, so we can integrate a automate tree selector into the modal.

method `setupModalOptions` sets which component with template should be rendered in the modal
according to where the button to open modal was pressed.

## Links

https://www.pivotaltracker.com/n/projects/1613907/stories/150600064
https://www.pivotaltracker.com/n/projects/1613907/stories/150614221

## Steps for Testing/QA

Automation -> Automate -> Customization -> Edit Dialog in Dialog Editor -> try to open a modal