### PR TITLE
[WIP] Add check that user is allowed to view cluster/resource pool children

### DIFF
--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -101,10 +101,18 @@ class TreeBuilderDatacenter < TreeBuilder
   end
 
   def x_get_tree_cluster_kids(parent, count_only = false)
-    count_only_or_many_objects(count_only, parent.resource_pools, parent.hosts, parent.vms, "name")
+    if parent.authorized_for_user?(@user_id)
+      count_only_or_many_objects(count_only, parent.resource_pools, parent.hosts, parent.vms, "name")
+    else
+      count_only ? 0 : []
+    end
   end
 
   def x_get_resource_pool_kids(parent, count_only = false)
-    count_only_or_many_objects(count_only, parent.resource_pools, parent.vms, "name")
+    if parent.authorized_for_user?(@user_id)
+      count_only_or_many_objects(count_only, parent.resource_pools, parent.vms, "name")
+    else
+      count_only ? 0 : []
+    end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1446580

Steps to Reproduce:
1. Navigate to Configuration->Access Control
2. Add Role, add group with created role, assign a tag for this group(ex. CostCenter->Cost Center 001)
3. Create user and assign it to the group
4. Add infra provider
5. Assign tag to cluster
6. Log in as restricted user
7. Navigate Compute -> Infrastructure -> Clusters
8. Open cluster detail page
9. In cluster navigation tree select Relationships-> All VMs(Tree View)
10. Click on one of VMs

Before:
invalid input
After:
Only allowed VMs are shown.

@miq-bot add_label bug, trees, wip