### PR TITLE
Fix Codeclimate issue for group_by_label 

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1675,7 +1675,7 @@ module ReportController::Reports::Editor
         msg = _('A Group by Tag must be selected')
       elsif @edit[:new][:cb_groupby] == "label" && !@edit[:new][:cb_groupby_label].present?
         msg = _('A Group by Label must be selected')
-      elsif @edit[:new][:cb_groupby] == "label" && rpt.cols.any? { |x| x.include? (CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX) }
+      elsif @edit[:new][:cb_groupby] == "label" && rpt.cols.any? { |x| x.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX) }
         msg = _('Can not add label columns when grouping by label')
       end
 


### PR DESCRIPTION
Remove the space between  the name of a called method and a left parenthesis

Links
----------------
Follow up for https://github.com/ManageIQ/manageiq-ui-classic/pull/2277

