### PR TITLE
[WIP] Enable additional options

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -407,7 +407,7 @@
   * @param {Boolean} isExplorer true | false if we are in explorer part of application.
   * @param {Object} settings settings object.
   * @param {Array} records array of reccords.
-  * @param {Object} additionalOptions
+  * @param {Object} additionalOptions specific options for current view.
   * @returns {Object} promise of retriveRowsAndColumnsFromUrl of MiQDataTableService.
   */
   ReportDataController.prototype.getData = function(modelName,

--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -292,7 +292,8 @@
                         initObject.parentId,
                         initObject.isExplorer,
                         this.settings,
-                        initObject.records)
+                        initObject.records,
+                        initObject.additionalOptions)
       .then(function(data) {
         this.settings.hideSelect = initObject.hideSelect;
         var start = (this.settings.current - 1) * this.settings.perpage;
@@ -406,9 +407,16 @@
   * @param {Boolean} isExplorer true | false if we are in explorer part of application.
   * @param {Object} settings settings object.
   * @param {Array} records array of reccords.
+  * @param {Object} additionalOptions
   * @returns {Object} promise of retriveRowsAndColumnsFromUrl of MiQDataTableService.
   */
-  ReportDataController.prototype.getData = function(modelName, activeTree, parentId, isExplorer, settings, records) {
+  ReportDataController.prototype.getData = function(modelName,
+                                                    activeTree,
+                                                    parentId,
+                                                    isExplorer,
+                                                    settings,
+                                                    records,
+                                                    additionalOptions) {
     var basicSettings = {
       current: 1,
       perpage: 20,
@@ -416,7 +424,7 @@
       sort_dir: 'DESC',
     };
     return this.MiQDataTableService
-      .retrieveRowsAndColumnsFromUrl(modelName, activeTree, parentId, isExplorer, settings, records)
+      .retrieveRowsAndColumnsFromUrl(modelName, activeTree, parentId, isExplorer, settings, records, additionalOptions)
       .then(function(gtlData) {
         this.settings = gtlData.settings || basicSettings;
         if (this.settings.sort_col === -1) {

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -209,6 +209,7 @@ module ApplicationController::CiProcessing
     end
     @layout = session["#{self.class.session_key_prefix}_type".to_sym] if session["#{self.class.session_key_prefix}_type".to_sym]
     @current_page = @pages[:current] unless @pages.nil? # save the current page number
+    process_show_list_options(options)
     build_listnav_search_list(@view.db) if !["miq_task"].include?(@layout) && !session[:menu_click]
   end
 

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -491,6 +491,7 @@ class ProviderForemanController < ApplicationController
 
   def process_show_list(options = {})
     options.merge!(update_options)
+    process_show_list_options(options)
     super
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1612,6 +1612,13 @@ module ApplicationHelper
     end
   end
 
+  def process_show_list_options(options)
+    # Warning: Please do not add any SQL options here.
+    @report_data_additiona_options = {
+      :named_scope => options[:named_scope]
+    }.freeze
+  end
+
   # Wrapper around jquery-rjs' remote_function which adds an extra .html_safe()
   # Remove if merged: https://github.com/amatsuda/jquery-rjs/pull/3
   def remote_function(options)

--- a/app/views/layouts/angular/_gtl.html.haml
+++ b/app/views/layouts/angular/_gtl.html.haml
@@ -40,6 +40,7 @@
   sendDataWithRx({initController: {
     name: 'reportDataController',
     data: {
+      additionalOptions: #{@report_data_additiona_options.to_json},
       modelName: '#{h(j_str(model_name))}',
       activeTree: '#{active_tree}',
       gtlType: '#{h(gtl_type_string)}',

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -308,6 +308,7 @@ describe AutomationManagerController do
     end
 
     it "renders the list view based on the nodetype(root,provider) and the search associated with it" do
+      controller.instance_variable_set(:@in_report_data, true)
       controller.instance_variable_set(:@_params, :id => "root")
       controller.instance_variable_set(:@search_text, "manager")
       controller.send(:tree_select)
@@ -358,6 +359,7 @@ describe AutomationManagerController do
 
     it "renders tree_select for ansible tower job templates tree node" do
       allow(controller).to receive(:x_active_tree).and_return(:configuration_scripts_tree)
+      controller.instance_variable_set(:@in_report_data, true)
       controller.instance_variable_set(:@_params, :id => "configuration_scripts")
       controller.send(:accordion_select)
       controller.instance_variable_set(:@_params, :id => "at-" + ApplicationRecord.compress_id(@automation_manager1.id))

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -20,6 +20,7 @@ describe CatalogController do
 
   it "returns all catalog items related to current tenant and root tenant when non-self service user is logged" do
     login_as child_tenant_user
+    controller.instance_variable_set(:@in_report_data, true)
     view, _pages = controller.send(:get_view, ServiceTemplate, {})
     expect(view.table.data.count).to eq(2)
   end
@@ -27,12 +28,14 @@ describe CatalogController do
   it "returns all catalog items related to current user's groups when self service user is logged" do
     allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
     login_as child_tenant_user
+    controller.instance_variable_set(:@in_report_data, true)
     view, _pages = controller.send(:get_view, ServiceTemplate, {})
     expect(view.table.data.count).to eq(1)
   end
 
   it "returns all catalog items when admin user is logged" do
     login_as admin_user
+    controller.instance_variable_set(:@in_report_data, true)
     view, _pages = controller.send(:get_view, ServiceTemplate, {})
     expect(view.table.data.count).to eq(2)
   end

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -37,7 +37,7 @@ describe MiqRequestController do
       login_as user_parent_tenant
       controller.instance_variable_set(:@settings, {})
       allow_any_instance_of(MiqRequestController).to receive(:fileicon)
-
+      controller.instance_variable_set(:@in_report_data, true)
       view, _pages = controller.send(:get_view, MiqRequest, {})
       expect(view.table.data.count).to eq(1)
     end

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -128,6 +128,7 @@ describe OpsController do
       it "gets the list of tenants" do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@settings, {})
+        controller.instance_variable_set(:@in_report_data, true)
         expect(response.status).to eq(200)
         controller.send(:rbac_tenants_list)
         expect(assigns(:view)).not_to be_nil

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -281,6 +281,7 @@ describe ProviderForemanController do
     end
 
     it "renders right cell text for ConfigurationManagerForeman node" do
+      controller.instance_variable_set(:@in_report_data, true)
       ems_id = ems_key_for_provider(@provider)
       controller.instance_variable_set(:@_params, :id => ems_id)
       controller.send(:tree_select)
@@ -320,6 +321,7 @@ describe ProviderForemanController do
     it "renders the list view based on the nodetype(root,provider,config_profile) and the search associated with it" do
       controller.instance_variable_set(:@_params, :id => "root")
       controller.instance_variable_set(:@search_text, "manager")
+      controller.instance_variable_set(:@in_report_data, true)
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
       expect(view.table.data.size).to eq(2)
@@ -380,6 +382,7 @@ describe ProviderForemanController do
 
     it "renders tree_select for a ConfigurationManagerForeman node that contains an unassigned profile" do
       ems_id = ems_key_for_provider(@provider)
+      controller.instance_variable_set(:@in_report_data, true)
       controller.instance_variable_set(:@_params, :id => ems_id)
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
@@ -395,6 +398,7 @@ describe ProviderForemanController do
 
     it "renders tree_select for a ConfigurationManagerForeman node that contains only an unassigned profile" do
       ems_id = ems_key_for_provider(@provider2)
+      controller.instance_variable_set(:@in_report_data, true)
       controller.instance_variable_set(:@_params, :id => ems_id)
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
@@ -404,12 +408,14 @@ describe ProviderForemanController do
 
     it "renders tree_select for an 'Unassigned Profiles Group' node for the first provider" do
       controller.instance_variable_set(:@_params, :id => "-#{ems_id_for_provider(@provider)}-unassigned")
+      controller.instance_variable_set(:@in_report_data, true)
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
       expect(view.table.data[0].data).to include('hostname' => "configured_system_unprovisioned")
     end
 
     it "renders tree_select for an 'Unassigned Profiles Group' node for the second provider" do
+      controller.instance_variable_set(:@in_report_data, true)
       controller.instance_variable_set(:@_params, :id => "-#{ems_id_for_provider(@provider2)}-unassigned")
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
@@ -438,6 +444,7 @@ describe ProviderForemanController do
     end
 
     it "does not display an automation manger configured system in the Configured Systems accordion" do
+      controller.instance_variable_set(:@in_report_data, true)
       stub_user(:features => :all)
       FactoryGirl.create(:configured_system_ansible_tower)
       allow(controller).to receive(:x_active_tree).and_return(:configuration_manager_cs_filter_tree)

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1223,6 +1223,7 @@ describe ReportController do
         end
 
         it "is allowed to see report created under Group1 for User 1(with current group Group2)" do
+          controller.instance_variable_set(:@in_report_data, true)
           controller.instance_variable_set(:@_params, :controller => "report", :action => "explorer")
           seed_session_trees('report', :saved_reports)
           allow(controller).to receive(:get_view_calculate_gtl_type).and_return("list")


### PR DESCRIPTION
### Additional options for report_data
Define new function in `app_helper` to set additional options for report data, which (right now) holds only `named_scope` when generating view. This can expand over couple of options. These options are then sent to server as `additional_options` in payload for report_data.

### Do not fetch multiple times view from DB
When generating view and attrs (settings) inside `get_view` function check if this function was called from `report_data` and if not, do not fetch these data from DB. It's dirty hack, but it will move us towards more cleaner and nicer way of fetching data for reports.

### Dependencies
To have this PR fully functional merge https://github.com/ManageIQ/ui-components/pull/176 as well (it's not blocked by it, but no additional options will be sent to report data unless it's merged)