### PR TITLE
Remove items keyword in My Settings

### DIFF
--- a/app/controllers/mixins/controller_constants.rb
+++ b/app/controllers/mixins/controller_constants.rb
@@ -1,15 +1,6 @@
 module Mixins
   module ControllerConstants
     # Per page choices and default
-    PPCHOICES = [
-      [N_("5 Items"), 5],
-      [N_("10 Items"), 10],
-      [N_("20 Items"), 20],
-      [N_("50 Items"), 50],
-      [N_("100 Items"), 100],
-      [N_("200 Items"), 200],
-      [N_("500 Items"), 500],
-      [N_("1000 Items"), 1000]
-    ].freeze
+    PPCHOICES = [5, 10, 20, 50, 100, 200, 500, 1000].map { |item| [item.to_s, item] }.freeze
   end
 end


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1422416

Remove "items" keyword from the dropdown list of Default Items Per Page.
Remove the keyword also from the dropdown list of Topology Default Items
in View.

Before:
![items1](https://user-images.githubusercontent.com/13417815/31384755-9d1bd38a-adc0-11e7-9e90-c9cfb47128eb.png)

After:
![items2](https://user-images.githubusercontent.com/13417815/31384757-a053311a-adc0-11e7-99da-2863086b5565.png)
