### PR TITLE
Try to capitalize when determining container status in topology

### DIFF
--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -65,7 +65,7 @@ class ContainerTopologyService < TopologyService
     elsif entity.kind_of?(ContainerGroup)
       status = entity.phase
     elsif entity.kind_of?(Container)
-      status = entity.state.capitalize
+      status = entity.state.try(:capitalize)
     elsif entity.kind_of?(ContainerReplicator)
       status = entity.current_replicas == entity.replicas ? 'OK' : 'Warning'
     elsif entity.kind_of?(ManageIQ::Providers::ContainerManager)

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -188,4 +188,18 @@ describe ContainerTopologyService do
       )
     end
   end
+
+  describe '#entity_status' do
+    context 'entity is a container' do
+      let(:entity) { FactoryGirl.create(:container) }
+
+      context 'state is not defined' do
+        before { allow(entity).to receive(:state).and_return(nil) }
+
+        it 'returns with nil' do
+          expect(container_topology_service.entity_status(entity)).to be_nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
It seems like `Container#state` can be `nil` sometimes and it throws and error when the topology `capitalize`s it. In other topology services we fixed this by using `try`, so here will be the same...

Spotted by @tbielawa, fixes #1275
https://bugzilla.redhat.com/show_bug.cgi?id=1500401