### PR TITLE
Adding section for Physical Servers in default filters configuration screen

### DIFF
--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -12,7 +12,8 @@ class TreeBuilderDefaultFilters < TreeBuilder
     :"manageiq::providers::cloudmanager::template" => %w(Cloud Instances Images),
     :"manageiq::providers::inframanager::template" => %w(Infrastructure Virtual\ Machines Templates),
     :"manageiq::providers::cloudmanager::vm"       => %w(Cloud Instances Instances),
-    :"manageiq::providers::inframanager::vm"       => %w(Infrastructure Virtual\ Machines VMs)
+    :"manageiq::providers::inframanager::vm"       => %w(Infrastructure Virtual\ Machines VMs),
+    :physicalserver                                => %w(Physical\ Infrastructure Servers)
   }.freeze
 
   def prepare_data(data)


### PR DESCRIPTION
**Depends on:**

https://github.com/ManageIQ/manageiq/pull/16158

This PR is able to:

- Add in "My Settings" -> "Default Filters" the section "Physical Infrastructure" to configure filters for physical servers.

![image](https://user-images.githubusercontent.com/8550928/31389891-c4b31862-ada8-11e7-80fe-c5ba52fb34e3.png)

- Also adds the filters to the page "Compute" ->  "Physical Infrastructure" -> "Servers"

![image](https://user-images.githubusercontent.com/8550928/31390012-1ddbfd28-ada9-11e7-9916-faae7980d952.png)