### PR TITLE
Add Picture support in Generic Object Definition editor

### DIFF
--- a/app/assets/javascripts/components/generic_object/custom-image-component.js
+++ b/app/assets/javascripts/components/generic_object/custom-image-component.js
@@ -5,6 +5,7 @@ ManageIQ.angular.app.component('customImageComponent', {
     angularForm: '<',
     pictureUrlPath: '@',
     pictureUploaded: '=',
+    pictureRemove: '=',
     pictureReset: '<',
   },
   controllerAs: 'vm',
@@ -71,6 +72,11 @@ function customImageComponentController($timeout) {
     if (!vm.changeImage) {
       restoreOriginalStatus();
     }
+  };
+
+  vm.removeImage = function() {
+    Object.assign(vm.picture, {});
+    vm.pictureRemove = true;
   };
 
   function restoreOriginalStatus() {

--- a/app/assets/javascripts/components/generic_object/custom-image-component.js
+++ b/app/assets/javascripts/components/generic_object/custom-image-component.js
@@ -3,6 +3,7 @@ ManageIQ.angular.app.component('customImageComponent', {
     picture: '=',
     newRecord: '<',
     angularForm: '<',
+    pictureUrlPath: '@',
   },
   controllerAs: 'vm',
   controller: customImageComponentController,
@@ -16,6 +17,7 @@ function customImageComponentController($timeout) {
 
   vm.$onInit = function() {
     vm.imageUploadStatus = "";
+    vm.changeImage = false;
   };
 
   vm.uploadClicked = function() {
@@ -53,6 +55,14 @@ function customImageComponentController($timeout) {
 
     if (imageFile) {
       reader.readAsBinaryString(imageFile);
+    }
+  };
+
+  vm.changeImageSelected = function() {
+    if (!vm.changeImage) {
+      vm.angularForm.generic_object_definition_image_file_status.$setValidity("incompatibleFileType", true);
+      vm.imageUploadStatus = "";
+      angular.element(":file").filestyle('clear');
     }
   };
 }

--- a/app/assets/javascripts/components/generic_object/custom-image-component.js
+++ b/app/assets/javascripts/components/generic_object/custom-image-component.js
@@ -33,9 +33,9 @@ function customImageComponentController($timeout) {
 
     if (angular.element('#generic_object_definition_image_file')[0].files.length === 0) {
       return;
-    } else {
-      imageFile = angular.element('#generic_object_definition_image_file')[0].files[0];
     }
+
+    imageFile = angular.element('#generic_object_definition_image_file')[0].files[0];
 
     var reader = new FileReader();
     vm.imageUploadStatus = "";
@@ -56,7 +56,7 @@ function customImageComponentController($timeout) {
     reader.onload = function(event) {
       vm.picture.content = btoa(event.target.result);
 
-      $timeout(function(){
+      $timeout(function() {
         vm.angularForm.generic_object_definition_image_file_status.$setValidity("incompatibleFileType", true);
         vm.imageUploadStatus = __("Image upload complete");
         vm.pictureUploaded = true;
@@ -69,7 +69,7 @@ function customImageComponentController($timeout) {
   };
 
   vm.changeImageSelected = function() {
-    if (!vm.changeImage) {
+    if (! vm.changeImage) {
       restoreOriginalStatus();
     }
   };

--- a/app/assets/javascripts/components/generic_object/custom-image-component.js
+++ b/app/assets/javascripts/components/generic_object/custom-image-component.js
@@ -5,6 +5,7 @@ ManageIQ.angular.app.component('customImageComponent', {
     angularForm: '<',
     pictureUrlPath: '@',
     pictureUploaded: '=',
+    pictureReset: '<',
   },
   controllerAs: 'vm',
   controller: customImageComponentController,
@@ -19,6 +20,11 @@ function customImageComponentController($timeout) {
   vm.$onInit = function() {
     vm.imageUploadStatus = "";
     vm.changeImage = false;
+  };
+
+  vm.$onChanges = function() {
+    vm.changeImage = false;
+    restoreOriginalStatus();
   };
 
   vm.uploadClicked = function() {
@@ -42,6 +48,7 @@ function customImageComponentController($timeout) {
     } else {
       vm.angularForm.generic_object_definition_image_file_status.$setValidity("incompatibleFileType", false);
       vm.imageUploadStatus = __("Incompatible image type");
+      vm.pictureUploaded = true;
       return;
     }
 
@@ -62,9 +69,15 @@ function customImageComponentController($timeout) {
 
   vm.changeImageSelected = function() {
     if (!vm.changeImage) {
-      vm.angularForm.generic_object_definition_image_file_status.$setValidity("incompatibleFileType", true);
-      vm.imageUploadStatus = "";
-      angular.element(":file").filestyle('clear');
+      restoreOriginalStatus();
     }
   };
+
+  function restoreOriginalStatus() {
+    if (vm.angularForm.generic_object_definition_image_file_status) {
+      vm.angularForm.generic_object_definition_image_file_status.$setValidity("incompatibleFileType", true);
+    }
+    vm.imageUploadStatus = "";
+    angular.element(":file").filestyle('clear');
+  }
 }

--- a/app/assets/javascripts/components/generic_object/custom-image-component.js
+++ b/app/assets/javascripts/components/generic_object/custom-image-component.js
@@ -23,9 +23,11 @@ function customImageComponentController($timeout) {
     vm.changeImage = false;
   };
 
-  vm.$onChanges = function() {
-    vm.changeImage = false;
-    restoreOriginalStatus();
+  vm.$onChanges = function(changes) {
+    if (changes.pictureReset) {
+      vm.changeImage = false;
+      restoreOriginalStatus();
+    }
   };
 
   vm.uploadClicked = function() {
@@ -42,10 +44,10 @@ function customImageComponentController($timeout) {
 
     if (imageFile.type === 'image/png') {
       vm.picture.extension = 'png';
-    } else if (imageFile.type === 'image/jpg') {
+    } else if (imageFile.type === 'image/jpg' || imageFile.type === 'image/jpeg') {
       vm.picture.extension = 'jpg';
-    } else if (imageFile.type === 'image/jpeg') {
-      vm.picture.extension = 'jpeg';
+    } else if (imageFile.type === 'image/svg') {
+      vm.picture.extension = 'svg';
     } else {
       vm.angularForm.generic_object_definition_image_file_status.$setValidity("incompatibleFileType", false);
       vm.imageUploadStatus = __("Incompatible image type");
@@ -58,7 +60,7 @@ function customImageComponentController($timeout) {
 
       $timeout(function() {
         vm.angularForm.generic_object_definition_image_file_status.$setValidity("incompatibleFileType", true);
-        vm.imageUploadStatus = __("Image upload complete");
+        vm.imageUploadStatus = __("Image is ready to be uploaded");
         vm.pictureUploaded = true;
       });
     };

--- a/app/assets/javascripts/components/generic_object/custom-image-component.js
+++ b/app/assets/javascripts/components/generic_object/custom-image-component.js
@@ -4,6 +4,7 @@ ManageIQ.angular.app.component('customImageComponent', {
     newRecord: '<',
     angularForm: '<',
     pictureUrlPath: '@',
+    pictureUploaded: '=',
   },
   controllerAs: 'vm',
   controller: customImageComponentController,
@@ -50,6 +51,7 @@ function customImageComponentController($timeout) {
       $timeout(function(){
         vm.angularForm.generic_object_definition_image_file_status.$setValidity("incompatibleFileType", true);
         vm.imageUploadStatus = __("Image upload complete");
+        vm.pictureUploaded = true;
       });
     };
 

--- a/app/assets/javascripts/components/generic_object/custom-image-component.js
+++ b/app/assets/javascripts/components/generic_object/custom-image-component.js
@@ -1,0 +1,58 @@
+ManageIQ.angular.app.component('customImageComponent', {
+  bindings: {
+    picture: '=',
+    newRecord: '<',
+    angularForm: '<',
+  },
+  controllerAs: 'vm',
+  controller: customImageComponentController,
+  templateUrl: '/static/generic_object/custom-image-component.html.haml',
+});
+
+customImageComponentController.$inject = ['$timeout'];
+
+function customImageComponentController($timeout) {
+  var vm = this;
+
+  vm.$onInit = function() {
+    vm.imageUploadStatus = "";
+  };
+
+  vm.uploadClicked = function() {
+    var imageFile;
+
+    if (angular.element('#generic_object_definition_image_file')[0].files.length === 0) {
+      return;
+    } else {
+      imageFile = angular.element('#generic_object_definition_image_file')[0].files[0];
+    }
+
+    var reader = new FileReader();
+    vm.imageUploadStatus = "";
+
+    if (imageFile.type === 'image/png') {
+      vm.picture.extension = 'png';
+    } else if (imageFile.type === 'image/jpg') {
+      vm.picture.extension = 'jpg';
+    } else if (imageFile.type === 'image/jpeg') {
+      vm.picture.extension = 'jpeg';
+    } else {
+      vm.angularForm.generic_object_definition_image_file_status.$setValidity("incompatibleFileType", false);
+      vm.imageUploadStatus = __("Incompatible image type");
+      return;
+    }
+
+    reader.onload = function(event) {
+      vm.picture.content = btoa(event.target.result);
+
+      $timeout(function(){
+        vm.angularForm.generic_object_definition_image_file_status.$setValidity("incompatibleFileType", true);
+        vm.imageUploadStatus = __("Image upload complete");
+      });
+    };
+
+    if (imageFile) {
+      reader.readAsBinaryString(imageFile);
+    }
+  };
+}

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
@@ -53,7 +53,7 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
     if (vm.recordId) {
       vm.newRecord = false;
       miqService.sparkleOn();
-      var dataPromise = API.get('/api/generic_object_definitions/' + vm.recordId + '?attributes=picture_url_path')
+      var dataPromise = API.get('/api/generic_object_definitions/' + vm.recordId + '?attributes=picture.image_href')
         .then(getGenericObjectDefinitionFormData)
         .catch(miqService.handleFailure);
 
@@ -114,6 +114,10 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
 
     if (vm.genericObjectDefinitionModel.method_names[0] !== '') {
       vm.genericObjectDefinitionModel.properties.methods = vm.genericObjectDefinitionModel.method_names;
+    }
+
+    if (vm.genericObjectDefinitionModel.picture.image_href) {
+      vm.genericObjectDefinitionModel.picture.image_href = undefined;
     }
 
     return {

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
@@ -33,6 +33,7 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
       properties: {},
       picture: {},
       pictureUploaded: false,
+      pictureRemove: false,
       attribute_names: [],
       attribute_types: [],
       attributesTableChanged: false,
@@ -115,17 +116,12 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
       vm.genericObjectDefinitionModel.properties.methods = vm.genericObjectDefinitionModel.method_names;
     }
 
-    var preppedObject =  {
+    return {
       name: vm.genericObjectDefinitionModel.name,
       description: vm.genericObjectDefinitionModel.description,
       properties: vm.genericObjectDefinitionModel.properties,
+      picture: vm.genericObjectDefinitionModel.picture,
     };
-
-    if (! angular.equals(vm.genericObjectDefinitionModel.picture, {})) {
-      preppedObject.picture = vm.genericObjectDefinitionModel.picture;
-    }
-
-    return preppedObject;
   };
 
   vm.saveWithAPI = function(method, url, saveObject, saveMsg) {

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
@@ -49,7 +49,7 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
     if (vm.recordId) {
       vm.newRecord = false;
       miqService.sparkleOn();
-      var dataPromise = API.get('/api/generic_object_definitions/' + vm.recordId)
+      var dataPromise = API.get('/api/generic_object_definitions/' + vm.recordId + '?attributes=picture_url_path')
         .then(getGenericObjectDefinitionFormData)
         .catch(miqService.handleFailure);
 

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
@@ -29,6 +29,7 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
       name: '',
       description: '',
       properties: {},
+      picture: {},
       attribute_names: [],
       attribute_types: [],
       attributesTableChanged: false,
@@ -109,11 +110,17 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
       vm.genericObjectDefinitionModel.properties.methods = vm.genericObjectDefinitionModel.method_names;
     }
 
-    return {
+    var preppedObject =  {
       name: vm.genericObjectDefinitionModel.name,
       description: vm.genericObjectDefinitionModel.description,
       properties: vm.genericObjectDefinitionModel.properties,
     };
+
+    if (! angular.equals(vm.genericObjectDefinitionModel.picture, {})) {
+      preppedObject.picture = vm.genericObjectDefinitionModel.picture;
+    }
+
+    return preppedObject;
   };
 
   vm.saveWithAPI = function(method, url, saveObject, saveMsg) {

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
@@ -18,6 +18,8 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
     vm.saveable = miqService.saveable;
     vm.afterGet = false;
 
+    vm.pictureReset = false;
+
     vm.attributeTableHeaders = [__("Name"), __("Type")];
     vm.associationTableHeaders = [__("Name"), __("Class")];
     vm.methodTableHeaders = [__("Name")];
@@ -77,6 +79,8 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
     vm.genericObjectDefinitionModel = Object.assign({}, vm.modelCopy);
 
     assignAllObjectsToKeyValueArrays(true);
+
+    vm.pictureReset = ! vm.pictureReset;
 
     angularForm.$setUntouched(true);
     angularForm.$setPristine(true);

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
@@ -30,6 +30,7 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
       description: '',
       properties: {},
       picture: {},
+      pictureUploaded: false,
       attribute_names: [],
       attribute_types: [],
       attributesTableChanged: false,

--- a/app/views/generic_object_definition/show.html.haml
+++ b/app/views/generic_object_definition/show.html.haml
@@ -4,6 +4,15 @@
   - else
     = render :partial => 'layouts/textual_groups_generic'
 
+  - if @record.picture
+    %hr
+      %h3
+        = _('Custom Image')
+      .form-horizontal
+        .form-group
+          .col-md-9
+            %img{:src => "#{@record.picture.url_path}", :style => "width:100px; height:100px;"}
+
   %generic-object-definition-toolbar#generic_object_definition_show_form{'generic-object-definition-id' => @record.id,
                                                                          'redirect-url'                 => "/#{controller_name}/show_list",}
 :javascript

--- a/app/views/static/generic_object/custom-image-component.html.haml
+++ b/app/views/static/generic_object/custom-image-component.html.haml
@@ -1,4 +1,5 @@
-.form-group{"ng-show" => "vm.newRecord || vm.changeImage", "ng-class" => "{'has-error': vm.angularForm.generic_object_definition_image_file_status.$invalid}"}
+.form-group{"ng-show" => "vm.newRecord || vm.changeImage || vm.pictureUrlPath === '' || vm.pictureRemove",
+            "ng-class" => "{'has-error': vm.angularForm.generic_object_definition_image_file_status.$invalid}"}
   %label.col-md-2.control-label{"for" => "generic_object_definition_image_file_status"}
     = _("Custom Image File")
   .col-md-4
@@ -19,12 +20,14 @@
                   :alt       => t,
                   :enabled   => "true",
                   'on-click' => "vm.uploadClicked(angularForm)"}
-.form-group{'ng-if' => "vm.pictureUrlPath !== '' && !vm.changeImage"}
+.form-group{'ng-if' => "vm.pictureUrlPath !== '' && !vm.changeImage && !vm.pictureRemove"}
   %label.col-md-2.control-label{"for" => "custom_image"}
     = _("Current Custom Image File")
   .col-md-4
     %img.form-control{'ng-src' => "{{vm.pictureUrlPath}}", :style => "width:100px; height:100px;"}
-.form-group{'ng-if' => "vm.pictureUrlPath !== ''"}
+      .btn.btn-default{:alt => t = _("Remove Custom Image"), :title => t, "ng-click" => "vm.removeImage()"}
+        %i.pficon.pficon-delete
+.form-group{'ng-if' => "vm.pictureUrlPath !== '' && !vm.pictureRemove"}
   %label.col-md-2.control-label{"for" => "update_image"}
     = _("Update Current Image")
   .col-md-4

--- a/app/views/static/generic_object/custom-image-component.html.haml
+++ b/app/views/static/generic_object/custom-image-component.html.haml
@@ -1,4 +1,4 @@
-.form-group{"ng-show" => "vm.newRecord", "ng-class" => "{'has-error': vm.angularForm.generic_object_definition_image_file_status.$invalid}"}
+.form-group{"ng-show" => "vm.newRecord || vm.changeImage", "ng-class" => "{'has-error': vm.angularForm.generic_object_definition_image_file_status.$invalid}"}
   %label.col-md-2.control-label{"for" => "generic_object_definition_image_file_status"}
     = _("Custom Image File")
   .col-md-4
@@ -19,6 +19,22 @@
                   :alt       => t,
                   :enabled   => "true",
                   'on-click' => "vm.uploadClicked(angularForm)"}
+.form-group{'ng-if' => "vm.pictureUrlPath !== '' && !vm.changeImage"}
+  %label.col-md-2.control-label{"for" => "custom_image"}
+    = _("Current Custom Image File")
+  .col-md-4
+    %img.form-control{'ng-src' => "{{vm.pictureUrlPath}}", :style => "width:100px; height:100px;"}
+.form-group{'ng-if' => "vm.pictureUrlPath !== ''"}
+  %label.col-md-2.control-label{"for" => "update_image"}
+    = _("Update Current Image")
+  .col-md-4
+    %input.form-control{"type"      => "checkbox",
+                        "id"        => "update_image",
+                        "name"      => "update_image",
+                        "bs-switch" => "",
+                        :data       => {:on_text => _('Yes'), :off_text => _('No')},
+                        "ng-change" => "vm.changeImageSelected()",
+                        "ng-model"  => "vm.changeImage"}
 
 :javascript
   $(":file").filestyle({placeholder: _("No file chosen"), icon: false});

--- a/app/views/static/generic_object/custom-image-component.html.haml
+++ b/app/views/static/generic_object/custom-image-component.html.haml
@@ -1,0 +1,24 @@
+.form-group{"ng-show" => "vm.newRecord", "ng-class" => "{'has-error': vm.angularForm.generic_object_definition_image_file_status.$invalid}"}
+  %label.col-md-2.control-label{"for" => "generic_object_definition_image_file_status"}
+    = _("Custom Image File")
+  .col-md-4
+    %input.form-control{"type"        => "file",
+                        "class"       => "filestyle",
+                        "id"          => "generic_object_definition_image_file",
+                        "name"        => "generic_object_definition_image_file"}
+    %input.form-control{"type"        => "hidden",
+                        "id"          => "generic_object_definition_image_file_status",
+                        "ng-model"    => "vm.imageUploadStatus",
+                        "name"        => "generic_object_definition_image_file_status"}
+    %span.help-block
+      {{vm.imageUploadStatus}}
+
+  .col-md-4
+    %miq-button{:name        => t = _("Upload chosen File"),
+                  :title     => t,
+                  :alt       => t,
+                  :enabled   => "true",
+                  'on-click' => "vm.uploadClicked(angularForm)"}
+
+:javascript
+  $(":file").filestyle({placeholder: _("No file chosen"), icon: false});

--- a/app/views/static/generic_object/custom-image-component.html.haml
+++ b/app/views/static/generic_object/custom-image-component.html.haml
@@ -40,4 +40,4 @@
                         "ng-model"  => "vm.changeImage"}
 
 :javascript
-  $(":file").filestyle({placeholder: _("No file chosen"), icon: false});
+  $(":file").filestyle({placeholder: __("No file chosen"), icon: false});

--- a/app/views/static/generic_object/generic_object_definition.html.haml
+++ b/app/views/static/generic_object/generic_object_definition.html.haml
@@ -83,6 +83,7 @@
                           'angular-form'     => 'angularForm',
                           'picture'          => 'vm.genericObjectDefinitionModel.picture',
                           'picture-uploaded' => 'vm.genericObjectDefinitionModel.pictureUploaded',
+                          'picture-remove'   => 'vm.genericObjectDefinitionModel.pictureRemove',
                           'picture-reset'    => 'vm.pictureReset',
                           'picture-url-path' => '{{vm.genericObjectDefinitionModel.picture_url_path}}'}
 

--- a/app/views/static/generic_object/generic_object_definition.html.haml
+++ b/app/views/static/generic_object/generic_object_definition.html.haml
@@ -79,8 +79,9 @@
                                       "table-rendered"   => "vm.tableRendered",
                                       "unique-property"  => "vm.uniqueProperty('Methods')",
                                       "angular-form"     => "angularForm"}
-  %custom-image-component{'new-record'   => "vm.newRecord",
-                          'angular-form' => 'angularForm',
-                          'picture'      => 'vm.genericObjectDefinitionModel.picture'}
+  %custom-image-component{'new-record'       => "vm.newRecord",
+                          'angular-form'     => 'angularForm',
+                          'picture'          => 'vm.genericObjectDefinitionModel.picture',
+                          'picture-url-path' => '{{vm.genericObjectDefinitionModel.picture_url_path}}'}
 
 = render :partial => "layouts/angular/generic_form_buttons"

--- a/app/views/static/generic_object/generic_object_definition.html.haml
+++ b/app/views/static/generic_object/generic_object_definition.html.haml
@@ -83,6 +83,7 @@
                           'angular-form'     => 'angularForm',
                           'picture'          => 'vm.genericObjectDefinitionModel.picture',
                           'picture-uploaded' => 'vm.genericObjectDefinitionModel.pictureUploaded',
+                          'picture-reset'    => 'vm.pictureReset',
                           'picture-url-path' => '{{vm.genericObjectDefinitionModel.picture_url_path}}'}
 
 = render :partial => "layouts/angular/generic_form_buttons"

--- a/app/views/static/generic_object/generic_object_definition.html.haml
+++ b/app/views/static/generic_object/generic_object_definition.html.haml
@@ -79,4 +79,8 @@
                                       "table-rendered"   => "vm.tableRendered",
                                       "unique-property"  => "vm.uniqueProperty('Methods')",
                                       "angular-form"     => "angularForm"}
+  %custom-image-component{'new-record'   => "vm.newRecord",
+                          'angular-form' => 'angularForm',
+                          'picture'      => 'vm.genericObjectDefinitionModel.picture'}
+
 = render :partial => "layouts/angular/generic_form_buttons"

--- a/app/views/static/generic_object/generic_object_definition.html.haml
+++ b/app/views/static/generic_object/generic_object_definition.html.haml
@@ -82,6 +82,7 @@
   %custom-image-component{'new-record'       => "vm.newRecord",
                           'angular-form'     => 'angularForm',
                           'picture'          => 'vm.genericObjectDefinitionModel.picture',
+                          'picture-uploaded' => 'vm.genericObjectDefinitionModel.pictureUploaded',
                           'picture-url-path' => '{{vm.genericObjectDefinitionModel.picture_url_path}}'}
 
 = render :partial => "layouts/angular/generic_form_buttons"

--- a/app/views/static/generic_object/generic_object_definition.html.haml
+++ b/app/views/static/generic_object/generic_object_definition.html.haml
@@ -85,6 +85,6 @@
                           'picture-uploaded' => 'vm.genericObjectDefinitionModel.pictureUploaded',
                           'picture-remove'   => 'vm.genericObjectDefinitionModel.pictureRemove',
                           'picture-reset'    => 'vm.pictureReset',
-                          'picture-url-path' => '{{vm.genericObjectDefinitionModel.picture_url_path}}'}
+                          'picture-url-path' => '{{vm.genericObjectDefinitionModel.picture.image_href}}'}
 
 = render :partial => "layouts/angular/generic_form_buttons"


### PR DESCRIPTION
Requires - https://github.com/ManageIQ/manageiq-api/pull/116

https://www.pivotaltracker.com/n/projects/1613907/stories/151742686

Automation > Automate > Generic Objects

----------
Create Generic Object Screen 

<img width="1416" alt="screen shot 2017-10-10 at 10 19 56 am" src="https://user-images.githubusercontent.com/1538216/31400560-e11f48f8-ada4-11e7-9e9b-76d65cd317b5.png">

<img width="1418" alt="screen shot 2017-10-10 at 10 21 03 am" src="https://user-images.githubusercontent.com/1538216/31400593-04f02e50-ada5-11e7-90ef-5c2b6dc440f5.png">

<img width="1420" alt="screen shot 2017-10-10 at 10 20 46 am" src="https://user-images.githubusercontent.com/1538216/31400579-eee0d18c-ada4-11e7-8410-a31a5aa6134e.png">

-------
Generic Object Definition Summary Screen

<img width="1418" alt="screen shot 2017-10-10 at 10 21 26 am" src="https://user-images.githubusercontent.com/1538216/31400646-3afd67f6-ada5-11e7-9b72-da111df4f2e8.png">

---------
Edit Generic Object Screen 

<img width="1416" alt="screen shot 2017-10-10 at 10 21 41 am" src="https://user-images.githubusercontent.com/1538216/31400703-739eb9e8-ada5-11e7-9ff7-b233b8cf737b.png">




