### PR TITLE
Add a blank option in drop down default value selections

### DIFF
--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -134,13 +134,14 @@ module ApplicationHelper::Dialogs
     add_options_unless_read_only({}, tag_options, field)
   end
 
-  def default_value_form_options(field_type, field_values, field_default_value)
+  def default_value_form_options(field_values, field_default_value)
     no_default_value = [["<#{_('None')}>", nil]]
     if field_values.empty?
       values = no_default_value
     else
       values = field_values.collect(&:reverse)
-      values = no_default_value + values if field_type == "DialogFieldRadioButton"
+      values = values.reject { |value| value[1].nil? }
+      values = no_default_value + values
     end
 
     selected = field_default_value || nil

--- a/app/views/miq_ae_customization/_dialog_field_form_non_dynamic_options.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form_non_dynamic_options.html.haml
@@ -110,7 +110,7 @@
       = _('Default Value')
     .col-md-8
       = select_tag("field_default_value",
-                   default_value_form_options(@edit[:field_typ], @edit[:field_values], @edit[:field_default_value]),
+                   default_value_form_options(@edit[:field_values], @edit[:field_default_value]),
                    :class    => "selectpicker")
       :javascript
         miqSelectPickerEvent("field_default_value", "#{url}")

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -600,48 +600,24 @@ describe ApplicationHelper::Dialogs do
   end
 
   describe "#default_value_form_options" do
-    let(:subject) { helper.default_value_form_options(field_type, field_values, field_default_value) }
+    let(:subject) { helper.default_value_form_options(field_values, field_default_value) }
 
     context "when the field values are empty" do
       let(:field_values) { [] }
 
-      context "when the field type is a DialogFieldDropDownList" do
-        let(:field_type) { "DialogFieldDropDownList" }
+      context "when the field default value is set" do
+        let(:field_default_value) { "some default" }
 
-        context "when the field default value is set" do
-          let(:field_default_value) { "some default" }
-
-          it "adds the ability to select no default value" do
-            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
-          end
-        end
-
-        context "when the field default value is not set" do
-          let(:field_default_value) { nil }
-
-          it "adds the ability to select no default value" do
-            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
-          end
+        it "adds the ability to select no default value" do
+          expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
         end
       end
 
-      context "when the field type is a DialogFieldRadioButton" do
-        let(:field_type) { "DialogFieldRadioButton" }
+      context "when the field default value is not set" do
+        let(:field_default_value) { nil }
 
-        context "when the field default value is set" do
-          let(:field_default_value) { "some default" }
-
-          it "adds the ability to select no default value" do
-            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
-          end
-        end
-
-        context "when the field default value is not set" do
-          let(:field_default_value) { nil }
-
-          it "adds the ability to select no default value" do
-            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
-          end
+        it "adds the ability to select no default value" do
+          expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
         end
       end
     end
@@ -649,51 +625,28 @@ describe ApplicationHelper::Dialogs do
     context "when the field values are not empty" do
       let(:field_values) { [%w(123 456)] }
 
-      context "when the field type is a DialogFieldDropDownList" do
-        let(:field_type) { "DialogFieldDropDownList" }
+      context "when the field default value is set" do
+        let(:field_default_value) { "123" }
 
-        context "when the field default value is set" do
-          let(:field_default_value) { "123" }
-
-          it "selects the default value and does not add any" do
-            expect(subject).to eq("<option selected=\"selected\" value=\"123\">456</option>")
-          end
-        end
-
-        context "when the field default value is not set" do
-          let(:field_default_value) { nil }
-
-          it "does not explicitly select anything" do
-            expect(subject).to eq("<option value=\"123\">456</option>")
-          end
+        it "adds a none option and selects the default value" do
+          expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>\n<option selected=\"selected\" value=\"123\">456</option>")
         end
       end
 
-      context "when the field type is a DialogFieldRadioButton" do
-        let(:field_type) { "DialogFieldRadioButton" }
+      context "when the field default value is not set" do
+        let(:field_default_value) { nil }
 
-        context "when the field default value is set" do
-          let(:field_default_value) { "123" }
-
-          it "adds the ability to select no default value but selects the default" do
-            expected_html = <<-HTML
-<option value=\"\">&lt;None&gt;</option>
-<option selected=\"selected\" value=\"123\">456</option>
-            HTML
-            expect(subject).to eq(expected_html.chomp)
-          end
+        it "adds a none option and does not explicitly select anything" do
+          expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>\n<option value=\"123\">456</option>")
         end
+      end
 
-        context "when the field default value is not set" do
-          let(:field_default_value) { nil }
+      context "when the field values contain a nil value" do
+        let(:field_default_value) { nil }
+        let(:field_values) { [%w(123 456), [nil, "empty"]] }
 
-          it "adds the ability to select no default value" do
-            expected_html = <<-HTML
-<option value=\"\">&lt;None&gt;</option>
-<option value=\"123\">456</option>
-            HTML
-            expect(subject).to eq(expected_html.chomp)
-          end
+        it "removes the nil value and replaces it with a 'none' option" do
+          expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>\n<option value=\"123\">456</option>")
         end
       end
     end


### PR DESCRIPTION
The main problem was that the way that the code was handling the list of values to show in the UI during runtime and during editing was the same. However, during editing the list of values to choose from for the purpose of selecting a default value should always include a "none" option, whereas if there is a default value selected already and the field is required, during runtime there is no reason to have a "choose" or "none" field there.

https://bugzilla.redhat.com/show_bug.cgi?id=1496946

Related to: https://github.com/ManageIQ/manageiq/pull/16167, will need this in order to not get odd duplications while editing the dialog.

@miq-bot add_label bug, fine/yes, euwe/yes