### PR TITLE
Cloud_Network: No value option for network types

### DIFF
--- a/app/assets/javascripts/controllers/cloud_network/cloud_network_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_network/cloud_network_form_controller.js
@@ -5,6 +5,7 @@ ManageIQ.angular.app.controller('cloudNetworkFormController', ['cloudNetworkForm
     vm.afterGet = false;
     vm.cloudNetworkModel = { name: '' };
     vm.providers_network_types = {
+      "None": "",
       "Local": "local",
       "Flat": "flat",
       "GRE": "gre",

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -246,7 +246,9 @@ class CloudNetworkController < ApplicationController
     # TODO: uncomment once form contains this field
     # options[:port_security_enabled] = params[:port_security_enabled] if params[:port_security_enabled]
     options[:qos_policy_id] = params[:qos_policy_id] if params[:qos_policy_id]
-    options[:provider_network_type] = params[:provider_network_type] if params[:provider_network_type]
+    if params[:provider_network_type] && !params[:provider_network_type].empty?
+      options[:provider_network_type] = params[:provider_network_type]
+    end
     options[:provider_physical_network] = params[:provider_physical_network] if params[:provider_physical_network]
     options[:provider_segmentation_id] = params[:provider_segmentation_id] if params[:provider_segmentation_id]
     options[:cloud_tenant] = find_record_with_rbac(CloudTenant, params[:cloud_tenant_id]) if params[:cloud_tenant_id]


### PR DESCRIPTION
Allows to select empty value for the provide network types. This will be aligned with default behaviour when creating network with Neutron.

Also it addresses the following bug, once backported to Fine branch:
https://bugzilla.redhat.com/show_bug.cgi?id=1490363