### PR TITLE
Fix duplicate DOM ID in analysis profile edit.

### DIFF
--- a/app/views/ops/_ap_form_registry.html.haml
+++ b/app/views/ops/_ap_form_registry.html.haml
@@ -79,7 +79,7 @@
             = hidden_field("item", "type2", :value => "registry")
             = hidden_field("entry", "id", :value => i)
         - else
-          %tr{:id => "#{i}_tr"}
+          %tr{:id => "registry_row_#{i}"}
             - url = {:action     => 'ap_ce_select',
                      :entry_id   => i,
                      :item2      => "registry",

--- a/app/views/ops/_ap_form_set.html.haml
+++ b/app/views/ops/_ap_form_set.html.haml
@@ -14,7 +14,6 @@
             - keyvalue.each do |k, v|
               - checked = @selected.include? k if @selected
               .col-md-4{:align => "left", :nowrap => "", :valign => "top"}
-                = hidden_field("item", "type", :value => "category")
                 = check_box_tag("check_#{k}", _(v), checked,
                   "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true,
                   "data-miq_observe_checkbox" => {:url => url}.to_json)


### PR DESCRIPTION
Fixing DOM mess in Analysis profiles editing.

Related to BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1485953
A don't know (yet) how to fix the BZ, as it has a pretty brief description. But this needs fixing anyway.

Before:

![an_prof_bad](https://user-images.githubusercontent.com/51095/31430800-42ecae9a-ae72-11e7-9640-c9a71d1e4116.png)

After:

![an_prof_good](https://user-images.githubusercontent.com/51095/31430807-46c65d86-ae72-11e7-8c0d-faeb1ef3c399.png)

