### PR TITLE
Hide bottom bar in Settings/Region when not in a form

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -761,7 +761,7 @@ class OpsController < ApplicationController
       end
       presenter.show(:paging_div)
     else
-      presenter.hide(:paging_div)
+      presenter.hide(:paging_div).hide(:form_buttons_div)
     end
   end
 


### PR DESCRIPTION
When on Configuration -> Settings -> Region, the bottom bar shows up on some tabs where it should not. The problem is that if the `@in_a_form` variable is not set, only the paginator is set to be hidden. However, after the GTL changes we split up the paginator from the bottom bar. This piece of code was probably missed.

https://bugzilla.redhat.com/show_bug.cgi?id=1498051