### PR TITLE
Simplify NTP settings and use ::Settings

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -539,15 +539,17 @@ module OpsController::Settings::Common
     end
   end
 
-  private def save_ntp_server_settings
+  private def new_ntp_servers
     old_ntp_servers = @edit[:new][:ntp][:server] || []
-    new_ntp_servers = [1,2,3].collect.with_index do |i, position|
+    [1, 2, 3].collect.with_index do |i, position|
       field = "ntp_server_#{i}"
       @edit[:new][:ntp].key?(field) ? @edit[:new][:ntp].delete(field).presence : old_ntp_servers[position]
     end.compact
+  end
 
-    if new_ntp_servers.present?
-      @update.config[:ntp] = {:server => new_ntp_servers}
+  private def save_ntp_server_settings
+    if (new_servers = new_ntp_servers).present?
+      @update.config[:ntp] = {:server => new_servers}
     else
       @update.config.delete(:ntp)
       MiqServer.find(@sb[:selected_server_id]).remove_settings_path_for_resource(:ntp)

--- a/app/controllers/ops_controller/settings/zones.rb
+++ b/app/controllers/ops_controller/settings/zones.rb
@@ -112,12 +112,12 @@ module OpsController::Settings::Zones
     zone.settings[:proxy_server_ip] = @edit[:new][:proxy_server_ip]
     zone.settings[:concurrent_vm_scans] = @edit[:new][:concurrent_vm_scans]
 
-    save_ntp_server_settings(zone)
+    zone_save_ntp_server_settings(zone)
 
     zone.update_authentication({:windows_domain => {:userid => @edit[:new][:userid], :password => @edit[:new][:password]}}, :save => (mode != :validate))
   end
 
-  private def save_ntp_server_settings(zone)
+  private def zone_save_ntp_server_settings(zone)
     if (new_servers = new_ntp_servers).present?
       zone.add_settings_for_resource(:ntp => {:server => new_servers})
     else

--- a/app/controllers/ops_controller/settings/zones.rb
+++ b/app/controllers/ops_controller/settings/zones.rb
@@ -111,13 +111,18 @@ module OpsController::Settings::Zones
     zone.settings ||= {}
     zone.settings[:proxy_server_ip] = @edit[:new][:proxy_server_ip]
     zone.settings[:concurrent_vm_scans] = @edit[:new][:concurrent_vm_scans]
-    if @edit[:new][:ntp][:server]
-      temp = []
-      @edit[:new][:ntp][:server].each { |svr| temp.push(svr) unless svr.blank? }
-      zone.settings[:ntp] ||= {}
-      zone.settings[:ntp][:server] = temp
-    end
+
+    save_ntp_server_settings(zone)
+
     zone.update_authentication({:windows_domain => {:userid => @edit[:new][:userid], :password => @edit[:new][:password]}}, :save => (mode != :validate))
+  end
+
+  private def save_ntp_server_settings(zone)
+    if (new_servers = new_ntp_servers).present?
+      zone.add_settings_for_resource(:ntp => {:server => new_servers})
+    else
+      zone.remove_settings_path_for_resource(:ntp)
+    end
   end
 
   # Validate the zone record fields
@@ -146,9 +151,7 @@ module OpsController::Settings::Zones
     @edit[:new][:password] = params[:password] if params[:password]
     @edit[:new][:verify] = params[:verify] if params[:verify]
 
-    @edit[:new][:ntp][:server][0] = params[:ntp_server_1] if params[:ntp_server_1]
-    @edit[:new][:ntp][:server][1] = params[:ntp_server_2] if params[:ntp_server_2]
-    @edit[:new][:ntp][:server][2] = params[:ntp_server_3] if params[:ntp_server_3]
+    settings_get_form_vars_sync_ntp
     set_verify_status
   end
 
@@ -175,10 +178,7 @@ module OpsController::Settings::Zones
     @edit[:new][:userid] = @zone.authentication_userid(:windows_domain)
     @edit[:new][:password] = @zone.authentication_password(:windows_domain)
     @edit[:new][:verify] = @zone.authentication_password(:windows_domain)
-    @edit[:new][:ntp] = @zone.settings[:ntp] if !@zone.settings.nil? && !@zone.settings[:ntp].nil?
-
-    @edit[:new][:ntp] ||= {}
-    @edit[:new][:ntp][:server] ||= []
+    @edit[:new][:ntp] = @zone.settings_for_resource.ntp.to_h
 
     session[:verify_ems_status] = nil
     set_verify_status

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -140,19 +140,19 @@
         = _("Servers")
       .col-md-8
         = text_field_tag("ntp_server_1",
-                          @edit[:new][:ntp][:server][0],
+                          @edit.fetch_path(:new, :ntp, :server, 0),
                           :maxlength => ViewHelper::MAX_NAME_LEN,
                           :class => "form-control",
                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
         %br/
         = text_field_tag("ntp_server_2",
-                          @edit[:new][:ntp][:server][1],
+                          @edit.fetch_path(:new, :ntp, :server, 1),
                           :maxlength => ViewHelper::MAX_NAME_LEN,
                           :class => "form-control",
                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
         %br/
         = text_field_tag("ntp_server_3",
-                          @edit[:new][:ntp][:server][2],
+                          @edit.fetch_path(:new, :ntp, :server, 2),
                           :maxlength => ViewHelper::MAX_NAME_LEN,
                           :class => "form-control",
                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)

--- a/app/views/ops/_zone_form.html.haml
+++ b/app/views/ops/_zone_form.html.haml
@@ -47,19 +47,19 @@
       = _("Servers")
     .col-md-8
       = text_field_tag("ntp_server_1",
-                        @edit[:new][:ntp][:server][0],
+                        @edit.fetch_path(:new, :ntp, :server, 0),
                         :maxlength => ViewHelper::MAX_NAME_LEN,
                         :class => "form-control",
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       %br/
       = text_field_tag("ntp_server_2",
-                        @edit[:new][:ntp][:server][1],
+                        @edit.fetch_path(:new, :ntp, :server, 1),
                         :maxlength => ViewHelper::MAX_NAME_LEN,
                         :class => "form-control",
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       %br/
       = text_field_tag("ntp_server_3",
-                        @edit[:new][:ntp][:server][2],
+                        @edit.fetch_path(:new, :ntp, :server, 2),
                         :maxlength => ViewHelper::MAX_NAME_LEN,
                         :class => "form-control",
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/16169

- Simplify syncing NTP settings to and from the form
- Deduplicate logic for determining the new NTP servers
- Extract saving NTP settings to a method
- Ensure all NTP settings are stored in ::Settings