### PR TITLE
also show genealogy for cloud instances and templates

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -52,7 +52,7 @@ module VmHelper::TextualSummary
     TextualGroup.new(
       _("Relationships"),
       %i(
-        ems ems_infra cluster host availability_zone cloud_tenant flavor vm_template drift scan_history service
+        ems ems_infra cluster host availability_zone cloud_tenant flavor vm_template drift scan_history service genealogy
         cloud_network cloud_subnet orchestration_stack cloud_networks cloud_subnets network_routers security_groups
         floating_ips network_ports load_balancers cloud_volumes
       )
@@ -60,7 +60,7 @@ module VmHelper::TextualSummary
   end
 
   def textual_group_template_cloud_relationships
-    TextualGroup.new(_("Relationships"), %i(ems parent_vm drift scan_history cloud_tenant))
+    TextualGroup.new(_("Relationships"), %i(ems parent_vm genealogy drift scan_history cloud_tenant))
   end
 
   def textual_group_security


### PR DESCRIPTION
When we edit the infra vm with parent and the child vm's, the details is displayed in the summary page but there is not such details when we edit the same for cloud instances.

parent and child VMs details should be shown for cloud instance summary page as well.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1399144

<img width="743" alt="screen shot 2017-10-12 at 12 14 39" src="https://user-images.githubusercontent.com/161888/31491728-8f4a052c-af48-11e7-93b7-c468bf6c9733.png">
<img width="674" alt="screen shot 2017-10-12 at 12 17 44" src="https://user-images.githubusercontent.com/161888/31491729-8f606470-af48-11e7-8130-e0a7cefd9412.png">

@miq-bot add_label bug
@miq-bot assign @dclarizio 
