### PR TITLE
Add button classes

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -248,10 +248,10 @@ module ApplicationController::Buttons
 
   BASE_MODEL_EXPLORER_CLASSES = [Vm, MiqTemplate, Service].freeze
   APPLIES_TO_CLASS_BASE_MODELS = %w(AvailabilityZone CloudNetwork CloudObjectStoreContainer CloudSubnet CloudTenant
-                                    CloudVolume ContainerGroup ContainerImage ContainerProject ContainerTemplate
-                                    ContainerVolume EmsCluster ExtManagementSystem Host LoadBalancer MiqTemplate
-                                    NetworkRouter OrchestrationStack SecurityGroup Service ServiceTemplate Storage
-                                    Switch Vm).freeze
+                                    CloudVolume ContainerGroup ContainerImage ContainerNode ContainerProject
+                                    ContainerTemplate ContainerVolume EmsCluster ExtManagementSystem Host LoadBalancer
+                                    MiqGroup MiqTemp NetworkRouter OrchestrationStack SecurityGroup Service
+                                    ServiceTemplate Storage Switch Tenant User Vm).freeze
   def applies_to_class_model(applies_to_class)
     # TODO: Give a better name for this concept, including ServiceTemplate using Service
     # This should probably live in the model once this concept is defined.

--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -42,4 +42,6 @@ class ContainerNodeController < ApplicationController
   end
 
   menu_section :cnt
+
+  has_custom_buttons
 end

--- a/app/controllers/mixins/custom_buttons.rb
+++ b/app/controllers/mixins/custom_buttons.rb
@@ -13,6 +13,8 @@ module Mixins::CustomButtons
         Mixins::CustomButtons::Result.new(:single)
       elsif @lastaction == "show_list"
         Mixins::CustomButtons::Result.new(:list)
+      elsif x_tree[:tree] == :rbac_tree
+        Mixins::CustomButtons::Result.new(:single)
       else
         'blank_view_tb'
       end

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -94,6 +94,10 @@ class OpsController < ApplicationController
     generic_x_button(OPS_X_BUTTON_ALLOWED_ACTIONS)
   end
 
+  def button
+    custom_buttons if params[:pressed] == 'custom_button'
+  end
+
   def explorer
     @explorer = true
     @trees = []

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -17,6 +17,7 @@ class OpsController < ApplicationController
   OPS_X_BUTTON_ALLOWED_ACTIONS = {
     'collect_logs'              => :logs_collect,
     'collect_current_logs'      => :collect_current_logs,
+    'custom_button'             => :custom_buttons,
     'db_refresh'                => :db_refresh,
     'delete_server'             => :delete_server,
     'demote_server'             => :demote_server,
@@ -761,9 +762,15 @@ class OpsController < ApplicationController
     } if @ajax_action
   end
 
+  def choose_custom_toolbar
+    if x_tree && x_tree[:tree] == :rbac_tree && x_node != 'root'
+      build_toolbar(@record ? Mixins::CustomButtons::Result.new(:single) : Mixins::CustomButtons::Result.new(:list))
+    end
+  end
+
   def rebuild_toolbars(presenter)
     c_tb = build_toolbar(center_toolbar_filename) unless @in_a_form
-    presenter.reload_toolbars(:center => c_tb)
+    presenter.reload_toolbars(:center => c_tb, :custom => choose_custom_toolbar)
     presenter[:record_id] = determine_record_id_for_presenter
   end
 
@@ -839,4 +846,6 @@ class OpsController < ApplicationController
   end
 
   menu_section :set
+
+  has_custom_buttons
 end

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -892,15 +892,19 @@ module OpsController::OpsRbac
       case id
       when "u"
         @right_cell_text = _("Access Control EVM Users")
+        @tree_selected_model = User
         rbac_users_list
       when "g"
         @right_cell_text = _("Access Control EVM Groups")
+        @tree_selected_model = MiqGroup
         rbac_groups_list
       when "ur"
         @right_cell_text = _("Access Control Roles")
+        @tree_selected_model = MiqUserRole
         rbac_roles_list
       when "tn"
         @right_cell_text = _("Access Control Tenants")
+        @tree_selected_model = Tenant
         rbac_tenants_list
       end
     when "u"

--- a/app/decorators/tenant_decorator.rb
+++ b/app/decorators/tenant_decorator.rb
@@ -1,4 +1,8 @@
 class TenantDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-tenant'
+  end
+
   def fonticon
     tenant? ? 'pficon pficon-tenant' : 'pficon pficon-project'
   end

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -22,10 +22,16 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
       name = case klass
              when 'ContainerGroup'
                _('Container Pod')
+             when 'ContainerNode'
+               _('Container Node')
              when 'ContainerProject'
                _('Container Project')
+             when 'MiqGroup'
+               _('Group')
              when 'Switch'
                _('Virtual Infra Switch')
+             when 'User'
+               _('User')
              else
                ui_lookup(:model => klass)
              end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2618,6 +2618,7 @@ Rails.application.routes.draw do
 
     :ops                      => {
       :get  => %w(
+        dialog_load
         explorer
         fetch_audit_log
         fetch_build
@@ -2643,6 +2644,7 @@ Rails.application.routes.draw do
         ap_set_active_tab
         aps_list
         automate_schedules_set_vars
+        button
         category_delete
         category_edit
         category_field_changed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2743,9 +2743,8 @@ Rails.application.routes.draw do
         ls_select
         ldap_entry_changed
         ls_delete
-      ) +
-        exp_post
-    },
+      ) + exp_post + dialog_runner_post
+   },
 
     :orchestration_stack      => {
       :get  => %w(

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -301,21 +301,21 @@ describe OpsController do
     it "does not render toolbar buttons when edit is clicked" do
       post :x_button, :params => {:id => @miq_server.id, :pressed => 'log_depot_edit', :format => :js}
       expect(response.status).to eq(200)
-      expect(JSON.parse(response.body)['reloadToolbars']).to match([nil])
+      expect(JSON.parse(response.body)['reloadToolbars']).to match([nil, nil])
     end
 
     it "renders toolbar buttons when cancel is clicked" do
       allow(controller).to receive(:diagnostics_set_form_vars)
       post :x_button, :params => {:id => @miq_server.id, :pressed => 'log_depot_edit', :button => "cancel", :format => :js}
       expect(response.status).to eq(200)
-      expect(JSON.parse(response.body)['reloadToolbars'].length).to eq(1)
+      expect(JSON.parse(response.body)['reloadToolbars'].length).to eq(2)
     end
 
     it "renders toolbar buttons when save is clicked" do
       allow(controller).to receive(:diagnostics_set_form_vars)
       post :x_button, :params => {:id => @miq_server.id, :pressed => 'log_depot_edit', :button => "save", :format => :js}
       expect(response.status).to eq(200)
-      expect(JSON.parse(response.body)['reloadToolbars'].length).to eq(1)
+      expect(JSON.parse(response.body)['reloadToolbars'].length).to eq(2)
     end
   end
 


### PR DESCRIPTION
Adding custom buttons to Container Node, Group, Tenant and User.

Create custom button without dialog:

Automation -> Automate -> Customization -> Buttons -> create a custom button without a dialog

Created buttons should show at:

Compute -> Containers -> Container Nodes
Configuration (right upper corner) -> Access Control -> Users/Groups/Tenants

https://www.pivotaltracker.com/story/show/147778977

Backend PR: https://github.com/ManageIQ/manageiq/pull/16181 MERGED  

After:
<img width="215" alt="screen shot 2017-10-31 at 1 26 06 pm" src="https://user-images.githubusercontent.com/9210860/32223782-18ee3c6c-be3f-11e7-869f-c2197bfa4c7d.png">


@miq-bot add_label wip, enhancement, euwe/no, automation/automate, pending core

https://bugzilla.redhat.com/show_bug.cgi?id=1508770

Issue with button that has a dialog will be solved in separate PR https://github.com/ManageIQ/manageiq-ui-classic/pull/2593. 