### PR TITLE
Show subnets dropdown for SCVMM provisioning

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -238,7 +238,7 @@
                :resource_group, :load_balancer,
                :sysprep_auto_logon_count, :sysprep_domain_name, :sysprep_server_license_mode,
                :vlan, :cloud_tenant, :src_configuration_profile_id, :vm_minimum_memory,
-               :vm_maximum_memory, :boot_disk_size].include?(field)
+               :vm_maximum_memory, :boot_disk_size, :subnet].include?(field)
         -# Pull Down fields
         -# Multiple select Pull Down fields
         - multiple = field == :security_groups

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -173,6 +173,7 @@
           :keys                       => keys})
   - when :network
     - keys = [:vlan, :mac_address]
+    - keys << :subnet if wf.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow)
     = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,


### PR DESCRIPTION
This adds a subnet dropdown for SCVMM provisioning

Depends on:

- [x] https://github.com/ManageIQ/manageiq/pull/16177

- [x] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/19

![screenshot from 2017-10-12 12-03-01](https://user-images.githubusercontent.com/12851112/31506443-72ab6936-af45-11e7-8ef9-30b97012f9b7.png)
