### PR TITLE
Display flash messages in Advanced search

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -159,18 +159,24 @@ module ApplicationController::AdvancedSearch
     @edit[@expkey][:selected] = nil                           # Clear selected search
   end
 
-  def adv_search_redraw_tree(tree)
+  def adv_search_redraw_tree_and_main(tree)
+    display_mode = params[:button] == 'save' ? params[:button] : nil
+    tree_name = x_active_tree.to_s
     render :update do |page|
       page << javascript_prologue
-      tree_name = x_active_tree.to_s
-      page.replace("#{tree_name}_div", :partial => "shared/tree", :locals => {:tree => tree, :name => tree_name})
+      page.replace("#{tree_name}_div",  :partial => "shared/tree",               :locals => {:tree => tree, :name => tree_name})
+      page.replace("adv_search_body",   :partial => "layouts/adv_search_body",   :locals => {:mode => display_mode})
+      page.replace("adv_search_footer", :partial => "layouts/adv_search_footer", :locals => {:mode => display_mode})
     end
   end
 
-  def adv_search_redraw_listnav
+  def adv_search_redraw_listnav_and_main
+    display_mode = params[:button] == 'save' ? params[:button] : nil
     render :update do |page|
       page << javascript_prologue
       page.replace(:listnav_div, :partial => "layouts/listnav")
+      page.replace("adv_search_body",   :partial => "layouts/adv_search_body",   :locals => {:mode => display_mode})
+      page.replace("adv_search_footer", :partial => "layouts/adv_search_footer", :locals => {:mode => display_mode})
     end
   end
 

--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -189,7 +189,7 @@ module ApplicationController::AdvancedSearch
       tree_type = x_active_tree.to_s.sub(/_tree/, '').to_sym
       builder = TreeBuilder.class_for_type(tree_type)
       tree = builder.new(x_active_tree, tree_type, @sb)
-      adv_search_redraw_tree(tree)
+      adv_search_redraw_tree_and_main(tree)
       return
     elsif %w(ems_cloud ems_infra).include?(@layout)
       build_listnav_search_list(@view.db)
@@ -197,7 +197,7 @@ module ApplicationController::AdvancedSearch
       build_listnav_search_list(@edit[@expkey][:exp_model])
     end
 
-    adv_search_redraw_listnav
+    adv_search_redraw_listnav_and_main
   end
 
   def adv_search_redraw_search_partials(display_mode = nil)

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -48,6 +48,7 @@
               %font{:color => "black"}
                 = _("Choose a %{model} report filter") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
   - elsif mode == "save"
+    = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'exp_editor_flash'}
     .modal-body
       .form-horizontal.static
         .form-group


### PR DESCRIPTION
fixing https://github.com/ManageIQ/manageiq-ui-classic/issues/2372

Display flash message in Advanced search after clicking on Save or Delete
button when saving or deleting a filter. Redraw Adv search window properly.
Rename the two methods corresponding to what was added to redraw Adv
search.

**Before:**
![a1](https://user-images.githubusercontent.com/13417815/31500734-867345e2-af68-11e7-8a8d-d9e024501b65.png)

**After:**
![a4](https://user-images.githubusercontent.com/13417815/31725447-b703de40-b424-11e7-9c19-c6e5de304a74.png)
![a2](https://user-images.githubusercontent.com/13417815/31500741-8d76ecf4-af68-11e7-8af9-cd079cc019d7.png)
![a3](https://user-images.githubusercontent.com/13417815/31501004-5ec28296-af69-11e7-9eac-6fccc8d80a9c.png)
![a5](https://user-images.githubusercontent.com/13417815/31725594-04df23f4-b425-11e7-8944-fadbc5055aa6.png)
