### PR TITLE
Foreman changed it's default model to display configured system

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -218,20 +218,22 @@ module ApplicationHelper
   end
 
   MODEL_STRING = {
-    "all_vms"                                => VmOrTemplate,
-    "all_miq_templates"                      => MiqTemplate,
-    "based_volumes"                          => CloudVolume,
-    "instances"                              => Vm,
-    "images"                                 => MiqTemplate,
-    "groups"                                 => Account,
-    "users"                                  => Account,
-    "host_services"                          => SystemService,
-    "chargebacks"                            => ChargebackRate,
-    "playbooks"                              => ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook,
-    "physical_servers_with_host"             => PhysicalServer,
-    "manageiq/providers/automation_managers" => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript,
-    "vms"                                    => VmOrTemplate,
-    "ServiceCatalog"                         => ServiceTemplate
+
+    "all_vms"                                   => VmOrTemplate,
+    "all_miq_templates"                         => MiqTemplate,
+    "based_volumes"                             => CloudVolume,
+    "instances"                                 => Vm,
+    "images"                                    => MiqTemplate,
+    "groups"                                    => Account,
+    "users"                                     => Account,
+    "host_services"                             => SystemService,
+    "chargebacks"                               => ChargebackRate,
+    "playbooks"                                 => ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook,
+    "physical_servers_with_host"                => PhysicalServer,
+    "manageiq/providers/automation_managers"    => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript,
+    "vms"                                       => VmOrTemplate,
+    "ServiceCatalog"                            => ServiceTemplate,
+    "manageiq/providers/configuration_managers" => ConfigurationProfile
   }.freeze
 
   HAS_ASSOCATION = {


### PR DESCRIPTION
### Fixes bug in Provider foreman explorer screen
When accessing foreman explorer screen, no data are visible, because there is an error in which model should be used. Foreman changed it's default class from `Manageiq::Providers::ConfigurationManager` to `ConfigurationProfile`.