### PR TITLE
miqDBBackupService - fix isModelValueNil to handle undefined

### DIFF
--- a/app/assets/javascripts/services/miq_db_backup_service.js
+++ b/app/assets/javascripts/services/miq_db_backup_service.js
@@ -44,7 +44,7 @@ ManageIQ.angular.app.service('miqDBBackupService', function() {
   };
 
   this.isModelValueNil = function(value) {
-    return value === null || value === '';
+    return value === undefined || value === null || value === '';
   };
 
   this.resetAll = function(model) {


### PR DESCRIPTION
Go to 👤 > Configuration > Diagnostics > (current server) -> Collect Logs; Edit

Change type to something other than No Depot.

You'll get an Infinite $digest Loop warning in the browser console without this.

---

`isModelValueNil` is supposed to return true for all nil-like values (but not 0 or false)

`dbRequired` tests that to see if the depot_name is actually required
.. but `depot_name` is using `dbRequired` to see if the field should be required or not

setting `depot_name` to an empty string will change the model value to `undefined`
and there's a watch that changes it to `null`

=> The value would oscilate between `undefined` and `null`, never settling, resulting in an infinite $digest Loop.

This adds `undefined` to `isModelValueNil`, causing the value to always settle.

https://bugzilla.redhat.com/show_bug.cgi?id=1498088
https://bugzilla.redhat.com/show_bug.cgi?id=1498097

Cc @mzazrivec 