### PR TITLE
Fixed typo in method name

### DIFF
--- a/app/controllers/planning_controller.rb
+++ b/app/controllers/planning_controller.rb
@@ -179,7 +179,7 @@ class PlanningController < ApplicationController
 
     @sb = {}
 
-    planning_build_options
+    build_options
   end
 
   private

--- a/spec/controllers/planning_controller_spec.rb
+++ b/spec/controllers/planning_controller_spec.rb
@@ -48,5 +48,29 @@ describe PlanningController do
       sb = controller.instance_variable_get(:@sb)
       expect(sb[:vms]).to eq(@vm1.id.to_s => @vm1.name, @vm3.id.to_s => @vm3.name, @vm4.id.to_s => @vm4.name)
     end
+
+    it 'successfully resets data' do
+      allow(controller).to receive(:render)
+      controller.instance_variable_set(:@sb, :vms => {}, :options => {})
+      controller.send(:reset)
+      sb = controller.instance_variable_get(:@sb)
+      sb_result = {
+        :options    => {
+          :time_profile      => nil,
+          :time_profile_tz   => nil,
+          :time_profile_days => nil,
+          :tz                => nil
+        },
+        :emss       => {},
+        :clusters   => {},
+        :hosts      => {
+          @host1.id.to_s => "Host1",
+          @host2.id.to_s => "Host2"
+        },
+        :datastores => {},
+        :vm_filters => {}
+      }
+      expect(sb).to eq(sb_result)
+    end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1501282

@lgalis please review/test

Fixes an error when pressing Reset button
```
I, [2017-10-13T11:37:13.849823 #13043]  INFO -- : Started POST "/planning/reset?button=reset" for ::1 at 2017-10-13 11:37:13 -0400
I, [2017-10-13T11:37:13.882706 #13043]  INFO -- : Processing by PlanningController#reset as JS
I, [2017-10-13T11:37:13.882830 #13043]  INFO -- :   Parameters: {"button"=>"reset"}
F, [2017-10-13T11:37:14.369933 #13043] FATAL -- : Error caught: [NameError] undefined local variable or method `planning_build_options' for #<PlanningController:0x007f59fb2cfa68>
Did you mean?  planning_url
/home/hkataria/dev/manageiq-ui-classic/app/controllers/planning_controller.rb:182:in `reset'
```