### PR TITLE
Map the 'Inactive' status to Error

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -183,6 +183,7 @@ ManageIQ.angular.app.service('topologyService', function() {
       case 'Error':
       case 'Unreachable':
       case 'Down':
+      case 'Inactive':
         return 'error';
       case 'Warning':
       case 'Waiting':


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1488135

When a router or cloud network has a status value of "inactive" the circle in the network topology view currently turns grey. This is because the "inactive" status is set to "unknown". This PR sets it to 'Error' so it runs red.

- Add an AWS provider
- Navigate to Compute/Clouds/Providers
- Open the AWS provider
- Click on the Network Manager
- Click on Topology
- Locate a network router or cloud network that is inactive (For this, I hardcoded the status property of a router to 'inactive' in the database)
- Ensure the circle is red, not grey.
