### PR TITLE
Use miqObserveRequest to force dialog submit to wait for auto refresh

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -1,4 +1,4 @@
-/* global miqInitSelectPicker miqSelectPickerEvent miqSparkle miqSparkleOn */
+/* global miqInitSelectPicker miqObserveRequest miqSelectPickerEvent miqSparkle miqSparkleOn */
 
 var dialogFieldRefresh = {
   unbindAllPreviousListeners: function() {
@@ -238,7 +238,7 @@ var dialogFieldRefresh = {
   },
 
   sendRefreshRequest: function(url, data, doneFunction) {
-    miqJqueryRequest(url, {
+    miqObserveRequest(url, {
       data: data,
       dataType: 'json',
       beforeSend: true,

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -923,4 +923,21 @@ describe('dialogFieldRefresh', function() {
       });
     });
   });
+
+  describe('#sendRefreshRequest', function() {
+    beforeEach(function() {
+      spyOn(window, 'miqObserveRequest');
+    });
+
+    it('delegates to miqObserveRequest', function() {
+      dialogFieldRefresh.sendRefreshRequest('the url', 'the data', 'the done function');
+      expect(window.miqObserveRequest).toHaveBeenCalledWith('the url', {
+        data: 'the data',
+        dataType: 'json',
+        beforeSend: true,
+        complete: true,
+        done: 'the done function'
+      });
+    });
+  });
 });


### PR DESCRIPTION
There was a small race condition before where while ordering a dialog, if the user had typed in something into a text box without tabbing away or clicking elsewhere, they could click the submit button and potentially submit the form before any auto refreshes were actually done processing.

This fix simply adds the auto refreshes to the observe queue which forces the submit to wait until they are finished.

https://bugzilla.redhat.com/show_bug.cgi?id=1499589

/cc @gmcculloug 

@miq-bot add_label bug, euwe/yes, fine/yes
@miq-bot assign @h-kataria 

@himdel We talked about this a bit throwing around ideas, but...ends up the simplest idea worked the best, haha!
@AparnaKarve Think you can review? Would be nice to get this in asap so we can get a hotfix for the customer and I think @himdel is gone for the day.
@h-kataria Can you merge when everything is good to go?