### PR TITLE
Toolbars - use send_checked, refactor params in miqToolbarOnClick

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1411,7 +1411,7 @@ function miqToolbarOnClick(_e) {
   }
 
   // put url_parms into params var, if defined
-  var params = getParams(button.data('url_parms'));
+  var params = getParams(button.data('url_parms'), !! button.data('send_checked'));
 
   // TODO:
   // Checking for perf_reload button to not turn off spinning Q (will be done after charts are drawn).
@@ -1434,25 +1434,24 @@ function miqToolbarOnClick(_e) {
   miqJqueryRequest(tb_url, options);
   return false;
 
-  function getParams(url_parms) {
-    if (! url_parms) {
-      return undefined;
+  function getParams(url_parms, send_checked) {
+    var params = [];
+
+    if (url_parms && (url_parms[0] === '?')) {
+      params.push( url_parms.slice(1) );
     }
 
-    if (url_parms.match('_div$')) {
-      if (ManageIQ.gridChecks.length) {
-        return 'miq_grid_checks=' + ManageIQ.gridChecks.join(',');
-      }
-
-      return miqSerializeForm(url_parms);
+    // FIXME - don't depend on length
+    // (but then params[:miq_grid_checks] || params[:id] does the wrong thing)
+    if (send_checked && ManageIQ.gridChecks.length) {
+      params.push('miq_grid_checks=' + ManageIQ.gridChecks.join(','));
     }
 
-    if (url_parms.match('id=LIST')) {
-      // this is used by custom buttons in lists
-      return url_parms.split("?")[1] + '&miq_grid_checks=' + ManageIQ.gridChecks.join(',');
+    if (url_parms && url_parms.match('_div$')) {
+      params.push(miqSerializeForm(url_parms));
     }
 
-    return url_parms.split('?')[1];
+    return _.filter(params).join('&') || undefined;
   }
 }
 

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1411,22 +1411,7 @@ function miqToolbarOnClick(_e) {
   }
 
   // put url_parms into params var, if defined
-  var params;
-  if (button.data('url_parms')) {
-    if (button.data('url_parms').match('_div$')) {
-      if (ManageIQ.gridChecks.length) {
-        params = 'miq_grid_checks=' + ManageIQ.gridChecks.join(',');
-      } else {
-        params = miqSerializeForm(button.data('url_parms'));
-      }
-    } else if (button.data('url_parms').match('id=LIST')) {
-      // this is used by custom buttons in lists
-      params = button.data('url_parms').split("?")[1] +
-        '&miq_grid_checks=' + ManageIQ.gridChecks.join(',');
-    } else {
-      params = button.data('url_parms').split('?')[1];
-    }
-  }
+  var params = getParams(button.data('url_parms'));
 
   // TODO:
   // Checking for perf_reload button to not turn off spinning Q (will be done after charts are drawn).
@@ -1448,6 +1433,27 @@ function miqToolbarOnClick(_e) {
 
   miqJqueryRequest(tb_url, options);
   return false;
+
+  function getParams(url_parms) {
+    if (! url_parms) {
+      return undefined;
+    }
+
+    if (url_parms.match('_div$')) {
+      if (ManageIQ.gridChecks.length) {
+        return 'miq_grid_checks=' + ManageIQ.gridChecks.join(',');
+      }
+
+      return miqSerializeForm(url_parms);
+    }
+
+    if (url_parms.match('id=LIST')) {
+      // this is used by custom buttons in lists
+      return url_parms.split("?")[1] + '&miq_grid_checks=' + ManageIQ.gridChecks.join(',');
+    }
+
+    return url_parms.split('?')[1];
+  }
 }
 
 function miqSupportCasePrompt(tb_url) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1411,7 +1411,7 @@ function miqToolbarOnClick(_e) {
   }
 
   // put url_parms into params var, if defined
-  var params = getParams(button.data('url_parms'), !! button.data('send_checked'));
+  var paramstring = getParams(button.data('url_parms'), !! button.data('send_checked'));
 
   // TODO:
   // Checking for perf_reload button to not turn off spinning Q (will be done after charts are drawn).
@@ -1428,27 +1428,27 @@ function miqToolbarOnClick(_e) {
   var options = {
     beforeSend: true,
     complete: ! no_complete,
-    data: params,
+    data: paramstring,
   };
 
   miqJqueryRequest(tb_url, options);
   return false;
 
-  function getParams(url_parms, send_checked) {
+  function getParams(urlParms, sendChecked) {
     var params = [];
 
-    if (url_parms && (url_parms[0] === '?')) {
-      params.push( url_parms.slice(1) );
+    if (urlParms && (urlParms[0] === '?')) {
+      params.push( urlParms.slice(1) );
     }
 
     // FIXME - don't depend on length
     // (but then params[:miq_grid_checks] || params[:id] does the wrong thing)
-    if (send_checked && ManageIQ.gridChecks.length) {
+    if (sendChecked && ManageIQ.gridChecks.length) {
       params.push('miq_grid_checks=' + ManageIQ.gridChecks.join(','));
     }
 
-    if (url_parms && url_parms.match('_div$')) {
-      params.push(miqSerializeForm(url_parms));
+    if (urlParms && urlParms.match('_div$')) {
+      params.push(miqSerializeForm(urlParms));
     }
 
     return _.filter(params).join('&') || undefined;

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -133,13 +133,14 @@ class ApplicationHelper::ToolbarBuilder
   # Set properties for button
   def apply_common_props(button, input)
     button.update(
-      :icon    => input[:icon],
-      :color   => input[:color],
-      :name    => button[:id],
-      :hidden  => button[:hidden] || !!input[:hidden],
-      :pressed => input[:pressed],
-      :onwhen  => input[:onwhen],
-      :data    => input[:data]
+      :color        => input[:color],
+      :data         => input[:data],
+      :hidden       => button[:hidden] || !!input[:hidden],
+      :icon         => input[:icon],
+      :name         => button[:id],
+      :onwhen       => input[:onwhen],
+      :pressed      => input[:pressed],
+      :send_checked => input[:send_checked],
     )
 
     button[:enabled] = input[:enabled]

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -270,10 +270,11 @@ class ApplicationHelper::ToolbarBuilder
       :enabled   => enabled,
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "button",
-      :url_parms => "?id=#{record_id}&button_id=#{button_id}&cls=#{model}&pressed=custom_button&desc=#{button_name}"
+      :url_parms => "?id=#{record_id}&button_id=#{button_id}&cls=#{model}&pressed=custom_button&desc=#{button_name}",
     }
     button[:text] = button_name if input[:text_display]
     button[:onwhen] = '1+' if cb_enabled_for_nested
+    button[:send_checked] = true if record_id == 'LIST'
     button
   end
 

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -431,24 +431,25 @@ describe ApplicationHelper, "::ToolbarBuilder" do
   context "toolbar_class" do
     before do
       controller.instance_variable_set(:@sb, :active_tree => :foo_tree)
-      @pdf_button = {:id        => "download_choice__download_pdf",
-                     :child_id  => "download_pdf",
-                     :type      => :button,
-                     :img       => "download_pdf.png",
-                     :imgdis    => "download_pdf.png",
-                     :img_url   => ActionController::Base.helpers.image_path("toolbars/download_pdf.png"),
-                     :icon      => "fa fa-file-pdf-o fa-lg",
-                     :color     => nil,
-                     :text      => "Download as PDF",
-                     :title     => "Download this report in PDF format",
-                     :name      => "download_choice__download_pdf",
-                     :hidden    => false,
-                     :pressed   => nil,
-                     :onwhen    => nil,
-                     :enabled   => true,
-                     :url       => "/download_data",
-                     :url_parms => "?download_type=pdf",
-                     :data      => nil}
+      @pdf_button = {:id           => "download_choice__download_pdf",
+                     :child_id     => "download_pdf",
+                     :type         => :button,
+                     :img          => "download_pdf.png",
+                     :imgdis       => "download_pdf.png",
+                     :img_url      => ActionController::Base.helpers.image_path("toolbars/download_pdf.png"),
+                     :icon         => "fa fa-file-pdf-o fa-lg",
+                     :color        => nil,
+                     :text         => "Download as PDF",
+                     :title        => "Download this report in PDF format",
+                     :name         => "download_choice__download_pdf",
+                     :hidden       => false,
+                     :pressed      => nil,
+                     :onwhen       => nil,
+                     :enabled      => true,
+                     :url          => "/download_data",
+                     :url_parms    => "?download_type=pdf",
+                     :send_checked => nil,
+                     :data         => nil}
       @layout = "catalogs"
       stub_user(:features => :all)
       allow(helper).to receive(:x_active_tree).and_return(:ot_tree)


### PR DESCRIPTION
~~Depends on https://github.com/ManageIQ/ui-components/pull/185~~

Fixes #588 (except for cleanup)

* makes `send_checked` propagate from toolbar definitions to the toolbar component
* makes custom buttons send `send_checked: true` whenever `id=LIST`
* refactors `miqToolbarOnClick` and changes to use `send_checked` instead of `url_params` when determining when to send `miq_grid_checks`:

#### miqToolbarOnClick differences

  * we no longer use `url_parms` to know when to send `miq_grid_checks`
    * before: when ending with `_div` and nonempty, or containing `id=LIST`
    * now: when `send_checked` and nonempty
    * change: `params[:miq_grid_checks]` will be `nil` instead of `""` when nothing is selected even for custom buttons

  * we always call `miqSerializeForm` when ending with `_div`, but clean up nothings
    * before: when `_div` and (`gridChecks`) empty
    * now: always, but returns `""` for GTLs
    * (but the alternative of sending when _div and not send_checked or empty is probably wrong anyway)

  * the ? url_params variant is handled a bit differently
    * `?` position
      * before: this would affect any url_parms containing a question mark
      * now: url_parms needs to start with it
      * but not seeing any url_parms values where this would matter
    * multiple `?`
      * before: split[1] pretty much means just anything between the first two question marks
      * now: slice(1) will use the whole string
      * but not seeing any url_parms values where this would matter

Cc @martinpovolny 