### PR TITLE
Menu::Item - don't do miqCheckForChanges when opening modals

### DIFF
--- a/app/presenters/menu/item.rb
+++ b/app/presenters/menu/item.rb
@@ -33,7 +33,8 @@ module Menu
                when :modal      then {'data-toggle' => 'modal', 'data-target' => href}
                else                  {:href => href}
                end
-      params.merge(:onclick => 'return miqCheckForChanges();')
+      params[:onclick] = 'return miqCheckForChanges();' unless type == :modal
+      params
     end
 
     def leaf?


### PR DESCRIPTION
Opening a menu item should call `miqCheckForChanges`, to prevent leaving the screen when a form is open.

But doing so for modals makes less sense because we're not actually leaving the screen.

=> removing the `miqCheckForChanges` call from modal menuitems.

https://bugzilla.redhat.com/show_bug.cgi?id=1501156

Cc @martinpovolny 