### PR TITLE
Show authentication status in middleware provider summary page

### DIFF
--- a/app/helpers/ems_middleware_helper/textual_summary.rb
+++ b/app/helpers/ems_middleware_helper/textual_summary.rb
@@ -17,7 +17,7 @@ module EmsMiddlewareHelper::TextualSummary
   end
 
   def textual_group_status
-    TextualGroup.new(_("Status"), %i(refresh_status refresh_date))
+    TextualGroup.new(_("Status"), %i(authentication_status refresh_status refresh_date))
   end
 
   def textual_group_smart_management
@@ -55,5 +55,12 @@ module EmsMiddlewareHelper::TextualSummary
      :icon  => "pficon pficon-topology",
      :link  => url_for_only_path(:controller => 'middleware_topology', :action => 'show', :id => @record.id),
      :title => _('Show topology')}
+  end
+
+  def textual_authentication_status
+    auth_status = @record.authentication_for_summary.first
+
+    short_status = auth_status[:status] || _('None')
+    "#{short_status} - #{auth_status[:status_details]}" unless auth_status[:status_details].blank?
   end
 end

--- a/spec/controllers/ems_middleware_controller_spec.rb
+++ b/spec/controllers/ems_middleware_controller_spec.rb
@@ -17,7 +17,15 @@ describe EmsMiddlewareController do
       session[:settings] = {:views => {}, :quadicons => {}}
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)
-      @middleware = FactoryGirl.create(:ems_hawkular)
+      auth = AuthToken.new(
+        :name     => "test",
+        :auth_key => "valid-token",
+        :userid   => "jdoe",
+        :password => "password",
+        :authtype => :default
+      )
+      @middleware = FactoryGirl.create(:ems_hawkular,
+                                       :authentications => [auth])
       MiddlewareDatasource.create(:ext_management_system => @middleware, :name => "Test Middleware")
     end
 


### PR DESCRIPTION
Some provider operations (notably, provider refresh) doesn't run if
provider's authentication is not valid. However, it wasn't clear to the
user what's the status.

Showing authentication status in mw provider summary page, along the
detailed status to clearly show to the user what's wrong (if something
is wrong).

![image](https://user-images.githubusercontent.com/23639005/31630903-a81c1ea4-b27d-11e7-99a2-4fbe0fe832ed.png)
