### PR TITLE
Create dialog for provisioning physical servers

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -39,7 +39,7 @@ class PhysicalServerController < ApplicationController
       %i(properties networks relationships power_management assets firmware_details network_adapters smart_management),
     ]
   end
-  helper_method :textual_group_list
+  helper_method(:textual_group_list)
 
   def button
     assign_policies(PhysicalServer) if params[:pressed] == "physical_server_protect"
@@ -52,5 +52,16 @@ class PhysicalServerController < ApplicationController
       show_timeline
       javascript_redirect(:action => 'show', :id => @record.id, :display => 'timeline')
     end
+  end
+
+  def provision
+    provisioning_ids = find_checked_ids_with_rbac(PhysicalServer)
+    provisioning_ids.push(find_id_with_rbac(PhysicalServer, params[:id])) if provisioning_ids.empty?
+
+    javascript_redirect(:controller     => "miq_request",
+                        :action         => "prov_edit",
+                        :prov_id        => provisioning_ids,
+                        :org_controller => "physical_server",
+                        :escape         => false)
   end
 end

--- a/app/helpers/application_helper/toolbar/physical_server_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_server_center.rb
@@ -193,6 +193,26 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
           ),
         ]
       ),
+      select(
+        :physical_server_lifecycle_choice,
+        'fa fa-recycle fa-lg',
+        t = N_('Lifecycle'),
+        t,
+        :enabled => true,
+        :items   => [
+          button(
+            :physical_server_provision,
+            'pficon pficon-add-circle-o fa-lg',
+            t = N_('Provision Physical Server'),
+            t,
+            :url       => "provision",
+            :url_parms => "main_div",
+            :enabled   => true,
+            :onwhen    => "0+",
+            :klass     => ApplicationHelper::Button::ConfiguredSystemProvision
+          )
+        ]
+      )
     ]
   )
 

--- a/app/helpers/application_helper/toolbar/physical_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_servers_center.rb
@@ -217,6 +217,26 @@ class ApplicationHelper::Toolbar::PhysicalServersCenter < ApplicationHelper::Too
           ),
         ]
       ),
+      select(
+        :physical_server_lifecycle_choice,
+        'fa fa-recycle fa-lg',
+        t = N_('Lifecycle'),
+        t,
+        :enabled => true,
+        :items   => [
+          button(
+            :physical_server_provision,
+            'pficon pficon-add-circle-o fa-lg',
+            t = N_('Provision Physical Server'),
+            t,
+            :url       => "provision",
+            :url_parms => "main_div",
+            :enabled   => true,
+            :onwhen    => "0+",
+            :klass     => ApplicationHelper::Button::ConfiguredSystemProvision
+          )
+        ]
+      )
     ]
   )
 end

--- a/app/views/miq_request/_prov_physical_server_dialog.html.haml
+++ b/app/views/miq_request/_prov_physical_server_dialog.html.haml
@@ -1,0 +1,58 @@
+-# wf          The workflow object currently in use
+-# dialog      The name (symbol) of the selected dialog
+
+- current_tab = @edit && @edit[:new] ? @edit[:new][:current_tab_key] : @options[:current_tab_key]
+%br
+
+- if dialog == current_tab
+  - case current_tab
+  - when :requester
+    - keys = [:owner_email, :owner_first_name, :owner_last_name, :owner_address, :owner_city, :owner_state, :owner_zip, :owner_country, :owner_title, :owner_company, :owner_department, :owner_office, :owner_phone, :owner_phone_mobile, :request_notes]
+    = render(:partial => "prov_dialog_fieldset",
+      :locals         => {:workflow => wf,
+        :dialog       => dialog,
+        :label        => _("Request Information"),
+        :keys         => keys})
+    - keys = [:owner_manager, :owner_manager_mail, :owner_manager_mail]
+    = render(:partial => "prov_dialog_fieldset",
+      :locals         => {:workflow => wf,
+        :dialog                     => dialog,
+        :label                      => _("Manager"),
+        :keys                       => keys})
+  - when :purpose
+    - keys = [:tag_ids]
+    = render(:partial => "prov_dialog_fieldset",
+      :locals         => {:workflow => wf,
+        :dialog                     => dialog,
+        :label                      => _("Select Tags to apply"),
+        :keys                       => keys})
+  - when :service
+    - keys = [:src_configured_system_ids, :src_configuration_profile_id]
+    = render(:partial => "prov_dialog_fieldset",
+      :locals         => {:workflow => wf,
+        :dialog                     => dialog,
+        :label                      => _("Physical Servers"),
+        :keys                       => keys})
+  - when :customize
+    - keys = [:root_password]
+    = render(:partial => "prov_dialog_fieldset",
+      :locals         => {:workflow => wf,
+        :dialog                     => dialog,
+        :label                      => _("Credentials"),
+        :prefix                     => "miq_request/",
+        :keys                       => keys})
+    - keys = [:hostname, :ip_addr]
+    = render(:partial => "prov_dialog_fieldset",
+      :locals         => {:workflow => wf,
+        :dialog                     => dialog,
+        :label                      => _("IP Address Information"),
+        :prefix                     => "miq_request/",
+        :keys                       => keys})
+  - when :schedule
+    - has_schedule_time = (@edit && @edit[:new] && @edit[:new][:schedule_type] && @edit[:new][:schedule_type][0] == "schedule") || (@options && @options[:schedule_type] && @options[:schedule_type][0] == "schedule")
+    - keys = [:schedule_type, has_schedule_time ? :schedule_time : nil, :stateless].compact
+    = render(:partial => "prov_dialog_fieldset",
+      :locals         => {:workflow => wf,
+        :dialog                     => dialog,
+        :label                      => _("Schedule Info"),
+        :keys                       => keys})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1335,6 +1335,7 @@ Rails.application.routes.draw do
         quick_search
         tl_chooser
         wait_for_task
+	provision
       ) +
           adv_search_post +
           exp_post +

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1335,7 +1335,7 @@ Rails.application.routes.draw do
         quick_search
         tl_chooser
         wait_for_task
-	provision
+        provision
       ) +
           adv_search_post +
           exp_post +


### PR DESCRIPTION
This PR creates a dialog for provisioning physical servers. Provisioning servers can be done by selecting and applying a LXCA config pattern to a server or group of servers. _Note:_ Currently, the dialog is not fully functional; it only displays the servers and available configuration patterns. The rest of the functionality will be delivered in a future PR.

Depends on ManageIQ/manageiq#16203

![image](https://user-images.githubusercontent.com/23690141/31673011-14807e38-b32c-11e7-93cd-7b6c38b40730.png)

![image](https://user-images.githubusercontent.com/23690141/31673026-1d3fb12e-b32c-11e7-8c1e-691f39235a60.png)
