### PR TITLE
Allow for VmdbDatabase to not be present

### DIFF
--- a/app/controllers/ops_controller/db.rb
+++ b/app/controllers/ops_controller/db.rb
@@ -99,9 +99,11 @@ module OpsController::Db
         @right_cell_text = _("VMDB Summary")
       elsif @sb[:active_tab] == "db_utilization"
         @record = VmdbDatabase.my_database
-        perf_gen_init_options               # Initialize perf chart options, charts will be generated async
-        @sb[:record_class] = @record.class.base_class.name  # Hang on to record class/id for async trans
-        @sb[:record_id] = @record.id
+        if @record
+          perf_gen_init_options               # Initialize perf chart options, charts will be generated async
+          @sb[:record_class] = @record.class.base_class.name  # Hang on to record class/id for async trans
+          @sb[:record_id] = @record.id
+        end
         @right_cell_text = _("VMDB Utilization")
       else
         @right_cell_text = case @sb[:active_tab]

--- a/app/helpers/ops_helper/textual_summary.rb
+++ b/app/helpers/ops_helper/textual_summary.rb
@@ -6,6 +6,8 @@ module OpsHelper::TextualSummary
   TOP_TABLES_BY_COUNT = 5
 
   def textual_group_vmdb_connection_properties
+    return if @record.nil?
+
     TextualGroup.new(
       _("Properties"),
       %i(
@@ -16,18 +18,26 @@ module OpsHelper::TextualSummary
   end
 
   def textual_group_vmdb_tables_most_rows
+    return if @record.nil?
+
     TextualListview.new_from_hash(textual_vmdb_tables_most_rows)
   end
 
   def textual_group_vmdb_tables_largest_size
+    return if @record.nil?
+
     TextualListview.new_from_hash(textual_vmdb_tables_largest_size)
   end
 
   def textual_group_vmdb_tables_most_wasted_space
+    return if @record.nil?
+
     TextualListview.new_from_hash(textual_vmdb_tables_most_wasted_space)
   end
 
   def textual_group_vmdb_connection_capacity_data
+    return if @record.nil?
+
     TextualGroup.new(
       _("Capacity Data"),
       %i(

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -25,7 +25,7 @@ class TreeBuilderOpsVmdb < TreeBuilderOps
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    objects = Rbac.filtered(VmdbDatabase.my_database.evm_tables).to_a
+    objects = Rbac.filtered(VmdbDatabase.my_database.try(:evm_tables).to_a).to_a
     # storing table names and their id in hash so they can be used to build links on summary screen in top 5 boxes
     @sb[:vmdb_tables] = {}
     objects.each do |o|

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -229,7 +229,7 @@
             = render :partial => "db_details_tab"
       - if tree_node == "root" || tree_node.split("-").first == TreeBuilder.get_prefix_for_model("VmdbTable")
         = miq_tab_content("db_utilization", @sb[:active_tab]) do
-          - if @sb[:active_tab] == "db_utilization"
+          - if @sb[:active_tab] == "db_utilization" && @record
             = render(:partial => "layouts/performance")
 :javascript
   miq_tabs_init("#ops_tabs", "/ops/change_tab");


### PR DESCRIPTION
This commit allows for the Ops screen to continue to work even if the VmdbDatabase record is not present.  Right now, a VmdbDatabase record is required to be present so that this screen does not blow up, and so it is required during seeding.  Seeding this table is expensive, so we want to delay it, but we can't unless the ops screen can handle that.