### PR TITLE
Projects Dashboard - fix quota error

### DIFF
--- a/app/services/container_project_dashboard_service.rb
+++ b/app/services/container_project_dashboard_service.rb
@@ -73,20 +73,20 @@ class ContainerProjectDashboardService
   end
 
   def quota
-    # Until https://github.com/ManageIQ/manageiq/pull/15639 is resolved
-    parser = ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser.new
-
     @project.container_quota_items.collect do |quota_item|
-      enforced = parser.parse_quantity(quota_item.quota_enforced)
-      observed = parser.parse_quantity(quota_item.quota_observed)
+      enforced = quota_item.quota_enforced
+      observed = quota_item.quota_observed
+      enforced = (enforced % 1).zero? ? enforced.to_i : enforced
+      observed = (observed % 1).zero? ? observed.to_i : observed
+
       units = ""
 
       if quota_item.resource.include?("cpu")
         units = "Cores"
       elsif quota_item.resource.include?("memory")
-        units = "MB"
-        enforced /= 1.megabytes
-        observed /= 1.megabytes
+        units = "GB"
+        enforced /= 1.gigabytes
+        observed /= 1.gigabytes
       end
 
       {


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1509872
The following error apears if the project dashboard youre viewing has quota items:
```Ruby
F, [2017-10-15T14:03:43.942021 #29488] FATAL -- : Error caught: [NoMethodError] undefined method `decimal_si_to_f' for 10.0:Float
/home/azellner/.rvm/gems/ruby-2.3.3/bundler/gems/manageiq-providers-kubernetes-63b2a2aaa70b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb:1053:in `rescue in parse_quantity'
/home/azellner/.rvm/gems/ruby-2.3.3/bundler/gems/manageiq-providers-kubernetes-63b2a2aaa70b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb:1050:in `parse_quantity'
/home/azellner/Projects/manageiq-ui-classic/app/services/container_project_dashboard_service.rb:80:in `block in quota'
/home/azellner/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.6/lib/active_record/relation/delegation.rb:38:in `collect'
/home/azellner/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.6/lib/active_record/relation/delegation.rb:38:in `collect'
/home/azellner/Projects/manageiq-ui-classic/app/services/container_project_dashboard_service.rb:79:in `quota'
/home/azellner/Projects/manageiq-ui-classic/app/services/container_project_dashboard_service.rb:19:in `all_data'
/home/azellner/Projects/manageiq-ui-classic/app/controllers/container_dashboard_controller.rb:63:in `collect_project_data'
/home/azellner/Projects/manageiq-ui-classic/app/controllers/container_dashboard_controller.rb:31:in `project_data'
```

@zakiva Please review
cc @simon3z 

@miq-bot add_label compute/containers, bug



