### PR TITLE
Twick ad-hoc metrics page css

### DIFF
--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -21,7 +21,7 @@
     line-height: 27px;
   }
   .ad-hoc-toolbar {
-    margin-left: 15px;
+    margin-left: 20px;
   }
   .toolbar-pf {
     border: 0;
@@ -44,6 +44,7 @@
     overflow-y: hidden;
     .rate-switch {
       margin-left: 5px;
+      margin-right: 5px;
     }
     .bootstrap-select.btn-group {
       .dropdown-menu {
@@ -109,6 +110,7 @@
     }
     .form-group.toolbar-actions.ng-scope {
       border: 0;
+      padding-left: 0;
     }
     .dropdown-kebab-pf {
       .dropdown-menu {
@@ -127,8 +129,13 @@
       }
     }
   }
+  .ad-hoc-back-button {
+    margin-bottom: 10px;
+  }
+  .ad-hoc-chart-toolbar{
+    margin-left: -18px;
+  }
   .ad-hoc-tenant {
-    margin-left: 5px;
     input {
       display: inline;
       width: 190px;
@@ -186,6 +193,7 @@
     margin-bottom: 0;
   }
   .timeline-date-input {
+    padding-left: 5px;
     width: 300px;
   }
   .list-group {
@@ -201,10 +209,9 @@
     }
   }
   .timeline-stepper {
-    margin-left: 5px;
+    margin-right: 5px;
   }
   .toolbar-pf-include-actions.ng-scope {
-    margin-left: 10px;
     width: 100%;
   }
   .toolbar-pf-actions.ng-pristine.ng-valid.no-filter-results {

--- a/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
@@ -1,10 +1,10 @@
 .col-md-12.ad-hoc-tenant
-  .form-group.pull-left.ad-hoc-tenant
+  .form-group.pull-left.ad-hoc-back-button
     %button.btn.btn-default{"type"     => "button",
                             "ng-click" => "dash.viewMetrics()"}
       = _("Return to list view")
 
-%div{"pf-toolbar" => "", "config" => "dash.graphToolbarConfig"}
+.ad-hoc-chart-toolbar{"pf-toolbar" => "", "config" => "dash.graphToolbarConfig"}
   %actions
     .input-group.bootstrap-touchspin.timeline-stepper.pull-left
       %span.input-group-btn


### PR DESCRIPTION
**Description**

Fix some regressions in the layout of the Ad-hoc metrics page.

[ compute-> containers -> select container -> monitoring -> ad hoc metrics ]

**Screenshots**

Fixed:
![screenshot-localhost 3000-2017-10-15-16-43-44](https://user-images.githubusercontent.com/2181522/31585355-c9057468-b1c8-11e7-942b-c1c205b0ff62.png)
![screenshot-localhost 3000-2017-10-15-16-44-06](https://user-images.githubusercontent.com/2181522/31585356-c92336ec-b1c8-11e7-816b-bd506fd8a119.png)

Before fix:
![screenshot-localhost 3000-2017-10-15-16-45-15](https://user-images.githubusercontent.com/2181522/31585357-c93e702e-b1c8-11e7-9e5c-fffdefe1e57a.png)
![screenshot-localhost 3000-2017-10-15-16-45-33](https://user-images.githubusercontent.com/2181522/31585358-c9583cac-b1c8-11e7-84f5-f8e011b1375e.png)
