### PR TITLE
Use Chargeable field for determining measure in rate editor

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -518,12 +518,11 @@ class ChargebackController < ApplicationController
       temp[:per_time] ||= "hourly"
 
       temp[:currency] = detail.detail_currency.id
-      temp[:detail_measure] = detail.detail_measure
 
-      if detail.detail_measure.present?
+      if detail.chargeable_field.detail_measure.present?
         temp[:detail_measure] = {}
-        temp[:detail_measure][:measures] = detail.detail_measure.measures
-        temp[:chargeback_rate_detail_measure_id] = detail.detail_measure.id
+        temp[:detail_measure][:measures] = detail.chargeable_field.detail_measure.measures
+        temp[:chargeback_rate_detail_measure_id] = detail.chargeable_field.detail_measure.id
       end
 
       temp[:id] = params[:pressed] == 'chargeback_rates_copy' ? nil : detail.id


### PR DESCRIPTION
previously ChargebackRate(variable `detail` in code) model had relation to `ChargebackRateDetailMeasure` model. But we removed it and we relations are:
`ChargebackRate  -> ChargeableField -> ChargebackRateDetailMeasure `

So we need to get `ChargebackRateDetailMeasure` from `ChargeableField` and it was causing that select box was disappeared.

before
![screen shot 2017-10-16 at 14 39 58](https://user-images.githubusercontent.com/14937244/31612423-f5a3931c-b27f-11e7-81e2-98017e482f7d.png)

after
![screen shot 2017-10-16 at 14 39 11](https://user-images.githubusercontent.com/14937244/31612425-f7e7163a-b27f-11e7-96a5-86a9034ef552.png)


## Testing steps
1. CI -> Chargeback -> Rates
2. Add and edit existing rate
3.  See it there are checkboxes in per unit column.


@miq-bot assign @mzazrivec 
@miq-bot add_label bug
