### PR TITLE
Add physical server buttons when displaying through ems_physical_infra

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -192,7 +192,8 @@ module EmsCommon
                                      "orchestration_stack_",
                                      "security_group_",
                                      "storage_",
-                                     "vm_")
+                                     "vm_",
+                                     "physical_server_")
 
       case params[:pressed]
       # Clusters
@@ -232,6 +233,10 @@ module EmsCommon
       when "network_router_tag"               then tag(NetworkRouter)
       when "orchestration_stack_tag"          then tag(OrchestrationStack)
       when "security_group_tag"               then tag(SecurityGroup)
+
+      when "physical_server_protect"          then assign_policies(PhysicalServer)
+      when "physical_server_tag"              then tag(PhysicalServer)
+
       end
 
       return if params[:pressed].include?("tag") && !%w(host_tag vm_tag miq_template_tag instance_tag).include?(params[:pressed])

--- a/app/helpers/application_helper/toolbar/physical_server_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_server_center.rb
@@ -117,4 +117,38 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
       ),
     ]
   )
+  button_group(
+    'physical_server_policy',
+    [
+      select(
+        :physical_server_policy_choice,
+        'fa fa-shield fa-lg',
+        N_('Policy'),
+        :enabled => true,
+        :onwhen  => "1+",
+        :items   => [
+          button(
+            :physical_server_protect,
+            'pficon pficon-edit fa-lg',
+            N_('Manage Policies for the selected items'),
+            N_('Manage Policies'),
+            :url_parms    => "main_div",
+            :send_checked => true,
+            :enabled      => true,
+            :onwhen       => "1+"
+          ),
+          button(
+            :physical_server_tag,
+            'pficon pficon-edit fa-lg',
+            N_('Edit tags for the selected items'),
+            N_('Edit Tags'),
+            :url_parms    => "main_div",
+            :send_checked => true,
+            :enabled      => true,
+            :onwhen       => "1+"
+          ),
+        ]
+      ),
+    ]
+  )
 end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -447,7 +447,7 @@ class ApplicationHelper::ToolbarChooser
                     load_balancers network_ports network_routers orchestration_stacks resource_pools
                     security_groups storages middleware_deployments middleware_datasources
                     middleware_messagings middleware_servers)
-    to_display_center = %w(stack_orchestration_template topology cloud_object_store_objects generic_objects)
+    to_display_center = %w(stack_orchestration_template topology cloud_object_store_objects generic_objects physical_servers)
     if @lastaction == 'show' && (@view || @display != 'main') && !@layout.starts_with?("miq_request")
       if @display == "vms" || @display == "all_vms"
         return "vm_infras_center_tb"

--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -2,6 +2,10 @@
   - arr = (controller_name.camelize + "Controller").constantize.display_methods
   - if arr.include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@ems.id}"}
+    - if %w(physical_servers).include?(@display)
+      %physical-server-toolbar#ems_physical_infra_show_list_form
+      :javascript
+        miq_bootstrap('#ems_physical_infra_show_list_form')
   - elsif @showtype == "details"
     = render(:partial => "layouts/gtl", :locals => {:action_url => @lastaction})
   - elsif @showtype ==  "item"


### PR DESCRIPTION
This PR displays:
- Physical server buttons when displaying Physical Server page through ems_physical_infra.
- Physical Server policy button when showing a specific Physical Server.

![image](https://user-images.githubusercontent.com/5839808/31617318-3e8b972a-b265-11e7-9ddc-688f47aba682.png)
![image](https://user-images.githubusercontent.com/5839808/31633285-3c563a10-b296-11e7-93bf-4d1d55e5eeea.png)
