### PR TITLE
Fix providers card height

### DIFF
--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -7,7 +7,7 @@
           %img.provider-icon-small{"ng-src" =>"{{providerTypeIconImage}}"}
           {{providerTypeName}}
           %img.provider-icon-small{"ng-src" =>"{{providerStatusIconImage}}"}
-      %div{:layout                     => "tall",
+      .provider-card{:layout          => "tall",
           "pf-aggregate-status-card"  => "",
           "show-top-border"           => "true",
           :status                     => "objectStatus.providers",


### PR DESCRIPTION
**Description**

compute->containers->overview

When no providers are present, the providers card is too short. This pull request fixes that issue.

**Screenshots**

Before:
![screenshot from 2017-10-16 18-05-13](https://user-images.githubusercontent.com/498903/31619485-51ee21a6-b29d-11e7-9321-9a497ab39aa2.png)

After:
![screenshot from 2017-10-16 18-04-39](https://user-images.githubusercontent.com/498903/31619491-56977482-b29d-11e7-8182-c6760ea520d4.png)
