### PR TITLE
Fix wrong flash messages after widget import

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -251,11 +251,7 @@ class ReportController < ApplicationController
           add_flash(_("Error: No widget was selected to be imported."), :error)
         else
           number = widget_import_service.import_widgets(import_file_upload, params[:widgets_to_import])
-          if number == 1
-            add_flash(_("1 widget imported successfully"), :success)
-          else
-            add_flash(_("%{number} widgets imported successfully") % {:number => number}, :success)
-          end
+          add_flash(n_("%{number} widget imported successfully", "%{number} widgets imported successfully", number) % {:number => number})
         end
       else
         add_flash(_("Error: Widget import file upload expired"), :error)

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -247,8 +247,16 @@ class ReportController < ApplicationController
       import_file_upload = ImportFileUpload.where(:id => params[:import_file_upload_id]).first
       if import_file_upload
         $log.info("[#{session[:userid]}] initiated import")
-        widget_import_service.import_widgets(import_file_upload, params[:widgets_to_import])
-        add_flash(_("Widgets imported successfully"), :success)
+        if params[:widgets_to_import].nil?
+          add_flash(_("Error: No widget was selected to be imported."), :error)
+        else
+          number = widget_import_service.import_widgets(import_file_upload, params[:widgets_to_import])
+          if number == 1
+            add_flash(_("1 widget imported successfully"), :success)
+          else
+            add_flash(_("%{number} widgets imported successfully") % {:number => number}, :success)
+          end
+        end
       else
         add_flash(_("Error: Widget import file upload expired"), :error)
       end

--- a/app/services/widget_import_service.rb
+++ b/app/services/widget_import_service.rb
@@ -28,6 +28,7 @@ class WidgetImportService
   end
 
   def import_widgets(import_file_upload, widgets_to_import)
+    number_imported_widgets = 0
     unless widgets_to_import.nil?
       widgets = YAML.load(import_file_upload.uploaded_content)
 
@@ -38,12 +39,13 @@ class WidgetImportService
       raise ParsedNonWidgetYamlError if widgets.empty?
 
       widgets.each do |widget|
-        import_widget_from_hash(widget["MiqWidget"])
+        number_imported_widgets += 1 if import_widget_from_hash(widget["MiqWidget"])
       end
     end
 
     destroy_queued_deletion(import_file_upload.id)
     import_file_upload.destroy
+    number_imported_widgets
   end
 
   def store_for_import(file_contents)

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1011,9 +1011,10 @@ describe ReportController do
         end
 
         it "returns the flash message" do
+          allow(widget_import_service).to receive(:import_widgets).and_return(1)
           post :import_widgets, :params => params, :xhr => true
           expect(controller.instance_variable_get(:@flash_array))
-            .to include(:message => "Widgets imported successfully", :level => :success)
+            .to include(:message => "1 widget imported successfully", :level => :success)
         end
       end
 


### PR DESCRIPTION
Cloud Intel -> Reports -> Import/Export -> Widgets -> Choose file (yml with exported widgets) -> Upload -> no widget is checked -> Commit

Before:
<img width="883" alt="screen shot 2017-10-16 at 5 10 07 pm" src="https://user-images.githubusercontent.com/9210860/31619469-e5b2d8d6-b294-11e7-859e-ee4c4417ed70.png">

No widget imported.

After:
<img width="886" alt="screen shot 2017-10-16 at 4 50 00 pm" src="https://user-images.githubusercontent.com/9210860/31618866-6946db5e-b293-11e7-9886-ffa2f2b33811.png">

Cloud Intel -> Reports -> Import/Export -> Widgets -> Choose file (yml with exported widgets) -> Upload -> check few widgets -> Commit

Before:
<img width="883" alt="screen shot 2017-10-16 at 5 10 07 pm" src="https://user-images.githubusercontent.com/9210860/31619469-e5b2d8d6-b294-11e7-859e-ee4c4417ed70.png">

After:
<img width="888" alt="screen shot 2017-10-16 at 5 03 54 pm" src="https://user-images.githubusercontent.com/9210860/31619257-43b6eb94-b294-11e7-8613-207d328714af.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1501119

Bug is present in Fine.

@miq-bot add_label bug, fine/yes