### PR TITLE
OrchestrationStack template copy: use session, not URL to pass the fl…

### DIFF
--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -222,12 +222,12 @@ class OrchestrationStackController < ApplicationController
           {:error_message => bang.message}, :error)
         render_flash
       else
-        flash_message = _("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => 'OrchestrationTemplate'),
-                                                               :name  => ot.name}
-        javascript_redirect :controller    => 'catalog',
-                            :action        => 'ot_show',
-                            :id            => ot.id,
-                            :flash_message => flash_message
+        add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => 'OrchestrationTemplate'),
+                                                         :name  => ot.name})
+        session[:flash_msgs] = @flash_array.dup
+        javascript_redirect :controller => 'catalog',
+                            :action     => 'ot_show',
+                            :id         => ot.id
       end
     end
   end


### PR DESCRIPTION
Use session rather than URL params to pass the flash message.

Related to:
https://bugzilla.redhat.com/show_bug.cgi?id=1475303

Clouds --> Stacks --> select stack --> Relations --> Template --> Copy

note: cannot copy on AWS, can copy on Azure

ping @mzazrivec : please, take a look