### PR TITLE
Set formnovalidate on "create host aggregate" form's cancel button

### DIFF
--- a/app/views/host_aggregate/new.html.haml
+++ b/app/views/host_aggregate/new.html.haml
@@ -59,8 +59,9 @@
                          "ng-disabled" => "angularForm.$pristine",
                          "ng-class"    => "{ disabled: angularForm.$pristine}")
           = button_tag(_("Cancel"),
-                       :class     => "btn btn-default",
-                       "ng-click" => "cancelClicked()")
+                       :class          => "btn btn-default",
+                       :formnovalidate => 'true',
+                       "ng-click"      => "cancelClicked()")
 
 :javascript
   ManageIQ.angular.app.value('hostAggregateFormId', '#{@host_aggregate.id || "new"}');


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1495719 by setting `formnovalidate` on the cancel button of the Create Host Aggregate form.

It's possible that this might be a flag we want on cancel buttons system-wide so that clicking them never causes html5 validation popouts to appear, but I'm not sure if there are any undesirable effects to such a sweeping change.