### PR TITLE
Restore Delete and Edit options to Cloud Networks toolbar

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud_networks_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_networks_center.rb
@@ -16,25 +16,23 @@ class ApplicationHelper::Toolbar::CloudNetworksCenter < ApplicationHelper::Toolb
             :klass => ApplicationHelper::Button::CloudNetworkNew
           ),
           separator,
-          # TODO: Restore when cross controllers show_list issue fully in place
-          # https://github.com/ManageIQ/manageiq/pull/12551
-          #button(
-          #  :cloud_network_edit,
-          #  'pficon pficon-edit fa-lg',
-          #  t = N_('Edit selected Cloud Network'),
-          #  t,
-          #  :url_parms => 'main_div',
-          #  :enabled   => false,
-          #  :onwhen    => '1'),
-          #button(
-          #  :cloud_network_delete,
-          #  'pficon pficon-delete fa-lg',
-          #  t = N_('Delete selected Cloud Networks'),
-          #  t,
-          #  :url_parms => 'main_div',
-          #  :confirm   => N_('Warning: The selected Cloud Networks and ALL of their components will be removed!'),
-          #  :enabled   => false,
-          #  :onwhen    => '1+')
+          button(
+            :cloud_network_edit,
+            'pficon pficon-edit fa-lg',
+            t = N_('Edit selected Cloud Network'),
+            t,
+            :url_parms => 'main_div',
+            :enabled   => false,
+            :onwhen    => '1'),
+          button(
+            :cloud_network_delete,
+            'pficon pficon-delete fa-lg',
+            t = N_('Delete selected Cloud Networks'),
+            t,
+            :url_parms => 'main_div',
+            :confirm   => N_('Warning: The selected Cloud Networks and ALL of their components will be removed!'),
+            :enabled   => false,
+            :onwhen    => '1+')
         ]
       )
     ]


### PR DESCRIPTION
Now that https://github.com/ManageIQ/manageiq/pull/12551 is merged as mentioned in the section that was commented out, it should be possible to restore this functionality. It appears to work correctly for me.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1490393