### PR TITLE
Display Generic Object Associations correctly

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1694,12 +1694,17 @@ class ApplicationController < ActionController::Base
   end
 
   def get_db_view(db, options = {})
-    if %w(ManageIQ_Providers_InfraManager_Template ManageIQ_Providers_InfraManager_Vm)
-       .include?(db) && options[:association] == "all_vms_and_templates" || controller_name == 'generic_object'
+    if unrequired_association_exists?(db, options)
       options[:association] = nil
     end
 
     MiqReport.load_from_view_options(db, current_user, options, db_view_yaml_cache)
+  end
+
+  def unrequired_association_exists?(db, options)
+    %w(ManageIQ_Providers_InfraManager_Template ManageIQ_Providers_InfraManager_Vm)
+      .include?(db) && options[:association] == "all_vms_and_templates" ||
+      controller_name == 'generic_object'
   end
 
   def db_view_yaml_cache

--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -5,7 +5,7 @@ class GenericObjectController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
-  before_action :create_display_methods, only: [:show]
+  before_action :create_display_methods, :only => [:show]
 
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin

--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -5,6 +5,8 @@ class GenericObjectController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  before_action :create_display_methods, only: [:show]
+
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
@@ -23,6 +25,17 @@ class GenericObjectController < ApplicationController
       end
       associations
     end
+  end
+
+  def create_display_methods
+    key = params[:display] || params[:model]
+    define_singleton_method("display_#{key}") do
+      nested_list(key, @record.generic_object_definition.properties[:associations][key], generate_options(key))
+    end
+  end
+
+  def generate_options(key)
+    {:breadcrumb_title => _("#{key.upcase}"), :association => key}
   end
 
   private

--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -32,10 +32,10 @@ module GenericObjectHelper::TextualSummary
       associations.push(key.to_sym)
       define_singleton_method("textual_#{key}") do
         num = @record.send(key).count
-        h = {:label => _("%{label}") % {:label => key.capitalize}, :value => num}
+        h = {:label => _("%{label}") % {:label => key}, :value => num}
         if role_allows?(:feature => "generic_object_view") && num > 0
           h.update(:link  => url_for_only_path(:action => 'show', :id => @record, :display => key),
-                   :title => _('Show all %{associated_models}') % {:associated_models => key.capitalize})
+                   :title => _('Show all %{associated_models}') % {:associated_models => key})
         end
       end
     end

--- a/spec/controllers/generic_object_controller_spec.rb
+++ b/spec/controllers/generic_object_controller_spec.rb
@@ -14,6 +14,31 @@ describe GenericObjectController do
       get :show, :params => {:id => generic_obj.id}
     end
     it { expect(response.status).to eq(200) }
+
+    it 'displays Generic Object association in the nested display list' do
+      generic_obj_defn = FactoryGirl.create(
+        :generic_object_definition,
+        :name       => "test_definition",
+        :properties => {
+          :attributes   => {
+            :flag       => "boolean",
+            :data_read  => "float",
+            :max_number => "integer",
+            :server     => "string",
+            :s_time     => "datetime"
+          },
+          :associations => {"cp" => "ManageIQ::Providers::CloudManager", "vms" => "Vm"},
+          :methods      => %w(some_method)
+        }
+      )
+      generic_obj = FactoryGirl.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
+      
+      get :show, :params => { :display => "cp", :id => generic_obj.id }
+      expect(response.status).to eq(200)
+
+      get :show, :params => { :display => "vms", :id => generic_obj.id }
+      expect(response.status).to eq(200)
+    end
   end
 
   describe "#show_list" do


### PR DESCRIPTION
The prior implementation of displaying GO Associations assumed that the Association name would be based off a valid model. For e.g. `services` or `vms`.
This assumption should not be made with Generic Objects since the association name could pretty much be anything.

The screenshot below displays a nested list of GO associations of type `'cp'` (short for Cloud Providers)
(I have purposely used a non-standard Association name to demonstrate that this fix can display a GO association with any name)
The nested display list url generated in this case would be -
`http://localhost:3000/generic_object/show/10000000000003?display=cp`

<img width="1395" alt="screen shot 2017-10-16 at 2 41 32 pm" src="https://user-images.githubusercontent.com/1538216/31636681-5f1a4228-b280-11e7-9180-3186396e1c19.png">

<img width="1397" alt="screen shot 2017-10-16 at 2 41 43 pm" src="https://user-images.githubusercontent.com/1538216/31636723-7ce19694-b280-11e7-8af9-a110cffe237c.png">



https://bugzilla.redhat.com/show_bug.cgi?id=1500829