### PR TITLE
Do not display the Custom Image in the nested Generic Object list

### DIFF
--- a/app/views/generic_object_definition/show.html.haml
+++ b/app/views/generic_object_definition/show.html.haml
@@ -4,14 +4,14 @@
   - else
     = render :partial => 'layouts/textual_groups_generic'
 
-  - if @record.picture
-    %hr
-      %h3
-        = _('Custom Image')
-      .form-horizontal
-        .form-group
-          .col-md-9
-            %img{:src => "#{@record.picture.url_path}", :style => "width:100px; height:100px;"}
+    - if @record.picture
+      %hr
+        %h3
+          = _('Custom Image')
+        .form-horizontal
+          .form-group
+            .col-md-9
+              %img{:src => "#{@record.picture.url_path}", :style => "width:100px; height:100px;"}
 
   %generic-object-definition-toolbar#generic_object_definition_show_form{'generic-object-definition-id' => @record.id,
                                                                          'redirect-url'                 => "/#{controller_name}/show_list",}


### PR DESCRIPTION
Adjusted the indentation for the `@record.picture` conditional in the haml which fixed the issue of custom image being displayed in the nested GO list.

Before:
<img width="1396" alt="screen shot 2017-10-16 at 4 55 31 pm" src="https://user-images.githubusercontent.com/1538216/31640393-f69aed0c-b292-11e7-81b6-fb7a652f3e84.png">

After:
<img width="1394" alt="screen shot 2017-10-16 at 4 55 10 pm" src="https://user-images.githubusercontent.com/1538216/31640397-fd9b7072-b292-11e7-8f87-32ec0665ed5e.png">

