### PR TITLE
Network Router: Use API; Fix fixed IPs subnet

### DIFF
--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -121,22 +121,10 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
   };
 
   vm.filterNetworkManagerChanged = function(id) {
-    miqService.sparkleOn();
-    if (id) {
-      vm.getCloudNetworksByEms(id);
-      miqService.getProviderTenants(function(data) {
-        vm.available_tenants = data.resources;
-      })(id);
-    }
-    miqService.sparkleOff();
-  };
-
-  vm.filterCloudNetworkChanged = function(id) {
-    miqService.sparkleOn();
-    if (id) {
-      vm.getCloudSubnetsByNetworkID(id);
-    }
-    miqService.sparkleOff();
+    vm.getCloudNetworksByEms(id);
+    miqService.getProviderTenants(function(data) {
+      vm.available_tenants = data.resources;
+    })(id);
   };
 
   init();

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -6,16 +6,12 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
 
     vm.networkRouterModel = {
       cloud_tenant: {
-        id: null,
-        name: null,
+        id: null
       },
       external_fixed_ips: [],
       external_gateway: false,
-      extra_attributes: {
-        external_gateway_info: {
-          enable_snat: true,
-        },
-      },
+      extra_attributes: null,
+      //extra_attributes: { external_gateway_info: { enable_snat: true, external_fixed_ips: [], network_id: null }}
     };
     vm.ems = [];
 

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -12,7 +12,9 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
       external_fixed_ips: [],
       external_gateway: false,
       extra_attributes: {
-        external_gateway_info: {}
+        external_gateway_info: {
+          enable_snat: true,
+        },
       },
     };
     vm.ems = [];
@@ -32,7 +34,6 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
 
         vm.networkRouterModel.name = '';
         vm.networkRouterModel.admin_state_up = true;
-//        vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat = true;
         vm.networkRouterModel.cloud_subnet_id = null;
 
         vm.afterGet = true;
@@ -40,7 +41,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
         miqService.sparkleOff();
       });
     } else {
-      API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,admin_state_up,cloud_network_id,cloud_tenant.name,ext_management_system.id,ext_management_system.name,extra_attributes").then(function(data) {
+      return API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,admin_state_up,cloud_network_id,cloud_tenant.name,ext_management_system.id,ext_management_system.name,extra_attributes").then(function(data) {
         Object.assign(vm.networkRouterModel, data);
         vm.networkRouterModel.admin_state_up = vm.networkRouterModel.admin_state_up == 't' ? true : false;
         if (vm.networkRouterModel.extra_attributes.external_gateway_info && vm.networkRouterModel.extra_attributes.external_gateway_info != {}) {

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -21,6 +21,8 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
   vm.newRecord = networkRouterFormId === "new";
   vm.saveable = miqService.saveable;
 
+  vm.saveUrl = vm.newRecord ? '/network_router/create/new' : '/network_router/update/' + networkRouterFormId;
+
   if (vm.newRecord) {
     vm.networkRouterModel.name = "";
     vm.networkRouterModel.enable_snat = true;
@@ -88,21 +90,17 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
   };
 
   vm.addClicked = function() {
-    var url = 'create/new' + '?button=add';
+    var url = vm.saveUrl + '?button=add';
     miqService.miqAjaxButton(url, vm.networkRouterModel, { complete: false });
   };
 
   vm.cancelClicked = function() {
-    if (networkRouterFormId == 'new') {
-      var url = '/network_router/create/new' + '?button=cancel';
-    } else {
-      var url = '/network_router/update/' + networkRouterFormId + '?button=cancel';
-    }
+    var url = vm.saveUrl + '?button=cancel';
     miqService.miqAjaxButton(url);
   };
 
   vm.saveClicked = function() {
-    var url = '/network_router/update/' + networkRouterFormId + '?button=save';
+    var url = vm.saveUrl + '?button=save';
     miqService.miqAjaxButton(url, vm.networkRouterModel, { complete: false });
   };
 

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -81,7 +81,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
 
   var getCloudNetworksByEms = function(id) {
     if (id) {
-      API.get("/api/cloud_networks?expand=resources&attributes=name,ems_ref&filter[]=external_facing=true&filter[]=ems_id=" + id).then(function(data) {
+      return API.get("/api/cloud_networks?expand=resources&attributes=name,ems_ref&filter[]=external_facing=true&filter[]=ems_id=" + id).then(function(data) {
         vm.available_networks = data.resources;
       }).catch(miqService.handleFailure);
     }
@@ -89,7 +89,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
 
   var getCloudSubnetsByNetworkID = function(id) {
     if (id) {
-      API.get("/api/cloud_subnets?expand=resources&attributes=name,ems_ref&filter[]=cloud_network_id=" + id).then(function(data) {
+      return API.get("/api/cloud_subnets?expand=resources&attributes=name,ems_ref&filter[]=cloud_network_id=" + id).then(function(data) {
         vm.available_subnets = data.resources;
       }).catch(miqService.handleFailure);
     }
@@ -97,7 +97,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
 
   var getCloudSubnetsByRef = function(ref) {
     if (ref) {
-      API.get("/api/cloud_subnets?expand=resources&attributes=name&filter[]=ems_ref=" + ref).then(function(data) {
+      return API.get("/api/cloud_subnets?expand=resources&attributes=name&filter[]=ems_ref=" + ref).then(function(data) {
         vm.networkRouterModel.cloud_subnet_id = data.resources[0].id;
       }).catch(miqService.handleFailure);
     }

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -65,15 +65,12 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
         Object.assign(vm.networkRouterModel, data);
         if (data.extra_attributes.external_gateway_info && ! _.isEmpty(data.extra_attributes.external_gateway_info)) {
           vm.networkRouterModel.external_gateway = true;
+          return getSubnetByRef(vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id);
         }
       }).then(function() {
-        if (vm.networkRouterModel.external_gateway) {
-          getSubnetByRef(vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id);
-        }
+        return getCloudNetworksByEms(vm.networkRouterModel.ext_management_system.id);
       }).then(function() {
-        getCloudNetworksByEms(vm.networkRouterModel.ext_management_system.id);
-      }).then(function() {
-        getCloudSubnetsByNetworkID(vm.networkRouterModel.cloud_network_id);
+        return getCloudSubnetsByNetworkID(vm.networkRouterModel.cloud_network_id);
       }).then(function() {
         vm.afterGet = true;
         vm.modelCopy = angular.copy(vm.networkRouterModel);

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -3,13 +3,12 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
 
   var init = function() {
     vm.afterGet = false;
+
     vm.networkRouterModel = {
       name: '',
+      extra_attributes: { external_gateway_info: { enable_snat: true } },
       cloud_subnet_id: null,
-      cloud_tenant: null,
-      enable_snat: true,
       external_gateway: false,
-      extra_attributes: null,
     };
 
 <<<<<<< HEAD
@@ -62,10 +61,18 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
     } else {
       miqService.sparkleOn();
       API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,ems_id,admin_state_up,cloud_network_id,extra_attributes,cloud_tenant,ext_management_system,cloud_subnets").then(function(data) {
-        Object.assign(vm.networkRouterModel, data);
+        vm.networkRouterModel = _.omit(data, [ 'cloud_tenant', 'ext_management_system' ]);
+        vm.networkRouterModel.ext_management_system = {
+          id: data.ext_management_system.id,
+          name: data.ext_management_system.name,
+        };
+        vm.networkRouterModel.cloud_tenant = { id: data.cloud_tenant.id,  name: data.cloud_tenant.name, };
+
         if (data.extra_attributes.external_gateway_info && ! _.isEmpty(data.extra_attributes.external_gateway_info)) {
           vm.networkRouterModel.external_gateway = true;
           return getCloudSubnetsByRef(vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id);
+        } else {
+          vm.networkRouterModel.external_gateway = false;
         }
       }).then(function() {
         return getCloudNetworksByEms(vm.networkRouterModel.ext_management_system.id);

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -42,11 +42,12 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
     } else {
       API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,admin_state_up,cloud_network_id,cloud_tenant.name,ext_management_system.id,ext_management_system.name,extra_attributes").then(function(data) {
         Object.assign(vm.networkRouterModel, data);
+        vm.networkRouterModel.admin_state_up = vm.networkRouterModel.admin_state_up == 't' ? true : false;
         if (vm.networkRouterModel.extra_attributes.external_gateway_info && vm.networkRouterModel.extra_attributes.external_gateway_info != {}) {
           vm.networkRouterModel.external_gateway = true;
           if (vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips) {
             var ref = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id;
-            getSubnetByRef(ref);
+            return getSubnetByRef(ref);
           }
         }
       }).then(function() {
@@ -62,7 +63,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
 
     var getSubnetByRef = function(ref) {
       if (ref) {
-        API.get("/api/cloud_subnets?expand=resources&attributes=name&filter[]=ems_ref=" + ref).then(function(data) {
+        return API.get("/api/cloud_subnets?expand=resources&attributes=name&filter[]=ems_ref=" + ref).then(function(data) {
           vm.networkRouterModel.cloud_subnet_id = data.resources[0].id;
         }).catch(miqService.handleFailure);
       }
@@ -71,7 +72,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
 
   vm.getCloudNetworksByEms = function(id) {
     if (id) {
-      API.get("/api/cloud_networks?expand=resources&attributes=name,ems_ref&filter[]=external_facing=true&filter[]=ems_id=" + id).then(function(data) {
+      return API.get("/api/cloud_networks?expand=resources&attributes=name,ems_ref&filter[]=external_facing=true&filter[]=ems_id=" + id).then(function(data) {
         vm.available_networks = data.resources;
       }).catch(miqService.handleFailure);
     }
@@ -79,7 +80,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
 
   vm.getCloudSubnetsByNetworkID = function(id) {
     if (id) {
-      API.get("/api/cloud_subnets?expand=resources&attributes=name,ems_ref&filter[]=cloud_network_id=" + id).then(function(data) {
+      return API.get("/api/cloud_subnets?expand=resources&attributes=name,ems_ref&filter[]=cloud_network_id=" + id).then(function(data) {
         vm.available_subnets = data.resources;
       }).catch(miqService.handleFailure);
     }

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -34,11 +34,9 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
         miqService.sparkleOff();
       });
     } else {
-      API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,ems_id,admin_state_up,cloud_network_id,extra_attributes,cloud_tenant,ext_management_system,cloud_subnets").then(function(data) {
+      API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,ems_id,admin_state_up,cloud_network_id,extra_attributes,cloud_tenant,cloud_subnets").then(function(data) {
         vm.networkRouterModel.name = data.name;
         vm.networkRouterModel.cloud_network_id = data.cloud_network_id;
-        vm.networkRouterModel.ems_id = data.ext_management_system.id;
-        vm.networkRouterModel.ems_name = data.ext_management_system.name;
         vm.networkRouterModel.cloud_tenant_name = data.cloud_tenant.name;
         vm.networkRouterModel.extra_attributes = data.extra_attributes;
         if (data.extra_attributes.external_gateway_info && data.networkRouterModel.extra_attributes.external_gateway_info !== {}) {

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -1,16 +1,18 @@
 ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope', 'networkRouterFormId', 'miqService', 'API', function($http, $scope, networkRouterFormId, miqService, API) {
   var vm = this;
 
-  vm.afterGet = false;
-  vm.networkRouterModel = {
-    name: '',
-    cloud_subnet_id: null,
-    cloud_tenant: null,
-    enable_snat: true,
-    external_gateway: false,
-    extra_attributes: null,
-  };
+  var init = function() {
+    vm.afterGet = false;
+    vm.networkRouterModel = {
+      name: '',
+      cloud_subnet_id: null,
+      cloud_tenant: null,
+      enable_snat: true,
+      external_gateway: false,
+      extra_attributes: null,
+    };
 
+<<<<<<< HEAD
   vm.formId = networkRouterFormId;
   vm.model = "networkRouterModel";
   vm.ems = [];
@@ -47,11 +49,38 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
     }).then(function() {
       getCloudSubnetsByNetworkID(vm.networkRouterModel.cloud_network_id);
     }).then(function() {
+=======
+    vm.formId = networkRouterFormId;
+    vm.model = "networkRouterModel";
+    vm.newRecord = networkRouterFormId === "new";
+    vm.saveable = miqService.saveable;
+
+    if (vm.newRecord) {
+>>>>>>> Using init() and lodash isEmpty
       vm.afterGet = true;
       vm.modelCopy = angular.copy(vm.networkRouterModel);
-      miqService.sparkleOff();
-    }).catch(miqService.handleFailure);
-  }
+    } else {
+      miqService.sparkleOn();
+      API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,ems_id,admin_state_up,cloud_network_id,extra_attributes,cloud_tenant,ext_management_system,cloud_subnets").then(function(data) {
+        Object.assign(vm.networkRouterModel, data);
+        if (data.extra_attributes.external_gateway_info && ! _.isEmpty(data.extra_attributes.external_gateway_info)) {
+          vm.networkRouterModel.external_gateway = true;
+        }
+      }).then(function() {
+        if (vm.networkRouterModel.external_gateway) {
+          getSubnetByRef(vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id);
+        }
+      }).then(function() {
+        getCloudNetworksByEms(vm.networkRouterModel.ext_management_system.id);
+      }).then(function() {
+        getCloudSubnetsByNetworkID(vm.networkRouterModel.cloud_network_id);
+      }).then(function() {
+        vm.afterGet = true;
+        vm.modelCopy = angular.copy(vm.networkRouterModel);
+        miqService.sparkleOff();
+      }).catch(miqService.handleFailure);
+    }
+  };
 
   var getCloudNetworksByEms = function(id) {
     if (id) {
@@ -78,7 +107,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
   };
 
   vm.addClicked = function() {
-    var url = 'create/new' + '?button=add';
+    var url = 'create/new?button=add';
     miqService.miqAjaxButton(url, vm.networkRouterModel, { complete: false });
   };
 
@@ -132,4 +161,6 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
     }
     miqService.sparkleOff();
   };
+
+  init();
 }]);

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -5,15 +5,15 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
     vm.afterGet = false;
 
     vm.networkRouterModel = {
-      cloud_tenant_name: null
+      cloud_tenant_name: null,
       external_fixed_ips: [],
-      extra_attributes: null
+      extra_attributes: null,
     };
     vm.ems = [];
 
     vm.formId = networkRouterFormId;
-    vm.model = "networkRouterModel";
-    vm.newRecord = networkRouterFormId === "new";
+    vm.model = 'networkRouterModel';
+    vm.newRecord = networkRouterFormId === 'new';
     vm.saveable = miqService.saveable;
 
     vm.saveUrl = vm.newRecord ? '/network_router/create/new' : '/network_router/update/' + networkRouterFormId;
@@ -24,7 +24,8 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
       .then(function(providers) {
         vm.ems = providers;
 
-        vm.networkRouterModel.name = "";
+        vm.networkRouterModel.name = '';
+        vm.networkRouterModel.admin_state_up = true;
         vm.networkRouterModel.enable_snat = true;
         vm.networkRouterModel.external_gateway = false;
         vm.networkRouterModel.cloud_subnet_id = null;
@@ -34,20 +35,19 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
         miqService.sparkleOff();
       });
     } else {
-      API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,ems_id,admin_state_up,cloud_network_id,extra_attributes,cloud_tenant,cloud_subnets").then(function(data) {
+      API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,ems_id,admin_state_up,cloud_network_id,cloud_tenant,extra_attributes").then(function(data) {
         vm.networkRouterModel.name = data.name;
+        vm.networkRouterModel.admin_state_up = data.admin_state_up;
         vm.networkRouterModel.cloud_network_id = data.cloud_network_id;
         vm.networkRouterModel.cloud_tenant_name = data.cloud_tenant.name;
         vm.networkRouterModel.extra_attributes = data.extra_attributes;
+
         if (data.extra_attributes.external_gateway_info && data.networkRouterModel.extra_attributes.external_gateway_info !== {}) {
           vm.networkRouterModel.external_gateway = true;
           vm.networkRouterModel.enable_snat = vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat;
           vm.networkRouterModel.external_fixed_ips = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips;
-        }
-      }).then(function() {
-        if (vm.networkRouterModel.external_gateway) {
           var ref = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id;
-          return getSubnetByRef(ref);
+          getSubnetByRef(ref);
         }
       }).then(function() {
         return getCloudNetworksByEms(vm.networkRouterModel.ems_id);

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -48,7 +48,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
           vm.networkRouterModel.external_gateway = true;
           if (vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips) {
             var ref = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id;
-            return getSubnetByRef(ref);
+            return vm.getSubnetByRef(ref);
           }
         }
       }).then(function() {
@@ -61,14 +61,6 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
         miqService.sparkleOff();
       }).catch(miqService.handleFailure);
     }
-
-    var getSubnetByRef = function(ref) {
-      if (ref) {
-        return API.get("/api/cloud_subnets?expand=resources&attributes=name&filter[]=ems_ref=" + ref).then(function(data) {
-          vm.networkRouterModel.cloud_subnet_id = data.resources[0].id;
-        }).catch(miqService.handleFailure);
-      }
-    };
   };
 
   vm.getCloudNetworksByEms = function(id) {
@@ -83,6 +75,14 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
     if (id) {
       return API.get("/api/cloud_subnets?expand=resources&attributes=name,ems_ref&filter[]=cloud_network_id=" + id).then(function(data) {
         vm.available_subnets = data.resources;
+      }).catch(miqService.handleFailure);
+    }
+  };
+
+  vm.getSubnetByRef = function(ref) {
+    if (ref) {
+      return API.get("/api/cloud_subnets?expand=resources&attributes=name&filter[]=ems_ref=" + ref).then(function(data) {
+        vm.networkRouterModel.cloud_subnet_id = data.resources[0].id;
       }).catch(miqService.handleFailure);
     }
   };

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -46,35 +46,22 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
           vm.networkRouterModel.external_gateway = true;
           vm.networkRouterModel.enable_snat = vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat;
           vm.networkRouterModel.external_fixed_ips = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips;
+        }
+      }).then(function() {
+        if (vm.networkRouterModel.external_gateway) {
           var ref = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id;
           getSubnetByRef(ref);
         }
       }).then(function() {
-        return getCloudNetworksByEms(vm.networkRouterModel.ems_id);
+        return vm.getCloudNetworksByEms(vm.networkRouterModel.ems_id);
       }).then(function() {
-        return getCloudSubnetsByNetworkID(vm.networkRouterModel.cloud_network_id);
+        return vm.getCloudSubnetsByNetworkID(vm.networkRouterModel.cloud_network_id);
       }).then(function() {
         vm.afterGet = true;
         vm.modelCopy = angular.copy(vm.networkRouterModel);
         miqService.sparkleOff();
       }).catch(miqService.handleFailure);
     }
-
-    var getCloudNetworksByEms = function(id) {
-      if (id) {
-        API.get("/api/cloud_networks?expand=resources&attributes=name,ems_ref&filter[]=external_facing=true&filter[]=ems_id=" + id).then(function(data) {
-          vm.available_networks = data.resources;
-        }).catch(miqService.handleFailure);
-      }
-    };
-
-    var getCloudSubnetsByNetworkID = function(id) {
-      if (id) {
-        API.get("/api/cloud_subnets?expand=resources&attributes=name,ems_ref&filter[]=cloud_network_id=" + id).then(function(data) {
-          vm.available_subnets = data.resources;
-        }).catch(miqService.handleFailure);
-      }
-    };
 
     var getSubnetByRef = function(ref) {
       if (ref) {
@@ -83,6 +70,22 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
         }).catch(miqService.handleFailure);
       }
     };
+  };
+
+  vm.getCloudNetworksByEms = function(id) {
+    if (id) {
+      API.get("/api/cloud_networks?expand=resources&attributes=name,ems_ref&filter[]=external_facing=true&filter[]=ems_id=" + id).then(function(data) {
+        vm.available_networks = data.resources;
+      }).catch(miqService.handleFailure);
+    }
+  };
+
+  vm.getCloudSubnetsByNetworkID = function(id) {
+    if (id) {
+      API.get("/api/cloud_subnets?expand=resources&attributes=name,ems_ref&filter[]=cloud_network_id=" + id).then(function(data) {
+        vm.available_subnets = data.resources;
+      }).catch(miqService.handleFailure);
+    }
   };
 
   vm.addClicked = function() {
@@ -121,7 +124,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
   vm.filterNetworkManagerChanged = function(id) {
     miqService.sparkleOn();
     if (id) {
-      getCloudNetworksByEms(id);
+      vm.getCloudNetworksByEms(id);
       miqService.getProviderTenants(function(data) {
         vm.available_tenants = data.resources;
       })(id);
@@ -132,7 +135,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
   vm.filterCloudNetworkChanged = function(id) {
     miqService.sparkleOn();
     if (id) {
-      getCloudSubnetsByNetworkID(id);
+      vm.getCloudSubnetsByNetworkID(id);
     }
     miqService.sparkleOff();
   };

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -65,7 +65,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
         Object.assign(vm.networkRouterModel, data);
         if (data.extra_attributes.external_gateway_info && ! _.isEmpty(data.extra_attributes.external_gateway_info)) {
           vm.networkRouterModel.external_gateway = true;
-          return getSubnetByRef(vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id);
+          return getCloudSubnetsByRef(vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id);
         }
       }).then(function() {
         return getCloudNetworksByEms(vm.networkRouterModel.ext_management_system.id);
@@ -95,7 +95,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
     }
   };
 
-  var getSubnetByRef = function(ref) {
+  var getCloudSubnetsByRef = function(ref) {
     if (ref) {
       API.get("/api/cloud_subnets?expand=resources&attributes=name&filter[]=ems_ref=" + ref).then(function(data) {
         vm.networkRouterModel.cloud_subnet_id = data.resources[0].id;

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -5,11 +5,10 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
   vm.networkRouterModel = {
     name: '',
     cloud_subnet_id: null,
-    cloud_tenant_name: null,
+    cloud_tenant: null,
     enable_snat: true,
     external_gateway: false,
-    external_fixed_ips: [],
-    extra_attributes: null
+    extra_attributes: null,
   };
 
   vm.formId = networkRouterFormId;
@@ -35,25 +34,16 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
   } else {
     miqService.sparkleOn();
     API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,ems_id,admin_state_up,cloud_network_id,extra_attributes,cloud_tenant,ext_management_system,cloud_subnets").then(function(data) {
-      vm.networkRouterModel.name = data.name;
-      vm.networkRouterModel.cloud_network_id = data.cloud_network_id;
-      vm.networkRouterModel.ems_id = data.ext_management_system.id;
-      vm.networkRouterModel.ems_name = data.ext_management_system.name;
-      vm.networkRouterModel.cloud_tenant_name = data.cloud_tenant.name;
-      vm.networkRouterModel.extra_attributes = data.extra_attributes;
-    }).then(function() {
-      if (data.extra_attributes.external_gateway_info && data.networkRouterModel.extra_attributes.external_gateway_info !== {}) {
+      Object.assign(vm.networkRouterModel, data);
+      if (data.extra_attributes.external_gateway_info && data.extra_attributes.external_gateway_info !== {}) {
         vm.networkRouterModel.external_gateway = true;
-        vm.networkRouterModel.enable_snat = vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat;
-        vm.networkRouterModel.external_fixed_ips = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips;
       }
     }).then(function() {
       if (vm.networkRouterModel.external_gateway) {
-        var ref = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id;
-        getSubnetByRef(ref);
+        getSubnetByRef(vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id);
       }
     }).then(function() {
-      getCloudNetworksByEms(vm.networkRouterModel.ems_id);
+      getCloudNetworksByEms(vm.networkRouterModel.ext_management_system.id);
     }).then(function() {
       getCloudSubnetsByNetworkID(vm.networkRouterModel.cloud_network_id);
     }).then(function() {

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -144,22 +144,14 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$http', '$scope
   };
 
   vm.filterNetworkManagerChanged = function(id) {
-    miqService.sparkleOn();
-    if (id) {
-      getCloudNetworksByEms(id);
-      miqService.getProviderTenants(function(data) {
-        vm.available_tenants = data.resources;
-      })(id);
-    }
-    miqService.sparkleOff();
+    getCloudNetworksByEms(id);
+    miqService.getProviderTenants(function(data) {
+      vm.available_tenants = data.resources;
+    })(id);
   };
 
   vm.filterCloudNetworkChanged = function(id) {
-    miqService.sparkleOn();
-    if (id) {
-      getCloudSubnetsByNetworkID(id);
-    }
-    miqService.sparkleOff();
+    getCloudSubnetsByNetworkID(id);
   };
 
   init();

--- a/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
+++ b/app/assets/javascripts/controllers/network_router/network_router_form_controller.js
@@ -1,92 +1,90 @@
 ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'networkRouterFormId', 'miqService', 'API', function($scope, networkRouterFormId, miqService, API) {
   var vm = this;
 
-  vm.afterGet = false;
-  vm.networkRouterModel = {
-    name: '',
-    cloud_subnet_id: null,
-    cloud_tenant_name: null,
-    enable_snat: true,
-    external_gateway: false,
-    external_fixed_ips: [],
-    extra_attributes: null
-  };
+  var init = function() {
+    vm.afterGet = false;
 
-  vm.formId = networkRouterFormId;
-  vm.model = "networkRouterModel";
-  vm.ems = [];
+    vm.networkRouterModel = {
+      cloud_tenant_name: null
+      external_fixed_ips: [],
+      extra_attributes: null
+    };
+    vm.ems = [];
 
-  ManageIQ.angular.scope = vm;
+    vm.formId = networkRouterFormId;
+    vm.model = "networkRouterModel";
+    vm.newRecord = networkRouterFormId === "new";
+    vm.saveable = miqService.saveable;
 
-  vm.newRecord = networkRouterFormId === "new";
-  vm.saveable = miqService.saveable;
+    vm.saveUrl = vm.newRecord ? '/network_router/create/new' : '/network_router/update/' + networkRouterFormId;
 
-  vm.saveUrl = vm.newRecord ? '/network_router/create/new' : '/network_router/update/' + networkRouterFormId;
-
-  if (vm.newRecord) {
-    vm.networkRouterModel.name = "";
-    vm.networkRouterModel.enable_snat = true;
-    vm.networkRouterModel.external_gateway = false;
-    vm.networkRouterModel.cloud_subnet_id = null;
-    vm.newRecord = true;
-
-    miqService.networkProviders()
+    miqService.sparkleOn();
+    if (vm.newRecord) {
+      miqService.networkProviders()
       .then(function(providers) {
         vm.ems = providers;
+
+        vm.networkRouterModel.name = "";
+        vm.networkRouterModel.enable_snat = true;
+        vm.networkRouterModel.external_gateway = false;
+        vm.networkRouterModel.cloud_subnet_id = null;
+
+        vm.afterGet = true;
+        vm.modelCopy = angular.copy(vm.networkRouterModel);
+        miqService.sparkleOff();
       });
-  } else {
-    miqService.sparkleOn();
-    API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,ems_id,admin_state_up,cloud_network_id,extra_attributes,cloud_tenant,ext_management_system,cloud_subnets").then(function(data) {
-      vm.networkRouterModel.name = data.name;
-      vm.networkRouterModel.cloud_network_id = data.cloud_network_id;
-      vm.networkRouterModel.ems_id = data.ext_management_system.id;
-      vm.networkRouterModel.ems_name = data.ext_management_system.name;
-      vm.networkRouterModel.cloud_tenant_name = data.cloud_tenant.name;
-      vm.networkRouterModel.extra_attributes = data.extra_attributes;
-    }).then(function() {
-      if (data.extra_attributes.external_gateway_info && data.networkRouterModel.extra_attributes.external_gateway_info !== {}) {
-        vm.networkRouterModel.external_gateway = true;
-        vm.networkRouterModel.enable_snat = vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat;
-        vm.networkRouterModel.external_fixed_ips = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips;
+    } else {
+      API.get("/api/network_routers/" + networkRouterFormId + "?attributes=name,ems_id,admin_state_up,cloud_network_id,extra_attributes,cloud_tenant,ext_management_system,cloud_subnets").then(function(data) {
+        vm.networkRouterModel.name = data.name;
+        vm.networkRouterModel.cloud_network_id = data.cloud_network_id;
+        vm.networkRouterModel.ems_id = data.ext_management_system.id;
+        vm.networkRouterModel.ems_name = data.ext_management_system.name;
+        vm.networkRouterModel.cloud_tenant_name = data.cloud_tenant.name;
+        vm.networkRouterModel.extra_attributes = data.extra_attributes;
+        if (data.extra_attributes.external_gateway_info && data.networkRouterModel.extra_attributes.external_gateway_info !== {}) {
+          vm.networkRouterModel.external_gateway = true;
+          vm.networkRouterModel.enable_snat = vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat;
+          vm.networkRouterModel.external_fixed_ips = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips;
+        }
+      }).then(function() {
+        if (vm.networkRouterModel.external_gateway) {
+          var ref = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id;
+          return getSubnetByRef(ref);
+        }
+      }).then(function() {
+        return getCloudNetworksByEms(vm.networkRouterModel.ems_id);
+      }).then(function() {
+        return getCloudSubnetsByNetworkID(vm.networkRouterModel.cloud_network_id);
+      }).then(function() {
+        vm.afterGet = true;
+        vm.modelCopy = angular.copy(vm.networkRouterModel);
+        miqService.sparkleOff();
+      }).catch(miqService.handleFailure);
+    }
+
+    var getCloudNetworksByEms = function(id) {
+      if (id) {
+        API.get("/api/cloud_networks?expand=resources&attributes=name,ems_ref&filter[]=external_facing=true&filter[]=ems_id=" + id).then(function(data) {
+          vm.available_networks = data.resources;
+        }).catch(miqService.handleFailure);
       }
-    }).then(function() {
-      if (vm.networkRouterModel.external_gateway) {
-        var ref = vm.networkRouterModel.extra_attributes.external_gateway_info.external_fixed_ips[0].subnet_id;
-        getSubnetByRef(ref);
+    };
+
+    var getCloudSubnetsByNetworkID = function(id) {
+      if (id) {
+        API.get("/api/cloud_subnets?expand=resources&attributes=name,ems_ref&filter[]=cloud_network_id=" + id).then(function(data) {
+          vm.available_subnets = data.resources;
+        }).catch(miqService.handleFailure);
       }
-    }).then(function() {
-      getCloudNetworksByEms(vm.networkRouterModel.ems_id);
-    }).then(function() {
-      getCloudSubnetsByNetworkID(vm.networkRouterModel.cloud_network_id);
-    }).then(function() {
-      vm.afterGet = true;
-      vm.modelCopy = angular.copy(vm.networkRouterModel);
-      miqService.sparkleOff();
-    }).catch(miqService.handleFailure);
-  }
+    };
 
-  var getCloudNetworksByEms = function(id) {
-    if (id) {
-      API.get("/api/cloud_networks?expand=resources&attributes=name,ems_ref&filter[]=external_facing=true&filter[]=ems_id=" + id).then(function(data) {
-        vm.available_networks = data.resources;
-      }).catch(miqService.handleFailure);
-    }
-  };
-
-  var getCloudSubnetsByNetworkID = function(id) {
-    if (id) {
-      API.get("/api/cloud_subnets?expand=resources&attributes=name,ems_ref&filter[]=cloud_network_id=" + id).then(function(data) {
-        vm.available_subnets = data.resources;
-      }).catch(miqService.handleFailure);
-    }
-  };
-
-  var getSubnetByRef = function(ref) {
-    if (ref) {
-      API.get("/api/cloud_subnets?expand=resources&attributes=name&filter[]=ems_ref=" + ref).then(function(data) {
-        vm.networkRouterModel.cloud_subnet_id = data.resources[0].id;
-      }).catch(miqService.handleFailure);
-    }
+    var getSubnetByRef = function(ref) {
+      if (ref) {
+        API.get("/api/cloud_subnets?expand=resources&attributes=name&filter[]=ems_ref=" + ref).then(function(data) {
+          vm.networkRouterModel.cloud_subnet_id = data.resources[0].id;
+        }).catch(miqService.handleFailure);
+      }
+    };
   };
 
   vm.addClicked = function() {
@@ -119,7 +117,7 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
   vm.resetClicked = function() {
     vm.networkRouterModel = angular.copy( vm.modelCopy );
     $scope.angularForm.$setPristine(true);
-    miqService.miqFlash("warn", "All changes have been reset");
+    miqService.miqFlash('warn', __("All changes have been reset"));
   };
 
   vm.filterNetworkManagerChanged = function(id) {
@@ -140,4 +138,6 @@ ManageIQ.angular.app.controller('networkRouterFormController', ['$scope', 'netwo
     }
     miqService.sparkleOff();
   };
+
+  init();
 }]);

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -401,7 +401,7 @@ class NetworkRouterController < ApplicationController
 
   def form_params(params)
     options = %i(name ems_id cloud_group_id cloud_subnet_id
-      cloud_network_id).each_with_object({}) do |param, opt|
+                 cloud_network_id).each_with_object({}) do |param, opt|
       opt[param] = params[param] if params[param]
     end
 

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -392,7 +392,9 @@ class NetworkRouterController < ApplicationController
         subnet = find_record_with_rbac(CloudSubnet, params[:cloud_subnet_id])
         options[:external_gateway_info][:external_fixed_ips] = [{:subnet_id => subnet.ems_ref}]
       end
-      options[:external_gateway_info][:enable_snat] = switch_to_bool(params[:enable_snat])
+      if params[:extra_attributes][:external_gateway_info][:enable_snat]
+        options[:external_gateway_info][:enable_snat] = params[:extra_attributes][:external_gateway_info][:enable_snat]
+      end
     end
     options
   end

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -70,7 +70,7 @@ class NetworkRouterController < ApplicationController
       options = form_params(params)
       options.merge!(form_external_gateway(params)) if switch_to_bool(params[:external_gateway])
 
-      ems = ExtManagementSystem.find(params[:ext_management_system][:id])
+      ems = ExtManagementSystem.find(params[:ems_id])
       task_id = ems.create_network_router_queue(session[:userid], options)
 
       add_flash(_("Network Router creation failed: Task start failed: ID [%{id}]") %

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -400,7 +400,7 @@ class NetworkRouterController < ApplicationController
   end
 
   def form_params(params)
-    options = %i(name ems_id cloud_group_id cloud_subnet_id
+    options = %i(name admin_state_up ems_id cloud_group_id cloud_subnet_id
                  cloud_network_id).each_with_object({}) do |param, opt|
       opt[param] = params[param] if params[param]
     end

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -67,11 +67,10 @@ class NetworkRouterController < ApplicationController
                           :flash_msg => _("Add of new Network Router was cancelled by the user")
 
     when "add"
-      @router = NetworkRouter.new
       options = form_params(params)
       options.merge!(form_external_gateway(params)) if switch_to_bool(params[:external_gateway])
 
-      ems = ExtManagementSystem.find(params[:ems_id])
+      ems = ExtManagementSystem.find(params[:ext_management_system][:id])
       task_id = ems.create_network_router_queue(session[:userid], options)
 
       add_flash(_("Network Router creation failed: Task start failed: ID [%{id}]") %

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -71,7 +71,7 @@ class NetworkRouterController < ApplicationController
       options = form_params(params)
       options.merge!(form_external_gateway(params)) if switch_to_bool(params[:external_gateway])
 
-      ems = ExtManagementSystem.find(params[:ext_management_system][:id])
+      ems = ExtManagementSystem.find(params[:ems_id])
       task_id = ems.create_network_router_queue(session[:userid], options)
 
       add_flash(_("Network Router creation failed: Task start failed: ID [%{id}]") %

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -391,7 +391,7 @@ class NetworkRouterController < ApplicationController
         subnet = find_record_with_rbac(CloudSubnet, params[:cloud_subnet_id])
         options[:external_gateway_info][:external_fixed_ips] = [{:subnet_id => subnet.ems_ref}]
       end
-      if params[:extra_attributes][:external_gateway_info][:enable_snat]
+      if params.fetch_path(:extra_attributes, :external_gateway_info, :enable_snat)
         options[:external_gateway_info][:enable_snat] = params[:extra_attributes][:external_gateway_info][:enable_snat]
       end
     end

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -378,14 +378,6 @@ class NetworkRouterController < ApplicationController
 
   private
 
-  def get_networks_by_ems(id)
-    Rbac::Filterer.filtered(CloudNetwork.where(:ems_id => id)).select(:id, :name).as_json
-  end
-
-  def get_subnets_by_network(id)
-    Rbac::Filterer.filtered(CloudSubnet.where(:cloud_network_id => id)).select(:id, :name).as_json
-  end
-
   def textual_group_list
     [%i(properties relationships), %i(tags)]
   end

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -46,57 +46,6 @@ class NetworkRouterController < ApplicationController
     end
   end
 
-  def network_router_form_fields
-    assert_privileges("network_router_edit")
-    router = find_record_with_rbac(NetworkRouter, params[:id])
-    available_networks = get_networks_by_ems(router.ems_id)
-    network_id = nil
-    subnet_id = nil
-    external_gateway = false
-    enable_snat = true
-    available_subnets = {}
-
-    unless router.external_gateway_info.nil? || router.external_gateway_info.empty?
-      external_gateway = true
-      cloud_network_ref = router.external_gateway_info["network_id"]
-      enable_snat = router.external_gateway_info["enable_snat"]
-      network = CloudNetwork.where(:ems_ref => cloud_network_ref).first
-      network_id = network.id
-      available_subnets = get_subnets_by_network(network_id)
-      external_fixed_ips = router.external_gateway_info["external_fixed_ips"]
-      unless external_fixed_ips.nil? || external_fixed_ips.empty?
-        # TODO: Replace with array/table
-        subnet = CloudSubnet.where(:ems_ref => external_fixed_ips[0]["subnet_id"]).first
-        subnet_id = subnet.id
-      end
-    end
-
-    render :json => {
-      :name               => router.name,
-      :ems_id             => router.ems_id,
-      :cloud_network_id   => network_id,
-      :cloud_subnet_id    => subnet_id,
-      :external_gateway   => external_gateway,
-      :enable_snat        => enable_snat,
-      :available_networks => available_networks,
-      :available_subnets  => available_subnets
-    }
-  end
-
-  def network_router_networks_by_ems
-    assert_privileges("network_router_new")
-    render :json => {
-      :available_networks => get_networks_by_ems(params[:id])
-    }
-  end
-
-  def network_router_subnets_by_network
-    assert_privileges("network_router_new")
-    render :json => {
-      :available_subnets => get_subnets_by_network(params[:id])
-    }
-  end
-
   def new
     @router = NetworkRouter.new
     assert_privileges("network_router_new")

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -146,18 +146,18 @@ class NetworkRouterController < ApplicationController
   def update
     assert_privileges("network_router_edit")
     @router = find_record_with_rbac(NetworkRouter, params[:id])
-    options = form_params(params)
-    if switch_to_bool(params[:external_gateway])
-      options.merge!(form_external_gateway(params))
-    else
-      options.merge!(form_external_gateway({}))
-    end
 
     case params[:button]
     when "cancel"
       cancel_action(_("Edit of Router \"%{name}\" was cancelled by the user") % {:name => @router.name})
 
     when "save"
+      options = form_params(params)
+      if switch_to_bool(params[:external_gateway])
+        options.merge!(form_external_gateway(params))
+      else
+        options.merge!(form_external_gateway({}))
+      end
       task_id = @router.update_network_router_queue(session[:userid], options)
 
       add_flash(_("Router update failed: Task start failed: ID [%{id}]") %

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -70,8 +70,8 @@ class NetworkRouterController < ApplicationController
       @router = NetworkRouter.new
       options = form_params(params)
       options.merge!(form_external_gateway(params)) if switch_to_bool(params[:external_gateway])
-      ems = ExtManagementSystem.find(options[:ems_id])
-      options.delete(:ems_id)
+
+      ems = ExtManagementSystem.find(params[:ext_management_system][:id])
       task_id = ems.create_network_router_queue(session[:userid], options)
 
       add_flash(_("Network Router creation failed: Task start failed: ID [%{id}]") %
@@ -406,7 +406,7 @@ class NetworkRouterController < ApplicationController
   end
 
   def form_params(params)
-    options = %i(name ems_id admin_state_up cloud_group_id cloud_subnet_id
+    options = %i(name ems_id cloud_group_id cloud_subnet_id
       cloud_network_id).each_with_object({}) do |param, opt|
       opt[param] = params[param] if params[param]
     end

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -115,7 +115,7 @@
         %select{"name"                        => "cloud_network_id",
                 "ng-model"                    => "vm.networkRouterModel.cloud_network_id",
                 "ng-options"                  => "network.id as network.name for network in vm.available_networks",
-                "ng-change"                   => "vm.filterCloudNetworkChanged(angularForm.cloud_network_id)",
+                "ng-change"                   => "vm.filterCloudNetworkChanged(vm.networkRouterModel.cloud_network_id)",
                 "pf-select"                   => true,
                 "ng-selected"                 => "vm.networkRouterModel.cloud_network_id",
                 "selectpicker-for-select-tag" => ""}

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -86,7 +86,7 @@
     = _('External Gateway')
   .form-horizontal
     .form-group
-      %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
+      %label.col-md-2.control-label{"for" => "network_router_external_gateway"}
         = _('Enabled')
       .col-md-8
         %input{"bs-switch"   => "",
@@ -97,7 +97,7 @@
                "ng-model"    => "vm.networkRouterModel.external_gateway"}
 
   .form-horizontal{"ng-if" => "vm.networkRouterModel.external_gateway"}
-    .form-group{"ng-if" => "vm.networkRouterModel.ext_management_system.id"}
+    .form-group
       %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
         = _('Source NAT')
       .col-md-8
@@ -106,7 +106,7 @@
                "type"        => "checkbox",
                "id"          => "network_router_enable_snat",
                "name"        => "enable_snat",
-               "ng-model"    => "vm.networkRouterModel.enable_snat"}
+               "ng-model"    => "vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat"}
 
     .form-group{"ng-class" => "{'has-error': angularForm.cloud_network_id.$invalid}"}
       %label.col-md-2.control-label

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -19,8 +19,8 @@
       .col-md-8{'ng-if' => 'vm.newRecord'}
         %select{'id'         => 'ems_id',
                 'name'       => 'ems_id',
-                'ng-change'  => 'vm.filterNetworkManagerChanged(vm.networkRouterModel.ext_management_system.id)',
-                'ng-model'   => 'vm.networkRouterModel.ext_management_system.id',
+                'ng-change'  => 'vm.filterNetworkManagerChanged(vm.networkRouterModel.ems_id)',
+                'ng-model'   => 'vm.networkRouterModel.ems_id',
                 'ng-options' => 'ems.id as ems.name for ems in vm.ems',
                 'pf-select'  => true,
                 'required'   => ''}
@@ -36,7 +36,7 @@
                             'disabled'    => true}
 
     .form-group{'ng-class' => '{"has-error": angularForm.cloud_tenant_id.$invalid}',
-                'ng-if'    => 'vm.networkRouterModel.ext_management_system.id'}
+                'ng-if'    => 'vm.networkRouterModel.ems_id'}
       %label.col-md-2.control-label
         = _('Cloud Tenant Placement')
       .col-md-8{'ng-if' => 'vm.newRecord'}

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -14,6 +14,7 @@
       .form-group
         %label.col-md-2.control-label
           = _('Network Manager')
+<<<<<<< HEAD
         .col-md-8
           %select{'id'         => 'ems_id',
                   'name'       => 'ems_id',
@@ -24,13 +25,22 @@
                   'required'   => ''}
             %option{:value => ""}
               = "<#{_('Choose')}>"
+=======
+        .col-md-8{"ng-class" => "{'has-error': angularForm.ems_id.$invalid}", "ng-if" => "vm.newRecord"}
+          = select_tag("ems_id",
+              options_for_select([["<#{_('Choose')}>", nil]] + @network_provider_choices.sort),
+              "ng-change"                   => "vm.filterNetworkManagerChanged(angularForm.ems_id)",
+              "ng-model"                    => "vm.networkRouterModel.ext_management_system.id",
+              "required"                    => "",
+              "selectpicker-for-select-tag" => "")
+>>>>>>> Use Object.assign
           %span.help-block{"ng-show" => "angularForm.ems_id.$error.required"}
             = _('Required')
         .col-md-8{"ng-if" => "!vm.newRecord"}
           %input.form-control{"type"         => "text",
             "name"         => "ems_name",
             "ng-maxlength" => 128,
-            "ng-model"     => "vm.networkRouterModel.ems_name",
+            "ng-model"     => "vm.networkRouterModel.ext_management_system.name",
             "ng-disabled"  => true}
   %div
     %h3
@@ -55,7 +65,7 @@
           %input.form-control{"type"         => "text",
                               "name"         => "cloud_tenant_name",
                               "ng-maxlength" => 128,
-                              "ng-model"     => "vm.networkRouterModel.cloud_tenant_name",
+                              "ng-model"     => "vm.networkRouterModel.cloud_tenant.name",
                               "ng-disabled"  => true}
 
   %h3
@@ -87,7 +97,7 @@
                "ng-model"    => "vm.networkRouterModel.external_gateway"}
 
   .form-horizontal{"ng-if" => "vm.networkRouterModel.external_gateway"}
-    .form-group{"ng-if" => "vm.networkRouterModel.ems_id"}
+    .form-group{"ng-if" => "vm.networkRouterModel.ext_management_system.id"}
       %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
         = _('Source NAT')
       .col-md-8
@@ -105,7 +115,7 @@
         %select{"name"                        => "cloud_network_id",
                 "ng-model"                    => "vm.networkRouterModel.cloud_network_id",
                 "ng-options"                  => "network.id as network.name for network in vm.available_networks",
-                "ng-change"                   => "vm.filterCloudNetworkChanged(vm.networkRouterModel.cloud_network_id)",
+                "ng-change"                   => "vm.filterCloudNetworkChanged(angularForm.cloud_network_id)",
                 "pf-select"                   => true,
                 "ng-selected"                 => "vm.networkRouterModel.cloud_network_id",
                 "selectpicker-for-select-tag" => ""}

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -82,60 +82,60 @@
                             "required"     => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
-  %h4
-    = _('External Gateway')
-  .form-horizontal
-    .form-group
-      %label.col-md-2.control-label{"for" => "network_router_external_gateway"}
-        = _('Enabled')
-      .col-md-8
-        %input{"bs-switch"   => "",
-               :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
-               "type"        => "checkbox",
-               "id"          => "network_router_external_gateway",
-               "name"        => "external_gateway",
-               "ng-model"    => "vm.networkRouterModel.external_gateway"}
 
-  .form-horizontal{"ng-if" => "vm.networkRouterModel.external_gateway"}
-    .form-group
-      %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
-        = _('Source NAT')
-      .col-md-8
-        %input{"bs-switch"   => "",
-               :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
-               "type"        => "checkbox",
-               "id"          => "network_router_enable_snat",
-               "name"        => "enable_snat",
-               "ng-model"    => "vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat"}
+  %div{"ng-if" => "vm.networkRouterModel.ext_management_system.id"}
+    %h4
+      = _('External Gateway')
+    .form-horizontal
+      .form-group
+        %label.col-md-2.control-label{"for" => "network_router_external_gateway"}
+          = _('Enabled')
+        .col-md-8
+          %input{"bs-switch"   => "",
+                 :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+                 "type"        => "checkbox",
+                 "id"          => "network_router_external_gateway",
+                 "name"        => "external_gateway",
+                 "ng-model"    => "vm.networkRouterModel.external_gateway"}
 
-    .form-group{"ng-class" => "{'has-error': angularForm.cloud_network_id.$invalid}"}
-      %label.col-md-2.control-label
-        = _('Network')
-      .col-md-8
-        %select{"name"                        => "cloud_network_id",
-                "ng-model"                    => "vm.networkRouterModel.cloud_network_id",
-                "ng-options"                  => "network.id as network.name for network in vm.available_networks",
-                "ng-change"                   => "vm.filterCloudNetworkChanged(vm.networkRouterModel.cloud_network_id)",
-                "pf-select"                   => true,
-                "ng-selected"                 => "vm.networkRouterModel.cloud_network_id",
-                "selectpicker-for-select-tag" => ""}
-          %option{"value" => ""}
-            = "<#{_('Choose')}>"
-        %span.help-block{"ng-show" => "angularForm.cloud_network_id.$error.required"}
-          = _("Required")
-
-    .form-group{"ng-if" => "vm.networkRouterModel.cloud_network_id"}
-      %label.col-md-2.control-label
-        = _('Fixed IPs subnet')
-      .col-md-8
-        %select{"name"                        => "cloud_subnet_id",
-                "ng-model"                    => "vm.networkRouterModel.cloud_subnet_id",
-                "ng-options"                  => "subnet.id as subnet.name for subnet in vm.available_subnets",
-                "pf-select"                   => true,
-                "ng-selected"                 => "vm.networkRouterModel.cloud_subnet_id",
-                "selectpicker-for-select-tag" => ""}
-          %option{"value" => ""}
-            = "<#{_('Choose')}>"
+    .form-horizontal{"ng-if" => "vm.networkRouterModel.external_gateway"}
+      .form-group{"ng-class" => "{'has-error': angularForm.cloud_network_id.$invalid}"}
+        %label.col-md-2.control-label
+          = _('Network')
+        .col-md-8
+          %select{"name"                        => "cloud_network_id",
+                  "ng-model"                    => "vm.networkRouterModel.cloud_network_id",
+                  "ng-options"                  => "network.id as network.name for network in vm.available_networks",
+                  "ng-change"                   => "vm.filterCloudNetworkChanged(vm.networkRouterModel.cloud_network_id)",
+                  "pf-select"                   => true,
+                  "ng-selected"                 => "vm.networkRouterModel.cloud_network_id",
+                  "selectpicker-for-select-tag" => ""}
+            %option{"value" => ""}
+              = "<#{_('Choose')}>"
+          %span.help-block{"ng-show" => "angularForm.cloud_network_id.$error.required"}
+            = _("Required")
+      .form-group{"ng-if" => "vm.networkRouterModel.cloud_network_id"}
+        %label.col-md-2.control-label
+          = _('Fixed IPs subnet')
+        .col-md-8
+          %select{"name"                        => "cloud_subnet_id",
+                  "ng-model"                    => "vm.networkRouterModel.cloud_subnet_id",
+                  "ng-options"                  => "subnet.id as subnet.name for subnet in vm.available_subnets",
+                  "pf-select"                   => true,
+                  "ng-selected"                 => "vm.networkRouterModel.cloud_subnet_id",
+                  "selectpicker-for-select-tag" => ""}
+            %option{"value" => ""}
+              = "<#{_('Choose')}>"
+      .form-group{"ng-if" => "vm.networkRouterModel.cloud_network_id"}
+        %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
+          = _('Source NAT')
+        .col-md-8
+          %input{"bs-switch"   => "",
+                 :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+                 "type"        => "checkbox",
+                 "id"          => "network_router_enable_snat",
+                 "name"        => "enable_snat",
+                 "ng-model"    => "vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat"}
 
   = render :partial => "layouts/angular/generic_form_buttons"
 

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -10,12 +10,13 @@
   = render :partial => 'layouts/flash_msg'
 
   %h3
-    = _('Network Provider')
+    = _('Network Management Provider')
+
   .form-horizontal
     .form-group
       %label.col-md-2.control-label
         = _('Network Manager')
-      .col-md-8
+      .col-md-8{'ng-if' => 'vm.newRecord'}
         %select{'id'         => 'ems_id',
                 'name'       => 'ems_id',
                 'ng-change'  => 'vm.filterNetworkManagerChanged(vm.networkRouterModel.ems_id)',
@@ -28,22 +29,19 @@
         %span.help-block{'ng-show' => 'angularForm.ems_id.$error.required'}
           = _('Required')
       .col-md-8{'ng-if' => '!vm.newRecord'}
-        %input.form-control{'type'         => 'text',
-                            'name'         => 'ems_name',
-                            'maxlength'    => 128,
-                            'ng-model'     => 'vm.networkRouterModel.ems_name',
-                            'ng-disabled'  => true}
-    %h3
-  .form-horizontal{'ng-if' => "vm.networkRouterModel.ems_id"}
-    %h3
-      = _('Placement')
-    .form-group
+        %input.form-control{'type'        => 'text',
+                            'name'        => 'ems_name',
+                            'maxlength'   => 128,
+                            'ng-model'    => 'vm.networkRouterModel.ext_management_system.name',
+                            'disabled'    => true}
+
+    .form-group{'ng-class' => '{"has-error": angularForm.cloud_tenant_id.$invalid}',
+                'ng-if'    => 'vm.networkRouterModel.ext_management_system.id'}
       %label.col-md-2.control-label
-        = _('Cloud Tenant')
-      .col-md-8{'ng-class' => "{'has-error': angularForm.cloud_tenant_id.$invalid}", 'ng-if' => 'vm.newRecord'}
+        = _('Cloud Tenant Placement')
+      .col-md-8{'ng-if' => 'vm.newRecord'}
         %select{'name'                        => 'cloud_tenant_id',
-                'ng-disabled'                 => '!vm.newRecord',
-                'ng-model'                    => 'vm.networkRouterModel.cloud_tenant_id',
+                'ng-model'                    => 'vm.networkRouterModel.cloud_tenant.id',
                 'ng-options'                  => 'tenant.id as tenant.name for tenant in vm.available_tenants',
                 'pf-select'                   => true,
                 'required'                    => '',
@@ -53,11 +51,11 @@
         %span.help-block{'ng-show' => 'angularForm.cloud_tenant_id.$error.required'}
           = _('Required')
       .col-md-8{'ng-if' => '!vm.newRecord'}
-        %input.form-control{'type'         => 'text',
-                            'name'         => 'cloud_tenant_name',
-                            'maxlength'    => 128,
-                            'ng-model'     => 'vm.networkRouterModel.cloud_tenant_name',
-                            'ng-disabled'  => true}
+        %input.form-control{'type'      => 'text',
+                            'name'      => 'cloud_tenant_name',
+                            'disabled'  => true,
+                            'maxlength' => 128,
+                            'ng-model'  => 'vm.networkRouterModel.cloud_tenant.name'}
   %h3
     = _('Router Information')
   .form-horizontal
@@ -65,48 +63,47 @@
       %label.col-md-2.control-label
         = _('Router Name')
       .col-md-8
-        %input.form-control{'type'         => 'text',
-                            'name'         => 'name',
-                            'ng-model'     => 'vm.networkRouterModel.name',
-                            'maxlength'    => 128,
-                            'required'     => ''}
+        %input.form-control{'type'      => 'text',
+                            'name'      => 'name',
+                            'ng-model'  => 'vm.networkRouterModel.name',
+                            'maxlength' => 128,
+                            'required'  => ''}
         %span.help-block{'ng-show' => 'angularForm.name.$error.required'}
           = _('Required')
     .form-group
       %label.col-md-2.control-label
         = _('Admin State Up')
       .col-md-8
-        %input{'bs-switch'   => '',
-               'data'        => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
-               'type'        => 'checkbox',
-               'id'          => '_admin_state_up',
-               'name'        => 'admin_state_up',
-               'ng-model'    => 'vm.networkRouterModel.admin_state_up'}
+        %input{'bs-switch' => '',
+               'data'      => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+               'type'      => 'checkbox',
+               'id'        => 'admin_state_up',
+               'name'      => 'admin_state_up',
+               'ng-model'  => 'vm.networkRouterModel.admin_state_up'}
   %h4
     = _('External Gateway')
   .form-horizontal
     .form-group
-      %label.col-md-2.control-label{'for' => 'network_router_enable_snat'}
+      %label.col-md-2.control-label{'for' => 'external_gateway'}
         = _('Enable')
       .col-md-8
-        %input{'bs-switch'   => '',
-               'data'        => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
-               'type'        => 'checkbox',
-               'id'          => 'external_gateway',
-               'name'        => 'external_gateway',
-               'ng-model'    => 'vm.networkRouterModel.external_gateway'}
+        %input{'bs-switch' => '',
+               'data'      => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+               'type'      => 'checkbox',
+               'id'        => 'external_gateway',
+               'name'      => 'external_gateway',
+               'ng-model'  => 'vm.networkRouterModel.external_gateway'}
   .form-horizontal{'ng-if' => 'vm.networkRouterModel.external_gateway'}
-    .form-group{'ng-if' => 'vm.networkRouterModel.ems_id'}
-      %label.col-md-2.control-label{'for' => 'network_router_enable_snat'}
+    .form-group
+      %label.col-md-2.control-label{'for' => 'enable_snat'}
         = _('Source NAT')
       .col-md-8
-        %input{'bs-switch'   => '',
-               'data'        => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
-               'type'        => 'checkbox',
-               'id'          => 'enable_snat',
-               'name'        => 'enable_snat',
-               'ng-model'    => 'vm.networkRouterModel.enable_snat'}
-
+        %input{'bs-switch' => '',
+               'data'      => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+               'type'      => 'checkbox',
+               'id'        => 'enable_snat',
+               'name'      => 'enable_snat',
+               'ng-model'  => 'vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat'}
     .form-group{'ng-class' => "{'has-error': angularForm.cloud_network_id.$invalid}"}
       %label.col-md-2.control-label
         = _('Network')

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -92,6 +92,7 @@
                'type'      => 'checkbox',
                'id'        => 'external_gateway',
                'name'      => 'external_gateway',
+               'ng-change' => 'vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat = true',
                'ng-model'  => 'vm.networkRouterModel.external_gateway'}
   .form-horizontal{'ng-if' => 'vm.networkRouterModel.external_gateway'}
     .form-group

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -107,8 +107,9 @@
                   "ng-model"                    => "vm.networkRouterModel.cloud_network_id",
                   "ng-options"                  => "network.id as network.name for network in vm.available_networks",
                   "ng-change"                   => "vm.filterCloudNetworkChanged(vm.networkRouterModel.cloud_network_id)",
-                  "pf-select"                   => true,
                   "ng-selected"                 => "vm.networkRouterModel.cloud_network_id",
+                  "pf-select"                   => true,
+                  "required"                    => "",
                   "selectpicker-for-select-tag" => ""}
             %option{"value" => ""}
               = "<#{_('Choose')}>"

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -7,11 +7,11 @@
                "model-copy"    => 'vm.modelCopy'}
   = render :partial => "layouts/flash_msg"
 
-  %div{"ng-if" => "vm.newRecord"}
+  %div
     %h3
       = _('Network Provider')
     .form-horizontal
-      .form-group{"ng-class" => "{'has-error': angularForm.ems_id.$invalid}"}
+      .form-group
         %label.col-md-2.control-label
           = _('Network Manager')
         .col-md-8
@@ -26,9 +26,40 @@
               = "<#{_('Choose')}>"
           %span.help-block{"ng-show" => "angularForm.ems_id.$error.required"}
             = _('Required')
+        .col-md-8{"ng-if" => "!vm.newRecord"}
+          %input.form-control{"type"         => "text",
+            "name"         => "ems_name",
+            "ng-maxlength" => 128,
+            "ng-model"     => "vm.networkRouterModel.ems_name",
+            "ng-disabled"  => true}
+  %div
+    %h3
+      = _('Placement')
+    .form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _('Cloud Tenant')
+        .col-md-8{"ng-class" => "{'has-error': angularForm.cloud_tenant_id.$invalid}", "ng-if" => "vm.newRecord"}
+          %select{"name"                        => "cloud_tenant_id",
+                  "ng-disabled"                 => "!vm.newRecord",
+                  "ng-model"                    => "vm.networkRouterModel.cloud_tenant_id",
+                  'ng-options'                  => 'tenant.id as tenant.name for tenant in vm.available_tenants',
+                  'pf-select'                   => true,
+                  "required"                    => "",
+                  "selectpicker-for-select-tag" => ""}
+            %option{"value" => ""}
+              = "<#{_('Choose')}>"
+          %span.help-block{"ng-show" => "angularForm.cloud_tenant_id.$error.required"}
+            = _("Required")
+        .col-md-8{"ng-if" => "!vm.newRecord"}
+          %input.form-control{"type"         => "text",
+                              "name"         => "cloud_tenant_name",
+                              "ng-maxlength" => 128,
+                              "ng-model"     => "vm.networkRouterModel.cloud_tenant_name",
+                              "ng-disabled"  => true}
 
   %h3
-    = _('Basic Information')
+    = _('Router Information')
   .form-horizontal
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label
@@ -41,11 +72,12 @@
                             "required"     => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
-  %h3
+  %h4
     = _('External Gateway')
   .form-horizontal
     .form-group
       %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
+        = _('Enabled')
       .col-md-8
         %input{"bs-switch"   => "",
                :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
@@ -57,7 +89,7 @@
   .form-horizontal{"ng-if" => "vm.networkRouterModel.external_gateway"}
     .form-group{"ng-if" => "vm.networkRouterModel.ems_id"}
       %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
-        = _('Enable Source NAT')
+        = _('Source NAT')
       .col-md-8
         %input{"bs-switch"   => "",
                :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
@@ -76,46 +108,24 @@
                 "ng-change"                   => "vm.filterCloudNetworkChanged(vm.networkRouterModel.cloud_network_id)",
                 "pf-select"                   => true,
                 "ng-selected"                 => "vm.networkRouterModel.cloud_network_id",
-                "ng-required"                 => "vm.networkRouterModel.enable_snat == true",
                 "selectpicker-for-select-tag" => ""}
           %option{"value" => ""}
             = "<#{_('Choose')}>"
         %span.help-block{"ng-show" => "angularForm.cloud_network_id.$error.required"}
           = _("Required")
 
-    %h3
-      = _('Fixed IPs')
-    .form-horizontal{"ng-if" => "vm.networkRouterModel.cloud_network_id"}
-      .form-group
-        %label.col-md-2.control-label
-          = _('Subnet')
-        .col-md-8
-          %select{"name"                        => "cloud_subnet_id",
-                  "ng-model"                    => "vm.networkRouterModel.cloud_subnet_id",
-                  "ng-options"                  => "subnet.id as subnet.name for subnet in vm.available_subnets",
-                  "pf-select"                   => true,
-                  "ng-selected"                 => "vm.networkRouterModel.cloud_subnet_id",
-                  "selectpicker-for-select-tag" => ""}
-            %option{"value" => ""}
-              = "<#{_('Choose')}>"
-  %div{"ng-if" => "vm.newRecord"}
-    %h3
-      = _('Placement')
-    .form-horizontal
-      .form-group{"ng-class" => "{'has-error': angularForm.cloud_tenant_id.$invalid}", "ng-if" => "vm.networkRouterModel.ems_id"}
-        %label.col-md-2.control-label
-          = _('Cloud Tenant')
-        .col-md-8
-          %select{"name"                        => "cloud_tenant_id",
-                  "ng-model"                    => "vm.networkRouterModel.cloud_tenant_id",
-                  "required"                    => "",
-                  'ng-options'                  => 'tenant.id as tenant.name for tenant in vm.available_tenants',
-                  'pf-select'                   => true,
-                  "selectpicker-for-select-tag" => ""}
-            %option{"value" => ""}
-              = "<#{_('Choose')}>"
-          %span.help-block{"ng-show" => "angularForm.cloud_tenant_id.$error.required"}
-            = _("Required")
+    .form-group{"ng-if" => "vm.networkRouterModel.cloud_network_id"}
+      %label.col-md-2.control-label
+        = _('Fixed IPs subnet')
+      .col-md-8
+        %select{"name"                        => "cloud_subnet_id",
+                "ng-model"                    => "vm.networkRouterModel.cloud_subnet_id",
+                "ng-options"                  => "subnet.id as subnet.name for subnet in vm.available_subnets",
+                "pf-select"                   => true,
+                "ng-selected"                 => "vm.networkRouterModel.cloud_subnet_id",
+                "selectpicker-for-select-tag" => ""}
+          %option{"value" => ""}
+            = "<#{_('Choose')}>"
 
   = render :partial => "layouts/angular/generic_form_buttons"
 

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -29,7 +29,7 @@
         .col-md-8{"ng-class" => "{'has-error': angularForm.ems_id.$invalid}", "ng-if" => "vm.newRecord"}
           = select_tag("ems_id",
               options_for_select([["<#{_('Choose')}>", nil]] + @network_provider_choices.sort),
-              "ng-change"                   => "vm.filterNetworkManagerChanged(angularForm.ems_id)",
+              "ng-change"                   => "vm.filterNetworkManagerChanged(vm.networkRouterModel.ext_management_system.id)",
               "ng-model"                    => "vm.networkRouterModel.ext_management_system.id",
               "required"                    => "",
               "selectpicker-for-select-tag" => "")

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -19,8 +19,8 @@
       .col-md-8{'ng-if' => 'vm.newRecord'}
         %select{'id'         => 'ems_id',
                 'name'       => 'ems_id',
-                'ng-change'  => 'vm.filterNetworkManagerChanged(vm.networkRouterModel.ems_id)',
-                'ng-model'   => 'vm.networkRouterModel.ems_id',
+                'ng-change'  => 'vm.filterNetworkManagerChanged(vm.networkRouterModel.ext_management_system.id)',
+                'ng-model'   => 'vm.networkRouterModel.ext_management_system.id',
                 'ng-options' => 'ems.id as ems.name for ems in vm.ems',
                 'pf-select'  => true,
                 'required'   => ''}
@@ -72,7 +72,7 @@
           = _('Required')
     .form-group
       %label.col-md-2.control-label
-        = _('Admin State Up')
+        = _('Administrative State')
       .col-md-8
         %input{'bs-switch' => '',
                'data'      => {:on_text => _('Up'), :off_text => _('Down'), :size => 'mini'},

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -72,12 +72,22 @@
                             "required"     => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
+    .form-group
+      %label.col-md-2.control-label
+        = _('Admin State Up')
+      .col-md-8
+        %input{"bs-switch"   => "",
+               :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+               "type"        => "checkbox",
+               "id"          => "network_router_admin_state_up",
+               "name"        => "admin_state_up",
+               "ng-model"    => "vm.networkRouterModel.admin_state_up"}
   %h4
     = _('External Gateway')
   .form-horizontal
     .form-group
       %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
-        = _('Enabled')
+        = _('Enable external gateway')
       .col-md-8
         %input{"bs-switch"   => "",
                :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -9,57 +9,55 @@
 
   = render :partial => 'layouts/flash_msg'
 
-  %div
+  %h3
+    = _('Network Provider')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Network Manager')
+      .col-md-8
+        %select{'id'         => 'ems_id',
+                'name'       => 'ems_id',
+                'ng-change'  => 'vm.filterNetworkManagerChanged(vm.networkRouterModel.ems_id)',
+                'ng-model'   => 'vm.networkRouterModel.ems_id',
+                'ng-options' => 'ems.id as ems.name for ems in vm.ems',
+                'pf-select'  => true,
+                'required'   => ''}
+          %option{:value => ''}
+            = "<#{_('Choose')}>"
+        %span.help-block{'ng-show' => 'angularForm.ems_id.$error.required'}
+          = _('Required')
+      .col-md-8{'ng-if' => '!vm.newRecord'}
+        %input.form-control{'type'         => 'text',
+                            'name'         => 'ems_name',
+                            'maxlength'    => 128,
+                            'ng-model'     => 'vm.networkRouterModel.ems_name',
+                            'ng-disabled'  => true}
     %h3
-      = _('Network Provider')
-    .form-horizontal
-      .form-group
-        %label.col-md-2.control-label
-          = _('Network Manager')
-        .col-md-8
-          %select{'id'         => 'ems_id',
-                  'name'       => 'ems_id',
-                  'ng-change'  => 'vm.filterNetworkManagerChanged(vm.networkRouterModel.ems_id)',
-                  'ng-model'   => 'vm.networkRouterModel.ems_id',
-                  'ng-options' => 'ems.id as ems.name for ems in vm.ems',
-                  'pf-select'  => true,
-                  'required'   => ''}
-            %option{:value => ''}
-              = "<#{_('Choose')}>"
-          %span.help-block{'ng-show' => 'angularForm.ems_id.$error.required'}
-            = _('Required')
-        .col-md-8{'ng-if' => '!vm.newRecord'}
-          %input.form-control{'type'         => 'text',
-                              'name'         => 'ems_name',
-                              'maxlength'    => 128,
-                              'ng-model'     => 'vm.networkRouterModel.ems_name',
-                              'ng-disabled'  => true}
-  %div
+  .form-horizontal{'ng-if' => "vm.networkRouterModel.ems_id"}
     %h3
       = _('Placement')
-    .form-horizontal
-      .form-group
-        %label.col-md-2.control-label
-          = _('Cloud Tenant')
-        .col-md-8{'ng-class' => "{'has-error': angularForm.cloud_tenant_id.$invalid}", 'ng-if' => 'vm.newRecord'}
-          %select{'name'                        => 'cloud_tenant_id',
-                  'ng-disabled'                 => '!vm.newRecord',
-                  'ng-model'                    => 'vm.networkRouterModel.cloud_tenant_id',
-                  'ng-options'                  => 'tenant.id as tenant.name for tenant in vm.available_tenants',
-                  'pf-select'                   => true,
-                  'required'                    => '',
-                  'selectpicker-for-select-tag' => ''}
-            %option{'value' => ''}
-              = "<#{_('Choose')}>"
-          %span.help-block{'ng-show' => 'angularForm.cloud_tenant_id.$error.required'}
-            = _('Required')
-        .col-md-8{'ng-if' => '!vm.newRecord'}
-          %input.form-control{'type'         => 'text',
-                              'name'         => 'cloud_tenant_name',
-                              'maxlength'    => 128,
-                              'ng-model'     => 'vm.networkRouterModel.cloud_tenant_name',
-                              'ng-disabled'  => true}
-
+    .form-group
+      %label.col-md-2.control-label
+        = _('Cloud Tenant')
+      .col-md-8{'ng-class' => "{'has-error': angularForm.cloud_tenant_id.$invalid}", 'ng-if' => 'vm.newRecord'}
+        %select{'name'                        => 'cloud_tenant_id',
+                'ng-disabled'                 => '!vm.newRecord',
+                'ng-model'                    => 'vm.networkRouterModel.cloud_tenant_id',
+                'ng-options'                  => 'tenant.id as tenant.name for tenant in vm.available_tenants',
+                'pf-select'                   => true,
+                'required'                    => '',
+                'selectpicker-for-select-tag' => ''}
+          %option{'value' => ''}
+            = "<#{_('Choose')}>"
+        %span.help-block{'ng-show' => 'angularForm.cloud_tenant_id.$error.required'}
+          = _('Required')
+      .col-md-8{'ng-if' => '!vm.newRecord'}
+        %input.form-control{'type'         => 'text',
+                            'name'         => 'cloud_tenant_name',
+                            'maxlength'    => 128,
+                            'ng-model'     => 'vm.networkRouterModel.cloud_tenant_name',
+                            'ng-disabled'  => true}
   %h3
     = _('Router Information')
   .form-horizontal
@@ -97,7 +95,6 @@
                'id'          => 'external_gateway',
                'name'        => 'external_gateway',
                'ng-model'    => 'vm.networkRouterModel.external_gateway'}
-
   .form-horizontal{'ng-if' => 'vm.networkRouterModel.external_gateway'}
     .form-group{'ng-if' => 'vm.networkRouterModel.ems_id'}
       %label.col-md-2.control-label{'for' => 'network_router_enable_snat'}

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -14,7 +14,6 @@
       .form-group
         %label.col-md-2.control-label
           = _('Network Manager')
-<<<<<<< HEAD
         .col-md-8
           %select{'id'         => 'ems_id',
                   'name'       => 'ems_id',
@@ -25,24 +24,15 @@
                   'required'   => ''}
             %option{:value => ""}
               = "<#{_('Choose')}>"
-=======
-        .col-md-8{"ng-class" => "{'has-error': angularForm.ems_id.$invalid}", "ng-if" => "vm.newRecord"}
-          = select_tag("ems_id",
-              options_for_select([["<#{_('Choose')}>", nil]] + @network_provider_choices.sort),
-              "ng-change"                   => "vm.filterNetworkManagerChanged(vm.networkRouterModel.ext_management_system.id)",
-              "ng-model"                    => "vm.networkRouterModel.ext_management_system.id",
-              "required"                    => "",
-              "selectpicker-for-select-tag" => "")
->>>>>>> Use Object.assign
           %span.help-block{"ng-show" => "angularForm.ems_id.$error.required"}
             = _('Required')
         .col-md-8{"ng-if" => "!vm.newRecord"}
           %input.form-control{"type"         => "text",
             "name"         => "ems_name",
-            "ng-maxlength" => 128,
-            "ng-model"     => "vm.networkRouterModel.ext_management_system.name",
+            "maxlength" => 128,
+            "ng-model"     => "vm.networkRouterModel.ems_name",
             "ng-disabled"  => true}
-  %div{"ng-if" => "vm.networkRouterModel.ext_management_system.id"}
+  %div
     %h3
       = _('Placement')
     .form-horizontal
@@ -64,8 +54,8 @@
         .col-md-8{"ng-if" => "!vm.newRecord"}
           %input.form-control{"type"         => "text",
                               "name"         => "cloud_tenant_name",
-                              "ng-maxlength" => 128,
-                              "ng-model"     => "vm.networkRouterModel.cloud_tenant.name",
+                              "maxlength" => 128,
+                              "ng-model"     => "vm.networkRouterModel.cloud_tenant_name",
                               "ng-disabled"  => true}
 
   %h3
@@ -78,65 +68,64 @@
         %input.form-control{:type          => "text",
                             :name          => "name",
                             "ng-model"     => "vm.networkRouterModel.name",
-                            "ng-maxlength" => 128,
+                            "maxlength" => 128,
                             "required"     => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
+  %h4
+    = _('External Gateway')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
+        = _('Enabled')
+      .col-md-8
+        %input{"bs-switch"   => "",
+               :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+               "type"        => "checkbox",
+               "id"          => "network_router_external_gateway",
+               "name"        => "external_gateway",
+               "ng-model"    => "vm.networkRouterModel.external_gateway"}
 
-  %div{"ng-if" => "vm.networkRouterModel.ext_management_system.id"}
-    %h4
-      = _('External Gateway')
-    .form-horizontal
-      .form-group
-        %label.col-md-2.control-label{"for" => "network_router_external_gateway"}
-          = _('Enabled')
-        .col-md-8
-          %input{"bs-switch"   => "",
-                 :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
-                 "type"        => "checkbox",
-                 "id"          => "network_router_external_gateway",
-                 "name"        => "external_gateway",
-                 "ng-model"    => "vm.networkRouterModel.external_gateway"}
+  .form-horizontal{"ng-if" => "vm.networkRouterModel.external_gateway"}
+    .form-group{"ng-if" => "vm.networkRouterModel.ems_id"}
+      %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
+        = _('Source NAT')
+      .col-md-8
+        %input{"bs-switch"   => "",
+               :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+               "type"        => "checkbox",
+               "id"          => "network_router_enable_snat",
+               "name"        => "enable_snat",
+               "ng-model"    => "vm.networkRouterModel.enable_snat"}
 
-    .form-horizontal{"ng-if" => "vm.networkRouterModel.external_gateway"}
-      .form-group{"ng-class" => "{'has-error': angularForm.cloud_network_id.$invalid}"}
-        %label.col-md-2.control-label
-          = _('Network')
-        .col-md-8
-          %select{"name"                        => "cloud_network_id",
-                  "ng-model"                    => "vm.networkRouterModel.cloud_network_id",
-                  "ng-options"                  => "network.id as network.name for network in vm.available_networks",
-                  "ng-change"                   => "vm.filterCloudNetworkChanged(vm.networkRouterModel.cloud_network_id)",
-                  "ng-selected"                 => "vm.networkRouterModel.cloud_network_id",
-                  "pf-select"                   => true,
-                  "required"                    => "",
-                  "selectpicker-for-select-tag" => ""}
-            %option{"value" => ""}
-              = "<#{_('Choose')}>"
-          %span.help-block{"ng-show" => "angularForm.cloud_network_id.$error.required"}
-            = _("Required")
-      .form-group{"ng-if" => "vm.networkRouterModel.cloud_network_id"}
-        %label.col-md-2.control-label
-          = _('Fixed IPs subnet')
-        .col-md-8
-          %select{"name"                        => "cloud_subnet_id",
-                  "ng-model"                    => "vm.networkRouterModel.cloud_subnet_id",
-                  "ng-options"                  => "subnet.id as subnet.name for subnet in vm.available_subnets",
-                  "pf-select"                   => true,
-                  "ng-selected"                 => "vm.networkRouterModel.cloud_subnet_id",
-                  "selectpicker-for-select-tag" => ""}
-            %option{"value" => ""}
-              = "<#{_('Choose')}>"
-      .form-group{"ng-if" => "vm.networkRouterModel.cloud_network_id"}
-        %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
-          = _('Source NAT')
-        .col-md-8
-          %input{"bs-switch"   => "",
-                 :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
-                 "type"        => "checkbox",
-                 "id"          => "network_router_enable_snat",
-                 "name"        => "enable_snat",
-                 "ng-model"    => "vm.networkRouterModel.extra_attributes.external_gateway_info.enable_snat"}
+    .form-group{"ng-class" => "{'has-error': angularForm.cloud_network_id.$invalid}"}
+      %label.col-md-2.control-label
+        = _('Network')
+      .col-md-8
+        %select{"name"                        => "cloud_network_id",
+                "ng-model"                    => "vm.networkRouterModel.cloud_network_id",
+                "ng-options"                  => "network.id as network.name for network in vm.available_networks",
+                "ng-change"                   => "vm.filterCloudNetworkChanged(vm.networkRouterModel.cloud_network_id)",
+                "pf-select"                   => true,
+                "ng-selected"                 => "vm.networkRouterModel.cloud_network_id",
+                "selectpicker-for-select-tag" => ""}
+          %option{"value" => ""}
+            = "<#{_('Choose')}>"
+        %span.help-block{"ng-show" => "angularForm.cloud_network_id.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-if" => "vm.networkRouterModel.cloud_network_id"}
+      %label.col-md-2.control-label
+        = _('Fixed IPs subnet')
+      .col-md-8
+        %select{"name"                        => "cloud_subnet_id",
+                "ng-model"                    => "vm.networkRouterModel.cloud_subnet_id",
+                "ng-options"                  => "subnet.id as subnet.name for subnet in vm.available_subnets",
+                "pf-select"                   => true,
+                "ng-selected"                 => "vm.networkRouterModel.cloud_subnet_id",
+                "selectpicker-for-select-tag" => ""}
+          %option{"value" => ""}
+            = "<#{_('Choose')}>"
 
   = render :partial => "layouts/angular/generic_form_buttons"
 

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -13,7 +13,7 @@
     = _('Network Management Provider')
 
   .form-horizontal
-    .form-group
+    .form-group{'ng-class' => '{"has-error": angularForm.ems_id.$invalid}'}
       %label.col-md-2.control-label
         = _('Network Manager')
       .col-md-8{'ng-if' => 'vm.newRecord'}

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -1,11 +1,13 @@
-%form#form_div{:name           => "angularForm",
-               'ng-controller' => "networkRouterFormController as vm",
+%form#form_div{'name'          => 'angularForm',
+               'ng-controller' => 'networkRouterFormController as vm',
                'ng-cloak'      => '',
-               "miq-form"      => true,
+               'miq-form'      => true,
                'form-changed'  => true,
-               "model"         => "vm.networkRouterModel",
-               "model-copy"    => 'vm.modelCopy'}
-  = render :partial => "layouts/flash_msg"
+               'model'         => 'vm.networkRouterModel',
+               'model-copy'    => 'vm.modelCopy',
+               'ng-show'       => 'vm.afterGet'}
+
+  = render :partial => 'layouts/flash_msg'
 
   %div
     %h3
@@ -17,21 +19,21 @@
         .col-md-8
           %select{'id'         => 'ems_id',
                   'name'       => 'ems_id',
-                  'ng-change'  => "vm.filterNetworkManagerChanged(vm.networkRouterModel.ems_id)",
-                  'ng-model'   => "vm.networkRouterModel.ems_id",
+                  'ng-change'  => 'vm.filterNetworkManagerChanged(vm.networkRouterModel.ems_id)',
+                  'ng-model'   => 'vm.networkRouterModel.ems_id',
                   'ng-options' => 'ems.id as ems.name for ems in vm.ems',
                   'pf-select'  => true,
                   'required'   => ''}
-            %option{:value => ""}
+            %option{:value => ''}
               = "<#{_('Choose')}>"
-          %span.help-block{"ng-show" => "angularForm.ems_id.$error.required"}
+          %span.help-block{'ng-show' => 'angularForm.ems_id.$error.required'}
             = _('Required')
-        .col-md-8{"ng-if" => "!vm.newRecord"}
-          %input.form-control{"type"         => "text",
-            "name"         => "ems_name",
-            "maxlength" => 128,
-            "ng-model"     => "vm.networkRouterModel.ems_name",
-            "ng-disabled"  => true}
+        .col-md-8{'ng-if' => '!vm.newRecord'}
+          %input.form-control{'type'         => 'text',
+                              'name'         => 'ems_name',
+                              'maxlength'    => 128,
+                              'ng-model'     => 'vm.networkRouterModel.ems_name',
+                              'ng-disabled'  => true}
   %div
     %h3
       = _('Placement')
@@ -39,105 +41,105 @@
       .form-group
         %label.col-md-2.control-label
           = _('Cloud Tenant')
-        .col-md-8{"ng-class" => "{'has-error': angularForm.cloud_tenant_id.$invalid}", "ng-if" => "vm.newRecord"}
-          %select{"name"                        => "cloud_tenant_id",
-                  "ng-disabled"                 => "!vm.newRecord",
-                  "ng-model"                    => "vm.networkRouterModel.cloud_tenant_id",
+        .col-md-8{'ng-class' => "{'has-error': angularForm.cloud_tenant_id.$invalid}", 'ng-if' => 'vm.newRecord'}
+          %select{'name'                        => 'cloud_tenant_id',
+                  'ng-disabled'                 => '!vm.newRecord',
+                  'ng-model'                    => 'vm.networkRouterModel.cloud_tenant_id',
                   'ng-options'                  => 'tenant.id as tenant.name for tenant in vm.available_tenants',
                   'pf-select'                   => true,
-                  "required"                    => "",
-                  "selectpicker-for-select-tag" => ""}
-            %option{"value" => ""}
+                  'required'                    => '',
+                  'selectpicker-for-select-tag' => ''}
+            %option{'value' => ''}
               = "<#{_('Choose')}>"
-          %span.help-block{"ng-show" => "angularForm.cloud_tenant_id.$error.required"}
-            = _("Required")
-        .col-md-8{"ng-if" => "!vm.newRecord"}
-          %input.form-control{"type"         => "text",
-                              "name"         => "cloud_tenant_name",
-                              "maxlength" => 128,
-                              "ng-model"     => "vm.networkRouterModel.cloud_tenant_name",
-                              "ng-disabled"  => true}
+          %span.help-block{'ng-show' => 'angularForm.cloud_tenant_id.$error.required'}
+            = _('Required')
+        .col-md-8{'ng-if' => '!vm.newRecord'}
+          %input.form-control{'type'         => 'text',
+                              'name'         => 'cloud_tenant_name',
+                              'maxlength'    => 128,
+                              'ng-model'     => 'vm.networkRouterModel.cloud_tenant_name',
+                              'ng-disabled'  => true}
 
   %h3
     = _('Router Information')
   .form-horizontal
-    .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
+    .form-group{'ng-class' => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label
         = _('Router Name')
       .col-md-8
-        %input.form-control{:type          => "text",
-                            :name          => "name",
-                            "ng-model"     => "vm.networkRouterModel.name",
-                            "maxlength" => 128,
-                            "required"     => ""}
-        %span.help-block{"ng-show" => "angularForm.name.$error.required"}
-          = _("Required")
+        %input.form-control{'type'         => 'text',
+                            'name'         => 'name',
+                            'ng-model'     => 'vm.networkRouterModel.name',
+                            'maxlength'    => 128,
+                            'required'     => ''}
+        %span.help-block{'ng-show' => 'angularForm.name.$error.required'}
+          = _('Required')
     .form-group
       %label.col-md-2.control-label
         = _('Admin State Up')
       .col-md-8
-        %input{"bs-switch"   => "",
-               :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
-               "type"        => "checkbox",
-               "id"          => "network_router_admin_state_up",
-               "name"        => "admin_state_up",
-               "ng-model"    => "vm.networkRouterModel.admin_state_up"}
+        %input{'bs-switch'   => '',
+               'data'        => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+               'type'        => 'checkbox',
+               'id'          => '_admin_state_up',
+               'name'        => 'admin_state_up',
+               'ng-model'    => 'vm.networkRouterModel.admin_state_up'}
   %h4
     = _('External Gateway')
   .form-horizontal
     .form-group
-      %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
-        = _('Enable external gateway')
+      %label.col-md-2.control-label{'for' => 'network_router_enable_snat'}
+        = _('Enable')
       .col-md-8
-        %input{"bs-switch"   => "",
-               :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
-               "type"        => "checkbox",
-               "id"          => "network_router_external_gateway",
-               "name"        => "external_gateway",
-               "ng-model"    => "vm.networkRouterModel.external_gateway"}
+        %input{'bs-switch'   => '',
+               'data'        => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+               'type'        => 'checkbox',
+               'id'          => 'external_gateway',
+               'name'        => 'external_gateway',
+               'ng-model'    => 'vm.networkRouterModel.external_gateway'}
 
-  .form-horizontal{"ng-if" => "vm.networkRouterModel.external_gateway"}
-    .form-group{"ng-if" => "vm.networkRouterModel.ems_id"}
-      %label.col-md-2.control-label{"for" => "network_router_enable_snat"}
+  .form-horizontal{'ng-if' => 'vm.networkRouterModel.external_gateway'}
+    .form-group{'ng-if' => 'vm.networkRouterModel.ems_id'}
+      %label.col-md-2.control-label{'for' => 'network_router_enable_snat'}
         = _('Source NAT')
       .col-md-8
-        %input{"bs-switch"   => "",
-               :data         => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
-               "type"        => "checkbox",
-               "id"          => "network_router_enable_snat",
-               "name"        => "enable_snat",
-               "ng-model"    => "vm.networkRouterModel.enable_snat"}
+        %input{'bs-switch'   => '',
+               'data'        => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+               'type'        => 'checkbox',
+               'id'          => 'enable_snat',
+               'name'        => 'enable_snat',
+               'ng-model'    => 'vm.networkRouterModel.enable_snat'}
 
-    .form-group{"ng-class" => "{'has-error': angularForm.cloud_network_id.$invalid}"}
+    .form-group{'ng-class' => "{'has-error': angularForm.cloud_network_id.$invalid}"}
       %label.col-md-2.control-label
         = _('Network')
       .col-md-8
-        %select{"name"                        => "cloud_network_id",
-                "ng-model"                    => "vm.networkRouterModel.cloud_network_id",
-                "ng-options"                  => "network.id as network.name for network in vm.available_networks",
-                "ng-change"                   => "vm.filterCloudNetworkChanged(vm.networkRouterModel.cloud_network_id)",
-                "pf-select"                   => true,
-                "ng-selected"                 => "vm.networkRouterModel.cloud_network_id",
-                "selectpicker-for-select-tag" => ""}
-          %option{"value" => ""}
+        %select{'name'                        => 'cloud_network_id',
+                'ng-model'                    => 'vm.networkRouterModel.cloud_network_id',
+                'ng-options'                  => 'network.id as network.name for network in vm.available_networks',
+                'ng-change'                   => 'vm.filterCloudNetworkChanged(vm.networkRouterModel.cloud_network_id)',
+                'pf-select'                   => true,
+                'ng-selected'                 => 'vm.networkRouterModel.cloud_network_id',
+                'selectpicker-for-select-tag' => ''}
+          %option{'value' => ''}
             = "<#{_('Choose')}>"
-        %span.help-block{"ng-show" => "angularForm.cloud_network_id.$error.required"}
-          = _("Required")
+        %span.help-block{'ng-show' => 'angularForm.cloud_network_id.$error.required'}
+          = _('Required')
 
-    .form-group{"ng-if" => "vm.networkRouterModel.cloud_network_id"}
+    .form-group{'ng-if' => 'vm.networkRouterModel.cloud_network_id'}
       %label.col-md-2.control-label
         = _('Fixed IPs subnet')
       .col-md-8
-        %select{"name"                        => "cloud_subnet_id",
-                "ng-model"                    => "vm.networkRouterModel.cloud_subnet_id",
-                "ng-options"                  => "subnet.id as subnet.name for subnet in vm.available_subnets",
-                "pf-select"                   => true,
-                "ng-selected"                 => "vm.networkRouterModel.cloud_subnet_id",
-                "selectpicker-for-select-tag" => ""}
-          %option{"value" => ""}
+        %select{'name'                        => 'cloud_subnet_id',
+                'ng-model'                    => 'vm.networkRouterModel.cloud_subnet_id',
+                'ng-options'                  => 'subnet.id as subnet.name for subnet in vm.available_subnets',
+                'pf-select'                   => true,
+                'ng-selected'                 => 'vm.networkRouterModel.cloud_subnet_id',
+                'selectpicker-for-select-tag' => ''}
+          %option{'value' => ''}
             = "<#{_('Choose')}>"
 
-  = render :partial => "layouts/angular/generic_form_buttons"
+  = render :partial => 'layouts/angular/generic_form_buttons'
 
 :javascript
   ManageIQ.angular.app.value('networkRouterFormId', '#{@router.id || "new"}');

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -42,7 +42,7 @@
             "ng-maxlength" => 128,
             "ng-model"     => "vm.networkRouterModel.ext_management_system.name",
             "ng-disabled"  => true}
-  %div
+  %div{"ng-if" => "vm.networkRouterModel.ext_management_system.id"}
     %h3
       = _('Placement')
     .form-horizontal

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -111,7 +111,7 @@
         %select{'name'                        => 'cloud_network_id',
                 'ng-model'                    => 'vm.networkRouterModel.cloud_network_id',
                 'ng-options'                  => 'network.id as network.name for network in vm.available_networks',
-                'ng-change'                   => 'vm.filterCloudNetworkChanged(vm.networkRouterModel.cloud_network_id)',
+                'ng-change'                   => 'vm.getCloudSubnetsByNetworkID(vm.networkRouterModel.cloud_network_id)',
                 'pf-select'                   => true,
                 'ng-selected'                 => 'vm.networkRouterModel.cloud_network_id',
                 'selectpicker-for-select-tag' => ''}

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -75,7 +75,7 @@
         = _('Admin State Up')
       .col-md-8
         %input{'bs-switch' => '',
-               'data'      => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
+               'data'      => {:on_text => _('Up'), :off_text => _('Down'), :size => 'mini'},
                'type'      => 'checkbox',
                'id'        => 'admin_state_up',
                'name'      => 'admin_state_up',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1644,9 +1644,6 @@ Rails.application.routes.draw do
         download_summary_pdf
         edit
         index
-        network_router_form_fields
-        network_router_networks_by_ems
-        network_router_subnets_by_network
         new
         remove_interface_select
         show

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -108,6 +108,11 @@ describe NetworkRouterController do
           :userid => controller.current_user.userid
         }
       end
+
+      let(:cloud_tenant) do
+        FactoryGirl.create(:cloud_tenant)
+      end
+
       let(:queue_options) do
         {
           :class_name  => @ems.class.name,
@@ -116,7 +121,12 @@ describe NetworkRouterController do
           :priority    => MiqQueue::HIGH_PRIORITY,
           :role        => 'ems_operations',
           :zone        => @ems.my_zone,
-          :args        => [{:name => "test"}]
+          :args        => [{
+            :name            => 'test',
+            :admin_state_up  => 'true',
+            :ems_id          => @ems.id.to_s,
+            :cloud_subnet_id => ''
+          }]
         }
       end
 
@@ -127,8 +137,19 @@ describe NetworkRouterController do
 
       it "queues the create action" do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :create, :params => { :button => "add", :format => :js, :name => 'test',
-                                   :tenant_id => 'id', :ext_management_system => {:id => @ems.id }}
+        post :create, :params => {
+          :button           => 'add',
+          :controller       => 'network_router',
+          :format           => :js,
+          :name             => 'test',
+          :admin_state_up   => 'true',
+          :cloud_subnet_id  => '',
+          :cloud_tenant     => {:id => cloud_tenant.id},
+          :ems_id           => @ems.id,
+          :external_gateway => 'false',
+          :extra_attributes => '',
+          :id               => 'new'
+        }
       end
     end
   end
@@ -168,7 +189,12 @@ describe NetworkRouterController do
 
       it "queues the update action" do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :update, :params => { :button => "save", :format => :js, :id => @router.id, :name => "foo2" }
+        post :update, :params => {
+          :button => "save",
+          :format => :js,
+          :id     => @router.id,
+          :name   => "foo2"
+        }
       end
     end
   end

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -128,7 +128,7 @@ describe NetworkRouterController do
       it "queues the create action" do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
         post :create, :params => { :button => "add", :format => :js, :name => 'test',
-                                   :tenant_id => 'id', :ems_id => @ems.id }
+                                   :tenant_id => 'id', :ext_management_system => {:id => @ems.id }}
       end
     end
   end


### PR DESCRIPTION
Networks > Network Routers

Replaces http calls in RoR controller by API calls 
See https://github.com/ManageIQ/manageiq-ui-classic/issues/737
Also:
* Filtering only external network and subsequently better proper subnet (floating IPs) handling.
* External gateway displays only when external management provider id has been selected
* Changes source NAT field position as it depends on the network id
* Adds administrative state field

Before:
![router1](https://user-images.githubusercontent.com/1901741/33698753-a3e6b854-db62-11e7-9055-b0337a48d1d6.png)

Now:
![network-routers-after](https://user-images.githubusercontent.com/1901741/39090428-1d93230c-4622-11e8-9e96-76b13c300bb3.png)



