### PR TITLE
Fix filters in config mgmt Configured systems 2

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -15,7 +15,7 @@ module ApplicationController::AdvancedSearch
     @expkey = :expression # Reset to use default expression key
     if session.fetch_path(:adv_search, model.to_s)
       adv_search_model = session[:adv_search][model.to_s]
-      @edit = copy_hash(adv_search_model[@expkey] ? adv_search_model : session[:edit])
+      @edit ||= copy_hash(adv_search_model[@expkey] ? adv_search_model : session[:edit])
       adv_search_clear_default_search_if_cant_be_seen
       @edit.delete(:exp_token)                                          # Remove any existing atom being edited
     else                                                                # Create new exp fields

--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -186,7 +186,7 @@ module ApplicationController::AdvancedSearch
 
   def adv_search_redraw_left_div
     if x_active_tree.to_s == "configuration_manager_cs_filter_tree"
-      build_configuration_manager_tree(:configuration_manager_cs_filter, x_active_tree)
+      build_configuration_manager_cs_filter_tree(x_active_tree)
       build_accordions_and_trees
       load_or_clear_adv_search
     elsif @edit[:in_explorer] || %w(storage_tree configuration_scripts_tree svcs_tree).include?(x_active_tree.to_s)

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -188,7 +188,7 @@ module Mixins
                            else
                              'summary'
                            end
-        replace_right_cell
+        replace_right_cell unless @edit && @edit[:adv_search_applied] && MiqExpression.quick_search?(@edit[:adv_search_applied][:exp])
       end
     end
 

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -367,7 +367,7 @@ module Mixins
     end
 
     def miq_search_node
-      options = {:model => "ConfiguredSystem"}
+      options = {:model => model_from_active_tree(x_active_tree)}
       if x_active_tree == :configuration_scripts_tree
         options = {:model      => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
                    :gtl_dbname => "automation_manager_configuration_scripts"}

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -83,23 +83,18 @@ class ProviderForemanController < ApplicationController
     session[:edit] = @edit
     @explorer = true
 
-    if (x_active_tree != :configuration_manager_cs_filter_tree || x_node == "root") && params[:button] != 'saveit'
-      listnav_search_selected(0)
-    else
+    if x_active_tree == :configuration_manager_cs_filter_tree && params[:button] != 'saveit' # Configured Systems accordion
       @nodetype, id = parse_nodetype_and_id(valid_active_node(x_node))
-
-      if x_active_tree == :cs_filter_tree && @nodetype == "xx-csf"
-        search_id = @nodetype == "root" ? 0 : from_cid(id)
-        listnav_search_selected(search_id) unless params.key?(:search_text) # Clear or set the adv search filter
-        if @edit[:adv_search_applied] &&
-           MiqExpression.quick_search?(@edit[:adv_search_applied][:exp]) &&
-           %w(reload tree_select).include?(params[:action])
-          self.x_node = params[:id]
-          quick_search_show
-        end
-      elsif x_active_tree == :configuration_manager_cs_filter_tree && params[:button].present? && params[:button] != 'saveit'
-        listnav_search_selected(from_cid(id))
+      search_id = @nodetype == "root" ? 0 : from_cid(id)
+      listnav_search_selected(search_id) if !params.key?(:search_text) && params[:action] != 'x_show' # Clear or set the adv search filter
+      if @edit[:adv_search_applied] &&
+         MiqExpression.quick_search?(@edit[:adv_search_applied][:exp]) &&
+         %w(reload tree_select).include?(params[:action])
+        self.x_node = params[:id]
+        quick_search_show # User will input the value
       end
+    else # Providers accordion, without Advanced Search
+      listnav_search_selected(0)
     end
   end
 

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -86,6 +86,7 @@ class ProviderForemanController < ApplicationController
     if x_active_tree == :configuration_manager_cs_filter_tree && params[:button] != 'saveit' # Configured Systems accordion
       @nodetype, id = parse_nodetype_and_id(valid_active_node(x_node))
       search_id = @nodetype == "root" ? 0 : from_cid(id)
+      search_id = @edit[@expkey][:selected][:id] if params[:button] == "save"
       listnav_search_selected(search_id) if !params.key?(:search_text) && params[:action] != 'x_show' # Clear or set the adv search filter
       if @edit[:adv_search_applied] &&
          MiqExpression.quick_search?(@edit[:adv_search_applied][:exp]) &&

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -93,7 +93,7 @@ class ProviderForemanController < ApplicationController
         self.x_node = params[:id]
         quick_search_show # User will input the value
       end
-    else # Providers accordion, without Advanced Search
+    elsif x_active_tree == :configuration_manager_providers_tree # Providers accordion, without Advanced Search
       listnav_search_selected(0)
     end
   end

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -79,7 +79,7 @@ class ProviderForemanController < ApplicationController
   end
 
   def load_or_clear_adv_search
-    adv_search_build("ConfiguredSystem")
+    adv_search_build(model_from_active_tree(x_active_tree))
     session[:edit] = @edit
     @explorer = true
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -991,8 +991,13 @@ module ApplicationHelper
 
   def model_from_active_tree(tree)
     case tree
-    when :configuration_manager_cs_filter_tree, :automation_manager_cs_filter_tree
-      "ConfiguredSystem"
+    when :automation_manager_cs_filter_tree
+      "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem"
+    when :configuration_manager_cs_filter_tree
+      "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"
+    when :configuration_manager_providers_tree
+      "ManageIQ::Providers::Foreman::ConfigurationManager" if x_node.include?("fr")
+      "ManageIQ::Providers::ConfigurationManager" if x_node == "root"
     when :instances_filter_tree
       "ManageIQ::Providers::CloudManager::Vm"
     when :images_filter_tree
@@ -1012,8 +1017,10 @@ module ApplicationHelper
 
   def configuration_manager_scripts_tree(tree)
     case tree
-    when :automation_manager_cs_filter_tree, :configuration_manager_cs_filter_tree
-      "ConfiguredSystem"
+    when :automation_manager_cs_filter_tree
+      "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem"
+    when :configuration_manager_cs_filter_tree
+      "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"
     when :configuration_scripts_tree
       "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript"
     end

--- a/spec/controllers/application_controller/advanced_search_spec.rb
+++ b/spec/controllers/application_controller/advanced_search_spec.rb
@@ -1,0 +1,19 @@
+describe ProviderForemanController, "::AdvancedSearch" do
+  before :each do
+    stub_user(:features => :all)
+    controller.instance_variable_set(:@sb, {})
+  end
+
+  describe "#adv_search_redraw_left_div" do
+    before :each do
+      controller.instance_variable_set(:@sb, :active_tree => :configuration_manager_cs_filter_tree)
+    end
+
+    it "calls build_configuration_manager_cs_filter_tree method in Config Mgmt Configured Systems when saving a filter" do
+      allow(controller).to receive(:adv_search_redraw_listnav_and_main)
+
+      expect(controller).to receive(:build_configuration_manager_cs_filter_tree).once
+      controller.send(:adv_search_redraw_left_div)
+    end
+  end
+end


### PR DESCRIPTION
**fixing:**
https://github.com/ManageIQ/manageiq-ui-classic/issues/2413
https://bugzilla.redhat.com/show_bug.cgi?id=1429519

Rename `build_configuration_manager_tree` method for proper
saving/using filters in Config Mgmt Configured Systems as this
method does not exist and causes error when saving a new filter.
Fix another issues related to Advanced search in this page.

![mgmt1](https://user-images.githubusercontent.com/13417815/33276531-1b1c5066-d396-11e7-9d37-af3db2cca1e6.png)

**Before:**
```
I, [2017-11-27T17:10:08.037097 #24419]  INFO -- : Started POST "/provider_foreman/adv_search_button?button=saveit" for ::1 at 2017-11-27 17:10:08 +0100
I, [2017-11-27T17:10:08.076079 #24419]  INFO -- : Processing by ProviderForemanController#adv_search_button as JS
I, [2017-11-27T17:10:08.076182 #24419]  INFO -- :   Parameters: {"button"=>"saveit"}
F, [2017-11-27T17:10:08.303248 #24419] FATAL -- : Error caught: [NoMethodError] undefined method `build_configuration_manager_tree' for #<ProviderForemanController:0x007f4391059200>
Did you mean?  build_configuration_manager_cs_filter_tree
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/advanced_search.rb:185:in `adv_search_redraw_left_div'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/advanced_search.rb:226:in `adv_search_button'
```

**After:**
![filter4](https://user-images.githubusercontent.com/13417815/33609102-1b240d1a-d9c7-11e7-92c6-c5d301499256.png)
![mgmtt](https://user-images.githubusercontent.com/13417815/33378344-c3085d72-d514-11e7-954e-49c212830c78.png)
![filter](https://user-images.githubusercontent.com/13417815/33378399-ee1d1f8e-d514-11e7-868a-ec58468f632c.png)
![kmcf](https://user-images.githubusercontent.com/13417815/33378500-46a9c530-d515-11e7-9c88-bd3ee3139eb7.png)

**The second last commit fixes this:**
_Before:_
![f](https://user-images.githubusercontent.com/13417815/33607970-1e8b988c-d9c3-11e7-9bed-612047d58308.png)

_After:_
![filter4](https://user-images.githubusercontent.com/13417815/33609094-148c334c-d9c7-11e7-818c-0e2629193810.png)

**The last commit fixes this:**
![todo](https://user-images.githubusercontent.com/13417815/33660881-c59f61ea-da85-11e7-83a7-68105f071d5d.png)
How this issue was reproducible:
1. Go to Adv Search
2. Click on _Load_ button and choose some existing filter (Global or not)
3. Click on _Load_ again
4. Click on _Save_ button and it's there!
- if you _Apply_ the filter before step 4, this issue appeared, too
- if you chose a filter from accordion and then went to Adv search to continue with step 4, the issue did not occur
- the issue did not appear in other pages
- the issue did not appear when creating and saving a fresh new filter
- the issue appeared because of this special line when saving a filter in Adv search, for `configuration_manager_cs_filter_tree`:
https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/application_controller/advanced_search.rb#L187
