### PR TITLE
Notification type error should be rendered in patternfly as danger

### DIFF
--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -47,6 +47,13 @@ function eventNotifications($timeout, API) {
     });
   };
 
+  var levelToType = function(level) {
+    if (level === 'error') {
+      return 'danger';
+    }
+    return level;
+  };
+
   this.doReset = function(seed) {
     state.groups.splice(0, state.groups.length);
     var events = {
@@ -117,7 +124,7 @@ function eventNotifications($timeout, API) {
       id: id,
       notificationType: notificationType,
       unread: true,
-      type: type,
+      type: levelToType(type),
       message: message,
       data: notificationData,
       href: id ? '/api/notifications/' + id : undefined,
@@ -154,7 +161,7 @@ function eventNotifications($timeout, API) {
         if (showToast) {
           notification.unread = true;
         }
-        notification.type = type;
+        notification.type = levelToType(type);
         notification.message = message;
         notification.data = notificationData;
         notification.timeStamp = (new Date()).getTime();


### PR DESCRIPTION
The notification backend operates with the levels [success, error, warning and info](https://github.com/ManageIQ/manageiq/blob/master/app/models/notification_type.rb#L9), however, PatternFly has [success, danger, warning and info](http://www.patternfly.org/pattern-library/communication/toast-notifications/#/code). We missed this inconsistency earlier so all the notifications with error levels appeared without the appropriate styling. I added a function in the frontend that converts the `error` to a `danger` so PatternFly will understand it.

**Before:**
![screenshot from 2017-10-17 15-39-28](https://user-images.githubusercontent.com/649130/31668046-61afdf62-b351-11e7-923d-da467a88f5dd.png)

**After:**
![screenshot from 2017-10-17 15-35-20](https://user-images.githubusercontent.com/649130/31668050-64cb09c4-b351-11e7-9b14-073b76d14f3c.png)

**Testing:**
```ruby
Notification.create(:type => :automate_user_error, :initiator => User.first, :options => { :message => 'hello' })
```

https://bugzilla.redhat.com/show_bug.cgi?id=1489798

@miq-bot add_label bug, fine/yes