### PR TITLE
Add the download_pdf button to summary view for infrastructure providers

### DIFF
--- a/app/helpers/application_helper/toolbar/dashboard_summary_toggle_view.rb
+++ b/app/helpers/application_helper/toolbar/dashboard_summary_toggle_view.rb
@@ -26,4 +26,14 @@ class ApplicationHelper::Toolbar::DashboardSummaryToggleView < ApplicationHelper
       :url_parms => "?display=topology",
       :klass     => ApplicationHelper::Button::TopologyFeatureButton)
   ])
+  button_group('summary_download', [
+    button(
+      :download_view,
+      'fa fa-file-pdf-o fa-lg',
+      N_('Download summary in PDF format'),
+      nil,
+      :klass => ApplicationHelper::Button::Pdf,
+      :url   => "/download_summary_pdf"
+    ),
+  ])
 end


### PR DESCRIPTION
Add the download_pdf button to summary view for infrastructure providers

Links 
-------
https://bugzilla.redhat.com/show_bug.cgi?id=1503213