### PR TITLE
Disable button Copy  for Middleware Reports - Fix issue #1740

### DIFF
--- a/app/helpers/application_helper/button/miq_report_copy.rb
+++ b/app/helpers/application_helper/button/miq_report_copy.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::MiqReportCopy < ApplicationHelper::Button::MiqReportAction
+  def disabled?
+    %w(MiddlewareServerPerformance MiddlewareDatasourcePerformance).include?(@record.db)
+  end
+end

--- a/app/helpers/application_helper/toolbar/miq_report_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_report_center.rb
@@ -31,7 +31,8 @@ class ApplicationHelper::Toolbar::MiqReportCenter < ApplicationHelper::Toolbar::
           'fa fa-files-o fa-lg',
           t = N_('Copy this Report'),
           t,
-          :klass => ApplicationHelper::Button::MiqReportAction),
+          :klass => ApplicationHelper::Button::MiqReportCopy
+        ),
         button(
           :saved_report_delete,
           'pficon pficon-delete fa-lg',

--- a/spec/helpers/application_helper/buttons/miq_report_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_report_copy_spec.rb
@@ -1,0 +1,19 @@
+describe ApplicationHelper::Button::MiqReportCopy do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  subject { described_class.new(view_context, {}, {'record' => record}, {}) }
+
+  describe '#disabled?' do
+    context 'when @record.db == MiddlewareServerPerformance' do
+      let(:record) { FactoryGirl.create(:miq_report, :db => 'MiddlewareServerPerformance') }
+      it { expect(subject.disabled?).to be_truthy }
+    end
+    context 'when @record.db == MiddlewareDatasourcePerformance' do
+      let(:record) { FactoryGirl.create(:miq_report, :db => 'MiddlewareDatasourcePerformance') }
+      it { expect(subject.disabled?).to be_truthy }
+    end
+    context 'when @record.db is another' do
+      let(:record) { FactoryGirl.create(:miq_report, :db => 'Vm') }
+      it { expect(subject.disabled?).to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
Disable button **Copy this Report** for Reports of Middleware Datasource and Middleware Servers

fix #1740

## With Middleware Servers
![report_middleware_server](https://user-images.githubusercontent.com/3019213/31683638-d4ab2766-b37d-11e7-8551-075aaecf6bb5.png)
## With Middleware Datasource
![middle_data](https://user-images.githubusercontent.com/3019213/31683643-d677e58e-b37d-11e7-8bc4-53b7f4afcf54.png)
## Others Reports
![one_report](https://user-images.githubusercontent.com/3019213/31683636-d2d73506-b37d-11e7-8ef6-3754f8328926.png)