### PR TITLE
Add physical server power operations buttons

### DIFF
--- a/app/helpers/application_helper/toolbar/physical_server_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_server_center.rb
@@ -62,6 +62,17 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
             :options                     => {:feature => :power_off}
           ),
           button(
+            :physical_server_power_off_now,
+            nil,
+            N_('Power off the server immediately'),
+            N_('Power Off Immediately'),
+            :image   => "power_off",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "power_off_now", "controller": "physicalServerToolbarController"}'},
+            :confirm => N_("Power off the server immediately?"),
+            :options => {:feature => :power_off_now}
+          ),
+          button(
             :physical_server_restart,
             nil,
             N_('Restart the server'),
@@ -72,6 +83,39 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
             :confirm                     => N_("Restart the server?"),
             :options                     => {:feature => :restart}
           ),
+          button(
+            :physical_server_restart_now,
+            nil,
+            N_('Restart Server Immediately'),
+            N_('Restart Immediately'),
+            :image   => "power_reset",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "restart_now", "controller": "physicalServerToolbarController"}'},
+            :confirm => N_("Restart the server immediately?"),
+            :options => {:feature => :restart_now}
+          ),
+          button(
+            :physical_server_restart_to_sys_setup,
+            nil,
+            N_('Restart Server to System Setup'),
+            N_('Restart to System Setup'),
+            :image   => "power_reset",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "restart_to_sys_setup", "controller": "physicalServerToolbarController"}'},
+            :confirm => N_("Restart the server to UEFI settings?"),
+            :options => {:feature => :restart_to_sys_setup}
+          ),
+          button(
+            :physical_server_restart_mgmt_controller,
+            nil,
+            N_('Restart Management Controller'),
+            N_('Restart Management Controller'),
+            :image   => "power_reset",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "restart_mgmt_controller", "controller": "physicalServerToolbarController"}'},
+            :confirm => N_("Restart management controller?"),
+            :options => {:feature => :restart_mgmt_controller}
+          )
         ]
       ),
       select(

--- a/app/helpers/application_helper/toolbar/physical_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_servers_center.rb
@@ -70,6 +70,19 @@ class ApplicationHelper::Toolbar::PhysicalServersCenter < ApplicationHelper::Too
             :options                     => {:feature => :power_off}
           ),
           button(
+            :physical_server_power_off_now,
+            nil,
+            N_('Power off the servers immediately'),
+            N_('Power Off Immediately'),
+            :image   => "power_off",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "power_off_now", "controller": "physicalServerToolbarController"}'},
+            :confirm => N_("Power off the servers immediately?"),
+            :enabled => false,
+            :onwhen  => "1+",
+            :options => {:feature => :power_off_now}
+          ),
+          button(
             :physical_server_restart,
             nil,
             N_('Restart the selected servers'),
@@ -82,6 +95,45 @@ class ApplicationHelper::Toolbar::PhysicalServersCenter < ApplicationHelper::Too
             :onwhen                      => "1+",
             :options                     => {:feature => :restart}
           ),
+          button(
+            :physical_server_restart_now,
+            nil,
+            N_('Restart Servers Immediately'),
+            N_('Restart Immediately'),
+            :image   => "power_reset",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "restart_now", "controller": "physicalServerToolbarController"}'},
+            :confirm => N_("Restart the servers immediately?"),
+            :enabled => false,
+            :onwhen  => "1+",
+            :options => {:feature => :restart_now}
+          ),
+          button(
+            :physical_server_restart_to_sys_setup,
+            nil,
+            N_('Restart Servers to System Setup'),
+            N_('Restart to System Setup'),
+            :image   => "power_reset",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "restart_to_sys_setup", "controller": "physicalServerToolbarController"}'},
+            :confirm => N_("Restart the servers to system setup?"),
+            :enabled => false,
+            :onwhen  => "1+",
+            :options => {:feature => :restart_to_sys_setup}
+          ),
+          button(
+            :physical_server_restart_mgmt_controller,
+            nil,
+            N_('Restart Management Controller'),
+            N_('Restart Management Controller'),
+            :image   => "power_reset",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "restart_mgmt_controller", "controller": "physicalServerToolbarController"}'},
+            :confirm => N_("Restart management controller for the selected servers?"),
+            :enabled => false,
+            :onwhen  => "1+",
+            :options => {:feature => :restart_mgmt_controller}
+          )
         ]
       ),
       select(


### PR DESCRIPTION
This PR adds the following buttons to the physical server summary and list pages:
- Power Off Immediately
- Restart Immediately
- Restart To System Setup
- Restart Management Controller

# Screenshots

## List page

When no physical servers are selected:
![screenshot from 2017-10-17 17-41-41](https://user-images.githubusercontent.com/18252261/31688347-77b50fce-b362-11e7-8f7a-f55b43e8d24f.png)

When 1+ physical servers are selected:
![screenshot from 2017-10-17 17-42-09](https://user-images.githubusercontent.com/18252261/31688387-9542e2fa-b362-11e7-8045-2427c3944ebb.png)

When action button is clicked and user is prompted:
![screenshot from 2017-10-17 17-49-14](https://user-images.githubusercontent.com/18252261/31688577-2836ca2c-b363-11e7-9228-a6002d47e5bc.png)

When the request is performed:
![screenshot from 2017-10-17 17-43-13](https://user-images.githubusercontent.com/18252261/31688398-9f9b9724-b362-11e7-9b9e-ceb54e7acdd4.png)

## Summary page

Available buttons:
![screenshot from 2017-10-17 17-43-33](https://user-images.githubusercontent.com/18252261/31688436-bb4195b4-b362-11e7-9609-f93fc84d5a5f.png)

When action button is clicked and user is prompted:
![screenshot from 2017-10-17 17-51-04](https://user-images.githubusercontent.com/18252261/31688645-6229298c-b363-11e7-8672-0880d6c0fddd.png)

When the request is performed:
![screenshot from 2017-10-17 17-47-09](https://user-images.githubusercontent.com/18252261/31688479-d7ce9466-b362-11e7-8b75-e1c54afc7bf3.png)







