### PR TITLE
Retain our string changes in a copied string

### DIFF
--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -133,9 +133,11 @@ module ReportFormatter
       if @row[@column].kind_of?(Time) || TIMELINE_TIME_COLUMNS.include?(@column)
         format_timezone(Time.parse(@row[@column].to_s).utc, @flags[:time_zone], "gtl")
       else
-        @row[@column].to_s.tr!('"', "'")
-        @row[@column].to_s.gsub('/', "\\\\/")
-        @row[@column].to_s.gsub('\\', "\\\\\\")
+        value = @row[@column].to_s.dup
+        value.tr!('"', "'")
+        value.gsub!('/', "\\\\/")
+        value.gsub!('\\', "\\\\\\")
+        value
       end
     end
 

--- a/spec/lib/report_formater/timeline_message_spec.rb
+++ b/spec/lib/report_formater/timeline_message_spec.rb
@@ -1,0 +1,21 @@
+describe ReportFormatter::TimelineMessage do
+  context "#message_html" do
+    context "for unknown column names" do
+      subject { described_class.new({'column' => @value}, nil, nil, nil).message_html('column') }
+      it "replaces double quotes with single quotes" do
+        @value = '123""45'
+        expect(subject).to eq "123''45"
+      end
+
+      it "escapes forwardslashes" do
+        @value = '123/45'
+        expect(subject).to eq '123\\\\/45'
+      end
+
+      it "escapes backslashes" do
+        @value = '123\\45'
+        expect(subject).to eq '123\\\\45'
+      end
+    end
+  end
+end


### PR DESCRIPTION
* the first gsub wasn't being saved
* the tr! only worked if the value was already a string and .to_s
  returned the same object
* only the last gsub had a chance of working

It seems odd that tr! was modifying the string in place and the gsubs
weren't.  I wouldn't expect this method to modify the string, so I made
a copy and made changes to this copy.

@h-kataria please review