### PR TITLE
Replace :where_clause in favor of :named_scope

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -795,7 +795,7 @@ module ApplicationController::MiqRequestMethods
       @options = @miq_request.options
       @options[:memory], @options[:mem_typ] = reconfigure_calculations(@options[:vm_memory][0]) if @options[:vm_memory]
       @force_no_grid_xml   = true
-      @view, @pages = get_view(Vm, :view_suffix => "VmReconfigureRequest", :where_clause => ["vms.id IN (?)", @miq_request.options[:src_ids]]) # Get the records (into a view) and the paginator
+      @view, @pages = get_view(Vm, :view_suffix => "VmReconfigureRequest", :selected_ids => @miq_request.options[:src_ids]) # Get the records (into a view) and the paginator
     end
     @user = User.find_by_userid(@miq_request.stamped_by)
   end

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -260,7 +260,7 @@ class AutomationManagerController < ApplicationController
       @no_checkboxes = true
       options = {:model                 => "ManageIQ::Providers::AutomationManager::InventoryRootGroup",
                  :match_via_descendants => ConfiguredSystem,
-                 :where_clause          => ["ems_id IN (?)", provider.id],
+                 :named_scope           => [[:with_provider, provider.id]],
                  :gtl_dbname            => "automation_manager_providers"}
       process_show_list(options)
       record_model = ui_lookup(:model => self.class.model_to_name(model || TreeBuilder.get_model_for_prefix(@nodetype)))
@@ -272,7 +272,7 @@ class AutomationManagerController < ApplicationController
   def cs_provider_node(provider)
     options = {:model                 => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
                :match_via_descendants => ConfigurationScript,
-               :where_clause          => ["manager_id IN (?)", provider.id],
+               :named_scope           => [[:with_manager, provider.id]],
                :gtl_dbname            => "automation_manager_configuration_scripts"}
     @show_adv_search = true
     process_show_list(options)
@@ -289,7 +289,7 @@ class AutomationManagerController < ApplicationController
       @show_adv_search = true
       options = {:model                 => "ConfiguredSystem",
                  :match_via_descendants => ConfiguredSystem,
-                 :where_clause          => ["inventory_root_group_id IN (?)", from_cid(@inventory_group_record.id)],
+                 :named_scope           => [[:with_inventory_root_group, from_cid(@inventory_group_record.id)]],
                  :gtl_dbname            => "automation_manager_configured_systems"}
       process_show_list(options)
       record_model = ui_lookup(:model => model || TreeBuilder.get_model_for_prefix(@nodetype))

--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -51,7 +51,7 @@ class EmsPhysicalInfraController < ApplicationController
   end
 
   def generate_options
-    {:where_clause     => "physical_servers.id in (select hosts.physical_server_id from hosts)",
+    {:named_scope      => :with_hosts,
      :breadcrumb_title => _("Physical Servers with Host")}
   end
 

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -248,7 +248,7 @@ class InfraNetworkingController < ApplicationController
   def dvswitches_list(id, model)
     return dvswitch_node(id, model) if id
     if x_active_tree == :infra_networking_tree
-      options = {:model => "Switch", :where_clause => ["shared = true"]}
+      options = {:model => "Switch", :named_scope => :shareable}
       @right_cell_text = _("All %{title}") % {:title => model_to_name(model)}
       process_show_list(options) if @show_list
     end
@@ -267,7 +267,7 @@ class InfraNetworkingController < ApplicationController
       self.x_node = "root"
       get_node_info("root")
     else
-      options = {:model => "Switch", :where_clause => ["shared = true and id in(?)", @host_record.switches.pluck(:id)]}
+      options = {:model => "Switch", :named_scope => :shareable, :selected_ids => @host_record.switches.pluck(:id)}
       process_show_list(options) if @show_list
       @showtype        = 'main'
       @pages           = nil
@@ -285,7 +285,7 @@ class InfraNetworkingController < ApplicationController
     else
       hosts = @cluster_record.hosts
       switch_ids = hosts.collect { |host| host.switches.pluck(:id) }
-      options = {:model => "Switch", :where_clause => ["shared = true and id in(?)", switch_ids.flatten.uniq]}
+      options = {:model => "Switch", :named_scope => :shareable, :selected_ids => switch_ids.flatten.uniq}
       process_show_list(options) if @show_list
       @showtype        = 'main'
       @pages           = nil
@@ -303,7 +303,7 @@ class InfraNetworkingController < ApplicationController
     else
       hosts = Host.where(:ems_id => @provider_record.id)
       switch_ids = hosts.collect { |host| host.switches.pluck(:id) }
-      options = {:model => "Switch", :where_clause => ["shared = true and id in(?)", switch_ids.flatten.uniq]}
+      options = {:model => "Switch", :named_scope => :shareable, :selected_ids => switch_ids.flatten.uniq}
       process_show_list(options) if @show_list
       @showtype        = 'main'
       @pages           = nil
@@ -321,7 +321,7 @@ class InfraNetworkingController < ApplicationController
 
   def default_node
     return unless x_node == "root"
-    options = {:model => "Switch", :where_clause => ["shared = true"]}
+    options = {:model => "Switch", :named_scope => :shareable}
     process_show_list(options) if @show_list
     @right_cell_text = _("All Switches")
     options

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -14,7 +14,7 @@ module Mixins
           @reconfigitems = find_records_with_rbac(Vm, reconfigure_ids)
           build_targets_hash(@reconfigitems)
           @force_no_grid_xml   = true
-          @view, @pages = get_view(Vm, :view_suffix => "VmReconfigureRequest", :where_clause => ["vms.id IN (?)", reconfigure_ids]) # Get the records (into a view) and the paginator
+          @view, @pages = get_view(Vm, :view_suffix => "VmReconfigureRequest", :selected_ids => reconfigure_ids) # Get the records (into a view) and the paginator
           get_reconfig_limits(reconfigure_ids)
           unless @explorer
             render :action => "show"

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -26,7 +26,7 @@ class OrchestrationStackController < ApplicationController
 
   def show_list
     process_show_list(
-      :where_clause => "orchestration_stacks.type != 'ManageIQ::Providers::AnsibleTower::AutomationManager::Job'"
+      :named_scope => [[:without_type, 'ManageIQ::Providers::AnsibleTower::AutomationManager::Job']]
     )
   end
 

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -277,7 +277,7 @@ class ProviderForemanController < ApplicationController
       @no_checkboxes = true
       case @record.type
       when "ManageIQ::Providers::Foreman::ConfigurationManager"
-        options = {:model => "ConfigurationProfile", :match_via_descendants => ConfiguredSystem, :where_clause => ["manager_id IN (?)", provider.id]}
+        options = {:model => "ConfigurationProfile", :match_via_descendants => ConfiguredSystem, :named_scope => [[:with_manager, provider.id]]}
         @show_list ? process_show_list(options) : options.merge!(update_options)
         unassigned_profiles = add_unassigned_configuration_profile_record(provider.id)
         options.merge!(unassigned_profiles) unless unassigned_profiles.nil?
@@ -298,9 +298,9 @@ class ProviderForemanController < ApplicationController
     else
       options = {:model => "ConfiguredSystem", :match_via_descendants => ConfiguredSystem}
       if empty_configuration_profile_record?(@configuration_profile_record)
-        options[:where_clause] = ["manager_id IN (?) AND configuration_profile_id IS NULL", id]
+        options[:named_scope] = [[:with_manager, id], [:with_configuration_profile_id, nil]]
       else
-        options[:where_clause] = ["configuration_profile_id IN (?)", @configuration_profile_record.id]
+        options[:named_scope] = [[:with_configuration_profile_id, @configuration_profile_record.id]]
       end
       @show_list ? process_show_list(options) : options.merge!(update_options)
       record_model = ui_lookup(:model => model || TreeBuilder.get_model_for_prefix(@nodetype))

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -253,7 +253,7 @@ module ReportController::Widgets
     else
       # show only specific type
       if !rep_id
-        @view, @pages = get_view(MiqWidget, :where_clause => ["content_type=?", nodeid])
+        @view, @pages = get_view(MiqWidget, :named_scope => [[:with_content_type, nodeid]])
       else
         # get all widgets for passed in report id
         @widget_nodes = MiqWidget.where(:content_type => "report", :resource_id => rep_id)

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -267,10 +267,10 @@ class ServiceController < ApplicationController
       @view, @pages = get_view(Vm, :parent => @record, :parent_method => :all_vms, :all_pages => true)  # Get the records (into a view) and the paginator
     when "Hash"
       if id == "asrv"
-        process_show_list(:where_clause => "retired is false and services.display is true")
+        process_show_list(:named_scope => [[:retired, false], :displayed])
         @right_cell_text = _("Active Services")
       else
-        process_show_list(:where_clause => "retired is true and services.display is true")
+        process_show_list(:named_scope => [:retired, :displayed])
         @right_cell_text = _("Retired Services")
       end
     else      # Get list of child Catalog Items/Services of this node

--- a/app/controllers/storage_controller/storage_pod.rb
+++ b/app/controllers/storage_controller/storage_pod.rb
@@ -14,7 +14,7 @@ module StorageController::StoragePod
     @sortdir = session[:dsc_sortdir].nil? ? "ASC" : session[:dsc_sortdir]
     dsc_id = x_node.split('-').last
     folder = EmsFolder.where(:id => from_cid(dsc_id))
-    @view, @pages = get_view(Storage, :where_clause => ["storages.id in (?)", folder.first.storages.collect(&:id)]) # Get the records (into a view) and the paginator
+    @view, @pages = get_view(Storage, :selected_ids => folder.first.storages.collect(&:id)) # Get the records (into a view) and the paginator
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number
     session[:ct_sortcol] = @sortcol

--- a/app/presenters/tree_builder_archived.rb
+++ b/app/presenters/tree_builder_archived.rb
@@ -5,8 +5,8 @@ module TreeBuilderArchived
                 [] # hidden all VMs
               else
                 case object[:id]
-                when "orph" then  klass.all_orphaned
-                when "arch" then  klass.all_archived
+                when "orph" then  klass.orphaned
+                when "arch" then  klass.archived
                 end
               end
     count_only_or_objects_filtered(count_only, objects, "name")

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -44,7 +44,7 @@ class TreeBuilderInfraNetworking < TreeBuilder
   def x_get_tree_cluster_kids(object, count_only)
     hosts = object.hosts
     switch_ids = hosts.collect { |host| host.switches.pluck(:id) }
-    count_only_or_objects(count_only, Rbac.filtered(Switch, :where_clause => ["shared = true and id in(?)", switch_ids.flatten.uniq]))
+    count_only_or_objects(count_only, Rbac.filtered(Switch, :named_scope => [:shareable, [:with_id, switch_ids.flatten.uniq]]))
   end
 
   def x_get_tree_host_kids(object, count_only)

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -43,7 +43,7 @@ class TreeBuilderInstances < TreeBuilder
   # Get AvailabilityZone children count/array
   def x_get_tree_az_kids(object, count_only)
     count_only_or_objects_filtered(count_only,
-                                   TreeBuilder.hide_vms ? [] : object.vms.not_archived_nor_orphaned,
+                                   TreeBuilder.hide_vms ? [] : object.vms.with_ems,
                                    "name")
   end
 end

--- a/spec/presenters/tree_builder_archived_spec.rb
+++ b/spec/presenters/tree_builder_archived_spec.rb
@@ -37,8 +37,8 @@ describe TreeBuilderArchived do
     template_orph = FactoryGirl.create(:template_infra, :storage => FactoryGirl.create(:storage))
     vm_arch = FactoryGirl.create(:vm_infra)
     template_arch = FactoryGirl.create(:template_infra)
-    allow(ManageIQ::Providers::InfraManager::VmOrTemplate).to receive(:all_orphaned) { [vm_orph, template_orph] }
-    allow(ManageIQ::Providers::InfraManager::VmOrTemplate).to receive(:all_archived) { [vm_arch, template_arch] }
+    allow(ManageIQ::Providers::InfraManager::VmOrTemplate).to receive(:orphaned) { [vm_orph, template_orph] }
+    allow(ManageIQ::Providers::InfraManager::VmOrTemplate).to receive(:archived) { [vm_arch, template_arch] }
     nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
                                                  false,
                                                  :leaf => 'ManageIQ::Providers::InfraManager::VmOrTemplate')


### PR DESCRIPTION
Remove `:where_clause` from `get_view` params where possible and replace
it with scopes.

Depends on:
- https://github.com/ManageIQ/manageiq/pull/16226
- https://github.com/ManageIQ/manageiq/pull/16236
- https://github.com/ManageIQ/manageiq-ui-classic/pull/2459