### PR TITLE
Enable MW Compliance and Control policies

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -176,7 +176,13 @@ module ApplicationController::PolicySupport
     end
   end
   %w(image instance vm miq_template
-     container container_replicator container_group container_node container_image ems_container).each do |old_name|
+     container
+     container_replicator
+     container_group
+     container_node
+     container_image
+     ems_container
+     middleware_server).each do |old_name|
     alias_method "#{old_name}_protect".to_sym, :assign_policies
   end
 

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -24,7 +24,14 @@ module ApplicationController::TreeSupport
   def find_record
     # TODO: This logic should probably be reversed - fixed list for VmOrTemplate.
     # (Better yet, override the method only in VmOrTemplate related controllers.)
-    if %w(host container_replicator container_group container_node container_image ext_management_system physical_server).include? controller_name
+    if %w(host
+          container_replicator
+          container_group
+          container_node
+          container_image
+          ext_management_system
+          physical_server
+          middleware_server).include?(controller_name)
       identify_record(params[:id], controller_name.classify)
     else
       identify_record(params[:id], VmOrTemplate)

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -13,7 +13,17 @@ class MiqPolicyController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
-  UI_FOLDERS = [Host, Vm, ContainerReplicator, ContainerGroup, ContainerNode, ContainerImage, ExtManagementSystem, PhysicalServer].freeze
+  UI_FOLDERS = [
+    Host,
+    Vm,
+    ContainerReplicator,
+    ContainerGroup,
+    ContainerNode,
+    ContainerImage,
+    ExtManagementSystem,
+    PhysicalServer,
+    MiddlewareServer
+  ].freeze
 
   def export
     @breadcrumbs = []

--- a/app/decorators/miq_policy_decorator.rb
+++ b/app/decorators/miq_policy_decorator.rb
@@ -17,6 +17,8 @@ class MiqPolicyDecorator < MiqDecorator
              'pficon pficon-server'
            when 'PhysicalServer'
              'pficon pficon-enterprise'
+           when 'MiddlewareServer'
+             'pficon pficon-middleware'
            end
     "#{icon}#{active ? '' : ' fa-inactive'}"
   end

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -37,6 +37,8 @@ class TreeBuilderCondition < TreeBuilder
       'pficon pficon-server'
     when 'PhysicalServer'
       'pficon pficon-enterprise'
+    when 'MiddlewareServer'
+      'pficon pficon-middleware'
     end
   end
 
@@ -49,7 +51,8 @@ class TreeBuilderCondition < TreeBuilder
                  :ContainerNode       => _("Container Node Conditions"),
                  :ContainerImage      => _("Container Image Conditions"),
                  :ExtManagementSystem => _("Provider Conditions"),
-                 :PhysicalServer      => _("Physical Infrastructure Conditions")}
+                 :PhysicalServer      => _("Physical Infrastructure Conditions"),
+                 :MiddlewareServer    => _("Middleware Server Conditions")}
 
     objects = MiqPolicyController::UI_FOLDERS.collect do |model|
       text = text_i18n[model.name.to_sym]

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -22,7 +22,8 @@ class TreeBuilderPolicy < TreeBuilder
                                  :ContainerNode       => _("Container Node Compliance Policies"),
                                  :ContainerImage      => _("Container Image Compliance Policies"),
                                  :ExtManagementSystem => _("Provider Compliance Policies"),
-                                 :PhysicalServer      => _("Physical Infrastructure Compliance Policies")},
+                                 :PhysicalServer      => _("Physical Infrastructure Compliance Policies"),
+                                 :MiddlewareServer    => _("Middleware Server Compliance Policies")},
                  :control    => {:Host                => _("Host Control Policies"),
                                  :Vm                  => _("Vm Control Policies"),
                                  :ContainerReplicator => _("Replicator Control Policies"),
@@ -30,7 +31,8 @@ class TreeBuilderPolicy < TreeBuilder
                                  :ContainerNode       => _("Container Node Control Policies"),
                                  :ContainerImage      => _("Container Image Control Policies"),
                                  :ExtManagementSystem => _("Provider Control Policies"),
-                                 :PhysicalServer      => _("Physical Infrastructure Control Policies")}}
+                                 :PhysicalServer      => _("Physical Infrastructure Control Policies"),
+                                 :MiddlewareServer    => _("Middleware Server Control Policies")}}
 
     MiqPolicyController::UI_FOLDERS.collect do |model|
       text = text_i18n[mode.to_sym][model.name.to_sym]
@@ -51,6 +53,8 @@ class TreeBuilderPolicy < TreeBuilder
                'pficon pficon-server'
              when 'PhysicalServer'
                'pficon pficon-enterprise'
+             when 'MiddlewareServer'
+               'pficon pficon-middleware'
              end
       {
         :id   => "#{mode}-#{model.name.camelize(:lower)}",

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -57,6 +57,8 @@ class TreeBuilderProtect < TreeBuilder
                'pficon pficon-server'
              when 'PhysicalServer'
                'pficon pficon-enterprise'
+             when 'MiddlewareServer'
+               'pficon pficon-middleware'
              end
       {
         :id           => "policy_#{policy.id}",

--- a/app/views/miq_policy/_policy_folders.html.haml
+++ b/app/views/miq_policy/_policy_folders.html.haml
@@ -9,6 +9,7 @@
                     "Container Image Compliance"         => _("Container Image Compliance Policies"),
                     "Ext Management System Compliance"   => _("Provider Compliance Policies"),
                     "Physical Server Compliance"         => _("Physical Infrastructure Compliance Policies"),
+                    "Middleware Server Compliance"       => _("Middleware Server Compliance Policies"),
                     "Host Control"                       => _("Host Control Policies"),
                     "Vm Control"                         => _("Vm Control Policies"),
                     "Container Replicator Control"       => _("Replicator Control Policies"),
@@ -17,6 +18,7 @@
                     "Container Image Control"            => _("Container Image Control Policies"),
                     "Ext Management System Control"      => _("Provider Control Policies"),
                     "Physical Server Control"            => _("Physical Infrastructure Control Policies"),
+                    "Middleware Server Control"          => _("Middleware Server Control Policies"),
                     }
   = render :partial => "layouts/flash_msg"
   %table.table.table-striped.table-bordered.table-hover


### PR DESCRIPTION
### Introduces new menu item in Policies
Middleware provider needs to set up Compliance and Control policies. Base model is MW server, to create policy for EAP we have to cewate policy with scope somehow set to EAP.

![screenshot from 2017-10-16 16-13-17 1](https://user-images.githubusercontent.com/3439771/31705585-3fd1f93a-b3e6-11e7-8fbb-e1bab99f5225.png)
![screenshot from 2017-10-11 15-20-53 1](https://user-images.githubusercontent.com/3439771/31705696-ba4245b2-b3e6-11e7-9e28-2d02775afa9f.png)
