### PR TITLE
Call the miqInitMainContent() later in the explorer presenter JS

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -273,7 +273,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
     ManageIQ.explorer.clearSearchToggle(data.clearSearch);
   }
 
-  miqInitMainContent();
+  setTimeout(miqInitMainContent);
   miqInitAccordions();
 
   if (data.hideModal) { $('#quicksearchbox').modal('hide'); }


### PR DESCRIPTION
When opening `Configuration -> Diagnostics -> Collect logs -> Edit`, the form buttons aren't visible. The problem was that the `miqInitMainContent` function was called too early (probably before some angular magic). This is just a temporary fix until https://github.com/ManageIQ/manageiq-ui-classic/issues/1884 is sorted out.

https://bugzilla.redhat.com/show_bug.cgi?id=1501871