### PR TITLE
Update app's locale when user locale preferences changed

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -137,6 +137,9 @@ class ConfigurationController < ApplicationController
       get_form_vars if @tabform != "ui_3"
       case @tabform
       when "ui_1"                                                 # Visual tab
+        if @settings[:display][:locale] != @edit[:new][:display][:locale]
+          FastGettext.locale = @edit[:new][:display][:locale]
+        end
         @settings.merge!(@edit[:new])                                   # Apply the new saved settings
 
         if current_user


### PR DESCRIPTION
Configuration -> My Settings -> Locale

Previously, after saving the new user locale preferences, the page rendered afterwards
was still in the previous locale. This would change with this PR.

https://bugzilla.redhat.com/show_bug.cgi?id=1486621