### PR TITLE
Fix custom button with dialog

### DIFF
--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -92,9 +92,8 @@ module ApplicationController::DialogRunner
     @record = Dialog.find_by_id(@edit[:rec_id])
     @dialog_prov = true
     @in_a_form = true
-    #@showtype = "dialog_provision"
+    @showtype = "dialog_provision"
     render :template => "shared/dialogs/dialog_provision"
-      #render :action => "show"
   end
 
   def dynamic_radio_button_refresh

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -90,7 +90,6 @@ module ApplicationController::DialogRunner
   def dialog_load
     @edit = session[:edit]
     @record = Dialog.find_by_id(@edit[:rec_id])
-    @dialog_prov = true
     @in_a_form = true
     @showtype = "dialog_provision"
     render :template => "shared/dialogs/dialog_provision"

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -92,8 +92,9 @@ module ApplicationController::DialogRunner
     @record = Dialog.find_by_id(@edit[:rec_id])
     @dialog_prov = true
     @in_a_form = true
-    @showtype = "dialog_provision"
-    render :action => "show"
+    #@showtype = "dialog_provision"
+    render :template => "shared/dialogs/dialog_provision"
+      #render :action => "show"
   end
 
   def dynamic_radio_button_refresh

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -28,9 +28,8 @@ class CloudSubnetController < ApplicationController
       delete_subnets
     when "cloud_subnet_edit"
       javascript_redirect :action => "edit", :id => checked_item_id
-    when params[:pressed] == "custom_button"
+    when "custom_button"
       custom_buttons
-      return
     else
       if params[:pressed] == "cloud_subnet_new"
         javascript_redirect :action => "new"

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -142,6 +142,12 @@ class InfraNetworkingController < ApplicationController
     render_tagging_form
   end
 
+  def button
+    if params[:pressed] == "custom_button"
+      custom_buttons
+    end  
+  end
+
   private
 
   def textual_group_list
@@ -568,7 +574,9 @@ class InfraNetworkingController < ApplicationController
 
     h_tb = build_toolbar("x_history_tb") unless @in_a_form
 
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb)
+    cb_tb = build_toolbar(Mixins::CustomButtons::Result.new(@nodetype == 'sw' ? :single : :list))
+
+    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb, :custom => cb_tb)
 
     presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.present?, :toolbar)
 

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -145,7 +145,7 @@ class InfraNetworkingController < ApplicationController
   def button
     if params[:pressed] == "custom_button"
       custom_buttons
-    end  
+    end
   end
 
   private

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -27,6 +27,8 @@ class NetworkRouterController < ApplicationController
       javascript_redirect :action => "edit", :id => checked_item_id
     elsif params[:pressed] == "network_router_new"
       javascript_redirect :action => "new"
+    elsif params[:pressed] == "custom_button"
+      custom_buttons
     elsif params[:pressed] == "network_router_add_interface"
       javascript_redirect :action => "add_interface_select", :id => checked_item_id
     elsif params[:pressed] == "network_router_remove_interface"

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -29,9 +29,8 @@ class SecurityGroupController < ApplicationController
       delete_security_groups
     when "security_group_edit"
       javascript_redirect :action => "edit", :id => checked_item_id(params)
-    when params[:pressed] == "custom_button"
+    when "custom_button"
       custom_buttons
-      return
     else
       if params[:pressed] == "security_group_new"
         javascript_redirect :action => "new"

--- a/app/views/ems_cluster/show.html.haml
+++ b/app/views/ems_cluster/show.html.haml
@@ -16,8 +16,6 @@
       = render :partial => "layouts/item"
     - when "timeline"
       = render(:partial => "layouts/tl_show_async")
-    - when "dialog_provision"
-      = render(:partial => "shared/dialogs/dialog_provision")
     - when "main"
       = render :partial => "layouts/textual_groups_generic"
     - when "config"

--- a/app/views/host/show.html.haml
+++ b/app/views/host/show.html.haml
@@ -15,8 +15,6 @@
       = render :partial => "layouts/performance_summary"
     - when "timeline"
       = render :partial => "layouts/tl_show_async"
-    - when "dialog_provision"
-      = render :partial => "shared/dialogs/dialog_provision"
     - when "compliance_history"
       = render :partial => "shared/views/compliance_history"
     - when "main"

--- a/app/views/shared/dialogs/dialog_provision.html.haml
+++ b/app/views/shared/dialogs/dialog_provision.html.haml
@@ -1,0 +1,3 @@
+#main_div
+  = render :partial => "shared/dialogs/dialog_provision"
+

--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -13,8 +13,6 @@
     = render :partial => "layouts/tl_show_async"
   - elsif @showtype == "performance"
     = render(:partial => "layouts/performance_async")
-  - elsif @showtype == "dialog_provision"
-    = render :partial => "shared/dialogs/dialog_provision"
   - elsif @showtype == "config"
     = render :partial => "shared/views/ems_common/config"
   - elsif @showtype == 'main'

--- a/app/views/storage/show.html.haml
+++ b/app/views/storage/show.html.haml
@@ -1,7 +1,5 @@
 #main_div
-  - if @dialog_prov
-    = render :partial => "shared/dialogs/dialog_provision"
-  - elsif %w(all_vms hosts miq_proxies all_miq_templates storage_extents storage_systems).include?(@display) && @showtype != "compare"
+  - if %w(all_vms hosts miq_proxies all_miq_templates storage_extents storage_systems).include?(@display) && @showtype != "compare"
     = render :partial => "layouts/x_gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
     - case @showtype

--- a/app/views/storage/show.html.haml
+++ b/app/views/storage/show.html.haml
@@ -11,7 +11,5 @@
       = render :partial => "layouts/item"
     - when "performance"
       = render :partial => "layouts/performance_async"
-    - when "dialog_provision"
-      = render :partial => "shared/dialogs/dialog_provision"
     - when "main"
       = render :partial => "layouts/textual_groups_generic"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,7 +228,7 @@ Rails.application.routes.draw do
         tag_edit_form_field_changed
         tl_chooser
         wait_for_task
-      ) + adv_search_post + compare_post + exp_post + perf_post + save_post
+      ) + adv_search_post + compare_post + exp_post + perf_post + save_post + dialog_runner_post
     },
 
     :host_aggregate           => {
@@ -425,12 +425,13 @@ Rails.application.routes.draw do
         tag_edit_form_field_changed
         create
         wait_for_task
-      ) + compare_post + adv_search_post + exp_post + save_post
+      ) + compare_post + adv_search_post + exp_post + save_post + dialog_runner_post
     },
 
     :cloud_tenant             => {
       :get => %w(
         cloud_tenant_form_fields
+        dialog_load
         download_data
         download_summary_pdf
         edit
@@ -456,7 +457,7 @@ Rails.application.routes.draw do
         update
         wait_for_task
       ) +
-               compare_post + adv_search_post + exp_post + save_post
+               compare_post + adv_search_post + exp_post + save_post + dialog_runner_post
     },
 
     :cloud_object_store_object => {
@@ -483,7 +484,7 @@ Rails.application.routes.draw do
         tagging_edit
         tag_edit_form_field_changed
         update
-      ) + compare_post + adv_search_post + exp_post + save_post
+      ) + compare_post + adv_search_post + exp_post
     },
 
     :cloud_volume             => {
@@ -524,7 +525,7 @@ Rails.application.routes.draw do
         tag_edit_form_field_changed
         update
         wait_for_task
-      ) + compare_post + adv_search_post + exp_post + save_post
+      ) + compare_post + adv_search_post + exp_post + save_post + dialog_runner_post
     },
 
     :cloud_volume_snapshot    => {
@@ -678,7 +679,8 @@ Rails.application.routes.draw do
                adv_search_post +
                exp_post +
                perf_post +
-               save_post
+               save_post +
+               dialog_runner_post
     },
 
     :container_node           => {
@@ -793,7 +795,7 @@ Rails.application.routes.draw do
         openscap_rule_results
         protect
         squash_toggle
-      ) + adv_search_post + exp_post + save_post
+      ) + adv_search_post + exp_post + save_post + dialog_runner_post
     },
 
     :container_image_registry => {
@@ -891,7 +893,8 @@ Rails.application.routes.draw do
                adv_search_post +
                exp_post +
                perf_post +
-               save_post
+               save_post +
+               dialog_runner_post
     },
 
     :container_route          => {
@@ -948,7 +951,7 @@ Rails.application.routes.draw do
         update
         tagging_edit
         tag_edit_form_field_changed
-      ) + adv_search_post + exp_post + save_post
+      ) + adv_search_post + exp_post + save_post + dialog_runner_post
     },
 
     :container_build          => {
@@ -1004,7 +1007,7 @@ Rails.application.routes.draw do
         show_list
         tagging_edit
         tag_edit_form_field_changed
-      ) + adv_search_post + exp_post + save_post
+      ) + adv_search_post + exp_post + save_post + dialog_runner_post
     },
 
     :container_topology       => {
@@ -1728,7 +1731,8 @@ Rails.application.routes.draw do
         adv_search_post +
         compare_post +
         save_post +
-        exp_post
+        exp_post +
+        dialog_runner_post
     },
 
     :floating_ip              => {
@@ -1797,7 +1801,8 @@ Rails.application.routes.draw do
         adv_search_post +
         compare_post +
         save_post +
-        exp_post
+        exp_post +
+        dialog_runner_post
     },
 
     :cloud_network             => {
@@ -1830,7 +1835,8 @@ Rails.application.routes.draw do
         adv_search_post +
         compare_post +
         save_post +
-        exp_post
+        exp_post +
+        dialog_runner_post
     },
 
     :network_port             => {
@@ -1902,7 +1908,8 @@ Rails.application.routes.draw do
         adv_search_post +
         compare_post +
         save_post +
-        exp_post
+        exp_post +
+        dialog_runner_post
     },
 
     :load_balancer             => {
@@ -1928,7 +1935,8 @@ Rails.application.routes.draw do
         adv_search_post +
         compare_post +
         save_post +
-        exp_post
+        exp_post +
+        dialog_runner_post
     },
 
     :flavor                   => {
@@ -2071,7 +2079,8 @@ Rails.application.routes.draw do
         adv_search_post +
         exp_post +
         save_post +
-        x_post
+        x_post +
+        dialog_runner_post
     },
 
     :generic_object => {
@@ -2750,7 +2759,8 @@ Rails.application.routes.draw do
       ) +
                adv_search_post +
                exp_post +
-               save_post
+               save_post +
+               dialog_runner_post
     },
 
     :provider_foreman         => {


### PR DESCRIPTION
Create custom button with dialog:
Automation -> Automate -> Customization -> Buttons -> create a custom button with a dialog

COMPUTE

- Cloud > Availability Zone
- Cloud > Stacks
- Infrastructure > Networking - explorer issue (submit/cancel in Dialog) - will be resolved in separate PR 
- Container > Project
- Container > Pod
- Container > Images
- Container > Volumes
- Container > Template

NETWORKS

- Network
- Subnet - not showing dialog - fixed
- Router - not showing dialog -fixed
- Load Balancer
- Security Group - not showing dialog - fixed

STORAGE:

- Block > Managers
- Block > Volume
- Object > Managers
- Object > Container

Go to detail page of object that has custom button with a dialog

Before:
```
No route matches {:action=>"dialog_load", :controller=>"cloud_tenant", :id=>"1000000000012"} [cloud_tenant/button]
```
After:
Displays a dialog like this
<img width="1204" alt="screen shot 2017-10-18 at 1 49 05 pm" src="https://user-images.githubusercontent.com/9210860/31717168-261317de-b40b-11e7-8d4c-7aa61e0aea5e.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1500199

@miq-bot add_label bug, fine/no

Dialog is generated directly instead of show's magic.
Template rendered instead of partial because of `#main_div` and styling.
