### PR TITLE
Correctly indent the blank slate widget

### DIFF
--- a/app/views/dashboard/_widget_blank.html.haml
+++ b/app/views/dashboard/_widget_blank.html.haml
@@ -3,8 +3,8 @@
     widget -- MiqWidget object
 .mc{:id => "dd_w#{widget.id}_box",
 :style => "#{@sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display: none;' : ''}"}
-.blank-slate-pf{:style => "padding: 10px"}
-  .blank-slate-pf-icon
-    %i.fa.fa-cog
-  %h1= _('No data found.')
-  %p= _('If this widget is new or has just been added to your dashboard, the data is being generated and should be available soon.')
+  .blank-slate-pf{:style => "padding: 10px"}
+    .blank-slate-pf-icon
+      %i.fa.fa-cog
+    %h1= _('No data found.')
+    %p= _('If this widget is new or has just been added to your dashboard, the data is being generated and should be available soon.')


### PR DESCRIPTION
The DOM elements werent contained in the .mc div, so the minimizing and maximizing did not work.

This is the same issue like #1782

https://bugzilla.redhat.com/show_bug.cgi?id=1503613