### PR TITLE
Move has_kids_for Dialog to a tree where is belongs.

### DIFF
--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -1,5 +1,4 @@
 class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
-  has_kids_for Dialog, [:x_get_tree_dialog_kids, :type]
   has_kids_for ServiceTemplateCatalog, [:x_get_tree_stc_kids]
 
   private

--- a/app/presenters/tree_builder_service_dialogs.rb
+++ b/app/presenters/tree_builder_service_dialogs.rb
@@ -1,12 +1,6 @@
 class TreeBuilderServiceDialogs < TreeBuilderAeCustomization
-  has_kids_for DialogGroup, [:x_get_tree_dialog_group_kids, :type]
-  has_kids_for DialogTab, [:x_get_tree_dialog_tab_kids, :type]
-  has_kids_for Dialog, [:x_get_tree_dialog_kids, :type]
-
-  private
-
   def tree_init_options(_tree_name)
-    {:leaf => "Dialog", :open_all => true}
+    {:open_all => true}
   end
 
   def root_options
@@ -20,29 +14,5 @@ class TreeBuilderServiceDialogs < TreeBuilderAeCustomization
   def x_get_tree_roots(count_only, _options)
     objects = Rbac.filtered(Dialog.all).sort_by { |a| a.label.downcase }
     count_only_or_objects(count_only, objects)
-  end
-
-  def x_get_tree_generic_dialog_kids(object, count_only, type, chk_dialog_type = false)
-    objects =
-      if chk_dialog_type == true && type == :dialogs
-        []
-      elsif count_only
-        object.dialog_resources
-      else
-        object.ordered_dialog_resources.collect(&:resource).compact
-      end
-    count_only_or_objects(count_only, objects)
-  end
-
-  def x_get_tree_dialog_kids(object, count_only, type)
-    x_get_tree_generic_dialog_kids(object, count_only, type, true)
-  end
-
-  def x_get_tree_dialog_tab_kids(object, count_only, type)
-    x_get_tree_generic_dialog_kids(object, count_only, type)
-  end
-
-  def x_get_tree_dialog_group_kids(object, count_only, type)
-    x_get_tree_generic_dialog_kids(object, count_only, type)
   end
 end

--- a/app/presenters/tree_builder_service_dialogs.rb
+++ b/app/presenters/tree_builder_service_dialogs.rb
@@ -1,6 +1,7 @@
 class TreeBuilderServiceDialogs < TreeBuilderAeCustomization
   has_kids_for DialogGroup, [:x_get_tree_dialog_group_kids, :type]
   has_kids_for DialogTab, [:x_get_tree_dialog_tab_kids, :type]
+  has_kids_for Dialog, [:x_get_tree_dialog_kids, :type]
 
   private
 


### PR DESCRIPTION
x_get_tree_dialog_kids lives in TreeBuilderServiceDialogs but is
referenced from TreeBuilderServiceCatalog.
But from TreeBuilderServiceCatalog it's actually never used.
Strangely it was not missing until now so we may just removing it

Moving the reference for now.

Ping @himdel, @skateman, @isimluk : any idea what that was supposed to do?