### PR TITLE
More deprecation fixes

### DIFF
--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -864,8 +864,7 @@ describe MiqAeClassController do
     end
 
     it "Can build the AE tree" do
-      allow(User).to receive(:current_tenant).and_return(Tenant.first)
-      allow(User.current_tenant).to receive(:visible_domains).and_return([])
+      allow(User).to receive_message_chain(:current_tenant, :visible_domains).and_return([])
       allow(controller).to receive(:domain_overrides)
 
       expect(controller).to receive(:reload_trees_by_presenter).with(

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -498,8 +498,8 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       let(:toolbar_to_build) { 'generic_object_definition_center_tb' }
 
       before do
+        @record = double(:generic_objects => [])
         allow(Rbac).to receive(:role_allows?).and_return(true)
-        allow(@record).to receive(:generic_objects).and_return([])
       end
 
       it "includes the button group" do

--- a/spec/presenters/tree_builder_report_widgets_spec.rb
+++ b/spec/presenters/tree_builder_report_widgets_spec.rb
@@ -2,7 +2,7 @@ describe TreeBuilderReportWidgets do
   subject { described_class.new("cb_rates_tree", "cb_rates", {}) }
 
   it "#set_locals_for_render (private)" do
-    expect(subject.send(:set_locals_for_render)).to have_attributes(:autoload => true)
+    expect(subject.send(:set_locals_for_render)).to include(:autoload => true)
   end
 
   it "#x_get_tree_roots (private)" do

--- a/spec/views/miq_policy/_alert_details.html.haml_spec.rb
+++ b/spec/views/miq_policy/_alert_details.html.haml_spec.rb
@@ -1,7 +1,7 @@
 describe "miq_policy/_alert_details.html.haml" do
   before do
     @alert = FactoryGirl.create(:miq_alert)
-    SEVERITIES = MiqPolicyController::Alerts::SEVERITIES
+    stub_const("#{controller.class}::SEVERITIES", MiqPolicyController::Alerts::SEVERITIES)
     exp = {:eval_method => 'nothing', :mode => 'internal', :options => {}}
     allow(@alert).to receive(:expression).and_return(exp)
     set_controller_for_view("miq_policy")


### PR DESCRIPTION
Cleans up the spec output, removing warnings, deprecations, etc...

@miq-bot assign @martinpovolny 
@miq-bot add-label test