### PR TITLE
Add target_id and target_class columns to dataset defined in MiqTask.yaml

### DIFF
--- a/product/views/MiqTask.yaml
+++ b/product/views/MiqTask.yaml
@@ -33,6 +33,10 @@ include:
   miq_server:
     columns:
     - name
+  job:
+    columns:
+    - target_class
+    - target_id
 
 # Order of columns (from all tables)
 col_order:


### PR DESCRIPTION
After merging ManageIQ/manageiq-ui-classic#592  there is no navigation to VmOrTemplate screen for selected job record.
https://bugzilla.redhat.com/show_bug.cgi?id=1502578 
issue:  https://github.com/ManageIQ/manageiq-ui-classic/issues/1206

`job.target_id` and `job.target_class` data used to provide navigation to target object from selected Smart State Analysis linked task.

**This PR:**
updates `MiqTask.yaml` to include `jobs.target_class` and `jobs.target_id`

**History:**
Those columns were already added to `MiqTask.yaml` in https://github.com/ManageIQ/manageiq/pull/14932 but were accidently removed in https://github.com/ManageIQ/manageiq-ui-classic/pull/1422. Removing went unnoticed since navigation to target was not implemented.

@miq-bot add-label bug, fine/no

/cc @h-kataria @gtanzillo 
