### PR TITLE
Dupe message when clicking Reset button in gtl page mode

### DIFF
--- a/app/views/layouts/_protect.html.haml
+++ b/app/views/layouts/_protect.html.haml
@@ -22,4 +22,4 @@
   - if @politems
     - @embedded = true
     - @quadicon_no_url = true
-    = render :partial => "layouts/gtl"
+    = render :partial => "layouts/gtl", :locals => {:no_flash_div => true}


### PR DESCRIPTION
Added early setting for no_flash_div, to determine page mode display, gtl or not. 

https://bugzilla.redhat.com/show_bug.cgi?id=1486699

https://bugzilla.redhat.com/show_bug.cgi?id=1486674


Screen shots prior to code fix showing dupe messages displayed, top and bottom of page:
======================
![bz1486699 dupe reset message top of page prior to code fix](https://user-images.githubusercontent.com/552686/31746561-e01324ba-b41c-11e7-9b33-8c84d9f5c122.png)

![bz1486699 dupe reset message bottom of page prior to code fix](https://user-images.githubusercontent.com/552686/31746564-e8a23f6c-b41c-11e7-9be8-e178173789c3.png)


Screen shots showing just one flash message displayed, at the top of page (2 parts):
======================

![bz1486699 dupe reset message top of page post code fix](https://user-images.githubusercontent.com/552686/31746596-1203bea8-b41d-11e7-8993-f17b3d5e4260.png)

![bz1486699 dupe reset message bottom of page post code fix png](https://user-images.githubusercontent.com/552686/31746611-1b003f04-b41d-11e7-9826-286bb2870bc8.png)

