### PR TITLE
Limit tag list in the Group Expression Editor to one set of categories

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -665,11 +665,11 @@ module ApplicationController::Filter
   def exp_commit(token)
     exp = exp_find_by_token(@edit[@expkey][:expression], token.to_i)
     case @edit[@expkey][:exp_typ]
-    when "field"  then exp_commit_field(exp)
-    when "count"  then exp_commit_count(exp)
-    when "tag"    then exp_commit_tag(exp)
-    when "regkey" then exp_commit_regkey(exp)
-    when "find"   then exp_commit_find(exp)
+    when "field"       then exp_commit_field(exp)
+    when "count"       then exp_commit_count(exp)
+    when "tag", "tags" then exp_commit_tag(exp)
+    when "regkey"      then exp_commit_regkey(exp)
+    when "find"        then exp_commit_find(exp)
     else
       add_flash(_("Select an expression element type"), :error)
     end

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -210,7 +210,7 @@ module ApplicationController::Filter
           if params[:user_input]
             self.exp_value = params[:user_input] == '1' ? :user_input : nil
           end
-        when 'tag'
+        when 'tag', 'tags'
           if params[:chosen_tag] && params[:chosen_tag] != exp_tag
             self.exp_tag = params[:chosen_tag] == '<Choose>' ? nil : params[:chosen_tag]
             self.exp_key = exp_model == '_display_filter_' ? '=' : 'CONTAINS'

--- a/app/views/layouts/exp_atom/_edit_tags.html.haml
+++ b/app/views/layouts/exp_atom/_edit_tags.html.haml
@@ -1,0 +1,38 @@
+- url = url_for_only_path(:action => 'exp_changed')
+
+-#
+  Parameters:
+    exp_model       Model in use for this expression
+
+- opts = ["<#{_('Choose')}>"]
+- opts += MiqExpression.tag_details(nil, {})
+
+%br
+
+= select_tag('chosen_tag', options_for_select(opts, @edit[@expkey][:exp_tag]),
+  :multiple              => false,
+  :class                 => 'selectpicker',
+  'data-live-search'     => true,
+  'data-miq_sparkle_on'  => true,
+  'data-miq_sparkle_off' => true)
+
+- if @edit[@expkey][:exp_tag]
+  %br
+  %font{:color => "black"}
+    = h(@edit[@expkey][:exp_key])
+  %br
+  - if @edit[@expkey][:exp_value] == :user_input
+    = "<#{_('user input')}>"
+  - else
+    - opts = ["<#{_('Choose')}>"] + MiqExpression.get_entry_details(@edit[@expkey][:exp_tag]).sort_by { |a| a.first.downcase }
+    = select_tag('chosen_value', options_for_select(opts, @edit[@expkey][:exp_value]),
+      :multiple              => false,
+      :class                 => 'selectpicker',
+      "data-miq_sparkle_on"  => true,
+      "data-miq_sparkle_off" => true,
+      "data-miq_observe"     => {:url => url}.to_json)
+
+:javascript
+  miqInitSelectPicker();
+  miqSelectPickerEvent('chosen_tag', '#{url}');
+  miqSelectPickerEvent('chosen_value', '#{url}');

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -59,12 +59,15 @@
         - else
           - opts += exptypes
 
-        = select_tag('chosen_typ', options_for_select(opts, @edit[@expkey][:exp_typ]),
-          :multiple              => false,
-          :class                 => 'selectpicker',
-          'data-miq_sparkle_on'  => true,
-          'data-miq_sparkle_off' => true,
-          'data-miq_observe'     => {:url => url}.to_json)
+        - if @edit[@expkey][:exp_typ] == 'tags'
+          = _('Tag')
+        - else
+          = select_tag('chosen_typ', options_for_select(opts, @edit[@expkey][:exp_typ]),
+            :multiple              => false,
+            :class                 => 'selectpicker',
+            'data-miq_sparkle_on'  => true,
+            'data-miq_sparkle_off' => true,
+            'data-miq_observe'     => {:url => url}.to_json)
 
       %br
       - if @edit[@expkey][:exp_typ]

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -54,7 +54,8 @@
           - unless @edit[@expkey].tags_for_display_filters.empty?
             - opts.push([_('Tag'), 'tag'])
         - when 'MiqGroup'
-          - opts += [[_('Tag'), 'tag']]
+          - opts = [[_('Tag'), 'tags']]
+          - @edit[@expkey][:exp_typ] = 'tags'
         - else
           - opts += exptypes
 


### PR DESCRIPTION

The group expression editor needs to show only the "My Company Tags: Department" type entries in the first drop down, so there will only be 1 set of tag categories to choose from.  

Links
-------
https://bugzilla.redhat.com/show_bug.cgi?id=1503146

![screenshot from 2017-10-20 12-51-07](https://user-images.githubusercontent.com/12769982/31832578-833f253e-b595-11e7-88a8-c79a969a083a.png)
