### PR TITLE
Change "Docker Labels" to "Image Labels"

### DIFF
--- a/app/helpers/container_image_helper/textual_summary.rb
+++ b/app/helpers/container_image_helper/textual_summary.rb
@@ -127,6 +127,6 @@ module ContainerImageHelper
   end
 
   def textual_group_container_docker_labels
-    TextualGroup.new(_("Docker Labels"), textual_key_value_group(@record.docker_labels.to_a))
+    TextualGroup.new(_("Image Labels"), textual_key_value_group(@record.docker_labels.to_a))
   end
 end

--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -30,7 +30,7 @@
     - if !@edit[:new][:cbshow_typ].blank? && @edit[:new][:cbshow_typ].ends_with?("-labels")
       .form-group
         %label.col-md-2.control-label
-          = _('Docker Labels')
+          = _('Image Labels')
         .col-md-8
           - options = Array(@edit[:cb_assign][:docker_label_keys].invert).sort_by { |a| a.first.downcase }
           = select_tag("cblabel_key", options_for_select([["<#{_('Choose a Label')}>", ""]] + options, @edit[:new][:cblabel_key].to_s),


### PR DESCRIPTION
**Description**
Change all "Docker Labels" strings to "Image Labels" in the ManageIQ UI.

cloud intel -> chargeback -> assignments -> compute -> labeled container images

before:
![before2](https://user-images.githubusercontent.com/498903/31763723-cae306a4-b4c7-11e7-9259-b26b785bd505.png)

after:
![after2](https://user-images.githubusercontent.com/498903/31763742-db4d1db8-b4c7-11e7-971e-259a6b94ae21.png)

compute -> containers -> container images -> click on one of the images

before:
![before1](https://user-images.githubusercontent.com/498903/31763788-0440920e-b4c8-11e7-935c-bd3252ad6837.png)

after:

![after1](https://user-images.githubusercontent.com/498903/31763797-09ba9112-b4c8-11e7-9759-040a4dcd4c06.png)
