### PR TITLE
Fix duplicate DOM IDs in automate customization.

### DIFF
--- a/app/views/miq_ae_customization/_dialog_edit_tree.html.haml
+++ b/app/views/miq_ae_customization/_dialog_edit_tree.html.haml
@@ -1,4 +1,4 @@
-#accordion.panel-group
+#accordion_dialog.panel-group
   .panel.panel-default
     .panel-heading
       %h4.panel-title

--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -22,15 +22,16 @@
                     %label.col-md-2.control-label{:title => field.description}
                       = field.label
                     .col-md-8{:title => field.description}
+                      - field_id = "field_#{field.id}"
                       - case field.type
                       - when "DialogFieldTextBox"
                         - if field.protected?
-                          = password_field_tag('field.id', '********', :maxlength => 20, :disabled => true)
+                          = password_field_tag(field_id, '********', :maxlength => 20, :disabled => true)
                         - else
-                          = text_field_tag('field.id', field.sample_text, :maxlength => 20, :disabled => true)
+                          = text_field_tag(field_id, field.sample_text, :maxlength => 20, :disabled => true)
 
                       - when "DialogFieldCheckBox"
-                        = check_box_tag("field.id", "1", false, :disabled => true)
+                        = check_box_tag(field_id, "1", false, :disabled => true)
                       - when "DialogFieldDateControl", "DialogFieldDateTimeControl"
                         - if field.show_past_dates
                           :javascript
@@ -75,10 +76,10 @@
                             - if field.type == "DialogFieldDropDownList"
                               - if field.required
                                 - if field.default_value.nil?
-                                  = select_tag('field.id',
+                                  = select_tag(field_id,
                                     options_for_select(val.collect(&:reverse), field.default_value))
                                 - else
-                                  = select_tag('field.id',
+                                  = select_tag(field_id,
                                               options_for_select(val.collect(&:reverse), field.default_value))
 
                               - else
@@ -106,7 +107,7 @@
                         = button_tag(_('Save'), :disabled => true)
                       - when "DialogFieldTagControl"
                         - multiple = field.single_value? ? {} : {:multiple => true}
-                        = select_tag('field.id', options_for_select(dialog_dropdown_select_values(field)), multiple)
+                        = select_tag(field_id, options_for_select(dialog_dropdown_select_values(field)), multiple)
 
 :javascript
   miq_tabs_init("#dialog_tabs");

--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -75,12 +75,7 @@
 
                             - if field.type == "DialogFieldDropDownList"
                               - if field.required
-                                - if field.default_value.nil?
-                                  = select_tag(field_id,
-                                    options_for_select(val.collect(&:reverse), field.default_value))
-                                - else
-                                  = select_tag(field_id,
-                                              options_for_select(val.collect(&:reverse), field.default_value))
+                                = select_tag(field_id, options_for_select(val.collect(&:reverse), field.default_value))
 
                               - else
                                 -# NOT REQUIRED

--- a/app/views/miq_ae_customization/_dialog_sample_buttons.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample_buttons.html.haml
@@ -1,5 +1,5 @@
 -# if dialogs is selected
-#form_buttons_div
+#sample_form_buttons_div
   - if @record.buttons
     %table{:width => "100%"}
       %tr


### PR DESCRIPTION
Before:

![screenshot_2017-10-19_11-33-51](https://user-images.githubusercontent.com/51095/31764435-7564d64a-b4c1-11e7-8623-e6b16fa500dd.png)

After:
![screenshot_2017-10-19_11-35-10](https://user-images.githubusercontent.com/51095/31764482-968acd98-b4c1-11e7-9159-7889d7786a1a.png)
