### PR TITLE
'ensure_managers' was moved to a separate job, api call mack is not needed

### DIFF
--- a/app/assets/images/svg/vendor-redhat_network.svg
+++ b/app/assets/images/svg/vendor-redhat_network.svg
@@ -1,0 +1,1 @@
+vendor-redhat.svg

--- a/app/controllers/application_controller/network.rb
+++ b/app/controllers/application_controller/network.rb
@@ -2,6 +2,8 @@ module ApplicationController::Network
   extend ActiveSupport::Concern
 
   def network_managers
-    Rbac::Filterer.filtered(ManageIQ::Providers::Openstack::NetworkManager).select(:id, :name, :parent_ems_id)
+    openstack_network_manager = Rbac::Filterer.filtered(ManageIQ::Providers::Openstack::NetworkManager).select(:id, :name, :parent_ems_id)
+    redhat_network_manager = Rbac::Filterer.filtered(ManageIQ::Providers::Redhat::NetworkManager).select(:id, :name, :parent_ems_id)
+    openstack_network_manager + redhat_network_manager
   end
 end

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -47,7 +47,7 @@ class CloudSubnetController < ApplicationController
     @subnet = CloudSubnet.new
     @in_a_form = true
     @network_provider_choices = {}
-    ExtManagementSystem.where(:type => "ManageIQ::Providers::Openstack::NetworkManager").find_each do |ems|
+    ExtManagementSystem.where(:type => ['ManageIQ::Providers::Openstack::NetworkManager', 'ManageIQ::Providers::Redhat::NetworkManager']).find_each do |ems|
       @network_provider_choices[ems.name] = ems.id
     end
     drop_breadcrumb(

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -1,5 +1,5 @@
 describe CloudSubnetController do
-  include_examples :shared_examples_for_cloud_subnet_controller, %w(openstack azure google amazon)
+  include_examples :shared_examples_for_cloud_subnet_controller, %w(openstack azure google amazon redhat)
 
   context "#tags_edit" do
     let!(:user) { stub_user(:features => :all) }

--- a/spec/controllers/ems_network_controller_spec.rb
+++ b/spec/controllers/ems_network_controller_spec.rb
@@ -1,5 +1,5 @@
 describe EmsNetworkController do
-  include_examples :shared_examples_for_ems_network_controller, %w(openstack azure google amazon)
+  include_examples :shared_examples_for_ems_network_controller, %w(openstack azure google amazon redhat)
 
   it_behaves_like "controller with custom buttons"
 end

--- a/spec/controllers/network_port_controller_spec.rb
+++ b/spec/controllers/network_port_controller_spec.rb
@@ -1,3 +1,3 @@
 describe NetworkPortController do
-  include_examples :shared_examples_for_network_port_controller, %w(openstack azure google amazon)
+  include_examples :shared_examples_for_network_port_controller, %w(openstack azure google amazon redhat)
 end


### PR DESCRIPTION
'ensure_managers' was moved to a separate job, api call mack is not needed