### PR TITLE
Support network manager

### DIFF
--- a/app/assets/images/svg/vendor-redhat_network.svg
+++ b/app/assets/images/svg/vendor-redhat_network.svg
@@ -1,0 +1,1 @@
+vendor-redhat.svg

--- a/app/controllers/application_controller/network.rb
+++ b/app/controllers/application_controller/network.rb
@@ -2,6 +2,8 @@ module ApplicationController::Network
   extend ActiveSupport::Concern
 
   def network_managers
-    Rbac::Filterer.filtered(ManageIQ::Providers::Openstack::NetworkManager).select(:id, :name, :parent_ems_id)
+    openstack_network_manager = Rbac::Filterer.filtered(ManageIQ::Providers::Openstack::NetworkManager).select(:id, :name, :parent_ems_id)
+    redhat_network_manager = Rbac::Filterer.filtered(ManageIQ::Providers::Redhat::NetworkManager).select(:id, :name, :parent_ems_id)
+    openstack_network_manager + redhat_network_manager
   end
 end

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -47,7 +47,7 @@ class CloudSubnetController < ApplicationController
     @subnet = CloudSubnet.new
     @in_a_form = true
     @network_provider_choices = {}
-    ExtManagementSystem.where(:type => "ManageIQ::Providers::Openstack::NetworkManager").find_each do |ems|
+    ExtManagementSystem.where(:type => ['ManageIQ::Providers::Openstack::NetworkManager', 'ManageIQ::Providers::Redhat::NetworkManager']).find_each do |ems|
       @network_provider_choices[ems.name] = ems.id
     end
     drop_breadcrumb(

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -607,15 +607,10 @@ describe EmsInfraController do
     before do
       allow(controller).to receive(:check_privileges).and_return(true)
       allow(controller).to receive(:assert_privileges).and_return(true)
-      ems = FactoryGirl.build(:user, :features => "ems_infra_new")
+      ems = FactoryGirl.create(:user, :features => "ems_infra_new")
       login_as ems
       allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager)
         .to receive(:supported_api_versions).and_return([3, 4])
-      ovirt_service = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4
-      allow_any_instance_of(ovirt_service)
-        .to receive(:collect_external_network_providers).and_return([])
-      ems.save
-
     end
 
     render_views


### PR DESCRIPTION
The PR includes-

Adding ovirt's 'network manager' to the 'cloud network' 'provider choices'
Adding ovirt's 'network manager' to the 'cloud subnet' 'provider choices'
Icon to oVirt's network manager
Tests for Redhat network provider
Reverting a test fix that is not needed any more (the api call was moved to a new job)
