### PR TITLE
Topology legend tooltip fix

### DIFF
--- a/app/assets/stylesheets/topology.css
+++ b/app/assets/stylesheets/topology.css
@@ -16,7 +16,6 @@ kubernetes-topology-graph {
 .topology .legend label {
   font-weight: 400;
   cursor: pointer;
-  vertical-align: 10px;
 }
 
 .topology #selected {
@@ -27,6 +26,7 @@ kubernetes-topology-graph {
 
 kubernetes-topology-icon {
   opacity: 0.4;
+  padding-bottom: 0;
 }
 
 kubernetes-topology-icon.active {
@@ -37,11 +37,6 @@ kubernetes-topology-icon svg {
   width: 39px !important;
   height: 39px !important;
   display: inline-block;
-}
-
-_:-ms-fullscreen, :root kubernetes-topology-icon svg,  /* IE11 hack */
-_:-ms-lang(x), _:-webkit-full-screen, kubernetes-topology-icon svg /* Edge hack */{
-  padding: 20px 0 0 20px;  
 }
 
 .kube-topology g text.attached-label {

--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -1,4 +1,4 @@
-- tooltip_options = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
+- tooltip_options = {"tooltip-placement" => "bottom", "tooltip" => "{{vm.legendTooltip}}"}
 .topology{'ng-controller' => "containerTopologyController as vm"}
   .legend
     %label#selected

--- a/app/views/infra_topology/show.html.haml
+++ b/app/views/infra_topology/show.html.haml
@@ -1,4 +1,4 @@
-- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
+- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{vm.legendTooltip}}"}
 .topology{'ng-controller' => "infraTopologyController as vm"}
   .legend
     %label#selected

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -1,4 +1,4 @@
-- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
+- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{vm.legendTooltip}}"}
 .topology{'ng-controller' => "middlewareTopologyController as vm"}
   .legend.middleware
     %label#selected

--- a/app/views/physical_infra_topology/show.html.haml
+++ b/app/views/physical_infra_topology/show.html.haml
@@ -1,4 +1,4 @@
-- tooltipOptions = {"tooltip-placement" => "bottom-right", "tooltip" => "{{legendTooltip}}"}
+- tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{vm.legendTooltip}}"}
 .topology{'ng-controller' => "physicalInfraTopologyController as vm"}
   .legend
     %label#selected


### PR DESCRIPTION
This PR fixes a problem where the legend tooltip was not appearing. It also adjusts the positioning.

https://bugzilla.redhat.com/show_bug.cgi?id=1432851
https://bugzilla.redhat.com/show_bug.cgi?id=1486660

Old
<img width="609" alt="screen shot 2017-10-19 at 3 39 30 pm" src="https://user-images.githubusercontent.com/1287144/31790529-ce05a1cc-b4e3-11e7-8718-50977e0ad567.png">

New
![screen shot 2017-10-20 at 11 07 16 am](https://user-images.githubusercontent.com/1287144/31827921-df1c17f4-b586-11e7-8133-8f73ff430bd2.png)