### PR TITLE
Show 'Cancel job' button on tasks screen

### DIFF
--- a/app/helpers/application_helper/button/miq_task_canceljob.rb
+++ b/app/helpers/application_helper/button/miq_task_canceljob.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::MiqTaskCanceljob < ApplicationHelper::Button::Basic
   def visible?
-    !%w(all_tasks my_tasks).include?(@layout)
+    %w(all_tasks my_tasks).include?(@layout)
   end
 end

--- a/spec/helpers/application_helper/buttons/miq_task_canceljob_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_task_canceljob_spec.rb
@@ -6,12 +6,12 @@ describe ApplicationHelper::Button::MiqTaskCanceljob do
     %w(all_tasks my_tasks).each do |layout|
       context "when layout == #{layout}" do
         let(:layout) { layout }
-        it { is_expected.to be_falsey }
+        it { is_expected.to be_truthy }
       end
     end
     context 'when !layout.in(%w(all_tasks my_tasks))' do
       let(:layout) { 'something' }
-      it { is_expected.to be_truthy }
+      it { is_expected.to be_falsey }
     end
   end
 end


### PR DESCRIPTION
**Issue:**
There was `Cancel Job` button on `Jobs` screen. After merging `Job` and `MiqTask` screens this button is missing and there is no way to cancel started job.
https://bugzilla.redhat.com/show_bug.cgi?id=1504244

This PR makes 'Cancel Job' button visible 

thank you @bzwei for finding this bug !

**BEFORE:**
<img width="1228" alt="before" src="https://user-images.githubusercontent.com/6556758/31790853-db628bc2-b4e4-11e7-8120-c897829b84f9.png">

**AFTER:**
![after-canceljob](https://user-images.githubusercontent.com/6556758/31790868-e379c4b0-b4e4-11e7-85c4-9d2943af8867.png)

@miq-bot add-label bug

/cc @dclarizio 
