### PR TITLE
Travis - spec:compile to try compiling assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   matrix:
   - TEST_SUITE=spec
   - TEST_SUITE=spec:javascript
+  - TEST_SUITE=spec:compile
 bundler_args: --no-deployment
 before_install: source tools/ci/before_install.sh
 before_script: bundle exec rake $TEST_SUITE:setup

--- a/Rakefile
+++ b/Rakefile
@@ -79,6 +79,14 @@ namespace :spec do
 
   desc "Run all javascript specs"
   task :javascript => ["app:test:initialize", :environment, "jasmine:ci"]
+
+  namespace :compile do
+    desc "Does nothing, needed by Travis"
+    task :setup
+  end
+
+  desc "Try to compile assets"
+  task :compile => ["app:assets:precompile"]
 end
 
 task :default => :spec

--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -33,7 +33,7 @@ module ManageIQ
       class Engine < ::Rails::Engine
         config.autoload_paths << root.join('app', 'controllers', 'mixins')
         config.autoload_paths << root.join('lib')
-        if Rails.env.production?
+        if Rails.env.production? || Rails.env.test?
           require 'uglifier'
           config.assets.js_compressor = Uglifier.new(
             :compress => {


### PR DESCRIPTION
This is to catch production-only asset compile bugs, after a few PRs broke production builds by using es6-only features.

Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/2471

Thus enabling uglifier for the test environment, and running this `spec:compile` on travis.

Cc @carbonin , @Fryguy 

---

This is how such an error looks like, during `evm:compile_assets` (or `RAILS_ENV=test rake spec:compile` in ui-classic with this).

```
ExecJS::RuntimeError: SyntaxError: Unexpected token: punc ()) (line: 118794, col: 8, pos: 8079401)

Error
    at new JS_Parse_Error (/tmp/execjs20171019-9239-1i1yv1bjs:3623:11948)
    at js_error (/tmp/execjs20171019-9239-1i1yv1bjs:3623:12167)
    at croak (/tmp/execjs20171019-9239-1i1yv1bjs:3623:22038)
    at token_error (/tmp/execjs20171019-9239-1i1yv1bjs:3623:22175)
    at unexpected (/tmp/execjs20171019-9239-1i1yv1bjs:3623:22263)
    at expr_atom (/tmp/execjs20171019-9239-1i1yv1bjs:3623:31010)
    at maybe_unary (/tmp/execjs20171019-9239-1i1yv1bjs:3624:1752)
    at expr_ops (/tmp/execjs20171019-9239-1i1yv1bjs:3624:2523)
    at maybe_conditional (/tmp/execjs20171019-9239-1i1yv1bjs:3624:2615)
    at maybe_assign (/tmp/execjs20171019-9239-1i1yv1bjs:3624:3058)
    at expression (/tmp/execjs20171019-9239-1i1yv1bjs:3624:3384)
    at expr_list (/tmp/execjs20171019-9239-1i1yv1bjs:3623:31548)
new JS_Parse_Error ((execjs):3623:11948)
js_error ((execjs):3623:12167)
croak ((execjs):3623:22038)
token_error ((execjs):3623:22175)
unexpected ((execjs):3623:22263)
expr_atom ((execjs):3623:31010)
maybe_unary ((execjs):3624:1752)
expr_ops ((execjs):3624:2523)
maybe_conditional ((execjs):3624:2615)
maybe_assign ((execjs):3624:3058)
expression ((execjs):3624:3384)
expr_list ((execjs):3623:31548)
```