### PR TITLE
For Automate expression methods include ids

### DIFF
--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -9,7 +9,9 @@
   -# Use list in @edit for reporting display filter
   - opts += @edit[@expkey][:exp_available_fields]
 - else
-  - opts += MiqExpression.miq_adv_search_lists(exp_model, :exp_available_fields)
+  - extra_opts = {}
+  - extra_opts.merge!(:include_id_columns => true) if @edit.fetch(:expression_method, false)
+  - opts += MiqExpression.miq_adv_search_lists(exp_model, :exp_available_fields, extra_opts)
 
 = select_tag('chosen_field', options_for_select(opts, @edit[@expkey][:exp_field]),
   :multiple              => false,

--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -10,7 +10,7 @@
   - opts += @edit[@expkey][:exp_available_fields]
 - else
   - extra_opts = {}
-  - extra_opts.merge!(:include_id_columns => true) if @edit.fetch(:expression_method, false)
+  - extra_opts[:include_id_columns] = true if @edit.fetch(:expression_method, false)
   - opts += MiqExpression.miq_adv_search_lists(exp_model, :exp_available_fields, extra_opts)
 
 = select_tag('chosen_field', options_for_select(opts, @edit[@expkey][:exp_field]),


### PR DESCRIPTION
The Expression Editor is used to build Advanced Search Filters and Automate Expression Methods.
When using it as an Automate Expression Method we need to compare object ids since custom dialogs for drop down items use ID to uniquely identify objects.

This PR passes in :include_id_columns => true into miq_adv_search_lists if we are using an expression method.

This PR depends on PR https://github.com/ManageIQ/manageiq/pull/16242

The screen shot below shows the list of columns (fields) that a user can select when using the Regular Advanced Search

![regular advanced search for vm](https://user-images.githubusercontent.com/6452699/31792194-367531be-b4e9-11e7-8311-a5e72edc9ccb.png)


The screen shot below shows the list of columns (fields) that a user can select when using the Expression Method, you would see the ID column listed

![expression method for vm](https://user-images.githubusercontent.com/6452699/31792230-578f8782-b4e9-11e7-91bd-7b72a146626b.png)
