### PR TITLE
Allow the type of controller to be passed in when adding a disk to a Vm ( VMWare )

### DIFF
--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -135,11 +135,11 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         var dmode = (vm.reconfigureModel.vmdisks[disk].hdMode == 'persistent');
         var dtype = (vm.reconfigureModel.vmdisks[disk].hdType == 'thin');
         vm.reconfigureModel.vmAddDisks.push({disk_size_in_mb: dsize,
-                                             persistent: dmode,
-                                             thin_provisioned: dtype,
-                                             new_controller_type: vm.reconfigureModel.vmdisks[disk].new_controller_type,
-                                             dependent: vm.reconfigureModel.vmdisks[disk].cb_dependent,
-                                             bootable: vm.reconfigureModel.vmdisks[disk].cb_bootable});
+          persistent: dmode,
+          thin_provisioned: dtype,
+          new_controller_type: vm.reconfigureModel.vmdisks[disk].new_controller_type,
+          dependent: vm.reconfigureModel.vmdisks[disk].cb_dependent,
+          bootable: vm.reconfigureModel.vmdisks[disk].cb_bootable});
       }
     }
   };
@@ -157,14 +157,14 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
 
   vm.addDisk = function() {
     vm.reconfigureModel.vmdisks.push({hdFilename:'',
-                                          hdType: vm.reconfigureModel.hdType,
-                                          hdMode: vm.reconfigureModel.hdMode,
-                                          hdSize: vm.reconfigureModel.hdSize,
-                                          hdUnit: vm.reconfigureModel.hdUnit,
-                                          new_controller_type: vm.reconfigureModel.new_controller_type,
-                                          cb_dependent: vm.reconfigureModel.cb_dependent,
-                                          cb_bootable: vm.reconfigureModel.cb_bootable,
-                                          add_remove: 'add'});
+      hdType: vm.reconfigureModel.hdType,
+      hdMode: vm.reconfigureModel.hdMode,
+      hdSize: vm.reconfigureModel.hdSize,
+      hdUnit: vm.reconfigureModel.hdUnit,
+      new_controller_type: vm.reconfigureModel.new_controller_type,
+      cb_dependent: vm.reconfigureModel.cb_dependent,
+      cb_bootable: vm.reconfigureModel.cb_bootable,
+      add_remove: 'add'});
     vm.resetAddValues();
 
     vm.updateDisksAddRemove();

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -12,6 +12,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       hdMode:                  'persistent',
       hdSize:                  '',
       hdUnit:                  'MB',
+      new_controller_type:     'VirtualLsiLogicController',
       cb_dependent:            true,
       addEnabled:              false,
       cb_bootable:             false,
@@ -134,10 +135,11 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         var dmode = (vm.reconfigureModel.vmdisks[disk].hdMode == 'persistent');
         var dtype = (vm.reconfigureModel.vmdisks[disk].hdType == 'thin');
         vm.reconfigureModel.vmAddDisks.push({disk_size_in_mb: dsize,
-                                                 persistent: dmode,
-                                                 thin_provisioned: dtype,
-                                                 dependent: vm.reconfigureModel.vmdisks[disk].cb_dependent,
-                                                 bootable: vm.reconfigureModel.vmdisks[disk].cb_bootable});
+                                             persistent: dmode,
+                                             thin_provisioned: dtype,
+                                             new_controller_type: vm.reconfigureModel.vmdisks[disk].new_controller_type,
+                                             dependent: vm.reconfigureModel.vmdisks[disk].cb_dependent,
+                                             bootable: vm.reconfigureModel.vmdisks[disk].cb_bootable});
       }
     }
   };
@@ -147,6 +149,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     vm.reconfigureModel.hdMode = 'persistent';
     vm.reconfigureModel.hdSize = '';
     vm.reconfigureModel.hdUnit = 'MB';
+    vm.reconfigureModel.new_controller_type = 'VirtualLsiLogicController';
     vm.reconfigureModel.cb_dependent = true;
     vm.reconfigureModel.addEnabled = false;
     vm.reconfigureModel.cb_bootable = false;
@@ -158,6 +161,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
                                           hdMode: vm.reconfigureModel.hdMode,
                                           hdSize: vm.reconfigureModel.hdSize,
                                           hdUnit: vm.reconfigureModel.hdUnit,
+                                          new_controller_type: vm.reconfigureModel.new_controller_type,
                                           cb_dependent: vm.reconfigureModel.cb_dependent,
                                           cb_bootable: vm.reconfigureModel.cb_bootable,
                                           add_remove: 'add'});

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -44,6 +44,7 @@ module Mixins
           # if coming in to edit from miq_request list view
           recs = checked_or_params
           if !session[:checked_items].nil? && (@lastaction == "set_checked_items" || params[:pressed] == "miq_request_edit")
+            recs = session[:checked_items]
             request_id = params[:id]
           end
 
@@ -128,7 +129,7 @@ module Mixins
                             :hdMode              => disk[:persistent] ? 'persistent' : 'nonpersistent',
                             :hdSize              => adsize.to_s,
                             :hdUnit              => adunit,
-                            :new_controller_type => disk[:new_controller_type],
+                            :new_controller_type => disk[:new_controller_type].to_s,
                             :cb_dependent        => disk[:dependent],
                             :cb_bootable         => disk[:bootable],
                             :add_remove          => 'add'}

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -151,15 +151,14 @@ module Mixins
                   end
                 end
                 dsize, dunit = reconfigure_calculations(disk.size / (1024 * 1024))
-                vmdisk =  {:hdFilename     => disk.filename,
-                           :hdType         => disk.disk_type.to_s,
-                           :hdMode         => disk.mode.to_s,
-                           :hdSize         => dsize.to_s,
-                           :hdUnit         => dunit.to_s,
-                           :delete_backing => delbacking,
-                           :cb_bootable    => disk.bootable,
-                           :add_remove     => removing}
-                vmdisk[:new_controller_type] = reconfig_item.first.scsi_controller_default_type if reconfig_item.first.respond_to?(:scsi_controller_default_type)
+                vmdisk = {:hdFilename     => disk.filename,
+                          :hdType         => disk.disk_type.to_s,
+                          :hdMode         => disk.mode.to_s,
+                          :hdSize         => dsize.to_s,
+                          :hdUnit         => dunit.to_s,
+                          :delete_backing => delbacking,
+                          :cb_bootable    => disk.bootable,
+                          :add_remove     => removing}
                 vmdisks << vmdisk
               end
             end
@@ -218,18 +217,6 @@ module Mixins
 
         def supports_reconfigure_disks?
           @reconfigitems && @reconfigitems.size == 1 && @reconfigitems.first.supports_reconfigure_disks?
-        end
-
-        def supports_new_scsi_controller?
-          @reconfigitems && @reconfigitems.size == 1 && @reconfigitems.first.respond_to?(:scsi_controller_types)
-        end
-
-        def scsi_controller_types
-          @reconfigitems.first.scsi_controller_types
-        end
-
-        def scsi_controller_default_type
-          @reconfigitems.first.scsi_controller_default_type
         end
 
         private

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -123,14 +123,15 @@ module Mixins
             if @req.options[:disk_add]
               @req.options[:disk_add].each do |disk|
                 adsize, adunit = reconfigure_calculations(disk[:disk_size_in_mb])
-                vmdisks << {:hdFilename   => disk[:disk_name],
-                            :hdType       => disk[:thin_provisioned] ? 'thin' : 'thick',
-                            :hdMode       => disk[:persistent] ? 'persistent' : 'nonpersistent',
-                            :hdSize       => adsize.to_s,
-                            :hdUnit       => adunit,
-                            :cb_dependent => disk[:dependent],
-                            :cb_bootable  => disk[:bootable],
-                            :add_remove   => 'add'}
+                vmdisks << {:hdFilename          => disk[:disk_name],
+                            :hdType              => disk[:thin_provisioned] ? 'thin' : 'thick',
+                            :hdMode              => disk[:persistent] ? 'persistent' : 'nonpersistent',
+                            :hdSize              => adsize.to_s,
+                            :hdUnit              => adunit,
+                            :new_controller_type => disk[:new_controller_type],
+                            :cb_dependent        => disk[:dependent],
+                            :cb_bootable         => disk[:bootable],
+                            :add_remove          => 'add'}
               end
             end
 
@@ -148,15 +149,17 @@ module Mixins
                     end
                   end
                 end
+                new_controller_type = 'VirtualLsiLogicController'
                 dsize, dunit = reconfigure_calculations(disk.size / (1024 * 1024))
-                vmdisks << {:hdFilename     => disk.filename,
-                            :hdType         => disk.disk_type.to_s,
-                            :hdMode         => disk.mode.to_s,
-                            :hdSize         => dsize.to_s,
-                            :hdUnit         => dunit.to_s,
-                            :delete_backing => delbacking,
-                            :cb_bootable    => disk.bootable,
-                            :add_remove     => removing}
+                vmdisks << {:hdFilename          => disk.filename,
+                            :hdType              => disk.disk_type.to_s,
+                            :hdMode              => disk.mode.to_s,
+                            :hdSize              => dsize.to_s,
+                            :hdUnit              => dunit.to_s,
+                            :new_controller_type => new_controller_type,
+                            :delete_backing      => delbacking,
+                            :cb_bootable         => disk.bootable,
+                            :add_remove          => removing}
               end
             end
             @reconfig_values[:disks] = vmdisks
@@ -195,13 +198,13 @@ module Mixins
           @reconfigureitems.first.hardware.disks.each do |disk|
             next if disk.device_type != 'disk'
             dsize, dunit = reconfigure_calculations(disk.size / (1024 * 1024))
-            vmdisks << {:hdFilename  => disk.filename,
-                        :hdType      => disk.disk_type,
-                        :hdMode      => disk.mode,
-                        :hdSize      => dsize,
-                        :hdUnit      => dunit,
-                        :add_remove  => '',
-                        :cb_bootable => disk.bootable}
+            vmdisks << {:hdFilename          => disk.filename,
+                        :hdType              => disk.disk_type,
+                        :hdMode              => disk.mode,
+                        :hdSize              => dsize,
+                        :hdUnit              => dunit,
+                        :add_remove          => '',
+                        :cb_bootable         => disk.bootable}
           end
 
           {:objectIds              => reconfigure_ids,

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -150,17 +150,17 @@ module Mixins
                     end
                   end
                 end
-                new_controller_type = 'VirtualLsiLogicController'
                 dsize, dunit = reconfigure_calculations(disk.size / (1024 * 1024))
-                vmdisks << {:hdFilename          => disk.filename,
-                            :hdType              => disk.disk_type.to_s,
-                            :hdMode              => disk.mode.to_s,
-                            :hdSize              => dsize.to_s,
-                            :hdUnit              => dunit.to_s,
-                            :new_controller_type => new_controller_type,
-                            :delete_backing      => delbacking,
-                            :cb_bootable         => disk.bootable,
-                            :add_remove          => removing}
+                vmdisk =  {:hdFilename     => disk.filename,
+                           :hdType         => disk.disk_type.to_s,
+                           :hdMode         => disk.mode.to_s,
+                           :hdSize         => dsize.to_s,
+                           :hdUnit         => dunit.to_s,
+                           :delete_backing => delbacking,
+                           :cb_bootable    => disk.bootable,
+                           :add_remove     => removing}
+                vmdisk[:new_controller_type] = reconfig_item.first.scsi_controller_default_type if reconfig_item.first.respond_to?(:scsi_controller_default_type)
+                vmdisks << vmdisk
               end
             end
             @reconfig_values[:disks] = vmdisks
@@ -218,6 +218,18 @@ module Mixins
 
         def supports_reconfigure_disks?
           @reconfigitems && @reconfigitems.size == 1 && @reconfigitems.first.supports_reconfigure_disks?
+        end
+
+        def supports_new_scsi_controller?
+          @reconfigitems && @reconfigitems.size == 1 && @reconfigitems.first.respond_to?(:scsi_controller_types)
+        end
+
+        def scsi_controller_types
+          @reconfigitems.first.scsi_controller_types
+        end
+
+        def scsi_controller_default_type
+          @reconfigitems.first.scsi_controller_default_type
         end
 
         private

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -199,13 +199,13 @@ module Mixins
           @reconfigureitems.first.hardware.disks.each do |disk|
             next if disk.device_type != 'disk'
             dsize, dunit = reconfigure_calculations(disk.size / (1024 * 1024))
-            vmdisks << {:hdFilename          => disk.filename,
-                        :hdType              => disk.disk_type,
-                        :hdMode              => disk.mode,
-                        :hdSize              => dsize,
-                        :hdUnit              => dunit,
-                        :add_remove          => '',
-                        :cb_bootable         => disk.bootable}
+            vmdisks << {:hdFilename  => disk.filename,
+                        :hdType      => disk.disk_type,
+                        :hdMode      => disk.mode,
+                        :hdSize      => dsize,
+                        :hdUnit      => dunit,
+                        :add_remove  => '',
+                        :cb_bootable => disk.bootable}
           end
 
           {:objectIds              => reconfigure_ids,

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -127,6 +127,7 @@
           %th= _('Name')
           %th= _('Type')
           %th{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Mode')
+          %th{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Controller Type')
           %th= _('Size')
           %th
           %th{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Dependent')
@@ -154,6 +155,13 @@
                             "required"                    => "",
                             "selectpicker-for-select-tag" => "",
                             "width"                       => "10")
+            %td{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
+              = select_tag('Controller',
+                           options_for_select(%w(VirtualLsiLogicController ParaVirtualSCSIController VirtualBusLogicController VirtualLsiLogicSASController)),
+                           "ng-model"                    => "vm.reconfigureModel.new_controller_type",
+                           "data-width"                  => "auto",
+                           "required"                    => "",
+                           "selectpicker-for-select-tag" => "")
             %td
               %input.form-control{"type"        => "text",
                                   "id"          => "dvcSize",
@@ -195,6 +203,8 @@
               {{disk.hdType}}
             %td{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
               {{disk.hdMode}}
+            %td{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
+              {{disk.new_controller_type}}
             %td
               {{disk.hdSize}}
             %td

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -156,7 +156,7 @@
                             "selectpicker-for-select-tag" => "",
                             "width"                       => "10")
             %td{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
-              - options = @reconfigitems.first.scsi_controller_types
+              - options = @reconfigitems.first.try(:scsi_controller_types) || {}
               = select_tag('Controller',
                            options_for_select(options),
                            "ng-model"                    => "vm.reconfigureModel.new_controller_type",

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -156,8 +156,9 @@
                             "selectpicker-for-select-tag" => "",
                             "width"                       => "10")
             %td{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
+              - options = @reconfigitems.first.scsi_controller_types
               = select_tag('Controller',
-                           options_for_select(%w(VirtualLsiLogicController ParaVirtualSCSIController VirtualBusLogicController VirtualLsiLogicSASController)),
+                           options_for_select(options),
                            "ng-model"                    => "vm.reconfigureModel.new_controller_type",
                            "data-width"                  => "auto",
                            "required"                    => "",

--- a/spec/javascripts/controllers/reconfigure/reconfigure_form_controller_spec.js
+++ b/spec/javascripts/controllers/reconfigure/reconfigure_form_controller_spec.js
@@ -16,7 +16,7 @@ describe('reconfigureFormController', function() {
       cb_cpu:                 'on',
       socket_count:           '2',
       cores_per_socket_count: '3',
-      disks:                 [{hdFilename: "test_disk.vmdk", hdType: "thick", hdMode: "persistent", hdSize: "0", hdUnit: "MB", add_remove: ""}]};
+      disks:                 [{hdFilename: "test_disk.vmdk", hdType: "thick", hdMode: "persistent", new_controller_type: "VirtualLsiLogicController", hdSize: "0", hdUnit: "MB", add_remove: ""}]};
 
     $httpBackend = _$httpBackend_;
     $httpBackend.whenGET('reconfigure_form_fields/1000000000003,1000000000001,1000000000002').respond(reconfigureFormResponse);
@@ -54,7 +54,7 @@ describe('reconfigureFormController', function() {
     });
 
     it('initializes the delete_backing flag to false if not retrived', function() {
-      expect(vm.reconfigureModel.vmdisks).toEqual([{hdFilename: "test_disk.vmdk", hdType: "thick", hdMode: "persistent", hdSize: "0", hdUnit: "MB", add_remove: "", delete_backing: false}]);
+      expect(vm.reconfigureModel.vmdisks).toEqual([{hdFilename: "test_disk.vmdk", hdType: "thick", hdMode: "persistent", new_controller_type: "VirtualLsiLogicController", hdSize: "0", hdUnit: "MB", add_remove: "", delete_backing: false}]);
     });
   });
 


### PR DESCRIPTION
Allow the user to enter a new disk controller type when adding a new disk to a VMWare VM via reconfigure

Links 
--------

https://www.pivotaltracker.com/story/show/152116440

Depends on https://github.com/ManageIQ/manageiq-providers-vmware/pull/126

Before:
![screenshot from 2017-10-26 11-15-56](https://user-images.githubusercontent.com/12769982/32061243-1b38f330-ba3f-11e7-9a7b-faae8ddda19c.png)


After - reconfigure VM and Edit Existing Reconfigure Request:

![screenshot from 2017-10-26 11-12-56](https://user-images.githubusercontent.com/12769982/32061291-36f826a4-ba3f-11e7-97c7-8bf402b760d1.png)
![screenshot from 2017-10-26 11-14-03](https://user-images.githubusercontent.com/12769982/32061292-370a473a-ba3f-11e7-8e2e-35170ef0d455.png)


