### PR TITLE
User Sync for OpenStack Cloud Provider

### DIFF
--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -42,4 +42,48 @@ class EmsCloudController < ApplicationController
 
   menu_section :clo
   has_custom_buttons
+
+  def sync_users
+    @ems = find_record_with_rbac(model, params[:id])
+    @in_a_form = true
+    drop_breadcrumb(:name => _("Sync Users"), :url => "/ems_cloud/sync_users")
+    @selected_admin_role = params[:admin_role]
+    @selected_member_role = params[:member_role]
+
+    if params[:cancel]
+      redirect_to(ems_cloud_path(params[:id]))
+      return
+    end
+
+    if params[:sync]
+      if @selected_admin_role.blank?
+        add_flash(_("An admin role must be selected."), :error)
+        populate_sync_user_parameters
+      elsif @selected_member_role.blank?
+        add_flash(_("A member role must be selected."), :error)
+        populate_sync_user_parameters
+      else
+        @ems.sync_users_queue(session[:userid], params[:admin_role], params[:member_role])
+        redirect_to(ems_cloud_path(params[:id], :flash_msg => _("Sync users queued.")))
+      end
+    else
+      populate_sync_user_parameters
+    end
+  end
+
+  def populate_sync_user_parameters
+    @admin_roles = {}
+    @admin_roles["Choose Admin Role"] = nil
+    Rbac::Filterer.filtered(MiqUserRole).each do |r|
+      @admin_roles[r.name] = r.id
+    end
+
+    @member_roles = {}
+    @member_roles["Choose Member Role"] = nil
+    Rbac::Filterer.filtered(MiqUserRole).each do |r|
+      @member_roles[r.name] = r.id
+    end
+
+    @number_of_new_users = @ems.new_users.count
+  end
 end

--- a/app/helpers/application_helper/button/provider_user_sync.rb
+++ b/app/helpers/application_helper/button/provider_user_sync.rb
@@ -2,6 +2,13 @@ class ApplicationHelper::Button::ProviderUserSync < ApplicationHelper::Button::B
   needs :@record
 
   def visible?
-    @record.class == ManageIQ::Providers::Openstack::CloudManager
+    # If tenant mapping is not enabled, then the provider will have no
+    # tenants being refreshed into the ems. This means no groups can
+    # be created because groups require a tenant and role pair. If
+    # no groups can be created, then any new users will have their
+    # current_group attribute set to nil. Users cannot login if
+    # they do not have a current group. Therefore user sync is
+    # a noop if tenant mapping is not enabled.
+    @record.class == ManageIQ::Providers::Openstack::CloudManager && @record.tenant_mapping_enabled == true
   end
 end

--- a/app/helpers/application_helper/button/provider_user_sync.rb
+++ b/app/helpers/application_helper/button/provider_user_sync.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::ProviderUserSync < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+    @record.class == ManageIQ::Providers::Openstack::CloudManager
+  end
+end

--- a/app/helpers/application_helper/toolbar/ems_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cloud_center.rb
@@ -19,6 +19,13 @@ class ApplicationHelper::Toolbar::EmsCloudCenter < ApplicationHelper::Toolbar::B
           :confirm => N_("Refresh relationships and power states for all items related to this Cloud Provider?")),
         separator,
         button(
+          :ems_cloud_user_sync,
+          'pficon pficon-edit fa-lg',
+          t = N_('Sync Users from Cloud Provider'),
+          t,
+          :url   => "/sync_users",
+          :klass => ApplicationHelper::Button::ProviderUserSync),
+        button(
           :ems_cloud_edit,
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Cloud Provider'),

--- a/app/views/ems_cloud/sync_users.html.haml
+++ b/app/views/ems_cloud/sync_users.html.haml
@@ -1,0 +1,44 @@
+= render :partial => "layouts/flash_msg"
+= form_tag('/ems_cloud/sync_users', :method => :post)
+= hidden_field_tag('id', @ems.id)
+- unless @ems.nil?
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Number of New Users')
+      .col-md-8
+        = @number_of_new_users
+    .form-group
+      %label.col-md-2.control-label
+        = _('Admin Role')
+      .col-md-8
+        = select_tag('admin_role',
+            options_for_select(@admin_roles.sort, @selected_admin_role),
+            :class  => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+    .form-group
+      %label.col-md-2.control-label
+        = _('Member Role')
+      .col-md-8
+        = select_tag('member_role',
+            options_for_select(@member_roles.sort, @selected_member_role),
+            :class  => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+  %table{:width => "100%"}
+    %tr
+      %td{:align => "right"}
+        #buttons_on
+          = button_tag(_("Sync"),
+                       :name  => "sync",
+                       :class => "btn btn-primary",
+                       :alt   => t = _("Sync Users"),
+                       :title => t,
+                       :type  => "submit")
+          = button_tag(_("Cancel"),
+                       :name  => "cancel",
+                       :class => "btn btn-default",
+                       :alt   => t = _("Cancel"),
+                       :title => t,
+                       :type  => "submit")

--- a/app/views/ems_cloud/sync_users.html.haml
+++ b/app/views/ems_cloud/sync_users.html.haml
@@ -26,6 +26,22 @@
             :class  => "selectpicker")
         :javascript
           miqInitSelectPicker();
+    .form-group
+      %label.col-md-2.control-label
+        = _("Password")
+      .col-md-8
+        = password_field_tag("password",
+                             @selected_password,
+                             :maxlength         => 50,
+                             :class => "form-control")
+    .form-group
+      %label.col-md-2.control-label
+        = _("Confirm Password")
+      .col-md-8
+        = password_field_tag("verify",
+                             @selected_verify,
+                             :maxlength         => 50,
+                             :class => "form-control")
   %table{:width => "100%"}
     %tr
       %td{:align => "right"}

--- a/app/views/ems_cloud/sync_users.html.haml
+++ b/app/views/ems_cloud/sync_users.html.haml
@@ -1,19 +1,19 @@
 = render :partial => "layouts/flash_msg"
 = form_tag('/ems_cloud/sync_users', :method => :post)
-= hidden_field_tag('id', @ems.id)
-- unless @ems.nil?
+= hidden_field_tag('id', ems.id)
+- unless ems.nil?
   .form-horizontal
     .form-group
       %label.col-md-2.control-label
         = _('Number of New Users')
       .col-md-8
-        = @number_of_new_users
+        = number_of_new_users
     .form-group
       %label.col-md-2.control-label
         = _('Admin Role')
       .col-md-8
         = select_tag('admin_role',
-            options_for_select(@admin_roles.sort, @selected_admin_role),
+            options_for_select(admin_roles.sort, selected_admin_role),
             :class  => "selectpicker")
         :javascript
           miqInitSelectPicker();
@@ -22,7 +22,7 @@
         = _('Member Role')
       .col-md-8
         = select_tag('member_role',
-            options_for_select(@member_roles.sort, @selected_member_role),
+            options_for_select(member_roles.sort, selected_member_role),
             :class  => "selectpicker")
         :javascript
           miqInitSelectPicker();
@@ -31,7 +31,7 @@
         = _("Password")
       .col-md-8
         = password_field_tag("password",
-                             @selected_password,
+                             selected_password,
                              :maxlength         => 50,
                              :class => "form-control")
     .form-group
@@ -39,7 +39,7 @@
         = _("Confirm Password")
       .col-md-8
         = password_field_tag("verify",
-                             @selected_verify,
+                             selected_verify,
                              :maxlength         => 50,
                              :class => "form-control")
   %table{:width => "100%"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1140,6 +1140,7 @@ Rails.application.routes.draw do
         ems_cloud_form_fields
         protect
         show_list
+        sync_users
         tagging_edit
       ) +
                compare_get,
@@ -1158,6 +1159,7 @@ Rails.application.routes.draw do
         sections_field_changed
         show
         show_list
+        sync_users
         tag_edit_form_field_changed
         tagging_edit
         tl_chooser

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -620,5 +620,24 @@ describe EmsCloudController do
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include("A member role must be selected.")
     end
+
+    def verify_password_and_confirm(password, verify)
+      post :sync_users, :params => {:id => @ems.id, :sync => "",
+                                    :admin_role => 1, :member_role => 2,
+                                    :password => password,
+                                    :verify => verify}
+      expect(controller.send(:flash_errors?)).to be_truthy
+      flash_messages = assigns(:flash_array)
+      expect(flash_messages.first[:message]).to include("Password/Confirm Password do not match")
+    end
+
+    it "password and confirm must be equal" do
+      verify_password_and_confirm("apples", "oranges")
+    end
+
+    it "if password or confirm is not empty, then the other cannot be empty" do
+      verify_password_and_confirm("apples", nil)
+      verify_password_and_confirm(nil, "oranges")
+    end
   end
 end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -592,37 +592,37 @@ describe EmsCloudController do
   it_behaves_like "controller with custom buttons"
 
   describe "#sync_users" do
+    let(:ems) { FactoryGirl.create(:ems_openstack_with_authentication) }
     before do
       stub_user(:features => :all)
-      @ems = FactoryGirl.create(:ems_openstack_with_authentication)
     end
 
     it "redirects when request is successful" do
-      expect(controller).to receive(:find_record_with_rbac).and_return(@ems)
-      expect(@ems).to receive(:sync_users_queue)
-      post :sync_users, :params => {:id => @ems.id, :sync => "", :admin_role => 1, :member_role => 2}
+      expect(controller).to receive(:find_record_with_rbac).and_return(ems)
+      expect(ems).to receive(:sync_users_queue)
+      post :sync_users, :params => {:id => ems.id, :sync => "", :admin_role => 1, :member_role => 2}
       expect(controller.send(:flash_errors?)).to be_falsey
       expect(response.body).to include("Sync+users+queued.")
       expect(response.body).to include("redirected")
-      expect(response.body).to include("ems_cloud/#{@ems.id}")
+      expect(response.body).to include("ems_cloud/#{ems.id}")
     end
 
     it "returns error if admin role is not selected" do
-      post :sync_users, :params => {:id => @ems.id, :sync => "", :member_role => 2}
+      post :sync_users, :params => {:id => ems.id, :sync => "", :member_role => 2}
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include("An admin role must be selected.")
     end
 
     it "returns error if member role is not selected" do
-      post :sync_users, :params => {:id => @ems.id, :sync => "", :admin_role => 1}
+      post :sync_users, :params => {:id => ems.id, :sync => "", :admin_role => 1}
       expect(controller.send(:flash_errors?)).to be_truthy
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include("A member role must be selected.")
     end
 
     def verify_password_and_confirm(password, verify)
-      post :sync_users, :params => {:id => @ems.id, :sync => "",
+      post :sync_users, :params => {:id => ems.id, :sync => "",
                                     :admin_role => 1, :member_role => 2,
                                     :password => password,
                                     :verify => verify}


### PR DESCRIPTION
UI for queuing a user sync. The user is required to select an admin
and a member role to be matched with the admin and member role in
OpenStack.

The user sync is a process where
1. user accounts are created for users who are not in ManageIQ but
in OpenStack.
2. groups are created, if needed, for tenant/project and
corresponding role combinations in OpenStack.
3. users are added to miq_groups corresponding to their membership
in OpenStack projects and roles

Requires: https://github.com/ManageIQ/manageiq-providers-openstack/pull/124
Requries: https://github.com/ManageIQ/manageiq/pull/16293