### PR TITLE
Add cloud volume disk types to rate editor

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -523,6 +523,8 @@ class ChargebackController < ApplicationController
       end
 
       temp[:id] = params[:pressed] == 'chargeback_rates_copy' ? nil : detail.id
+      temp[:sub_metrics] = detail.sub_metrics
+      temp[:sub_metric_human] = detail.sub_metric_human
 
       tiers[detail_index] ||= []
 
@@ -560,7 +562,7 @@ class ChargebackController < ApplicationController
       @edit[:new][:code_currency] = ChargebackRateDetailCurrency.find(params[:currency]).code
     end
     @edit[:new][:details].each_with_index do |detail, detail_index|
-      %i{per_time per_unit}.each do |measure|
+      %i(per_time per_unit sub_metric).each do |measure|
         key = "#{measure}_#{detail_index}".to_sym
         detail[measure] = params[key] if params[key]
       end
@@ -584,6 +586,7 @@ class ChargebackController < ApplicationController
     @edit[:new][:details].each_with_index do |detail, detail_index|
       rate_detail = detail[:id] ? ChargebackRateDetail.find(detail[:id]) : ChargebackRateDetail.new
       rate_detail.attributes = detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES)
+      rate_detail.sub_metric = detail[:sub_metric] if rate_detail.sub_metric
       rate_detail_edit = @edit[:new][:details][detail_index]
       # C: Record the currency selected in the edit view, in my chargeback_rate_details table
       rate_detail.chargeback_rate_detail_currency_id = rate_detail_edit[:currency]

--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -1,9 +1,12 @@
 - url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => @edit[:rec_id] || "new")
+- breakdown_present = @edit[:new][:details].any? { |d| d[:sub_metric].present? }
 %table.table.table-bordered{:id => "chargeback_rate_edit_form"}
   %thead
     %tr
       %th{:rowspan => "2"}= _('Group')
       %th{:rowspan => "2"}= _('Description')
+      - if breakdown_present
+        %th{:rowspan => '2'}= _('Sub Metric')
       %th{:rowspan => "2"}= _('Per Time')
       %th{:rowspan => "2"}= _('Per Unit')
       %th{:colspan => "2"}= _('Range')
@@ -28,6 +31,11 @@
           = h(rate_detail_group(detail[:group]))
         %td{:rowspan => num_tiers}
           = detail[:description]
+        - if breakdown_present
+          %td{:rowspan => num_tiers}
+            - sub_metrics = detail[:sub_metrics]
+            - if sub_metrics.present?
+              = detail[:sub_metric_human]
         %td{:rowspan => num_tiers}
           = select_tag("per_time_#{detail_index}",
             options_for_select(@edit[:new][:per_time_types].invert, detail[:per_time]),

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -1,3 +1,4 @@
+- breakdown_present = @record.chargeback_rate_details.any? { |d| d.sub_metric.present? }
 %h3= _('Basic Info')
 .form-horizontal.static
   .form-group
@@ -13,6 +14,9 @@
     %tr
       %th{:rowspan => "2"}= _('Group')
       %th{:rowspan => "2"}= _('Description')
+      - if breakdown_present
+        %th{:rowspan => '2'}= _('Sub Metric')
+
       %th{:colspan => "2"}= _('Range')
       %th{:colspan => "2"}= _('Rate')
       %th{:rowspan => "2"}= _('Units')
@@ -36,6 +40,10 @@
           = h(rate_detail_group(detail.chargeable_field[:group]))
         %td{:rowspan => num_tiers}
           = detail.chargeable_field[:description]
+          - if breakdown_present
+            %td{:rowspan => num_tiers}
+              - if detail.sub_metrics.present?
+                = detail.sub_metric_human
         - tier = tiers.first
         %td
           = tier.start ? tier.start : 0

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -23,7 +23,7 @@
       %th= _("Variable")
   %tbody
     /Currency code is the same for all the chargeback_rate_details
-    - @record.chargeback_rate_details.to_a.sort_by { |rd| [rd.chargeable_field[:group].downcase, rd.chargeable_field[:description].downcase] }.each_with_index do |detail, detail_index|
+    - @record.chargeback_rate_details.to_a.sort_by { |rd| [rd.chargeable_field[:group].downcase, rd.chargeable_field[:description].downcase, rd[:sub_metric].to_s.downcase] }.each_with_index do |detail, detail_index|
     - tiers = detail.chargeback_tiers.order(:start)
       - @cur_group = detail.chargeable_field[:group] if @cur_group.nil?
       - if @cur_group != detail.chargeable_field[:group]

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -2,12 +2,18 @@
 - r = @edit[:new][:details][i.to_i]
 - url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => (@edit[:rec_id] || "new"))
 - n = @edit[:new][:num_tiers][i.to_i]
+- breakdown_present = @edit[:new][:details].any? { |d| d[:sub_metric].present? }
 
 %tr.rdetail{:id => "rate_detail_row_#{i}_0"}
   %td{:rowspan => n.to_s}
     = Dictionary.gettext(r[:group], :type => :rate_detail_group, :notfound => :titleize)
   %td{:rowspan => n.to_s}
     = r[:description]
+    - if breakdown_present
+      %td{:rowspan => n.to_s}
+        - sub_metrics = r[:sub_metrics]
+        - if sub_metrics.present?
+          = r[:sub_metric_human]
   %td{:rowspan => n.to_s}
     = select_tag("per_time_#{i}",
       options_for_select(ChargebackRateDetail::PER_TIME_TYPES.invert, @edit[:new][:details][i.to_i][:per_time]),


### PR DESCRIPTION
Before change our chargeback rate editor for storage type looks like this:

![screen shot 2017-10-24 at 10 45 33](https://user-images.githubusercontent.com/14937244/31933132-855d9704-b8a8-11e7-8113-b04564f9a410.png)

After this change, when you have cloud volume types, the metric 'Allocated Storage Metric' is extended  by items in cloud volumes types in
`Storage -> Block Storage -> Cloud Volumes `

So you can populate rates for this new dynamic cloud volume types. 
The change is for newly added rates.

Test Scenario
----------------

![cpsefwjltg](https://user-images.githubusercontent.com/14937244/31933720-3503d186-b8aa-11e7-94de-c1beafe50ab6.gif)

@miq-bot assign @mzazrivec 
cc @gtanzillo 


Links
----------------
* https://github.com/ManageIQ/manageiq/pull/16264 - backend merged