### PR TITLE
Allow configuring hawkular tenant names in settings

### DIFF
--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -163,7 +163,12 @@ class HawkularProxyService
   end
 
   def labelize(id)
-    TENANT_LABEL_SPECIAL_CASES.fetch(id, id.truncate(TENANT_LABEL_MAX_LEN))
+    tenant_labels = TENANT_LABEL_SPECIAL_CASES.symbolize_keys
+    if Settings.hawkular_tenant_labels
+      tenant_labels.merge!(Settings.hawkular_tenant_labels.to_hash)
+    end
+
+    tenant_labels.fetch(id.to_sym, id.truncate(TENANT_LABEL_MAX_LEN))
   end
 
   def _metric_definitions(params)


### PR DESCRIPTION
**Description**
Compute -> Containers -> Providers -> Choose provider -> Monitoring -> Ad-hoc metrics

Allow configuring hawkular tenant labels in settings, so users can make the labels look good in the UI.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1503541

**Before**
![hawkular_admin_before](https://user-images.githubusercontent.com/498903/31939002-c4675c78-b8c1-11e7-82f5-f5ccf7ef58a2.png)

**After**
![hawkular_admin_after](https://user-images.githubusercontent.com/498903/31939116-199a952a-b8c2-11e7-9af7-6a6d6af9071c.png)


**Settings**
![hawkular_settings](https://user-images.githubusercontent.com/498903/31939037-ddba0c3e-b8c1-11e7-95c1-c7e59a2d8d4d.png)
