### PR TITLE
v2v: Extend 'VM Transform' dialog to select VMs by tag

### DIFF
--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -75,16 +75,18 @@ class VmInfraController < ApplicationController
   has_custom_buttons
 
   def simple_dialog_initialize(ra, options)
-    @edit = {}
-    @edit[:new] = options[:dialog] || {}
-    @edit[:wf] = ResourceActionWorkflow.new(@edit[:new], current_user, ra, {})
     @record = Dialog.find_by(:id => ra.dialog_id.to_i)
-    @edit[:rec_id]   = @record.id
-    @edit[:key]      = "dialog_edit__#{@edit[:rec_id] || "new"}"
-    @edit[:explorer] = @explorer ? @explorer : false
-    @edit[:dialog_mode] = options[:dialog_mode]
-    @edit[:current] = copy_hash(@edit[:new])
-    @edit[:right_cell_text] = options[:header].to_s
+    new = options[:dialog] || {}
+    @edit = {
+      :new             => new,
+      :wf              => ResourceActionWorkflow.new(new, current_user, ra, {}),
+      :rec_id          => @record.id,
+      :key             => "dialog_edit__#{@record.id || "new"}",
+      :explorer        => @explorer || false,
+      :dialog_mode     => options[:dialog_mode],
+      :current         => copy_hash(new),
+      :right_cell_text => options[:header].to_s
+    }
     @in_a_form = true
     @changed = session[:changed] = true
     if @edit[:explorer]
@@ -95,10 +97,10 @@ class VmInfraController < ApplicationController
   end
 
   def vm_transform
+    dialog = Dialog.find_by(:label => 'Transform VM')
     if params.key?(:id)
       vm = Vm.find_by(:id => params[:id].to_i)
       @right_cell_text = _("Transform VM %{name} to RHV") % {:name => vm.name}
-      dialog = Dialog.find_by(:label => 'Transform VM')
       dialog_initialize(
         dialog.resource_actions.first,
         :header     => @right_cell_text,
@@ -107,7 +109,6 @@ class VmInfraController < ApplicationController
       )
     else
       @right_cell_text = _("Transform VMs to RHV")
-      dialog = Dialog.find_by(:label => 'Transform VM')
       simple_dialog_initialize(
         dialog.resource_actions.first,
         :header => @right_cell_text

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -90,12 +90,12 @@ class VmInfraController < ApplicationController
     if @edit[:explorer]
       replace_right_cell(:action => "dialog_provision")
     else
-      javascript_redirect :action => 'dialog_load'
+      javascript_redirect(:action => 'dialog_load')
     end
   end
 
   def vm_transform
-    if params.has_key?(:id)
+    if params.key?(:id)
       vm = Vm.find_by(:id => params[:id].to_i)
       @right_cell_text = _("Transform VM %{name} to RHV") % {:name => vm.name}
       dialog = Dialog.find_by(:label => 'Transform VM')

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -77,7 +77,7 @@ class VmInfraController < ApplicationController
   def simple_dialog_initialize(ra, options)
     @record = Dialog.find_by(:id => ra.dialog_id.to_i)
     new = options[:dialog] || {}
-    id = @record.present? ? @record.id : nil
+    id = @record.try(:id)
     @edit = {
       :new             => new,
       :wf              => ResourceActionWorkflow.new(new, current_user, ra, {}),

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -77,11 +77,12 @@ class VmInfraController < ApplicationController
   def simple_dialog_initialize(ra, options)
     @record = Dialog.find_by(:id => ra.dialog_id.to_i)
     new = options[:dialog] || {}
+    id = @record.present? ? @record.id : nil
     @edit = {
       :new             => new,
       :wf              => ResourceActionWorkflow.new(new, current_user, ra, {}),
-      :rec_id          => @record.id,
-      :key             => "dialog_edit__#{@record.id || "new"}",
+      :rec_id          => id,
+      :key             => "dialog_edit__#{id || "new"}",
       :explorer        => @explorer || false,
       :dialog_mode     => options[:dialog_mode],
       :current         => copy_hash(new),

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -78,7 +78,7 @@ class VmInfraController < ApplicationController
     @edit = {}
     @edit[:new] = options[:dialog] || {}
     @edit[:wf] = ResourceActionWorkflow.new(@edit[:new], current_user, ra, {})
-    @record = Dialog.find_by_id(ra.dialog_id.to_i)
+    @record = Dialog.find_by(:id => ra.dialog_id.to_i)
     @edit[:rec_id]   = @record.id
     @edit[:key]      = "dialog_edit__#{@edit[:rec_id] || "new"}"
     @edit[:explorer] = @explorer ? @explorer : false

--- a/app/helpers/application_helper/button/mass_transform_vm_button.rb
+++ b/app/helpers/application_helper/button/mass_transform_vm_button.rb
@@ -10,6 +10,6 @@ class ApplicationHelper::Button::MassTransformVmButton < ApplicationHelper::Butt
 
   def destination_exists?
     # Is there a provider that supports import?
-    !EmsInfra.all.select(&:validate_import_vm).empty?
+    !ManageIQ::Providers::Redhat::InfraManager.all.select(&:validate_import_vm).empty?
   end
 end

--- a/app/helpers/application_helper/button/mass_transform_vm_button.rb
+++ b/app/helpers/application_helper/button/mass_transform_vm_button.rb
@@ -1,0 +1,17 @@
+class ApplicationHelper::Button::MassTransformVmButton < ApplicationHelper::Button::Basic
+
+  def visible?
+    true
+  end
+
+  def disabled?
+    @error_message = _('No suitable target infra provider exists') unless destination_exists?
+    @error_message.present?
+  end
+
+  def destination_exists?
+    # Is there a provider that supports import?
+    !EmsInfra.all.select(&:validate_import_vm).empty?
+  end
+
+end

--- a/app/helpers/application_helper/button/mass_transform_vm_button.rb
+++ b/app/helpers/application_helper/button/mass_transform_vm_button.rb
@@ -1,5 +1,4 @@
 class ApplicationHelper::Button::MassTransformVmButton < ApplicationHelper::Button::Basic
-
   def visible?
     true
   end
@@ -13,5 +12,4 @@ class ApplicationHelper::Button::MassTransformVmButton < ApplicationHelper::Butt
     # Is there a provider that supports import?
     !EmsInfra.all.select(&:validate_import_vm).empty?
   end
-
 end

--- a/app/helpers/application_helper/button/mass_transform_vm_button.rb
+++ b/app/helpers/application_helper/button/mass_transform_vm_button.rb
@@ -10,6 +10,6 @@ class ApplicationHelper::Button::MassTransformVmButton < ApplicationHelper::Butt
 
   def destination_exists?
     # Is there a provider that supports import?
-    !ManageIQ::Providers::Redhat::InfraManager.all.select(&:validate_import_vm).empty?
+    ManageIQ::Providers::Redhat::InfraManager.all.detect(&:validate_import_vm).present?
   end
 end

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -190,6 +190,13 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :onwhen       => "1+",
           :klass        => ApplicationHelper::Button::BasicImage),
         button(
+          :vm_transform,
+          'fa fa-random fa-lg',
+          t = N_('Transform tagged VMs to RHV'),
+          t,
+          :klass => ApplicationHelper::Button::MassTransformVmButton
+        ),
+        button(
           :vm_retire,
           'fa fa-clock-o fa-lg',
           N_('Set Retirement Dates for the selected items'),


### PR DESCRIPTION
Added a new button in the toolbar under 'Lifecycle' that opens the 'VM
Transform' dialog with ability to start transformation of several VMs
marked with some tag.

Depends on https://github.com/ManageIQ/manageiq-providers-ovirt/pull/115
Depends on https://github.com/ManageIQ/manageiq-content/pull/200

![screenshot from 2017-10-24 19-37-47](https://user-images.githubusercontent.com/1369041/32011136-8d6cda62-b9bc-11e7-8099-bdce6db43bd0.png)

![screenshot from 2017-10-24 20-04-51](https://user-images.githubusercontent.com/1369041/32011137-8d8e81bc-b9bc-11e7-868c-f895cc22e9a1.png)