### PR TITLE
Fix styling issues on  vm reconfigure request screen

### DIFF
--- a/app/views/miq_request/_reconfigure_show.html.haml
+++ b/app/views/miq_request/_reconfigure_show.html.haml
@@ -1,57 +1,49 @@
 #main_div
-  %fieldset
-    %h3
-      = _("Options")
-    .form-horizontal
-      - if @options[:vm_memory]
-        .form-group
-          %label.control-label.col-md-2
-            = _("Memory")
-          .col-md-8
-            = h(@options[:vm_memory])
-            &nbsp;
-            = @options[:mem_typ]
-      - if @options[:number_of_sockets]
-        .form-group
-          %label.control-label.col-md-2
-            = _("Processor Sockets")
-          .col-md-8
-            = h(@options[:number_of_sockets])
-      - if @options[:cores_per_socket]
-        .form-group
-          %label.control-label.col-md-2
-            = _("Processor Cores_Per_Socket")
-          .col-md-8
-            = h(@options[:cores_per_socket])
-      - if @options[:number_of_cpus]
-        %tr
-          %td.key
-            = _("Total Processors")
-          %td
-            = h(@options[:number_of_cpus])
-      - if @options[:disk_add]
-        .form-group
-          %label.control-label.col-md-2
-            = _("Add Disks")
-          .col-md-8
-            = h(@options[:disk_add].size)
-            &nbsp;
-      - if @options[:disk_remove]
-        .form-group
-          %label.control-label.col-md-2
-            = _("Remove Disks")
-          .col-md-8
-            = h(@options[:disk_remove].size)
-            &nbsp;
-
-  %fieldset
-    %h3
-      = _("Affected VMs")
-    .form-horizontal
+  %hr
+  %h3
+    = _("Options")
+  .form-horizontal
+    - if @options[:vm_memory]
       .form-group
         %label.control-label.col-md-2
+          = _("Memory")
         .col-md-8
-          - if @view
-            - @embedded = true
-            - @gtl_type = "list"
-            = render :partial => "layouts/gtl"
+          = h(@options[:vm_memory])
+          = @options[:mem_typ]
+    - if @options[:number_of_sockets]
+      .form-group
+        %label.control-label.col-md-2
+          = _("Processor Sockets")
+        .col-md-8
+          = h(@options[:number_of_sockets])
+    - if @options[:cores_per_socket]
+      .form-group
+        %label.control-label.col-md-2
+          = _("Processor Cores_Per_Socket")
+        .col-md-8
+          = h(@options[:cores_per_socket])
+    - if @options[:number_of_cpus]
+      %tr
+        %td.key
+          = _("Total Processors")
+        %td
+          = h(@options[:number_of_cpus])
+    - if @options[:disk_add]
+      .form-group
+        %label.control-label.col-md-2
+          = _("Add Disks")
+        .col-md-8
+          = h(@options[:disk_add].size)
+    - if @options[:disk_remove]
+      .form-group
+        %label.control-label.col-md-2
+          = _("Remove Disks")
+        .col-md-8
+          = h(@options[:disk_remove].size)
+  %hr
+  %h3
+    = _("Affected VMs")
+  - if @view
+    - @embedded = true
+    - @gtl_type = "list"
+    = render :partial => "layouts/gtl"

--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -3,107 +3,104 @@
 #request_div
   %h3
     = _("Request Details")
-  .row
-    .form-horizontal.static
+
+  .form-horizontal
+    .form-group
+      %label.control-label.col-md-2
+        = _("Request ID")
+      .col-md-8
+        = h(number_with_delimiter(@miq_request.id))
+    .form-group
+      %label.control-label.col-md-2
+        = _("Status")
+      .col-md-8
+        = h(@miq_request.status)
+    .form-group
+      %label.control-label.col-md-2
+        = _("Request State")
+      .col-md-8
+        = h(@miq_request.state.titleize)
+    - if @miq_request.requester
       .form-group
         %label.control-label.col-md-2
-          = _("Request ID")
+          = _("Requester")
         .col-md-8
-          = h(number_with_delimiter(@miq_request.id))
+          = h(@miq_request.requester_name)
+    .form-group
+      %label.control-label.col-md-2
+        = _("Request Type")
+      .col-md-8
+        = h(@miq_request.request_type_display)
+    .form-group
+      %label.control-label.col-md-2
+        = _("Description")
+      .col-md-8
+        = h(@miq_request.description)
+    .form-group
+      %label.control-label.col-md-2
+        = _("Last Message")
+      .col-md-8
+        = h(@miq_request.message)
+    .form-group
+      %label.control-label.col-md-2
+        = _("Created On")
+      .col-md-8
+        = h(format_timezone(@miq_request.created_on))
+    .form-group
+      %label.control-label.col-md-2
+        = _("Last Update")
+      .col-md-8
+        = h(format_timezone(@miq_request.updated_on))
+    - if @miq_request.fulfilled_on
       .form-group
         %label.control-label.col-md-2
-          = _("Status")
+          = _("Completed")
         .col-md-8
-          = h(@miq_request.status)
+          = h(format_timezone(@miq_request.fulfilled_on))
+    .form-group
+      %label.control-label.col-md-2
+        = _("Approval State")
+      .col-md-8
+        = h(@miq_request.approval_state.titleize)
+    - if @miq_request.stamped_by
       .form-group
         %label.control-label.col-md-2
-          = _("Request State")
+          = _("Approved/Denied by")
         .col-md-8
-          = h(@miq_request.state.titleize)
-      - if @miq_request.requester
+          = h(@miq_request.stamped_by + (@user && " (#{@user.name})"))
+    .form-group
+      %label.control-label.col-md-2
+        = _("Approved/Denied on")
+      .col-md-8
+        = h(format_timezone(@miq_request.stamped_on))
+    .form-group
+      %label.control-label.col-md-2
+        = _("Reason")
+      - if @edit && @edit[:stamp_typ]
+        .col-md-8
+          = text_field_tag("reason", @edit[:reason],
+            :class             => "form-control",
+            :maxlength         => ViewHelper::MAX_NAME_LEN,
+            "data-miq_focus"   => true,
+            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+      - else
+        .col-md-8
+          = h(@miq_request.reason)
+    - if !@edit && @miq_request.approval_state.downcase == "approved"
+      - if @miq_request.resource_type == "MiqProvisionRequest" && @miq_request.resource.miq_provisions.length > 0
         .form-group
           %label.control-label.col-md-2
-            = _("Requester")
-          .col-md-8
-            = h(@miq_request.requester_name)
-      .form-group
-        %label.control-label.col-md-2
-          = _("Request Type")
-        .col-md-8
-          = h(@miq_request.request_type_display)
-    .form-horizontal.static
-      .form-group
-        %label.control-label.col-md-2
-          = _("Description")
-        .col-md-8
-          = h(@miq_request.description)
-      .form-group
-        %label.control-label.col-md-2
-          = _("Last Message")
-        .col-md-8
-          = h(@miq_request.message)
-      .form-group
-        %label.control-label.col-md-2
-          = _("Created On")
-        .col-md-8
-          = h(format_timezone(@miq_request.created_on))
-      .form-group
-        %label.control-label.col-md-2
-          = _("Last Update")
-        .col-md-8
-          = h(format_timezone(@miq_request.updated_on))
-      - if @miq_request.fulfilled_on
+            = _("Provisioned VMs")
+          .col-md-8{:onclick => "DoNav('#{'/miq_request/show/' << @miq_request.id.to_s << '?display=miq_provisions'}');",
+                    :title   => _("Click to view details")}
+            = h(@miq_request.resource.miq_provisions.length)
+      - if @miq_request.resource_type == "MiqHostProvisionRequest" && @miq_request.resource.miq_host_provisions.length > 0
         .form-group
           %label.control-label.col-md-2
-            = _("Completed")
-          .col-md-8
-            = h(format_timezone(@miq_request.fulfilled_on))
-  .row
-    .form-horizontal
-      .form-group
-        %label.control-label.col-md-2
-          = _("Approval State")
-        .col-md-8
-          = h(@miq_request.approval_state.titleize)
-      - if @miq_request.stamped_by
-        .form-group
-          %label.control-label.col-md-2
-            = _("Approved/Denied by")
-          .col-md-8
-            = h(@miq_request.stamped_by + (@user && " (#{@user.name})"))
-      .form-group
-        %label.control-label.col-md-2
-          = _("Approved/Denied on")
-        .col-md-8
-          = h(format_timezone(@miq_request.stamped_on))
-      .form-group
-        %label.control-label.col-md-2
-          = _("Reason")
-        - if @edit && @edit[:stamp_typ]
-          .col-md-8
-            = text_field_tag("reason", @edit[:reason],
-              :class             => "form-control",
-              :maxlength         => ViewHelper::MAX_NAME_LEN,
-              "data-miq_focus"   => true,
-              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-        - else
-          .col-md-8
-            = h(@miq_request.reason)
-      - if !@edit && @miq_request.approval_state.downcase == "approved"
-        - if @miq_request.resource_type == "MiqProvisionRequest" && @miq_request.resource.miq_provisions.length > 0
-          .form-group
-            %label.control-label.col-md-2
-              = _("Provisioned VMs")
-            .col-md-8{:onclick => "DoNav('#{'/miq_request/show/' << @miq_request.id.to_s << '?display=miq_provisions'}');",
-                      :title   => _("Click to view details")}
-              = h(@miq_request.resource.miq_provisions.length)
-        - if @miq_request.resource_type == "MiqHostProvisionRequest" && @miq_request.resource.miq_host_provisions.length > 0
-          .form-group
-            %label.control-label.col-md-2
-              = _("Provisioned Hosts")
-            .col-md-8{:title => _("Click to view details"),
-                      :onclick => "DoNav('#{'/miq_request/show/' << @miq_request.id.to_s << '?display=miq_provisions'}');"}
-              = h(@miq_request.resource.miq_host_provisions.length)
+            = _("Provisioned Hosts")
+          .col-md-8{:title => _("Click to view details"),
+                    :onclick => "DoNav('#{'/miq_request/show/' << @miq_request.id.to_s << '?display=miq_provisions'}');"}
+            = h(@miq_request.resource.miq_host_provisions.length)
   - if @edit && @edit[:stamp_typ]
     %table{:width => "100%"}
       %tr


### PR DESCRIPTION
This PR fixes numerous styling issues on the vm reconfigure request screen

https://bugzilla.redhat.com/show_bug.cgi?id=1501209

Before
<img width="1463" alt="screen shot 2017-10-24 at 1 25 28 pm" src="https://user-images.githubusercontent.com/1287144/31958415-af27a3d8-b8bf-11e7-84b9-dc7f3bc4421c.png">


After
<img width="1440" alt="screen shot 2017-10-24 at 1 25 43 pm" src="https://user-images.githubusercontent.com/1287144/31958413-af165c9a-b8bf-11e7-91a1-d830ec21c024.png">