### PR TITLE
My Settings Physical Infrastructure text typo

### DIFF
--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -146,7 +146,7 @@
         - if has_any_role?(%w(ems_physical_infra_show_list physical_server_show_list))
           %fieldset
             %h3
-              = _('Phyisical Infrascructure')
+              = _('Physical Infrastructure')
             - {:manageiq_providers_physicalinframanager => ["ems_physical_infra_show_list", _('Providers')],
               :physicalserver                           => ["physical_server_show_list",    _('Servers')],
               }.each do |resource, (feature, view_name)|


### PR DESCRIPTION
Fixed misspelled label on the page.

https://bugzilla.redhat.com/show_bug.cgi?id=1505469


Screen shot prior to code fix:
![physical infrastructure typo](https://user-images.githubusercontent.com/552686/31966562-ec101b2c-b8bf-11e7-92d9-db2890eaf6ef.png)


Screen shot post code fix:
![physical infrastructure type after code fix](https://user-images.githubusercontent.com/552686/31966577-f53b59f0-b8bf-11e7-8c58-2626741bde9f.png)


