### PR TITLE
Replace :conditions in favor of :named_scope

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -82,7 +82,7 @@ class ChargebackController < ApplicationController
     @sortcol = session[:rates_sortcol].nil? ? 0 : session[:rates_sortcol].to_i
     @sortdir = session[:rates_sortdir].nil? ? "ASC" : session[:rates_sortdir]
 
-    @view, @pages = get_view(ChargebackRate, :conditions => ["rate_type=?", x_node.split('-').last])  # Get the records (into a view) and the paginator
+    @view, @pages = get_view(ChargebackRate, :named_scope => [[:with_rate_type, x_node.split('-').last]]) # Get the records (into a view) and the paginator
 
     @current_page = @pages[:current] unless @pages.nil?  # save the current page number
     session[:rates_sortcol] = @sortcol

--- a/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -155,7 +155,7 @@ module MiqAeCustomizationController::OldDialogs
     if x_node == "root"
       @view, @pages = get_view(MiqDialog) # Get the records (into a view) and the paginator
     else
-      @view, @pages = get_view(MiqDialog, :conditions => ["dialog_type=?", x_node.split('_').last]) # Get the records (into a view) and the paginator
+      @view, @pages = get_view(MiqDialog, :named_scope => [[:with_dialog_type, x_node.split('_').last]]) # Get the records (into a view) and the paginator
     end
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -185,7 +185,7 @@ module MiqPolicyController::Policies
   end
 
   def policy_get_all
-    peca_get_all('policy', -> { get_view(MiqPolicy, :conditions => ["mode = ? and towhat = ?", @sb[:mode].downcase, @sb[:nodeid].camelize]) })
+    peca_get_all('policy', -> { get_view(MiqPolicy, :named_scope => [[:with_mode, @sb[:mode].downcase], [:with_towhat, @sb[:nodeid].camelize]]) })
   end
 
   def policies_node(mode, towhat)

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -181,7 +181,7 @@ class MiqRequestController < ApplicationController
       @listicon = "miq_request"
       @no_checkboxes = true
       @showlinks = true
-      @view, @pages = get_view(MiqProvision, :conditions => ["miq_request_id=?", @miq_request.id])  # Get all requests
+      @view, @pages = get_view(MiqProvision, :named_scope => [[:with_miq_request_id, @miq_request.id]]) # Get all requests
       drop_breadcrumb(:name => _("Provisioned VMs [%{description}]") % {:description => @miq_request.description},
                       :url  => "/miq_request/show/#{@miq_request.id}?display=#{@display}")
     end

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -406,7 +406,7 @@ module OpsController::Diagnostics
     @force_no_grid_xml = true
     if x_node.split("-").first == "z"
       zone = Zone.find_by_id(from_cid(x_node.split("-").last))
-      @view, @pages = get_view(MiqServer, :conditions => ["zone_id=?", zone.id]) # Get the records (into a view) and the paginator
+      @view, @pages = get_view(MiqServer, :named_scope => [[:with_zone_id, zone.id]]) # Get the records (into a view) and the paginator
     else
       @view, @pages = get_view(MiqServer) # Get the records (into a view) and the paginator
     end
@@ -556,7 +556,7 @@ module OpsController::Diagnostics
     @showlinks = true
     status = ["started", "ready", "working"]
     # passing all_pages option to show all records on same page
-    @view, @pages = get_view(MiqWorker, :conditions => ["(miq_server_id = ? and status IN (?))", @sb[:selected_server_id], status], :all_pages => true) # Get the records (into a view) and the paginator
+    @view, @pages = get_view(MiqWorker, :named_scope => [[:with_miq_server_id, @sb[:selected_server_id]], [:with_status, status]], :all_pages => true) # Get the records (into a view) and the paginator
     # setting @embedded and @pages to nil, we don't want to show sorting/paging bar on the screen'
     @embedded = @pages = nil
   end

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -393,7 +393,7 @@ module OpsController::Settings::Schedules
     @sortcol = session[:schedule_sortcol].nil? ? 0 : session[:schedule_sortcol].to_i
     @sortdir = session[:schedule_sortdir].nil? ? "ASC" : session[:schedule_sortdir]
 
-    @view, @pages = get_view(MiqSchedule, :conditions => ["prod_default!=? or prod_default IS NULL And adhoc IS NULL", "system"]) # Get the records (into a view) and the paginator
+    @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_prod_default_not_in, "system"], [:with_adhoc, nil]]) # Get the records (into a view) and the paginator
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number
     session[:schedule_sortcol] = @sortcol

--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -35,9 +35,9 @@ module PxeController::PxeCustomizationTemplates
     @sortdir = session[:ct_sortdir].nil? ? "ASC" : session[:ct_sortdir]
     pxe_img_id = x_node.split('-').last == "system" ? nil : x_node.split('-').last
     if pxe_img_id
-      @view, @pages = get_view(CustomizationTemplate, :conditions => ["pxe_image_type_id=?", from_cid(pxe_img_id)]) # Get the records (into a view) and the paginator
+      @view, @pages = get_view(CustomizationTemplate, :named_scope => [[:with_pxe_image_type_id, from_cid(pxe_img_id)]]) # Get the records (into a view) and the paginator
     else
-      @view, @pages = get_view(CustomizationTemplate, :conditions => ["system=?", true])  # Get the records (into a view) and the paginator
+      @view, @pages = get_view(CustomizationTemplate, :named_scope => [:with_system]) # Get the records (into a view) and the paginator
     end
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -38,9 +38,9 @@ module ReportController::Schedules
     @sortdir = session[:schedule_sortdir].nil? ? "ASC" : session[:schedule_sortdir]
 
     if super_admin_user? # Super admins see all user's schedules
-      @view, @pages = get_view(MiqSchedule, :conditions => ["towhat=?", "MiqReport"]) # Get the records (into a view) and the paginator
+      @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_towhat, "MiqReport"]]) # Get the records (into a view) and the paginator
     else
-      @view, @pages = get_view(MiqSchedule, :conditions => ["towhat=? AND userid=?", "MiqReport", session[:userid]])  # Get the records (into a view) and the paginator
+      @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_towhat, "MiqReport"], [:with_userid, session[:userid]]]) # Get the records (into a view) and the paginator
     end
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number


### PR DESCRIPTION
Remove `:conditions` from get_view params where possible and replace
it with scopes.

Depends on: https://github.com/ManageIQ/manageiq/pull/16303
Should help with: https://github.com/ManageIQ/manageiq-ui-classic/pull/2383