### PR TITLE
Implement clickable labels for provisioning radio buttons

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -450,9 +450,10 @@
               - checked = options[field] && options[field][0] == f[0]
               - current_div = "#{@edit[:new][:current_tab_key]}"
               - onclick = remote_function(:with => "miqSerializeField('#{current_div}', '#{field_id}')", :url => url, :loading => "miqSparkle(true);", :complete => "miqSparkle(false);")
-              .radio-inline
-                %input{:type => "radio", :id => field_id, :value => f[0], :name => field_id, :checked => checked, :onclick => disabled ? "" : onclick}
-                = f[1]
+              .radio
+                %label
+                  %input{:type => "radio", :id => field_id, :value => f[0], :name => field_id, :checked => checked, :onclick => disabled ? "" : onclick}
+                  = f[1]
           - else
             = options[field][1]
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?


### PR DESCRIPTION
This PR adjusts the markup around the provisioning dialog radio buttons to make the associated labels clickable.

https://bugzilla.redhat.com/show_bug.cgi?id=1503237

<img width="871" alt="screen shot 2017-10-25 at 12 33 39 pm" src="https://user-images.githubusercontent.com/1287144/32010844-e93f69c2-b980-11e7-9b6b-4de6b4950bf8.png">