### PR TITLE
Add missing VM count back to quadicon for Infra Providers

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -567,6 +567,7 @@ module QuadiconHelper
       # reduce font-size of the item_count so it will fit in its quadrant
       output << flobj_p_simple("a72", item_count, item_count.to_s.size > 2 ? "font-size: 12px;" : "")
       output << flobj_p_simple("b72", item.total_miq_templates) if item.kind_of?(EmsCloud)
+      output << flobj_p_simple("b72", item.total_vms) if item.kind_of?(EmsInfra)
       output << currentstate_icon(item.enabled? ? "on" : "paused") if item.kind_of?(::ManageIQ::Providers::ContainerManager)
       output << flobj_img_simple("svg/vendor-#{h(item.image_name)}.svg", "c72")
       output << flobj_img_simple(img_for_auth_status(item), "d72")

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -634,6 +634,7 @@ describe QuadiconHelper do
       @settings = {:quadicons => {:ems => true}}
       allow(item).to receive(:hosts).and_return(%w(foo bar))
       allow(item).to receive(:image_name).and_return("foo")
+      allow(item).to receive(:total_vms).and_return('42')
       @layout = "ems_infra"
     end
 
@@ -647,6 +648,10 @@ describe QuadiconHelper do
 
     it "displays Host Name in the tooltip" do
       expect(ext_quad).to match(/Hostname/)
+    end
+
+    it "displays the total VM count" do
+      expect(ext_quad).to have_selector('p', :text => item.total_vms.to_s)
     end
 
     context "when type is not listicon" do


### PR DESCRIPTION
@miq-bot add_labels bug, compute/infrastructure

https://bugzilla.redhat.com/show_bug.cgi?id=1501044