### PR TITLE
Add scopes selector for MiqTasks

### DIFF
--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -350,44 +350,21 @@ class MiqTaskController < ApplicationController
 
     # Specify user scope
     if @tabform == "tasks_1"
-      scope << [:with_user_id, session[:userid]]
+      scope << [:with_userid, session[:userid]]
     elsif opts[:user_choice] && opts[:user_choice] != "all"
-      scope << [:with_user_id, opts[:user_choice]]
+      scope << [:with_userid, opts[:user_choice]]
     end
-
-    # Add status scope
-    scope += status_scope(opts)
 
     # Add time scope
     if use_times
       t = format_timezone(opts[:time_period].to_i != 0 ? opts[:time_period].days.ago : Time.now, Time.zone, "raw")
-      scope << [:with_update_on_between, t.beginning_of_day..t.end_of_day]
+      scope << [:with_updated_on_between, t.beginning_of_day..t.end_of_day]
     end
 
     # Add zone scope
     scope << [:with_zone, opts[:zone]] if opts[:zone] && opts[:zone] != "<all>"
 
-    # Add state scope
-    scope << [:with_state, opts[:state_choice]] if opts[:state_choice] != "all"
-  end
-
-  def status_scope(opts)
-    scope = []
-    status_scopes = {
-      :ok      => [[:with_status, 'Finished'], [:with_status, 'Ok']],
-      :error   => [[:with_status, 'Finished'], [:with_status, 'Error']],
-      :warn    => [[:with_status, 'Finished'], [:with_status, 'Warn']],
-      :running => [[:with_status, 'Finished'], [:with_status, 'Waiting_to_start'], [:with_status, 'Queued']],
-      :queued  => [[:with_status, %w[Waiting_to_start Queued]]]
-    }
-
-    statuses = (opts.keys & status_scopes.keys)
-    if statuses.any?
-      statuses.each { |status| scope += status_scopes[status] }
-      scope
-    else
-      [[:without_status, %w[Ok Error Warn Finished Queued Waiting_to_start]]]
-    end
+    scope
   end
 
   def reload_tasks

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -79,7 +79,7 @@ class MiqTaskController < ApplicationController
     when "tasks_2", "alltasks_2" then @layout = "all_tasks"
     end
 
-    @view, @pages = get_view(MiqTask, :conditions => tasks_condition(@tasks_options[@tabform]))
+    @view, @pages = get_view(MiqTask, :named_scope => tasks_scopes(@tasks_options[@tabform]))
     @user_names = MiqTask.distinct.pluck("userid").delete_if(&:blank?) if @active_tab.to_i == 2
   end
 
@@ -342,6 +342,52 @@ class MiqTaskController < ApplicationController
 
   def build_query_for_state(opts)
     ["miq_tasks.state=?", opts[:state_choice]]
+  end
+
+  # Create a scope chain from the passed in options
+  def tasks_scopes(opts, use_times = true)
+    scope = []
+
+    # Specify user scope
+    if @tabform == "tasks_1"
+      scope << [:with_user_id, session[:userid]]
+    elsif opts[:user_choice] && opts[:user_choice] != "all"
+      scope << [:with_user_id, opts[:user_choice]]
+    end
+
+    # Add status scope
+    scope += status_scope(opts)
+
+    # Add time scope
+    if use_times
+      t = format_timezone(opts[:time_period].to_i != 0 ? opts[:time_period].days.ago : Time.now, Time.zone, "raw")
+      scope << [:with_update_on_between, t.beginning_of_day..t.end_of_day]
+    end
+
+    # Add zone scope
+    scope << [:with_zone, opts[:zone]] if opts[:zone] && opts[:zone] != "<all>"
+
+    # Add state scope
+    scope << [:with_state, opts[:state_choice]] if opts[:state_choice] != "all"
+  end
+
+  def status_scope(opts)
+    scope = []
+    status_scopes = {
+      :ok      => [[:with_status, 'Finished'], [:with_status, 'Ok']],
+      :error   => [[:with_status, 'Finished'], [:with_status, 'Error']],
+      :warn    => [[:with_status, 'Finished'], [:with_status, 'Warn']],
+      :running => [[:with_status, 'Finished'], [:with_status, 'Waiting_to_start'], [:with_status, 'Queued']],
+      :queued  => [[:with_status, %w[Waiting_to_start Queued]]]
+    }
+
+    statuses = (opts.keys & status_scopes.keys)
+    if statuses.any?
+      statuses.each { |status| scope += status_scopes[status] }
+      scope
+    else
+      [[:without_status, %w[Ok Error Warn Finished Queued Waiting_to_start]]]
+    end
   end
 
   def reload_tasks

--- a/spec/controllers/miq_task_controller_spec.rb
+++ b/spec/controllers/miq_task_controller_spec.rb
@@ -827,7 +827,7 @@ describe MiqTaskController do
       it 'sets the active tab' do
         controller.instance_variable_set(:@tabform, "ui_2")
         controller.instance_variable_set(:@tasks_options, {})
-        allow(controller).to receive(:tasks_condition)
+        allow(controller).to receive(:tasks_scopes)
         allow(controller).to receive(:get_view)
         controller.list_jobs
         expect(assigns(:active_tab)).to eq("2")


### PR DESCRIPTION
Copy the `tasks_condition` behavior, but return `:named_scopes` instead of `:conditions`.

In future replace the `tasks_condition` method, when possible.

Depends on: ManageIQ/manageiq/pull/16308, https://github.com/ManageIQ/manageiq/pull/16323
Should help with: #2383