### PR TITLE
Move tagging-related tabs into subtabs on the Settings/Region screen

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -903,7 +903,7 @@ function miqClickAndPop(el) {
   return false;
 }
 
-function miq_tabs_init(id, url) {
+function miq_tabs_init(id, url, parms) {
   $(id + ' > ul.nav-tabs a[data-toggle="tab"]').on('show.bs.tab', function(e) {
     if ($(e.target).parent().hasClass('disabled')) {
       e.preventDefault();
@@ -911,7 +911,11 @@ function miq_tabs_init(id, url) {
     } else if (typeof url != 'undefined') {
       // Load remote tab if an URL is specified
       var currTabTarget = $(e.target).attr('href').substring(1);
-      miqObserveRequest(url + '/?tab_id=' + currTabTarget, {beforeSend: true})
+      var urlParams = _.reduce(parms || [], function(sum, value, key) {
+        return sum + '&' + key + '=' + value;
+      }, '?tab_id=' + currTabTarget);
+
+      miqObserveRequest(url + urlParams, {beforeSend: true})
         .catch(function(err) {
           add_flash(__('Error requesting data from server'), 'error');
           console.log(err);

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1093,33 +1093,36 @@ module OpsController::Settings::Common
       when "settings_cu_collection"                                 # C&U collection settings
         cu_build_edit_screen
         @in_a_form = true
-      when "settings_co_categories"
-        category_get_all
-      when "settings_co_tags"
-        # dont hide the disabled categories, so user can remove tags from the disabled ones
-        cats = Classification.categories.sort_by(&:description)  # Get the categories, sort by name
-        @cats = {}                                        # Classifications array for first chooser
-        cats.each do |c|
-          @cats[c.description] = c.name unless c.read_only?    # Show the non-read_only categories
+      when "settings_tags"
+        case @sb[:active_subtab]
+        when "settings_co_categories"
+          category_get_all
+        when "settings_co_tags"
+          # dont hide the disabled categories, so user can remove tags from the disabled ones
+          cats = Classification.categories.sort_by(&:description)  # Get the categories, sort by name
+          @cats = {}                                        # Classifications array for first chooser
+          cats.each do |c|
+            @cats[c.description] = c.name unless c.read_only?    # Show the non-read_only categories
+          end
+          @cat = cats.first
+          ce_build_screen                                         # Build the Classification Edit screen
+        when "settings_import_tags"
+          @edit = {}
+          @edit[:new] = {}
+          @edit[:key] = "#{@sb[:active_tab]}_edit__#{@sb[:selected_server_id]}"
+          add_flash(_("Locate and upload a file to start the import process"), :info)
+          @in_a_form = true
+        when "settings_import"                                  # Import tab
+          @edit = {}
+          @edit[:new] = {}
+          @edit[:key] = "#{@sb[:active_tab]}_edit__#{@sb[:selected_server_id]}"
+          @edit[:new][:upload_type] = nil
+          @sb[:good] = nil unless @sb[:show_button]
+          add_flash(_("Choose the type of custom variables to be imported"), :info)
+          @in_a_form = true
+        when "settings_label_tag_mapping"
+          label_tag_mapping_get_all
         end
-        @cat = cats.first
-        ce_build_screen                                         # Build the Classification Edit screen
-      when "settings_import_tags"
-        @edit = {}
-        @edit[:new] = {}
-        @edit[:key] = "#{@sb[:active_tab]}_edit__#{@sb[:selected_server_id]}"
-        add_flash(_("Locate and upload a file to start the import process"), :info)
-        @in_a_form = true
-      when "settings_import"                                  # Import tab
-        @edit = {}
-        @edit[:new] = {}
-        @edit[:key] = "#{@sb[:active_tab]}_edit__#{@sb[:selected_server_id]}"
-        @edit[:new][:upload_type] = nil
-        @sb[:good] = nil unless @sb[:show_button]
-        add_flash(_("Choose the type of custom variables to be imported"), :info)
-        @in_a_form = true
-      when "settings_label_tag_mapping"
-        label_tag_mapping_get_all
       when "settings_rhn"
         @edit = session[:edit] || {}
         @edit[:new] ||= {}

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -46,6 +46,7 @@
           #settings_list
             = render :partial => "settings_list_tab"
       - else
+        = render(:partial => "layouts/flash_msg")
         %ul.nav.nav-tabs
           = miq_tab_header("settings_details", @sb[:active_tab]) do
             = _("Details")
@@ -63,7 +64,6 @@
           = miq_tab_content("settings_cu_collection", @sb[:active_tab]) do
             = render :partial => "settings_cu_collection_tab"
           = miq_tab_content("settings_tags", @sb[:active_tab]) do
-            = render(:partial => "layouts/flash_msg")
             #ops_tags_subtabs
               %ul.nav.nav-tabs.nav-tabs-pf{:style => 'font-size: 12px'}
                 = miq_tab_header("settings_co_categories", @sb[:active_subtab]) do

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -51,18 +51,8 @@
             = _("Details")
           = miq_tab_header("settings_cu_collection", @sb[:active_tab]) do
             = _("C & U Collection")
-          = miq_tab_header("settings_co_categories", @sb[:active_tab]) do
-            = escape_javascript(current_tenant.name)
-            = _("Categories")
-          = miq_tab_header("settings_co_tags", @sb[:active_tab]) do
-            = escape_javascript(current_tenant.name)
+          = miq_tab_header("settings_tags", @sb[:active_tab]) do
             = _("Tags")
-          = miq_tab_header("settings_import_tags", @sb[:active_tab]) do
-            = _("Import Tags")
-          = miq_tab_header("settings_import", @sb[:active_tab]) do
-            = _("Import Variables")
-          = miq_tab_header("settings_label_tag_mapping", @sb[:active_tab]) do
-            = _("Map Tags")
           = miq_tab_header("settings_rhn", @sb[:active_tab]) do
             = _("Red Hat Updates")
           = miq_tab_header("settings_replication", @sb[:active_tab]) do
@@ -72,16 +62,35 @@
             = render :partial => "settings_details_tab"
           = miq_tab_content("settings_cu_collection", @sb[:active_tab]) do
             = render :partial => "settings_cu_collection_tab"
-          = miq_tab_content("settings_co_categories", @sb[:active_tab]) do
-            = render :partial => "settings_co_categories_tab"
-          = miq_tab_content("settings_co_tags", @sb[:active_tab]) do
-            = render :partial => "settings_co_tags_tab"
-          = miq_tab_content("settings_import_tags", @sb[:active_tab]) do
-            = render :partial => "settings_import_tags_tab"
-          = miq_tab_content("settings_import", @sb[:active_tab]) do
-            = render :partial => "settings_import_tab"
-          = miq_tab_content("settings_label_tag_mapping", @sb[:active_tab]) do
-            = render :partial => "settings_label_tag_mapping_tab"
+          = miq_tab_content("settings_tags", @sb[:active_tab]) do
+            = render(:partial => "layouts/flash_msg")
+            #ops_tags_subtabs
+              %ul.nav.nav-tabs.nav-tabs-pf{:style => 'font-size: 12px'}
+                = miq_tab_header("settings_co_categories", @sb[:active_subtab]) do
+                  = escape_javascript(current_tenant.name)
+                  = _("Categories")
+                = miq_tab_header("settings_co_tags", @sb[:active_subtab]) do
+                  = escape_javascript(current_tenant.name)
+                  = _("Tags")
+                = miq_tab_header("settings_import_tags", @sb[:active_subtab]) do
+                  = _("Import Tags")
+                = miq_tab_header("settings_import", @sb[:active_subtab]) do
+                  = _("Import Variables")
+                = miq_tab_header("settings_label_tag_mapping", @sb[:active_subtab]) do
+                  = _("Map Tags")
+              .tab-content
+                = miq_tab_content("settings_co_categories", @sb[:active_subtab]) do
+                  = render :partial => "settings_co_categories_tab"
+                = miq_tab_content("settings_co_tags", @sb[:active_subtab]) do
+                  = render :partial => "settings_co_tags_tab"
+                = miq_tab_content("settings_import_tags", @sb[:active_subtab]) do
+                  = render :partial => "settings_import_tags_tab"
+                = miq_tab_content("settings_import", @sb[:active_subtab]) do
+                  = render :partial => "settings_import_tab"
+                = miq_tab_content("settings_label_tag_mapping", @sb[:active_subtab]) do
+                  = render :partial => "settings_label_tag_mapping_tab"
+            :javascript
+              miq_tabs_init("#ops_tags_subtabs", "/ops/change_tab", {parent_tab_id: 'settings_tags'});
           = miq_tab_content("settings_rhn", @sb[:active_tab]) do
             = render :partial => "settings_rhn_tab"
           = miq_tab_content("settings_replication", @sb[:active_tab]) do

--- a/app/views/ops/_classification_entries.html.haml
+++ b/app/views/ops/_classification_entries.html.haml
@@ -1,6 +1,5 @@
 #classification_entries_div
   %h3= "#{@cat.description} Entries"
-  = render :partial => "layouts/flash_msg"
   %table.table.table-striped.table-bordered.table-hover
     %thead
       %tr

--- a/app/views/ops/_settings_co_categories_tab.html.haml
+++ b/app/views/ops/_settings_co_categories_tab.html.haml
@@ -1,5 +1,4 @@
-- if @sb[:active_tab] == "settings_co_categories"
-  = render :partial => "layouts/flash_msg"
+- if @sb[:active_tab] == "settings_tags" && @sb[:active_subtab] == "settings_co_categories"
   %table.table.table-striped.table-bordered.table-hover
     %thead
       %tr

--- a/app/views/ops/_settings_co_tags_tab.html.haml
+++ b/app/views/ops/_settings_co_tags_tab.html.haml
@@ -1,4 +1,4 @@
-- if @sb[:active_tab] == "settings_co_tags"
+- if @sb[:active_tab] == "settings_tags" && @sb[:active_subtab] == "settings_co_tags"
   #tab_div
     - url = url_for_only_path(:action => 'ce_new_cat')
     .form-horizontal

--- a/app/views/ops/_settings_cu_collection_tab.html.haml
+++ b/app/views/ops/_settings_cu_collection_tab.html.haml
@@ -5,7 +5,6 @@
              :id     => "config_form",
              :class  => "form-horizontal",
              :method => :post) do
-    = render :partial => "layouts/flash_msg"
     .row
       .col-md-12.col-lg-6
         %fieldset

--- a/app/views/ops/_settings_details_tab.html.haml
+++ b/app/views/ops/_settings_details_tab.html.haml
@@ -1,6 +1,5 @@
 - if @sb[:active_tab] == "settings_details"
   - if super_admin_user?
-    = render :partial => "layouts/flash_msg"
     - region = MiqRegion.my_region
     - if @edit
       - url = url_for_only_path(:action => 'region_form_field_changed', :id => (region.id || "new"))

--- a/app/views/ops/_settings_import_tab.html.haml
+++ b/app/views/ops/_settings_import_tab.html.haml
@@ -1,7 +1,6 @@
-- if @sb[:active_tab] == "settings_import"
+- if @sb[:active_tab] == "settings_tags" && @sb[:active_subtab] == "settings_import"
   - url = url_for_only_path(:action => 'upload_form_field_changed', :id => @sb[:active_tab].split('_').last)
   %h3= _("Messages")
-  = render(:partial => "layouts/flash_msg")
   %hr
   %h3= _("Upload Custom Variable Values")
   = form_tag({:action => "upload_csv",

--- a/app/views/ops/_settings_import_tags_tab.html.haml
+++ b/app/views/ops/_settings_import_tags_tab.html.haml
@@ -1,8 +1,7 @@
-- if @sb[:active_tab] == "settings_import_tags"
+- if @sb[:active_tab] == "settings_tags" && @sb[:active_subtab] == "settings_import_tags"
   #tab_div
     %h3
       = _("Messages")
-    = render(:partial => "layouts/flash_msg")
     %hr
     %h3
       = _("Upload %{customer_name} Tag Assignments for VMs") % {:customer_name => session[:customer_name]}

--- a/app/views/ops/_settings_label_tag_mapping_tab.html.haml
+++ b/app/views/ops/_settings_label_tag_mapping_tab.html.haml
@@ -1,5 +1,4 @@
-- if @sb[:active_tab] == "settings_label_tag_mapping"
-  = render :partial => "layouts/flash_msg"
+- if @sb[:active_tab] == "settings_tags" && @sb[:active_subtab] == "settings_label_tag_mapping"
   %table.table.table-striped.table-bordered.table-hover
     %thead
       %tr

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -4,7 +4,6 @@
   %form.form-horizontal#form_div{"name"          => "angularForm",
                                  "ng-controller" => "pglogicalReplicationFormController",
                                  "ng-show"       => "afterGet"}
-    = render :partial => "layouts/flash_msg"
     .form-group{"ng-class" => "{'has-error': angularForm.subscriptions.$invalid}"}
       %label.col-md-2.control-label
         = _('Type')

--- a/app/views/ops/_settings_rhn_tab.html.haml
+++ b/app/views/ops/_settings_rhn_tab.html.haml
@@ -6,7 +6,6 @@
     @updates[]  -- update information for individual servers passed to the server_table partial
 
 - if @sb[:active_tab] == "settings_rhn"
-  = render :partial => 'layouts/flash_msg'
 
   %h3
     Red Hat Software Updates

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -329,7 +329,7 @@ describe OpsController do
         allow(controller).to receive(:assert_privileges).and_return(true)
         seed_session_trees('ops', :settings_tree, 'root')
         expect(controller).to receive(:render_to_string).with(any_args).exactly(3).times
-        post :change_tab, :params => {:tab_id => tab}
+        post :change_tab, :params => {:tab_id => tab, :parent_tab_id => 'settings_tags'}
       end
 
       it "Apply button remains disabled with flash errors" do

--- a/spec/views/ops/_settings_label_tag_mapping_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_label_tag_mapping_tab.html.haml_spec.rb
@@ -1,5 +1,5 @@
 describe 'ops/_settings_label_tag_mapping_tab.html.haml' do
-  before { assign(:sb, :active_tab => 'settings_label_tag_mapping') }
+  before { assign(:sb, :active_tab => 'settings_tags', :active_subtab => 'settings_label_tag_mapping') }
 
   context 'table view' do
     it 'renders the table with zero mappings' do


### PR DESCRIPTION
To have enough space for the [help menu customization](https://www.pivotaltracker.com/story/show/150933794) I had to free up some space among the tabs on the `Settings -> Region` screen. The solution proposed by the UX team was to join the tabs related to tagging into a single tab and create a second level of tabs. 

I introduced a new `:active_subtab` key in the sandbox for distinguishing. Unfortunately, the tab switching logic in `miq_tabs_init` concatenates a `tab_id` after the URL and it is too widely used. So I introduced a hack: we still send the `tab_id` for the second level tabs, but we append the `parent_tab_id` parameter to minimize the number of changes in the controller. I know it is ugly and I'm sorry for this :cry: but it will be gone when we convert this screen to angular.

There were some issues with the `flash_msg_div` when switching tabs, so as @martinpovolny suggested, I went through all the partials and moved the div to a single place above the first level of tabs.

**Before:**
![screenshot from 2017-10-26 15-31-31](https://user-images.githubusercontent.com/649130/32055680-c52b06c6-ba62-11e7-939a-8a34dcc123b3.png)

**After:**
![screenshot from 2017-10-26 21-22-01](https://user-images.githubusercontent.com/649130/32072728-eecdaa70-ba93-11e7-9051-1ae80e7e79a9.png)

@martinpovolny and @epwinchell can you please review?