### PR TITLE
Removed old dialog buttons

### DIFF
--- a/app/helpers/application_helper/toolbar/dialog_center.rb
+++ b/app/helpers/application_helper/toolbar/dialog_center.rb
@@ -7,17 +7,9 @@ class ApplicationHelper::Toolbar::DialogCenter < ApplicationHelper::Toolbar::Bas
       t,
       :items => [
         button(
-          :dialog_edit,
-          'pficon pficon-edit fa-lg',
-          t = N_('Edit this Dialog'),
-          t,
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :klass        => ApplicationHelper::Button::DialogAction),
-        button(
           :dialog_edit_editor,
           'pficon pficon-edit fa-lg',
-          t = N_('Edit this Dialog in the Dialog Editor'),
+          t = N_('Edit this Dialog'),
           t,
           :url_parms    => "main_div",
           :send_checked => true,

--- a/app/helpers/application_helper/toolbar/dialogs_center.rb
+++ b/app/helpers/application_helper/toolbar/dialogs_center.rb
@@ -7,31 +7,15 @@ class ApplicationHelper::Toolbar::DialogsCenter < ApplicationHelper::Toolbar::Ba
       t,
       :items => [
         button(
-          :dialog_new,
+          :dialog_new_editor,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Dialog'),
           t,
           :klass => ApplicationHelper::Button::DialogNew),
         button(
-          :dialog_new_editor,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a new Dialog with the Dialog Editor'),
-          t,
-          :klass => ApplicationHelper::Button::DialogNew),
-        button(
-          :dialog_edit,
-          'pficon pficon-edit fa-lg',
-          t = N_('Edit the selected Dialog'),
-          t,
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :enabled      => false,
-          :onwhen       => "1",
-          :klass        => ApplicationHelper::Button::DialogAction),
-        button(
           :dialog_edit_editor,
           'pficon pficon-edit fa-lg',
-          t = N_('Edit the selected Dialog in the Dialog Editor'),
+          t = N_('Edit the selected Dialog'),
           t,
           :url_parms    => "main_div",
           :send_checked => true,


### PR DESCRIPTION
Removing toolbar buttons for old dialog editor

@h-kataria 

Steps for Testing/QA
-------------------------------

Automation -> Automate -> Customization -> Service Dialogs -> [Add / Edit] Dialog
