### PR TITLE
SmartState Docker Creds for AWS

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -31,6 +31,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       default_password: '',
       amqp_userid: '',
       amqp_password: '',
+      smartstate_docker_userid: '',
+      smartstate_docker_password: '',
       metrics_userid: '',
       metrics_password: '',
       metrics_database_name: '',
@@ -131,6 +133,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.default_userid                  = data.default_userid;
       $scope.emsCommonModel.amqp_userid                     = data.amqp_userid;
       $scope.emsCommonModel.metrics_userid                  = data.metrics_userid;
+      $scope.emsCommonModel.smartstate_docker_userid               = data.smartstate_docker_userid;
       $scope.emsCommonModel.vmware_cloud_api_version        = data.api_version;
 
       $scope.emsCommonModel.ssh_keypair_userid              = data.ssh_keypair_userid;
@@ -169,6 +172,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       }
       if ($scope.emsCommonModel.metrics_userid !== '') {
         $scope.emsCommonModel.metrics_password = miqService.storedPasswordPlaceholder;
+      }
+      if ($scope.emsCommonModel.smartstate_docker_userid !== '') {
+        $scope.emsCommonModel.smartstate_docker_password = miqService.storedPasswordPlaceholder;
       }
       if ($scope.emsCommonModel.ssh_keypair_userid !== '') {
         $scope.emsCommonModel.ssh_keypair_password = miqService.storedPasswordPlaceholder;
@@ -252,6 +258,10 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       ($scope.emsCommonModel.amqp_hostname) &&
       ($scope.emsCommonModel.amqp_userid != '' && $scope.angularForm.amqp_userid !== undefined && $scope.angularForm.amqp_userid.$valid &&
        $scope.emsCommonModel.amqp_password != '' && $scope.angularForm.amqp_password !== undefined && $scope.angularForm.amqp_password.$valid)) {
+      return true;
+    } else if(($scope.currentTab == "smartstate_docker") &&
+      ($scope.emsCommonModel.smartstate_docker_userid != '' && $scope.angularForm.smartstate_docker_userid !== undefined &&
+       $scope.emsCommonModel.smartstate_docker_password != '' && $scope.angularForm.smartstate_docker_password !== undefined)) {
       return true;
     } else if(($scope.currentTab == "default" && $scope.emsCommonModel.emstype == "azure") &&
       ($scope.emsCommonModel.azure_tenant_id != '' && $scope.angularForm.azure_tenant_id.$valid) &&
@@ -470,6 +480,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     if ($scope.emsCommonModel.amqp_auth_status === true) {
       $scope.postValidationModelRegistry("amqp");
     }
+    if ($scope.emsCommonModel.smartstate_docker_auth_status === true) {
+      $scope.postValidationModelRegistry("smartstate_docker");
+    }
     if ($scope.emsCommonModel.service_account_auth_status === true) {
       $scope.postValidationModelRegistry("service_account");
     }
@@ -489,6 +502,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.postValidationModel = {
         default: {},
         amqp: {},
+        smartstate_docker: {},
         metrics: {},
         ssh_keypair: {},
         prometheus_alerts: {},
@@ -525,6 +539,16 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         amqp_security_protocol:    $scope.emsCommonModel.amqp_security_protocol,
         amqp_userid:               $scope.emsCommonModel.amqp_userid,
         amqp_password:             amqp_password,
+      };
+    } else if (prefix === "smartstate_docker") {
+      if ($scope.newRecord) {
+        var smartstate_docker_password = $scope.emsCommonModel.smartstate_docker_password;
+      } else {
+        var smartstate_docker_password = $scope.emsCommonModel.smartstate_docker_password === "" ? "" : miqService.storedPasswordPlaceholder;
+      }
+      $scope.postValidationModel.smartstate_docker = {
+        smartstate_docker_userid:      $scope.emsCommonModel.smartstate_docker_userid,
+        smartstate_docker_password:    smartstate_docker_password,
       };
     } else if (prefix === "metrics") {
       var metricsValidationModel = {

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -181,6 +181,7 @@ module Mixins
       amqp_hostname = ""
       amqp_port = ""
       amqp_security_protocol = ""
+      smartstate_docker_userid = ""
       ssh_keypair_userid = ""
       metrics_userid = ""
       metrics_hostname = ""
@@ -204,6 +205,11 @@ module Mixins
       if @ems.has_authentication_type?(:amqp)
         amqp_userid = @ems.has_authentication_type?(:amqp) ? @ems.authentication_userid(:amqp).to_s : ""
         amqp_auth_status = @ems.authentication_status_ok?(:amqp)
+      end
+
+      if @ems.has_authentication_type?(:smartstate_docker)
+        smartstate_docker_userid = @ems.has_authentication_type?(:smartstate_docker) ? @ems.authentication_userid(:smartstate_docker).to_s : ""
+        smartstate_docker_auth_status = true
       end
 
       if @ems.has_authentication_type?(:ssh_keypair)
@@ -296,6 +302,7 @@ module Mixins
                        :openstack_infra_providers_exist => retrieve_openstack_infra_providers.length > 0,
                        :default_userid                  => @ems.authentication_userid ? @ems.authentication_userid : "",
                        :amqp_userid                     => amqp_userid,
+                       :smartstate_docker_userid               => smartstate_docker_userid,
                        :service_account                 => service_account ? service_account : "",
                        :azure_tenant_id                 => azure_tenant_id ? azure_tenant_id : "",
                        :keystone_v3_domain_id           => keystone_v3_domain_id,
@@ -308,6 +315,7 @@ module Mixins
                        :ems_controller                  => controller_name,
                        :default_auth_status             => default_auth_status,
                        :amqp_auth_status                => amqp_auth_status,
+                       :smartstate_docker_auth_status                => smartstate_docker_auth_status,
                        :service_account_auth_status     => service_account_auth_status
       } if controller_name == "ems_cloud" || controller_name == "ems_network"
 
@@ -574,6 +582,7 @@ module Mixins
       endpoints = {:default           => default_endpoint,
                    :ceilometer        => ceilometer_endpoint,
                    :amqp              => amqp_endpoint,
+                   :smartstate_docker              => default_endpoint,
                    :ssh_keypair       => ssh_keypair_endpoint,
                    :metrics           => metrics_endpoint,
                    :hawkular          => hawkular_endpoint,
@@ -595,7 +604,7 @@ module Mixins
       authentications = build_credentials(ems, mode)
       configurations = []
 
-      [:default, :ceilometer, :amqp, :ssh_keypair, :metrics, :hawkular, :prometheus, :prometheus_alerts].each do |role|
+      [:default, :ceilometer, :amqp, :smartstate_docker, :ssh_keypair, :metrics, :hawkular, :prometheus, :prometheus_alerts].each do |role|
         configurations << build_configuration(ems, authentications, endpoints, role)
       end
 
@@ -621,6 +630,11 @@ module Mixins
       if ems.supports_authentication?(:amqp) && params[:amqp_userid]
         amqp_password = params[:amqp_password] ? params[:amqp_password] : ems.authentication_password(:amqp)
         creds[:amqp] = {:userid => params[:amqp_userid], :password => amqp_password, :save => (mode != :validate)}
+      end
+      if ems.kind_of?(ManageIQ::Providers::Amazon::CloudManager) &&
+         ems.supports_authentication?(:smartstate_docker) && params[:smartstate_docker_userid]
+        smartstate_docker_password = params[:smartstate_docker_password] ? params[:smartstate_docker_password] : ems.authentication_password(:smartstate_docker)
+        creds[:smartstate_docker] = {:userid => params[:smartstate_docker_userid], :password => smartstate_docker_password, :save => true}
       end
       if ems.kind_of?(ManageIQ::Providers::Openstack::InfraManager) &&
          ems.supports_authentication?(:ssh_keypair) && params[:ssh_keypair_userid]

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -302,7 +302,7 @@ module Mixins
                        :openstack_infra_providers_exist => retrieve_openstack_infra_providers.length > 0,
                        :default_userid                  => @ems.authentication_userid ? @ems.authentication_userid : "",
                        :amqp_userid                     => amqp_userid,
-                       :smartstate_docker_userid               => smartstate_docker_userid,
+                       :smartstate_docker_userid        => smartstate_docker_userid,
                        :service_account                 => service_account ? service_account : "",
                        :azure_tenant_id                 => azure_tenant_id ? azure_tenant_id : "",
                        :keystone_v3_domain_id           => keystone_v3_domain_id,
@@ -315,7 +315,7 @@ module Mixins
                        :ems_controller                  => controller_name,
                        :default_auth_status             => default_auth_status,
                        :amqp_auth_status                => amqp_auth_status,
-                       :smartstate_docker_auth_status                => smartstate_docker_auth_status,
+                       :smartstate_docker_auth_status   => smartstate_docker_auth_status,
                        :service_account_auth_status     => service_account_auth_status
       } if controller_name == "ems_cloud" || controller_name == "ems_network"
 
@@ -582,7 +582,7 @@ module Mixins
       endpoints = {:default           => default_endpoint,
                    :ceilometer        => ceilometer_endpoint,
                    :amqp              => amqp_endpoint,
-                   :smartstate_docker              => default_endpoint,
+                   :smartstate_docker => default_endpoint,
                    :ssh_keypair       => ssh_keypair_endpoint,
                    :metrics           => metrics_endpoint,
                    :hawkular          => hawkular_endpoint,

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -183,14 +183,15 @@ module TextualSummaryHelper
 
     authentications.collect do |auth|
       label = case auth[:authtype]
-              when "default"     then _("Default")
-              when "metrics"     then _("C & U Database")
-              when "amqp"        then _("AMQP")
-              when "ipmi"        then _("IPMI")
-              when "remote"      then _("Remote Login")
-              when "ws"          then _("Web Services")
-              when "ssh_keypair" then _("SSH Key Pair")
-              else;              _("<Unknown>")
+              when "default"           then _("Default")
+              when "metrics"           then _("C & U Database")
+              when "amqp"              then _("AMQP")
+              when "ipmi"              then _("IPMI")
+              when "remote"            then _("Remote Login")
+              when "smartstate_docker" then _("SmartState Docker")
+              when "ws"                then _("Web Services")
+              when "ssh_keypair"       then _("SSH Key Pair")
+              else;                    _("<Unknown>")
               end
 
       {:label => _("%{label} Credentials") % {:label => label},

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -9,7 +9,7 @@
   - validate = "#{main_scope}.validateClicked({target: '.validate_button:visible'}, '#{valtype}', true, angularForm, '#{url_for_only_path(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
 - else
   - validate = "#{main_scope}.validateClicked('#{url_for_only_path(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
-%div{"ng-show" => ng_show}
+%div{"ng-if" => "#{main_scope}.currentTab != 'smartstate_docker'"}
   %miq-button{:class           => 'validate_button',
               :name            => _("Validate"),
               "disabled-title" => verify_title_off,

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -172,7 +172,7 @@
                                                 :passwd_mismatch        => _("SmartState Docker Passwords do not match"),
                                                 :change_stored_password => _("Change stored SmartState Docker password"),
                                                 :cancel_password_change => _("Cancel SmartState Docker password change"),
-                                                :verify_title_off       => _("Docker Registry User Name and Password fields are needed to perform SmartState Analysis on AWS"),
+                                                :verify_title_off       => _("Docker Registry User Name and Password for SmartState Analysis on AWS"),
                                                 :basic_info_needed      => true}
         .form-group
           .col-md-12

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -21,6 +21,9 @@
       = miq_tab_header('ssh_keypair', nil, {'ng-click' => "changeAuthTab('ssh_keypair')"}) do
         %i{"error-on-tab" => "ssh_keypair", :style => "color:#cc0000"}
         = _("RSA key pair")
+      = miq_tab_header('smartstate_docker', nil, {'ng-click' => "changeAuthTab('smartstate_docker')"}) do
+        %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
+        = _("SmartState Docker")
     - elsif controller_name == "ems_container"
       = miq_tab_header('metrics', nil, 'ng-click' => "changeAuthTab('metrics')") do
         %div{"ng-if" => "emsCommonModel.metrics_selection == 'prometheus' || emsCommonModel.metrics_selection == 'hawkular'"}
@@ -149,6 +152,32 @@
           %span{:style => "color:black"}
             = _("Required. Used to gather Utilization data.")
 
+    - if %w(ems_cloud).include?(params[:controller])
+      = miq_tab_content('smartstate_docker', 'default') do
+        .form-group
+          .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'ec2'"}
+            = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                                   :locals  => {:ng_show                => true,
+                                                :ng_model               => "#{ng_model}",
+                                                :ng_reqd_userid         => false,
+                                                :ng_reqd_password       => false,
+                                                :ng_show_userid         => "true",
+                                                :ng_show_password       => "true",
+                                                :validate_url           => validate_url,
+                                                :id                     => record.id,
+                                                :prefix                 => "smartstate_docker",
+                                                :userid_label           => _("SmartState Docker User Name"),
+                                                :password_label         => _("SmartState Docker Password"),
+                                                :verify_label           => _("Confirm SmartState Password"),
+                                                :passwd_mismatch        => _("SmartState Docker Passwords do not match"),
+                                                :change_stored_password => _("Change stored SmartState Docker password"),
+                                                :cancel_password_change => _("Cancel SmartState Docker password change"),
+                                                :verify_title_off       => _("Docker Registry User Name and Password fields are needed to perform SmartState Analysis on AWS"),
+                                                :basic_info_needed      => true}
+        .form-group
+          .col-md-12
+            %span{:style => "color:black"}
+              = _("Used for Docker Registry credentials required to perform SmartState Analysis on AWS.")
     - if %w(ems_cloud ems_infra ems_network).include?(params[:controller])
       = miq_tab_content('metrics', 'default') do
         .form-group
@@ -387,8 +416,7 @@
 %div{"ng-if" => "#{ng_model}.emstype == ''"}
   :javascript
     $('#auth_tabs').hide();
-%div{"ng-if" => "#{ng_model}.emstype == 'ec2'                    || " + |
-                "#{ng_model}.emstype == 'gce'                    || " + |
+%div{"ng-if" => "#{ng_model}.emstype == 'gce'                    || " + |
                 "#{ng_model}.emstype == 'scvmm'                  || " + |
                 "#{ng_model}.emstype == 'vmwarews'               || " + |
                 "#{ng_model}.emstype == 'lenovo_ph_infra'        || " + |
@@ -398,6 +426,15 @@
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_show_hide("#smartstate_docker_tab", false);
+    miq_tabs_init('#auth_tabs');
+    $('#auth_tabs').show();
+%div{"ng-if" => "#{ng_model}.emstype == 'ec2'"}
+  :javascript
+    miq_tabs_show_hide("#amqp_tab", false);
+    miq_tabs_show_hide("#metrics_tab", false);
+    miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_show_hide("#smartstate_docker_tab", true);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.emstype == 'rhevm'"}
@@ -405,6 +442,7 @@
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", true);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_show_hide("#smartstate_docker_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'vmware_cloud'"}
@@ -412,6 +450,7 @@
     miq_tabs_show_hide("#amqp_tab", true);
     miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_show_hide("#smartstate_docker_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.emstype == 'openstack_infra'"}
@@ -419,6 +458,7 @@
     miq_tabs_show_hide("#amqp_tab", true);
     miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", true);
+    miq_tabs_show_hide("#smartstate_docker_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.emstype == 'nuage_network'"}


### PR DESCRIPTION
Add a new credentials tab for the Amazon provider that takes a userid and password
to be used when performing Smartstate Analysis.  This tab is labeled "SmartState Docker".
These credentials will be passed to the AWS instance actually performing SSA to be used to log in to the Docker Registry.  These credentials are *NOT* required, and no validation will be performed on them.  They will simply be saved in the database to be passed to the SmartState Analysis agent.

This PR is dependent upon https://github.com/ManageIQ/manageiq-providers-amazon/pull/330 which adds the smartstate_docker authtype to the Amazon provider.

Please note that while this PR is marked as WIP, it will need to be merged for the 4.6 build.  It is functioning properly except for the following nits:

1) The SmartState Docker tab is marked with a red "!" which would lead one to believe that it is
not valid even after credentials are entered.  This is related to the fact that we are not validating them.

2) Even though the SmartState Docker credentials are not *required*, the "Add" button for a new provider is not enabled until the new tab is clicked on.  The credentials do not have to be entered.

3) If credentials on the SmartState Docker tab are entered and saved in the database, the next
time the Amazon provider is edited - the userid is not filled in to the appropriate field to be modified.
It needs to be entered again if one wishes to make changes to the password.

Finally - as a follow on we wish to enable or disable this tab based on a configuration setting.  This will be added in a separate PR.

@roliveri @hsong-rh @Fryguy @AparnaKarve @h-kataria please review.  We may wish to merge this as is if we cannot resolve the above nits so that the feature makes it into the build.  Your mileage may vary.

Screenshots - 

Old page to add Amazon Provider with Validation Required - 

<img width="1114" alt="old add amazon validation required" src="https://user-images.githubusercontent.com/6118503/32123956-2bb49a3e-bb34-11e7-9bf8-c2adc41d0f8a.png">

New Page to add Amazon Provider - Default Credentials Tab - 

<img width="1114" alt="add amazon provider default tab valid" src="https://user-images.githubusercontent.com/6118503/32123981-43037d2c-bb34-11e7-8960-1adcdddd9b0d.png">

Old Page to add Amazon Provider - Credentials Validated - 

<img width="1115" alt="old add amazon validated" src="https://user-images.githubusercontent.com/6118503/32124018-60115e70-bb34-11e7-8abe-b550465daa79.png">

New Page to add Amazon Provider - Smartstate Tab

<img width="1112" alt="add amazon provider smartstate tab add tab" src="https://user-images.githubusercontent.com/6118503/32124050-76ee8b5e-bb34-11e7-9d18-f7cdf513ae0d.png">

Old page to Edit Amazon Provider - Validation Required

<img width="1114" alt="old add amazon validation required" src="https://user-images.githubusercontent.com/6118503/32124073-86400f7e-bb34-11e7-83c4-9bb1fab9b978.png">

New page to edit Amazon Provider - Default Tab

<img width="1115" alt="edit amazon provider default tab" src="https://user-images.githubusercontent.com/6118503/32124090-9937fe5c-bb34-11e7-80eb-e9304aa14ff3.png">

Old page to edit Amazon Provider - Validated credentials 

<img width="1110" alt="old edit validated" src="https://user-images.githubusercontent.com/6118503/32124120-aa516aa2-bb34-11e7-870b-e51e623e7bc8.png">

New page to edit Amazon Provider - Smartstate Tab

<img width="1113" alt="edit amazon provider filled smartstate tab" src="https://user-images.githubusercontent.com/6118503/32124141-bd0b4b36-bb34-11e7-8d51-c510b79c39d1.png">


Links
----------------

* https://github.com/ManageIQ/manageiq-providers-amazon/pull/330

Steps for Testing/QA 
-------------------------------

Add an Amazon Provider.  Enter the default credentials.  Click on the "SmartState Docker" tab.
enter the userid and password.  Click "Add".  Both sets of credentials will be stored in the VMDB.
These can be validated by inspecting the "authentications" table in the database.