### PR TITLE
Fix cut-off dropdowns on Set Ownership screen

### DIFF
--- a/app/views/shared/views/_ownership.html.haml
+++ b/app/views/shared/views/_ownership.html.haml
@@ -24,6 +24,7 @@
                       "ng-model"                    => "vm.ownershipModel.user",
                       "id"                          => "user_name",
                       "checkchange"                 => "",
+                      "data-container"              => "body",
                       "selectpicker-for-select-tag" => "")
       %td{:width => "100"}
     .form-group{"ng-class" => "{'has-error': angularForm.group.$invalid}"}
@@ -39,6 +40,7 @@
                       "ng-model"                    => "vm.ownershipModel.group",
                       "id"                          => "group_name",
                       "checkchange"                 => "",
+                      "data-container"              => "body",
                       "selectpicker-for-select-tag" => "")
 
   %hr


### PR DESCRIPTION
This PR fixes a problem where the bootstrap-select dropdowns were conflicting with the GTL #main_div by setting the data-container to "body."

https://bugzilla.redhat.com/show_bug.cgi?id=1500689

Before
<img width="724" alt="screen shot 2017-10-26 at 3 28 49 pm" src="https://user-images.githubusercontent.com/1287144/32072934-6c084e78-ba62-11e7-95b3-0c54129fa104.png">

After
<img width="682" alt="screen shot 2017-10-26 at 3 28 16 pm" src="https://user-images.githubusercontent.com/1287144/32072936-6c1316dc-ba62-11e7-83f8-61261446ab90.png">