### PR TITLE
Proper type for openstack_infra + optimization

### DIFF
--- a/app/helpers/application_helper/discover.rb
+++ b/app/helpers/application_helper/discover.rb
@@ -1,26 +1,31 @@
 module ApplicationHelper
   module Discover
-    def discover_type(dtype)
-      dtypes = {
-        "azure"           => _("Azure"),
-        "ec2"             => _("Amazon"),
-        "esx"             => _("ESX"),
-        "hyperv"          => _("Hyper-V"),
-        "ipmi"            => _("IPMI"),
-        "kvm"             => _("KVM"),
-        "msvirtualserver" => _("MS vCenter"),
-        "rhevm"           => _("Red Hat Virtualization"),
-        "scvmm"           => _("Microsoft System Center VMM"),
-        "virtualcenter"   => _("VMware vCenter"),
-        "vmwareserver"    => _("VMware Server"),
-        "lenovo_ph_infra" => _("Lenovo XClarity Administrator")
-      }
+    DTYPES = {
+      'azure'           => _('Azure'),
+      'ec2'             => _('Amazon'),
+      'esx'             => _('ESX'),
+      'hyperv'          => _('Hyper-V'),
+      'ipmi'            => _('IPMI'),
+      'kvm'             => _('KVM'),
+      'lenovo_ph_infra' => _('Lenovo XClarity Administrator'),
+      'msvirtualserver' => _('MS vCenter'),
+      'openstack_infra' => _('OpenStack Infrastructure'),
+      'rhevm'           => _('Red Hat Virtualization'),
+      'scvmm'           => _('Microsoft System Center VMM'),
+      'virtualcenter'   => _('VMware vCenter'),
+      'vmwareserver'    => _('VMware Server')
+    }.freeze
 
+    def discover_type(dtype)
       if dtypes.key?(dtype)
         dtypes[dtype]
       else
         dtype.titleize
       end
+    end
+
+    def dtypes
+      DTYPES
     end
   end
 end


### PR DESCRIPTION
Adds discovery name for OpenStack Infrastructure.
A wee bit of optimization including moving `dtypes` Hash to avoid initialization at every `discover_type` call.

Needed by 
https://github.com/ManageIQ/manageiq/pull/16318 
as part of 
https://bugzilla.redhat.com/show_bug.cgi?id=1212947