### PR TITLE
Add fallback hostname form input fields for Nuage Network Provider

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -108,6 +108,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.hostname                        = data.hostname;
       $scope.emsCommonModel.default_hostname                = data.default_hostname;
       $scope.emsCommonModel.amqp_hostname                   = data.amqp_hostname;
+      $scope.emsCommonModel.amqp_fallback_hostname1         = data.amqp_fallback_hostname1;
+      $scope.emsCommonModel.amqp_fallback_hostname2         = data.amqp_fallback_hostname2;
       $scope.emsCommonModel.metrics_selection               = data.metrics_selection;
       $scope.emsCommonModel.metrics_hostname                = data.metrics_hostname;
       $scope.emsCommonModel.project                         = data.project;

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -96,6 +96,50 @@
                   :xs              => 'true',
                   :primary         => 'true'}
 
+%div{"ng-if" => (defined?(hostname_hide) ? false : true) && (defined?(fallback_hostnames) ? fallback_hostnames : false)}
+  .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_fallback_hostname1.$invalid}"}
+    %label.col-md-2.control-label{"for" => "#{prefix}_fallback_hostname1"}
+      = _('Fallback Hostname 1')
+    .col-md-4
+      %input.form-control{"type"                    => "text",
+                          "id"                      => "#{prefix}_fallback_hostname1",
+                          "name"                    => "#{prefix}_fallback_hostname1",
+                          "ng-model"                => "#{ng_model}.#{prefix}_fallback_hostname1",
+                          "maxlength"               => ViewHelper::MAX_NAME_LEN.to_s,
+                          "ng-required"             => "#{ng_model}.#{prefix}_fallback_hostname2",
+                          "ng-trim"                 => false,
+                          "detect-spaces"           => "",
+                          "checkchange"             => "",
+                          "prefix"                  => prefix.to_s,
+                          "reset-validation-status" => "#{prefix}_auth_status",
+                          "placeholder"             => "Hostname or IPv4 or IPv6 address"}
+      %span.help-block{"ng-show" => "angularForm.#{prefix}_fallback_hostname1.$error.required"}
+        = _("Required")
+      %span.help-block{"ng-show" => "angularForm.#{prefix}_fallback_hostname1.$error.detectedSpaces"}
+        = _("Spaces are prohibited")
+
+%div{"ng-if" => (defined?(hostname_hide) ? false : true) && (defined?(fallback_hostnames) ? fallback_hostnames : false)}
+  .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_fallback_hostname2.$invalid}"}
+    %label.col-md-2.control-label{"for" => "#{prefix}_fallback_hostname2"}
+      = _('Fallback Hostname 2')
+    .col-md-4
+      %input.form-control{"type"                    => "text",
+                          "id"                      => "#{prefix}_fallback_hostname2",
+                          "name"                    => "#{prefix}_fallback_hostname2",
+                          "ng-model"                => "#{ng_model}.#{prefix}_fallback_hostname2",
+                          "maxlength"               => ViewHelper::MAX_NAME_LEN.to_s,
+                          "ng-required"             => "#{ng_model}.#{prefix}_fallback_hostname1",
+                          "ng-trim"                 => false,
+                          "detect-spaces"           => "",
+                          "checkchange"             => "",
+                          "prefix"                  => prefix.to_s,
+                          "reset-validation-status" => "#{prefix}_auth_status",
+                          "placeholder"             => "Hostname or IPv4 or IPv6 address"}
+      %span.help-block{"ng-show" => "angularForm.#{prefix}_fallback_hostname2.$error.required"}
+        = _("Required")
+      %span.help-block{"ng-show" => "angularForm.#{prefix}_fallback_hostname2.$error.detectedSpaces"}
+        = _("Spaces are prohibited")
+
 %div{"ng-if" => defined?(apiport_hide) ? false : true}
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_api_port.$invalid}",
               "ng-if" => "emsCommonModel.emstype == 'openstack'              || " + |

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -244,7 +244,8 @@
                                     :ng_model               => "#{ng_model}",
                                     :id                     => record.id,
                                     :prefix                 => "amqp",
-                                    :ng_reqd_api_port       => "false"}
+                                    :ng_reqd_api_port       => "false",
+                                    :fallback_hostnames     => "#{ng_model}.emstype == 'nuage_network'"}
               = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                        :locals  => {:ng_show           => true,
                                     :ng_model          => "#{ng_model}",


### PR DESCRIPTION
Added two fallback fields in add and edit network provider forms in
case a Nuage network provider is being added.

@miq-bot add_label enhancement

![nuage_add_network_fields](https://user-images.githubusercontent.com/1094567/32093076-526a0b5c-bafb-11e7-98c2-406dcd7ecca7.png)
