### PR TITLE
Add a new tab in Settings for customizing the help menu items

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -892,6 +892,10 @@ img.tiny { margin: 0; padding: 0;width:20px;height:20px; border: 0; vertical-ali
   opacity: 0.4;
 }
 
+.no-border {
+  border: none !important;
+}
+
 /// ===================================================================
 /// end misc styling
 /// ===================================================================

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -125,7 +125,9 @@ class OpsController < ApplicationController
     # setting active record object here again, since they are no longer there due to redirect
     @ldap_group = @edit[:ldap_group] if params[:cls_id] && params[:cls_id].split('_')[0] == "lg"
     @x_edit_buttons_locals = set_form_locals if @in_a_form
-    edit_changed? if @edit && (@sb[:active_tab] == 'settings_tags' && !%w(settings_import settings_import_tags).include?(@sb[:active_subtab]))
+    if @edit && (@sb[:active_tab] == 'settings_help_menu' || (@sb[:active_tab] == 'settings_tags' && !%w(settings_import settings_import_tags).include?(@sb[:active_subtab])))
+      edit_changed?
+    end
     render :layout => "application"
   end
 
@@ -413,6 +415,11 @@ class OpsController < ApplicationController
         action_url = "cu_collection_update"
         record_id = @sb[:active_tab].split("settings_").last
         locals[:no_cancel] = true
+      elsif @sb[:active_tab] == "settings_help_menu"
+        action_url = "settings_update_help_menu"
+        locals[:submit_button] = true
+        locals[:no_cancel] = true
+        locals[:no_reset] = true
       elsif %w(settings_evm_servers settings_list).include?(@sb[:active_tab]) && @in_a_form
         if %w(ap_copy ap_edit ap_host_edit ap_vm_edit).include?(@sb[:action])
           action_url = "ap_edit"

--- a/app/controllers/ops_controller/settings.rb
+++ b/app/controllers/ops_controller/settings.rb
@@ -13,6 +13,7 @@ module OpsController::Settings
   include_concern 'Upload'
   include_concern 'Zones'
   include_concern 'RHN'
+  include_concern 'HelpMenu'
 
   # Apply the good records from an uploaded import file
   def apply_imports

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1,5 +1,6 @@
 module OpsController::Settings::Common
   extend ActiveSupport::Concern
+  include OpsHelper
 
   logo_dir = File.expand_path(File.join(Rails.root, "public/upload"))
   Dir.mkdir logo_dir unless File.exist?(logo_dir)
@@ -1130,6 +1131,16 @@ module OpsController::Settings::Common
         @customer = rhn_subscription
         @buttons_on = @edit[:new][:servers].detect { |_, value| !!value }
         @updates = rhn_update_information
+      when "settings_help_menu"
+        @in_a_form = true
+        @edit = {:new => {}, :key => 'customize_help_menu'}
+        @edit[:new] = Settings.help_menu
+        help_menu_items.each do |item|
+          @edit[:new][item] = Settings.help_menu.try(item).try(:to_h) || {}
+        end
+        @edit[:current] = copy_hash(@edit[:new])
+        session[:edit] = @edit
+        session[:changed] = false
       end
     when "xx"
       case nodes[1]

--- a/app/controllers/ops_controller/settings/help_menu.rb
+++ b/app/controllers/ops_controller/settings/help_menu.rb
@@ -1,0 +1,57 @@
+module OpsController::Settings::HelpMenu
+  extend ActiveSupport::Concern
+
+  def settings_update_help_menu
+    return unless load_edit('customize_help_menu')
+
+    konfig = VMDB::Config.new("vmdb")
+
+    begin
+      konfig.config = Vmdb::Settings.decrypt_passwords!(Settings.to_hash)
+      konfig.config[:help_menu].merge!(@edit[:new])
+      konfig.validate
+    rescue Psych::SyntaxError, StandardError
+      add_flash(_('Invalid configuration parameters.'), :error)
+      success = false
+    end
+
+    success = konfig.errors.blank? if success.nil?
+
+    if success
+      konfig.save
+      session.delete(:edit)
+      add_flash(_('Help menu customization changes successfully stored.'), :success)
+    else
+      add_flash(_('Storing the custom help menu configuration was not successful.'), :error)
+    end
+
+    session[:changed] = !success
+
+    render :update do |page|
+      page << javascript_prologue
+      page << javascript_for_miq_button_visibility(!success)
+      page.replace(:flash_msg_div, :partial => "layouts/flash_msg")
+    end
+  end
+
+  def help_menu_form_field_changed
+    return unless load_edit('customize_help_menu')
+
+    help_menu_items.each do |item|
+      %i(title href type).map do |field|
+        param = params["#{item}_#{field}"]
+        next if param.nil?
+
+        @edit[:new][item][field] = param == 'null' ? false : param
+      end
+    end
+
+    changed = @edit[:new] != @edit[:current]
+    session[:changed] = changed
+
+    render :update do |page|
+      page << javascript_prologue
+      page << javascript_for_miq_button_visibility(changed)
+    end
+  end
+end

--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -38,4 +38,12 @@ module OpsHelper
       _('Database')
     end
   end
+
+  def help_menu_items
+    items = []
+    Menu::Manager.menu(:help) do |menu|
+      items = menu.items.map { |item| item.id.to_sym }
+    end
+    items
+  end
 end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -276,26 +276,33 @@ module Menu
       end
 
       def help_menu_section
-        Menu::Section.new(:help, N_('Help'), 'pficon pficon-help', [
-          Menu::Item.new('documentation',
-                         Settings.help_menu.try(:documentation).try(:title) || N_('Documentation'),
-                         'documentation',
-                         {:feature => 'documentation'},
-                         Settings.help_menu.try(:documentation).try(:link) || '/support/index?support_tab=about',
-                         Settings.help_menu.try(:documentation).try(:type)),
-          Menu::Item.new('product',
-                         Settings.help_menu.try(:product).try(:title) || N_('ManageIQ.org'),
-                         'product',
-                         {:feature => 'product'},
-                         Settings.help_menu.try(:product).try(:link) || I18n.t("product.support_website").html_safe,
-                         Settings.help_menu.try(:product).try(:type) || :new_window),
-          Menu::Item.new('about',
-                         Settings.help_menu.try(:about).try(:title) || N_('About'),
-                         'about',
-                         {:feature => 'about'},
-                         Settings.help_menu.try(:about).try(:link) || '#aboutModal',
-                         Settings.help_menu.try(:about).try(:type) || :modal)
-        ], :help)
+        menu = {
+          :documentation => {
+            :title => N_('Documentation'),
+            :href  => '/support/index?support_tab=about',
+            :type  => nil,
+          },
+          :product       => {
+            :title => N_('ManageIQ.org'),
+            :href  =>  I18n.t("product.support_website").html_safe,
+            :type  =>:new_window,
+          },
+          :about         => {
+            :title => N_('About'),
+            :href  => '#aboutModal',
+            :type  => :modal
+          }
+        }.map do |key, value|
+          Menu::Item.new(key,
+                         help_menu_field(Settings.help_menu.try(key).try(:title), value[:title]),
+                         key.to_s,
+                         {:feature => key.to_s},
+                         help_menu_field(Settings.help_menu.try(key).try(:href), value[:href]),
+                         help_menu_field(Settings.help_menu.try(key).try(:type), value[:type]).try(:to_sym),
+                         value)
+        end
+
+        Menu::Section.new(:help, N_('Help'), 'pficon pficon-help', menu, :help)
       end
 
       def default_menu
@@ -303,6 +310,12 @@ module Menu
          network_menu_section, middleware_menu_section, datawarehouse_menu_section, storage_menu_section,
          control_menu_section, automation_menu_section, optimize_menu_section, monitor_menu_section,
          settings_menu_section, help_menu_section].compact
+      end
+
+      private
+
+      def help_menu_field(item, default)
+        (item.nil? || item.blank?) ? default : item
       end
     end
   end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -284,8 +284,8 @@ module Menu
           },
           :product       => {
             :title => N_('ManageIQ.org'),
-            :href  =>  I18n.t("product.support_website").html_safe,
-            :type  =>:new_window,
+            :href  => I18n.t("product.support_website").html_safe,
+            :type  => :new_window,
           },
           :about         => {
             :title => N_('About'),
@@ -315,7 +315,7 @@ module Menu
       private
 
       def help_menu_field(item, default)
-        (item.nil? || item.blank?) ? default : item
+        item.nil? || item.blank? ? default : item
       end
     end
   end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -294,11 +294,11 @@ module Menu
           }
         }.map do |key, value|
           Menu::Item.new(key,
-                         help_menu_field(Settings.help_menu.try(key).try(:title), value[:title]),
+                         help_menu_field(key, :title, value[:title]),
                          key.to_s,
                          {:feature => key.to_s},
-                         help_menu_field(Settings.help_menu.try(key).try(:href), value[:href]),
-                         help_menu_field(Settings.help_menu.try(key).try(:type), value[:type]).try(:to_sym),
+                         help_menu_field(key, :href, value[:href]),
+                         help_menu_field(key, :type, value[:type]),
                          value)
         end
 
@@ -314,8 +314,11 @@ module Menu
 
       private
 
-      def help_menu_field(item, default)
-        item.nil? || item.blank? ? default : item
+      def help_menu_field(key, item, default)
+        lambda do
+          field = Settings.help_menu.try(key).try(:[], item)
+          field.nil? || field.blank? ? default : field
+        end
       end
     end
   end

--- a/app/presenters/menu/item.rb
+++ b/app/presenters/menu/item.rb
@@ -1,5 +1,5 @@
 module Menu
-  Item = Struct.new(:id, :name, :feature, :rbac_feature, :href, :type) do
+  Item = Struct.new(:id, :name, :feature, :rbac_feature, :href, :type, :defaults) do
     extend ActiveModel::Naming
 
     def self.base_class
@@ -10,7 +10,7 @@ module Menu
       model_name
     end
 
-    def initialize(an_id, a_name, features, rbac_feature, href, type = :default)
+    def initialize(an_id, a_name, features, rbac_feature, href, type = :default, defaults = nil)
       super
       @parent = nil
       @name = a_name.kind_of?(Proc) ? a_name : -> { a_name }

--- a/app/presenters/menu/item.rb
+++ b/app/presenters/menu/item.rb
@@ -14,6 +14,8 @@ module Menu
       super
       @parent = nil
       @name = a_name.kind_of?(Proc) ? a_name : -> { a_name }
+      @href = href.kind_of?(Proc) ? href : -> { href }
+      @type = type.kind_of?(Proc) ? type : -> { type }
     end
 
     attr_accessor :parent
@@ -22,18 +24,26 @@ module Menu
       @name.call
     end
 
+    def href
+      @href.call
+    end
+
+    def type
+      @type.call
+    end
+
     def visible?
       ApplicationHelper.role_allows?(rbac_feature)
     end
 
     def link_params
-      params = case type
+      params = case type.try(:to_sym)
                when :big_iframe then {:href => "/dashboard/iframe?id=#{id}"}
                when :new_window then {:href => href, :target => '_new'}
                when :modal      then {'data-toggle' => 'modal', 'data-target' => href}
                else                  {:href => href}
                end
-      params[:onclick] = 'return miqCheckForChanges();' unless type == :modal
+      params[:onclick] = 'return miqCheckForChanges();' unless type.try(:to_sym) == :modal
       params
     end
 

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -58,6 +58,8 @@
             = _("Red Hat Updates")
           = miq_tab_header("settings_replication", @sb[:active_tab]) do
             = _("Replication")
+          = miq_tab_header("settings_help_menu", @sb[:active_tab]) do
+            = _("Help Menu")
         .tab-content
           = miq_tab_content("settings_details", @sb[:active_tab]) do
             = render :partial => "settings_details_tab"
@@ -95,6 +97,8 @@
             = render :partial => "settings_rhn_tab"
           = miq_tab_content("settings_replication", @sb[:active_tab]) do
             = render :partial => "settings_replication_tab"
+          = miq_tab_content("settings_help_menu", @sb[:active_tab]) do
+            = render :partial => "settings_help_menu_tab"
     -# Diagnostics
   - when :diagnostics_tree
     - if x_node.split("-")[0] == "z"

--- a/app/views/ops/_settings_help_menu_tab.html.haml
+++ b/app/views/ops/_settings_help_menu_tab.html.haml
@@ -5,7 +5,7 @@
   .alert.alert-info
     %span.pficon.pficon-info
     %strong
-      = _("Any change to the help menu will require a server restart.")
+      = _("Any change to the help menu will take effect upon a full page reload.")
   = form_tag({:action => "settings_update_help_menu"}, :class => "form-horizontal", :method => :post) do
     %table.table
       %tr
@@ -14,7 +14,7 @@
         %th.no-border
           = _('URL')
         %th.no-border
-          = _('Type')
+          = _('Open in')
 
       - Menu::Manager.menu(:help) do |menu|
         - menu.items.each do |item|
@@ -31,9 +31,9 @@
                                'data-miq_observe' => {:interval => '.5', :url => url}.to_json)
             %td.no-border
               - val = @edit[:new][item.id.to_sym].try(:[], :type) || item.defaults[:type]
-              = select_tag("#{item.id}_type", options_for_select([[_("Default"), 'default'],
-                                                                 [_("New window"), "new_window"],
-                                                                 [_("Modal"),  "modal"]], val.to_s),
+              = select_tag("#{item.id}_type", options_for_select([[_("Current Window"), 'default'],
+                                                                 [_("New Window"), "new_window"],
+                                                                 [_("Overlay Window"),  "modal"]], val.to_s),
                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
 
           - Settings.help_menu.try(item.id.to_s).try(:title).nil?

--- a/app/views/ops/_settings_help_menu_tab.html.haml
+++ b/app/views/ops/_settings_help_menu_tab.html.haml
@@ -1,0 +1,39 @@
+- if @sb[:active_tab] == "settings_help_menu"
+  - url = url_for_only_path(:action => 'help_menu_form_field_changed')
+
+  %h3= _("Customize Help Menu")
+  .alert.alert-info
+    %span.pficon.pficon-info
+    %strong
+      = _("Any change to the help menu will require a server restart.")
+  = form_tag({:action => "settings_update_help_menu"}, :class => "form-horizontal", :method => :post) do
+    %table.table
+      %tr
+        %th.no-border
+          = _('Menu item label')
+        %th.no-border
+          = _('URL')
+        %th.no-border
+          = _('Type')
+
+      - Menu::Manager.menu(:help) do |menu|
+        - menu.items.each do |item|
+          %tr
+            %td.no-border
+              = text_field_tag("#{item.id}_title", @edit[:new][item.id.to_sym].try(:[], :title),
+                               :placeholder       => item.defaults[:title],
+                               :class             => 'form-control',
+                               'data-miq_observe' => {:interval => '.5', :url => url}.to_json)
+            %td.no-border
+              = text_field_tag("#{item.id}_href", @edit[:new][item.id.to_sym].try(:[], :href),
+                               :placeholder => item.defaults[:href],
+                               :class => 'form-control',
+                               'data-miq_observe' => {:interval => '.5', :url => url}.to_json)
+            %td.no-border
+              - val = @edit[:new][item.id.to_sym].try(:[], :type) || item.defaults[:type]
+              = select_tag("#{item.id}_type", options_for_select([[_("Default"), 'default'],
+                                                                 [_("New window"), "new_window"],
+                                                                 [_("Modal"),  "modal"]], val.to_s),
+                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+
+          - Settings.help_menu.try(item.id.to_s).try(:title).nil?

--- a/app/views/ops/_settings_help_menu_tab.html.haml
+++ b/app/views/ops/_settings_help_menu_tab.html.haml
@@ -34,6 +34,9 @@
               = select_tag("#{item.id}_type", options_for_select([[_("Current Window"), 'default'],
                                                                  [_("New Window"), "new_window"],
                                                                  [_("Overlay Window"),  "modal"]], val.to_s),
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+                          :class             => 'selectpicker')
 
           - Settings.help_menu.try(item.id.to_s).try(:title).nil?
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent("#{item.id}_type", '#{url}')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2665,6 +2665,7 @@ Rails.application.routes.draw do
         forest_delete
         forest_form_field_changed
         forest_select
+        help_menu_form_field_changed
         label_tag_mapping_delete
         label_tag_mapping_edit
         label_tag_mapping_update
@@ -2707,6 +2708,7 @@ Rails.application.routes.draw do
         schedule_update
         settings_form_field_changed
         settings_update
+        settings_update_help_menu
         show
         show_product_update
         smartproxy_affinity_field_changed

--- a/spec/controllers/ops_controller/settings/help_menu_spec.rb
+++ b/spec/controllers/ops_controller/settings/help_menu_spec.rb
@@ -1,0 +1,25 @@
+describe OpsController do
+  describe 'OpsController::Settings::HelpMenu' do
+    include_context "valid session"
+
+    describe '#help_menu_form_field_changed' do
+      let(:session) do
+        {
+          :edit => {
+            :new => {
+              :documentation => {
+                :title => 'something'
+              },
+            },
+            :key => 'customize_help_menu'
+          }
+        }
+      end
+
+      it 'sets the form field value internally' do
+        post :help_menu_form_field_changed, :params => {:documentation_title => 'something_else'}, :session => session
+        expect(assigns(:edit)[:new][:documentation][:title]).to eq('something_else')
+      end
+    end
+  end
+end


### PR DESCRIPTION
The code is ugly and I :cry:ed a lot while writing it, but it does what it should and after the big angular rewrite most of it can be removed. I tried to follow the designs provided by the UX, but I have some slight changes:
* The design wasn't counting with the type dropdown, but it is necessary so I added it
* The `customize` checkboxes weren't necessary, it is enough to leave the fields empty
* I was not sure if I have to use the `bootstrap-select` so I didn't
* I don't know how to use the `bootstrap-switch`, maybe someone can help with it

The layout uses a `<table>` and I'm not sure if it is a good idea like this, but I did not see any other option with the provided design. So I'd like to ask @epwinchell to review and maybe to give me some ideas what to use instead.

It seems like the `Settings` object isn't designed for editing its content partially. The only place it is being edited is the `Advanced` tab under a `Server` treenode and that's a full rewrite. I tried to inspire from that one, and I did not wanted to open a core PR as we need this feature ASAP. I think @Fryguy or maybe @jrafanie should review his part. 

~~For performance reasons the menus are loaded when the server starts, so any change in the menu will take effect only after a server restart. We might change this in the future, but it might be a lot of work. Maybe @martinpovolny has some ideas as he created most of the menu code.~~

![screenshot from 2017-10-30 18-21-35](https://user-images.githubusercontent.com/649130/32185372-357ee69c-bd9f-11e7-997f-25104b09babf.png)

Pivotal story: https://www.pivotaltracker.com/story/show/150933794