### PR TITLE
Set minimum vSphere API version for WebMKS consoles

### DIFF
--- a/app/helpers/application_helper/button/vm_webmks_console.rb
+++ b/app/helpers/application_helper/button/vm_webmks_console.rb
@@ -7,10 +7,9 @@ class ApplicationHelper::Button::VmWebmksConsole < ApplicationHelper::Button::Vm
   end
 
   def disabled?
-    canned_msg = _('The web-based WebMKS console is not available because')
-    @error_message = _("%{canned_msg} the required libraries aren't installed" % {:canned_msg => canned_msg}) unless webmks_assets_provided?
-    @error_message = _("%{canned_msg} the VM is not powered on" % {:canned_msg => canned_msg}) unless on?
-    @error_message = _("%{canned_msg} the VM does not support the minimum required vSphere API version." % {:canned_msg => canned_msg}) unless supported_vendor_api?
+    @error_message = _("The web-based WebMKS console is not available because the required libraries aren't installed") unless webmks_assets_provided?
+    @error_message = _("The web-based WebMKS console is not available because the VM is not powered on") unless on?
+    @error_message = _("The web-based WebMKS console is not available because the VM does not support the minimum required vSphere API version.") unless supported_vendor_api?
     @error_message.present?
   end
 

--- a/app/helpers/application_helper/button/vm_webmks_console.rb
+++ b/app/helpers/application_helper/button/vm_webmks_console.rb
@@ -7,8 +7,18 @@ class ApplicationHelper::Button::VmWebmksConsole < ApplicationHelper::Button::Vm
   end
 
   def disabled?
-    @error_message = _("The web-based WebMKS console is not available because the required libraries aren't installed") unless webmks_assets_provided?
-    @error_message = _('The web-based WebMKS console is not available because the VM is not powered on') unless on?
+    canned_msg = _('The web-based WebMKS console is not available because')
+    @error_message = _("%{canned_msg} the required libraries aren't installed" % {:canned_msg => canned_msg}) unless webmks_assets_provided?
+    @error_message = _("%{canned_msg} the VM is not powered on" % {:canned_msg => canned_msg}) unless on?
+    @error_message = _("%{canned_msg} the VM does not support the minimum required vSphere API version." % {:canned_msg => canned_msg}) unless supported_vendor_api?
     @error_message.present?
+  end
+
+  def supported_vendor_api?
+    ExtManagementSystem.find(@record.ems_id).api_version.to_f >= min_required_api_version
+  end
+
+  def min_required_api_version
+    6.0
   end
 end

--- a/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
@@ -25,12 +25,24 @@ describe ApplicationHelper::Button::VmWebmksConsole do
 
     context 'when record.vendor == vmware' do
       let(:power_state) { 'on' }
-      let(:ems) { FactoryGirl.create(:ems_vmware) }
+      let(:api_version) { 6.5 }
+      let(:ems) { FactoryGirl.create(:ems_vmware, :api_version => api_version) }
       let(:record) { FactoryGirl.create(:vm_vmware, :ems_id => ems.id) }
 
       context 'and the power is on' do
         it_behaves_like 'vm_console_with_power_state_on_off',
                         "The web-based WebMKS console is not available because the VM is not powered on"
+      end
+
+      context 'and the api version' do
+        context 'is < 6' do
+          let(:api_version) { 5.5 }
+          it_behaves_like 'a disabled button',
+                          'The web-based WebMKS console is not available because the VM does not support the minimum required vSphere API version.'
+        end
+        context 'is >= 6' do
+          it_behaves_like 'an enabled button'
+        end
       end
     end
   end


### PR DESCRIPTION
WebMKS is not available when a VM is using a vSphere API less than version 6.

@miq-bot add_labels bug, compute/infrastructure, fine/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1483936