### PR TITLE
Security group: Fix Display

### DIFF
--- a/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
+++ b/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
@@ -18,23 +18,23 @@ ManageIQ.angular.app.controller('securityGroupFormController', ['securityGroupFo
     vm.newRecord = securityGroupFormId === "new";
     vm.saveable = miqService.saveable;
 
-    API.get("/api/security_groups/?expand=resources&attributes=ems_ref,id,name").then(function(data) {
-      vm.security_groups_list = data.resources;
-    }).then(function() {
-      if (vm.newRecord) {
-        vm.afterGet = true;
-        vm.modelCopy = angular.copy( vm.securityGroupModel );
-      } else {
-        miqService.sparkleOn();
-        API.get("/api/security_groups/" + securityGroupFormId + "?attributes=name,ext_management_system.name,description,cloud_tenant.name,firewall_rules").then(function(data) {
-          Object.assign(vm.securityGroupModel, data);
-          vm.securityGroupModel.firewall_rules_delete = false;
-          vm.afterGet = true;
-          vm.modelCopy = _.cloneDeep(vm.securityGroupModel);
-          miqService.sparkleOff();
+    if (vm.newRecord) {
+      vm.afterGet = true;
+      vm.modelCopy = angular.copy( vm.securityGroupModel );
+    } else {
+      miqService.sparkleOn();
+      API.get("/api/security_groups/" + securityGroupFormId + "?attributes=name,ext_management_system.name,description,cloud_tenant.name,firewall_rules").then(function(data) {
+        Object.assign(vm.securityGroupModel, data);
+        vm.securityGroupModel.firewall_rules_delete = false;
+        API.get("/api/security_groups/?expand=resources&attributes=ems_ref,id,name").then(function(data) {
+          vm.security_groups_list = data.resources;
         }).catch(miqService.handleFailure);
-      }
-    }).catch(miqService.handleFailure);
+      }).then(function() {
+        vm.afterGet = true;
+        vm.modelCopy = _.cloneDeep(vm.securityGroupModel);
+        miqService.sparkleOff();
+      }).catch(miqService.handleFailure);
+    }
   };
 
   vm.addClicked = function() {

--- a/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
+++ b/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
@@ -28,7 +28,7 @@ ManageIQ.angular.app.controller('securityGroupFormController', ['securityGroupFo
         miqService.sparkleOn();
         API.get("/api/security_groups/" + securityGroupFormId + "?attributes=name,ext_management_system.name,description,cloud_tenant.name,firewall_rules").then(function(data) {
           Object.assign(vm.securityGroupModel, data);
-          vm.securityGroupModel.firewall_rules_delete = false;        vm.securityGroupModel.name = data.name;
+          vm.securityGroupModel.firewall_rules_delete = false;
           vm.afterGet = true;
           vm.modelCopy = _.cloneDeep(vm.securityGroupModel);
           miqService.sparkleOff();

--- a/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
+++ b/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
@@ -6,11 +6,9 @@ ManageIQ.angular.app.controller('securityGroupFormController', ['securityGroupFo
     vm.securityGroupModel = {
       name: "",
       description: "",
-      cloud_tenant_name: "",
       firewall_rules: [],
     };
 
-    getSecurityGroups();
     vm.hostProtocols = ["", "TCP", "UDP", "ICMP"];
     vm.networkProtocols = ["IPV4", "IPV6"];
     vm.directions = ["inbound", "outbound"];
@@ -20,33 +18,27 @@ ManageIQ.angular.app.controller('securityGroupFormController', ['securityGroupFo
     vm.newRecord = securityGroupFormId === "new";
     vm.saveable = miqService.saveable;
 
-    if (vm.newRecord) {
-      vm.afterGet = true;
-      vm.modelCopy = angular.copy( vm.securityGroupModel );
-    } else {
-      miqService.sparkleOn();
-      API.get("/api/security_groups/" + securityGroupFormId + "?attributes=name,ext_management_system.name,description,cloud_tenant.name,firewall_rules").then(function(data) {
-        vm.securityGroupModel.name = data.name;
-        vm.securityGroupModel.ems_name = data.ext_management_system.name;
-        vm.securityGroupModel.description = data.description;
-        vm.securityGroupModel.cloud_tenant_name = angular.isDefined(data.cloud_tenant) ? data.cloud_tenant.name : undefined;
-        vm.securityGroupModel.firewall_rules = data.firewall_rules;
-        vm.securityGroupModel.firewall_rules_delete = false;
-        vm.afterGet = true;
-        vm.modelCopy = angular.copy( vm.securityGroupModel );
-      }).catch(miqService.handleFailure);
-      miqService.sparkleOff();
-    }
-  };
-
-  var getSecurityGroups = function() {
     API.get("/api/security_groups/?expand=resources&attributes=ems_ref,id,name").then(function(data) {
       vm.security_groups_list = data.resources;
+    }).then(function() {
+      if (vm.newRecord) {
+        vm.afterGet = true;
+        vm.modelCopy = angular.copy( vm.securityGroupModel );
+      } else {
+        miqService.sparkleOn();
+        API.get("/api/security_groups/" + securityGroupFormId + "?attributes=name,ext_management_system.name,description,cloud_tenant.name,firewall_rules").then(function(data) {
+          Object.assign(vm.securityGroupModel, data);
+          vm.securityGroupModel.firewall_rules_delete = false;        vm.securityGroupModel.name = data.name;
+          vm.afterGet = true;
+          vm.modelCopy = _.cloneDeep(vm.securityGroupModel);
+          miqService.sparkleOff();
+        }).catch(miqService.handleFailure);
+      }
     }).catch(miqService.handleFailure);
   };
 
   vm.addClicked = function() {
-    var url = 'create/new' + '?button=add';
+    var url = 'create/new?button=add';
     miqService.miqAjaxButton(url, vm.securityGroupModel, { complete: false });
   };
 
@@ -69,7 +61,7 @@ ManageIQ.angular.app.controller('securityGroupFormController', ['securityGroupFo
 
   vm.cancelClicked = function() {
     if (vm.newRecord) {
-      var url = '/security_group/create/new' + '?button=cancel';
+      var url = '/security_group/create/new?button=cancel';
     } else {
       var url = '/security_group/update/' + securityGroupFormId + '?button=cancel';
     }
@@ -89,7 +81,12 @@ ManageIQ.angular.app.controller('securityGroupFormController', ['securityGroupFo
   };
 
   vm.resetClicked = function(angularForm) {
-    vm.securityGroupModel = angular.copy( vm.modelCopy );
+    vm.securityGroupModel = _.cloneDeep(vm.modelCopy);
+    for (var index = 0, len = vm.securityGroupModel.firewall_rules.length; index < len; index++) {
+      if (vm.securityGroupModel.firewall_rules[index] == undefined || vm.securityGroupModel.firewall_rules[index].deleted === true) {
+        vm.securityGroupModel.firewall_rules.splice(index, 1);
+      }
+    }
     angularForm.$setPristine(true);
     miqService.miqFlash("warn", "All changes have been reset");
   };

--- a/app/views/security_group/_fw_rules.haml
+++ b/app/views/security_group/_fw_rules.haml
@@ -28,25 +28,19 @@
             "data-width"                  => "auto",
             "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].direction",
             "ng-options"                  => "direction for direction in vm.directions",
-            "ng-selected"                 => "fw_rule.direction",
-            "required"                    => "",
-            "selectpicker-for-select-tag" => ""}
+            "required"                    => ""}
         %td.table-view-pf-select
           %select{"name"                        => "network_protocol",
             "data-width"                  => "auto",
             "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].network_protocol",
-            "ng-options"                  => "network_protocol for network_protocol in vm.networkProtocols",
-            "ng-selected"                 => "fw_rule.network_protocol",
-            "selectpicker-for-select-tag" => ""}
+            "ng-options"                  => "network_protocol for network_protocol in vm.networkProtocols"}
             %option{"value" => ""}
               = "<#{_('Choose')}>"
         %td.table-view-pf-select
           %select{"name"                        => "host_protocol",
             "data-width"                  => "auto",
             "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].host_protocol",
-            "ng-options"                  => "host_protocol for host_protocol in vm.hostProtocols",
-            "ng-selected"                 => "fw_rule.host_protocol",
-            "selectpicker-for-select-tag" => ""}
+            "ng-options"                  => "host_protocol for host_protocol in vm.hostProtocols"}
             %option{"value" => ""}
               = "<#{_('Choose')}>"
         %td.table-view-pf-select
@@ -54,9 +48,7 @@
             "data-width"                  => "auto",
             "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].source_security_group_id",
             "ng-options"                  => "sg.id as sg.name + ' - ' + sg.ems_ref for sg in vm.security_groups_list",
-            "ng-selected"                 => "fw_rules.source_security_group_id",
-            "ng-change"                   => "vm.securityGroupModel.firewall_rules[$index].source_ip_range = null",
-            "selectpicker-for-select-tag" => ""}
+            "ng-change"                   => "vm.securityGroupModel.firewall_rules[$index].source_ip_range = null"}
             %option{"value" => ""}
               = "<#{_('Choose')}>"
         %td

--- a/app/views/security_group/_fw_rules.haml
+++ b/app/views/security_group/_fw_rules.haml
@@ -23,57 +23,57 @@
       %tr{"ng-repeat" => "fw_rule in vm.securityGroupModel.firewall_rules",
           "ng-form"   => "rowForm",
           "ng-if"     => "!fw_rule.deleted"}
-        %td.table-view-pf-select
+        %td
           %select{"name"                        => "direction",
-            "data-width"                  => "auto",
-            "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].direction",
-            "ng-options"                  => "direction for direction in vm.directions",
-            "required"                    => ""}
-        %td.table-view-pf-select
+                  "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].direction",
+                  "ng-options"                  => "direction for direction in vm.directions",
+                  'pf-select'                   => true,
+                  "required"                    => ""}
+        %td
           %select{"name"                        => "network_protocol",
-            "data-width"                  => "auto",
-            "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].network_protocol",
-            "ng-options"                  => "network_protocol for network_protocol in vm.networkProtocols"}
+                  "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].network_protocol",
+                  "ng-options"                  => "network_protocol for network_protocol in vm.networkProtocols",
+                  'pf-select'                   => true}
             %option{"value" => ""}
               = "<#{_('Choose')}>"
-        %td.table-view-pf-select
+        %td
           %select{"name"                        => "host_protocol",
-            "data-width"                  => "auto",
-            "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].host_protocol",
-            "ng-options"                  => "host_protocol for host_protocol in vm.hostProtocols"}
+                  "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].host_protocol",
+                  "ng-options"                  => "host_protocol for host_protocol in vm.hostProtocols",
+                  'pf-select'                   => true}
             %option{"value" => ""}
               = "<#{_('Choose')}>"
-        %td.table-view-pf-select
+        %td
           %select{"name"                        => "source_security_group_id",
-            "data-width"                  => "auto",
-            "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].source_security_group_id",
-            "ng-options"                  => "sg.id as sg.name + ' - ' + sg.ems_ref for sg in vm.security_groups_list",
-            "ng-change"                   => "vm.securityGroupModel.firewall_rules[$index].source_ip_range = null"}
+                  "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].source_security_group_id",
+                  "ng-options"                  => "sg.id as sg.name + ' - ' + sg.ems_ref for sg in vm.security_groups_list",
+                  "ng-change"                   => "vm.securityGroupModel.firewall_rules[$index].source_ip_range = null",
+                  'pf-select'                   => true}
             %option{"value" => ""}
               = "<#{_('Choose')}>"
         %td
-          %input.form-control{:type         => "text",
-            "name"         => "source_ip_range",
-            "data-width"   => "auto",
-            "ng-model"     => "vm.securityGroupModel.firewall_rules[$index].source_ip_range",
-            "ng-change"    => "vm.securityGroupModel.firewall_rules[$index].source_security_group_id = null"}
+          %input.form-control{:type          => "text",
+                              "name"         => "source_ip_range",
+                              "data-width"   => "auto",
+                              "ng-model"     => "vm.securityGroupModel.firewall_rules[$index].source_ip_range",
+                              "ng-change"    => "vm.securityGroupModel.firewall_rules[$index].source_security_group_id = null"}
         %td
-          %input.form-control{:type         => "text",
-            "name"         => "port",
-            "ng-model"     => "vm.securityGroupModel.firewall_rules[$index].port"}
+          %input.form-control{:type          => "text",
+                              "name"         => "port",
+                              "ng-model"     => "vm.securityGroupModel.firewall_rules[$index].port"}
         %td
-          %input.form-control{:type         => "text",
-            "name"         => "end_port",
-            "ng-model"     => "vm.securityGroupModel.firewall_rules[$index].end_port"}
+          %input.form-control{:type          => "text",
+                              "name"         => "end_port",
+                              "ng-model"     => "vm.securityGroupModel.firewall_rules[$index].end_port"}
         %td
-          %miq-button{"name"      => t = _("Delete"),
-            :title     => t,
-            :alt       => t,
-            :enabled   => 'true',
-            'on-click' => "vm.deleteFirewallRuleClicked($index)"}
+          %miq-button{"name"     => t = _("Delete"),
+                      :title     => t,
+                      :alt       => t,
+                      :enabled   => 'true',
+                      'on-click' => "vm.deleteFirewallRuleClicked($index)"}
 
-  %miq-button{"name"      => t = _("Add a Firewall Rule"),
-    :title     => t,
-    :alt       => t,
-    :enabled   => 'true',
-    'on-click' => "vm.addFirewallRuleClicked()"}
+  %miq-button{"name"     => t = _("Add a Firewall Rule"),
+              :title     => t,
+              :alt       => t,
+              :enabled   => 'true',
+              'on-click' => "vm.addFirewallRuleClicked()"}

--- a/app/views/security_group/edit.html.haml
+++ b/app/views/security_group/edit.html.haml
@@ -19,7 +19,7 @@
         %input.form-control{:type          => "text",
                             :name          => "ems_name",
                             "data-width"   => "auto",
-                            "ng-model"     => "vm.securityGroupModel.ems_name",
+                            "ng-model"     => "vm.securityGroupModel.ext_management_system.name",
                             "ng-maxlength" => 128,
                             "readonly"     => true}
 
@@ -35,7 +35,7 @@
         %input.form-control{:type          => "text",
                             :name          => "cloud_tenant_name",
                             "data-width"   => "auto",
-                            "ng-model"     => "vm.securityGroupModel.cloud_tenant_name",
+                            "ng-model"     => "vm.securityGroupModel.cloud_tenant.name",
                             "ng-maxlength" => 128,
                             "readonly"     => true}
 


### PR DESCRIPTION
The security group rules are not displayed properly any more, this seems to be related with  "selectpicker-for-select-tag" => "", removing them restores normal behaviour of ng-repeat and ng-options

Also
* Removes `ng-selected` which is not needed and not recommended along `ng-repeat` which takes care of it.
* Changes `security_groups_list` retrieval to proper synchronous flow. 
* Simplifies copy of data to Model using Object.assign and relationships in form.
* Better reset using `cloneDeep` and cleanup for firewall_rules.

https://bugzilla.redhat.com/show_bug.cgi?id=1507915
