### PR TITLE
Use decorators and fonticons on policy listing screens if possible

### DIFF
--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -146,7 +146,7 @@
                 %tr{:title => _("View this Condition"),
                   :onclick => "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_co-#{to_cid(c.id)}');"}
                   %td.table-view-pf-select
-                    %i{:class => "fa fa-diamond"}
+                    %i{:class => c.decorate.fonticon}
                   %td
                     = c.description
                   %td
@@ -267,7 +267,7 @@
                   %tr{:title => _("View this Profile"),
                     :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy_profile")}
                     %td.table-view-pf-select
-                      %img{:src => image_path("100/policy_profile#{pp.active? ? '' : '_inactive'}.png")}
+                      %i{:class => pp.decorate.fonticon}
                     %td
                       = pp.description
   %br

--- a/app/views/miq_policy/_policy_folders.html.haml
+++ b/app/views/miq_policy/_policy_folders.html.haml
@@ -31,6 +31,6 @@
           - click = "#{type}_xx-#{type}-#{model_name}"
         %tr{:onclick => "miqTreeActivateNode('policy_tree', 'xx-#{click}');", :title => _("Open Folder")}
           %td.table-view-pf-select
-            %img{:src => image_path("100/#{model_name.underscore}.png")}
+            %i{:class => model_name.camelize.safe_constantize.try(:decorate).try(:fonticon)}
           %td
             = folders_i18n[f]

--- a/app/views/miq_policy/_profile_list.html.haml
+++ b/app/views/miq_policy/_profile_list.html.haml
@@ -14,7 +14,7 @@
             %tr{:title => _("View this Profile"),
               :onclick => "miqTreeActivateNode('policy_profile_tree', 'pp-#{to_cid(profile.id)}');"}
               %td.table-view-pf-select
-                %img{:src => image_path("100/policy_profile#{profile.active? ? '' : '_inactive'}.png")}
+                %i{:class => profile.decorate.fonticon}
               %td
                 = profile.description
 - else


### PR DESCRIPTION
There was a BZ where the physical infra image was missing with a 404 error. I found out that we're still using static images on some policy listing screens, so I'm replacing them with icons.

**Before:**
![screenshot from 2017-10-30 13-33-53](https://user-images.githubusercontent.com/649130/32170967-0e0b109a-bd77-11e7-8246-56d299adfabb.png)

**After:**
![screenshot from 2017-10-30 13-34-56](https://user-images.githubusercontent.com/649130/32170990-26f4a67a-bd77-11e7-8676-438fd4311e7d.png)

**Please ignore the error that there's some missing text in the last item, I'm going to fix it in a separate PR.**

@miq-bot add_label bug

https://bugzilla.redhat.com/show_bug.cgi?id=1501139