### PR TITLE
Add Lenovo infra provider authentication args for queue task

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -138,6 +138,8 @@ module Mixins
       when 'ManageIQ::Providers::Nuage::NetworkManager'
         endpoint_opts = {:protocol => params[:default_security_protocol], :hostname => params[:default_hostname], :api_port => params[:default_api_port], :api_version => params[:api_version]}
         [user, params[:default_password], endpoint_opts]
+      when 'ManageIQ::Providers::Lenovo::PhysicalInfraManager'
+        [user, password, params[:default_hostname], params[:default_api_port], "token", false]
       end
     end
 


### PR DESCRIPTION
This PR adds Lenovo provider authentication args for the authentication method called on the queue.
This is a follow up to [#2243](https://github.com/ManageIQ/manageiq-ui-classic/pull/2243) which changed the authentication method to use the queue.