### PR TITLE
Add missing text for physical infrastructure folder view

### DIFF
--- a/app/views/miq_policy/_policy_folders.html.haml
+++ b/app/views/miq_policy/_policy_folders.html.haml
@@ -8,7 +8,7 @@
                     "Container Node Compliance"          => _("Container Node Compliance Policies"),
                     "Container Image Compliance"         => _("Container Image Compliance Policies"),
                     "Ext Management System Compliance"   => _("Provider Compliance Policies"),
-                    "Physical Infrastructure Compliance" => _("Physical Infrastructure Compliance Policies"),
+                    "Physical Server Compliance"         => _("Physical Infrastructure Compliance Policies"),
                     "Host Control"                       => _("Host Control Policies"),
                     "Vm Control"                         => _("Vm Control Policies"),
                     "Container Replicator Control"       => _("Replicator Control Policies"),
@@ -16,7 +16,7 @@
                     "Container Node Control"             => _("Container Node Control Policies"),
                     "Container Image Control"            => _("Container Image Control Policies"),
                     "Ext Management System Control"      => _("Provider Control Policies"),
-                    "Physical Infrastructure Control"    => _("Physical Infrastructure Control Policies"),
+                    "Physical Server Control"            => _("Physical Infrastructure Control Policies"),
                     }
   = render :partial => "layouts/flash_msg"
   %table.table.table-striped.table-bordered.table-hover


### PR DESCRIPTION
Some keys have been changed and the lookup was unsuccessful for this one.

**Before:**
![screenshot from 2017-10-30 13-33-53](https://user-images.githubusercontent.com/649130/32171269-dbf28236-bd77-11e7-9a23-a97009aae2f5.png)

**After:**
![screenshot from 2017-10-30 13-37-00](https://user-images.githubusercontent.com/649130/32171147-7c52f770-bd77-11e7-960a-4d51e4c43448.png)

**Please ignore the missing icon issue, that's being addressed in a different PR with a BZ.**