### PR TITLE
Allow Metering reports in views

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -186,7 +186,7 @@ module ReportController::Reports::Editor
     build_tabs
 
     get_time_profiles # Get time profiles list (global and user specific)
-    cb_entities_by_provider if Chargeback.db_is_chargeback?(@edit[:new][:model]) && [ChargebackContainerImage, ChargebackContainerProject].include?(@edit[:new][:model].safe_constantize)
+    cb_entities_by_provider if Chargeback.db_is_chargeback?(@edit[:new][:model]) && [ChargebackContainerImage, ChargebackContainerProject, MeteringContainerImage, MeteringContainerProject].include?(@edit[:new][:model].safe_constantize)
     case @sb[:miq_tab].split("_")[1]
     when "1"  # Select columns
       @edit[:models] ||= reportable_models
@@ -1328,7 +1328,7 @@ module ReportController::Reports::Editor
       @edit[:new][:cb_interval_size] = options[:interval_size]
       @edit[:new][:cb_end_interval_offset] = options[:end_interval_offset]
       @edit[:new][:cb_groupby] = options[:groupby]
-      cb_entities_by_provider if [ChargebackContainerImage, ChargebackContainerProject].include?(@rpt.db.safe_constantize)
+      cb_entities_by_provider if [ChargebackContainerImage, ChargebackContainerProject, MeteringContainerImage, MeteringContainerProject].include?(@rpt.db.safe_constantize)
     end
 
     # Only show chargeback users choice if an admin

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -1,5 +1,5 @@
 - url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
-- if @edit[:new][:model] == "ChargebackVm"
+- if @edit[:new][:model] == "ChargebackVm" || @edit[:new][:model] == "MeteringVm"
   %h3
     = _('Chargeback Resources')
   .form-horizontal
@@ -32,11 +32,11 @@
         = _('Show Costs by')
       .col-md-8
         - opts = [["<#{_('Choose')}>", nil]]
-        - if @edit[:new][:model] == "ChargebackContainerProject"
+        - if @edit[:new][:model] == "ChargebackContainerProject" || @edit[:new][:model] == "MeteringContainerProject"
           - opts += [[ui_lookup(:model => @edit[:new][:cb_model]), "entity"], ["%s Tag" % current_tenant.name, "tag"]]
-        - elsif @edit[:new][:model] == "ChargebackVm"
+        - elsif @edit[:new][:model] == "ChargebackVm" || @edit[:new][:model] == "MeteringVm"
           - opts += [[_('Owner'), "owner"], ["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"], [_('Tenant'), "tenant"]]
-        - elsif @edit[:new][:model] == "ChargebackContainerImage"
+        - elsif @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
           - opts += [[ui_lookup(:model => @edit[:new][:cb_model]), "entity"]]
         - else
           - opts += [[_('Owner'), "owner"], ["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"], [_(@edit[:new][:cb_model].to_s), "entity"]]
@@ -134,8 +134,8 @@
       = _('Group by')
     .col-md-8
       - opts = [["#{_('Date')}", "date"], ["#{_(@edit[:new][:cb_model])}", "vm"]]
-      - opts += [["#{_('Tag')}", "tag"]] unless @edit[:new][:model] == "ChargebackContainerImage"
-      - opts += [["#{_('Project')}", "project"], [_('Label'), 'label']] if @edit[:new][:model] == "ChargebackContainerImage"
+      - opts += [["#{_('Tag')}", "tag"]] unless @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
+      - opts += [["#{_('Project')}", "project"], [_('Label'), 'label']] if @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
       = select_tag("cb_groupby",
         options_for_select(opts, @edit[:new][:cb_groupby]),
         :class                 => "selectpicker")


### PR DESCRIPTION
Depends on:

- [x] https://github.com/ManageIQ/manageiq/pull/16342

Metering reports are similar like a chargeback report, as were are added in https://github.com/ManageIQ/manageiq/pull/16342


in views there are lot of ifs, so I need to extend them. Otherwise it will break filter tab in metering reports:
<img width="1264" alt="screen shot 2017-10-30 at 14 00 23" src="https://user-images.githubusercontent.com/14937244/32172116-d1c2d592-bd7a-11e7-8be2-3f8ee40abeec.png">


@miq-bot add_label chargeback, enhancement


@miq-bot assign @mzazrivec

