### PR TITLE
Fix Search to filter VMs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1502,7 +1502,7 @@ class ApplicationController < ActionController::Base
     if @search_text && (
         (!@parent && @lastaction == "show_list" && !session[:menu_click]) ||
         (@explorer && !session[:menu_click]) ||
-        (@layout == "miq_policy")) # Added to handle search text from list views in control explorer
+        %w(miq_policy vm_infra).include?(@layout)) # Added to handle search text from list views in control explorer
 
       stxt = @search_text.gsub("_", "`_")                 # Escape underscores
       stxt.gsub!("%", "`%")                               #   and percents


### PR DESCRIPTION
**fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1497278

Fix Search to filter out VMs correctly under
Compute -> Infrastructure -> Virtual Machines.

**Before:**
![cf1](https://user-images.githubusercontent.com/13417815/32179006-848bf3b2-bd8e-11e7-8351-4c91eba2e51f.png)

**After:**
![cf2](https://user-images.githubusercontent.com/13417815/32177719-46efe868-bd8b-11e7-957c-8ad86e381272.png)

