### PR TITLE
Fixed broken refresh functionality on all topology screens

### DIFF
--- a/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
@@ -15,7 +15,7 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService,
   topologyService.mixinContextMenu(vm, vm);
 
   ManageIQ.angular.rxSubject.subscribe(function(event) {
-    if (event.controller === 'cloudTopologyController' && event.name === 'refresh') {
+    if (event.name === 'refreshTopology') {
       vm.refresh();
     }
   });

--- a/app/assets/javascripts/controllers/topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/container_topology_controller.js
@@ -13,6 +13,12 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
 
   topologyService.mixinContextMenu(vm, vm);
 
+  ManageIQ.angular.rxSubject.subscribe(function(event) {
+    if (event.name === 'refreshTopology') {
+      vm.refresh();
+    }
+  });
+
   vm.refresh = function() {
     var id;
     var type;

--- a/app/assets/javascripts/controllers/topology/infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/infra_topology_controller.js
@@ -13,6 +13,12 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService,
 
   topologyService.mixinContextMenu(vm, vm);
 
+  ManageIQ.angular.rxSubject.subscribe(function(event) {
+    if (event.name === 'refreshTopology') {
+      vm.refresh();
+    }
+  });
+
   vm.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {

--- a/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
@@ -12,6 +12,12 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
 
   topologyService.mixinContextMenu(vm, vm);
 
+  ManageIQ.angular.rxSubject.subscribe(function(event) {
+    if (event.name === 'refreshTopology') {
+      vm.refresh();
+    }
+  });
+
   vm.refresh = function() {
     var id;
     if ($location.absUrl().match('show/$') || $location.absUrl().match('show$')) {

--- a/app/assets/javascripts/controllers/topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/network_topology_controller.js
@@ -13,6 +13,12 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
 
   topologyService.mixinContextMenu(this, $scope);
 
+  ManageIQ.angular.rxSubject.subscribe(function(event) {
+    if (event.name === 'refreshTopology') {
+      $scope.refresh();
+    }
+  });
+
   $scope.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {

--- a/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
@@ -13,6 +13,12 @@ function physicalInfraTopologyCtrl($scope, $http, $interval, $location, topology
 
   topologyService.mixinContextMenu(vm, vm);
 
+  ManageIQ.angular.rxSubject.subscribe(function(event) {
+    if (event.name === 'refreshTopology') {
+      vm.refresh();
+    }
+  });
+
   vm.refresh = function() {
     var id;
     if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {

--- a/app/views/shared/_topology_header_toolbar.html.haml
+++ b/app/views/shared/_topology_header_toolbar.html.haml
@@ -5,8 +5,7 @@
 
 .form-group
   %button.btn.btn-default{'data-function'      => 'sendDataWithRx',
-                          'data-function-data' => {:controller => 'cloudTopologyController',
-                                                   :name => 'refresh'}.to_json}
+                          'data-function-data' => {:name => 'refreshTopology'}.to_json}
     %i.fa.fa-refresh.fa-lg
     = _("Refresh")
 %form.search-pf.topology-search{:role     => 'form',


### PR DESCRIPTION
The regression was created by one of @Hyperkid123's [topology refactoring PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/1898/commits/dca1a32012d4ededf0f34f91f2caa74f1926f574#diff-a68b7b1eebf9174812f5a34789c80cb3R8) that made the refresh a bit too specific. The fix for now is just a simple copy-paste but it should be addressed later.

@miq-bot add_label bug

https://bugzilla.redhat.com/show_bug.cgi?id=1501048