### PR TITLE
Pass specific dialog local variables for custom buttons

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -30,8 +30,14 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
   function submitButtonClicked() {
     vm.dialogData.action = apiAction;
     miqService.sparkleOn();
-    API.post(apiSubmitEndpoint, vm.dialogData).then(function() {
-      miqService.redirectBack(__('Service ordered successfully!'), 'info', '/miq_request?typ=service');
+    var apiData;
+    if (apiSubmitEndpoint.match(/generic_objects/)) {
+      apiData = {parameters: vm.dialogData};
+    } else {
+      apiData = vm.dialogData;
+    }
+    API.post(apiSubmitEndpoint, apiData).then(function() {
+      miqService.redirectBack(__('Dialog submitted successfully!'), 'info', cancelEndpoint);
     }).catch(function(err) {
       miqService.sparkleOff();
       add_flash(__('Error requesting data from server'), 'error');

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -326,6 +326,8 @@ module ApplicationController::Buttons
         :target_kls => obj.class.name,
       }
 
+      options[:dialog_locals] = determine_dialog_locals_for_custom_button(obj, button.name)
+
       dialog_initialize(button.resource_action, options)
 
     elsif button.options && button.options.key?(:open_url) && button.options[:open_url]
@@ -345,6 +347,32 @@ module ApplicationController::Buttons
       end
       javascript_flash
     end
+  end
+
+  def determine_dialog_locals_for_custom_button(obj, button_name)
+    case obj.class.name.demodulize
+    when /Vm/
+      api_collection_name = "vms"
+      cancel_endpoint = "/vm_infra/explorer"
+      force_old_dialog_use = false
+    when /Service/
+      api_collection_name = "services"
+      cancel_endpoint = "/service/explorer"
+      force_old_dialog_use = false
+    when /GenericObject/
+      api_collection_name = "generic_objects"
+      cancel_endpoint = "/generic_object/show_list"
+      force_old_dialog_use = false
+    else
+      force_old_dialog_use = true
+    end
+
+    {
+      :force_old_dialog_use => force_old_dialog_use,
+      :api_submit_endpoint  => "/api/#{api_collection_name}/#{obj.id}",
+      :api_action           => button_name,
+      :cancel_endpoint      => cancel_endpoint
+    }
   end
 
   def get_available_dialogs

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -92,7 +92,7 @@ module ApplicationController::DialogRunner
     @record = Dialog.find_by_id(@edit[:rec_id])
     @in_a_form = true
     @showtype = "dialog_provision"
-    render :template => "shared/dialogs/dialog_provision"
+    render :template => "shared/dialogs/dialog_provision", :locals => params[:dialog_locals]
   end
 
   def dynamic_radio_button_refresh
@@ -157,7 +157,7 @@ module ApplicationController::DialogRunner
     if @edit[:explorer]
       replace_right_cell(:action => "dialog_provision", :dialog_locals => options[:dialog_locals])
     else
-      javascript_redirect :action => 'dialog_load'
+      javascript_redirect(:action => 'dialog_load', :dialog_locals => options[:dialog_locals])
     end
   end
 

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -92,7 +92,8 @@ module ApplicationController::DialogRunner
     @record = Dialog.find_by_id(@edit[:rec_id])
     @in_a_form = true
     @showtype = "dialog_provision"
-    render :template => "shared/dialogs/dialog_provision", :locals => params[:dialog_locals]
+    @dialog_locals = params[:dialog_locals]
+    render :template => "shared/dialogs/dialog_provision"
   end
 
   def dynamic_radio_button_refresh

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -392,7 +392,11 @@ class ServiceController < ApplicationController
     )
     if %w(dialog_provision ownership tag).include?(action)
       presenter.show(:form_buttons_div).hide(:pc_div_1, :toolbar).show(:paging_div)
-      unless action == "dialog_provision"
+      if action == "dialog_provision" && params[:pressed] == "service_reconfigure"
+        presenter.update(:form_buttons_div, r[:partial => "layouts/x_dialog_buttons",
+                                              :locals  => {:action_url => action_url,
+                                                           :record_id  => @edit[:rec_id]}])
+      else
         if action == "tag"
           locals = {:action_url => action_url}
           locals[:multi_record] = true    # need save/cancel buttons on edit screen even tho @record.id is not there

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -381,7 +381,7 @@ class ServiceController < ApplicationController
     # Replace right cell divs
     presenter.update(:main_div,
       if ["dialog_provision", "ownership", "retire", "service_edit", "tag"].include?(action)
-        r[:partial => partial]
+        r[:partial => partial, :locals => options[:dialog_locals]]
       elsif params[:display]
         r[:partial => 'layouts/x_gtl', :locals => {:controller => "vm", :action_url => @lastaction}]
       elsif record_showing
@@ -392,11 +392,7 @@ class ServiceController < ApplicationController
     )
     if %w(dialog_provision ownership tag).include?(action)
       presenter.show(:form_buttons_div).hide(:pc_div_1, :toolbar).show(:paging_div)
-      if action == "dialog_provision"
-        presenter.update(:form_buttons_div, r[:partial => "layouts/x_dialog_buttons",
-                                              :locals  => {:action_url => action_url,
-                                                           :record_id  => @edit[:rec_id]}])
-      else
+      unless action == "dialog_provision"
         if action == "tag"
           locals = {:action_url => action_url}
           locals[:multi_record] = true    # need save/cancel buttons on edit screen even tho @record.id is not there

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -173,11 +173,11 @@ module ApplicationHelper::Dialogs
     options.merge(:trigger => trigger_override)
   end
 
-  def force_old_dialogs?(params, force_old_dialog_use)
+  def force_old_dialogs?(dialog_locals, force_old_dialog_use)
     return false if force_old_dialog_use == false
 
-    if params[:dialog_locals]
-      return params[:dialog_locals][:force_old_dialog_use] || true
+    if dialog_locals
+      return dialog_locals[:force_old_dialog_use].to_s == "true"
     else
       return true
     end

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -173,6 +173,16 @@ module ApplicationHelper::Dialogs
     options.merge(:trigger => trigger_override)
   end
 
+  def force_old_dialogs?(params, force_old_dialog_use)
+    return false if force_old_dialog_use == false
+
+    if params[:dialog_locals]
+      return params[:dialog_locals][:force_old_dialog_use] || true
+    else
+      return true
+    end
+  end
+
   private
 
   def auto_refresh_options(field, auto_refresh_options_hash)

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -1,13 +1,14 @@
 - wf = @edit[:wf] if @edit && @edit[:wf]
 = render :partial => "layouts/flash_msg"
-- if params[:dialog_locals]
-  - api_submit_endpoint ||= params[:dialog_locals][:api_submit_endpoint]
-  - api_action ||= params[:dialog_locals][:api_action]
-  - cancel_endpoint ||= params[:dialog_locals][:cancel_endpoint]
+- if @dialog_locals
+  - api_submit_endpoint ||= @dialog_locals[:api_submit_endpoint]
+  - api_action ||= @dialog_locals[:api_action]
+  - cancel_endpoint ||= @dialog_locals[:cancel_endpoint]
+  - force_old_dialog_use = @dialog_locals[:force_old_dialog_use].to_s == "true"
 
-- force_old_dialog_use = force_old_dialogs?(params, force_old_dialog_use)
+- force_old_dialog_use ||= true
 
-- if Settings.product.old_dialog_user_ui || force_old_dialog_use == true
+- if Settings.product.old_dialog_user_ui || force_old_dialog_use
   :javascript
     dialogFieldRefresh.unbindAllPreviousListeners();
 

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -1,7 +1,13 @@
 - wf = @edit[:wf] if @edit && @edit[:wf]
 = render :partial => "layouts/flash_msg"
+- if params[:dialog_locals]
+  - api_submit_endpoint ||= params[:dialog_locals][:api_submit_endpoint]
+  - api_action ||= params[:dialog_locals][:api_action]
+  - cancel_endpoint ||= params[:dialog_locals][:cancel_endpoint]
 
-- if Settings.product.old_dialog_user_ui || action_name != "svc_catalog_provision"
+- force_old_dialog_use = force_old_dialogs?(params, force_old_dialog_use)
+
+- if Settings.product.old_dialog_user_ui || force_old_dialog_use == true
   :javascript
     dialogFieldRefresh.unbindAllPreviousListeners();
 

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -599,6 +599,45 @@ describe ApplicationHelper::Dialogs do
     end
   end
 
+  describe "#force_old_dialogs?" do
+    let(:force_old_dialog_use) { true }
+
+    context "when force_old_dialog_use is false" do
+      let(:force_old_dialog_use) { false }
+      let(:dialog_locals) { nil }
+
+      it "returns false" do
+        expect(helper.force_old_dialogs?(dialog_locals, force_old_dialog_use)).to eq(false)
+      end
+    end
+
+    context "when dialog locals exist" do
+      context "when the dialog local force old dialog use string matches 'true'" do
+        let(:dialog_locals) { {:force_old_dialog_use => "true"} }
+
+        it "returns true" do
+          expect(helper.force_old_dialogs?(dialog_locals, force_old_dialog_use)).to eq(true)
+        end
+      end
+
+      context "when the dialog local force old dialog use string does not match 'true'" do
+        let(:dialog_locals) { {:force_old_dialog_use => "potato"} }
+
+        it "returns false" do
+          expect(helper.force_old_dialogs?(dialog_locals, force_old_dialog_use)).to eq(false)
+        end
+      end
+    end
+
+    context "when dialog locals do not exist" do
+      let(:dialog_locals) { nil }
+
+      it "returns true" do
+        expect(helper.force_old_dialogs?(dialog_locals, force_old_dialog_use)).to eq(true)
+      end
+    end
+  end
+
   describe "#default_value_form_options" do
     let(:subject) { helper.default_value_form_options(field_values, field_default_value) }
 

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -107,7 +107,7 @@ describe('dialogUserController', function() {
       it('redirects to the miq_request screen', function(done) {
         $controller.submitButtonClicked();
         setTimeout(function() {
-          expect(miqService.redirectBack).toHaveBeenCalledWith('Service ordered successfully!', 'info', '/miq_request?typ=service');
+          expect(miqService.redirectBack).toHaveBeenCalledWith('Dialog submitted successfully!', 'info', 'cancel endpoint');
           done();
         });
       });


### PR DESCRIPTION
This PR allows a few custom buttons to go through the new dialog-user ui-component. Namely custom buttons that have been put on Services, Vms, or Generic Objects. Other custom buttons such as Hosts or Providers will need multiple PRs from both the main repo and the API repo before they can be enabled.

https://www.pivotaltracker.com/story/show/150645792

/cc @gmcculloug 
@miq-bot add_label enhancement, automation/automate

@d-m-u Can you review?

