### PR TITLE
 Prevent long text strings from overflowing modals

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -723,6 +723,12 @@ td.action > .btn.btn-default {
   }
 }
 
+/// force word-break for long text strings in modals
+
+.modal-body p {
+  word-wrap: break-word;
+}
+
 /// Panel in sidebar doesn't need bottom margin
 .sidebar-pf-left {
   .panel-group {


### PR DESCRIPTION
This PR forces a word break to prevent long text strings from overflowing modals

https://bugzilla.redhat.com/show_bug.cgi?id=1501503

Old
<img width="692" alt="screen shot 2017-10-30 at 1 36 47 pm" src="https://user-images.githubusercontent.com/1287144/32186209-d8bdaef6-bd77-11e7-904e-e8098b153c0c.png">

New
<img width="654" alt="screen shot 2017-10-30 at 1 37 25 pm" src="https://user-images.githubusercontent.com/1287144/32186207-d8ae25bc-bd77-11e7-8673-7742dc330e87.png">


