### PR TITLE
Change with_adhoc scope to without_adhoc

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -393,7 +393,7 @@ module OpsController::Settings::Schedules
     @sortcol = session[:schedule_sortcol].nil? ? 0 : session[:schedule_sortcol].to_i
     @sortdir = session[:schedule_sortdir].nil? ? "ASC" : session[:schedule_sortdir]
 
-    @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_prod_default_not_in, "system"], [:with_adhoc, nil]]) # Get the records (into a view) and the paginator
+    @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_prod_default_not_in, "system"], :without_adhoc]) # Get the records (into a view) and the paginator
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number
     session[:schedule_sortcol] = @sortcol


### PR DESCRIPTION
Fix `with_adhoc` scope to process nil values only.

![image](https://user-images.githubusercontent.com/7453394/32186735-31db779a-bda3-11e7-99f4-38826fd26a45.png)

Depends on: https://github.com/ManageIQ/manageiq/pull/16348