### PR TITLE
Sort reports alphabetically

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1046,6 +1046,7 @@ class ApplicationController < ActionController::Base
           end
         else
           if @temp_title1 != title[1]
+            reports.sort!
             reports = []
             @temp_title1 = title[1]
           end

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -51,7 +51,7 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
     node_id = nodes.last.to_i
 
     child_names = @rpt_menu[parent_id][1][node_id][1]
-    count_only ? child_names.size : MiqReport.where(:name => child_names)
+    count_only ? child_names.size : MiqReport.where(:name => child_names).order(:name)
   end
 
   def folder_hash(id, text, blue)


### PR DESCRIPTION
Fixing report sorting: reports are not sorted, sorting order in navigation tree is not consistent  and different than in table
Issue: https://github.com/ManageIQ/manageiq/issues/16083

**BEFORE:**
<img width="814" alt="before" src="https://user-images.githubusercontent.com/6556758/32188663-d9864468-bd7e-11e7-917b-92216edcf700.png">

**AFTER:**
<img width="807" alt="after" src="https://user-images.githubusercontent.com/6556758/32188696-e9c45b26-bd7e-11e7-9293-6dce427d15b9.png">

@miq-bot add-label enhancement, reporting
