### PR TITLE
Do not run JS on the saved reports screen before the tree is ready

### DIFF
--- a/app/views/report/explorer.html.haml
+++ b/app/views/report/explorer.html.haml
@@ -3,6 +3,7 @@
     = render :partial => list
     -# Include the center cell divs
 
+-# FIXME: we should not do javascript like this
 %script{:type => "text/javascript"}
   function miqReportAfterOnload() {
   - if @right_cell_div == "role_list"
@@ -12,7 +13,9 @@
         = javascript_hide("menu_div1")
         = javascript_show("menu_div3")
   - else
+    setTimeout(function() {
     miqTreeForceActivateNode('#{x_active_tree}', '#{x_node}')
+    });
   };
   ManageIQ.afterOnload = "miqReportAfterOnload();"
 


### PR DESCRIPTION
This node activation is called too early, but it should not even exist in this place. Will refactor it in a separate PR. It creates random JS errors when there are no saved reports.