### PR TITLE
Refactor flash message text for consistency across all actions (Add/Edit/Delete/Cancel)

### DIFF
--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -92,7 +92,7 @@ module PxeController::PxeCustomizationTemplates
     if params[:button] == "cancel"
       @edit = session[:edit] = nil # clean out the saved info
       if @ct.id
-        add_flash(_("Edit of Customization Template \"%{name}\" was cancelled by the user") % {:name => @ct.name})
+        add_flash(_("Edit of Customization Template \"%{name}\" was cancelled by the user") % {:name => get_record_display_name(@ct)})
       else
         add_flash(_("Add of new Customization Template was cancelled by the user"))
       end
@@ -120,9 +120,9 @@ module PxeController::PxeCustomizationTemplates
 
       if !flash_errors? && ct.valid? && ct.save
         if ct.id
-          add_flash(_("Customization Template \"%{name}\" was saved") % {:name => ct.name})
+          add_flash(_("Customization Template \"%{name}\" was saved") % {:name => get_record_display_name(ct)})
         else
-          add_flash(_("Customization Template \"%{name}\" was added") % {:name => ct.name})
+          add_flash(_("Customization Template \"%{name}\" was added") % {:name => get_record_display_name(ct)})
         end
         AuditEvent.success(build_created_audit(ct, @edit))
         @edit = session[:edit] = nil # clean out the saved info


### PR DESCRIPTION
Refactor flash message ext construction to be consistent for all user actions. Previously code displayed Custom template name when adding or editing one and description when deleting. Code now calls same common to return consistent text, template description when available and name when description is not available. 

https://bugzilla.redhat.com/show_bug.cgi?id=1486615


Screen shots prior to code fix, all showing hard coded template name:
=======================
![custom template add flash msg prior to code fix](https://user-images.githubusercontent.com/552686/32571861-bc9cea9a-c47d-11e7-9a95-53bbde90ce5b.png)

![custom template edit flash msg prior to code fix](https://user-images.githubusercontent.com/552686/32571889-d1f3445c-c47d-11e7-8c56-0f1f130c96bd.png)

![custom template cancel flash msg prior to code fix](https://user-images.githubusercontent.com/552686/32571908-ddcb977a-c47d-11e7-9d7f-2ac2fa872b04.png)



Screen shots post code fix, showing common method returning template description for display:
========================
![custom template add flash msg post code fix](https://user-images.githubusercontent.com/552686/32571934-f3d5d6fc-c47d-11e7-9d06-bf18d464cb61.png)

![custom template edit flash msg post code fix](https://user-images.githubusercontent.com/552686/32571948-ff8ff540-c47d-11e7-8eb3-70ef577bde22.png)

![custom template cancel flash msg post code fix](https://user-images.githubusercontent.com/552686/32571960-0a0c1bd4-c47e-11e7-8136-7f58e80c1efe.png)

![custom template delete flash msg post code fix](https://user-images.githubusercontent.com/552686/32571973-12bff0b6-c47e-11e7-9477-25e877059810.png)


