### PR TITLE
Provide the custom uploaded picture attribute separately in report_data

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1166,14 +1166,15 @@ class ApplicationController < ActionController::Base
       # Generate html for the list icon
       if has_listicon
         item = listicon_item(view, row['id'])
-        icon, icon2, image = listicon_glyphicon(item)
+        icon, icon2, image, picture = listicon_glyphicon(item)
         image = "100/#{(@listicon || view.db).underscore}.png" if icon.nil? && image.nil? # TODO: we want to get rid of this
         icon = nil if %w(pxe).include? params[:controller]
         new_row[:img_url] = ActionController::Base.helpers.image_path(image.to_s)
         new_row[:cells] << {:title => _('View this item'),
-                            :image => image,
-                            :icon  => icon,
-                            :icon2 => icon2}
+                            :image   => image,
+                            :picture => picture,
+                            :icon    => icon,
+                            :icon2   => icon2}
 
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1595,7 +1595,14 @@ module ApplicationHelper
   end
 
   def listicon_glyphicon(item)
-    [item.decorate.try(:fonticon), item.decorate.try(:secondary_icon), item.decorate.try(:fileicon)] if item
+    return nil unless item
+    decorated = item.decorate
+    [
+      decorated.try(:fonticon),
+      decorated.try(:secondary_icon),
+      decorated.try(:fileicon),
+      item.try(:picture) ? decorated.try(:fileicon) : nil
+    ]
   end
   private :listicon_glyphicon
 


### PR DESCRIPTION
For now we have two types of node images in GTL list views: fonticons and fileicons. The priority is always fonticons first, however, sometimes we have custom uploaded pictures and they should be favored even over fonticons.

My solution is to introduce the new picture type with the highest priority. This will be sent for some nodes only and it should not affect the behavior of screens where there are no custom uploaded pictures. The change for now is simple and it doesn't affect the decorators but I think it should be refactored later.

There's also a related [ui-components PR](https://github.com/ManageIQ/ui-components/pull/196), that I also used to create the screenshots below.

**Before:**
![screenshot from 2017-10-31 14-04-35](https://user-images.githubusercontent.com/649130/32225154-7330b920-be44-11e7-838a-d51372d644e5.png)

**After:**
![screenshot from 2017-10-31 14-01-57](https://user-images.githubusercontent.com/649130/32225159-7773a6be-be44-11e7-8b6c-948e12f87c50.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1487056
