### PR TITLE
Fix SCVMM Credential Validation

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -127,8 +127,16 @@ module Mixins
       when 'ManageIQ::Providers::Google::CloudManager'
         [params[:project], params[:service_account], {:service => "compute"}]
       when 'ManageIQ::Providers::Microsoft::InfraManager'
-        endpoint = ems.auth_url(params[:default_hostname], params[:default_api_port])
-        [{:endpoint => endpoint, :user => user, :password => password}, true]
+        connect_opts = {
+          :hostname          => params[:default_hostname],
+          :user              => user,
+          :password          => password,
+          :port              => params[:default_api_port],
+          :realm             => params[:realm],
+          :security_protocol => params[:default_security_protocol],
+        }
+
+        [ems.build_connect_params(connect_opts), true]
       when 'ManageIQ::Providers::Openstack::InfraManager'
         auth_url = ems.auth_url(params[:default_hostname], params[:default_api_port])
         [user, password, auth_url]

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -127,7 +127,8 @@ module Mixins
       when 'ManageIQ::Providers::Google::CloudManager'
         [params[:project], params[:service_account], {:service => "compute"}]
       when 'ManageIQ::Providers::Microsoft::InfraManager'
-        [{:endpoint => params[:default_hostname], :user => user, :password => password}, true]
+        endpoint = ems.auth_url(params[:default_hostname], params[:default_api_port])
+        [{:endpoint => endpoint, :user => user, :password => password}, true]
       when 'ManageIQ::Providers::Openstack::InfraManager'
         auth_url = ems.auth_url(params[:default_hostname], params[:default_api_port])
         [user, password, auth_url]

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -461,6 +461,8 @@ describe EmsInfraController do
     end
 
     it "validates credentials for a new record" do
+      expect(ManageIQ::Providers::Microsoft::InfraManager).to receive(:build_connect_params)
+
       post :create, :params => {
         "button"           => "validate",
         "cred_type"        => "default",


### PR DESCRIPTION
The SCVMM endpoint needs to be built with the .auth_url method to set
the port/path/protocol.

~~Note: This only fixes SSL connection mode.  For the kerberos mode we
need to move the build_connection_params to be a class method.  Up to
you if we want to merge this to fix SSL (the default) or wait and fix
both.~~

Depends on: ~~https://github.com/ManageIQ/manageiq-providers-scvmm/pull/34~~