### PR TITLE
[GAPRINDASHVILI] We support Ruby 2.3.1 on gaprindashvili appliances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-- '2.3.3'
-- '2.4.1'
+- '2.3.1'
 sudo: false
 cache:
   bundler: true


### PR DESCRIPTION
2.4.x was tested on master and is no longer tested on the gaprindashvili