### PR TITLE
Fix credential validation in Hawkular provider about number of arguments

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -162,6 +162,8 @@ module Mixins
         [user, params[:default_password], endpoint_opts]
       when 'ManageIQ::Providers::Lenovo::PhysicalInfraManager'
         [user, password, params[:default_hostname], params[:default_api_port], "token", false, true]
+      when 'ManageIQ::Providers::Hawkular::MiddlewareManager'
+        [params[:default_hostname], params[:default_api_port], user, params[:default_password], params[:default_security_protocol], params[:default_tls_ca_certs], true]
       end
     end
 


### PR DESCRIPTION
Adding a new hawkular provider throws this error
**Credential validation was not successful: wrong number of arguments (given 0, expected 6)**

We need to add the hawkular provider.

Fix https://github.com/ManageIQ/manageiq-ui-classic/issues/2572

```ruby
[----] I, [2017-10-31T09:26:25.828095 #29354:3e6c910]  INFO -- : Started GET "/ws/notifications" for 127.0.0.1 at 2017-10-31 09:26:25 +0100
[----] F, [2017-10-31T09:26:25.872112 #29354:3e6c910] FATAL -- :   
[----] F, [2017-10-31T09:26:25.872172 #29354:3e6c910] FATAL -- : ActionController::RoutingError (No route matches [GET] "/ws/notifications"):
[----] F, [2017-10-31T09:26:25.872211 #29354:3e6c910] FATAL -- :   
[----] F, [2017-10-31T09:26:25.872239 #29354:3e6c910] FATAL -- : actionpack (5.0.6) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
actionpack (5.0.6) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
railties (5.0.6) lib/rails/rack/logger.rb:36:in `call_app'
railties (5.0.6) lib/rails/rack/logger.rb:26:in `call'
sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
actionpack (5.0.6) lib/action_dispatch/middleware/request_id.rb:24:in `call'
rack (2.0.3) lib/rack/method_override.rb:22:in `call'
rack (2.0.3) lib/rack/runtime.rb:22:in `call'
activesupport (5.0.6) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
actionpack (5.0.6) lib/action_dispatch/middleware/executor.rb:12:in `call'
actionpack (5.0.6) lib/action_dispatch/middleware/static.rb:136:in `call'
rack (2.0.3) lib/rack/sendfile.rb:111:in `call'
railties (5.0.6) lib/rails/engine.rb:522:in `call'
puma (3.7.1) lib/puma/configuration.rb:232:in `call'
puma (3.7.1) lib/puma/server.rb:578:in `handle_request'
puma (3.7.1) lib/puma/server.rb:415:in `process_client'
puma (3.7.1) lib/puma/server.rb:275:in `block in run'
puma (3.7.1) lib/puma/thread_pool.rb:120:in `block in spawn_thread'
```

cc @abonas @agrare 

@agrare i don't know in the case of a custom CA how pass the argument "Trusted CA Certificates" in this array, it seems is default_tls_ca_certs so the array will be 
```ruby
[user, password, params[:default_hostname], params[:default_api_port], params[:default_tls_ca_certs], params[:default_security_protocol]]
```

But I can't test it, I tested with no SSL case and now is working again.