### PR TITLE
Ext targeted alerts in the monitoring screen

### DIFF
--- a/app/assets/javascripts/services/alerts_center_service.js
+++ b/app/assets/javascripts/services/alerts_center_service.js
@@ -635,7 +635,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
                 matchingTag = _.find(_this.tags, function(nextTag) {
                   return nextTag.id === providerTag.id;
                 });
-                if (matchingTag !== undefined) {
+                if (matchingTag !== undefined  && matchingTag.categorization.category !== undefined  ) {
                   summaryItem.tags.push({
                     id: providerTag.id,
                     categoryName: matchingTag.categorization.category.name,

--- a/app/assets/stylesheets/alerts.scss
+++ b/app/assets/stylesheets/alerts.scss
@@ -84,6 +84,9 @@
     font-size: 16px;
     vertical-align: middle;
   }
+  .transparent {
+    display: table-column!important;
+  }
   .list-view-type-img {
     width: 16px;
     height: 16px;

--- a/app/views/shared/views/_alerts_list.html.haml
+++ b/app/views/shared/views/_alerts_list.html.haml
@@ -18,7 +18,8 @@
               %a{"href" => "#", "ng-click" => "customScope.showHostPage(item, $event)"}
                 %span.no-wrap{"tooltip" => "{{item.hostName}}",
                               "tooltip-placement" => "bottom",
-                              "tooltip-popup-delay" => "1000"}
+                              "tooltip-popup-delay" => "1000",
+                              "ng-class" => "{'transparent': item.hostImg == item.objectTypeImg}"}
                   %img.list-view-type-img{"ng-src" => "{{item.hostImg}}"}
                   {{item.hostName}}
             %div


### PR DESCRIPTION
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1507990

- Consider only categorised tags for filtering
- Hide target icon for ems alerts

Before
![screenshot from 2017-10-31 17-04-56](https://user-images.githubusercontent.com/3010449/32231582-a3788706-be5e-11e7-9782-42331e650c57.png)

After
![alerts2](https://user-images.githubusercontent.com/3010449/32280675-56978b2c-bf25-11e7-932c-08c44419fffb.png)

TBD:
1. ~the ext icon should be aligned to the bottom for ems alerts (like it is in node alerts)~
1. ~the link should be fixed for ems alerts (still leads to node)~