### PR TITLE
Add a dismiss button for dynamically generated flash messages

### DIFF
--- a/app/assets/javascripts/miq_flash.js
+++ b/app/assets/javascripts/miq_flash.js
@@ -32,14 +32,11 @@ function add_flash(msg, level, options) {
   var textStrong = $('<strong></strong>');
   textStrong.text(msg);
 
-  var alertDiv = $('<div class="' + cls.alert + '"></div>');
+  var alertDiv = $('<div class="' + cls.alert + '"><button class="close" data-dismiss="alert"><span class="pficon pficon-close"></span></button></div>');
   alertDiv.append(iconSpan, textStrong);
 
   var textDiv = $('<div class="flash_text_div"></div>');
-  textDiv.attr('title', __('Click to remove message'));
-  textDiv.on('click', function() {
-    textDiv.remove();
-  });
+
   textDiv.append(alertDiv);
 
   // if options.id is provided, only one flash message with that id may exist


### PR DESCRIPTION
Some JS-generated flash messages were dismissable by clicking on them which made copying error messages impossible. I removed this feature and rather added a dismiss button.

**Before:**
![screenshot from 2017-10-31 16-55-11](https://user-images.githubusercontent.com/649130/32234131-506448a4-be5c-11e7-8c57-4aa7bfe23e1a.png)

**After:**
![screenshot from 2017-10-31 16-54-04](https://user-images.githubusercontent.com/649130/32234057-205ffedc-be5c-11e7-9cb7-503244f76c32.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1467629