### PR TITLE
Display flash message after updating Chargeback Rate

### DIFF
--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -1,3 +1,4 @@
+= render :partial => 'layouts/flash_msg'
 - breakdown_present = @record.chargeback_rate_details.any? { |d| d.sub_metric.present? }
 %h3= _('Basic Info')
 .form-horizontal.static


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1468561

Display flash message in Cloud Intel -> Chargeback -> Rates tab
after updating or copying a chargeback rate.

**Before:**
![rate1](https://user-images.githubusercontent.com/13417815/32234967-7409e406-be5e-11e7-8d1b-ffa6735aa2cb.png)

**After:**
![rate2](https://user-images.githubusercontent.com/13417815/32234871-31133eea-be5e-11e7-86e7-6e165a387403.png)
![rate3](https://user-images.githubusercontent.com/13417815/32235025-a3864242-be5e-11e7-9771-fc56344fe4cb.png)
