### PR TITLE
 Styling fix for Bootstrap switch on Tenant Quota screen

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -489,7 +489,7 @@ table.table.table-summary-screen tbody td img {
 
 /// begin table view styling
 
-table.table td {
+table.table td:not(.table-view-pf-select) { //Force word break but prevent bs-switch from wrapping
   word-break: break-all
 }
 

--- a/app/views/ops/_tenant_quota_form.html.haml
+++ b/app/views/ops/_tenant_quota_form.html.haml
@@ -1,49 +1,47 @@
 - @angular_form = true
 
-%form.form-horizontal#form_div{"name"          => "angularForm",
-                               "ng-controller" => "tenantQuotaFormController as vm",
-                               "ng-show"       => "vm.afterGet",
-                               "miq-form"      => 'true',
-                               "model-copy"    => 'vm.modelCopy',
-                               "novalidate"    => true}
+%form#form_div{"name"          => "angularForm",
+               "ng-controller" => "tenantQuotaFormController as vm",
+               "ng-show"       => "vm.afterGet",
+               "miq-form"      => 'true',
+               "model-copy"    => 'vm.modelCopy',
+               "novalidate"    => true}
   = render :partial => "layouts/flash_msg"
-  %div
-    %div
-      %table.table.datatable.table-striped.table-bordered
-        %thead
-          %tr
-            %th
-              = _("Enforced")
-            %th
-              = _("Description")
-            %th
-              = _("Value")
-            %th
-              = _("Units")
-        %tbody
-          %tr{"ng-repeat" => "(quota_name, quota_obj) in vm.tenantQuotaModel.quotas", "ng-form" => "rowForm", "ng-class" => "{'has-error': rowForm.value.$invalid}"}
-            %td.table-view-pf-select
-              %input{"bs-switch"  => "",
-                    "id"          => "{{quota_name}}",
-                    "type"        => "checkbox",
-                    "name"        => "enforced",
-                    "ng-change"   => "vm.enforcedChanged(quota_name)",
-                    "ng-model"    => "quota_obj.enforced"}
-            %td {{quota_obj.description}}
-            %td
-              %input.form-control{"type"        => "text",
-                                  "id"          => "id_{{quota_name}}",
-                                  "name"        => "id_{{quota_name}}",
-                                  "ng-model"    => "quota_obj.value",
-                                  "ng-required" => "quota_obj.enforced",
-                                  "ng-disabled" => "!quota_obj.enforced",
-                                  "ng-pattern"  => "quota_obj.valpattern",
-                                  "placeholder" => "Not enforced",
-                                  "ng-change"   => "vm.valueChanged()"}
-              %span{"style"=>"color:red", "ng-show" => "rowForm.value.$invalid"}
-                = _(" Valid numeric quota value required ")
+  %table.table.table-striped.table-bordered
+    %thead
+      %tr
+        %th
+          = _("Enforced")
+        %th
+          = _("Description")
+        %th
+          = _("Value")
+        %th
+          = _("Units")
+    %tbody
+      %tr{"ng-repeat" => "(quota_name, quota_obj) in vm.tenantQuotaModel.quotas", "ng-form" => "rowForm", "ng-class" => "{'has-error': rowForm.value.$invalid}"}
+        %td.table-view-pf-select
+          %input{"bs-switch"  => "",
+                "id"          => "{{quota_name}}",
+                "type"        => "checkbox",
+                "name"        => "enforced",
+                "ng-change"   => "vm.enforcedChanged(quota_name)",
+                "ng-model"    => "quota_obj.enforced"}
+        %td {{quota_obj.description}}
+        %td
+          %input.form-control{"type"        => "text",
+                              "id"          => "id_{{quota_name}}",
+                              "name"        => "id_{{quota_name}}",
+                              "ng-model"    => "quota_obj.value",
+                              "ng-required" => "quota_obj.enforced",
+                              "ng-disabled" => "!quota_obj.enforced",
+                              "ng-pattern"  => "quota_obj.valpattern",
+                              "placeholder" => "Not enforced",
+                              "ng-change"   => "vm.valueChanged()"}
+          %span{"style"=>"color:red", "ng-show" => "rowForm.value.$invalid"}
+            = _(" Valid numeric quota value required ")
 
-            %td &nbsp; {{quota_obj.text_modifier}}
+        %td &nbsp; {{quota_obj.text_modifier}}
 
   = render :partial => "layouts/angular/x_edit_buttons_angular"
 


### PR DESCRIPTION
This PR fixes a bug on the "Manage quotas for tenant" screen, where bootstrap switch was malformed because of a css setting that forced word breaks in TDs. This fix excludes the "table-view-pf-select" class (used for checkboxes, switches and icons) from using word-break and also cleans up extraneous markup on the screen. The problem is exposed when the UI is set to use the Japanese language.

https://bugzilla.redhat.com/show_bug.cgi?id=1495190

Before
<img width="1212" alt="screen shot 2017-10-31 at 12 05 46 pm" src="https://user-images.githubusercontent.com/1287144/32235010-ab715c0a-be34-11e7-9cbb-c9ad5b31c7ac.png">

After
<img width="1210" alt="screen shot 2017-10-31 at 12 05 17 pm" src="https://user-images.githubusercontent.com/1287144/32235011-ab7f38a2-be34-11e7-8470-9b3c94b22d09.png">

