### PR TITLE
Add a new tab for separate VMRC console credentials for vmware infra

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -31,6 +31,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       default_password: '',
       amqp_userid: '',
       amqp_password: '',
+      console_userid: '',
+      console_password: '',
       smartstate_docker_userid: '',
       smartstate_docker_password: '',
       metrics_userid: '',
@@ -62,6 +64,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       prometheus_alerts_security_protocol: '',
       smartstate_docker_auth_status: true,
       alerts_selection: '',
+      console_auth_status: true,
     };
 
     $scope.emsOptionsModel = {
@@ -135,8 +138,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.provider_region                 = data.provider_region;
       $scope.emsCommonModel.default_userid                  = data.default_userid;
       $scope.emsCommonModel.amqp_userid                     = data.amqp_userid;
+      $scope.emsCommonModel.console_userid                  = data.console_userid;
       $scope.emsCommonModel.metrics_userid                  = data.metrics_userid;
-      $scope.emsCommonModel.smartstate_docker_userid               = data.smartstate_docker_userid;
+      $scope.emsCommonModel.smartstate_docker_userid        = data.smartstate_docker_userid;
       $scope.emsCommonModel.vmware_cloud_api_version        = data.api_version;
 
       $scope.emsCommonModel.ssh_keypair_userid              = data.ssh_keypair_userid;
@@ -172,6 +176,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       }
       if ($scope.emsCommonModel.amqp_userid !== '') {
         $scope.emsCommonModel.amqp_password = miqService.storedPasswordPlaceholder;
+      }
+      if ($scope.emsCommonModel.console_userid !== '') {
+        $scope.emsCommonModel.console_password = miqService.storedPasswordPlaceholder;
       }
       if ($scope.emsCommonModel.metrics_userid !== '') {
         $scope.emsCommonModel.metrics_password = miqService.storedPasswordPlaceholder;
@@ -261,6 +268,10 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       ($scope.emsCommonModel.amqp_hostname) &&
       ($scope.emsCommonModel.amqp_userid != '' && $scope.angularForm.amqp_userid !== undefined && $scope.angularForm.amqp_userid.$valid &&
        $scope.emsCommonModel.amqp_password != '' && $scope.angularForm.amqp_password !== undefined && $scope.angularForm.amqp_password.$valid)) {
+      return true;
+    } else if(($scope.currentTab == "console") &&
+      ($scope.emsCommonModel.console_userid != '' && $scope.angularForm.console_userid !== undefined &&
+       $scope.emsCommonModel.console_password != '' && $scope.angularForm.console_password !== undefined)) {
       return true;
     } else if(($scope.currentTab == "smartstate_docker") &&
       ($scope.emsCommonModel.smartstate_docker_userid != '' && $scope.angularForm.smartstate_docker_userid !== undefined &&
@@ -483,6 +494,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     if ($scope.emsCommonModel.amqp_auth_status === true) {
       $scope.postValidationModelRegistry("amqp");
     }
+    if ($scope.emsCommonModel.console_auth_status === true) {
+      $scope.postValidationModelRegistry("console");
+    }
     if ($scope.emsCommonModel.service_account_auth_status === true) {
       $scope.postValidationModelRegistry("service_account");
     }
@@ -502,6 +516,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.postValidationModel = {
         default: {},
         amqp: {},
+        console: {},
+        smartstate_docker: {},
         metrics: {},
         ssh_keypair: {},
         prometheus_alerts: {},
@@ -538,6 +554,16 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         amqp_security_protocol:    $scope.emsCommonModel.amqp_security_protocol,
         amqp_userid:               $scope.emsCommonModel.amqp_userid,
         amqp_password:             amqp_password,
+      };
+    } else if (prefix === "console") {
+      if ($scope.newRecord) {
+        var console_password = $scope.emsCommonModel.console_password;
+      } else {
+        var console_password = $scope.emsCommonModel.console_password === "" ? "" : miqService.storedPasswordPlaceholder;
+      }
+      $scope.postValidationModel.console = {
+        console_userid:           $scope.emsCommonModel.console_userid,
+        console_password:         console_password,
       };
     } else if (prefix === "metrics") {
       var metricsValidationModel = {

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -203,6 +203,7 @@ module Mixins
       amqp_hostname = ""
       amqp_port = ""
       amqp_security_protocol = ""
+      console_userid = ""
       smartstate_docker_userid = ""
       ssh_keypair_userid = ""
       metrics_userid = ""
@@ -228,6 +229,11 @@ module Mixins
       if @ems.has_authentication_type?(:amqp)
         amqp_userid = @ems.authentication_userid(:amqp).to_s
         amqp_auth_status = @ems.authentication_status_ok?(:amqp)
+      end
+
+      if @ems.has_authentication_type?(:console)
+        console_userid = @ems.authentication_userid(:console).to_s
+        console_auth_status = true
       end
 
       if @ems.has_authentication_type?(:smartstate_docker)
@@ -353,6 +359,7 @@ module Mixins
                         :provider_id                   => @ems.provider_id || "",
                         :default_hostname              => @ems.connection_configurations.default.endpoint.hostname,
                         :amqp_hostname                 => amqp_hostname,
+                        :console_userid                => console_userid,
                         :metrics_hostname              => metrics_hostname,
                         :metrics_database_name         => metrics_database_name,
                         :metrics_default_database_name => metrics_default_database_name,
@@ -376,6 +383,7 @@ module Mixins
                         :event_stream_selection        => retrieve_event_stream_selection,
                         :ems_controller                => controller_name,
                         :default_auth_status           => default_auth_status,
+                        :console_auth_status           => console_auth_status,
                         :metrics_auth_status           => metrics_auth_status.nil? ? true : metrics_auth_status,
                         :ssh_keypair_auth_status       => ssh_keypair_auth_status.nil? ? true : ssh_keypair_auth_status
       } if controller_name == "ems_infra"
@@ -615,6 +623,7 @@ module Mixins
       endpoints = {:default           => default_endpoint,
                    :ceilometer        => ceilometer_endpoint,
                    :amqp              => amqp_endpoint,
+                   :console           => default_endpoint,
                    :smartstate_docker => default_endpoint,
                    :amqp_fallback1    => amqp_fallback_endpoint1,
                    :amqp_fallback2    => amqp_fallback_endpoint2,
@@ -639,7 +648,7 @@ module Mixins
       authentications = build_credentials(ems, mode)
       configurations = []
 
-      [:default, :ceilometer, :amqp, :amqp_fallback1, :amqp_fallback2, :smartstate_docker, :ssh_keypair, :metrics, :hawkular, :prometheus, :prometheus_alerts].each do |role|
+      [:default, :ceilometer, :amqp, :amqp_fallback1, :amqp_fallback2, :console, :smartstate_docker, :ssh_keypair, :metrics, :hawkular, :prometheus, :prometheus_alerts].each do |role|
         configurations << build_configuration(ems, authentications, endpoints, role)
       end
 
@@ -665,6 +674,11 @@ module Mixins
       if ems.supports_authentication?(:amqp) && params[:amqp_userid]
         amqp_password = params[:amqp_password] ? params[:amqp_password] : ems.authentication_password(:amqp)
         creds[:amqp] = {:userid => params[:amqp_userid], :password => amqp_password, :save => (mode != :validate)}
+      end
+      if ems.kind_of?(ManageIQ::Providers::Vmware::InfraManager) &&
+         ems.supports_authentication?(:console) && params[:console_userid]
+        console_password = params[:console_password] ? params[:console_password] : ems.authentication_password(:console)
+        creds[:console] = {:userid => params[:console_userid], :password => console_password, :save => (mode != :validate)} # FIXME: skateman was here
       end
       if ems.kind_of?(ManageIQ::Providers::Amazon::CloudManager) &&
          ems.supports_authentication?(:smartstate_docker) && params[:smartstate_docker_userid]

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -186,6 +186,7 @@ module TextualSummaryHelper
               when "default"           then _("Default")
               when "metrics"           then _("C & U Database")
               when "amqp"              then _("AMQP")
+              when "console"           then _("VMRC Console")
               when "ipmi"              then _("IPMI")
               when "remote"            then _("Remote Login")
               when "smartstate_docker" then _("SmartState Docker")

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -21,6 +21,9 @@
       = miq_tab_header('ssh_keypair', nil, {'ng-click' => "changeAuthTab('ssh_keypair')"}) do
         %i{"error-on-tab" => "ssh_keypair", :style => "color:#cc0000"}
         = _("RSA key pair")
+      = miq_tab_header('console', nil, {'ng-click' => "changeAuthTab('console')"}) do
+        %i{"error-on-tab" => "console", :style => "color:#cc0000"}
+        = _("VMRC Console")
       = miq_tab_header('smartstate_docker', nil, {'ng-click' => "changeAuthTab('smartstate_docker')"}) do
         %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
         = _("SmartState Docker")
@@ -293,10 +296,23 @@
                                               :id                     => record.id,
                                               :prefix                 => "ssh_keypair",
                                               :basic_info_needed      => true}
+      = miq_tab_content('console', 'default') do
+        .form-group
+          .col-md-12.col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'vmwarews'"}
+            = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                                 :locals  => {:ng_show                => true,
+                                              :ng_model               => "#{ng_model}",
+                                              :ng_reqd_userid         => false,
+                                              :ng_reqd_password       => "#{ng_model}.console_userid != ''",
+                                              :validate_url           => validate_url,
+                                              :id                     => record.id,
+                                              :verify_title_off       => _("Console userid and password fields are needed to perform validation."),
+                                              :prefix                 => "console",
+                                              :basic_info_needed      => true}
         .form-group
           .col-md-12
             %span{:style => "color:black"}
-              = _("Used for SSH connection to all %{hosts} in this provider.") % {:hosts => title_for_hosts}
+              = _("Used for VMRC connections to all VMs in this provider. If not set, the credentials from the Default tab will be used.")
     - elsif controller_name == "ems_container"
       = miq_tab_content('metrics', 'default') do
         .form-group
@@ -419,12 +435,21 @@
     $('#auth_tabs').hide();
 %div{"ng-if" => "#{ng_model}.emstype == 'gce'                    || " + |
                 "#{ng_model}.emstype == 'scvmm'                  || " + |
-                "#{ng_model}.emstype == 'vmwarews'               || " + |
                 "#{ng_model}.emstype == 'lenovo_ph_infra'        || " + |
                 "#{ng_model}.emstype == 'hawkular_datawarehouse' || " + |
                 "#{ng_model}.emstype == 'hawkular'"}                    |
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
+    miq_tabs_show_hide("#metrics_tab", false);
+    miq_tabs_show_hide("#console_tab", false);
+    miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_show_hide("#smartstate_docker_tab", false);
+    miq_tabs_init('#auth_tabs');
+    $('#auth_tabs').show();
+%div{"ng-if" => "#{ng_model}.emstype == 'vmwarews'"}
+  :javascript
+    miq_tabs_show_hide("#amqp_tab", false);
+    miq_tabs_show_hide("#console_tab", true);
     miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
     miq_tabs_show_hide("#smartstate_docker_tab", false);
@@ -434,6 +459,7 @@
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", false);
+    miq_tabs_show_hide("#console_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
     miq_tabs_show_hide("#smartstate_docker_tab", true);
     miq_tabs_init('#auth_tabs');
@@ -442,6 +468,7 @@
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", true);
+    miq_tabs_show_hide("#console_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
     miq_tabs_show_hide("#smartstate_docker_tab", false);
     miq_tabs_init('#auth_tabs');
@@ -450,6 +477,7 @@
   :javascript
     miq_tabs_show_hide("#amqp_tab", true);
     miq_tabs_show_hide("#metrics_tab", false);
+    miq_tabs_show_hide("#console_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
     miq_tabs_show_hide("#smartstate_docker_tab", false);
     miq_tabs_init('#auth_tabs');
@@ -458,6 +486,7 @@
   :javascript
     miq_tabs_show_hide("#amqp_tab", true);
     miq_tabs_show_hide("#metrics_tab", false);
+    miq_tabs_show_hide("#console_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", true);
     miq_tabs_show_hide("#smartstate_docker_tab", false);
     miq_tabs_init('#auth_tabs');


### PR DESCRIPTION
This is specific for the VMware infra provider only as it's the only one provider with VMRC support. The remote consoles should be able to run under a user other than the admin, therefore, @agrare [created](https://github.com/ManageIQ/manageiq-providers-vmware/pull/125) a new `console` authentication type on which PR depends.

![screenshot from 2017-11-01 11-32-18](https://user-images.githubusercontent.com/649130/32271008-6188e1ac-bef8-11e7-9ac3-db3f4db1a995.png)
