### PR TITLE
Fix redirect to Hosts page when no host is associated with a Physical Server.

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -55,7 +55,11 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_host
-    {:label => _("Host"), :value => @record.host.try(:name), :icon => "pficon pficon-virtual-machine", :link => url_for(:controller => 'host', :action => 'show', :id => @record.host.try(:id))}
+    h = {:label => _("Host"), :value => @record.host.try(:name), :icon => "pficon pficon-virtual-machine"}
+    unless @record.host.nil?
+      h[:link] = url_for(:controller => 'host', :action => 'show', :id => @record.host.try(:id))
+    end
+    h
   end
 
   def textual_ext_management_system


### PR DESCRIPTION
This PR contains:
- A restriction, In Physical Server Summary page, to only redict to Hosts page when exists a Host associated with a Physical Server.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1508509