### PR TITLE
Adding methods for treeSelector into Dialog Editor's controller

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -1,7 +1,7 @@
 ManageIQ.angular.app.controller('dialogEditorController', ['$window', '$http', 'API', 'miqService', 'DialogEditor', 'DialogValidation', 'dialogId', function($window, $http, API, miqService, DialogEditor, DialogValidation, dialogId) {
   var vm = this;
 
-  vm.cache = {}
+  vm.cache = {};
   vm.$http = $http;
 
   vm.saveDialogDetails = saveDialogDetails;
@@ -110,7 +110,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', '$http', '
   }
 
   function treeSelectorToggle() {
-    vm.treeSelectorShow = !vm.treeSelectorShow;
+    vm.treeSelectorShow = ! vm.treeSelectorShow;
   }
 
   var beingCloned = null; // hack that solves recursion problem for cloneDeep

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -1,5 +1,23 @@
-ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'miqService', 'DialogEditor', 'DialogValidation', 'dialogId', function($window, API, miqService, DialogEditor, DialogValidation, dialogId) {
+ManageIQ.angular.app.controller('dialogEditorController', ['$window', '$http', 'API', 'miqService', 'DialogEditor', 'DialogValidation', 'dialogId', function($window, $http, API, miqService, DialogEditor, DialogValidation, dialogId) {
   var vm = this;
+
+  vm.cache = {}
+  vm.$http = $http;
+
+  vm.saveDialogDetails = saveDialogDetails;
+  vm.dismissChanges = dismissChanges;
+  vm.setupModalOptions = setupModalOptions;
+
+  // treeSelector related
+  vm.lazyLoad = lazyLoad;
+  vm.onSelect = onSelect;
+  vm.node = {};
+  vm.treeSelectorToggle = treeSelectorToggle;
+  vm.treeSelectorIncludeDomain = false;
+  vm.treeSelectorShow = false;
+  vm.$http.get('/tree/automate_entrypoint').then(function(response) {
+    vm.treeSelectorData = response.data;
+  });
 
   if (dialogId === 'new') {
     var dialogInitContent = {
@@ -59,10 +77,6 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
     vm.DialogEditor = DialogEditor;
   }
 
-  vm.saveDialogDetails = saveDialogDetails;
-  vm.dismissChanges = dismissChanges;
-  vm.setupModalOptions = setupModalOptions;
-
   function setupModalOptions(type, tab, box, field) {
     var components = {
       tab: 'dialog-editor-modal-tab',
@@ -75,6 +89,28 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'API', 'mi
     };
     vm.elementInfo = { type: type, tabId: tab, boxId: box, fieldId: field };
     vm.visible = true;
+  }
+
+
+  function lazyLoad(node) {
+    return vm.$http.get('/tree/automate_entrypoint?id=' + encodeURIComponent(node.key))
+    .then(function(response) {
+      vm.cache[node.key] = response.data;
+      return response.data;
+    });
+  }
+
+  function onSelect(node, elementData) {
+    var fqname = node.fqname.split('/');
+    if (vm.treeSelectorIncludeDomain === false) {
+      fqname.splice(1, 1);
+    }
+    elementData.resource_action.ae_namespace = fqname.join('/');
+    vm.treeSelectorShow = false;
+  }
+
+  function treeSelectorToggle() {
+    vm.treeSelectorShow = !vm.treeSelectorShow;
   }
 
   var beingCloned = null; // hack that solves recursion problem for cloneDeep

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -14,6 +14,8 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'ManageIQ.fonticonPicker',
   'miqStaticAssets.dialogEditor',
   'miqStaticAssets.dialogUser',
+  'miqStaticAssets.treeSelector',
+  'miqStaticAssets.treeView',
 ]);
 miqHttpInject(ManageIQ.angular.app);
 

--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -1,6 +1,7 @@
 # This is a highly experimental implementation of something that we would like to have probably in an UI-API
 # It is definitely not a good example and it SHOULD NOT BE COPY-PASTED in any case
 class TreeController < ApplicationController
+  skip_after_action :set_global_session_data
   before_action :check_privileges
 
   def automate_entrypoint

--- a/app/presenters/tree_builder_automate_entrypoint.rb
+++ b/app/presenters/tree_builder_automate_entrypoint.rb
@@ -1,7 +1,7 @@
 class TreeBuilderAutomateEntrypoint < TreeBuilderAutomate
   def override(node, object, _pid, _options)
     node.delete(:selectable)
-    node[:dataAttr] = {:fqname => object.fqname} if object.try(:fqname)
+    node[:fqname] = object.fqname if object.try(:fqname)
   end
 
   def root_options

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -18,6 +18,12 @@
     .dialog-designer-container
       %dialog-editor-modal{"modal-options" => "vm.modalOptions",
                            "element-info" => "vm.elementInfo",
+                           "lazy-load" => "vm.lazyLoad",
+                           "on-select" => "vm.onSelect",
+                           "tree-selector-data" => "vm.treeSelectorData",
+                           "tree-selector-include-domain" => "vm.treeSelectorIncludeDomain",
+                           "tree-selector-show" => "vm.treeSelectorShow",
+                           "tree-selector-toggle" => "vm.treeSelectorToggle",
                            :visible => "vm.modalVisible"}
       .toolbox-container
         #toolbox.static-field-container


### PR DESCRIPTION
## Need to be merged together with https://github.com/ManageIQ/ui-components/pull/198

Adding methods for `treeSelector` component that is necessary for selecting automate methods in dialog editor

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1507066
* https://www.pivotaltracker.com/story/show/147779457

Steps for Testing/QA
-------------------------------

Automate -> Automation -> Customization -> Service Dialogs -> Add / Edit Dialog
![screencast from 2017-11-02 13-00-11](https://user-images.githubusercontent.com/1187051/32325134-fda452bc-bfcd-11e7-8d81-9fdd5d55b121.gif)

