### PR TITLE
Fix custom button with dialog in explorer  

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -246,7 +246,7 @@ module ApplicationController::Buttons
 
   private
 
-  BASE_MODEL_EXPLORER_CLASSES = [Vm, MiqTemplate, Service, Switch].freeze
+  BASE_MODEL_EXPLORER_CLASSES = [MiqGroup, MiqTemplate, Service, Switch, Tenant, User, Vm].freeze
   APPLIES_TO_CLASS_BASE_MODELS = %w(AvailabilityZone CloudNetwork CloudObjectStoreContainer CloudSubnet CloudTenant
                                     CloudVolume ContainerGroup ContainerImage ContainerNode ContainerProject
                                     ContainerTemplate ContainerVolume EmsCluster ExtManagementSystem Host LoadBalancer

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -246,7 +246,7 @@ module ApplicationController::Buttons
 
   private
 
-  BASE_MODEL_EXPLORER_CLASSES = [Vm, MiqTemplate, Service].freeze
+  BASE_MODEL_EXPLORER_CLASSES = [Vm, MiqTemplate, Service, Switch].freeze
   APPLIES_TO_CLASS_BASE_MODELS = %w(AvailabilityZone CloudNetwork CloudObjectStoreContainer CloudSubnet CloudTenant
                                     CloudVolume ContainerGroup ContainerImage ContainerNode ContainerProject
                                     ContainerTemplate ContainerVolume EmsCluster ExtManagementSystem Host LoadBalancer
@@ -299,7 +299,6 @@ module ApplicationController::Buttons
   def custom_buttons
     button = CustomButton.find_by_id(params[:button_id])
     cls = applies_to_class_model(button.applies_to_class)
-
     @explorer = true if BASE_MODEL_EXPLORER_CLASSES.include?(cls)
 
     if params[:id].to_s == 'LIST'

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -15,10 +15,14 @@ module ApplicationController::DialogRunner
     @in_a_form = false
     if session[:edit][:explorer]
       add_flash(flash)
-      replace_right_cell
+      dialog_replace_right_cell
     else
       javascript_redirect redirect_url(flash)
     end
+  end
+
+  def dialog_replace_right_cell
+    replace_right_cell
   end
 
   def dialog_form_button_pressed
@@ -34,7 +38,7 @@ module ApplicationController::DialogRunner
         add_flash(_("Error during 'Provisioning': %{error_message}") % {:error_message => bang.message}, :error)
         javascript_flash(:spinner_off => true)
       else
-        unless result[:errors].blank?
+        if result[:errors].present?
           # show validation errors
           result[:errors].each do |err|
             add_flash(err, :error)
@@ -48,7 +52,7 @@ module ApplicationController::DialogRunner
             if session[:edit][:explorer]
               add_flash(flash)
               if result[:request].nil?
-                replace_right_cell
+                dialog_replace_right_cell
               else
                 javascript_redirect :controller => 'miq_request',
                                     :action     => 'show_list',

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -362,9 +362,10 @@ class InfraNetworkingController < ApplicationController
     if action_type == "dialog_form_button_pressed"
       presenter = set_custom_button_dialog_presenter
       render :json => presenter.for_render
+      return
     end
 
-    return if @in_a_form && action
+    return if @in_a_form
 
     if !@in_a_form && !@sb[:action]
       get_node_info(x_node)
@@ -437,7 +438,7 @@ class InfraNetworkingController < ApplicationController
         x_history_add_item(:id => x_node, :text => header, :action => @sb[:action])
       end
     end
-    action = @sb[:action] == "button" ? "dialog_form_button_pressed" : nil
+    action = params[:pressed] == "custom_button" ? "dialog_form_button_pressed" : nil
     return partial, action, header
   end
 

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -8,6 +8,7 @@ class InfraNetworkingController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::ExplorerPresenterMixin
   include Mixins::FindRecord
+  include Mixins::CustomButtonDialogFormMixin
 
   def self.model
     Switch
@@ -359,34 +360,7 @@ class InfraNetworkingController < ApplicationController
     end
 
     if action_type == "dialog_form_button_pressed"
-      presenter ||= ExplorerPresenter.new(
-        :active_tree => x_active_tree,
-        :add_nodes   => nil,         # Update the tree with any new nodes
-        :delete_node => nil,      # Remove a new node from the tree
-      )
-      presenter.show(:default_left_cell).hide(:custom_left_cell)
-      presenter.update(:main_div, r[:partial => partial])
-      if @record.try(:dialog_fields)
-        @record.dialog_fields.each do |field|
-          if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
-            presenter[:build_calendar] = {
-              :date_from => field.show_past_dates ? nil : Time.zone.now,
-            }
-          end
-        end
-      end
-      presenter.update(:form_buttons_div, r[
-        :partial => 'layouts/x_dialog_buttons',
-        :locals  => {
-          :action_url => action_type,
-          :record_id  => @edit[:rec_id],
-        }
-      ])
-      presenter.show(:form_buttons_div)
-      presenter[:right_cell_text] = @right_cell_text
-      presenter.set_visibility(false, :toolbar)
-      presenter.set_visibility(false, :adv_searchbox_div)
-      presenter[:lock_sidebar] = true
+      presenter = set_custom_button_dialog_presenter
       render :json => presenter.for_render
     end
 

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -416,8 +416,6 @@ class InfraNetworkingController < ApplicationController
                 "layouts/x_gtl"
               elsif @showtype == "item"
                 "layouts/item"
-              elsif params[:pressed] == 'custom_button'
-                "shared/dialogs/dialog_provision"
               else
                 @showtype.to_s
               end
@@ -428,8 +426,6 @@ class InfraNetworkingController < ApplicationController
         :action    => action_type(@sb[:action], 1)
       }
       x_history_add_item(:id => x_node, :text => header, :action => @sb[:action], :item => @item.id)
-    elsif @sb[:action] == "dialog_provision"
-      header = @right_cell_text
     else
       header = _("\"%{action}\" for Switch \"%{name}\"") % {
         :name   => name,

--- a/app/controllers/mixins/custom_button_dialog_form_mixin.rb
+++ b/app/controllers/mixins/custom_button_dialog_form_mixin.rb
@@ -6,14 +6,6 @@ module Mixins
       )
       presenter.show(:default_left_cell).hide(:custom_left_cell)
       presenter.update(:main_div, r[:partial => "shared/dialogs/dialog_provision"])
-      if @record.try(:dialog_fields)
-        @record.dialog_fields.each do |field|
-          next unless %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
-          presenter[:build_calendar] = {
-            :date_from => field.show_past_dates ? nil : Time.zone.now,
-          }
-        end
-      end
       presenter.update(:form_buttons_div, r[
         :partial => 'layouts/x_dialog_buttons',
         :locals  => {

--- a/app/controllers/mixins/custom_button_dialog_form_mixin.rb
+++ b/app/controllers/mixins/custom_button_dialog_form_mixin.rb
@@ -3,8 +3,6 @@ module Mixins
     def set_custom_button_dialog_presenter
       presenter ||= ExplorerPresenter.new(
         :active_tree => x_active_tree,
-        :add_nodes   => nil, # Update the tree with any new nodes
-        :delete_node => nil, # Remove a new node from the tree
       )
       presenter.show(:default_left_cell).hide(:custom_left_cell)
       presenter.update(:main_div, r[:partial => "shared/dialogs/dialog_provision"])

--- a/app/controllers/mixins/custom_button_dialog_form_mixin.rb
+++ b/app/controllers/mixins/custom_button_dialog_form_mixin.rb
@@ -1,0 +1,34 @@
+module Mixins
+  module CustomButtonDialogFormMixin
+    def set_custom_button_dialog_presenter
+      presenter ||= ExplorerPresenter.new(
+        :active_tree => x_active_tree,
+        :add_nodes   => nil, # Update the tree with any new nodes
+        :delete_node => nil, # Remove a new node from the tree
+      )
+      presenter.show(:default_left_cell).hide(:custom_left_cell)
+      presenter.update(:main_div, r[:partial => "shared/dialogs/dialog_provision"])
+      if @record.try(:dialog_fields)
+        @record.dialog_fields.each do |field|
+          next unless %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
+          presenter[:build_calendar] = {
+            :date_from => field.show_past_dates ? nil : Time.zone.now,
+          }
+        end
+      end
+      presenter.update(:form_buttons_div, r[
+        :partial => 'layouts/x_dialog_buttons',
+        :locals  => {
+          :action_url => "dialog_form_button_pressed",
+          :record_id  => @edit[:rec_id],
+        }
+      ])
+      presenter.show(:form_buttons_div)
+      presenter[:right_cell_text] = @right_cell_text
+      presenter.set_visibility(false, :toolbar)
+      presenter.set_visibility(false, :adv_searchbox_div)
+      presenter[:lock_sidebar] = true
+      presenter
+    end
+  end
+end

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -727,7 +727,7 @@ class OpsController < ApplicationController
     end
   end
 
-  # set all needed thing before calling replace_right_cell with nodetype
+  # set all needed things before calling replace_right_cell with nodetype
   def dialog_replace_right_cell
     model, id = TreeBuilder.extract_node_model_and_id(x_node)
     @record = model.constantize.find(from_cid(id))

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -305,7 +305,6 @@ class OpsController < ApplicationController
       @sb[:active_tab] ||= "db_summary"
     end
 
-    @sb[:tab_label] ||= _('Zones')
     @sb[:active_node] ||= {}
 
     if MiqServer.my_server(true).logon_status != :ready
@@ -698,7 +697,6 @@ class OpsController < ApplicationController
   end
 
   def rbac_replace_right_cell(nodetype, presenter)
-    @sb[:tab_label] = @tagging ? _("Tagging") : rbac_set_tab_label
     if %w(accordion_select change_tab tree_select).include?(params[:action])
       presenter.replace(:ops_tabs, r[:partial => "all_tabs"])
     elsif nodetype == "group_seq"
@@ -735,39 +733,6 @@ class OpsController < ApplicationController
     @record = model.constantize.find(from_cid(id))
     rbac_group_get_details(@record.id) if @record.kind_of?(MiqGroup) # set Group's trees
     replace_right_cell(:nodetype => 'dialog_return')
-  end
-
-  def rbac_set_tab_label
-    nodes = x_node.split("-")
-    case nodes.first
-    when "xx"
-      case nodes.last
-      when "u"
-        _("Users")
-      when "g"
-        _("Groups")
-      when "ur"
-        _("Roles")
-      when "tn"
-        _("Tenants")
-      end
-    when "u"
-      @record.present? ? @record.name : _('Users')
-    when "g"
-      if @record && @record.id
-        @record.description
-      elsif @group && @group.id
-        @group.description
-      else
-        _("Groups")
-      end
-    when "ur"
-      @role.present? ? @role.name : _("Roles")
-    when "tn"
-      @record.present? ? @record.name : _("Tenants")
-    else
-      _("Details")
-    end
   end
 
   def extra_js_commands(presenter)

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -5,6 +5,7 @@ class OpsController < ApplicationController
   include_concern 'OpsRbac'
   include_concern 'Settings'
   include OpsHelper::MyServer
+  include Mixins::CustomButtonDialogFormMixin
 
   before_action :check_privileges
   before_action :get_session_data
@@ -532,38 +533,6 @@ class OpsController < ApplicationController
       end
       tree_add_child_nodes(existing_node) # Build the new nodes hash
     end
-  end
-
-  def set_custom_button_dialog_presenter
-    presenter ||= ExplorerPresenter.new(
-      :active_tree => x_active_tree,
-      :add_nodes   => nil,         # Update the tree with any new nodes
-      :delete_node => nil,      # Remove a new node from the tree
-    )
-    presenter.show(:default_left_cell).hide(:custom_left_cell)
-    presenter.update(:main_div, r[:partial => "shared/dialogs/dialog_provision"])
-    if @record.try(:dialog_fields)
-      @record.dialog_fields.each do |field|
-        if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
-          presenter[:build_calendar] = {
-            :date_from => field.show_past_dates ? nil : Time.zone.now,
-          }
-        end
-      end
-    end
-    presenter.update(:form_buttons_div, r[
-      :partial => 'layouts/x_dialog_buttons',
-      :locals  => {
-        :action_url => "dialog_form_button_pressed",
-        :record_id  => @edit[:rec_id],
-      }
-    ])
-    presenter.show(:form_buttons_div)
-    presenter[:right_cell_text] = @right_cell_text
-    presenter.set_visibility(false, :toolbar)
-    presenter.set_visibility(false, :adv_searchbox_div)
-    presenter[:lock_sidebar] = true
-    presenter
   end
 
   def replace_right_cell(options = {}) # replace_trees can be an array of tree symbols to be replaced

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -733,15 +733,7 @@ class OpsController < ApplicationController
   def dialog_replace_right_cell
     model, id = TreeBuilder.extract_node_model_and_id(x_node)
     @record = model.constantize.find(from_cid(id))
-    case @record
-    when User
-      @user = @record
-    when MiqGroup
-      @group = @record
-      rbac_group_get_details(@record.id)
-    when Tenant
-      @tenant = @record
-    end
+    rbac_group_get_details(@record.id) if @record.kind_of?(MiqGroup) # set Group's trees
     replace_right_cell(:nodetype => 'dialog_return')
   end
 
@@ -760,7 +752,7 @@ class OpsController < ApplicationController
         _("Tenants")
       end
     when "u"
-      @user.present? ? @user.name : _('Users')
+      @record.present? ? @record.name : _('Users')
     when "g"
       if @record && @record.id
         @record.description
@@ -772,7 +764,7 @@ class OpsController < ApplicationController
     when "ur"
       @role.present? ? @role.name : _("Roles")
     when "tn"
-      @tenant.present? ? @tenant.name : _("Tenants")
+      @record.present? ? @record.name : _("Tenants")
     else
       _("Details")
     end

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1207,7 +1207,6 @@ module OpsController::Settings::Common
     when "z"
       @servers = []
       @record = @zone = @selected_zone = Zone.find(from_cid(nodes.last))
-      @sb[:tab_label] = @selected_zone.description
       @right_cell_text = my_zone_name == @selected_zone.name ?
           _("Settings %{model} \"%{name}\" (current)") % {:name  => @selected_zone.description,
                                                           :model => ui_lookup(:model => @selected_zone.class.to_s)} :

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -197,12 +197,8 @@
           = miq_tab_content("diagnostics_orphaned_data", @sb[:active_tab]) do
             = render :partial => "diagnostics_orphaned_data_tab"
   - when :rbac_tree
-    %ul.nav.nav-tabs
-      = miq_tab_header("rbac_details", "rbac_details") do
-        = @sb[:tab_label]
-    .tab-content
-      = miq_tab_content("rbac_details", "rbac_details") do
-        = render :partial => "rbac_details_tab"
+    #rbac_details
+      = render :partial => "rbac_details_tab"
   - when :vmdb_tree
     %ul.nav.nav-tabs
       - tree_node = x_node

--- a/app/views/ops/_detail_page.html.haml
+++ b/app/views/ops/_detail_page.html.haml
@@ -1,0 +1,3 @@
+#main_div
+  - if role_allows?(:feature => "ops_settings") || role_allows?(:feature => "ops_rbac", :any => true) || role_allows?(:feature => "ops_diagnostics") || role_allows?(:feature => "ops_db")
+    #tab_all_tabs_div= render :partial => "all_tabs"

--- a/app/views/ops/_rbac_tenant_details.html.haml
+++ b/app/views/ops/_rbac_tenant_details.html.haml
@@ -1,6 +1,6 @@
 = render :partial => "layouts/flash_msg"
 #tenant_info
-  - type = @tenant.tenant? ? "Tenant" : "Project"
+  - type = @record.tenant? ? "Tenant" : "Project"
   %h3
     = _("%{type} Information") % {:type => type}
   .form-horizontal
@@ -8,13 +8,13 @@
       %label.control-label.col-md-2
         = _("Name")
       .col-md-8
-        = h(@tenant.name)
+        = h(@record.name)
     .form-group
       %label.control-label.col-md-2
         = _("Description")
       .col-md-8
-        = h(@tenant.description)
-    - parent = @tenant.parent
+        = h(@record.description)
+    - parent = @record.parent
     - if parent && parent.allowed?
       .form-group
         %label.control-label.col-md-2
@@ -27,7 +27,7 @@
         = _("Groups in this %{type}") % {:type => type}
       .col-md-8
         %table{:cellpadding => "0", :cellspacing => "0"}
-          - @tenant.miq_groups.non_tenant_groups.sort_by { |group| group.name.downcase }.each do |g|
+          - @record.miq_groups.non_tenant_groups.sort_by { |group| group.name.downcase }.each do |g|
             - if role_allows?(:feature => "rbac_group_show")
               - params = {:class   => "pointer",
                           :onclick => "miqTreeActivateNode('rbac_tree', 'g-#{to_cid(g.id)}');",
@@ -38,7 +38,7 @@
               %td
                 %i.ff.ff-group
                 = h(g.name)
-  - all_subtenants = @tenant.all_subtenants
+  - all_subtenants = @record.all_subtenants
   - unless all_subtenants.blank?
     %h3= _("Child Tenants")
     %table.table.table-striped.table-bordered.table-hover
@@ -52,7 +52,7 @@
               %td.table-view-pf-select
                 %i.pficon.pficon-tenant
               %td= tenant.name
-  - all_subprojects = @tenant.all_subprojects
+  - all_subprojects = @record.all_subprojects
   - unless all_subprojects.blank?
     %h3= _("Projects")
     %table.table.table-striped.table-bordered.table-hover

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -19,7 +19,7 @@
       .col-md-8
         - if !@edit
           %p.form-control-static
-            = h(@user.name)
+            = h(@record.name)
         - else
           = text_field_tag("name",
                            @edit[:new][:name],
@@ -36,7 +36,7 @@
       .col-md-8
         - if !@edit
           %p.form-control-static
-            = h(@user.userid)
+            = h(@record.userid)
         - else
           = text_field_tag("userid",
                            @edit[:new][:userid],
@@ -81,7 +81,7 @@
       .col-md-8
         - if !@edit
           %p.form-control-static
-            = h(@user.email)
+            = h(@record.email)
         - else
           = text_field_tag("email",
                            @edit[:new][:email],
@@ -95,13 +95,13 @@
           = _("Current Group")
         .col-md-8
           - params = {}
-          - if @user.current_group
+          - if @record.current_group
             - if role_allows?(:feature => "rbac_group_show")
               - params = {:class => "pointer",
-                          :onclick => "miqOnClickSelectRbacTreeNode('g-#{to_cid(@user.current_group.id)}');",
+                          :onclick => "miqOnClickSelectRbacTreeNode('g-#{to_cid(@record.current_group.id)}');",
                           :title => _("View this Group")}
             %i.ff.ff-group{params}
-            = link_to(@user.current_group.description, "#", params)
+            = link_to(@record.current_group.description, "#", params)
     .form-group
       %label.col-md-2.control-label
         - if !@edit
@@ -109,7 +109,7 @@
         - else
           = _("Available Groups")
       .col-md-2
-        - groups = @user.present? && @user.miq_groups.present? ? @user.miq_groups.order(:description) : []
+        - groups = @record.present? && @record.miq_groups.present? ? @record.miq_groups.order(:description) : []
         - if groups.present? && @edit.blank?
           - if role_allows?(:feature => "rbac_group_show")
             - groups.each do |group|
@@ -151,18 +151,18 @@
         %label.col-md-2.control-label
           = _("Role")
         .col-md-8
-          - if @user.current_group && @user.current_group.miq_user_role
+          - if @record.current_group && @record.current_group.miq_user_role
             - if role_allows?(:feature => "rbac_user_show")
               - params = {:class => "pointer",
-                          :onclick => "miqOnClickSelectRbacTreeNode('ur-#{to_cid(@user.current_group.miq_user_role.id)}');",
+                          :onclick => "miqOnClickSelectRbacTreeNode('ur-#{to_cid(@record.current_group.miq_user_role.id)}');",
                           :title => _("View this Role")}
             - else
               - params = {}
             %i.ff.ff-user-role{params}
-            = link_to(@user.miq_user_role_name, "#", params)
+            = link_to(@record.miq_user_role_name, "#", params)
           - else
             %p.form-control-static
-              = h(@user.miq_user_role_name)
+              = h(@record.miq_user_role_name)
   %hr
   - unless @edit
     = render :partial => "rbac_tag_box"

--- a/app/views/ops/explorer.html.haml
+++ b/app/views/ops/explorer.html.haml
@@ -1,6 +1,4 @@
-#main_div
-  - if role_allows?(:feature => "ops_settings") || role_allows?(:feature => "ops_rbac", :any => true) || role_allows?(:feature => "ops_diagnostics") || role_allows?(:feature => "ops_db")
-    #tab_all_tabs_div= render :partial => "all_tabs"
+= render :partial => "detail_page"
 
 %script{:type => "text/javascript"}
   -# Create from/to date JS vars to limit calendar starting from

--- a/spec/controllers/application_controller/dialog_runner_spec.rb
+++ b/spec/controllers/application_controller/dialog_runner_spec.rb
@@ -170,4 +170,11 @@ describe CatalogController do
       controller.send(:dialog_form_button_pressed)
     end
   end
+
+  describe '#dialog_replace_right_cell' do
+    it 'calls #replace_right_cell' do
+      expect(controller).to receive(:replace_right_cell)
+      controller.dialog_replace_right_cell
+    end
+  end
 end

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -352,4 +352,32 @@ describe OpsController do
       end
     end
   end
+
+  context '#dialog_replace_right_cell' do
+    describe 'for an User' do
+      before do
+        user = FactoryGirl.create(:user)
+        allow(controller).to receive(:x_node).and_return("u-#{user.id}")
+      end
+
+      it 'calls #replace_right_cell with nodetype set to dialog_return' do
+        expect(controller).to receive(:replace_right_cell).with(:nodetype => 'dialog_return')
+        controller.send(:dialog_replace_right_cell)
+      end
+    end
+
+    describe 'for a Group' do
+      let(:group) { FactoryGirl.create(:miq_group) }
+
+      before do
+        allow(controller).to receive(:x_node).and_return("g-#{group.id}")
+      end
+
+      it 'calls #replace_right_cell with nodetype set to dialog_return and #rbac_group_get_details with group id' do
+        expect(controller).to receive(:rbac_group_get_details).with(group.id)
+        expect(controller).to receive(:replace_right_cell).with(:nodetype => 'dialog_return')
+        controller.send(:dialog_replace_right_cell)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Automate - >Automatization -> Customization -> Buttons -> Add custom button for Switch,User, Tenant, Group that has(!) a dialog
Try it out:
*Switch*
Compute -> Infrastructure -> choose a switch -> click on the button with a dialog
*User, Tenant, Group*
Configuration -> Access Control -> choose user, tenant or group -> click on the button with a dialog
After (example):
<img width="896" alt="screen shot 2017-11-08 at 4 18 52 pm" src="https://user-images.githubusercontent.com/9210860/32556765-99416fc6-c4a0-11e7-9340-bd69bb62edfd.png">


A dialog form should be displayed. `Submit/Cancel` should work. 

Setting of calendar is resolved in https://github.com/ManageIQ/manageiq-ui-classic/pull/2775 should be merged before this one.

@miq-bot add_label gaprindashvili/yes, wip

TODO:

- [x] Infra networking
- [x] User
- [x] Group
- [x] Tenant
- [x] DRY