### PR TITLE
Display Generic Object Associations correctly (Post `/report_data` related GTL fixes)

### DIFF
--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -17,14 +17,21 @@ class GenericObjectController < ApplicationController
     GenericObject
   end
 
-  def self.populate_display_methods(record)
-    define_singleton_method("display_methods") do
-      associations = %w()
-      record.property_associations.each do |key, _value|
-        associations.push(key)
-      end
-      associations
+  def self.display_methods
+    []
+  end
+
+  def display_methods(record)
+    associations = %w()
+    record.property_associations.each do |key, _value|
+      associations.push(key)
     end
+    associations
+  end
+
+  def display_nested_generic(display)
+    return unless @record.property_associations.key?(display)
+    nested_list(display, @record.generic_object_definition.properties[:associations][display], :association => display)
   end
 
   private

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -5,8 +5,6 @@ module Mixins
       return unless init_show
       @center_toolbar = self.class.toolbar_singular if self.class.toolbar_singular
 
-      self.class.populate_display_methods(@record) if self.class.respond_to?(:populate_display_methods)
-
       case @display
       # these methods are defined right in GenericShowMixin
       when "summary_only"

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -28,8 +28,12 @@ module Mixins
       when "topology"
         show_topology
 
-      # nested list methods as enabled by 'display_methods'
+      # nested list methods as enabled by 'display_methods' on the class
       when *self.class.display_methods
+        display_nested_list(@display)
+
+      # .. or on an instance
+      when *display_methods(@record)
         display_nested_list(@display)
 
       else
@@ -42,6 +46,10 @@ module Mixins
       if params[:action] == 'show' && !performed? && self.class.respond_to?(:default_show_template)
         render :template => self.class.default_show_template
       end
+    end
+
+    def display_methods
+      []
     end
 
     def custom_display_method(display)

--- a/spec/controllers/generic_object_controller_spec.rb
+++ b/spec/controllers/generic_object_controller_spec.rb
@@ -14,6 +14,30 @@ describe GenericObjectController do
       get :show, :params => {:id => generic_obj.id}
     end
     it { expect(response.status).to eq(200) }
+
+    it 'displays Generic Object association in the nested display list' do
+      generic_obj_defn = FactoryGirl.create(
+        :generic_object_definition,
+        :name       => "test_definition",
+        :properties => {
+          :attributes   => {
+            :flag       => "boolean",
+            :data_read  => "float",
+            :max_number => "integer",
+            :server     => "string",
+            :s_time     => "datetime"
+          },
+          :associations => {"cp" => "ManageIQ::Providers::CloudManager", "vms" => "Vm"},
+          :methods      => %w(some_method)
+        }
+      )
+      generic_obj = FactoryGirl.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
+      get :show, :params => { :display => "cp", :id => generic_obj.id }
+      expect(response.status).to eq(200)
+
+      get :show, :params => { :display => "vms", :id => generic_obj.id }
+      expect(response.status).to eq(200)
+    end
   end
 
   describe "#show_list" do


### PR DESCRIPTION
PR https://github.com/ManageIQ/manageiq-ui-classic/pull/2420 was cleaned up here, post `/report_data` related GTL fixes.

The only GTL change retained from #2420 is the dynamic creation of `create_display_methods`, which requires an `association` value to be passed in order to render the List successfully.

https://bugzilla.redhat.com/show_bug.cgi?id=1500829