### PR TITLE
Remove dependency of two fields in Alerts

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -119,7 +119,6 @@ module MiqPolicyController::Alerts
         @edit[:expression_options] = MiqAlert.expression_options(@edit[:new][:expression][:eval_method])
         alert_build_exp_options_info
       end
-      @edit[:new][:repeat_time] = alert_default_repeat_time
     end
 
     @edit[:new][:expression][:options][:event_types] = [params[:event_types]].reject(&:blank?) if params[:event_types]


### PR DESCRIPTION
Remove dependency between What to Evaluate and Notification Frequency

Control -> Explorer -> Alerts -> Add/Edit an Alert
change `Notification Frequency` than change `What to Evaluate`
Before:
`Notification Frequency` is reset to default value after changing `What to Evaluate`
After:
Changing `What to Evaluate` doesn't reset `Notification Frequency` 

Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/2147

@miq-bot add_label bug, gaprindashvili/no
