### PR TITLE
Allow to pause\resume multiple containers providers at a time

### DIFF
--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -28,16 +28,18 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
           'pficon pficon-trend-up fa-lg',
           t = N_('Resume this Containers Provider'),
           t,
-          :confirm => N_("Resume this Containers Provider?"),
-          :enabled => proc { !@record.enabled? }),
+          :confirm   => N_("Resume this Containers Provider?"),
+          :enabled   => proc { !@record.enabled? },
+          :url_parms => "main_div"),
         button(
           :ems_container_pause,
           'pficon pficon-trend-down fa-lg',
           t = N_('Pause this Containers Provider'),
           t,
-          :confirm => N_("Warning: While this provider is paused no data will be collected from it. " \
+          :confirm   => N_("Warning: While this provider is paused no data will be collected from it. " \
                          "This may cause gaps in inventory, metrics and events!"),
-          :enabled => proc { @record.enabled? }),
+          :enabled   => proc { @record.enabled? },
+          :url_parms => "main_div"),
         button(
           :ems_container_delete,
           'pficon pficon-delete fa-lg',

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -41,6 +41,25 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
           :enabled      => false,
           :onwhen       => "1"),
         button(
+          :ems_container_resume,
+          'pficon pficon-trend-up fa-lg',
+          t = N_('Resume selected Containers Providers'),
+          t,
+          :confirm   => N_("Resume these Containers Providers?"),
+          :enabled   => false,
+          :url_parms => "main_div",
+          :onwhen    => "1+"),
+        button(
+          :ems_container_pause,
+          'pficon pficon-trend-down fa-lg',
+          t = N_('Pause selected Containers Providers'),
+          t,
+          :confirm   => N_("Warning: While these providers are paused no data will be collected from them. " \
+                           "This may cause gaps in inventory, metrics and events!"),
+          :enabled   => false,
+          :url_parms => "main_div",
+          :onwhen    => "1+"),
+        button(
           :ems_container_delete,
           'pficon pficon-delete fa-lg',
           N_('Remove selected Containers Providers from Inventory'),


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1507532
Allow to pause\resume multiple containers providers at a time.
![manageiq containers providers](https://user-images.githubusercontent.com/11256940/32321634-68da5a44-bfca-11e7-8c84-f0496d574103.png)


cc @simon3z @moolitayer 
@miq-bot add_label providers/containers