### PR TITLE
Generic Object - don't error modal on validation errors

### DIFF
--- a/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
@@ -130,7 +130,9 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
 
   vm.saveWithAPI = function(method, url, saveObject, saveMsg) {
     miqService.sparkleOn();
-    API[method](url, saveObject)
+    API[method](url, saveObject, {
+      skipErrors: [400],  // disable error modal on validation errors
+    })
       .then(miqService.redirectBack.bind(vm, saveMsg, 'success', vm.redirectUrl))
       .catch(miqService.handleFailure);
   };

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -140,13 +140,17 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', 'API'
   this.handleFailure = function(e) {
     miqSparkleOff();
 
-    if (e.error !== undefined && e.error.message !== undefined) {
-      console.error(e.error.message);
-      miqService.miqFlash('error', e.error.message);
+    var message = __("Unknown error");
+    if (e.data && e.data.error && e.data.error.message) {
+      message = e.data.error.message;
+    } else if (e.error && e.error.message) {
+      message = e.error.message;
     } else if (e.message) {
-      console.error(e.message);
-      miqService.miqFlash('error', e.message);
+      message = e.message;
     }
+
+    console.error(message);
+    miqService.miqFlash('error', message);
 
     return $q.reject(e);
   };


### PR DESCRIPTION
When the server responds with an error-like response, we're showing the error modal, since https://github.com/ManageIQ/manageiq-ui-classic/pull/1976 .

That is wrong when the error is a 400 validation error.

Using the mechanism introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/2075 to skip the error modal in such cases.


Testing..

> 1. Go to Autmation-->Automate-->Generic Object
> 2. Create a generic object with name and description as "test"
> 3. Try to create another generic object with same name and description "test"
> 4. Click on Add button
> 
> Expected - see a flash message
> Actual - see error modal



Cc @AparnaKarve 

https://bugzilla.redhat.com/show_bug.cgi?id=1501322