### PR TITLE
Travis - Fix Jasmine by forcing host to 127.0.0.1, not localhost

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,23 @@ module Jasmine
       # serve weback-compiled packs from public/packs/ on /packs/
       @config.add_rack_path('/packs', -> { Rack::File.new(Rails.root.join('public', 'packs')) })
     end
+
+    alias old_server_is_listening_on server_is_listening_on
+
+    def server_is_listening_on(_hostname, port)
+      # hack around Travis resolving localhost to IPv6 and failing
+      old_server_is_listening_on('127.0.0.1', port)
+    end
+  end
+
+  class Configuration
+    alias old_initialize initialize
+
+    def initialize
+      # hack around Travis resolving localhost to IPv6 and failing
+      @host = '127.0.0.1'
+      old_initialize
+    end
   end
 end
 


### PR DESCRIPTION
jasmine hardcodes localhost and tries to use that to detect whether the server is running

localhost recently started to resolve to ::1 on travis, but ipv6 seems disabled
therefore it fails with..

```
Errno::EADDRNOTAVAIL: Cannot assign requested address - connect(2) for "localhost" port 39463
/home/travis/build/ManageIQ/manageiq-ui-classic/vendor/bundle/ruby/2.3.0/gems/jasmine-2.5.2/lib/jasmine/base.rb:25:in `initialize'
/home/travis/build/ManageIQ/manageiq-ui-classic/vendor/bundle/ruby/2.3.0/gems/jasmine-2.5.2/lib/jasmine/base.rb:25:in `open'
/home/travis/build/ManageIQ/manageiq-ui-classic/vendor/bundle/ruby/2.3.0/gems/jasmine-2.5.2/lib/jasmine/base.rb:25:in `server_is_listening_on'
/home/travis/build/ManageIQ/manageiq-ui-classic/vendor/bundle/ruby/2.3.0/gems/jasmine-2.5.2/lib/jasmine/base.rb:35:in `wait_for_listener'
/home/travis/build/ManageIQ/manageiq-ui-classic/vendor/bundle/ruby/2.3.0/gems/jasmine-2.5.2/lib/jasmine/ci_runner.rb:34:in `run'
```

Overriding jasmine to use 127.0.0.1 instead of localhost.