### PR TITLE
Fix using filters under Job Templates

### DIFF
--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -368,8 +368,12 @@ module Mixins
 
     def miq_search_node
       options = {:model => "ConfiguredSystem"}
+      if x_active_tree == :configuration_scripts_tree
+        options = {:model      => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
+                   :gtl_dbname => "automation_manager_configuration_scripts"}
+      end
       process_show_list(options)
-      @right_cell_text = _("All Configured Systems")
+      @right_cell_text = x_active_tree == :configuration_scripts_tree ? _("All Ansible Tower Job Templates") : _("All Configured Systems")
     end
 
     def render_form


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1472855

Fix applying filters in Automation -> Ansible Tower -> Explorer ->
Job Templates tab from Advanced Search and also from accordion.

**Before:**
![job_temp1](https://user-images.githubusercontent.com/13417815/32330999-0346fc7e-bfe2-11e7-8648-41c82fa6d43f.png)

**After:**
![job_temp2](https://user-images.githubusercontent.com/13417815/32331007-0a2b09fe-bfe2-11e7-8eac-0223dce394ad.png)
