### PR TITLE
Display the missing notification type icons in the drawer

### DIFF
--- a/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
+++ b/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
@@ -97,14 +97,14 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
 
   vm.customScope.getNotficationStatusIconClass = function(notification) {
     var retClass = '';
-    if (notification && notification.data && notification.data.type) {
-      if (notification.data.type == 'info') {
+    if (notification && notification.type) {
+      if (notification.type == 'info') {
         retClass = "pficon pficon-info";
-      } else if ((notification.data.type == 'error') || (notification.data.type == 'danger')) {
+      } else if ((notification.type == 'error') || (notification.type == 'danger')) {
         retClass = "pficon pficon-error-circle-o";
-      } else if (notification.data.type == 'warning') {
+      } else if (notification.type == 'warning') {
         retClass = "pficon pficon-warning-triangle-o";
-      } else if ((notification.data.type == 'success') || (notification.data.type == 'ok')) {
+      } else if ((notification.type == 'success') || (notification.type == 'ok')) {
         retClass = "pficon pficon-ok";
       }
     }


### PR DESCRIPTION
The problem was that the `notification` object has the `type` attribute instead of the `notification.data`.

**Before:**
![screenshot from 2017-11-02 16-28-31](https://user-images.githubusercontent.com/649130/32334508-e5f755f2-bfea-11e7-9140-5a5d61a19b98.png)

**After:**
![screenshot from 2017-11-02 16-27-40](https://user-images.githubusercontent.com/649130/32334516-eaeb70ca-bfea-11e7-8d87-a7598ea305c8.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1508982
