### PR TITLE
[FINE] Travis - Fix Jasmine by forcing host to 127.0.0.1, not localhost

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,26 @@ end
 require 'jasmine'
 load 'jasmine/tasks/jasmine.rake'
 
+# hack around Travis resolving localhost to IPv6 and failing
+module Jasmine
+  class << self
+    alias old_server_is_listening_on server_is_listening_on
+
+    def server_is_listening_on(_hostname, port)
+      old_server_is_listening_on('127.0.0.1', port)
+    end
+  end
+
+  class Configuration
+    alias old_initialize initialize
+
+    def initialize
+      @host = 'http://127.0.0.1'
+      old_initialize
+    end
+  end
+end
+
 namespace :spec do
   namespace :javascript do
     desc "Setup environment for javascript specs"


### PR DESCRIPTION
This is a `fine` version of https://github.com/ManageIQ/manageiq-ui-classic/pull/2605, *with* the fix from https://github.com/ManageIQ/manageiq-ui-classic/pull/2614.

---

jasmine hardcodes localhost and tries to use that to detect whether the server is running

localhost recently started to resolve to ::1 on travis, but ipv6 seems disabled
therefore it fails with..

```
Errno::EADDRNOTAVAIL: Cannot assign requested address - connect(2) for "localhost" port 39463
/home/travis/build/ManageIQ/manageiq-ui-classic/vendor/bundle/ruby/2.3.0/gems/jasmine-2.5.2/lib/jasmine/base.rb:25:in `initialize'
/home/travis/build/ManageIQ/manageiq-ui-classic/vendor/bundle/ruby/2.3.0/gems/jasmine-2.5.2/lib/jasmine/base.rb:25:in `open'
/home/travis/build/ManageIQ/manageiq-ui-classic/vendor/bundle/ruby/2.3.0/gems/jasmine-2.5.2/lib/jasmine/base.rb:25:in `server_is_listening_on'
/home/travis/build/ManageIQ/manageiq-ui-classic/vendor/bundle/ruby/2.3.0/gems/jasmine-2.5.2/lib/jasmine/base.rb:35:in `wait_for_listener'
/home/travis/build/ManageIQ/manageiq-ui-classic/vendor/bundle/ruby/2.3.0/gems/jasmine-2.5.2/lib/jasmine/ci_runner.rb:34:in `run'
```

Overriding jasmine to use 127.0.0.1 instead of localhost.