### PR TITLE
Jasmine - add missing protocol to @host

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -82,7 +82,7 @@ module Jasmine
 
     def initialize
       # hack around Travis resolving localhost to IPv6 and failing
-      @host = '127.0.0.1'
+      @host = 'http://127.0.0.1'
       old_initialize
     end
   end


### PR DESCRIPTION
introduced in ManageIQ/manageiq-ui-classic#2605

setting `@host` to `127.0.0.1` caused [the URL](https://github.com/jasmine/jasmine-gem/blob/v2.5.2/lib/jasmine/ci_runner.rb#L19) to change..

```diff
-"http://localhost:12345/?throwFailures=false&random=false"
+"127.0.0.1:12345/?throwFailures=false&random=false"
```

that resulted in `0 specs, 0 failures.`

So.. adding back that `http://` .. and expecting a non-0 spec count now..
.. `920 specs, 0 failures` :+1: 
