### PR TITLE
form button styling clean up

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -470,20 +470,31 @@ table.table.table-summary-screen tbody td img {
 
 @media (min-width: $screen-sm) {
   #paging_div { /* sets paging_div at bottom of screen and styles */
+    background-color: #f5f5f5;
     border-top: 1px solid #d1d1d1;
+    height: 44px;
     margin-top: 0;
+    padding: 3px 0 0 0;
     top:0;
     .col-md-12 {
       padding: 0;
     }
     .content-view-pf-pagination {
       border: 0;
-      height: 44px;
       margin: 0;
-      padding: 3px 0 0 0;
     }
   }
 }
+
+#form_buttons_div:not(.content-view-pf-pagination) .form-group {  // aligns form buttons right
+  padding-top: 8px;
+  margin-bottom: 0;
+}
+
+#angular_paging_div_buttons button {
+  margin-left: 3px;
+}
+
 
 /// end paginator styling
 

--- a/app/views/layouts/_x_dialog_buttons.html.haml
+++ b/app/views/layouts/_x_dialog_buttons.html.haml
@@ -2,59 +2,56 @@
 - action_url ||= nil
 -# Set default record id to nil, if none passed in
 - record_id ||= nil
-- align ||= "right"
 - buttons = @record.buttons.split(',')
-%table{:width => "100%"}
-  %tr
-    %td{:align => align}
-      #buttons_on{:style => session[:changed] ? "" : "display: none;"}
-        - buttons.each do |b|
-          - case b
-          - when "save"
-            = button_tag(_('Save'),
-              :class   => "btn btn-primary",
-              :alt     => t = _("Save Changes"),
-              :title   => t,
-              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', false, { complete: false });")
-          - when "submit"
-            = button_tag(t = _('Submit'),
-              :class   => "btn btn-primary",
-              :alt     => t,
-              :title   => t,
-              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "submit")}', false, { complete: false });")
-          - when "continue"
-            = button_tag(t = _('Continue'),
-              :class   => "btn btn-default",
-              :alt     => t,
-              :title   => t,
-              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "continue")}', false, { complete: false });")
-          - when "reset"
-            = button_tag(_('Reset'),
-              :class   => "btn btn-default",
-              :alt     => t = _("Reset Changes"),
-              :title   => t,
-              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "reset")}', false, { complete: false });")
-          - when "cancel"
-            = button_tag(t = _('Cancel'),
-              :class   => "btn btn-default",
-              :alt     => t,
-              :title   => t,
-              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}', false, { complete: false });")
+.pull-right
+  #buttons_on{:style => session[:changed] ? "" : "display: none;"}
+    - buttons.each do |b|
+      - case b
+      - when "save"
+        = button_tag(_('Save'),
+          :class   => "btn btn-primary",
+          :alt     => t = _("Save Changes"),
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', false, { complete: false });")
+      - when "submit"
+        = button_tag(t = _('Submit'),
+          :class   => "btn btn-primary",
+          :alt     => t,
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "submit")}', false, { complete: false });")
+      - when "continue"
+        = button_tag(t = _('Continue'),
+          :class   => "btn btn-default",
+          :alt     => t,
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "continue")}', false, { complete: false });")
+      - when "reset"
+        = button_tag(_('Reset'),
+          :class   => "btn btn-default",
+          :alt     => t = _("Reset Changes"),
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "reset")}', false, { complete: false });")
+      - when "cancel"
+        = button_tag(t = _('Cancel'),
+          :class   => "btn btn-default",
+          :alt     => t,
+          :title   => t,
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}', false, { complete: false });")
 
-      #buttons_off{:style => session[:changed] ? "display: none;" : ""}
-        - buttons.each do |b|
-          - case b
-          - when "save"
-            = button_tag(_("Save"), :class => "btn btn-primary disabled")
-          - when "submit"
-            = button_tag(_("Submit"), :class => "btn btn-primary disabled")
-          - when "continue"
-            = button_tag(_("Continue"), :class => "btn btn-default disabled")
-          - when "reset"
-            = button_tag(_("Reset"), :class => "btn btn-default disabled")
-          - when "cancel"
-            = button_tag(t = _('Cancel'),
-             :class   => "btn btn-default",
-             :alt     => t,
-             :title   => t,
-             :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}', false, { complete: false });")
+  #buttons_off{:style => session[:changed] ? "display: none;" : ""}
+    - buttons.each do |b|
+      - case b
+      - when "save"
+        = button_tag(_("Save"), :class => "btn btn-primary disabled")
+      - when "submit"
+        = button_tag(_("Submit"), :class => "btn btn-primary disabled")
+      - when "continue"
+        = button_tag(_("Continue"), :class => "btn btn-default disabled")
+      - when "reset"
+        = button_tag(_("Reset"), :class => "btn btn-default disabled")
+      - when "cancel"
+        = button_tag(t = _('Cancel'),
+         :class   => "btn btn-default",
+         :alt     => t,
+         :title   => t,
+         :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}', false, { complete: false });")

--- a/app/views/layouts/_x_edit_buttons.html.haml
+++ b/app/views/layouts/_x_edit_buttons.html.haml
@@ -38,154 +38,154 @@
 -# need to pass this as true if need to send up serialized form data when save is pressed
 - serialize ||= false
 
+%div
+  .form-group.pull-right
+    - if action_url && !export_button
+      #buttons_on{:style => session[:changed] ? "" : "display: none;"}
+        - if record_id.blank? && multi_record.nil? && submit_button.nil? && continue_button.nil?
+          = button_tag(t = _('Add'),
+            :class   => "btn btn-primary",
+            :alt     => t,
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => "add")}', #{serialize});")
+        - else
+          - if apply_button
+            = link_to(_("Apply"),
+              {:action => action_url, :button => "apply", :id => record_id},
+              :method => apply_method,
+              :class => "btn btn-primary",
+              :alt   => apply_text,
+              :title => apply_text)
+          - elsif export_button
+            - t = _("Download Report to YAML")
+            = link_to(_("Export"),
+              {:action => action_url},
+              :class  => "btn btn-primary",
+              :type   => "application/txt",
+              :alt    => t,
+              :title  => t)
+          - elsif submit_button
+            = button_tag(t = _('Submit'),
+              :class   => "btn btn-primary",
+              :alt     => t,
+              :title   => t,
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "submit")}');")
+          - elsif continue_button
+            = button_tag(t = _('Continue'),
+              :class   => "btn btn-primary",
+              :alt     => t,
+              :title   => t,
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "continue")}');")
+          - elsif create_button
+            = button_tag(t = _('Create'),
+              :class   => "btn btn-primary",
+              :alt     => t,
+              :title   => t,
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "create")}',true);")
+          - elsif copy_button
+            = button_tag(t = _('Copy'),
+              :class   => "btn btn-primary",
+              :alt     => t,
+              :title   => t,
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "copy")}',true);")
+          - else
+            - if save_confirm_text
+              -# Ask for confirmation before saving
+              = button_tag(_('Save'),
+                :class   => "btn btn-primary",
+                :alt     => save_text,
+                :title   => save_text,
+                :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
+            - else
+              = button_tag(_('Save'),
+                :class   => "btn btn-primary",
+                :alt     => t = _("Save Changes"),
+                :title   => t,
+                :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
 
-%div{:style => 'padding-top: 5px'}
-  - if action_url && !export_button
-    #buttons_on{:style => session[:changed] ? "" : "display: none;"}
-      - if record_id.blank? && multi_record.nil? && submit_button.nil? && continue_button.nil?
-        = button_tag(t = _('Add'),
-          :class   => "btn btn-primary",
-          :alt     => t,
-          :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => "add")}', #{serialize});")
-      - else
-        - if apply_button
-          = link_to(_("Apply"),
-            {:action => action_url, :button => "apply", :id => record_id},
-            :method => apply_method,
-            :class => "btn btn-primary",
-            :alt   => apply_text,
-            :title => apply_text)
-        - elsif export_button
-          - t = _("Download Report to YAML")
+          - unless no_reset
+            = button_tag(_('Reset'),
+              :class   => "btn btn-default",
+              :alt     => t = _("Reset Changes"),
+              :title   => t,
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "reset")}');")
+        - if default_button
+          = button_tag(_('Default'),
+            :class   => "btn btn-default",
+            :alt     => t = _("Reset All menus to %{product} defaults") % {:product => I18n.t('product.name')},
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update", :button => "default")}');")
+        - unless no_cancel
+          = button_tag(t = _('Cancel'),
+            :class   => "btn btn-default",
+            :alt     => t,
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}');")
+
+      #buttons_off{:style => session[:changed] ? "display: none;" : ""}
+        - if record_id.blank? && multi_record.nil? && submit_button.nil? && continue_button.nil?
+          = button_tag(_("Add"), :class => "btn btn-primary disabled")
+        - else
+          - if apply_button
+            = button_tag(_("Apply"), :class => "btn btn-primary disabled")
+          - elsif submit_button
+            = button_tag(_("Submit"), :class => "btn btn-primary disabled")
+          - elsif continue_button
+            = button_tag(_("Continue"), :class => "btn btn-primary disabled")
+          - elsif copy_button
+            = button_tag(_("Copy"), :class => "btn btn-primary disabled")
+          - else
+            = button_tag(_("Save"), :class => "btn btn-primary disabled")
+
+          - unless no_reset
+            = button_tag(_("Reset"), :class => "btn btn-default disabled")
+
+        - if default_button
+          = button_tag(_('Default'),
+            :class   => "btn btn-default",
+            :alt     => t = _("Reset All menus to %{product} defaults") % {:product => I18n.t('product.name')},
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update", :button => "default")}');")
+
+        - unless no_cancel
+          = button_tag(t = _('Cancel'),
+            :class   => "btn btn-default",
+            :alt     => t,
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}');")
+    - elsif record_id || export_button
+      -# show button to go back
+      #buttons
+        - if params[:action] == "policies" || %w(right_size).include?(@sb[:action])
+          - action = (params[:action] == "policies" ? "policy_sim" : "x_history")
+          -# Button to go back to policy simulation screen from 1 VMs policies
+          = button_tag(t = _('Back'),
+            :class   => "btn btn-default",
+            :alt     => t,
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action, :continue => true)}');")
+        - elsif %w(drift policy_sim).include?(@sb[:action])
+          -# Button to cancel policy simulation/drift and return to latest tree node
+          = button_tag(t = _('Cancel'),
+            :class   => "btn btn-default",
+            :alt     => t,
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item   => 0)}');")
+        - else
+          -# export_button
           = link_to(_("Export"),
             {:action => action_url},
-            :class  => "btn btn-primary",
-            :type   => "application/txt",
-            :alt    => t,
-            :title  => t)
-        - elsif submit_button
-          = button_tag(t = _('Submit'),
-            :class   => "btn btn-primary",
-            :alt     => t,
-            :title   => t,
-            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "submit")}');")
-        - elsif continue_button
-          = button_tag(t = _('Continue'),
-            :class   => "btn btn-primary",
-            :alt     => t,
-            :title   => t,
-            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "continue")}');")
-        - elsif create_button
-          = button_tag(t = _('Create'),
-            :class   => "btn btn-primary",
-            :alt     => t,
-            :title   => t,
-            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "create")}',true);")
-        - elsif copy_button
-          = button_tag(t = _('Copy'),
-            :class   => "btn btn-primary",
-            :alt     => t,
-            :title   => t,
-            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "copy")}',true);")
-        - else
-          - if save_confirm_text
-            -# Ask for confirmation before saving
-            = button_tag(_('Save'),
-              :class   => "btn btn-primary",
-              :alt     => save_text,
-              :title   => save_text,
-              :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
-          - else
-            = button_tag(_('Save'),
-              :class   => "btn btn-primary",
-              :alt     => t = _("Save Changes"),
-              :title   => t,
-              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
+            :class    => "btn btn-primary disabled",
+            :type     => "application/txt",
+            :alt      => t = _("Download Report to YAML"),
+            :title    => t,
+            :id       => "export_button")
 
-        - unless no_reset
-          = button_tag(_('Reset'),
-            :class   => "btn btn-default",
-            :alt     => t = _("Reset Changes"),
-            :title   => t,
-            :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "reset")}');")
-      - if default_button
-        = button_tag(_('Default'),
-          :class   => "btn btn-default",
-          :alt     => t = _("Reset All menus to %{product} defaults") % {:product => I18n.t('product.name')},
-          :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update", :button => "default")}');")
-      - unless no_cancel
+    - elsif ["compare"].include?(@sb[:action])
+      #buttons
+        -# Button to cancel policy simulation and return to latest tree node
         = button_tag(t = _('Cancel'),
           :class   => "btn btn-default",
           :alt     => t,
           :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}');")
-
-    #buttons_off{:style => session[:changed] ? "display: none;" : ""}
-      - if record_id.blank? && multi_record.nil? && submit_button.nil? && continue_button.nil?
-        = button_tag(_("Add"), :class => "btn btn-primary disabled")
-      - else
-        - if apply_button
-          = button_tag(_("Apply"), :class => "btn btn-primary disabled")
-        - elsif submit_button
-          = button_tag(_("Submit"), :class => "btn btn-primary disabled")
-        - elsif continue_button
-          = button_tag(_("Continue"), :class => "btn btn-primary disabled")
-        - elsif copy_button
-          = button_tag(_("Copy"), :class => "btn btn-primary disabled")
-        - else
-          = button_tag(_("Save"), :class => "btn btn-primary disabled")
-
-        - unless no_reset
-          = button_tag(_("Reset"), :class => "btn btn-default disabled")
-
-      - if default_button
-        = button_tag(_('Default'),
-          :class   => "btn btn-default",
-          :alt     => t = _("Reset All menus to %{product} defaults") % {:product => I18n.t('product.name')},
-          :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => "menu_update", :button => "default")}');")
-
-      - unless no_cancel
-        = button_tag(t = _('Cancel'),
-          :class   => "btn btn-default",
-          :alt     => t,
-          :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "cancel")}');")
-  - elsif record_id || export_button
-    -# show button to go back
-    #buttons
-      - if params[:action] == "policies" || %w(right_size).include?(@sb[:action])
-        - action = (params[:action] == "policies" ? "policy_sim" : "x_history")
-        -# Button to go back to policy simulation screen from 1 VMs policies
-        = button_tag(t = _('Back'),
-          :class   => "btn btn-default",
-          :alt     => t,
-          :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action, :continue => true)}');")
-      - elsif %w(drift policy_sim).include?(@sb[:action])
-        -# Button to cancel policy simulation/drift and return to latest tree node
-        = button_tag(t = _('Cancel'),
-          :class   => "btn btn-default",
-          :alt     => t,
-          :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item   => 0)}');")
-      - else
-        -# export_button
-        = link_to(_("Export"),
-          {:action => action_url},
-          :class    => "btn btn-primary disabled",
-          :type     => "application/txt",
-          :alt      => t = _("Download Report to YAML"),
-          :title    => t,
-          :id       => "export_button")
-
-  - elsif ["compare"].include?(@sb[:action])
-    #buttons
-      -# Button to cancel policy simulation and return to latest tree node
-      = button_tag(t = _('Cancel'),
-        :class   => "btn btn-default",
-        :alt     => t,
-        :title   => t,
-        :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item => 0)}');")
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item => 0)}');")

--- a/app/views/layouts/_x_form_buttons.html.haml
+++ b/app/views/layouts/_x_form_buttons.html.haml
@@ -1,4 +1,4 @@
 -# view to hold form_buttons_div
-.form-group.pull-right#form_buttons_div{:style => "border-right: 0"}
+#form_buttons_div
   - if @x_edit_buttons_locals
     = render :partial => '/layouts/x_edit_buttons', :locals => @x_edit_buttons_locals

--- a/app/views/layouts/angular/_paging_div_buttons.html.haml
+++ b/app/views/layouts/angular/_paging_div_buttons.html.haml
@@ -1,1 +1,2 @@
-%div#angular_paging_div_buttons
+.form-group.pull-right
+  #angular_paging_div_buttons

--- a/app/views/vm_common/_right_size.html.haml
+++ b/app/views/vm_common/_right_size.html.haml
@@ -214,7 +214,7 @@
     = _("* Recommendations are subject to minimum of CPU: %{cpu} and Memory: %{memory}.") % {:cpu => arr[0], :memory => arr[1]}
 
   - unless @explorer
-    #buttons_on{:style => "float: right"}
+    #buttons_on.pull-right
       = button_tag((t = _('Back')),
         :class   => 'btn btn-default',
         :alt     => t,


### PR DESCRIPTION
This PR standardizes the markup used in the various form button files and makes some styling adjustments so that the bottom bar appears the same for both pagination and form buttons.

https://bugzilla.redhat.com/show_bug.cgi?id=1510121

Old
<img width="903" alt="screen shot 2017-11-03 at 9 53 02 am" src="https://user-images.githubusercontent.com/1287144/32377037-dc9f9414-c07c-11e7-8c3a-8d59f9127e03.png">

<img width="901" alt="screen shot 2017-11-03 at 9 52 41 am" src="https://user-images.githubusercontent.com/1287144/32377038-dcafafde-c07c-11e7-865b-82efd815ab05.png">

<img width="900" alt="screen shot 2017-11-03 at 9 52 23 am" src="https://user-images.githubusercontent.com/1287144/32377039-dcc02cd8-c07c-11e7-9271-d9f75d3a7b9c.png">

New
<img width="902" alt="screen shot 2017-11-03 at 9 51 28 am" src="https://user-images.githubusercontent.com/1287144/32377040-dcdd61e0-c07c-11e7-87dc-ae826bd566c2.png">

<img width="899" alt="screen shot 2017-11-03 at 9 51 04 am" src="https://user-images.githubusercontent.com/1287144/32377041-dcee0d4c-c07c-11e7-9330-39d4ee361965.png">

<img width="901" alt="screen shot 2017-11-03 at 9 50 47 am" src="https://user-images.githubusercontent.com/1287144/32377042-dd0bd8cc-c07c-11e7-898e-cea3467891e6.png">

