### PR TITLE
Fix Hawkular failed credentials validation

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -140,6 +140,8 @@ module Mixins
         [user, params[:default_password], endpoint_opts]
       when 'ManageIQ::Providers::Lenovo::PhysicalInfraManager'
         [user, password, params[:default_hostname], params[:default_api_port], "token", false]
+      when 'ManageIQ::Providers::Hawkular::MiddlewareManager'
+        [params[:default_hostname], params[:default_api_port], user, password, params[:default_security_protocol], params[:default_tls_ca_certs]]
       end
     end
 


### PR DESCRIPTION
Add mapping for Hawkular parameters for `raw_connect`. Since a switch to Angular credential validation we're no longer able to add a new Hawkular Provider. This should solve it.

Please verify I get the params right. Reference:
```
def self.raw_connect(host, port, username, password, security_protocol, cert_store)
```

Fixes https://github.com/ManageIQ/manageiq-providers-hawkular/issues/97