### PR TITLE
Fix wrong routes for Middleware Server icons

### DIFF
--- a/app/decorators/middleware_server_decorator.rb
+++ b/app/decorators/middleware_server_decorator.rb
@@ -6,11 +6,11 @@ class MiddlewareServerDecorator < MiqDecorator
   def fileicon
     case product
     when 'Hawkular'
-      'svg/vendor-hawkular.svg'
+      '/assets/svg/vendor-hawkular.svg'
     when /EAP$/
-      'svg/vendor-jboss-eap.svg'
+      '/assets/svg/vendor-jboss-eap.svg'
     else
-      'svg/vendor-wildfly.svg'
+      '/assets/svg/vendor-wildfly.svg'
     end
   end
 end


### PR DESCRIPTION
When listing the MW servers the icons went missing since the routes were relative:

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1509935

Before:
![before](https://user-images.githubusercontent.com/7453394/32384070-059155dc-c0ba-11e7-8548-1025925bbf7a.png)

After:
![after](https://user-images.githubusercontent.com/7453394/32384083-0b4d594e-c0ba-11e7-9829-61a3ce82161b.png)
