### PR TITLE
[GAPRINDASHVILI] Update ui-components to 1.0.0, semver

### DIFF
--- a/bower-locker.bower.json
+++ b/bower-locker.bower.json
@@ -40,7 +40,7 @@
     "jquery-ujs": "~1.2.2",
     "jquery.observe_field": "himdel/jquery.observe_field#~0.1.0",
     "kubernetes-topology-graph": "~0.0.23",
-    "manageiq-ui-components": "bower-dev",
+    "manageiq-ui-components": "~1.0.0",
     "moment-duration-format": "~1.3.0",
     "moment-strftime": "~0.2.0",
     "moment-timezone": "~0.4.1",

--- a/bower.json
+++ b/bower.json
@@ -57,7 +57,7 @@
     "jquery.observe_field": "https://github.com/himdel/jquery.observe_field.git#a60d9aabffeb66955948a5a0cb89eedcf92ebb50",
     "kubernetes-topology-graph": "https://github.com/kubernetes-ui/topology-graph.git#3751ae5dbaf26407fb93fc6a4c9bc97310886daa",
     "lodash": "https://github.com/lodash/lodash.git#ef20b4290cc4fe7551c82a552ea7ffa76548eec8",
-    "manageiq-ui-components": "https://github.com/ManageIQ/ui-components.git#40502715815716e4defea38fcabecf0da83305fc",
+    "manageiq-ui-components": "https://github.com/ManageIQ/ui-components.git#85c4876ac54f91b3bdf94a97825d79de9671a5c9",
     "matchHeight": "https://github.com/liabru/jquery-match-height.git#2446ac654f694bc05a1297cbab0b2d875e278bbd",
     "moment": "https://github.com/moment/moment.git#1fe469f0b78050d3b405b90d2e39a874034a3f01",
     "moment-duration-format": "https://github.com/jsmreese/moment-duration-format.git#8d0bf29a1eab180cb83d0f13f93f6974faedeafd",
@@ -119,7 +119,7 @@
     "jquery.observe_field": "a60d9aabffeb66955948a5a0cb89eedcf92ebb50",
     "kubernetes-topology-graph": "3751ae5dbaf26407fb93fc6a4c9bc97310886daa",
     "lodash": "ef20b4290cc4fe7551c82a552ea7ffa76548eec8",
-    "manageiq-ui-components": "40502715815716e4defea38fcabecf0da83305fc",
+    "manageiq-ui-components": "85c4876ac54f91b3bdf94a97825d79de9671a5c9",
     "matchHeight": "2446ac654f694bc05a1297cbab0b2d875e278bbd",
     "moment": "1fe469f0b78050d3b405b90d2e39a874034a3f01",
     "moment-duration-format": "8d0bf29a1eab180cb83d0f13f93f6974faedeafd",
@@ -141,7 +141,7 @@
     "xml_display": "ed5fb8e5dc10f4d66e05c6c27a50defff14672e4"
   },
   "bowerLocker": {
-    "lastUpdated": "2017-10-31T16:45:37.605Z",
+    "lastUpdated": "2017-11-03T16:29:41.730Z",
     "lockedVersions": {
       "angular": "1.6.6",
       "angular-animate": "1.6.6",
@@ -183,7 +183,7 @@
       "jquery.observe_field": "0.1.0",
       "kubernetes-topology-graph": "0.0.23",
       "lodash": "3.10.1",
-      "manageiq-ui-components": "4050271581",
+      "manageiq-ui-components": "1.0.0",
       "matchHeight": "0.7.2",
       "moment": "2.14.2",
       "moment-duration-format": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "~1.4.0",
+    "bower-locker": "~1.0.7",
     "coffee-loader": "~0.7.3",
     "coffee-script": "~1.12.5",
     "compression-webpack-plugin": "~0.4.0",


### PR DESCRIPTION
This..

* adds `bower-locker` as a npm dependency, so that anyone can run it when necessary
* updates the unlocked `bower.json` to depend on `manageiq-ui-components ~1.0.0`
* locks to the newly released 1.0.0

After this is merged, the process for updating manageiq-ui-components for gaprindashvili fixes should be pretty much just this ([details](http://talk.manageiq.org/t/getting-ui-components-updates-backported-to-gaprindashvili/2858)):

```sh
yarn run bower-locker unlock
bower install manageiq-ui-components
yarn run bower-locker lock
```