### PR TITLE
Use the `product.support_website_text` for the second help menu item

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -283,7 +283,7 @@ module Menu
             :type  => nil,
           },
           :product       => {
-            :title => N_('ManageIQ.org'),
+            :title => I18n.t('product.support_website_text'),
             :href  => I18n.t("product.support_website").html_safe,
             :type  => :new_window,
           },


### PR DESCRIPTION
This way after productization the default value will change accordingly.

@miq-bot add_label bug

https://bugzilla.redhat.com/show_bug.cgi?id=1509430