### PR TITLE
Rename Network Adapters table to Network Devices

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -44,7 +44,7 @@ module PhysicalServerHelper::TextualSummary
 
   def textual_group_network_adapters
     TextualCustom.new(
-      _("Network Adapters"),
+      _("Network Devices"),
       "textual_network_adapter_table",
       %i(network_adapter)
     )


### PR DESCRIPTION
This PR renames the _Network Adapters_ table on the physical server summary page to _Network Devices_.