### PR TITLE
Ansible service - rescue from Ansible role disabled exception

### DIFF
--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -36,7 +36,7 @@
       - if @record.type == "ServiceAnsiblePlaybook"
         = miq_tab_content("provisioning", 'default', :class => 'cm-tab') do
           = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_provisioning_group_list}
-          - if @job && @job.try(:raw_stdout)
+          - if (@job && @job.try(:raw_stdout) rescue false)
             %h3
               = _('Standard Output')
             .form-horizontal.static


### PR DESCRIPTION
Opening a service detail if the service is related to Ansible, and the server has no embedded ansible role dies with..

```
I, [2017-11-03T19:56:54.395297 #25106]  INFO -- :   Rendered /home/martin/Projects/manageiq-ui-classic/app/views/service/_svcs_show.html.haml (1167.0ms)
F, [2017-11-03T19:56:54.395613 #25106] FATAL -- : Error caught: [ActionView::Template::Error] Embedded ansible is disabled
/home/martin/Projects/manageiq/app/models/manageiq/providers/embedded_ansible/provider.rb:14:in `raw_connect'
/home/martin/.rvm/gems/ruby-2.3.3/bundler/gems/manageiq-providers-ansible_tower-6426bea65f1b/app/models/manageiq/providers/ansible_tower/shared/provider.rb:41:in `connect'
/home/martin/Projects/manageiq/app/models/provider.rb:49:in `with_provider_connection'
/home/martin/.rvm/gems/ruby-2.3.3/bundler/gems/manageiq-providers-ansible_tower-6426bea65f1b/app/models/manageiq/providers/ansible_tower/shared/automation_manager.rb:5:in `with_provider_connection'
/home/martin/.rvm/gems/ruby-2.3.3/bundler/gems/manageiq-providers-ansible_tower-6426bea65f1b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb:139:in `raw_stdout'
/home/martin/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.6/lib/active_support/core_ext/object/try.rb:17:in `public_send'
/home/martin/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.6/lib/active_support/core_ext/object/try.rb:17:in `try!'
/home/martin/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.6/lib/active_support/core_ext/object/try.rb:6:in `try'
/home/martin/Projects/manageiq-ui-classic/app/views/service/_svcs_show.html.haml:39:in `block in __home_martin__rojects_manageiq_ui_classic_app_views_service__svcs_show_html_haml___1096271421441941554_6999664174
5020'
```

Pending the resolution of https://github.com/ManageIQ/manageiq-ui-classic/issues/2470, this is a quick fix that hides the offending portion instead of failing.

@martinpovolny I can't test this right now, can you? :)