### PR TITLE
Fix errors in New Group and New Role forms

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -828,6 +828,7 @@ module OpsController::OpsRbac
     if rec_type == "group"
       bad = (@edit[:new][:role].blank? || @edit[:new][:group_tenant].blank?)
     end
+    bad = @edit[:new][:name].blank? if rec_type == 'role'
 
     render :update do |page|
       page << javascript_prologue
@@ -856,7 +857,9 @@ module OpsController::OpsRbac
         # don't do anything to lookup box when checkboxes on the right side are checked
         page << set_element_visible('group_lookup', @edit[:new][:lookup]) unless params[:check]
       end
-      changed ? page << 'ManageIQ.changes = true;' : page << 'ManageIQ.changes = false;' if rec_type == 'group'
+      if rec_type == 'group'
+        page << changed ? 'ManageIQ.changes = true;' : 'ManageIQ.changes = false;'
+      end
       page << javascript_for_miq_button_visibility(changed && !bad)
     end
   end

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -856,6 +856,7 @@ module OpsController::OpsRbac
         # don't do anything to lookup box when checkboxes on the right side are checked
         page << set_element_visible('group_lookup', @edit[:new][:lookup]) unless params[:check]
       end
+      changed ? page << 'ManageIQ.changes = true;' : page << 'ManageIQ.changes = false;' if rec_type == 'group'
       page << javascript_for_miq_button_visibility(changed && !bad)
     end
   end


### PR DESCRIPTION
Fixed error where "Abandon Changes" dialog was not being displayed when leaving the Add New Group form.  Also fixed error where the Add and Cancel buttons were still enabled on the Add New Role form when the name field was populated and depopulated.

@miq-bot add_labels bug, settings

https://bugzilla.redhat.com/show_bug.cgi?id=1486666
https://bugzilla.redhat.com/show_bug.cgi?id=1486681