### PR TITLE
Removed unneeded :onwhen from summary screen toolbar

### DIFF
--- a/app/helpers/application_helper/toolbar/service_center.rb
+++ b/app/helpers/application_helper/toolbar/service_center.rb
@@ -5,7 +5,6 @@ class ApplicationHelper::Toolbar::ServiceCenter < ApplicationHelper::Toolbar::Ba
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :onwhen => "1+",
       :items  => [
         button(
           :service_edit,


### PR DESCRIPTION
This was causing the button group to be disabled when switching reloading screens.

https://bugzilla.redhat.com/show_bug.cgi?id=1509168

before:
![before](https://user-images.githubusercontent.com/3450808/32396440-9554a420-c0bb-11e7-99ec-4908b4cffc2f.png)

after:
![after](https://user-images.githubusercontent.com/3450808/32396406-71ee9388-c0bb-11e7-9af5-bc8a05b3dbe9.png)
