### PR TITLE
GTL: do not set parent_id directly  from params[:id].

### DIFF
--- a/app/views/layouts/angular/_gtl.html.haml
+++ b/app/views/layouts/angular/_gtl.html.haml
@@ -7,7 +7,7 @@
 - selected_records = params[:rec_ids] unless params.nil? || params[:rec_ids].nil?
 - selected_records = selected_records.map(&:to_i) if !selected_records.nil? && selected_records.first.kind_of?(String)
 - selected_records = selected_records.map(&:id) if !selected_records.nil? && !selected_records.first.kind_of?(Integer)
-- parent_id = @report_data_additional_options && @report_data_additional_options[:parent_id] ? @report_data_additional_options[:parent_id] : params[:id]
+- parent_id = @report_data_additional_options && @report_data_additional_options[:parent_id] ? @report_data_additional_options[:parent_id] : nil
 #miq-gtl-view{"ng-controller" => "reportDataController as dataCtrl"}
   - unless no_flash_div
     = render :partial => "layouts/flash_msg"


### PR DESCRIPTION
This was introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/2383

I am failing to find a usecase where the assignment from `params[:id]`
would be needed so I am removing it.

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1509171
Changing ownership from VM detail page.

Ping @karelhala I need to figure out why this was needed. Want to be sure it does not break something elsewhere.