### PR TITLE
[FINE] Block unsupported VMs reset

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1848,6 +1848,8 @@ module ApplicationController::CiProcessing
         return
       end
 
+      return if method == 'reset' && !check_reset_requirements(selected_items)
+
       if selected_items.empty?
         add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => request.parameters["controller"]), :task => display_name}, :error)
       else
@@ -1884,6 +1886,14 @@ module ApplicationController::CiProcessing
       end
     end
     selected_items.count
+  end
+
+  def check_reset_requirements(selected_items)
+    if VmOrTemplate.find(selected_items).any? { |vm| !vm.supports_reset? }
+      javascript_flash(:text => _("Reset does not apply to at least one of the selected items"), :severity => :error, :scroll_top => true)
+      return false
+    end
+    true
   end
 
   def process_cloud_object_storage_buttons(pressed)

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -263,6 +263,17 @@ describe VmInfraController do
     expect(response.status).to eq(200)
   end
 
+  it 'can reset selected items' do
+    get :show, :params => { :id => vm_vmware.id }
+    expect(response).to redirect_to(:action => 'explorer')
+
+    post :explorer
+    expect(response.status).to eq(200)
+
+    post :x_button, :params => { :pressed => 'vm_reset', :id => vm_vmware.id }
+    expect(response.status).to eq(200)
+  end
+
   it 'can migrate selected items' do
     get :show, :params => { :id => vm_vmware.id }
     expect(response).to redirect_to(:action => 'explorer')


### PR DESCRIPTION
When selecting VMs to be reset via the VMs center dialog, no validation
is done for the selected VMs. Therefore VMs which doesn't meet the
criteria and would block such action if applied on a VM specific, can be
selected and later on failed.

A pre-check is added to make sure VMs which doesn't meet the expected
terms for reset are prevented from being reset.

This is a backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/1924

https://bugzilla.redhat.com/show_bug.cgi?id=1476592
