### PR TITLE
Fixed node id for policy link in control explorer accordion

### DIFF
--- a/app/views/miq_policy/_action_details.html.haml
+++ b/app/views/miq_policy/_action_details.html.haml
@@ -253,7 +253,7 @@
             %table.table.table-striped.table-bordered.table-hover
               %tbody
                 - @action_policies.each do |p|
-                  - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.downcase}_p-#{to_cid(p.id)}"
+                  - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.camelize(:lower)}_p-#{to_cid(p.id)}"
                   %tr{:title => _("Click to view Policy"),
                     :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
                     %td.table-view-pf-select

--- a/app/views/miq_policy/_condition_details.html.haml
+++ b/app/views/miq_policy/_condition_details.html.haml
@@ -104,7 +104,7 @@
               %table.table.table-striped.table-bordered.table-hover
                 %tbody
                   - @condition_policies.each do |p|
-                    - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.downcase}_p-#{to_cid(p.id)}"
+                    - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.camelize(:lower)}_p-#{to_cid(p.id)}"
                     %tr{:title => _("Click to view Policy"),
                       :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
                       %td.table-view-pf-select


### PR DESCRIPTION
Fixed node id for policy link under Control>Explorer accordion - this causes the title to compress when moving to the policy link from screens under the Explorer accordion.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1404463
cc: @cben 
@simon3z 

Screentshot:
Before:
![screenshot from 2017-11-06 16-16-21](https://user-images.githubusercontent.com/8366181/32446213-d03eaeb2-c310-11e7-9f48-e1fe66d2ad29.png)
After:
![screenshot from 2017-11-06 16-16-12](https://user-images.githubusercontent.com/8366181/32446219-d6779852-c310-11e7-8a86-afccdff85d04.png)
