### PR TITLE
Add parent class name to additional options for report data

### DIFF
--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -5,6 +5,7 @@ class ApplicationController
     :model,
     :match_via_descendants,
     :parent_id,
+    :parent_class_name,
     :parent_method,
     :association,
     :view_suffix
@@ -16,6 +17,7 @@ class ApplicationController
       additional_options.with_model(options[:model]) if options[:model]
       additional_options.match_via_descendants = options[:match_via_descendants]
       additional_options.parent_id = options[:parent].id if options[:parent]
+      additional_options.parent_class_name = options[:parent].class.name if options[:parent]
       additional_options.association = options[:association]
       additional_options.view_suffix = options[:view_suffix]
       additional_options.parent_method = options[:parent_method]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1639,6 +1639,11 @@ module ApplicationHelper
     if additional_options[:match_via_descendants].present?
       additional_options[:match_via_descendants] = additional_options[:match_via_descendants].constantize
     end
+    if additional_options[:parent_id].present? && additional_options[:parent_class_name].present?
+      parent_id = from_cid(additional_options[:parent_id])
+      parent_class = additional_options[:parent_class_name].constantize
+      additional_options[:parent] = parent_class.find(parent_id) if parent_class < ActiveRecord::Base
+    end
     additional_options
   end
 


### PR DESCRIPTION
### Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/2632
Parent is not all the times just class from which `/report_data` was called, so send `parent_class_name` as well so we can query for more specific items.