### PR TITLE
Drop the img_url attribute from the report_data hash

### DIFF
--- a/app/assets/javascripts/miq_qe.js
+++ b/app/assets/javascripts/miq_qe.js
@@ -126,8 +126,7 @@ ManageIQ.qe.gtl = {
         gtlType: this.gtlType,
         id: item.id,
         long_id: item.long_id,
-        quadicon: item.quadicon,
-        img_url: item.img_url
+        quadicon: item.quadicon
       }
     }.bind(this);
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1169,10 +1169,9 @@ class ApplicationController < ActionController::Base
         icon, icon2, image, picture = listicon_glyphicon(item)
         image = "100/#{(@listicon || view.db).underscore}.png" if icon.nil? && image.nil? # TODO: we want to get rid of this
         icon = nil if %w(pxe).include? params[:controller]
-        new_row[:img_url] = ActionController::Base.helpers.image_path(image.to_s)
         new_row[:cells] << {:title => _('View this item'),
-                            :image   => image,
-                            :picture => picture,
+                            :image   => ActionController::Base.helpers.image_path(image.to_s),
+                            :picture => ActionController::Base.helpers.image_path(picture.to_s),
                             :icon    => icon,
                             :icon2   => icon2}
 


### PR DESCRIPTION
This fixes a regression caused by https://github.com/ManageIQ/ui-components/pull/196 and a replacement for https://github.com/ManageIQ/manageiq-ui-classic/pull/2621. The `img_url` was an "almost redundant" attribute as it contained the URL to the image specified by the `image` attribute. After this fix the `image` and `picture` attributes will carry the whole URL to the files instead of pointing somewhere that the frontend can't understand.

**Before:**
![screenshot from 2017-11-06 17-54-15](https://user-images.githubusercontent.com/649130/32453045-87dc7766-c31b-11e7-8b04-191cfa809dcd.png)

**After:**
![screenshot from 2017-11-06 17-53-47](https://user-images.githubusercontent.com/649130/32453052-8b538042-c31b-11e7-9dcb-7a234891f10f.png)

@izapolsk I received the information from @karelhala that you needed some things in the `miq_qe.js` where this `img_url` was referred. Can you please validate if droping this attribute in favor of `cells.image` is OK from your side?

@karelhala @tumido can you please review?

@miq-bot add_label bug

https://bugzilla.redhat.com/show_bug.cgi?id=1509935