### PR TITLE
Make Save button responsive for changing groups

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -823,6 +823,7 @@ module OpsController::OpsRbac
     when "role"  then rbac_role_get_form_vars
     end
 
+    @edit[:new][:group] = rbac_user_get_group_ids.map(&:to_i)
     session[:changed] = changed = (@edit[:new] != @edit[:current])
     bad = false
     if rec_type == "group"
@@ -838,7 +839,7 @@ module OpsController::OpsRbac
         end
         bad = false
       else
-        # only do following if groups of a user change (adding/editing a user)
+        # only do following for user (adding/editing a user)
         if x_node.split("-").first == "u" || x_node == "xx-u"
           page.replace("group_selected",
                        :partial => "ops/rbac_group_selected")
@@ -1057,9 +1058,9 @@ module OpsController::OpsRbac
     when 'null', nil
       []
     when String
-      @edit[:new][:group].split(',').delete_if(&:blank?)
+      @edit[:new][:group].split(',').delete_if(&:blank?).sort
     when Array
-      @edit[:new][:group]
+      @edit[:new][:group].sort
     end
   end
 


### PR DESCRIPTION
**fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1501242

Make Save button responsive for changing groups in _Configuration -> Access Control_
tab _-> Users_ when editing an existing user, for example if choosing some more groups
in dropdown menu and then removing them so there is no change when editing a user,
_Save_ button changes and is disabled which is a proper behavior.

### Explanation:
1. when comparing `@edit[:new]` and `@edit[:current]` to decect if some change is present,
`@edit[:new][:group]` and `@edit[:current][:group]` have different type (_String_ vs. _Array_),
so we cannot simply compare them until we get the same type of these variables.
Normally we get string of group ids when we choose some groups from drop down menu
when adding/editing a user.

The result of this was that even when there was no change when editing user's info,
the variables I have mentioned were different because of the type, so the change was
present because `@edit[:new] != @edit[:current]` was `true`, so _Save_ button stayed
enabled even it should have been disabled.

2. even if `@edit[:new][:group]` and `@edit[:current][:group]` were the same type, it is
important to say, that if we want to simply compare them, we have to sort the ids of both
of them to get proper answer if there are the same ids (= no change related to groups)
or not (= change is present related to groups of a user which is edited).

### Solution:
The simplest way to fix this was to edit `@edit[:new][:group]` to be able to easily compare with 
`@edit[:current]` and to get a proper info if the change is present. This is the only place
where it is important how `@edit[:new][:group]` and `@edit[:current][:group]`look like.

I also changed one comment to provide better info what was going on there.

![user](https://user-images.githubusercontent.com/13417815/32454565-e3241882-c31f-11e7-8745-60f29f38d5db.png)
