### PR TITLE
Add ems_infra_admin_ui feature support

### DIFF
--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -185,7 +185,7 @@ class EmsInfraController < ApplicationController
     if task.results_ready?
       javascript_open_window(task.task_results)
     else
-      javascript_flash(:text     => _("Infrastructure provider failed to generate Admin UI URL"),
+      javascript_flash(:text     => _("Infrastructure provider failed to generate Admin UI URL: %{message}") % {:message => task.message},
                        :severity => :error)
     end
   end

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -166,6 +166,30 @@ class EmsInfraController < ApplicationController
     end
   end
 
+  def open_admin_ui
+    assert_privileges("ems_infra_admin_ui")
+    ems = identify_record(params[:id], ManageIQ::Providers::InfraManager)
+
+    if ems.supports?(:admin_ui)
+      task_id = ems.queue_generate_admin_ui_url
+      initiate_wait_for_task(:task_id => task_id, :action => "open_admin_ui_done")
+    else
+      javascript_flash(:text     => _("Admin UI feature is not supported for this infrastructure provider"),
+                       :severity => :error)
+    end
+  end
+
+  def open_admin_ui_done
+    task = MiqTask.find(params[:task_id])
+
+    if task.results_ready?
+      javascript_open_window(task.task_results)
+    else
+      javascript_flash(:text     => _("Infrastructure provider failed to generate Admin UI URL"),
+                       :severity => :error)
+    end
+  end
+
   def ems_infra_form_fields
     ems_form_fields
   end

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -182,10 +182,11 @@ class EmsInfraController < ApplicationController
   def open_admin_ui_done
     task = MiqTask.find(params[:task_id])
 
-    if task.results_ready?
+    if task.results_ready? && task.task_results.kind_of?(String)
       javascript_open_window(task.task_results)
     else
-      javascript_flash(:text     => _("Infrastructure provider failed to generate Admin UI URL: %{message}") % {:message => task.message},
+      message = MiqTask.status_ok?(task.status) ? _("The URL is blank or not a String") : task.message
+      javascript_flash(:text     => _("Infrastructure provider failed to generate Admin UI URL: %{message}") % {:message => message},
                        :severity => :error)
     end
   end

--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -114,4 +114,22 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
       ]
     ),
   ])
+  button_group('ems_infra_access', [
+    select(
+      :ems_infra_remote_access_choice,
+      'pficon pficon-screen fa-lg',
+      N_('Infrastructure Provider Remote Access'),
+      N_('Access'),
+      :items => [
+        button(
+          :ems_infra_admin_ui,
+          'pficon pficon-screen fa-lg',
+          N_('Open Admin UI for this Infrastructure Provider'),
+          N_('Admin UI'),
+          :url     => "open_admin_ui",
+          :klass   => ApplicationHelper::Button::GenericFeatureButton,
+          :options => {:feature => :admin_ui}),
+      ]
+    ),
+  ])
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1255,6 +1255,8 @@ Rails.application.routes.draw do
         scaling
         scaledown
         squash_toggle
+        open_admin_ui
+        open_admin_ui_done
       ) +
                adv_search_post +
                compare_post +


### PR DESCRIPTION
This PR is part of the following series:
- [Add ems_infra_admin_ui feature](https://github.com/ManageIQ/manageiq/pull/16403) (manageiq)
- **[Add ems_infra_admin_ui feature support](https://github.com/ManageIQ/manageiq-ui-classic/pull/2644) (manageiq-ui-classic)**
- [Add admin_ui feature support to InfraManager](https://github.com/ManageIQ/manageiq-providers-ovirt/pull/133) (manageiq-providers-ovirt)

![admin_ui_toolbar_button](https://user-images.githubusercontent.com/648971/32622396-ff4b5ccc-c582-11e7-866b-292c520e1b9b.png)

This adds `Access` dropdown to Infrastructure Provider's toolbar, which contains `Admin UI` button to open provider-specific administration UI.

The `Admin UI` button is visible only if the Infrastructure Provider supports the `admin_ui` feature. Once clicked, URL is generated by the Provider via `queue_generate_admin_ui_url` task, while expecting `task_results` to contain the URL string. The URL is then opened in a new browser tab/window.

Inspired by @jhernand (see original PR [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/2489)).