### PR TITLE
Fix AWS Docker Credentials Tab Issues

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -539,12 +539,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         amqp_userid:               $scope.emsCommonModel.amqp_userid,
         amqp_password:             amqp_password,
       };
-    } else if (prefix === "smartstate_docker") {
-      if ($scope.newRecord) {
-        var smartstate_docker_password = $scope.emsCommonModel.smartstate_docker_password;
-      } else {
-        var smartstate_docker_password = $scope.emsCommonModel.smartstate_docker_password === "" ? "" : miqService.storedPasswordPlaceholder;
-      }
     } else if (prefix === "metrics") {
       var metricsValidationModel = {
         metrics_hostname: $scope.emsCommonModel.metrics_hostname,

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -60,6 +60,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       prometheus_alerts_tls_ca_certs: '',
       prometheus_alerts_auth_status: '',
       prometheus_alerts_security_protocol: '',
+      smartstate_docker_auth_status: true,
       alerts_selection: '',
     };
 
@@ -482,9 +483,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     if ($scope.emsCommonModel.amqp_auth_status === true) {
       $scope.postValidationModelRegistry("amqp");
     }
-    if ($scope.emsCommonModel.smartstate_docker_auth_status === true) {
-      $scope.postValidationModelRegistry("smartstate_docker");
-    }
     if ($scope.emsCommonModel.service_account_auth_status === true) {
       $scope.postValidationModelRegistry("service_account");
     }
@@ -504,7 +502,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.postValidationModel = {
         default: {},
         amqp: {},
-        smartstate_docker: {},
         metrics: {},
         ssh_keypair: {},
         prometheus_alerts: {},
@@ -548,10 +545,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       } else {
         var smartstate_docker_password = $scope.emsCommonModel.smartstate_docker_password === "" ? "" : miqService.storedPasswordPlaceholder;
       }
-      $scope.postValidationModel.smartstate_docker = {
-        smartstate_docker_userid:      $scope.emsCommonModel.smartstate_docker_userid,
-        smartstate_docker_password:    smartstate_docker_password,
-      };
     } else if (prefix === "metrics") {
       var metricsValidationModel = {
         metrics_hostname: $scope.emsCommonModel.metrics_hostname,

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -345,7 +345,6 @@ module Mixins
                        :ems_controller                  => controller_name,
                        :default_auth_status             => default_auth_status,
                        :amqp_auth_status                => amqp_auth_status,
-                       :smartstate_docker_auth_status   => smartstate_docker_auth_status,
                        :service_account_auth_status     => service_account_auth_status,
                        :amqp_fallback_hostname1         => amqp_fallback_hostname1 ? amqp_fallback_hostname1 : "",
                        :amqp_fallback_hostname2         => amqp_fallback_hostname2 ? amqp_fallback_hostname2 : ""

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -234,7 +234,6 @@ module Mixins
 
       if @ems.has_authentication_type?(:smartstate_docker)
         smartstate_docker_userid = @ems.authentication_userid(:smartstate_docker).to_s
-        smartstate_docker_auth_status = true
       end
 
       if @ems.has_authentication_type?(:ssh_keypair)

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -9,7 +9,7 @@
   - validate = "#{main_scope}.validateClicked({target: '.validate_button:visible'}, '#{valtype}', true, angularForm, '#{url_for_only_path(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
 - else
   - validate = "#{main_scope}.validateClicked('#{url_for_only_path(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
-%div{"ng-if" => "#{main_scope}.currentTab != 'smartstate_docker'"}
+%div{"ng-hide" => "#{main_scope}.currentTab === 'smartstate_docker'"}
   %miq-button{:class           => 'validate_button',
               :name            => _("Validate"),
               "disabled-title" => verify_title_off,


### PR DESCRIPTION
This fixes the following issues with the Docker Credentials Tab on
Amazon Providers:

1) Regardless of whether or not Docker Credentials were added, a red "!"
   was shown on the tab.  Since these are not required credentials and in
   addition there is no validation, this should never have happened.  It has been fixed.

2) After the Default Credentials were entered and validated, the "Add" button
   was not enabled until one clicked on the Docker Credentials tab.  This is wrong
   and has been fixed.

This BZ has been opened to track the 2nd issue above: https://bugzilla.redhat.com/show_bug.cgi?id=1509941

@AparnaKarve @h-kataria please review and merge when appropriate.  Thank you.

Links 
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1509941

Steps for Testing/QA
-------------------------------

Add an Amazon Provider.  Enter Default Credentials.  Validate them.  The "Add" button should be active and allow you to add the provider, whether or not you also click on the "Docker Credentials" tab and enter anything there.  There should be no red "!" on the Docker Credentials tab at any time.