### PR TITLE
Fix Openstack InfraManager credential validation

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -139,8 +139,7 @@ module Mixins
 
         [ems.build_connect_params(connect_opts), true]
       when 'ManageIQ::Providers::Openstack::InfraManager'
-        auth_url = ems.auth_url(params[:default_hostname], params[:default_api_port])
-        [user, password, auth_url]
+        [password, params.except(:default_password)]
       when 'ManageIQ::Providers::Redhat::InfraManager'
         [{
           :username   => user,


### PR DESCRIPTION
This fixes the openstack platform director credential validation.  The
Openstack InfraManager doesn't define an auth_url so this was raising an
exception during validation.  This aligns the task arguments with the
openstack cloud manager, ref: https://github.com/agrare/manageiq-ui-classic/blob/ed4a431034499f83a05965d4e6a6cd02ba61f271/app/controllers/mixins/ems_common_angular.rb#L120-L121