### PR TITLE
Enable credentials validation for Lenovo provider

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -139,7 +139,7 @@ module Mixins
         endpoint_opts = {:protocol => params[:default_security_protocol], :hostname => params[:default_hostname], :api_port => params[:default_api_port], :api_version => params[:api_version]}
         [user, params[:default_password], endpoint_opts]
       when 'ManageIQ::Providers::Lenovo::PhysicalInfraManager'
-        [user, password, params[:default_hostname], params[:default_api_port], "token", false]
+        [user, password, params[:default_hostname], params[:default_api_port], "token", false, true]
       end
     end
 


### PR DESCRIPTION
This change allow proper credentials verification on Lenovo provider

Depends on: https://github.com/ManageIQ/manageiq-providers-lenovo/pull/108