### PR TITLE
Plugins can now use custom defined NPM packages.

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,6 +17,7 @@
       = stylesheet_link_tag 'miq_debug'
     = csrf_meta_tag
     = render :partial => 'layouts/i18n_js'
+    = javascript_pack_tag 'vendor'
     -# FIXME: the conditional below is a temporary fix for a webpacker issue, remove when it's resolved
     - unless Rails.env.test?
       - Webpacker::Manifest.instance.data.keys.each do |pack|

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -56,16 +56,18 @@ module.exports = {
 
     new ManifestPlugin({
       publicPath: output.publicPath,
-      writeToFileEmit: true
-    })
+      writeToFileEmit: true,
+    }),
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
+    }),
   ],
 
   resolve: {
     extensions: settings.extensions,
-    modules: [
-      resolve(settings.source_path),
-      'node_modules'
-    ]
+    modules: [resolve(settings.source_path)].concat(
+      Object.values(engines).map(engine => `${engine}/node_modules`)
+    ),
   },
 
   resolveLoader: {

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -17,6 +17,7 @@ src_files:
 - assets/jasmine-jquery
 - assets/angular-mocks
 - __spec__/helpers/fixtures-fix.js
+- packs/vendor.js
 - packs/manageiq-ui-classic/application-common.js
 - packs/manageiq-ui-classic/miq-redux-common.js
 


### PR DESCRIPTION
This PR enables plugin developers to define their own package.json and to
allow webpack to load those dependencies.

Further, if multiple libraries are defined twice (e.g. in two different
plugins, or core and a plugin), webpack can now de dupe those libraries
into a common 'vendor' pack which will ensure the dependencies are
loaded only once.