### PR TITLE
Fix performance drop-down button in container view

### DIFF
--- a/app/helpers/application_helper/button/container_perf.rb
+++ b/app/helpers/application_helper/button/container_perf.rb
@@ -1,0 +1,8 @@
+class ApplicationHelper::Button::ContainerPerf < ApplicationHelper::Button::Basic
+  needs(:@record)
+
+  def disabled?
+    @error_message = _('No Capacity & Utilization data has been collected for this Container') unless @record.has_perf_data?
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/toolbar/container_center.rb
+++ b/app/helpers/application_helper/toolbar/container_center.rb
@@ -11,16 +11,20 @@ class ApplicationHelper::Toolbar::ContainerCenter < ApplicationHelper::Toolbar::
           'ff ff-timeline fa-lg',
           N_('Show Timelines for this Container'),
           N_('Timelines'),
+          :url       => "/show",
           :url_parms => "?display=timeline",
           :options   => {:entity => 'Container'},
-          :klass     => ApplicationHelper::Button::ContainerTimeline),
+          :klass     => ApplicationHelper::Button::ContainerTimeline
+        ),
         button(
           :container_perf,
           'ff ff-monitoring fa-lg',
           N_('Show Capacity & Utilization data for this Container'),
           N_('Utilization'),
+          :url       => "/show",
           :url_parms => "?display=performance",
-          :klass     => ApplicationHelper::Button::VmPerf),
+          :klass     => ApplicationHelper::Button::ContainerPerf
+        ),
       ]
     ),
   ])


### PR DESCRIPTION
**Description**

compute -> containers -> containers -> [ chose one container ] -> monitoring -> utilization

The utilization button is not working.

a. fix the button.
b. fix the message form "VM" to "Container" when no data.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1509674

**Screenshot**

Before:
![gifrecord_2017-11-13_181622](https://user-images.githubusercontent.com/2181522/32735937-da3553b0-c89e-11e7-8017-7362a2d3005c.gif)

After:
![untitled](https://user-images.githubusercontent.com/2181522/32735670-0dd9e074-c89e-11e7-94f0-aa44cb8252de.png)

![gifrecord_2017-11-13_181322](https://user-images.githubusercontent.com/2181522/32735832-77af98d6-c89e-11e7-9a38-e30fd8b7d493.gif)


