### PR TITLE
Amazon Docker Creds Visibility Based on Setting

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -62,7 +62,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       prometheus_alerts_tls_ca_certs: '',
       prometheus_alerts_auth_status: '',
       prometheus_alerts_security_protocol: '',
-      smartstate_docker_auth_status: true,
       alerts_selection: '',
       console_auth_status: true,
     };
@@ -516,7 +515,10 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.postValidationModel = {
         default: {},
         amqp: {},
+<<<<<<< ac8191621962baf3d53ce5e86a922d7964bfdc51
         console: {},
+=======
+>>>>>>> Revert "Fix AWS Docker Credentials Tab Issues"
         smartstate_docker: {},
         metrics: {},
         ssh_keypair: {},
@@ -561,9 +563,15 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       } else {
         var console_password = $scope.emsCommonModel.console_password === "" ? "" : miqService.storedPasswordPlaceholder;
       }
+<<<<<<< ac8191621962baf3d53ce5e86a922d7964bfdc51
       $scope.postValidationModel.console = {
         console_userid:           $scope.emsCommonModel.console_userid,
         console_password:         console_password,
+=======
+      $scope.postValidationModel.smartstate_docker = {
+        smartstate_docker_userid:      $scope.emsCommonModel.smartstate_docker_userid,
+        smartstate_docker_password:    smartstate_docker_password,
+>>>>>>> Revert "Fix AWS Docker Credentials Tab Issues"
       };
     } else if (prefix === "metrics") {
       var metricsValidationModel = {

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -354,6 +354,7 @@ module Mixins
                        :ems_controller                  => controller_name,
                        :default_auth_status             => default_auth_status,
                        :amqp_auth_status                => amqp_auth_status,
+                       :smartstate_docker_auth_status   => smartstate_docker_auth_status,
                        :service_account_auth_status     => service_account_auth_status,
                        :amqp_fallback_hostname1         => amqp_fallback_hostname1 ? amqp_fallback_hostname1 : "",
                        :amqp_fallback_hostname2         => amqp_fallback_hostname2 ? amqp_fallback_hostname2 : ""

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -9,7 +9,7 @@
   - validate = "#{main_scope}.validateClicked({target: '.validate_button:visible'}, '#{valtype}', true, angularForm, '#{url_for_only_path(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
 - else
   - validate = "#{main_scope}.validateClicked('#{url_for_only_path(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
-%div{"ng-hide" => "#{main_scope}.currentTab === 'smartstate_docker'"}
+%div{"ng-if" => "#{main_scope}.currentTab != 'smartstate_docker'"}
   %miq-button{:class           => 'validate_button',
               :name            => _("Validate"),
               "disabled-title" => verify_title_off,

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -27,6 +27,10 @@
       = miq_tab_header('smartstate_docker', nil, {'ng-click' => "changeAuthTab('smartstate_docker')"}) do
         %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
         = _("SmartState Docker")
+      - if ::Settings.ems.ems_amazon.agent_coordinator.docker_login_required
+        = miq_tab_header('smartstate_docker', nil, {'ng-click' => "changeAuthTab('smartstate_docker')"}) do
+          %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
+          = _("SmartState Docker")
     - elsif controller_name == "ems_container"
       = miq_tab_header('metrics', nil, 'ng-click' => "changeAuthTab('metrics')") do
         %div{"ng-if" => "emsCommonModel.metrics_selection == 'prometheus' || emsCommonModel.metrics_selection == 'hawkular'"}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -25,7 +25,7 @@
         %i{"error-on-tab" => "console", :style => "color:#cc0000"}
         = _("VMRC Console")
       - if ::Settings.ems.ems_amazon.agent_coordinator.docker_login_required
-        = miq_tab_header('smartstate_docker', nil, {'ng-click' => "changeAuthTab('smartstate_docker')"}) do
+        = miq_tab_header('smartstate_docker', nil, 'ng-click' => "changeAuthTab('smartstate_docker')") do
           %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
           = _("SmartState Docker")
     - elsif controller_name == "ems_container"

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -24,9 +24,6 @@
       = miq_tab_header('console', nil, {'ng-click' => "changeAuthTab('console')"}) do
         %i{"error-on-tab" => "console", :style => "color:#cc0000"}
         = _("VMRC Console")
-      = miq_tab_header('smartstate_docker', nil, {'ng-click' => "changeAuthTab('smartstate_docker')"}) do
-        %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
-        = _("SmartState Docker")
       - if ::Settings.ems.ems_amazon.agent_coordinator.docker_login_required
         = miq_tab_header('smartstate_docker', nil, {'ng-click' => "changeAuthTab('smartstate_docker')"}) do
           %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}


### PR DESCRIPTION
The visibility of the Amazon Docker Creds tab will be based on a true
Settings value.  The setting used is Settings.ems.ems_amazon.agent_coordinator.docker_login_required.
If the value is false no tab is presented.
    
This feature is implemented based on offline discussions around the original PR implementing
the tab - https://github.com/ManageIQ/manageiq-ui-classic/pull/2525 with @fryguy.
This is the original desired functionality but it was not implemented in time for the 4.6 cutoff.

@AparnaKarve @h-kataria please review and merge this simple change.  Thanks.

Steps for Testing/QA
-------------------------------

In the UI go to Configuration -> Advanced and search for "docker_login_required".
Set it to false if it is not already set to that.  Save.
Add an Amazon Cloud Provider.  You should see the form to enter Default Credentials but
nothing for the Docker Credentials.

Now go to the Configuration and change "docker_login_required" to true and save.
Add an Amazon Cloud Provider.  In addition to the Default Credentials tab you should see the
"SmartState Docker" tab.