### PR TITLE
Fix Reset button on Edit Button Group page

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -455,7 +455,7 @@ module ApplicationController::Buttons
     @in_a_form  = true
     @lastaction = "automate_button"
     @layout     = "miq_ae_automate_button"
-    replace_right_cell(:nodetype => "button_edit")
+    replace_right_cell(:nodetype => "group_edit")
   end
 
   def group_create_update(typ)


### PR DESCRIPTION
**fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1486649

Fix **Reset** button when editing a _Button Group_ in _Automation -> Automate -> Customization -> Buttons_ tab.

The problem was wrong `nodetype` in `group_button_reset` method. We want to reset _Button **Group**_, not a button nor anything else.

![reset1](https://user-images.githubusercontent.com/13417815/32510617-7df3deac-c3f1-11e7-83c7-eee70bdf1390.png)

**Before:**
```
, [2017-11-07T19:17:07.574795 #25832]  INFO -- : Started POST "/miq_ae_customization/group_update/1000000000041?button=reset" for ::1 at 2017-11-07 19:17:07 +0100
I, [2017-11-07T19:17:07.595585 #25832]  INFO -- : Processing by MiqAeCustomizationController#group_update as JS
I, [2017-11-07T19:17:07.595689 #25832]  INFO -- :   Parameters: {"button"=>"reset", "id"=>"1000000000041"}
I, [2017-11-07T19:17:07.631769 #25832]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/_flash_msg.html.haml (0.0ms)
I, [2017-11-07T19:17:07.657902 #25832]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/shared/_playbook_options.html.haml (8.3ms)
I, [2017-11-07T19:17:07.658024 #25832]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/shared/buttons/_ab_options_form.html.haml (23.2ms)
I, [2017-11-07T19:17:07.658095 #25832]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/shared/buttons/_ab_form.html.haml (32.8ms)
F, [2017-11-07T19:17:07.658257 #25832] FATAL -- : Error caught: [ActionView::Template::Error] no implicit conversion of nil into Array
/home/hstastna/manageiq/manageiq-ui-classic/app/views/shared/_playbook_options.html.haml:8:in `+'
/home/hstastna/manageiq/manageiq-ui-classic/app/views/shared/_playbook_options.html.haml:8:in `__home_hstastna_manageiq_manageiq_ui_classic_app_views_shared__playbook_options_html_haml___3899560385906568952_70135775787060'

```

**After:**
![reset2](https://user-images.githubusercontent.com/13417815/32510630-8a9c4c7a-c3f1-11e7-99ec-cc9c4ee36caf.png)
