### PR TITLE
Enable queued credentials validation for middleware

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -83,7 +83,7 @@ module Mixins
     def create_ems_button_validate
       @in_a_form = true
       ems_type = model.model_from_emstype(params[:emstype])
-      result, details = if %w(ems_cloud ems_infra).include?(params[:controller]) && session[:selected_roles].try(:include?, 'user_interface')
+      result, details = if %w(ems_cloud ems_infra ems_middleware).include?(params[:controller]) && session[:selected_roles].try(:include?, 'user_interface')
                           realtime_raw_connect(ems_type)
                         elsif %w(ems_cloud ems_infra).include?(params[:controller])
                           ems_type.validate_credentials_task(get_task_args(ems_type), session[:userid], params[:zone])


### PR DESCRIPTION
Allow Middleware to have validated credentials via queued job instead of realtime.

**This is an umbrella PR for all related commits**

Merge/backport together with (in this order):
1. Enables both workflows on provider https://github.com/ManageIQ/manageiq-providers-hawkular/pull/100
2. Fixes SSL certificate handling for new wokflow https://github.com/ManageIQ/manageiq-providers-hawkular/pull/101
3. Provides mapping to UI for new workflow https://github.com/ManageIQ/manageiq-ui-classic/pull/2577

By merging the dependent PRs both credential validations are possible. Merging this umbrella PR provides a switch between old and new workflow.