### PR TITLE
Ntp settings

### DIFF
--- a/app/controllers/ops_controller/settings/zones.rb
+++ b/app/controllers/ops_controller/settings/zones.rb
@@ -31,6 +31,7 @@ module OpsController::Settings::Zones
       # zone = @zone.id.blank? ? Zone.new : Zone.find(@zone.id)  # Get new or existing record
       zone_set_record_vars(@zone)
       if valid_record?(@zone) && @zone.save
+        zone_save_ntp_server_settings(@zone)
         AuditEvent.success(build_created_audit(@zone, @edit))
         if params[:button] == "save"
           add_flash(_("Zone \"%{name}\" was saved") % {:name => @edit[:new][:name]})
@@ -111,8 +112,6 @@ module OpsController::Settings::Zones
     zone.settings ||= {}
     zone.settings[:proxy_server_ip] = @edit[:new][:proxy_server_ip]
     zone.settings[:concurrent_vm_scans] = @edit[:new][:concurrent_vm_scans]
-
-    zone_save_ntp_server_settings(zone)
 
     zone.update_authentication({:windows_domain => {:userid => @edit[:new][:userid], :password => @edit[:new][:password]}}, :save => (mode != :validate))
   end

--- a/app/controllers/ops_controller/settings/zones.rb
+++ b/app/controllers/ops_controller/settings/zones.rb
@@ -123,6 +123,8 @@ module OpsController::Settings::Zones
     else
       zone.remove_settings_path_for_resource(:ntp)
     end
+
+    zone.ntp_reload_queue
   end
 
   # Validate the zone record fields


### PR DESCRIPTION
- Queue the ntp settings reload for all servers in the zone.
- Ensure that the zone has an ID before trying to save its settings
https://bugzilla.redhat.com/show_bug.cgi?id=1476365

Depends on https://github.com/ManageIQ/manageiq/pull/16393