### PR TITLE
Prometheus Alerts Endpoint: add detection

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -355,7 +355,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     miqService.sparkleOn();
     miqService.detectWithRest($event, $scope.actionUrl)
       .then(function success(data) {
-        $scope.updateHawkularHostname(data.hostname);
+        $scope.updateHostname(data.hostname);
         miqService.miqFlash(data.level, data.message);
         miqSparkleOff();
       });
@@ -615,8 +615,12 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     $scope.angularForm[$scope.authType + '_auth_status'].$setViewValue(updatedValue);
   };
 
-  $scope.updateHawkularHostname = function(value) {
-    $scope.emsCommonModel.metrics_hostname = value;
+  $scope.updateHostname = function(value) {
+    if ($scope.currentTab === "alerts") {
+      $scope.emsCommonModel.prometheus_alerts_hostname = value;
+    } else {
+      $scope.emsCommonModel.metrics_hostname = value;
+    }
   };
 
   $scope.radioSelectionChanged = function() {

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -13,8 +13,9 @@ class EmsContainerController < ApplicationController
   after_action :set_session_data
 
   OPENSHIFT_ROUTES = {
-    "hawkular"   => %w(hawkular-metrics openshift-infra),
-    "prometheus" => %w(prometheus prometheus)
+    "hawkular"          => %w(hawkular-metrics openshift-infra),
+    "prometheus"        => %w(prometheus prometheus),
+    "prometheus_alerts" => %w(alerts prometheus)
   }.freeze
   OPENSHIFT_DEFAULT_ROUTE = %w(hawkular-metrics openshift-infra).freeze
 
@@ -67,7 +68,12 @@ class EmsContainerController < ApplicationController
   end
 
   def update_ems_button_detect(verify_ems = nil)
-    route, project = OPENSHIFT_ROUTES.fetch(params[:metrics_selection], OPENSHIFT_DEFAULT_ROUTE)
+    route_type = if params[:current_tab] == "alerts"
+                   "prometheus_alerts"
+                 else
+                   params[:metrics_selection]
+                 end
+    route, project = OPENSHIFT_ROUTES.fetch(route_type, OPENSHIFT_DEFAULT_ROUTE)
     verify_ems ||= find_record_with_rbac(model, params[:id])
     set_ems_record_vars(verify_ems, :validate)
     @in_a_form = true

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -17,7 +17,6 @@ class EmsContainerController < ApplicationController
     "prometheus"        => %w(prometheus prometheus),
     "prometheus_alerts" => %w(alerts prometheus)
   }.freeze
-  OPENSHIFT_DEFAULT_ROUTE = %w(hawkular-metrics openshift-infra).freeze
 
   def self.model
     ManageIQ::Providers::ContainerManager
@@ -73,7 +72,7 @@ class EmsContainerController < ApplicationController
                  else
                    params[:metrics_selection]
                  end
-    route, project = OPENSHIFT_ROUTES.fetch(route_type, OPENSHIFT_DEFAULT_ROUTE)
+    route, project = OPENSHIFT_ROUTES[route_type]
     verify_ems ||= find_record_with_rbac(model, params[:id])
     set_ems_record_vars(verify_ems, :validate)
     @in_a_form = true

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -14,8 +14,8 @@ class EmsContainerController < ApplicationController
 
   OPENSHIFT_ROUTES = {
     "hawkular"          => %w(hawkular-metrics openshift-infra),
-    "prometheus"        => %w(prometheus prometheus),
-    "prometheus_alerts" => %w(alerts prometheus)
+    "prometheus"        => %w(prometheus openshift-metrics),
+    "prometheus_alerts" => %w(alerts openshift-metrics)
   }.freeze
 
   def self.model

--- a/app/views/ems_container/_form.html.haml
+++ b/app/views/ems_container/_form.html.haml
@@ -84,7 +84,11 @@
                      "checkchange"                 => "",
                      "required"                    => "",
                      "selectpicker-for-select-tag" => "")
-
+    %input{:type      => 'text',
+           :id        => "current_tab",
+           :name      => "current_tab",
+           "ng-model" => "currentTab",
+           "ng-hide"  => "true"}
 
   %hr
   = render :partial => "layouts/angular/multi_auth_credentials", :locals => {:record => @ems, :ng_model => "emsCommonModel"}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -357,7 +357,8 @@
                                                 :id                     => record.id,
                                                 :ng_reqd_hostname       => "true",
                                                 :ng_reqd_api_port       => "true",
-                                                :prefix                 => "prometheus_alerts"}
+                                                :prefix                 => "prometheus_alerts",
+                                                :detection              => true}
             = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                          :locals  => {:ng_show           => true,
                                       :ng_model          => ng_model.to_s,

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -116,8 +116,8 @@ describe EmsContainerController do
     it "detects openshift prometheus alert route" do
       require 'kubeclient'
       controller.instance_variable_set(:@_params,
-                                       :id                => openshift_manager.id,
-                                       :current_tab       => "alerts")
+                                       :id          => openshift_manager.id,
+                                       :current_tab => "alerts")
       controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
 
       # set kubeclient to return a mock route.
@@ -134,9 +134,9 @@ describe EmsContainerController do
 
     it "tolerates detection exceptions" do
       controller.instance_variable_set(:@_params,
-                                       :id => openshift_manager.id,
+                                       :id                => openshift_manager.id,
                                        :current_tab       => "metrics",
-                                        :metrics_selection => 'hawkular')
+                                       :metrics_selection => 'hawkular')
       controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
 
       # set kubeclient to return a mock route.

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -103,7 +103,7 @@ describe EmsContainerController do
 
       # set kubeclient to return a mock route.
       allow(Kubeclient::Client).to receive(:new).and_return(mock_client)
-      expect(mock_client).to receive(:get_route).with('prometheus', 'prometheus')
+      expect(mock_client).to receive(:get_route).with('prometheus', 'openshift-metrics')
         .and_return(RecursiveOpenStruct.new(:spec => {:host => "prometheus-metrics.example.com"}))
 
       ret = JSON.parse(controller.send(:update_ems_button_detect))
@@ -122,7 +122,7 @@ describe EmsContainerController do
 
       # set kubeclient to return a mock route.
       allow(Kubeclient::Client).to receive(:new).and_return(mock_client)
-      expect(mock_client).to receive(:get_route).with('alerts', 'prometheus')
+      expect(mock_client).to receive(:get_route).with('alerts', 'openshift-metrics')
         .and_return(RecursiveOpenStruct.new(:spec => {:host => "prometheus-alerts.example.com"}))
 
       ret = JSON.parse(controller.send(:update_ems_button_detect))


### PR DESCRIPTION
Currently for OpenShift we have detection for both metrics implementations (Hawkular, Prometheus)
but not for alerts (Prometheus).

![out](https://user-images.githubusercontent.com/3010449/32521826-ac8bc7c6-c41d-11e7-8886-4ea9177f3e36.gif)
