### PR TITLE
Don't send `scheme` and `version` to oVirt

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -147,8 +147,6 @@ module Mixins
           :password         => password,
           :server           => params[:default_hostname],
           :port             => params[:default_api_port],
-          :scheme           => 'https',
-          :version          => 4,
           :verify_ssl       => params[:default_tls_verify] == 'on' ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE,
           :ca_certs         => params[:default_tls_ca_certs],
           :metrics_username => metrics_user,


### PR DESCRIPTION
The oVirt provider has been recently modified so that the `raw_connect`
method no longer needs the `scheme` and `version` parameters. If they
are sent they will be silently ignored. This patch is just a clean up,
to remove those now useless parameters from the call.

This is related to the following bug:

  Failed validation when adding RHV provider
  https://bugzilla.redhat.com/1509432