### PR TITLE
Fix topology refresh

### DIFF
--- a/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
@@ -11,7 +11,6 @@ function CloudTopologyCtrl($scope, $interval, topologyService) {
   var d3 = window.d3;
   // NOTE: for search
   vm.d3 = d3;
-
   topologyService.mixinContextMenu(vm, vm);
 
   vm.checkboxModel = {
@@ -139,15 +138,6 @@ function CloudTopologyCtrl($scope, $interval, topologyService) {
     /* Don't do default rendering */
     ev.preventDefault();
   });
-
-  vm.getIcon = function getIcon(d) {
-    switch (d.item.kind) {
-      case 'CloudManager':
-        return vm.icons[d.item.display_kind];
-      default:
-        return vm.icons[d.item.kind];
-    }
-  };
 
   vm.getDimensions = function getDimensions(d) {
     var defaultDimensions = topologyService.defaultElementDimensions();

--- a/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
@@ -1,55 +1,18 @@
 angular.module('ManageIQ').controller('cloudTopologyController', CloudTopologyCtrl);
-CloudTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
+CloudTopologyCtrl.$inject = ['$scope', '$interval', 'topologyService'];
 
-function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
+function CloudTopologyCtrl($scope, $interval, topologyService) {
   var vm = this;
 
   miqHideSearchClearButton();
   vm.vs = null;
-  var icons = null;
-
+  vm.icons = null;
+  vm.dataUrl = '/cloud_topology/data';
   var d3 = window.d3;
   // NOTE: for search
   vm.d3 = d3;
 
   topologyService.mixinContextMenu(vm, vm);
-
-  ManageIQ.angular.rxSubject.subscribe(function(event) {
-    if (event.name === 'refreshTopology') {
-      vm.refresh();
-    }
-  });
-
-  vm.refresh = function() {
-    var id;
-    if ($location.absUrl().match('show/$') || $location.absUrl().match('show$')) {
-      id = '';
-    } else {
-      id = '/' + (/cloud_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
-    }
-
-    var url = '/cloud_topology/data' + id;
-
-    $http.get(url)
-      .then(getCloudTopologyFormDataComplete)
-      .catch(miqService.handleFailure);
-  };
-
-  function getCloudTopologyFormDataComplete(response) {
-    var data = response.data;
-
-    var currentSelectedKinds = vm.kinds;
-
-    vm.items = data.data.items;
-    vm.relations = data.data.relations;
-    // NOTE: $scope.kind is required by kubernetes-topology-icon
-    vm.kinds = $scope.kinds = data.data.kinds;
-    icons = data.data.icons;
-
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys(vm.kinds).length)) {
-      vm.kinds = currentSelectedKinds;
-    }
-  }
 
   vm.checkboxModel = {
     value: false,
@@ -58,6 +21,7 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService,
   vm.legendTooltip = __('Click here to show/hide entities of this type');
 
   $('input#box_display_names').click(topologyService.showHideNames(vm));
+  topologyService.mixinRefresh(vm, $scope);
   vm.refresh();
   var promise = $interval(vm.refresh, 1000 * 60 * 3);
   $scope.$on('$destroy', function() {
@@ -178,9 +142,9 @@ function CloudTopologyCtrl($scope, $http, $interval, $location, topologyService,
   vm.getIcon = function getIcon(d) {
     switch (d.item.kind) {
       case 'CloudManager':
-        return icons[d.item.display_kind];
+        return vm.icons[d.item.display_kind];
       default:
-        return icons[d.item.kind];
+        return vm.icons[d.item.kind];
     }
   };
 

--- a/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
@@ -22,6 +22,7 @@ function CloudTopologyCtrl($scope, $interval, topologyService) {
 
   $('input#box_display_names').click(topologyService.showHideNames(vm));
   topologyService.mixinRefresh(vm, $scope);
+  topologyService.mixinGetIcon(vm);
   vm.refresh();
   var promise = $interval(vm.refresh, 1000 * 60 * 3);
   $scope.$on('$destroy', function() {

--- a/app/assets/javascripts/controllers/topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/container_topology_controller.js
@@ -6,8 +6,9 @@ function ContainerTopologyCtrl($scope, $interval, topologyService) {
   miqHideSearchClearButton();
   var vm = this;
   vm.dataUrl = '/container_topology/data';
+  vm.detailUrl = '/container_project_topology/data';
   vm.vs = null;
-  var icons = null;
+  vm.icons = null;
 
   var d3 = window.d3;
   vm.d3 = d3;
@@ -18,40 +19,21 @@ function ContainerTopologyCtrl($scope, $interval, topologyService) {
     value: false
   };
 
+  vm.remove_hierarchy = [
+    'Container',
+    'ContainerGroup',
+    'ContainerReplicator',
+    'ContainerService',
+    'ContainerRoute',
+    'Host',
+    'Vm',
+    'ContainerNode',
+    'ContainerManager'
+  ];
+
   vm.legendTooltip = __("Click here to show/hide entities of this type");
-
-  vm.getTopologyData = function(response) {
-    var data = response.data;
-
-    var currentSelectedKinds = vm.kinds;
-
-    vm.items = data.data.items;
-    vm.relations = data.data.relations;
-    // NOTE: $scope.kinds is required by kubernetes-topology-icon
-    vm.kinds = $scope.kinds = data.data.kinds;
-    icons = data.data.icons;
-
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys(vm.kinds).length)) {
-      vm.kinds = $scope.kinds = currentSelectedKinds;
-    } else if (data.data.settings && data.data.settings.containers_max_items) {
-      var size_limit = data.data.settings.containers_max_items;
-      var remove_hierarchy = [
-        'Container',
-        'ContainerGroup',
-        'ContainerReplicator',
-        'ContainerService',
-        'ContainerRoute',
-        'Host',
-        'Vm',
-        'ContainerNode',
-        'ContainerManager'
-      ];
-      vm.kinds = $scope.kinds = topologyService.reduce_kinds(vm.items, vm.kinds, size_limit, remove_hierarchy);
-    }
-  };
-
   $('input#box_display_names').click(topologyService.showHideNames(vm));
-  topologyService.mixinRefresh(vm);
+  topologyService.mixinRefresh(vm, $scope);
   vm.refresh();
   var promise = $interval(vm.refresh, 1000 * 60 * 3);
 
@@ -170,7 +152,7 @@ function ContainerTopologyCtrl($scope, $interval, topologyService) {
   });
 
   vm.getIcon = function getIcon(d) {
-    return d.item.kind === 'ContainerManager' ? icons[d.item.display_kind] : icons[d.item.kind];
+    return d.item.kind === 'ContainerManager' ? vm.icons[d.item.display_kind] : vm.icons[d.item.kind];
   };
 
   vm.getDimensions = function getDimensions(d) {

--- a/app/assets/javascripts/controllers/topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/container_topology_controller.js
@@ -1,10 +1,11 @@
 angular.module('ManageIQ').controller('containerTopologyController', ContainerTopologyCtrl);
-ContainerTopologyCtrl.$inject = ['$scope', '$http', '$interval', 'topologyService', '$window', 'miqService'];
+ContainerTopologyCtrl.$inject = ['$scope', '$interval', 'topologyService'];
 
-function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $window, miqService) {
+function ContainerTopologyCtrl($scope, $interval, topologyService) {
   ManageIQ.angular.scope = $scope;
   miqHideSearchClearButton();
   var vm = this;
+  vm.dataUrl = '/container_topology/data';
   vm.vs = null;
   var icons = null;
 
@@ -13,49 +14,44 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
 
   topologyService.mixinContextMenu(vm, vm);
 
-  ManageIQ.angular.rxSubject.subscribe(function(event) {
-    if (event.name === 'refreshTopology') {
-      vm.refresh();
-    }
-  });
-
-  vm.refresh = function() {
-    var id;
-    var type;
-    var arr;
-    var pathname = $window.location.pathname.replace(/\/$/, '');
-    if (pathname.match('/container_topology/show$')) {
-      // specifically the container_topology page - all container ems's
-      type = 'container_topology';
-      id = '';
-    } else if (pathname.match('/(.+)/show/([0-9]+)')) {
-      // any container entity except the ems
-      // search for pattern ^/<controller>/show/<id>$ in the pathname - /container_project/show/11
-      arr = pathname.match('/(.+)/show/([0-9]+)');
-      type = arr[1] + '_topology';
-      id = '/' + arr[2];
-    } else if (pathname.match('/(.+)/([0-9]+)')) {
-      // single entity topology of ems_container
-      // search for pattern ^/<controller>/<id>$ in the pathname - /ems_container/4
-      arr = pathname.match('/(.+)/([0-9]+)');
-      type = 'container_topology';
-      id = '/' + arr[2];
-    }
-
-    var url = '/' + type + '/data' + id;
-
-    $http.get(url)
-      .then(getContainerTopologyData)
-      .catch(miqService.handleFailure);
-  };
-
   vm.checkboxModel = {
     value: false
   };
 
   vm.legendTooltip = __("Click here to show/hide entities of this type");
 
+  vm.getTopologyData = function(response) {
+    var data = response.data;
+
+    var currentSelectedKinds = vm.kinds;
+
+    vm.items = data.data.items;
+    vm.relations = data.data.relations;
+    // NOTE: $scope.kinds is required by kubernetes-topology-icon
+    vm.kinds = $scope.kinds = data.data.kinds;
+    icons = data.data.icons;
+
+    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys(vm.kinds).length)) {
+      vm.kinds = $scope.kinds = currentSelectedKinds;
+    } else if (data.data.settings && data.data.settings.containers_max_items) {
+      var size_limit = data.data.settings.containers_max_items;
+      var remove_hierarchy = [
+        'Container',
+        'ContainerGroup',
+        'ContainerReplicator',
+        'ContainerService',
+        'ContainerRoute',
+        'Host',
+        'Vm',
+        'ContainerNode',
+        'ContainerManager'
+      ];
+      vm.kinds = $scope.kinds = topologyService.reduce_kinds(vm.items, vm.kinds, size_limit, remove_hierarchy);
+    }
+  };
+
   $('input#box_display_names').click(topologyService.showHideNames(vm));
+  topologyService.mixinRefresh(vm);
   vm.refresh();
   var promise = $interval(vm.refresh, 1000 * 60 * 3);
 
@@ -200,36 +196,6 @@ function ContainerTopologyCtrl($scope, $http, $interval, topologyService, $windo
         return defaultDimensions;
     }
   };
-
-  function getContainerTopologyData(response) {
-    var data = response.data;
-
-    var currentSelectedKinds = vm.kinds;
-
-    vm.items = data.data.items;
-    vm.relations = data.data.relations;
-    // NOTE: $scope.kinds is required by kubernetes-topology-icon
-    vm.kinds = $scope.kinds = data.data.kinds;
-    icons = data.data.icons;
-
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys(vm.kinds).length)) {
-      vm.kinds = currentSelectedKinds;
-    } else if (data.data.settings && data.data.settings.containers_max_items) {
-      var size_limit = data.data.settings.containers_max_items;
-      var remove_hierarchy = [
-        'Container',
-        'ContainerGroup',
-        'ContainerReplicator',
-        'ContainerService',
-        'ContainerRoute',
-        'Host',
-        'Vm',
-        'ContainerNode',
-        'ContainerManager'
-      ];
-      vm.kinds = topologyService.reduce_kinds(vm.items, vm.kinds, size_limit, remove_hierarchy);
-    }
-  }
 
   topologyService.mixinSearch(vm);
 }

--- a/app/assets/javascripts/controllers/topology/infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/infra_topology_controller.js
@@ -1,39 +1,18 @@
 angular.module('ManageIQ').controller('infraTopologyController', InfraTopologyCtrl);
-InfraTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
+InfraTopologyCtrl.$inject = ['$scope', '$interval', 'topologyService'];
 
-function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
+function InfraTopologyCtrl($scope, $interval, topologyService) {
   ManageIQ.angular.scope = $scope;
   miqHideSearchClearButton();
   var vm = this;
+  vm.dataUrl = '/infra_topology/data';
   vm.vs = null;
-  var icons = null;
+  vm.icons = null;
 
   var d3 = window.d3;
   vm.d3 = d3;
 
   topologyService.mixinContextMenu(vm, vm);
-
-  ManageIQ.angular.rxSubject.subscribe(function(event) {
-    if (event.name === 'refreshTopology') {
-      vm.refresh();
-    }
-  });
-
-  vm.refresh = function() {
-    var id;
-    if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
-      id = '';
-    } else {
-      id = '/' + (/infra_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
-    }
-
-    var url = '/infra_topology/data' + id;
-
-    $http.get(url)
-      .then(getInfraTopologyData)
-      .catch(miqService.handleFailure);
-  };
-
   vm.checkboxModel = {
     value: false
   };
@@ -41,6 +20,7 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService,
   vm.legendTooltip = __("Click here to show/hide entities of this type");
 
   $('input#box_display_names').click(topologyService.showHideNames(vm));
+  topologyService.mixinRefresh(vm, $scope);
   vm.refresh();
   var promise = $interval(vm.refresh, 1000 * 60 * 3);
 
@@ -161,9 +141,9 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService,
   this.getIcon = function getIcon(d) {
     switch(d.item.kind) {
       case 'InfraManager':
-        return icons[d.item.display_kind];
+        return vm.icons[d.item.display_kind];
       default:
-        return icons[d.item.kind];
+        return vm.icons[d.item.kind];
     }
   };
 
@@ -182,21 +162,6 @@ function InfraTopologyCtrl($scope, $http, $interval, $location, topologyService,
         return defaultDimensions;
     }
   };
-
-  function getInfraTopologyData(response) {
-    var data = response.data;
-
-    var currentSelectedKinds = vm.kinds;
-
-    vm.items = data.data.items;
-    vm.relations = data.data.relations;
-    vm.kinds = $scope.kinds = data.data.kinds;
-    icons = data.data.icons;
-
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys(vm.kinds).length)) {
-      vm.kinds = currentSelectedKinds;
-    }
-  }
 
   topologyService.mixinSearch(vm);
 }

--- a/app/assets/javascripts/controllers/topology/infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/infra_topology_controller.js
@@ -21,6 +21,7 @@ function InfraTopologyCtrl($scope, $interval, topologyService) {
 
   $('input#box_display_names').click(topologyService.showHideNames(vm));
   topologyService.mixinRefresh(vm, $scope);
+  topologyService.mixinGetIcon(vm);
   vm.refresh();
   var promise = $interval(vm.refresh, 1000 * 60 * 3);
 
@@ -137,15 +138,6 @@ function InfraTopologyCtrl($scope, $interval, topologyService) {
     /* Don't do default rendering */
     ev.preventDefault();
   });
-
-  this.getIcon = function getIcon(d) {
-    switch(d.item.kind) {
-      case 'InfraManager':
-        return vm.icons[d.item.display_kind];
-      default:
-        return vm.icons[d.item.kind];
-    }
-  };
 
   this.getDimensions = function getDimensions(d) {
     var defaultDimensions = topologyService.defaultElementDimensions();

--- a/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/middleware_topology_controller.js
@@ -8,7 +8,6 @@ function MiddlewareTopologyCtrl($scope, $interval, topologyService) {
   vm.vs = null;
   var d3 = window.d3;
   vm.d3 = d3;
-  vm.icons;
   vm.dataUrl = '/middleware_topology/data';
 
   topologyService.mixinContextMenu(vm, vm);

--- a/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
@@ -21,6 +21,7 @@ function physicalInfraTopologyCtrl($scope, $interval, topologyService) {
 
   $('input#box_display_names').click(topologyService.showHideNames(vm));
   topologyService.mixinRefresh(vm, $scope);
+  topologyService.mixinGetIcon(vm);
   vm.refresh();
   var promise = $interval(vm.refresh, 1000 * 60 * 3);
 
@@ -137,15 +138,6 @@ function physicalInfraTopologyCtrl($scope, $interval, topologyService) {
     /* Don't do default rendering */
     ev.preventDefault();
   });
-
-  vm.getIcon = function getIcon(d) {
-    switch(d.item.kind) {
-      case 'PhysicalInfraManager':
-        return vm.icons[d.item.display_kind];
-      default:
-        return vm.icons[d.item.kind];
-    }
-  };
 
   vm.getDimensions = function getDimensions(d) {
     var defaultDimensions = topologyService.defaultElementDimensions();

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -272,4 +272,17 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
     });
     controller.refresh = refresh;
   };
+
+  this.mixinGetIcon = function(controller) {
+    controller.getIcon = function(d) {
+      switch (d.item.kind) {
+        case 'CloudManager':
+        case 'InfraManager':
+        case 'PhysicalInfraManager':
+          return controller.icons[d.item.display_kind];
+        default:
+          return controller.icons[d.item.kind];
+      }
+    };
+  };
 }]);

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -257,7 +257,7 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
       if ($location.absUrl().match('show/$') || $location.absUrl().match('show$')) {
         id = '';
       } else {
-        id = '/' + controller.dataUrl + (/\/show\/(\d+)/.exec($location.absUrl())[1]);
+        id = '/' + (/\/show\/(\d+)/.exec($location.absUrl())[1]);
       }
 
       var url = controller.dataUrl + id;

--- a/app/views/ops/_schedule_form.html.haml
+++ b/app/views/ops/_schedule_form.html.haml
@@ -54,6 +54,8 @@
                          "checkchange"                 => "",
                          "selectpicker-for-select-tag" => "")
 
+    %label
+      test
     = render :partial => "schedule_form_filter"
     = render :partial => "schedule_form_timer"
     = render :partial => "layouts/angular/x_edit_buttons_angular"

--- a/app/views/shared/_topology_header_toolbar.html.haml
+++ b/app/views/shared/_topology_header_toolbar.html.haml
@@ -5,7 +5,8 @@
 
 .form-group
   %button.btn.btn-default{'data-function'      => 'sendDataWithRx',
-                          'data-function-data' => {:name => 'refreshTopology'}.to_json}
+                          'data-function-data' => {:service => 'topologyService',
+                                                   :name => 'refreshTopology'}.to_json}
     %i.fa.fa-refresh.fa-lg
     = _("Refresh")
 %form.search-pf.topology-search{:role     => 'form',

--- a/spec/javascripts/controllers/containers/container_topology_controller_spec.js
+++ b/spec/javascripts/controllers/containers/container_topology_controller_spec.js
@@ -43,14 +43,15 @@ describe('containerTopologyController', function() {
 
     beforeEach(module('ManageIQ'));
     beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, $location) {
-      spyOn($location, 'absUrl').and.returnValue('/container_topology/show/1');
+      spyOn($location, 'absUrl').and.returnValue('/container_topology/show/1?display=topology');
       scope = $rootScope.$new();
       $httpBackend = _$httpBackend_;
-      $httpBackend.when('GET','/container_topology/data/1').respond(mock_data);
+      $httpBackend.when('GET','/container_project_topology/data/1').respond(mock_data);
       ctrl = _$controller_('containerTopologyController',
-        {$scope: scope}
+        {
+          $scope: scope,
+        }
       );
-      console.log('ctrl: ', ctrl);
       $httpBackend.flush();
     }));
 
@@ -61,7 +62,6 @@ describe('containerTopologyController', function() {
 
     describe('data loads successfully', function() {
       it('in all main objects', function() {
-        console.log('controller: ', ctrl);
         expect(ctrl.items).toBeDefined();
         expect(ctrl.relations).toBeDefined();
         expect(ctrl.kinds).toBeDefined();

--- a/spec/javascripts/controllers/containers/container_topology_controller_spec.js
+++ b/spec/javascripts/controllers/containers/container_topology_controller_spec.js
@@ -42,25 +42,15 @@ describe('containerTopologyController', function() {
     };
 
     beforeEach(module('ManageIQ'));
-
-    beforeEach(function() {
-      var $window = {
-          location: {
-              pathname: '/ems_container/1',
-          },
-      };
-
-      module(function($provide) {
-        $provide.value('$window', $window);
-      });
-    });
-
-    beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, $window) {
+    beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, $location) {
+      spyOn($location, 'absUrl').and.returnValue('/container_topology/show/1');
       scope = $rootScope.$new();
-
       $httpBackend = _$httpBackend_;
       $httpBackend.when('GET','/container_topology/data/1').respond(mock_data);
-      ctrl = _$controller_('containerTopologyController', {$scope: scope});
+      ctrl = _$controller_('containerTopologyController',
+        {$scope: scope}
+      );
+      console.log('ctrl: ', ctrl);
       $httpBackend.flush();
     }));
 


### PR DESCRIPTION
While refactoring the topology Angular controllers(#1898), i forgot to move refresh listener to topology service and it stopped working.
https://bugzilla.redhat.com/show_bug.cgi?id=1501048

@skateman made a quick fix in his PR #2557 (ty)

Also fixes related issue this issue https://bugzilla.redhat.com/show_bug.cgi?id=1511504. Was not refreshing while filtering some entities.