### PR TITLE
Amazon Docker Creds Visibility Based on Setting

### DIFF
--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -24,9 +24,10 @@
       = miq_tab_header('console', nil, {'ng-click' => "changeAuthTab('console')"}) do
         %i{"error-on-tab" => "console", :style => "color:#cc0000"}
         = _("VMRC Console")
-      = miq_tab_header('smartstate_docker', nil, {'ng-click' => "changeAuthTab('smartstate_docker')"}) do
-        %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
-        = _("SmartState Docker")
+      - if ::Settings.ems.ems_amazon.agent_coordinator.docker_login_required
+        = miq_tab_header('smartstate_docker', nil, {'ng-click' => "changeAuthTab('smartstate_docker')"}) do
+          %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
+          = _("SmartState Docker")
     - elsif controller_name == "ems_container"
       = miq_tab_header('metrics', nil, 'ng-click' => "changeAuthTab('metrics')") do
         %div{"ng-if" => "emsCommonModel.metrics_selection == 'prometheus' || emsCommonModel.metrics_selection == 'hawkular'"}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -25,7 +25,7 @@
         %i{"error-on-tab" => "console", :style => "color:#cc0000"}
         = _("VMRC Console")
       - if ::Settings.ems.ems_amazon.agent_coordinator.docker_login_required
-        = miq_tab_header('smartstate_docker', nil, {'ng-click' => "changeAuthTab('smartstate_docker')"}) do
+        = miq_tab_header('smartstate_docker', nil, 'ng-click' => "changeAuthTab('smartstate_docker')") do
           %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
           = _("SmartState Docker")
     - elsif controller_name == "ems_container"


### PR DESCRIPTION
The visibility of the Amazon Docker Creds tab will be based on a true
Settings value. The setting used is Settings.ems.ems_amazon.agent_coordinator.docker_login_required.
If the value is false no tab is presented.

This feature is implemented based on offline discussions around the original PR implementing
the tab - #2525 with @Fryguy.
This is the original desired functionality but it was not implemented in time for the 4.6 cutoff.

@AparnaKarve @h-kataria please review and merge this simple change. Thanks.

Steps for Testing/QA

In the UI go to Configuration -> Advanced and search for "docker_login_required".
Set it to false if it is not already set to that. Save.
Add an Amazon Cloud Provider. You should see the form to enter Default Credentials but
nothing for the Docker Credentials.

Now go to the Configuration and change "docker_login_required" to true and save.
Add an Amazon Cloud Provider. In addition to the Default Credentials tab you should see the
"SmartState Docker" tab.