### PR TITLE
Add additional options to report_data for tagging and other functions which use get_db_view instead of get_view

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1722,6 +1722,8 @@ class ApplicationController < ActionController::Base
       options[:association] = nil
     end
 
+    process_show_list_options(options, db) if @report_data_additional_options.nil?
+
     MiqReport.load_from_view_options(db, current_user, options, db_view_yaml_cache)
   end
 


### PR DESCRIPTION
### Fixes problem with no additional data set for some actions
When tagging, live migrating adding policies and other functions which were using `get_db_view` to get view without going trough more complex `get_view` function attribute `@report_data_additional_options` is set so `report_data` can use these additional options.