### PR TITLE
Remove deprecated call to ActionController::Parameters#deep_clone 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -395,7 +395,7 @@ class ApplicationController < ActionController::Base
     session[:async][:interval] ||= 1000 # Default interval to 1 second
     session[:async][:params] ||= {}
 
-    session[:async][:params] = copy_hash(params) # Save the incoming parms
+    session[:async][:params] = params.deep_dup # Save the incoming parms
     session[:async][:params][:task_id] = task_id
 
     # override method to be called, when the task is done


### PR DESCRIPTION
**Issue:**
There is deprecation warning:
`"... Method deep_clone is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability ... (called from copy_hash at /lib/vmdb/global_methods.rb:25)"`

https://bugzilla.redhat.com/show_bug.cgi?id=1511011

**Solution:**
use `deep_dup` instead of `deep_clone`

@miq-bot add-label  bug
