### PR TITLE
GTL: add options needed for quadicon rendering.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -435,6 +435,7 @@ class ApplicationController < ActionController::Base
   # @option params :model_id [String]
   #     String value of model's ID to be filtered with.
   def process_params_options(params)
+    restore_quadicon_options(params[:additional_options] || {})
     options = from_additional_options(params[:additional_options] || {})
     if params[:explorer]
       params[:action] = "explorer"

--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -8,7 +8,12 @@ class ApplicationController
     :parent_class_name,
     :parent_method,
     :association,
-    :view_suffix
+    :view_suffix,
+
+    :listicon,
+    :embedded,
+    :showlinks,
+    :policy_sim
   ) do
     def self.from_options(options)
       additional_options = new
@@ -22,6 +27,13 @@ class ApplicationController
       additional_options.view_suffix = options[:view_suffix]
       additional_options.parent_method = options[:parent_method]
       additional_options
+    end
+
+    def with_quadicon_options(options)
+      self.listicon   = options[:listicon]
+      self.embedded   = options[:embedded]
+      self.showlinks  = options[:showlinks]
+      self.policy_sim = options[:policy_sim]
     end
 
     def with_model(curr_model)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1623,6 +1623,12 @@ module ApplicationHelper
 
   def process_show_list_options(options, curr_model = nil)
     @report_data_additional_options = ApplicationController::ReportDataAdditionalOptions.from_options(options)
+    @report_data_additional_options.with_quadicon_options(
+      :listicon   => @listicon,
+      :embedded   => @embedded,
+      :showlinks  => @showlinks,
+      :policy_sim => @policy_sim
+    )
     @report_data_additional_options.with_model(curr_model) if curr_model
     @report_data_additional_options.freeze
   end
@@ -1637,6 +1643,20 @@ module ApplicationHelper
       additional_options[:parent] = parent_class.find(parent_id) if parent_class < ActiveRecord::Base
     end
     additional_options
+  end
+
+  # Restore instance variables necessary for proper rendering of quadicons.
+  # This is a temporary solution that is ot be replaced by proper
+  # parametrization of an ancessor class of QuadiconHelper.
+  def restore_quadicon_options(quadicon_options)
+    @listicon = quadicon_options[:listicon]
+    @embedded = quadicon_options[:embedded]
+    @showlinks = quadicon_options[:showlinks]
+    @policy_sim = quadicon_options[:policy_sim]
+    # @explorer
+    # @view.db
+    # @parent
+    @lastaction = quadicon_options[:lastaction]
   end
 
   # Wrapper around jquery-rjs' remote_function which adds an extra .html_safe()


### PR DESCRIPTION
To properly render quadicons a set of controller instance variables is needed :-(

This PR adds this to the /report_data interface.

This is a partial fix for:

https://bugzilla.redhat.com/show_bug.cgi?id=1501376
https://bugzilla.redhat.com/show_bug.cgi?id=1503076

There are more problems with that area.

@ZitaNemeckova is working on one issue and @karelhala is working on another.