### PR TITLE
Enable new dialog-user feature for more custom buttons

### DIFF
--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -1,4 +1,18 @@
 class DialogLocalService
+  NEW_DIALOG_USERS = %w(
+    CloudTenant
+    CloudVolume
+    ContainerNode
+    EmsCluster
+    GenericObject
+    Host
+    InfraManager
+    MiqTemplate
+    Service
+    Storage
+    Vm
+  ).freeze
+
   def determine_dialog_locals_for_svc_catalog_provision(resource_action, target, finish_submit_endpoint)
     api_submit_endpoint = "/api/service_catalogs/#{target.service_template_catalog_id}/service_templates/#{target.id}"
 
@@ -16,32 +30,67 @@ class DialogLocalService
   end
 
   def determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)
-    case obj.class.name.demodulize
-    when /Vm/
-      api_collection_name = "vms"
-      cancel_endpoint = "/vm_infra/explorer"
-      force_old_dialog_use = false
-    when /Service/
-      api_collection_name = "services"
-      cancel_endpoint = "/service/explorer"
-      force_old_dialog_use = false
-    when /GenericObject/
-      api_collection_name = "generic_objects"
-      cancel_endpoint = "/generic_object/show_list"
-      force_old_dialog_use = false
-    else
-      force_old_dialog_use = true
-    end
+    dialog_locals = {:force_old_dialog_use => true}
 
-    {
+    return dialog_locals unless NEW_DIALOG_USERS.include?(obj.class.name.demodulize)
+
+    submit_endpoint, cancel_endpoint = determine_api_endpoints(obj)
+
+    dialog_locals.merge!(
       :resource_action_id     => resource_action_id,
       :target_id              => obj.id,
       :target_type            => obj.class.name.demodulize.underscore,
-      :force_old_dialog_use   => force_old_dialog_use,
-      :api_submit_endpoint    => "/api/#{api_collection_name}/#{obj.id}",
+      :force_old_dialog_use   => false,
+      :api_submit_endpoint    => submit_endpoint,
       :api_action             => button_name,
       :finish_submit_endpoint => cancel_endpoint,
       :cancel_endpoint        => cancel_endpoint
-    }
+    )
+
+    dialog_locals
+  end
+
+  private
+
+  def determine_api_endpoints(obj)
+    case obj.class.name.demodulize
+    when /CloudTenant/
+      api_collection_name = "cloud_tenants"
+      cancel_endpoint = "/cloud_tenant"
+    when /CloudVolume/
+      api_collection_name = "cloud_volumes"
+      cancel_endpoint = "/cloud_volume"
+    when /ContainerNode/
+      api_collection_name = "container_nodes"
+      cancel_endpoint = "/container_node"
+    when /EmsCluster/
+      api_collection_name = "clusters"
+      cancel_endpoint = "/ems_cluster"
+    when /GenericObject/
+      api_collection_name = "generic_objects"
+      cancel_endpoint = "/generic_object/show_list"
+    when /Host/
+      api_collection_name = "hosts"
+      cancel_endpoint = "/host"
+    when /InfraManager/
+      api_collection_name = "providers"
+      cancel_endpoint = "/ems_infra"
+    when /MiqTemplate/
+      api_collection_name = "templates"
+      cancel_endpoint = "/vm_or_template/explorer"
+    when /Service/
+      api_collection_name = "services"
+      cancel_endpoint = "/service/explorer"
+    when /Storage/
+      api_collection_name = "datastores"
+      cancel_endpoint = "/storage/explorer"
+    when /Vm/
+      api_collection_name = "vms"
+      cancel_endpoint = "/vm_infra/explorer"
+    end
+
+    submit_endpoint = "/api/#{api_collection_name}/#{obj.id}"
+
+    return submit_endpoint, cancel_endpoint
   end
 end

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -27,19 +27,138 @@ describe DialogLocalService do
     let(:button_name) { "custom-button-name" }
     let(:resource_action_id) { 321 }
 
-    context "when the object is a Vm" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Vm, :id => 123) }
+    context "when the object is a CloudTenant" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::CloudTenant, :id => 123) }
 
       it "returns a hash" do
         expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
-          :target_type            => 'vm',
+          :target_type            => 'cloud_tenant',
           :force_old_dialog_use   => false,
-          :api_submit_endpoint    => "/api/vms/123",
+          :api_submit_endpoint    => "/api/cloud_tenants/123",
           :api_action             => "custom-button-name",
-          :finish_submit_endpoint => "/vm_infra/explorer",
-          :cancel_endpoint        => "/vm_infra/explorer"
+          :finish_submit_endpoint => "/cloud_tenant",
+          :cancel_endpoint        => "/cloud_tenant"
+        )
+      end
+    end
+
+    context "when the object is a CloudVolume" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::CloudVolume, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'cloud_volume',
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/cloud_volumes/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/cloud_volume",
+          :cancel_endpoint        => "/cloud_volume"
+        )
+      end
+    end
+
+    context "when the object is a ContainerNode" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ContainerNode, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'container_node',
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/container_nodes/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/container_node",
+          :cancel_endpoint        => "/container_node"
+        )
+      end
+    end
+
+    context "when the object is an EmsCluster" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::EmsCluster, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'ems_cluster',
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/clusters/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/ems_cluster",
+          :cancel_endpoint        => "/ems_cluster"
+        )
+      end
+    end
+
+    context "when the object is a GenericObject" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::GenericObject, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'generic_object',
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/generic_objects/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/generic_object/show_list",
+          :cancel_endpoint        => "/generic_object/show_list"
+        )
+      end
+    end
+
+    context "when the object is a Host" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Host, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'host',
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/hosts/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/host",
+          :cancel_endpoint        => "/host"
+        )
+      end
+    end
+
+    context "when the object is an InfraManager" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'infra_manager',
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/providers/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/ems_infra",
+          :cancel_endpoint        => "/ems_infra"
+        )
+      end
+    end
+
+    context "when the object is an MiqTemplate" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::MiqTemplate, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'miq_template',
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/templates/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/vm_or_template/explorer",
+          :cancel_endpoint        => "/vm_or_template/explorer"
         )
       end
     end
@@ -61,19 +180,46 @@ describe DialogLocalService do
       end
     end
 
-    context "when the object is a GenericObject" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::GenericObject, :id => 123) }
+    context "when the object is a Storage" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Storage, :id => 123) }
 
       it "returns a hash" do
         expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
-          :target_type            => 'generic_object',
+          :target_type            => 'storage',
           :force_old_dialog_use   => false,
-          :api_submit_endpoint    => "/api/generic_objects/123",
+          :api_submit_endpoint    => "/api/datastores/123",
           :api_action             => "custom-button-name",
-          :finish_submit_endpoint => "/generic_object/show_list",
-          :cancel_endpoint        => "/generic_object/show_list"
+          :finish_submit_endpoint => "/storage/explorer",
+          :cancel_endpoint        => "/storage/explorer"
+        )
+      end
+    end
+
+    context "when the object is a Vm" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Vm, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'vm',
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/vms/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/vm_infra/explorer",
+          :cancel_endpoint        => "/vm_infra/explorer"
+        )
+      end
+    end
+
+    context "when the object does not support new dialogs" do
+      let(:obj) { double(:id => 123) }
+
+      it "returns a hash with 'force_old_dialog_use' set to true" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :force_old_dialog_use => true
         )
       end
     end


### PR DESCRIPTION
Related to #2562, it is a continuation for other objects. This one will make custom buttons for the following classes go through the new dialog-user ui-component:

`CloudTenant`
`CloudVolume`
`ContainerNode`
`EmsCluster`
`Host`
`InfraManager` (Provider)
`MiqTemplate`
`Storage`

https://www.pivotaltracker.com/story/show/152449649

/cc @gmcculloug 
@d-m-u Can you review, please?
@himdel Can you also review or tag someone to review, please?

@miq-bot assign @h-kataria 
@miq-bot add_label gaprindashvili/yes, enhancement, automation/automate