### PR TITLE
Disk Name should not display 0 for unavailable Used/Provisioned size

### DIFF
--- a/app/helpers/textual_mixins/textual_devices.rb
+++ b/app/helpers/textual_mixins/textual_devices.rb
@@ -42,11 +42,10 @@ module TextualMixins::TextualDevices
       location = disk.location
       size = disk.size
       prov = disk.used_percent_of_provisioned
-      device_name = _("Hard Disk (%{controller_type} %{location}), Size %{size}, " \
-                      "Percent Used Provisioned Space %{space}") % {:controller_type => ctrl_type,
-                                                                    :location        => location,
-                                                                    :size            => size,
-                                                                    :space           => prov}
+      device_name = _("Hard Disk (%{controller_type} %{location}), Size %{size}") % {:controller_type => ctrl_type,
+                                                                                     :location        => location,
+                                                                                     :size            => size}
+      device_name << _(", Percent Used Provisioned Space %{space}") % {:space => prov} unless disk.size_on_disk.nil?
       description = _("%{filename}, Mode: %{mode}") % {:filename => disk.filename, :mode => disk.mode}
       Device.new(device_name, description, nil, :disk)
     end

--- a/spec/helpers/textual_mixins/textual_devices_spec.rb
+++ b/spec/helpers/textual_mixins/textual_devices_spec.rb
@@ -35,6 +35,18 @@ describe TextualMixins::TextualDevices do
       end
       it { is_expected.not_to be_empty }
     end
+
+    context "with hdd with no size_on_disk collected (AZURE)" do
+      let(:hw) do
+        FactoryGirl.create(:hardware,
+                           :disks => [FactoryGirl.create(:disk,
+                                                         :device_type     => "disk",
+                                                         :size            => "1072693248",
+                                                         :controller_type => "AZURE")])
+      end
+      it { expect(subject[0][:name]).to include("Hard Disk (AZURE ), Size 1072693248") }
+      it { expect(subject[0][:name]).not_to include("Percent Used Provisioned Space") }
+    end
   end
 
   describe "#network_attributes" do


### PR DESCRIPTION
Remove the Provisioned Size listed as 0.0 for Azure Containers Disk Name, as the size_on_disk is not available.

Links 
-------
https://bugzilla.redhat.com/show_bug.cgi?id=1510177

Steps for Testing/QA 
----------------------------
Steps to Reproduce:
1. Add an Azure provider
2. Select any instance
3. Click on Containers
4. View the details of a disk
5. Percent Used Provisioned Space: 0.0%


Before:
![screenshot from 2017-11-08 14-00-43](https://user-images.githubusercontent.com/12769982/32568774-440223ba-c48d-11e7-89ef-fa730a8c701d.png)


After:
![screenshot from 2017-11-08 12-03-35](https://user-images.githubusercontent.com/12769982/32568348-f4e773d0-c48b-11e7-9fc1-a9d2edb0b0a4.png)

