### PR TITLE
Remove capitalization of Generic Object Association names

### DIFF
--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -32,10 +32,10 @@ module GenericObjectHelper::TextualSummary
       associations.push(key.to_sym)
       define_singleton_method("textual_#{key}") do
         num = @record.send(key).count
-        h = {:label => _("%{label}") % {:label => key.capitalize}, :value => num}
+        h = {:label => _("%{label}") % {:label => key}, :value => num}
         if role_allows?(:feature => "generic_object_view") && num > 0
           h.update(:link  => url_for_only_path(:action => 'show', :id => @record, :display => key),
-                   :title => _('Show all %{associated_models}') % {:associated_models => key.capitalize})
+                   :title => _('Show all %{associated_models}') % {:associated_models => key})
         end
       end
     end


### PR DESCRIPTION
Generic Object Association names should be displayed as they were set by the Generic Object Definition. Capitalizing Association names is not necessary.

https://bugzilla.redhat.com/show_bug.cgi?id=1500829

(This fixes only part of the problem specified in the BZ.
The other part of linking the `Service` association to the `Service Explorer` is still WIP)