### PR TITLE
Delete duplicate flash message after Reset in RBAC Group Name

### DIFF
--- a/app/views/layouts/_exp_editor.html.haml
+++ b/app/views/layouts/_exp_editor.html.haml
@@ -7,7 +7,7 @@
   = javascript_tag("ManageIQ.expEditor.second.title = '#{@edit[@expkey][:val2][:title]}';")
 
 #exp_editor_div
-  = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'exp_editor_flash'}
+  = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'exp_editor_flash'} if !params[:button] == "reset"
   %fieldset
     .toolbar-pf-actions{:style => "margin-left: 20px"}
       .form-group


### PR DESCRIPTION
Eliminated display of duplicate flash message upon Reset of RBAC Group Name field.  

https://bugzilla.redhat.com/show_bug.cgi?id=1506634

Screen shot prior to code change:
![rbac group name dupe flash message prior to code fix](https://user-images.githubusercontent.com/552686/32578519-623e985e-c492-11e7-9b58-f6a76d86ac87.png)


Screen shot after code change:
![rbac group name flash message post code fix](https://user-images.githubusercontent.com/552686/32578523-6ac2a33a-c492-11e7-9075-0c2aced2e598.png)
