### PR TITLE
OPS RBAC Tagging GTL Fix.

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -4,7 +4,6 @@ module ApplicationController::Tags
   # Edit user, group or tenant tags
   def tagging_edit(db = nil, assert = true)
     assert_privileges("#{controller_for_common_methods}_tag") if assert
-    @showlinks = true
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
     case params[:button]
     when "cancel"
@@ -199,6 +198,10 @@ module ApplicationController::Tags
 
   # Build the @edit elements for the tag edit screen
   def tag_edit_build_screen
+    @gtl_type = 'list' # show items in tagging screen a list
+    @embedded = true   # with no links
+    @showlinks = false
+
     cats = Classification.categories.select(&:show).sort_by(&:name) # Get the categories, sort by name
     @categories = {}    # Classifications array for first chooser
     cats.delete_if { |c| c.read_only? || c.entries.length == 0 }  # Remove categories that are read only or have no entries

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -616,7 +616,6 @@ module OpsController::OpsRbac
       session[:tag_db] = @tagging = tagging
     end
 
-    @gtl_type = "list" # No quad icons for user/group list views
     x_tags_set_form_vars
     @in_a_form = true
     session[:changed] = false


### PR DESCRIPTION
OPS/RBAC Tagging displays the entities being tagged in a GTL.

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1503076
https://bugzilla.redhat.com/show_bug.cgi?id=1501376

Some entities are still clickable but that is not a serious problem as long as the links don't blow up. More cleanup is needed here but AFTER the release.