### PR TITLE
Fix custom toolbar explorer

### DIFF
--- a/app/controllers/mixins/custom_buttons.rb
+++ b/app/controllers/mixins/custom_buttons.rb
@@ -13,8 +13,6 @@ module Mixins::CustomButtons
         Mixins::CustomButtons::Result.new(:single)
       elsif @lastaction == "show_list"
         Mixins::CustomButtons::Result.new(:list)
-      elsif x_tree[:tree] == :rbac_tree
-        Mixins::CustomButtons::Result.new(:single)
       else
         'blank_view_tb'
       end

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -767,7 +767,7 @@ class OpsController < ApplicationController
   end
 
   def choose_custom_toolbar
-    if x_tree && x_tree[:tree] == :rbac_tree && x_node != 'root'
+    if x_tree && x_tree[:tree] == :rbac_tree && x_node != 'root' && params[:action] != 'x_button'
       build_toolbar(@record ? Mixins::CustomButtons::Result.new(:single) : Mixins::CustomButtons::Result.new(:list))
     end
   end

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -766,6 +766,20 @@ class OpsController < ApplicationController
     } if @ajax_action
   end
 
+  def custom_toolbar_explorer
+    if x_tree
+      if @display == "main" && @record
+        Mixins::CustomButtons::Result.new(:single)
+      elsif @lastaction == "show_list"
+        Mixins::CustomButtons::Result.new(:list)
+      elsif x_tree[:tree] == :rbac_tree
+        Mixins::CustomButtons::Result.new(:single)
+      else
+        'blank_view_tb'
+      end
+    end
+  end
+
   def choose_custom_toolbar
     if x_tree && x_tree[:tree] == :rbac_tree && x_node != 'root' && params[:action] != 'x_button'
       build_toolbar(@record ? Mixins::CustomButtons::Result.new(:single) : Mixins::CustomButtons::Result.new(:list))


### PR DESCRIPTION
Add custom buttons to User, Group and Tenant(group or single). Those buttons are visible in toolbar. 

Clicking on tagging of any of them loads a tagging screen or `Add child Tenant to this Tenant` for a tenant.
Before:

```
F, [2017-11-09T13:36:59.580264 #55571] FATAL -- : Error caught: [NoMethodError] undefined method `>=' for nil:NilClass
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:325:in `button_class_name'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:342:in `get_custom_buttons'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:276:in `custom_button_selects'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:306:in `build_custom_toolbar_class'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:296:in `custom_toolbar_class'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:70:in `toolbar_class'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:18:in `build_toolbar'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:6:in `call'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper.rb:521:in `build_toolbar'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/ops_controller.rb:771:in `choose_custom_toolbar'
```
After:

Tagging page/New tenant form is loaded.

Try for any tenant Configuration -> Add child Tenant to this Tenant. After adding child Tenant custom button should be visible as it was before.

When `x_tree[:tree] == :rbac_tree` is not present in `custom_toolbar_explorer`:

<img width="1197" alt="screen shot 2017-11-09 at 1 46 16 pm" src="https://user-images.githubusercontent.com/9210860/32606148-79c4f960-c554-11e7-8e96-a0cc6c52b7ad.png">

When `x_tree[:tree] == :rbac_tree` is present in `custom_toolbar_explorer`:

<img width="1184" alt="screen shot 2017-11-09 at 1 57 44 pm" src="https://user-images.githubusercontent.com/9210860/32606552-0129dbe0-c556-11e7-9433-aadfa7299977.png">



There may be some issues on tagging screen that will be fixed by https://github.com/ManageIQ/manageiq-ui-classic/pull/2667 or https://github.com/ManageIQ/manageiq-ui-classic/pull/2678 .

Custom buttons functionality is fixed here https://github.com/ManageIQ/manageiq-ui-classic/pull/2593
 
@miq_bot add_label bug, gaprindashvili/yes

Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/2654
