### PR TITLE
Fix Reset button for tag page in Services

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -85,7 +85,7 @@ module ApplicationController::Explorer
   def x_button
     model, action = pressed2model_action(params[:pressed])
 
-    allowed_models = %w(common image instance vm miq_template provider storage configscript infra_networking automation_manager_provider configuration_manager_provider)
+    allowed_models = %w(common image instance vm miq_template provider storage configscript infra_networking automation_manager_provider configuration_manager_provider service)
     raise ActionController::RoutingError.new('invalid button action') unless
       allowed_models.include?(model)
 

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -16,7 +16,7 @@ module ApplicationController::Tags
     end
   end
 
-  def service_tag
+  def service_tag(_db = nil)
     tagging_edit('Service')
   end
 

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -232,12 +232,6 @@ class ServiceController < ApplicationController
     replace_right_cell(:action => 'ownership')
   end
 
-  def service_tag_edit
-    @explorer = true
-    service_tag
-    replace_right_cell(:action => 'tag')
-  end
-
   def service_retire
     @explorer = true
     retirevms

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -11,7 +11,7 @@ class ServiceController < ApplicationController
     'service_delete'      => :service_delete,
     'service_edit'        => :service_edit,
     'service_ownership'   => :service_ownership,
-    'service_tag'         => :service_tag_edit,
+    'service_tag'         => :service_tag,
     'service_retire'      => :service_retire,
     'service_retire_now'  => :service_retire_now,
     'service_reconfigure' => :service_reconfigure

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -28,10 +28,6 @@ class ServiceController < ApplicationController
     tag(GenericObject) if @display == 'generic_objects' && params[:pressed] == 'generic_object_tag'
   end
 
-  def x_button
-    generic_x_button(SERVICE_X_BUTTON_ALLOWED_ACTIONS)
-  end
-
   def title
     _("My Services")
   end
@@ -387,6 +383,7 @@ class ServiceController < ApplicationController
       return
     end
     action, replace_trees = options.values_at(:action, :replace_trees)
+    action = @sb[:action] if action.nil?
     @explorer = true
     partial, action_url, @right_cell_text = set_right_cell_vars(action) if action # Set partial name, action and cell header
     get_node_info(x_node) if !action && !@in_a_form && !params[:display]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -946,7 +946,7 @@ module ApplicationHelper
   end
 
   def pressed2model_action(pressed)
-    pressed =~ /^(ems_cluster|miq_template|infra_networking|automation_manager_provider|configuration_manager_provider)_(.*)$/ ? [$1, $2] : pressed.split('_', 2)
+    pressed =~ /^(ems_cluster|miq_template|infra_networking|automation_manager_provider|configuration_manager_provider|service)_(.*)$/ ? [$1, $2] : pressed.split('_', 2)
   end
 
   def model_for_ems(record)


### PR DESCRIPTION
**fixing:**
(1) https://bugzilla.redhat.com/show_bug.cgi?id=1445313
(2) https://bugzilla.redhat.com/show_bug.cgi?id=1445303

Fix _Reset_ button for tag page opened from Service item detail page in _Services -> My Services_.

The problem was that _Reset_ button did nothing but produced an error after choosing _Edit Tags_ under _Policy_ , making a change and resetting the change, in Service item detail page in _Services -> My Services_. The action was not set properly for Services which lead to unwanted behavior.

**Before: (1)**
![r1](https://user-images.githubusercontent.com/13417815/32607461-6be91a92-c559-11e7-9059-480cff80b154.png)
![r3](https://user-images.githubusercontent.com/13417815/32607820-718ecd38-c55a-11e7-8d72-2dd327416a60.png)

**After: (1)**
![r2](https://user-images.githubusercontent.com/13417815/32607292-be660a60-c558-11e7-8e5c-89d96d70bd84.png)

**Before: (2)**
![rr1](https://user-images.githubusercontent.com/13417815/32609534-4b41c210-c560-11e7-85bf-46704d7886a6.png)

**After: (2)**
![rr2](https://user-images.githubusercontent.com/13417815/32609416-f5662520-c55f-11e7-872e-c3303983f835.png)

  