### PR TITLE
List Provisioned disk name as N/A if size_on_disk is not collected

### DIFF
--- a/app/helpers/textual_mixins/textual_devices.rb
+++ b/app/helpers/textual_mixins/textual_devices.rb
@@ -41,11 +41,12 @@ module TextualMixins::TextualDevices
       ctrl_type = disk.controller_type.upcase
       location = disk.location
       size = disk.size
-      prov = disk.used_percent_of_provisioned
-      device_name = _("Hard Disk (%{controller_type} %{location}), Size %{size}") % {:controller_type => ctrl_type,
-                                                                                     :location        => location,
-                                                                                     :size            => size}
-      device_name << _(", Percent Used Provisioned Space %{space}") % {:space => prov} unless disk.size_on_disk.nil?
+      prov = disk.size_on_disk.nil? ? 'N/A' : disk.used_percent_of_provisioned
+      device_name = _("Hard Disk (%{controller_type} %{location}), Size %{size}, " \
+                      "Percent Used Provisioned Space %{space}") % {:controller_type => ctrl_type,
+                                                                    :location        => location,
+                                                                    :size            => size,
+                                                                    :space           => prov}
       description = _("%{filename}, Mode: %{mode}") % {:filename => disk.filename, :mode => disk.mode}
       Device.new(device_name, description, nil, :disk)
     end

--- a/spec/helpers/textual_mixins/textual_devices_spec.rb
+++ b/spec/helpers/textual_mixins/textual_devices_spec.rb
@@ -44,8 +44,7 @@ describe TextualMixins::TextualDevices do
                                                          :size            => "1072693248",
                                                          :controller_type => "AZURE")])
       end
-      it { expect(subject[0][:name]).to include("Hard Disk (AZURE ), Size 1072693248") }
-      it { expect(subject[0][:name]).not_to include("Percent Used Provisioned Space") }
+      it { expect(subject[0][:name]).to include("Hard Disk (AZURE ), Size 1072693248, Percent Used Provisioned Space N/A") }
     end
   end
 


### PR DESCRIPTION
Follow up for https://github.com/ManageIQ/manageiq-ui-classic/pull/2673
- list the used/porovisioned space on the disk name as N/A if not collected

Links 
-------
https://bugzilla.redhat.com/show_bug.cgi?id=1510177

Steps for Testing/QA 
----------------------------
Steps to Reproduce:
1. Add an Azure provider
2. Select any instance
3. Click on Containers
4. View the details of a disk
5. Percent Used Provisioned Space: 0.0%


Before:
![screenshot from 2017-11-08 12-03-35](https://user-images.githubusercontent.com/12769982/32568348-f4e773d0-c48b-11e7-9fc1-a9d2edb0b0a4.png)

After:
![screenshot from 2017-11-09 09-00-40](https://user-images.githubusercontent.com/12769982/32609275-2cc6d308-c52d-11e7-89b4-61e4b3683dfc.png)


