### PR TITLE
Report Dashboard actions confirmation messages consistency

### DIFF
--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -58,7 +58,7 @@ module ReportController::Dashboards
       if !@db || @db.id.blank?
         add_flash(_("Add of new Dashboard was cancelled by the user"))
       else
-        add_flash(_("Edit of Dashboard \"%{name}\" was cancelled by the user") % {:name => @db.name})
+        add_flash(_("Edit of Dashboard \"%{name}\" was cancelled by the user") % {:name => get_record_display_name(@db)})
       end
       get_node_info
       @edit = session[:edit] = nil # clean out the saved info
@@ -76,7 +76,7 @@ module ReportController::Dashboards
       if @flash_array.nil? && @db.save
         db_save_members
         AuditEvent.success(build_saved_audit(@db, @edit))
-        add_flash(_("Dashboard \"%{name}\" was saved") % {:name => @db.name})
+        add_flash(_("Dashboard \"%{name}\" was saved") % {:name => get_record_display_name(@db)})
         if params[:button] == "add"
           widgetset = MiqWidgetSet.where_unique_on(@edit[:new][:name]).first
           settings = g.settings ? g.settings : {}


### PR DESCRIPTION
Use common method when building action confirmation messages for consistency.

https://bugzilla.redhat.com/show_bug.cgi?id=1501115


Screen shot prior to code fix, notice message displaying name, not description even though description is available:
![report dashboard added name message prior to code fix](https://user-images.githubusercontent.com/552686/32635766-75b3dc94-c566-11e7-9a22-6b8a1e96669c.png)


Screen shot after code fix, all displaying description since its available. Had description not been available, then message would display name:
![report dashboard added message post code fix](https://user-images.githubusercontent.com/552686/32635775-830c06dc-c566-11e7-984f-bb015dda2d83.png)
 
![report dashboard edit saved message post code fix](https://user-images.githubusercontent.com/552686/32635783-8f5e6786-c566-11e7-8a61-9e0ed668b51a.png)

![report dashboard delete confirm message post code fix](https://user-images.githubusercontent.com/552686/32635791-985cde76-c566-11e7-95dd-8b52a4fa7590.png)


 