### PR TITLE
Fix skipping "first step" when saving a filter

### DIFF
--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -48,7 +48,7 @@
               %font{:color => "black"}
                 = _("Choose a %{model} report filter") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
   - elsif mode == "save"
-    = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'exp_editor_flash'}
+    = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'exp_editor_flash'} if params[:button] != 'save'
     .modal-body
       .form-horizontal.static
         .form-group


### PR DESCRIPTION
**fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1511532

Fix appearing _"Search Name is required"_ if user has not clicked on _Save_
button yet, in Advanced search, when entering a name of a new filter.

Practically, no step is skipped when saving a filter, just flash message is
rendered in Adv search by default, when entering _"save"_ mode. This was
fixed by a simple condition. **No flash message** appears **in the second
step** of saving a filter anymore, when user has not clicked on _Save_ button
(for the second time) yet.

**Before:**
![save1](https://user-images.githubusercontent.com/13417815/32654424-8026f12a-c60b-11e7-8725-2eb87fffbfe5.png)

**After:**
![save2](https://user-images.githubusercontent.com/13417815/32654427-835efdba-c60b-11e7-9ec9-8509cf9b2026.png)
