### PR TITLE
Display all clusters in Compute Rate Assignment page

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -786,6 +786,10 @@ class ChargebackController < ApplicationController
     @edit[:cb_assign][:hierarchy] ||= {}
     all_of_classtype.each do |instance|
       @edit[:cb_assign][:cis][instance.id] = instance.name
+      if klass == "ems_cluster"
+        provider_name = instance.ext_management_system.name
+        @edit[:cb_assign][:cis][instance.id] = "#{provider_name}/#{instance.name}"
+      end
       next unless klass == "tenant" && instance.root?
       @edit[:cb_assign][:hierarchy][instance.id] = {}
       @edit[:cb_assign][:hierarchy][instance.id][:name] = instance.name


### PR DESCRIPTION
**fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1456825

Fix displaying clusters in _Compute Rate Assignment_ page when selecting
_'Selected Cluster/Deployment Roles'_ in _Assign to_ drop down menu even
when clusters have the same name (and belong to different providers) so
the name of their providers was added to their original names as prefix.

**Before:**
![cluster1](https://user-images.githubusercontent.com/13417815/32658922-818a4d9e-c61c-11e7-9094-bff76763a00a.png)

**After:**
![cluster2](https://user-images.githubusercontent.com/13417815/32658925-842f3cb2-c61c-11e7-9dc2-68e07cfadc90.png)
