### PR TITLE
Fix variable name in miqSupportCasePrompt()

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1447,7 +1447,7 @@ function miqSupportCasePrompt(tb_url) {
   var supportCase = prompt(__('Enter Support Case:'), '');
   if (supportCase === null) {
     return false;
-  } else if (support_case.trim() === '') {
+  } else if (supportCase.trim() === '') {
     alert(__('Support Case must be provided to collect logs'));
     return false;
   }


### PR DESCRIPTION
How to reproduce:
1. Settings -> Diagnostics -> Server -> Collect Logs -> Set RH Dropbox
2. Collect -> Collect current logs -> Enter support case

Actual results:
An error would show in JavaScript console, the button submission wouldn't work correctly.

Caused by commit 0414b8ba1c3e2257455ac75d60c2a68771833f44

https://bugzilla.redhat.com/show_bug.cgi?id=1506990