### PR TITLE
Fix cut-off dropdowns on Tag Edit screen

### DIFF
--- a/app/views/layouts/_tag_edit.html.haml
+++ b/app/views/layouts/_tag_edit.html.haml
@@ -18,6 +18,7 @@
             options_for_select(@categories.sort_by{|key, _| key.downcase}, @edit[:cat].name),
             "data-miq_observe"     => {:url => url}.to_json,
             "data-live-search"     => "true",
+            "data-container"       => "body",
             "class"                => "selectpicker")
           :javascript
             miqInitSelectPicker();

--- a/app/views/layouts/_tag_edit_cat_tags.html.haml
+++ b/app/views/layouts/_tag_edit_cat_tags.html.haml
@@ -6,6 +6,7 @@
     options_for_select(options, "select"),
     "data-miq_observe" => {:url => url}.to_json,
     "data-live-search" => "true",
+    "data-container"   => "body",
     "class"            => "selectpicker")
   :javascript
     miqInitSelectPicker();


### PR DESCRIPTION
This PR fixes a problem where the bootstrap-select dropdowns were conflicting with the GTL #main_div by setting the data-container to "body."

https://bugzilla.redhat.com/show_bug.cgi?id=1509083

Old
<img width="1112" alt="screen shot 2017-11-10 at 12 08 56 pm" src="https://user-images.githubusercontent.com/1287144/32669861-f935efb8-c60f-11e7-87d2-75d36aa1e995.png">

New
![screen shot 2017-11-10 at 10 16 38 am](https://user-images.githubusercontent.com/1287144/32669822-db9be782-c60f-11e7-8920-e81f5029c380.png)

