### PR TITLE
Simplify ansibleCredentialOptions angular component

### DIFF
--- a/app/assets/javascripts/components/ansible-credential-options.js
+++ b/app/assets/javascripts/components/ansible-credential-options.js
@@ -2,7 +2,6 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
   bindings: {
     model: '=',
     options: '<',
-    type: '<',
     newRecord: '<',
     reset: '=',
     deleteFromModel: '=',
@@ -13,18 +12,6 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
 
   controller: ['$scope', function($scope) {
     $scope.__ = __;
-
-    this.setOptions = function() {
-      this.current_options = this.options[this.type];
-    };
-
-    this.$onInit = function() {
-      this.setOptions();
-    };
-
-    this.$onChanges = function(changes) {
-      this.setOptions();
-    };
 
     this.updatePassword = function(name) {
       this[name] = true;
@@ -43,7 +30,7 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
   }],
 
   template: [
-    '<div class="form-group" ng-repeat="(name, attr) in vm.current_options.attributes">',
+    '<div class="form-group" ng-repeat="(name, attr) in vm.options.attributes">',
       '<label class="control-label col-md-2">',
         '{{ __(attr.label) }}',
        '</label>',

--- a/app/views/ansible_credential/_credential_form.html.haml
+++ b/app/views/ansible_credential/_credential_form.html.haml
@@ -38,8 +38,7 @@
           {{ vm.credential_options[vm.credentialModel.type].label }}
 
     %ansible-credential-options{:model                        => 'vm.credentialModel',
-                                :options                      => 'vm.credential_options',
-                                :type                         => 'vm.credentialModel.type',
+                                :options                      => 'vm.credential_options[vm.credentialModel.type]',
                                 :reset                        => 'vm.reset',
                                 'new-record'                  => 'vm.newRecord',
                                 'delete-from-model'           => 'vm.deleteFromModel',


### PR DESCRIPTION
We can pass options of the particular credential type to the component right away. That would
make the whole component simpler.

At the same time, this fix would resolve some obscure angular timing issues, which would lead
to the credential form not being rendered correctly in certain situations.

https://bugzilla.redhat.com/show_bug.cgi?id=1510855