### PR TITLE
Icons to discern automate method types

### DIFF
--- a/app/assets/stylesheets/icon_customizations.scss
+++ b/app/assets/stylesheets/icon_customizations.scss
@@ -59,4 +59,8 @@ opacity:0.6;
   color: #ec7a08; //pf-orange-400
 }
 
+.fa-ruby {
+  @extend .fa, .fa-lg, .fa-diamond;
+  color: red;
+}
 /*end icon class customizations*/

--- a/app/decorators/miq_ae_method_decorator.rb
+++ b/app/decorators/miq_ae_method_decorator.rb
@@ -1,5 +1,18 @@
 class MiqAeMethodDecorator < MiqDecorator
-  def self.fonticon
-    'ff ff-method'
+  def fileicon
+    "svg/vendor-ansible.svg" if location == 'playbook'
+  end
+
+  def fonticon
+    case location
+    when "inline"
+      'fa-ruby'
+    when "expression"
+      'fa fa-search'
+    when "playbook"
+      nil
+    else
+      'ff ff-method'
+    end
   end
 end

--- a/app/presenters/tree_node/miq_ae_method.rb
+++ b/app/presenters/tree_node/miq_ae_method.rb
@@ -1,4 +1,5 @@
 module TreeNode
   class MiqAeMethod < MiqAeNode
+    set_attribute(:image) { @object.try(:decorate).try(:fileicon) }
   end
 end

--- a/app/views/miq_ae_class/_class_methods.html.haml
+++ b/app/views/miq_ae_class/_class_methods.html.haml
@@ -16,7 +16,10 @@
               %td.table-view-pf-select.noclick
                 %input{:type => 'checkbox', :value => cls_cid}
               %td.table-view-pf-select
-                %i{:class => record.decorate.fonticon}
+                - if record.decorate.try(:fileicon)
+                  %img{:src => ActionController::Base.helpers.image_path(record.decorate.fileicon)}
+                - else
+                  %i{:class => record.decorate.fonticon}
               %td
                 = record_name(record)
       :javascript

--- a/spec/presenters/tree_node/miq_ae_method_spec.rb
+++ b/spec/presenters/tree_node/miq_ae_method_spec.rb
@@ -5,6 +5,6 @@ describe TreeNode::MiqAeMethod do
   let(:object) { FactoryGirl.create(:miq_ae_method, :scope => :class, :language => :ruby, :location => :inline) }
 
   include_examples 'TreeNode::Node#key prefix', 'aem-'
-  include_examples 'TreeNode::Node#icon', 'ff ff-method'
+  include_examples 'TreeNode::Node#icon', 'fa-ruby'
   include_examples 'TreeNode::Node#tooltip prefix', 'Automate Method'
 end


### PR DESCRIPTION
There are different automate method types like
* Inline (Ruby)
* Playbook (Ansible)
* Expression (MiqExpression/Search)
* Builtin (Macros)

In the Automate Explorer we can't discern the method type if they all have the same icons, this PR adds different icons for different method types.

Before, my_method is an Ansible method but the icon doesn't give you a hint.

<img width="783" alt="screen shot 2017-11-10 at 11 10 00 am" src="https://user-images.githubusercontent.com/6452699/32678275-b78e02c4-c62f-11e7-9b1b-8ba363596f65.png">

After the my_method has ansible logo to indicate that its a Ansible Playbook method, we dont have to open the method to figure out its type.

![screen shot 2017-11-13 at 12 10 50 pm](https://user-images.githubusercontent.com/6452699/32738847-26bfca54-c86c-11e7-9124-6c4d6fe2f764.png)




