### PR TITLE
/report_data: :model_name takes precedence over :active_tree

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -486,8 +486,8 @@ class ApplicationController < ActionController::Base
   #     If model was chosen somehow before calling this method use this model instead of finding it.
   def process_params_model_view(params, options)
     model_view   = options[:model_name].constantize if options[:model_name]
-    model_view ||= model_from_active_tree(params[:active_tree].to_sym) if params[:active_tree]
     model_view ||= model_string_to_constant(params[:model_name]) if params[:model_name]
+    model_view ||= model_from_active_tree(params[:active_tree].to_sym) if params[:active_tree]
     model_view ||  controller_to_model
   end
   private :process_params_model_view

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -320,7 +320,7 @@ describe ApplicationController do
       end
 
       it "with params[:active_tree]" do
-        expect(subject.send(:process_params_model_view, {:active_tree => :vms_instances_filter_tree, :model_name => "instances"}, {})).to eq("Vm")
+        expect(subject.send(:process_params_model_view, {:active_tree => :vms_instances_filter_tree}, {})).to eq("Vm")
       end
 
       it "with params[:model_name]" do

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -136,5 +136,28 @@ describe ServiceController do
     end
   end
 
+  context "#report_data" do
+    let(:service) { FactoryGirl.create(:service) }
+
+    let!(:vm) do
+      vm = FactoryGirl.create(:vm)
+      vm.add_to_service(service)
+      vm
+    end
+
+    it 'returns VMs associated to selected Service' do
+      report_data_request(
+        :model         => 'Vm',
+        :parent_model  => 'Service',
+        :parent_id     => service.id,
+        :active_tree   => 'svcs_tree',
+        :parent_method => 'all_vms'
+      )
+      results = assert_report_data_response
+      expect(results['data']['rows'].length).to eq(1)
+      expect(results['data']['rows'][0]['long_id']).to eq(vm.id)
+    end
+  end
+
   it_behaves_like "explorer controller with custom buttons"
 end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -75,6 +75,54 @@ module Spec
         # display needs to be saved to session for GTL pagination and such
         expect(session["#{controller.class.table_name}_display".to_sym]).to eq(relation)
       end
+
+
+      # Formats POST data for /report_data request
+      #
+      # Supported options:
+      #   :model
+      #   :parent_model
+      #   :parent_id
+      #   :active_tree
+      #   :parent_method
+      #
+      # FIXME: This hash needs cleanups as we clenup the /report_data,
+      #        angular/_gtl and the calling sites.
+      #
+      def report_data_request_data(options)
+        {
+          'model_name'  => options[:model],
+          'model'       => options[:model],
+          'active_tree' => options[:active_tree],
+          'parent_id'   => options[:parent_id],
+          'model_id'    => options[:parent_id],
+          'explorer'    => true,
+          'additional_options' => {
+            'named_scope' => nil, 'gtl_dbname' => nil, 'model' => options[:model], 'match_via_descendants' => nil,
+            'parent_id' => options[:parent_id], 'parent_class_name' => options[:parent_model],
+            'parent_method' => options[:parent_method], 'association' => nil,
+            'view_suffix' => nil, 'listicon' => nil, 'embedded' => nil, 'showlinks' => nil, 'policy_sim' => nil
+          }.compact
+        }.compact
+      end
+
+      # Fires a POST request to the current controller's /report_data action
+      #
+      def report_data_request(options)
+        post :report_data, :params => report_data_request_data(options)
+      end
+
+      # Assert a valid /report_data response, parse the response.
+      #
+      # Returns: response as a hash
+      #
+      def assert_report_data_response
+        expect(response.status).to eq(200)
+        parsed_data = JSON.parse(response.body)
+        expect(parsed_data).to have_key('settings')
+        expect(parsed_data).to have_key('data')
+        parsed_data
+      end
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1510797

Testing: go to 'My Services' and observe that w/o this patch there are no VMs
under any services.

WARNING: this PR changes the order of argument preference in report data ---> we need to click through a bunch of GTL screens and verify that nothing got broken

ping @karelhala, @h-kataria 