### PR TITLE
Add placeholder record in display methods

### DIFF
--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -46,7 +46,7 @@ module Mixins
       end
     end
 
-    def display_methods
+    def display_methods(_record = nil)
       []
     end
 

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -32,6 +32,12 @@ describe EmsContainerController do
         expect(response.body).to_not be_empty
         expect(response).to render_template('container_topology/show')
       end
+
+      it "renders ad hoc view" do
+        get :show, :params => { :id => @container.id, :display => 'ad_hoc_metrics' }
+        expect(response.status).to eq(200)
+        expect(response.body).to_not be_empty
+      end
     end
 
     context "render dashboard" do


### PR DESCRIPTION
**Description**

In line 36 [1] we call the method `display_methods` with a parameter, this method is defined in line 51 [2] without parameter. This PR add a mock parameter for this method.

See: https://github.com/ManageIQ/manageiq-ui-classic/pull/2596

**Screenshot**
![screenshot-localhost 3000-2017-11-12-10-56-57](https://user-images.githubusercontent.com/2181522/32697406-5ef557b0-c798-11e7-8945-d63dd94e9f88.png)

[1] https://github.com/ManageIQ/manageiq-ui-classic/blob/d1f5b655f9397cea98f6342e7db18b0990269399/app/controllers/mixins/generic_show_mixin.rb#L36

[2] https://github.com/ManageIQ/manageiq-ui-classic/blob/d1f5b655f9397cea98f6342e7db18b0990269399/app/controllers/mixins/generic_show_mixin.rb#L51