### PR TITLE
Display flash message during duplicate class add

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1279,10 +1279,7 @@ class MiqAeClassController < ApplicationController
       rescue => bang
         add_flash(_("Error during 'add': %{error_message}") % {:error_message => bang.message}, :error)
         @in_a_form = true
-        render :update do |page|
-          page << javascript_prologue
-          page.replace("flash_msg", :partial => "layouts/flash_msg")
-        end
+        javascript_flash
       else
         add_flash(_("Automate Class \"%{name}\" was added") % {:name => add_aeclass.fqname})
         @in_a_form = false


### PR DESCRIPTION
**fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1428424

Display flash message in _Automation -> Automate -> Explorer ->
Datastore_ tab when creating a new _Class_ with an existing name.
The flash message informs that the name was already been taken.

**Before:**
![class1](https://user-images.githubusercontent.com/13417815/32727145-c1c71994-c87b-11e7-8535-ac9b14ed2078.png)

**After:**
![class2](https://user-images.githubusercontent.com/13417815/32727149-c4721fcc-c87b-11e7-8780-fef89a6f792d.png)
