### PR TITLE
Networks > Networks - fix uninitialized constant and render :change

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -144,7 +144,7 @@ class CloudNetworkController < ApplicationController
       :name => _("Edit Cloud Network \"%{name}\"") % {:name => @network.name},
       :url  => "/cloud_network/edit/#{@network.id}"
     )
-    render :change
+    render :action => 'change'
   end
 
   def new
@@ -157,7 +157,7 @@ class CloudNetworkController < ApplicationController
     end
 
     drop_breadcrumb(:name => _("Add New Cloud Network"), :url => "/cloud_network/new")
-    render :change
+    render :action => 'change'
   end
 
   def update

--- a/app/helpers/application_helper/button/cloud_network_new.rb
+++ b/app/helpers/application_helper/button/cloud_network_new.rb
@@ -8,6 +8,6 @@ class ApplicationHelper::Button::CloudNetworkNew < ApplicationHelper::Button::Bu
 
   # disable button if no active providers support create action
   def disabled?
-    EmsNetwork.all.none? { |ems| CloudNetwork.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.none? { |ems| CloudNetwork.class_by_ems(ems).supports_create? }
   end
 end

--- a/app/helpers/application_helper/button/network_router_new.rb
+++ b/app/helpers/application_helper/button/network_router_new.rb
@@ -8,6 +8,6 @@ class ApplicationHelper::Button::NetworkRouterNew < ApplicationHelper::Button::B
 
   # disable button if no active providers support create action
   def disabled?
-    EmsNetwork.all.none? { |ems| NetworkRouter.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.none? { |ems| NetworkRouter.class_by_ems(ems).supports_create? }
   end
 end

--- a/app/helpers/application_helper/button/security_group_new.rb
+++ b/app/helpers/application_helper/button/security_group_new.rb
@@ -8,6 +8,6 @@ class ApplicationHelper::Button::SecurityGroupNew < ApplicationHelper::Button::B
 
   # disable button if no active providers support create action
   def disabled?
-    EmsNetwork.all.none? { |ems| SecurityGroup.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.none? { |ems| SecurityGroup.class_by_ems(ems).supports_create? }
   end
 end


### PR DESCRIPTION
Go to Networks > Networks

this fixes the `uninitalized constant .....CloudNetworkNew::EmsNetwork` on the show_list screen.

Click Configure > Add / Edit

this makes the transition use a more idiomatic `render :action => 'change'` as opposed to `render :change` (which does the same thing; introduced in #1955).


Cc @gildub 
Ping @martinpovolny 