### PR TITLE
Enable button in service catalog items via additional options

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -497,6 +497,12 @@ table.table td:not(.table-view-pf-select) { //Force word break but prevent bs-sw
   word-break: normal !important;
 }
 
+.card .card-content .miq-info-section > div {
+  position: absolute;
+  top: -35px;
+  right: 0px;
+}
+
 table.table tbody td img {
   height: 20px;
   width: 20px;

--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -10,6 +10,8 @@ class ApplicationController
     :association,
     :view_suffix,
 
+    :row_button,
+
     :listicon,
     :embedded,
     :showlinks,
@@ -34,6 +36,10 @@ class ApplicationController
       self.embedded   = options[:embedded]
       self.showlinks  = options[:showlinks]
       self.policy_sim = options[:policy_sim]
+    end
+
+    def with_row_button(row_button)
+      self.row_button = row_button
     end
 
     def with_model(curr_model)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1629,6 +1629,7 @@ module ApplicationHelper
       :showlinks  => @showlinks,
       :policy_sim => @policy_sim
     )
+    @report_data_additional_options.with_row_button(@row_button) if @row_button
     @report_data_additional_options.with_model(curr_model) if curr_model
     @report_data_additional_options.freeze
   end
@@ -1642,6 +1643,9 @@ module ApplicationHelper
       parent_class = additional_options[:parent_class_name].constantize
       additional_options[:parent] = parent_class.find(parent_id) if parent_class < ActiveRecord::Base
     end
+
+    @row_button = additional_options[:row_button]
+
     additional_options
   end
 


### PR DESCRIPTION
### Fixes missing button in service catalog
After adding `additional_options` for report data buttons for service catalog was missing. This PR adds it back

### UI Changes
![screenshot from 2017-11-13 16-06-33](https://user-images.githubusercontent.com/3439771/32732386-af36631e-c88c-11e7-91da-9195142c0b82.png)
![screenshot from 2017-11-13 16-06-40](https://user-images.githubusercontent.com/3439771/32732387-af8bab12-c88c-11e7-897e-f96e1eec7c25.png)


### BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1512113
