### PR TITLE
Enable font icon for middleware servers

### DIFF
--- a/app/decorators/middleware_server_decorator.rb
+++ b/app/decorators/middleware_server_decorator.rb
@@ -1,6 +1,6 @@
 class MiddlewareServerDecorator < MiqDecorator
   def self.fonticon
-    nil
+    'pficon pficon-middleware'
   end
 
   def fileicon


### PR DESCRIPTION
### Fixes Missing icon in policies for MW server
When navigating to policies (Compliance and Control) icon for MW servers was missing, this PR fixes such issue.

### UI changes
#### Before
![mws-icon-missing 1](https://user-images.githubusercontent.com/3439771/32734582-bcb48646-c892-11e7-872f-d559f77df768.png)
#### After
![screenshot from 2017-11-13 16-46-36](https://user-images.githubusercontent.com/3439771/32734557-b028c158-c892-11e7-834a-3fcbf3cbe53e.png)


### BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1511956