### PR TITLE
Enable navigation between tasks and affected items - VMs and such

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -204,7 +204,9 @@
     if (this.initObject.showUrl) {
       var prefix = this.initObject.showUrl;
       var splitUrl = this.initObject.showUrl.split('/');
-      if (this.initObject.isExplorer && isCurrentControllerOrPolicies(splitUrl)) {
+      if (item.parent_path && item.parent_id) {
+        this.$window.DoNav(item.parent_path + '/' + item.parent_id);
+      } else if (this.initObject.isExplorer && isCurrentControllerOrPolicies(splitUrl)) {
         var itemId = item.id;
         if (this.initObject.showUrl.indexOf('?id=') !== -1 ) {
           itemId = constructSuffixForTreeUrl(this.initObject, item);
@@ -217,7 +219,7 @@
         $.post(url).always(function() {
           this.setExtraClasses();
         }.bind(this));
-      } else {
+      } else if (prefix !== "true") {
         var lastChar = prefix[prefix.length - 1];
         prefix = (lastChar !== '/' && lastChar !== '=') ? prefix + '/' : prefix;
         this.$window.DoNav(prefix + (item.long_id || item.id));

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1095,6 +1095,11 @@ class ApplicationController < ActionController::Base
       end
       new_row[:parent_id] = "xx-#{CONTENT_TYPE_ID[target[:content_type]]}" if target && target[:content_type]
       new_row[:tree_id] = TreeBuilder.build_node_cid(target) if target
+      if row.data["job.target_class"] && row.data["job.target_id"]
+        underscore_class = row.data["job.target_class"].underscore
+        new_row[:parent_path] = url_for_only_path(:controller => underscore_class, :action => "show")
+        new_row[:parent_id] = row.data["job.target_id"] if row.data["job.target_id"]
+      end
       root[:rows] << new_row
 
       if has_checkbox

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -355,9 +355,12 @@ module ApplicationHelper
         return ems_networks_path
       end
       # If we do not want to use redirect or any kind of click action
-      if %w(Job VmdbDatabaseSetting VmdbDatabaseConnection VmdbIndex MiqTask).include?(view.db) &&
-         %w(miq_task ops miq_task).include?(params[:controller])
+      if %w(Job VmdbDatabaseSetting VmdbDatabaseConnection VmdbIndex).include?(view.db) &&
+         %w(ops).include?(params[:controller])
         return false
+      end
+      if %w(MiqTask).include?(view.db) && %w(miq_task).include?(params[:controller])
+        return true
       end
       if @explorer
         # showing a list view of another CI inside vmx


### PR DESCRIPTION
### Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/1206
When clicking on job with corresponding VM attached to it, navigate to such vm. If no vm is assigned to job, no action is triggered.
### BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1502578