### PR TITLE
Encrypt service account information for GCE

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -126,7 +126,7 @@ module Mixins
       when 'ManageIQ::Providers::Vmware::CloudManager'
         [params[:default_hostname], params[:default_api_port], user, password, true]
       when 'ManageIQ::Providers::Google::CloudManager'
-        [params[:project], params[:service_account], {:service => "compute"}, true]
+        [params[:project], MiqPassword.encrypt(params[:service_account]), {:service => "compute"}, true]
       when 'ManageIQ::Providers::Microsoft::InfraManager'
         connect_opts = {
           :hostname          => params[:default_hostname],


### PR DESCRIPTION
The unencrypted service account information is being logged, this should be encrypted as the method is [already implemented](https://github.com/ManageIQ/manageiq-providers-google/blob/master/app/models/manageiq/providers/google/manager_mixin.rb#L29) to decrypt it.

Before:
```
[----] D, [2017-11-13T12:43:05.912401 #44602:3fdc4f88d5cc] DEBUG -- :   SQL (5.7ms)  INSERT INTO "miq_queue" ("priority", "method_name", "state", "created_on", "updated_on", "queue_name", "class_name", "args", "miq_callback", "zone", "role", "msg_timeout", "lock_version") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING "id"  [["priority", 100], ["method_name", "raw_connect"], ["state", "ready"], ["created_on", "2017-11-13 17:43:05.904062"], ["updated_on", "2017-11-13 17:43:05.904062"], ["queue_name", "generic"], ["class_name", "ManageIQ::Providers::Google::CloudManager"], ["args", "---\n- uitesting\n- \"{\\r\\n  \\\"type\\\": \\\"service_account\\\",\\r\\n  \\\"project_id\\\": \\\"uitesting\\\",\\r\\n  \\\"private_key_id\\\":\n  \\\"80\\\",\\r\\n  \\\"private_key\\\": \\\"-----BEGIN PRIVATE KEY-----\\\\nprivatekeyhere=\\\\n-----END\n  PRIVATE KEY-----\\\\n\\\",\\r\\n  \\\"client_email\\\": \\\"uitesting@iam.gserviceaccount.com\\\",\\r\\n\n  \\ \\\"client_id\\\": \\\"<client_id>\\\",\\r\\n  \\\"auth_uri\\\": \\\"https://accounts.google.com/o/oauth2/auth\\\",\\r\\n\n  \\ \\\"token_uri\\\": \\\"https://accounts.google.com/o/oauth2/token\\\",\\r\\n  \\\"auth_provider_x509_cert_url\\\":\n  \\\"https://www.googleapis.com/oauth2/v1/certs\\\",\\r\\n  \\\"client_x509_cert_url\\\": \\\"https://www.googleapis.com/robot/v1/metadata/x509/...\\\"\\r\\n}\"\n- :service: compute\n- true\n"], ["miq_callback", "---\n:class_name: MiqTask\n:instance_id: 10000000125481\n:method_name: :queue_callback\n:args:\n- Finished\n"], ["zone", "default"], ["role", "ems_operations"], ["msg_timeout", 600], ["lock_version", 0]]
```

After:
```
e", "raw_connect"], ["state", "ready"], ["created_on", "2017-11-13 17:39:31.230550"], ["updated_on", "2017-11-13 17:39:31.230550"], ["queue_name", "generic"], ["class_name", "ManageIQ::Providers::Google::CloudManager"], ["args", "---\n- uitesting\n- v2:{UZRUREWK0kNWe239t0JsexSu+9HOO6GyWkKAg5DVucrs8uDcQwh3Z5LNkQBJos8mQCCnv3Y0wfT5R3rp93jxPuytR2MyPyejrRRi7sNLw28PCpSAX9f6idvvcQ28sex+ld09+yZOiM9lpvuI9aLuP4lsyT6ah6eczJhh1d696Ritd5EwWKGQi+pdHU8JQK52nGAHSgwg/Hhtxe/L/sjR3PHEHfcsKHCF8hJ0HHZranSzpwFUA5RS+ast1ddML3SpxpfAWXciPtO5IyzmLtqpsGEW35jokg5rfRo6w9HGKP4XJ+d/eY5N+hjnyRcHN9Ke/9pyUGygiv1wBIe9ghHEZ1Bq0oPJX6rTCwHxvZErV77+U40ONe3NCaf7X85fLhQIJ/EVbyekC3w3P1NU81UsOKoAkz9W93HLuPLhwraDO7k+yCyt6tNm21hjGXWNB6KkBcEbc2R5BGejsScvxpnPCB4L+xQ1DfgrVXA5H3IjozeKtMuHyR9y2GzuBgL1aahKWxTSp1SfmMPO79/pEc7zEBIAtqD1McIrUp7bXVyJVw3IXrE1oSYQJAkF6AnJySvQWiqqLDU8V5Afy/wWFQzNbnjs+WPdhJxMSwp72H9MufjgIJxXIbJo7vq26/Zy1WuRskEmKHlUdUdwmOZS9JZn0Wjb7ujjYZaVZXPb+YwmngcXMVDzCuYPJ2OKXnkgrQrsdkTwOOTEiXiRPN7WerBMvAvbHQFGMehcjcddbzXWhHJainH0vZ0KMsjjQjzeX/Obkpf+uAz+sHtauAGVUXOMeRztFIhJsuwr/UCH3L8QjhKFKZPznhuzjzwgQfb5/6HWbGfOqZhgjani3DFoAo9bERmvIQ57M7wxi0zmZa/GU5OZ3n0Zj3BsUOFMxiyR/67znL/KV8BSrqrJxtZjY5l+sc3jUT5bZjaPjWyQVr39vLWoSQzc42AbSLOSAuxiEZV/FmuyQR5x8ezMLkDDvULyO76+46MSgl/RYg90XUsV6GSi9LEFXb8LFetzd8RGTzERLLK4oOZ6q89h1jKaigWx8JxIOIwBjpbSXS4zaRCcZGMZrtjoEh/BwJYKeWAgaetpm5ynVSwQREdzjX/QUXu4uYcAe2PhULsvXDQNv5tv7iBniqgm7Sk5WXdOQ6gsEUveSkQpGwCdM8acAqo7LuH3JyjSNQyicvVzifZdMxjREIKNAaokeC0yjLElx8iXBAKAM/fW7XCvdUGeEB7lFVfst2NHWLMjZ4DvCg81nLpH98MoEsFQ5MSBiR7qOOt1G/BVaXgz6f3Fyvf5zgPkRDeIIHgeHYGG39UIFad8MixI0DkGO9V4ck7rPlVHF8k06V320LHaqzKNx5MhpwZX8eCKpzz5sMW1rcvQ5MSREDZxnkfUB+RvoqrBM+pWfsQcp6f7ToRZYR8Ad855O5QYAgDNZ99AZojpbgHj9JclNypXLTy0u2vgIIEtXbfu9CZB0axhPvf8PLOYl+0helTze+w0fxuE1oHwSV2QXgXoWUzRlAYQ3/OsIzXYl6YxuvYLA8Ppz4M6NhegxzHwGsT5gSfFCXqhdQGSe7VYEcq8PGB8mxW5C8StsJp4R9c5inFHX5gB3r1VmMtFL5Kn8oWjFW4nPzWIvEc/rCVvFbpTav9s0JEVh/c1rBFSX+2Q5qIEfeJ7aMLxBP+gSbWQ80ssS7CFBNxEhgQWHTKkI1fCUM5G/8oJHtJ0HcKQHjrfk1MdyOYuomVI1j/t1Qex0txsnOAkBJR8FbXW9bt1/rhdEgRNoKCsfmIaXIOVpfGX6DdKWwcAoRmjgNYziw8z5ix9a3/mss8aWExpYKCGYrJ1m+pT7GjJzI7SxZIKrwukKwx9UOoD+KtGYKzf1PGrEswFU0FfK6+vKG2jnu3ZzOjb8X2zw93qPAifemj7tdfppGVPnhLvgt5cBIuGvpbXmjt9M6ag0dVV0lrrM6JFYGVe6cg0RKrsc0/IwydeMdQM71o93jCxRuQa0d21Fk++Bh+9p/+ZLr21DzoztkNrtNgODfJa2z4Ji/Ak+Q/ZNQCaSXA4CTH4vFtnLQkWGgx75ifbQc7n9yaUBl3/YQ7IiJIQ/uF2zgJlWw/UrrlqjlZNvsO3ya4LMmyth8uyZ+dquTVmpeVmqcrcoRrI/PbbJ+4BupJQpQ4hvnRBs0hFWtvMxbDYVAXhGIemQSdWFh4EEAMU7EaqBE5/L0dsccIUTAfMOC==}\n- :service: compute\n- true\n"], ["miq_callback", "---\n:class_name: MiqTask\n:instance_id: 10000000125480\n:method_name: :queue_callback\n:args:\n- Finished\n"], ["zone", "default"], ["role", "ems_operations"], ["msg_timeout", 600], ["lock_version", 0]]
```

@miq-bot add_label bug, gaprindashvili/yes 
cc: @gtanzillo 