### PR TITLE
Conditionally update alert repeat times

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -116,6 +116,7 @@ module MiqPolicyController::Alerts
         @edit[:expression_options] = MiqAlert.expression_options(@edit[:new][:expression][:eval_method])
         alert_build_exp_options_info
       end
+      @edit[:new][:repeat_time] = alert_default_repeat_time if apply_default_repeat_time?
     end
 
     @edit[:new][:expression][:options][:event_types] = [params[:event_types]].reject(&:blank?) if params[:event_types]
@@ -366,6 +367,13 @@ module MiqPolicyController::Alerts
     else
       10.minutes.to_i
     end
+  end
+
+  def apply_default_repeat_time?
+    event = @edit[:new]
+    return true if event[:exp_event] == '_hourly_timer_'
+    return false if event[:eval_method].nil?
+    event[:eval_method] =~ /hourly_performance|dwh_generic/
   end
 
   def alert_get_perf_column_unit(val)

--- a/spec/controllers/miq_policy_controller/alerts_spec.rb
+++ b/spec/controllers/miq_policy_controller/alerts_spec.rb
@@ -49,6 +49,38 @@ describe MiqPolicyController do
         end
       end
 
+      context "#alert_field_changed" do
+        before :each do
+          controller.params = {:id => 0, :exp_name => ""}
+          session[:edit] = {:key => "alert_edit__0", :new => {}}
+          allow(controller).to receive(:send_button_changes).and_return(nil)
+          allow(controller).to receive(:build_snmp_options).and_return(nil)
+        end
+
+        it "does not reset repeat_time for most inputs" do
+          expect(controller).to receive(:apply_default_repeat_time?).and_call_original
+          expect(controller).not_to receive(:alert_default_repeat_time)
+          controller.send(:alert_field_changed)
+          expect(session[:edit][:new]).not_to include(:repeat_time)
+        end
+
+        it "resets repeat_time to defult for dwh events" do
+          session[:edit][:new] = {:eval_method => 'dwh_generic'}
+          expect(controller).to receive(:apply_default_repeat_time?).and_call_original
+          expect(controller).to receive(:alert_default_repeat_time).and_call_original
+          controller.send(:alert_field_changed)
+          expect(session[:edit][:new]).to include(:repeat_time)
+        end
+
+        it "resets repeat_time to defult for hourly performance" do
+          session[:edit][:new] = {:eval_method => 'hourly_performance'}
+          expect(controller).to receive(:apply_default_repeat_time?).and_call_original
+          expect(controller).to receive(:alert_default_repeat_time).and_call_original
+          controller.send(:alert_field_changed)
+          expect(session[:edit][:new]).to include(:repeat_time)
+        end
+      end
+
       context "#alert_edit_cancel" do
         before :each do
           allow(controller).to receive(:replace_right_cell).and_return(true)


### PR DESCRIPTION
commit ea2f7ec1cf7c3b332f64c7e5a5667e80f58d31ee[1] removed setting of
'notification frequency' after changing what to evaluate. Prometheus
alerts relayed on that behavior and it has become impossible to create
them. alert_default_repeat_time sets the value to zero and the field
is then hidden[2]. Since there is a model validation for the zero value
the alerts can't be created. A similar behavior for "hourly alerts"
changed - their default notification frequency should change to 1 Hour.

[1] https://github.com/ManageIQ/manageiq-ui-classic/pull/2601
[2] :https://github.com/ManageIQ/manageiq-ui-classic/blob/86b535f749a41309ad299015ed03208f6f5c956a/app/views/miq_policy/_alert_details.html.haml#L114