### PR TITLE
Redirect to login screen on API 401

### DIFF
--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -1,4 +1,4 @@
-/* global miqDeferred */
+/* global miqDeferred, add_flash */
 
 /* functions to use the API from our JS/Angular:
  *
@@ -174,6 +174,14 @@
     if (response.status === 204) {
       // No content
       return Promise.resolve(null);
+    }
+
+    if (response.status === 401) {
+      // Unauthorized - always redirect to dashboard#login
+      add_flash(__('API logged out, redirecting to the login page'), 'warning');
+      window.document.location.href = '/dashboard/login?timeout=true';
+
+      return Promise.reject(response);
     }
 
     if (response.status >= 300) {

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -415,7 +415,7 @@ class DashboardController < ApplicationController
     end
     @settings = copy_hash(DEFAULT_SETTINGS)               # Need settings, else pages won't display
     @more = params[:type] && params[:type] != "less"
-    flash[:notice] = _("Session was timed out due to inactivity. Please log in again.") if params[:timeout] == "true"
+    add_flash(_("Session was timed out due to inactivity. Please log in again."), :error) if params[:timeout] == "true"
     logon_details = MiqServer.my_server(true).logon_status_details
     @login_message = logon_details[:message] if logon_details[:status] == :starting && logon_details[:message]
 


### PR DESCRIPTION
Right now - when the authentication token expires:

* on non-API calls, we get a redirect to `dashboard#login` with `?timeout=true`
* on API calls, we only see the error modal.

This updates the API js code to redirect to `/dashboard/login?timeout=true` on receiving a 401 response.

It also fixes the `timeout=true` message to actually appear on the login screen (the same one for both cases).

https://bugzilla.redhat.com/show_bug.cgi?id=1512525

---

When an API 401 happens:

![f1](https://user-images.githubusercontent.com/289743/32743667-f8b63196-c8a4-11e7-92f2-d4e59cdbd42d.png)

(..and the browser starts loading the login screen..)

![f3](https://user-images.githubusercontent.com/289743/32743695-07e7f712-c8a5-11e7-86e3-f2788c0dcb9a.png)

---

## Testing:

 * log in in the UI
 * run `delete sessionStorage.miq_token` in the browser console
 * wait for a minute
 * :-1: before: an error modal
 * :+1: now: redirects to the login page, *with* a message

(or log in, put the computer to sleep for longer than the token expiration interval, wake up, and wait)
