### PR TITLE
API(js) - don't show error modal when trying to log out

### DIFF
--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -71,7 +71,10 @@
 
   API.logout = function() {
     if (sessionStorage.miq_token) {
-      API.delete('/api/auth');
+      API.delete('/api/auth', {
+        skipErrors: [401],
+        skipLoginRedirect: true,
+      });
     }
 
     API.ws_destroy();


### PR DESCRIPTION
When the browser still thinks it has a valid API token, but gets redirected to the login screen becuase it doesn't have a valid cookie, it tries to API.logout to invalidate the old token.

When a 401 happens during that logout, we would trigger the error modal.

This adds an exception to that, so that the error modal (or [login redirect](https://github.com/ManageIQ/manageiq-ui-classic/pull/2715)) are not triggered when failing to logout.

https://bugzilla.redhat.com/show_bug.cgi?id=1508940

---

## Testing:

* Go to user > Configuration > accordion Settings, choose current server, tab Advanced
* search for `:session:`, and `:timeout:` under it.
* Change the value to 60, save.
* Kill and restart rails.
* Log in
* Wait for 60 seconds, not doing anything.
* Click on anything in the menu.
* :-1: before: you will get redirected to the login page, the error modal will appear
* :+1: now: you will get redirected to the login page, no error modal there
* (after, don't forget to reset that `session.timeout` to 3600)
