### PR TITLE
Allow the Maintenance mode to be displayed

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -443,6 +443,7 @@ module ApplicationController::MiqRequestMethods
                   "vmm_product" => _("Platform"),
                   "vmm_version" => _("Version"),
                   "state"       => _("State"),
+                  "maintenance" => _("Maintenance")
                 }
               end
 

--- a/app/views/miq_request/_prov_host_grid.html.haml
+++ b/app/views/miq_request/_prov_host_grid.html.haml
@@ -30,6 +30,7 @@
           %td
           %td
           %td
+          %td
       - @hosts.each do |row|
         - @id = row.id
         - if options[:wf].kind_of?(MiqHostProvisionWorkflow)


### PR DESCRIPTION
From the Provisioning screen will show if the `host` is in maintenance mode.

<img width="773" alt="screen shot 2017-11-13 at 3 28 56 pm" src="https://user-images.githubusercontent.com/697347/32747855-283129ac-c888-11e7-97d3-7cd5877cbcee.png">


Depends on https://github.com/ManageIQ/manageiq/pull/16464

https://bugzilla.redhat.com/show_bug.cgi?id=1506268

