### PR TITLE
[WIP] Selector for MiddlewareDatasource and MiddlewareMessaging for alerts

### DIFF
--- a/app/helpers/term_of_service_helper.rb
+++ b/app/helpers/term_of_service_helper.rb
@@ -31,8 +31,10 @@ module TermOfServiceHelper
       "miq_server" => N_("Selected Servers"),
     },
     "MiddlewareServer"    => {
-      "enterprise"        => N_("The Enterprise"),
-      "middleware_server" => N_("Selected Middleware Servers")
+      "enterprise"            => N_("The Enterprise"),
+      "middleware_server"     => N_("Selected Middleware Servers"),
+      "middleware_datasource" => N_("Selected Middleware DataSources"),
+      "middleware_messaging"  => N_("Selected Middleware Messagings")
     },
     "ContainerNode" => {
       "enterprise" => N_("The Enterprise"),

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -8,7 +8,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def override(node, object, _pid, _options)
-    node[:text] = (object.name.presence || object.description) unless object.kind_of?(MiddlewareServer)
+    node[:text] = (object.name.presence || object.description) unless object.kind_of?(MiddlewareServer) || object.kind_of?(MiddlewareDatasource) || object.kind_of?(MiddlewareMessaging)
     node[:hideCheckbox] = false
     node[:select] = @selected.include?(object.id)
   end

--- a/app/presenters/tree_node/middleware_datasource.rb
+++ b/app/presenters/tree_node/middleware_datasource.rb
@@ -1,0 +1,5 @@
+module TreeNode
+  class MiddlewareDatasource < Node
+    set_attribute(:text) { [@object.middleware_server.name, @object.name].join(" - ") }
+  end
+end

--- a/app/presenters/tree_node/middleware_messaging.rb
+++ b/app/presenters/tree_node/middleware_messaging.rb
@@ -1,0 +1,5 @@
+module TreeNode
+  class MiddlewareMessaging < Node
+    set_attribute(:text) { [@object.middleware_server.name.presence, @object.name.presence].join(" - ") }
+  end
+end


### PR DESCRIPTION
Required [Hawkular Provider PR #103](https://github.com/ManageIQ/manageiq-providers-hawkular/pull/103)

Discussion in [Issues hawkular](https://github.com/ManageIQ/manageiq-providers-hawkular/issues/99)

## Selector of type of Middleware Resource
![selector](https://user-images.githubusercontent.com/3019213/32752197-9f6eae3c-c8c8-11e7-81ce-ea8162cdb0ea.png)
## Selector of type Middleware Datasource
![datrasources](https://user-images.githubusercontent.com/3019213/32752200-a092ad2c-c8c8-11e7-8122-41b5f3a750eb.png)
## Selector of type of Middleware Messaging
![messaging selector](https://user-images.githubusercontent.com/3019213/32752202-a2248f5c-c8c8-11e7-98b2-57722954b083.png)

cc @abonas , @mtho11, @jdoyleoss & @jshaughn

What do you think about this views? With [Hawkular Provider PR #103](https://github.com/ManageIQ/manageiq-providers-hawkular/pull/103) now alerts are creating well for Datasource and Messaging. 
