### PR TITLE
Add EAP and Wildfly to allowed types for MW topology

### DIFF
--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -13,7 +13,19 @@ class MiddlewareTopologyService < TopologyService
     ]
   ]
 
-  @kinds = %i(MiddlewareDeployment MiddlewareDatasource MiddlewareDomain MiddlewareManager Vm Container MiddlewareServer MiddlewareServerGroup MiddlewareMessaging)
+  @kinds = %i(
+    MiddlewareDeployment
+    MiddlewareDatasource
+    MiddlewareDomain
+    MiddlewareManager
+    Vm
+    Container
+    MiddlewareServer
+    MiddlewareServerEap
+    MiddlewareServerWildfly
+    MiddlewareServerGroup
+    MiddlewareMessaging
+  )
 
   def build_topology
     topology = super

--- a/spec/javascripts/controllers/middleware/middleware_topology_controller_spec.js
+++ b/spec/javascripts/controllers/middleware/middleware_topology_controller_spec.js
@@ -28,6 +28,28 @@ describe('middlewareTopologyController', function () {
     }
   };
 
+  var mw_server_wildfly = {
+    id: "MiddlewareServerWildfly1", item: {
+      "name": "Local DMR",
+      "kind": "MiddlewareServerWildfly",
+      "miq_id": 1,
+      "status": "Running",
+      "display_kind": "MiddlewareServerWildfly",
+      "icon": "vendor-wildfly"
+    }
+  };
+
+  var mw_server_eap = {
+    id: "MiddlewareServerEap1", item: {
+      "name": "Local DMR",
+      "kind": "MiddlewareServerEap",
+      "miq_id": 1,
+      "status": "Running",
+      "display_kind": "MiddlewareServerEap",
+      "icon": "vendor-jboss-eap"
+    }
+  };
+
   var mw_server_starting = {
     id: "MiddlewareServer1", item: {
       "status": "Starting"
@@ -162,9 +184,11 @@ describe('middlewareTopologyController', function () {
 
   describe('kinds contains all expected mw kinds', function () {
     it('in all main objects', function () {
-      expect(Object.keys(scope.kinds).length).toBe(8);
+      expect(Object.keys(scope.kinds).length).toBe(10);
       expect(ctrl.kinds["MiddlewareManager"]).toBeDefined();
       expect(ctrl.kinds["MiddlewareServer"]).toBeDefined();
+      expect(ctrl.kinds["MiddlewareServerEap"]).toBeDefined();
+      expect(ctrl.kinds["MiddlewareServerWildfly"]).toBeDefined();
       expect(ctrl.kinds["MiddlewareDeployment"]).toBeDefined();
       expect(ctrl.kinds["MiddlewareDatasource"]).toBeDefined();
       expect(ctrl.kinds["Vm"]).toBeDefined();
@@ -179,6 +203,8 @@ describe('middlewareTopologyController', function () {
     it('in graph elements', function () {
       expect(ctrl.getIcon(mw_manager).icon).toContain("vendor-hawkular");
       expect(ctrl.getIcon(mw_server).icon).toContain("vendor-wildfly");
+      expect(ctrl.getIcon(mw_server_wildfly).icon).toContain("vendor-wildfly");
+      expect(ctrl.getIcon(mw_server_eap).icon).toContain("vendor-jboss-eap");
       expect(ctrl.getIcon(mw_deployment).fontfamily).toEqual("font-fabulous");
       expect(ctrl.getIcon(mw_datasource).fontfamily).toEqual("FontAwesome");
       expect(ctrl.getIcon(vm).fontfamily).toEqual("PatternFlyIcons-webfont");
@@ -192,6 +218,8 @@ describe('middlewareTopologyController', function () {
     it('for all objects', function () {
       expect(ctrl.getCircleDimensions(mw_manager)).toEqual({x: -20, y: -20, height: 40, width: 40, r: 28});
       expect(ctrl.getCircleDimensions(mw_server)).toEqual({x: -12, y: -12, height: 23, width: 23, r: 19});
+      expect(ctrl.getCircleDimensions(mw_server_eap)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
+      expect(ctrl.getCircleDimensions(mw_server_wildfly)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
       expect(ctrl.getCircleDimensions(mw_deployment)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
       expect(ctrl.getCircleDimensions(mw_datasource)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
       expect(ctrl.getCircleDimensions(vm)).toEqual({ x: 0, y: 9, height: 40, width: 40, r: 21 });
@@ -205,6 +233,8 @@ describe('middlewareTopologyController', function () {
     it('for all objects', function () {
       expect(ctrl.getIcon(mw_manager).type).toEqual("image");
       expect(ctrl.getIcon(mw_server).type).toEqual("image");
+      expect(ctrl.getIcon(mw_server_wildfly).type).toEqual("image");
+      expect(ctrl.getIcon(mw_server_eap).type).toEqual("image");
       expect(ctrl.getIcon(mw_deployment).type).toEqual("glyph");
       expect(ctrl.getIcon(mw_datasource).type).toEqual("glyph");
       expect(ctrl.getIcon(vm).type).toEqual("glyph");
@@ -222,6 +252,8 @@ describe('middlewareTopologyController', function () {
     });
     it('for servers', function() {
       expect(topologyService.getItemStatusClass(mw_server)).toEqual('success');
+      expect(topologyService.getItemStatusClass(mw_server_wildfly)).toEqual('success');
+      expect(topologyService.getItemStatusClass(mw_server_eap)).toEqual('success');
       expect(topologyService.getItemStatusClass(mw_server_down)).toEqual('error');
       expect(topologyService.getItemStatusClass(mw_server_starting)).toEqual('information');
       expect(topologyService.getItemStatusClass(mw_server_reload)).toEqual('warning');

--- a/spec/javascripts/fixtures/json/middleware_topology_response.json
+++ b/spec/javascripts/fixtures/json/middleware_topology_response.json
@@ -17,6 +17,22 @@
         "display_kind": "MiddlewareServer",
         "icon": "vendor-wildfly"
       },
+      "MiddlewareServerWildfly1": {
+        "name": "Local DMR",
+        "kind": "MiddlewareServerWildfly",
+        "miq_id": 1,
+        "status": "Unknown",
+        "display_kind": "MiddlewareServerWildfly",
+        "icon": "vendor-wildfly"
+      },
+      "MiddlewareServerEap1": {
+        "name": "Local DMR",
+        "kind": "MiddlewareServerEap",
+        "miq_id": 1,
+        "status": "Unknown",
+        "display_kind": "MiddlewareServerEap",
+        "icon": "vendor-jboss-eap"
+      },
       "MiddlewareDeployment1": {
         "name": "hawkular-command-gateway-war.war",
         "kind": "MiddlewareDeployment",
@@ -80,6 +96,14 @@
         "target": "MiddlewareServer1"
       },
       {
+        "source": "MiddlewareManager1",
+        "target": "MiddlewareServerEap1"
+      },
+      {
+        "source": "MiddlewareManager1",
+        "target": "MiddlewareServerWildfly1"
+      },
+      {
         "source": "MiddlewareServer1",
         "target": "MiddlewareDeployment1"
       },
@@ -119,6 +143,8 @@
       "MiddlewareManager": true,
       "Vm": true,
       "MiddlewareServer": true,
+      "MiddlewareServerEap": true,
+      "MiddlewareServerWildfly": true,
       "MiddlewareServerGroup": true,
       "MiddlewareMessaging": true
     },


### PR DESCRIPTION
### Fixes missing EAP and Wildfly item in topology
When there are any providers with EAP or Wildfly server monitored, they were not displayed in topology view. This PR fixes such issue
### UI changes
#### Before
![screenshot-toplogypage-servers 2](https://user-images.githubusercontent.com/3439771/32783321-9a9c9ddc-c94b-11e7-916a-da2ec61ba623.png)
#### After
![screenshot from 2017-11-14 14-53-05](https://user-images.githubusercontent.com/3439771/32783309-8d3de754-c94b-11e7-8b73-ef0772bf605e.png)

#### Waiting on core
* [x] https://github.com/ManageIQ/manageiq/pull/16478

### BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1512549