### PR TITLE
Fix logic for service ownership

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -213,7 +213,7 @@ module Mixins
 
         def filter_ownership_items(klass, ownership_ids)
           records = find_records_with_rbac(klass.order(:name), ownership_ids)
-          records.with_ownership if klass.respond_to?(:with_ownership)
+          records.try(:with_ownership) || records
         end
       end
     end


### PR DESCRIPTION
The broken logic would return `nil` in case the class in question (Service, Vm, Template ...)
doesn't support (respond to) `with_ownership` class method -> this would seem
like the class in question doesn't support ownership change.

https://bugzilla.redhat.com/show_bug.cgi?id=1512644