### PR TITLE
Use miq-calendar directive in schedule editor

### DIFF
--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -19,7 +19,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
       uri_prefix: '',
       filter_value: ''
     };
-    $scope.date_from = null;
+    $scope.date_from = new Date();
     $scope.formId = scheduleFormId;
     $scope.afterGet = false;
     $scope.validateClicked = miqService.validateWithAjax;
@@ -34,7 +34,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
       $scope.scheduleModel.filter_typ = 'all';
       $scope.scheduleModel.enabled    = true;
       $scope.filterValuesEmpty        = true;
-      $scope.scheduleModel.start_date = moment(moment.utc().toDate()).format('MM/DD/YYYY');
+      $scope.scheduleModel.start_date = moment.utc().toDate();
       $scope.scheduleModel.timer_typ  = 'Once';
       $scope.scheduleModel.time_zone  = 'UTC';
       $scope.scheduleModel.start_hour = '0';
@@ -42,7 +42,6 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
       $scope.afterGet                 = true;
       $scope.modelCopy                = angular.copy( $scope.scheduleModel );
       $scope.setTimerType();
-      $scope.date_from = new Date();
     } else {
       $scope.newRecord = false;
 
@@ -66,7 +65,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
       $scope.scheduleModel.name         = data.schedule_name;
       $scope.scheduleModel.timer_typ    = data.schedule_timer_type;
       $scope.scheduleModel.timer_value  = data.schedule_timer_value;
-      $scope.scheduleModel.start_date   = data.schedule_start_date;
+      $scope.scheduleModel.start_date   = moment.utc(data.schedule_start_date, 'MM/DD/YYYY').toDate();
       $scope.scheduleModel.start_hour   = data.schedule_start_hour.toString();
       $scope.scheduleModel.start_min    = data.schedule_start_min.toString();
       $scope.scheduleModel.time_zone    = data.schedule_time_zone;

--- a/app/views/ops/_schedule_form_timer.html.haml
+++ b/app/views/ops/_schedule_form_timer.html.haml
@@ -38,19 +38,14 @@
         %label.col-md-2.control-label{"for" => "start_date"}
           = _("Starting Date")
         .col-md-3
-          .input-group.date
-            %input{:type             => "text",
-                   :id               => "start_date",
-                   :name             => "start_date",
-                   "ng-model"        => "scheduleModel.start_date",
-                   "datepicker-init" => "",
-                   :language         => FastGettext.locale,
-                   :required         => true,
-                   :checkchange      => "",
-                   :class            => "form-control bootstrap-datepicker",
-                   :readonly         => true}
-            %span.input-group-addon{"data-toggle" => "datepicker"}
-              %span.fa.fa-calendar
+          = datepicker_input_tag('start_date', nil,
+                                 'id'                => 'start_date',
+                                 'class'             => 'form-control',
+                                 'ng-model'          => 'scheduleModel.start_date',
+                                 'miq-calendar'      => true,
+                                 'miq-cal-date-from' => 'date_from',
+                                 'required'          => true,
+                                 'checkchange'       => true)
       .form-group
         %label.col-md-2.control-label{"for" => "start_hour"}
           = _("Starting Time")

--- a/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
+++ b/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
@@ -82,7 +82,7 @@ describe('scheduleFormController', function() {
     });
 
     it('sets the scheduleDate', function() {
-      expect($scope.scheduleModel.start_date).toEqual(moment('01/01/2015').format('MM/DD/YYYY'));
+      expect($scope.scheduleModel.start_date).toEqual(moment.utc('01/01/2015').toDate());
     });
 
     it('sets the scheduleStartHour', function() {
@@ -141,7 +141,7 @@ describe('scheduleFormController', function() {
       });
 
       it('sets the scheduleDate to today', function() {
-        expect($scope.scheduleModel.start_date).toEqual(moment("01/02/2014").format('MM/DD/YYYY'));
+        expect($scope.scheduleModel.start_date).toEqual(moment("01/02/2014").toDate());
       });
 
       it('sets the scheduleTimerType to once', function() {


### PR DESCRIPTION
Go to: Configuration -> Settings -> Schedules and make sure the schedule creation & editing
works correctly. In particular, once you create a schedule for the future, you should be able
to back-date the schedule (i.e. be able to set any day between today and previously set date).

This would fix some problems with `datepicker-init`:
1. the controller now can work with Date object internally
2. the controller can now correctly set datepicker start date

https://bugzilla.redhat.com/show_bug.cgi?id=1493386