### PR TITLE
postService - skipError on 400, deduplicate

### DIFF
--- a/app/assets/javascripts/services/post_service.js
+++ b/app/assets/javascripts/services/post_service.js
@@ -1,57 +1,48 @@
 /* global miqFlashLater */
 
-ManageIQ.angular.app.service('postService', ['miqService', '$timeout', '$window', 'API', function(miqService, $timeout, $window, API) {
-  this.saveRecord = function(apiURL, redirectURL, updateObject, successMsg) {
-    miqService.sparkleOn();
-    return API.post(apiURL,
-      angular.toJson({
-        action: 'edit',
-        resource: updateObject,
-      })).then(handleSuccess)
-         .catch(miqService.handleFailure);
-
-    function handleSuccess(response) {
-      $timeout(function() {
-        if (response.error) {
-          var msg = __(response.error.klass + ': ' + response.error.message);
-          miqService.miqFlash('error', msg);
-          miqService.sparkleOff();
-        } else {
-          miqFlashLater({ message: successMsg });
-          $window.location.href = redirectURL;
-        }
-      });
-    }
+ManageIQ.angular.app.service('postService', ['miqService', '$window', 'API', function(miqService, $window, API) {
+  this.saveRecord = function(apiURL, redirectURL, object, successMsg) {
+    return saveRecord(apiURL, redirectURL, object, successMsg, 'edit');
   };
 
-  this.createRecord = function(apiURL, redirectURL, createObject, successMsg) {
-    miqService.sparkleOn();
-    return API.post(apiURL,
-      angular.toJson({
-        action: 'create',
-        resource: createObject,
-      })).then(handleSuccess)
-         .catch(miqService.handleFailure);
-
-    function handleSuccess(response) {
-      $timeout(function() {
-        if (response.error) {
-          var msg = __(response.error.klass + ': ' + response.error.message);
-          miqService.miqFlash('error', msg);
-          miqService.sparkleOff();
-        } else {
-          miqFlashLater({ message: successMsg });
-          $window.location.href = redirectURL;
-        }
-      });
-    }
+  this.createRecord = function(apiURL, redirectURL, object, successMsg) {
+    return saveRecord(apiURL, redirectURL, object, successMsg, 'create');
   };
 
   this.cancelOperation = function(redirectURL, msg) {
-    $timeout(function() {
-      miqFlashLater({ message: msg });
-      $window.location.href = redirectURL;
-    });
+    miqFlashLater({ message: msg });
+    $window.location.href = redirectURL;
   };
+
+
+  function saveRecord(apiURL, redirectURL, object, successMsg, action) {
+    miqService.sparkleOn();
+
+    return API.post(apiURL, angular.toJson({
+      action: action,
+      resource: object,
+    }), {
+      skipErrors: [400],
+    })
+      .then(handleErrors)
+      .then(handleSuccess(successMsg, redirectURL))
+      .catch(miqService.handleFailure);
+  }
+
+  function handleErrors(response) {
+    if (response.error) {
+      // flash & sparkleOff handled by miqService.handleFailure
+      return Promise.reject({
+        message: __(response.error.klass) + ': ' + __(response.error.message),
+      });
+    }
+  }
+
+  function handleSuccess(message, url) {
+    return function() {
+      miqFlashLater({ message: message });
+      $window.location.href = url;
+    };
+  }
 }]);
 


### PR DESCRIPTION
go to Services > Catalogs, Catalog Items accordion
create a new Catalog Item, of type Ansible Playbook
do stuff to trigger a validation error on saving (duplicate name, badly configured embedded ansible)

Before - you'll see the error modal pop up, and a flash message.

Now - you'll only see the flash message.

This also cleans up `postService`:
  * there were 2 identical branches differing in `action: 'edit'` vs `action: 'create'`
  * `handleSuccess` handled errors, separately from `handleFailure` but same way
  * `$timeout` was being used to compensate for not having originally injected the angular API variant

(`postService` is only used by that single form - but that's a TODO for later)

https://bugzilla.redhat.com/show_bug.cgi?id=1509809
(at this point, I'm only assuming the BZ is about this, but this goes in line with #2075 and #2604)