### PR TITLE
Fix GCE credential validation

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -126,7 +126,7 @@ module Mixins
       when 'ManageIQ::Providers::Vmware::CloudManager'
         [params[:default_hostname], params[:default_api_port], user, password, true]
       when 'ManageIQ::Providers::Google::CloudManager'
-        [params[:project], MiqPassword.encrypt(params[:service_account]), {:service => "compute"}, true]
+        [params[:project], MiqPassword.encrypt(params[:service_account]), {:service => "compute"}, nil, true]
       when 'ManageIQ::Providers::Microsoft::InfraManager'
         connect_opts = {
           :hostname          => params[:default_hostname],

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -303,9 +303,10 @@ describe EmsCloudController do
   end
 
   context "#create_ems_button_validate" do
+    let(:mocked_params) { {:controller => mocked_class_controller, :cred_type => "default"} }
     before do
       allow(controller).to receive(:render)
-      controller.instance_variable_set(:@_params, :controller => mocked_class_controller, :cred_type => "default")
+      controller.instance_variable_set(:@_params, mocked_params)
       allow(ExtManagementSystem).to receive(:model_from_emstype).and_return(mocked_class)
     end
 
@@ -323,6 +324,20 @@ describe EmsCloudController do
 
         expect(mocked_class).to receive(:raw_connect)
         controller.send(:create_ems_button_validate)
+      end
+
+      context "google compute engine" do
+        let(:mocked_params)   { {:controller => mocked_class_controller, :cred_type => "default", :project => project, :service_account => service_account} }
+        let(:mocked_class)    { ManageIQ::Providers::Google::CloudManager }
+        let(:project)         { "gce-project-1" }
+        let(:service_account) { "PRIVATE_KEY" }
+        let(:compute_service) { {:service => "compute"} }
+
+        it "queues the correct number of arguments" do
+          expected_validate_args = [project, MiqPassword.encrypt(service_account), compute_service, nil, true]
+          expect(mocked_class).to receive(:validate_credentials_task).with(expected_validate_args, nil, nil)
+          controller.send(:create_ems_button_validate)
+        end
       end
     end
 


### PR DESCRIPTION
Google::CloudManager.raw_connect expects [`google_project,
google_json_key, options, proxy_uri = nil, validate = false`](https://github.com/ManageIQ/manageiq-providers-google/blob/master/app/models/manageiq/providers/google/manager_mixin.rb#L23) but we were passing true for validate in the location of proxy_uri.  This was causing the google client to try to use `true` as the proxy and this was failing which caused the credential validation to error out.

This was introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/2647

https://bugzilla.redhat.com/show_bug.cgi?id=1512110