### PR TITLE
Adjust the haml indentation for custom image

### DIFF
--- a/app/views/generic_object_definition/_show_god.html.haml
+++ b/app/views/generic_object_definition/_show_god.html.haml
@@ -4,14 +4,14 @@
   - else
     = render :partial => 'layouts/textual_groups_generic'
 
-  - if @record.picture
-    %hr
-      %h3
-        = _('Custom Image')
-      .form-horizontal
-        .form-group
-          .col-md-9
-            %img{:src => "#{@record.picture.url_path}", :style => "width:100px; height:100px;"}
+    - if @record.picture
+      %hr
+        %h3
+          = _('Custom Image')
+        .form-horizontal
+          .form-group
+            .col-md-9
+              %img{:src => "#{@record.picture.url_path}", :style => "width:100px; height:100px;"}
 
   %generic-object-definition-toolbar#generic_object_definition_show_form{'record-id'    => @record.id,
                                                                          'entity'       => _('Generic Object Class'),


### PR DESCRIPTION
Adjust the haml indentation to adjust the issue of Custom Image being displayed in the GO instances listview.

https://bugzilla.redhat.com/show_bug.cgi?id=1513185

Before:
<img width="1434" alt="screen shot 2017-11-14 at 2 31 30 pm" src="https://user-images.githubusercontent.com/1538216/32808615-8a2a63d8-c948-11e7-9f75-fed5493af9f8.png">


After:
<img width="1425" alt="screen shot 2017-11-14 at 2 33 21 pm" src="https://user-images.githubusercontent.com/1538216/32808695-d2b91b1c-c948-11e7-9692-06c5b2888e78.png">


