### PR TITLE
[WIP] Do not set default api_version which breakes validation on UI

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -241,7 +241,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.prometheus_alerts_auth_status   = data.prometheus_alerts_auth_status;
       $scope.emsCommonModel.prometheus_alerts_security_protocol = data.prometheus_alerts_security_protocol;
       $scope.emsCommonModel.prometheus_alerts_tls_ca_certs  = data.prometheus_alerts_tls_ca_certs;
-      $scope.emsCommonModel.api_version                     = 'v2';
+      $scope.emsCommonModel.api_version                     = data.api_version;
       $scope.emsCommonModel.ems_controller                  = data.ems_controller;
       $scope.emsCommonModel.ems_controller === 'ems_container' ? $scope.emsCommonModel.default_api_port = '8443' : $scope.emsCommonModel.default_api_port = '';
       $scope.emsCommonModel.metrics_api_port                = '443';

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -350,7 +350,7 @@ module Mixins
                        :amqp_hostname                   => amqp_hostname,
                        :default_api_port                => default_api_port || "",
                        :amqp_api_port                   => amqp_port || "",
-                       :api_version                     => @ems.api_version || "v2",
+                       :api_version                     => @ems.api_version,
                        :default_security_protocol       => default_security_protocol,
                        :amqp_security_protocol          => amqp_security_protocol,
                        :provider_region                 => @ems.provider_region,

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -164,6 +164,7 @@
                      options_for_select(@nuage_api_versions),
                      "ng-model"                    => "emsCommonModel.api_version",
                      "checkchange"                 => "",
+                     "required"                    => true,
                      "selectpicker-for-select-tag" => "")
 
     .form-group{"ng-class" => "{'has-error': angularForm.provider_id.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack' && emsCommonModel.openstack_infra_providers_exist"}


### PR DESCRIPTION
The default value for api_version was set to 'v2' and the nuage provider
not having that version defined, a value of '? string v2 ?' was selected by 
default in the api version dropdown on the add network provider form. If 
the user does not change that value no validation error is show, the value 
gets submitted and an error is returned. I have removed that default value.