### PR TITLE
show error message when deleting router

### DIFF
--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -167,6 +167,8 @@ class NetworkRouterController < ApplicationController
       router = NetworkRouter.find_by(:id => s)
       if router.nil?
         add_flash(_("Router no longer exists."), :error)
+      elsif !router.supports?(:delete)
+        add_flash(_(router.unsupported_reason(:delete)), :error)
       else
         routers_to_delete.push(router)
       end


### PR DESCRIPTION
Router is not deleted if delete action is not supported and shows error message
Fixes this BZ https://bugzilla.redhat.com/show_bug.cgi?id=1470754  