### PR TITLE
Fix copy RBAC Role to a new Role

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1003,6 +1003,7 @@ module OpsController::OpsRbac
 
   def build_rbac_feature_tree
     @role = @sb[:typ] == "copy" ? @record.dup : @record if @role.nil? # if on edit screen use @record
+    @role.miq_product_features = @record.miq_product_features if @sb[:typ] == "copy"
     TreeBuilderOpsRbacFeatures.new("features_tree", "features", @sb, true, :role => @role, :editable => @edit.present?)
   end
 


### PR DESCRIPTION
Configuration -> Access Control -> choose any Role -> Configuration -> Copy this Role to a new Role -> tree has nothing selected

Original RBAC Role:
<img width="747" alt="screen shot 2017-11-15 at 1 35 31 pm" src="https://user-images.githubusercontent.com/9210860/32837674-b2ba31f4-ca0e-11e7-9841-299be743d4ec.png">
Before:
<img width="892" alt="screen shot 2017-11-15 at 1 55 43 pm" src="https://user-images.githubusercontent.com/9210860/32837697-c4757232-ca0e-11e7-861d-924747b0c9b2.png">
After:
<img width="887" alt="screen shot 2017-11-15 at 1 35 50 pm" src="https://user-images.githubusercontent.com/9210860/32837686-bb24af90-ca0e-11e7-966e-0e3880575fa9.png">

@miq-bot add_label bug

https://bugzilla.redhat.com/show_bug.cgi?id=1512358

@mzazrivec please have look, thanks :)
