### PR TITLE
Add menu_click and sb_controller for additional data in report data

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1500,7 +1500,8 @@ class ApplicationController < ActionController::Base
              params[:type]                          # gtl type
            )
       refresh_view = true
-      session[:menu_click] = params[:menu_click]      # Creating a new view, remember if came from a menu_click
+      # Creating a new view, remember if came from a menu_click
+      session[:menu_click] = params[:menu_click] || options[:menu_click]
       session[:bc]         = params[:bc]              # Remember incoming breadcrumb as well
     end
 
@@ -1574,7 +1575,7 @@ class ApplicationController < ActionController::Base
       :supported_features_filter => options[:supported_features_filter],
       :page                      => options[:all_pages] ? 1 : @current_page,
       :per_page                  => options[:all_pages] ? ONE_MILLION : @items_per_page,
-      :where_clause              => get_view_where_clause(options[:where_clause]),
+      :where_clause              => get_view_where_clause(options[:where_clause], options[:sb_controller]),
       :named_scope               => options[:named_scope],
       :display_filter_hash       => options[:display_filter_hash],
       :userid                    => session[:userid],
@@ -1609,10 +1610,11 @@ class ApplicationController < ActionController::Base
       !@force_no_grid_xml && (@gtl_type == "list" || @force_grid_xml)
   end
 
-  def get_view_where_clause(default_where_clause)
+  def get_view_where_clause(default_where_clause, sb_controller = nil)
     # If doing charts, limit the records to ones showing in the chart
-    if session[:menu_click] && session[:sandboxes][params[:sb_controller]][:chart_reports]
-      chart_reports = session[:sandboxes][params[:sb_controller]][:chart_reports]
+    sb_controller = params[:sb_controller] if sb_controller.nil?
+    if !sb_controller.nil? && session[:menu_click] && session[:sandboxes][sb_controller][:chart_reports]
+      chart_reports = session[:sandboxes][sb_controller][:chart_reports]
       chart_click = parse_chart_click(Array(session[:menu_click]).first)
       model_downcase = chart_click.model.downcase
 

--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -11,6 +11,8 @@ class ApplicationController
     :view_suffix,
 
     :row_button,
+    :menu_click,
+    :sb_controller,
 
     :listicon,
     :embedded,
@@ -40,6 +42,14 @@ class ApplicationController
 
     def with_row_button(row_button)
       self.row_button = row_button
+    end
+
+    def with_menu_click(menu_click)
+      self.menu_click = menu_click
+    end
+
+    def with_sb_controller(sb_controller)
+      self.sb_controller = sb_controller
     end
 
     def with_model(curr_model)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1639,6 +1639,8 @@ module ApplicationHelper
       :policy_sim => @policy_sim
     )
     @report_data_additional_options.with_row_button(@row_button) if @row_button
+    @report_data_additional_options.with_menu_click(params[:menu_click]) if params[:menu_click]
+    @report_data_additional_options.with_sb_controller(params[:sb_controller]) if params[:sb_controller]
     @report_data_additional_options.with_model(curr_model) if curr_model
     @report_data_additional_options.freeze
   end


### PR DESCRIPTION
### Fixes wrong number of items when clicking trough Utilization graph https://github.com/ManageIQ/manageiq-ui-classic/issues/2723
When in Datasources -> Utilization graph and clicking on display VMs or Hosts wrong number of items was returned, this PR fixes such issue.

### UI changes
#### Before
![screenshot from 2017-11-15 15-16-53](https://user-images.githubusercontent.com/3439771/32840474-08ca8716-ca18-11e7-9f3b-dd66320ffef9.png)
#### After
![screenshot from 2017-11-15 15-13-30](https://user-images.githubusercontent.com/3439771/32840341-a7b08034-ca17-11e7-9021-0e17fbb34ac7.png)

