### PR TITLE
Fix using view selector in My Services page

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -301,6 +301,7 @@ class ServiceController < ApplicationController
       end
     when "MiqSearch"
       load_adv_search # Select/load filter from Global/My Filters
+      process_show_list
       @right_cell_text = _("All Services")
     end
     @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && @edit && @edit[:adv_search_applied]

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -1,4 +1,6 @@
 describe ServiceController do
+  include CompressedIds
+
   before(:each) do
     stub_user(:features => :all)
   end
@@ -245,6 +247,27 @@ describe ServiceController do
       record = FactoryGirl.create(:service)
       controller.instance_variable_set(:@record, record)
       expect(controller.send(:textual_group_list)).to include(array_including(:generic_objects))
+    end
+  end
+
+  context 'displaying a list of All Services' do
+    describe '#tree_select' do
+      render_views
+
+      let(:service_search) { FactoryGirl.create(:miq_search, :description => 'a', :db => 'Service') }
+
+      it 'renders GTL of All Services, filtered by choosen filter from accordion' do
+        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+          :model_name                     => 'Service',
+          :report_data_additional_options => {
+            :model       => 'Service',
+            :named_scope => nil
+          }
+        )
+        expect(controller).to receive(:process_show_list).once.and_call_original
+        post :tree_select, :params => {:id => "ms-#{to_cid(service_search.id)}"}
+        expect(response.status).to eq(200)
+      end
     end
   end
 

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -268,6 +268,12 @@ describe ServiceController do
         post :tree_select, :params => {:id => "ms-#{to_cid(service_search.id)}"}
         expect(response.status).to eq(200)
       end
+
+      it 'calls load_adv_search method to load filter from filters in accordion' do
+        expect(controller).to receive(:load_adv_search).once
+        post :tree_select, :params => {:id => "ms-#{to_cid(service_search.id)}"}
+        expect(response.status).to eq(200)
+      end
     end
   end
 


### PR DESCRIPTION
fixing issue mentioned in https://bugzilla.redhat.com/show_bug.cgi?id=1500608

This PR fixes using view selector in _Services -> My Services_ when using _Global/My
Filters_ from accordion. The core of the problem was that `@gtl_type` and another
variables were not set properly before displaying filtered items.

Adding `process_show_list` method solves the problem. Originally, this method was
accessed when applying a filter from _Advanced search_, but not from filters in the tree
in accordion.

Before:
![tile1](https://user-images.githubusercontent.com/13417815/32842939-c0720e92-ca1e-11e7-87a5-9f0eb966427f.png)

After:
![tile2](https://user-images.githubusercontent.com/13417815/32842865-8f292e06-ca1e-11e7-8045-a9624dd769e3.png)
