### PR TITLE
Fix error after canceling editing Chargeback rate

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -892,6 +892,7 @@ class ChargebackController < ApplicationController
       else
         # Added so buttons can be turned off even tho div is not being displayed it still pops up Abandon changes box when trying to change a node on tree after saving a record
         presenter.hide(:buttons_on).show(:toolbar).hide(:paging_div)
+        presenter.hide(:form_buttons_div) if params[:button]
       end
     else
       presenter.hide(:form_buttons_div).show(:pc_div_1)


### PR DESCRIPTION
**fixing** https://github.com/ManageIQ/manageiq-ui-classic/issues/2561

Fix error after canceling editing Chargeback rate in _Cloud Intel -> Chargeback -> Rates_
tab when clicking on _**Cancel**_ button _for the second time_. Error occurred because Cancel
button was still present and clickable after clicking on it.

Error is fixed simply by hiding the buttons Save, Reset and Cancel button so we "return"
to the same screen as before editing the rate so we cannot click on Cancel button more
times so we don't come to the error.

The issue also occurs when you successfully edit the rate, click _Save_ **and then** **_Cancel_**.
Cancel button and others (but unclickable) are still there! They should not be there after
you click on Save or Cancel button.

**Before:**
![rate1](https://user-images.githubusercontent.com/13417815/32851338-00dda714-ca35-11e7-967d-297f89c0cd04.png)

**After:**
![rate2](https://user-images.githubusercontent.com/13417815/32850840-a5ac2268-ca33-11e7-8cc9-7b508cc1b16e.png)
