### PR TITLE
Fixed "ASSIGN_TOS" hash to merge other values into it appropriately

### DIFF
--- a/app/helpers/term_of_service_helper.rb
+++ b/app/helpers/term_of_service_helper.rb
@@ -51,5 +51,10 @@ module TermOfServiceHelper
   }
 
   ASSIGN_TOS[:chargeback_storage] = ASSIGN_TOS["Storage"]
+
+  ASSIGN_TOS["EmsCluster"].merge!(ASSIGN_TOS["ExtManagementSystem"])
+  ASSIGN_TOS["Host"].merge!(ASSIGN_TOS["EmsCluster"])
+  ASSIGN_TOS["Vm"].merge!(ASSIGN_TOS["Host"])
+
   ASSIGN_TOS.freeze
 end

--- a/spec/helpers/term_of_service_helper_spec.rb
+++ b/spec/helpers/term_of_service_helper_spec.rb
@@ -1,0 +1,21 @@
+describe TermOfServiceHelper do
+  context "#ASSIGN_TOS" do
+    it "verify that other CI values have been merged into Vm hash" do
+      vm_values = {
+        "ems_folder"                 => "Selected Folders",
+        "resource_pool"              => "Selected Resource Pools",
+        "resource_pool-tags"         => "Tagged Resource Pools",
+        "vm-tags"                    => "Tagged VMs and Instances",
+        "host"                       => "Selected Host / Nodes",
+        "host-tags"                  => "Tagged Host / Nodes",
+        "ems_cluster"                => "Selected Cluster / Deployment Roles",
+        "ems_cluster-tags"           => "Tagged Cluster / Deployment Roles",
+        "enterprise"                 => "The Enterprise",
+        "ext_management_system"      => "Selected Providers",
+        "ext_management_system-tags" => "Tagged Providers"
+      }
+      expect(TermOfServiceHelper::ASSIGN_TOS["Vm"]).to eq(vm_values)
+      expect(TermOfServiceHelper::ASSIGN_TOS["Vm"].length).to eq(11)
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1501895

@dclarizio please test/review

Added back values that were lost during cleanup of UI Constants in https://github.com/ManageIQ/manageiq-ui-classic/pull/2082

before:
![before](https://user-images.githubusercontent.com/3450808/32866038-c9dab884-ca33-11e7-9c6d-cbaa4482568e.png)


after:
![after](https://user-images.githubusercontent.com/3450808/32866001-9beac2f2-ca33-11e7-8d9c-90c6079cbab7.png)
