### PR TITLE
Fix for Generic Objects Tagging

### DIFF
--- a/app/controllers/picture_controller.rb
+++ b/app/controllers/picture_controller.rb
@@ -1,5 +1,14 @@
 class PictureController < ApplicationController
+  before_action :check_privileges
+  before_action :get_session_data
+
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  include Mixins::GenericSessionMixin
+
   def show # GET /pictures/:basename
+    @edit = session[:edit]
     compressed_id, extension = params[:basename].split('.')
     picture = Picture.find_by_id(from_cid(compressed_id))
     if picture && picture.extension == extension

--- a/spec/controllers/picture_controller_spec.rb
+++ b/spec/controllers/picture_controller_spec.rb
@@ -9,10 +9,13 @@ describe PictureController do
 
     picture.content = picture_content.dup # dup because destructive operation
     picture.save
+
+    session[:edit] = {:key => "GenericObject_edit_tags__1111", :tagging => "GenericObject"}
   end
 
   it 'can serve a picture directly from the database' do
     get :show, :params => { :basename => "#{picture.compressed_id}.#{picture.extension}" }
+    expect(controller.instance_variable_get(:@edit)).to eq(session[:edit])
     expect(response.status).to eq(200)
     expect(response.body).to eq(picture_content)
   end


### PR DESCRIPTION
This fixes the issue described in https://github.com/ManageIQ/manageiq-ui-classic/issues/2625

As described in #2625, the cause for the crash can be attributed to the fact that `@edit`/`session[:edit]` values are nil.

This occurs only when the Generic Objects have a custom image associated with them via their definition (`GenericObjectDefinition`).

When the tagging screen is loaded, there is an additional GET request made by the `PictureController` to load the custom image.  `@edit` loses it's value and becomes `nil` during this GET request since it's never restored with `session[:edit]` - thus leading to the crash described in #2625 

(It is not possible to capture this entire scenario in a unit test written in the Generic Object controller, hence I have written a simple spec only from the `picture_controller` point of view)


Fixes #2625