### PR TITLE
Fixed replace_right_cell regression in the tag mapping on OPS screen

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -676,7 +676,8 @@ class OpsController < ApplicationController
       elsif %w(zone_delete).include?(params[:pressed])
         presenter.replace(:ops_tabs, r[:partial => "all_tabs"])
       else
-        presenter[:update_partials][@sb[:active_tab.to_sym]] = r[:partial => "#{@sb[:active_tab]}_tab"]
+        tab = @sb[:active_tab] == 'settings_tags' ? @sb[:active_subtab] : @sb[:active_tab]
+        presenter[:update_partials][tab] = r[:partial => "#{tab}_tab"]
       end
       active_id = from_cid(x_node.split("-").last)
       # server node


### PR DESCRIPTION
The regression was introduced in #2522 by missing to add the condition for the `active_subtab`. We should not fetch partial names so dynamically btw. You can reproduce the issue by visiting `Settings -> Region (treenode) -> Tags (tab) -> Map Tags (subtab)`, try to add a new mapping or just hit the cancel button.

@miq-bot add_label bug, gaprindashvili/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1513507