### PR TITLE
Fix delete of Orchestration Stack from EmsCloud controller

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -943,7 +943,7 @@ module ApplicationController::CiProcessing
   def delete_elements(model_class, destroy_method, model_name = nil)
     elements = []
     model_name ||= model_class.table_name
-    if @lastaction == "show_list" || (@lastaction == "show" && @layout != model_name.singularize) # showing a list
+    if params[:miq_grid_checks].present? || @lastaction == "show_list" || (@lastaction == "show" && @layout != model_name.singularize) # showing a list
       elements = find_checked_ids_with_rbac(model_class)
       if elements.empty?
         add_flash(_("No %{model} were selected for deletion") %

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -236,10 +236,15 @@ module EmsCommon
 
       when "physical_server_protect"          then assign_policies(PhysicalServer)
       when "physical_server_tag"              then tag(PhysicalServer)
-
+      when "orchestration_stack_delete"       then orchestration_stack_delete
       end
 
       return if params[:pressed].include?("tag") && !%w(host_tag vm_tag miq_template_tag instance_tag).include?(params[:pressed])
+      if params[:pressed].include?("orchestration_stack_delete")
+        session[:flash_msgs] = @flash_array.dup
+        javascript_redirect(polymorphic_path(EmsCloud.find(params[:id]), :display => 'orchestration_stacks'))
+        return
+      end
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       # Handle Host power buttons
       if host_power_button?(params[:pressed])


### PR DESCRIPTION
Compute -> Cloud -> Providers -> choose one -> click Orchestration Stacks -> check one or more -> Configuration -> Remove Orchestration Stack from Inventory
Before:
If Orchestration Stack id matches a VM id
![image](https://user-images.githubusercontent.com/9210860/32907327-efca9fd8-caff-11e7-8f76-4a9178379850.png)
or if it doesn't (or you try to delete it again)
![image](https://user-images.githubusercontent.com/9210860/32907434-4aea8608-cb00-11e7-9939-e8ce0342f3dc.png)
After:
<img width="1197" alt="screen shot 2017-11-16 at 4 10 07 pm" src="https://user-images.githubusercontent.com/9210860/32907215-94dcf058-caff-11e7-9710-26885f5de945.png">

@miq-bot add_label gaprindashvili/yes, wip, bug

https://bugzilla.redhat.com/show_bug.cgi?id=1501116