### PR TITLE
Only force old dialog use when legitimate api endpoint does not exist

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -9,6 +9,7 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
 
   function init(dialog) {
     vm.dialog = dialog.content[0];
+    vm.dialogLoaded = true;
   }
 
   vm.refreshField = refreshField;

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -6,7 +6,7 @@
   - cancel_endpoint ||= @dialog_locals[:cancel_endpoint]
   - force_old_dialog_use = @dialog_locals[:force_old_dialog_use].to_s == "true"
 
-- force_old_dialog_use ||= true
+- force_old_dialog_use ||= true if api_submit_endpoint.nil?
 
 - if Settings.product.old_dialog_user_ui || force_old_dialog_use
   :javascript

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -3,7 +3,7 @@
     %dialog-user{"dialog" =>"vm.dialog", "refresh-field" => "vm.refreshField(field)", "on-update" => "vm.setDialogData(data)"}
 
   .clearfix
-  .pull-right.button-group
+  .pull-right.button-group{'ng-show' => "vm.dialogLoaded"}
     %miq-button{:name      => t = _("Submit"),
                 :title     => t,
                 :alt       => t,

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -47,6 +47,10 @@ describe('dialogUserController', function() {
     it('sets the refreshUrl', function() {
       expect($controller.refreshUrl).toEqual('/api/service_dialogs/');
     });
+
+    it('sets dialogLoaded to true', function() {
+      expect($controller.dialogLoaded).toEqual(true);
+    });
   });
 
   describe('refreshField', function() {


### PR DESCRIPTION
This is part of the fix for this BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1513162
~~(I think it may also help out on https://bugzilla.redhat.com/show_bug.cgi?id=1513108)~~ 1513108 is not related.

When I set up the logic for defaulting back to the old dialog component (since some custom buttons are currently not supported), I inadvertently made the ordering of services default to the old dialog component since it does not set up a `@dialog_locals` instance variable as it goes through a presenter, not a javascript redirect. This fixes that by checking to see if we have an api endpoint set before defaulting to the old dialog component.

The other part is making sure that when dialogs are imported, that the associations are being created properly (which is [here](https://github.com/ManageIQ/manageiq/pull/16471)) for the new dialog targeted auto refresh mechanism. Otherwise, the users will need to set up the associations themselves in the editor after importing the dialog as a workaround.

@miq-bot add_label gaprindashvili/yes, bug, fine/no

@miq-bot assign @h-kataria 
/cc @gmcculloug @d-m-u 