### PR TITLE
Changed find_by back to find_by_fqname

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -217,7 +217,7 @@ class MiqAeClassController < ApplicationController
         self.x_node = "#{selected_node[0]}-#{to_cid(record.id)}"
         parents.push(record)
       else
-        ns = MiqAeNamespace.find_by(:fqname => nodes[0..i].join("/"))
+        ns = MiqAeNamespace.find_by_fqname(nodes[0..i].join("/"))
         parents.push(ns) if ns
       end
     end

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -911,4 +911,47 @@ describe MiqAeClassController do
       expect(assigns(:edit)[:new][:data]).to eq("exit MIQ_OK...")
     end
   end
+
+  context "#open_parent_nodes" do
+    it "returns parent nodes hash for newly added item in tree" do
+      ns = FactoryGirl.create(:miq_ae_namespace)
+      cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id, :name => "foo_cls")
+      method = FactoryGirl.create(:miq_ae_method,
+                                  :name     => "method01",
+                                  :scope    => "class",
+                                  :language => "ruby",
+                                  :class_id => cls.id,
+                                  :data     => "exit MIQ_OK",
+                                  :location => "inline")
+      controller.instance_variable_set(:@record, cls)
+      controller.instance_variable_set(
+        :@sb,
+        :trees       => {
+          :ae_tree => {
+            :active_node => "aec-#{cls.id}",
+            :open_nodes  => [],
+            :klass_name  => "TreeBuilderAeClass"
+          }
+        },
+        :active_tree => :ae_tree
+      )
+      tree_node = controller.send(:open_parent_nodes, method)
+      node_to_add = {
+        :key   => "aen-#{ApplicationRecord.compress_id(ns.id)}",
+        :nodes => [
+          {
+            :key        => "aec-#{ApplicationRecord.compress_id(cls.id)}",
+            :text       => "foo_cls",
+            :tooltip    => "Automate Class: foo_cls",
+            :icon       => "ff ff-class",
+            :selectable => true,
+            :lazyLoad   => true,
+            :state      => {:expanded => false},
+            :class      => "",
+          }
+        ]
+      }
+      expect(tree_node).to eq(node_to_add)
+    end
+  end
 end


### PR DESCRIPTION
Issue was introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/2004, commit c281edf74f2210340535be75718429f467de6709 find_by_fqname was changed to use rails find_by but in this case fqname is not an actual column, find_by_fqname is an actual method in MiqAeNamespace class https://github.com/ManageIQ/manageiq/blob/cb5e0de1766fa363ecfd19715316e17053925d1e/app/models/miq_ae_namespace.rb#L20

https://bugzilla.redhat.com/show_bug.cgi?id=1510463

@mkanoor please test/review.

cc @dclarizio @martinpovolny 