### PR TITLE
Fix session[:edit] breakage in picture controller.

### DIFF
--- a/app/controllers/picture_controller.rb
+++ b/app/controllers/picture_controller.rb
@@ -1,4 +1,7 @@
 class PictureController < ApplicationController
+  skip_before_action :get_global_session_data
+  skip_after_action :set_global_session_data
+
   def show # GET /pictures/:basename
     compressed_id, extension = params[:basename].split('.')
     picture = Picture.find_by_id(from_cid(compressed_id))


### PR DESCRIPTION
When picture controller is accessed the current content of
`session[:edit]` is lost. This is due to asymetry in
`get_global_session_data` vs `set_global_session_data`. One side always sets
the `session[:edit]` while the other does not always read it.

Furthemor the logic of `{set/get}_global_session_data` is not needed in
the picture controller.

Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/2625
Replaces: https://github.com/ManageIQ/manageiq-ui-classic/pull/2747

ping @AparnaKarve, please, review, test, add a spec for this. Thank you!