### PR TITLE
VM Transform not working from a provider page

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -15,6 +15,7 @@ module ApplicationController::CiProcessing
     include Mixins::Actions::VmActions::Reconfigure
     helper_method :supports_reconfigure_disks?
     include Mixins::Actions::VmActions::PolicySimulation
+    include Mixins::Actions::VmActions::Transform
 
     include Mixins::Actions::HostActions::Discover
     include Mixins::Actions::HostActions::Power
@@ -1063,6 +1064,7 @@ module ApplicationController::CiProcessing
     when "#{pfx}_terminate"                 then terminatevms
     when "instance_add_security_group"      then add_security_group_vms
     when "instance_remove_security_group"   then remove_security_group_vms
+    when "vm_transform"                     then vm_transform
     end
   end
 

--- a/app/controllers/mixins/actions/vm_actions/transform.rb
+++ b/app/controllers/mixins/actions/vm_actions/transform.rb
@@ -1,0 +1,27 @@
+module Mixins
+  module Actions
+    module VmActions
+      module Transform
+        def vm_transform
+          dialog = Dialog.find_by(:label => 'Transform VM')
+          if params.key?(:id)
+            vm = Vm.find_by(:id => params[:id].to_i)
+            @right_cell_text = _("Transform VM %{name} to RHV") % {:name => vm.name}
+            dialog_initialize(
+              dialog.resource_actions.first,
+              :header     => @right_cell_text,
+              :target_id  => vm.id,
+              :target_kls => Vm.name
+            )
+          else
+            @right_cell_text = _("Transform VMs to RHV")
+            simple_dialog_initialize(
+              dialog.resource_actions.first,
+              :header => @right_cell_text
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -2,6 +2,7 @@ class VmInfraController < ApplicationController
   include VmCommon # common methods for vm controllers
   include VmRemote # methods for VM remote access
   include VmShowMixin
+  include Mixins::Actions::VmActions::Transform
 
   before_action :check_privileges
   before_action :get_session_data
@@ -94,26 +95,6 @@ class VmInfraController < ApplicationController
       replace_right_cell(:action => "dialog_provision")
     else
       javascript_redirect(:action => 'dialog_load')
-    end
-  end
-
-  def vm_transform
-    dialog = Dialog.find_by(:label => 'Transform VM')
-    if params.key?(:id)
-      vm = Vm.find_by(:id => params[:id].to_i)
-      @right_cell_text = _("Transform VM %{name} to RHV") % {:name => vm.name}
-      dialog_initialize(
-        dialog.resource_actions.first,
-        :header     => @right_cell_text,
-        :target_id  => vm.id,
-        :target_kls => Vm.name
-      )
-    else
-      @right_cell_text = _("Transform VMs to RHV")
-      simple_dialog_initialize(
-        dialog.resource_actions.first,
-        :header => @right_cell_text
-      )
     end
   end
 end

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -2,7 +2,6 @@ class VmInfraController < ApplicationController
   include VmCommon # common methods for vm controllers
   include VmRemote # methods for VM remote access
   include VmShowMixin
-  include Mixins::Actions::VmActions::Transform
 
   before_action :check_privileges
   before_action :get_session_data

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -83,6 +83,13 @@ describe EmsInfraController do
       post :button, :params => {:pressed => "host_analyze_check_compliance", :id => ems_infra.id, :format => :js}
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
+
+    it "when vm_transform is pressed" do
+      ems_infra = FactoryGirl.create(:ems_vmware)
+      expect(controller).to receive(:vm_transform)
+      post :button, :params => {:pressed => "vm_transform", :id => ems_infra.id, :format => :js}
+      expect(controller.send(:flash_errors?)).not_to be_truthy
+    end
   end
 
   describe "#create" do


### PR DESCRIPTION
Move the vm_transform action to a mixin 

Links 
-------
https://bugzilla.redhat.com/show_bug.cgi?id=1514032


Steps for Testing/QA
-------------------------------
Steps to Reproduce:
1. Browse CFME UI -> Compute -> Infrastructure -> Providers
2. Select VMware 
3. click on VMs
4. Select lifecycle -> Transform tagged VMs to RHV.

With this PR, the dialog opens from ems_infra:

![screenshot from 2017-11-17 01-54-53](https://user-images.githubusercontent.com/12769982/32934672-942fd432-cb3a-11e7-9d0f-3fc5ffe08e57.png)
