### PR TITLE
Allow linking to Services adding test coverage for Services Explorer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -450,9 +450,6 @@ class ApplicationController < ActionController::Base
     if !@policy_sim.nil? && session[:policies] && !session[:policies].empty?
       settings[:url] = '/' + controller + '/policies/'
     end
-    if session[:sandboxes] && @sb && controller
-      session[:sandboxes][controller] = @sb
-    end
     settings
   end
   private :set_variables_report_data

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2302,11 +2302,18 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def set_active_elements(feature)
+  # Set active tree and accordion according to given node.
+  # Optionally set x_node.
+  #
+  # Warning: the new x_node must exist in the tree.
+  #
+  def set_active_elements(feature, x_node_to_set = nil)
     if feature
       self.x_active_tree ||= feature.tree_list_name
       self.x_active_accord ||= feature.accord_name
     end
+
+    self.x_node = x_node_to_set if x_node_to_set.present?
     get_node_info(x_node)
   end
 
@@ -2320,12 +2327,14 @@ class ApplicationController < ActionController::Base
     @flash_array = nil if params[:button] != "reset"
   end
 
-  def build_accordions_and_trees
+  # Build all trees and accordions accoding to features available to the current user.
+  #
+  def build_accordions_and_trees(x_node_to_set = nil)
     # Build the Explorer screen from scratch
     allowed_features = ApplicationController::Feature.allowed_features(features)
     @trees = allowed_features.collect { |feature| feature.build_tree(@sb) }
     @accords = allowed_features.map(&:accord_hash)
-    set_active_elements(allowed_features.first)
+    set_active_elements(allowed_features.first, x_node_to_set)
   end
 
   def fetch_name_from_object(klass, id)

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -224,7 +224,7 @@ class MiqAeCustomizationController < ApplicationController
     end
   end
 
-  def set_active_elements(feature)
+  def set_active_elements(feature, _x_node_to_set = nil)
     if feature
       self.x_active_tree ||= feature.tree_list_name
       self.x_active_accord ||= feature.accord_name

--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -70,7 +70,7 @@ module VmShowMixin
 
   private
 
-  def set_active_elements(feature)
+  def set_active_elements(feature, _x_node_to_set = nil)
     if feature
       self.x_active_tree ||= feature.tree_list_name
       self.x_active_accord ||= feature.accord_name

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -266,7 +266,7 @@ class OpsController < ApplicationController
     end
   end
 
-  def set_active_elements(feature)
+  def set_active_elements(feature, _x_node_to_set = nil)
     if feature
       self.x_active_tree ||= feature.tree_list_name
       self.x_active_accord ||= feature.accord_name

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -274,7 +274,7 @@ class ReportController < ApplicationController
 
   private ###########################
 
-  def set_active_elements(feature)
+  def set_active_elements(feature, _x_node_to_set = nil)
     if feature
       self.x_active_tree ||= feature.tree_list_name
       self.x_active_accord ||= feature.accord_name

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -74,14 +74,15 @@ class ServiceController < ApplicationController
       return
     end
 
-    build_accordions_and_trees
+    x_node_to_set = nil
 
-    if params[:id]  # If a tree node id came in, show in one of the trees
+    if params[:id] # Tree node id came in, show it in the tree.
       @find_with_aggregates = true
       nodetype, id = params[:id].split("-")
-      self.x_node = "#{nodetype}-#{to_cid(id)}"
-      get_node_info(x_node)
+      x_node_to_set = "#{nodetype}-#{to_cid(id)}"
     end
+
+    build_accordions_and_trees(x_node_to_set)
 
     params.instance_variable_get(:@parameters).merge!(session[:exp_parms]) if session[:exp_parms]  # Grab any explorer parm overrides
     session.delete(:exp_parms)

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -280,38 +280,27 @@ class ServiceController < ApplicationController
     @nodetype, id = parse_nodetype_and_id(valid_active_node(treenodeid))
     # resetting action that was stored during edit to determine what is being edited
     @sb[:action] = nil
+
     case TreeBuilder.get_model_for_prefix(@nodetype)
-    when "Service"  # VM or Template record, show the record
+    when "Service"
       show_record(from_cid(id))
-      @right_cell_text = _("%{model} \"%{name}\"") % {:name => @record.name, :model => ui_lookup(:model => TreeBuilder.get_model_for_prefix(@nodetype))}
+      @right_cell_text = _("%{model} \"%{name}\"") % {:name => @record.name, :model => ui_lookup(:model => 'Service')}
       @no_checkboxes = true
       @gtl_type = "grid"
       @items_per_page = ONE_MILLION
       @view, @pages = get_view(Vm, :parent => @record, :parent_method => :all_vms, :all_pages => true)  # Get the records (into a view) and the paginator
     when "Hash"
-      if id == "asrv"
+      case id
+      when 'asrv'
         process_show_list(:named_scope => [[:retired, false], :displayed])
         @right_cell_text = _("Active Services")
-      else
+      when 'rsrv'
         process_show_list(:named_scope => [:retired, :displayed])
         @right_cell_text = _("Retired Services")
       end
     when "MiqSearch"
       load_adv_search # Select/load filter from Global/My Filters
       @right_cell_text = _("All Services")
-    else      # Get list of child Catalog Items/Services of this node
-      if x_node == "root"
-        process_show_list(:where_clause => "ancestry is null")
-        @right_cell_text = if x_active_tree == :svcs_tree
-                             _("All Services")
-                           else
-                             _("All Service Catalog Items")
-                           end
-      else
-        show_record(from_cid(id))
-        typ = x_active_tree == :svcs_tree ? "Service" : TreeBuilder.get_model_for_prefix(@nodetype)
-        @right_cell_text = _("%{model} \"%{name}\"") % {:name => @record.name, :model => ui_lookup(:model => typ)}
-      end
     end
     @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && @edit && @edit[:adv_search_applied]
 

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -155,7 +155,7 @@ module QuadiconHelper
   def quadicon_builder_factory(item, options)
     case quadicon_builder_name_from(item)
     when 'service', 'service_template', 'service_ansible_tower', 'service_template_ansible_tower'
-      render_service_quadicon(item, options.merge!(:url => "/service/explorer/s-#{item.id}"))
+      render_service_quadicon(item, options)
     when 'resource_pool'         then render_resource_pool_quadicon(item, options)
     when 'host'                  then render_host_quadicon(item, options)
     when 'ext_management_system' then render_ext_management_system_quadicon(item, options)
@@ -461,7 +461,7 @@ module QuadiconHelper
     link_opts = {}
 
     if quadicon_show_links?
-      url = options[:url] || quadicon_url_to_xshow_from_cid(item, options)
+      quadicon_url_to_xshow_from_cid(item, options)
       link_opts = {:sparkle => true, :remote => true}
     end
 

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -16,7 +16,7 @@ class TreeBuilderServices < TreeBuilder
   end
 
   def root_options
-    { }
+    {}
   end
 
   # Get root nodes count/array for explorer tree
@@ -45,13 +45,16 @@ class TreeBuilderServices < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
-    services = Rbac.filtered(Service.where(:retired => object[:id] != 'asrv', :display => true))
-    if %w(global my).include?(object[:id]) # Get My Filters and Global Filters
-      count_only_or_objects(count_only, x_get_search_results(object, _options[:leaf]))
-    elsif count_only
-      services.size
-    else
+  def x_get_tree_custom_kids(object, count_only, options)
+    case object[:id]
+    when 'my', 'global'
+      # Get My Filters and Global Filters
+      count_only_or_objects(count_only, x_get_search_results(object, options[:leaf]))
+    when 'asrv', 'rsrv'
+      retired = object[:id] != 'asrv'
+      services = Rbac.filtered(Service.where(:retired => retired, :display => true))
+      return sevices.size if count_only
+
       MiqPreloader.preload(services.to_a, :picture)
       Service.arrange_nodes(services.sort_by { |n| [n.ancestry.to_s, n.name.downcase] })
     end

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -21,27 +21,33 @@ class TreeBuilderServices < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    objects = []
-    objects.push(:id            => "asrv",
-                 :text          => _("Active Services"),
-                 :icon          => "pficon pficon-folder-close",
-                 :load_children => true,
-                 :tip           => _("Active Services"))
-    objects.push(:id            => "rsrv",
-                 :text          => _("Retired Services"),
-                 :icon          => "pficon pficon-folder-close",
-                 :load_children => true,
-                 :tip           => _("Retired Services"))
-    objects.push(:id         => "global",
-                 :text       => _("Global Filters"),
-                 :icon       => "pficon pficon-folder-close",
-                 :selectable => false,
-                 :tip        => _("Global Shared Filters"))
-    objects.push(:id         => "my",
-                 :text       => _("My Filters"),
-                 :icon       => "pficon pficon-folder-close",
-                 :selectable => false,
-                 :tip        => _("My Personal Filters"))
+    objects = [
+      {
+        :id            => "asrv",
+        :text          => _("Active Services"),
+        :icon          => "pficon pficon-folder-close",
+        :load_children => true,
+        :tip           => _("Active Services")
+      }, {
+        :id            => "rsrv",
+        :text          => _("Retired Services"),
+        :icon          => "pficon pficon-folder-close",
+        :load_children => true,
+        :tip           => _("Retired Services")
+      }, {
+        :id         => "global",
+        :text       => _("Global Filters"),
+        :icon       => "pficon pficon-folder-close",
+        :selectable => false,
+        :tip        => _("Global Shared Filters")
+      }, {
+        :id         => "my",
+        :text       => _("My Filters"),
+        :icon       => "pficon pficon-folder-close",
+        :selectable => false,
+        :tip        => _("My Personal Filters")
+      }
+    ]
     count_only_or_objects(count_only, objects)
   end
 

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -19,34 +19,30 @@ class TreeBuilderServices < TreeBuilder
     {}
   end
 
+  def root_node(id, text, tip)
+    {
+      :id   => id,
+      :text => text,
+      :icon => 'pficon pficon-folder-close',
+      :tip  => tip
+    }
+  end
+
+  def services_root(id, name, tip)
+    root_node(id, name, tip).update(:load_children => true)
+  end
+
+  def filter_root(id, name, tip)
+    root_node(id, name, tip).update(:selectable => false)
+  end
+
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
     objects = [
-      {
-        :id            => "asrv",
-        :text          => _("Active Services"),
-        :icon          => "pficon pficon-folder-close",
-        :load_children => true,
-        :tip           => _("Active Services")
-      }, {
-        :id            => "rsrv",
-        :text          => _("Retired Services"),
-        :icon          => "pficon pficon-folder-close",
-        :load_children => true,
-        :tip           => _("Retired Services")
-      }, {
-        :id         => "global",
-        :text       => _("Global Filters"),
-        :icon       => "pficon pficon-folder-close",
-        :selectable => false,
-        :tip        => _("Global Shared Filters")
-      }, {
-        :id         => "my",
-        :text       => _("My Filters"),
-        :icon       => "pficon pficon-folder-close",
-        :selectable => false,
-        :tip        => _("My Personal Filters")
-      }
+      services_root('asrv', _('Active Services'),  _('Active Services')),
+      services_root('rsrv', _('Retired Services'), _('Retired Services')),
+      filter_root('global', _('Global Filters'),   _('Global Shared Filters')),
+      filter_root('my',     _('My Filters'),       _('My Personal Filters'))
     ]
     count_only_or_objects(count_only, objects)
   end

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -32,7 +32,7 @@
             %h3
               = _('VMs')
             - if @view
-              = render :partial => "layouts/gtl", :locals => {:view => @view}
+              = render :partial => "layouts/gtl", :locals => {:view => @view, :no_flash_div => true}
 
       - if @record.type == "ServiceAnsiblePlaybook"
         = miq_tab_content("provisioning", 'default', :class => 'cm-tab') do

--- a/app/views/service/show.html.haml
+++ b/app/views/service/show.html.haml
@@ -3,6 +3,6 @@
     - if @lastaction == 'generic_object' && @item
       = render :partial => "layouts/item", :locals => {:action_url => "show/#{@item}"}
     - else
-      = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+      = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}", :no_flash_div => true}
   - else
     = render :partial => 'layouts/textual_groups_generic'

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -199,5 +199,40 @@ describe ServiceController do
     end
   end
 
+  # Request URL: http://localhost:3000/service/tree_select?id=xx-asrv
+  context 'displaying a list of Active Services' do
+    describe '#tree_select' do
+      render_views
+
+      it 'renders GTL of Active services' do
+        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+          :model_name                     => 'Service',
+          :report_data_additional_options => {
+            :named_scope => [[:retired, false], :displayed]
+          }
+        )
+        post :tree_select, :params => {:id => 'xx-asrv'}
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
+  context 'displaying a list of Retired Services' do
+    describe '#tree_select' do
+      render_views
+
+      it 'renders GTL of Retired services' do
+        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+          :model_name                     => 'Service',
+          :report_data_additional_options => {
+            :named_scope => [:retired, :displayed]
+          }
+        )
+        post :tree_select, :params => {:id => 'xx-rsrv'}
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
   it_behaves_like "explorer controller with custom buttons"
 end

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -7,6 +7,13 @@ describe TreeBuilderServices do
     create_deep_tree
 
     expect(root_nodes.size).to eq(4)
+    expect(root_nodes).to match [
+      a_hash_including(:id => 'asrv'),
+      a_hash_including(:id => 'rsrv'),
+      a_hash_including(:id => 'global'),
+      a_hash_including(:id => 'my')
+    ]
+
     active_nodes = kid_nodes(root_nodes[0])
     retired_nodes = kid_nodes(root_nodes[1])
     expect(active_nodes).to eq(


### PR DESCRIPTION
The goal of this PR is to handle links from GO to services. Linking to services seem to have never been working before.

The code that handles links to services lives in `show` action. That is similar to other controllers.

I needed to revert the exceptional behavior introduced in 77124054987a8e740463d4b575cd33034ad84ea1 that produced links in the form:
http://localhost:3000/service/explorer/s-10000000000273
back to original:
http://localhost:3000/service/show/10000000000273

Commit "GTL: do not change `session[:sandboxes]`." fixes the root cause of the crashes after that. What happed is that the active tree is Services controller was set to `generic_object_tree`. This causes confusion in the `ServicesController`.

I needed to understand the `get_node_info` in Services so I removed dead code from there and added some test coverage for that.

I also needed to see clearly what nodes existed in the tree so I made that more explicit in the `TreeBuilderServices` and added a bit to the test coverage there. More changes originate in fixing of Rubocop and CC issues.

I fixed anoying "Duplicate DOM ID" messages in Service controller popping out everywhere under "My Services".

To test links from GO to services (well actually to test anything GO) one needs to create GO definitions and instances. Here is a tool to do that:
https://gist.github.com/martinpovolny/4d960e550a7838a9b04cb4d8396514b0
It should:
 1. Create a GO definition
 2. Create a GO (instance)
 3. Create a Service
 4. Assign Service to GO
 5. Add GO to the Service

The script can be run multiple times and each time it will add a new set of the entities.

Pinging also @h-kataria, @mzazrivec : please read, review. I think this can use more eyes.