### PR TITLE
escaped \\' in the output to get it to render/display output on screen.

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -164,6 +164,7 @@ class ServiceController < ApplicationController
     htm = stdout.gsub('"', '\"')
 
     regex_map = {
+      /\\'/ => "'",
       /'/  => "\\\\'",
       /{{/ => '\{\{',
       /}}/ => '\}\}'

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -131,8 +131,8 @@ describe ServiceController do
 
   context "#sanitize_output" do
     it "escapes characters in the output string" do
-      output = controller.send(:sanitize_output, "I'm \"Fred\" {{Flintstone}}")
-      expect(output).to eq("I\\'m \\\"Fred\\\" \\{\\{Flintstone\\}\\}")
+      output = controller.send(:sanitize_output, "I'm \"\\'Fred\\'\" {{Flintstone}}")
+      expect(output).to eq("I\\'m \\\"\\'Fred\\'\\\" \\{\\{Flintstone\\}\\}")
     end
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1451352

@syncrou please test.

before:
![before](https://user-images.githubusercontent.com/3450808/32964064-ee28a71a-cb9f-11e7-8696-82343b138a63.png)

after
![after](https://user-images.githubusercontent.com/3450808/32964069-f1a4ebf6-cb9f-11e7-8bb0-09a140b51b22.png)
