### PR TITLE
Spec to verify if `session[:edit]` is retained after picture GET request

### DIFF
--- a/spec/controllers/picture_controller_spec.rb
+++ b/spec/controllers/picture_controller_spec.rb
@@ -11,6 +11,18 @@ describe PictureController do
     picture.save
   end
 
+  context 'skip_before_action :get_global_session_data / skip_after_action :set_global_session_data' do
+    before do
+      session[:edit] = "abc"
+    end
+
+    it 'retains the existing value of session[:edit] after the GET request' do
+      get :show, :params => { :basename => "#{picture.compressed_id}.#{picture.extension}" }
+      expect(session[:edit]).to eq("abc")
+      expect(response.status).to eq(200)
+    end
+  end
+
   it 'can serve a picture directly from the database' do
     get :show, :params => { :basename => "#{picture.compressed_id}.#{picture.extension}" }
     expect(response.status).to eq(200)


### PR DESCRIPTION
Spec for https://github.com/ManageIQ/manageiq-ui-classic/pull/2756

Verifies if `session[:edit]` is retained after the picture GET request.

To be merged after https://github.com/ManageIQ/manageiq-ui-classic/pull/2756 is merged.