### PR TITLE
Fix to show "Cloud Credentials" drop down on Retirement tab

### DIFF
--- a/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
+++ b/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
@@ -215,15 +215,15 @@ function playbookReusableCodeMixin(API, $q, miqService) {
   };
 
   var cloudTypeChanged = function(vm, prefix, value) {
-    var valueChanged = (value !== vm.provisioning_cloud_type);
+    var valueChanged = (value !== vm[prefix + "_cloud_type"]);
     if (value) {
-      vm.provisioning_cloud_type = value;
+      vm[prefix + "_cloud_type"] = value;
     } else {
-      vm.provisioning_cloud_type = '';
+      vm[prefix + "_cloud_type"] = '';
     }
     if (valueChanged) {
-      var typ = vm.provisioning_cloud_type;
-      vm[vm.model].provisioning_cloud_credential_id = '';
+      var typ = vm[prefix + "_cloud_type"];
+      vm[vm.model][prefix + "_cloud_credential_id"] = '';
       getCloudCredentialsforType(prefix, typ, vm);
     }
   };


### PR DESCRIPTION
Both Provisioning & Retirement tabs have Cloud Type drop downs. Fixed cloudTypeChanged method to use prefix variable that is being passed in to determine which cloud type drop down is being edited in UI

https://bugzilla.redhat.com/show_bug.cgi?id=1510407

@syncrou can you please test/verify. Thanks.

before after selecting Cloud type on Retirement tab, Cloud Credentials drop down was missing:
![before](https://user-images.githubusercontent.com/3450808/32968920-049bae3c-cbb1-11e7-8fe5-d967445bd398.png)

after:
![after](https://user-images.githubusercontent.com/3450808/32968885-e0f634d4-cbb0-11e7-96dd-af935e5d4540.png)
