### PR TITLE
[WIP] refactoring ScheduleFormController as vm

### DIFF
--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -1,5 +1,6 @@
 ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 'scheduleFormId', 'oneMonthAgo', 'miqService', 'timerOptionService', function($http, $scope, scheduleFormId, oneMonthAgo, miqService, timerOptionService) {
   var init = function() {
+    console.log('schedule');
     $scope.scheduleModel = {
       action_typ: '',
       depot_name: '',


### PR DESCRIPTION
Configuration -> Settings -> Schedules ->Configuration -> Add new Schedule / Edit the selected Schedule



### Pull Request ###
- [x] scheduleFormController form seriliazing #3452 
- [ ] scheduleFormTimer partial to component #3454 
- [ ] scheduleFormFilter partial to component
  - [ ] editLogDepotSettingsAngularBootstrap partial to component #3470
  - [x] aeResolveOptions partial to component #3499 
  - [ ] authCredentials partial to component #3501 

### Refactoring progress ###
- [ ] uses as vm
- [ ] ManageIQ.angular.scope points to vm
- [ ] does not inject $scope unless needed for a $watch or events, or angularForm
- [ ] using a common button partial
- [ ] uses miq-form
- [ ] uses form-changed, no checkchange
- [ ] no separate edit & new, use the same partial
- [ ] specs
-  [ ] no copying values one by one - use Object.assign - I think that's valid even when only one value is being copied.
- [x] no miqAjaxButton(url, true) - always submit the actual model, don't rely on magic form serialization
- [ ] no extra $setPristine etc. where it doesn't make sense (form submit, form reset..)
- [ ] no if (condition) return true; else return false;
- [ ] no miqrequired, use required or ng-required