### PR TITLE
Fixed harmless missing CSS error in WebMKS remote consoles

### DIFF
--- a/app/views/vm_common/console_webmks.html.haml
+++ b/app/views/vm_common/console_webmks.html.haml
@@ -4,7 +4,7 @@
     %title
       = _('%{product_name} WebMKS Remote Console') % {:product_name => I18n.t('product.name')}
     = favicon_link_tag
-    = stylesheet_link_tag '/webmks/css/wmks-all.css', 'application', 'webmks'
+    = stylesheet_link_tag '/webmks/css/wmks-all.css', 'application'
     = javascript_include_tag 'jquery/dist/jquery.js', 'jquery-ui/jquery-ui.js', '/webmks/wmks.min.js', 'remote_console'
     :javascript
       $(function () {


### PR DESCRIPTION
Regression caused by #2662 FYI @bmclaughlin, it shows a 404 for a missing CSS file when opening a WebMKS console.

https://bugzilla.redhat.com/show_bug.cgi?id=1490640