### PR TITLE
Adjust the remote console views/controllers for WebMKS proxying

### DIFF
--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -27,15 +27,14 @@ module VmRemote
     @vm = @record = identify_record(params[:id], VmOrTemplate)
     options = case console_type
               when "webmks"
-                override_content_security_policy_directives(
-                  :connect_src => ["'self'", "wss://#{params[:host]}"]
-                )
-                {
-                  :webmks_uri => URI::Generic.build(:scheme => 'wss',
-                                                    :host   => params[:host],
-                                                    :port   => params[:port],
-                                                    :path   => "/ticket/#{params[:ticket]}")
+                # TODO: move this part to the launch_html5_console method
+                override_content_security_policy_directives(:connect_src => ["'self'", websocket_origin], :img_src => %w(data: self))
+                %i(secret url).each { |p| params.require(p) }
+                @console = {
+                  :url    => j(params[:url]),
+                  :secret => j(params[:secret])
                 }
+                {} # This is just for compatibility, see the TODO above
               when "vmrc"
                 host = @record.ext_management_system.hostname || @record.ext_management_system.ipaddress
                 vmid = @record.ems_ref

--- a/app/views/vm_common/console_webmks.html.haml
+++ b/app/views/vm_common/console_webmks.html.haml
@@ -14,7 +14,16 @@
             console.log("connection state change: connected");
           }
         });
-        wmks.connect("#{j webmks_uri.to_s}");
+
+        var host = window.location.hostname;
+        var encrypt = window.location.protocol === 'https:';
+        var port = encrypt ? 443 : 80;
+        if (window.location.port) {
+          port = window.location.port;
+        }
+        var proto = encrypt ? 'wss' : 'ws';
+
+        wmks.connect(proto + "://" + host + ":" + port + "/#{@console[:url]}");
 
         $('#ctrlaltdel').on('click', function() {
           wmks.sendCAD();


### PR DESCRIPTION
The WebMKS connections will be [proxied](https://github.com/ManageIQ/manageiq/pull/16490) through the `WebsocketWorker` similarly to VNC/SPICE. The required motifications in the UI might seem not the most ideal, but I tried to minimize the number of changes for backporting. I am planning to continue @bmclaughlin's effort with the [remote console unification](https://github.com/ManageIQ/manageiq-ui-classic/pull/2662) in a future PR.

https://bugzilla.redhat.com/show_bug.cgi?id=1504299