### PR TITLE
Explicitly disable broker for vSphere validation

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -156,7 +156,7 @@ module Mixins
           :metrics_database => params[:metrics_database_name],
         }]
       when 'ManageIQ::Providers::Vmware::InfraManager'
-        [{:pass => password, :user => user, :ip => params[:default_hostname]}]
+        [{:pass => password, :user => user, :ip => params[:default_hostname], :use_broker => false}]
       when 'ManageIQ::Providers::Nuage::NetworkManager'
         endpoint_opts = {:protocol => params[:default_security_protocol], :hostname => params[:default_hostname], :api_port => params[:default_api_port], :api_version => params[:api_version]}
         [user, params[:default_password], endpoint_opts]

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -349,6 +349,17 @@ describe EmsCloudController do
         expect(mocked_class).to receive(:validate_credentials_task)
         controller.send(:create_ems_button_validate)
       end
+
+      context "vmware infrastructure manager" do
+        let(:mocked_class) { ManageIQ::Providers::Vmware::InfraManager }
+        let(:mocked_class_controller) { "ems_infra" }
+
+        it "disables the broker" do
+          expected_validate_args = [{:pass => nil, :user => nil, :ip => nil, :use_broker => false}]
+          expect(mocked_class).to receive(:validate_credentials_task).with(expected_validate_args, nil, nil)
+          controller.send(:create_ems_button_validate)
+        end
+      end
     end
 
     context "with a container manager" do


### PR DESCRIPTION
The [`Vmware::InfraManager#verify_credentials`](https://github.com/ManageIQ/manageiq-providers-vmware/blob/master/app/models/manageiq/providers/vmware/infra_manager.rb#L133) method explicitly disabled
broker connections when verifying credentials so that new providers
aren't saved in the brokered connection list in addition to the issue
that the broker will not typically be running when validating
credentials for the first VMware provider.

When moving to `.validate_credentials_task` which calls `raw_connect` this
option wasn't passed in, but we were checking for `:fault_tolerant` and
using `MiqVim` instead of `MiqFaultTolerantVim` which implicitly doesn't use
the broker so everything worked fine.

In https://github.com/ManageIQ/manageiq/commit/cf1eae992eae10b38a3efec92b0d04cc68aa31ea we removed the `:fault_tolerant` option because it should always be
enabled, the `:use_broker` option is intended to control if we connect to
the broker or not.  This however broke the implicit skip broker option
that credential validation was using.

This mimics the `Vmware::InfraManager#verify_credentials` way of
explicitly disabling use of the broker by passing it as a task argument.