### PR TITLE
Added missing flash message

### DIFF
--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -1,5 +1,6 @@
 #dialog-editor{"ng-controller" => "dialogEditorController as vm"}
   %div{"ng-if" => "vm.dialog"}
+    = render :partial => "layouts/flash_msg"
     .row
       .col-md-12
         %h2= _("General")


### PR DESCRIPTION
Adding back missing flash message, that was removed by mistake in PR https://github.com/ManageIQ/manageiq-ui-classic/commit/ac550a199d#diff-f2a71f0771c7127acd96c99347571cf4L3

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/commit/ac550a199d#diff-f2a71f0771c7127acd96c99347571cf4L3
* https://bugzilla.redhat.com/show_bug.cgi?id=1514117
* https://bugzilla.redhat.com/show_bug.cgi?id=1511789

Steps for Testing/QA
-------------------------------

Try to add a dialog with a name, that already exists in the database

**Before**: no flash message was displayed

**Now**:
![screenshot from 2017-11-20 15-22-35](https://user-images.githubusercontent.com/1187051/33022943-fcaffef0-ce06-11e7-9869-5ecdf149295a.png)

/cc @d-m-u
