### PR TITLE
Move date_start logic from controllers to data/time_tag_options

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2052,13 +2052,6 @@ class CatalogController < ApplicationController
         presenter.hide(:toolbar)
         # incase it was hidden for summary screen, and incase there were no records on show_list
         presenter.hide(:form_buttons_div, :paging_div, :pc_div_1)
-        @record.dialog_fields.each do |field|
-          if ["DialogFieldDateControl", "DialogFieldDateTimeControl"].include?(field.type)
-            presenter[:build_calendar] = {
-              :date_from => field.show_past_dates ? nil : Time.zone.now,
-            }
-          end
-        end
         if Settings.product.old_dialog_user_ui
           presenter.show(:form_buttons_div, :buttons_on)
           presenter.update(

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -454,16 +454,6 @@ class ServiceController < ApplicationController
     # Clear the JS gtl_list_grid var if changing to a type other than list
     presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
 
-    if @record.kind_of?(Dialog)
-      @record.dialog_fields.each do |field|
-        if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
-          presenter[:build_calendar] = {
-            :date_from => field.show_past_dates ? nil : Time.zone.now,
-          }
-        end
-      end
-    end
-
     presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb, :custom => cb_tb)
 
     presenter.set_visibility(h_tb.present? || c_tb.present? || !v_tb.present?, :toolbar)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1263,16 +1263,6 @@ module VmCommon
         locals[:create_button] = true
       end
 
-      if @record.kind_of?(Dialog)
-        @record.dialog_fields.each do |field|
-          if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
-            presenter[:build_calendar] = {
-              :date_from => field.show_past_dates ? nil : Time.zone.now,
-            }
-          end
-        end
-      end
-
       if %w(ownership protect reconfigure retire tag).include?(@sb[:action])
         locals[:multi_record] = true    # need save/cancel buttons on edit screen even tho @record.id is not there
         locals[:record_id]    = @sb[:rec_id] || @edit[:object_ids][0] if @sb[:action] == "tag"

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -95,17 +95,16 @@ module ApplicationHelper::Dialogs
     miq_observe_options = {
       :url => url
     }.merge(auto_refresh_options(field, auto_refresh_options_hash)).to_json
-    extra_options = {"data-miq_observe_date" => miq_observe_options}
+    extra_options = {"data-miq_observe_date" => miq_observe_options,
+                     "data_date_start"       => field.show_past_dates ? nil : Time.zone.now.iso8601}
 
     add_options_unless_read_only(extra_options, tag_options, field)
   end
 
   def time_tag_options(field, url, hour_or_min, auto_refresh_options_hash)
     tag_options = {:class => "dynamic-date-#{hour_or_min}-#{field.id}"}
-    extra_options = {"data-miq_observe" => {
-      :url => url
-    }.merge(auto_refresh_options(field, auto_refresh_options_hash)).to_json}
-
+    extra_options = {"data_date_start"  => field.show_past_dates ? nil : Time.zone.now.iso8601,
+                     "data-miq_observe" => {:url => url}.merge(auto_refresh_options(field, auto_refresh_options_hash)).to_json}
     add_options_unless_read_only(extra_options, tag_options, field)
   end
 

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -6,6 +6,7 @@ describe ApplicationHelper::Dialogs do
       :read_only            => read_only,
       :trigger_auto_refresh => trigger_auto_refresh,
       :force_multi_value    => true,
+      :show_past_dates      => true,
     )
   end
   let(:trigger_auto_refresh) { nil }
@@ -345,6 +346,7 @@ describe ApplicationHelper::Dialogs do
           expect(helper.date_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
             :class                  => "css1 dynamic-date-100",
             :readonly               => "true",
+            "data_date_start"       => nil,
             "data-miq_observe_date" => {
               :url                             => "url",
               :auto_refresh                    => true,
@@ -367,6 +369,7 @@ describe ApplicationHelper::Dialogs do
           expect(helper.date_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
             :class                  => "css1 dynamic-date-100",
             :readonly               => "true",
+            "data_date_start"       => nil,
             "data-miq_observe_date" => '{"url":"url"}'
           )
         end
@@ -407,6 +410,7 @@ describe ApplicationHelper::Dialogs do
         it "returns the tag options with a few data-miq attributes" do
           expect(helper.time_tag_options(dialog_field, "url", "hour_or_min", auto_refresh_options_hash)).to eq(
             :class             => "dynamic-date-hour_or_min-100",
+            "data_date_start"  => nil,
             "data-miq_observe" => {
               :url                             => "url",
               :auto_refresh                    => true,
@@ -428,6 +432,7 @@ describe ApplicationHelper::Dialogs do
         it "returns the tag options with a few data-miq attributes" do
           expect(helper.time_tag_options(dialog_field, "url", "hour_or_min", auto_refresh_options_hash)).to eq(
             :class             => "dynamic-date-hour_or_min-100",
+            "data_date_start"  => nil,
             "data-miq_observe" => '{"url":"url"}'
           )
         end


### PR DESCRIPTION
Only for old dialogs -> `Settings.product.old_dialog_user_ui`

Automation -> Automate -> Customization -> Buttons -> add a custom button to VM or Service that has a dialog with date/time pickers(preferably one shows past dates and another doesn't)

Go to Vm/Service summary page and click custom button with dialog - > see date/time pickery
 
**Before:** all data/time_pickers were  set as last one
*One that is set to show past dates:*
<img width="543" alt="screen shot 2017-11-22 at 2 20 53 pm" src="https://user-images.githubusercontent.com/9210860/33129545-7d8008f6-cf90-11e7-8bb6-851add870036.png">
*One that is NOT set to show past dates:*
<img width="505" alt="screen shot 2017-11-22 at 2 20 58 pm" src="https://user-images.githubusercontent.com/9210860/33129546-80b247b4-cf90-11e7-9b3c-d5ccac778b1a.png">

**After:** it's set one by one
*One that is set to show past dates:*
<img width="506" alt="screen shot 2017-11-22 at 2 13 59 pm" src="https://user-images.githubusercontent.com/9210860/33129195-68c06ef2-cf8f-11e7-9edc-8791dd06eca3.png">
*One that is NOT set to show past dates:*
<img width="519" alt="screen shot 2017-11-22 at 2 14 05 pm" src="https://user-images.githubusercontent.com/9210860/33129198-6b6cddac-cf8f-11e7-8534-b95dabfcc0de.png">


@miq-bot add_label wip, bug, gaprindashvili/yes
