### PR TITLE
ansible_form_options - Remove dead ng-change

### DIFF
--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -39,7 +39,6 @@
                   'ng-options'       => "playbook as playbook.name for playbook in vm.#{prefix}_playbooks",
                   "required"         => "",
                   :miqrequired       => true,
-                  "ng-change"        => "playbookTypeChanged('#{prefix}')",
                   "data-live-search" => "true",
                   'pf-select'        => true}
             %option{"value" => ""}


### PR DESCRIPTION
`playbookTypeChanged` was removed in #761.

Removing the last reference.

Cc @h-kataria 