### PR TITLE
TenantComponent - don't error modal on validation errors

### DIFF
--- a/app/assets/javascripts/components/ops/tenant-component.js
+++ b/app/assets/javascripts/components/ops/tenant-component.js
@@ -64,7 +64,9 @@ function tenantFormController(API, miqService) {
 
   vm.saveWithAPI = function(method, url, saveObject, saveMsg) {
     miqService.sparkleOn();
-    API[method](url, saveObject)
+    API[method](url, saveObject, {
+      skipErrors: [400],  // server-side validation
+    })
       .then(miqService.redirectBack.bind(vm, saveMsg, 'success', vm.redirectUrl))
       .catch(miqService.handleFailure);
   };

--- a/spec/javascripts/components/ops/tenant-component_spec.js
+++ b/spec/javascripts/components/ops/tenant-component_spec.js
@@ -32,7 +32,17 @@ describe('tenant-component', function() {
       vm.tenantModel.description = 'newTenant_desc';
       vm.tenantModel.ancestry = null;
       vm.addClicked();
-      expect(API.post).toHaveBeenCalledWith('/api/tenants/', {name: vm.tenantModel.name, description: vm.tenantModel.description, divisible: true, parent: {id: vm.tenantModel.ancestry}});
+
+      expect(API.post).toHaveBeenCalledWith('/api/tenants/', {
+        name: vm.tenantModel.name,
+        description: vm.tenantModel.description,
+        divisible: true,
+        parent: {
+          id: vm.tenantModel.ancestry,
+        },
+      }, {
+        skipErrors: [400],
+      });
       expect(miqService.redirectBack.bind).toHaveBeenCalledWith(vm, 'Tenant \"newTenant\" has been successfully added.', 'success', vm.redirectUrl);
     });
   });
@@ -92,7 +102,10 @@ describe('tenant-component', function() {
       expect(API.put).toHaveBeenCalledWith('/api/tenants/1111', {
         name: vm.tenantModel.name,
         description: vm.tenantModel.description,
-        use_config_for_attributes: vm.tenantModel.use_config_for_attributes,});
+        use_config_for_attributes: vm.tenantModel.use_config_for_attributes,
+      }, {
+        skipErrors: [400],
+      });
       expect(miqService.redirectBack.bind).toHaveBeenCalledWith(vm, 'Tenant \"xyz\" has been successfully saved.', 'success', vm.redirectUrl);
     });
   });


### PR DESCRIPTION
user > Configuration > Access Control - Tenant - add a new tenant with a duplicate name

Don't show the error modal on validation errors - this time in TenantComponent.

https://bugzilla.redhat.com/show_bug.cgi?id=1507852