### PR TITLE
Fix tagging issus for Configuration Management Providers and Configured Systems

### DIFF
--- a/app/helpers/application_helper/toolbar/configuration_manager_provider_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_manager_provider_center.rb
@@ -31,19 +31,4 @@ class ApplicationHelper::Toolbar::ConfigurationManagerProviderCenter < Applicati
       ]
     ),
   ])
-  button_group('configuration_manager_policy', [
-    select(
-      :configuration_manager_policy_choice,
-      'fa fa-shield fa-lg',
-      t = N_('Policy'),
-      t,
-      :items => [
-        button(
-          :configuration_manager_provider_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit Tags for this Ansible Tower Providers'),
-          N_('Edit Tags'))
-      ]
-    )
-  ])
 end


### PR DESCRIPTION
- Use the corresponding model according to the node selected when tagging
- Remove the tagging menu item for the Configuration Profiles list 
- Specs


Links 
-------
https://bugzilla.redhat.com/show_bug.cgi?id=1512116

Steps for Testing/QA 
---------------------------

1. Add a Foreman provider, refresh
2. Select a Manager and a Configuration Profile
3. Select a configured system by checking it from either the list in the Configuration Profile or from it's summary page and tryy tagging
