### PR TITLE
Fixed visibility of form buttons, paging div etc in Catalog Explorer

### DIFF
--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -24,6 +24,7 @@ module ApplicationController::DialogRunner
   def dialog_form_button_pressed
     case params[:button]
     when "cancel"
+      return unless load_edit("dialog_edit__#{params[:id]}", "replace_cell__explorer")
       flash = _("Service Order was cancelled by the user")
       dialog_cancel_form(flash)
     when "submit"

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2051,7 +2051,7 @@ class CatalogController < ApplicationController
       elsif action == "dialog_provision"
         presenter.hide(:toolbar)
         # incase it was hidden for summary screen, and incase there were no records on show_list
-        presenter.show(:paging_div, :form_buttons_div).hide(:pc_div_1)
+        presenter.hide(:form_buttons_div, :paging_div, :pc_div_1)
         @record.dialog_fields.each do |field|
           if ["DialogFieldDateControl", "DialogFieldDateTimeControl"].include?(field.type)
             presenter[:build_calendar] = {
@@ -2060,6 +2060,7 @@ class CatalogController < ApplicationController
           end
         end
         if Settings.product.old_dialog_user_ui || action_name != "svc_catalog_provision"
+          presenter.show(:form_buttons_div, :buttons_on)
           presenter.update(
             :form_buttons_div,
             r[
@@ -2084,10 +2085,10 @@ class CatalogController < ApplicationController
         presenter.update(:form_buttons_div, r[:partial => "layouts/x_edit_buttons", :locals => locals])
       else
         # Added so buttons can be turned off even tho div is not being displayed it still pops up Abandon changes box when trying to change a node on tree after saving a record
-        presenter.hide(:buttons_on).show(:toolbar).hide(:paging_div)
+        presenter.hide(:buttons_on, :form_buttons_div).show(:toolbar).hide(:paging_div)
       end
     else
-      presenter.show(:form_buttons_div, :pc_div_1, :toolbar, :paging_div)
+      presenter.hide(:form_buttons_div).show(:pc_div_1, :toolbar, :paging_div)
     end
 
     presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb)


### PR DESCRIPTION
- When ordering a Service Catalog, form buttons were displayed along with paging div randomly and sometimes submit button was not enabled. Fixed several issues with form buttons visibility.
- Fixed an error when pressing "cancel" on Service catalog order screen, this was only happening when pressing going to order screen from Service Catalog details screen.

@lgalis please test/review.

before:
![before1](https://user-images.githubusercontent.com/3450808/33040767-159733cc-ce0a-11e7-8037-fe6ab8e503d4.png)
![before2](https://user-images.githubusercontent.com/3450808/33040773-17709576-ce0a-11e7-9883-8a85c3502b87.png)
![before3](https://user-images.githubusercontent.com/3450808/33040777-1a8cae8e-ce0a-11e7-98c7-f6725c891e00.png)


after:
![after1](https://user-images.githubusercontent.com/3450808/33040754-0ec8196c-ce0a-11e7-8378-071ecf6fa5df.png)

![after2](https://user-images.githubusercontent.com/3450808/33040760-122c8296-ce0a-11e7-8ff0-f50c0b3b8fdc.png)
