### PR TITLE
Fix Ansible Tower provider node tagging to take into account the selected node model

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -47,7 +47,7 @@ class AutomationManagerController < ApplicationController
     case x_active_accord
     when :automation_manager_providers
       assert_privileges("automation_manager_provider_tag")
-      tagging_edit('ManageIQ::Providers::AnsibleTower::AutomationManager', false)
+      tagging_edit(class_for_provider_node.to_s, false)
     when :automation_manager_cs_filter
       assert_privileges("automation_manager_configured_system_tag")
       tagging_edit('ConfiguredSystem', false)
@@ -100,18 +100,22 @@ class AutomationManagerController < ApplicationController
       end
   end
 
-  def automation_manager_providers_tree_rec
+  def class_for_provider_node
     nodes = x_node.split('-')
     case nodes.first
-    when "root" then find_record(ManageIQ::Providers::AnsibleTower::AutomationManager, params[:id])
-    when "at", "e" then find_record(ManageIQ::Providers::AutomationManager::InventoryRootGroup, params[:id])
-    when "f"    then find_record(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem, params[:id])
+    when "root" then ManageIQ::Providers::AnsibleTower::AutomationManager
+    when "at", "e" then ManageIQ::Providers::AutomationManager::InventoryRootGroup
+    when "f"    then ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem
     when "xx" then
       case nodes.second
-      when "at"  then find_record(ManageIQ::Providers::AnsibleTower::AutomationManager, params[:id])
-      when "csa" then find_record(ConfiguredSystem, params[:id])
+      when "at"  then ManageIQ::Providers::AnsibleTower::AutomationManager
+      when "csa" then ConfiguredSystem
       end
     end
+  end
+
+  def automation_manager_providers_tree_rec
+    find_record(class_for_provider_node, params[:id])
   end
 
   def automation_manager_cs_filter_tree_rec

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -105,7 +105,7 @@ class AutomationManagerController < ApplicationController
     case nodes.first
     when "root" then ManageIQ::Providers::AnsibleTower::AutomationManager
     when "at", "e" then ManageIQ::Providers::AutomationManager::InventoryRootGroup
-    when "f"    then ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem
+    when "f", "cs"    then ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem
     when "xx" then
       case nodes.second
       when "at"  then ManageIQ::Providers::AnsibleTower::AutomationManager

--- a/app/helpers/application_helper/toolbar/automation_manager_provider_center.rb
+++ b/app/helpers/application_helper/toolbar/automation_manager_provider_center.rb
@@ -34,19 +34,4 @@ class ApplicationHelper::Toolbar::AutomationManagerProviderCenter < ApplicationH
       ]
     ),
   ])
-  button_group('automation_manager_policy', [
-    select(
-      :automation_manager_policy_choice,
-      'fa fa-shield fa-lg',
-      t = N_('Policy'),
-      t,
-      :items => [
-        button(
-          :automation_manager_provider_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit Tags for this Ansible Tower Providers'),
-          N_('Edit Tags'))
-      ]
-    )
-  ])
 end

--- a/app/helpers/application_helper/toolbar/configured_system/automation/policy_mixin.rb
+++ b/app/helpers/application_helper/toolbar/configured_system/automation/policy_mixin.rb
@@ -1,4 +1,4 @@
-module ApplicationHelper::Toolbar::ConfiguredSystem::AutomationPolicyMixin
+module ApplicationHelper::Toolbar::ConfiguredSystem::Automation::PolicyMixin
   def self.included(included_class)
     included_class.button_group('automation_manager_policy', [
        included_class.select(

--- a/app/helpers/application_helper/toolbar/configured_system/foreman/lifecycle_mixin.rb
+++ b/app/helpers/application_helper/toolbar/configured_system/foreman/lifecycle_mixin.rb
@@ -1,4 +1,4 @@
-module ApplicationHelper::Toolbar::ConfiguredSystem::LifecycleMixin
+module ApplicationHelper::Toolbar::ConfiguredSystem::Foreman::LifecycleMixin
   def self.included(included_class)
     included_class.button_group('provider_foreman_lifecycle', [
       included_class.select(

--- a/app/helpers/application_helper/toolbar/configured_system/foreman/policy_mixin.rb
+++ b/app/helpers/application_helper/toolbar/configured_system/foreman/policy_mixin.rb
@@ -1,4 +1,4 @@
-module ApplicationHelper::Toolbar::ConfiguredSystem::PolicyMixin
+module ApplicationHelper::Toolbar::ConfiguredSystem::Foreman::PolicyMixin
   def self.included(included_class)
     included_class.button_group('provider_foreman_policy', [
       included_class.select(

--- a/app/helpers/application_helper/toolbar/configured_systems_ansible_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_systems_ansible_center.rb
@@ -1,3 +1,3 @@
 class ApplicationHelper::Toolbar::ConfiguredSystemsAnsibleCenter < ApplicationHelper::Toolbar::Basic
-  include ApplicationHelper::Toolbar::ConfiguredSystem::PolicyMixin
+  include ApplicationHelper::Toolbar::ConfiguredSystem::Automation::PolicyMixin
 end

--- a/app/helpers/application_helper/toolbar/configured_systems_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_systems_center.rb
@@ -1,4 +1,4 @@
 class ApplicationHelper::Toolbar::ConfiguredSystemsCenter < ApplicationHelper::Toolbar::Basic
-  include ApplicationHelper::Toolbar::ConfiguredSystem::LifecycleMixin
-  include ApplicationHelper::Toolbar::ConfiguredSystem::PolicyMixin
+  include ApplicationHelper::Toolbar::ConfiguredSystem::Foreman::LifecycleMixin
+  include ApplicationHelper::Toolbar::ConfiguredSystem::Foreman::PolicyMixin
 end

--- a/app/helpers/application_helper/toolbar/unassigned_profiles_group_center.rb
+++ b/app/helpers/application_helper/toolbar/unassigned_profiles_group_center.rb
@@ -1,4 +1,4 @@
 class ApplicationHelper::Toolbar::UnassignedProfilesGroupCenter < ApplicationHelper::Toolbar::Basic
-  include ApplicationHelper::Toolbar::ConfiguredSystem::LifecycleMixin
-  include ApplicationHelper::Toolbar::ConfiguredSystem::PolicyMixin
+  include ApplicationHelper::Toolbar::ConfiguredSystem::Foreman::LifecycleMixin
+  include ApplicationHelper::Toolbar::ConfiguredSystem::Foreman::PolicyMixin
 end

--- a/app/helpers/application_helper/toolbar/x_automation_manager_ansible_tower_configured_system_center.rb
+++ b/app/helpers/application_helper/toolbar/x_automation_manager_ansible_tower_configured_system_center.rb
@@ -1,3 +1,22 @@
 class ApplicationHelper::Toolbar::XAutomationManagerAnsibleTowerConfiguredSystemCenter < ApplicationHelper::Toolbar::Basic
-  include ApplicationHelper::Toolbar::ConfiguredSystem::AutomationPolicyMixin
+  button_group('record_summary', [
+    select(
+      :automation_manager_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :enabled => true,
+      :items   => [
+        button(
+          :configured_system_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for this Configured System'),
+          N_('Edit Tags'),
+          :url          => "tagging",
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :enabled      => true),
+      ]
+    ),
+  ])
 end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -598,7 +598,7 @@ class ApplicationHelper::ToolbarChooser
     when "f"        then  inventory_group_center_tb
     when "xx"       then
       case nodes.last
-      when "f"  then "configured_systems_ansible_center_tb"
+      when "f"  then "configured_systems_center_tb"
       when "cp" then "unassigned_profiles_group_center_tb"
       else "configuration_manager_providers_center_tb"
       end


### PR DESCRIPTION
Fix Ansible Tower provider node tagging to take into account the selected node model


Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1510821


Steps for Testing/QA 
---------------------------
Tagging a configured system in the Ansible Provider Manager accordion
