### PR TITLE
Make /report_data protect @lastaction. Fix "No items were selected for XXXXX"

### DIFF
--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -17,7 +17,8 @@ class ApplicationController
     :listicon,
     :embedded,
     :showlinks,
-    :policy_sim
+    :policy_sim,
+    :lastaction
   ) do
     def self.from_options(options)
       additional_options = new
@@ -38,6 +39,7 @@ class ApplicationController
       self.embedded   = options[:embedded]
       self.showlinks  = options[:showlinks]
       self.policy_sim = options[:policy_sim]
+      self.lastaction = options[:lastaction]
     end
 
     def with_row_button(row_button)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1636,7 +1636,8 @@ module ApplicationHelper
       :listicon   => @listicon,
       :embedded   => @embedded,
       :showlinks  => @showlinks,
-      :policy_sim => @policy_sim
+      :policy_sim => @policy_sim,
+      :lastaction => @lastaction
     )
     @report_data_additional_options.with_row_button(@row_button) if @row_button
     @report_data_additional_options.with_menu_click(params[:menu_click]) if params[:menu_click]

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -19,6 +19,14 @@ describe VmInfraController do
   render_views
 
   it 'can render the explorer' do
+    expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      :model_name                     => 'VmOrTemplate',
+      :report_data_additional_options => {
+        :model      => "VmOrTemplate",
+        :lastaction => 'show_list'
+      }
+    )
+
     get :explorer
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty


### PR DESCRIPTION
The `@lastaction` is lost in `/report_data` due to a regression in 
https://github.com/ManageIQ/manageiq-ui-classic/pull/2669

GTL should pass last action and last action should stay unchanged through the /report_data request.

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1514334

**Before:**
![retire1](https://user-images.githubusercontent.com/13417815/33073044-e6e1d998-cec1-11e7-990d-5870b773d873.png)

**After:**
![retire2](https://user-images.githubusercontent.com/13417815/33072914-8891b5de-cec1-11e7-8c6b-6d0ca115ad28.png)
