### PR TITLE
Label tag mapping form requires url_for_only_path

### DIFF
--- a/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
+++ b/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
@@ -1,6 +1,7 @@
 describe 'ops/_label_tag_mapping_form.html.haml' do
   before do
     assign(:sb, :active_tab => 'settings_label_tag_mapping')
+    allow(view).to receive(:url_for_only_path).and_return("test")
   end
 
   context 'add new mapping' do


### PR DESCRIPTION
Fix label tag mapping form spec test which needs url_for_only_path on
the view.

cc @h-kataria