### PR TITLE
Fix test errors with :container_label_tag_mapping factory

### DIFF
--- a/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
+++ b/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
@@ -41,7 +41,7 @@ describe 'ops/_label_tag_mapping_form.html.haml' do
 
   context 'edit existing mapping' do
     before(:each) do
-      @lt_map = FactoryGirl.create(:container_label_tag_mapping)
+      @lt_map = FactoryGirl.create(:tag_mapping_with_category)
       @edit = {:id  => nil,
                :new => {:options    => [["<All>", nil]],
                         :entity     => nil,


### PR DESCRIPTION
Alternative to https://github.com/ManageIQ/manageiq/pull/16517

https://github.com/ManageIQ/manageiq/pull/16501 added validation that ContainerLabelTagMapping has a Tag, appropriately named, and with a read_only Classification.

The UI has always created mappings satisfying all this (it's just now core started depending on these assumptions).

But this test didn't create Tag & Classification, only a ContainerLabelTagMapping, which no longer works:
https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/305345808#L2351-L2381

=> Switch to recently added factory that ensures such Tag & Classification.

@miq-bot add-label test, gaprindashvili/yes
https://github.com/ManageIQ/manageiq/pull/16501 is gaprindashvili/backported, and broke manageiq-ui-classic on gaprindashvili too.

@h-kataria @agrare @NickLaMuro what do you think?