### PR TITLE
Fixed if condition to check for action instead of action_name

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2059,7 +2059,7 @@ class CatalogController < ApplicationController
             }
           end
         end
-        if Settings.product.old_dialog_user_ui || action_name != "svc_catalog_provision"
+        if Settings.product.old_dialog_user_ui
           presenter.show(:form_buttons_div, :buttons_on)
           presenter.update(
             :form_buttons_div,


### PR DESCRIPTION
When Order button is clicked from list view, action_name value is sent up as x_button making the code go thru if condition and show double buttons on screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1514593

@gmcculloug please test.