### PR TITLE
Add `long_id`s (original, uncompressed id's) in ManageIQ.gridChecks

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -242,15 +242,15 @@
   */
   ReportDataController.prototype.onItemSelect = function(item, isSelected) {
     if (typeof item !== 'undefined') {
-      var selectedItem = _.find(this.gtlData.rows, {id: item.id});
+      var selectedItem = _.find(this.gtlData.rows, {long_id: item.long_id});
       if (selectedItem) {
         selectedItem.checked = isSelected;
         selectedItem.selected = isSelected;
         this.$window.sendDataWithRx({rowSelect: selectedItem});
         if (isSelected) {
-          ManageIQ.gridChecks.push(item.id);
+          ManageIQ.gridChecks.push(item.long_id);
         } else {
-          var index = ManageIQ.gridChecks.indexOf(item.id);
+          var index = ManageIQ.gridChecks.indexOf(item.long_id);
           index !== -1 && ManageIQ.gridChecks.splice(index, 1);
         }
       }

--- a/spec/javascripts/controllers/report_data_controller_spec.js
+++ b/spec/javascripts/controllers/report_data_controller_spec.js
@@ -126,44 +126,47 @@ describe('reportDataController', function () {
 
     it('should select item and call rowSelect', function() {
       var itemId = "10";
+      var itemLongId = "10";
       var selected = true;
       spyOn(window, 'sendDataWithRx');
-      $controller.onItemSelect({id: itemId}, selected);
+      $controller.onItemSelect({id: itemId, long_id: itemLongId}, selected);
       selectedItem = $controller.gtlData.rows.filter(function(item) {
-        return item.id === itemId;
+        return item.long_id === itemLongId;
       });
       expect(selectedItem[0].checked).toBe(selected);
       expect(selectedItem[0].selected).toBe(selected);
       expect(window.sendDataWithRx).toHaveBeenCalledWith({rowSelect: selectedItem[0]});
-      expect(ManageIQ.gridChecks.indexOf(itemId) !== -1).toBeTruthy();
+      expect(ManageIQ.gridChecks.indexOf(itemLongId) !== -1).toBeTruthy();
     });
 
     it('should deselect item and call rowSelect', function() {
       var itemId = "10";
+      var itemLongId = "10";
       var selected = false;
       spyOn(window, 'sendDataWithRx');
-      $controller.onItemSelect({id: itemId}, selected);
+      $controller.onItemSelect({id: itemId, long_id: itemLongId}, selected);
       selectedItem = $controller.gtlData.rows.filter(function(item) {
-        return item.id === itemId;
+        return item.long_id === itemLongId;
       });
       expect(selectedItem[0].checked).toBe(selected);
       expect(selectedItem[0].selected).toBe(selected);
       expect(window.sendDataWithRx).toHaveBeenCalledWith({rowSelect: selectedItem[0]});
-      expect(ManageIQ.gridChecks.indexOf(itemId) === -1).toBeTruthy();
+      expect(ManageIQ.gridChecks.indexOf(itemLongId) === -1).toBeTruthy();
     });
 
     it('should create redirect for non explorer click on item', function() {
       var itemId = "10";
+      var itemLongId = "10";
       var clickEvent = $.Event('click');
       initObject.isExplorer = false;
       spyOn(clickEvent, 'stopPropagation');
       spyOn(clickEvent, 'preventDefault');
       spyOn(window, 'DoNav');
       selectedItem = $controller.gtlData.rows.filter(function(item) {
-        return item.id === itemId;
+        return item.long_id === itemLongId;
       });
       $controller.onItemClicked(selectedItem[0], clickEvent);
-      expect(window.DoNav).toHaveBeenCalledWith(initObject.showUrl + '/' + selectedItem[0].id);
+      expect(window.DoNav).toHaveBeenCalledWith(initObject.showUrl + '/' + selectedItem[0].long_id);
       expect(clickEvent.stopPropagation).toHaveBeenCalled();
       expect(clickEvent.preventDefault).toHaveBeenCalled();
     });

--- a/spec/javascripts/fixtures/json/report_data_response.json
+++ b/spec/javascripts/fixtures/json/report_data_response.json
@@ -85,6 +85,7 @@
       "rows":[
          {
             "id":"12",
+            "long_id":"12",
             "cells":[
                {
                   "is_checkbox":true
@@ -133,6 +134,7 @@
          },
          {
             "id":"53",
+            "long_id":"53",
             "cells":[
                {
                   "is_checkbox":true
@@ -181,6 +183,7 @@
          },
          {
             "id":"52",
+            "long_id":"52",
             "cells":[
                {
                   "is_checkbox":true
@@ -229,6 +232,7 @@
          },
          {
             "id":"51",
+            "long_id":"51",
             "cells":[
                {
                   "is_checkbox":true
@@ -277,6 +281,7 @@
          },
          {
             "id":"50",
+            "long_id":"50",
             "cells":[
                {
                   "is_checkbox":true
@@ -325,6 +330,7 @@
          },
          {
             "id":"49",
+            "long_id":"49",
             "cells":[
                {
                   "is_checkbox":true
@@ -373,6 +379,7 @@
          },
          {
             "id":"11",
+            "long_id":"11",
             "cells":[
                {
                   "is_checkbox":true
@@ -421,6 +428,7 @@
          },
          {
             "id":"10",
+            "long_id":"10",
             "cells":[
                {
                   "is_checkbox":true
@@ -469,6 +477,7 @@
          },
          {
             "id":"48",
+            "long_id":"48",
             "cells":[
                {
                   "is_checkbox":true
@@ -517,6 +526,7 @@
          },
          {
             "id":"47",
+            "long_id":"47",
             "cells":[
                {
                   "is_checkbox":true
@@ -565,6 +575,7 @@
          },
          {
             "id":"46",
+            "long_id":"46",
             "cells":[
                {
                   "is_checkbox":true
@@ -613,6 +624,7 @@
          },
          {
             "id":"45",
+            "long_id":"45",
             "cells":[
                {
                   "is_checkbox":true
@@ -661,6 +673,7 @@
          },
          {
             "id":"9",
+            "long_id":"9",
             "cells":[
                {
                   "is_checkbox":true
@@ -709,6 +722,7 @@
          },
          {
             "id":"8",
+            "long_id":"8",
             "cells":[
                {
                   "is_checkbox":true
@@ -757,6 +771,7 @@
          },
          {
             "id":"7",
+            "long_id":"7",
             "cells":[
                {
                   "is_checkbox":true
@@ -805,6 +820,7 @@
          },
          {
             "id":"6",
+            "long_id":"6",
             "cells":[
                {
                   "is_checkbox":true
@@ -853,6 +869,7 @@
          },
          {
             "id":"5",
+            "long_id":"5",
             "cells":[
                {
                   "is_checkbox":true
@@ -901,6 +918,7 @@
          },
          {
             "id":"44",
+            "long_id":"44",
             "cells":[
                {
                   "is_checkbox":true
@@ -949,6 +967,7 @@
          },
          {
             "id":"43",
+            "long_id":"43",
             "cells":[
                {
                   "is_checkbox":true
@@ -997,6 +1016,7 @@
          },
          {
             "id":"42",
+            "long_id":"42",
             "cells":[
                {
                   "is_checkbox":true


### PR DESCRIPTION
Noticed that `ManageIQ.gridChecks` now contains compressed id's instead of the non-compressed ids (or long ids).

This seems like a recent change...

and has introduced a bug, because newer screens like Physical Servers and Generic Object Definitions, use the id to pass it to the REST API for a Delete operation

Since the API does not recognize the compressed id, it causes a 404 error.

The change in the PR fixes the issue.
Although, I would need @karelhala input here, because we did not need this code before.

@karelhala Any idea what changed? Also should this be fixed some place else (and not here)?