### PR TITLE
Fix quadicon on VM drift page

### DIFF
--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -15,23 +15,7 @@
       %div{:style => "position: relative; width: 152px; height: #{height}; z-index: 0; margin: 0px auto;"}
         - if %w(MiqTemplate VmOrTemplate Vm).include?(@sb[:compare_db])
           - if settings(:quadicons, :vm)
-            .flobj
-              %img{:src => image_path("layout/base.svg")}
-            %div{:class => "flobj b72"}
-              - if @drift_obj.template?
-                - if @drift_obj.host
-                  %img{:src => image_path('100/template.png')}
-                - else
-                  %img{:src => image_path('100/template-no-host.png')}
-              - else
-                %img{:src => image_path("svg/currentstate-#{h(@drift_obj.current_state.downcase)}.svg")}
-            %div{:class => "flobj c72"}
-              %img{:src => image_path("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg")}
-            %div{:class => "flobj a72"}
-              %img{:src => image_path("svg/os-#{h(@drift_obj.os_image_name.downcase)}.svg")}
-            %div{:class => "flobj d72"}
-              %p
-                = @drift_obj.number_of(:snapshots)
+            = render_quadicon(@drift_obj, :mode => :icon, :size => 72, :height => height, :typ => :listnav)
           - else
             .flobj
               %img{:src => image_path("layout/base-single.png")}


### PR DESCRIPTION
Before:
![1502773-before](https://user-images.githubusercontent.com/1630348/33098065-1a77f89c-ceda-11e7-9e9f-e196310ff956.png)

After:
![1502773-after](https://user-images.githubusercontent.com/1630348/33098076-1f0686d0-ceda-11e7-99d4-e16dd36baa5e.png)

@miq-bot add_labels bug, compute/infrastructure, gaprindashvili/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1502773