### PR TITLE
QuadiconHelper: fix: capture quadicon_url_to_xshow_from_cid.

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -461,7 +461,7 @@ module QuadiconHelper
     link_opts = {}
 
     if quadicon_show_links?
-      quadicon_url_to_xshow_from_cid(item, options)
+      url = quadicon_url_to_xshow_from_cid(item, options)
       link_opts = {:sparkle => true, :remote => true}
     end
 


### PR DESCRIPTION
A small follow up for:
https://github.com/ManageIQ/manageiq-ui-classic/pull/2758

The problem does not surface as a bug, but should be fixed anyway.

ping @AparnaKarve, @himdel 