### PR TITLE
Fix unnecessary separator at monitoring/all_alerts view

### DIFF
--- a/app/assets/javascripts/controllers/alerts/alerts_list_controller.js
+++ b/app/assets/javascripts/controllers/alerts/alerts_list_controller.js
@@ -69,7 +69,7 @@ angular.module('alertsCenter').controller('alertsListController',
         filterConfig: vm.filterConfig,
         sortConfig: vm.sortConfig,
         actionsConfig: {
-          actionsInclude: true,
+          actionsInclude: false,
         },
       };
     }


### PR DESCRIPTION
Currently we show an unnecessary separator at `Monitoring > All Alerts` view - Possibly for more action items? (buttons, drop-downs etc.)
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1513410
_Screenshots_
Before:
![screenshot from 2017-11-22 12-46-43](https://user-images.githubusercontent.com/8366181/33124029-81649736-cf84-11e7-8f94-883019a1a236.png)
After:
![screenshot from 2017-11-22 12-47-01](https://user-images.githubusercontent.com/8366181/33124033-83f14242-cf84-11e7-8371-0d8dee574998.png)

cc: @himdel @moolitayer 