### PR TITLE
GTLs: use ExplorerPresenter to fix styles in Services.

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -149,6 +149,11 @@ ManageIQ.explorer.focus = function(data) {
   }
 };
 
+ManageIQ.explorer.removeSand = function() {
+  var mainContent = $('#main-content');
+  mainContent.removeClass('miq-sand-paper');
+};
+
 ManageIQ.explorer.processReplaceRightCell = function(data) {
   /* variables for the expression editor */
   if (_.isObject(data.expEditor)) {
@@ -291,6 +296,8 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
   if (data.hideModal) { $('#quicksearchbox').modal('hide'); }
   if (data.initAccords) { miqInitAccordions(); }
   if (data.lockSidebar !== undefined) { ManageIQ.explorer.lockSidebar(data.lockSidebar); }
+
+  if (data.removeSand) { ManageIQ.explorer.removeSand(); }
 
   if (_.isString(data.ajaxUrl)) {
     miqAsyncAjax(data.ajaxUrl);

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -411,6 +411,7 @@ class ServiceController < ApplicationController
       elsif params[:display]
         r[:partial => 'layouts/x_gtl', :locals => {:controller => "vm", :action_url => @lastaction}]
       elsif record_showing
+        presenter.remove_sand
         if action
           partial_locals[:item_id] = @item.id
           cb_tb = build_toolbar(Mixins::CustomButtons::Result.new(:single))

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -78,8 +78,14 @@ class ExplorerPresenter
       :show_miq_buttons     => false,
       :load_chart           => nil,
       :open_window          => nil,
+      :remove_sand          => nil,
       :rx                   => nil,
     }.update(options)
+  end
+
+  def remove_sand
+    @options[:remove_sand] = true
+    self
   end
 
   def reset_changes
@@ -296,6 +302,7 @@ class ExplorerPresenter
     data[:lockSidebar] = !!@options[:lock_sidebar]
     data[:chartData] = @options[:load_chart]
     data[:resetChanges] = !!@options[:reset_changes]
+    data[:removeSand] = !!@options[:remove_sand]
     data[:resetOneTrans] = !!@options[:reset_one_trans]
     data[:oneTransIE] = !!@options[:one_trans_ie]
     data[:focus] = @options[:focus]

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -28,7 +28,7 @@
                       %td
                         = h(s.name)
         .row
-          .col-md-12.col-lg-6
+          .col-md-12
             %h3
               = _('VMs')
             - if @view


### PR DESCRIPTION
The GTL sets 'miq-sand-paper' on the 'main_content'. But when navigating
using the left tree it has no way to set the style back.

Adding this so that the ExplorerPresenter can remove the
'miq-sand-paper' style.

This fixes the styling in the ServicesController.

Before:
![b1](https://user-images.githubusercontent.com/51095/33140541-95a405ac-cfb0-11e7-9e1c-68c9da528017.png)

After:
![a1](https://user-images.githubusercontent.com/51095/33140538-93159dd2-cfb0-11e7-91fc-1face5f392bc.png)
