### PR TITLE
Store the session data in the right format for OPS/help_menu

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1156,7 +1156,7 @@ module OpsController::Settings::Common
       when "settings_help_menu"
         @in_a_form = true
         @edit = {:new => {}, :key => 'customize_help_menu'}
-        @edit[:new] = Settings.help_menu
+        @edit[:new] = Settings.help_menu.to_h
         help_menu_items.each do |item|
           @edit[:new][item] = Settings.help_menu.try(item).try(:to_h) || {}
         end

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -218,5 +218,19 @@ describe OpsController do
         expect(assigns(:flash_array).first[:message]).to include("Replication configuration save was successful")
       end
     end
+
+    describe '#settings_get_info' do
+      before { MiqRegion.seed }
+
+      let(:edit) { controller.instance_variable_get(:@edit) }
+
+      context 'help menu' do
+        it 'current and new in the edit hash equals' do
+          controller.instance_variable_set(:@sb, :active_tab => 'settings_help_menu')
+          controller.send(:settings_get_info, 'root-0')
+          expect(edit[:new]).to eq(edit[:current])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The `Settings` class doesn't play well with the `OpsController#edit_changed?` method. This caused the submit button to be enabled under certain conditions under `Settings -> Region (node) -> Help Menu (tab)`. 

For more details see the BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1511427

@miq-bot add_label bug