### PR TITLE
Do not show record's info when status of record is not completed

### DIFF
--- a/app/views/layouts/_warn_msg.html.haml
+++ b/app/views/layouts/_warn_msg.html.haml
@@ -1,0 +1,4 @@
+.alert.alert-warning
+  %span.pficon-warning-triangle-o
+  %strong
+    = h(message)

--- a/app/views/report/_report_list.html.haml
+++ b/app/views/report/_report_list.html.haml
@@ -92,19 +92,22 @@
                   %td
                     = @sb[:rep_details][rep]["group"]
     - elsif x_active_tree == :reports_tree
-      #rep_tabs
-        %ul.nav.nav-tabs
-          = miq_tab_header('report_info', @sb[:active_tab]) do
-            = _('Report Info')
-          %li
-          = miq_tab_header('saved_reports', @sb[:active_tab]) do
-            = _('Saved Reports')
-        .tab-content
-          = miq_tab_content('report_info', @sb[:active_tab]) do
-            = render :partial => "report_info"
-          = miq_tab_content('saved_reports', @sb[:active_tab]) do
-            = render :partial => "report_saved_reports"
-      :javascript
-        miq_tabs_init('#rep_tabs', '/report/rep_change_tab');
+      - if @report.nil? && x_node.split('-').length >= 6
+        = render :partial => 'layouts/warn_msg', :locals => {:message => _("No records found for this report")}
+      - else
+        #rep_tabs
+          %ul.nav.nav-tabs
+            = miq_tab_header('report_info', @sb[:active_tab]) do
+              = _('Report Info')
+            %li
+            = miq_tab_header('saved_reports', @sb[:active_tab]) do
+              = _('Saved Reports')
+          .tab-content
+            = miq_tab_content('report_info', @sb[:active_tab]) do
+              = render :partial => "report_info"
+            = miq_tab_content('saved_reports', @sb[:active_tab]) do
+              = render :partial => "report_saved_reports"
+        :javascript
+          miq_tabs_init('#rep_tabs', '/report/rep_change_tab');
     - else
       = render :partial => 'layouts/info_msg', :locals => {:message => _("Choose a Report to view from the menus on the left.")}


### PR DESCRIPTION
### Fixes error when navigating to not yet finished report
When queuing new report in CI -> reports, and the report is not yet finished it will throw nasty error. This PR fixes such issue and won't allow users to do changes to such report unless it's finished.

### UI changes
#### Before
![screenshot from 2017-11-22 15-31-50](https://user-images.githubusercontent.com/3439771/33132577-489e0bba-cf9a-11e7-9d26-aedc91825de9.png)

#### After
![screenshot from 2017-11-22 15-28-05](https://user-images.githubusercontent.com/3439771/33132465-070343aa-cf9a-11e7-84be-9326a1196163.png)

### BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1508152
