### PR TITLE
Drop fileicon decorator from MiqRequestDecorator

### DIFF
--- a/app/decorators/miq_request_decorator.rb
+++ b/app/decorators/miq_request_decorator.rb
@@ -7,15 +7,4 @@ class MiqRequestDecorator < MiqDecorator
       "pficon pficon-error-circle-o"
     end
   end
-
-  def fileicon
-    case request_status.to_s.downcase
-    when "ok"
-      "100/checkmark.png"
-    when "error"
-      "100/x.png"
-    else
-      "100/miq_request.png"
-    end
-  end
 end


### PR DESCRIPTION
The list on the `Services -> Requests` page displays `MiqRequest` and `ServiceTemplateProvisionRequest` at the same time. The `ServiceTemplateProvisionRequest` entries might have a related `picture` that causes to force the `fileicon` over the `fonticon` that causes listicon inconsistencies:
![bz_inconsistent_request_status_icons](https://user-images.githubusercontent.com/649130/33132676-936d89f4-cf9a-11e7-826f-f2d46aff8b50.png)

As the `fileicon` is not used anywhere else, simply dropping the `fileicon` method solves the issue...

https://bugzilla.redhat.com/show_bug.cgi?id=1514620

@miq-bot add_label bug