### PR TITLE
GTL missing parent fix

### DIFF
--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -530,7 +530,6 @@ class HostController < ApplicationController
   def get_session_data
     super
     @drift_db   = "Host"
-    @use_action = true
   end
 
   def set_session_data

--- a/app/controllers/mixins/explorer_show.rb
+++ b/app/controllers/mixins/explorer_show.rb
@@ -44,7 +44,6 @@ module Mixins
     end
 
     def init_show_variables(db = nil)
-      @use_action = true
       @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
       @db = db || params[:db] || controller_name

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -245,9 +245,6 @@ module ApplicationHelper
   }.freeze
 
   def model_to_report_data
-    # Hosts do not store correct @display in nested attributes (Relationship, Security and Attributes) so use action
-    return params[:action].classify if @display == "main" && @use_action && params && params[:action] && params[:action] != 'show'
-
     # @report_data_additional_options[:model] is most important, others can be removed
     return @report_data_additional_options[:model] if @report_data_additional_options && @report_data_additional_options[:model]
     return @display.classify if @display && @display != "main"

--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -53,7 +53,7 @@ module GtlHelper
       :model_name                     => model_to_report_data,
       :no_flash_div                   => no_flash_div || false,
       :gtl_type_string                => @gtl_type,
-      :active_tree                    => (x_active_tree unless params[:display] || @use_action),
+      :active_tree                    => (x_active_tree unless params[:display]),
       :parent_id                      => parent_id,
       :selected_records               => gtl_selected_records,
 

--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -63,6 +63,7 @@ module GtlHelper
       :explorer                       => @explorer,
       :view                           => @view,
       :db                             => @db,
+      :parent                         => @parent,
 
       :report_data_additional_options => @report_data_additional_options,
     }

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -169,6 +169,42 @@ describe HostController do
     end
   end
 
+  context 'nested lists' do # these are similar to #show_association but require 'render_views'
+    render_views
+
+    before(:each) do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+
+      @host = FactoryGirl.create(:host, :name =>'hostname1')
+    end
+
+    # http://localhost:3000/host/users/10000000000005?db=host
+    it "renders a grid of associated Users" do
+      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        :model_name      => 'Account',
+        :parent_id       => @host.id,
+        :parent          => @host,
+        :gtl_type_string => 'list'
+      )
+      get :users, :params => {:id => @host.id, :db => 'host'}
+      expect(response.status).to eq(200)
+    end
+
+    # http://localhost:3000/host/guest_applications/10000000000005?db=host
+    it "renders a grid of associated GuestApplications" do
+      @guest_application = FactoryGirl.create(:guest_application, :name => "foo", :host_id => @host.id)
+      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        :model_name      => 'GuestApplication',
+        :parent_id       => @host.id,
+        :parent          => @host,
+        :gtl_type_string => 'list'
+      )
+      get :guest_applications, :params => {:id => @host.id, :db => 'host'}
+      expect(response.status).to eq(200)
+    end
+  end
+
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1310,46 +1310,37 @@ Datasources\" href=\"/ems_middleware/#{ems.id}?display=middleware_datasources\">
     let(:test_class) do
       Class.new do
         include ApplicationHelper
-        attr_accessor :display, :params, :use_action, :report_data_additional_options
+        attr_accessor :display, :params, :report_data_additional_options
 
         def controller; HostController.new; end
       end
     end
 
-    it "the first case" do
-      # All 3 required
-      instance.params = {:action => "vm_or_template"}
-      instance.display = "main"
-      instance.use_action = true
-
-      expect(instance.model_to_report_data).to eq("VmOrTemplate")
-    end
-
-    it "the second case" do
+    it "the prefered case" do
       instance.report_data_additional_options = {:model => "Something"}
 
       expect(instance.model_to_report_data).to eq("Something")
     end
 
-    it "the third case" do
+    it "the @display fallback" do
       instance.display = "vm_or_template"
 
       expect(instance.model_to_report_data).to eq("VmOrTemplate")
     end
 
-    it "the fourth case" do
+    it "the params[:db] fallback" do
       instance.params = {:db => "vm_or_template", :display => "something" }
 
       expect(instance.model_to_report_data).to eq("VmOrTemplate")
     end
 
-    it "the fifth case" do
+    it "the params[:display] fallback" do
       instance.params = {:display => "vm_or_template"}
 
       expect(instance.model_to_report_data).to eq("VmOrTemplate")
     end
 
-    it "the sixth case" do
+    it "the controller.class.model fallback case" do
       instance.params = {}
 
       expect(instance.model_to_report_data).to eq("Host")


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1516331

Pass @parent to the rendering routine. The variable is missing since #2727

Remove @use_action (see details in the commit message).

The @use_action is set

  * for the whole Host controller                                                                  
  (HostController.get_session_data)                                                                 
                                                                                                    
  * in init_show_variables in ExplorerShow                                                         
    that is called from:                                                                            
      * hosts  -- not tested (don't have data)
      * users
      * groups
      * patches -- not tested (don't have data)
      * guest_application ("packages")  

I have added some specs. And have manually tested:

host --> {users,groups,guest_application,host_services}                                                                     
vm   --> {guest_application,linux_initprocesses}

Have not tested "hosts" and "patches" -- don't have the data, but the pattern is the same.

I have noticed that  host-->groups,guest_application has broken breadcrumb: "Services". But that is unrelated to this PR.

Ping @himdel, this needs a detailed reading, please help.
Ping @karelhala : I know you said that removing the @use_action "should be ok", but please, take a look.
Ping @alexander-demichev : this should unlock your fixing of the issue we discussed.

Testers welcome.
