### PR TITLE
Gather nets and subnets for the "new network router" form as hashes

### DIFF
--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -437,11 +437,11 @@ class NetworkRouterController < ApplicationController
   private
 
   def get_networks_by_ems(id)
-    CloudNetwork.where(:ems_id => id).pluck(:name, :id)
+    CloudNetwork.where(:ems_id => id).select(:id, :name).as_json
   end
 
   def get_subnets_by_network(id)
-    CloudSubnet.where(:cloud_network_id => id).pluck(:name, :id)
+    CloudSubnet.where(:cloud_network_id => id).select(:id, :name).as_json
   end
 
   def textual_group_list


### PR DESCRIPTION
Fixes a problem where the network and subnet dropdowns on the create/edit network router form were full of empty entries because they expected to receive an array of hashes with ids and names rather than a list of arrays.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1515668