### PR TITLE
Render Generic Object Definition center toolbar for `show` properly

### DIFF
--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -176,7 +176,7 @@ class GenericObjectDefinitionController < ApplicationController
 
   def god_node_info(node)
     @god_node = true
-    @center_toolbar = 'generic_object_definition_node'
+    @center_toolbar = 'generic_object_definition'
     @record = GenericObjectDefinition.find(from_cid(node.split('-').last))
     @right_cell_text = _("Generic Object Class %{record_name}") % {:record_name => @record.name}
   end
@@ -227,7 +227,7 @@ class GenericObjectDefinitionController < ApplicationController
     god_node_info(node)
     presenter.replace(:main_div, r[:partial => 'show_god'])
     presenter.hide(:paging_div)
-    [build_toolbar("x_summary_view_tb"), build_toolbar("generic_object_definition_node_center_tb")]
+    [build_toolbar("x_summary_view_tb"), build_toolbar("generic_object_definition_center_tb")]
   end
 
   def process_actions_node(presenter, node)

--- a/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Toolbar::GenericObjectDefinitionNodeCenter < ApplicationHelper::Toolbar::Basic
+class ApplicationHelper::Toolbar::GenericObjectDefinitionCenter < ApplicationHelper::Toolbar::Basic
   button_group('generic_object_definition', [
     select(
       :generic_object_definition_configuration,

--- a/app/views/layouts/listnav/_generic_object_definition_show_list_with_treeview.html.haml
+++ b/app/views/layouts/listnav/_generic_object_definition_show_list_with_treeview.html.haml
@@ -1,4 +1,4 @@
-- return if @display == 'generic_objects'
+- return if @display == 'generic_objects' || @display == 'main'
 = miq_accordion_panel(_("Generic Object Classes"), true, "god") do
   %tree_div{'ng-controller' => 'treeViewController as vm'}
     %miq-tree-view{:name       => @tree.name,

--- a/spec/controllers/generic_object_definition_controller_spec.rb
+++ b/spec/controllers/generic_object_definition_controller_spec.rb
@@ -18,6 +18,17 @@ describe GenericObjectDefinitionController do
       expect(response).to redirect_to(:action => 'show_list')
       expect(controller.x_node).to eq("god-#{to_cid(generic_obj_defn.id)}")
     end
+
+    context "#show when display=main" do
+      before do
+        allow_any_instance_of(GenericObjectDefinition).to receive(:generic_objects)
+      end
+      it "show the generic_object_definition record when display=main" do
+        generic_obj_defn = FactoryGirl.create(:generic_object_definition)
+        get :show, :params => {:id => generic_obj_defn.id, :display => "main"}
+        expect(response.status).to eq(200)
+      end
+    end
   end
 
   describe "#show_list" do


### PR DESCRIPTION
Fixed the toolbar rendering while displaying a Generic Object Definition record from the screen below where `@display = 'main'` -

<img width="1429" alt="screen shot 2017-11-22 at 12 10 57 pm" src="https://user-images.githubusercontent.com/1538216/33147830-3d4fe7ae-cf7e-11e7-8b8b-ca49a46cd3fb.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1515942