### PR TITLE
Order Sub Metrics of Storage types in Rate editor

### DIFF
--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -18,12 +18,13 @@
       %th= _("Fixed")
       %th= _("Variable")
   %tbody
-    - @edit[:new][:details].each_with_index do |detail, detail_index|
+    - @edit[:new][:details].sort_by { |rd| [rd[:group], rd[:description], rd[:sub_metric].to_s] }.each do |detail|
       - @cur_group = detail[:group] if @cur_group.nil?
       - if @cur_group != detail[:group]
         - @cur_group = detail[:group]
         %tr
           %td{:colspan => "10", :style => "background-color: #f5f5f5;"} &nbsp;
+      - detail_index = @edit[:new][:tiers].index { |x| x.detect { |tier_hash| tier_hash['chargeback_rate_detail_id'] == detail[:id] }.present? }
       - num_tiers = @edit[:new][:tiers][detail_index].blank? ? "1" : @edit[:new][:tiers][detail_index].length.to_s
 
       %tr.rdetail{:id => "rate_detail_row_#{detail_index}_0"}


### PR DESCRIPTION
**fixing** 
Issue with more info: https://github.com/ManageIQ/manageiq-ui-classic/issues/2799
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1517802

Order _Sub Metrics_ of Storage types (under _Rate Details_) in Rate editor
correctly when editing newly created Chargeback Rate in _Cloud Intel ->
Chargeback -> Rates_.

**Details:**
The problem was that Rate Details were not sorted when editing the details after choosing
_Edit this Chargeback Rate_ under _Configuration_ comparing to showing the details where the
details are sorted by group, description and sub metric.

**Solution:**
Adding just sorting the details by group, description and sub metric was not enough. It solved
ordering but then there the problem occurred that after editing the rate and saving the changes,
the changes did not correspond to the right row under Rate Details.

Getting the right `detail_index`solved this. We cannot rely just on order of the details, so
detail_index is set according to the id of rate detail, so we can now get proper array from
`@edit[:new][:tiers]` and edit appropriate values correctly.

**Before:**
Video:
https://user-images.githubusercontent.com/14937244/33130609-35639070-cf94-11e7-9826-86bb8a18cb61.gif
Example:
![sub4](https://user-images.githubusercontent.com/13417815/33181673-6564e804-d071-11e7-94c2-7c2edce589d2.png)

**After:**
![sub2](https://user-images.githubusercontent.com/13417815/33181534-de5d71d2-d070-11e7-945c-1aa4d8886d70.png)
![sub3](https://user-images.githubusercontent.com/13417815/33181541-e3c42e54-d070-11e7-98d9-424a3b0358aa.png)

