### PR TITLE
Corrected mixin include for automation manager toolbar

### DIFF
--- a/app/helpers/application_helper/toolbar/x_ansible_tower_configured_system_center.rb
+++ b/app/helpers/application_helper/toolbar/x_ansible_tower_configured_system_center.rb
@@ -1,3 +1,3 @@
 class ApplicationHelper::Toolbar::XAnsibleTowerConfiguredSystemCenter < ApplicationHelper::Toolbar::Basic
-  include ApplicationHelper::Toolbar::ConfiguredSystem::AutomationPolicyMixin
+  include ApplicationHelper::Toolbar::ConfiguredSystem::Automation::PolicyMixin
 end

--- a/app/helpers/application_helper/toolbar/x_automation_manager_configured_system_center.rb
+++ b/app/helpers/application_helper/toolbar/x_automation_manager_configured_system_center.rb
@@ -1,3 +1,3 @@
 class ApplicationHelper::Toolbar::XAutomationManagerConfiguredSystemCenter < ApplicationHelper::Toolbar::Basic
-  include ApplicationHelper::Toolbar::ConfiguredSystem::AutomationPolicyMixin
+  include ApplicationHelper::Toolbar::ConfiguredSystem::Automation::PolicyMixin
 end


### PR DESCRIPTION
This PR is correcting mixin include for automation manager toolbar.

After selecting a host in automation manager, I was getting error in console:

```log
F, [2017-11-22T14:43:52.340898 #24616] FATAL -- : Error caught: [NameError] uninitialized constant ApplicationHelper::Toolbar::Configu
redSystem::AutomationPolicyMixin
/home/rblanco/devel/manageiq-ui-classic/app/helpers/application_helper/toolbar/x_ansible_tower_configured_system_center.rb:2:in `<clas
s:XAnsibleTowerConfiguredSystemCenter>'
/home/rblanco/devel/manageiq-ui-classic/app/helpers/application_helper/toolbar/x_ansible_tower_configured_system_center.rb:1:in `<top 
(required)>'
```

Steps for Testing/QA
-------------------------------

1) Go to _Automation_ → _Ansible Tower_ → _Explorer_
2) Select _Configured Systems_ accordion
3) Select one of the hosts in GTL list
