### PR TITLE
Force the showtype to nil when displaying the provider list page 🐍

### DIFF
--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -26,6 +26,11 @@ class EmsInfraController < ApplicationController
     new_ems_infra_path
   end
 
+  def show_list
+    @showtype = nil
+    super
+  end
+
   def index
     redirect_to :action => 'show_list'
   end


### PR DESCRIPTION
This way the dashboard view of a provider's summary will not interfere with the provider list screen.

**Before:**
![screenshot from 2017-11-23 18-53-36](https://user-images.githubusercontent.com/649130/33184926-a53e8724-d07f-11e7-9463-776e8269ac57.png)

**After:**
![screenshot from 2017-11-23 18-52-03](https://user-images.githubusercontent.com/649130/33184930-ac5705e0-d07f-11e7-9314-7b129d371a67.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1500779