### PR TITLE
Add @targets_hash as another source of records for GTL.

### DIFF
--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -1,6 +1,7 @@
 module GtlHelper
   def gtl_selected_records
-    records = params.try(:[], :rec_ids) || @edit.try(:[], :pol_items) || @edit.try(:[], :object_ids)
+    records = params.try(:[], :rec_ids) || @edit.try(:[], :pol_items) ||
+              @edit.try(:[], :object_ids) || @targets_hash.try(:keys)
 
     if records.present?
       records = records.map(&:to_i) if records.first.kind_of?(String)

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -9,13 +9,20 @@ describe HostController do
       ApplicationController.handle_exceptions = true
     end
 
-    it "doesn't break" do
+    it 'edit renders GTL grid with selected Host records' do
       h1 = FactoryGirl.create(:host)
       h2 = FactoryGirl.create(:host)
       session[:host_items] = [h1.id, h2.id]
       session[:settings] = {:views     => {:host => 'grid'},
                             :display   => {:quad_truncate => 'f'},
                             :quadicons => {:host => 'foo'}}
+
+      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        :model_name       => 'Host',
+        :gtl_type_string  => 'grid',
+        :parent_id        => nil,
+        :selected_records => [h1.id, h2.id]
+      )
       get :edit
       expect(response.status).to eq(200)
     end


### PR DESCRIPTION
There's still one more way to specify records for the GTL grid to
display -- @targets_hash. Adding that + specs for /host/edit.

https://bugzilla.redhat.com/show_bug.cgi?id=1515725
