### PR TITLE
Do not display Hosts/VMs on the container topology screen

### DIFF
--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -12,7 +12,7 @@ class ContainerTopologyService < TopologyService
     ]
   ]
 
-  @kinds = %i(ContainerReplicator ContainerGroup Container ContainerNode ContainerService Host Vm ContainerRoute ContainerManager)
+  @kinds = %i(ContainerReplicator ContainerGroup Container ContainerNode ContainerService ContainerRoute ContainerManager)
 
   def entity_display_type(entity)
     if entity.kind_of?(ManageIQ::Providers::ContainerManager)

--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -27,14 +27,6 @@
         %label
           %i.pficon.pficon-container-node
           = _("Nodes")
-      %kubernetes-topology-icon{tooltip_options, :kind => "Vm"}
-        %label
-          %i.pficon.pficon-virtual-machine
-          = _("VMs")
-      %kubernetes-topology-icon{tooltip_options, :kind => "Host"}
-        %label
-          %i.pficon.pficon-screen
-          = _("Hosts")
 
   .alert.alert-info.alert-dismissable
     %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}


### PR DESCRIPTION
**Before:**
![screenshot from 2017-11-24 12-47-27](https://user-images.githubusercontent.com/649130/33209371-b8b585be-d115-11e7-87e1-a3100a8f7d33.png)

**After:**
![screenshot from 2017-11-24 12-47-04](https://user-images.githubusercontent.com/649130/33209376-bced8780-d115-11e7-8830-7365be46581a.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1516771