### PR TITLE
Performance: revert refactoring find_by_name vs find_by(:name ...

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -820,7 +820,7 @@ module ApplicationController::Performance
 
     charts = []
     chart_data = []
-    cat_desc = Classification.find_by(:name => @perf_options[:cat]).description
+    cat_desc = Classification.find_by_name(@perf_options[:cat]).description
 
     layout_name = case @perf_options[:typ]
                   when "Hourly" then 'hourly_tag_charts'
@@ -1547,7 +1547,7 @@ module ApplicationController::Performance
   end
 
   def breadcrumb_tag(report, legend_index)
-    category = Classification.find_by(:name => @perf_options[:cat]).description
+    category = Classification.find_by_name(@perf_options[:cat]).description
     group_by = report.extras[:group_by_tag_descriptions][legend_index]
     "#{category}:#{group_by}"
   end

--- a/spec/controllers/application_controller/performance_spec.rb
+++ b/spec/controllers/application_controller/performance_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationController do
   context "#perf_planning_gen_data" do
     it "should not get nil error when submitting up Manual Input data" do
-      enterprise = FactoryGirl.create(:miq_enterprise)
+      _enterprise = FactoryGirl.create(:miq_enterprise)
       allow(MiqServer).to receive(:my_zone).and_return("default")
       sb = {
         :options => {
@@ -34,6 +34,63 @@ describe ApplicationController do
 
     it 'should handle Sundays' do
       expect(subject.call((1..6).to_a)).to eq([7])
+    end
+  end
+
+  context 'peformance charts generation' do
+    before(:each) do
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
+
+    describe 'perf_gen_tag_data_before_wait' do
+      %w(Hourly Daily).each do |type|
+        it "calls initiate_wait_for_task for '#{type}'" do
+          controller.instance_variable_set(:@perf_record, FactoryGirl.create(:host))
+          controller.instance_variable_set(
+            :@perf_options,
+            {
+              :typ          => type,
+              :daily_date   => '12/12/2017',
+              :hourly_date  => '12/12/2017',
+              :tz           => TimeProfile.rollup_daily_metrics.all_timezones.first,
+              :cat          => 'foobar',
+              :time_profile => 'bar'
+            }
+          )
+          expect(controller).to receive(:initiate_wait_for_task)
+          controller.send(:perf_gen_tag_data_before_wait)
+        end
+      end
+    end
+
+    describe 'perf_gen_tag_data_after_wait' do
+      it 'calls Classification.find_by_name and other specific methods' do
+        task = double(:task)
+        allow(task).to receive_message_chain(:miq_report_result, :report_results)
+        expect(task).to receive(:destroy)
+
+        expect(MiqTask).to receive(:find).and_return(task)
+
+        cat = double(:cat)
+        allow(cat).to receive(:description)
+        expect(Classification).to receive(:find_by_name).with('cat').and_return(cat)
+
+        controller.instance_variable_set(:@sb, {})
+        controller.instance_variable_set(:@perf_record, FactoryGirl.create(:host))
+        controller.instance_variable_set(
+          :@perf_options,
+          {
+            :typ   => 'Hourly',
+            :cat   => 'cat',
+            :model => 'Host',
+          }
+        )
+        expect(controller).to receive(:prepare_perf_tag_chart).at_least(:once)
+        expect(controller).to receive(:gen_perf_chart).at_least(:once)
+        allow(controller).to receive(:perf_zoom_url)
+        expect(controller).to receive(:perf_report_to_html)
+        controller.send(:perf_gen_tag_data_after_wait)
+      end
     end
   end
 end


### PR DESCRIPTION
`Classification.find_by_name` is a method on the model, not AR finder.

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1509904


@romanblanco, @PanSpagetka : please, review, test. Marking this as WIP until I produce a spec.