### PR TITLE
Corrected CSS class for sortable fields

### DIFF
--- a/app/views/shared/summary/_textual_multilabel.html.haml
+++ b/app/views/shared/summary/_textual_multilabel.html.haml
@@ -11,7 +11,7 @@
             .pull-left
               = label[:value]
             .pull-right
-              %i{:class => label[:sortable] == :asc ? "fa-sort-asc" : "fa-sort-desc"}
+              %i{:class => label[:sortable] == :asc ? "fa fa-sort-asc" : "fa fa-sort-desc"}
           - else
             = label
     - values.each do |item|


### PR DESCRIPTION
Before:
![screenshot-2017-11-24 manageiq builds](https://user-images.githubusercontent.com/1187051/33213975-33c2dc7a-d12a-11e7-9042-59943c3162fc.png)

After:
![screenshot-2017-11-24 manageiq builds 1](https://user-images.githubusercontent.com/1187051/33213981-37f4c7cc-d12a-11e7-9f0b-a8f33b8d1f9f.png)



Steps for Testing/QA
-------------------------------

_Compute_ → _Containers_ → _Container Builds_ → [select a build in GTL]
