### PR TITLE
Return whole x_node if new report is queued in reports tab for CI

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -367,7 +367,7 @@ class ReportController < ApplicationController
   def rebuild_trees
     rep = MiqReportResult.with_current_user_groups_and_report.maximum("created_on")
     return false unless rep
-    build_trees = rep > @sb[:rep_tree_build_time]
+    build_trees = @sb[:rep_tree_build_time].nil? || rep > @sb[:rep_tree_build_time]
     # save last tree build time to decide if tree needs to be refreshed automatically
     @sb[:rep_tree_build_time] = Time.now.utc if build_trees
     build_trees

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -392,7 +392,7 @@ module ApplicationHelper
                  MiqReportResult).include?(view.db) &&
               %w(report automation_manager).include?(request.parameters[:controller])
           suffix = ''
-          suffix = x_node if params[:tab_id] == "saved_reports"
+          suffix = x_node if params[:tab_id] == "saved_reports" || params[:pressed] == "miq_report_run"
           return "/" + request.parameters[:controller] + "/tree_select?id=" + suffix
         elsif %w(User MiqGroup MiqUserRole Tenant).include?(view.db) &&
               %w(ops).include?(request.parameters[:controller])


### PR DESCRIPTION
### Fixes option to navigate to correct report after new report is queued
When queuing new report inside CI -> reports and clicking on such newly created report, wrong url is present and user is redirected to some wrong report. This PR fixes such issue by adding `x_node` to url if new report is queued.

### Tasks
* [x] add tests

### BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1508151