### PR TITLE
Use record instead of ems instance var in textual authentication status

### DIFF
--- a/app/helpers/textual_mixins/textual_authentications_status.rb
+++ b/app/helpers/textual_mixins/textual_authentications_status.rb
@@ -39,8 +39,8 @@ module TextualMixins::TextualAuthenticationsStatus
   end
 
   def textual_authentications_status
-    authentications = @ems.authentications.order(:authtype).collect
-    return [{ :label => _("%{label} Authentication") % { :label => @ems.default_authentication_type.to_s.titleize },
+    authentications = @record.authentications.order(:authtype).collect
+    return [{ :label => _("%{label} Authentication") % { :label => @record.default_authentication_type.to_s.titleize },
               :title => t = _("None"),
               :value => t }] if authentications.blank?
 

--- a/app/helpers/textual_mixins/textual_metrics_status.rb
+++ b/app/helpers/textual_mixins/textual_metrics_status.rb
@@ -4,11 +4,11 @@ module TextualMixins::TextualMetricsStatus
       :label => _("Last Metrics Collection"),
       :title => _("None"),
       :value => _("None")
-    } unless @ems.last_metrics_update_date
+    } unless @record.last_metrics_update_date
 
-    status        = (@ems.last_metrics_error || :valid).to_s.titleize
-    updated_on    = @ems.last_metrics_update_date
-    last_valid_on = @ems.last_metrics_success_date
+    status        = (@record.last_metrics_error || :valid).to_s.titleize
+    updated_on    = @record.last_metrics_update_date
+    last_valid_on = @record.last_metrics_success_date
 
     {
       :label => _("Last Metrics Collection"),


### PR DESCRIPTION
Somehow the container PDF report summary generation is different from the other screens. I'm not sure about the fix, @martinpovolny could you please check? 

https://bugzilla.redhat.com/show_bug.cgi?id=1516710