### PR TITLE
Set initial url for ajax calls when parsing url params (Hawkular part)

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-parse-url-factroy.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-parse-url-factroy.js
@@ -37,5 +37,8 @@ angular.module('miq.util').factory('metricsParseUrlFactory', function() {
     dash.minBucketDurationInSecondes = parseInt(dash.params.bucket, 10) || 20 * 60;
     dash.max_metrics = parseInt(dash.params.max_metrics, 10) || 10000;
     dash.items_per_page = parseInt(dash.params.items_per_page, 10) || 8;
+
+    // the proxy service shuold use the currect tenant if none is given
+    dash.url = '/container_dashboard/data' + dash.providerId  + '/?live=true';
   };
 });


### PR DESCRIPTION
**Description**
Compute --> Containers --> Container Nodes -> Monitoring -> Ad-hoc metrics

Attempting to open Ad hoc Metrics for Nodes yields an error message, because we do not have an ajax url defined. This PR adds the missing url, without specifying the tenant.
The backend proxy knows the correct tenant to use for Hawkular.

Notes: 
a. This only fixes the link for Container Nodes using Hawkular metrics.
b. Container Nodes using Prometheus will no longer show the error, but will fail to show node metrics.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1516320

**Screenshots**

Before
![screenshot-localhost 3000-2017-11-23-16-14-27](https://user-images.githubusercontent.com/2181522/33176940-84b8d6be-d069-11e7-9b70-da4979ca5a1e.png)

After:
![gifrecord_2017-11-23_160938](https://user-images.githubusercontent.com/2181522/33176882-4f938b1e-d069-11e7-9a7f-050c2da7b13a.gif)
