### PR TITLE
Rename 'phase' to 'status' for container groups summary page

### DIFF
--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -6,7 +6,7 @@ module ContainerGroupHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i(name phase message reason creation_timestamp resource_version restart_policy dns_policy ip)
+      %i(name status message reason creation_timestamp resource_version restart_policy dns_policy ip)
     )
   end
 
@@ -78,7 +78,7 @@ module ContainerGroupHelper::TextualSummary
   # Items
   #
 
-  def textual_phase
+  def textual_status
     @record.phase
   end
 

--- a/app/views/container_project/_show_dashboard.html.haml
+++ b/app/views/container_project/_show_dashboard.html.haml
@@ -86,7 +86,7 @@
               %thead
                 %tr
                   %th Name
-                  %th Phase
+                  %th Status
                   %th Ready Status
                   %th Running Containers
               %tr{"ng-repeat" => "pod in pods"}


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1406741

Status is the term that appears on the provider side so theres no reason for this to be named differently.  

@moolitayer @nimrodshn please review
cc @bazulay 

