### PR TITLE
Translate hawkular node labels to prometheus

### DIFF
--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-config-factory.js
@@ -10,7 +10,8 @@ angular.module('miq.util').factory('metricsConfigFactory', function() {
       dash.itemSelected = dash.selectedItems.length > 0;
     };
 
-    dash.DEFAULT_TENANT = "_system";
+    dash.DEFAULT_HAWKULAR_TENANT = "_system";
+    dash.DEFAULT_PROMETHEUS_TENANT = "kubernetes-cadvisor";
     dash.tenant = {value: null};
 
     dash.actionsConfig = {

--- a/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
+++ b/app/assets/javascripts/controllers/live_metrics/util/metrics-http-factory.js
@@ -108,7 +108,7 @@ angular.module('miq.util').factory('metricsHttpFactory', function() {
 
         // try to set the current tenant to be the default one
         dash.tenantList.forEach(function callback(obj, i) {
-          if (obj.value === dash.DEFAULT_TENANT) {
+          if (obj.value === dash.DEFAULT_HAWKULAR_TENANT || obj.value === dash.DEFAULT_PROMETHEUS_TENANT) {
             dash.tenant = dash.tenantList[i];
           }
         });

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -9,7 +9,8 @@ class HawkularProxyService
     "admin"                        => _("Admin"),
     "openshift-infra"              => _("OpenShift Infra"),
     "kubernetes-nodes"             => _("Kubernetes Nodes"),
-    "kubernetes-apiserver"         => _("Kubernetes API server"),
+    "kubernetes-apiservers"        => _("Kubernetes API servers"),
+    "kubernetes-cadvisor"          => _("Kubernetes cAdvisor"),
     "kubernetes-service-endpoints" => _("Kubernetes Service"),
   }.freeze
 


### PR DESCRIPTION
**Description**
Compute --> Containers --> Container Nodes -> Monitoring -> Ad-hoc metrics

Attempting to open Ad hoc Metrics for Nodes on a provider with Prometheus metrics, does not query correctly. This PR translate the Hawakular query to Prometheus query.

Notes: 
a. Add the new `kubernetes-cadvisor` as the default job/tenant in Prometheus view.
b. Fix typo in the tenants list.
c. Only translate labels if we need the translation for the list view o/w leave tags as they are.
d. Remove `job` from the tags list, users should not have access to the jobs in the tags dropdown.

Note II:
Include commit from https://github.com/ManageIQ/manageiq-ui-classic/pull/2824 that fixes the link from node page.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1516320

**Screenshots**

Before
![screenshot-localhost 3000-2017-11-23-16-14-27](https://user-images.githubusercontent.com/2181522/33176940-84b8d6be-d069-11e7-9b70-da4979ca5a1e.png)

After
![gifrecord_2017-11-26_130719](https://user-images.githubusercontent.com/2181522/33239447-dc0fe6e4-d2aa-11e7-8190-9416563bc4ec.gif)


