### PR TITLE
Fix Service request filtering

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -89,6 +89,8 @@
         this.onUnsubscribe();
       } else if (event.toolbarEvent && (event.toolbarEvent === 'itemClicked')) {
         this.setExtraClasses();
+      } else if (event.refreshData && event.refreshData.name === CONTROLLER_NAME) {
+        this.refreshData();
       }
 
       if (event.controller === CONTROLLER_NAME && this.apiFunctions && this.apiFunctions[event.action]) {
@@ -144,6 +146,10 @@
     }
     subscribeToSubject.bind(vm)();
     vm.perPage = defaultPaging();
+  };
+
+  ReportDataController.prototype.refreshData = function() {
+    this.initController(this.initObject);
   };
 
   ReportDataController.prototype.setSort = function(headerId, isAscending) {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -399,8 +399,8 @@ class ApplicationController < ActionController::Base
     # handle exceptions
     if params[:model_name]
       options = case params[:model_name]
-                when 'miq_requests'
-                  page_params
+                when 'MiqRequest'
+                  page_display_options
                 when 'miq_tasks'
                   jobs_info
                 when 'physical_servers_with_host'

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -162,15 +162,6 @@ class MiqRequestController < ApplicationController
     {:view => @view, :pages => @pages}
   end
 
-  def page_params
-    @request_tab = params[:typ] if params[:typ] # set this to be used to identify which Requests subtab was clicked
-    @layout = layout_from_tab_name(@request_tab)
-    kls = @layout == "miq_request_ae" ? AutomationRequest : MiqRequest
-    gv_options = page_display_options
-    @view, @pages = get_view(kls, gv_options)
-    {:view => @view, :pages => @pages}
-  end
-
   def show
     identify_request
     return if record_no_longer_exists?(@miq_request)

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -387,25 +387,9 @@ class MiqRequestController < ApplicationController
     end
     show_list
 
-    # need to call this outside render :update
-    grid_options, js_options = replace_list_grid
-
-    render :update do |page|
-      page << javascript_prologue
-      page.replace("prov_options_div", :partial => "prov_options")
-      if @view.table.data.length >= 1
-        page << javascript_hide("no_records_div")
-        page << javascript_show("records_div")
-      else
-        page << javascript_show("no_records_div")
-        page << javascript_hide("records_div")
-      end
-
-      page.replace_html("list_grid", :partial => "layouts/list_grid",
-                                     :locals => {:options    => grid_options,
-                                                 :js_options => js_options})
-      page << "miqGridOnCheck();" # Reset the center buttons
-      page << "miqSparkle(false);"
+    render :update do |js|
+      js << javascript_prologue
+      js << 'sendDataWithRx({refreshData: {name: "reportDataController"}});'
     end
   end
 


### PR DESCRIPTION
### Reproducer

1. Services -> Requests
2. Select only Approved, or only Denied requests
3. Press `Apply`

BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1512719

Closes: #2742

@mzazrivec : PTAL

### TODO:
  * ~~Looking as some strange stuff in the case statement,~~ will be done in a separate PR.
  * ~~looking at what code to remove~~ removed just a bit
  * specs

### Explanation:

The filters are composed from SQL fragments. So no scopes for now :-(. 

It's handled (statefully) in `/report_data` via the "exceptions". This one is for "MiqRequest" and calls `page_params`.

So we can keep the code that updates the session when form fields are changed. (That needs a rework no soner then when it's redone to client side.)

And all that is really needed is the reload of the GTL grid -- that will reload `/report_data` and apply the changed filter (remember, it's in the session). So doing just that.
