### PR TITLE
Use parentNode.removeChild in IE11 when determining fonticon char

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1715,6 +1715,10 @@ var fontIconChar = _.memoize(function(klass) {
   document.body.appendChild(tmp);
   var char = window.getComputedStyle(tmp, ':before').content.replace(/'|"/g, '');
   var font = window.getComputedStyle(tmp, ':before').fontFamily;
-  tmp.remove();
+  if (tmp.hasOwnProperty('remove')) {
+    tmp.remove();
+  } else { // IE11 doesn't support ChildNode.remove()
+    tmp.parentNode.removeChild(tmp);
+  }
   return {font: font, char: char};
 });


### PR DESCRIPTION
The topology screens on IE11 did not display fonticon-based nodes because the `ChildNode.remove()` called in `fontIconChar` fails as it is not supported in IE11. This fix replaces the call with `ChildNode.parentNode.removeChild()` when it's not available.

@miq-bot add_label bug, topology

https://bugzilla.redhat.com/show_bug.cgi?id=1516823