### PR TITLE
Fixed CSP for HTML5 Console

### DIFF
--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -55,7 +55,7 @@ module VmRemote
   end
 
   def launch_html5_console
-    override_content_security_policy_directives(:connect_src => ["'self'", websocket_origin], :img_src => %w(data: self))
+    override_content_security_policy_directives(:connect_src => ["'self'", websocket_origin], :img_src => %w(data: 'self'))
     %i(secret url proto).each { |p| params.require(p) }
 
     proto = j(params[:proto])


### PR DESCRIPTION
Images we added to our HTML5 Console page were blocked by the CSP because of the quotes missing around 'self'.