### PR TITLE
Add flash message when OrchestrationStack delete returns an exception

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -891,7 +891,15 @@ module ApplicationController::CiProcessing
   # Delete all selected or single displayed stack(s)
   def orchestration_stack_delete
     assert_privileges("orchestration_stack_delete")
-    delete_elements(OrchestrationStack, :process_orchestration_stacks)
+    begin
+      delete_elements(OrchestrationStack, :process_orchestration_stacks)
+    rescue StandardError => err
+      add_flash(_("Error during deletion: %{error_message}") % {:error_message => err.message}, :error)
+      if @lastaction == "show_list"
+        show_list
+        @refresh_partial = "layouts/gtl"
+      end
+    end
   end
 
   def configuration_job_delete

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -944,3 +944,37 @@ describe VmOrTemplateController do
     end
   end
 end
+
+describe OrchestrationStackController do
+  context "#orchestration_stack_delete" do
+    let(:orchestration_stack) { FactoryGirl.create(:orchestration_stack_cloud) }
+    let(:orchestration_stack_deleted) { FactoryGirl.create(:orchestration_stack_cloud) }
+
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as FactoryGirl.create(:user_admin)
+      controller.instance_variable_set(:@lastaction, "show_list")
+      allow(controller).to receive(:role_allows?).and_return(true)
+    end
+
+    it "should render error flash message if OrchestrationStack doesn't exist" do
+      id = orchestration_stack_deleted.id
+      orchestration_stack_deleted.destroy
+      controller.instance_variable_set(:@_params, :miq_grid_checks => id.to_s) # Orchestration Stack id that doesn't exist
+      expect(controller).to receive(:show_list)
+      controller.send('orchestration_stack_delete')
+      flash_messages = assigns(:flash_array)
+      expect(flash_messages.first).to eq(:message => "Error during deletion: Unauthorized object or action",
+                                         :level   => :error)
+    end
+
+    it "should render success flash message if OrchestrationStack deletion was initiated" do
+      controller.instance_variable_set(:@_params, :miq_grid_checks => orchestration_stack.id.to_s) # Orchestration Stack id that exists
+      expect(controller).to receive(:show_list)
+      controller.send('orchestration_stack_delete')
+      flash_messages = assigns(:flash_array)
+      expect(flash_messages.first).to eq(:message => "Delete initiated for 1 Orchestration Stacks from the ManageIQ Database",
+                                         :level   => :success)
+    end
+  end
+end


### PR DESCRIPTION
Steps to reproduce:

Compute -> Cloud -> Stacks
Check one Orchestration Stack
Configuration -> Remove Orchestration Stack from Inventory 
Check again Orchestration Stack that was deleted
Configuration -> Remove Orchestration Stack from Inventory

Before:
<img width="1394" alt="screen shot 2017-11-27 at 2 16 06 pm" src="https://user-images.githubusercontent.com/9210860/33268738-9118189e-d37e-11e7-887b-4d9fa2ecc8d5.png">
After:
<img width="1212" alt="screen shot 2017-11-27 at 5 10 32 pm" src="https://user-images.githubusercontent.com/9210860/33276439-ded0dae6-d395-11e7-9e54-e96a94ceca95.png">


@miq-bot add_label bug, gaprindashvili/yes, blocker

@h-kataria please have a look, thanks :) Maybe you can think about nicer error message.

https://bugzilla.redhat.com/show_bug.cgi?id=1515310