### PR TITLE
fix typo in function name

### DIFF
--- a/app/services/prometheus_proxy_service.rb
+++ b/app/services/prometheus_proxy_service.rb
@@ -15,7 +15,7 @@ class PrometheusProxyService < HawkularProxyService
     @conn = cli.prometheus_client
   end
 
-  def replace_hawular_tags(tags)
+  def replace_hawkular_tags(tags)
     if tags && tags["type"] == "node" && tags["hostname"]
       tags["id"] = "/"
       tags["instance"] = tags["hostname"]
@@ -31,7 +31,7 @@ class PrometheusProxyService < HawkularProxyService
     tags = params[:tags]
 
     # check for hawkular style type / hostname tags and replace if needed
-    tags = replace_hawular_tags(tags)
+    tags = replace_hawkular_tags(tags)
 
     tags_str = if tags.present?
                  tags.map { |x, y| ",#{x}=~\"#{y}\"" }.join


### PR DESCRIPTION
**Description**

Fix typo in function name:
`replace_hawular_tags => replace_hawkular_tags`

See: https://github.com/ManageIQ/manageiq-ui-classic/pull/2826#issuecomment-347234073