### PR TITLE
Fix rendering of datastore's list of templates

### DIFF
--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -13,7 +13,7 @@ class StorageController < ApplicationController
   after_action :set_session_data
 
   def self.display_methods
-    %w(all_vms hosts)
+    %w(all_vms hosts all_miq_templates)
   end
 
   def self.custom_display_method


### PR DESCRIPTION
Compute -> Infra -> Datastores -> [Some Datastore] -> All Managed VM Templates

Before the fix, it would throw an error / exception. With the fix, rendering of the template list
should work.

https://bugzilla.redhat.com/show_bug.cgi?id=1515312