### PR TITLE
Render flash when running compliance check for a container node 🐞

### DIFF
--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -173,6 +173,7 @@ module ContainersCommonMixin
         add_flash(_("\"%{record}\": Compliance check successfully initiated") % {:record => entity.name})
       end
     end
+    javascript_flash
   end
 
   included do

--- a/spec/controllers/container_node_controller_spec.rb
+++ b/spec/controllers/container_node_controller_spec.rb
@@ -44,6 +44,22 @@ describe ContainerNodeController do
     end
   end
 
+  describe "#button" do
+    let(:node) { FactoryGirl.create(:container_node) }
+
+    context "container_node_check_compliance" do
+      before do
+        EvmSpecHelper.create_guid_miq_server_zone
+        login_as FactoryGirl.create(:user)
+      end
+
+      it 'displays a flash message' do
+        post :button, :pressed => 'container_node_check_compliance', :id => node.id
+        expect(JSON.parse(response.body)['replacePartials']).to have_key('flash_msg_div')
+      end
+    end
+  end
+
   it "renders show_list" do
     session[:settings] = {:default_search => 'foo',
                           :views          => {:containernode => 'list'},


### PR DESCRIPTION
We were rendering a blank page after the compliance check for a container node has been initiated. This PR forces the flash rendering as there's always a positive/negative message to be displayed.

https://bugzilla.redhat.com/show_bug.cgi?id=1516864