### PR TITLE
Tag expression fix for group editor

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1152,10 +1152,10 @@ module OpsController::OpsRbac
 
     if params[:use_filter_expression]
       @edit[:new][:use_filter_expression] = params[:use_filter_expression]
+      @group = MiqGroup.find_by(:id => @edit[:group_id])
+      rbac_group_right_tree(@edit[:new][:belongsto].keys)
       if params[:use_filter_expression] == 'false'
         @edit[:new][:use_filter_expression] = false
-        @group = MiqGroup.find_by(:id => @edit[:group_id])
-        rbac_group_right_tree(@edit[:new][:belongsto].keys)
       elsif params[:use_filter_expression] == 'true'
         @edit[:use_filter_expression] = true
       end

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -476,6 +476,23 @@ describe OpsController do
       expect(MiqExpression).to receive(:tag_details)
       post :rbac_group_field_changed, :params => { :id => 'new',  :use_filter_expression => "true"}
     end
+
+    it "initializes the group record and tag tree when switching tabs" do
+      controller.instance_variable_set(:@edit,
+                                       :group_id => @group.id,
+                                       :new      => {:use_filter_expression => true,
+                                                     :name                  => 'Name',
+                                                     :description           => "Test",
+                                                     :role                  => @role.id,
+                                                     :filter_expression     => @exp.exp,
+                                                     :belongsto             => {},
+                                                     :filters               => {'managed/env' => '/managed/env'}})
+      controller.instance_variable_set(:@sb, :active_rbac_group_tab => 'rbac_customer_tags')
+      controller.instance_variable_set(:@_params, :use_filter_expression => "false", :id => @group.id)
+      controller.send(:rbac_group_get_form_vars)
+      expect(controller.instance_variable_get(:@group).name).to eq(@group.name)
+      expect(controller.instance_variable_get(:@tags_tree)).to_not be_nil
+    end
   end
 
   context "rbac_role_edit" do


### PR DESCRIPTION
Initialize the tags_tree and @group when switching between tabs on group editor.


Links 
-------
https://bugzilla.redhat.com/show_bug.cgi?id=1501346
 
Steps for Testing/QA 
----------------------------
1. Navigate to add group page
2. Switch to 'Tag based on expression' on 'My company Tags'
3. Select 'Host & Cluster' tab
4. Select 'My company Tags'
5. Switch tag filter to 'Specific Tags'

