### PR TITLE
Display 'No Attributes defined' in a Generic Object Summary screen when there are no Attributes defined for the GO instance

### DIFF
--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -37,7 +37,7 @@ class GenericObjectController < ApplicationController
   private
 
   def textual_group_list
-    [%i(properties attribute_details_list associations)]
+    [%i(properties attribute_details_list associations methods)]
   end
 
   helper_method :textual_group_list

--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -17,13 +17,25 @@ module GenericObjectHelper::TextualSummary
     {:label => _("Updated"), :value => format_timezone(@record.updated_at)}
   end
 
+  def textual_attributes_none
+    {:label => _("No Attributes defined")}
+  end
+
+  def textual_associations_none
+    {:label => _("No Associations defined")}
+  end
+
   def textual_group_attribute_details_list
-    TextualMultilabel.new(
-      _("Attributes (#{@record.property_attributes.count})"),
-      :additional_table_class => "table-fixed",
-      :labels                 => [_("Name"), _("Value")],
-      :values                 => attributes_array
-    )
+    if @record.property_attributes.count > 0
+      TextualMultilabel.new(
+        _("Attributes"),
+        :additional_table_class => "table-fixed",
+        :labels                 => [_("Name"), _("Value")],
+        :values                 => attributes_array
+      )
+    else
+      TextualGroup.new(_("Attributes"), %i(attributes_none))
+    end
   end
 
   def textual_group_associations
@@ -39,7 +51,11 @@ module GenericObjectHelper::TextualSummary
         end
       end
     end
-    TextualGroup.new(_("Associations"), associations)
+    if associations.count > 0
+      TextualGroup.new(_("Associations"), associations)
+    else
+      TextualGroup.new(_("Associations"), %i(associations_none))
+    end
   end
 
   def attributes_array

--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -25,6 +25,10 @@ module GenericObjectHelper::TextualSummary
     {:label => _("No Associations defined")}
   end
 
+  def textual_methods_none
+    {:label => _("No Methods defined")}
+  end
+
   def textual_group_attribute_details_list
     if @record.property_attributes.count > 0
       TextualMultilabel.new(
@@ -55,6 +59,21 @@ module GenericObjectHelper::TextualSummary
       TextualGroup.new(_("Associations"), associations)
     else
       TextualGroup.new(_("Associations"), %i(associations_none))
+    end
+  end
+
+  def textual_group_methods
+    methods = %i()
+    @record.property_methods.each do |key|
+      methods.push(key.to_sym)
+      define_singleton_method("textual_#{key}") do
+        {:label => _("%{label}") % {:label => key}}
+      end
+    end
+    if methods.count > 0
+      TextualGroup.new(_("Methods"), methods)
+    else
+      TextualGroup.new(_("Methods"), %i(methods_none))
     end
   end
 

--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -43,6 +43,14 @@ module GenericObjectHelper::TextualSummary
   end
 
   def textual_group_associations
+    if @record.property_associations.count > 0
+      TextualGroup.new(_("Associations"), associations)
+    else
+      TextualGroup.new(_("Associations"), %i(associations_none))
+    end
+  end
+
+  def associations
     associations = %i()
     @record.property_associations.each do |key, _value|
       associations.push(key.to_sym)
@@ -55,11 +63,7 @@ module GenericObjectHelper::TextualSummary
         end
       end
     end
-    if associations.count > 0
-      TextualGroup.new(_("Associations"), associations)
-    else
-      TextualGroup.new(_("Associations"), %i(associations_none))
-    end
+    associations
   end
 
   def textual_group_methods

--- a/app/views/shared/summary/_textual.html.haml
+++ b/app/views/shared/summary/_textual.html.haml
@@ -20,6 +20,7 @@
             :onclick => item[:link] ? click : ""}
           %td.label
             = item[:label]
-          %td
-            = render :partial => "shared/summary/icon_or_image", :locals => {:item => item}
-            = !item[:value].kind_of?(Array) ? item[:value] : render(:partial => "shared/summary/textual_multivalue", :locals => {:items => item[:value]})
+          - if item[:value]
+            %td
+              = render :partial => "shared/summary/icon_or_image", :locals => {:item => item}
+              = !item[:value].kind_of?(Array) ? item[:value] : render(:partial => "shared/summary/textual_multivalue", :locals => {:items => item[:value]})

--- a/spec/helpers/generic_object_helper/textual_summary_spec.rb
+++ b/spec/helpers/generic_object_helper/textual_summary_spec.rb
@@ -1,0 +1,83 @@
+describe GenericObjectHelper::TextualSummary do
+  context "Textual Properties for GO instances" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as FactoryGirl.create(:user)
+      @generic_obj_defn = FactoryGirl.create(
+        :generic_object_definition,
+        :name       => "test_definition",
+        :properties => {
+          :attributes   => {
+            :flag       => "boolean",
+            :data_read  => "float",
+            :max_number => "integer",
+            :server     => "string",
+            :s_time     => "datetime"
+          },
+          :associations => {"cp" => "ManageIQ::Providers::CloudManager", "vms" => "Vm"},
+          :methods      => %w(some_method)
+        }
+      )
+      @generic_obj_defn_with_no_properties = FactoryGirl.create(:generic_object_definition)
+    end
+
+    it "displays the GO Attributes in the name/value format when Attributes exist" do
+      @record = FactoryGirl.create(:generic_object, :generic_object_definition_id => @generic_obj_defn.id, :flag => true)
+
+      expected = TextualMultilabel.new(
+        _("Attributes"),
+        :additional_table_class => "table-fixed",
+        :labels                 => [_("Name"), _("Value")],
+        :values                 => {"flag" => true}
+      )
+
+      expect(textual_group_attribute_details_list).to eq(expected)
+    end
+
+    it "displays 'No Attributes defined' when Attributes do not exist" do
+      @record = FactoryGirl.create(:generic_object, :generic_object_definition_id => @generic_obj_defn.id)
+
+      expected = TextualGroup.new(_("Attributes"), %i(attributes_none))
+
+      expect(textual_group_attribute_details_list).to eq(expected)
+    end
+
+    it "displays the GO Associations when Associations exist" do
+      vm1 = FactoryGirl.create(:vm_vmware)
+      vm2 = FactoryGirl.create(:vm_openstack)
+      ems = FactoryGirl.create(:ems_cloud)
+      @record = FactoryGirl.create(:generic_object,
+                                   :generic_object_definition_id => @generic_obj_defn.id,
+                                   :cp                           => [ems],
+                                   :vms                          => [vm1, vm2])
+
+      expected = TextualGroup.new(_("Associations"), %i(cp vms))
+
+      expect(textual_group_associations).to eq(expected)
+    end
+
+    it "displays 'No Associations defined' when do not Associations exist" do
+      @record = FactoryGirl.create(:generic_object, :generic_object_definition_id => @generic_obj_defn_with_no_properties.id)
+
+      expected = TextualGroup.new(_("Associations"), %i(associations_none))
+
+      expect(textual_group_associations).to eq(expected)
+    end
+
+    it "displays the GO Methods when Methods exist" do
+      @record = FactoryGirl.create(:generic_object, :generic_object_definition_id => @generic_obj_defn.id)
+
+      expected = TextualGroup.new(_("Methods"), %i(some_method))
+
+      expect(textual_group_methods).to eq(expected)
+    end
+
+    it "displays 'No Methods defined' when do not Methods exist" do
+      @record = FactoryGirl.create(:generic_object, :generic_object_definition_id => @generic_obj_defn_with_no_properties.id)
+
+      expected = TextualGroup.new(_("Methods"), %i(methods_none))
+
+      expect(textual_group_methods).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
When Generic Object instances do not have `Attributes`, `Associations` or `Methods` defined, the Summary screen explicitly needs to specify that.
For e.g. The GO Summary screen needs to display `No Attributes defined` when there are no `Attributes` defined.

While I'm still waiting for NEEDINFO on the BZ, I think the reason why the BZ was opened was because there was no explicit mention of `Attributes` in the Summary screen, when the `Attributes` were not defined for a GO instance.

Before - GO Summary Screen does not mention missing `Attributes`, `Associations` or `Methods`

<img width="1432" alt="screen shot 2017-11-27 at 3 17 25 pm" src="https://user-images.githubusercontent.com/1538216/33294588-300b2b2e-d386-11e7-87c9-7abec36461e0.png">

After - GO Summary Screen explicitly mentions missing `Attributes`, `Associations` or `Methods`

<img width="1429" alt="screen shot 2017-11-27 at 3 18 28 pm" src="https://user-images.githubusercontent.com/1538216/33294611-46c39824-d386-11e7-8174-750d8fd229de.png">


(For reference) GO Summary screen that shows `Attributes`, `Associations`,  `Methods` when these properties are available -

<img width="1435" alt="screen shot 2017-11-27 at 3 03 40 pm" src="https://user-images.githubusercontent.com/1538216/33294442-759c2c52-d385-11e7-990c-cf4792a2ff2b.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1515936


