### PR TITLE
Revert "Do not display Hosts/VMs on the container topology screen"

### DIFF
--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -12,7 +12,7 @@ class ContainerTopologyService < TopologyService
     ]
   ]
 
-  @kinds = %i(ContainerReplicator ContainerGroup Container ContainerNode ContainerService ContainerRoute ContainerManager)
+  @kinds = %i(ContainerReplicator ContainerGroup Container ContainerNode ContainerService Host Vm ContainerRoute ContainerManager)
 
   def entity_display_type(entity)
     if entity.kind_of?(ManageIQ::Providers::ContainerManager)

--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -27,6 +27,14 @@
         %label
           %i.pficon.pficon-container-node
           = _("Nodes")
+      %kubernetes-topology-icon{tooltip_options, :kind => "Vm"}
+        %label
+          %i.pficon.pficon-virtual-machine
+          = _("VMs")
+      %kubernetes-topology-icon{tooltip_options, :kind => "Host"}
+        %label
+          %i.pficon.pficon-screen
+          = _("Hosts")
 
   .alert.alert-info.alert-dismissable
     %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}


### PR DESCRIPTION
These objects should be displayed in the topology, the BZ was invalid.

This reverts commit 4c7389d83020879be09536098caed668114c49d3.

https://bugzilla.redhat.com/show_bug.cgi?id=1516771

@miq-bot add_label gaprindashvili/yes