### PR TITLE
GenericFeatureButton - don't catch NoMethodError

### DIFF
--- a/app/helpers/application_helper/button/generic_feature_button.rb
+++ b/app/helpers/application_helper/button/generic_feature_button.rb
@@ -7,10 +7,12 @@ class ApplicationHelper::Button::GenericFeatureButton < ApplicationHelper::Butto
   end
 
   def visible?
-    begin
-      return @record.send("supports_#{@feature}?")
-    rescue NoMethodError # TODO: remove with deleting AvailabilityMixin module
-      return @record.is_available?(@feature)
+    method = "supports_#{@feature}?"
+
+    if @record.respond_to?(method)
+      @record.send(method)
+    else # TODO: remove with deleting AvailabilityMixin module
+      @record.is_available?(@feature)
     end
   end
 end


### PR DESCRIPTION
Right now, if a `@record` has a `supports_foo?` method, but calling that method fails with a `NoMethodError`, `GenericFeatureButton#visible?` will try to fall back to `AvailabilityMixin` and fail on missing `is_available?`.

We should only fall back to `is_available?` if the actual `supports_foo?` is missing.

Thus, using `respond_to?` to decide which to call, and not catching any exceptions.

Cc @borod108 

(`gaprindashvili/no` because this does have a subtle difference in behaviour and I'm not sure this won't cause *any* regressions..)