### PR TITLE
Disable buttons for adding new cloud items when no provider available 🐛

### DIFF
--- a/app/helpers/application_helper/button/new_cloud_tenant.rb
+++ b/app/helpers/application_helper/button/new_cloud_tenant.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::NewCloudTenant < ApplicationHelper::Button::ButtonNewDiscover
+  def disabled?
+    super || ManageIQ::Providers::Openstack::CloudManager.count == 0
+  end
+end

--- a/app/helpers/application_helper/button/new_flavor.rb
+++ b/app/helpers/application_helper/button/new_flavor.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::NewFlavor < ApplicationHelper::Button::Basic
+  def disabled?
+    super || ManageIQ::Providers::CloudManager.all.none? { |ems| ems.class::Flavor.supports?(:create) }
+  end
+end

--- a/app/helpers/application_helper/button/new_host_aggregate.rb
+++ b/app/helpers/application_helper/button/new_host_aggregate.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::NewHostAggregate < ApplicationHelper::Button::ButtonNewDiscover
+  def disabled?
+    super || ManageIQ::Providers::CloudManager.all.none? { |ems| ems.supports?(:create_host_aggregate) }
+  end
+end

--- a/app/helpers/application_helper/toolbar/cloud_tenants_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_tenants_center.rb
@@ -11,7 +11,7 @@ class ApplicationHelper::Toolbar::CloudTenantsCenter < ApplicationHelper::Toolba
           'pficon pficon-edit fa-lg',
           t = N_('Create Cloud Tenant'),
           t,
-          :klass => ApplicationHelper::Button::ButtonNewDiscover),
+          :klass => ApplicationHelper::Button::NewCloudTenant),
         button(
           :cloud_tenant_edit,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/flavors_center.rb
+++ b/app/helpers/application_helper/toolbar/flavors_center.rb
@@ -11,6 +11,7 @@ class ApplicationHelper::Toolbar::FlavorsCenter < ApplicationHelper::Toolbar::Ba
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Flavor'),
           t,
+          :klass => ApplicationHelper::Button::NewFlavor
         ),
         separator,
         button(

--- a/app/helpers/application_helper/toolbar/host_aggregates_center.rb
+++ b/app/helpers/application_helper/toolbar/host_aggregates_center.rb
@@ -12,7 +12,7 @@ class ApplicationHelper::Toolbar::HostAggregatesCenter < ApplicationHelper::Tool
           t = N_('Add a New Host Aggregate'),
           t,
           :url   => "/new",
-          :klass => ApplicationHelper::Button::ButtonNewDiscover),
+          :klass => ApplicationHelper::Button::NewHostAggregate),
         button(
           :host_aggregate_edit,
           'pficon pficon-edit fa-lg',

--- a/spec/helpers/application_helper/buttons/new_cloud_tenant_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_cloud_tenant_spec.rb
@@ -1,0 +1,23 @@
+describe ApplicationHelper::Button::NewCloudTenant do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:button) { described_class.new(view_context, {}, {}, {}) }
+
+  describe '#disabled?' do
+    subject { button[:title] }
+
+    context 'no provider available' do
+      before { button.calculate_properties }
+
+      it_behaves_like 'a disabled button'
+    end
+
+    context 'provider available' do
+      before do
+        FactoryGirl.create(:ems_openstack)
+        button.calculate_properties
+      end
+
+      it_behaves_like 'an enabled button'
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/new_flavor_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_flavor_spec.rb
@@ -1,0 +1,24 @@
+describe ApplicationHelper::Button::NewFlavor do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:button) { described_class.new(view_context, {}, {}, {}) }
+
+  describe '#disabled?' do
+    subject { button[:title] }
+
+    context 'no provider available' do
+      before { button.calculate_properties }
+
+      it_behaves_like 'a disabled button'
+    end
+
+    context 'provider available' do
+      before do
+        provider = FactoryGirl.create(:ems_cloud)
+        allow(provider.class::Flavor).to receive(:create).and_return(true)
+        button.calculate_properties
+      end
+
+      it_behaves_like 'an enabled button'
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/new_host_aggregate_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_host_aggregate_spec.rb
@@ -1,0 +1,23 @@
+describe ApplicationHelper::Button::NewHostAggregate do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:button) { described_class.new(view_context, {}, {}, {}) }
+
+  describe '#disabled?' do
+    subject { button[:title] }
+
+    context 'no provider available' do
+      before { button.calculate_properties }
+
+      it_behaves_like 'a disabled button'
+    end
+
+    context 'provider available' do
+      before do
+        provider = FactoryGirl.create(:ems_openstack)
+        button.calculate_properties
+      end
+
+      it_behaves_like 'an enabled button'
+    end
+  end
+end


### PR DESCRIPTION
There were some cloud-related item buttons that were enabled even when there was no available provider for them:
* Creating a new Flavor
* Creating a new Cloud Tenant
* Creating a new Host Aggregate

These now will be disabled when there is no related provider available. Tests included to make @martinpovolny happy.

https://bugzilla.redhat.com/show_bug.cgi?id=1516877