### PR TITLE
Add column to MW Deployments

### DIFF
--- a/product/views/MiddlewareDeployment.yaml
+++ b/product/views/MiddlewareDeployment.yaml
@@ -29,6 +29,9 @@ include:
     columns:
     - name
     - hostname
+  middleware_server_group:
+    columns:
+    - name
 
 # Included tables and columns for query performance
 
@@ -39,6 +42,7 @@ col_order:
 - status
 - middleware_server.name
 - middleware_server.hostname
+- middleware_server_group.name
 
 # Column titles, in order
 headers:
@@ -46,6 +50,7 @@ headers:
 - Status
 - Server
 - Host Name
+- Server Group
 
 # Condition(s) string for the SQL query
 conditions:
@@ -57,6 +62,7 @@ order: Ascending
 sortby:
 - name
 - middleware_server.name
+- middleware_server_group.name
 - middleware_server.hostname
 
 # Group rows (y=yes,n=no,c=count)


### PR DESCRIPTION
Add a Middleware Server Group column to Middleware Deployments list.

When the MW deployment is deployed to a server group (to each server there), let's show the group in the deployments list as well.

Resolves: [BUG 1443155](https://bugzilla.redhat.com/show_bug.cgi?id=1443155)

![image](https://user-images.githubusercontent.com/7453394/33325756-78ac2fae-d453-11e7-9721-540169d4eec7.png)
