### PR TITLE
Set @tree_selected_model when explorer or tree_select is called in OPS

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -99,6 +99,18 @@ class OpsController < ApplicationController
     custom_buttons if params[:pressed] == 'custom_button'
   end
 
+  def tree_selected_model
+    @tree_selected_model = if x_node == 'root'
+                             MiqRegion
+                           else
+                             model, id, _ = TreeBuilder.extract_node_model_and_id(x_node)
+                             if model == 'Hash'
+                               model = TreeBuilder.get_model_for_prefix(id)
+                             end
+                             model.constantize
+                           end
+  end
+
   def explorer
     @explorer = true
     @trees = []
@@ -115,6 +127,8 @@ class OpsController < ApplicationController
     return unless load_edit(params[:edit_key], "explorer") if params[:edit_key]
     @breadcrumbs = []
     build_accordions_and_trees
+
+    tree_selected_model
 
     @sb[:rails_log] = $rails_log.filename.to_s.include?("production.log") ? N_("Production") : N_("Development")
 
@@ -151,6 +165,7 @@ class OpsController < ApplicationController
     session[:flash_msgs] = @flash_array = nil           # clear out any messages from previous screen i.e import tab
     @sb[:active_node] ||= {}
     self.x_node = params[:id]
+    tree_selected_model
     set_active_tab(params[:id])
     session[:changed] = false
     self.x_node = params[:id] # if x_active_tree == :vmdb_tree #params[:action] == "x_show"

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -891,19 +891,15 @@ module OpsController::OpsRbac
       case id
       when "u"
         @right_cell_text = _("Access Control EVM Users")
-        @tree_selected_model = User
         rbac_users_list
       when "g"
         @right_cell_text = _("Access Control EVM Groups")
-        @tree_selected_model = MiqGroup
         rbac_groups_list
       when "ur"
         @right_cell_text = _("Access Control Roles")
-        @tree_selected_model = MiqUserRole
         rbac_roles_list
       when "tn"
         @right_cell_text = _("Access Control Tenants")
-        @tree_selected_model = Tenant
         rbac_tenants_list
       end
     when "u"

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -266,6 +266,13 @@ describe OpsController do
       expect(response.status).to eq(200)
       expect(assigns(:sb)[:active_accord]).to eq(:rbac)
     end
+
+    it 'calls #tree_selected_model' do
+      controller.instance_variable_set(:@sb, {})
+      allow(controller).to receive(:render)
+      expect(controller).to receive(:tree_selected_model)
+      controller.send(:explorer)
+    end
   end
 
   context "#replace_explorer_trees" do
@@ -378,6 +385,74 @@ describe OpsController do
         expect(controller).to receive(:replace_right_cell).with(:nodetype => 'dialog_return')
         controller.send(:dialog_replace_right_cell)
       end
+    end
+  end
+
+  context "#tree_selected_model" do
+    it 'sets @tree_model_selected to User for user node' do
+      allow(controller).to receive(:x_node).and_return('u-42')
+      controller.tree_selected_model
+      expect(assigns(:tree_selected_model)).to eq(User)
+    end
+
+    it 'sets @tree_model_selected to Tenant for tenant node' do
+      allow(controller).to receive(:x_node).and_return('tn-42')
+      controller.tree_selected_model
+      expect(assigns(:tree_selected_model)).to eq(Tenant)
+    end
+
+    it 'sets @tree_model_selected to MiqGroup for group node' do
+      allow(controller).to receive(:x_node).and_return('g-42')
+      controller.tree_selected_model
+      expect(assigns(:tree_selected_model)).to eq(MiqGroup)
+    end
+
+    it 'sets @tree_model_selected to MiqUserRole for group node' do
+      allow(controller).to receive(:x_node).and_return('ur-42')
+      controller.tree_selected_model
+      expect(assigns(:tree_selected_model)).to eq(MiqUserRole)
+    end
+
+    it 'sets @tree_model_selected to User for all users node' do
+      allow(controller).to receive(:x_node).and_return('xx-u')
+      controller.tree_selected_model
+      expect(assigns(:tree_selected_model)).to eq(User)
+    end
+
+    it 'sets @tree_model_selected to Tenant for all tenants node' do
+      allow(controller).to receive(:x_node).and_return('xx-tn')
+      controller.tree_selected_model
+      expect(assigns(:tree_selected_model)).to eq(Tenant)
+    end
+
+    it 'sets @tree_model_selected to MiqGroup for all groups node' do
+      allow(controller).to receive(:x_node).and_return('xx-g')
+      controller.tree_selected_model
+      expect(assigns(:tree_selected_model)).to eq(MiqGroup)
+    end
+
+    it 'sets @tree_model_selected to MiqUserRole for all roles node' do
+      allow(controller).to receive(:x_node).and_return('xx-ur')
+      controller.tree_selected_model
+      expect(assigns(:tree_selected_model)).to eq(MiqUserRole)
+    end
+
+    it 'sets @tree_model_selected to MiqRegion for root node' do
+      allow(controller).to receive(:x_node).and_return('root')
+      controller.tree_selected_model
+      expect(assigns(:tree_selected_model)).to eq(MiqRegion)
+    end
+  end
+
+  context '#tree_select' do
+    it 'calls #tree_select_model' do
+      controller.instance_variable_set(:@sb, {})
+      controller.params[:id] = 'root'
+      allow(controller).to receive(:set_active_tab)
+      allow(controller).to receive(:get_node_info)
+      allow(controller).to receive(:replace_right_cell)
+      expect(controller).to receive(:tree_selected_model)
+      controller.send(:tree_select)
     end
   end
 end


### PR DESCRIPTION
Steps to Reproduce:
1. Create new tenant
2. Create a group and set it to have with new tenant (from step 1) and  `EvmRole-tenant_administrator` role
3. Create new user and set it to have only the new group (from step 2)
4. Logout and login as the created user (from step 3)
5. Navigate to user -> Configuration

**Before:**
*Log:*
```
F, [2017-11-28T13:42:47.420122 #53404] FATAL -- : Error caught: [ActionView::Template::Error] undefined method `>=' for nil:NilClass
ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:366:in `button_class_name'
ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:389:in `get_custom_buttons'
ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:299:in `custom_button_selects'
ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:341:in `build_custom_toolbar_class'
ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:331:in `custom_toolbar_class'
ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:70:in `toolbar_class'
ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:18:in `build_toolbar'
ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:6:in `call'
ManageIQ/manageiq-ui-classic/app/helpers/application_helper.rb:528:in `build_toolbar'
```
*Screen:*
<img width="587" alt="screen shot 2017-11-28 at 1 42 51 pm" src="https://user-images.githubusercontent.com/9210860/33320333-31e6d1d4-d442-11e7-8f83-e302fa454c51.png">

**After:**
<img width="1211" alt="screen shot 2017-11-28 at 1 42 03 pm" src="https://user-images.githubusercontent.com/9210860/33320256-e8100904-d441-11e7-8b26-f18ee8939d4a.png">

@miq-bot add_label gaprindashvili/yes, bug, settings, blocker

https://bugzilla.redhat.com/show_bug.cgi?id=1515204