### PR TITLE
Follow-up for 2846

### DIFF
--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -18,15 +18,15 @@ module GenericObjectHelper::TextualSummary
   end
 
   def textual_attributes_none
-    {:label => _("No Attributes defined")}
+    {:label => _("No Attributes defined"), :no_value => true}
   end
 
   def textual_associations_none
-    {:label => _("No Associations defined")}
+    {:label => _("No Associations defined"), :no_value => true}
   end
 
   def textual_methods_none
-    {:label => _("No Methods defined")}
+    {:label => _("No Methods defined"), :no_value => true}
   end
 
   def textual_group_attribute_details_list
@@ -71,7 +71,7 @@ module GenericObjectHelper::TextualSummary
     @record.property_methods.each do |key|
       methods.push(key.to_sym)
       define_singleton_method("textual_#{key}") do
-        {:label => _("%{label}") % {:label => key}}
+        {:label => _("%{label}") % {:label => key}, :no_value => true}
       end
     end
     if methods.count > 0

--- a/app/views/shared/summary/_textual.html.haml
+++ b/app/views/shared/summary/_textual.html.haml
@@ -20,7 +20,7 @@
             :onclick => item[:link] ? click : ""}
           %td.label
             = item[:label]
-          - if item[:value]
+          - if item[:no_value].nil?
             %td
               = render :partial => "shared/summary/icon_or_image", :locals => {:item => item}
               = !item[:value].kind_of?(Array) ? item[:value] : render(:partial => "shared/summary/textual_multivalue", :locals => {:items => item[:value]})


### PR DESCRIPTION
A follow-up for PR #2846 -

An explicit parameter `:no-value` which will be used in the textual summary haml to skip rendering the value column.