### PR TITLE
Refer `::Settings` value before rendering SmartState docker credentials

### DIFF
--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -156,7 +156,7 @@
           %span{:style => "color:black"}
             = _("Required. Used to gather Utilization data.")
 
-    - if %w(ems_cloud).include?(params[:controller])
+    - if %w(ems_cloud).include?(params[:controller]) && ::Settings.ems.ems_amazon.agent_coordinator.docker_login_required
       = miq_tab_content('smartstate_docker', 'default') do
         .form-group
           .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'ec2'"}


### PR DESCRIPTION
Follow up for https://github.com/ManageIQ/manageiq-ui-classic/pull/2666

https://bugzilla.redhat.com/show_bug.cgi?id=1517061

/cc @jerryk55 