### PR TITLE
Tests: match_gtl_options should ignore order in :selected_records.

### DIFF
--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -134,9 +134,15 @@ module Spec
           expected.keys.find_all { |key| expected[key] != actual[key] }.empty?
         end
 
+        def matches_selected_records(actual, expected)
+          return true unless expected
+          actual.sort == expected.sort
+        end
+
         match do |actual|
           additional_options = expected.delete(:report_data_additional_options)
-          matches_basic(actual, expected) && matches_additional(actual[:report_data_additional_options], additional_options)
+          selected_records = expected.delete(:selected_records)
+          matches_basic(actual, expected) && matches_additional(actual[:report_data_additional_options], additional_options) && matches_selected_records(actual[:selected_records], selected_records)
         end
       end
     end


### PR DESCRIPTION
Tests: `match_gtl_options` should ignore order in `:selected_records`.

This should fix a sporadic test failure in https://github.com/ManageIQ/manageiq-ui-classic/blob/master/spec/controllers/host_controller_spec.rb#L24

https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/308502672

Ping @skateman 