### PR TITLE
Add OpenID-Connect authentication support

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
     # MiqWebServerWorkerMixin.configure_secret_token for rails server, UI, and
     # web service worker processes.
     protect_from_forgery(:secret => SecureRandom.hex(64),
-                         :except => %i[authenticate external_authenticate kerberos_authenticate saml_login initiate_saml_login oidc_login initiate_oidc_login csp_report],
+                         :except => %i(authenticate external_authenticate kerberos_authenticate saml_login initiate_saml_login oidc_login initiate_oidc_login csp_report),
                          :with   => :exception)
 
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,9 @@ class ApplicationController < ActionController::Base
     # This secret is reset to a value found in the miq_databases table in
     # MiqWebServerWorkerMixin.configure_secret_token for rails server, UI, and
     # web service worker processes.
-    protect_from_forgery :secret => SecureRandom.hex(64), :except => [:authenticate, :external_authenticate, :kerberos_authenticate, :saml_login, :initiate_saml_login, :oidc_login, :initiate_oidc_login, :csp_report], :with => :exception
+    protect_from_forgery(:secret => SecureRandom.hex(64),
+                         :except => %i[authenticate external_authenticate kerberos_authenticate saml_login initiate_saml_login oidc_login initiate_oidc_login csp_report],
+                         :with   => :exception)
 
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,8 @@ class ApplicationController < ActionController::Base
     # This secret is reset to a value found in the miq_databases table in
     # MiqWebServerWorkerMixin.configure_secret_token for rails server, UI, and
     # web service worker processes.
-    protect_from_forgery :secret => SecureRandom.hex(64), :except => [:authenticate, :external_authenticate, :kerberos_authenticate, :saml_login, :initiate_saml_login, :csp_report], :with => :exception
+    protect_from_forgery :secret => SecureRandom.hex(64), :except => [:authenticate, :external_authenticate, :kerberos_authenticate, :saml_login, :initiate_saml_login, :oidc_login, :initiate_oidc_login, :csp_report], :with => :exception
+
   end
 
   helper GtlHelper

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -7,12 +7,12 @@ class DashboardController < ApplicationController
   @@items_per_page = 8
 
   before_action :check_privileges, :except => %i(csp_report authenticate
-                                               external_authenticate kerberos_authenticate
-                                               logout login login_retry wait_for_task
-                                               saml_login initiate_saml_login
-                                               oidc_login, initiate_oidc_login)
+                                                 external_authenticate kerberos_authenticate
+                                                 logout login login_retry wait_for_task
+                                                 saml_login initiate_saml_login
+                                                 oidc_login initiate_oidc_login)
   before_action :get_session_data, :except => %i(csp_report authenticate
-                                               external_authenticate kerberos_authenticate saml_login oidc_login)
+                                                 external_authenticate kerberos_authenticate saml_login oidc_login)
   after_action :cleanup_action,    :except => %i(csp_report)
 
   def index

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -477,10 +477,6 @@ class DashboardController < ApplicationController
 
   # Login support for OpenIDC - GET /oidc_login
   def oidc_login
-    request.env.each do |key, value|
-      $log.info("    request.env[#{key}] = #{value}") if key =~ /^HTTP_/
-    end
-
     if @user_name.blank? && request.env.key?("HTTP_X_REMOTE_USER").present?
       @user_name = params[:user_name] = request.env["HTTP_X_REMOTE_USER"].split("@").first
     else

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -58,12 +58,12 @@ class DashboardController < ApplicationController
   def oidc_protected_page
     request.base_url + '/oidc_login'
   end
-  helper_method :oidc_protected_page
+  helper_method(:oidc_protected_page)
 
   def oidc_protected_page_logout
     request.base_url + '/oidc_login/redirect_uri?logout=' + CGI.escape(request.base_url)
   end
-  helper_method :oidc_protected_page_logout
+  helper_method(:oidc_protected_page_logout)
 
   def iframe
     override_content_security_policy_directives(:frame_src => ['*'])
@@ -427,7 +427,7 @@ class DashboardController < ApplicationController
     end
 
     if ext_auth?(:oidc_enabled) && ext_auth?(:local_login_disabled)
-      redirect_to oidc_protected_page
+      redirect_to(oidc_protected_page)
       return
     end
 
@@ -472,7 +472,7 @@ class DashboardController < ApplicationController
 
   # Initiate an OpenIDC Login from the main login page
   def initiate_oidc_login
-    javascript_redirect oidc_protected_page
+    javascript_redirect(oidc_protected_page)
   end
 
   # Login support for OpenIDC - GET /oidc_login
@@ -480,7 +480,7 @@ class DashboardController < ApplicationController
     if @user_name.blank? && request.env.key?("HTTP_X_REMOTE_USER").present?
       @user_name = params[:user_name] = request.env["HTTP_X_REMOTE_USER"].split("@").first
     else
-      redirect_to :action => 'logout'
+      redirect_to(:action => 'logout')
       return
     end
 
@@ -496,7 +496,7 @@ class DashboardController < ApplicationController
       return
     when :fail
       session[:user_validation_error] = validation.flash_msg || "User validation failed"
-      redirect_to :action => 'logout'
+      redirect_to(:action => 'logout')
       return
     end
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -9,9 +9,10 @@ class DashboardController < ApplicationController
   before_action :check_privileges, :except => %i(csp_report authenticate
                                                external_authenticate kerberos_authenticate
                                                logout login login_retry wait_for_task
-                                               saml_login initiate_saml_login)
+                                               saml_login initiate_saml_login
+                                               oidc_login, initiate_oidc_login)
   before_action :get_session_data, :except => %i(csp_report authenticate
-                                               external_authenticate kerberos_authenticate saml_login)
+                                               external_authenticate kerberos_authenticate saml_login oidc_login)
   after_action :cleanup_action,    :except => %i(csp_report)
 
   def index
@@ -53,6 +54,16 @@ class DashboardController < ApplicationController
     request.base_url + '/saml_login'
   end
   helper_method :saml_protected_page
+
+  def oidc_protected_page
+    request.base_url + '/oidc_login'
+  end
+  helper_method :oidc_protected_page
+
+  def oidc_protected_page_logout
+    request.base_url + '/oidc_login/redirect_uri?logout=' + CGI.escape(request.base_url)
+  end
+  helper_method :oidc_protected_page_logout
 
   def iframe
     override_content_security_policy_directives(:frame_src => ['*'])
@@ -415,6 +426,11 @@ class DashboardController < ApplicationController
       return
     end
 
+    if ext_auth?(:oidc_enabled) && ext_auth?(:local_login_disabled)
+      redirect_to oidc_protected_page
+      return
+    end
+
     if ::Settings.product.allow_passed_in_credentials # Only pre-populate credentials if setting is turned on
       @user_name     = params[:user_name]
       @user_password = params[:user_password]
@@ -452,6 +468,41 @@ class DashboardController < ApplicationController
   # Initiate a SAML Login from the main login page
   def initiate_saml_login
     javascript_redirect(saml_protected_page)
+  end
+
+  # Initiate an OpenIDC Login from the main login page
+  def initiate_oidc_login
+    javascript_redirect oidc_protected_page
+  end
+
+  # Login support for OpenIDC - GET /oidc_login
+  def oidc_login
+    request.env.each do |key, value|
+      $log.info("    request.env[#{key}] = #{value}") if key =~ /^HTTP_/
+    end
+
+    if @user_name.blank? && request.env.key?("HTTP_X_REMOTE_USER").present?
+      @user_name = params[:user_name] = request.env["HTTP_X_REMOTE_USER"].split("@").first
+    else
+      redirect_to :action => 'logout'
+      return
+    end
+
+    user = {:name => @user_name}
+    validation = validate_user(user, nil, request, :require_user => true, :timeout => 30)
+
+    case validation.result
+    when :pass
+      render :template => "dashboard/oidc_login",
+             :layout   => false,
+             :locals   => {:api_auth_token => generate_ui_api_token(@user_name),
+                           :validation_url => validation.url}
+      return
+    when :fail
+      session[:user_validation_error] = validation.flash_msg || "User validation failed"
+      redirect_to :action => 'logout'
+      return
+    end
   end
 
   # Login support for SAML - GET /saml_login
@@ -651,6 +702,8 @@ class DashboardController < ApplicationController
     # For SAML, let's do the SAML logout to clear mod_auth_mellon IdP cookies and such
     if ext_auth?(:saml_enabled)
       redirect_to("/saml2/logout?ReturnTo=/")
+    elsif ext_auth?(:oidc_enabled)
+      redirect_to(oidc_protected_page_logout)
     else
       redirect_to(:action => 'login')
     end

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -21,13 +21,13 @@
               %strong= _("Invalid Single Sign-On credentials")
         = render :partial => "layouts/flash_msg"
 
-        - if ext_auth?(:saml_enabled)
+        - if ext_auth?(:saml_enabled) || ext_auth?(:oidc_enabled)
           .form-group
             %label.col-md-3.control-label
             .col-md-9
-              = link_to(_("Log In to Corporate System"), {:action => "initiate_saml_login",
-                                                         :button => "saml_login"},
-                        :id                   => "saml_login",
+              = link_to(_("Log In to Corporate System"), {:action => (ext_auth?(:saml_enabled) ? "initiate_saml_login" : "initiate_oidc_login"),
+                                                         :button => (ext_auth?(:saml_enabled) ? "saml_login" : "oidc_login")},
+                        :id                   => (ext_auth?(:saml_enabled) ? "saml_login" : "oidc_login"),
                         :class                => "btn btn-primary form-control",
                         :alt                  => _("Log In"),
                         :title                => _("Log In to Corporate System"),
@@ -139,6 +139,11 @@
       :javascript
         $(function () {
           $('#saml_login').click();
+        });
+    - elsif ext_auth?(:oidc_enabled)
+      :javascript
+        $(function () {
+          $('#oidc_login').click();
         });
     - else
       :javascript

--- a/app/views/dashboard/oidc_login.html.haml
+++ b/app/views/dashboard/oidc_login.html.haml
@@ -8,7 +8,7 @@
     - if api_auth_token && validation_url
       :javascript
         miqFlashClearSaved();
-        sessionStorage.miq_token = '#{j_str api_auth_token}';
+        localStorage.miq_token = '#{j_str api_auth_token}';
         window.location = '#{j_str validation_url}';
     - else
       :javascript

--- a/app/views/dashboard/oidc_login.html.haml
+++ b/app/views/dashboard/oidc_login.html.haml
@@ -1,0 +1,16 @@
+%html.login-pf{:class => ::Settings.server.custom_login_logo ? '' : 'rcue-login', :lang => I18n.locale.to_s.sub('-', '_')}
+  %head
+    = favicon_link_tag
+    = stylesheet_link_tag 'application'
+    = javascript_include_tag 'application'
+
+  %body
+    - if api_auth_token && validation_url
+      :javascript
+        miqFlashClearSaved();
+        sessionStorage.miq_token = '#{j_str api_auth_token}';
+        window.location = '#{j_str validation_url}';
+    - else
+      :javascript
+        miqFlashClearSaved();
+        window.location = '/dashboard/logout';

--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -246,15 +246,30 @@
           = _("Provider Type:")
         .col-md-8
           %label
-            %input{:type => 'radio', :name => 'provider_type', :id => 'provider_type', :value => 'none', "data-miq_observe" => {:url => url}.to_json, :checked => @edit[:new][:authentication][:provider_type] == "none" }
+            %input{:type              => 'radio',
+                   :name              => 'provider_type',
+                   :id                => 'provider_type',
+                   :value             => 'none',
+                   "data-miq_observe" => {:url => url}.to_json,
+                   :checked           => @edit[:new][:authentication][:provider_type] == "none"}
             = _("None")
           %br
           %label
-            %input{:type => 'radio', :name => 'provider_type', :id => 'provider_type', :value => 'saml', "data-miq_observe" => {:url => url}.to_json, :checked => @edit[:new][:authentication][:provider_type] == "saml" }
+            %input{:type              => 'radio',
+                   :name              => 'provider_type',
+                   :id                => 'provider_type',
+                   :value             => 'saml',
+                   "data-miq_observe" => {:url => url}.to_json,
+                   :checked           => @edit[:new][:authentication][:provider_type] == "saml"}
             = _("Enable SAML")
           %br
           %label
-            %input{:type => 'radio', :name => 'provider_type', :id => 'provider_type', :value => 'oidc', "data-miq_observe" => {:url => url}.to_json, :checked => @edit[:new][:authentication][:provider_type] == "oidc" }
+            %input{:type              => 'radio',
+                   :name              => 'provider_type',
+                   :id                => 'provider_type',
+                   :value             => 'oidc',
+                   "data-miq_observe" => {:url => url}.to_json,
+                   :checked           => @edit[:new][:authentication][:provider_type] == "oidc"}
             = _("Enable OpenID-Connect")
 
       = hidden_div_if(@edit[:new][:authentication][:provider_type] == "none", :id => "none_local_login_div") do

--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -239,14 +239,25 @@
           = check_box_tag("sso_enabled", "1",
                           @edit[:new][:authentication][:sso_enabled],
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
+    %h3
+    .form-horizontal
       .form-group
-        %label.col-md-2.control-label
-          = _("Enable SAML")
-        .col-md-4
-          = check_box_tag("saml_enabled", "1",
-                          @edit[:new][:authentication][:saml_enabled],
-                          "data-miq_observe_checkbox" => {:url => url}.to_json)
-      = hidden_div_if(@edit[:new][:authentication][:saml_enabled] == false, :id => "saml_local_login_div") do
+        %label.control-label.col-md-2
+          = _("Provider Type:")
+        .col-md-8
+          %label
+            %input{:type => 'radio', :name => 'provider_type', :id => 'provider_type', :value => 'none', "data-miq_observe" => {:url => url}.to_json, :checked => @edit[:new][:authentication][:provider_type] == "none" }
+            = _("None")
+          %br
+          %label
+            %input{:type => 'radio', :name => 'provider_type', :id => 'provider_type', :value => 'saml', "data-miq_observe" => {:url => url}.to_json, :checked => @edit[:new][:authentication][:provider_type] == "saml" }
+            = _("Enable SAML")
+          %br
+          %label
+            %input{:type => 'radio', :name => 'provider_type', :id => 'provider_type', :value => 'oidc', "data-miq_observe" => {:url => url}.to_json, :checked => @edit[:new][:authentication][:provider_type] == "oidc" }
+            = _("Enable OpenID-Connect")
+
+      = hidden_div_if(@edit[:new][:authentication][:provider_type] == "none", :id => "none_local_login_div") do
         .form-group
           %label.col-md-2.control-label
             = _("Disable Local Login")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1091,6 +1091,7 @@ Rails.application.routes.draw do
         login
         logout
         saml_login
+        oidc_login
         maintab
         render_csv
         render_pdf
@@ -1111,6 +1112,7 @@ Rails.application.routes.draw do
         external_authenticate
         kerberos_authenticate
         initiate_saml_login
+        initiate_oidc_login
         authenticate
         change_group
         csp_report
@@ -3196,6 +3198,7 @@ Rails.application.routes.draw do
   get '/pictures/:basename' => 'picture#show', :basename => /[\da-zA-Z]+\.[\da-zA-Z]+/
 
   get '/saml_login(/*path)' => 'dashboard#saml_login'
+  get '/oidc_login(/*path)' => 'dashboard#oidc_login'
 
   # ping response for load balancing
   get '/ping' => 'ping#index'

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -92,85 +92,50 @@ describe DashboardController do
     end
   end
 
-  context "SAML support" do
+  context "SAML and OIDC support" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
     end
 
-    it "SAML Login should redirect to the protected page" do
-      page = double("page")
-      allow(page).to receive(:<<).with(any_args)
-      expect(page).to receive(:redirect_to).with(controller.saml_protected_page)
-      expect(controller).to receive(:render).with(:update).and_yield(page)
-      controller.send(:initiate_saml_login)
+    %i(saml oidc).each do |protocol|
+      it "#{protocol.upcase} login should redirect to the protected page" do
+        page = double("page")
+        allow(page).to receive(:<<).with(any_args)
+        expect(page).to receive(:redirect_to).with(controller.send("#{protocol}_protected_page"))
+        expect(controller).to receive(:render).with(:update).and_yield(page)
+        controller.send("initiate_#{protocol}_login")
+      end
     end
 
-    it "SAML protected page should redirect to logout without a valid user" do
-      get :saml_login
-      expect(response).to redirect_to(:action => "logout")
+    %i(saml oidc).each do |protocol|
+      it "#{protocol.upcase} protected page should redirect to #{protocol}_logout without a valid user" do
+        get "#{protocol}_login".to_sym
+        expect(response).to redirect_to(:action => "logout")
+      end
     end
 
-    it "SAML protected page should render the saml_login page with the proper validation_url and api token" do
-      user           = FactoryGirl.create(:user, :userid => "johndoe", :role => "test")
-      auth_token     = "aabbccddeeff"
-      validation_url = "/user_validation_url"
+    %i(saml oidc).each do |protocol|
+      it "#{protocol.upcase} protected page should render the #{protocol}_login page with the proper validation_url and api token" do
+        user           = FactoryGirl.create(:user, :userid => "johndoe", :role => "test")
+        auth_token     = "aabbccddeeff"
+        validation_url = "/user_validation_url"
 
-      request.env["HTTP_X_REMOTE_USER"] = user.userid
-      skip_data_checks(validation_url)
+        request.env["HTTP_X_REMOTE_USER"] = user.userid
+        skip_data_checks(validation_url)
 
-      allow(User).to receive(:authenticate).and_return(user)
-      allow_any_instance_of(Api::UserTokenService).to receive(:generate_token)
-        .with(user.userid, "ui")
-        .and_return(auth_token)
+        allow(User).to receive(:authenticate).and_return(user)
+        allow_any_instance_of(Api::UserTokenService).to receive(:generate_token)
+          .with(user.userid, "ui")
+          .and_return(auth_token)
 
-      expect(controller).to receive(:render)
-        .with(:template => "dashboard/saml_login",
-              :layout   => false,
-              :locals   => {:api_auth_token => auth_token, :validation_url => validation_url})
-        .exactly(1).times
+        expect(controller).to receive(:render)
+          .with(:template => "dashboard/#{protocol}_login",
+                :layout   => false,
+                :locals   => {:api_auth_token => auth_token, :validation_url => validation_url})
+          .exactly(1).times
 
-      controller.send(:saml_login)
-    end
-  end
-
-  context "OIDC support" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
-
-    it "OIDC Login should redirect to the protected page" do
-      page = double("page")
-      allow(page).to receive(:<<).with(any_args)
-      expect(page).to receive(:redirect_to).with(controller.oidc_protected_page)
-      expect(controller).to receive(:render).with(:update).and_yield(page)
-      controller.send(:initiate_oidc_login)
-    end
-
-    it "OIDC protected page should redirect to logout without a valid user" do
-      get :oidc_login
-      expect(response).to redirect_to(:action => "logout")
-    end
-
-    it "OIDC protected page should render the oidc_login page with the proper validation_url and api token" do
-      user           = FactoryGirl.create(:user, :userid => "johndoe", :role => "test")
-      auth_token     = "aabbccddeeff"
-      validation_url = "/user_validation_url"
-
-      request.env["HTTP_X_REMOTE_USER"] = user.userid
-      skip_data_checks(validation_url)
-
-      allow(User).to receive(:authenticate).and_return(user)
-      allow_any_instance_of(Api::UserTokenService).to receive(:generate_token)
-        .with(user.userid, "ui")
-        .and_return(auth_token)
-
-      expect(controller).to receive(:render)
-        .with(:template => "dashboard/oidc_login",
-              :layout   => false,
-              :locals   => {:api_auth_token => auth_token, :validation_url => validation_url})
-        .exactly(1).times
-
-      controller.send(:oidc_login)
+        controller.send("#{protocol}_login")
+      end
     end
   end
 

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -133,6 +133,47 @@ describe DashboardController do
     end
   end
 
+  context "OIDC support" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
+
+    it "OIDC Login should redirect to the protected page" do
+      page = double("page")
+      allow(page).to receive(:<<).with(any_args)
+      expect(page).to receive(:redirect_to).with(controller.oidc_protected_page)
+      expect(controller).to receive(:render).with(:update).and_yield(page)
+      controller.send(:initiate_oidc_login)
+    end
+
+    it "OIDC protected page should redirect to logout without a valid user" do
+      get :oidc_login
+      expect(response).to redirect_to(:action => "logout")
+    end
+
+    it "OIDC protected page should render the oidc_login page with the proper validation_url and api token" do
+      user           = FactoryGirl.create(:user, :userid => "johndoe", :role => "test")
+      auth_token     = "aabbccddeeff"
+      validation_url = "/user_validation_url"
+
+      request.env["HTTP_X_REMOTE_USER"] = user.userid
+      skip_data_checks(validation_url)
+
+      allow(User).to receive(:authenticate).and_return(user)
+      allow_any_instance_of(Api::UserTokenService).to receive(:generate_token)
+        .with(user.userid, "ui")
+        .and_return(auth_token)
+
+      expect(controller).to receive(:render)
+        .with(:template => "dashboard/oidc_login",
+              :layout   => false,
+              :locals   => {:api_auth_token => auth_token, :validation_url => validation_url})
+        .exactly(1).times
+
+      controller.send(:oidc_login)
+    end
+  end
+
   # would like to test these controller by calling authenticate
   # need to ensure all cases are handled before deleting these
   context "#validate_user" do


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1610127/stories/121849185

The changes introduced by this PR will provide support for enabling OpenID-Connect
authentication.

This PR depends on [PR16495](https://github.com/ManageIQ/manageiq/pull/16495)


Steps for Testing/QA [Optional]
-------------------------------

1. Install and configure Identity and Access Management server, such as [Keycloak](http://www.keycloak.org/), for the OpenID-Connect provider type
2. Install and configure the Apache module: mod_auth_openidc on the ManageIQ appliance to point to the  Identity and Access Management server configured in step 1
3. Log into the appliance as _**admin**_ and configure authentication for OpenId-Connect by checking the _**Provider Type:**_ button  **_Enable OpenID-Connect_**
4. Log out and back in by selecting the **_Log In to Corporate System_** button on the log in screen specifying valid credentials, as configured on the Identity and Access Management server

