### PR TITLE
Containers link broken on container provider relationships

### DIFF
--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -42,7 +42,7 @@ module ContainerSummaryHelper
   end
 
   def textual_containers
-    textual_link(@record.containers, :feature => "containers") # should it be container_show_list?
+    textual_link(@record.containers) # should it be container_show_list?
   end
 
   def textual_container_nodes


### PR DESCRIPTION
`Containers` link was broken at container provider relationships.
This patch fixes the link.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1515255
cc @himdel @zeari 