### PR TITLE
Fix handling default values for help menu settings

### DIFF
--- a/app/controllers/ops_controller/settings/help_menu.rb
+++ b/app/controllers/ops_controller/settings/help_menu.rb
@@ -42,7 +42,8 @@ module OpsController::Settings::HelpMenu
         param = params["#{item}_#{field}"]
         next if param.nil?
 
-        @edit[:new][item][field] = param == 'null' ? false : param
+        @edit[:new][item][field] = param
+        @edit[:new][item].delete(field) if param.empty?
       end
     end
 

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -279,18 +279,15 @@ module Menu
         menu = {
           :documentation => {
             :title => N_('Documentation'),
-            :href  => '/support/index?support_tab=about',
-            :type  => nil,
+            :href  => '/support/index?support_tab=about'
           },
           :product       => {
             :title => I18n.t('product.support_website_text'),
-            :href  => I18n.t("product.support_website").html_safe,
-            :type  => :new_window,
+            :href  => I18n.t("product.support_website").html_safe
           },
           :about         => {
             :title => N_('About'),
-            :href  => '#aboutModal',
-            :type  => :modal
+            :href  => '#aboutModal'
           }
         }.map do |key, value|
           Menu::Item.new(key,


### PR DESCRIPTION
The submit button was not disabled under [certain conditions](https://bugzilla.redhat.com/show_bug.cgi?id=1517908#c2) in the settings -> region -> help menu.
![screenshot from 2017-11-29 13-41-17](https://user-images.githubusercontent.com/649130/33375728-23dfddaa-d50b-11e7-8d72-82c7056b1f73.png)

Backend part: https://github.com/ManageIQ/manageiq/pull/16549

https://bugzilla.redhat.com/show_bug.cgi?id=1517908