### PR TITLE
Clean tenant names

### DIFF
--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -115,13 +115,17 @@ class HawkularProxyService
                           :order          => params[:order] || 'ASC')
   end
 
+  def tenant_id(id)
+    id.split(':')[0] if id
+  end
+
   def tenants(limit)
     tenants = @cli.hawkular_client.http_get('/tenants')
 
     if @params['include'].blank?
-      tenants.map! { |x| {:label => labelize(x["id"]), :value => x["id"]} }
+      tenants.map! { |x| {:label => labelize(x["id"]), :value => tenant_id(x["id"])} }
     else
-      tenants.map! { |x| {:label => labelize(x["id"]), :value => x["id"]} if x["id"].include?(@params['include']) }
+      tenants.map! { |x| {:label => labelize(x["id"]), :value => tenant_id(x["id"])} if x["id"].include?(@params['include']) }
     end
 
     tenants.compact[0...limit]
@@ -164,6 +168,8 @@ class HawkularProxyService
   end
 
   def labelize(id)
+    id = tenant_id(id)
+
     tenant_labels = TENANT_LABEL_SPECIAL_CASES.symbolize_keys
     if Settings.hawkular_tenant_labels
       tenant_labels.merge!(Settings.hawkular_tenant_labels.to_hash)


### PR DESCRIPTION
**Description**
Compute --> Containers --> Container Nodes -> Monitoring -> Ad-hoc metrics

Because of a change in Hawkulars API [1] we need to clean up the strings we get from the /tenant endpoint before using them.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1518538

**Screenshots**

Before, we have a tenants named `name:hash`, trying to use them will end with error 500.
![screenshot-localhost 3000-2017-12-04-16-12-08](https://user-images.githubusercontent.com/2181522/33556882-20739a10-d90e-11e7-9ad8-6a9d45238ee9.png)

![screenshot-localhost 3000-2017-12-04-16-18-37](https://user-images.githubusercontent.com/2181522/33557077-d6431726-d90e-11e7-956d-de488cee557c.png)


After ( tenant names are cleaned )
![screenshot-localhost 3000-2017-12-04-16-16-46](https://user-images.githubusercontent.com/2181522/33557022-9a72ed16-d90e-11e7-8e6e-ed5b4dad1602.png)

[1] https://issues.jboss.org/browse/HWKMETRICS-745