### PR TITLE
Update SPICE to the latest version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -51,7 +51,7 @@
     "qs": "~0.3.10",
     "rx-angular": "rx.angular#~1.1.3",
     "rxjs": "~4.1.0",
-    "spice-html5-bower": "himdel/spice-html5-bower#~1.6.3",
+    "spice-html5-bower": "himdel/spice-html5-bower#~1.7.1",
     "spin.js": "~2.3.2",
     "sprintf": "~1.0.3",
     "tota11y": "~0.1.6",


### PR DESCRIPTION
When opening a SPICE console served by RHEV 4.1 provider, the browser's CPU usage is significantly high. Updating the SPICE-HTML5 client to the latest version fixes the issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1518273