### PR TITLE
Adding view full log in alerts button

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -617,7 +617,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
             } else {
               $scope.updateAuthStatus(true);
             }
-            miqService.miqFlash(data.level, data.message);
+            miqService.miqFlash(data.level, data.message, data.options);
             miqSparkleOff();
           });
         });

--- a/app/assets/javascripts/miq_flash.js
+++ b/app/assets/javascripts/miq_flash.js
@@ -27,6 +27,10 @@ function add_flash(msg, level, options) {
       throw("add_flash: unknown level: " + level);
   }
 
+  if (options.long_alert) {
+    cls.alert += " text-overflow-pf";
+  }
+
   var iconSpan = $('<span class="' + cls.icon + '"></span>');
 
   var textStrong = $('<strong></strong>');
@@ -34,6 +38,17 @@ function add_flash(msg, level, options) {
 
   var alertDiv = $('<div class="' + cls.alert + '"><button class="close" data-dismiss="alert"><span class="pficon pficon-close"></span></button></div>');
   alertDiv.append(iconSpan, textStrong);
+
+  // if options.long alert is given than add a `See More` button to the alert div to allow user the get more details of the error/alert.
+  if (options.long_alert) {
+    var detailsLinkTxt = __("View More");
+    var detailsLink = $('<div class="alert_expand_link"><strong><a href="#">' + detailsLinkTxt + '</a></strong></div>');
+    var params = {clicked: false, alert_elem: alertDiv, link: detailsLink};
+    detailsLink.on('click', function() {
+      expandAlert(params);
+    });
+    alertDiv.append(detailsLink);
+  }
 
   var textDiv = $('<div class="flash_text_div"></div>');
 
@@ -46,10 +61,46 @@ function add_flash(msg, level, options) {
   }
 
   $('#flash_msg_div').append(textDiv).show();
+
+  // remove dangling 'Show More' link when the alert msg is short.
+  if ( options.long_alert && ! checkElipsis(alertDiv) ) {
+    detailsLink.hide();
+  }
 }
 
 function clearFlash() {
   $('#flash_msg_div').empty();
+}
+
+function checkElipsis(element) {
+  var found = false;
+  var $c = element
+    .clone()
+    .css({display: 'inline-block', width: 'auto', visibility: 'hidden'})
+    .appendTo('body');
+  if ( $c.width() > element.width() ) {
+    found = true;
+  }
+
+  $c.remove();
+
+  return found;
+}
+
+function expandAlert(params) {
+  var viewMoreTxt = __("View More");
+  var viewLessTxt = __("View Less");
+  if (! params.clicked) {
+    params.clicked = true;
+    params.alert_elem.removeClass('text-overflow-pf');
+    params.alert_elem.addClass('text-vertical-overflow-pf');
+    params.link.find('a').text(viewLessTxt);
+  } else {
+    params.clicked = false;
+    params.alert_elem.removeClass('text-vertical-overflow-pf');
+    params.alert_elem.addClass('text-overflow-pf');
+    params.link.find('a').text(viewMoreTxt);
+  }
 }
 
 function _miqFlashLoad() {

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -44,9 +44,9 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', 'API'
     miqSparkleOff();
   };
 
-  this.miqFlash = function(type, msg) {
+  this.miqFlash = function(type, msg, options) {
     miqService.miqFlashClear();
-    add_flash(msg, type);
+    add_flash(msg, type, options);
   };
 
   // FIXME: usually we just hide it, merge the logic

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -913,6 +913,11 @@ img.tiny { margin: 0; padding: 0;width:20px;height:20px; border: 0; vertical-ali
   border: 2px dashed #ddd;
 }
 
+.text-vertical-overflow-pf {
+  overflow-y: auto;
+  max-height: 17ex;
+}
+
 /// ===================================================================
 /// end misc styling
 /// ===================================================================

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -98,7 +98,7 @@ module Mixins
         level = :error
       end
 
-      render_flash_json(msg, level)
+      render_flash_json(msg, level, :long_alert => true)
     end
 
     def create

--- a/app/controllers/mixins/generic_form_mixin.rb
+++ b/app/controllers/mixins/generic_form_mixin.rb
@@ -16,8 +16,8 @@ module Mixins
       end
     end
 
-    def render_flash_json(msg, level = :success)
-      render :json => {:message => msg, :level => level}
+    def render_flash_json(msg, level = :success, options = {})
+      render :json => {:message => msg, :level => level, :options => options}
     end
   end
 end

--- a/spec/javascripts/miq_flash_spec.js
+++ b/spec/javascripts/miq_flash_spec.js
@@ -10,4 +10,24 @@ describe('miq_flash.js', function() {
       expect($('#flash_msg_div').html()).toEqual('');
     });
   });
+  describe('longAlert', function() {
+    beforeEach(function() {
+      var html = '<html><head></head><body><div id="flash_msg_div"></div></body></html>';
+      setFixtures(html);
+    });
+
+    it('displays flash_msg_div "View More" button', function() {
+      // Expect alert msg div to add the "See More" button to the div.
+      add_flash("Lorem ipsum dolor sit amet, usu ei mollis vivendum, ancillae indoctum philosophia an pri, affert partiendo cum ne. Nec animal tincidunt philosophia ea. Ne mea liber gloriatur, ignota dictas mei ne. Omittam eleifend consequuntur vix eu, everti accusata accommodare et eam. Ut vidit semper instructior duo, usu in autem inermis. Viris pertinax constituto per id, at debet apeirian persecuti has. Nostrum expetenda qui ad, mazim iriure id duo, est alii wisi at.", 'error' , {long_alert: true});
+      var flash_msg_div = '<div class="flash_text_div"><div class="alert alert-danger text-overflow-pf"><button class="close" data-dismiss="alert"><span class="pficon pficon-close"></span></button><span class="pficon pficon-error-circle-o"></span><strong>Lorem ipsum dolor sit amet, usu ei mollis vivendum, ancillae indoctum philosophia an pri, affert partiendo cum ne. Nec animal tincidunt philosophia ea. Ne mea liber gloriatur, ignota dictas mei ne. Omittam eleifend consequuntur vix eu, everti accusata accommodare et eam. Ut vidit semper instructior duo, usu in autem inermis. Viris pertinax constituto per id, at debet apeirian persecuti has. Nostrum expetenda qui ad, mazim iriure id duo, est alii wisi at.</strong><div class="alert_expand_link" style="display: none;"><strong><a href="#">View More</a></strong></div></div></div>'
+      expect($('#flash_msg_div').html()).toEqual(flash_msg_div);
+    });
+
+    it('does not display flash_msg_div "See More" button', function() {
+      // Expect alert msg div to *not add* the "See More" button to the div.
+      add_flash("This is a really long alert!", 'error');
+      var flash_msg_div = '<div class="flash_text_div"><div class="alert alert-danger"><button class="close" data-dismiss="alert"><span class="pficon pficon-close"></span></button><span class="pficon pficon-error-circle-o"></span><strong>This is a really long alert!</strong></div></div>'
+      expect($('#flash_msg_div').html()).toEqual(flash_msg_div);
+    });
+  });
 });


### PR DESCRIPTION
Currently we truncate (after 200 characters) the log error / warning that was received when connecting to a provider - In this patch I purpose a way of dealing with the **full** log error by adding a button to the alert when the alert is too long (above 200 characters).
Summary of scenarios tested:
Short alert:
![short_alert](https://user-images.githubusercontent.com/8366181/34154169-3e223c6e-e4bd-11e7-9c42-2113ed1939fc.gif)
Long alert:
![middle_alert](https://user-images.githubusercontent.com/8366181/34154181-485c86e4-e4bd-11e7-8d0c-7107ea619c8d.gif)
Very Long alert
![long_alert](https://user-images.githubusercontent.com/8366181/34154199-58fc6fdc-e4bd-11e7-8d4b-318ef66a1d3a.gif)


BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1506718
cc: @cben , @serenamarie125 , @himdel 
Please share thoughts on this 😅  - this is just a proposition 😇 