### PR TITLE
Added autofocus on "Dialog's name" field

### DIFF
--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -11,7 +11,8 @@
             %input#name{"ng-model" => "vm.dialog.content[0].label",
               :type => "text",
               :required => "",
-              :title => _("Dialog's name")}
+              :title => _("Dialog's name"),
+              :autofocus => true}
           %div{"pf-form-group" => "", "pf-label" => _("Dialog's description")}
             %textarea#description{"ng-model" => "vm.dialog.content[0].description",
               :title => _("Dialog's description")}


### PR DESCRIPTION
This change should enable autofocus on the first required field in the Dialog Editor (_Dialog's name_).

This change was suggested in https://bugzilla.redhat.com/show_bug.cgi?id=1514117#c12 (# 1)

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1514117

Steps for Testing/QA
-------------------------------

Automate → Automation → Customization → Service Dialog → Edit / Add a dialog