### PR TITLE
[WIP] Generate settings for GTL as hash object to make it understandable

### DIFF
--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -53,8 +53,7 @@ module GtlHelper
   #
   def render_gtl_outer(no_flash_div)
     parent_id = @report_data_additional_options.try(:[], :parent_id)
-
-    options = {
+    options = GtlOptions.from_hash(
       :model_name                     => model_to_report_data,
       :no_flash_div                   => no_flash_div || false,
       :gtl_type_string                => @gtl_type,
@@ -71,8 +70,8 @@ module GtlHelper
       :parent                         => @parent,
 
       :report_data_additional_options => @report_data_additional_options,
-    }
-
+      :url                            => (view_to_url(@view, @paren) if @view.present? && @view.db.present?)
+    )
     render_gtl(options)
   end
 
@@ -110,34 +109,8 @@ module GtlHelper
       miq_bootstrap('##{REPORT_DOM_ID}', '#{REPORT_ANGULAR_MODULE}');
       sendDataWithRx({initController: {
         name: '#{REPORT_CONTROLLER_NAME}',
-        data: #{generate_data(options).transform_keys { |key| key.to_s.camelize(:lower) }.to_json}
+        data: #{options.transform_to_settings.transform_keys { |key| key.to_s.camelize(:lower) }.to_json}
       }});
 EOJ
-  end
-
-  def generate_data(options)
-    {
-      :additionl_opitons => options[:report_data_additional_options],
-      :model_name        => options[:model_name],
-      :active_tree       => options[:active_tree],
-      :gtl_type          => options[:gtl_type_string],
-      :parent_id         => escape_parent_id(options[:parent_id], options[:display]).to_s,
-      :sort_col_idx      => options[:sort_col].to_s,
-      :sort_dir          => options[:sort_dir],
-      :is_explorer       => options[:explorer],
-      :records           => !options[:selected_records].nil? ? options[:selected_records] : '',
-      :hide_select       => options[:selected_records].kind_of?(Array),
-      :show_url          => generate_url(options[:view], options[:parent])
-    }
-  end
-
-  private
-  
-  def escape_parent_id(parent_id, display)
-    (h(j_str(parent_id)) unless display.nil?)
-  end
-
-  def generate_url(view, parent)
-    view_to_url(view, parent) if view.present? && view.db.present?
   end
 end

--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -1,4 +1,8 @@
 module GtlHelper
+  REPORT_CONTROLLER_NAME = "reportDataController".freeze
+  REPORT_DOM_ID = "miq-gtl-view".freeze
+  REPORT_ANGULAR_MODULE = "ManageIQ.report_data".freeze
+
   def gtl_selected_records
     records = params.try(:[], :rec_ids) || @edit.try(:[], :pol_items) ||
               @edit.try(:[], :object_ids) || @targets_hash.try(:keys) || @selected_ids
@@ -83,7 +87,7 @@ module GtlHelper
   end
 
   def render_gtl_markup(no_flash_div)
-    content_tag('div', :id => 'miq-gtl-view', "ng-controller" => "reportDataController as dataCtrl") do
+    content_tag('div', :id => REPORT_DOM_ID, "ng-controller" => "reportDataController as dataCtrl") do
       capture do
         concat(render(:partial => 'layouts/flash_msg')) unless no_flash_div
         concat(miq_tile_view)
@@ -101,27 +105,39 @@ module GtlHelper
   end
 
   def render_gtl_javascripts(options)
-    parent_id_escaped = (h(j_str(options[:parent_id])) unless options[:display].nil?)
-
     javascript_tag <<EOJ
-      sendDataWithRx({unsubscribe: 'reportDataController'});
-      miq_bootstrap('#miq-gtl-view', 'ManageIQ.report_data');
+      sendDataWithRx({unsubscribe: '#{REPORT_CONTROLLER_NAME}'});
+      miq_bootstrap('##{REPORT_DOM_ID}', '#{REPORT_ANGULAR_MODULE}');
       sendDataWithRx({initController: {
-        name: 'reportDataController',
-        data: {
-          additionalOptions: #{options[:report_data_additional_options].to_json},
-          modelName: '#{h(j_str(options[:model_name]))}',
-          activeTree: '#{options[:active_tree]}',
-          gtlType: '#{h(j_str(options[:gtl_type_string]))}',
-          parentId: '#{parent_id_escaped}',
-          sortColIdx: '#{options[:sort_col]}',
-          sortDir: '#{options[:sort_dir]}',
-          isExplorer: '#{options[:explorer]}' === 'true' ? true : false,
-          records: #{!options[:selected_records].nil? ? h(j_str(options[:selected_records].to_json)) : "\'\'"},
-          hideSelect: #{options[:selected_records].kind_of?(Array)},
-          showUrl: '#{view_to_url(options[:view], options[:parent]) if options[:view].present? && options[:view].db.present?}'
-        }
+        name: '#{REPORT_CONTROLLER_NAME}',
+        data: #{generate_data(options).transform_keys { |key| key.to_s.camelize(:lower) }.to_json}
       }});
 EOJ
+  end
+
+  def generate_data(options)
+    {
+      :additionl_opitons => options[:report_data_additional_options],
+      :model_name        => options[:model_name],
+      :active_tree       => options[:active_tree],
+      :gtl_type          => options[:gtl_type_string],
+      :parent_id         => escape_parent_id(options[:parent_id], options[:display]).to_s,
+      :sort_col_idx      => options[:sort_col].to_s,
+      :sort_dir          => options[:sort_dir],
+      :is_explorer       => options[:explorer],
+      :records           => !options[:selected_records].nil? ? options[:selected_records] : '',
+      :hide_select       => options[:selected_records].kind_of?(Array),
+      :show_url          => generate_url(options[:view], options[:parent])
+    }
+  end
+
+  private
+  
+  def escape_parent_id(parent_id, display)
+    (h(j_str(parent_id)) unless display.nil?)
+  end
+
+  def generate_url(view, parent)
+    view_to_url(view, parent) if view.present? && view.db.present?
   end
 end

--- a/app/helpers/gtl_helper/gtl_options.rb
+++ b/app/helpers/gtl_helper/gtl_options.rb
@@ -1,0 +1,40 @@
+module GtlHelper
+  GtlOptions = Struct.new(
+    :model_name,
+    :no_flash_div,
+    :gtl_type_string,
+    :active_tree,
+    :parent_id,
+    :selected_records,
+    :display,
+    :sort_col,
+    :sort_dir,
+    :explorer,
+    :view,
+    :db,
+    :parent,
+    :report_data_additional_options,
+    :url
+  ) do
+
+    def self.from_hash(opts)
+      new(*opts.values_at(*GtlOptions.members))
+    end
+
+    def transform_to_settings
+      {
+        :additionl_opitons => report_data_additional_options,
+        :model_name        => model_name,
+        :active_tree       => active_tree.to_s,
+        :gtl_type          => gtl_type_string,
+        :parent_id         => (parent_id.to_s unless display.nil?),
+        :sort_col_idx      => sort_col.to_s,
+        :sort_dir          => sort_dir,
+        :is_explorer       => explorer,
+        :records           => !selected_records.nil? ? selected_records : '',
+        :hide_select       => selected_records.kind_of?(Array),
+        :show_url          => url
+      }
+    end
+  end
+end


### PR DESCRIPTION
### This PR improves readability of report data options
Right now we are generating settings for report data inside javascript, which is not completely ok, since we might make some bugs just by bad readability of such strings. This PR moved such generation to separate function which returns hash object, which is translated to JavaScript object.

### UI changes
NONE

### Task list
* [ ] Add unit tests to `generate_data` function