### PR TITLE
auth-credentials: fix label for password field when adding new provider

### DIFF
--- a/app/assets/javascripts/components/auth-credentials.js
+++ b/app/assets/javascripts/components/auth-credentials.js
@@ -24,7 +24,7 @@ ManageIQ.angular.app.component('authCredentials', {
     vm.model = 'formModel';
 
     this.$onInit = function() {
-      this.bChangeStoredPassword = this.newRecord;
+      this.bChangeStoredPassword = false;
       this.bCancelPasswordChange = this.newRecord;
       this.buildInputsLabels();
     };


### PR DESCRIPTION
When adding a new Foreman / Ansible Tower provider, the password input label should
say `Password`. The form should only say `New Password` when changing password of
an existing provider.

Before:
![new-provider-before](https://user-images.githubusercontent.com/6648365/33389850-638ba2da-d534-11e7-9804-bccc9d3b9423.jpg)

After:
![new-provider-after](https://user-images.githubusercontent.com/6648365/33389854-6a19c366-d534-11e7-862c-18ec80253a6b.jpg)


https://bugzilla.redhat.com/show_bug.cgi?id=1518720