### PR TITLE
Render flash messages when deleting cloud tenants from list view

### DIFF
--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -211,6 +211,7 @@ class CloudTenantController < ApplicationController
     # refresh the list if applicable
     if @lastaction == "show_list"
       show_list
+      render_flash
       @refresh_partial = "layouts/gtl"
     elsif @lastaction == "show" && @layout == "cloud_tenant"
       # deleting from 'show' so we:


### PR DESCRIPTION
Cause flash messages to be rendered when deleting cloud tenants from the list view.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1489394