### PR TITLE
Change redirect path and message after ordering service catalog

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'cancelEndpoint', function(API, dialogFieldRefreshService, miqService, dialogId, apiSubmitEndpoint, apiAction, cancelEndpoint) {
+ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', function(API, dialogFieldRefreshService, miqService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint) {
   var vm = this;
 
   vm.$onInit = function() {
@@ -38,7 +38,7 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
       apiData = vm.dialogData;
     }
     API.post(apiSubmitEndpoint, apiData).then(function() {
-      miqService.redirectBack(__('Dialog submitted successfully!'), 'info', cancelEndpoint);
+      miqService.redirectBack(__('Order Request was Submitted'), 'info', finishSubmitEndpoint);
     }).catch(function(err) {
       miqService.sparkleOff();
       add_flash(__('Error requesting data from server'), 'error');

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -375,10 +375,11 @@ module ApplicationController::Buttons
     end
 
     {
-      :force_old_dialog_use => force_old_dialog_use,
-      :api_submit_endpoint  => "/api/#{api_collection_name}/#{obj.id}",
-      :api_action           => button_name,
-      :cancel_endpoint      => cancel_endpoint
+      :force_old_dialog_use   => force_old_dialog_use,
+      :api_submit_endpoint    => "/api/#{api_collection_name}/#{obj.id}",
+      :api_action             => button_name,
+      :finish_submit_endpoint => cancel_endpoint,
+      :cancel_endpoint        => cancel_endpoint
     }
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -544,9 +544,10 @@ class CatalogController < ApplicationController
       options[:target_id] = st.id
       options[:target_kls] = st.class.name
       options[:dialog_locals] = {
-        :api_submit_endpoint => "/api/service_catalogs/#{st.service_template_catalog_id}/service_templates/#{st.id}",
-        :api_action          => "order",
-        :cancel_endpoint     => "/catalog/explorer"
+        :api_submit_endpoint    => "/api/service_catalogs/#{st.service_template_catalog_id}/service_templates/#{st.id}",
+        :api_action             => "order",
+        :finish_submit_endpoint => svc_catalog_provision_finish_submit_endpoint,
+        :cancel_endpoint        => "/catalog/explorer"
       }
       dialog_initialize(ra, options)
     else
@@ -808,6 +809,10 @@ class CatalogController < ApplicationController
   end
 
   private
+
+  def svc_catalog_provision_finish_submit_endpoint
+    role_allows?(:feature => "miq_request_show_list", :any => true) ? "/miq_request/show_list" : "/catalog/explorer"
+  end
 
   def ansible_playbook?
     prov_type = params[:st_prov_type] ? params[:st_prov_type] : @record.prov_type

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -3,6 +3,7 @@
 - if @dialog_locals
   - api_submit_endpoint ||= @dialog_locals[:api_submit_endpoint]
   - api_action ||= @dialog_locals[:api_action]
+  - finish_submit_endpoint ||= @dialog_locals[:finish_submit_endpoint]
   - cancel_endpoint ||= @dialog_locals[:cancel_endpoint]
   - force_old_dialog_use = @dialog_locals[:force_old_dialog_use].to_s == "true"
 
@@ -38,7 +39,8 @@
 
 - else
   = render :partial => "shared/dialogs/dialog_user",
-    :locals => {:wf                  => wf,
-                :api_submit_endpoint => api_submit_endpoint,
-                :api_action          => api_action,
-                :cancel_endpoint     => cancel_endpoint}
+    :locals => {:wf                     => wf,
+                :finish_submit_endpoint => finish_submit_endpoint,
+                :api_submit_endpoint    => api_submit_endpoint,
+                :api_action             => api_action,
+                :cancel_endpoint        => cancel_endpoint}

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -18,6 +18,7 @@
 
 :javascript
   ManageIQ.angular.app.value('dialogId', '#{wf.dialog.id}');
+  ManageIQ.angular.app.value('finishSubmitEndpoint', '#{finish_submit_endpoint}');
   ManageIQ.angular.app.value('apiSubmitEndpoint', '#{api_submit_endpoint}');
   ManageIQ.angular.app.value('apiAction', '#{api_action}');
   ManageIQ.angular.app.value('cancelEndpoint', '#{cancel_endpoint}');

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -28,6 +28,7 @@ describe('dialogUserController', function() {
       apiSubmitEndpoint: 'submit endpoint',
       apiAction: 'order',
       cancelEndpoint: 'cancel endpoint',
+      finishSubmitEndpoint: 'finish submit endpoint',
     });
   }));
 
@@ -111,7 +112,9 @@ describe('dialogUserController', function() {
       it('redirects to the miq_request screen', function(done) {
         $controller.submitButtonClicked();
         setTimeout(function() {
-          expect(miqService.redirectBack).toHaveBeenCalledWith('Dialog submitted successfully!', 'info', 'cancel endpoint');
+          expect(miqService.redirectBack).toHaveBeenCalledWith(
+            'Order Request was Submitted', 'info', 'finish submit endpoint'
+          );
           done();
         });
       });


### PR DESCRIPTION
As described in https://bugzilla.redhat.com/show_bug.cgi?id=1518430, the message that was being displayed as well as the redirect location were incorrect after ordering a service catalog.

This change passes down a parameter for the redirect location so that other things like custom buttons can then pass down their own "finished with submitting" redirect path if necessary. We can also pass down the message later on if that needs to be changed on a case by case basis as well, but for the purposes of this BZ I've changed it to the original wording.

/cc @gmcculloug 

@miq-bot add_label gaprindashvili/yes, bug, fine/no

@miq-bot assign @h-kataria 

@h-kataria Let me know if you think someone else should be assigned.
@d-m-u Can you review please?