### PR TITLE
Fix CPU summary for VMs without cores_per_socket

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -138,7 +138,7 @@ module VmHelper::TextualSummary
       h[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'hv_info')
 
       cpu_details =
-        if @record.num_cpu && @record.cpu_cores_per_socket
+        if @record.num_cpu > 0 && @record.cpu_cores_per_socket > 0
           " (#{pluralize(@record.num_cpu, 'socket')} x #{pluralize(@record.cpu_cores_per_socket, 'core')})"
         else
           ""


### PR DESCRIPTION
For VMs which do not set cpu_sockets or cpu_cores_per_socket we only
want to show cpu_total_cores.  There is a check for this already but
since cpu_sockets has a default value of 1 (assuming for divide-by-zero
issues) and cpu_total_cores is a virtual delegate with a default value
of 1 this is always showing up as ' (1 Socket x 0 Cores)'.

Before:
![screenshot from 2017-11-29 14-11-29](https://user-images.githubusercontent.com/12851112/33394815-8e6b895c-d511-11e7-9dca-325b661ca732.png)

After:
![screenshot from 2017-11-29 14-15-30](https://user-images.githubusercontent.com/12851112/33394827-92bafb28-d511-11e7-9e35-7ab7a4eafcb2.png)

The behavior was changed by https://github.com/ManageIQ/manageiq/pull/12911 which conceptually changed `cpu_cores_per_socket` from `hardware.nil? ? 0 : hardware.cpu_cores_per_socket` to `hardware.try(:cpu_cores_per_socket) || 0`

https://bugzilla.redhat.com/show_bug.cgi?id=1514463