### PR TITLE
Only show sockets and cores_per_socket if present

### DIFF
--- a/app/helpers/textual_mixins/textual_devices.rb
+++ b/app/helpers/textual_mixins/textual_devices.rb
@@ -14,12 +14,16 @@ module TextualMixins::TextualDevices
   end
 
   def processor_description
-    Device.new(_("Processors"),
-               _("%{total_cores} (%{num_sockets} Sockets x %{num_cores} Cores)") %
-                  {:total_cores => @record.cpu_total_cores,
-                   :num_sockets => @record.num_cpu,
-                   :num_cores   => @record.cpu_cores_per_socket},
-               nil, :processor)
+    description = if @record.num_cpu > 0 && @record.cpu_cores_per_socket > 0
+                    _("%{total_cores} (%{num_sockets} Sockets x %{num_cores} Cores)") %
+                      {:total_cores => @record.cpu_total_cores,
+                       :num_sockets => @record.num_cpu,
+                       :num_cores   => @record.cpu_cores_per_socket}
+                  else
+                    _("%{total_cores}") % {:total_cores => @record.cpu_total_cores}
+                  end
+
+    Device.new(_("Processors"), description, nil, :processor)
   end
 
   def cpu_attributes


### PR DESCRIPTION
On the container textual summary we were showing the sockets and
cores_per_socket even if these were unset.

Before:
![screenshot from 2017-11-29 14-14-48](https://user-images.githubusercontent.com/12851112/33395173-acab1724-d512-11e7-8336-bd17ffac7e8b.png)

After:
![screenshot from 2017-11-29 14-15-34](https://user-images.githubusercontent.com/12851112/33395176-b08f3d16-d512-11e7-8a5f-7f32cc584a70.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1514463