### PR TITLE
GenericShowMixin: simplify nested_list()

### DIFF
--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -22,7 +22,7 @@ class AnsibleCredentialController < ApplicationController
   end
 
   def display_repositories
-    nested_list("repository", ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource)
+    nested_list(ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource)
   end
 
   def button

--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -95,7 +95,7 @@ class AnsibleRepositoryController < ApplicationController
   end
 
   def display_playbooks
-    nested_list("ansible_playbook", ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook)
+    nested_list(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook, :breadcrumb_title => _('Playbooks'))
   end
 
   def repository_refresh

--- a/app/controllers/cloud_volume_snapshot_controller.rb
+++ b/app/controllers/cloud_volume_snapshot_controller.rb
@@ -14,7 +14,7 @@ class CloudVolumeSnapshotController < ApplicationController
   end
 
   def display_based_volumes
-    nested_list('cloud_volumes', CloudVolume, :association => :based_volumes)
+    nested_list(CloudVolume, :association => :based_volumes)
   end
 
   private

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -54,27 +54,27 @@ module EmsCommon
   end
 
   def display_block_storage_managers
-    nested_list('block_storage_manager', ManageIQ::Providers::StorageManager, :parent_method => :block_storage_managers)
+    nested_list(ManageIQ::Providers::StorageManager, :parent_method => :block_storage_managers, :breadcrumb_title => _('Block Storage Managers'))
   end
 
   def display_object_storage_managers
-    nested_list('object_storage_manager', ManageIQ::Providers::StorageManager, :parent_method => :object_storage_managers)
+    nested_list(ManageIQ::Providers::StorageManager, :parent_method => :object_storage_managers, :breadcrumb_title => _('Object Storage Managers'))
   end
 
   def display_storage_managers
-    nested_list('storage_manager', ManageIQ::Providers::StorageManager, :parent_method => :storage_managers)
+    nested_list(ManageIQ::Providers::StorageManager, :parent_method => :storage_managers)
   end
 
   def display_ems_clusters
-    nested_list('ems_cluster', EmsCluster, :breadcrumb_title => title_for_clusters)
+    nested_list(EmsCluster, :breadcrumb_title => title_for_clusters)
   end
 
   def display_persistent_volumes
-    nested_list('persistent_volume', PersistentVolume, :parent_method => :persistent_volumes)
+    nested_list(PersistentVolume, :parent_method => :persistent_volumes)
   end
 
   def display_hosts
-    nested_list('hosts', Host, :breadcrumb_title => _("Managed Hosts"))
+    nested_list(Host, :breadcrumb_title => _('Managed Hosts'))
   end
 
   class_methods do

--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -47,7 +47,7 @@ class EmsPhysicalInfraController < ApplicationController
   end
 
   def display_physical_servers_with_host
-    nested_list('physical_servers', PhysicalServer, generate_options)
+    nested_list(PhysicalServer, generate_options)
   end
 
   def generate_options

--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -31,7 +31,7 @@ class GenericObjectController < ApplicationController
 
   def display_nested_generic(display)
     return unless @record.property_associations.key?(display)
-    nested_list(display, @record.generic_object_definition.properties[:associations][display], :association => display)
+    nested_list(@record.generic_object_definition.properties[:associations][display], :association => display)
   end
 
   private

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -142,7 +142,7 @@ module Mixins
     end
 
     def display_nested_generic(display)
-      nested_list(display, display.camelize.singularize.constantize)
+      nested_list(display.camelize.singularize.constantize)
     end
 
     def display_descendant_vms
@@ -154,32 +154,32 @@ module Mixins
     end
 
     def display_all_vms
-      nested_list("vms", Vm, :association => "all_vms")
+      nested_list(Vm, :association => "all_vms")
     end
 
     def display_vms
-      nested_list(nil, Vm, :breadcrumb_title => _("Direct VMs"))
+      nested_list(Vm, :breadcrumb_title => _("Direct VMs"))
     end
 
     def display_resource_pools
-      nested_list("resource_pools", ResourcePool)
+      nested_list(ResourcePool)
     end
 
     def display_instances
-      nested_list("vm_cloud", ManageIQ::Providers::CloudManager::Vm)
+      nested_list(ManageIQ::Providers::CloudManager::Vm)
     end
 
     def display_images
-      nested_list("template_cloud", ManageIQ::Providers::CloudManager::Template, :named_scope => :without_volume_templates)
+      nested_list(ManageIQ::Providers::CloudManager::Template, :named_scope => :without_volume_templates)
     end
 
     # options:
     #   breadcrumb_title -- title for the breadcrumb, defaults to
-    #                       ui_lookup(:tables => table_name)
+    #                       ui_lookup(:models => model.to_s)
     #   parent_method    -- parent_method to be passed to get_view call
     #   association      -- get_view option association - implicit nil
-    def nested_list(table_name, model, options = {})
-      title = options[:breadcrumb_title] || ui_lookup(:tables => table_name)
+    def nested_list(model, options = {})
+      title = options[:breadcrumb_title] || ui_lookup(:models => model.to_s)
 
       drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @record.name},
                       :url  => "/#{self.class.table_name}/show/#{@record.id}")

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -179,7 +179,7 @@ class ServiceController < ApplicationController
   end
 
   def display_generic_objects
-    nested_list("generic_object", GenericObject)
+    nested_list(GenericObject)
   end
 
   private

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -21,7 +21,7 @@ class StorageController < ApplicationController
   end
 
   def display_all_miq_templates
-    nested_list("miq_templates", MiqTemplate, :parent => @record, :association => "all_miq_templates")
+    nested_list(MiqTemplate, :parent => @record, :association => "all_miq_templates")
   end
 
   def show_list


### PR DESCRIPTION
Changes done:
1. use `ui_lookup(:models => model.to_s)` rather than `ui_lookup(:tables => table_name)`
2. Get rid of the `table_name` parameter, since we can use `ui_lookup(:models => model.to_s)`

@martinpovolny PTAL