### PR TITLE
Display Name/Description in confirmation messages for PXE Custom Temp…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2212,7 +2212,7 @@ class ApplicationController < ActionController::Base
 
   def get_record_display_name(record)
     return record.label                      if record.respond_to?("label")
-    return record.description                if record.respond_to?("description") && !record.description.nil?
+    return record.description                if record.respond_to?("description") && record.description.present?
     return record.ext_management_system.name if record.respond_to?("ems_id")
     return record.title                      if record.respond_to?("title")
     return record.name                       if record.respond_to?("name")


### PR DESCRIPTION
Display either template Name or Description in action confirmation flash message depending on whether Template Description exists or not. If no Template Description is available, default to Template Name display. 

https://bugzilla.redhat.com/show_bug.cgi?id=1517951

Screen shots prior to code fix, notice "" in place of actual Name or Description:
![bz1517951_custom template with no description added](https://user-images.githubusercontent.com/552686/33401711-0f02d55a-d50f-11e7-9c7a-6dfe8156818a.png)

![bz1517951_custom template with no description deleted](https://user-images.githubusercontent.com/552686/33401721-171dd834-d50f-11e7-8361-38c90d220516.png)

============================
Screen shots post code fix, notice initial Name display in message when no Description is available and then Description in message body when it is available:

![bz1517951_custom template add with no description added post code fix](https://user-images.githubusercontent.com/552686/33401729-24a61e08-d50f-11e7-9277-c88706266577.png)

![bz1517951_custom template edit with description post code fix](https://user-images.githubusercontent.com/552686/33401735-2afa263c-d50f-11e7-9bc4-4196567e10b0.png)

![bz1517951_custom template delete with description post code fix](https://user-images.githubusercontent.com/552686/33401745-346dea64-d50f-11e7-8c4c-5e2c621ccae0.png)

