### PR TITLE
Life Migrate: Fix single record case for non-explorer screens.

### DIFF
--- a/app/views/vm_common/_live_migrate.html.haml
+++ b/app/views/vm_common/_live_migrate.html.haml
@@ -64,7 +64,7 @@
       - @quadicon_no_url = true
       = render :partial => "layouts/gtl"
 
-- unless @explorer
+- if @record.present?
   %table{:width => '100%'}
     %tr
       %td{:align => 'right'}


### PR DESCRIPTION
Single vs multiple is not driven by @explorer. It's more about the
presence of the @record.

I believe this is the correct fix.

Handing this back to openstackers. Ping @mansam, @aufi. Guys, please, check this, add some test coverage.

Related BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1518436
