### PR TITLE
dropdownMenu - don't use data-remote when not provided

### DIFF
--- a/app/views/static/dropdown-menu.html.haml
+++ b/app/views/static/dropdown-menu.html.haml
@@ -8,10 +8,11 @@
 
   %ul.dropdown-menu.dropdown-menu-right{'aria-labelledby' => "{{vm.dropdown_id}}"}
     %li{'ng-repeat' => "button in vm.buttons"}
+      -# data-remote="" breaks PDF donwnload, can't exist when empty, thus the ng-attr
       %a{'id'                  => "{{button.id}}",
          'title'               => "{{button.title}}",
          'data-method'         => "{{button.dataMethod}}",
-         'data-remote'         => "{{button.dataRemote}}",
+         'ng-attr-data-remote' => "{{button.dataRemote}}",
          'data-confirm'        => "{{button.confirm}}",
          'href'                => "{{button.href}}",
          'data-miq_sparkle_on' => "{{button.sparkleOn ? 'true' : 'false'}}"}


### PR DESCRIPTION
When the link has `data-remote=""`, downloading a PDF doesn't work. (The request succeeds, the data is returned, but the browser ignores it and doesn't download.)

`data-remote` is used for other things, like minimizing the dashboard.

Thus, changing to use `ng-attr-data-remote`, which will do the same thing as before when the attribute value is provided, but won't add the attr when empty.

Cc @mzazrivec , @ZitaNemeckova 

https://bugzilla.redhat.com/show_bug.cgi?id=1516784