### PR TITLE
ToolbarController#setClickHandler - don't handle click for disabled toolbar items

### DIFF
--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -109,22 +109,27 @@
 
   ToolbarController.prototype.setClickHandler = function() {
     _.chain(this.toolbarItems)
-     .flatten()
-     .map(function(item) {
-       return (item && item.hasOwnProperty('items')) ? item.items : item;
-     })
-     .flatten()
-     .filter(function(item) {
-       return item.type &&
-         (isButton(item) || isButtonTwoState(item));
-     })
-     .each(function(item) {
-       item.eventFunction = function($event) {
-         sendDataWithRx({toolbarEvent: 'itemClicked'});
-         miqToolbarOnClick.bind($event.delegateTarget)($event);
-       };
-     })
-     .value();
+      .flatten()
+      .map(function(item) {
+        return (item && item.hasOwnProperty('items')) ? item.items : item;
+      })
+      .flatten()
+      .filter(function(item) {
+        return item.type &&
+          (isButton(item) || isButtonTwoState(item));
+      })
+      .each(function(item) {
+        item.eventFunction = function($event) {
+          // clicking on disabled or hidden things shouldn't do anything
+          if (item.hidden === true || item.enabled === false) {
+            return;
+          }
+
+          sendDataWithRx({toolbarEvent: 'itemClicked'});
+          miqToolbarOnClick.bind($event.delegateTarget)($event);
+        };
+      })
+      .value();
   };
 
   /**


### PR DESCRIPTION
clicking on a disabled toolbar item doesn't really do anything in `miqToolbarOnClick`, but the `itemClicked` rx message still got sent, causing the paging toolbar to disappear (by calling `ReportDataController#setExtraClasses`).

Changing to only send the event when a visible non-disabled button is clicked.

https://bugzilla.redhat.com/show_bug.cgi?id=1518929

Cc @karelhala 