### PR TITLE
Pass additional information to the API when ordering a service catalog

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -1,9 +1,14 @@
-ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', function(API, dialogFieldRefreshService, miqService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint) {
+ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', 'resourceActionId', 'targetId', 'targetType', function(API, dialogFieldRefreshService, miqService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint, resourceActionId, targetId, targetType) {
   var vm = this;
 
   vm.$onInit = function() {
     return new Promise(function(resolve) {
-      resolve(API.get('/api/service_dialogs/' + dialogId, {expand: 'resources', attributes: 'content'}).then(init));
+      var url = '/api/service_dialogs/' + dialogId +
+        '?resource_action_id=' + resourceActionId +
+        '&target_id=' + targetId +
+        '&target_type=' + targetType;
+
+      resolve(API.get(url, {expand: 'resources', attributes: 'content'}).then(init));
     });
   };
 

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -26,7 +26,14 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
   vm.saveable = saveable;
 
   function refreshField(field) {
-    return dialogFieldRefreshService.refreshField(vm.dialogData, [field.name], vm.refreshUrl, dialogId);
+    var idList = {
+      dialogId: dialogId,
+      resourceActionId: resourceActionId,
+      targetId: targetId,
+      targetType: targetType
+    };
+
+    return dialogFieldRefreshService.refreshField(vm.dialogData, [field.name], vm.refreshUrl, idList);
   }
 
   function setDialogData(data) {

--- a/app/assets/javascripts/services/dialog_field_refresh_service.js
+++ b/app/assets/javascripts/services/dialog_field_refresh_service.js
@@ -1,18 +1,21 @@
 ManageIQ.angular.app.service('dialogFieldRefreshService', ['miqService', function(miqService) {
   this.areFieldsBeingRefreshed = false;
 
-  this.refreshField = function(dialogData, dialogField, url, resourceId) {
+  this.refreshField = function(dialogData, dialogField, url, idList) {
     this.areFieldsBeingRefreshed = true;
     var data = angular.toJson({
       action: 'refresh_dialog_fields',
       resource: {
         dialog_fields: dialogData,
         fields: dialogField,
+        resource_action_id: idList.resourceActionId,
+        target_id: idList.targetId,
+        target_type: idList.targetType,
       },
     });
 
     return new Promise(function(resolve) {
-      miqService.jqueryRequest(url + resourceId, {data: data, dataType: 'json'}).then(function(response) {
+      miqService.jqueryRequest(url + idList.dialogId, {data: data, dataType: 'json'}).then(function(response) {
         resolve(response.result[dialogField]);
         if ($.active < 1) {
           this.areFieldsBeingRefreshed = false;

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -333,7 +333,9 @@ module ApplicationController::Buttons
         :target_kls => obj.class.name,
       }
 
-      options[:dialog_locals] = determine_dialog_locals_for_custom_button(obj, button.name, button.resource_action.id)
+      options[:dialog_locals] = DialogLocalService.new.determine_dialog_locals_for_custom_button(
+        obj, button.name, button.resource_action.id
+      )
 
       dialog_initialize(button.resource_action, options)
 
@@ -354,36 +356,6 @@ module ApplicationController::Buttons
       end
       javascript_flash
     end
-  end
-
-  def determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)
-    case obj.class.name.demodulize
-    when /Vm/
-      api_collection_name = "vms"
-      cancel_endpoint = "/vm_infra/explorer"
-      force_old_dialog_use = false
-    when /Service/
-      api_collection_name = "services"
-      cancel_endpoint = "/service/explorer"
-      force_old_dialog_use = false
-    when /GenericObject/
-      api_collection_name = "generic_objects"
-      cancel_endpoint = "/generic_object/show_list"
-      force_old_dialog_use = false
-    else
-      force_old_dialog_use = true
-    end
-
-    {
-      :resource_action_id     => resource_action_id,
-      :target_id              => obj.id,
-      :target_type            => obj.class.name.underscore,
-      :force_old_dialog_use   => force_old_dialog_use,
-      :api_submit_endpoint    => "/api/#{api_collection_name}/#{obj.id}",
-      :api_action             => button_name,
-      :finish_submit_endpoint => cancel_endpoint,
-      :cancel_endpoint        => cancel_endpoint
-    }
   end
 
   def get_available_dialogs

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -333,7 +333,7 @@ module ApplicationController::Buttons
         :target_kls => obj.class.name,
       }
 
-      options[:dialog_locals] = determine_dialog_locals_for_custom_button(obj, button.name)
+      options[:dialog_locals] = determine_dialog_locals_for_custom_button(obj, button.name, button.resource_action.id)
 
       dialog_initialize(button.resource_action, options)
 
@@ -356,7 +356,7 @@ module ApplicationController::Buttons
     end
   end
 
-  def determine_dialog_locals_for_custom_button(obj, button_name)
+  def determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)
     case obj.class.name.demodulize
     when /Vm/
       api_collection_name = "vms"
@@ -375,6 +375,9 @@ module ApplicationController::Buttons
     end
 
     {
+      :resource_action_id     => resource_action_id,
+      :target_id              => obj.id,
+      :target_type            => obj.class.name.underscore,
       :force_old_dialog_use   => force_old_dialog_use,
       :api_submit_endpoint    => "/api/#{api_collection_name}/#{obj.id}",
       :api_action             => button_name,

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -543,16 +543,9 @@ class CatalogController < ApplicationController
       options[:header] = @right_cell_text
       options[:target_id] = st.id
       options[:target_kls] = st.class.name
-      options[:dialog_locals] = {
-        :resource_action_id     => ra.id,
-        :target_id              => st.id,
-        :target_type            => st.class.name.underscore,
-        :dialog_id              => ra.dialog_id,
-        :api_submit_endpoint    => "/api/service_catalogs/#{st.service_template_catalog_id}/service_templates/#{st.id}",
-        :api_action             => "order",
-        :finish_submit_endpoint => svc_catalog_provision_finish_submit_endpoint,
-        :cancel_endpoint        => "/catalog/explorer"
-      }
+      options[:dialog_locals] = DialogLocalService.new.determine_dialog_locals_for_svc_catalog_provision(
+        ra, st, svc_catalog_provision_finish_submit_endpoint
+      )
 
       replace_right_cell(:action => "dialog_provision", :dialog_locals => options[:dialog_locals])
     else

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -544,12 +544,17 @@ class CatalogController < ApplicationController
       options[:target_id] = st.id
       options[:target_kls] = st.class.name
       options[:dialog_locals] = {
+        :resource_action_id     => ra.id,
+        :target_id              => st.id,
+        :target_type            => st.class.name.underscore,
+        :dialog_id              => ra.dialog_id,
         :api_submit_endpoint    => "/api/service_catalogs/#{st.service_template_catalog_id}/service_templates/#{st.id}",
         :api_action             => "order",
         :finish_submit_endpoint => svc_catalog_provision_finish_submit_endpoint,
         :cancel_endpoint        => "/catalog/explorer"
       }
-      dialog_initialize(ra, options)
+
+      replace_right_cell(:action => "dialog_provision", :dialog_locals => options[:dialog_locals])
     else
       # if catalog item has no dialog and provision button was pressed from list view
       add_flash(_("No Ordering Dialog is available"), :warning)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -547,7 +547,11 @@ class CatalogController < ApplicationController
         ra, st, svc_catalog_provision_finish_submit_endpoint
       )
 
-      replace_right_cell(:action => "dialog_provision", :dialog_locals => options[:dialog_locals])
+      if Settings.product.old_dialog_user_ui
+        dialog_initialize(ra, options)
+      else
+        replace_right_cell(:action => "dialog_provision", :dialog_locals => options[:dialog_locals])
+      end
     else
       # if catalog item has no dialog and provision button was pressed from list view
       add_flash(_("No Ordering Dialog is available"), :warning)

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -1,0 +1,47 @@
+class DialogLocalService
+  def determine_dialog_locals_for_svc_catalog_provision(resource_action, target, finish_submit_endpoint)
+    api_submit_endpoint = "/api/service_catalogs/#{target.service_template_catalog_id}/service_templates/#{target.id}"
+
+    {
+      :resource_action_id     => resource_action.id,
+      :target_id              => target.id,
+      :target_type            => target.class.name.underscore,
+      :dialog_id              => resource_action.dialog_id,
+      :force_old_dialog_use   => false,
+      :api_submit_endpoint    => api_submit_endpoint,
+      :api_action             => "order",
+      :finish_submit_endpoint => finish_submit_endpoint,
+      :cancel_endpoint        => "/catalog/explorer"
+    }
+  end
+
+  def determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)
+    case obj.class.name.demodulize
+    when /Vm/
+      api_collection_name = "vms"
+      cancel_endpoint = "/vm_infra/explorer"
+      force_old_dialog_use = false
+    when /Service/
+      api_collection_name = "services"
+      cancel_endpoint = "/service/explorer"
+      force_old_dialog_use = false
+    when /GenericObject/
+      api_collection_name = "generic_objects"
+      cancel_endpoint = "/generic_object/show_list"
+      force_old_dialog_use = false
+    else
+      force_old_dialog_use = true
+    end
+
+    {
+      :resource_action_id     => resource_action_id,
+      :target_id              => obj.id,
+      :target_type            => obj.class.name.demodulize.underscore,
+      :force_old_dialog_use   => force_old_dialog_use,
+      :api_submit_endpoint    => "/api/#{api_collection_name}/#{obj.id}",
+      :api_action             => button_name,
+      :finish_submit_endpoint => cancel_endpoint,
+      :cancel_endpoint        => cancel_endpoint
+    }
+  end
+end

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -5,6 +5,10 @@
   - api_action ||= @dialog_locals[:api_action]
   - finish_submit_endpoint ||= @dialog_locals[:finish_submit_endpoint]
   - cancel_endpoint ||= @dialog_locals[:cancel_endpoint]
+  - target_id ||= @dialog_locals[:target_id]
+  - target_type ||= @dialog_locals[:target_type]
+  - dialog_id ||= @dialog_locals[:dialog_id]
+  - resource_action_id ||= @dialog_locals[:resource_action_id]
   - force_old_dialog_use = @dialog_locals[:force_old_dialog_use].to_s == "true"
 
 - force_old_dialog_use ||= true if api_submit_endpoint.nil?
@@ -39,7 +43,10 @@
 
 - else
   = render :partial => "shared/dialogs/dialog_user",
-    :locals => {:wf                     => wf,
+    :locals => {:dialog_id              => dialog_id,
+                :resource_action_id     => resource_action_id,
+                :target_id              => target_id,
+                :target_type            => target_type,
                 :finish_submit_endpoint => finish_submit_endpoint,
                 :api_submit_endpoint    => api_submit_endpoint,
                 :api_action             => api_action,

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -17,7 +17,10 @@
                 'on-click' => "vm.cancelClicked($event)"}
 
 :javascript
-  ManageIQ.angular.app.value('dialogId', '#{wf.dialog.id}');
+  ManageIQ.angular.app.value('resourceActionId', '#{resource_action_id}');
+  ManageIQ.angular.app.value('targetId', '#{target_id}');
+  ManageIQ.angular.app.value('targetType', '#{target_type}');
+  ManageIQ.angular.app.value('dialogId', '#{dialog_id}');
   ManageIQ.angular.app.value('finishSubmitEndpoint', '#{finish_submit_endpoint}');
   ManageIQ.angular.app.value('apiSubmitEndpoint', '#{api_submit_endpoint}');
   ManageIQ.angular.app.value('apiAction', '#{api_action}');

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -68,7 +68,7 @@ describe('dialogUserController', function() {
         'dialogData',
         ['dialogName'],
         '/api/service_dialogs/',
-        '1234'
+        {dialogId: '1234', resourceActionId: '789', targetId: '987', targetType: 'targettype'}
       );
     });
   });

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -16,7 +16,6 @@ describe('dialogUserController', function() {
 
     spyOn(dialogFieldRefreshService, 'refreshField');
     spyOn(miqService, 'miqAjaxButton');
-    spyOn(miqService, 'redirectBack');
     spyOn(miqService, 'sparkleOn');
     spyOn(miqService, 'sparkleOff');
 
@@ -29,6 +28,9 @@ describe('dialogUserController', function() {
       apiAction: 'order',
       cancelEndpoint: 'cancel endpoint',
       finishSubmitEndpoint: 'finish submit endpoint',
+      resourceActionId: '789',
+      targetId: '987',
+      targetType: 'targettype',
     });
   }));
 
@@ -38,7 +40,10 @@ describe('dialogUserController', function() {
     });
 
     it('requests the current dialog based on the service template', function() {
-      expect(API.get).toHaveBeenCalledWith('/api/service_dialogs/1234', {expand: 'resources', attributes: 'content'});
+      expect(API.get).toHaveBeenCalledWith(
+        '/api/service_dialogs/1234?resource_action_id=789&target_id=987&target_type=targettype',
+        {expand: 'resources', attributes: 'content'}
+      );
     });
 
     it('resolves the request and stores the information in the dialog property', function() {
@@ -85,6 +90,7 @@ describe('dialogUserController', function() {
 
     context('when the API call succeeds', function() {
       beforeEach(function() {
+        spyOn(miqService, 'redirectBack');
         spyOn(API, 'post').and.returnValue(Promise.resolve('awesome'));
       });
 
@@ -122,6 +128,7 @@ describe('dialogUserController', function() {
 
     context('when the API call fails', function() {
       beforeEach(function() {
+        spyOn(miqService, 'redirectBack');
         spyOn(API, 'post').and.returnValue(Promise.reject('not awesome'));
         spyOn(window, 'add_flash');
       });

--- a/spec/javascripts/services/dialog_field_refresh_service_spec.js
+++ b/spec/javascripts/services/dialog_field_refresh_service_spec.js
@@ -22,13 +22,18 @@ describe('dialogFieldRefreshService', function() {
     var data = 'the data';
     var field = 'the field';
     var url = 'url';
-    var resourceId = '123';
+    var idList = {
+      dialogId: '123',
+      resourceActionId: '321',
+      targetId: '456',
+      targetType: 'service_template',
+    };
 
     var refreshPromise;
     var resolvedValue;
 
     beforeEach(function(done) {
-      refreshPromise = testDialogFieldRefreshService.refreshField(data, field, url, resourceId);
+      refreshPromise = testDialogFieldRefreshService.refreshField(data, field, url, idList);
 
       refreshPromise.then(function(value) {
         resolvedValue = value;
@@ -45,7 +50,10 @@ describe('dialogFieldRefreshService', function() {
         action: 'refresh_dialog_fields',
         resource: {
           dialog_fields: 'the data',
-          fields: 'the field'
+          fields: 'the field',
+          resource_action_id: '321',
+          target_id: '456',
+          target_type: 'service_template',
         }
       };
 

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -1,0 +1,81 @@
+describe DialogLocalService do
+  let(:service) { described_class.new }
+
+  describe "#determine_dialog_locals_for_svc_catalog_provision" do
+    let(:resource_action) { instance_double("ResourceAction", :id => 456, :dialog_id => 654) }
+    let(:target) { instance_double("ServiceTemplate", :class => ServiceTemplate, :id => 321, :service_template_catalog_id => 123) }
+    let(:finish_submit_endpoint) { "finishsubmitendpoint" }
+
+    it "returns a hash" do
+      expect(service.determine_dialog_locals_for_svc_catalog_provision(
+        resource_action, target, finish_submit_endpoint
+      )).to eq(
+        :resource_action_id     => 456,
+        :target_id              => 321,
+        :target_type            => 'service_template',
+        :dialog_id              => 654,
+        :force_old_dialog_use   => false,
+        :api_submit_endpoint    => "/api/service_catalogs/123/service_templates/321",
+        :api_action             => "order",
+        :finish_submit_endpoint => "finishsubmitendpoint",
+        :cancel_endpoint        => "/catalog/explorer"
+      )
+    end
+  end
+
+  describe "#determine_dialog_locals_for_custom_button" do
+    let(:button_name) { "custom-button-name" }
+    let(:resource_action_id) { 321 }
+
+    context "when the object is a Vm" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Vm, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'vm',
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/vms/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/vm_infra/explorer",
+          :cancel_endpoint        => "/vm_infra/explorer"
+        )
+      end
+    end
+
+    context "when the object is a Service" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Service, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'service',
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/services/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/service/explorer",
+          :cancel_endpoint        => "/service/explorer"
+        )
+      end
+    end
+
+    context "when the object is a GenericObject" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::GenericObject, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'generic_object',
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/generic_objects/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/generic_object/show_list",
+          :cancel_endpoint        => "/generic_object/show_list"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resource action id, target id, and target type need to be passed in order to establish the context that some dynamic methods may use when going through automate. This corresponds with @jntullo's [API PR here](https://github.com/ManageIQ/manageiq-api/pull/231). 

https://bugzilla.redhat.com/show_bug.cgi?id=1518390

@miq-bot add_label gaprindashvili/yes, bug, blocker

@miq-bot assign @h-kataria 

@d-m-u, @jntullo Mind taking a look and making sure I didn't miss something obvious?