### PR TITLE
Check for nil Clusters/Datastores on C/U tab

### DIFF
--- a/app/views/ops/_settings_cu_collection_tab.html.haml
+++ b/app/views/ops/_settings_cu_collection_tab.html.haml
@@ -10,51 +10,59 @@
         %fieldset
           %h3
             = clusters_title
-          .form-group
-            %label.col-md-4.control-label
-              = _("Collect for All %{clusters}") % {:clusters => clusters_title}
-            .col-md-8
-              = check_box_tag("all_clusters", true, @edit[:new][:all_clusters],
-                              "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :data => {:on_text => _('Yes'), :off_text => _('No')})
-            :javascript
-              miqInitBootstrapSwitch('all_clusters', "#{url}")
-          .note
-            %b= _("Note: Collect for All %{clusters} must be checked to be able to collect C & U data from Cloud Providers such as Red Hat OpenStack or Amazon EC2") % {:clusters => clusters_title}
-          #clusters_div{:style => "display:#{@edit[:new][:all_clusters] ? "none" : ""}"}
-            - cluster_title = title_for_cluster
-            - if @edit[:new][:clusters].blank? && @edit[:new][:non_cl_hosts].blank?
-              = _("No %{clusters} found in the current region.") % {:clusters => clusters_title}
-            - else
-              %br/
-              %b= _("Enable Collection by %{clusters}") % {:clusters => cluster_title}
-              %br/
-              %input#cl_toggle{:name => "cl_toggle", :onchange => "miqCheckCUAll(this,'#{@cluster_tree.name}');", :type => "checkbox"}/
-              = _("Check All")
+          - if @cluster_tree.present?
+            .form-group
+              %label.col-md-4.control-label
+                = _("Collect for All %{clusters}") % {:clusters => clusters_title}
+              .col-md-8
+                = check_box_tag("all_clusters", true, @edit[:new][:all_clusters],
+                                "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :data => {:on_text => _('Yes'), :off_text => _('No')})
               :javascript
-                miqTreeResetState('#{j_str @cluster_tree.name}');
-              = render(:partial => 'shared/tree', :locals => {:tree => @cluster_tree, :name => @cluster_tree.name})
-              %br/
-              .note= _("VM data will be collected for VMs under selected %{hosts} only. Data is collected for a %{cluster} and all of its %{hosts} when at least one %{host} is selected.") % {:hosts => title_for_hosts, :cluster => cluster_title, :host => title_for_host}
+                miqInitBootstrapSwitch('all_clusters', "#{url}")
+            .note
+              %b= _("Note: Collect for All %{clusters} must be checked to be able to collect C & U data from Cloud Providers such as Red Hat OpenStack or Amazon EC2") % {:clusters => clusters_title}
+            #clusters_div{:style => "display:#{@edit[:new][:all_clusters] ? "none" : ""}"}
+              - cluster_title = title_for_cluster
+              - if @edit[:new][:clusters].blank? && @edit[:new][:non_cl_hosts].blank?
+                = _("No %{clusters} found in the current region.") % {:clusters => clusters_title}
+              - else
+                %br/
+                %b= _("Enable Collection by %{clusters}") % {:clusters => cluster_title}
+                %br/
+                %input#cl_toggle{:name => "cl_toggle", :onchange => "miqCheckCUAll(this,'#{@cluster_tree.name}');", :type => "checkbox"}/
+                = _("Check All")
+                :javascript
+                  miqTreeResetState('#{j_str @cluster_tree.name}');
+                = render(:partial => 'shared/tree', :locals => {:tree => @cluster_tree, :name => @cluster_tree.name})
+                %br/
+                .note= _("VM data will be collected for VMs under selected %{hosts} only. Data is collected for a %{cluster} and all of its %{hosts} when at least one %{host} is selected.") % {:hosts => title_for_hosts, :cluster => cluster_title, :host => title_for_host}
+          - else
+            .note
+              %b= _("Note: No %{clusters} available.") % {:clusters => clusters_title}
       .col-md-12.col-lg-6
         %fieldset
           %h3= _("Datastores")
-          .form-group
-            %label.col-md-4.control-label
-              = _("Collect for All Datastores")
-            .col-md-8
-              = check_box_tag("all_storages", true, @edit[:new][:all_storages],
-                "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :data => {:on_text => _('Yes'), :off_text => _('No')})
-            :javascript
-              miqInitBootstrapSwitch('all_storages', "#{url}")
-          #storages_div{:style => "display:#{@edit[:new][:all_storages] ? "none" : ""}"}
-            - if @edit[:new][:storages].blank?
-              = _("No Datastores found in the current region.")
-            - else
-              %br/
-              %b= _("Enable Collection by Datastore")
-              %br/
-              %input#ds_toggle{:name => "ds_toggle", :onchange => "miqCheckCUAll(this,'#{@datastore_tree.name}');", :type => "checkbox"}/
-              = _("Check All")
+          - if @datastore_tree.present?
+            .form-group
+              %label.col-md-4.control-label
+                = _("Collect for All Datastores")
+              .col-md-8
+                = check_box_tag("all_storages", true, @edit[:new][:all_storages],
+                  "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :data => {:on_text => _('Yes'), :off_text => _('No')})
               :javascript
-                miqTreeResetState('#{j_str @datastore_tree.name}');
-              = render(:partial => 'shared/tree', :locals => {:tree => @datastore_tree, :name => @datastore_tree.name})
+                miqInitBootstrapSwitch('all_storages', "#{url}")
+            #storages_div{:style => "display:#{@edit[:new][:all_storages] ? "none" : ""}"}
+              - if @edit[:new][:storages].blank?
+                = _("No Datastores found in the current region.")
+              - else
+                %br/
+                %b= _("Enable Collection by Datastore")
+                %br/
+                %input#ds_toggle{:name => "ds_toggle", :onchange => "miqCheckCUAll(this,'#{@datastore_tree.name}');", :type => "checkbox"}/
+                = _("Check All")
+                :javascript
+                  miqTreeResetState('#{j_str @datastore_tree.name}');
+                = render(:partial => 'shared/tree', :locals => {:tree => @datastore_tree, :name => @datastore_tree.name})
+          - else
+            .note
+              %b= _("Note: No Datastores available.")

--- a/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
@@ -42,4 +42,18 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
     render
     expect(response).to have_selector("input#ds_toggle")
   end
+
+  it "Displays note if there are no Clusters" do
+    @cluster_tree = nil
+    assign(:edit, :new => {:all_clusters => false})
+    render
+    expect(response).to have_selector("div.note b", :text => "Note: No Clusters available.")
+  end
+
+  it "Displays note if there are no Datastores" do
+    @datastore_tree = nil
+    assign(:edit, :new => {:all_storages => false})
+    render
+    expect(response).to have_selector("div.note b", :text => "Note: No Datastores available.")
+  end
 end


### PR DESCRIPTION
Show a note if there is no data to populate the Clusters and/or Datastore trees on the C/U tab under Configuration.

@miq-bot add_label bug, settings, blocker

https://bugzilla.redhat.com/show_bug.cgi?id=1518087