### PR TITLE
Add an exception for middleware server listicons to prefer fileicon

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1122,7 +1122,7 @@ class ApplicationController < ActionController::Base
         item = listicon_item(view, row['id'])
         icon, icon2, image, picture = listicon_glyphicon(item)
         image = "100/#{(@listicon || view.db).underscore}.png" if icon.nil? && image.nil? # TODO: we want to get rid of this
-        icon = nil if %w(pxe).include? params[:controller]
+        icon = nil if %w(pxe middleware_server).include?(params[:controller]) # TODO: adding exceptions here is a wrong approach
         new_row[:cells] << {:title => _('View this item'),
                             :image   => ActionController::Base.helpers.image_path(image.to_s),
                             :picture => ActionController::Base.helpers.image_path(picture.to_s),

--- a/spec/controllers/middleware_server_controller_spec.rb
+++ b/spec/controllers/middleware_server_controller_spec.rb
@@ -233,4 +233,22 @@ describe MiddlewareServerController do
       end
     end
   end
+
+  describe '#report_data' do
+    context 'list of middleware servers' do
+      let!(:server) { FactoryGirl.create(:middleware_server) }
+
+      subject { assert_report_data_response }
+
+      it 'returns a single middleware server that has an image but not an icon' do
+        report_data_request(:model => 'MiddlewareServer')
+
+        expect(subject["data"]["rows"].length).to eq(1)
+        expect(subject["data"]["rows"][0]["cells"][2]["text"]).to eq(server.name)
+
+        expect(subject["data"]["rows"][0]["cells"][1]["icon"]).to be_nil
+        expect(subject["data"]["rows"][0]["cells"][1]["image"]).not_to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adding exceptions is the worst way of fixing this issue, however, after consulting with @epwinchell I did not find any other option. For now a `fonticon` has a higher priority than a `fileicon` which is a problem in the middleware server listview. Eventually we want to swap these priorities, however, we have some legacy `fileicon`s that are PNG based and they should be deleted, but for now the quadicons depend on them. So until we have `fonticon` support in quadicons, we can't swap the priority and adding this exception seemed the simplest possible solution. 

But maybe I'm wrong and @karelhala, @himdel or @martinpovolny could come up with a better idea.

**Before:**
![screenshot from 2017-11-30 20-39-59](https://user-images.githubusercontent.com/649130/33451289-ded673e0-d60e-11e7-9be2-9c57b0876ea0.png)

**After:**
![screenshot from 2017-11-30 20-40-13](https://user-images.githubusercontent.com/649130/33451303-e56a71ca-d60e-11e7-9d72-05a3dd124637.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1509935