### PR TITLE
bz 1402867: Prevent scale down in scaling UI

### DIFF
--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -70,6 +70,10 @@ class EmsInfraController < ApplicationController
       return_message = _("Scaling")
       @count_parameters.each do |p|
         if !scale_parameters[p.name].nil? && scale_parameters[p.name] != p.value
+          if scale_parameters[p.name].to_s < p.value.to_s
+            add_flash(_("Scaling down is not supported. New value for %{name} %{new_value} is lower than current value %{current_value}.") % {:name => p.name, :new_value => scale_parameters[p.name], :current_value => p.value}, :error)
+            return
+          end
           return_message += _(" %{name} from %{value} to %{parameters} ") % {:name => p.name, :value => p.value, :parameters => scale_parameters[p.name]}
           scale_parameters_formatted[p.name] = scale_parameters[p.name]
         end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1402867

In the scaling UI, added checks to allow scaling up but not down.
Scale down is handled explicitly via a separate UI action with
validation around maintenance mode on the node and lack of active
VMs.
