### PR TITLE
Remove record.id from live migrate submit and cancel buttons

### DIFF
--- a/app/views/vm_common/_live_migrate.html.haml
+++ b/app/views/vm_common/_live_migrate.html.haml
@@ -73,12 +73,12 @@
             :class   => "btn btn-primary",
             :alt     => t,
             :title   => t,
-            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "live_migrate_vm", :id => "#{@record.id}", :button => "submit")}');")
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "live_migrate_vm", :button => "submit")}');")
           = button_tag(t = _('Cancel'),
             :class   => "btn btn-default",
             :alt     => t,
             :title   => t,
-            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "live_migrate_vm", :id => "#{@record.id}", :button => "cancel")}');")
+            :onclick => "miqAjaxButton('#{url_for_only_path(:action => "live_migrate_vm", :button => "cancel")}');")
 
 :javascript
   ManageIQ.angular.app.value('vmCloudLiveMigrateFormId', "#{@live_migrate_items.length == 1 ? @live_migrate_items[0].id : ''}");


### PR DESCRIPTION
Remove erroneous reference to `@record.id` from the submit and cancel buttons that are displayed when viewing the live migrate form outside of an explorer view. IDs of instances to migrate are tracked by `@live_migrate_items`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518436
Obsoletes https://github.com/ManageIQ/manageiq-ui-classic/pull/2877