### PR TITLE
Fix for storages under storage pods

### DIFF
--- a/app/controllers/storage_controller/storage_pod.rb
+++ b/app/controllers/storage_controller/storage_pod.rb
@@ -12,9 +12,9 @@ module StorageController::StoragePod
     end
     @sortcol = session[:dsc_sortcol].nil? ? 0 : session[:dsc_sortcol].to_i
     @sortdir = session[:dsc_sortdir].nil? ? "ASC" : session[:dsc_sortdir]
+
     dsc_id = x_node.split('-').last
-    folder = EmsFolder.where(:id => from_cid(dsc_id))
-    @view, @pages = get_view(Storage, :selected_ids => folder.first.storages.collect(&:id)) # Get the records (into a view) and the paginator
+    @view, @pages = get_view(Storage, :association => 'storages', :parent => EmsFolder.find(from_cid(dsc_id)))
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number
     session[:ct_sortcol] = @sortcol
@@ -47,11 +47,8 @@ module StorageController::StoragePod
     end
   end
 
-
   # Get information for an event
   def build_storage_pod_tree
     TreeBuilderStoragePod.new("storage_pod_tree", "storage_pod", @sb)
   end
-
-
 end

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -224,6 +224,7 @@ describe StorageController do
       end
 
       [
+        ['Datastores', 'storage_tree'],
         ['All Datastore Clusters', 'storage_pod_tree'],
       ].each do |elements, tree|
         it "renders list of #{elements} for #{tree} root node" do
@@ -233,6 +234,41 @@ describe StorageController do
           post :tree_select, :params => { :id => 'root', :format => :js }
           expect(response.status).to eq(200)
         end
+      end
+
+      it 'renders list of Datastores in given cluster' do
+        storage
+        storage_cluster
+        seed_session_trees('storage', :storage_pod_tree, 'root')
+        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+          :model_name                     => 'Storage',
+          :parent_id                      => storage_cluster.id,
+          :report_data_additional_options => {
+            :association       => 'storages',
+            :parent_class_name => 'StorageCluster',
+          }
+        )
+
+        post :tree_select, :params => {:id => "xx-#{to_cid(storage_cluster.id)}", :format => :js}
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
+  describe 'report_data' do
+    context 'for selected StorageCluster' do
+      it 'returns associated Storages' do
+        storage_cluster.add_child(storage)
+
+        report_data_request(
+          :model        => 'Storage',
+          :parent_model => 'StorageCluster',
+          :parent_id    => storage_cluster.id,
+          :association  => 'storages'
+        )
+        results = assert_report_data_response
+        expect(results['data']['rows'].length).to eq(1)
+        expect(results['data']['rows'][0]['long_id']).to eq(storage.id)
       end
     end
   end


### PR DESCRIPTION
Selected records should be passed to get_view only when records cannot be specified using associations or named scopes.
    
Furthemore this imperfect implementation was broken in during the GTL conversion.

https://bugzilla.redhat.com/show_bug.cgi?id=1501063

Ping @lgalis, @tumido : please, review
