### PR TITLE
Delay the force node activation call on the edit report menu explorer

### DIFF
--- a/app/views/report/explorer.html.haml
+++ b/app/views/report/explorer.html.haml
@@ -6,6 +6,7 @@
 -# FIXME: we should not do javascript like this
 %script{:type => "text/javascript"}
   function miqReportAfterOnload() {
+  window.setTimeout(function() {
   - if @right_cell_div == "role_list"
     - if role_allows?(:feature => "miq_report_menu_editor")
       miqTreeForceActivateNode('roles_tree','#{x_node}');
@@ -16,6 +17,7 @@
     setTimeout(function() {
     miqTreeForceActivateNode('#{x_active_tree}', '#{x_node}')
     });
+  });
   };
   ManageIQ.afterOnload = "miqReportAfterOnload();"
 


### PR DESCRIPTION
When refreshing an Edit Report Menu subpage (see the BZ for reproduction details) the right cell becomes empty because the angular-based tree is not rendered in the time the `ManageIQ.afterOnload` is being :angry: **eval**uated. Together with all the `miqTreeForceActivateNode` calls this is a good victim for :scissors: :toilet: refactoring in the future. In general this `afterOnload` seems to me as a big hack and the simplest way to fix this without making possible breaking changes was to wrap the tree activation in a `setTimeout`. The code seems ancient and as it is included inline in a template with interpolation, I don't think there's a meaningful way to test this.

https://bugzilla.redhat.com/show_bug.cgi?id=1519644