### PR TITLE
Generate the policy profile permalink on the timelines correctly

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -243,7 +243,7 @@ class MiqPolicyController < ApplicationController
       self.x_active_tree = 'policy_profile_tree'
       profile_id = params[:profile].to_i
       if MiqPolicySet.exists?(:id => profile_id)
-        self.x_node = "pp_#{profile_id}"
+        self.x_node = "pp-#{profile_id}"
       else
         add_flash(_("Policy Profile no longer exists"), :error)
         self.x_node = "root"

--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -55,7 +55,7 @@ module ReportFormatter
       unless @event.event_type.nil?
         e_text += "<br/><b>#{_("Assigned Profiles")}:</b>&nbsp;"
         assigned_profiles.each_with_index do |p, i|
-          e_text += "<a href=/miq_policy/explorer/?id=pp-#{p[0]}>#{p[1]}</a>"
+          e_text += "<a href=/miq_policy/explorer/?profile=#{p[0]}>#{p[1]}</a>"
           e_text += ", " if assigned_profiles.length > 1 && i < assigned_profiles.length
         end
       end

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -172,7 +172,7 @@ describe MiqPolicyController do
         expect(response).to render_template('explorer')
         flash_messages = controller.instance_variable_get(:@flash_array)
         expect(flash_messages).to be_nil
-        expect(controller.x_node).to eq("pp_#{profile.id}")
+        expect(controller.x_node).to eq("pp-#{profile.id}")
       end
     end
   end

--- a/spec/lib/report_formater/timeline_spec.rb
+++ b/spec/lib/report_formater/timeline_spec.rb
@@ -90,6 +90,19 @@ describe ReportFormatter::TimelineMessage do
     tests = {'event_type'  => 'vm_poweroff',
              'target_name' => 'Test VM<br><b>VM or Template:</b>&nbsp;<a href=/vm_or_template/show/42>Test VM</a><br/><b>Assigned Profiles:</b>&nbsp;'}
 
+    context 'policy profile assigned' do
+      let(:event_content) { FactoryGirl.create(:policy_event_content, :resource => policy_set) }
+      let(:policy_set) { FactoryGirl.create(:miq_policy_set) }
+
+      before { event.contents << event_content }
+
+      subject { ReportFormatter::TimelineMessage.new({'event_type' => 'vm_poweroff'}, event, {}, 'PolicyEvent').message_html('target_name') }
+
+      it 'generates a link to the affected policy profile' do
+        is_expected.to include("?profile=#{policy_set.id}")
+      end
+    end
+
     tests.each do |column, href|
       it "Evaluate column #{column} content" do
         row[column] = 'vm_poweroff'


### PR DESCRIPTION
The permalinks to assigned policy profiles on a policy event VM timeline have been generated with the wrong GET param. Also the parameter had the old style underscore tree node ID instead of the hyphenated version.

![screenshot from 2017-12-01 13-16-29](https://user-images.githubusercontent.com/649130/33482549-e21d4b56-d699-11e7-8981-55448e0c72eb.png)

To reproduce this, you need a VM with policy timeline events collected. If you need help, I can provide you a database created by @izapolsk. 

https://bugzilla.redhat.com/show_bug.cgi?id=1500420