### PR TITLE
ae_import multiple domains

### DIFF
--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -94,7 +94,11 @@ class GitBasedDomainImportService
     task = MiqTask.wait_for_taskid(task_id)
 
     domain = task.task_results
-    error_message = _("Selected branch or tag does not contain a valid domain")
+    error_message = if task.message == _('multiple domains')
+                      _('Selected branch or tag contains more than one domain')
+                    else
+                      _('Selected branch or tag does not contain a valid domain')
+                    end
     raise MiqException::Error, error_message unless domain.kind_of?(MiqAeDomain)
     domain.update_attribute(:enabled, true)
   end

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -68,6 +68,7 @@ describe GitBasedDomainImportService do
       allow(domain).to receive(:update_attribute).with(:enabled, true)
       allow(MiqTask).to receive(:wait_for_taskid).with(task.id).and_return(task)
       allow(User).to receive(:current_user).and_return(user)
+      allow(task).to receive(:message).and_return(nil)
     end
 
     context "when git branches that match the given name exist" do
@@ -91,7 +92,6 @@ describe GitBasedDomainImportService do
         allow(task).to receive(:task_results).and_return(domain)
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
         expect(domain).to receive(:update_attribute).with(:enabled, true)
-
         subject.import(git_repo.id, ref_name, 321)
       end
     end
@@ -99,12 +99,22 @@ describe GitBasedDomainImportService do
     context "when import fails and the task result is nil" do
       let(:git_branches) { [double("GitBranch", :name => ref_name)] }
 
-      it "raises an exception with a message" do
+      it "raises an exception with a message about invalid domain" do
         allow(task).to receive(:task_results).and_return(nil)
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
 
         expect { subject.import(git_repo.id, ref_name, 321) }.to raise_exception(
           MiqException::Error, "Selected branch or tag does not contain a valid domain"
+        )
+      end
+
+      it "raises an exception with a message about multiple domains" do
+        allow(task).to receive(:task_results).and_return(nil)
+        allow(task).to receive(:message).and_return('multiple domains')
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+        expect { subject.import(git_repo.id, ref_name, 321) }.to raise_exception(
+          MiqException::Error, 'Selected branch or tag contains more than one domain'
         )
       end
     end
@@ -115,6 +125,7 @@ describe GitBasedDomainImportService do
     before do
       allow(GitRepository).to receive(:find_by).with(:id => git_repo.id).and_return(git_repo)
       allow(User).to receive(:current_user).and_return(user)
+      allow(task).to receive(:message).and_return(nil)
     end
 
     context "when git branches that match the given name exist" do
@@ -144,6 +155,7 @@ describe GitBasedDomainImportService do
     include_context "import setup"
     before do
       allow(User).to receive(:current_user).and_return(user)
+      allow(task).to receive(:message).and_return(nil)
     end
 
     context "when git branches that match the given name do not exist" do


### PR DESCRIPTION
Automate import no longer allow to import multiple domains from a single git repo. This PR adds a new flash message about that.

Depends On:
https://github.com/ManageIQ/manageiq-automation_engine/pull/124

Based On:
https://bugzilla.redhat.com/show_bug.cgi?id=1497570