### PR TITLE
ReportData - change long_id to string

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1097,7 +1097,7 @@ class ApplicationController < ActionController::Base
       end
       new_row = {
         :id       => list_row_id(row),
-        :long_id  => row['id'],
+        :long_id  => row['id'].to_s,
         :cells    => [],
         :quadicon => quadicon
       }

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -176,7 +176,7 @@ describe ServiceController do
         )
         results = assert_report_data_response
         expect(results['data']['rows'].length).to eq(1)
-        expect(results['data']['rows'][0]['long_id']).to eq(vm.id)
+        expect(results['data']['rows'][0]['long_id']).to eq(vm.id.to_s)
       end
     end
 


### PR DESCRIPTION
`long_id` in report data comes from the `@record.id` field - but Ruby ints can be bigger than JS ints => we 
need a string so that it's not bigger than INT_MAX in JS, for large region numbers.

Cc @karelhala 