### PR TITLE
Disable editing Region on Cloud Edit Screen

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -464,6 +464,7 @@ module EmsCommon
     @openstack_api_versions = retrieve_openstack_api_versions
     @vmware_cloud_api_versions = retrieve_vmware_cloud_api_versions
     @emstype_display = model.supported_types_and_descriptions_hash[@ems.emstype]
+    @ems_region_display = @ems.provider_region
     @nuage_api_versions = retrieve_nuage_api_versions
     @hawkular_security_protocols = retrieve_hawkular_security_protocols
   end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -464,7 +464,9 @@ module EmsCommon
     @openstack_api_versions = retrieve_openstack_api_versions
     @vmware_cloud_api_versions = retrieve_vmware_cloud_api_versions
     @emstype_display = model.supported_types_and_descriptions_hash[@ems.emstype]
-    @ems_region_display = @ems.provider_region
+    if @ems.respond_to?(:description)
+      @ems_region_display = @ems.description
+    end
     @nuage_api_versions = retrieve_nuage_api_versions
     @hawkular_security_protocols = retrieve_hawkular_security_protocols
   end

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -475,7 +475,7 @@ module Mixins
 
     def set_ems_record_vars(ems, mode = nil)
       ems.name                   = params[:name].strip if params[:name]
-      ems.provider_region        = params[:provider_region]
+      ems.provider_region        = params[:provider_region] if params[:provider_region]
       ems.api_version            = params[:api_version].strip if params[:api_version]
       ems.provider_id            = params[:provider_id]
       ems.zone                   = Zone.find_by_name(params[:zone])

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -47,15 +47,23 @@
         = _('Region')
       .col-md-8
         - @provider_regions.each do |name, regions|
-          = select_tag('provider_region',
-                       options_for_select([["<#{_('Choose')}>", nil]] + regions, disabled: ["<#{_('Choose')}>", nil]),
-                       "ng-model"                    => "emsCommonModel.provider_region",
-                       "ng-switch-when"              => name,
-                       "required"                    => "",
-                       "checkchange"                 => "",
-                       "selectpicker-for-select-tag" => "",
-                       "prefix"                      => "default",
-                       "reset-validation-status"     => "default_auth_status")
+          %div{"ng-switch-when" => name}
+            = select_tag('provider_region',
+                         options_for_select([["<#{_('Choose')}>", nil]] + regions, disabled: ["<#{_('Choose')}>", nil]),
+                         "ng-model"                    => "emsCommonModel.provider_region",
+                         "required"                    => "",
+                         "checkchange"                 => "",
+                         "selectpicker-for-select-tag" => "",
+                         "prefix"                      => "default",
+                         "reset-validation-status"     => "default_auth_status",
+                         "ng-if"                       => "newRecord")
+            %label.form-control{"type"        => "text",
+                                "id"          => "provider_region",
+                                "name"        => "provider_region",
+                                "readonly"    => true,
+                                "style"       => "color: black; font-weight: normal;",
+                                "ng-if"       => "!newRecord"}
+              = @ems_region_display
 
     .form-group{"ng-class" => "{'has-error': angularForm.project.$invalid}", "ng-if" => "emsCommonModel.emstype == 'gce'"}
       %label.col-md-2.control-label{"for" => "ems_project"}


### PR DESCRIPTION
Changing regions, changes all the inventory as AWS is very region based
If a user wishes to chnage region, they should create another AWS
provider and remove the original.

Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1517076

This also affects Google, and Azure.