### PR TITLE
Fix timeline text escapings

### DIFF
--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -133,11 +133,7 @@ module ReportFormatter
       if @row[@column].kind_of?(Time) || TIMELINE_TIME_COLUMNS.include?(@column)
         format_timezone(Time.parse(@row[@column].to_s).utc, @flags[:time_zone], "gtl")
       else
-        value = @row[@column].to_s.dup
-        value.tr!('"', "'")
-        value.gsub!('/', "\\\\/")
-        value.gsub!('\\', "\\\\\\")
-        value
+        @row[@column].to_s
       end
     end
 

--- a/spec/lib/report_formater/timeline_message_spec.rb
+++ b/spec/lib/report_formater/timeline_message_spec.rb
@@ -1,20 +1,16 @@
 describe ReportFormatter::TimelineMessage do
   context "#message_html" do
     context "for unknown column names" do
-      subject { described_class.new({'column' => @value}, nil, nil, nil).message_html('column') }
-      it "replaces double quotes with single quotes" do
-        @value = '123""45'
-        expect(subject).to eq "123''45"
+      subject { described_class.new({'column' => @value}, nil, {:time_zone => 'Mexico City'}, nil).message_html('column') }
+
+      it 'returns a string for text columns' do
+        @value = '123""45/\\'
+        expect(subject).to eq '123""45/\\'
       end
 
-      it "escapes forwardslashes" do
-        @value = '123/45'
-        expect(subject).to eq '123\\\\/45'
-      end
-
-      it "escapes backslashes" do
-        @value = '123\\45'
-        expect(subject).to eq '123\\\\45'
+      it 'returns formatted time for time columns' do
+        @value = Time.new(2002, 10, 31, 2, 2, 2, '+02:00')
+        expect(subject).to eq '2002-10-30 18:02:02 CST'
       end
     end
   end


### PR DESCRIPTION
Formatter is doing too much escaping to the text, leading to extra slashes in the user view.

BEFORE:
![image](https://user-images.githubusercontent.com/23639005/33497531-d743712a-d693-11e7-97bf-440b61835cfb.png)

AFTER:
![image](https://user-images.githubusercontent.com/23639005/33497522-cda39fe6-d693-11e7-815a-1ec7bacc2103.png)

(There is a backslash introduced artificially to show the escaping problem)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1511671
