### PR TITLE
UI changes to show options as disabled if those are not supported.

### DIFF
--- a/app/views/catalog/_st_form.html.haml
+++ b/app/views/catalog/_st_form.html.haml
@@ -8,9 +8,14 @@
       .form-group
         %label.col-md-2.control-label= _('Catalog Item Type')
         .col-md-8
-          - array = Array(ServiceTemplate::CATALOG_ITEM_TYPES.invert).sort_by { |a| a.first.downcase }
+          - catalog_item_types = ServiceTemplate.catalog_item_types
+          - array = catalog_item_types.collect { |x| [x[1][:description], x[0]]}
+          - array.sort_by! { |a| a.first.downcase }
+          - disabled_options = catalog_item_types.collect { |x| x[0] if !x[1][:display]}
           = select_tag('st_prov_type',
-                       options_for_select(([["<#{_('Choose')}>",nil]]) + array, nil),
+                       options_for_select(([["<#{_('Choose')}>",nil]]) + array,
+                       :selected => '',
+                       :disabled => disabled_options),
                        "data-miq_sparkle_on" => true,
                        :class    => "selectpicker")
           :javascript


### PR DESCRIPTION
This PR uses changes from backend in https://github.com/ManageIQ/manageiq/pull/16559 to determine whether options in the drop down should be available or disabled based upon results returned in hash by backend method.

https://bugzilla.redhat.com/show_bug.cgi?id=1515371

before all options were always available:
![before](https://user-images.githubusercontent.com/3450808/33504210-978a53c0-d6b4-11e7-8afb-92c59e23f8d1.png)


after:
![after](https://user-images.githubusercontent.com/3450808/33504182-79c9602e-d6b4-11e7-936d-0dbedc7750e9.png)

@mkanoor please test/review.

@dclarizio please review, this PR depends upon core PR https://github.com/ManageIQ/manageiq/pull/16559
