### PR TITLE
Follow-up for #2794 (fix the UrlGenerationError crash)

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -461,7 +461,7 @@ module QuadiconHelper
     link_opts = {}
 
     if quadicon_show_links?
-      url = quadicon_url_to_xshow_from_cid(item, options)
+      url = url_for_record(item, "x_show")
       link_opts = {:sparkle => true, :remote => true}
     end
 

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -668,6 +668,14 @@ describe QuadiconHelper do
     let(:item) { FactoryGirl.build(:service, :id => 100) }
     subject(:service_quad) { helper.render_service_quadicon(item, options) }
 
+    context "url for service quadicon" do
+      it "renders quadicon with service url" do
+        expect(service_quad).to have_selector("a[href*='service/x_show/#{item.id}']")
+        expect(service_quad).to have_selector('div.flobj', :count => 2)
+        expect(service_quad).to match(/service-[\w]*.png/)
+      end
+    end
+
     context "for service w/o custom picture" do
       it "renders quadicon" do
         allow(helper).to receive(:url_for).and_return("/path")

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -721,6 +721,20 @@ describe QuadiconHelper do
     end
   end
 
+  describe "render_service_quadicon - displays correct quadicon hover url for service_template" do
+    let(:options) { {:size => 72, :type => 'grid'} }
+    let(:item) { FactoryGirl.build(:service_template, :id => 100) }
+    subject(:service_quad) { helper.render_service_quadicon(item, options) }
+
+    context "url for service_template quadicon" do
+      it "renders quadicon with catalog url" do
+        expect(service_quad).to have_selector("a[href*='catalog/x_show/#{item.id}']")
+        expect(service_quad).to have_selector('div.flobj', :count => 2)
+        expect(service_quad).to match(/service_template-[\w]*.png/)
+      end
+    end
+  end
+
   describe "#render_resource_pool_quadicon" do
     let(:item) { FactoryGirl.create(:resource_pool) }
     let(:options) { {:mode => :icon} }


### PR DESCRIPTION
Follow-up for #2794

- Fixes the `UrlGenerationError` crash in #2794
- Displays correct quadicon hover url


