### PR TITLE
MiqRequest: fix listing of affected items.

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -803,7 +803,11 @@ module ApplicationController::MiqRequestMethods
       @options = @miq_request.options
       @options[:memory], @options[:mem_typ] = reconfigure_calculations(@options[:vm_memory][0]) if @options[:vm_memory]
       @force_no_grid_xml   = true
-      @view, @pages = get_view(Vm, :view_suffix => "VmReconfigureRequest", :selected_ids => @miq_request.options[:src_ids]) # Get the records (into a view) and the paginator
+
+      @selected_ids = @miq_request.options[:src_ids]
+      @view, @pages = get_view(Vm, :view_suffix => "VmReconfigureRequest")
+      # FIXME: use selected_ids passed through get_view to replace all of
+      # gtl_selected_records after Gaprindashvili
     end
     @user = User.find_by_userid(@miq_request.stamped_by)
   end

--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -1,7 +1,7 @@
 module GtlHelper
   def gtl_selected_records
     records = params.try(:[], :rec_ids) || @edit.try(:[], :pol_items) ||
-              @edit.try(:[], :object_ids) || @targets_hash.try(:keys)
+              @edit.try(:[], :object_ids) || @targets_hash.try(:keys) || @selected_ids
 
     if records.present?
       records = records.map(&:to_i) if records.first.kind_of?(String)

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -231,6 +231,32 @@ describe MiqRequestController do
     end
   end
 
+  context 'showing details of a VM reconfigure task' do
+    before do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
+
+    let(:vm) { FactoryGirl.create(:vm) }
+    let!(:other_vm) { FactoryGirl.create(:vm) }
+
+    let(:reconfigure_request) do
+      FactoryGirl.create(:vm_reconfigure_request, :options => {:src_ids => [vm.id]})
+    end
+
+    # http://localhost:3000/miq_request/show/10000000000342
+    it 'shows a grid with affected VMs' do
+      expect(controller).to receive(:prov_set_show_vars).once.and_call_original
+      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        :model_name       => 'Vm',
+        :gtl_type_string  => 'list',
+        :selected_records => [vm.id] # vm.id is here, other_vm.id is not
+      )
+      get :show, :params => {:id => reconfigure_request.id}
+      expect(response.status).to eq(200)
+    end
+  end
+
   context "#edit_button" do
     before do
       stub_user(:features => :all)


### PR DESCRIPTION
Passing of :selected_ids throught get_view(..) is not implemented.
We shall implement that after Gaprindashvili.

For now pass record ids throught an instance variable.

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1513303

### TODO: 
  * ~~write a spec~~
  * ~~create TODO item for passing the selected_records through `get_view`~~