### PR TITLE
Assign proper menu section to alert* controllers.

### DIFF
--- a/app/controllers/alerts_list_controller.rb
+++ b/app/controllers/alerts_list_controller.rb
@@ -39,5 +39,5 @@ class AlertsListController < ApplicationController
     session[:layout] = @layout
   end
 
-  menu_section :monitor
+  menu_section :monitor_alerts
 end

--- a/app/controllers/alerts_most_recent_controller.rb
+++ b/app/controllers/alerts_most_recent_controller.rb
@@ -26,5 +26,5 @@ class AlertsMostRecentController < ApplicationController
     session[:layout] = @layout
   end
 
-  menu_section :monitor
+  menu_section :monitor_alerts
 end

--- a/app/controllers/alerts_overview_controller.rb
+++ b/app/controllers/alerts_overview_controller.rb
@@ -26,5 +26,5 @@ class AlertsOverviewController < ApplicationController
     session[:layout] = @layout
   end
 
-  menu_section :monitor
+  menu_section :monitor_alerts
 end


### PR DESCRIPTION
### Testing
 * Select anything under Monitor --> Alerts
 * observe that the menu section "Alerts" is (not) active

https://bugzilla.redhat.com/show_bug.cgi?id=1501037

