### PR TITLE
Provisioning form: "logical_cpus" is called "cpu_total_cores".

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -401,7 +401,7 @@ module ApplicationController::MiqRequestMethods
       "name"                          => _("Name"),
       "operating_system.product_name" => _("Operating System"),
       "platform"                      => _("Platform"),
-      "logical_cpus"                  => _("CPUs"),
+      "cpu_total_cores"               => _("CPUs"),
       "mem_cpu"                       => _("Memory"),
       "allocated_disk_storage"        => _("Disk Size"),
       "deprecated"                    => _("Deprecated"),
@@ -415,7 +415,7 @@ module ApplicationController::MiqRequestMethods
     # currently the only ones that support the field.
     headers["image?"] = _("Type") if vms.any? { |vm| vm.respond_to?(:image?) }
 
-    integer_fields = %w(allocated_disk_storage mem_cpu logical_cpus v_total_snapshots)
+    integer_fields = %w(allocated_disk_storage mem_cpu cpu_total_cores v_total_snapshots)
 
     filtered_vms = vms.select { |x| filter_by.call(x) }
 

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -14,7 +14,7 @@
       %tr
         - id = @edit[:req_id] || "new"
         - ["name", "image?", "operating_system.product_name", "platform",
-            "logical_cpus", "mem_cpu", "allocated_disk_storage", "deprecated",
+            "cpu_total_cores", "mem_cpu", "allocated_disk_storage", "deprecated",
             "ext_management_system.name", "v_total_snapshots", "cloud_tenant"].each do |column_name|
           - if @edit[:vm_headers].include?(column_name)
             %th


### PR DESCRIPTION
### Testing

 1. Go to Compute->Infrastructure->Virtual Machines  
 2. From Lifecycle-> VM Provision
 3. Sort templates by CPUs
 4. Observe that sorting does (not) work

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1501053
