### PR TITLE
The id returned by report_data() is now a string

### DIFF
--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -297,7 +297,7 @@ describe StorageController do
         )
         results = assert_report_data_response
         expect(results['data']['rows'].length).to eq(1)
-        expect(results['data']['rows'][0]['long_id']).to eq(storage.id)
+        expect(results['data']['rows'][0]['long_id']).to eq(storage.id.to_s)
       end
     end
   end


### PR DESCRIPTION
The behavior changed in 716037a305eb462f5ee6a6ae4caadd593f7ee015 and PR https://github.com/ManageIQ/manageiq-ui-classic/pull/2902