### PR TITLE
Update menu icons

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -213,7 +213,7 @@ module Menu
       end
 
       def automation_menu_section
-        Menu::Section.new(:aut, N_("Automation"), 'fa fa-recycle', [
+        Menu::Section.new(:aut, N_("Automation"), 'pficon pficon-automation', [
           ansible_menu_section,
           automation_manager_menu_section,
           automate_menu_section
@@ -228,7 +228,7 @@ module Menu
       end
 
       def ansible_menu_section
-        Menu::Section.new(:ansible, N_("Ansible"), 'fa fa-recycle', [
+        Menu::Section.new(:ansible, N_("Ansible"), 'pficon pficon-automation', [
           Menu::Item.new('ansible_playbooks', N_('Playbooks'), 'embedded_configuration_script_payload', {:feature => 'embedded_configuration_script_payload', :any => true}, '/ansible_playbook'),
           Menu::Item.new('ansible_repositories', N_('Repositories'), 'embedded_configuration_script_source', {:feature => 'embedded_configuration_script_source', :any => true}, '/ansible_repository'),
           Menu::Item.new('ansible_credentials', N_('Credentials'), 'embedded_automation_manager_credentials', {:feature => 'embedded_automation_manager_credentials', :any => true}, '/ansible_credential'),
@@ -236,7 +236,7 @@ module Menu
       end
 
       def automate_menu_section
-        Menu::Section.new(:automate, N_("Automate"), 'fa fa-recycle', [
+        Menu::Section.new(:automate, N_("Automate"), 'pficon pficon-automation', [
           Menu::Item.new('miq_ae_class',         N_('Explorer'),        'miq_ae_class_explorer',         {:feature => 'miq_ae_domain_view'},            '/miq_ae_class/explorer'),
           Menu::Item.new('miq_ae_tools',         N_('Simulation'),      'miq_ae_class_simulation',       {:feature => 'miq_ae_class_simulation'},       '/miq_ae_tools/resolve'),
           Menu::Item.new('miq_ae_customization', N_('Customization'),   'miq_ae_customization_explorer', {:feature => 'miq_ae_customization_explorer'}, '/miq_ae_customization/explorer'),
@@ -248,7 +248,7 @@ module Menu
       end
 
       def optimize_menu_section
-        Menu::Section.new(:opt, N_("Optimize"), 'fa fa-lightbulb-o', [
+        Menu::Section.new(:opt, N_("Optimize"), 'pficon pficon-optimize', [
           Menu::Item.new('miq_capacity_utilization', N_('Utilization'), 'utilization', {:feature => 'utilization'}, '/utilization'),
           Menu::Item.new('miq_capacity_planning',    N_('Planning'),    'planning',    {:feature => 'planning'},    '/planning'),
           Menu::Item.new('miq_capacity_bottlenecks', N_('Bottlenecks'), 'bottlenecks', {:feature => 'bottlenecks'}, '/bottlenecks')


### PR DESCRIPTION
Update vertical nav font icons for Automate and Optimize. (Depends on upgrade to Patternfly Sass 3.23.1)

Old
<img width="258" alt="screen shot 2017-12-07 at 9 08 02 am" src="https://user-images.githubusercontent.com/1287144/33719262-2cfb1750-db2e-11e7-8638-42b78443ad46.png">

New
<img width="274" alt="screen shot 2017-12-07 at 9 07 49 am" src="https://user-images.githubusercontent.com/1287144/33719264-2d1f1a42-db2e-11e7-9c61-4a1a740f29b9.png">


