### PR TITLE
Fix broken containers link in container dashboard

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1149,7 +1149,7 @@ class ApplicationController < ActionController::Base
           value = row[col] || ' '
           new_row[:cells] << {:span => severity_span_class(value), :text => severity_title(value)}
         when 'state'
-          celltext = row[col].titleize
+          celltext = row[col].to_s.titleize
         when 'hardware.bitness'
           celltext = row[col] ? "#{row[col]} bit" : ''
         when 'image?'


### PR DESCRIPTION
`Containers` link is broken when `state` is nill - this patch fixes this behavior.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1519382
cc: @himdel 
