### PR TITLE
Display option Delete selected Groups

### DIFF
--- a/app/helpers/application_helper/toolbar/miq_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_groups_center.rb
@@ -30,8 +30,8 @@ class ApplicationHelper::Toolbar::MiqGroupsCenter < ApplicationHelper::Toolbar::
           :send_checked => true,
           :confirm      => N_("Delete all selected Groups?"),
           :enabled      => false,
-          :onwhen       => "1+",
-          :klass        => ApplicationHelper::Button::RbacGroupDelete),
+          :onwhen       => "1+"
+        ),
         separator,
         button(
           :rbac_group_seq_edit,


### PR DESCRIPTION
**fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1514723

Display option to _Delete selected Groups_ under _Configuration -> Access Control
EVM Groups_ and enable the option when selecting multiple Groups in the list.

_Delete selected Groups_ button was not visible due to the fact that it was being set to
visible based upon the result from _RbacGroupDelete_ class, which expects `@record`
to be set.

**Before:**
![delete3](https://user-images.githubusercontent.com/13417815/33562547-d7a553a2-d915-11e7-92f8-6aad709c5b00.png)

**After:**
![delete](https://user-images.githubusercontent.com/13417815/33562162-d8d0a2dc-d914-11e7-854f-d6e9302927d8.png)
![delete2](https://user-images.githubusercontent.com/13417815/33562275-2aea5f90-d915-11e7-972f-89bdebe83b26.png)
