### PR TITLE
Fix `ProvisionCustomizeHelper` helper method access in VM controllers

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -2,6 +2,7 @@ module VmCommon
   extend ActiveSupport::Concern
   include ActionView::Helpers::JavaScriptHelper
   include ChargebackPreview
+  include ProvisionCustomizeHelper
 
   def textual_group_list
     [
@@ -14,6 +15,8 @@ module VmCommon
     private :textual_group_list
     helper_method :textual_group_list
     helper_method :parent_choices_with_no_parent_choice
+    helper_method :select_check?
+    helper_method :disable_check?
   end
 
   # handle buttons pressed on the button bar

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -539,4 +539,15 @@ describe VmInfraController do
   include_examples '#download_summary_pdf', :template_vmware
 
   it_behaves_like "explorer controller with custom buttons"
+
+  it "executes select_check? and disable_check? helper methods" do
+    admin_user = FactoryGirl.create(:user_with_group, :role => 'super_administrator')
+    wf = FactoryGirl.create(:miq_provision_workflow, :requester => admin_user)
+
+    controller.send(:select_check?, wf)
+    expect(response.status).to eq(200)
+
+    controller.send(:disable_check?, wf)
+    expect(response.status).to eq(200)
+  end
 end


### PR DESCRIPTION
Include the helper `ProvisionCustomizeHelper` in `VmCommon` in order to make the helper methods accessible in VM controllers.

https://bugzilla.redhat.com/show_bug.cgi?id=1515710