### PR TITLE
Do not render 'Set Default' button in listnav if saved searches don't exist

### DIFF
--- a/app/views/layouts/listnav/_show_list.html.haml
+++ b/app/views/layouts/listnav/_show_list.html.haml
@@ -62,7 +62,7 @@
       "data-method"          => :post,
       :alt                   => t,
       :title                 => t)
-  - else
+  - elsif !@my_searches.blank?
     = button_tag(_("Set Default"),
       :class => "btn btn-default disabled pull-right",
       :title => _("Select a filter to set it as my default"))

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -690,4 +690,29 @@ describe EmsCloudController do
       verify_password_and_confirm(nil, "oranges")
     end
   end
+
+  context "'Set Default' button rendering in listnav" do
+    render_views
+    before do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
+
+    it "renders 'Set Default' button when a user defined search exists" do
+      MiqSearch.create(:db          => 'EmsCloud',
+                       :search_type => "user",
+                       :description => 'abc',
+                       :name        => 'abc',
+                       :search_key  => session[:userid])
+      get :show_list
+      expect(response.status).to eq(200)
+      expect(response.body).to have_selector("button[title*='Select a filter to set it as my default']", :text => "Set Default")
+    end
+
+    it "does not render set default button when a user defined search does not exist" do
+      get :show_list
+      expect(response.status).to eq(200)
+      expect(response.body).not_to have_selector("button[title*='Select a filter to set it as my default']", :text => "Set Default")
+    end
+  end
 end


### PR DESCRIPTION
Render 'Set Default' button in listnav only if `@my_searches` is not blank

Before 
`Generic Object Definition` - 'Set Default' button rendered even though `@my_searches` is blank

<img width="1419" alt="screen shot 2017-12-04 at 3 05 00 pm" src="https://user-images.githubusercontent.com/1538216/33581178-ad3f0b3c-d904-11e7-88ae-24257127ccf0.png">

-------
After
`Generic Object Definition`(`@my_searches` array is blank) - `Set Default` button not rendered -

<img width="1417" alt="screen shot 2017-12-04 at 2 41 46 pm" src="https://user-images.githubusercontent.com/1538216/33580940-d980ae36-d903-11e7-9517-107de7c1db5e.png">

-------

Other `show_list` screens for reference -

Ems Infra(`@my_searches` array contains value - `Hyper`) with no Default set-
<img width="1417" alt="screen shot 2017-12-04 at 2 55 39 pm" src="https://user-images.githubusercontent.com/1538216/33580766-44f37d8e-d903-11e7-8c37-61087acce755.png">

---------------

Ems Cloud(`@my_searches` array contains value - `['Am', 'Az']`)  with `Az` set to Default -
<img width="1421" alt="screen shot 2017-12-04 at 2 42 16 pm" src="https://user-images.githubusercontent.com/1538216/33580850-90c9137c-d903-11e7-8335-2c960d6eea54.png">

-----------------



 
