### PR TITLE
Unembed Custom Report Export select to hide the unnecessary scrollbar

### DIFF
--- a/app/views/report/_export_custom_reports.html.haml
+++ b/app/views/report/_export_custom_reports.html.haml
@@ -36,21 +36,20 @@
     %label.control-label.col-md-2
       = _('Available Custom Reports:')
     .col-md-8
-      %div{:style => "overflow: auto; width: 400px; border: 1px solid #999999;"}
-        = select_tag('choices_chosen',
-          options_for_select(@export_reports.sort),
-          :size              => 15,
-          :style             => "width:400px; min-width:375px; background-color:#fff; border: 0px;",
-          :multiple          => true)
+      = select_tag('choices_chosen',
+        options_for_select(@export_reports.sort),
+        :size              => 15,
+        :style             => "width:400px; background-color:#fff; border: 1px solid #999999;",
+        :multiple          => true)
 
-        :javascript
-          miqInitSelectPicker();
-          miqSelectPickerEvent("choices_chosen", "#{url}");
-          $('#choices_chosen').on("change",
-            function() {
-              if ($(this).val()) {
-                $('#export_button').removeClass('disabled');
-              } else {
-                $('#export_button').addClass('disabled');
-              }
-            });
+      :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent("choices_chosen", "#{url}");
+        $('#choices_chosen').on("change",
+          function() {
+            if ($(this).val()) {
+              $('#export_button').removeClass('disabled');
+            } else {
+              $('#export_button').addClass('disabled');
+            }
+          });


### PR DESCRIPTION
`Cloud Intel -> Reports -> Import/Export (accordion) -> Custom Reports (treenode)`

**Before:**
![screenshot from 2017-12-05 10-21-49](https://user-images.githubusercontent.com/649130/33599445-7c530972-d9a6-11e7-83f0-a0127f77d7b7.png)

**After:**
![screenshot from 2017-12-05 10-21-31](https://user-images.githubusercontent.com/649130/33599456-8266d23a-d9a6-11e7-97d5-d52b2756c76b.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1519341

@miq-bot assign @epwinchell 
@miq-bot add_label bug