### PR TITLE
Changed CSS class for button

### DIFF
--- a/app/views/miq_ae_customization/_dialog_import_export.html.haml
+++ b/app/views/miq_ae_customization/_dialog_import_export.html.haml
@@ -38,7 +38,7 @@
         .col-md-4
           = render :partial => "shared/file_chooser", :locals => {:object_name => "upload", :method => "file"}
         .col-md-6
-          = button_tag(_("Upload"), :id => "upload_service_dialog_import", :class => "btn btn-default", :action => "submit")
+          = button_tag(_("Upload"), :id => "upload_service_dialog_import", :class => "btn btn-primary", :action => "submit")
 
   %hr
   %h3


### PR DESCRIPTION
Changed CSS class for *Import* button, so both the buttons with action (*Import* / *Export*) are consistent:

Before:
![screenshot from 2017-12-05 11-09-42](https://user-images.githubusercontent.com/1187051/33601547-e19f46be-d9ac-11e7-90c4-48a825289455.png)
After:
![screenshot from 2017-12-05 11-09-07](https://user-images.githubusercontent.com/1187051/33601549-e28ec6e4-d9ac-11e7-9b47-ea2b7ba653ed.png)

Steps for Testing/QA
-------------------------------
Automate → Automation → Customization → Import/Export accordion

cc/ @epwinchell