### PR TITLE
Deleted dead owner_changed? method.

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1075,9 +1075,4 @@ module ApplicationController::CiProcessing
     when "vm_transform"                     then vm_transform
     end
   end
-
-  def owner_changed?(owner)
-    return false if @edit[:new][owner].blank?
-    @edit[:new][owner] != @edit[:current][owner]
-  end
 end


### PR DESCRIPTION
This method was dead and was not calling any other method or creating new objects. I tried these commands: ag owner_changed? ; ag owner_#.* ; ag #.*_changed. Miss Nemeckova confirmed the fact that this method is dead.

@miq-bot add_label technical debt, gaprindashvili/no

