### PR TITLE
Deleting dead method parent_entity_name from middleware_deployments_mixin

### DIFF
--- a/app/controllers/mixins/middleware_deployments_mixin.rb
+++ b/app/controllers/mixins/middleware_deployments_mixin.rb
@@ -39,10 +39,6 @@ module Mixins::MiddlewareDeploymentsMixin
     end
   end
 
-  def parent_entity_name
-    @is_server ? 'server.' : 'server group.'
-  end
-
   def prepare_properties
     @entity_id = identify_selected_entities
     @klass = self.class


### PR DESCRIPTION
@miq-bot add_label technical debt, gaprindashvili/no

Deleting dead method parent_entity_name from middleware_deployments_mixin

app -> controllers -> mixins -> middleware_deployements_mixin.rb

Please review @himdel.

