### PR TITLE
Deleted dead methods process_host_provide and deletedialogs

### DIFF
--- a/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -1,11 +1,6 @@
 module MiqAeCustomizationController::OldDialogs
   extend ActiveSupport::Concern
 
-  # Delete all selected or single displayed PXE Server(s)
-  def deletedialogs
-    old_dialogs_button_operation('destroy', 'deletion')
-  end
-
   # Get variables from edit form
   def old_dialogs_get_form_vars
     @dialog = @edit[:dialog]

--- a/app/controllers/mixins/actions/host_actions/misc.rb
+++ b/app/controllers/mixins/actions/host_actions/misc.rb
@@ -123,7 +123,7 @@ module Mixins
           end
         end
 
-        def process_host_provide(hosts, display_name)
+        def process_hosts_provide(hosts, display_name)
           each_host(hosts, display_name) do |host|
             if host.hardware.provision_state == "manageable"
               host.provide_queue(session[:userid])


### PR DESCRIPTION
@himdel @ZitaNemeckova 
Methods process_host_provide and deletedialogs has been deleted. They were just defined but uncalled anywhere. 
@miq-bot add_label technical debt, gaprindashvili/no