### PR TITLE
Custom Button Group Edit styling  fix

### DIFF
--- a/app/views/shared/buttons/_column_lists.html.haml
+++ b/app/views/shared/buttons/_column_lists.html.haml
@@ -34,7 +34,7 @@
           %i.fa.fa-lg.fa-angle-left.fa-rotate-90.hidden-md.hidden-lg
       - else
         - t = _("Move selected fields left")
-        %button.btn.btn-default{:title           => t,
+        %button.btn.btn-default.btn-block{:title           => t,
                                 :remote          => true,
                                 "data-submit"    => 'column_lists',
                                 "data-method"    => :post,


### PR DESCRIPTION
Add missing "btn-block" class to button for proper responsive styling

https://bugzilla.redhat.com/show_bug.cgi?id=1516840

Old
<img width="864" alt="screen shot 2017-12-05 at 9 58 21 am" src="https://user-images.githubusercontent.com/1287144/33614433-6307c8a0-d9a5-11e7-99d9-5c888a68be92.png">

New
<img width="773" alt="screen shot 2017-12-05 at 10 12 57 am" src="https://user-images.githubusercontent.com/1287144/33614432-62fa41f8-d9a5-11e7-8d2c-1905e2f8fc49.png">

