### PR TITLE
Remove an extraneous string format causing errors.

### DIFF
--- a/app/controllers/ops_controller/settings/zones.rb
+++ b/app/controllers/ops_controller/settings/zones.rb
@@ -9,7 +9,7 @@ module OpsController::Settings::Zones
       if @zone && @zone.id
         add_flash(_("Edit of Zone \"%{name}\" was cancelled by the user") % {:name => @zone.name})
       else
-        add_flash(_("Add of new Zone was cancelled by the user") % {:name => @zone.name})
+        add_flash(_("Add of new Zone was cancelled by the user"))
       end
       get_node_info(x_node)
       replace_right_cell(:nodetype => @nodetype)


### PR DESCRIPTION
`@zone` may be `nil` in the else branch and therefore failing to retrieve `.name`. Since the name is not necessary in that flash message, it can be safely removed.

https://bugzilla.redhat.com/show_bug.cgi?id=1520999