### PR TITLE
Fix PDF and full-screen links for dashboard widgets

### DIFF
--- a/app/presenters/widget_presenter.rb
+++ b/app/presenters/widget_presenter.rb
@@ -62,14 +62,14 @@ class WidgetPresenter
                    :title       => title,
                    :name        => _("Full Screen"),
                    :confirm     => confirm,
-                   :href        => "/dashboard/report_only?rr_id=#{@widget.id}&type=#{@widget.content_type == "chart" ? 'hybrid' : 'tabular'}",
+                   :href        => "/dashboard/report_only?rr_id=#{@widget.contents_for_user(current_user).miq_report_result_id}&type=#{@widget.content_type == "chart" ? 'hybrid' : 'tabular'}",
                    :fonticon    => 'fa fa-arrows-alt fa-fw',
                    :target      => "_blank")
       if PdfGenerator.available?
         buttons.push(:id       => "w_#{@widget.id}_pdf",
                      :title    => _("Download the full report (all rows) as a PDF file"),
                      :name     => _("Download PDF"),
-                     :href     => '/dashboard/widget_to_pdf?rr_id=' + @widget.id.to_s,
+                     :href     => '/dashboard/widget_to_pdf?rr_id=' + @widget.contents_for_user(current_user).miq_report_result_id.to_s,
                      :fonticon => 'fa fa-file-pdf-o fa-fw')
       end
     end


### PR DESCRIPTION
1. Go to Cloud Intel -> Dashboard
2. for each and every widget present, try do download its PDF report (if possible). Correct report should be rendered, no error should occur.
3. for each and every widget present, try to go full screen (if possible). Correct report should be rendered, no error should occur.

for `rr_id=...` we need to correctly pass the report result id, not the widget id.

https://bugzilla.redhat.com/show_bug.cgi?id=1518949
https://bugzilla.redhat.com/show_bug.cgi?id=1517059