### PR TITLE
[FINE] Changed validation of Service Dialog Fields to allow hyphen

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -688,7 +688,7 @@ module MiqAeCustomizationController::Dialogs
         add_flash(_("Entry Point must be given."), :error)
         res = false
       end
-      if @edit[:field_name].to_s !~ /^[a-z0-9_]+$/i
+      if @edit[:field_name].to_s !~ /^[a-z0-9_-]+$/i
         add_flash(_("Element Name must be alphanumeric characters and underscores without spaces"), :error)
         res = false
       end


### PR DESCRIPTION
This PR allows to have a hyphen in the Dialog Field's name.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1518600

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1518600

Steps for Testing/QA
-------------------------------

Try to name a Field by a name with hyphen