### PR TITLE
Fix saving a new filter after deleting another one

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -159,7 +159,7 @@ module ApplicationController::AdvancedSearch
     @edit[:new][@expkey] = @edit[@expkey][:expression]                        # Copy to new exp
     @edit[@expkey].history.reset(@edit[@expkey][:expression])
     @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression]) # Rebuild the expression table
-    @edit[:adv_search_name] = nil                                             # Clear search name
+    @edit[:adv_search_name] = @edit[:new_search_name] = nil                   # Clear search name
     @edit[:adv_search_report] = nil                                           # Clear the report name
   end
 

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -212,7 +212,7 @@ module ApplicationController::Filter
     @edit[@expkey].history.reset(@edit[@expkey][:expression])
     @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression]) # Rebuild the expression table
     @edit[@expkey][:selected] = {:id => 0}                                    # Save the last search loaded
-    @edit[:adv_search_name] = nil                                             # Clear search name
+    @edit[:adv_search_name] = @edit[:new_search_name] = nil                   # Clear search name
     @edit[:adv_search_report] = nil                                           # Clear the report name
     session[:adv_search] ||= {}                                               # Create/reuse the adv search hash
     session[:adv_search][@edit[@expkey][:exp_model]] = copy_hash(@edit)       # Save by model name in settings


### PR DESCRIPTION
**fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1521055

Fix saving a new filter in Advanced search after deleting another one,
by proper resetting all the necessary fields when deleting a filter.

**The problem was:**
---
**Filter was created** (with the same name as previously deleted filter) even when we did not click on _Save/Cancel_ or any other button in Advanced search, **after first clicking on _Save_** button. The form with the previously deleted filter name was displayed and the filter was already created (and displayed in accordion) even when we did not click on Save button (or any other button) for the second time and even when we did not enter any name of a new filter (it was already there - the name of previously deleted filter, by default, in the form). Shortly, filter was created before finishing the right process of saving a new filter (with the same name as previously deleted filter). It behaved like it skipped the step with naming a new filter.

This problem occured in all of the pages with filters. The important step is deleting some filter (the filter was not properly deleted, the name of deleted filtered was not cleared properly which caused this problem). If no filter was deleted, process of creating a new filter was without problems.

**Before:**
![before_second_step](https://user-images.githubusercontent.com/13417815/33622986-c588390c-d9ef-11e7-912d-3e48dd6f62de.png)

**After:**
The blank form is displayed for entering a new name of a filter, in Adv search, and no filter is created (and appeared in accordion) until the second clicking on Save button with a name of a new filter entered in the form.
![newer](https://user-images.githubusercontent.com/13417815/33623175-6d51a790-d9f0-11e7-8420-30e7b50f08ba.png)
