### PR TITLE
Show VM transform button only if permitted

### DIFF
--- a/app/helpers/application_helper/button/mass_transform_vm_button.rb
+++ b/app/helpers/application_helper/button/mass_transform_vm_button.rb
@@ -1,6 +1,7 @@
 class ApplicationHelper::Button::MassTransformVmButton < ApplicationHelper::Button::Basic
   def visible?
-    true
+    store = Vmdb::PermissionStores.instance
+    store.can?('vm_transform_mass')
   end
 
   def disabled?


### PR DESCRIPTION
Show VM transform button for mass transforms only if `vm_transform_mass` permission is set in the permission store. By default, it is visible in ManageIQ, that uses `Null` permission store, and hidden in CFME, if `vm_transform_mass` is not set explicitly in `YAML` permission store.