### PR TITLE
Update Cap & U option styling

### DIFF
--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -3,53 +3,59 @@
 #perf_options_div{:onclick => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
   - if @charts || @perf_options[:chart_type] != :performance
     %h3= _("Options %{model}") % {:model => (@record != @perf_record ? "(#{ui_lookup(:model => @perf_record.class.to_s)}: #{@perf_record.name})" : "")}
-    %dl.dl-horizontal
-      %dt
-        = _("Interval")
-      %dd
-        :javascript
-           miqInitSelectPicker();
-        - if @perf_options[:index] && %w(host vm).include?(request.parameters["controller"])
-          - rt_chart = YAML.load(File.open("#{ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER}/realtime_perf_charts/#{@perf_options[:model]}.yaml"))
-          - @rt_hide = rt_chart[@perf_options[:index].to_i][:type] == "None"
-        - if request.parameters["controller"] == "storage" && @perf_options[:cat]
-          = select("perf", "typ", [[_("Hourly"), "Hourly"], [_("Daily"), "Daily"]], {:selected => @perf_options[:typ]},
-                                                      :disabled => "")
-        - elsif %w(Host VmOrTemplate ContainerNode Container ContainerGroup MiddlewareServer MiddlewareDatasource MiddlewareMessaging).include?(@perf_options[:model]) && !@rt_hide
-          = select_tag("perf_typ",
-                        options_for_select([[_("Hourly"), "Hourly"], [_("Daily"), "Daily"], [_("Most Recent Hour"), "realtime"]], @perf_options[:typ]),
-                        "data-miq_sparkle_on" => true,
-                        :class    => "selectpicker")
+    .form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _("Interval")
+        .col-md-8
           :javascript
-             miqSelectPickerEvent("perf_typ", "#{url}")
-        - else
-          = select_tag("perf_typ",
-                        options_for_select([[_("Hourly"), "Hourly"], [_("Daily"), "Daily"]], @perf_options[:typ]),
-                        "data-miq_sparkle_on" => true,
-                        :class    => "selectpicker")
-          :javascript
-             miqSelectPickerEvent("perf_typ", "#{url}")
+             miqInitSelectPicker();
+          - if @perf_options[:index] && %w(host vm).include?(request.parameters["controller"])
+            - rt_chart = YAML.load(File.open("#{ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER}/realtime_perf_charts/#{@perf_options[:model]}.yaml"))
+            - @rt_hide = rt_chart[@perf_options[:index].to_i][:type] == "None"
+          - if request.parameters["controller"] == "storage" && @perf_options[:cat]
+            = select("perf", "typ", [[_("Hourly"), "Hourly"], [_("Daily"), "Daily"]], {:selected => @perf_options[:typ]},
+                                                        :disabled => "")
+          - elsif %w(Host VmOrTemplate ContainerNode Container ContainerGroup MiddlewareServer MiddlewareDatasource MiddlewareMessaging).include?(@perf_options[:model]) && !@rt_hide
+            = select_tag("perf_typ",
+                          options_for_select([[_("Hourly"), "Hourly"], [_("Daily"), "Daily"], [_("Most Recent Hour"), "realtime"]], @perf_options[:typ]),
+                          "data-miq_sparkle_on" => true,
+                          :class    => "selectpicker")
+            :javascript
+               miqSelectPickerEvent("perf_typ", "#{url}")
+          - else
+            = select_tag("perf_typ",
+                          options_for_select([[_("Hourly"), "Hourly"], [_("Daily"), "Daily"]], @perf_options[:typ]),
+                          "data-miq_sparkle_on" => true,
+                          :class    => "selectpicker")
+            :javascript
+               miqSelectPickerEvent("perf_typ", "#{url}")
 
       - if @perf_options[:typ] == "realtime"
-        %dt
-          = _("Show")
-        %dd
-          = select_tag("perf_minutes",
-                       options_for_select(ViewHelper::REALTIME_CHOICES.map { |k, v| [_(v), k] }.sort_by(&:last),
-                       @perf_options[:rt_minutes]),
-                       "data-miq_sparkle_on" => true,
-                       :class    => "selectpicker")
-          :javascript
-             miqSelectPickerEvent("perf_minutes", "#{url}")
-          = _("back")
-        %dt
-          = _("Range")
-        %dd= @perf_options[:range]
+        .form-group
+          %label.col-md-2.control-label
+            = _("Show")
+          .col-md-8
+            = select_tag("perf_minutes",
+                         options_for_select(ViewHelper::REALTIME_CHOICES.map { |k, v| [_(v), k] }.sort_by(&:last),
+                         @perf_options[:rt_minutes]),
+                         "data-miq_sparkle_on" => true,
+                         :class    => "selectpicker")
+            :javascript
+               miqSelectPickerEvent("perf_minutes", "#{url}")
+            = _("back")
+        .form-group
+          %label.col-md-2.control-label
+            = _("Range")
+          .col-md-8
+            %p.form-control-static
+              = @perf_options[:range]
 
       - unless @perf_options[:typ] == "realtime"
-        %dt
-          = _("Date")
-          %dd
+        .form-group
+          %label.col-md-2.control-label
+            = _("Date")
+          .col-md-8
             = datepicker_input_tag("miq_date_1",
               h(@perf_options[:typ] == "Hourly" ? @perf_options[:hourly_date] : @perf_options[:daily_date]),
               :readonly               => "true",
@@ -58,59 +64,65 @@
               "data-miq_observe_date" => {:url => url}.to_json)
 
         - unless @perf_options[:typ] == "Hourly"
-          %dt
-            = _("Show")
-          %dd
-            = select_tag("perf_days",
-                          options_for_select(ViewHelper::WEEK_CHOICES.map { |k, v| [_(v), k] }.sort,
-                            @perf_options[:days].to_i),
-                          "data-miq_sparkle_on" => true,
-                          :class    => "selectpicker")
-            :javascript
-               miqSelectPickerEvent("perf_days", "#{url}")
-            = _("back")
+          .form-group
+            %label.col-md-2.control-label
+              = _("Show")
+            .col-md-8
+              = select_tag("perf_days",
+                            options_for_select(ViewHelper::WEEK_CHOICES.map { |k, v| [_(v), k] }.sort,
+                              @perf_options[:days].to_i),
+                            "data-miq_sparkle_on" => true,
+                            :class    => "selectpicker")
+              :javascript
+                 miqSelectPickerEvent("perf_days", "#{url}")
+              = _("back")
       - unless @perf_options[:typ] == "realtime"
         - unless @perf_options[:typ] == "Hourly" && request.parameters["controller"] == "storage"
           - if @perf_options.cats
-            %dt
-              = _("Group by")
-            %dd
-              = select_tag("perf_cat",
-                           options_for_select(Array(@perf_options.cats.invert).sort_by { |name, _value| name },
-                                              "#{@perf_options[:cat_model]}:#{@perf_options[:cat]}"),
-                           "data-miq_sparkle_on" => true,
-                           :class    => "selectpicker")
-              :javascript
-                miqSelectPickerEvent("perf_cat", "#{url}")
+            .form-group
+              %label.col-md-2.control-label
+                = _("Group by")
+              .col-md-8
+                = select_tag("perf_cat",
+                             options_for_select(Array(@perf_options.cats.invert).sort_by { |name, _value| name },
+                                                "#{@perf_options[:cat_model]}:#{@perf_options[:cat]}"),
+                             "data-miq_sparkle_on" => true,
+                             :class    => "selectpicker")
+                :javascript
+                  miqSelectPickerEvent("perf_cat", "#{url}")
         - unless @perf_options[:cat]
           - if @perf_options.vmtypes && (@perf_options[:index].nil? || @charts.first[:title].include?("by Type"))
-            %dt
-              = _("Show VM Types")
-            %dd
-              = select_tag("perf_vmtype",
-                           options_for_select(@perf_options.vmtypes,
-                           @perf_options[:vmtype]),
-                           "data-miq_sparkle_on" => true,
-                           :class    => "selectpicker")
-              :javascript
-                miqSelectPickerEvent("perf_vmtype", "#{url}")
+
+            .form-group
+              %label.col-md-2.control-label
+                = _("Show VM Types")
+              .col-md-8
+                = select_tag("perf_vmtype",
+                             options_for_select(@perf_options.vmtypes,
+                             @perf_options[:vmtype]),
+                             "data-miq_sparkle_on" => true,
+                             :class    => "selectpicker")
+                :javascript
+                  miqSelectPickerEvent("perf_vmtype", "#{url}")
 
       - unless @perf_options[:typ] == "realtime"
-        %dt
-          = _("Time Profile")
-        %dd
-          - if session[:time_profiles].blank?
-            = _("No Time Profiles found")
-          - elsif session[:time_profiles].length == 1
-            = session[:time_profiles][@perf_options[:time_profile].to_i]
-          - else
-            = select_tag("time_profile",
-                         options_for_select(Array(session[:time_profiles].invert).sort_by(&:first),
-                         @perf_options[:time_profile]),
-                         "data-miq_sparkle_on" => true,
-                         :class    => "selectpicker")
-            :javascript
-              miqSelectPickerEvent("time_profile", "#{url}")
+        .form-group
+          %label.col-md-2.control-label
+            = _("Time Profile")
+          .col-md-8
+            %p.form-control-static
+              - if session[:time_profiles].blank?
+                = _("No Time Profiles found")
+              - elsif session[:time_profiles].length == 1
+                = session[:time_profiles][@perf_options[:time_profile].to_i]
+              - else
+                = select_tag("time_profile",
+                             options_for_select(Array(session[:time_profiles].invert).sort_by(&:first),
+                             @perf_options[:time_profile]),
+                             "data-miq_sparkle_on" => true,
+                             :class    => "selectpicker")
+                :javascript
+                  miqSelectPickerEvent("time_profile", "#{url}")
 
       - if @perf_options[:model] == "VmOrTemplate" && @perf_options[:typ] != "realtime"
         - compare_choices = []
@@ -118,17 +130,20 @@
         - compare_choices.push(["Parent '#{title_for_cluster}'", "EmsCluster"]) if @perf_record.ems_cluster
 
         - unless compare_choices.empty?
-          %dt
-            = _("Compare To")
-          %dd
-            = select_tag("compare_to",
-                           options_for_select([["<Nothing>", nil]] + compare_choices,
-                           @perf_options[:parent]),
-                           "data-miq_sparkle_on" => true,
-                           :class    => "selectpicker")
-            :javascript
-              miqSelectPickerEvent("compare_to", "#{url}")
+          .form-group
+            %label.col-md-2.control-label
+              = _("Compare To")
+            .col-md-8
+              = select_tag("compare_to",
+                             options_for_select([["<Nothing>", nil]] + compare_choices,
+                             @perf_options[:parent]),
+                             "data-miq_sparkle_on" => true,
+                             :class    => "selectpicker")
+              :javascript
+                miqSelectPickerEvent("compare_to", "#{url}")
       - if @perf_options[:typ] == "Daily"
-        %dt
-        %dd= _("* Daily charts only include days for which all 24 hours of data has been collected.")
+        .form-group
+          %label.col-md-2.control-label
+          .col-md-8
+            = _("* Daily charts only include days for which all 24 hours of data has been collected.")
   %hr


### PR DESCRIPTION
This PR updates the Cap & U options to use PF "form-horizontal" styling

Old
<img width="779" alt="screen shot 2017-12-05 at 4 53 34 pm" src="https://user-images.githubusercontent.com/1287144/33632830-ddda1bbe-d9dc-11e7-85f1-5b835a11adb4.png">

After
<img width="952" alt="screen shot 2017-12-05 at 4 48 52 pm" src="https://user-images.githubusercontent.com/1287144/33632776-b5e8d776-d9dc-11e7-93ae-8037179d20d7.png">
