### PR TITLE
Apply gettext on general object definitions strings coming from API

### DIFF
--- a/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
@@ -221,7 +221,7 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
 
   function buildOptionObject(optionData, optionObject) {
     _.forEach(optionData, function(item) {
-      optionObject.push({id: item[1], name: item[0]});
+      optionObject.push({id: item[1], name: __(item[0])});
     });
   }
 


### PR DESCRIPTION
For more context, this is the data coming from API:
```
  "data": {
        "allowed_association_types": [
            [
                "Bottleneck Event",
                "BottleneckEvent"
            ],
            [
                "Chargeback Container Image",
                "ChargebackContainerImage"
            ],
            [
                "Cloud Resource Quota",
                "CloudResourceQuota"
            ],
...
       "allowed_types": [
            [
                "Boolean",
                "boolean"
            ],
            [
                "Date/Time",
                "datetime"
            ],
            [
                "Float",
                "float"
            ],
...
```

And this is the relevant part of javascript, processing that API data:
```javascript
   function getGenericObjectDefinitionOptions(response) {
     buildOptionObject(response.data.allowed_association_types, vm.classes);
     buildOptionObject(response.data.allowed_types, vm.types);
   }
 
   function buildOptionObject(optionData, optionObject) {
     _.forEach(optionData, function(item) {
       optionObject.push({id: item[1], name: item[0]});
```