### PR TITLE
The data sent from GO Definition API are hashes, not arrays

### DIFF
--- a/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
@@ -220,9 +220,11 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
   }
 
   function buildOptionObject(optionData, optionObject) {
-    _.forEach(optionData, function(item) {
-      optionObject.push({id: item[1], name: __(item[0])});
-    });
+    for (var key in optionData) {
+      if (optionData.hasOwnProperty(key)) {
+        optionObject.push({id: key, name: __(optionData[key])});
+      }
+    }
   }
 
   function promisesResolvedForLoad() {


### PR DESCRIPTION
This is a client change that needs to be done after https://github.com/ManageIQ/manageiq-api/pull/238 is merged.

In essence, we want to send hash over the API, rather than an array, since on the client side we're doing a transformation back to a hash anyway.