### PR TITLE
Helper specs - remove allow_any_instance_of

### DIFF
--- a/spec/helpers/compliance_summary_helper_spec.rb
+++ b/spec/helpers/compliance_summary_helper_spec.rb
@@ -4,7 +4,7 @@ describe ComplianceSummaryHelper do
     @record = FactoryGirl.build(:vm_vmware, :miq_server => server)
     @compliance1 = FactoryGirl.build(:compliance)
     @compliance2 = FactoryGirl.build(:compliance)
-    allow_any_instance_of(described_class).to receive(:role_allows?).and_return(true)
+    allow(self).to receive(:role_allows?).and_return(true)
   end
 
   context "when @explorer is set" do

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -2,7 +2,7 @@ describe EmsCloudHelper::TextualSummary do
   context "#textual_instances and #textual_images" do
     before do
       @record = FactoryGirl.create(:ems_openstack, :zone => FactoryGirl.build(:zone))
-      allow_any_instance_of(described_class).to receive(:role_allows?).and_return(true)
+      allow(self).to receive(:role_allows?).and_return(true)
       allow(controller).to receive(:restful?).and_return(true)
       allow(controller).to receive(:controller_name).and_return("ems_cloud")
     end

--- a/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
@@ -2,7 +2,7 @@ describe EmsContainerHelper::TextualSummary do
   context "providers custom attributes" do
     before do
       @record = FactoryGirl.build(:ems_openshift)
-      allow_any_instance_of(described_class).to receive(:role_allows?).and_return(true)
+      allow(self).to receive(:role_allows?).and_return(true)
       allow(controller).to receive(:restful?).and_return(true)
       allow(controller).to receive(:controller_name).and_return("ems_container")
     end


### PR DESCRIPTION
We don't want to use `allow_any_instance_of` unless necessary.

3 textual summary helper specs are using it to mock `role_allows?`, but according to https://github.com/ManageIQ/manageiq-ui-classic/pull/2901#discussion_r155236459 the same can be achieved using `allow(self)`.

Cc @skateman :cookie: 