### PR TITLE
spec_helper - include ApplicationHelper

### DIFF
--- a/spec/helpers/application_helper/buttons/cloud_subnet_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/cloud_subnet_new_spec.rb
@@ -1,4 +1,6 @@
 describe ApplicationHelper::Button::CloudSubnetNew do
+  include ApplicationHelper
+
   describe '#disabled?' do
     it "when at least one provider supports subnet create then the button is not disabled" do
       view_context = setup_view_context_with_sandbox({})

--- a/spec/helpers/application_helper/buttons/floating_ip_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/floating_ip_new_spec.rb
@@ -1,4 +1,6 @@
 describe ApplicationHelper::Button::FloatingIpNew do
+  include ApplicationHelper
+
   describe '#disabled?' do
     it "when at least one provider supports floating ip create then the button is not disabled" do
       view_context = setup_view_context_with_sandbox({})

--- a/spec/helpers/compliance_summary_helper_spec.rb
+++ b/spec/helpers/compliance_summary_helper_spec.rb
@@ -1,4 +1,6 @@
 describe ComplianceSummaryHelper do
+  include ApplicationHelper
+
   before do
     server  = FactoryGirl.build(:miq_server, :id => 0)
     @record = FactoryGirl.build(:vm_vmware, :miq_server => server)

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -98,6 +98,7 @@ end
 # FIXME: complex describe blocks mirror the existing complex control flow
 
 describe QuadiconHelper do
+  include ApplicationHelper
   helper ImageEncodeHelper
 
   describe "#render_quadicon" do

--- a/spec/helpers/textual_summary_helper_spec.rb
+++ b/spec/helpers/textual_summary_helper_spec.rb
@@ -1,4 +1,6 @@
 describe TextualSummaryHelper do
+  include ApplicationHelper
+
   before do
     stub_user(:features => :all)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,7 @@ RSpec.configure do |config|
 
   config.include Spec::Support::AuthHelper, :type => :view
   config.include Spec::Support::ViewHelper, :type => :view
+  config.include ApplicationHelper, :type => :view
 
   config.include Spec::Support::ControllerHelper, :type => :controller
   config.include Spec::Support::AuthHelper, :type => :controller


### PR DESCRIPTION
without this, running single spec files, many tests fail on not being able to run `url_for_only_path`

~~Reverts f62bb815b855d895d2f514fac621fb94c127a9a7 - now we know why this was there :)~~

EDIT:

Updated to include ApplicationHelper only for view specs (since 44 fail), and added manually to the 5 failing helper specs.

Cc @bdunne 