### PR TITLE
[FINE] Re-enable Web Console button

### DIFF
--- a/app/helpers/application_helper/button/cockpit_console.rb
+++ b/app/helpers/application_helper/button/cockpit_console.rb
@@ -2,11 +2,9 @@ class ApplicationHelper::Button::CockpitConsole < ApplicationHelper::Button::Bas
   needs :@record
 
   def disabled?
-    canned_msg = _('The web-based console is not available because the')
-    @error_message = _("%{canned_msg} 'Cockpit' role is not enabled." % {:canned_msg => canned_msg}) unless MiqRegion.my_region.role_active?('cockpit_ws')
     record_type = @record.respond_to?(:current_state) ? _('VM') : _('Container Node')
-    @error_message = _("%{canned_msg} %{record_type} is not powered on" % {:canned_msg => canned_msg, :record_type => record_type}) unless on?
-    @error_message = _("%{canned_msg} Windows platform is not supported" % {:canned_msg => canned_msg}) unless platform_supported?
+    @error_message = _("The web-based console is not available because the %{record_type} is not powered on" % {:record_type => record_type}) unless on?
+    @error_message = _('The web-based console is not available because the Windows platform is not supported') unless platform_supported?
     @error_message.present?
   end
 

--- a/spec/controllers/container_node_controller_spec.rb
+++ b/spec/controllers/container_node_controller_spec.rb
@@ -2,7 +2,6 @@ describe ContainerNodeController do
   render_views
   before(:each) do
     stub_user(:features => :all)
-    MiqRegion.seed
   end
 
   it "renders index" do

--- a/spec/controllers/vm_cloud_controller/trees_spec.rb
+++ b/spec/controllers/vm_cloud_controller/trees_spec.rb
@@ -2,7 +2,6 @@ describe VmCloudController do
   render_views
   before :each do
     stub_user(:features => :all)
-    MiqRegion.seed
     EvmSpecHelper.create_guid_miq_server_zone
   end
 

--- a/spec/controllers/vm_infra_controller/trees_spec.rb
+++ b/spec/controllers/vm_infra_controller/trees_spec.rb
@@ -2,7 +2,6 @@ describe VmInfraController do
   render_views
   before :each do
     stub_user(:features => :all)
-    MiqRegion.seed
     EvmSpecHelper.create_guid_miq_server_zone
   end
 

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -12,7 +12,6 @@ describe VmInfraController do
     allow(controller).to receive(:protect_build_tree).and_return(nil)
     controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name"))
 
-    MiqRegion.seed
     EvmSpecHelper.create_guid_miq_server_zone
   end
 

--- a/spec/helpers/application_helper/buttons/cockpit_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/cockpit_console_spec.rb
@@ -1,60 +1,30 @@
 describe ApplicationHelper::Button::CockpitConsole do
   describe '#disabled?' do
-    before do
-      @record = FactoryGirl.create(:vm)
-      MiqRegion.seed
-      EvmSpecHelper.create_guid_miq_server_zone
-
-      allow(@record).to receive(:platform).and_return('linux')
-      allow(@record).to receive(:power_state).and_return('on')
-    end
-
+    before { @record = FactoryGirl.create(:vm) }
     let(:view_context) { setup_view_context_with_sandbox({}) }
     let(:button) { described_class.new(view_context, {}, {:record => @record}, {}) }
-
-    context 'passes checks' do
-      before do
-        @server_role = FactoryGirl.create(
-          :server_role,
-          :name              => 'cockpit_ws',
-          :description       => 'Cockpit WS',
-          :max_concurrent    => 1,
-          :external_failover => false,
-          :role_scope        => 'zone'
-        )
-        FactoryGirl.create(
-          :assigned_server_role,
-          :miq_server_id  => MiqServer.first.id,
-          :server_role_id => @server_role.id,
-          :active         => true,
-          :priority       => 1
-        )
-      end
-
-      it 'returns false' do
-        expect(button.disabled?).to be false
+    context "when the power state of the record is 'on'" do
+      let(:power_state) { 'on' }
+      it "returns false" do
+        expect(button[:disabled?]).to be_falsey
       end
     end
-
-    context 'returns true and disables button' do
-      context 'when cockpit_ws role' do
-        it 'is disabled' do
-          expect(button.disabled?).to be true
-        end
+    context "when the power state of the record is not 'on'" do
+      let(:power_state) { 'unknown' } # orphaned and archived VM's
+      it "returns true" do
+        expect(button[:disabled?]).to be_nil
       end
-
-      context 'when power_state' do
-        it "is not 'on'" do
-          allow(@record).to receive(:power_state).and_return('unknown')
-          expect(button.disabled?).to be true
-        end
+    end
+    context "when platform is 'windows'" do
+      it "returns true" do
+        allow(@record).to receive(:platform).and_return('windows')
+        expect(button[:disabled?]).to be_nil
       end
-
-      context 'when platform' do
-        it 'is Windows' do
-          allow(@record).to receive(:platform).and_return('windows')
-          expect(button.disabled?).to be true
-        end
+    end
+    context "when platform is 'linux'" do
+      it "returns false" do
+        allow(@record).to receive(:platform).and_return('linux')
+        expect(button[:disabled?]).to be_falsey
       end
     end
   end


### PR DESCRIPTION
Reverts commit 67a0f0ae8a3fada5746cd72e119bd8bf8f598dab to re-enable Cockpit console functionality.  There was no Cockpit role in FINE to enable the Web Console button.

@miq-bot add_labels bug, console

https://bugzilla.redhat.com/show_bug.cgi?id=1522951