### PR TITLE
Standardize 'page refresh' text and font icon

### DIFF
--- a/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
@@ -2,9 +2,9 @@ class ApplicationHelper::Toolbar::AnsibleRepositoriesCenter < ApplicationHelper:
   button_group('ansible_repositories_reloading', [
     button(
       :ansible_repositories_reload,
-      'fa fa-repeat fa-lg',
-      N_('Reload the current display'),
-      N_('Reload'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
+      N_('Refresh'),
       :url_parms    => "main_div",
       :send_checked => true,
       :klass        => ApplicationHelper::Button::ButtonWithoutRbacCheck),

--- a/app/helpers/application_helper/toolbar/ansible_repository_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repository_center.rb
@@ -2,9 +2,9 @@ class ApplicationHelper::Toolbar::AnsibleRepositoryCenter < ApplicationHelper::T
   button_group('ansible_repositories_reloading', [
     button(
       :ansible_repository_reload,
-      'fa fa-repeat fa-lg',
-      N_('Reload the current display'),
-      N_('Reload'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
+      N_('Refresh'),
       :url_parms    => "main_div",
       :send_checked => true,
       :klass        => ApplicationHelper::Button::ButtonWithoutRbacCheck),

--- a/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
@@ -4,8 +4,8 @@ class ApplicationHelper::Toolbar::DiagnosticsRegionCenter < ApplicationHelper::T
   button_group('support_reloading', [
     button(
       :reload_server_tree,
-      'fa fa-repeat fa-lg',
-      N_('Reload Current Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil,
       :klass => ApplicationHelper::Button::ReloadServerTree),
   ])

--- a/app/helpers/application_helper/toolbar/diagnostics_server_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_server_center.rb
@@ -42,7 +42,7 @@ class ApplicationHelper::Toolbar::DiagnosticsServerCenter < ApplicationHelper::T
       :refresh_production_log,
       'fa fa-refresh fa-lg',
       proc do
-        _('Refresh this page') % {:log_type => _(@sb[:rails_log])}
+        _('Refresh this page')
       end,
       nil,
       :klass => ApplicationHelper::Button::DiagnosticsProductionLogs),

--- a/app/helpers/application_helper/toolbar/diagnostics_server_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_server_center.rb
@@ -2,20 +2,20 @@ class ApplicationHelper::Toolbar::DiagnosticsServerCenter < ApplicationHelper::T
   button_group('support_reloading', [
     button(
       :refresh_server_summary,
-      'fa fa-repeat fa-lg',
-      N_('Reload Current Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil,
       :klass => ApplicationHelper::Button::DiagnosticsSummary),
     button(
       :refresh_workers,
-      'fa fa-repeat fa-lg',
-      N_('Reload current workers display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil,
       :klass => ApplicationHelper::Button::RefreshWorkers),
     button(
       :refresh_audit_log,
-      'fa fa-repeat fa-lg',
-      N_('Reload the Audit Log Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil,
       :klass => ApplicationHelper::Button::DiagnosticsAuditLogs),
     button(
@@ -27,8 +27,8 @@ class ApplicationHelper::Toolbar::DiagnosticsServerCenter < ApplicationHelper::T
       :klass => ApplicationHelper::Button::DiagnosticsAuditLogs),
     button(
       :refresh_log,
-      'fa fa-repeat fa-lg',
-      N_('Reload the EVM Log Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil,
       :klass => ApplicationHelper::Button::DiagnosticsEvmLogs),
     button(
@@ -40,9 +40,9 @@ class ApplicationHelper::Toolbar::DiagnosticsServerCenter < ApplicationHelper::T
       :klass => ApplicationHelper::Button::DiagnosticsEvmLogs),
     button(
       :refresh_production_log,
-      'fa fa-repeat fa-lg',
+      'fa fa-refresh fa-lg',
       proc do
-        _('Reload the %{log_type} Log Display') % {:log_type => _(@sb[:rails_log])}
+        _('Refresh this page') % {:log_type => _(@sb[:rails_log])}
       end,
       nil,
       :klass => ApplicationHelper::Button::DiagnosticsProductionLogs),

--- a/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
@@ -4,8 +4,8 @@ class ApplicationHelper::Toolbar::DiagnosticsZoneCenter < ApplicationHelper::Too
   button_group('support_reloading', [
     button(
       :reload_server_tree,
-      'fa fa-repeat fa-lg',
-      N_('Reload Current Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil,
       :klass => ApplicationHelper::Button::ReloadServerTree),
   ])

--- a/app/helpers/application_helper/toolbar/ems_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cloud_center.rb
@@ -2,8 +2,8 @@ class ApplicationHelper::Toolbar::EmsCloudCenter < ApplicationHelper::Toolbar::B
   button_group('ems_cloud_vmdb', [
     button(
       :refresh_server_summary,
-      'fa fa-repeat fa-lg',
-      N_('Reload Current Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil),
     select(
       :ems_cloud_vmdb_choice,

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -2,8 +2,8 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
   button_group('ems_container_vmdb', [
     button(
       :refresh_server_summary,
-      'fa fa-repeat fa-lg',
-      N_('Reload Current Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil),
     select(
       :ems_container_vmdb_choice,

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -8,7 +8,7 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
       :items => [
         button(
           :ems_container_refresh,
-          'icon fa fa-refresh fa-lg',
+          'fa fa-refresh fa-lg',
           N_('Refresh Items and Relationships for all Containers Providers'),
           N_('Refresh Items and Relationships'),
           :confirm      => N_("Refresh Items and Relationships related to Containers Providers?"),

--- a/app/helpers/application_helper/toolbar/ems_datawarehouses_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_datawarehouses_center.rb
@@ -8,7 +8,7 @@ class ApplicationHelper::Toolbar::EmsDatawarehousesCenter < ApplicationHelper::T
       :items => [
         button(
           :ems_datawarehouse_refresh,
-          'icon fa fa-refresh fa-lg',
+          'fa fa-refresh fa-lg',
           N_('Refresh Items and Relationships for these Datawarehouse Providers'),
           N_('Refresh Items and Relationships'),
           :confirm      => N_("Refresh Items and Relationships related to these Datawarehouse Providers?"),

--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -2,8 +2,8 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
   button_group('ems_infra_vmdb', [
     button(
       :refresh_server_summary,
-      'fa fa-repeat fa-lg',
-      N_('Reload Current Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil),
     select(
       :ems_infra_vmdb_choice,

--- a/app/helpers/application_helper/toolbar/ems_middlewares_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_middlewares_center.rb
@@ -8,7 +8,7 @@ class ApplicationHelper::Toolbar::EmsMiddlewaresCenter < ApplicationHelper::Tool
       :items => [
         button(
           :ems_middleware_refresh,
-          'icon fa fa-refresh fa-lg',
+          'fa fa-refresh fa-lg',
           N_('Refresh Items and Relationships for these Middleware Providers'),
           N_('Refresh Items and Relationships'),
           :confirm      => N_("Refresh Items and Relationships related to these Middleware Providers?"),

--- a/app/helpers/application_helper/toolbar/ems_network_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_network_center.rb
@@ -2,8 +2,8 @@ class ApplicationHelper::Toolbar::EmsNetworkCenter < ApplicationHelper::Toolbar:
   button_group('ems_network_vmdb', [
     button(
       :refresh_server_summary,
-      'fa fa-repeat fa-lg',
-      N_('Reload Current Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil),
     select(
       :ems_network_vmdb_choice,

--- a/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
@@ -2,8 +2,8 @@ class ApplicationHelper::Toolbar::EmsPhysicalInfraCenter < ApplicationHelper::To
   button_group('ems_physical_infra_vmdb', [
     button(
       :refresh_server_summary,
-      'fa fa-repeat fa-lg',
-      N_('Reload Current Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil),
     select(
       :ems_physical_infra_vmdb_choice,

--- a/app/helpers/application_helper/toolbar/ems_storage_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_storage_center.rb
@@ -2,8 +2,8 @@ class ApplicationHelper::Toolbar::EmsStorageCenter < ApplicationHelper::Toolbar:
   button_group('ems_storage_vmdb', [
                  button(
                    :refresh_server_summary,
-                   'fa fa-repeat fa-lg',
-                   N_('Reload Current Display'),
+                   'fa fa-refresh fa-lg',
+                   N_('Refresh this page'),
                    nil),
                  select(
                    :ems_storage_vmdb_choice,

--- a/app/helpers/application_helper/toolbar/logs_center.rb
+++ b/app/helpers/application_helper/toolbar/logs_center.rb
@@ -4,7 +4,7 @@ class ApplicationHelper::Toolbar::LogsCenter < ApplicationHelper::Toolbar::Basic
       :refresh_log,
       'fa fa-refresh fa-lg',
       proc do
-        _('Refresh this page') % {:log_type => @msg_title}
+        _('Refresh this page')
       end,
       nil),
     button(

--- a/app/helpers/application_helper/toolbar/logs_center.rb
+++ b/app/helpers/application_helper/toolbar/logs_center.rb
@@ -2,9 +2,9 @@ class ApplicationHelper::Toolbar::LogsCenter < ApplicationHelper::Toolbar::Basic
   button_group('log_reloading', [
     button(
       :refresh_log,
-      'fa fa-repeat fa-lg',
+      'fa fa-refresh fa-lg',
       proc do
-        _('Reload the %{log_type} Log Display') % {:log_type => @msg_title}
+        _('Refresh this page') % {:log_type => @msg_title}
       end,
       nil),
     button(

--- a/app/helpers/application_helper/toolbar/miq_request_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_request_center.rb
@@ -24,9 +24,9 @@ class ApplicationHelper::Toolbar::MiqRequestCenter < ApplicationHelper::Toolbar:
       :klass     => ApplicationHelper::Button::MiqRequestDelete),
     button(
       :miq_request_reload,
-      'fa fa-repeat fa-lg',
-      N_('Reload the current display'),
-      N_('Reload'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
+      N_('Refresh'),
       :url_parms => "&display=miq_provisions"),
   ])
   button_group('miq_request_approve', [

--- a/app/helpers/application_helper/toolbar/miq_requests_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_requests_center.rb
@@ -2,9 +2,9 @@ class ApplicationHelper::Toolbar::MiqRequestsCenter < ApplicationHelper::Toolbar
   button_group('miq_request_reloading', [
     button(
       :miq_request_reload,
-      'fa fa-repeat fa-lg',
-      N_('Reload the current display'),
-      N_('Reload'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
+      N_('Refresh'),
       :url_parms    => "main_div",
       :send_checked => true),
   ])

--- a/app/helpers/application_helper/toolbar/miq_widgets_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_widgets_center.rb
@@ -2,8 +2,8 @@ class ApplicationHelper::Toolbar::MiqWidgetsCenter < ApplicationHelper::Toolbar:
   button_group('widget_reloading', [
     button(
       :widget_refresh,
-      'fa fa-repeat fa-lg',
-      N_('Reload Widgets'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh Widgets'),
       nil),
   ])
   button_group('widget_vmdb', [

--- a/app/helpers/application_helper/toolbar/saved_reports_center.rb
+++ b/app/helpers/application_helper/toolbar/saved_reports_center.rb
@@ -2,8 +2,8 @@ class ApplicationHelper::Toolbar::SavedReportsCenter < ApplicationHelper::Toolba
   button_group('saved_report_reloading', [
     button(
       :reload,
-      'fa fa-repeat fa-lg',
-      N_('Reload selected Reports'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh selected Reports'),
       nil,
       :url   => "reload",
       :klass => ApplicationHelper::Button::Reload)

--- a/app/helpers/application_helper/toolbar/tasks_center.rb
+++ b/app/helpers/application_helper/toolbar/tasks_center.rb
@@ -2,9 +2,9 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
   button_group('miq_task_reloading', [
     button(
       :miq_task_reload,
-      'fa fa-repeat fa-lg',
-      N_('Reload the current display'),
-      N_('Reload'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
+      N_('Refresh'),
       :url_parms    => "main_div",
       :send_checked => true),
   ])

--- a/app/helpers/application_helper/toolbar/vmdb_table_center.rb
+++ b/app/helpers/application_helper/toolbar/vmdb_table_center.rb
@@ -2,8 +2,8 @@ class ApplicationHelper::Toolbar::VmdbTableCenter < ApplicationHelper::Toolbar::
   button_group('support_reloading', [
     button(
       :db_refresh,
-      'fa fa-repeat fa-lg',
-      N_('Reload Current Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil,
       :klass => ApplicationHelper::Button::DbRefresh),
   ])

--- a/app/helpers/application_helper/toolbar/vmdb_tables_center.rb
+++ b/app/helpers/application_helper/toolbar/vmdb_tables_center.rb
@@ -2,8 +2,8 @@ class ApplicationHelper::Toolbar::VmdbTablesCenter < ApplicationHelper::Toolbar:
   button_group('support_reloading', [
     button(
       :db_refresh,
-      'fa fa-repeat fa-lg',
-      N_('Reload Current Display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil,
       :klass => ApplicationHelper::Button::DbRefresh),
   ])

--- a/app/helpers/application_helper/toolbar/x_history.rb
+++ b/app/helpers/application_helper/toolbar/x_history.rb
@@ -19,8 +19,8 @@ class ApplicationHelper::Toolbar::XHistory < ApplicationHelper::Toolbar::Basic
     ),
     button(
       :summary_reload,
-      'fa fa-repeat fa-lg',
-      N_('Reload current display'),
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
       nil,
       :url => "reload",
       :klass => ApplicationHelper::Button::SummaryReload),

--- a/app/views/shared/_topology_header_toolbar.html.haml
+++ b/app/views/shared/_topology_header_toolbar.html.haml
@@ -4,7 +4,8 @@
     = _("Display Names")
 
 .form-group
-  %button.btn.btn-default{'data-function'      => 'sendDataWithRx',
+  %button.btn.btn-default{:title               =>  'Refresh this page',
+                          'data-function'      => 'sendDataWithRx',
                           'data-function-data' => {:name => 'refreshTopology'}.to_json}
     %i.fa.fa-refresh.fa-lg
     = _("Refresh")


### PR DESCRIPTION
This PR standardizes the font icon and hover text for Page Refresh per Issue 1 here: http://talk.manageiq.org/t/ux-feedback-vertical-navigation/2899 

The Diagnostics area was also updated for consistency, but should be reviewed here:
https://github.com/ManageIQ/manageiq-ui-classic/compare/master...epwinchell:refresh?expand=1#diff-74f4eada98cda846759986f1eb35f327 

and here:

https://github.com/ManageIQ/manageiq-ui-classic/compare/master...epwinchell:refresh?expand=1#diff-88ef2e84e3c0a397f32501e06cffe561


Old
<img width="641" alt="screen shot 2017-12-06 at 3 52 33 pm" src="https://user-images.githubusercontent.com/1287144/33684811-90879f0a-da9d-11e7-80b5-4c9995393662.png">

New
<img width="771" alt="screen shot 2017-12-06 at 3 52 49 pm" src="https://user-images.githubusercontent.com/1287144/33684810-906fa1de-da9d-11e7-9aa7-76cc9bbb3579.png">

/cc @dclarizio @ohadlevy  @serenamarie125 @KendraMar @jonnyfiveiq