### PR TITLE
Improved UX around uploading custom images for Generic Object Definitions

### DIFF
--- a/app/assets/javascripts/components/generic_object/custom-image-component.js
+++ b/app/assets/javascripts/components/generic_object/custom-image-component.js
@@ -81,11 +81,22 @@ function customImageComponentController($timeout) {
     vm.pictureRemove = true;
   };
 
+  vm.cancelUpdateImage = function() {
+    vm.changeImage = false;
+    vm.changeImageSelected();
+  };
+
+  vm.cancelDeleteImage = function() {
+    vm.pictureRemove = false;
+    vm.changeImageSelected();
+  };
+
   function restoreOriginalStatus() {
     if (vm.angularForm.generic_object_definition_image_file_status) {
       vm.angularForm.generic_object_definition_image_file_status.$setValidity("incompatibleFileType", true);
     }
     vm.imageUploadStatus = "";
+    vm.pictureUploaded = false;
     angular.element(":file").filestyle('clear');
   }
 }

--- a/app/views/static/generic_object/custom-image-component.html.haml
+++ b/app/views/static/generic_object/custom-image-component.html.haml
@@ -11,6 +11,10 @@
                         "id"          => "generic_object_definition_image_file_status",
                         "ng-model"    => "vm.imageUploadStatus",
                         "name"        => "generic_object_definition_image_file_status"}
+    .btn.btn-default{"ng-if" => "vm.changeImage", :alt => t = _("Cancel Updating Custom Image"), :title => t, "ng-click" => "vm.cancelUpdateImage()"}
+      %i.pficon.pficon-close
+    .btn.btn-default{"ng-if" => "vm.pictureRemove", :alt => t = _("Cancel Deleting Custom Image"), :title => t, "ng-click" => "vm.cancelDeleteImage()"}
+      %i.pficon.pficon-close
     %span.help-block
       {{vm.imageUploadStatus}}
 
@@ -25,19 +29,10 @@
     = _("Current Custom Image File")
   .col-md-4
     %img.form-control{'ng-src' => "{{vm.pictureUrlPath}}", :style => "width:100px; height:100px;"}
-      .btn.btn-default{:alt => t = _("Remove Custom Image"), :title => t, "ng-click" => "vm.removeImage()"}
+      .btn.btn-default{:alt => t = _("Delete Custom Image"), :title => t, "ng-click" => "vm.removeImage()"}
         %i.pficon.pficon-delete
-.form-group{'ng-if' => "vm.pictureUrlPath !== '' && !vm.pictureRemove"}
-  %label.col-md-2.control-label{"for" => "update_image"}
-    = _("Update Current Image")
-  .col-md-4
-    %input.form-control{"type"      => "checkbox",
-                        "id"        => "update_image",
-                        "name"      => "update_image",
-                        "bs-switch" => "",
-                        :data       => {:on_text => _('Yes'), :off_text => _('No')},
-                        "ng-change" => "vm.changeImageSelected()",
-                        "ng-model"  => "vm.changeImage"}
+      .btn.btn-default{:alt => t = _("Update Custom Image"), :title => t, "ng-click" => "vm.changeImage = true"}
+        %i.pficon.pficon-edit
 
 :javascript
   $(":file").filestyle({placeholder: __("No file chosen"), icon: false});


### PR DESCRIPTION
Before -
<img width="1414" alt="screen shot 2017-12-06 at 12 58 02 pm" src="https://user-images.githubusercontent.com/1538216/33685027-214e49d0-da85-11e7-86f5-63661269dfcc.png">

After - 
<img width="1416" alt="screen shot 2017-12-06 at 12 46 45 pm" src="https://user-images.githubusercontent.com/1538216/33684760-35394ba8-da84-11e7-901b-25b35c775b64.png">

------------------------------
Displays button for canceling update (could not capture the tooltip: `Cancel Updating custom image` in the screenshot)
<img width="1420" alt="screen shot 2017-12-06 at 12 51 25 pm" src="https://user-images.githubusercontent.com/1538216/33684778-4aa191da-da84-11e7-823c-4bf5f2c19234.png">
