### PR TITLE
Fix the Grid View and Tile View for Configuration Profiles

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,6 +110,7 @@ class ApplicationController < ActionController::Base
       :catalog                                  => "list",
       :cm_providers                             => "list",
       :cm_configured_systems                    => "list",
+      :cm_configuration_profiles                => "list",
       :compare                                  => "expanded",
       :compare_mode                             => "details",
       :condition                                => "list",

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -476,11 +476,18 @@ class ProviderForemanController < ApplicationController
     @grid_hash = view_to_hash(@view)
   end
 
-  def update_options
-    options = {}
+  def update_options(options = {})
+    options ||= {}
     options[:dbname] = case x_active_accord
                        when :configuration_manager_providers
-                         options[:model] && options[:model] == 'ConfiguredSystem' ? :cm_configured_systems : :cm_providers
+                         case options[:model]
+                         when 'ConfiguredSystem'
+                           :cm_configured_systems
+                         when 'ConfigurationProfile'
+                           :cm_configuration_profiles
+                         else
+                           :cm_providers
+                         end
                        when :configuration_manager_cs_filter
                          :cm_configured_systems
                        end
@@ -490,7 +497,7 @@ class ProviderForemanController < ApplicationController
   private :update_options
 
   def process_show_list(options = {})
-    options.merge!(update_options)
+    options.merge!(update_options(options))
     process_show_list_options(options)
     super
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -183,7 +183,7 @@ module ApplicationHelper
 
   def type_has_quadicon(type)
     !%w(
-      ManageIQ::Providers::Foreman::ConfigurationManager::ConfigurationProfile
+      ConfigurationProfile
       Account
       GuestApplication
       SystemService

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -434,6 +434,22 @@ describe ProviderForemanController do
       controller.send(:accordion_select)
     end
 
+    it "calls get_view with the associated dbname for the Configuration Profiles list" do
+      stub_user(:features => :all)
+      allow(controller).to receive(:x_active_tree).and_return(:configuration_manager_providers_tree)
+      allow(controller).to receive(:x_active_accord).and_return(:configuration_manager_providers)
+      ems_id = ems_id_for_provider(@provider)
+      controller.instance_variable_set(:@in_report_data, true)
+      controller.instance_variable_set(:@_params, :id => ems_key_for_provider(@provider))
+      allow(controller).to receive(:build_listnav_search_list)
+      allow(controller).to receive(:apply_node_search_text)
+      expect(controller).to receive(:get_view).with("ConfigurationProfile", :match_via_descendants => "ConfiguredSystem",
+                                                                            :named_scope           => [[:with_manager, ems_id]],
+                                                                            :dbname                => :cm_configuration_profiles,
+                                                                            :gtl_dbname            => :cm_configuration_profiles).and_call_original
+      controller.send(:tree_select)
+    end
+
     it "calls get_view with the associated dbname for the Configured Systems accordion" do
       stub_user(:features => :all)
       allow(controller).to receive(:x_active_tree).and_return(:configuration_manager_cs_filter_tree)


### PR DESCRIPTION
Fix the Grid View and Tile View for Configuration Profiles

Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/2984

Links 
--------
Remaining fix for https://github.com/ManageIQ/manageiq-ui-classic/issues/2927

After:

![screenshot from 2017-12-06 15-58-24](https://user-images.githubusercontent.com/12769982/33685191-caeca626-da9e-11e7-91ea-7d01421858a2.png)
![screenshot from 2017-12-06 15-58-27](https://user-images.githubusercontent.com/12769982/33685192-caf71d5e-da9e-11e7-909e-2f8c8a90046a.png)

