### PR TITLE
Add GenericObject to APPLIES_TO_CLASS_BASE_MODEL

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -250,7 +250,7 @@ module ApplicationController::Buttons
   APPLIES_TO_CLASS_BASE_MODELS = %w(AvailabilityZone CloudNetwork CloudObjectStoreContainer CloudSubnet CloudTenant
                                     CloudVolume ContainerGroup ContainerImage ContainerNode ContainerProject
                                     ContainerTemplate ContainerVolume EmsCluster ExtManagementSystem
-                                    GenericObjectDefinition Host LoadBalancer
+                                    GenericObject GenericObjectDefinition Host LoadBalancer
                                     MiqGroup MiqTemp MiqTemplate NetworkRouter OrchestrationStack SecurityGroup Service
                                     ServiceTemplate Storage Switch Tenant User Vm VmOrTemplate).freeze
   def applies_to_class_model(applies_to_class)


### PR DESCRIPTION
Add GenericObject to APPLIES_TO_CLASS_BASE_MODEL

- fixes an error that occurs for custom buttons created in the customization->Buttons for generic objects

Before:
![screenshot from 2017-12-06 17-40-10](https://user-images.githubusercontent.com/12769982/33689265-ce727a7e-daac-11e7-806f-9dcd8c83ec52.png)

After 
![screenshot from 2017-12-06 17-39-06](https://user-images.githubusercontent.com/12769982/33689304-ea8b0136-daac-11e7-8c0c-3083c522af09.png)

