### PR TITLE
Display Generic Object instances for Ansible Playbook Services as well

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -200,7 +200,7 @@ class ServiceController < ApplicationController
 
   def textual_group_list
     if @record.type == "ServiceAnsiblePlaybook"
-      [%i(properties), %i(lifecycle tags)]
+      [%i(properties), %i(lifecycle tags generic_objects)]
     else
       [%i(properties lifecycle relationships generic_objects miq_custom_attributes), %i(vm_totals tags)]
     end

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -234,5 +234,19 @@ describe ServiceController do
     end
   end
 
+  context "Generic Object instances in Textual Summary" do
+    it "displays Generic Objects in Ansible Playbook Service Textual Summary" do
+      record = FactoryGirl.create(:service_ansible_playbook)
+      controller.instance_variable_set(:@record, record)
+      expect(controller.send(:textual_group_list)).to include(array_including(:generic_objects))
+    end
+
+    it "displays Generic Objects for all other Services" do
+      record = FactoryGirl.create(:service)
+      controller.instance_variable_set(:@record, record)
+      expect(controller.send(:textual_group_list)).to include(array_including(:generic_objects))
+    end
+  end
+
   it_behaves_like "explorer controller with custom buttons"
 end


### PR DESCRIPTION
For some reason `generic_objects` were excluded from being displayed in the Textual Summary screen for Ansible Playbook Services.

-- fixed that.

https://bugzilla.redhat.com/show_bug.cgi?id=1496984


Before -
<img width="1384" alt="screen shot 2017-12-06 at 3 51 15 pm" src="https://user-images.githubusercontent.com/1538216/33691496-54fe1b58-da9d-11e7-99ec-755b06b7f449.png">


After -
<img width="1382" alt="screen shot 2017-12-06 at 3 44 35 pm" src="https://user-images.githubusercontent.com/1538216/33691459-2b051310-da9d-11e7-9e75-825b81c615a6.png">
