### PR TITLE
Add MiddlewareServerEap and MiddlewareServerWildfly for Utilization charts

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -634,7 +634,7 @@ module ApplicationController::Performance
                              from_dt,
                              to_dt,
                              interval_type]
-      elsif %w(MiddlewareServer MiddlewareDatasource MiddlewareMessaging).include?(@perf_record.class.name.demodulize)
+      elsif %w(MiddlewareServer MiddlewareDatasource MiddlewareMessaging).any? { |e| @perf_record.kind_of?(e.constantize) }
         rpt = perf_get_chart_rpt("vim_perf_#{interval_type}_#{@perf_record.chart_report_name}")
         rpt.where_clause = ["resource_type = ? and resource_id = ? and timestamp >= ? and timestamp <= ? " \
                             "and capture_interval_name = ?",
@@ -660,7 +660,7 @@ module ApplicationController::Performance
       f, to_dt = @perf_record.first_and_last_capture("realtime")
       from_dt = to_dt.nil? ? nil : to_dt - @perf_options[:rt_minutes]
       suffix = if %w(MiddlewareServer MiddlewareDatasource MiddlewareMessaging)
-                  .include?(@perf_record.class.name.demodulize)
+                  .any? { |e| @perf_record.kind_of?(e.constantize) }
                  "_#{@perf_record.chart_report_name}"
                else
                  ""


### PR DESCRIPTION
Bugzilla [#1510548](https://bugzilla.redhat.com/show_bug.cgi?id=1510548)

MiddlewareServerEap and MiddlewareServerWildfly was not in the list of types.

![charts_utilization](https://user-images.githubusercontent.com/3019213/33713047-e9335ef8-db49-11e7-93c9-e19e40315d7f.png)

cc @abonas 
