### PR TITLE
Improve per provider settings ui

### DIFF
--- a/app/assets/stylesheets/icon_customizations.scss
+++ b/app/assets/stylesheets/icon_customizations.scss
@@ -41,6 +41,11 @@
     color: #0088ce; //pf-blue-400
 }
 
+.popover{
+  max-width: none;
+}
+
+
 .compare-same {
   @extend .fa, .fa-lg, .fa-check;
 

--- a/app/assets/stylesheets/icon_customizations.scss
+++ b/app/assets/stylesheets/icon_customizations.scss
@@ -36,6 +36,11 @@
   opacity: 0.6;
 }
 /* stylelint-disable at-rule-no-unknown */
+
+.pf-blue-info {
+    color: #0088ce; //pf-blue-400
+}
+
 .compare-same {
   @extend .fa, .fa-lg, .fa-check;
 

--- a/app/views/static/provider_option_field_input.html.haml
+++ b/app/views/static/provider_option_field_input.html.haml
@@ -1,6 +1,7 @@
 .form-group{"ng-class" => "{{ \"{'has_error': angularForm.\"  + $ctrl.elemID + \".$invalid}\" }}"}
   %label.col-md-2.control-label{"for" => "{{ $ctrl.elemID }}"}
     {{ $ctrl.option.label }}
+    .pf-blue-info.pficon.pficon-info{:title => _("{{ $ctrl.option.help_text }}")}
   .col-md-4
     %input.form-control{"type"          => "text",
                         "id"            => "{{ $ctrl.elemID }}",

--- a/app/views/static/provider_option_field_input.html.haml
+++ b/app/views/static/provider_option_field_input.html.haml
@@ -1,7 +1,10 @@
 .form-group{"ng-class" => "{{ \"{'has_error': angularForm.\"  + $ctrl.elemID + \".$invalid}\" }}"}
   %label.col-md-2.control-label{"for" => "{{ $ctrl.elemID }}"}
     {{ $ctrl.option.label }}
-    .pf-blue-info.pficon.pficon-info{:title => _("{{ $ctrl.option.help_text }}")}
+    %span.pf-blue-info.pficon.pficon-info{:tabindex            => 0,
+                                          :"popover-trigger"   => "focus",
+                                          :"popover-placement" => "top-right",
+                                          :"uib-popover-html"  => "$ctrl.option.help_text | translate"}
   .col-md-4
     %input.form-control{"type"          => "text",
                         "id"            => "{{ $ctrl.elemID }}",

--- a/app/views/static/provider_option_section.html.haml
+++ b/app/views/static/provider_option_section.html.haml
@@ -1,3 +1,5 @@
+%h3
+  {{ $ctrl.label }}
 %provider-option-field-input{"ng-repeat" => "option in $ctrl.settings",
   "option" => "option",
   "section-name" => "{{ $ctrl.sectionName }}"}


### PR DESCRIPTION
Improving two problems with the per-provider UI:
It seems that without titles it is hard to understand the meaning of each setting and also it is not clear that the help text exits.
This added titles and also a question mark icon for the hover help text.

![provider_settigns_improvement_wip](https://user-images.githubusercontent.com/3123328/34220388-27c0d010-e5bd-11e7-9f00-3fb674479f87.png)

![gifrecord_2018-01-31_125342](https://user-images.githubusercontent.com/3123328/35619214-ed2e7aee-0685-11e8-93ff-2bbbdb0b9f52.gif)
