### PR TITLE
Fix wrong icon for action in Policy Profiles

### DIFF
--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -49,6 +49,16 @@ class TreeBuilderPolicyProfile < TreeBuilder
 
     success = count_only_or_objects(count_only, pol_rec ? pol_rec.actions_for_event(parent, :success) : [])
     failure = count_only_or_objects(count_only, pol_rec ? pol_rec.actions_for_event(parent, :failure) : [])
+    unless count_only
+      add_flag_to(success, :success) unless success.empty?
+      add_flag_to(failure, :failure) unless failure.empty?
+    end
     success + failure
+  end
+
+  def add_flag_to(array, flag)
+    array.each do |i|
+      i.instance_variable_set(:@flag, flag)
+    end
   end
 end


### PR DESCRIPTION
The action `success` or `failure` icon is not rendered properly for _Policy Profiles_ tree while it works fine for _Policies_ tree. Let's provide the information about `success` and `failure` to _Policy Profiles_ tree nodes as well. 

Code is copy-pasted from [app/presenters/tree_builder_policy.rb](https://github.com/ManageIQ/manageiq-ui-classic/blob/507ad213a8e63af033e953a5c6b4caef014817d3/app/presenters/tree_builder_policy.rb#L127).

_Policy Profiles_ tree:
![image](https://user-images.githubusercontent.com/7453394/33726557-a79f4c00-db75-11e7-9b85-73d0ab381cd9.png)

_Policies_ tree:
![image](https://user-images.githubusercontent.com/7453394/33726501-7e951bf0-db75-11e7-81d6-797a3cdd68a1.png)
