### PR TITLE
Add rbac check to toolbar button for New Host Aggregates create new action

### DIFF
--- a/app/helpers/application_helper/button/new_host_aggregate.rb
+++ b/app/helpers/application_helper/button/new_host_aggregate.rb
@@ -1,5 +1,11 @@
 class ApplicationHelper::Button::NewHostAggregate < ApplicationHelper::Button::ButtonNewDiscover
+  def supports_button_action?
+    filtered_providers = Rbac::Filterer.filtered(ManageIQ::Providers::CloudManager)
+    filtered_providers.any? { |ems| ems.supports?(:create_host_aggregate) }
+  end
+
   def disabled?
-    super || Rbac::Filterer.filtered(ManageIQ::Providers::CloudManager).none? { |ems| ems.supports?(:create_host_aggregate) }
+    @error_message = _("No cloud provider supports creating host aggregates.") unless supports_button_action?
+    super || @error_message.present?
   end
 end

--- a/app/helpers/application_helper/button/new_host_aggregate.rb
+++ b/app/helpers/application_helper/button/new_host_aggregate.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::NewHostAggregate < ApplicationHelper::Button::ButtonNewDiscover
   def disabled?
-    super || ManageIQ::Providers::CloudManager.all.none? { |ems| ems.supports?(:create_host_aggregate) }
+    super || Rbac::Filterer.filtered(ManageIQ::Providers::CloudManager).none? { |ems| ems.supports?(:create_host_aggregate) }
   end
 end

--- a/spec/helpers/application_helper/buttons/new_host_aggregate_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_host_aggregate_spec.rb
@@ -1,21 +1,43 @@
 describe ApplicationHelper::Button::NewHostAggregate do
+  let(:user)   { FactoryGirl.create(:user, :miq_groups => [group]) }
+  let(:group)  { FactoryGirl.create(:miq_group, :tenant => tenant, :entitlement => entitlement) }
+  let(:tenant) { FactoryGirl.create(:tenant) }
+  let(:entitlement) { nil }
+
+  let!(:provider) { FactoryGirl.create(:ems_openstack, :tenant => tenant) }
+
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:button) { described_class.new(view_context, {}, {}, {}) }
+  let(:button)       { described_class.new(view_context, {}, {}, {}) }
+
+  before do
+    EvmSpecHelper.local_miq_server
+    allow(User).to receive(:current_user).and_return(user)
+  end
 
   describe '#disabled?' do
     subject { button[:title] }
 
     context 'no provider available' do
+      let(:provider) { nil }
       before { button.calculate_properties }
 
-      it_behaves_like 'a disabled button'
+      it_behaves_like 'a disabled button', 'No cloud provider supports creating host aggregates.'
     end
 
-    context 'provider available' do
+    context 'provider is not available due to RBAC rules' do
+      let(:entitlement) { FactoryGirl.create(:entitlement) }
+
       before do
-        provider = FactoryGirl.create(:ems_openstack)
+        entitlement.set_managed_filters([["/managed/environment/prod"]])
+        entitlement.set_belongsto_filters([])
         button.calculate_properties
       end
+
+      it_behaves_like 'a disabled button', 'No cloud provider supports creating host aggregates.'
+    end
+
+    context 'a provider is available' do
+      before { button.calculate_properties }
 
       it_behaves_like 'an enabled button'
     end


### PR DESCRIPTION
RBAC check to the  toolbar button for New Host Aggregates for create new action:
Compute -> Cloud -> Host Aggregates
after
![screen shot 2017-12-07 at 17 50 29](https://user-images.githubusercontent.com/14937244/33727058-427a9486-db77-11e7-8edc-79aedf5cd18c.png)

I am going to do similar thing in more screens, so please review and then I will use it in others screen.
What I am doing here:

- added rbac check
- add disabled message
- added specs
- added spec module to be able simply use restricted user

cc @skateman 

@miq-bot add_label bug, rbac

@miq-bot assign @martinpovolny 

### Links
--------
https://bugzilla.redhat.com/show_bug.cgi?id=1516229 (around 10 % done by this PR)

