### PR TITLE
Don't use localized name of authentication mode in an if condition

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -21,7 +21,7 @@
                            :class => "form-control",
                            "data-miq_observe" => {:interval => '.5',
                                                   :url      => url}.to_json)
-          - unless "database".include?(auth_mode_name.downcase)
+          - if ::Settings.authentication.mode.casecmp('database') != 0
             = check_box_tag("lookup",
                             "1",
                             false,


### PR DESCRIPTION
`auth_mode_name()` returns localized name of authentication mode and as such its result cannot be used in an if condition (its return value would depend on the current locale being used).

https://bugzilla.redhat.com/show_bug.cgi?id=1495152