### PR TITLE
Dialogs for custom buttons are not displayed

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -334,7 +334,7 @@ module ApplicationController::Buttons
       }
 
       options[:dialog_locals] = DialogLocalService.new.determine_dialog_locals_for_custom_button(
-        obj, button.name, button.resource_action.id
+        obj, button.name, button.resource_action
       )
 
       dialog_initialize(button.resource_action, options)

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -29,7 +29,7 @@ class DialogLocalService
     }
   end
 
-  def determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)
+  def determine_dialog_locals_for_custom_button(obj, button_name, resource_action)
     dialog_locals = {:force_old_dialog_use => true}
 
     return dialog_locals unless NEW_DIALOG_USERS.include?(obj.class.name.demodulize)
@@ -37,9 +37,10 @@ class DialogLocalService
     submit_endpoint, cancel_endpoint = determine_api_endpoints(obj)
 
     dialog_locals.merge!(
-      :resource_action_id     => resource_action_id,
+      :resource_action_id     => resource_action.id,
       :target_id              => obj.id,
       :target_type            => obj.class.name.demodulize.underscore,
+      :dialog_id              => resource_action.dialog_id,
       :force_old_dialog_use   => false,
       :api_submit_endpoint    => submit_endpoint,
       :api_action             => button_name,

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -25,16 +25,17 @@ describe DialogLocalService do
 
   describe "#determine_dialog_locals_for_custom_button" do
     let(:button_name) { "custom-button-name" }
-    let(:resource_action_id) { 321 }
+    let(:resource_action) { instance_double("ResourceAction", :id => 321, :dialog_id => 654) }
 
     context "when the object is a CloudTenant" do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::CloudTenant, :id => 123) }
 
       it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => 'cloud_tenant',
+          :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/cloud_tenants/123",
           :api_action             => "custom-button-name",
@@ -48,10 +49,11 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::CloudVolume, :id => 123) }
 
       it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => 'cloud_volume',
+          :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/cloud_volumes/123",
           :api_action             => "custom-button-name",
@@ -65,10 +67,11 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ContainerNode, :id => 123) }
 
       it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => 'container_node',
+          :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/container_nodes/123",
           :api_action             => "custom-button-name",
@@ -82,10 +85,11 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::EmsCluster, :id => 123) }
 
       it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => 'ems_cluster',
+          :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/clusters/123",
           :api_action             => "custom-button-name",
@@ -99,10 +103,11 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::GenericObject, :id => 123) }
 
       it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => 'generic_object',
+          :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/generic_objects/123",
           :api_action             => "custom-button-name",
@@ -116,10 +121,11 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Host, :id => 123) }
 
       it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => 'host',
+          :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/hosts/123",
           :api_action             => "custom-button-name",
@@ -133,10 +139,11 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager, :id => 123) }
 
       it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => 'infra_manager',
+          :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/providers/123",
           :api_action             => "custom-button-name",
@@ -150,10 +157,11 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::MiqTemplate, :id => 123) }
 
       it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => 'miq_template',
+          :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/templates/123",
           :api_action             => "custom-button-name",
@@ -167,10 +175,11 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Service, :id => 123) }
 
       it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => 'service',
+          :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/services/123",
           :api_action             => "custom-button-name",
@@ -184,10 +193,11 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Storage, :id => 123) }
 
       it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => 'storage',
+          :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/datastores/123",
           :api_action             => "custom-button-name",
@@ -201,10 +211,11 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Vm, :id => 123) }
 
       it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => 'vm',
+          :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/vms/123",
           :api_action             => "custom-button-name",
@@ -218,7 +229,7 @@ describe DialogLocalService do
       let(:obj) { double(:id => 123) }
 
       it "returns a hash with 'force_old_dialog_use' set to true" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action_id)).to eq(
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
           :force_old_dialog_use => true
         )
       end


### PR DESCRIPTION
After the changes related to https://github.com/ManageIQ/manageiq-ui-classic/pull/2885,  dialogs for custom buttons are no longer displayed.

Fix dialog_id parameter for custom buttons

Steps for Testing/QA
-------------------------------
Create a custom button with a dilaog.
Invoke the button.

Before:
![screenshot from 2017-12-07 14-48-01](https://user-images.githubusercontent.com/12769982/33735600-bed3709e-db5d-11e7-9f69-d3faa1245ea8.png)


After:
![screenshot from 2017-12-07 14-30-49](https://user-images.githubusercontent.com/12769982/33735247-ca53ba2e-db5c-11e7-9438-211df9a002e1.png)
