### PR TITLE
Move MiqReportable methods to ui code

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -197,7 +197,7 @@ module ApplicationController::PolicySupport
     # session[:pol_db] = session[:pol_db] == Vm ? VmOrTemplate : session[:pol_db]
     @politems = session[:pol_db].find(session[:pol_items]).sort_by(&:name)  # Get the db records
     @view = get_db_view(session[:pol_db])             # Instantiate the MIQ Report view object
-    @view.table = MiqFilter.records2table(@politems, @view.cols + ['id'])
+    @view.table = ReportFormatter::Converter.records2table(@politems, @view.cols + ['id'])
 
     @edit = {}
     @edit[:explorer] = true if @explorer
@@ -261,7 +261,7 @@ module ApplicationController::PolicySupport
     @catinfo = {}
     @lastaction = "policy_sim"
     @pol_view = get_db_view(session[:tag_db])       # Instantiate the MIQ Report view object
-    @pol_view.table = MiqFilter.records2table(@tagitems, @pol_view.cols + ['id'])
+    @pol_view.table = ReportFormatter::Converter.records2table(@tagitems, @pol_view.cols + ['id'])
 
     # Build the profiles selection list
     @all_profs = {}

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -231,7 +231,7 @@ module ApplicationController::Tags
     end
 
     @view = get_db_view(@tagging)               # Instantiate the MIQ Report view object
-    @view.table = MiqFilter.records2table(@tagitems, @view.cols + ['id'])
+    @view.table = ReportFormatter::Converter.records2table(@tagitems, @view.cols + ['id'])
 
     # Start with the first items assignments
     @edit[:new][:assignments] =

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -207,7 +207,7 @@ class HostController < ApplicationController
       end
       build_targets_hash(hostitems)
       @view = get_db_view(Host)       # Instantiate the MIQ Report view object
-      @view.table = MiqFilter.records2table(hostitems, @view.cols + ['id'])
+      @view.table = ReportFormatter::Converter.records2table(hostitems, @view.cols + ['id'])
     end
   end
 

--- a/app/controllers/mixins/actions/vm_actions/evacuate.rb
+++ b/app/controllers/mixins/actions/vm_actions/evacuate.rb
@@ -12,7 +12,7 @@ module Mixins
           @evacuate_items = find_records_with_rbac(VmOrTemplate, session[:evacuate_items]).sort_by(&:name)
           build_targets_hash(@evacuate_items)
           @view = get_db_view(VmOrTemplate)
-          @view.table = MiqFilter.records2table(@evacuate_items, @view.cols + ['id'])
+          @view.table = ReportFormatter::Converter.records2table(@evacuate_items, @view.cols + ['id'])
 
           render :action => "show" unless @explorer
         end

--- a/app/controllers/mixins/actions/vm_actions/live_migrate.rb
+++ b/app/controllers/mixins/actions/vm_actions/live_migrate.rb
@@ -25,7 +25,7 @@ module Mixins
           @live_migrate_items = find_records_with_rbac(VmOrTemplate.order(:name), session[:live_migrate_items])
           build_targets_hash(@live_migrate_items)
           @view = get_db_view(VmOrTemplate)
-          @view.table = MiqFilter.records2table(@live_migrate_items, @view.cols + ['id'])
+          @view.table = ReportFormatter::Converter.records2table(@live_migrate_items, @view.cols + ['id'])
 
           render :action => "show" unless @explorer
         end

--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -99,7 +99,7 @@ module Mixins
           Rbac.filtered(MiqGroup.non_tenant_groups).each { |g| @groups[g.description] = g.id.to_s }
           @edit[:object_ids] = ownership_ids
           @view = get_db_view(klass == VmOrTemplate ? Vm : klass) # Instantiate the MIQ Report view object
-          @view.table = MiqFilter.records2table(@ownershipitems, @view.cols + ['id'])
+          @view.table = ReportFormatter::Converter.records2table(@ownershipitems, @view.cols + ['id'])
           session[:edit] = @edit
         end
 

--- a/app/controllers/mixins/actions/vm_actions/retire.rb
+++ b/app/controllers/mixins/actions/vm_actions/retire.rb
@@ -93,7 +93,7 @@ module Mixins
           session[:cat] = nil                 # Clear current category
           build_targets_hash(@retireitems)
           @view = get_db_view(kls)              # Instantiate the MIQ Report view object
-          @view.table = MiqFilter.records2table(@retireitems, @view.cols + ['id'])
+          @view.table = ReportFormatter::Converter.records2table(@retireitems, @view.cols + ['id'])
           if @retireitems.length == 1 && !@retireitems[0].retires_on.nil?
             t = @retireitems[0].retires_on                                         # Single VM, set to current time
             w = @retireitems[0].retirement_warn if @retireitems[0].retirement_warn # Single VM, get retirement warn

--- a/app/controllers/utilization_controller.rb
+++ b/app/controllers/utilization_controller.rb
@@ -70,7 +70,7 @@ class UtilizationController < ApplicationController
                            :extras    => {},
                            :group     => "y")
     report.db = "MetricRollup"
-    report.table = MiqReportable.hashes2table(summ_hashes, :only => report.cols)
+    report.table = ReportFormatter::Converter.hashes2table(summ_hashes, :only => report.cols)
     filename = report.title
     disable_client_cache
     case params[:typ]

--- a/lib/report_formatter.rb
+++ b/lib/report_formatter.rb
@@ -2,6 +2,7 @@ include ActionView::Helpers::NumberHelper
 
 require 'report_formatter/report_renderer'
 require 'report_formatter/c3'
+require 'report_formatter/converter'
 require 'report_formatter/html'
 require 'report_formatter/text'
 require 'report_formatter/timeline'

--- a/lib/report_formatter/converter.rb
+++ b/lib/report_formatter/converter.rb
@@ -1,0 +1,35 @@
+module ReportFormatter
+  class Converter
+    # generate a ruport table from an array of db objects
+    def self.records2table(records, only_columns)
+      return Ruport::Data::Table.new if records.blank?
+
+      data_records = records.map do |r|
+        only_columns.each_with_object({}) do |column, attrs|
+          attrs[column] = r.send(column) if r.respond_to?(column)
+        end
+      end
+
+      column_names = data_records.flat_map(&:keys).uniq
+
+      Ruport::Data::Table.new(:data         => data_records,
+                              :column_names => column_names)
+    end
+
+    # generate a ruport table from an array of hashes where the keys are the column names
+    def self.hashes2table(hashes, options)
+      return Ruport::Data::Table.new if hashes.blank?
+
+      data = hashes.inject([]) do |arr, h|
+        nh = {}
+        options[:only].each { |col| nh[col] = h[col] }
+        arr << nh
+      end
+
+      data = data[0..options[:limit] - 1] if options[:limit] # apply limit
+      Ruport::Data::Table.new(:data         => data,
+                              :column_names => options[:only],
+                              :filters      => options[:filters])
+    end
+  end
+end


### PR DESCRIPTION
# High level goal:

Move ruport gem dependency from manageiq to ui-classic

# What was changed

`MiqFilter.hashes2table` was just a passthrough to `MiqReportable.hashes2table`
`MiqReportable.records2table` is only used in 1 place.

# other comments

The git history for these methods can be found
in manageiq: [app/models/miq_reportable.rb](https://github.com/ManageIQ/manageiq/blob/8ec14c859726d9c8936b06f885194d8805c49ec0/app/models/miq_reportable.rb)

Next Steps:

Delete `MiqReportable` and `MiqFilter.hashes2table`
See Also https://github.com/ManageIQ/manageiq/pull/16620