### PR TITLE
Make the 'Copy dialog' action work with the new Dialog Editor

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -21,11 +21,11 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', '$http', '
   });
 
   function requestDialogId() {
-    return JSON.parse(dialogIdAction)['id']
+    return JSON.parse(dialogIdAction).id;
   }
 
   function requestDialogAction() {
-    return JSON.parse(dialogIdAction)['action']
+    return JSON.parse(dialogIdAction).action;
   }
 
   if (requestDialogAction() === 'new') {

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -143,7 +143,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', '$http', '
 
   var beingCloned = null; // hack that solves recursion problem for cloneDeep
   function customizer(value) {
-    var keysToDelete = ['active', '$$hashKey', 'href', 'dynamicFieldList'];
+    var keysToDelete = ['active', '$$hashKey', 'href', 'dynamicFieldList', 'id'];
     var useCustomizer =
       (value !== beingCloned) &&
       _.isObject(value) &&

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -80,6 +80,11 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', '$http', '
     }
 
     translateResponderNamesToIds(dialog.content[0]);
+
+    if (requestDialogAction() === 'copy') {
+      dialog.label = dialog.content[0].label = "Copy of " + dialog.label;
+    }
+
     DialogEditor.setData(dialog);
     vm.dialog = dialog;
     vm.DialogValidation = DialogValidation;

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -141,6 +141,8 @@ class MiqAeCustomizationController < ApplicationController
   def editor
     if params[:id].present?
       @record = Dialog.find(params[:id])
+    elsif params[:copy].present?
+      @record = Dialog.find(params[:copy])
     else
       @record = Dialog.new
     end

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -17,7 +17,7 @@ class MiqAeCustomizationController < ApplicationController
   AE_CUSTOM_X_BUTTON_ALLOWED_ACTIONS = {
     'dialog_edit_editor'     => :dialog_edit_editor,
     'dialog_edit'            => :dialog_edit,
-    'dialog_copy'            => :dialog_copy,
+    'dialog_copy_editor'     => :dialog_copy_editor,
     'dialog_delete'          => :dialog_delete,
     'dialog_add_tab'         => :dialog_add_tab,
     'dialog_add_box'         => :dialog_add_box,

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -99,6 +99,26 @@ module MiqAeCustomizationController::Dialogs
     javascript_redirect :controller => 'miq_ae_customization', :action => 'editor', :id => @record.id
   end
 
+  # Edit dialog using the Dialog Editor
+  def dialog_edit_editor
+    assert_privileges("dialog_edit")
+    @record = find_records_with_rbac(Dialog, checked_or_params)
+    javascript_redirect :controller => 'miq_ae_customization',
+                        :action     => 'editor',
+                        :id         => Array.wrap(@record).first.id
+  end
+
+  # Copy dialog using the Dialog Editor
+  def dialog_copy_editor
+    assert_privileges("dialog_copy_editor")
+    record_to_copy = find_record_with_rbac(Dialog, checked_or_params)
+    @record = Dialog.new
+    javascript_redirect :controller => 'miq_ae_customization',
+                        :action     => 'editor',
+                        :copy       => record_to_copy.id,
+                        :id         => @record.id
+  end
+
   # Add new dialog
   def dialog_new
    assert_privileges("dialog_new")
@@ -177,15 +197,6 @@ module MiqAeCustomizationController::Dialogs
     else
       javascript_flash(:spinner_off => true)
     end
-  end
-
-  # Edit dialog using the Dialog Editor
-  def dialog_edit_editor
-    assert_privileges("dialog_edit")
-    @record = find_records_with_rbac(Dialog, checked_or_params)
-    javascript_redirect :controller => 'miq_ae_customization',
-                        :action     => 'editor',
-                        :id         => Array.wrap(@record).first.id
   end
 
   # edit dialog

--- a/app/helpers/application_helper/toolbar/dialog_center.rb
+++ b/app/helpers/application_helper/toolbar/dialog_center.rb
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::DialogCenter < ApplicationHelper::Toolbar::Bas
           :send_checked => true,
           :klass        => ApplicationHelper::Button::DialogAction),
         button(
-          :dialog_copy,
+          :dialog_copy_editor,
           'fa fa-files-o fa-lg',
           t = N_('Copy this Dialog'),
           t,

--- a/app/helpers/application_helper/toolbar/dialogs_center.rb
+++ b/app/helpers/application_helper/toolbar/dialogs_center.rb
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::DialogsCenter < ApplicationHelper::Toolbar::Ba
           :onwhen       => "1",
           :klass        => ApplicationHelper::Button::DialogAction),
         button(
-          :dialog_copy,
+          :dialog_copy_editor,
           'fa fa-files-o fa-lg',
           t = N_('Copy the selected Dialog to a new Dialog'),
           t,

--- a/app/helpers/miq_ae_customization_helper.rb
+++ b/app/helpers/miq_ae_customization_helper.rb
@@ -1,0 +1,12 @@
+module MiqAeCustomizationHelper
+  def dialog_id_action
+    url = request.parameters
+    if url[:id].present?
+      {:id => @record.id, :action => 'edit'}
+    elsif url[:copy].present?
+      {:id => url[:copy], :action => 'copy'}
+    else
+      {:id => '', :action => 'new'}
+    end
+  end
+end

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -45,7 +45,7 @@
                               :type => "button"}= _("Save")
 
 :javascript
-  ManageIQ.angular.app.value('dialogId', '#{ @record.id || "new" }');
+  ManageIQ.angular.app.value('dialogIdAction', '#{ dialog_id_action.to_json }');
   miq_bootstrap('#dialog-editor');
   // Fixes wrong coordinates of draggable element after scrolling in #main-content.
   // To be selected as scrollParent it cannot have position: static(default setting of #main-content) so it's overridden here

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2264,7 +2264,7 @@ Rails.application.routes.draw do
         playbook_options_field_changed
         cancel_import
         change_tab
-        dialog_edit
+        dialog_copy_editor
         dialog_edit_editor
         dialog_new_editor
         dialog_form_field_changed

--- a/spec/routing/miq_ae_customization_routing_spec.rb
+++ b/spec/routing/miq_ae_customization_routing_spec.rb
@@ -25,7 +25,7 @@ describe MiqAeCustomizationController do
     button_update
     cancel_import
     change_tab
-    dialog_edit
+    dialog_copy_editor
     dialog_form_field_changed
     dialog_list
     dialog_res_remove


### PR DESCRIPTION
The old dialog was showing up instead of the new one. After these changes, the new dialog should be used.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1518918

Steps for Testing/QA
-------------------------------

Automate → Automation → Customization → Service Dialogs → Copy this Dialog

EDIT:
Needs to be merged together with https://github.com/ManageIQ/manageiq/pull/16623