### PR TITLE
Initialize embedded_methods property for new Automate methods

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -745,7 +745,7 @@ class MiqAeClassController < ApplicationController
       end
     end
     @edit[:new][:available_datatypes] = MiqAeField.available_datatypes_for_ui
-    @edit[:new][:embedded_methods] = @ae_method.embedded_methods if @ae_method.location == 'inline'
+    @edit[:new][:embedded_methods] = @ae_method.embedded_methods
     @edit[:current] = copy_hash(@edit[:new])
     @right_cell_text = if @edit[:rec_id].nil?
                          _("Adding a new Automate Method")

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -664,6 +664,11 @@ describe MiqAeClassController do
       expect(@cls.ae_fields.last.name).to eq("Bar")
       expect(@cls.ae_fields.last.default_value).to eq("Foo")
     end
+
+    it "#new_method" do
+      controller.send(:new_method)
+      expect(session['edit'][:new][:embedded_methods].count).to eq(0)
+    end
   end
 
   context "#copy_objects_edit_screen" do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1523379

The form property embedded_methods was not being initialized since
the method type was not initialized.