### PR TITLE
Fix routing for `sort template grid` in vm_cloud controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3206,6 +3206,7 @@ Rails.application.routes.draw do
         scan_histories
         sections_field_changed
         security_groups
+        sort_template_grid
         floating_ips
         network_routers
         network_ports

--- a/spec/routing/vm_cloud_routing_spec.rb
+++ b/spec/routing/vm_cloud_routing_spec.rb
@@ -51,4 +51,10 @@ describe 'routes for VmCloud' do
       expect(get("/#{controller_name}/filesystem_download")).to route_to("#{controller_name}#filesystem_download")
     end
   end
+
+  describe '#sort_template_grid' do
+    it 'routes with POST' do
+      expect(post("/#{controller_name}/sort_template_grid")).to route_to("#{controller_name}#sort_template_grid")
+    end
+  end
 end


### PR DESCRIPTION
Fixes the `sort template grid` routing issue encountered while provisioning a cloud instance.

https://bugzilla.redhat.com/show_bug.cgi?id=1454829

