### PR TITLE
Fix ordering an Ansible Playbook catalog items

### DIFF
--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -19,7 +19,7 @@ class DialogLocalService
     {
       :resource_action_id     => resource_action.id,
       :target_id              => target.id,
-      :target_type            => target.class.name.underscore,
+      :target_type            => target.kind_of?(ServiceTemplate) ? "service_template" : target.class.name.underscore,
       :dialog_id              => resource_action.dialog_id,
       :force_old_dialog_use   => false,
       :api_submit_endpoint    => api_submit_endpoint,

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -5,6 +5,7 @@ describe DialogLocalService do
     let(:resource_action) { instance_double("ResourceAction", :id => 456, :dialog_id => 654) }
     let(:target) { instance_double("ServiceTemplate", :class => ServiceTemplate, :id => 321, :service_template_catalog_id => 123) }
     let(:finish_submit_endpoint) { "finishsubmitendpoint" }
+    let(:target_ansible) { instance_double("ServiceTemplateAnsiblePlaybook", :class => ServiceTemplateAnsiblePlaybook, :id => 987, :service_template_catalog_id => 798) }
 
     it "returns a hash" do
       expect(service.determine_dialog_locals_for_svc_catalog_provision(
@@ -20,6 +21,19 @@ describe DialogLocalService do
         :finish_submit_endpoint => "finishsubmitendpoint",
         :cancel_endpoint        => "/catalog/explorer"
       )
+    end
+
+    it "uses the base class for service_template derived classes" do
+      allow(target_ansible).to receive(:kind_of?).with(ServiceTemplate).and_return(true)
+      expect(service.determine_dialog_locals_for_svc_catalog_provision(resource_action, target_ansible, finish_submit_endpoint)).to eq(:resource_action_id     => 456,
+                                                                                                                                       :target_id              => 987,
+                                                                                                                                       :target_type            => 'service_template',
+                                                                                                                                       :dialog_id              => 654,
+                                                                                                                                       :force_old_dialog_use   => false,
+                                                                                                                                       :api_submit_endpoint    => "/api/service_catalogs/798/service_templates/987",
+                                                                                                                                       :api_action             => "order",
+                                                                                                                                       :finish_submit_endpoint => "finishsubmitendpoint",
+                                                                                                                                       :cancel_endpoint        => "/catalog/explorer")
     end
   end
 


### PR DESCRIPTION
Use service template in api_submit_endpoint for service template subclasses, as there are no collections for subclasses

Links
-------
https://bugzilla.redhat.com/show_bug.cgi?id=1523580


Before:
![screenshot from 2017-12-08 16-56-46](https://user-images.githubusercontent.com/12769982/33786863-cf824d44-dc38-11e7-9c94-d27c5c102e7c.png)


After
![screenshot from 2017-12-08 16-53-41](https://user-images.githubusercontent.com/12769982/33786757-639a884e-dc38-11e7-85df-301032a6386a.png)
