### PR TITLE
Fix the navigation to Services maintab after viewing a Generic Object item via Services Explorer

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -42,11 +42,12 @@ class ServiceController < ApplicationController
     @lastaction = "show"
 
     @gtl_url = "/show"
-    @display = params[:display] if params[:display]
+
+    @display = params[:display]
+    @display ||= default_display unless pagination_or_gtl_request?
 
     if self.class.display_methods.include?(@display)
-      params[:display] = @display
-      display_nested_list(@display)
+      nested_list_show
       return
     end
 
@@ -58,6 +59,10 @@ class ServiceController < ApplicationController
       return
     end
     redirect_to(:action => 'show', :controller => @record.class.base_model.to_s.underscore, :id => @record.id)
+  end
+
+  def nested_list_show
+    params[:generic_object_id] ? generic_object : display_nested_list(@display)
   end
 
   def show_list
@@ -161,17 +166,14 @@ class ServiceController < ApplicationController
   def generic_object
     return unless init_show_variables
 
-    id = params[:show] || params[:x_show]
-    if id.present?
-      @lastaction = "generic_object"
-      @item = @record.generic_objects.find(from_cid(id)).first
-      drop_breadcrumb(:name => _("%{name} (All Generic Objects)") % {:name => @record.name},
-                      :url  => show_link(@record, :display => @display))
-      drop_breadcrumb(:name => @item.name, :url => "/#{controller_name}/show/#{@record.id}?display=generic_objects/show=#{id}")
-      @view = get_db_view(GenericObject)
-      @sb[:rec_id] = id
-      show_item
-    end
+    @lastaction = 'generic_object'
+    @item ||= @record.generic_objects.find(params[:generic_object_id]).first
+    drop_breadcrumb(:name => _("%{name} (All Generic Objects)") % {:name => @record.name},
+                    :url  => show_link(@record, :display => @display))
+    drop_breadcrumb(:name => @item.name, :url => "/#{controller_name}/show/#{@record.id}?display=generic_objects&generic_object_id=#{params[:generic_object_id]}")
+    @view = get_db_view(GenericObject)
+    @sb[:rec_id] = params[:generic_object_id]
+    show_item
   end
 
   def self.display_methods

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -43,8 +43,7 @@ class ServiceController < ApplicationController
 
     @gtl_url = "/show"
 
-    @display = params[:display]
-    @display ||= default_display unless pagination_or_gtl_request?
+    set_display
 
     if self.class.display_methods.include?(@display)
       nested_list_show
@@ -59,6 +58,11 @@ class ServiceController < ApplicationController
       return
     end
     redirect_to(:action => 'show', :controller => @record.class.base_model.to_s.underscore, :id => @record.id)
+  end
+
+  def set_display
+    @display = params[:display]
+    @display ||= default_display unless pagination_or_gtl_request?
   end
 
   def nested_list_show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -352,9 +352,8 @@ module ApplicationHelper
         return ems_networks_path
       end
       if request[:controller] == 'service' && view.db == 'GenericObject'
-        controller = "service"
-        action = 'generic_object'
-        return url_for_only_path(:action => action, :id => params[:id]) + "?show="
+        action = 'show'
+        return url_for_only_path(:action => action, :id => params[:id]) + "?display=generic_objects&generic_object_id="
       end
       # If we do not want to use redirect or any kind of click action
       if %w(Job VmdbDatabaseSetting VmdbDatabaseConnection VmdbIndex).include?(view.db) &&

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -98,7 +98,7 @@ describe ServiceController do
       expect(assigns(:breadcrumbs)).to eq([{:name => "Abc (All Generic Objects)", :url => "/service/show/#{service.id}?display=generic_objects"}])
     end
 
-    it 'displays one generic object from the nested list' do
+    it 'redirects to service detail page when Services maintab is clicked right after viewing the GO object' do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)
       controller.instance_variable_set(:@breadcrumbs, [])
@@ -112,10 +112,16 @@ describe ServiceController do
         :services                  => [service]
       )
       go.add_to_service(service)
-      get :generic_object, :params => { :id => service.id, :show => go.id}
+      get :show, :params => { :id => service.id, :display => 'generic_objects', :generic_object_id => go.id}
       expect(response.status).to eq(200)
-      expect(assigns(:breadcrumbs)).to eq([{:name => "Abc (All Generic Objects)", :url => "/service/show/#{service.id}"},
-                                           {:name => "GOTest", :url => "/service/show/#{service.id}?display=generic_objects/show=#{go.id}"}])
+      expect(assigns(:breadcrumbs)).to eq([{:name => "Abc (All Generic Objects)", :url => "/service/show/#{service.id}?display=generic_objects"},
+                                           {:name => "GOTest", :url => "/service/show/#{service.id}?display=generic_objects&generic_object_id=#{go.id}"}])
+      is_expected.to render_template("layouts/_item")
+      is_expected.to render_template("service/show")
+
+      get :show, :params => { :id => service.id}
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to(:action => 'explorer', :id => "s-#{service.id}")
     end
 
     context "#button" do


### PR DESCRIPTION
Fixed the navigation to Services maintab issue reproduced with the steps below -

1. Navigate to Services -> My Services -> Select the Service with the GO instance
2. Click on the GO Instances count in the Summary screen
3. Pick a GO Instance to view in detail
4. Click on the Services maintab on the left

https://bugzilla.redhat.com/show_bug.cgi?id=1523396