### PR TITLE
Extend the icon deletion exception for middleware servers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1124,7 +1124,9 @@ class ApplicationController < ActionController::Base
         item = listicon_item(view, row['id'])
         icon, icon2, image, picture = listicon_glyphicon(item)
         image = "100/#{(@listicon || view.db).underscore}.png" if icon.nil? && image.nil? # TODO: we want to get rid of this
-        icon = nil if %w(pxe middleware_server).include?(params[:controller]) # TODO: adding exceptions here is a wrong approach
+        # FIXME: adding exceptions here is a wrong approach
+        icon = nil if params[:controller] == 'pxe'
+        icon = nil if params[:model] == 'MiddlewareServer'
         new_row[:cells] << {:title => _('View this item'),
                             :image   => ActionController::Base.helpers.image_path(image.to_s),
                             :picture => ActionController::Base.helpers.image_path(picture.to_s),

--- a/spec/controllers/ems_middleware_controller_spec.rb
+++ b/spec/controllers/ems_middleware_controller_spec.rb
@@ -101,5 +101,24 @@ describe EmsMiddlewareController do
     end
   end
 
+  describe '#report_data' do
+    context 'list of middleware servers related to a provider' do
+      let!(:provider) { FactoryGirl.create(:ems_hawkular) }
+      let!(:server) { FactoryGirl.create(:hawkular_middleware_server, :ext_management_system => provider) }
+
+      subject { assert_report_data_response }
+
+      it 'returns a single middleware server that has an image but not an icon' do
+        report_data_request(:model => 'MiddlewareServer', :parent_model => provider.type, :parent_id => provider.id)
+
+        expect(subject["data"]["rows"].length).to eq(1)
+        expect(subject["data"]["rows"][0]["cells"][2]["text"]).to eq(server.name)
+
+        expect(subject["data"]["rows"][0]["cells"][1]["icon"]).to be_nil
+        expect(subject["data"]["rows"][0]["cells"][1]["image"]).not_to be_nil
+      end
+    end
+  end
+
   include_examples '#download_summary_pdf', :ems_hawkular
 end


### PR DESCRIPTION
I had to extend the exception for the middleware servers displayed for a single provider.

`Middleware -> Providers (select a provider) -> Relationships (accordion) -> Middleware Servers`

Explanation why am I introducing this exception: https://github.com/ManageIQ/manageiq-ui-classic/pull/2888

@miq-bot add_label bug, gtls, middleware, gaprindashvili/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1509935