### PR TITLE
Fixed invalid HTML markup in drift fonticons

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -1223,7 +1223,7 @@ module ApplicationController::Compare
 
   def drift_add_image_col(idx, img_src, img_bkg, val)
     html = ViewHelper.content_tag(:div, :class => img_bkg) do
-      ViewHelper.tag(:i, :class => img_src, :title => val)
+      ViewHelper.content_tag(:i, nil, :class => img_src, :title => val)
     end
     {"col#{idx + 1}".to_sym => html}
   end


### PR DESCRIPTION
The [`tag`](http://api.rubyonrails.org/v5.0/classes/ActionView/Helpers/TagHelper.html#method-i-tag) helper method in Rails is a little bit inconsistent when it's about self-closing tags. It works well with an `input` field, but it fails to work with an `i` tag that we're using for fonticons. This causes random duplication of tags when displaying a drift history of a host. Forcing the tag to be closed by using an empty [`content_tag`](http://api.rubyonrails.org/v5.0/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag) instead solves the issue.

**Before:**
![screenshot from 2017-12-11 15-22-11](https://user-images.githubusercontent.com/649130/33835535-15a91a5a-de87-11e7-8b23-e17942a8e8e4.png)

**After:**
![screenshot from 2017-12-11 15-21-41](https://user-images.githubusercontent.com/649130/33835521-0a50971e-de87-11e7-993d-c3bf91eacc09.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1466402

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot assign @epwinchell 