### PR TITLE
Display the VNC start/end port when adding a vmware provider

### DIFF
--- a/app/views/ems_infra/_form.html.haml
+++ b/app/views/ems_infra/_form.html.haml
@@ -72,7 +72,7 @@
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
 
-    .form-group{"ng-class" => "{'has-error': angularForm.host_default_vnc_port_start.$invalid}", "ng-if" => "formId != 'new' && emsCommonModel.emstype == 'vmwarews'"}
+    .form-group{"ng-class" => "{'has-error': angularForm.host_default_vnc_port_start.$invalid}", "ng-if" => "emsCommonModel.emstype == 'vmwarews'"}
       %label.col-md-2.control-label{"for" => "ems_vnc_start_port"}
         = _('Host Default VNC Start Port')
       .col-md-8
@@ -83,7 +83,7 @@
                             "maxlength"   => 6,
                             "checkchange" => ""}
 
-    .form-group{"ng-class" => "{'has-error': angularForm.host_default_vnc_port_end.$invalid}", "ng-if" => "formId != 'new' && emsCommonModel.emstype == 'vmwarews'"}
+    .form-group{"ng-class" => "{'has-error': angularForm.host_default_vnc_port_end.$invalid}", "ng-if" => "emsCommonModel.emstype == 'vmwarews'"}
       %label.col-md-2.control-label{"for" => "ems_vnc_end_port"}
         = _('Host Default VNC End Port')
       .col-md-8


### PR DESCRIPTION
When adding a vmware infra provider, the VNC start/end port fields aren't displayed. However, when editing the same provider they are there. I don't know the reason behind this inconsistency, but I got a :beetle: for it so here's the fix.

**Before:**
![screenshot from 2017-12-11 17-16-42](https://user-images.githubusercontent.com/649130/33841140-28b3e87c-de97-11e7-9749-88d8d51ddf87.png)

**After:**
![screenshot from 2017-12-11 17-15-54](https://user-images.githubusercontent.com/649130/33841143-2becf6dc-de97-11e7-9e48-cc8fa5190951.png)

@miq-bot add_label bug

https://bugzilla.redhat.com/show_bug.cgi?id=1514594

@AparnaKarve could you please review?