### PR TITLE
[FINE] Prioritize the custom uploaded picture over listicons in GTL grids

### DIFF
--- a/app/views/layouts/_list_grid.html.haml
+++ b/app/views/layouts/_list_grid.html.haml
@@ -78,7 +78,9 @@
               %span{:class => "#{cell[:span]}"}
                 = cell[:text]
             - else
-              - if cell[:icon]
+              - if cell[:image] && cell[:image].starts_with?('/pictures/')
+                = image_tag(image_path(cell[:image]), :alt => cell[:title], :title => cell[:title])
+              - elsif cell[:icon]
                 %i{:class => cell[:icon], :title => cell[:title]}
               - elsif cell[:image]
                 = image_tag(image_path(cell[:image]), :alt => cell[:title], :title => cell[:title])


### PR DESCRIPTION
This is an ugly but necessary workaround, as https://github.com/ManageIQ/manageiq-ui-classic/pull/2573 can't be backported. 

**Before:**
![screenshot from 2017-12-11 22-35-40](https://user-images.githubusercontent.com/649130/33854933-aced5bba-dec3-11e7-8e99-9561a0f0b0bc.png)

**After:**
![screenshot from 2017-12-11 22-36-10](https://user-images.githubusercontent.com/649130/33854946-b9b20828-dec3-11e7-80db-0472a1dc79c0.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1515367