### PR TITLE
Display Policy button for all Container Relationship lists

### DIFF
--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -465,6 +465,8 @@ class ApplicationHelper::ToolbarChooser
         return "#{@display}_center_tb"
       elsif to_display_center.include?(@display)
         return "#{@display}_center"
+      elsif @layout == 'ems_container'
+        return "#{@display}_center"
       end
     elsif @display == 'generic_objects'
       return "#{@display}_center"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1346,4 +1346,37 @@ Datasources\" href=\"/ems_middleware/#{ems.id}?display=middleware_datasources\">
       expect(instance.model_to_report_data).to eq("Host")
     end
   end
+
+  context "calculate_toolbars for ems_container" do
+    before do
+      allow(helper).to receive(:inner_layout_present?).and_return(false)
+      allow(controller).to receive(:restful?).and_return(true)
+      allow(controller.class).to receive(:toolbar_plural).and_return(nil)
+      allow(controller.class).to receive(:toolbar_singular).and_return(nil)
+      allow(controller).to receive(:custom_toolbar)
+      @layout = 'ems_container'
+    end
+
+    it "displays ems_containers_center toolbar for ems_container show_list action" do
+      @lastaction = "show_list"
+      expect(calculate_toolbars).to include("center_tb" => "ems_containers_center_tb")
+    end
+
+    it "displays ems_container_center toolbar for ems_container show_dashboard action" do
+      @lastaction = "show_dashboard"
+      expect(calculate_toolbars).to include("center_tb" => "ems_container_center_tb")
+    end
+
+    it "displays container routes center toolbar for 'container_routes' nested display lists" do
+      @lastaction = "show"
+      @display = "container_routes"
+      expect(calculate_toolbars).to include("center_tb" => "container_routes_center")
+    end
+
+    it "displays container projects center toolbar for 'container_projects' nested display lists" do
+      @lastaction = "show"
+      @display = "container_projects"
+      expect(calculate_toolbars).to include("center_tb" => "container_projects_center")
+    end
+  end
 end


### PR DESCRIPTION
Render center toolbar for all Container nested display lists, which resolves the issue of `Policy` button not being rendered in Container Relationship lists

Before (No Policy button)
<img width="1389" alt="screen shot 2017-12-11 at 6 00 36 pm" src="https://user-images.githubusercontent.com/1538216/33863604-606c9d58-de9d-11e7-9b60-49dd94edaa30.png">

After (Renders toolbar with Policy button)
<img width="1387" alt="screen shot 2017-12-11 at 6 01 37 pm" src="https://user-images.githubusercontent.com/1538216/33863601-5e3d2c78-de9d-11e7-91b8-a9c7443fa5f3.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1516766


