### PR TITLE
resolve issue where vm smart scan option is incorrectly disabled

### DIFF
--- a/app/helpers/application_helper/button/smart_state_scan.rb
+++ b/app/helpers/application_helper/button/smart_state_scan.rb
@@ -2,9 +2,13 @@ class ApplicationHelper::Button::SmartStateScan < ApplicationHelper::Button::Bas
   def check_smart_roles
     my_zone = MiqServer.my_server.my_zone
     MiqServer::ServerSmartProxy::SMART_ROLES.each do |role|
-      unless MiqServer.all.any? { |s| s.has_active_role?(role) && (s.my_zone == my_zone) }
-        @error_message = _("There is no server with the %{role_name} role enabled") % {:role_name => role}
+      next if MiqServer.all.any? do |s|
+        s.has_active_role?(role) &&
+        s.my_zone == (@record.respond_to?(:zone) ? @record.zone : my_zone)
       end
+
+      @error_message = _("There is no server with the %{role_name} role enabled") %
+                       {:role_name => role}
     end
   end
 

--- a/app/helpers/application_helper/button/vm_instance_template_scan.rb
+++ b/app/helpers/application_helper/button/vm_instance_template_scan.rb
@@ -6,7 +6,6 @@ class ApplicationHelper::Button::VmInstanceTemplateScan < ApplicationHelper::But
   end
 
   def disabled?
-    super
     @error_message ||= @record.active_proxy_error_message unless @record.has_active_proxy?
     @error_message.present?
   end

--- a/spec/helpers/application_helper/buttons/vm_instance_template_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_instance_template_scan_spec.rb
@@ -34,8 +34,6 @@ describe ApplicationHelper::Button::VmInstanceTemplateScan do
       allow(record).to receive(:has_active_proxy?).and_return(has_active_proxy?)
     end
 
-    it_behaves_like 'a smart state scan button'
-
     context 'when smart_roles are enabled' do
       before do
         roles = %w(smartproxy smartstate).collect { |role| FactoryGirl.create(:server_role, :name => role) }

--- a/spec/support/examples_group/shared_examples_for_smart_state_scan_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_smart_state_scan_buttons.rb
@@ -17,11 +17,21 @@ shared_examples_for 'a smart state scan button' do
         let(:active_role) { true }
         it_behaves_like 'an enabled button'
       end
+
       context "when there is no server with enabled #{role} role" do
         let(:roles) { [role == 'smartproxy' ? smartscan_role : smartproxy_role] }
         let(:active_role) { false }
         it_behaves_like 'a disabled button', "There is no server with the #{role} role enabled"
       end
     end
+
+    context "when there is no server in the zone" do
+      let(:roles) { [smartproxy_role, smartscan_role] }
+      let(:active_role) { true }
+      let(:zone1) { FactoryGirl.create(:zone) }
+      let(:server) { FactoryGirl.create(:miq_server, :zone => zone1, :active_roles => roles) }
+      it_behaves_like 'a disabled button', "There is no server with the #{MiqServer::ServerSmartProxy::SMART_ROLES.last} role enabled"
+    end
   end
 end
+


### PR DESCRIPTION
This removed the call to `super` in the vm_instance_template_scan toolbar button, since the call to `@record.has_active_proxy?` is sufficient to ascertain if smart scan can be invoked. Fixes superclass SmartStateScan button to attempt to match records zone against target server zone if possible

https://bugzilla.redhat.com/show_bug.cgi?id=1513053