### PR TITLE
Display only manually added my company tags on topology screens

### DIFF
--- a/app/services/cloud_topology_service.rb
+++ b/app/services/cloud_topology_service.rb
@@ -2,9 +2,9 @@ class CloudTopologyService < TopologyService
   @provider_class = ManageIQ::Providers::CloudManager
 
   @included_relations = [
-    :tags,
-    :availability_zones => [:tags, :vms => :tags],
-    :cloud_tenants      => [:tags, :vms => :tags],
+    :writable_classification_tags,
+    :availability_zones => [:writable_classification_tags, :vms => :writable_classification_tags],
+    :cloud_tenants      => [:writable_classification_tags, :vms => :writable_classification_tags],
   ]
 
   @kinds = %i(CloudManager AvailabilityZone CloudTenant Vm Tag)

--- a/app/services/infra_topology_service.rb
+++ b/app/services/infra_topology_service.rb
@@ -2,17 +2,17 @@ class InfraTopologyService < TopologyService
   @provider_class = ManageIQ::Providers::InfraManager
 
   @included_relations = [
-    :tags,
+    :writable_classification_tags,
     :ems_clusters      => [
-      :tags,
+      :writable_classification_tags,
       :hosts => [
-        :tags,
-        :vms => :tags
+        :writable_classification_tags,
+        :vms => :writable_classification_tags
       ]
     ],
     :clusterless_hosts => [
-      :tags,
-      :vms => :tags
+      :writable_classification_tags,
+      :vms => :writable_classification_tags
     ],
   ]
 

--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -2,15 +2,15 @@ class NetworkTopologyService < TopologyService
   @provider_class = ManageIQ::Providers::NetworkManager
 
   @included_relations = [
-    :tags,
+    :writable_classification_tags,
     :availability_zones => [
       :vms => [
-        :tags,
-        :floating_ips    => :tags,
-        :cloud_tenant    => :tags,
-        :security_groups => :tags,
+        :writable_classification_tags,
+        :floating_ips    => :writable_classification_tags,
+        :cloud_tenant    => :writable_classification_tags,
+        :security_groups => :writable_classification_tags,
         :load_balancers  => [
-          :tags,
+          :writable_classification_tags,
           :floating_ips,
           :security_groups,
         ]
@@ -18,13 +18,13 @@ class NetworkTopologyService < TopologyService
     ],
     :cloud_subnets      => [
       :parent_cloud_subnet,
-      :tags,
+      :writable_classification_tags,
       :vms,
-      :cloud_network  => :tags,
+      :cloud_network  => :writable_classification_tags,
       :network_router => [
-        :tags,
+        :writable_classification_tags,
         :cloud_network => [
-          :floating_ips => :tags
+          :floating_ips => :writable_classification_tags
         ]
       ]
     ]

--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -2,12 +2,12 @@ class PhysicalInfraTopologyService < TopologyService
   @provider_class = ManageIQ::Providers::PhysicalInfraManager
 
   @included_relations = [
-    :tags,
+    :writable_classification_tags,
     :physical_servers => [
-      :tags,
+      :writable_classification_tags,
       :host => [
-        :tags,
-        :vms => :tags
+        :writable_classification_tags,
+        :vms => :writable_classification_tags
       ]
     ],
   ]


### PR DESCRIPTION
When building the JSON for a topology, all the related tags are being fetched. This is a problem as we don't want to expose internal tags in the UI. As a :christmas_tree: :gift: @lpichler [added a new method](https://github.com/ManageIQ/manageiq/pull/16607) into `ActsAsTaggable` that fetches only the tags we need.

**Before:**
![screenshot from 2017-12-12 13-22-24](https://user-images.githubusercontent.com/649130/33884323-85317288-df3f-11e7-86f8-d6cb84cbe7d9.png)

**After:**
![screenshot from 2017-12-12 13-21-56](https://user-images.githubusercontent.com/649130/33884330-88509a5c-df3f-11e7-957a-7e61890f8c52.png)

@miq-bot add_label topology, bug, pending core, gaprindashvili/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1519457