### PR TITLE
Fixes wrong coordinates of draggable element after scrolling in #main-content

### DIFF
--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -47,3 +47,6 @@
 :javascript
   ManageIQ.angular.app.value('dialogId', '#{ @record.id || "new" }');
   miq_bootstrap('#dialog-editor');
+  // Fixes wrong coordinates of draggable element after scrolling in #main-content.
+  // To be selected as scrollParent it cannot have position: static(default setting of #main-content) so it's overridden here
+  $("#main-content").css("position", "relative");


### PR DESCRIPTION

How to reproduce:
- Automation -> Automate -> Customization -> Service Dialog -> Create/Edit Service Dialog with enough elements to see a scrollbar on right side
- Drag one element and scroll at the same time

**Actual results:**
Dragged element is not under mouse cursor. But if dropped it will be added based on cursor location.
**Expected result:**
Dragged element is under mouse cursor (but you have to move the mouse a bit after scroll).

Background for the change :godmode: :
Coordinates of dragged element are changed if there is a scroll action in its `scrollParent`. To be selected as `scrollParent` it cannot have `position: static` (default setting of `#main-content`) so it's overridden in this PR.

@miq-bot add_label gaprindashvili/yes, bug, blocker, automation/automate

@romanblanco here goes your evil thingy 😈 

https://bugzilla.redhat.com/show_bug.cgi?id=1519015