### PR TITLE
Deleted dead method deletetemplates (pxe controller)

### DIFF
--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -145,11 +145,6 @@ module PxeController::PxeCustomizationTemplates
 
   private #######################
 
-  # Delete all selected or single displayed PXE Server(s)
-  def deletetemplates
-    template_button_operation('destroy', 'deletion')
-  end
-
   # Get variables from edit form
   def template_get_form_vars
     @ct = @edit[:ct_id] ? CustomizationTemplate.find_by_id(@edit[:ct_id]) : CustomizationTemplate.new


### PR DESCRIPTION
Deleted following dead method: deletetemplates in pxe_controller/pxe_customization_templates.rb

@miq-bot add_label technical debt, gaprindashvili/no