### PR TITLE
Rename 'Networks' table title (physical server summary)

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -17,7 +17,7 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_group_networks
-    TextualGroup.new(_("Networks"), %i(mac ipv4 ipv6))
+    TextualGroup.new(_("Management Networks"), %i(mac ipv4 ipv6))
   end
 
   def textual_group_assets


### PR DESCRIPTION
Currently, management network details such as IMM IP addresses are displayed in the "Networks" table on the physical server page. This is confusing because the name "Networks" implies that generic network details are displayed in the table; however, this is not the case. This patch renames that title in order to better describes the content of the table.