### PR TITLE
Removed method iso_datastore_tree_select

### DIFF
--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -2,18 +2,14 @@
 module PxeController::IsoDatastores
   extend ActiveSupport::Concern
 
-  def iso_datastore_tree_select
-    typ, id = params[:id].split("_")
-    case typ
-    when "img"
-      @record = MiqServer.find(from_cid(id))
-    when "wimg"
-      @record = WindowsImage.find(from_cid(id))
-    when "ps"
-      @record = ServerRole.find(from_cid(id))
-    end
+  def iso_datastore_new
+    assert_privileges("iso_datastore_new")
+    @isd = IsoDatastore.new
+    iso_datastore_set_form_vars
+    @in_a_form = true
+    replace_right_cell(:nodetype => "isd")
   end
-  
+
   def iso_datastore_edit
     unless params[:id]
       obj           = find_checked_items

--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -13,15 +13,7 @@ module PxeController::IsoDatastores
       @record = ServerRole.find(from_cid(id))
     end
   end
-
-  def iso_datastore_new
-    assert_privileges("iso_datastore_new")
-    @isd = IsoDatastore.new
-    iso_datastore_set_form_vars
-    @in_a_form = true
-    replace_right_cell(:nodetype => "isd")
-  end
-
+  
   def iso_datastore_edit
     unless params[:id]
       obj           = find_checked_items


### PR DESCRIPTION
removed dead method iso_datastore_tree_select from app/controllers/pxe_controller/iso_datastores.rb on line 5-15 (in commit there are written different lines, because it were different in RubyMine)

@miq-bot add_label technical debt, gaprindashvili/no