### PR TITLE
Removed dead method cb_docker_image_labels

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1456,10 +1456,6 @@ module ReportController::Reports::Editor
     end
   end
 
-  def cb_docker_image_labels
-    CustomAttribute.where(:section => "docker_labels").pluck(:name).uniq
-  end
-
   def categories_hash
     # Omit categories for which entries dropdown would be empty.
     cats = Classification.categories.select { |c| c.show && !c.entries.empty? }


### PR DESCRIPTION
@miq-bot add_label technical debt, gaprindashvili/no

Deleted dead method cb_docker_image_labels from report_controller/reports/editor.rb:1459-1460

Review please @lpichler
