### PR TITLE
Delete dead method change_subtab (ops_controller)

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -224,11 +224,6 @@ class OpsController < ApplicationController
     end
   end
 
-  def change_subtab
-    @sb[:active_tab] = params[:tab_id]
-    change_tab
-  end
-
   def rbac_group_load_tab
     tab_id = params[:tab_id]
     _, group_id = TreeBuilder.extract_node_model_and_id(x_node)


### PR DESCRIPTION
Deleted following dead method: change_subtab in controllers/ops_controller.rb

@miq-bot add_label technical debt, gaprindashvili/no