### PR TITLE
Deleted unused method 'delete_pxe_image_types'

### DIFF
--- a/app/controllers/pxe_controller/pxe_image_types.rb
+++ b/app/controllers/pxe_controller/pxe_image_types.rb
@@ -148,11 +148,6 @@ module PxeController::PxeImageTypes
     end
   end
 
-  # Delete all selected or single displayed PXEImageType(s)
-  def delete_pxe_image_types
-    pxe_image_type_button_operation('destroy', 'deletion')
-  end
-
   def pxe_image_type_set_record_vars(pxe)
     pxe.name = @edit[:new][:name]
     pxe.provision_type = @edit[:new][:provision_type]


### PR DESCRIPTION
This commit removes unused method `delete_pxe_image_types` in `app/controllers/pxe_controller/pxe_image_types.rb`

@miq-bot add_label technical debt, gaprindashvili/no
