### PR TITLE
Delete unused methods deleteisds, rbac_group_filter_expression

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -442,15 +442,6 @@ module OpsController::OpsRbac
     end
   end
 
-  def rbac_group_filter_expression
-    rbac_group_set_form_vars
-    @changed = session[:changed] = (@edit[:new] != @edit[:current])
-    @expkey = params[:button].to_sym
-    @edit[:filter_expression_table] = exp_build_table_or_nil(@edit[:new][:filter_expression])
-    @in_a_form = true
-    replace_right_cell(:nodetype => x_node)
-  end
-
   def rbac_group_seq_edit_screen
     @edit = {}
     @edit[:new] = {}

--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -224,11 +224,6 @@ module PxeController::IsoDatastores
     img.pxe_image_type = @edit[:new][:img_type].blank? ? nil : PxeImageType.find_by_id(@edit[:new][:img_type])
   end
 
-  # Delete all selected or single displayed ISO Datastore(s)
-  def deleteisds
-    iso_datastore_button_operation('destroy', 'deletion')
-  end
-
   def iso_datastore_set_record_vars(isd)
     ems = ManageIQ::Providers::Redhat::InfraManager.find_by_id(@edit[:new][:ems_id])
     isd.ext_management_system = ems


### PR DESCRIPTION
Check project manageiq-ui-classic, where is used method rbac_group_filter_expression. Delete this method from file app/controllers/ops_controller/ops_rbac.rb:445.

Check project manageiq-ui-classic, where is used method deleteisds. Delete this method from file app/controllers/pxe_controller/iso_datastores.rb:249.

@miq-bot add_label technical debt, gaprindashvili/no
