### PR TITLE
Deleted method automation_manager_provider_tag from file application_controller/tags.rb on line: 27-29

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -24,10 +24,6 @@ module ApplicationController::Tags
     tagging_edit('Container')
   end
 
-  def automation_manager_provider_tag
-    tagging_edit('ManageIQ::Providers::AnsibleTower::AutomationManager')
-  end
-
   def configuration_manager_provider_tag
     tagging_edit('ManageIQ::Providers::ConfigurationManager')
   end


### PR DESCRIPTION

**Not sure if method is dead because it might be called from toolbar in file app\helpers\application_helper\toolbar\automation_manager_providers_center.rb**

@miq-bot add_label technical debt, gaprindashvili/no