### PR TITLE
Make Save button responsive when editing Host

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -808,7 +808,7 @@ module OpsController::OpsRbac
     when "role"  then rbac_role_get_form_vars
     end
 
-    @edit[:new][:group] = rbac_user_get_group_ids.map(&:to_i)
+    @edit[:new][:group] = rbac_user_get_group_ids.map(&:to_i) if rec_type == "user"
     session[:changed] = changed = (@edit[:new] != @edit[:current])
     bad = false
     if rec_type == "group"

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -564,4 +564,52 @@ describe OpsController do
       expect(controller.instance_variable_get(:@users_count)).to eq(5)
     end
   end
+
+  describe '#rbac_field_changed' do
+    let(:getvars) { "rbac_#{rec_type}_get_form_vars".to_sym }
+
+    before do
+      allow(controller).to receive(:load_edit).and_return(true)
+      allow(controller).to receive(getvars).and_call_original
+      allow(controller).to receive(:render).and_return(true)
+
+      controller.instance_variable_set(:@_params, params)
+      controller.instance_variable_set(:@edit, edit)
+    end
+
+    subject { controller.instance_variable_get(:@edit)[:new][:group] }
+
+    context 'editing/adding a new user' do
+      let(:rec_type) { "user" }
+      let(:params) { {:name => "new_user", :id => "new", :chosen_group => "12,34"} }
+      let(:edit) { {:new => {:name => nil, :group => []}} }
+
+      it 'sets list of selected groups' do
+        controller.send(:rbac_field_changed, rec_type)
+        expect(subject.count).to eq(2)
+      end
+    end
+
+    context 'editing/adding a new group' do
+      let(:rec_type) { "group" }
+      let(:params) { {:description => "new_group", :id => "new"} }
+      let(:edit) { {:new => {:description => nil}} }
+
+      it 'does not set list of selected groups' do
+        controller.send(:rbac_field_changed, rec_type)
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'editing/adding a new role' do
+      let(:rec_type) { "role" }
+      let(:params) { {:description => "new_role", :id => "new"} }
+      let(:edit) { {:new => {:description => nil, :features => []}} }
+
+      it 'does not set list of selected groups' do
+        controller.send(:rbac_field_changed, rec_type)
+        expect(subject).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
**fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1515215

Make _Save_ button responsive properly when deselecting Host in the
tree when assigning filters in _Edit Group page_ under **Hosts & Clusters**.

After adding an appropriate infra provider (if it is not added yet):
1. access _Configuration -> Access Control_ tab, choose _Groups_ from accordion
2. in _Configuration_ in the left upper corner, choose _Add a new Group_
3. fill in some info and assign some filters: choose _Hosts & Clusters_ tab and select some Host in the tree, exactly like this:
![select_host](https://user-images.githubusercontent.com/13417815/33881886-862fd7be-df36-11e7-8c17-1144d5743582.png)
4. save the new group
5. then try to edit the group: under _Hosts & Clusters_, try to **deselect the same host** as you have previously selected => and you should see that _Save_ button is active. This is ok.
6. then try to select the same host again. Now the group looks like it was before editing and the **Save button should be deselect again, but it remains selected!**

The main problem occurs here: https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/ops_controller/ops_rbac.rb#L811 This line of the code above is executed even when creating/editing users or roles (`rbac_field_changed` method is common for users, groups and also roles).

When editing groups or roles, we don't need `@edit[:new][:group]` to be set, because this variable represents the groups which the user belongs to, so it is needed only when creating/adding a new User. This is why I added a simple condition to the line:
`@edit[:new][:group] = rbac_user_get_group_ids.map(&:to_i) if rec_type == "user"`
so then https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/ops_controller/ops_rbac.rb#L812 in the same file is set properly.

The `Save` button did not disable in the step 6 even when it should have been disabled because `@edit[:new]` and `@edit[:current]` were not the same and they should have been (because in fact, no change was made after step 6). The only one difference between `@edit[:new]` and `@edit[:current]` was that `@edit[:new]` contained `group`  (@edit[:new][:group] = [] was set in https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/ops_controller/ops_rbac.rb#L812). By disabling setting new groups when creating/editing a new group or role we fix the problem.

**Starting editing the Group:**
![host](https://user-images.githubusercontent.com/13417815/33887132-02e9f0c0-df49-11e7-9b90-b4ab24352078.png)
![deselect_host](https://user-images.githubusercontent.com/13417815/34939214-53be957a-f9eb-11e7-81e4-94e46d47d587.png)

**Before fixing the bug:**
![select_host_again1](https://user-images.githubusercontent.com/13417815/34941527-61e29044-f9f4-11e7-9aef-b3112281b8ca.png)

**After fixing the bug:**
![select_host_again](https://user-images.githubusercontent.com/13417815/34939211-4f93bf20-f9eb-11e7-98f1-7fcf4f3c56de.png)

