### PR TITLE
Display Filter Tab of Policy Events for the Last 7 Days

### DIFF
--- a/app/views/report/_form_expression_buttons.html.haml
+++ b/app/views/report/_form_expression_buttons.html.haml
@@ -11,8 +11,8 @@
     - else
       = display_label
 .spacer
-- unless @edit[expression_key][:expression].key?('???')
-  - @edit[expression_key][:exp_table].each do |token|
+- unless @edit[@expkey][:expression].key?('???')
+  - @edit[@expkey][:exp_table].each do |token|
     - single_token = [token].flatten.first
     - if %w(AND OR ( )).include?(single_token)
       %font{:color => "black"}


### PR DESCRIPTION
**fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1523271

Display _Filter_ Tab of _Policy Events for the Last 7 Days_, when editing report in _Cloud Intel -> Reports -> Reports_ tab.

The problem was the typo in https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/report/_form_expression_buttons.html.haml#L14 and https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/report/_form_expression_buttons.html.haml#L15, where `expression_key` was renamed to` @expkey`. `expression_key` as parameter or variable does not exist anywhere in _manageiq-ui-classic_ repo.

**Before:**
![filter_tab1](https://user-images.githubusercontent.com/13417815/33889861-be0e77ec-df51-11e7-9c99-13b9fb4ee045.png)
```
I, [2017-12-12T15:32:21.817790 #14908]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/report/_report_list.html.haml (752.4ms)
F, [2017-12-12T15:32:21.817966 #14908] FATAL -- : Error caught: [ActionView::Template::Error] undefined local variable or method `expression_key' for #<#<Class:0x007f3f755eec58>:0x007f3f6d768258>
/home/hstastna/manageiq/manageiq-ui-classic/app/views/report/_form_expression_buttons.html.haml:14:in `__home_hstastna_manageiq_manageiq_ui_classic_app_views_report__form_expression_buttons_html_haml__1322907729802975545_69955322409320'
```

**After:**
![filter_tab2](https://user-images.githubusercontent.com/13417815/33889766-7e208de6-df51-11e7-9d2f-761f9dae4498.png)
