### PR TITLE
Name the tags on the topology screens based on its classifications

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -6,13 +6,19 @@ ManageIQ.angular.app.service('topologyService', function() {
       __('Status: ') + d.item.status,
     ];
 
+    if (d.item.kind === 'Tag') {
+      status = [
+        d.item.name,
+        __('Type: ') + d.item.display_kind,
+      ];
+    }
+
     if (d.item.kind === 'Host' || d.item.kind === 'Vm') {
       status.push(__('Provider: ') + d.item.provider);
     }
 
     return status;
   };
-
 
   this.showHideNames = function($scope) {
     return function() {

--- a/app/services/topology_service.rb
+++ b/app/services/topology_service.rb
@@ -24,9 +24,18 @@ class TopologyService
     entity_type(entity) + entity.compressed_id.to_s
   end
 
+  def entity_name(entity)
+    if entity.kind_of?(Tag)
+      cls = entity.classification
+      [cls.parent, cls].map(&:description).join(': ')
+    else
+      entity.name
+    end
+  end
+
   def build_base_entity_data(entity)
     {
-      :name   => entity.name,
+      :name   => entity_name(entity),
       :kind   => entity_type(entity),
       :model  => entity.class.to_s,
       :miq_id => entity.id,

--- a/spec/services/topology_service_spec.rb
+++ b/spec/services/topology_service_spec.rb
@@ -128,4 +128,26 @@ describe TopologyService do
       end
     end
   end
+
+  describe '#entity_name' do
+    let(:name) { subject.send(:entity_name, entity) }
+
+    context 'entity is not a tag' do
+      let(:entity) { FactoryGirl.create(:vm_vmware) }
+
+      it 'returns with the name of the entity' do
+        expect(name).to eq(entity.name)
+      end
+    end
+
+    context 'entity is a tag' do
+      let(:parent_cls) { FactoryGirl.create(:classification, :description => 'foo') }
+      let(:cls) { FactoryGirl.create(:classification, :parent => parent_cls, :description => 'bar') }
+      let(:entity) { FactoryGirl.create(:tag, :classification => cls) }
+
+      it 'returns with the parent and the child classification description' do
+        expect(name).to eq('foo: bar')
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `name` attribute on tags is displaying the full tag URI instead of a human-readable name. The [tags we want to display on topology screens](https://github.com/ManageIQ/manageiq-ui-classic/pull/3007) always provide a related `Classification` object with an appropriate description. This object always has a parent `Classification` also with the description. Using these objects we can build the desired human-readable tag name by joining the two descriptions together.

As the tag name is being displayed on a tooltip with a `Name:` prefix before, I did not wanted to use a second colon for joining the two descriptions. Instead of that I am dropping the prefix for tags.

**Before:**
![screenshot from 2017-12-12 15-34-11](https://user-images.githubusercontent.com/649130/33889930-fd13633a-df51-11e7-8270-f8e6865f217e.png)

**After:**
![screenshot from 2017-12-14 17-31-18](https://user-images.githubusercontent.com/649130/34004051-294d7e08-e0f7-11e7-9e35-87c38a516656.png)

Depends on:
https://github.com/ManageIQ/manageiq/pull/16607
https://github.com/ManageIQ/manageiq-ui-classic/pull/3007

https://bugzilla.redhat.com/show_bug.cgi?id=1467805

@miq-bot add_label bug, pending core, gaprindashvili/yes, topology