### PR TITLE
Do not pass in all action controller params to raw_connect

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -4,6 +4,8 @@ module Mixins
   module EmsCommonAngular
     extend ActiveSupport::Concern
 
+    OPENSTACK_PARAMS = [:name, :provider_region, :api_version, :default_security_protocol, :keystone_v3_domain_id, :default_hostname, :default_api_port, :default_userid, :event_stream_selection].freeze
+
     included do
       include Mixins::GenericFormMixin
     end
@@ -115,7 +117,7 @@ module Mixins
       user, password = params[:default_userid], MiqPassword.encrypt(params[:default_password])
       case ems.to_s
       when 'ManageIQ::Providers::Openstack::CloudManager'
-        [password, params.except(:default_password)]
+        [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)]
       when 'ManageIQ::Providers::Amazon::CloudManager'
         [user, password, :EC2, params[:provider_region], nil, true]
       when 'ManageIQ::Providers::Azure::CloudManager'
@@ -136,7 +138,7 @@ module Mixins
 
         [ems.build_connect_params(connect_opts), true]
       when 'ManageIQ::Providers::Openstack::InfraManager'
-        [password, params.except(:default_password)]
+        [password, params.to_hash.symbolize_keys.slice(*(OPENSTACK_PARAMS))]
       when 'ManageIQ::Providers::Redhat::InfraManager'
         metrics_user, metrics_password = params[:metrics_userid], MiqPassword.encrypt(params[:metrics_password])
         [{


### PR DESCRIPTION
Currently, validation on the queue is sending all action controller params to `raw_connect`, which are ending up in the log. We should not be sending all action controller params to the `raw_connect` method.  This update makes them into a hash and excludes the unnecessary parameters. 

Before:
```
[----] I, [2017-12-07T15:58:52.312693 #19968:2b156f45a010]  INFO -- : MIQ(MiqQueue.put) Message id: [109180],  id: [], Zone: [default], Role: [ems_operations], Server: [], Ident: [generic], Target id: [], Instance id: [], Task id: [], Command: [ManageIQ::Providers::Openstack::CloudManager.raw_connect], Timeout: [600], Priority: [100], State: [ready], Deliver On: [], Data: [], Args: ["********", <ActionController::Parameters {"utf8"=>"✓", "authenticity_token"=>"+c/4Y7PVtO==", "button"=>"validate", "cred_type"=>"default", "name"=>"name", "emstype"=>"openstack", "api_version"=>"v3", "provider_region"=>"", "keystone_v3_domain_id"=>"default", "provider_id"=>"", "zone"=>"default", "default_security_protocol"=>"non-ssl", "default_hostname"=>"107", "default_api_port"=>"0", "default_userid"=>"admin", "event_stream_selection"=>"ceilometer", "controller"=>"ems_cloud", "action"=>"create"} permitted: false>]
```

After:
```
[----] I, [2017-12-12T10:08:33.365891 #80964:3fee3c3360ac]  INFO -- : MIQ(MiqQueue.put) Message id: [10000066183456],  id: [], Zone: [default], Role: [ems_operations], Server: [], Ident: [generic], Target id: [], Instance id: [], Task id: [], Command: [ManageIQ::Providers::Openstack::CloudManager.raw_connect], Timeout: [600], Priority: [100], State: [ready], Deliver On: [], Data: [], Args: ["********", {:cred_type=>"default", :name=>"testing", :emstype=>"openstack", :api_version=>"v2", :provider_region=>"region", :provider_id=>"", :zone=>"default", :default_security_protocol=>"ssl", :default_hostname=>"test", :default_api_port=>"13000", :default_userid=>"admin", :event_stream_selection=>"ceilometer"}]
```

Could I get some 👀 from the OpenStack team? @aufi 
@miq-bot assign @Fryguy

related to  https://github.com/ManageIQ/manageiq/pull/16636