### PR TITLE
Add missing route for Object Store Objects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -484,7 +484,7 @@ Rails.application.routes.draw do
         tagging_edit
         tag_edit_form_field_changed
         update
-      ) + compare_post + adv_search_post + exp_post
+      ) + compare_post + adv_search_post + exp_post + save_post
     },
 
     :cloud_volume             => {


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1444089

Add missing route for _Object Store Objects_ to enable `save_default_search` method, fixing  an error 
occurred when saving a new filter in Adv Search in _Storage -> Object Storage -> Object Store Objects_
page.
![obj_store](https://user-images.githubusercontent.com/13417815/33895439-cbc08286-df60-11e7-953b-9b4e640294a1.png)

**Before:**
![obj_store2](https://user-images.githubusercontent.com/13417815/33895881-ce695e94-df61-11e7-9053-586ae294a7b6.png)

**After:**
![obj_store1](https://user-images.githubusercontent.com/13417815/33895423-c52ca594-df60-11e7-8513-95baf4d08af9.png)
