### PR TITLE
[WIP] Display only the inline methods in the embedded methods tree

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -504,7 +504,7 @@ class MiqAeClassController < ApplicationController
       @in_a_form = true
     end
     session[:changed] = @changed = false
-    build_ae_tree(:ae_methods, :automate_tree)
+    build_ae_tree(:ae_inline_methods, :automate_tree)
     replace_right_cell
   end
 

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -38,12 +38,18 @@ class TreeBuilderAeClass < TreeBuilder
     count_only_or_objects(count_only, object.ae_methods, [:display_name, :name])
   end
 
+  def ae_inline_methods(object, count_only)
+    count_only_or_objects(count_only, object.ae_methods.where(:location => 'inline'), [:display_name, :name])
+  end
+
   def x_get_tree_class_kids(object, count_only, type)
     case type
     when :ae
       ae_instances(object, count_only) + ae_methods(object, count_only)
     when :ae_methods
       ae_methods(object, count_only)
+    when :ae_inline_methods
+      ae_inline_methods(object, count_only)
     else
       ae_instances(object, count_only)
     end


### PR DESCRIPTION
When editing an automate method, there's a possibility to add embedded methods. However, these can be inline methods only, so it makes sense to display only those in the tree where the method selection can be done. There are no tests and I will look into it how to do them here. I'm not sure about adding the `where` clause into the `TreeBuilder`, maybe it should be a named scope in the model, what do you think @lpichler?

![screenshot from 2017-12-12 17-26-07](https://user-images.githubusercontent.com/649130/33895872-ca1147a8-df61-11e7-9831-d0a6f4290a22.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1512683

@miq-bot assign @mkanoor 