### PR TITLE
Middlware toolbar buttons - fix failing travis

### DIFF
--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -5,6 +5,7 @@ class MiddlewareServerController < ApplicationController
   include MiddlewareCommonMixin
   include Mixins::MiddlewareDeploymentsMixin
 
+  toolbar :middleware_server
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/helpers/application_helper/button/middleware_datasource_action.rb
+++ b/app/helpers/application_helper/button/middleware_datasource_action.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::MiddlewareDatasourceAction < ApplicationHelper::Button::Basic
+  def visible?
+    return false if @record.middleware_server.nil?
+
+    !@record.try(:in_domain?) && @record.try(:mutable?)
+  end
+end

--- a/app/helpers/application_helper/button/middleware_domain_server_action.rb
+++ b/app/helpers/application_helper/button/middleware_domain_server_action.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::MiddlewareDomainServerAction < ApplicationHelper::Button::MiddlewareServerAction
+class ApplicationHelper::Button::MiddlewareDomainServerAction < ApplicationHelper::Button::Basic
   def visible?
     @record.try(:in_domain?)
   end

--- a/app/helpers/application_helper/button/middleware_standalone_server_action.rb
+++ b/app/helpers/application_helper/button/middleware_standalone_server_action.rb
@@ -1,5 +1,5 @@
-class ApplicationHelper::Button::MiddlewareStandaloneServerAction < ApplicationHelper::Button::MiddlewareServerAction
+class ApplicationHelper::Button::MiddlewareStandaloneServerAction < ApplicationHelper::Button::Basic
   def visible?
-    !@record.try(:in_domain?) && super
+    !@record.try(:in_domain?) && @record.try(:mutable?)
   end
 end

--- a/app/helpers/application_helper/toolbar/middleware_datasource_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_datasource_center.rb
@@ -47,7 +47,8 @@ class ApplicationHelper::Toolbar::MiddlewareDatasourceCenter < ApplicationHelper
             N_('Remove'),
             :confirm => N_('Do you want to remove this Datasource? Some Applications could be using this '\
  +                             'Datasource and may malfunction if it is deleted.'),
-            :klass   => ApplicationHelper::Button::MiddlewareStandaloneServerAction)
+            :klass   => ApplicationHelper::Button::MiddlewareDatasourceAction,
+          )
         ]
       ),
     ])

--- a/app/helpers/application_helper/toolbar/middleware_datasources_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_datasources_center.rb
@@ -41,7 +41,7 @@ class ApplicationHelper::Toolbar::MiddlewareDatasourcesCenter < ApplicationHelpe
             :onwhen       => "1+",
             :confirm      => N_('Do you want to remove these Datasources? Some Applications could be using these '\
                              'Datasources and may malfunction if they are deleted.'),
-            :klass     => ApplicationHelper::Button::MiddlewareStandaloneServerAction
+            :klass        => ApplicationHelper::Button::MiddlewareDatasourceAction,
           )
         ]
       ),


### PR DESCRIPTION
This flattens the class hierarchy for middleware buttons - now it should be obvious when which is visible.

And adds a new kind specifically for datasources - this should fix travis failing on..

```
     Failure/Error: !@record.try(:in_domain?) && super

     ActionView::Template::Error:
       MiddlewareDatasource#in_domain? delegated to middleware_server.in_domain?, but middleware_server is nil: #<ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource id: 63000000000038, name: "ExampleDS", ems_ref: nil, nativeid: "Local~/subsystem=datasources/data-source=ExampleDS", server_id: nil, properties: {"Driver Name"=>"foo", "Connection URL"=>"bar", "JNDI Name"=>"foo-bar", "Enabled"=>"yes"}, ems_id: nil, created_at: "2017-12-12 16:59:57", updated_at: "2017-12-12 16:59:57", feed: nil, type: "ManageIQ::Providers::Hawkular::MiddlewareManager::...">
     # /home/himdel/manageiq/app/models/middleware_datasource.rb:10:in `rescue in in_domain?'
     # /home/himdel/manageiq/app/models/middleware_datasource.rb:10:in `in_domain?'
     # ./app/helpers/application_helper/button/middleware_standalone_server_action.rb:3:in `visible?'
     # ./app/helpers/application_helper/button/basic.rb:77:in `skipped?'
```

Cc @tumido - this was caused by https://github.com/ManageIQ/manageiq/pull/16611, hope it's the right fix :).