### PR TITLE
Fix broken asset path for PDF downloads

### DIFF
--- a/app/assets/stylesheets/pdf/_patternfly.scss.erb
+++ b/app/assets/stylesheets/pdf/_patternfly.scss.erb
@@ -4,7 +4,7 @@
 
 @font-face {
   font-family: "PatternFlyIcons-webfont";
-  src: url(<%= asset_data_uri("patternfly/PatternFlyIcons-webfont.ttf") %>);
+  src: url(<%= asset_data_uri("patternfly/dist/fonts/PatternFlyIcons-webfont.ttf") %>);
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Fixes broken PDF download caused by asset path change in the upgrade to PatternFly v3.31.1 https://github.com/ManageIQ/manageiq-ui-classic/pull/2989

Before
<img width="1171" alt="screen shot 2017-12-12 at 12 58 47 pm" src="https://user-images.githubusercontent.com/1287144/33900769-a7b4da86-df3d-11e7-9295-88776255f45e.png">

After
<img width="1204" alt="screen shot 2017-12-12 at 12 59 21 pm" src="https://user-images.githubusercontent.com/1287144/33900787-b3739b28-df3d-11e7-93e5-8d841fe8b8df.png">


