### PR TITLE
Fix observation of cloned volume fieldsets

### DIFF
--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -11,13 +11,13 @@
     .form-group
       .col-md-2
       .col-md-8
-        %button.btn.btn-primary.pull-right#add-additional-volume-button
+        %button.btn.btn-primary.pull-right.add-additional-volume-button
           Add Volume
   %hr
 
 .form-horizontal#add-volumes-form
   - while (draw_fields)
-    #add-volume-fieldset
+    .add-volume-fieldset
       - keys.each do |key|
         .form-group
           %label.col-md-2.control-label{:valign => "top"}
@@ -32,7 +32,7 @@
                                     :value             => options[:"#{key}_#{counter}"],
                                     :id                => "volumes__#{key}_#{counter}",
                                     :name              => "volumes__#{key}_#{counter}",
-                                    "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
+                                    "data-miq_observe" => {:interval => ".1", :url => url}.to_json}
               - else
                 = options[:"#{key}_#{counter}"]
             - elsif workflow.get_field(key, dialog)[:data_type] == :boolean
@@ -42,7 +42,7 @@
                      :required          => workflow.get_field(key, dialog)[:required],
                      :name              => "volumes__#{key}_#{counter}",
                      :disabled          => !(@edit && workflow.get_field(key, dialog)[:display] == :edit && !@edit[:stamp_typ]),
-                     "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
+                     "data-miq_observe_checkbox" => {:url => url}.to_json}
           .col-md-2
       %hr
       %div
@@ -51,10 +51,10 @@
 
 :javascript
   (function(){
-      var button = $("#add-additional-volume-button");
+      var button = $(".add-additional-volume-button");
 
       button.click(function() {
-        var sourceNode = $("#add-volume-fieldset");
+        var sourceNode = $(".add-volume-fieldset").first();
         var node = duplicateNode(sourceNode, ["id", "name"]);
 
         sourceNode.parent().append(node);

--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -70,6 +70,9 @@
             if (node.hasAttribute(attr)) {
               $(node).prop(attr, increment_attr($(node).prop(attr)));
             }
+            // reset the observed flag so that the listener properly tracks
+            // changes to this field
+            $(node).data('isObserved', false);
           });
           node.value = '';
           node.checked = false;


### PR DESCRIPTION
If the volume fieldset was cloned after focusing a field, the isObserved flag would be true on the original field, causing the clone not to be watched for changes.
Also cleans up IDs that should have been classes to get rid of duplicate node warnings.

Fixes the remaining issue from https://bugzilla.redhat.com/show_bug.cgi?id=1520540, which was not fixed completely by the previous patch.