### PR TITLE
Fix test for MW datasource - missing parent

### DIFF
--- a/spec/controllers/middleware_datasource_controller_spec.rb
+++ b/spec/controllers/middleware_datasource_controller_spec.rb
@@ -3,6 +3,7 @@ describe MiddlewareDatasourceController do
   before(:each) do
     stub_user(:features => :all)
   end
+  let(:mw_server) { FactoryGirl.create(:middleware_server) }
 
   it 'renders index' do
     get :index
@@ -20,7 +21,8 @@ describe MiddlewareDatasourceController do
                                          'Connection URL' => 'bar',
                                          'JNDI Name'      => 'foo-bar',
                                          'Enabled'        => 'yes'
-                                       })
+                                       },
+                                       :middleware_server => mw_server)
     end
 
     subject { get :show, :id => @datasource.id }


### PR DESCRIPTION
Fix broken Travis where test for MW Datasource controller was failing due to missing parent MW server.

Found thanks to: https://github.com/ManageIQ/manageiq/pull/16611
Competiton PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/3040
Related: https://github.com/ManageIQ/manageiq-ui-classic/pull/2972

@himdel, please review