### PR TITLE
Set @tree_selected_model

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -559,6 +559,7 @@ class OpsController < ApplicationController
     # get_node_info might set this
     replace_trees = @replace_trees if @replace_trees
     @explorer = true
+    tree_selected_model if @tree_selected_model.nil?
 
     # Clicked on right cell record, open the tree enough to show the node,
     # if not already showing a record

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -26,6 +26,7 @@ describe OpsController do
 
     describe 'x_button actions' do
       it 'rbac group add' do
+        allow(controller).to receive(:x_node).and_return('xx-g')
         post :x_button, :params => {:pressed => 'rbac_group_add'}
         expect(response.status).to eq(200)
       end
@@ -38,6 +39,7 @@ describe OpsController do
       it 'rbac role add' do
         MiqProductFeature.seed
         session[:sandboxes] = {"ops" => {:trees => {}}}
+        allow(controller).to receive(:x_node).and_return('xx-ur')
         post :x_button, :params => {:pressed => 'rbac_role_add'}
         expect(response.status).to eq(200)
       end

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -150,6 +150,7 @@ describe OpsController do
         expect(controller).to receive(:render)
         @zone = FactoryGirl.create(:zone, :name => 'zoneName', :description => "description1")
         allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:x_node).and_return('root')
 
         @params = {:id     => 'new',
                    :action => "zone_edit",
@@ -237,6 +238,7 @@ describe OpsController do
                                        :active_accord => 'active_accord',
                                        :active_tab    => 'settings_server',
                                        :active_tree   => :settings_tree)
+      allow(controller).to receive(:x_node).and_return('xx-svr')
       expect(controller).to receive(:x_active_tree_replace_cell)
       expect(controller).to receive(:replace_explorer_trees)
       expect(controller).to receive(:rebuild_toolbars)


### PR DESCRIPTION
Configuration -> Access Control -> Users/Group/Role -> Add a User/Group/Role -> fill and save

Before:
Nothing happens on screen.
*Log:*
```
F, [2017-12-13T14:16:22.941154 #29252] FATAL -- : Error caught: [NoMethodError] undefined method `>=' for nil:NilClass
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:366:in `button_class_name'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:389:in `get_custom_buttons'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:299:in `custom_button_selects'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:341:in `build_custom_toolbar_class'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:331:in `custom_toolbar_class'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:70:in `toolbar_class'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:18:in `build_toolbar'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:6:in `call'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/helpers/application_helper.rb:527:in `build_toolbar'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/ops_controller.rb:782:in `choose_custom_toolbar'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/ops_controller.rb:788:in `rebuild_toolbars'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/ops_controller.rb:574:in `replace_right_cell'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/ops_controller/ops_rbac.rb:768:in `rbac_edit_save_or_add'

```
After:
<img width="1212" alt="screen shot 2017-12-13 at 2 05 05 pm" src="https://user-images.githubusercontent.com/9210860/33940471-64a6670a-e00f-11e7-8fd0-b9f33efd6386.png">
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1524933
Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/2926

@miq-bot add_label gaprindashvili/yes, bug, blocker