### PR TITLE
Enable to edit Chargeback rate after resetting changes

### DIFF
--- a/app/views/chargeback/_rates_tabs.html.haml
+++ b/app/views/chargeback/_rates_tabs.html.haml
@@ -1,7 +1,7 @@
 #rates_tabs_div
   - if x_node == "root"
     = render :partial => "rates_list"
-  - elsif @edit && @edit[:new] && params[:pressed] && params[:pressed] != "chargeback_rates_delete"
+  - elsif @edit && @edit[:new] && ((params[:pressed] && params[:pressed] != "chargeback_rates_delete") || params[:button] == "reset")
     = render :partial => "cb_rate_edit"
   - elsif %w(Compute Storage).include?(x_node.split('-').last)
     = render :partial => 'layouts/x_gtl', :locals => {:action_url => "cb_rates_list"}


### PR DESCRIPTION
**fixing** https://github.com/ManageIQ/manageiq-ui-classic/issues/2744

Enable to edit _Chargeback rate_ again after clicking on _Reset_ button in _Cloud Intel -> Chargeback -> Rates_ tab.

Before:
![reset1](https://user-images.githubusercontent.com/13417815/33940706-5fa13c5c-e010-11e7-935b-cd5ecb3de078.png)

After:
![reset2](https://user-images.githubusercontent.com/13417815/33940664-29048c94-e010-11e7-9130-26658c39cbce.png)

