### PR TITLE
Add missing protect routes to availability_zone

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,6 +212,7 @@ Rails.application.routes.draw do
         download_summary_pdf
         index
         perf_top_chart
+        protect
         show
         show_list
         tagging_edit
@@ -220,6 +221,7 @@ Rails.application.routes.draw do
       :post => %w(
         button
         listnav_search_selected
+        protect
         quick_search
         sections_field_changed
         show


### PR DESCRIPTION
Compute -> Cloud -> Availability Zones -> choose one with instances -> click Instances in Relationships -> check one or more Instances -> Policy -> Manage Policies

Before:
<img width="1393" alt="screen shot 2017-12-13 at 2 56 39 pm" src="https://user-images.githubusercontent.com/9210860/33942319-dcd767fa-e015-11e7-8964-f1b4f684b018.png">

*Log:*
```
F, [2017-12-13T14:56:37.062567 #30823] FATAL -- : Error caught: [ActionController::UrlGenerationError] No route matches {:action=>"protect", :controller=>"availability_zone", :db=>VmOrTemplate(id: integer, vendor: string, format: string, version: string, name: string, description: text, location: string, config_xml: string, autostart: string, host_id: integer, last_sync_on: datetime, created_on: datetime, updated_on: datetime, storage_id: integer, guid: string, ems_id: integer, last_scan_on: datetime, last_scan_attempt_on: datetime, uid_ems: string, retires_on: datetime, retired: boolean, boot_time: datetime, tools_status: string, standby_action: string, power_state: string, state_changed_on: datetime, previous_state: string, connection_state: string, last_perf_capture_on: datetime, registered: boolean, busy: boolean, smart: boolean, memory_reserve: integer, memory_reserve_expand: boolean, memory_limit: integer, memory_shares: integer, memory_shares_level: string, cpu_reserve: integer, cpu_reserve_expand: boolean, cpu_limit: integer, cpu_shares: integer, cpu_shares_level: string, cpu_affinity: string, ems_created_on: datetime, template: boolean, evm_owner_id: integer, ems_ref_obj: string, miq_group_id: integer, linked_clone: boolean, fault_tolerance: boolean, type: string, ems_ref: string, ems_cluster_id: integer, retirement_warn: integer, retirement_last_warn: datetime, vnc_port: integer, flavor_id: integer, availability_zone_id: integer, cloud: boolean, retirement_state: string, cloud_network_id: integer, cloud_subnet_id: integer, cloud_tenant_id: integer, raw_power_state: string, publicly_available: boolean, orchestration_stack_id: integer, retirement_requester: string, tenant_id: integer, resource_group_id: integer, deprecated: boolean, storage_profile_id: integer, cpu_hot_add_enabled: boolean, cpu_hot_remove_enabled: boolean, memory_hot_add_enabled: boolean, memory_hot_add_limit: integer, memory_hot_add_increment: integer, href_slug: string, region_number: integer, region_description: string, aggressive_recommended_vcpus: integer, aggressive_recommended_mem: integer, aggressive_vcpus_recommended_change_pct: float, aggressive_vcpus_recommended_change: integer, aggressive_mem_recommended_change_pct: float, aggressive_mem_recommended_change: integer, moderate_recommended_vcpus: integer, moderate_recommended_mem: integer, moderate_vcpus_recommended_change_pct: float, moderate_vcpus_recommended_change: integer, moderate_mem_recommended_change_pct: float, moderate_mem_recommended_change: integer, conservative_recommended_vcpus: integer, conservative_recommended_mem: integer, conservative_vcpus_recommended_change_pct: float, conservative_vcpus_recommended_change: integer, conservative_mem_recommended_change_pct: float, conservative_mem_recommended_change: integer, recommended_vcpus: integer, recommended_mem: integer, overallocated_vcpus_pct: float, overallocated_mem_pct: float, max_cpu_usage_rate_average_max_over_time_period: float, max_mem_usage_absolute_average_max_over_time_period: float, cpu_usagemhz_rate_average_max_over_time_period: float, derived_memory_used_max_over_time_period: float, v_total_snapshots: integer, v_snapshot_oldest_name: string, v_snapshot_oldest_description: string, v_snapshot_oldest_total_size: integer, v_snapshot_oldest_timestamp: datetime, v_snapshot_newest_name: string, v_snapshot_newest_description: string, v_snapshot_newest_total_size: integer, v_snapshot_newest_timestamp: datetime, last_compliance_status: boolean, last_compliance_timestamp: datetime, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, custom_1: string, custom_2: string, custom_3: string, custom_4: string, custom_5: string, custom_6: string, custom_7: string, custom_8: string, custom_9: string, is_evm_appliance: boolean, os_image_name: string, platform: string, vendor_display: string, v_owning_cluster: string, v_owning_resource_pool: string, v_owning_datacenter: string, v_owning_folder: string, v_owning_folder_path: string, v_owning_blue_folder: string, v_owning_blue_folder_path: string, v_datastore_path: string, thin_provisioned: boolean, used_storage: integer, used_storage_by_state: integer, uncommitted_storage: integer, ipaddresses: string_set, hostnames: string_set, mac_addresses: string_set, memory_exceeds_current_host_headroom: string, num_hard_disks: integer, num_disks: integer, num_cpu: integer, has_rdm_disk: boolean, disks_aligned: string, paravirtualization: boolean, vmsafe_enable: boolean, vmsafe_agent_address: string, vmsafe_agent_port: integer, vmsafe_fail_open: boolean, vmsafe_immutable_vm: boolean, vmsafe_timeout_ms: integer, disk_1_disk_type: string, disk_1_mode: string, disk_1_size: integer, disk_1_size_on_disk: integer, disk_1_used_percent_of_provisioned: float, disk_1_partitions_aligned: string, disk_2_disk_type: string, disk_2_mode: string, disk_2_size: integer, disk_2_size_on_disk: integer, disk_2_used_percent_of_provisioned: float, disk_2_partitions_aligned: string, disk_3_disk_type: string, disk_3_mode: string, disk_3_size: integer, disk_3_size_on_disk: integer, disk_3_used_percent_of_provisioned: float, disk_3_partitions_aligned: string, disk_4_disk_type: string, disk_4_mode: string, disk_4_size: integer, disk_4_size_on_disk: integer, disk_4_used_percent_of_provisioned: float, disk_4_partitions_aligned: string, disk_5_disk_type: string, disk_5_mode: string, disk_5_size: integer, disk_5_size_on_disk: integer, disk_5_used_percent_of_provisioned: float, disk_5_partitions_aligned: string, disk_6_disk_type: string, disk_6_mode: string, disk_6_size: integer, disk_6_size_on_disk: integer, disk_6_used_percent_of_provisioned: float, disk_6_partitions_aligned: string, disk_7_disk_type: string, disk_7_mode: string, disk_7_size: integer, disk_7_size_on_disk: integer, disk_7_used_percent_of_provisioned: float, disk_7_partitions_aligned: string, disk_8_disk_type: string, disk_8_mode: string, disk_8_size: integer, disk_8_size_on_disk: integer, disk_8_used_percent_of_provisioned: float, disk_8_partitions_aligned: string, disk_9_disk_type: string, disk_9_mode: string, disk_9_size: integer, disk_9_size_on_disk: integer, disk_9_used_percent_of_provisioned: float, disk_9_partitions_aligned: string, parent_blue_folder_1_name: string, parent_blue_folder_2_name: string, parent_blue_folder_3_name: string, parent_blue_folder_4_name: string, parent_blue_folder_5_name: string, parent_blue_folder_6_name: string, parent_blue_folder_7_name: string, parent_blue_folder_8_name: string, parent_blue_folder_9_name: string, first_drift_state_timestamp: time, last_drift_state_timestamp: time, cpu_usagemhz_rate_average_avg_over_time_period: float, cpu_usagemhz_rate_average_low_over_time_period: float, cpu_usagemhz_rate_average_high_over_time_period: float, derived_memory_used_avg_over_time_period: float, derived_memory_used_low_over_time_period: float, derived_memory_used_high_over_time_period: float, max_cpu_usage_rate_average_avg_over_time_period: float, max_cpu_usage_rate_average_low_over_time_period: float, max_cpu_usage_rate_average_high_over_time_period: float, max_mem_usage_absolute_average_avg_over_time_period: float, max_mem_usage_absolute_average_low_over_time_period: float, max_mem_usage_absolute_average_high_over_time_period: float, max_cpu_usage_rate_average_avg_over_time_period_without_overhead: float, max_cpu_usage_rate_average_low_over_time_period_without_overhead: float, max_cpu_usage_rate_average_high_over_time_period_without_overhead: float, max_mem_usage_absolute_average_avg_over_time_period_without_overhead: float, max_mem_usage_absolute_average_low_over_time_period_without_overhead: float, max_mem_usage_absolute_average_high_over_time_period_without_overhead: float, vm_ram_size: integer, snapshot_size: integer, disk_size: integer, debris_size: integer, vm_misc_size: integer, archived: boolean, orphaned: boolean, active: boolean, disconnected: boolean, v_is_a_template: string, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string, ram_size_in_bytes: integer, mem_cpu: integer, ram_size: integer, cpu_total_cores: integer, cpu_cores_per_socket: integer, v_annotation: text, host_name: string, storage_name: string, ems_cluster_name: string, v_host_vmm_product: string, v_pct_free_disk_space: float, v_pct_used_disk_space: float, allocated_disk_storage: integer, used_disk_storage: integer, provisioned_storage: integer), :id=>"10000000000032"}
```
After:
<img width="526" alt="screen shot 2017-12-13 at 2 51 31 pm" src="https://user-images.githubusercontent.com/9210860/33942197-69411c00-e015-11e7-915e-fb686d2aac6b.png">

@miq-bot add_label bug, gaprindashvili/yes, compute/cloud