### PR TITLE
Display only the inline methods in the embedded methods tree

### DIFF
--- a/app/assets/javascripts/angular_modules/module_automate_selector.js
+++ b/app/assets/javascripts/angular_modules/module_automate_selector.js
@@ -1,0 +1,9 @@
+/* global miqHttpInject */
+miqHttpInject(
+  angular.module('ManageIQ.automateSelector', [
+    'miqStaticAssets.treeSelector',
+    'miqStaticAssets.treeView',
+    'ui.bootstrap',
+    'frapontillo.bootstrap-switch',
+  ])
+);

--- a/app/assets/javascripts/controllers/miq_ae_class/ae_inline_method_selection_controller.js
+++ b/app/assets/javascripts/controllers/miq_ae_class/ae_inline_method_selection_controller.js
@@ -1,0 +1,62 @@
+/* global miqJqueryRequest, miqPassFields */
+(function() {
+  var CONTROLLER_NAME = 'aeInlineMethodSelectionController';
+
+  var AeInlineMethodSelectionController = function($http, $uibModal) {
+    var vm = this;
+    vm.$http = $http;
+    vm.$uibModal = $uibModal;
+
+    vm.includeDomain = false;
+    vm.selectable = {key: '^aem-'};
+
+    vm.$http.get('/tree/automate_inline_methods').then(function(response) {
+      vm.data = response.data;
+    });
+  };
+
+  AeInlineMethodSelectionController.prototype.lazyLoad = function(node) {
+    return this.$http.get('/tree/automate_inline_methods?id=' + encodeURIComponent(node.key))
+      .then(function(response) {
+        return response.data;
+      });
+  };
+
+  AeInlineMethodSelectionController.prototype.openModal = function() {
+    this.modal = this.$uibModal.open({
+      templateUrl: '/static/automate-selection-modal.html',
+      keyboard: false,
+      backdrop: 'static',
+      size: 'lg',
+      controllerAs: '$ctrl',
+      controller: ['parent', function(parent) { this.parent = parent; }],
+      resolve: {
+        parent: function() {
+          return this;
+        }.bind(this),
+      },
+    });
+  };
+
+  AeInlineMethodSelectionController.prototype.onSelect = function(node) {
+    var fqname = node.fqname;
+    // Chop the first part of the fqname if includeDomain is set to false
+    if (this.includeDomain === false) {
+      fqname = fqname.split('/');
+      fqname.splice(1, 1);
+      fqname = fqname.join('/');
+    }
+
+    var url = '/' + ManageIQ.controller + '/embedded_methods_add';
+    miqJqueryRequest(miqPassFields(url, {fqname: fqname}));
+
+    this.modal.close();
+  };
+
+  AeInlineMethodSelectionController.prototype.closeModal = function() {
+    this.modal.close();
+  };
+
+  AeInlineMethodSelectionController.$inject = ['$http', '$uibModal'];
+  window.miqHttpInject(angular.module('ManageIQ.automateSelector')).controller(CONTROLLER_NAME, AeInlineMethodSelectionController);
+})();

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -504,7 +504,6 @@ class MiqAeClassController < ApplicationController
       @in_a_form = true
     end
     session[:changed] = @changed = false
-    build_ae_tree(:ae_methods, :automate_tree)
     replace_right_cell
   end
 
@@ -1676,6 +1675,18 @@ class MiqAeClassController < ApplicationController
     end
 
     session[:edit] = @edit
+  end
+
+  def embedded_methods_add
+    submit_embedded_method(URI.unescape(params[:fqname]))
+    @changed = (@edit[:new] != @edit[:current])
+    render :update do |page|
+      page << javascript_prologue
+      page << javascript_show("flash_msg_div")
+      page << javascript_for_miq_button_visibility(@changed)
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page.replace("embedded_methods_div", :partial => "embedded_methods")
+    end
   end
 
   def embedded_methods_remove

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -900,7 +900,6 @@ class MiqAeClassController < ApplicationController
                            else
                              @edit[:new][:data]
                            end
-      build_ae_tree(:ae_methods, :automate_tree)
       @changed = (@edit[:new] != @edit[:current])
       @edit[:default_verify_status] = @edit[:new][:location] == "inline" && @edit[:new][:data] && @edit[:new][:data] != ""
       angular_form_specific_data if @edit[:new][:location] == "playbook"
@@ -1228,7 +1227,6 @@ class MiqAeClassController < ApplicationController
       @in_a_form = true
       add_flash(_("All changes have been reset"), :warning)
       @button = "reset"
-      build_ae_tree(:ae_methods, :automate_tree)
       replace_right_cell
     else
       @changed = session[:changed] = (@edit[:new] != @edit[:current])
@@ -1667,11 +1665,11 @@ class MiqAeClassController < ApplicationController
   def ae_tree_select_toggle
     @edit = session[:edit]
     self.x_active_tree = :ae_tree
-    method_edit_or_new_method? ? at_tree_select_toggle(:method) : at_tree_select_toggle(:namespace)
+    at_tree_select_toggle(:namespace)
 
     if params[:button] == 'submit'
       x_node_set(@edit[:active_id], :automate_tree)
-      @edit[:namespace] = @edit[:new][:namespace] unless method_edit_or_new_method?
+      @edit[:namespace] = @edit[:new][:namespace]
     end
 
     session[:edit] = @edit
@@ -1691,7 +1689,6 @@ class MiqAeClassController < ApplicationController
 
   def embedded_methods_remove
     @edit[:new][:embedded_methods].delete_at(params[:id].to_i)
-    build_ae_tree(:ae_methods, :automate_tree)
     @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
@@ -1703,7 +1700,7 @@ class MiqAeClassController < ApplicationController
 
   def ae_tree_select
     @edit = session[:edit]
-    method_edit_or_new_method? ? at_tree_select(:method) : at_tree_select(:namespace)
+    at_tree_select(:namespace)
     session[:edit] = @edit
   end
 
@@ -1728,10 +1725,6 @@ class MiqAeClassController < ApplicationController
   end
 
   private
-
-  def method_edit_or_new_method?
-    %w(miq_ae_method_edit miq_ae_method_new).include?(@sb[:action])
-  end
 
   def playbook_inputs(method)
     existing_inputs = method.inputs

--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -9,6 +9,11 @@ class TreeController < ApplicationController
     render :body => json, :content_type => 'application/json'
   end
 
+  def automate_inline_methods
+    json = fetch_tree(TreeBuilderAutomateInlineMethod, :automate_inline_method, params[:id])
+    render :body => json, :content_type => 'application/json'
+  end
+
   private
 
   def fetch_tree(klass, name, node_id = nil)

--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -5,13 +5,19 @@ class TreeController < ApplicationController
   before_action :check_privileges
 
   def automate_entrypoint
-    tree = TreeBuilderAutomateEntrypoint.new(:automate_entrypoint, :automate_entrypoint_tree, {})
-    json = if params[:id]
-             TreeBuilder.convert_bs_tree(tree.x_get_child_nodes(params[:id])).to_json
-           else
-             tree.instance_variable_get(:@bs_tree)
-           end
-
+    json = fetch_tree(TreeBuilderAutomateEntrypoint, :automate_entrypoint, params[:id])
     render :body => json, :content_type => 'application/json'
+  end
+
+  private
+
+  def fetch_tree(klass, name, node_id = nil)
+    tree = klass.new(name, "#{name}_tree".to_sym, {})
+
+    if node_id
+      TreeBuilder.convert_bs_tree(tree.x_get_child_nodes(node_id)).to_json
+    else
+      tree.instance_variable_get(:@bs_tree)
+    end
   end
 end

--- a/app/helpers/automate_tree_helper.rb
+++ b/app/helpers/automate_tree_helper.rb
@@ -1,13 +1,13 @@
 module AutomateTreeHelper
-  def submit_embedded_method
-    if @edit[:new][:embedded_methods].include?(@edit[:automate_tree_selected_path])
+  def submit_embedded_method(fqname)
+    if @edit[:new][:embedded_methods].include?(fqname)
       add_flash(_("This embedded method is already selected"), :warning)
     elsif @edit[:new][:embedded_methods].count >= 20
       add_flash(_("It is not allowed to have more than 20 embedded methods"), :warning)
-    elsif MiqAeMethod.find_by(:id => (@edit[:ae_method_id])).try(:fqname) == @edit[:automate_tree_selected_path]
+    elsif MiqAeMethod.find_by(:id => (@edit[:ae_method_id])).try(:fqname) == fqname
       add_flash(_("It is not allowed to choose method itself"), :warning)
     else
-      @edit[:new][:embedded_methods].push(@edit[:automate_tree_selected_path])
+      @edit[:new][:embedded_methods].push(fqname)
     end
   end
 

--- a/app/helpers/automate_tree_helper.rb
+++ b/app/helpers/automate_tree_helper.rb
@@ -11,41 +11,27 @@ module AutomateTreeHelper
     end
   end
 
-  def include_domain_prefix
-    if MiqAeDatastore.path_includes_domain?(@edit[:automate_tree_selected_path])
-      selected_path = @edit[:automate_tree_selected_path]
-      @edit[:automate_tree_selected_path] = selected_path.slice(selected_path.index('/', 1), selected_path.length)
-    end
-  end
-  private :include_domain_prefix, :submit_embedded_method
+  private :submit_embedded_method
 
   def at_tree_select_toggle(edit_key)
-    edit_key == :method ? build_ae_tree(:ae_methods, :automate_tree) : build_ae_tree(:automate, :automate_tree)
-    if params[:button] == 'submit'
-      include_domain_prefix if @edit[:include_domain_prefix].nil?
-      submit_embedded_method if edit_key == :method
-    end
+    build_ae_tree(:automate, :automate_tree)
     render :update do |page|
       page << javascript_prologue
       tree_close = proc do
         @edit[:ae_tree_select] = false
         @changed = (@edit[:new] != @edit[:current])
         @changed = @edit[:new][:override_source] if params[:controller] == "miq_ae_class" &&
-                                                    @edit[:new][:namespace].nil? && edit_key != :method
+                                                    @edit[:new][:namespace].nil?
         page << javascript_hide("ae_tree_select_div")
         page << javascript_hide("blocker_div")
         page << javascript_for_miq_button_visibility(@changed)
-        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-        page << javascript_show("flash_msg_div")
         page << "miqSparkle(false);"
       end
       case params[:button]
       when 'submit'
-        if edit_key != :method
-          @edit[:new][@edit[:ae_field_typ]] = @edit[:active_id]
-          page << set_element_visible("#{edit_key}_div", true)
-          @edit[:new][edit_key] = @edit[:automate_tree_selected_path]
-        end
+        @edit[:new][@edit[:ae_field_typ]] = @edit[:active_id]
+        page << set_element_visible("#{edit_key}_div", true)
+        @edit[:new][edit_key] = @edit[:automate_tree_selected_path]
         if @edit[:new][edit_key]
           page << "$('##{edit_key}').val('#{@edit[:new][edit_key]}');"
           page << "$('##{edit_key}').prop('title', '#{@edit[:new][edit_key]}');"
@@ -55,11 +41,7 @@ module AutomateTreeHelper
           @edit[:include_domain_prefix] = nil
           @edit[:domain_prefix_check] = nil
         end
-        if edit_key == :method
-          page.replace("embedded_methods_div", :partial => "embedded_methods")
-        elsif params[:controller] == "miq_ae_class"
-          page.replace("form_div", :partial => "copy_objects_form")
-        end
+        page.replace("form_div", :partial => "copy_objects_form") if params[:controller] == "miq_ae_class"
         tree_close.call
 
       when 'cancel'
@@ -114,19 +96,15 @@ module AutomateTreeHelper
     id = from_cid(parse_nodetype_and_id(params[:id]).last)
     if params[:id].start_with?("aei-")
       record = MiqAeInstance.find_by_id(id)
-    elsif params[:id].start_with?("aen-") && controller_name == "miq_ae_class" && edit_key != :method
+    elsif params[:id].start_with?("aen-") && controller_name == "miq_ae_class"
       record = MiqAeNamespace.find_by_id(id)
       record = nil if record.domain?
-    elsif params[:id].start_with?("aem-") && controller_name == "miq_ae_class"
-      record = MiqAeMethod.find_by(:id => id)
     end
-    if edit_key != :method
-      @edit[:new][edit_key] = @edit[edit_key] if @edit[:new][edit_key].nil?
-      @edit[:current][:selected] = @edit[:new][:selected].nil? ? "" : @edit[:new][:selected]
-      @edit[:new][:selected] = params[:id]
-    end
+    @edit[:new][edit_key] = @edit[edit_key] if @edit[:new][edit_key].nil?
+    @edit[:current][:selected] = @edit[:new][:selected].nil? ? "" : @edit[:new][:selected]
+    @edit[:new][:selected] = params[:id]
     if record
-      @edit[:automate_tree_selected_path] = controller_name == "miq_ae_class" && edit_key != :method ? record.fqname_sans_domain : record.fqname
+      @edit[:automate_tree_selected_path] = controller_name == "miq_ae_class" ? record.fqname_sans_domain : record.fqname
       # save selected id in edit until save button is pressed
       @edit[:active_id] = params[:id]
       @changed = @edit[:new][edit_key] != @edit[:automate_tree_selected_path]

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -30,22 +30,14 @@ class TreeBuilderAeClass < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def ae_instances(object, count_only)
-    count_only_or_objects(count_only, object.ae_instances, [:display_name, :name])
-  end
-
-  def ae_methods(object, count_only)
-    count_only_or_objects(count_only, object.ae_methods, [:display_name, :name])
-  end
-
   def x_get_tree_class_kids(object, count_only, type)
-    case type
-    when :ae
-      ae_instances(object, count_only) + ae_methods(object, count_only)
-    when :ae_methods
-      ae_methods(object, count_only)
+    instances = count_only_or_objects(count_only, object.ae_instances, [:display_name, :name])
+    # show methods in automate explorer tree
+    if type == :ae # FIXME: is this ever false?
+      methods = count_only_or_objects(count_only, object.ae_methods, [:display_name, :name])
+      instances + methods
     else
-      ae_instances(object, count_only)
+      instances
     end
   end
 

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -5,7 +5,6 @@ class TreeBuilderAutomate < TreeBuilderAeClass
 
   def initialize(name, type, sandbox, build = true, controller = nil)
     @controller = controller
-    sandbox[:trees][:automate_tree][:type] = :ae_methods if type == :ae_methods && sandbox.has_key_path?(:trees, 'automate_tree')
     super(name, type, sandbox, build)
   end
 

--- a/app/presenters/tree_builder_automate_inline_method.rb
+++ b/app/presenters/tree_builder_automate_inline_method.rb
@@ -1,0 +1,5 @@
+class TreeBuilderAutomateInlineMethod < TreeBuilderAutomateEntrypoint
+  def x_get_tree_class_kids(object, count_only, _type)
+    count_only_or_objects(count_only, object.ae_methods.where(:location => 'inline'), [:display_name, :name])
+  end
+end

--- a/app/views/miq_ae_class/_embedded_methods.html.haml
+++ b/app/views/miq_ae_class/_embedded_methods.html.haml
@@ -14,19 +14,17 @@
                 %text_field_tag
                   = _(method.to_s)
   - else
-    = hidden_div_if(!@edit[:new][:method], :id => "ae_tree_select_div") do
-      = render(:partial => 'layouts/ae_tree_select', :locals => {:entry_point => "Method"})
     %hr
     %h3
       = _('Embedded Methods')
-    %table{:width => "100%", :align => "bottom"}
-      %tr
-        %td{:align => "right"}
-          %button.btn.btn-primary{:type        => "button",
-                                  :onFocus     => 'miqShowAE_Tree("namespace");miqButtons("hide");',
-                                  :align       => "left"}= _('Add Method')
-          %br
-          %br
+    #automate-inline-method-select{'ng-controller' => 'aeInlineMethodSelectionController as vm'}
+      .pull-right
+        %button.btn.btn-primary{:type        => "button",
+                                'ng-click'   => 'vm.openModal();',
+                                :align       => "left"}= _('Add Method')
+      .clearfix
+    :javascript
+      miq_bootstrap('#automate-inline-method-select', 'ManageIQ.automateSelector');
     - if !@edit[:new][:embedded_methods].nil? && !@edit[:new][:embedded_methods].empty?
       %table.table.table-striped.table-hover.table-condensed.table-bordered
         %thead

--- a/app/views/static/automate-selection-modal.html
+++ b/app/views/static/automate-selection-modal.html
@@ -1,0 +1,23 @@
+<div class="modal-header">
+  <h4 class="modal-title" translate>Select Item</h4>
+</div>
+<div class="modal-body">
+  <div class="pull-left">
+    <miq-tree-selector
+      name="entrypoint_selection"
+      selected="$ctrl.parent.selected"
+      selectable="$ctrl.parent.selectable"
+      data="$ctrl.parent.data"
+      lazy-load="$ctrl.parent.lazyLoad(node)"
+      on-select="$ctrl.parent.onSelect(node)"
+    ></miq-tree-selector>
+  </div>
+  <div class="form-group pull-right">
+    <label class="control-label" translate>Include domain prefix in the path:</label>
+    <input bs-switch type="checkbox" ng-model="$ctrl.parent.includeDomain" ng-show="$ctrl.parent.showInclude"/>
+  </div>
+  <div class="clearfix"></div>
+</div>
+<div class="modal-footer">
+  <button class="btn btn-default" ng-click="$ctrl.parent.closeModal(false);" translate>Close</button>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3483,6 +3483,7 @@ Rails.application.routes.draw do
 
   # API-like JSON trees
   get '/tree/automate_entrypoint', :to => 'tree#automate_entrypoint'
+  get '/tree/automate_inline_methods', :to => 'tree#automate_inline_methods'
 
   # pure-angular templates
   get '/static/*id' => 'static#show', :format => false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2210,6 +2210,7 @@ Rails.application.routes.draw do
         create_method
         create_ns
         domains_priority_edit
+        embedded_methods_add
         embedded_methods_remove
         explorer
         expand_toggle

--- a/spec/controllers/tree_controller_spec.rb
+++ b/spec/controllers/tree_controller_spec.rb
@@ -29,6 +29,12 @@ describe TreeController do
     include_examples 'valid HTTP JSON response', :automate_entrypoint
   end
 
+  describe '#automate_inline_methods' do
+    let(:record) { FactoryGirl.create(:miq_ae_namespace) }
+
+    include_examples 'valid HTTP JSON response', :automate_inline_methods
+  end
+
   describe '#fetch_tree' do
     let(:klass) { dup }
     let(:tree) { dup }

--- a/spec/controllers/tree_controller_spec.rb
+++ b/spec/controllers/tree_controller_spec.rb
@@ -1,0 +1,46 @@
+describe TreeController do
+  before { stub_user(:features => :all) }
+
+  shared_examples 'valid HTTP JSON response' do |endpoint|
+    context 'whole tree requested' do
+      it 'returns with a valid HTTP JSON response' do
+        get endpoint
+
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq('application/json')
+      end
+    end
+
+    context 'part a tree requested' do
+      let(:node_id) { TreeNode.new(record).key }
+
+      it 'returns with a valid HTTP JSON response' do
+        get endpoint, :params => {:id => node_id}
+
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq('application/json')
+      end
+    end
+  end
+
+  describe '#automate_entrypoint' do
+    let(:record) { FactoryGirl.create(:miq_ae_namespace) }
+
+    include_examples 'valid HTTP JSON response', :automate_entrypoint
+  end
+
+  describe '#fetch_tree' do
+    let(:klass) { dup }
+    let(:tree) { dup }
+    let(:node_id) { nil }
+
+    before { tree.instance_variable_set(:@bs_tree, :foo => :bar) }
+
+    subject { controller.send(:fetch_tree, klass, :foo, node_id) }
+
+    it 'returns with a tree hash' do
+      expect(klass).to receive(:new).with(:foo, :foo_tree, {}).and_return(tree)
+      expect(subject).to eq(:foo => :bar)
+    end
+  end
+end


### PR DESCRIPTION
The `TreeBuilder` calls are playing too much with the session, I even [failed with a simpler solution](https://github.com/ManageIQ/manageiq-ui-classic/pull/3038). I decided to utilize the same `TreeSelector` component that we're using in the dialog editor for entry point selection. I created a new method into the `TreeController` that retrieves a special automate tree with inline methods only. The most complicated part was the link between the session-based edit form and the angular controller, but I sorted it out by salvaging @pkomanek's code into a new `embedded_methods_add` route. 

![screenshot from 2017-12-12 17-26-07](https://user-images.githubusercontent.com/649130/33895872-ca1147a8-df61-11e7-9831-d0a6f4290a22.png)

I also tried to remove some dead code, but maybe missed a lot ... so this needs future refactoring.

https://bugzilla.redhat.com/show_bug.cgi?id=1512683

ping @martinpovolny @himdel @mkanoor 