### PR TITLE
Add KubeVirt provider

### DIFF
--- a/app/assets/images/svg/vendor-kubevirt.svg
+++ b/app/assets/images/svg/vendor-kubevirt.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<!--
+Copyright (c) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="5cm"
+   height="5cm"
+   viewBox="0 0 50 49.999999"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92+devel unknown"
+   sodipodi:docname="vendor-kubevirt.svg">
+  <defs
+     id="defs2">
+    <inkscape:path-effect
+       effect="fillet_chamfer"
+       id="path-effect3542"
+       is_visible="true"
+       satellites_param="F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1"
+       unit="mm"
+       method="auto"
+       mode="F"
+       radius="12"
+       chamfer_steps="1"
+       helper_size="0"
+       flexible="false"
+       use_knot_distance="false"
+       mirror_knots="true"
+       apply_no_radius="true"
+       apply_with_radius="true"
+       only_selected="false"
+       hide_knots="false" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="90.411308"
+     inkscape:cy="72.733828"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="1920"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     units="cm"
+     inkscape:measure-start="112.497,4.65149"
+     inkscape:measure-end="0,0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-247.00002)"
+     style="display:inline">
+    <g
+       id="g4361"
+       transform="matrix(0.978121,0,0,0.978121,-33.360291,-0.6207906)">
+      <g
+         id="g4356">
+        <path
+           sodipodi:type="star"
+           style="fill:#326de6;fill-opacity:1;fill-rule:evenodd;stroke-width:0.29651502"
+           id="path3515"
+           sodipodi:sides="7"
+           sodipodi:cx="42.936275"
+           sodipodi:cy="287.44345"
+           sodipodi:r1="26.060047"
+           sodipodi:r2="23.479292"
+           sodipodi:arg1="1.118925"
+           sodipodi:arg2="1.567724"
+           inkscape:flatsided="true"
+           inkscape:rounded="0"
+           inkscape:randomized="0"
+           d="m 52.786398,310.89259 -19.555971,0.0601 a 3.175,3.175 25.538252 0 1 -2.485976,-1.18778 L 18.504528,294.51287 a 3.175,3.175 76.966823 0 1 -0.621331,-2.68418 l 4.293036,-19.07904 a 3.175,3.175 128.39539 0 1 1.711189,-2.15934 l 17.593251,-8.53915 a 3.175,3.175 179.82397 0 1 2.755149,-0.008 l 17.64539,8.43088 a 3.175,3.175 51.252537 0 1 1.724425,2.14879 l 4.41019,19.05229 a 3.175,3.175 102.68111 0 1 -0.604826,2.68795 l -12.145973,15.32694 a 3.175,3.175 154.10968 0 1 -2.47863,1.20304 z"
+           inkscape:transform-center-x="-0.00091401786"
+           inkscape:transform-center-y="-1.2859785"
+           inkscape:path-effect="#path-effect3542"
+           transform="rotate(0.2,2199.3965,5058.3309)" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         id="path4353"
+         d="m 59.20602,295.48257 c -0.207887,-0.0959 -0.474733,-0.27962 -0.592992,-0.40817 -0.208541,-0.22669 -10.227127,-24.75626 -10.362028,-25.37045 -0.168328,-0.7664 0.521645,-1.7846 1.365499,-2.01509 0.732496,-0.20008 1.692369,0.19629 2.019159,0.83378 0.07189,0.14024 1.948805,4.74108 4.170928,10.2241 2.222123,5.48301 4.068721,10.00147 4.103552,10.04101 0.03483,0.0395 1.821778,-4.38278 3.970994,-9.82738 2.149215,-5.4446 3.986874,-10.0593 4.083687,-10.25489 0.362361,-0.73208 1.359717,-1.16701 2.109036,-0.91972 0.421561,0.13913 0.948178,0.58738 1.151111,0.97981 0.37275,0.72082 0.508716,0.33147 -4.766134,13.64815 -3.076063,7.7657 -4.998617,12.49872 -5.138858,12.65104 -0.305765,0.33209 -0.902307,0.59226 -1.358001,0.59226 -0.207887,0 -0.548066,-0.0785 -0.755953,-0.17445 z"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:1.34464288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+  </g>
+</svg>

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -65,6 +65,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       smartstate_docker_auth_status: true,
       alerts_selection: '',
       console_auth_status: true,
+      kubevirt_token: '',
     };
 
     $scope.emsOptionsModel = {
@@ -171,6 +172,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.prometheus_alerts_security_protocol = data.prometheus_alerts_security_protocol;
       $scope.emsCommonModel.prometheus_alerts_tls_ca_certs  = data.prometheus_alerts_tls_ca_certs;
 
+      $scope.emsCommonModel.kubevirt_token                  = data.kubevirt_token
+
       if ($scope.emsCommonModel.default_userid !== '') {
         $scope.emsCommonModel.default_password = miqService.storedPasswordPlaceholder;
       }
@@ -259,6 +262,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
        $scope.emsCommonModel.emstype == "openstack_infra" && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "nuage_network"  && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "rhevm" && $scope.emsCommonModel.default_hostname ||
+       $scope.emsCommonModel.emstype == "kubevirt" && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "vmwarews" && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "vmware_cloud" && $scope.emsCommonModel.default_hostname) &&
       ($scope.emsCommonModel.default_userid != '' && $scope.angularForm.default_userid.$valid &&
@@ -312,6 +316,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     } else if($scope.emsCommonModel.emstype == "gce" && $scope.emsCommonModel.project != '' &&
       ($scope.currentTab == "default" ||
       ($scope.currentTab == "service_account" && $scope.emsCommonModel.service_account != ''))) {
+      return true;
+    } else if($scope.emsCommonModel.emstype == "kubevirt") {
       return true;
     } else {
       return false;
@@ -444,6 +450,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.metrics_api_port = "5432";
       $scope.emsCommonModel.default_api_port = $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
       $scope.emsCommonModel.metrics_database_name = "ovirt_engine_history";
+    } else if ($scope.emsCommonModel.emstype === 'kubevirt') {
+      $scope.emsCommonModel.default_api_port = "8443";
     } else if ($scope.emsCommonModel.emstype === 'vmware_cloud') {
       $scope.emsCommonModel.default_api_port = "443";
       $scope.emsCommonModel.event_stream_selection = "none";

--- a/app/services/ui_service_mixin.rb
+++ b/app/services/ui_service_mixin.rb
@@ -33,6 +33,7 @@ module UiServiceMixin
       :Azure                   => {:type => "image", :icon => provider_icon(:Azure)},
       :Google                  => {:type => "image", :icon => provider_icon(:Google)},
       :Kubernetes              => {:type => "image", :icon => provider_icon(:Kubernetes)},
+      :Kubevirt                => {:type => "image", :icon => provider_icon(:Kubevirt)},
       :Lenovo                  => {:type => "image", :icon => provider_icon(:Lenovo)},
       :Microsoft               => {:type => "image", :icon => provider_icon(:Microsoft)},
       :Nuage                   => {:type => "image", :icon => provider_icon(:Nuage_Network)},

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -18,14 +18,14 @@
 - main_scope            = vm_scope ? "$parent.vm" : "$parent"
 
 %div{"ng-controller" => "CredentialsController as vm", "vm-scope" => "$parent.vm.model ? $parent.vm : $parent"}
-  %div{"ng-show" => "#{ng_show} && #{ng_show_userid}"}
+  %div{"ng-show" => "#{ng_show} && #{ng_show_userid} && emsCommonModel.emstype != 'kubevirt'"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_userid.$invalid}"}
       %label.col-md-2.control-label{"for" => "#{prefix}_userid"}
         = userid_label
       .col-md-4
         - hash_for_userid = {"type"                    => "text",
                              "id"                      => "#{prefix}_userid",
-                             "ng-required"             => "#{ng_reqd_userid}",
+                             "ng-required"             => "#{ng_reqd_userid} && emsCommonModel.emstype != 'kubevirt'",
                              "ng-disabled"             => userid_disabled,
                              "name"                    => "#{prefix}_userid",
                              "ng-model"                => "#{main_scope}.#{ng_model}.#{prefix}_userid",
@@ -46,7 +46,7 @@
         .note{"ng-if" => "emsCommonModel.emstype == 'scvmm' && emsCommonModel.default_security_protocol == 'kerberos'"}
           = _("Note: Username must be in the format: name@realm")
 
-  %div{"ng-show" => "#{ng_show} && #{ng_show_password}"}
+  %div{"ng-show" => "#{ng_show} && #{ng_show_password} && emsCommonModel.emstype != 'kubevirt'"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_password.$error.required}"}
       %label.col-md-2.control-label{"for" => "#{prefix}_password"}
         %div{"ng-show" => "vm.bChangeStoredPassword != true"}
@@ -56,7 +56,7 @@
       .col-md-4
         %input.form-control{"type"                    => "password",
                             "id"                      => "#{prefix}_password",
-                            "ng-required"             => "#{ng_reqd_password}",
+                            "ng-required"             => "#{ng_reqd_password} && emsCommonModel.emstype != 'kubevirt'",
                             "ng-disabled"             => "!vm.showVerify('#{prefix}_userid')" || password_disabled,
                             "name"                    => "#{prefix}_password",
                             "ng-model"                => "#{main_scope}.#{ng_model}.#{prefix}_password",

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -146,6 +146,7 @@
                          "emsCommonModel.emstype == 'openstack_infra'        || " + |
                          "emsCommonModel.emstype == 'nuage_network'          || " + |
                          "emsCommonModel.emstype == 'rhevm'                  || " + |
+                         "emsCommonModel.emstype == 'kubevirt'               || " + |
                          "emsCommonModel.emstype == 'vmware_cloud'           || " + |
                          "emsCommonModel.emstype == 'hawkular'               || " + |
                          "emsCommonModel.emstype == 'hawkular_datawarehouse' || " + |
@@ -194,9 +195,8 @@
       %span.help-block{"ng-show" => "angularForm.#{prefix}_database_name.$error.detectedSpaces"}
         = _("Spaces are prohibited")
 
-
 %div{"ng-if" => defined?(tls_verify_hide) ? false : true}
-  .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm'"}
+  .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm' || emsCommonModel.emstype == 'kubevirt'"}
     %label.col-md-2.control-label{"for" => "#{prefix}_tls_verify"}
       = _('Verify TLS Certificates')
     .col-md-8
@@ -213,6 +213,7 @@
 
 %div{"ng-if" => defined?(tls_ca_certs_hide) ? false : true}
   .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm' || " +                                             |
+                        "emsCommonModel.emstype == 'kubevirt' || " +                                          |
                         "(emsCommonModel.ems_controller == 'ems_container' && " +                             |
                         " emsCommonModel.#{prefix}_security_protocol == 'ssl-with-validation-custom-ca') || " |
                         "(emsCommonModel.emstype == 'hawkular' && " +                                         |
@@ -223,13 +224,31 @@
       %textarea.form-control{"id"          => "#{prefix}_tls_ca_certs",
                              "name"        => "#{prefix}_tls_ca_certs",
                              "ng-model"    => "#{ng_model}.#{prefix}_tls_ca_certs",
-                             "ng-disabled" => "emsCommonModel.emstype == 'rhevm' && !#{ng_model}.#{prefix}_tls_verify",
+                             "ng-disabled" => "(emsCommonModel.emstype == 'rhevm' || emsCommonModel.emstype == 'kubevirt') && !#{ng_model}.#{prefix}_tls_verify",
                              "ng-required" => false,
                              "ng-trim"     => false,
                              "prefix"      => prefix.to_s,
                              "reset-validation-status" => "#{prefix}_auth_status"}
       %span.help-block
         = _("Paste here the trusted CA certificates, in PEM format.")
+
+%div{"ng-if"=> "emsCommonModel.emstype == 'kubevirt'"}
+  .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_kubevirt_token.$invalid}"}
+    %label.col-md-2.control-label{"for" => "#{prefix}_kubevirt_token"}
+      = _('Token')
+    .col-md-4
+      %input.form-control{"type"                    => "text",
+                          "id"                      => "#{prefix}_kubevirt_token",
+                          "name"                    => "#{prefix}_kubevirt_token",
+                          "ng-model"                => "#{ng_model}.#{prefix}_kubevirt_token",
+                          "ng-required"             => true,
+                          "ng-trim"                 => false,
+                          "detect-spaces"           => "",
+                          "checkchange"             => "",
+                          "prefix"                  => prefix.to_s,
+                          "reset-validation-status" => "#{prefix}_auth_status"}
+      %span.help-block{"ng-show" => "angularForm.#{prefix}_kubevirt_token.$error.required"}
+        = _("Required")
 
 .form-group{"ng-class" => "{'has-error': angularForm.realm.$invalid}",
             "ng-if" => "emsCommonModel.emstype == 'scvmm' && emsCommonModel.default_security_protocol == 'kerberos'"}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -475,6 +475,13 @@
     miq_tabs_show_hide("#smartstate_docker_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
+%div{"ng-if" => "#{ng_model}.emstype == 'kubevirt'"}
+  :javascript
+    miq_tabs_show_hide("#amqp_tab", false);
+    miq_tabs_show_hide("#metrics_tab", false);
+    miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_init('#auth_tabs');
+    $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'vmware_cloud'"}
   :javascript
     miq_tabs_show_hide("#amqp_tab", true);


### PR DESCRIPTION
This patch modifies the infrastructure providers add/edit dialog to add
support for KubeVirt.

Initially this dialog will allow the user to type all the connection
details: host, port, TLS details and token. Eventually this dialog will
be replaced with an automatic discover mechanism in the Kubernetes and
OpenShift providers.

![kubevirt_add_provider_dialog](https://user-images.githubusercontent.com/1423971/34006119-7be4eccc-e0fd-11e7-927d-7d502790902e.png)