### PR TITLE
Show correct validation messages when ordering a service

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -49,11 +49,16 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
     } else {
       apiData = vm.dialogData;
     }
-    API.post(apiSubmitEndpoint, apiData).then(function() {
+    API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]}).then(function() {
       miqService.redirectBack(__('Order Request was Submitted'), 'info', finishSubmitEndpoint);
     }).catch(function(err) {
       miqService.sparkleOff();
-      add_flash(__('Error requesting data from server'), 'error');
+      var fullErrorMessage = err.data.error.message;
+      var allErrorMessages = fullErrorMessage.split('-')[1].split(',');
+      clearFlash();
+      _.forEach(allErrorMessages, (function(errorMessage) {
+        add_flash(errorMessage, 'error');
+      }));
       console.log(err);
       return Promise.reject(err);
     });

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -110,7 +110,7 @@ describe('dialogUserController', function() {
           expect(API.post).toHaveBeenCalledWith('submit endpoint', {
             action: 'order',
             field1: 'field1'
-          });
+          }, {skipErrors: [400]});
           done();
         });
       });
@@ -128,8 +128,10 @@ describe('dialogUserController', function() {
 
     context('when the API call fails', function() {
       beforeEach(function() {
+        var rejectionData = {data: {error: {message: "Failed! -One,Two"}}};
         spyOn(miqService, 'redirectBack');
-        spyOn(API, 'post').and.returnValue(Promise.reject('not awesome'));
+        spyOn(API, 'post').and.returnValue(Promise.reject(rejectionData));
+        spyOn(window, 'clearFlash');
         spyOn(window, 'add_flash');
       });
 
@@ -141,11 +143,21 @@ describe('dialogUserController', function() {
         });
       });
 
-      it('adds a flash message', function(done) {
+      it('clears flash messages', function(done) {
         $controller.submitButtonClicked();
 
         setTimeout(function() {
-          expect(window.add_flash).toHaveBeenCalledWith('Error requesting data from server', 'error');
+          expect(window.clearFlash).toHaveBeenCalled();
+          done();
+        });
+      });
+
+      it('adds flash messages for each message after the -', function(done) {
+        $controller.submitButtonClicked();
+
+        setTimeout(function() {
+          expect(window.add_flash).toHaveBeenCalledWith('One', 'error');
+          expect(window.add_flash).toHaveBeenCalledWith('Two', 'error');
           done();
         });
       });


### PR DESCRIPTION
This fixes an issue where the UI was popping up a modal with the rejected request with errors when it should've been handled gracefully with error flash notifications.

https://bugzilla.redhat.com/show_bug.cgi?id=1518895

Before
![screen shot 2017-12-13 at 9 17 27 am](https://user-images.githubusercontent.com/164557/33952386-80f76d2e-dfe6-11e7-9073-b0d339dc6093.png)

After
![screen shot 2017-12-13 at 9 15 51 am](https://user-images.githubusercontent.com/164557/33952387-811335f4-dfe6-11e7-89ec-279a52090ce6.png)

@miq-bot add_label gaprindashvili/yes, bug, blocker

Thanks @syncrou for the help!

@himdel Can you review?
@miq-bot assign @h-kataria 