### PR TITLE
CloudSubnetNew button: fix class name

### DIFF
--- a/app/helpers/application_helper/button/cloud_subnet_new.rb
+++ b/app/helpers/application_helper/button/cloud_subnet_new.rb
@@ -8,6 +8,6 @@ class ApplicationHelper::Button::CloudSubnetNew < ApplicationHelper::Button::But
 
   # disable button if no active providers support create action
   def disabled?
-    EmsNetwork.all.none? { |ems| CloudSubnet.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.none? { |ems| CloudSubnet.class_by_ems(ems).supports_create? }
   end
 end


### PR DESCRIPTION
This is to avoid the following error:
```
Error caught: [ActionView::Template::Error] undefined method `all' for ApplicationHelper::Button::EmsNetwork:Class
app/helpers/application_helper/button/cloud_subnet_new.rb:11:in `disabled?'
app/helpers/application_helper/button/basic.rb:50:in `calculate_properties'
...
```

For some reason, this error would show only in gaprindashvili branch, but I'd much rather have it fixed in both master & gaprindashvili.