### PR TITLE
Change getTrustedHtml to trustAsHtml in report Dashboard

### DIFF
--- a/app/assets/javascripts/components/widget-report.js
+++ b/app/assets/javascripts/components/widget-report.js
@@ -9,7 +9,7 @@ ManageIQ.angular.app.component('widgetReport', {
 
     this.$onInit = function() {
       $http.get('/dashboard/widget_report_data/' + vm.id)
-        .then(function(response) { vm.widgetReportModel.content = $sce.getTrustedHtml(response.data.content);})
+        .then(function(response) { vm.widgetReportModel.content = $sce.trustAsHtml(response.data.content);})
         .catch(miqService.handleFailure);
       vm.div_id = "dd_w" + vm.id + "_box";
     };


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/1805

`getTrustedHtml` eats `DoNav` in HTML that is fetched from db so it cannot be used :(

Cloud Intel -> Dashboards -> some report widget like Top Storage Consumers -> try click any Vm/Instance
Before:
*Nothing happens*
<img width="647" alt="screen shot 2017-12-14 at 11 44 11 am" src="https://user-images.githubusercontent.com/9210860/33992360-7f2e8b20-e0d2-11e7-9ba6-a82b83122e20.png">
After:
*Redirected to Vm/Instance summary page*
<img width="622" alt="screen shot 2017-12-14 at 11 43 05 am" src="https://user-images.githubusercontent.com/9210860/33992353-7c6036aa-e0d2-11e7-93ac-4290e32d0af4.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1525648

@miq-bot add_label bug, blocker, gaprindashvili/yes, dashboards