### PR TITLE
Fix for Dynamic dialogs triggering HTTP auth popup in classic ui

### DIFF
--- a/app/assets/javascripts/services/dialog_field_refresh_service.js
+++ b/app/assets/javascripts/services/dialog_field_refresh_service.js
@@ -1,6 +1,4 @@
-ManageIQ.angular.app.service('dialogFieldRefreshService', ['miqService', function(miqService) {
-  this.areFieldsBeingRefreshed = false;
-
+ManageIQ.angular.app.service('dialogFieldRefreshService', ['API', function(API) {
   this.refreshField = function(dialogData, dialogField, url, idList) {
     this.areFieldsBeingRefreshed = true;
     var data = angular.toJson({
@@ -15,7 +13,7 @@ ManageIQ.angular.app.service('dialogFieldRefreshService', ['miqService', functio
     });
 
     return new Promise(function(resolve) {
-      miqService.jqueryRequest(url + idList.dialogId, {data: data, dataType: 'json'}).then(function(response) {
+      API.post(url + idList.dialogId, data).then(function(response) {
         resolve(response.result[dialogField]);
         if ($.active < 1) {
           this.areFieldsBeingRefreshed = false;

--- a/spec/javascripts/services/dialog_field_refresh_service_spec.js
+++ b/spec/javascripts/services/dialog_field_refresh_service_spec.js
@@ -1,11 +1,11 @@
 describe('dialogFieldRefreshService', function() {
-  var testDialogFieldRefreshService, miqService;
+  var testDialogFieldRefreshService, API;
 
   beforeEach(module('ManageIQ'));
 
-  beforeEach(inject(function(dialogFieldRefreshService, _miqService_) {
+  beforeEach(inject(function(dialogFieldRefreshService, _API_) {
     testDialogFieldRefreshService = dialogFieldRefreshService;
-    miqService = _miqService_;
+    API = _API_;
 
     var responseResult = {
       result: {
@@ -13,7 +13,7 @@ describe('dialogFieldRefreshService', function() {
       }
     };
 
-    spyOn(miqService, 'jqueryRequest').and.callFake(function() {
+    spyOn(API, 'post').and.callFake(function() {
       return {then: function(response) { response(responseResult); }};
     });
   }));
@@ -45,7 +45,7 @@ describe('dialogFieldRefreshService', function() {
       expect(refreshPromise instanceof Promise).toBe(true);
     });
 
-    it('uses a jqueryRequest', function() {
+    it('uses a post on the API', function() {
       var requestData = {
         action: 'refresh_dialog_fields',
         resource: {
@@ -57,10 +57,7 @@ describe('dialogFieldRefreshService', function() {
         }
       };
 
-      expect(miqService.jqueryRequest).toHaveBeenCalledWith('url123', {
-        data: JSON.stringify(requestData),
-        dataType: 'json'
-      });
+      expect(API.post).toHaveBeenCalledWith('url123', JSON.stringify(requestData));
     });
 
     it('resolves the promise with the results', function() {


### PR DESCRIPTION
This PR switches out the API call from `miqService.jqueryRequest` to `API.post`. The old way I believe doesn't have the right authentication context when calling to the API and is intended to be used on non-API calls.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1525686

@miq-bot add_label gaprindashvili/yes, bug, blocker

@miq-bot assign @h-kataria 
@d-m-u Can you review, please?