### PR TITLE
miq_token - move API auth from sessionStorage to localStorage

### DIFF
--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -62,7 +62,7 @@
       skipLoginRedirect: true,
     })
     .then(function(response) {
-      sessionStorage.miq_token = response.auth_token;
+      localStorage.miq_token = response.auth_token;
     });
   };
 
@@ -71,7 +71,7 @@
   };
 
   API.logout = function() {
-    if (sessionStorage.miq_token) {
+    if (localStorage.miq_token) {
       API.delete('/api/auth', {
         skipErrors: [401],
         skipLoginRedirect: true,
@@ -79,7 +79,7 @@
     }
 
     API.ws_destroy();
-    delete sessionStorage.miq_token;
+    delete localStorage.miq_token;
   };
 
   API.autorenew = function() {
@@ -150,9 +150,9 @@
       o.headers['X-Auth-Skip-Token-Renewal'] = 'true';
     }
 
-    if (sessionStorage.miq_token) {
+    if (localStorage.miq_token) {
       o.headers = o.headers || {};
-      o.headers['X-Auth-Token'] = sessionStorage.miq_token;
+      o.headers['X-Auth-Token'] = localStorage.miq_token;
     }
 
     if (o.headers) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -737,7 +737,7 @@ function miqAjaxAuthSso(url) {
 
   // Note: /dashboard/kerberos_authenticate creates an API token
   //       based on the authenticated external user
-  //       and stores it in sessionStore.miq_token
+  //       and stores it in localStorage.miq_token
 
   miqJqueryRequest(url || '/dashboard/kerberos_authenticate', {
     beforeSend: true,
@@ -751,7 +751,7 @@ function miqAjaxExtAuth(url) {
 
   // Note: /dashboard/external_authenticate creates an API token
   //       based on the authenticated external user
-  //       and stores it in sessionStore.miq_token
+  //       and stores it in localStorage.miq_token
 
   var credentials = {
     login: $('#user_name').val(),

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -538,7 +538,7 @@ class DashboardController < ApplicationController
       miq_api_token = require_api_token ? generate_ui_api_token(user[:name]) : nil
       render :update do |page|
         page << javascript_prologue
-        page << "sessionStorage.miq_token = '#{j_str miq_api_token}';" if miq_api_token
+        page << "localStorage.miq_token = '#{j_str miq_api_token}';" if miq_api_token
         page.redirect_to(validation.url)
       end
     when :fail

--- a/app/views/dashboard/saml_login.html.haml
+++ b/app/views/dashboard/saml_login.html.haml
@@ -8,7 +8,7 @@
     - if api_auth_token && validation_url
       :javascript
         miqFlashClearSaved();
-        sessionStorage.miq_token = '#{j_str api_auth_token}';
+        localStorage.miq_token = '#{j_str api_auth_token}';
         window.location = '#{j_str validation_url}';
     - else
       :javascript


### PR DESCRIPTION
sessionStorage is tab-local, so new browser tabs opened from manageiq now immediately log off (since we started logging off on API authentication failures - https://github.com/ManageIQ/manageiq-ui-classic/pull/2715)

To fix this, moving `miq_token` to `localStorage` which is persistent.

(Note: this also means the token won't be forgotten on closing the tab, and may still be used until it expires on the backend, there should be no change in visibility though.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1528326

Cc @martinpovolny, @abellotti 

---

Testing:

1. log in to manageiq
2. open a menu link in a new tab

Before:

the new tab immediately goes to the login screen

After:

the link is opened in the new tab