### PR TITLE
Add spec test for rendering form expression buttons

### DIFF
--- a/spec/views/report/_form_expression_buttons.html.haml_spec.rb
+++ b/spec/views/report/_form_expression_buttons.html.haml_spec.rb
@@ -1,0 +1,30 @@
+describe 'report/_form_filter.html.haml' do
+  let(:report) { FactoryGirl.create(:miq_report) }
+  let(:exp_table) { [["Example AFTER \"value1\"", 1]] }
+  let(:expression) { {"after" => {"field" => "field_example", "value" => "value1"}, :token => 1} }
+  let(:edit) { { :rpt_id => report.id, :record_filter => {:exp_table => exp_table, :expression => expression}} }
+
+  before do
+    assign(:expkey, :record_filter)
+    assign(:edit, edit)
+  end
+
+  it 'renders form expression buttons for other report and Edit Display Filter button' do
+    render :partial => 'report/form_expression_buttons',
+           :locals  => {:create_label  => _('Create Display Filter'),
+                        :display_label => _('Edit Display Filter')}
+    expect(rendered).to match(/Edit Display Filter/)
+  end
+
+  context 'Create Display Filter button' do
+    let(:exp_table) { [["???", 1]] }
+    let(:expression) { {"???" => "???", :token => 1} }
+
+    it 'renders form expression buttons for other report and Create Display Filter button' do
+      render :partial => 'report/form_expression_buttons',
+             :locals  => {:create_label  => _('Create Display Filter'),
+                          :display_label => _('Edit Display Filter')}
+      expect(rendered).to match(/Create Display Filter/)
+    end
+  end
+end


### PR DESCRIPTION
Add spec test for fix in https://github.com/ManageIQ/manageiq-ui-classic/pull/3033, for rendering form expression buttons to display Filter tab properly, when editing report in Cloud Intel -> Reports -> Reports tab.