### PR TITLE
Passing in `@in_a_form` to report_data call

### DIFF
--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -18,6 +18,7 @@ class ApplicationController
     :embedded,
     :showlinks,
     :policy_sim,
+    :in_a_form,
     :lastaction,
     :display
   ) do
@@ -41,6 +42,7 @@ class ApplicationController
       self.showlinks  = options[:showlinks]
       self.policy_sim = options[:policy_sim]
       self.lastaction = options[:lastaction]
+      self.in_a_form  = options[:in_a_form]
       self.display    = options[:display]
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1634,6 +1634,7 @@ module ApplicationHelper
       :showlinks  => @showlinks,
       :policy_sim => @policy_sim,
       :lastaction => @lastaction,
+      :in_a_form  => @in_a_form,
       :display    => @display
     )
     @report_data_additional_options.with_row_button(@row_button) if @row_button
@@ -1674,6 +1675,10 @@ module ApplicationHelper
     # we also need to pass the @display because @display passed throught the
     # session does not persist the null value
     @display = quadicon_options[:display]
+
+    # need to pass @in_a_form so get_view does not set advanced search options
+    # in the forms that render gtl that mess up @edit
+    @in_a_form = quadicon_options[:in_a_form]
   end
 
   # Wrapper around jquery-rjs' remote_function which adds an extra .html_safe()

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -588,4 +588,26 @@ describe VmInfraController do
     controller.send(:disable_check?, wf)
     expect(response.status).to eq(200)
   end
+
+  it "should not add search variables in @edit[:new] when rendering Policy assignment form" do
+    controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
+    controller.instance_variable_set(:@_params,
+                                     :pressed                => "vm_protect",
+                                     "check_#{vm_vmware.id}" => "1",
+                                     :active_tree            => "vandt_tree",
+                                     :model_name             => "VmOrTemplate",
+                                     :model                  => "VmOrTemplate",
+                                     :explorer               => true,
+                                     :additional_options     => {:in_a_form => true}
+    )
+    edit = {:new => {}, :current => {}}
+    controller.instance_variable_set(:@sb, {})
+    controller.instance_variable_set(:@edit, edit)
+    session[:edit] = edit
+    allow(controller).to receive(:assign_policies)
+    allow(controller).to receive(:replace_right_cell)
+    controller.send(:x_button)
+    controller.report_data
+    expect(assigns(:edit)[:new]).to_not include(:expression)
+  end
 end


### PR DESCRIPTION
Added changes to pass in `@in_a_form` so gtl_view does not set advanced search variables in @edit while rendering forms such as Policy Assignment form.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1524862

@dclarizio @martinpovolny please review.