### PR TITLE
Re-enable Cloud Provider C&U data collection

### DIFF
--- a/app/views/ops/_settings_cu_collection_tab.html.haml
+++ b/app/views/ops/_settings_cu_collection_tab.html.haml
@@ -10,7 +10,6 @@
         %fieldset
           %h3
             = clusters_title
-          - if @cluster_tree.present?
             .form-group
               %label.col-md-4.control-label
                 = _("Collect for All %{clusters}") % {:clusters => clusters_title}
@@ -21,36 +20,38 @@
                 miqInitBootstrapSwitch('all_clusters', "#{url}")
             .note
               %b= _("Note: Collect for All %{clusters} must be checked to be able to collect C & U data from Cloud Providers such as Red Hat OpenStack or Amazon EC2") % {:clusters => clusters_title}
-            #clusters_div{:style => "display:#{@edit[:new][:all_clusters] ? "none" : ""}"}
-              - cluster_title = title_for_cluster
-              - if @edit[:new][:clusters].blank? && @edit[:new][:non_cl_hosts].blank?
-                = _("No %{clusters} found in the current region.") % {:clusters => clusters_title}
-              - else
-                %br/
-                %b= _("Enable Collection by %{clusters}") % {:clusters => cluster_title}
-                %br/
-                %input#cl_toggle{:name => "cl_toggle", :onchange => "miqCheckCUAll(this,'#{@cluster_tree.name}');", :type => "checkbox"}/
-                = _("Check All")
-                :javascript
-                  miqTreeResetState('#{j_str @cluster_tree.name}');
-                = render(:partial => 'shared/tree', :locals => {:tree => @cluster_tree, :name => @cluster_tree.name})
-                %br/
-                .note= _("VM data will be collected for VMs under selected %{hosts} only. Data is collected for a %{cluster} and all of its %{hosts} when at least one %{host} is selected.") % {:hosts => title_for_hosts, :cluster => cluster_title, :host => title_for_host}
-          - else
-            .note
-              %b= _("Note: No %{clusters} available.") % {:clusters => clusters_title}
+            - if @cluster_tree.present?
+              #clusters_div{:style => "display:#{@edit[:new][:all_clusters] ? "none" : ""}"}
+                - cluster_title = title_for_cluster
+                - if @edit[:new][:clusters].blank? && @edit[:new][:non_cl_hosts].blank?
+                  = _("No %{clusters} found in the current region.") % {:clusters => clusters_title}
+                - else
+                  %br/
+                  %b= _("Enable Collection by %{clusters}") % {:clusters => cluster_title}
+                  %br/
+                  %input#cl_toggle{:name => "cl_toggle", :onchange => "miqCheckCUAll(this,'#{@cluster_tree.name}');", :type => "checkbox"}/
+                  = _("Check All")
+                  :javascript
+                    miqTreeResetState('#{j_str @cluster_tree.name}');
+                  = render(:partial => 'shared/tree', :locals => {:tree => @cluster_tree, :name => @cluster_tree.name})
+                  %br/
+                  .note= _("VM data will be collected for VMs under selected %{hosts} only. Data is collected for a %{cluster} and all of its %{hosts} when at least one %{host} is selected.") % {:hosts => title_for_hosts, :cluster => cluster_title, :host => title_for_host}
+            - else
+              %br/
+              .note
+                %b= _("Note: No %{clusters} available.") % {:clusters => clusters_title}
       .col-md-12.col-lg-6
         %fieldset
           %h3= _("Datastores")
+          .form-group
+            %label.col-md-4.control-label
+              = _("Collect for All Datastores")
+            .col-md-8
+              = check_box_tag("all_storages", true, @edit[:new][:all_storages],
+                "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :data => {:on_text => _('Yes'), :off_text => _('No')})
+            :javascript
+              miqInitBootstrapSwitch('all_storages', "#{url}")
           - if @datastore_tree.present?
-            .form-group
-              %label.col-md-4.control-label
-                = _("Collect for All Datastores")
-              .col-md-8
-                = check_box_tag("all_storages", true, @edit[:new][:all_storages],
-                  "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :data => {:on_text => _('Yes'), :off_text => _('No')})
-              :javascript
-                miqInitBootstrapSwitch('all_storages', "#{url}")
             #storages_div{:style => "display:#{@edit[:new][:all_storages] ? "none" : ""}"}
               - if @edit[:new][:storages].blank?
                 = _("No Datastores found in the current region.")


### PR DESCRIPTION
Updated conditional checking for nil trees to allow 'Collect for all Clusters/Datastores' to be accessible for Cloud Provider CU collection.

@miq-bot add_labels bug, blocker, compute/cloud

https://bugzilla.redhat.com/show_bug.cgi?id=1525296