### PR TITLE
Enables Save button when the SmartState Docker EC2 form is valid

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -517,7 +517,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         default: {},
         amqp: {},
         console: {},
-        smartstate_docker: {},
         metrics: {},
         ssh_keypair: {},
         prometheus_alerts: {},

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -15,6 +15,7 @@
 - ng_show_password       ||= true
 - guid_regex             ||= false
 - vm_scope               ||= false
+- validate_button        ||= true
 - main_scope            = vm_scope ? "$parent.vm" : "$parent"
 
 %div{"ng-controller" => "CredentialsController as vm", "vm-scope" => "$parent.vm.model ? $parent.vm : $parent"}
@@ -72,7 +73,7 @@
           = change_stored_password
         %a{:href => "", "ng-show" => "vm.bChangeStoredPassword", "ng-click" => "vm.cancelPasswordChange()"}
           = cancel_password_change
-  %div{"ng-show" => "#{ng_show}"}
+  %div{"ng-show" => "#{ng_show}", "ng-if" => "#{validate_button}"}
     .form-group
       %label.col-md-2
       .col-md-4

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -9,7 +9,7 @@
   - validate = "#{main_scope}.validateClicked({target: '.validate_button:visible'}, '#{valtype}', true, angularForm, '#{url_for_only_path(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
 - else
   - validate = "#{main_scope}.validateClicked('#{url_for_only_path(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
-%div{"ng-hide" => "#{main_scope}.currentTab === 'smartstate_docker'"}
+%div{"ng-show" => ng_show}
   %miq-button{:class           => 'validate_button',
               :name            => _("Validate"),
               "disabled-title" => verify_title_off,

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -177,6 +177,7 @@
                                                 :change_stored_password => _("Change stored SmartState Docker password"),
                                                 :cancel_password_change => _("Cancel SmartState Docker password change"),
                                                 :verify_title_off       => _("Docker Registry User Name and Password for SmartState Analysis on AWS"),
+                                                :validate_button        => "false",
                                                 :basic_info_needed      => true}
         .form-group
           .col-md-12

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -146,6 +146,17 @@ describe('emsCommonFormController', function() {
     it('sets the default_password', function() {
       expect($scope.emsCommonModel.default_password).toEqual(miqService.storedPasswordPlaceholder);
     });
+
+    it('initializes $scope.postValidationModel with credential objects for only those providers that support validation', function () {
+      $scope.postValidationModelRegistry('default');
+      expect($scope.postValidationModel).toEqual(jasmine.objectContaining({
+        default: jasmine.objectContaining({provider_region: 'ap-southeast-2'}),
+        console: jasmine.objectContaining({console_userid: undefined}),
+        amqp: {},
+        metrics: {},
+        ssh_keypair: {},
+        prometheus_alerts: {}}));
+    });
   });
 
   describe('when the emsCommonFormId is an Openstack Id', function() {


### PR DESCRIPTION
Adjustments around the new `SmartState Docker` for EC2.

Includes -
- Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1525515, which enables the Save button
- Removes provider-specific code in `_form_buttons_verify_angular.html.haml`, to keep it generic
- Provisions for a use case where Validation button should not be rendered (like the `SmartState Docker` case)
