### PR TITLE
Switched fields around on the form/summary screen.

### DIFF
--- a/app/views/miq_ae_class/_angular_inputs_form.html.haml
+++ b/app/views/miq_ae_class/_angular_inputs_form.html.haml
@@ -14,6 +14,12 @@
           %span.help-block{"ng-show" => "#{ng_model}.#{prefix}_key === ''"}
             = _("Required")
         %td
+          %select{"ng-model" => "#{ng_model}.#{prefix}_type",
+                  "name"       => "#{prefix}_type",
+                  'ng-options' => "v as v for v in #{ng_model}.available_datatypes",
+                  'ng-change'  => '',
+                  "pf-select"  => true}
+        %td
           %input{:type         => "text",
                  'ng-model'    => "#{ng_model}.#{prefix}_value",
                  'ng-if'       => "#{ng_model}.#{prefix}_type != 'password'",
@@ -26,12 +32,6 @@
                  'ng-model'    => "#{ng_model}.#{prefix}_value",
                  "placeholder" => placeholder_if_present("#{ng_model}.#{prefix}_value"),
                  "ng-change" => ""}
-        %td
-          %select{"ng-model" => "#{ng_model}.#{prefix}_type",
-                  "name"       => "#{prefix}_type",
-                  'ng-options' => "v as v for v in #{ng_model}.available_datatypes",
-                  'ng-change'  => '',
-                  "pf-select"  => true}
         %td{"ng-if" => "#{ng_model}.#{prefix}_key != ''"}
           %button{:class     => "btn btn-link",
                   :type      => "button",
@@ -48,9 +48,9 @@
             %th
               = _("Input Name")
             %th
-              = _("Default value")
-            %th
               = _("Data Type")
+            %th
+              = _("Default value")
             %th
               = _("Actions")
           %tbody
@@ -63,6 +63,14 @@
                                     'ng-model'    => "#{ng_model}.key",
                                     "ng-change" => "",
                                     "miqrequired" => ""}
+              %td{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)"}
+                {{arr[2]}}
+              %td{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}
+                %select.form-control{"ng-model"   => "#{ng_model}.key_type",
+                                     "name"       => "key_type",
+                                     'ng-options' => "v as v for v in #{ng_model}.available_datatypes",
+                                     "ng-change"  => '',
+                                     "pf-select"  => true}
               %td{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)"}
                 {{arr[2] == 'password' ? '******' : arr[1]}}
               %td{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}
@@ -77,14 +85,6 @@
                                     'ng-model'    => "#{ng_model}.key_value",
                                     "placeholder" => placeholder_if_present("#{ng_model}.key_value"),
                                     "ng-change" => ""}
-              %td{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)"}
-                {{arr[2]}}
-              %td{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}
-                %select.form-control{"ng-model"   => "#{ng_model}.key_type",
-                                     "name"       => "key_type",
-                                     'ng-options' => "v as v for v in #{ng_model}.available_datatypes",
-                                     "ng-change"  => '',
-                                     "pf-select"  => true}
 
               %td.table-view-pf-select
                 %div{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}

--- a/app/views/miq_ae_class/_inputs.html.haml
+++ b/app/views/miq_ae_class/_inputs.html.haml
@@ -7,8 +7,8 @@
     %tr
       %th.table-view-pf-select
       %th= _('Name')
-      %th= _('Default Value')
       %th= _('Data Type')
+      %th= _('Default Value')
   %tbody
     - @edit[:new][:fields].each_with_index do |flds, i|
       - unless @edit[:fields_to_delete].include?(flds["id"])
@@ -28,6 +28,10 @@
               :maxlength         => 50,
               "data-miq_observe" => obs)
           %td
+            = select_tag("#{prefix}fields_datatype_#{i}",
+              options_for_select(@edit[:new][:available_datatypes], flds["datatype"]),
+              "data-miq_observe" => {:url => url}.to_json)
+          %td
             = text_field_tag("#{prefix}fields_value_#{i}", flds["default_value"],
               :style             => flds["datatype"] == "password" ? "display:none" : "",
               "data-miq_observe" => obs)
@@ -35,10 +39,6 @@
               :placeholder       => placeholder_if_present(flds['default_value']),
               :style             => flds["datatype"] == "password" ? "" : "display:none",
               "data-miq_observe" => obs)
-          %td
-            = select_tag("#{prefix}fields_datatype_#{i}",
-              options_for_select(@edit[:new][:available_datatypes], flds["datatype"]),
-              "data-miq_observe" => {:url => url}.to_json)
     - if !params[:add] && params[:add] != "new" && session[:field_data].blank?
       %tr{:title => _("Click to add a new parameter"),
         :onclick => remote_function(:url => {:action => 'field_method_select', :add => 'new', :item => "field"})}
@@ -65,6 +65,8 @@
             session[:field_data][:name],
             "data-miq_observe" => obs)
         %td
+          = select_tag("#{prefix}field_datatype", options_for_select(@edit[:new][:available_datatypes], session[:field_data][:datatype]), "data-miq_observe" => {:url => url}.to_json)
+        %td
           = text_field_tag("#{prefix}field_default_value",
             session[:field_data][:default_value],
             :style             => session[:field_data][:datatype] == "password" ? "display:none" : "",
@@ -73,5 +75,3 @@
             :placeholder       => placeholder_if_present(session[:field_data][:data_value]),
             :style             => session[:field_data][:datatype] == "password" ? "" : "display:none",
             "data-miq_observe" => obs)
-        %td
-          = select_tag("#{prefix}field_datatype", options_for_select(@edit[:new][:available_datatypes], session[:field_data][:datatype]), "data-miq_observe" => {:url => url}.to_json)

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -68,15 +68,15 @@
         %thead
           %tr
             %th= _('Input Name')
-            %th= _('Default Value')
             %th= _('Data Type')
+            %th= _('Default Value')
         %tbody
           - @record.inputs.each do |record|
             %tr
               %td= record_name(record)
+              %td= record.datatype.blank? ? 'string' : record.datatype
               %td
                 - if record.datatype == 'password'
                   ********
                 - else
                   = record.default_value
-              %td= record.datatype.blank? ? 'string' : record.datatype


### PR DESCRIPTION
After user entered data in Default value field and then switched Data Type drop down value, form resets Default Value field to be empty which was causing confusion. By switching fields around user will first pick data type and then enter data in Default Value field.
To be consistent switched fields on both Ansible/Non-Ansible forms.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1525584

before:
![before](https://user-images.githubusercontent.com/3450808/34014677-140ae7cc-e0ea-11e7-9fb6-c291b5ba1758.png)
![before1](https://user-images.githubusercontent.com/3450808/34014681-17574f9c-e0ea-11e7-8169-3673c7253925.png)

after:
![after](https://user-images.githubusercontent.com/3450808/34014684-1a87c016-e0ea-11e7-8882-db32fbd10bec.png)
![after_1](https://user-images.githubusercontent.com/3450808/34014691-1d843704-e0ea-11e7-9407-db46877702e1.png)
![after3](https://user-images.githubusercontent.com/3450808/34014694-1f7b952a-e0ea-11e7-8283-66ae40b00939.png)


@mkanoor please review.