### PR TITLE
Fixes Custom Button Group page header text

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -214,7 +214,7 @@ module ApplicationController::Buttons
   def ab_group_delete
     assert_privileges("ab_group_delete")
     if x_node.split('_').last == "ub"
-      add_flash(_("'Unassigned Buttons Group' can not be deleted"), :error)
+      add_flash(_("'Unassigned Button Group' can not be deleted"), :error)
       get_node_info
       replace_right_cell(:nodetype => x_node)
       return
@@ -668,7 +668,7 @@ module ApplicationController::Buttons
         CustomButtonSet.new :
         CustomButtonSet.find(from_cid(params[:id]))
     if typ == "edit" && x_node.split('_').last == "ub"
-      add_flash(_("'Unassigned Buttons Group' can not be edited"), :error)
+      add_flash(_("'Unassigned Button Group' can not be edited"), :error)
       get_node_info
       replace_right_cell(:nodetype => x_node)
       return

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -406,7 +406,7 @@ class MiqAeCustomizationController < ApplicationController
 
   def right_cell_text_for_node(record, model_name)
     if record && record.id
-      _("Editing %{model} \"%{name}\"") % {:name  => record.name,
+      _("Editing %{model} \"%{name}\"") % {:name  => record.kind_of?(CustomButtonSet) ? record.name.split("|").first : record.name,
                                            :model => ui_lookup(:model => model_name)}
     else
       _("Adding a new %{model}") % {:model => ui_lookup(:model => model_name)}


### PR DESCRIPTION
@miq-bot add_labels "pending core"

Fixes page header text by stripping off parent class name prior to display, see screen shot prior and post code fix below.

Dependent on Core PR: https://github.com/ManageIQ/manageiq/pull/16664
 
https://bugzilla.redhat.com/show_bug.cgi?id=1516836

Screen shot prior to code fix:
![custom button group edit page prior to code fix](https://user-images.githubusercontent.com/552686/34015090-45267a5a-e0d2-11e7-9ac9-f6e1aaa1f257.png)

Screen shot post code fix:
![custom button group edit page post code fix](https://user-images.githubusercontent.com/552686/34015110-510d5d98-e0d2-11e7-98ec-5aaa96f7a6ef.png)

