### PR TITLE
Target for mass VM transformation dialog

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -21,6 +21,8 @@ module ApplicationController::CiProcessing
     include Mixins::Actions::HostActions::Power
     include Mixins::Actions::HostActions::Misc
 
+    include Mixins::Actions::ProviderActions::MassTransform
+
     include Mixins::ExplorerShow
   end
 
@@ -1073,6 +1075,7 @@ module ApplicationController::CiProcessing
     when "instance_add_security_group"      then add_security_group_vms
     when "instance_remove_security_group"   then remove_security_group_vms
     when "vm_transform"                     then vm_transform
+    when "vm_transform_mass"                then vm_transform_mass
     end
   end
 end

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -69,6 +69,7 @@ module ApplicationController::Explorer
     'tag'          => :s2, 'timeline'         => :s2, 'resize'          => :s2,
     'live_migrate' => :s2, 'attach'           => :s2, 'detach'          => :s2,
     'evacuate'     => :s2, 'service_dialog'   => :s2, 'transform'       => :s2,
+    'transform_mass'           => :s2,
     'associate_floating_ip'    => :s2,
     'disassociate_floating_ip' => :s2,
     'add_security_group'       => :s2,

--- a/app/controllers/mixins/actions/provider_actions/mass_transform.rb
+++ b/app/controllers/mixins/actions/provider_actions/mass_transform.rb
@@ -1,0 +1,56 @@
+module Mixins
+  module Actions
+    module ProviderActions
+      module MassTransform
+        def vm_transform_mass
+          dialog = Dialog.find_by!(:label => 'Transform VM')
+          @right_cell_text = _("Transform VMs to RHV")
+          if params.key?(:id)
+            provider = ExtManagementSystem.find_by!(:id => params[:id].to_i)
+            dialog_initialize(
+              dialog.resource_actions.first,
+              :header     => @right_cell_text,
+              :target_id  => provider.id,
+              :target_kls => Provider.name
+            )
+          else
+            provider = ExtManagementSystem.find_by!(:type => 'ManageIQ::Providers::Redhat::InfraManager')
+            simple_dialog_initialize(
+              dialog.resource_actions.first,
+              :header => @right_cell_text,
+              :target => provider
+            )
+          end
+        end
+
+        private
+
+        def simple_dialog_initialize(ra, options)
+          @record = Dialog.find_by(:id => ra.dialog_id.to_i)
+          new = options[:dialog] || {}
+          id = @record.try(:id)
+          opts = {
+            :target => options[:target]
+          }
+          @edit = {
+            :new             => new,
+            :wf              => ResourceActionWorkflow.new(new, current_user, ra, opts),
+            :rec_id          => id,
+            :key             => "dialog_edit__#{id || "new"}",
+            :explorer        => @explorer || false,
+            :dialog_mode     => options[:dialog_mode],
+            :current         => copy_hash(new),
+            :right_cell_text => options[:header].to_s
+          }
+          @in_a_form = true
+          @changed = session[:changed] = true
+          if @edit[:explorer]
+            replace_right_cell(:action => "dialog_provision")
+          else
+            javascript_redirect(:action => 'dialog_load')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/mixins/actions/vm_actions/transform.rb
+++ b/app/controllers/mixins/actions/vm_actions/transform.rb
@@ -4,22 +4,14 @@ module Mixins
       module Transform
         def vm_transform
           dialog = Dialog.find_by(:label => 'Transform VM')
-          if params.key?(:id)
-            vm = Vm.find_by(:id => params[:id].to_i)
-            @right_cell_text = _("Transform VM %{name} to RHV") % {:name => vm.name}
-            dialog_initialize(
-              dialog.resource_actions.first,
-              :header     => @right_cell_text,
-              :target_id  => vm.id,
-              :target_kls => Vm.name
-            )
-          else
-            @right_cell_text = _("Transform VMs to RHV")
-            simple_dialog_initialize(
-              dialog.resource_actions.first,
-              :header => @right_cell_text
-            )
-          end
+          vm = Vm.find_by(:id => params[:id].to_i)
+          @right_cell_text = _("Transform VM %{name} to RHV") % {:name => vm.name}
+          dialog_initialize(
+            dialog.resource_actions.first,
+            :header     => @right_cell_text,
+            :target_id  => vm.id,
+            :target_kls => Vm.name
+          )
         end
       end
     end

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -73,27 +73,4 @@ class VmInfraController < ApplicationController
 
   menu_section :inf
   has_custom_buttons
-
-  def simple_dialog_initialize(ra, options)
-    @record = Dialog.find_by(:id => ra.dialog_id.to_i)
-    new = options[:dialog] || {}
-    id = @record.try(:id)
-    @edit = {
-      :new             => new,
-      :wf              => ResourceActionWorkflow.new(new, current_user, ra, {}),
-      :rec_id          => id,
-      :key             => "dialog_edit__#{id || "new"}",
-      :explorer        => @explorer || false,
-      :dialog_mode     => options[:dialog_mode],
-      :current         => copy_hash(new),
-      :right_cell_text => options[:header].to_s
-    }
-    @in_a_form = true
-    @changed = session[:changed] = true
-    if @edit[:explorer]
-      replace_right_cell(:action => "dialog_provision")
-    else
-      javascript_redirect(:action => 'dialog_load')
-    end
-  end
 end

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -190,7 +190,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :onwhen       => "1+",
           :klass        => ApplicationHelper::Button::BasicImage),
         button(
-          :vm_transform,
+          :vm_transform_mass,
           'fa fa-random fa-lg',
           t = N_('Transform tagged VMs to RHV'),
           t,

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -84,10 +84,10 @@ describe EmsInfraController do
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
-    it "when vm_transform is pressed" do
+    it "when vm_transform_mass is pressed" do
       ems_infra = FactoryGirl.create(:ems_vmware)
-      expect(controller).to receive(:vm_transform)
-      post :button, :params => {:pressed => "vm_transform", :id => ems_infra.id, :format => :js}
+      expect(controller).to receive(:vm_transform_mass)
+      post :button, :params => {:pressed => "vm_transform_mass", :id => ems_infra.id, :format => :js}
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
   end

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -354,14 +354,6 @@ describe VmInfraController do
       post :x_button, :params => {:pressed => 'vm_transform', :id => vm_vmware.id}
       expect(response.status).to eq(200)
     end
-
-    it 'can Transform VMs by tag' do
-      post :explorer
-      expect(response.status).to eq(200)
-
-      post :x_button, :params => {:pressed => 'vm_transform'}
-      expect(response.status).to eq(200)
-    end
   end
 
   it 'can Shutdown Guest' do


### PR DESCRIPTION
Created a separate vm_transform_mass action to handle VM Transform
button clicks in on Providers page and on Compute > Infrastructure >
Virtual Machines page. This action interprets the ID passed to it as
provider ID, while regular vm_transform action interprets it as VM ID.
If provider ID is not passed, the Redhat provider EMS object is used as
target.

Depends on https://github.com/ManageIQ/manageiq/pull/16686

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1514939
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1516497

(See also @mkanoor comments here: https://github.com/ManageIQ/manageiq/pull/16584#pullrequestreview-82004845)