### PR TITLE
Remove severity from Alerts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1200,14 +1200,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def severity_title(value)
-    if self.class.instance_of?(MiqPolicyController)
-      self.class::SEVERITIES[value]
-    else
-      value.titleize
-    end
-  end
-
   def listicon_item(view, id = nil)
     id = @id if id.nil?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1148,8 +1148,7 @@ class ApplicationController < ActionController::Base
         when "result"
           new_row[:cells] << {:span => result_span_class(row[col]), :text => row[col].titleize}
         when "severity"
-          value = row[col] || ' '
-          new_row[:cells] << {:span => severity_span_class(value), :text => severity_title(value)}
+          new_row[:cells] << {:span => severity_span_class(row[col]), :text => row[col].titleize}
         when 'state'
           celltext = row[col].to_s.titleize
         when 'hardware.bitness'

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -1,8 +1,6 @@
 module MiqPolicyController::Alerts
   extend ActiveSupport::Concern
 
-  SEVERITIES = {"info" => _('Info'), "warning" => _('Warning'), "error" => _('Error')}.freeze
-
   def alert_edit_cancel
     @edit = nil
     @alert = session[:edit][:alert_id] ? MiqAlert.find(session[:edit][:alert_id]) : MiqAlert.new

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -16,9 +16,9 @@ module MiqPolicyController::Alerts
   def alert_edit_save_add
     id = params[:id] && params[:button] != "add" ? params[:id] : "new"
     return unless load_edit("alert_edit__#{id}", "replace_cell__explorer")
-
     alert = @alert = @edit[:alert_id] ? MiqAlert.find(@edit[:alert_id]) : MiqAlert.new
     alert_set_record_vars(alert)
+
     unless alert_valid_record?(alert) && alert.valid? && !@flash_array && alert.save
       alert.errors.each do |field, msg|
         add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -86,7 +86,6 @@ module MiqPolicyController::Alerts
 
     @edit[:new][:description] = params[:description].blank? ? nil : params[:description] if params[:description]
     @edit[:new][:enabled] = params[:enabled_cb] == "1" if params.key?(:enabled_cb)
-    @edit[:new][:severity] = params[:miq_alert_severity] if params.key?(:miq_alert_severity)
     if params[:exp_event]
       @edit[:new][:exp_event] = params[:exp_event] == "_hourly_timer_" ? params[:exp_event] : params[:exp_event].to_i
       @edit[:new][:repeat_time] = alert_default_repeat_time
@@ -301,7 +300,6 @@ module MiqPolicyController::Alerts
 
     @edit[:new][:description] = @alert.description
     @edit[:new][:enabled] = @alert.enabled == true
-    @edit[:new][:severity] = @alert.severity
     @edit[:new][:db] = @alert.db.nil? ? "Vm" : @alert.db
     @edit[:expression_types] = MiqAlert.expression_types(@edit[:new][:db])
 
@@ -522,7 +520,6 @@ module MiqPolicyController::Alerts
   def alert_set_record_vars(alert)
     alert.description = @edit[:new][:description]
     alert.enabled = @edit[:new][:enabled]
-    alert.severity = @edit[:new][:severity]
     alert.db = @edit[:new][:db]
     unless @edit[:new][:expression][:eval_method]
       alert.expression = @edit[:new][:expression]["???"] ? nil : MiqExpression.new(@edit[:new][:expression])
@@ -562,9 +559,6 @@ module MiqPolicyController::Alerts
   def alert_valid_record?(alert)
     if alert.expression.nil?
       add_flash(_("A valid expression must be present"), :error)
-    end
-    if alert.severity.nil?
-      add_flash(_('Severity must be selected'), :error)
     end
     unless @edit[:new][:expression][:eval_method] && @edit[:new][:expression][:eval_method] != "nothing"
       add_flash(_("A Driving Event must be selected"), :error) if alert.responds_to_events.blank?

--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -32,23 +32,6 @@
             .col-md-8
               %p.form-control-static
                 = @alert.enabled ? _("Yes") : _("No")
-        .form-group
-          %label.control-label.col-md-2
-            = _("Severity")
-          - if @edit
-            .col-md-8
-              - options = [[_("<Choose>"), nil]]
-              - controller.class::SEVERITIES.each { |key, value| options.push([value, key]) }
-              = select_tag('miq_alert_severity',
-                options_for_select(options, @edit[:new][:severity]),
-                :class => "selectpicker")
-              :javascript
-                miqInitSelectPicker();
-                miqSelectPickerEvent('miq_alert_severity', '#{url}', {beforeSend: true, complete: true})
-          - else
-            .col-md-8
-              %p.form-control-static
-                = controller.class::SEVERITIES[@alert.severity]
         -# Based on (model)
         .form-group
           %label.control-label.col-md-2

--- a/product/views/MiqAlert.yaml
+++ b/product/views/MiqAlert.yaml
@@ -27,7 +27,6 @@ cols:
 - notify_snmp
 - notify_evm_event
 - notify_automate
-- severity
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -42,7 +41,6 @@ col_order:
 - notify_snmp
 - notify_evm_event
 - notify_automate
-- severity
 
 # Column titles, in order
 headers:
@@ -54,7 +52,6 @@ headers:
 - SNMP
 - Event on Timeline
 - Management Event Raised
-- Severity
 
 # Condition(s) string for the SQL query
 conditions:

--- a/spec/views/miq_policy/_alert_details.html.haml_spec.rb
+++ b/spec/views/miq_policy/_alert_details.html.haml_spec.rb
@@ -1,7 +1,6 @@
 describe "miq_policy/_alert_details.html.haml" do
   before do
     @alert = FactoryGirl.create(:miq_alert)
-    stub_const("#{controller.class}::SEVERITIES", MiqPolicyController::Alerts::SEVERITIES)
     exp = {:eval_method => 'nothing', :mode => 'internal', :options => {}}
     allow(@alert).to receive(:expression).and_return(exp)
     set_controller_for_view("miq_policy")


### PR DESCRIPTION
Reverts #2280 due to some collisions with Prometheus Alerts. It should be added back once all issues with Prometheus Alerts are resolved.
Before:
<img width="897" alt="screen shot 2017-10-03 at 4 13 19 pm" src="https://user-images.githubusercontent.com/9210860/31129780-e0164a5a-a855-11e7-8586-ca4014e781e8.png">

<img width="452" alt="screen shot 2017-10-04 at 11 02 00 am" src="https://user-images.githubusercontent.com/9210860/31167768-7e3f4ffe-a8f3-11e7-9a99-a7b338ca75bb.png">

<img width="769" alt="screen shot 2017-10-04 at 2 29 31 pm" src="https://user-images.githubusercontent.com/9210860/31175733-7ab35a20-a910-11e7-9069-ef7645858b58.png">

After:
<img width="886" alt="screen shot 2017-12-15 at 12 29 10 pm" src="https://user-images.githubusercontent.com/9210860/34040358-9c906b90-e193-11e7-8755-b64e99b86151.png">
<img width="382" alt="screen shot 2017-12-15 at 12 29 20 pm" src="https://user-images.githubusercontent.com/9210860/34040357-9c795770-e193-11e7-8ddf-d8a7cb807a7f.png">
<img width="763" alt="screen shot 2017-12-15 at 12 29 36 pm" src="https://user-images.githubusercontent.com/9210860/34040356-9c60aed2-e193-11e7-93d6-495215ea915f.png">



Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1525036

@miq-bot add_label bug, blocker, gaprindashvili/yes, control