### PR TITLE
Pull out the presenter update for custom buttons

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1324,13 +1324,15 @@ module VmCommon
         # these subviews use angular, so they need to use a special partial
         # so the form buttons on the outer frame can be updated.
         if @sb[:action] == 'dialog_provision'
-          presenter.update(:form_buttons_div, r[
-            :partial => 'layouts/x_dialog_buttons',
-            :locals  => {
-              :action_url => action,
-              :record_id  => @edit[:rec_id],
-            }
-          ])
+          if Settings.product.old_dialog_user_ui
+            presenter.update(:form_buttons_div, r[
+              :partial => 'layouts/x_dialog_buttons',
+              :locals  => {
+                :action_url => action,
+                :record_id  => @edit[:rec_id],
+              }
+            ])
+          end
         elsif %w(attach detach live_migrate resize evacuate ownership add_security_group remove_security_group
                  associate_floating_ip disassociate_floating_ip).include?(@sb[:action])
           presenter.update(:form_buttons_div, r[:partial => "layouts/angular/paging_div_buttons"])


### PR DESCRIPTION
Pulling out the presenter update for `custom_buttons`.

Huge thank you to @eclarizio for all the help - in fact I'm just the messenger with this code change

Before: 

<img width="1215" alt="screen shot 2017-12-15 at 2 31 04 pm" src="https://user-images.githubusercontent.com/697347/34057365-a41bd712-e1a4-11e7-803b-b7922458195a.png">

After:

<img width="1212" alt="screen shot 2017-12-15 at 2 32 53 pm" src="https://user-images.githubusercontent.com/697347/34057416-e112a7cc-e1a4-11e7-8db5-015ac55fa5d5.png">


Links
----------------


* [BZ 1515017](https://bugzilla.redhat.com/show_bug.cgi?id=1515017)
* Possibly related to or partially fixed by https://bugzilla.redhat.com/show_bug.cgi?id=1514593

Steps for Testing/QA
-------------------------------

1. Create an Ansible Playbook Service
2. Set up a custom button pointing to that service.
3. Go to the entity that has the button attached ( the example is using VMs.)
4. Click the button.
5. The resulting button page should look like the _After_ page.
