### PR TITLE
Display Category Deleted confirmation message

### DIFF
--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -25,6 +25,7 @@ module OpsController::Settings::Tags
       category_get_all
       render :update do |page|
         page << javascript_prologue
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page.replace_html 'settings_co_categories', :partial => 'settings_co_categories_tab'
       end
     else


### PR DESCRIPTION
Fixes display of Category Delete action confirmation message. 

https://bugzilla.redhat.com/show_bug.cgi?id=1525929

Screen shot post code fix:
![category delete confirmation msg post code fix](https://user-images.githubusercontent.com/552686/34065034-cc0da54e-e1b2-11e7-8088-5cde66795978.png)

