### PR TITLE
Services: fix styling on detail page reload.

### DIFF
--- a/app/views/service/explorer.html.haml
+++ b/app/views/service/explorer.html.haml
@@ -5,6 +5,13 @@
   -# Showing a specific Service
   #main_div
     = render :partial => "svcs_show", :locals => {:controller => "service"}
+    -# FIXME: remove sand-paper style hack when we resolve the div shared between
+    -# the GTL grid an details.
+    :javascript
+      setTimeout(function() {
+        var mainContent = $('#main-content');
+        mainContent.removeClass('miq-sand-paper');
+      });
 - else
   -# Showing a list of VMs
   #main_div


### PR DESCRIPTION
### Testing:
 * go to "Services" --> "My services"
 * click on a service to get it's details displayed (with a GTL grid showing related VMs for example)
 * press CTRL-R or reload
 * observe that the background of the main content ares is (not) grey.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1517910