### PR TITLE
Deduplicate CloudVolumeController buttons using GenericButtonMixin.

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -358,7 +358,7 @@ class CloudVolumeController < ApplicationController
         end
       end
     end
-    process_cloud_volumes(volumes_to_delete, "destroy") unless volumes_to_delete.empty?
+    delete_cloud_volumes(volumes_to_delete) unless volumes_to_delete.empty?
 
     # refresh the list if applicable
     if @lastaction == "show_list" && @breadcrumbs.last[:url].include?(@lastaction)
@@ -601,26 +601,21 @@ class CloudVolumeController < ApplicationController
     options
   end
 
-  # dispatches tasks to multiple volumes
-  def process_cloud_volumes(volumes, task)
-    return if volumes.empty?
-
-    if task == "destroy"
-      volumes.each do |volume|
-        audit = {
-          :event        => "cloud_volume_record_delete_initiateed",
-          :message      => "[#{volume.name}] Record delete initiated",
-          :target_id    => volume.id,
-          :target_class => "CloudVolume",
-          :userid       => session[:userid]
-        }
-        AuditEvent.success(audit)
-        volume.delete_volume_queue(session[:userid])
-      end
-      add_flash(n_("Delete initiated for %{number} Cloud Volume.",
-                   "Delete initiated for %{number} Cloud Volumes.",
-                   volumes.length) % {:number => volumes.length})
+  def delete_cloud_volumes(volumes)
+    volumes.each do |volume|
+      audit = {
+        :event        => "cloud_volume_record_delete_initiateed",
+        :message      => "[#{volume.name}] Record delete initiated",
+        :target_id    => volume.id,
+        :target_class => "CloudVolume",
+        :userid       => session[:userid]
+      }
+      AuditEvent.success(audit)
+      volume.delete_volume_queue(session[:userid])
     end
+    add_flash(n_("Delete initiated for %{number} Cloud Volume.",
+                 "Delete initiated for %{number} Cloud Volumes.",
+                 volumes.length) % {:number => volumes.length})
   end
 
   menu_section :bst

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -366,9 +366,6 @@ class CloudVolumeController < ApplicationController
       @refresh_partial = "layouts/gtl"
     elsif @lastaction == "show" && @layout == "cloud_volume"
       @single_delete = true unless flash_errors?
-      if @flash_array.nil?
-        add_flash(_("The selected Cloud Volume was deleted"))
-      end
     else
       drop_breadcrumb(:name => 'dummy', :url => " ") # missing a bc to get correctly back so here's a dummy
       session[:flash_msgs] = @flash_array.dup if @flash_array

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -21,25 +21,24 @@ class CloudVolumeController < ApplicationController
       delete_volumes
       return false
     when 'cloud_volume_attach'
-      javascript_redirect :action => 'attach', :id => checked_item_id
+      javascript_redirect(:action => 'attach', :id => checked_item_id)
     when 'cloud_volume_detach'
       volume = find_record_with_rbac(CloudVolume, checked_item_id)
       if volume.attachments.empty?
-        render_flash(_("Cloud Volume \"%{volume_name}\" is not attached to any Instances") % {
-                     :volume_name => volume.name}, :error)
+        render_flash(_("Cloud Volume \"%{volume_name}\" is not attached to any Instances") % {:volume_name => volume.name}, :error)
       else
-        javascript_redirect :action => 'detach', :id => checked_item_id
+        javascript_redirect(:action => 'detach', :id => checked_item_id)
       end
     when 'cloud_volume_edit'
-      javascript_redirect :action => 'edit', :id => checked_item_id
+      javascript_redirect(:action => 'edit', :id => checked_item_id)
     when 'cloud_volume_snapshot_create'
-      javascript_redirect :action => 'snapshot_new', :id => checked_item_id
+      javascript_redirect(:action => 'snapshot_new', :id => checked_item_id)
     when 'cloud_volume_new'
-      javascript_redirect :action => 'new'
+      javascript_redirect(:action => 'new')
     when 'cloud_volume_backup_create'
-      javascript_redirect :action => 'backup_new', :id => checked_item_id
+      javascript_redirect(:action => 'backup_new', :id => checked_item_id)
     when 'cloud_volume_backup_restore'
-      javascript_redirect :action => 'backup_select', :id => checked_item_id
+      javascript_redirect(:action => 'backup_select', :id => checked_item_id)
     else
       return false
     end
@@ -47,7 +46,7 @@ class CloudVolumeController < ApplicationController
   end
 
   def attach
-    params[:id] = checked_item_id unless params[:id].present?
+    params[:id] = checked_item_id if params[:id].blank?
     assert_privileges("cloud_volume_attach")
     @vm_choices = {}
     @volume = find_record_with_rbac(CloudVolume, params[:id])
@@ -56,11 +55,12 @@ class CloudVolumeController < ApplicationController
     @in_a_form = true
     drop_breadcrumb(
       :name => _("Attach Cloud Volume \"%{name}\"") % {:name => @volume.name},
-      :url  => "/cloud_volume/attach")
+      :url  => "/cloud_volume/attach"
+    )
   end
 
   def detach
-    params[:id] = checked_item_id unless params[:id].present?
+    params[:id] = checked_item_id if params[:id].blank?
     assert_privileges("cloud_volume_detach")
     @volume = find_record_with_rbac(CloudVolume, params[:id])
     @vm_choices = @volume.vms.each_with_object({}) { |vm, hash| hash[vm.name] = vm.id }
@@ -68,7 +68,8 @@ class CloudVolumeController < ApplicationController
     @in_a_form = true
     drop_breadcrumb(
       :name => _("Detach Cloud Volume \"%{name}\"") % {:name => @volume.name},
-      :url  => "/cloud_volume/detach")
+      :url  => "/cloud_volume/detach"
+    )
   end
 
   def attach_volume
@@ -261,7 +262,7 @@ class CloudVolumeController < ApplicationController
   end
 
   def edit
-    params[:id] = checked_item_id unless params[:id].present?
+    params[:id] = checked_item_id if params[:id].blank?
     assert_privileges("cloud_volume_edit")
     @volume = find_record_with_rbac(CloudVolume, params[:id])
     @in_a_form = true

--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -74,6 +74,11 @@ module Mixins
 
       check_if_button_is_implemented
 
+      if single_delete_test
+        single_delete_redirect
+        return
+      end
+
       if params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                   "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
         render_or_redirect_partial(pfx)


### PR DESCRIPTION
 * Deduplicate CloudVolumeController buttons using GenericButtonMixin.
 * Fixing single_delete behavior and 
 * removing dead code.

### Todo:

~~`delete_volumes` is strange.~~

 * ~~Part of the logic below `process_cloud_volumes` can never be called because there's always a flash message set.~~ (removed)
 * ~~The `@single_delete` logic does not execute (it's meant to execute when deleting an entity while displaying that entity). I don't know if it's broken due to some regression or it never worked and the code is a c-n-p remnant.~~ Fixed the `single_delete` behavior by including it in the `GenericButtonMixin`
 * ~~`process_cloud_volumes` seems to be a remnant c-n-ped from somewhere. It only knows 'destroy' so it thould be renamed and simplified.~~

@aufi: can you get someone to review and test this?





  
  
  
  