### PR TITLE
[WIP] Proposal to separate provider specific add/edit dialogs to separate files

### DIFF
--- a/app/views/ems_infra/_form.html.haml
+++ b/app/views/ems_infra/_form.html.haml
@@ -62,61 +62,6 @@
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
 
-    .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack_infra'"}
-      %label.col-md-2.control-label{"for" => "ems_api_version"}
-        = _("API Version")
-      .col-md-8
-        = select_tag('api_version',
-                     options_for_select(@openstack_api_versions),
-                     "ng-model"                    => "emsCommonModel.api_version",
-                     "checkchange"                 => "",
-                     "selectpicker-for-select-tag" => "")
-
-    .form-group{"ng-class" => "{'has-error': angularForm.host_default_vnc_port_start.$invalid}", "ng-if" => "emsCommonModel.emstype == 'vmwarews'"}
-      %label.col-md-2.control-label{"for" => "ems_vnc_start_port"}
-        = _('Host Default VNC Start Port')
-      .col-md-8
-        %input.form-control{"type"        => "text",
-                            "id"          => "ems_vnc_start_port",
-                            "name"        => "host_default_vnc_port_start",
-                            "ng-model"    => "emsCommonModel.host_default_vnc_port_start",
-                            "maxlength"   => 6,
-                            "checkchange" => ""}
-
-    .form-group{"ng-class" => "{'has-error': angularForm.host_default_vnc_port_end.$invalid}", "ng-if" => "emsCommonModel.emstype == 'vmwarews'"}
-      %label.col-md-2.control-label{"for" => "ems_vnc_end_port"}
-        = _('Host Default VNC End Port')
-      .col-md-8
-        %input.form-control{"type"        => "text",
-                            "id"          => "ems_vnc_end_port",
-                            "name"        => "host_default_vnc_port_end",
-                            "ng-model"    => "emsCommonModel.host_default_vnc_port_end",
-                            "maxlength"   => 6,
-                            "checkchange" => ""}
-
-  %hr
-  - if controller_name == "ems_container"
-    = render :partial => "/layouts/container_auth", :locals  => {:record => @ems}
-  - else
-    %div{"ng-show" => "emsCommonModel.emstype != '' && emsCommonModel.emstype == 'azure'"}
-      %h3
-        = _("Credentials")
-      = render :partial => "/layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
-               :locals  => {:record                 => @ems,
-                            :ng_model               => "emsCommonModel",
-                            :ng_reqd_password       => "emsCommonModel.default_userid != ''",
-                            :prefix                 => "default",
-                            :validate_url           => @ems.id ? "update" : "create",
-                            :id                     => @ems.id || "new",
-                            :basic_info_needed      => true,
-                            :userid_label           => _("Client ID"),
-                            :password_label         => _("Client Key"),
-                            :verify_label           => _("Confirm Client Key"),
-                            :passwd_mismatch        => _("Client Keys do not match"),
-                            :change_stored_password => _("Change stored client key"),
-                            :cancel_password_change => _("Cancel client key change"),
-                            :verify_title_off       => _("Tenant ID, Client ID and matching Client Key fields are needed to perform verification of credentials")}
-    %div{"ng-show" => "emsCommonModel.emstype != 'azure'"}
-      = render :partial => "/layouts/angular/multi_auth_credentials", :locals  => {:record => @ems, :ng_model => "emsCommonModel"}
+  = render :partial => "providers/common/properties"
 
   = render :partial => "layouts/angular/x_edit_buttons_angular", :locals => {:record => @ems, :restful => true}

--- a/app/views/ems_infra/_form.html.haml
+++ b/app/views/ems_infra/_form.html.haml
@@ -40,16 +40,6 @@
                               "style"       => "color: black; font-weight: normal;"}
             = @emstype_display
 
-    .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack_infra'"}
-      %label.col-md-2.control-label{"for" => "ems_api_version"}
-        = _("API Version")
-      .col-md-8
-        = select_tag('api_version',
-                     options_for_select(@openstack_api_versions),
-                     "ng-model"                    => "emsCommonModel.api_version",
-                     "checkchange"                 => "",
-                     "selectpicker-for-select-tag" => "")
-
     .form-group{"ng-class" => "{'has-error': angularForm.zone.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_zone"}
         = _("Zone")
@@ -71,6 +61,16 @@
                        "checkchange"                 => "",
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack_infra'"}
+      %label.col-md-2.control-label{"for" => "ems_api_version"}
+        = _("API Version")
+      .col-md-8
+        = select_tag('api_version',
+                     options_for_select(@openstack_api_versions),
+                     "ng-model"                    => "emsCommonModel.api_version",
+                     "checkchange"                 => "",
+                     "selectpicker-for-select-tag" => "")
 
     .form-group{"ng-class" => "{'has-error': angularForm.host_default_vnc_port_start.$invalid}", "ng-if" => "emsCommonModel.emstype == 'vmwarews'"}
       %label.col-md-2.control-label{"for" => "ems_vnc_start_port"}

--- a/app/views/ems_infra/_form.html.haml
+++ b/app/views/ems_infra/_form.html.haml
@@ -62,6 +62,7 @@
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
 
-  = render :partial => "providers/common/properties"
+  %div{"ng-if"      => "!!emsCommonModel.emstype",
+       "ng-include" => "'#{properties_path}?id=#{@ems.id}&type=' + emsCommonModel.emstype"}
 
   = render :partial => "layouts/angular/x_edit_buttons_angular", :locals => {:record => @ems, :restful => true}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -12,9 +12,6 @@
       %i{"error-on-tab" => "default", :style => "color:#cc0000"}
       = _("Default")
     - if %w(ems_cloud ems_infra).include?(controller_name)
-      = miq_tab_header('metrics', nil, {'ng-click' => "changeAuthTab('metrics')"}) do
-        %i{"error-on-tab" => "metrics", :style => "color:#cc0000"}
-        = _("C & U Database")
       = miq_tab_header('amqp', nil, {'ng-click' => "changeAuthTab('amqp')"}) do
         %i{"error-on-tab" => "amqp", :style => "color:#cc0000"}
         = _("Events")
@@ -88,19 +85,12 @@
                                             :prefix                 => "service_account",
                                             :basic_info_needed      => true}
         .col-md-12{"ng-if" => "#{ng_model}.emstype != 'gce' && #{ng_model}.emstype != 'ec2'" || "#{ng_model}" != "emsCommonModel"}
-          %div{"ng-if" => "#{ng_model}.emstype == 'openstack' || (#{ng_model}.ems_controller == 'ems_infra' && #{ng_model}.emstype != 'rhevm')  || #{ng_model}.emstype == 'vmware_cloud'"}
+          %div{"ng-if" => "#{ng_model}.emstype == 'openstack' || #{ng_model}.ems_controller == 'ems_infra' || #{ng_model}.emstype == 'vmware_cloud'"}
             = render :partial => "layouts/angular-bootstrap/endpoints_angular",
                                    :locals  => {:ng_show                => true,
                                                 :ng_model               => "#{ng_model}",
                                                 :id                     => record.id,
                                                 :prefix                 => "default"}
-          %div{"ng-if" => "#{ng_model}.ems_controller == 'ems_infra' && #{ng_model}.emstype == 'rhevm'"}
-            = render :partial => "layouts/angular-bootstrap/endpoints_angular",
-                                   :locals  => {:ng_show                => true,
-                                                :ng_model               => "#{ng_model}",
-                                                :id                     => record.id,
-                                                :prefix                 => "default",
-                                                :ng_reqd_api_port       => "false"}
           %div{"ng-if" => controller_name != "ems_container" && controller_name != "ems_datawarehouse"}
             = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                    :locals  => {:ng_show           => "true",
@@ -183,33 +173,6 @@
             %span{:style => "color:black"}
               = _("Used for Docker Registry credentials required to perform SmartState Analysis on AWS.")
     - if %w(ems_cloud ems_infra ems_network).include?(params[:controller])
-      = miq_tab_content('metrics', 'default') do
-        .form-group
-          .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'rhevm'"}
-            = render :partial => "layouts/angular-bootstrap/endpoints_angular",
-                                 :locals  => {:ng_show                => true,
-                                              :ng_model               => "#{ng_model}",
-                                              :id                     => record.id,
-                                              :ng_reqd_db_name        => "#{ng_model}.metrics_hostname != ''",
-                                              :database_name_show     => true,
-                                              :tls_verify_hide        => true,
-                                              :tls_ca_certs_hide      => true,
-                                              :prefix                 => "metrics",
-                                              :ng_reqd_hostname       => "#{ng_model}.metrics_userid != '' && #{ng_model}.metrics_userid != undefined",
-                                              :ng_reqd_api_port       => "false"}
-            = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
-                                 :locals  => {:ng_show           => true,
-                                              :ng_model          => "#{ng_model}",
-                                              :ng_reqd_userid    => "#{ng_model}.metrics_hostname != ''",
-                                              :ng_reqd_password  => "#{ng_model}.metrics_userid != ''",
-                                              :validate_url      => validate_url,
-                                              :id                => record.id,
-                                              :prefix            => "metrics",
-                                              :basic_info_needed => true}
-        .form-group
-          .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'rhevm'"}
-            %span{:style => "color:black"}
-              = _("Used to gather Capacity & Utilization metrics.")
       = miq_tab_content('amqp', 'default') do
         .form-group
           .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'openstack_infra' || #{ng_model}.emstype == 'vmware_cloud' || #{ng_model}.emstype == 'nuage_network'"}
@@ -464,15 +427,6 @@
     miq_tabs_show_hide("#console_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
     miq_tabs_show_hide("#smartstate_docker_tab", true);
-    miq_tabs_init('#auth_tabs');
-    $('#auth_tabs').show();
-%div{"ng-if" => "#{ng_model}.emstype == 'rhevm'"}
-  :javascript
-    miq_tabs_show_hide("#amqp_tab", false);
-    miq_tabs_show_hide("#metrics_tab", true);
-    miq_tabs_show_hide("#console_tab", false);
-    miq_tabs_show_hide("#ssh_keypair_tab", false);
-    miq_tabs_show_hide("#smartstate_docker_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'vmware_cloud'"}

--- a/app/views/providers/common/_properties.html.haml
+++ b/app/views/providers/common/_properties.html.haml
@@ -1,0 +1,56 @@
+.form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack_infra'"}
+  %label.col-md-2.control-label{"for" => "ems_api_version"}
+    = _("API Version")
+  .col-md-8
+    = select_tag('api_version',
+                 options_for_select(@openstack_api_versions),
+                 "ng-model"                    => "emsCommonModel.api_version",
+                 "checkchange"                 => "",
+                 "selectpicker-for-select-tag" => "")
+
+.form-group{"ng-class" => "{'has-error': angularForm.host_default_vnc_port_start.$invalid}", "ng-if" => "emsCommonModel.emstype == 'vmwarews'"}
+  %label.col-md-2.control-label{"for" => "ems_vnc_start_port"}
+    = _('Host Default VNC Start Port')
+  .col-md-8
+    %input.form-control{"type"        => "text",
+                        "id"          => "ems_vnc_start_port",
+                        "name"        => "host_default_vnc_port_start",
+                        "ng-model"    => "emsCommonModel.host_default_vnc_port_start",
+                        "maxlength"   => 6,
+                        "checkchange" => ""}
+
+.form-group{"ng-class" => "{'has-error': angularForm.host_default_vnc_port_end.$invalid}", "ng-if" => "emsCommonModel.emstype == 'vmwarews'"}
+  %label.col-md-2.control-label{"for" => "ems_vnc_end_port"}
+    = _('Host Default VNC End Port')
+  .col-md-8
+    %input.form-control{"type"        => "text",
+                        "id"          => "ems_vnc_end_port",
+                        "name"        => "host_default_vnc_port_end",
+                        "ng-model"    => "emsCommonModel.host_default_vnc_port_end",
+                        "maxlength"   => 6,
+                        "checkchange" => ""}
+
+%hr
+- if controller_name == "ems_container"
+  = render :partial => "/layouts/container_auth", :locals  => {:record => @ems}
+- else
+  %div{"ng-show" => "emsCommonModel.emstype != '' && emsCommonModel.emstype == 'azure'"}
+    %h3
+      = _("Credentials")
+    = render :partial => "/layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+             :locals  => {:record                 => @ems,
+                          :ng_model               => "emsCommonModel",
+                          :ng_reqd_password       => "emsCommonModel.default_userid != ''",
+                          :prefix                 => "default",
+                          :validate_url           => @ems.id ? "update" : "create",
+                          :id                     => @ems.id || "new",
+                          :basic_info_needed      => true,
+                          :userid_label           => _("Client ID"),
+                          :password_label         => _("Client Key"),
+                          :verify_label           => _("Confirm Client Key"),
+                          :passwd_mismatch        => _("Client Keys do not match"),
+                          :change_stored_password => _("Change stored client key"),
+                          :cancel_password_change => _("Cancel client key change"),
+                          :verify_title_off       => _("Tenant ID, Client ID and matching Client Key fields are needed to perform verification of credentials")}
+  %div{"ng-show" => "emsCommonModel.emstype != 'azure'"}
+    = render :partial => "/layouts/angular/multi_auth_credentials", :locals  => {:record => @ems, :ng_model => "emsCommonModel"}

--- a/app/views/providers/rhevm/_properties.html.haml
+++ b/app/views/providers/rhevm/_properties.html.haml
@@ -1,0 +1,73 @@
+- validate_url ||= @ems.id ? "update" : "create"
+
+%hr
+
+#auth_tabs
+  %h3
+    = _("Endpoints")
+
+  %ul.nav.nav-tabs
+    = miq_tab_header('default', nil, {'ng-click' => "changeAuthTab('default')"}) do
+      %i{"error-on-tab" => "default", :style => "color:#cc0000"}
+      = _("Default")
+    = miq_tab_header('metrics', nil, {'ng-click' => "changeAuthTab('metrics')"}) do
+      %i{"error-on-tab" => "metrics", :style => "color:#cc0000"}
+      = _("C & U Database")
+
+  .tab-content
+    = miq_tab_content('default', 'default') do
+      .form-group
+        .col-md-12
+          %div
+            = render :partial => "layouts/angular-bootstrap/endpoints_angular",
+                     :locals  => {:ng_show          => true,
+                                  :ng_model         => "emsCommonModel",
+                                  :id               => @ems.id,
+                                  :prefix           => "default",
+                                  :ng_reqd_api_port => false}
+            = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                     :locals  => {:ng_show           => true,
+                                  :ng_model          => "emsCommonModel",
+                                  :ng_reqd_userid    => true,
+                                  :ng_reqd_password  => true,
+                                  :validate_url      => validate_url,
+                                  :id                => @ems.id,
+                                  :prefix            => "default",
+                                  :basic_info_needed => true}
+      .form-group
+        .col-md-12
+          %span{:style => "color:black"}
+            = _("Required. Should have privileged access, such as root or administrator.")
+
+    = miq_tab_content('metrics', 'default') do
+      .form-group
+        .col-md-12
+          = render :partial => "layouts/angular-bootstrap/endpoints_angular",
+                   :locals  => {:ng_show            => true,
+                                :ng_model           => "emsCommonModel",
+                                :id                 => @ems.id,
+                                :ng_reqd_db_name    => "emsCommonModel.metrics_hostname != ''",
+                                :database_name_show => true,
+                                :tls_verify_hide    => true,
+                                :tls_ca_certs_hide  => true,
+                                :prefix             => "metrics",
+                                :ng_reqd_hostname   => "emsCommonModel.metrics_userid != '' && emsCommonModel.metrics_userid != undefined",
+                                :ng_reqd_api_port   => "false"}
+          = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                   :locals  => {:ng_show           => true,
+                                :ng_model          => "emsCommonModel",
+                                :ng_reqd_userid    => "emsCommonModel.metrics_hostname != ''",
+                                :ng_reqd_password  => "emsCommonModel.metrics_userid != ''",
+                                :validate_url      => validate_url,
+                                :id                => @ems.id,
+                                :prefix            => "metrics",
+                                :basic_info_needed => true}
+      .form-group
+        .col-md-12
+          %span{:style => "color:black"}
+            = _("Used to gather Capacity & Utilization metrics.")
+
+:javascript
+  miq_tabs_show_hide("#metrics_tab", true);
+  miq_tabs_init('#auth_tabs');
+  $('#auth_tabs').show();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1233,6 +1233,7 @@ Rails.application.routes.draw do
         scaling
         show_list
         tagging_edit
+        properties
       ) +
                compare_get,
       :post => %w(


### PR DESCRIPTION
Currently the authentication dialogs for all the supported providers
are all in the same `_multi_auth_credentials.html.haml` file. This makes
it difficult to modify the dialog for a specific provider, or to add dialogs
for new providers as it is very easy to break the behaviour for the existing
providers.

In order to simplify that, this pull requests proposes a mechanism to
separate the part of the dialog that is specific for a provider type to
a separate file. For example, for the `rhevm` provider the file could
be `/providers/rhevm/_properties.html.haml`.

This separate file would be loaded dynamically (using the `ng-include`
directive) when the user selects the corresponding provider type in the
UI. In that situation the UI would send a request like this to the server:

```
GET /ems_infra/properties?id=123&type=rhevm
```

The `id` parameter will contain the identifier of the edited provider,
and will be empty when adding a new provider.
    
The `type` parameter will contain the type of the provider, for example
`rhevm` or `openstack_infra`.
    
In the server side the `ems_common/properties` route would check if there
is a template specific for that provider type. For example, if the type
is `rhevm` it will check if there is a template with this path:

```
/providers/rhevm/properties
```

If that template exists, it would render it. If it doesn't exist, then it
would render the default, which would be the existing template that currently
supports all the types of providers:

```
/providers/common/properties
```

As a proof of concept of that mechanism this pull request includes
a patch that moves the _oVirt_ provider specific parts of the dialog
to a separate file.

Note also that the provider specific template can be part of the
`manageiq-ui-classic` repository, or it can be part of a provider
specific repository. That could also be helpful as a first step
in the direction of making the UI more pluggable.
