### PR TITLE
Hide the not implemented recent alerts screen

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -259,7 +259,6 @@ module Menu
         Menu::Section.new(:monitor_alerts, N_("Alerts"), 'fa fa-bullhorn-o fa-2x', [
                             Menu::Item.new('monitor_alerts_overview', N_('Overview'), 'monitor_alerts_overview', {:feature => 'monitor_alerts_overview', :any => true}, '/alerts_overview'),
                             Menu::Item.new('monitor_alerts_list', N_('All Alerts'), 'monitor_alerts_list', {:feature => 'monitor_alerts_list', :any => true}, '/alerts_list'),
-                            Menu::Item.new('monitor_alerts_most_recent', N_('Most Recent Alerts'), 'monitor_alerts_most_recent', {:feature => 'monitor_alerts_most_recent', :any => true}, '/alerts_most_recent')
                           ])
       end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1526882

Before:
![most_recent_alerts](https://user-images.githubusercontent.com/3010449/34095904-fa05b0c4-e3db-11e7-9ea4-bd6fd9040173.png)

After:
![recent_hidden](https://user-images.githubusercontent.com/3010449/34095897-ebc7913a-e3db-11e7-9af2-7612ec230f7d.png)

