### PR TITLE
Hide suspend server button from toolbar for standalone Middleware Ser…

### DIFF
--- a/app/helpers/application_helper/toolbar/middleware_server_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_server_center.rb
@@ -89,7 +89,7 @@ class ApplicationHelper::Toolbar::MiddlewareServerCenter < ApplicationHelper::To
                      'target'        => '#modal_param_div',
                      'function'      => 'sendDataWithRx',
                      'function-data' => '{"type": "mwServerOps", "operation": "suspend", "timeout": 10}'},
-          :klass => ApplicationHelper::Button::MiddlewareServerAction),
+          :klass => ApplicationHelper::Button::MiddlewareDomainServerAction),
         button(
           :middleware_server_resume,
           nil,


### PR DESCRIPTION
This PR disable the button from toolbar that suspend Middleware Server for only standalone. This operation is not supported.

Toolbar for Middleware Server Standalone, We **can't** suspend server this action **is not supported**
![mw_standalone](https://user-images.githubusercontent.com/3019213/34095870-6c58f5b8-e3d3-11e7-9a59-aed7248001da.png)
Toolbar for Middleware Server Domain, We **can** suspend server this action **is supported**
![mw_server_standalone](https://user-images.githubusercontent.com/3019213/34095871-6c701c34-e3d3-11e7-9584-6a11238362ca.png)

cc @israel-hdez 
