### PR TITLE
Show hostname in MiddlewareServer Timeline event

### DIFF
--- a/app/controllers/mixins/middleware_operations_mixin.rb
+++ b/app/controllers/mixins/middleware_operations_mixin.rb
@@ -109,6 +109,7 @@ module Mixins::MiddlewareOperationsMixin
         :event_type      => operation_info.fetch(:log_timeline),
         :message         => _('%{server} will be %{operation} per user request') %
           {:operation => operation_info.fetch(:hawk), :server => mw_item.name},
+        :host_name       => mw_item.hostname,
         :middleware_ref  => mw_item.ems_ref,
         :middleware_type => mw_item.class.name.demodulize,
         :username        => current_userid

--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -29,7 +29,7 @@ module ReportFormatter
     end
 
     def host_name
-      "<a href=/host/show/#{to_cid(@event.host_id)}>#{text}</a>" if @event.host_id
+      @event.host_id ? "<a href=/host/show/#{to_cid(@event.host_id)}>#{text}</a>" : text
     end
 
     def dest_host_name


### PR DESCRIPTION
We need to add more information to the events about servers (such as hostname, or make some events clickable if server already exists in the inventory).

In some cases MiddlwareServer are in a container or in a host that it's not in the inventory.

![timeline_with_hostname](https://user-images.githubusercontent.com/3019213/34098065-761e58d8-e3db-11e7-89d2-736159bf2463.png)

JIRA [JMAN4-242](https://issues.jboss.org/browse/JMAN4-242)

