### PR TITLE
Convert array of default values to string, so it can be saved correctly

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -150,6 +150,9 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', '$http', '
     keysToDelete.forEach(function(key) {
       delete copy[key];
     });
+    if (value.type === "DialogFieldDropDownList" && Array.isArray(value.default_value)) {
+      value.default_value = value.default_value.join(',');
+    }
     return copy;
   }
 


### PR DESCRIPTION
The values for multi-select dropdown defalut_value are now sent as an array (`["a", "b"]`), but since the type in the database is a string, they have to be sent as string (`"a,b"`).

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1516721
* https://github.com/ManageIQ/ui-components/pull/223
* https://github.com/ManageIQ/manageiq/pull/16680
* https://bugzilla.redhat.com/show_bug.cgi?id=1520001