### PR TITLE
Update Notification drawer styling

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -98,57 +98,14 @@ div#saml-login hr {
 /// begin header styling
 /// ===================================================================
 
-// badge position and color
-.navbar-pf-vertical .nav .nav-item-iconic {
-  &.drawer-pf-trigger-icon {
-    width: 40px;
-  }
-  .badge {
-    position: relative;
-    top: -23px;
-    right : -10px;
-    margin: 0px;
-    min-width: 13px;
-    background-color: #0088ce;
-  }
-}
-
 /// toast notifications positioning
 .toast-notifications-list-pf {
   top: 65px
 }
 
-/// notifications drawer positioning
-.drawer-pf {
-  bottom: 20px;
-  position: absolute;
-  top: 60px;
-  z-index: 950;
-  .panel-body {
-    margin: 0;
-  }
-}
-.drawer-pf.vertical-scroll {
-  right: 15px;
-}
-
 .navbar__user-name {
   display: inline-block;
   color: #FFFFFF; margin-left: 1ex;
-}
-
-.miq-drawer-close {
-  color: inherit;
-  cursor: pointer;
-  right: 0;
-  padding: 2px 5px;
-  position: absolute;
-}
-
-.drawer-pf-expanded .drawer-pf-title {
-  width: auto;
-  left: 0;
-  right: 0;
 }
 
 /// group switcher styling

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -12,12 +12,11 @@
   %nav.collapse.navbar-collapse
     %ul.nav.navbar-nav.navbar-right.navbar-iconic
       %li{:class => "dropdown brand-white-label #{::Settings.server.custom_logo ? "whitelabeled" : ""}"}
-      %li
+      %li.drawer-pf-trigger.dropdown{"open" => "!hideDrawer"}
         %a{:class => "nav-item-iconic drawer-pf-trigger-icon", :title => "{{vm.notificationsIndicatorTooltip}}", "ng-click" => "vm.toggleNotificationsList()"}
-          %span.fa{"ng-class" => "{'fa-bell': vm.newNotifications, 'fa-bell-o': !vm.newNotifications}"}
-          %span.badge.info{"ng-show" => "vm.newNotifications"}
-            -# Small circle
-            &#8226;
+          %span.fa.fa-bell
+          %span{"ng-class" => "{'badge badge-pf-bordered': vm.newNotifications}"} 
+            = ' '
       - Menu::Manager.menu(:help) do |menu_section|
         - if menu_section.visible?
           %li.dropdown

--- a/app/views/static/notification_drawer/notification-drawer.html.haml
+++ b/app/views/static/notification_drawer/notification-drawer.html.haml
@@ -2,7 +2,7 @@
   .drawer-pf-title{'ng-if' => "drawerTitle"}
     %a.drawer-pf-toggle-expand{'ng-if'    => "allowExpand",
                                'ng-click' => "toggleExpandDrawer()"}
-    %a.miq-drawer-close{'ng-click' => "closeDrawer()"}
+    %a.drawer-pf-close{'ng-click' => "closeDrawer()"}
       %i.pficon.pficon-close
     %h3.text-center
       {{drawerTitle}}


### PR DESCRIPTION
Update Notification Drawer markup and styling to take advantage of updates in recent versions of Patternfly (though Patternfly Sass 3.23.1).

This resolves issues 1-3 here: http://talk.manageiq.org/t/ux-feedback-notification-drawer/2928

Without Notifications

<img width="316" alt="screen shot 2017-12-18 at 10 42 34 am" src="https://user-images.githubusercontent.com/1287144/34114228-331ea3ee-e3e0-11e7-85cb-107ef95a9429.png">

With Notifications

<img width="331" alt="screen shot 2017-12-18 at 10 32 48 am" src="https://user-images.githubusercontent.com/1287144/34113789-d75e730a-e3de-11e7-9ea5-ad8b7826c201.png">

