### PR TITLE
Show custom report menus in Cloud Intel -> Reports -> Reports

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -640,7 +640,7 @@ class ReportController < ApplicationController
   end
 
   def reports_menu_in_sb
-    @sb[:rpt_menu]  = populate_reports_menu("reports", "default")
+    @sb[:rpt_menu]  = populate_reports_menu("reports", "menu")
     @sb[:grp_title] = reports_group_title
   end
 

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1354,7 +1354,7 @@ describe ReportController do
       controller.instance_variable_set(:@_params, :controller => "report", :action => "explorer")
       controller.instance_variable_set(:@sb, {})
       allow(controller).to receive(:get_node_info)
-      controller.send(:reports_menu_in_sb)
+      controller.send(:populate_reports_menu, "reports", "default")
       rpt_menu = controller.instance_variable_get(:@sb)[:rpt_menu]
       expect(rpt_menu.first.first).to eq("#{user.current_tenant.name} (Group): #{user.current_group.name}")
     end


### PR DESCRIPTION
When you edit the report menus in `Cloud Intel -> Report -> Edit Report Menus`, the customized items arent appearing without this change. Credit goes to @h-kataria, se the BZ for details.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1525346