### PR TITLE
[FINE] Do not require the VMRC tab when adding a new vmware provider

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -58,7 +58,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       metrics_auth_status: '',
       ssh_keypair_auth_status: '',
       hawkular_auth_status: '',
-      vmware_cloud_api_version: ''
+      vmware_cloud_api_version: '',
+      console_auth_status: true,
     };
     $scope.formId = emsCommonFormId;
     $scope.afterGet = false;


### PR DESCRIPTION
There's a strange issue where the VMRC fields are required in downstream. @AparnaKarve found out that the problem is that I missed a line, but strangely it works well in upstream. 

![screenshot from 2017-12-18 19-08-13](https://user-images.githubusercontent.com/649130/34120992-d4995f6a-e427-11e7-845b-4289bd9b7ce5.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1526050