### PR TITLE
Drop unnecessary assets from the precompilation pipeline

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,10 +11,6 @@ Rails.application.config.assets.precompile += %w(
   jquery
   jquery-ui
   jquery_overrides.js
-  novnc-rails
-  noVNC/web-socket-js/WebSocketMain.swf
   remote_consoles/*.js
   remote_console.js
-  spice-html5-bower
-  spice-html5-bower/spiceHTML5/spicearraybuffer.js
 )


### PR DESCRIPTION
These files are no longer need to be precompiled as there are being just required in other files.

@miq-bot add_label refactoring, gaprindashvili/no