### PR TITLE
Set all fields in mixin method when form field transaction is sent

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -969,11 +969,6 @@ class CatalogController < ApplicationController
     process_show_list(options)
   end
 
-  def ot_edit_get_form_vars
-    copy_params_if_set(@edit[:new], params, %i(name description dialog_name manager_id))
-    @edit[:new][:draft] = params[:draft] == "true" if params[:draft]
-  end
-
   def ot_edit_set_form_vars(right_cell_text)
     checked = find_checked_items
     checked[0] = params[:id] if checked.blank? && params[:id]

--- a/app/controllers/mixins/service_dialog_creation_mixin.rb
+++ b/app/controllers/mixins/service_dialog_creation_mixin.rb
@@ -5,7 +5,8 @@ module ServiceDialogCreationMixin
 
   def dialog_creation_form_field_changed(id)
     return unless load_edit(id)
-    @edit[:new][:dialog_name] = params[:dialog_name] if params[:dialog_name]
+    copy_params_if_set(@edit[:new], params, %i(name description dialog_name manager_id))
+    @edit[:new][:draft] = params[:draft] == "true" if params[:draft]
     render :update do |page|
       page << javascript_prologue
       page << javascript_hide("buttons_off")

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -394,6 +394,42 @@ describe CatalogController do
     end
   end
 
+  context "#ot_copy" do
+    it "Orchestration Template is copied but name is changed" do
+      controller.instance_variable_set(:@sb, {})
+      controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
+      ot = FactoryGirl.create(:orchestration_template_amazon)
+      controller.x_node = "xx-otcfn_ot-#{ot.id}"
+      name = "New Name"
+      description = "New Description"
+      new_content = "{\"AWSTemplateFormatVersion\" : \"new-version\"}"
+      session[:edit] = {
+        :new => {
+          :name        => name,
+          :description => description
+        },
+        :key => "ot_edit__#{ot.id}"
+      }
+
+      new_name = "New name for copied OT"
+      new_description = "New description for copied OT"
+
+      allow(controller).to receive(:replace_right_cell)
+      controller.instance_variable_set(:@_params,
+                                       :name        => new_name,
+                                       :description => new_description,
+                                       :id          => ot.id.to_s)
+      controller.send(:ot_form_field_changed)
+      controller.instance_variable_set(:@_params,
+                                       :button           => "add",
+                                       :original_ot_id   => ot.id,
+                                       :template_content => new_content)
+      controller.send(:ot_copy_submit)
+      expect(OrchestrationTemplate.where(:name        => new_name,
+                                         :description => new_description).first).to_not be_nil
+    end
+  end
+
   context "#ot_delete" do
     before(:each) do
       controller.instance_variable_set(:@sb, {})


### PR DESCRIPTION
Removed redundant method from controller that was not being called and updated method in mixin to set form field values in `@edit[:new]` correctly.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1527026

@dclarizio please review/test