### PR TITLE
Add missing IE11 support for remote console fullscreen

### DIFF
--- a/app/assets/javascripts/remote_console.js
+++ b/app/assets/javascripts/remote_console.js
@@ -22,6 +22,13 @@ $(function() {
           document.documentElement.mozRequestFullScreen();
         }
         break;
+      case document.msFullScreenEnabled:
+        if (document.msFullScreenElement) {
+          document.msExitFullScreen();
+        } else {
+          document.documentElement.msRequestFullScreen();
+        }
+        break;
     }
   });
 });


### PR DESCRIPTION
![ie-troll-84](https://user-images.githubusercontent.com/649130/34127947-3d8bad36-e43f-11e7-9e22-5b3a5215dde6.jpg)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1523839