### PR TITLE
Display the correct report title on full screen widget screens

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,7 +3,7 @@
   - if @report_only
     %head
       %title
-        = "%{product}: %{title}" % {:product => Vmdb::Appliance.PRODUCT_NAME, :title => @layout.titleize}
+        = "%{product}: %{title}" % {:product => Vmdb::Appliance.PRODUCT_NAME, :title => @report.title}
       = favicon_link_tag
       = stylesheet_link_tag 'application'
       = javascript_include_tag 'application'


### PR DESCRIPTION
When displaying a dashboard widget in a new window (full screen option in its kebab), the title was set by the `@layout` instance variable. Instead of this it should set to `@report.title`, so changing it.

TODO: it would be better to move out this `report_only` condition from the `application.html.haml` and create a new layout. It would ease testing and maintainability.

@miq-bot add_label bug, gaprindashvili/yes, cloud intel/dashboard

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1526302