### PR TITLE
VMs should be displayed as quadicons in tagging.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1410,7 +1410,7 @@ class ApplicationController < ActionController::Base
   def get_view_calculate_gtl_type(db_sym)
     gtl_type = settings(:views, db_sym) unless %w(scanitemset miqschedule pxeserver customizationtemplate).include?(db_sym.to_s)
     gtl_type = 'grid' if ['vm'].include?(db_sym.to_s) && request.parameters[:controller] == 'service'
-    gtl_type = 'grid' if params[:records] && params[:records].kind_of?(Array)
+    gtl_type ||= 'grid' if params[:records] && params[:records].kind_of?(Array)
     gtl_type ||= 'list' # return a sane default
     gtl_type
   end
@@ -1524,7 +1524,7 @@ class ApplicationController < ActionController::Base
     # Set up the list view type (grid/tile/list)
     @settings.store_path(:views, db_sym, params[:type]) if params[:type] # Change the list view type, if it's sent in
 
-    @gtl_type = get_view_calculate_gtl_type(db_sym)
+    @gtl_type = get_view_calculate_gtl_type(db_sym) unless fetch_data
 
     # Get the view for this db or use the existing one in the session
     view = refresh_view ? get_db_view(db.gsub('::', '_'), :association => association, :view_suffix => view_suffix) : session[:view]

--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -20,7 +20,8 @@ class ApplicationController
     :policy_sim,
     :in_a_form,
     :lastaction,
-    :display
+    :display,
+    :gtl_type
   ) do
     def self.from_options(options)
       additional_options = new
@@ -48,6 +49,10 @@ class ApplicationController
 
     def with_row_button(row_button)
       self.row_button = row_button
+    end
+
+    def with_gtl_type(gtl_type)
+      self.gtl_type = gtl_type
     end
 
     def with_menu_click(menu_click)

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -189,9 +189,7 @@ module ApplicationController::Tags
 
   # Build the @edit elements for the tag edit screen
   def tag_edit_build_screen
-    @gtl_type = 'list' # show items in tagging screen a list
-    @embedded = true   # with no links
-    @showlinks = false
+    @showlinks = true
 
     cats = Classification.categories.select(&:show).sort_by(&:name) # Get the categories, sort by name
     @categories = {}    # Classifications array for first chooser

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -616,6 +616,7 @@ module OpsController::OpsRbac
       session[:tag_db] = @tagging = tagging
     end
 
+    @gtl_type = "list" # No quad icons for user/group list views
     x_tags_set_form_vars
     @in_a_form = true
     session[:changed] = false

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -395,7 +395,11 @@ module ApplicationHelper
           return "/" + request.parameters[:controller] + "/tree_select?id=" + suffix
         elsif %w(User MiqGroup MiqUserRole Tenant).include?(view.db) &&
               %w(ops).include?(request.parameters[:controller])
-          return "/" + request.parameters[:controller] + "/tree_select/?id=" + x_node.split("-")[1]
+          if @tagging
+            return false # when tagging Users, Groups, Roles and Tennants, the table is non-clickable
+          else
+            return "/" + request.parameters[:controller] + "/tree_select/?id=" + x_node.split("-")[1]
+          end
         elsif %w(VmdbTableEvm MiqServer).include?(view.db) &&
               %w(ops report).include?(request.parameters[:controller])
           return "/" + request.parameters[:controller] + "/tree_select/?id=" + TREE_WITH_TAB[active_tab]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1645,7 +1645,9 @@ module ApplicationHelper
     @report_data_additional_options.with_menu_click(params[:menu_click]) if params[:menu_click]
     @report_data_additional_options.with_sb_controller(params[:sb_controller]) if params[:sb_controller]
     @report_data_additional_options.with_model(curr_model) if curr_model
-    @report_data_additional_options.freeze
+    # FIXME: we would like to freeze here, but the @gtl_type is calculated no sooner than in view templates.
+    # So until that if fixed we cannot freeze.
+    # @report_data_additional_options.freeze
   end
 
   def from_additional_options(additional_options)
@@ -1683,6 +1685,9 @@ module ApplicationHelper
     # need to pass @in_a_form so get_view does not set advanced search options
     # in the forms that render gtl that mess up @edit
     @in_a_form = quadicon_options[:in_a_form]
+
+    # take GTL type from the component
+    @gtl_type = quadicon_options[:gtl_type]
   end
 
   # Wrapper around jquery-rjs' remote_function which adds an extra .html_safe()

--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -49,11 +49,13 @@ module GtlHelper
   #
   def render_gtl_outer(no_flash_div)
     parent_id = @report_data_additional_options.try(:[], :parent_id)
+    gtl_type_string = @gtl_type || 'list'
+    @report_data_additional_options.with_gtl_type(gtl_type_string) if @report_data_additional_options
 
     options = {
       :model_name                     => model_to_report_data,
       :no_flash_div                   => no_flash_div || false,
-      :gtl_type_string                => @gtl_type,
+      :gtl_type_string                => gtl_type_string,
       :active_tree                    => (x_active_tree unless params[:display]),
       :parent_id                      => parent_id,
       :selected_records               => gtl_selected_records,

--- a/spec/controllers/ems_middleware_controller_spec.rb
+++ b/spec/controllers/ems_middleware_controller_spec.rb
@@ -109,7 +109,7 @@ describe EmsMiddlewareController do
       subject { assert_report_data_response }
 
       it 'returns a single middleware server that has an image but not an icon' do
-        report_data_request(:model => 'MiddlewareServer', :parent_model => provider.type, :parent_id => provider.id)
+        report_data_request(:model => 'MiddlewareServer', :parent_model => provider.type, :parent_id => provider.id, :explorer => false)
 
         expect(subject["data"]["rows"].length).to eq(1)
         expect(subject["data"]["rows"][0]["cells"][2]["text"]).to eq(server.name)

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -385,11 +385,10 @@ describe HostController do
         session[:sandboxes] = {}
         session.store_path(:sandboxes, 'host', :search_text, 'foobar')
         report_data_request(
-          :model                          => 'Host',
-          :parent_id                      => nil,
-          :report_data_additional_options => {
-            :lastaction => 'show_list',
-          }
+          :model      => 'Host',
+          :parent_id  => nil,
+          :explorer   => false,
+          :lastaction => 'show_list',
         )
         results = assert_report_data_response
         expect(results['data']['rows'].length).to eq(1)

--- a/spec/controllers/middleware_server_controller_spec.rb
+++ b/spec/controllers/middleware_server_controller_spec.rb
@@ -241,7 +241,7 @@ describe MiddlewareServerController do
       subject { assert_report_data_response }
 
       it 'returns a single middleware server that has an image but not an icon' do
-        report_data_request(:model => 'MiddlewareServer')
+        report_data_request(:model => 'MiddlewareServer', :explorer => false)
 
         expect(subject["data"]["rows"].length).to eq(1)
         expect(subject["data"]["rows"][0]["cells"][2]["text"]).to eq(server.name)

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -87,6 +87,7 @@ module Spec
       #   :parent_method
       #   :gtl_dbname
       #   :explorer (defaults to true)
+      #   :lastaction
       #
       # FIXME: This hash needs cleanups as we clenup the /report_data,
       #        angular/_gtl and the calling sites.
@@ -108,6 +109,7 @@ module Spec
             'parent_id'             => options[:parent_id],
             'parent_class_name'     => options[:parent_model],
             'parent_method'         => options[:parent_method],
+            'lastaction'            => options[:lastaction],
             'association' => nil, 'view_suffix' => nil, 'listicon' => nil, 'embedded' => nil, 'showlinks' => nil, 'policy_sim' => nil
           }.compact
         }.compact


### PR DESCRIPTION
This reverts b2f3f83d

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1514426

### These BZs need retesting:
 * ~~https://bugzilla.redhat.com/show_bug.cgi?id=1503076~~
 * ~~https://bugzilla.redhat.com/show_bug.cgi?id=1501376~~

Problems in those BZ should have been meanwhile fixed in other ways so reverting b2f3f83d should not cause the breakages any more.

Bottom line: by reverting the previous behavior the BZ is fixed, however
the behavior was not consistend before and is not consistent after this
change. More complex changes and an actual specification on what is the
expected behavior is needed to address all the problems here.

### There's a number of problems with this solution

See below the calculation of the `gtl_type`.

```
    def get_view_calculate_gtl_type(db_sym)                                                           
      gtl_type = settings(:views, db_sym) unless %w(scanitemset miqschedule pxeserver customizationtemplate).include?(db_sym.to_s)
      gtl_type = 'grid' if ['vm'].include?(db_sym.to_s) && request.parameters[:controller] == 'service'
      gtl_type = 'grid' if params[:records] && params[:records].kind_of?(Array)                       
      gtl_type ||= 'list' # return a sane default                                                     
      gtl_type                                                                                        
    end 
```

 * There's an exceptions for `vm` under services. That is probably an intended exception.
 * There's an exception for `scanitemset miqschedule pxeserver customizationtemplate`. No idea why we need a line to ignore the settings. Simply NOT having the setting for these items would do the same w/o extra exception.
 * There's an exception for cases when `params[:records]` is set. This is used in tagging. But for some reason this does not fire for all the entities that can be tagged.
 * The `params[:records]` is one of several ways to pass indivitual records to the grid. It SHOULD NOT be used to decide which mode is to be used for display. (See `def get_view` for more ways to pass in individual records).

```
    def get_view(db, options = {}, fetch_data = false)                                                
      if !fetch_data && @report_data_additional_options.nil?                                          
        process_show_list_options(options, db)                                                        
      end                                                                                             
      unless @edit.nil?                                                                               
        object_ids = @edit[:object_ids] unless @edit[:object_ids].nil?                                
        object_ids = @edit[:pol_items] unless @edit[:pol_items].nil?                                  
      end                                                                                             
      object_ids   = params[:records].map(&:to_i) unless params[:records].nil?                        
 ```

This needs to be unified at some point and at that point the exception on `param[:records]` will get broken whatever it's purpose originally was.

The `get_view_calculate_gtl_type` is used in the "prepare phase" call of `get_view` and also in the phase where `/report_data` is called from the grid. The gtl_type in these cases should match, but does not always. This can cause problems especially when the GTL component would want to display quadicons and the `/report_data` call would not pass the quadicon data, because it would think that the mode was `list`. This needs fixing in the `/report_data` phase, the gtl_type should be fully driven by the request from the grid.

Reading the code I believe that the inconsistencies are not a regressions for this release but rather a result of long term small changes w/o refactoring. Changes needed to address all the issues here are potentially dangerous and should not be done for Gaprindashvili at this point, because they could cause real regression.

### Next steps:
 * We need a specification. A detailed description of the intended behavior. 
 * We need to compare that specification with the behavior that we have.
 * Then we can plan next steps.

Ping @dclarizio 