### PR TITLE
Indent <hr> properly for notification frequency when editing alerts

### DIFF
--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -129,10 +129,10 @@
                   - hide = true
                 - else
                   = h(@sb[:alert][:repeat_times][@alert.options[:notifications][:delay_next_evaluation]])
+          %hr
           - if hide
             :javascript
               $(".notification-frequency").hide();
-      %hr
       -# Expression
       - if @edit
         - if !@edit[:new][:expression][:eval_method]


### PR DESCRIPTION
When creating/editing an alert under `Control -> Explorer -> Alerts`, there is a special case when the notification frequency triggers the visibility of some extra items. After each part of the form there's a `<hr>` and the one related to the extra items was not indented properly. 

**Before:**
![before](https://user-images.githubusercontent.com/649130/34155756-e379bbfe-e4ba-11e7-8482-8c2ec8ffd3df.png)

**After:**
![after](https://user-images.githubusercontent.com/649130/34155763-ebeb7d4a-e4ba-11e7-90da-61c122e10e55.png)

@miq-bot add_label formatting/styling, bug, gaprindashvili/yes
@miq-bot assign @epwinchell 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1523281