### PR TITLE
Move the report_only layout from application out to a separate one

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -530,7 +530,6 @@ class ApplicationController < ActionController::Base
 
   # Common method to show a standalone report
   def report_only
-    @report_only = true # Indicate stand alone report for views
     # Render error message if report doesn't exist
     if params[:rr_id].nil? && @sb.fetch_path(:pages, :rr_id).nil?
       add_flash(_("This report isn't generated yet. It cannot be rendered."), :error)
@@ -548,7 +547,8 @@ class ApplicationController < ActionController::Base
     @html     = report_build_html_table(rr.report_results, rr.html_rows.join)
     @ght_type = params[:type] || (@report.graph.blank? ? 'tabular' : 'hybrid')
     @render_chart = (@ght_type == 'hybrid')
-    render 'shared/show_report'
+    # Indicate stand alone report for views
+    render 'shared/show_report', :layout => 'report_only'
   end
 
   def show_statistics

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -146,7 +146,6 @@ module ApplicationController::ReportDownloads
   end
 
   def set_summary_pdf_data
-    @report_only = true
     @showtype    = @display
     run_time     = Time.now
     klass        = ui_lookup(:model => @record.class.name)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,52 +1,38 @@
 = render :partial => 'layouts/doctype'
 %html.layout-pf.layout-pf-fixed.transitions{:lang => I18n.locale.to_s.sub('-', '_')}
-  - if @report_only
-    %head
-      %title
-        = "%{product}: %{title}" % {:product => Vmdb::Appliance.PRODUCT_NAME, :title => @report.title}
-      = favicon_link_tag
-      = stylesheet_link_tag 'application'
-      = javascript_include_tag 'application'
-      - if Rails.env.development?
-        = javascript_include_tag 'miq_debug'
-        = stylesheet_link_tag 'miq_debug'
-      = render :partial => 'layouts/i18n_js'
-    %body{:style => "overflow: scroll; padding: 0 20px 0 20px !important"}
-      = yield
-  - else
-    %head
-      %title= h page_title
+  %head
+    %title= h page_title
 
-      %meta{"http-equiv" => "Pragma", :content => "no-cache"}
-      %meta{"http-equiv" => "Pragma", :content => "no-store"}
-      %meta{"http-equiv" => "Pragma", :content => "must-revalidate"}
-      %meta{"http-equiv" => "cache-control", :content => "no-cache, no-store"}
+    %meta{"http-equiv" => "Pragma", :content => "no-cache"}
+    %meta{"http-equiv" => "Pragma", :content => "no-store"}
+    %meta{"http-equiv" => "Pragma", :content => "must-revalidate"}
+    %meta{"http-equiv" => "cache-control", :content => "no-cache, no-store"}
 
-      = favicon_link_tag
-      = stylesheet_link_tag 'application'
-      = render :partial => "stylesheets/template50"
-      = javascript_include_tag 'application'
-      - if Rails.env.development?
-        = javascript_include_tag 'miq_debug'
-        = stylesheet_link_tag 'miq_debug'
-      = csrf_meta_tag
-      = render :partial => 'layouts/i18n_js'
-      -# FIXME: the conditional below is a temporary fix for a webpacker issue, remove when it's resolved
-      - unless Rails.env.test?
-        - Webpacker::Manifest.instance.data.keys.each do |pack|
-          = javascript_pack_tag pack if pack.ends_with? '-common.js'
+    = favicon_link_tag
+    = stylesheet_link_tag 'application'
+    = render :partial => "stylesheets/template50"
+    = javascript_include_tag 'application'
+    - if Rails.env.development?
+      = javascript_include_tag 'miq_debug'
+      = stylesheet_link_tag 'miq_debug'
+    = csrf_meta_tag
+    = render :partial => 'layouts/i18n_js'
+    -# FIXME: the conditional below is a temporary fix for a webpacker issue, remove when it's resolved
+    - unless Rails.env.test?
+      - Webpacker::Manifest.instance.data.keys.each do |pack|
+        = javascript_pack_tag pack if pack.ends_with? '-common.js'
 
+    :javascript
+      ManageIQ.charts.provider = "#{Charting.backend}";
+      ManageIQ.browser = "#{j browser_info(:name_ui)}";
+      ManageIQ.controller = "#{j controller_name}";
+      vanillaJsAPI.autorenew();
+
+    - if ::Settings.server.asynchronous_notifications
       :javascript
-        ManageIQ.charts.provider = "#{Charting.backend}";
-        ManageIQ.browser = "#{j browser_info(:name_ui)}";
-        ManageIQ.controller = "#{j controller_name}";
-        vanillaJsAPI.autorenew();
+        miqInitNotifications();
 
-      - if ::Settings.server.asynchronous_notifications
-        :javascript
-          miqInitNotifications();
-
-    %body{:onload => is_browser_ie? ? '' : 'miqOnLoad();', 'data-controller' => controller_name}
-      = render :partial => "layouts/header"
-      = render :partial => "layouts/content"
-      = render :partial => 'layouts/footer'
+  %body{:onload => is_browser_ie? ? '' : 'miqOnLoad();', 'data-controller' => controller_name}
+    = render :partial => "layouts/header"
+    = render :partial => "layouts/content"
+    = render :partial => 'layouts/footer'

--- a/app/views/layouts/report_only.html.haml
+++ b/app/views/layouts/report_only.html.haml
@@ -1,0 +1,14 @@
+= render :partial => 'layouts/doctype'
+%html.layout-pf.layout-pf-fixed.transitions{:lang => I18n.locale.to_s.sub('-', '_')}
+  %head
+    %title
+      = "%{product}: %{title}" % {:product => Vmdb::Appliance.PRODUCT_NAME, :title => @report.title}
+    = favicon_link_tag
+    = stylesheet_link_tag 'application'
+    = javascript_include_tag 'application'
+    - if Rails.env.development?
+      = javascript_include_tag 'miq_debug'
+      = stylesheet_link_tag 'miq_debug'
+    = render :partial => 'layouts/i18n_js'
+  %body{:style => "overflow: scroll; padding: 0 20px 0 20px !important"}
+    = yield


### PR DESCRIPTION
During #3104 I noticed this low hanging fruit and moved it out to a separate layout. Hopefully it will ease the readability. Can be triggered/tested from the main dashboard by opening a widget's full screen option from the kebab dropdown.

![screenshot from 2017-12-20 10-50-19](https://user-images.githubusercontent.com/649130/34201062-9b3e7b86-e573-11e7-93b6-7ba165f95dc1.png)

@miq-bot add_label cloud intel/dashboard, refactoring, gaprindashvili/no
