### PR TITLE
Use suffix for tree select when in reload action - report data

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -391,7 +391,9 @@ module ApplicationHelper
                  MiqReportResult).include?(view.db) &&
               %w(report automation_manager).include?(request.parameters[:controller])
           suffix = ''
-          suffix = x_node if params[:tab_id] == "saved_reports" || params[:pressed] == "miq_report_run"
+          if params[:tab_id] == "saved_reports" || params[:pressed] == "miq_report_run" || params[:action] == "reload"
+            suffix = x_node
+          end
           return "/" + request.parameters[:controller] + "/tree_select?id=" + suffix
         elsif %w(User MiqGroup MiqUserRole Tenant).include?(view.db) &&
               %w(ops).include?(request.parameters[:controller])


### PR DESCRIPTION
### Fixes error in saved reports
When navigating to reports: CI -> Reports and queueing new shedule correct page is shown, however clicking on refresh breaks it and clicking on new schedule leads to wrong entry. This PR fixes such issue so clicking on refresh and on new record will lead show correct schedule.

### BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1508152