### PR TITLE
Add spinner when item in gtl is clicked and has showUrl

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -208,6 +208,7 @@
     event.stopPropagation();
     event.preventDefault();
     if (this.initObject.showUrl) {
+      miqSparkleOn();
       var prefix = this.initObject.showUrl;
       var splitUrl = this.initObject.showUrl.split('/');
       if (item.parent_path && item.parent_id) {


### PR DESCRIPTION
Compute -> Infrastructure -> Virtual Machines -> click one of them or any other GTL

Before:

*Redirected without spinner*

<img width="1215" alt="screen shot 2017-12-20 at 1 04 54 pm" src="https://user-images.githubusercontent.com/9210860/34206319-52f341dc-e586-11e7-8b2a-a1f6c2790b5e.png">

After:

*Redirected with a spinner*

<img width="1214" alt="screen shot 2017-12-20 at 12 57 39 pm" src="https://user-images.githubusercontent.com/9210860/34206131-7c15b06e-e585-11e7-83bc-d82f6e5d75c3.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1500506
@miq-bot add_label blocker, gaprindashvili/yes, bug, gtls