### PR TITLE
Reconfigure VM: Add / Remove Network Adapters

### DIFF
--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -2,27 +2,27 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
   var vm = this;
   var init = function() {
     vm.reconfigureModel = {
-      memory:                  '0',
-      memory_type:             '',
-      socket_count:            '1',
-      cores_per_socket_count:  '1',
-      total_cpus:              '1',
-      vmdisks:                 [],
-      hdType:                  'thin',
-      hdMode:                  'persistent',
-      hdSize:                  '',
-      hdUnit:                  'MB',
-      new_controller_type:     'VirtualLsiLogicController',
-      cb_dependent:            true,
-      nicsEnabled:             false,
-      addEnabled:              false,
-      enableAddDiskButton:     true,
+      memory: '0',
+      memory_type: '',
+      socket_count: '1',
+      cores_per_socket_count: '1',
+      total_cpus: '1',
+      vmdisks: [],
+      hdType: 'thin',
+      hdMode: 'persistent',
+      hdSize: '',
+      hdUnit: 'MB',
+      new_controller_type: 'VirtualLsiLogicController',
+      cb_dependent: true,
+      nicsEnabled: false,
+      addEnabled: false,
+      enableAddDiskButton: true,
       enableAddNetworkAdapterButton: true,
-      cb_bootable:             false,
-      vmAddDisks:              [],
-      vmRemoveDisks:           [],
-      vmResizeDisks:           [],
-      vLan_requested:          ''
+      cb_bootable: false,
+      vmAddDisks: [],
+      vmRemoveDisks: [],
+      vmResizeDisks: [],
+      vLan_requested: '',
     };
     vm.cb_disks = false;
     vm.cb_networkAdapters = false;
@@ -65,9 +65,9 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     vm.reconfigureModel.enableAddDiskButton = (nrDisksAfterReconfigure < 4);
   };
 
-  vm.setEnableAddNetworkAdapterButton = function () {
-    var nrNetworksAfterReconfigure=0;
-    angular.forEach(vm.reconfigureModel.vmNetworkAdapters, function(network){
+  vm.setEnableAddNetworkAdapterButton = function() {
+    var nrNetworksAfterReconfigure = 0;
+    angular.forEach(vm.reconfigureModel.vmNetworkAdapters, function(network) {
       switch (network.add_remove) {
         case "remove":
           break;
@@ -79,8 +79,8 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     vm.reconfigureModel.enableAddNetworkAdapterButton = (nrNetworksAfterReconfigure < 4);
   };
 
-  vm.canValidateBasicInfo = function () {
-    if (vm.isBasicInfoValid())
+  vm.canValidateBasicInfo = function() {
+    if (vm.isBasicInfoValid()) {
       return true;
     }
     return false;
@@ -206,22 +206,19 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
   };
 
   vm.updateNetworkAdaptersAddRemove = function() {
-    vm.reconfigureModel.vmAddNetworkAdapters=[];
+    vm.reconfigureModel.vmAddNetworkAdapters = [];
     vm.reconfigureModel.vmRemoveNetworkAdapters = [];
-    angular.forEach(vm.reconfigureModel.vmNetworkAdapters, function (networkAdapter)
-    {
-      if (networkAdapter['add_remove'] === 'add') {
+    angular.forEach(vm.reconfigureModel.vmNetworkAdapters, function(networkAdapter) {
+      if (networkAdapter.add_remove === 'add') {
         vm.reconfigureModel.vmAddNetworkAdapters.push({network: networkAdapter.vlan});
       }
-      if (networkAdapter['add_remove'] === 'remove') {
+      if (networkAdapter.add_remove === 'remove') {
         vm.reconfigureModel.vmRemoveNetworkAdapters.push({network: networkAdapter});
       }
     });
     vm.setEnableAddNetworkAdapterButton();
-    if( vm.reconfigureModel.vmAddNetworkAdapters.length > 0  || vm.reconfigureModel.vmRemoveNetworkAdapters.length > 0)
-      vm.cb_networkAdapters = true;
-    else
-      vm.cb_networkAdapters = false;
+    vm.cb_networkAdapters = vm.reconfigureModel.vmAddNetworkAdapters.length > 0  ||
+                            vm.reconfigureModel.vmRemoveNetworkAdapters.length > 0;
   };
 
   vm.resetAddValues = function() {
@@ -240,15 +237,15 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       {
         name: 'to be determined',
         vlan: vm.reconfigureModel.vLan_requested,
-        mac:  'not available yet',
-        add_remove: 'add'
+        mac: 'not available yet',
+        add_remove: 'add',
       });
     vm.resetAddNetworkAdapterValues();
     vm.updateNetworkAdaptersAddRemove();
   };
 
   vm.removeExistingNetworkAdapter = function(thisNetworkAdapter) {
-    thisNetworkAdapter['add_remove'] = 'remove';
+    thisNetworkAdapter.add_remove = 'remove';
     vm.updateNetworkAdaptersAddRemove();
   };
 
@@ -259,7 +256,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     vm.reconfigureModel.vLan_requested = '';
   };
 
-  vm.hideAddNetworkAdapter= function() {
+  vm.hideAddNetworkAdapter = function() {
     vm.resetAddNetworkAdapterValues();
   };
 
@@ -272,9 +269,9 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
   };
 
   vm.cancelAddRemoveNetworkAdapter = function(vmNetworkAdapter) {
-    if (vmNetworkAdapter.add_remove ==="remove"){
-      vmNetworkAdapter.add_remove= "";
-    } else if (vmNetworkAdapter.add_remove === "add"){
+    if (vmNetworkAdapter.add_remove === "remove") {
+      vmNetworkAdapter.add_remove = "";
+    } else if (vmNetworkAdapter.add_remove === "add") {
       var index = vm.reconfigureModel.vmNetworkAdapters.indexOf(vmNetworkAdapter);
       vm.reconfigureModel.vmNetworkAdapters.splice(index, 1);
     }
@@ -294,6 +291,8 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       add_remove: 'add'});
     vm.resetAddValues();
     vm.updateDisksAddRemove();
+
+    vm.cb_disks = vm.reconfigureModel.vmAddDisks.length > 0  || vm.reconfigureModel.vmRemoveDisks.length > 0;
   };
 
   vm.enableDiskAdd = function() {
@@ -331,6 +330,8 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       }
     }
     vm.updateDisksAddRemove();
+
+    vm.cb_disks = vm.reconfigureModel.vmAddDisks.length > 0  || vm.reconfigureModel.vmRemoveDisks.length > 0;
   };
 
   vm.cancelAddRemoveDisk = function(vmDisk) {
@@ -373,7 +374,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         vmRemoveDisks: vm.reconfigureModel.vmRemoveDisks,
         vmResizeDisks: vm.reconfigureModel.vmResizeDisks,
         vmAddNetworkAdapters: vm.reconfigureModel.vmAddNetworkAdapters,
-        vmRemoveNetworkAdapters: vm.reconfigureModel.vmRemoveNetworkAdapters
+        vmRemoveNetworkAdapters: vm.reconfigureModel.vmRemoveNetworkAdapters,
       });
     }
   };

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -66,16 +66,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
   };
 
   vm.setEnableAddNetworkAdapterButton = function() {
-    var nrNetworksAfterReconfigure = 0;
-    angular.forEach(vm.reconfigureModel.vmNetworkAdapters, function(network) {
-      switch (network.add_remove) {
-        case "remove":
-          break;
-        default:
-          nrNetworksAfterReconfigure++;
-          break;
-      }
-    });
+    var nrNetworksAfterReconfigure = _.reject(vm.reconfigureModel.vmNetworkAdapters, { add_remove: 'remove' }).length;
     vm.reconfigureModel.enableAddNetworkAdapterButton = (nrNetworksAfterReconfigure < 4);
   };
 
@@ -235,9 +226,9 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
   vm.processAddSelectedNetwork = function() {
     vm.reconfigureModel.vmNetworkAdapters.push(
       {
-        name: 'to be determined',
+        name: __('to be determined'),
         vlan: vm.reconfigureModel.vLan_requested,
-        mac: 'not available yet',
+        mac: __('not available yet'),
         add_remove: 'add',
       });
     vm.resetAddNetworkAdapterValues();
@@ -291,8 +282,6 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       add_remove: 'add'});
     vm.resetAddValues();
     vm.updateDisksAddRemove();
-
-    vm.cb_disks = vm.reconfigureModel.vmAddDisks.length > 0  || vm.reconfigureModel.vmRemoveDisks.length > 0;
   };
 
   vm.enableDiskAdd = function() {
@@ -330,8 +319,6 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       }
     }
     vm.updateDisksAddRemove();
-
-    vm.cb_disks = vm.reconfigureModel.vmAddDisks.length > 0  || vm.reconfigureModel.vmRemoveDisks.length > 0;
   };
 
   vm.cancelAddRemoveDisk = function(vmDisk) {

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -15,6 +15,7 @@ module ApplicationController::CiProcessing
     include Mixins::Actions::VmActions::Reconfigure
     helper_method(:supports_reconfigure_disks?)
     helper_method(:supports_reconfigure_disksize?)
+    helper_method(:supports_reconfigure_network_adapters?)
     include Mixins::Actions::VmActions::PolicySimulation
     include Mixins::Actions::VmActions::Transform
 

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -234,9 +234,9 @@ module Mixins
           if @reconfigureitems.size == 1
             vm = @reconfigureitems.first
 
-            vm.hardware.guest_devices.order(device_name: 'asc').each do |guest_device|
-              lan = Lan.find_by(id: guest_device.lan_id)
-              network_adapters << {name: guest_device.device_name, vlan: lan.name, mac: guest_device.address, :add_remove  => ''} unless lan.nil?
+            vm.hardware.guest_devices.order(:device_name => 'asc').each do |guest_device|
+              lan = Lan.find_by(:id => guest_device.lan_id)
+              network_adapters << {:name => guest_device.device_name, :vlan => lan.name, :mac => guest_device.address, :add_remove => ''} unless lan.nil?
             end
           end
 
@@ -326,15 +326,15 @@ module Mixins
           end
 
           if params[:vmAddNetworkAdapters]
-            params[:vmAddNetworkAdapters].values.each do |p|
-              p.transform_values!{ |v| eval_if_bool_string(v) }
+            params[:vmAddNetworkAdapters].each_value do |p|
+              p.transform_values! { |v| eval_if_bool_string(v) }
             end
             options[:network_adapter_add] = params[:vmAddNetworkAdapters].values
           end
 
           if params[:vmRemoveNetworkAdapters]
-            params[:vmRemoveNetworkAdapters].values.each do |p|
-              p.transform_values!{ |v| eval_if_bool_string(v) }
+            params[:vmRemoveNetworkAdapters].each_value do |p|
+              p.transform_values! { |v| eval_if_bool_string(v) }
             end
             options[:network_adapter_remove] = params[:vmRemoveNetworkAdapters].values
           end

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -16,6 +16,12 @@ module Mixins
           @force_no_grid_xml   = true
           @view, @pages = get_view(Vm, :view_suffix => "VmReconfigureRequest", :selected_ids => reconfigure_ids) # Get the records (into a view) and the paginator
           get_reconfig_limits(reconfigure_ids)
+
+          if @reconfigitems.size == 1
+            vm = Vm.find(@reconfigitems)
+            @vlan_options = get_vlan_options(vm.host_id)
+          end
+
           unless @explorer
             render :action => "show"
           end
@@ -181,6 +187,21 @@ module Mixins
           return humansize.to_s, fmt
         end
 
+        def get_vlan_options(host_id)
+          vlan_options = []
+
+          # determine available switches for this host...
+          switch_ids = []
+          HostSwitch.where("host_id = ?", host_id).each do |host_switch|
+            switch_ids << host_switch.switch_id
+          end
+
+          Lan.where("switch_id IN (?)", switch_ids).each do |lan|
+            vlan_options << lan.name
+          end
+          vlan_options
+        end
+
         def get_reconfig_info(reconfigure_ids)
           @reconfigureitems = Vm.find(reconfigure_ids).sort_by(&:name)
           # set memory to nil if multiple items were selected with different mem_cpu values
@@ -208,12 +229,24 @@ module Mixins
                         :cb_bootable => disk.bootable}
           end
 
+          # reconfiguring network adapters is only supported when one vm was selected
+          network_adapters = []
+          if @reconfigureitems.size == 1
+            vm = @reconfigureitems.first
+
+            vm.hardware.guest_devices.order(device_name: 'asc').each do |guest_device|
+              lan = Lan.find_by(id: guest_device.lan_id)
+              network_adapters << {name: guest_device.device_name, vlan: lan.name, mac: guest_device.address, :add_remove  => ''} unless lan.nil?
+            end
+          end
+
           {:objectIds              => reconfigure_ids,
            :memory                 => memory,
            :memory_type            => memory_type,
            :socket_count           => socket_count.to_s,
            :cores_per_socket_count => cores_per_socket.to_s,
-           :disks                  => vmdisks}
+           :disks                  => vmdisks,
+           :network_adapters       => network_adapters}
         end
 
         def supports_reconfigure_disks?
@@ -222,6 +255,10 @@ module Mixins
 
         def supports_reconfigure_disksize?
           @reconfigitems && @reconfigitems.size == 1 && @reconfigitems.first.supports_reconfigure_disksize? && @reconfigitems.first.supports_reconfigure_disks?
+        end
+
+        def supports_reconfigure_network_adapters?
+          @reconfigitems && @reconfigitems.size == 1 && @reconfigitems.first.supports_reconfigure_network_adapters?
         end
 
         private
@@ -286,6 +323,20 @@ module Mixins
               p.transform_values! { |v| eval_if_bool_string(v) }
             end
             options[:disk_remove] = params[:vmRemoveDisks].values
+          end
+
+          if params[:vmAddNetworkAdapters]
+            params[:vmAddNetworkAdapters].values.each do |p|
+              p.transform_values!{ |v| eval_if_bool_string(v) }
+            end
+            options[:network_adapter_add] = params[:vmAddNetworkAdapters].values
+          end
+
+          if params[:vmRemoveNetworkAdapters]
+            params[:vmRemoveNetworkAdapters].values.each do |p|
+              p.transform_values!{ |v| eval_if_bool_string(v) }
+            end
+            options[:network_adapter_remove] = params[:vmRemoveNetworkAdapters].values
           end
 
           if params[:id] && params[:id] != 'new'

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -192,11 +192,11 @@ module Mixins
 
           # determine available switches for this host...
           switch_ids = []
-          HostSwitch.where("host_id = ?", host_id).each do |host_switch|
+          Rbac.filtered(HostSwitch.where("host_id = ?", host_id)).each do |host_switch|
             switch_ids << host_switch.switch_id
           end
 
-          Lan.where("switch_id IN (?)", switch_ids).each do |lan|
+          Rbac.filtered(Lan.where("switch_id IN (?)", switch_ids)).each do |lan|
             vlan_options << lan.name
           end
           vlan_options

--- a/app/views/miq_request/_reconfigure_show.html.haml
+++ b/app/views/miq_request/_reconfigure_show.html.haml
@@ -46,6 +46,20 @@
           = _("Resize Disks")
         .col-md-8
           = h(@options[:disk_resize].size)
+    - if @options[:network_adapter_add]
+      .form-group
+        %label.control-label.col-md-2
+          = _("Add Network Adapters")
+        .col-md-8
+          = h(@options[:network_adapter_add].size)
+          &nbsp;
+    - if @options[:network_adapter_remove]
+      .form-group
+        %label.control-label.col-md-2
+          = _("Remove Network Adapters")
+        .col-md-8
+          = h(@options[:network_adapter_remove].size)
+          &nbsp;
     - if @options[:instance_type]
       .form-group
         %label.control-label.col-md-2

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -310,14 +310,15 @@
                                       "ng-disabled" => "!vm.reconfigureModel.enableAddNetworkAdapterButton"}= _('Add Network')
               %button.btn.btn-default.btn-sm{:type      => "button",
                                              "ng-click" => "vm.hideAddNetworkAdapter()",
-                                             "ng-show"  => "vm.reconfigureModel.nicsEnabled"}= ('Cancel Add')
+                                             "ng-show"  => "vm.reconfigureModel.nicsEnabled"}= _('Cancel Add')
       %table.table.table-striped.table-condensed.table-bordered
         %thead
           %th= _('Name')
           %th= _('vLan')
           %th= _('MAC Address')
           %th{:colspan => 2}= _('Actions')
-        %tr{"ng-repeat" => "networkAdapter in vm.reconfigureModel.vmNetworkAdapters", "ng-class" => "{'danger': networkAdapter.add_remove == 'remove', 'active': networkAdapter.add_remove == 'add'}"}
+        %tr{"ng-repeat" => "networkAdapter in vm.reconfigureModel.vmNetworkAdapters",
+            "ng-class"  => "{'danger': networkAdapter.add_remove == 'remove', 'active': networkAdapter.add_remove == 'add'}"}
           %td
             {{networkAdapter.name}}
           %td
@@ -343,7 +344,7 @@
           %td
           %td
             = select_tag('vLan',
-                       options_for_select([["<#{_('Choose')}>", '']] + @vlan_options, disabled: ["<#{_('Choose')}>", nil]),
+                       options_for_select([["<#{_('Choose')}>", '']] + @vlan_options, :disabled => ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "vm.reconfigureModel.vLan_requested",
                        "ng-change"                   => "",
                        "data-width"                  => "auto",
@@ -352,8 +353,8 @@
           %td
           %td.action-cell
             %button.btn.btn-default.btn-block.btn-sm{:type => "button",
-                                                              "ng-click" => "vm.processAddSelectedNetwork();rowForm.vLan.selectionpicker('refresh')",
-                                                              "ng-disabled" => "rowForm.vLan.$invalid || !vm.reconfigureModel.vmNetworkAdapters.length >= 4"}= _('Confirm Add')
+                       "ng-click" => "vm.processAddSelectedNetwork();rowForm.vLan.selectionpicker('refresh')",
+                       "ng-disabled" => "rowForm.vLan.$invalid || !vm.reconfigureModel.vmNetworkAdapters.length >= 4"}= _('Confirm Add')
           %td.action-cell
             %button.btn.btn-default.btn-block.btn-sm{:type => "button",
                                                               "ng-click" => "vm.hideAddNetworkAdapter()"}= _('Cancel Add')

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -295,6 +295,69 @@
               %button.btn.btn-default.btn-block.btn-sm{:type      => "button",
                                             "ng-if"    => "disk.add_remove == 'resize'",
                                             "ng-click" => "vm.cancelAddRemoveDisk(disk)"}= _('Cancel Resize')
+  - if supports_reconfigure_network_adapters?
+    %hr
+    %div
+      %h3
+        = _('Network Adapters')
+        %table{:width => "100%", :align => "bottom"}
+          %tr
+            %td#buttons_on_nics{:align => "right"}
+              %button.btn.btn-primary{:type      => "button",
+                                      "ng-click" => "vm.enableAddNetworkAdapter()",
+                                      :align     => "left",
+                                      "ng-show"  => "!vm.reconfigureModel.nicsEnabled",
+                                      "ng-disabled" => "!vm.reconfigureModel.enableAddNetworkAdapterButton"}= _('Add Network')
+              %button.btn.btn-default.btn-sm{:type      => "button",
+                                             "ng-click" => "vm.hideAddNetworkAdapter()",
+                                             "ng-show"  => "vm.reconfigureModel.nicsEnabled"}= ('Cancel Add')
+      %table.table.table-striped.table-condensed.table-bordered
+        %thead
+          %th= _('Name')
+          %th= _('vLan')
+          %th= _('MAC Address')
+          %th{:colspan => 2}= _('Actions')
+        %tr{"ng-repeat" => "networkAdapter in vm.reconfigureModel.vmNetworkAdapters", "ng-class" => "{'danger': networkAdapter.add_remove == 'remove', 'active': networkAdapter.add_remove == 'add'}"}
+          %td
+            {{networkAdapter.name}}
+          %td
+            {{networkAdapter.vlan}}
+          %td.narrow
+            {{networkAdapter.mac}}
+          %td.action-cell
+            %button.btn.btn-default.btn-block.btn-sm{:type         => "button",
+                                                     :style        => "visibility:hidden"}= _('Intentionally left empty')
+          %td.action-cell
+            %button.btn.btn-default.btn-block.btn-sm{:type => "button",
+                                                              "ng-if"    => "networkAdapter.add_remove == ''",
+                                                              "ng-click" => "vm.removeExistingNetworkAdapter(networkAdapter)"}= _('Delete')
+            %button.btn.btn-default.btn-block.btn-sm{:type => "button",
+                                                              "ng-if"    => "networkAdapter.add_remove == 'remove'",
+                                                              "ng-disabled" => "!vm.reconfigureModel.enableAddNetworkAdapterButton",
+                                                              "ng-click" => "vm.cancelAddRemoveNetworkAdapter(networkAdapter)"}= _('Cancel Delete')
+            %button.btn.btn-default.btn-block.btn-sm{:type => "button",
+                                                              "ng-if"    => "networkAdapter.add_remove == 'add'",
+                                                              "ng-click" => "vm.cancelAddRemoveNetworkAdapter(networkAdapter)"}= _('Cancel Add')
+        %tr{"ng-if"       => "vm.reconfigureModel.showDropDownNetwork",
+            "ng-form"     => "rowForm"}
+          %td
+          %td
+            = select_tag('vLan',
+                       options_for_select([["<#{_('Choose')}>", '']] + @vlan_options, disabled: ["<#{_('Choose')}>", nil]),
+                       "ng-model"                    => "vm.reconfigureModel.vLan_requested",
+                       "ng-change"                   => "",
+                       "data-width"                  => "auto",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "")
+          %td
+          %td.action-cell
+            %button.btn.btn-default.btn-block.btn-sm{:type => "button",
+                                                              "ng-click" => "vm.processAddSelectedNetwork();rowForm.vLan.selectionpicker('refresh')",
+                                                              "ng-disabled" => "rowForm.vLan.$invalid || !vm.reconfigureModel.vmNetworkAdapters.length >= 4"}= _('Confirm Add')
+          %td.action-cell
+            %button.btn.btn-default.btn-block.btn-sm{:type => "button",
+                                                              "ng-click" => "vm.hideAddNetworkAdapter()"}= _('Cancel Add')
+
   %hr
 
   %table{:width => "100%", :align => "bottom"}
@@ -303,7 +366,7 @@
         %miq-button{:name      => t = _('Submit'),
                     :title     => t,
                     :alt       => t,
-                    :enabled   => "!((angularForm.$pristine && !vm.cb_disks) || angularForm.$invalid || (!vm.cb_memory && !vm.cb_cpu && !vm.cb_disks))",
+                    :enabled   => "!((angularForm.$pristine && !vm.cb_disks && !vm.cb_networkAdapters) || angularForm.$invalid || (!vm.cb_memory && !vm.cb_cpu && !vm.cb_disks && !vm.cb_networkAdapters))",
                     'on-click' => "vm.submitClicked()",
                     :primary   => 'true'}
         %miq-button{:name      => t = _('Reset'),

--- a/spec/javascripts/controllers/reconfigure/reconfigure_form_controller_spec.js
+++ b/spec/javascripts/controllers/reconfigure/reconfigure_form_controller_spec.js
@@ -16,7 +16,8 @@ describe('reconfigureFormController', function() {
       cb_cpu:                 'on',
       socket_count:           '2',
       cores_per_socket_count: '3',
-      disks:                 [{hdFilename: "test_disk.vmdk", hdType: "thick", hdMode: "persistent", new_controller_type: "VirtualLsiLogicController", hdSize: "0", hdUnit: "MB", add_remove: ""}]};
+      disks:                 [{hdFilename: "test_disk.vmdk", hdType: "thick", hdMode: "persistent", new_controller_type: "VirtualLsiLogicController", hdSize: "0", hdUnit: "MB", add_remove: ""}],
+      network_adapters:      [{name: "Network adapter 1", vlan: "test_network", mac: "00:00:00:00:00:00", add_remove: ""}]};
 
     $httpBackend = _$httpBackend_;
     $httpBackend.whenGET('reconfigure_form_fields/1000000000003,1000000000001,1000000000002').respond(reconfigureFormResponse);
@@ -55,6 +56,9 @@ describe('reconfigureFormController', function() {
 
     it('initializes the delete_backing flag to false if not retrived', function() {
       expect(vm.reconfigureModel.vmdisks[0].delete_backing).toEqual(false);
+    });
+    it('sets the network adapter data to the network adapter data returned with the http request', function() {
+      expect(vm.reconfigureModel.vmNetworkAdapters).toEqual([{name: "Network adapter 1", vlan: "test_network", mac: "00:00:00:00:00:00", add_remove: ""}]);
     });
   });
 
@@ -95,7 +99,8 @@ describe('reconfigureFormController', function() {
                            memory_type:            vm.reconfigureModel.memory_type,
                            socket_count:           vm.reconfigureModel.socket_count,
                            cores_per_socket_count: vm.reconfigureModel.cores_per_socket_count,
-                           vmAddDisks: [  ], vmRemoveDisks: [  ], vmResizeDisks: [  ] };
+                           vmAddDisks: [  ], vmRemoveDisks: [  ], vmResizeDisks: [  ],
+                           vmAddNetworkAdapters: [  ], vmRemoveNetworkAdapters: [  ] };
 
       expect(miqService.miqAjaxButton).toHaveBeenCalledWith('reconfigure_update/1000000000003?button=submit', submitContent);
     });

--- a/spec/javascripts/controllers/reconfigure/reconfigure_form_controller_spec.js
+++ b/spec/javascripts/controllers/reconfigure/reconfigure_form_controller_spec.js
@@ -100,7 +100,7 @@ describe('reconfigureFormController', function() {
                            socket_count:           vm.reconfigureModel.socket_count,
                            cores_per_socket_count: vm.reconfigureModel.cores_per_socket_count,
                            vmAddDisks: [  ], vmRemoveDisks: [  ], vmResizeDisks: [  ],
-                           vmAddNetworkAdapters: [  ], vmRemoveNetworkAdapters: [  ] };
+                           vmAddNetworkAdapters: [  ], vmRemoveNetworkAdapters: [  ]};
 
       expect(miqService.miqAjaxButton).toHaveBeenCalledWith('reconfigure_update/1000000000003?button=submit', submitContent);
     });


### PR DESCRIPTION
This PR adds a new feature to the 'Reconfigure VM' webpage: Add / Remove Network Adapters.

This PR is part of a set of PRs:
https://github.com/ManageIQ/vmware_web_service/pull/25
https://github.com/ManageIQ/manageiq-providers-vmware/pull/163
https://github.com/ManageIQ/manageiq/pull/16700
https://github.com/ManageIQ/manageiq-ui-classic/pull/3121

Issue #3119 describes the lack of support for adding or removing network adapters at the Reconfigure VM webpage. There are some screenshots and a link to the four PRs implementing this new functionality.