### PR TITLE
Fix Display Vm option, when clicking on chart

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -527,7 +527,7 @@ module ApplicationController::Performance
   # Send error message if record is found and authorized, else return the record
   def perf_menu_record_valid(model, id)
     record = find_record_with_rbac(model.constantize, id)
-    if record.present?
+    if record.blank?
       add_flash(_("Can't access selected record"))
     end
     unless @flash_array.blank?

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -180,13 +180,11 @@ module ApplicationController::Performance
 
     report = @sb[:chart_reports].kind_of?(Array) ? @sb[:chart_reports][chart_click_data.chart_index] : @sb[:chart_reports]
     data_row = report.table.data[chart_click_data.data_index]
-
     ts = data_row["timestamp"].in_time_zone(@perf_options[:tz]) # Grab the timestamp from the row in selected tz
-
     request_displayed, unavailability_reason = case chart_click_data.cmd
     when "Display"
       if chart_click_data.model == "Current" && chart_click_data.type == "Top"
-        display_current_top(chart_click_data, data_row)
+        display_current_top(data_row)
       elsif chart_click_data.type == "bytag"
         display_by_tag(chart_click_data, data_row, report, ts, bc_model)
       else


### PR DESCRIPTION
Fix Display Vm option, when clicking on chart. 

`display_current_top` functions was called with to parameters instead of one and logic used for evaluate result of RBAC check was inverted.


Links [Optional]
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1527554


GIF
-------------------------------
![screencast from 2017-12-20 15-08-00](https://user-images.githubusercontent.com/9535558/34210921-c202624a-e597-11e7-8cf2-c5b637b7ed36.gif)


Steps for Testing/QA
-------------------------------

1. Drill any graph select:  'chart' > 'Top VMs on this day' .
2. Now check for display> other/ vm_name
