### PR TITLE
Fix issues related to adding, editing Chargeback Rates

### DIFF
--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -18,13 +18,14 @@
       %th= _("Fixed")
       %th= _("Variable")
   %tbody
-    - @edit[:new][:details].sort_by { |rd| [rd[:group], rd[:description], rd[:sub_metric].to_s] }.each do |detail|
+    - @edit[:new][:details].sort_by { |rd| [rd[:group], rd[:description], rd[:sub_metric].to_s] }.each_with_index do |detail, detail_index|
       - @cur_group = detail[:group] if @cur_group.nil?
       - if @cur_group != detail[:group]
         - @cur_group = detail[:group]
         %tr
           %td{:colspan => "10", :style => "background-color: #f5f5f5;"} &nbsp;
-      - detail_index = @edit[:new][:tiers].index { |x| x.detect { |tier_hash| tier_hash['chargeback_rate_detail_id'] == detail[:id] }.present? }
+      - if params[:pressed] == "chargeback_rates_edit"
+        - detail_index = @edit[:new][:tiers].index { |x| x.detect { |tier_hash| tier_hash['chargeback_rate_detail_id'] == detail[:id] }.present? }
       - num_tiers = @edit[:new][:tiers][detail_index].blank? ? "1" : @edit[:new][:tiers][detail_index].length.to_s
 
       %tr.rdetail{:id => "rate_detail_row_#{detail_index}_0"}


### PR DESCRIPTION
**fixing** https://github.com/ManageIQ/manageiq/issues/16699

Fix issues related to adding new or editing existing chargeback rates in _Cloud Intel -> Chargeback
-> Rates_ tab, caused by improper `detail_index` in the chargeback rate edit table.

**Issues:**
- on mouse focus, the whole form/table is highlighted instead of one row, when adding a new chargeback rate
https://user-images.githubusercontent.com/14937244/34208255-0446729a-e58e-11e7-8e4a-ecaadf5b419b.gif
- if a new tier is added (by pressing _Add_ button in the table), the then tier is added to the improper metric
https://user-images.githubusercontent.com/14937244/34208319-56445364-e58e-11e7-803b-d0c4673727ab.gif

**After:**
![rate_highlight](https://user-images.githubusercontent.com/13417815/34255746-60cceaf2-e652-11e7-8e6b-4e07813c5112.png)
![tier_add](https://user-images.githubusercontent.com/13417815/34255756-657179ba-e652-11e7-9ebf-66eb842b76f9.png)

**Details:**
Simple condition was added to haml, because it is accessed not only if editing chargeback rate, but also if adding a new one. We don't need editing `detail_index` if we just add a new rate.