### PR TITLE
find_records_with_rbac raises exception if ids contains nil

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -180,7 +180,6 @@ module ApplicationController::CiProcessing
   def identify_record(id, klass = self.class.model)
     begin
       record = find_record_with_rbac(klass, from_cid(id))
-    rescue ActiveRecord::RecordNotFound
     rescue => @bang
       self.x_node = "root" if @explorer
       add_flash(@bang.message, :error, true)

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -123,9 +123,9 @@ module Mixins
     #   either sets flash or raises exception
     #
     def find_records_with_rbac(klass, ids, options = {})
-      raise(_("Can't access records without id")) if ids.include?(nil) || ids.empty?
+      raise(ActiveRecord::RecordNotFound, _("Can't access records without id")) if ids.include?(nil) || ids.empty?
       filtered = Rbac.filtered(klass.where(:id => ids), :named_scope => options[:named_scope])
-      raise(_("Can't access selected records")) unless ids.length == filtered.length
+      raise(ActiveRecord::RecordNotFound, _("Can't access selected records")) unless ids.length == filtered.length
       filtered
     end
 

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -123,6 +123,7 @@ module Mixins
     #   either sets flash or raises exception
     #
     def find_records_with_rbac(klass, ids, options = {})
+      raise(_("Can't access records without id")) if ids.include?(nil) || ids.empty?
       filtered = Rbac.filtered(klass.where(:id => ids), :named_scope => options[:named_scope])
       raise(_("Can't access selected records")) unless ids.length == filtered.length
       filtered

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -123,7 +123,7 @@ module Mixins
     #   either sets flash or raises exception
     #
     def find_records_with_rbac(klass, ids, options = {})
-      raise(ActiveRecord::RecordNotFound, _("Can't access records without id")) if ids.include?(nil) || ids.empty?
+      raise(ActiveRecord::RecordNotFound, _("Can't access records without an id")) if ids.include?(nil) || ids.empty?
       filtered = Rbac.filtered(klass.where(:id => ids), :named_scope => options[:named_scope])
       raise(ActiveRecord::RecordNotFound, _("Can't access selected records")) unless ids.length == filtered.length
       filtered

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -119,20 +119,10 @@ module ReportController::Schedules
 
   def schedule_toggle(enable)
     assert_privileges("miq_report_schedule_#{enable ? 'enable' : 'disable'}")
-    msg1, msg2 = if enable
-                   [_("No Report Schedules were selected to be enabled"),
-                    _("The selected Report Schedules were enabled")]
-                 else
-                   [_("No Report Schedules were selected to be disabled"),
-                    _("The selected Report Schedules were disabled")]
-                 end
+    msg = enable ? _("The selected Report Schedules were enabled") : _("The selected Report Schedules were disabled")
     scheds = find_records_with_rbac(MiqSchedule, checked_or_params)
-    if scheds.empty?
-      add_flash(msg1, :error)
-      javascript_flash
-    end
-    schedule_enable_disable(scheds, enable) unless scheds.empty?
-    add_flash(msg2, :info, true) unless flash_errors?
+    schedule_enable_disable(scheds, enable)
+    add_flash(msg, :info, true)
     schedule_get_all
     replace_right_cell
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,11 +12,11 @@ describe ApplicationController do
     end
 
     it "Verify Invalid input flash error message when invalid id is passed in" do
-      expect { controller.send(:find_record_with_rbac, ExtManagementSystem, "invalid") }.to raise_error(RuntimeError, "Can't access selected records")
+      expect { controller.send(:find_record_with_rbac, ExtManagementSystem, "invalid") }.to raise_error(ActiveRecord::RecordNotFound, "Can't access selected records")
     end
 
     it "Verify flash error message when passed in id no longer exists in database" do
-      expect { controller.send(:find_record_with_rbac, ExtManagementSystem, "1") }.to raise_error(RuntimeError, match(/Can't access selected records/))
+      expect { controller.send(:find_record_with_rbac, ExtManagementSystem, "1") }.to raise_error(ActiveRecord::RecordNotFound, match(/Can't access selected records/))
     end
 
     it "Verify record gets set when valid id is passed in" do

--- a/spec/controllers/container_image_controller_spec.rb
+++ b/spec/controllers/container_image_controller_spec.rb
@@ -16,9 +16,8 @@ describe ContainerImageController do
     ApplicationController.handle_exceptions = true
 
     expect(controller).to receive(:check_compliance).and_call_original
-    expect(controller).to receive(:add_flash).with("Error: Record no longer exists in the database", :error, true)
-    expect(controller).to receive(:add_flash).with("Container Image no longer exists", :error)
     expect(controller).to receive(:add_flash).with("No Container Images were selected for Compliance Check", :error)
+    expect(controller).to receive(:add_flash).with("Container Image no longer exists", :error)
     post :button, :params => { :pressed => 'container_image_check_compliance', :format => :js }
   end
 

--- a/spec/controllers/mixins/checked_id_mixin_spec.rb
+++ b/spec/controllers/mixins/checked_id_mixin_spec.rb
@@ -33,7 +33,7 @@ describe Mixins::CheckedIdMixin do
       before { allow(Rbac).to receive(:filtered).and_return([vm1, vm2]) }
       let(:model) { VmOrTemplate }
       let(:id) { [vm1.id, vm2.id, vm3.id] }
-      it 'is expected to raise exeption' do
+      it 'is expected to raise exception' do
         expect { subject }.to raise_error("Can't access selected records")
       end
     end
@@ -42,7 +42,7 @@ describe Mixins::CheckedIdMixin do
       let(:model) { VmOrTemplate }
       let(:missing_vm_id) { VmOrTemplate.maximum(:id) + 1000 }
       let(:id) { [vm1.id, vm2.id, missing_vm_id] }
-      it 'is expected to raise exeption' do
+      it 'is expected to raise exception' do
         expect { subject }.to raise_error("Can't access selected records")
       end
     end
@@ -50,16 +50,16 @@ describe Mixins::CheckedIdMixin do
     context 'when there is no record id' do
       let(:model) { VmOrTemplate }
       let(:id) { [] }
-      it 'is expected to raise exeption' do
-        expect { subject }.to raise_error("Can't access records without id")
+      it 'is expected to raise exception' do
+        expect { subject }.to raise_error("Can't access records without an id")
       end
     end
 
     context 'when user tries to access record with nil id ' do
       let(:model) { VmOrTemplate }
       let(:id) { [vm1.id, nil] }
-      it 'is expected to raise exeption' do
-        expect { subject }.to raise_error("Can't access records without id")
+      it 'is expected to raise exception' do
+        expect { subject }.to raise_error("Can't access records without an id")
       end
     end
   end

--- a/spec/controllers/mixins/checked_id_mixin_spec.rb
+++ b/spec/controllers/mixins/checked_id_mixin_spec.rb
@@ -46,5 +46,21 @@ describe Mixins::CheckedIdMixin do
         expect { subject }.to raise_error("Can't access selected records")
       end
     end
+
+    context 'when there is no record id' do
+      let(:model) { VmOrTemplate }
+      let(:id) { [] }
+      it 'is expected to raise exeption' do
+        expect { subject }.to raise_error("Can't access records without id")
+      end
+    end
+
+    context 'when user tries to access record with nil id ' do
+      let(:model) { VmOrTemplate }
+      let(:id) { [vm1.id, nil] }
+      it 'is expected to raise exeption' do
+        expect { subject }.to raise_error("Can't access records without id")
+      end
+    end
   end
 end

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -14,11 +14,11 @@ describe OpsController do
       end
 
       it "#schedule_enable" do
-        expect { controller.schedule_enable }.to raise_error("Can't access records without id")
+        expect { controller.schedule_enable }.to raise_error("Can't access records without an id")
       end
 
       it "#schedule_disable" do
-        expect { controller.schedule_disable }.to raise_error("Can't access records without id")
+        expect { controller.schedule_disable }.to raise_error("Can't access records without an id")
       end
     end
 

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -11,22 +11,14 @@ describe OpsController do
         silence_warnings { OpsController::Settings::Schedules::STGROOT = 'ST'.freeze }
 
         allow(controller).to receive(:find_checked_items).and_return([])
-        expect(controller).to receive(:render)
-        expect(controller).to receive(:schedule_build_list)
-        expect(controller).to receive(:settings_get_info)
-        expect(controller).to receive(:replace_right_cell)
       end
 
       it "#schedule_enable" do
-        controller.schedule_enable
-        flash_messages = controller.instance_variable_get(:@flash_array)
-        expect(flash_messages.first).to eq(:message => "The selected Schedules were enabled", :level => :error)
+        expect { controller.schedule_enable }.to raise_error("Can't access records without id")
       end
 
       it "#schedule_disable" do
-        controller.schedule_disable
-        flash_messages = controller.instance_variable_get(:@flash_array)
-        expect(flash_messages.first).to eq(:message => "The selected Schedules were disabled", :level => :error)
+        expect { controller.schedule_disable }.to raise_error("Can't access records without id")
       end
     end
 

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -727,11 +727,11 @@ describe ReportController do
       end
 
       it "#miq_report_schedule_enable" do
-        expect { controller.miq_report_schedule_enable }.to raise_error("Can't access records without id")
+        expect { controller.miq_report_schedule_enable }.to raise_error("Can't access records without an id")
       end
 
       it "#miq_report_schedule_disable" do
-        expect { controller.miq_report_schedule_disable }.to raise_error("Can't access records without id")
+        expect { controller.miq_report_schedule_disable }.to raise_error("Can't access records without an id")
       end
     end
 

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -724,23 +724,14 @@ describe ReportController do
     context "no schedules selected" do
       before do
         allow(controller).to receive(:find_checked_items).and_return([])
-        expect(controller).to receive(:render)
-        expect(controller).to receive(:schedule_get_all)
-        expect(controller).to receive(:replace_right_cell)
       end
 
       it "#miq_report_schedule_enable" do
-        controller.miq_report_schedule_enable
-        flash_messages = assigns(:flash_array)
-        expect(flash_messages.first[:message]).to eq("No Report Schedules were selected to be enabled")
-        expect(flash_messages.first[:level]).to eq(:error)
+        expect { controller.miq_report_schedule_enable }.to raise_error("Can't access records without id")
       end
 
       it "#miq_report_schedule_disable" do
-        controller.miq_report_schedule_disable
-        flash_messages = assigns(:flash_array)
-        expect(flash_messages.first[:message]).to eq("No Report Schedules were selected to be disabled")
-        expect(flash_messages.first[:level]).to eq(:error)
+        expect { controller.miq_report_schedule_disable }.to raise_error("Can't access records without id")
       end
     end
 


### PR DESCRIPTION
Change `find_records_with_rbac(klass, ids, options = {})` method behavior if ids contains nil. Now when you call this method with ids contains nil or empty array, it just returns nil or empty array.

After this change  `find_records_with_rbac(klass, ids, options = {})` will raise exception if ids contains nil value. Because when you want to access record with nil id something is probably wrong and this method shouldn't hide it.

Works analogically for `find_record_with_rbac` which uses `find_records_with_rbac`
  