### PR TITLE
Delete perf_menu_record_valid method

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -225,12 +225,12 @@ module ApplicationController::Performance
 
   # display the CI selected from a Top chart
   def display_current_top(data_row)
-    unless perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"])
-      return [true, nil]
-    end
+    # Record needs to exist and user must have rights to access it
+    record = find_record_with_rbac(data_row["resource_type"], data_row["resource_id"])
+
     javascript_redirect :controller => data_row["resource_type"].underscore,
                         :action     => "show",
-                        :id         => data_row["resource_id"],
+                        :id         => record.id,
                         :escape     => false
     [true, nil]
   end
@@ -322,7 +322,7 @@ module ApplicationController::Performance
 
   # display timeline for the selected CI
   def timeline_selected(chart_click_data, data_row, ts)
-    @record = perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"])
+    @record = find_record_with_rbac(data_row["resource_type"], data_row["resource_id"])
     return [true, nil] unless @record
     controller = data_row["resource_type"].underscore
     new_opts = tl_session_data(controller) || ApplicationController::Timelines::Options.new
@@ -437,7 +437,7 @@ module ApplicationController::Performance
 
   # Create daily/hourly chart for selected CI
   def chart_selected(chart_click_data, data_row, ts)
-    @record = perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"])
+    @record = find_record_with_rbac(data_row["resource_type"], data_row["resource_id"])
     return [true, nil] unless @record
     # Set the perf options in the selected controller's sandbox
     cont = data_row["resource_type"].underscore.downcase.to_sym

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -524,19 +524,6 @@ module ApplicationController::Performance
     end
   end
 
-  # Send error message if record is found and authorized, else return the record
-  def perf_menu_record_valid(model, id)
-    record = find_record_with_rbac(model.constantize, id)
-    if record.blank?
-      add_flash(_("Can't access selected record"))
-    end
-    unless @flash_array.blank?
-      javascript_flash(:spinner_off => true)
-      return false
-    end
-    record # Record is found and authorized
-  end
-
   # Load a chart miq_report object from YML
   def perf_get_chart_rpt(chart_rpt)
     MiqReport.new(YAML.load(File.open("#{CHARTS_REPORTS_FOLDER}/#{chart_rpt}.yaml")))


### PR DESCRIPTION
Should be merged after #3131 

Delete  `perf_menu_record_valid` validation method, because its not necessary.
Replace it with direct call of `find_record_with_rbac`.  After #3131 changes `find_record_with_rbac` raises exception instead of returning `[]` or `nil`

Links
----------------
 #3131


  