### PR TITLE
Apply gettext on db attribute in analysis profile error flash message

### DIFF
--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -278,7 +278,7 @@ module OpsController::Settings::AnalysisProfiles
             replace_right_cell(:nodetype => x_node, :replace_trees => [:settings])
           else
             scanitemset.errors.each do |field, msg|
-              add_flash("#{field.to_s.capitalize} #{msg}", :error)
+              add_flash("#{_(field.to_s.capitalize)} #{msg}", :error)
             end
             @edit[:new] = ap_sort_array(@edit[:new])
             @edit[:current] = ap_sort_array(@edit[:current])


### PR DESCRIPTION
Before
![ap-add-before](https://user-images.githubusercontent.com/6648365/34264425-27c8442e-e673-11e7-9023-ba6efdd86af7.jpg)

After
![ap-add-after](https://user-images.githubusercontent.com/6648365/34264428-2d8c571a-e673-11e7-8219-5416779ba746.jpg)


https://bugzilla.redhat.com/show_bug.cgi?id=1525908