### PR TITLE
Refresh button disabled when credentials are not valid

### DIFF
--- a/app/helpers/application_helper/button/ems_refresh.rb
+++ b/app/helpers/application_helper/button/ems_refresh.rb
@@ -1,0 +1,9 @@
+class ApplicationHelper::Button::EmsRefresh < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def disabled?
+    super
+    @error_message ||= _("Credentials must be valid to refresh a provider") unless @record.authentication_status.downcase == "valid"
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/toolbar/ems_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cloud_center.rb
@@ -16,7 +16,8 @@ class ApplicationHelper::Toolbar::EmsCloudCenter < ApplicationHelper::Toolbar::B
           'fa fa-refresh fa-lg',
           N_('Refresh relationships and power states for all items related to this Cloud Provider'),
           N_('Refresh Relationships and Power States'),
-          :confirm => N_("Refresh relationships and power states for all items related to this Cloud Provider?")),
+          :confirm => N_("Refresh relationships and power states for all items related to this Cloud Provider?"),
+          :klass   => ApplicationHelper::Button::EmsRefresh),
         separator,
         button(
           :ems_cloud_user_sync,

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -16,7 +16,8 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
           'fa fa-refresh fa-lg',
           N_('Refresh items and relationships related to this Containers Provider'),
           N_('Refresh items and relationships'),
-          :confirm => N_("Refresh items and relationships related to this Containers Provider?")),
+          :confirm => N_("Refresh items and relationships related to this Containers Provider?"),
+          :klass   => ApplicationHelper::Button::EmsRefresh),
         separator,
         button(
           :ems_container_edit,

--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -16,7 +16,8 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
           'fa fa-refresh fa-lg',
           N_('Refresh relationships and power states for all items related to this Infrastructure Provider'),
           N_('Refresh Relationships and Power States'),
-          :confirm => N_("Refresh relationships and power states for all items related to this Infrastructure Provider?")),
+          :confirm => N_("Refresh relationships and power states for all items related to this Infrastructure Provider?"),
+          :klass   => ApplicationHelper::Button::EmsRefresh),
         button(
           :host_register_nodes,
           'pficon pficon-add-circle-o fa-lg',

--- a/app/helpers/application_helper/toolbar/ems_middleware_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_middleware_center.rb
@@ -11,7 +11,8 @@ class ApplicationHelper::Toolbar::EmsMiddlewareCenter < ApplicationHelper::Toolb
           'fa fa-refresh fa-lg',
           N_('Refresh items and relationships related to this Middleware Provider'),
           N_('Refresh items and relationships'),
-          :confirm => N_("Refresh items and relationships related to this Middleware Provider?")),
+          :confirm => N_("Refresh items and relationships related to this Middleware Provider?"),
+          :klass   => ApplicationHelper::Button::EmsRefresh),
         separator,
         button(
           :ems_middleware_edit,

--- a/app/helpers/application_helper/toolbar/ems_network_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_network_center.rb
@@ -16,7 +16,8 @@ class ApplicationHelper::Toolbar::EmsNetworkCenter < ApplicationHelper::Toolbar:
           'fa fa-refresh fa-lg',
           N_('Refresh relationships and power states for all items related to this Network Provider'),
           N_('Refresh Relationships and Power States'),
-          :confirm => N_("Refresh relationships and power states for all items related to this Network Provider?")),
+          :confirm => N_("Refresh relationships and power states for all items related to this Network Provider?"),
+          :klass   => ApplicationHelper::Button::EmsRefresh),
         separator,
         button(
           :ems_network_edit,

--- a/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
@@ -16,7 +16,8 @@ class ApplicationHelper::Toolbar::EmsPhysicalInfraCenter < ApplicationHelper::To
           'fa fa-refresh fa-lg',
           N_('Refresh relationships and power states for all items related to this Infrastructure Provider'),
           N_('Refresh Relationships and Power States'),
-          :confirm => N_("Refresh relationships and power states for all items related to this Infrastructure Provider?")),
+          :confirm => N_("Refresh relationships and power states for all items related to this Infrastructure Provider?"),
+          :klass   => ApplicationHelper::Button::EmsRefresh),
         separator,
         button(
           :ems_physical_infra_edit,

--- a/spec/helpers/application_helper/buttons/ems_refresh_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_refresh_spec.rb
@@ -1,0 +1,20 @@
+describe ApplicationHelper::Button::EmsRefresh do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:record) { FactoryGirl.create(:ems_infra) }
+  let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
+
+  describe '#disabled?' do
+    subject { button[:title] }
+    before { allow(record).to receive(:authentication_status).and_return(auth_status) }
+
+    context 'and record authentication status is valid' do
+      let(:auth_status) { "Valid" }
+      it { expect(button.disabled?).to be_falsey }
+    end
+
+    context 'and record authentication status is not valid' do
+      let(:auth_status) { "Invalid" }
+      it { expect(button.disabled?).to be_truthy }
+    end
+  end
+end


### PR DESCRIPTION
Disables Refresh button on Provider summary screen based upon authentication status

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1515798

@dclarizio please review.

after screenshots:
![after1](https://user-images.githubusercontent.com/3450808/34269186-661f3650-e651-11e7-839f-36a5949ad9fb.png)

![after2](https://user-images.githubusercontent.com/3450808/34269150-41402de4-e651-11e7-84a5-a740acc9a33b.png)
