### PR TITLE
Disable Provision Physical Server button for specific cases

### DIFF
--- a/app/helpers/application_helper/button/physical_server_provision.rb
+++ b/app/helpers/application_helper/button/physical_server_provision.rb
@@ -1,0 +1,15 @@
+class ApplicationHelper::Button::PhysicalServerProvision < ApplicationHelper::Button::Basic
+  def disabled?
+    disabled = true
+    if EmsPhysicalInfra.count.zero?
+      @error_message = _('No Physical Infrastructure Provider that supports VM provisioning added')
+    elsif PhysicalServer.count.zero?
+      @error_message = _('No Physical Servers that support VM provisioning available')
+    elsif EmsPhysicalInfra.all.none?(&:supports_provisioning?)
+      @error_message = _('No Physical Infrastructure Providers that support VM provisioning available')
+    else
+      disabled = false
+    end
+    disabled
+  end
+end

--- a/app/helpers/application_helper/toolbar/physical_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_servers_center.rb
@@ -233,9 +233,7 @@ class ApplicationHelper::Toolbar::PhysicalServersCenter < ApplicationHelper::Too
             t,
             :url       => "provision",
             :url_parms => "main_div",
-            :enabled   => true,
-            :onwhen    => "0+",
-            :klass     => ApplicationHelper::Button::ConfiguredSystemProvision
+            :klass     => ApplicationHelper::Button::PhysicalServerProvision
           )
         ]
       )

--- a/spec/helpers/application_helper/buttons/physical_server_provision_spec.rb
+++ b/spec/helpers/application_helper/buttons/physical_server_provision_spec.rb
@@ -1,0 +1,50 @@
+describe ApplicationHelper::Button::PhysicalServerProvision do
+  describe '#disabled?' do
+    context "button should not be disabled" do
+      before do
+        ems = FactoryGirl.create(:ems_physical_infra)
+        @record = FactoryGirl.create(:physical_server, :ems_id => ems.id)
+      end
+
+      it "does not disable the Provision button" do
+        allow_any_instance_of(EmsPhysicalInfra).to receive(:supports_provisioning?).and_return(true)
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {}, {})
+        expect(button.disabled?).to be_falsey
+      end
+    end
+
+    context "button should be disabled when there are no Physical infrastructure providers" do
+      it "disable the Provision button" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {}, {})
+        expect(button.disabled?).to be_truthy
+      end
+    end
+
+    context "button should be disabled when there are no Physical Servers" do
+      before do
+        FactoryGirl.create(:ems_physical_infra)
+      end
+
+      it "disable the Provision button" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {}, {})
+        expect(button.disabled?).to be_truthy
+      end
+    end
+
+    context "button should be disabled when there are no Physical infrastructure providers that support VM Provisioning" do
+      before do
+        ems = FactoryGirl.create(:ems_physical_infra)
+        @record = FactoryGirl.create(:physical_server, :ems_id => ems.id)
+      end
+
+      it "disable the Provision button" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {}, {})
+        expect(button.disabled?).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Disables `Provision Physical Server` toolbar button if -

- There are no Physical Infra Providers
- There are no Physical Servers
- There are no Physical Infra Providers that support provisioning

https://bugzilla.redhat.com/show_bug.cgi?id=1525113