### PR TITLE
Add missing ldap_region_delete to whitelist in ops_controller

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -81,8 +81,10 @@ class OpsController < ApplicationController
     'schedule_disable'          => :schedule_disable,
     'ldap_region_add'           => :ldap_region_add,
     'ldap_region_edit'          => :ldap_region_edit,
+    'ldap_region_delete'        => :ldap_region_delete,
     'ldap_domain_add'           => :ldap_domain_add,
     'ldap_domain_edit'          => :ldap_domain_edit,
+    'ldap_domain_delete'        => :ldap_domain_delete,
   }.freeze
 
   def collect_current_logs


### PR DESCRIPTION
Resolves issue with https://github.com/ManageIQ/manageiq-ui-classic/pull/2942

Product feature must be set. Have `ldap_new: true` for `product` in current server Advanced.
Add LDAP authentication for any server.
Restart server.
Configuration -> Settings -> LDAP -> select any Region/Domain -> Configuration -> Delete 
<img width="283" alt="screen shot 2017-12-22 at 2 45 03 pm" src="https://user-images.githubusercontent.com/9210860/34300047-a1b89564-e726-11e7-9b87-2033a17c12da.png">


Before:
```
F, [2017-12-22T14:28:10.772374 #39186] FATAL -- : Error caught: [ActionController::RoutingError] invalid button action
/Users/zita/Desktop/ManageIQ/manageiq-ui-
classic/app/controllers/application_controller/explorer.rb:196:in `generic_x_button'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/ops_controller.rb:95:in `x_button'
```
After:
<img width="902" alt="screen shot 2017-12-22 at 2 38 18 pm" src="https://user-images.githubusercontent.com/9210860/34299921-e900453a-e725-11e7-9cd5-151933f73b0e.png">

cc: @jvlcek (LDAP)

@miq-bot add_label settings, bug