### PR TITLE
Add kubevirt provider

### DIFF
--- a/app/assets/images/svg/vendor-kubevirt.svg
+++ b/app/assets/images/svg/vendor-kubevirt.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<!--
+Copyright (c) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="5cm"
+   height="5cm"
+   viewBox="0 0 50 49.999999"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92+devel unknown"
+   sodipodi:docname="vendor-kubevirt.svg">
+  <defs
+     id="defs2">
+    <inkscape:path-effect
+       effect="fillet_chamfer"
+       id="path-effect3542"
+       is_visible="true"
+       satellites_param="F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1 @ F,0,0,1,0,1.5289994,0,1"
+       unit="mm"
+       method="auto"
+       mode="F"
+       radius="12"
+       chamfer_steps="1"
+       helper_size="0"
+       flexible="false"
+       use_knot_distance="false"
+       mirror_knots="true"
+       apply_no_radius="true"
+       apply_with_radius="true"
+       only_selected="false"
+       hide_knots="false" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="90.411308"
+     inkscape:cy="72.733828"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="1920"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     units="cm"
+     inkscape:measure-start="112.497,4.65149"
+     inkscape:measure-end="0,0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-247.00002)"
+     style="display:inline">
+    <g
+       id="g4361"
+       transform="matrix(0.978121,0,0,0.978121,-33.360291,-0.6207906)">
+      <g
+         id="g4356">
+        <path
+           sodipodi:type="star"
+           style="fill:#326de6;fill-opacity:1;fill-rule:evenodd;stroke-width:0.29651502"
+           id="path3515"
+           sodipodi:sides="7"
+           sodipodi:cx="42.936275"
+           sodipodi:cy="287.44345"
+           sodipodi:r1="26.060047"
+           sodipodi:r2="23.479292"
+           sodipodi:arg1="1.118925"
+           sodipodi:arg2="1.567724"
+           inkscape:flatsided="true"
+           inkscape:rounded="0"
+           inkscape:randomized="0"
+           d="m 52.786398,310.89259 -19.555971,0.0601 a 3.175,3.175 25.538252 0 1 -2.485976,-1.18778 L 18.504528,294.51287 a 3.175,3.175 76.966823 0 1 -0.621331,-2.68418 l 4.293036,-19.07904 a 3.175,3.175 128.39539 0 1 1.711189,-2.15934 l 17.593251,-8.53915 a 3.175,3.175 179.82397 0 1 2.755149,-0.008 l 17.64539,8.43088 a 3.175,3.175 51.252537 0 1 1.724425,2.14879 l 4.41019,19.05229 a 3.175,3.175 102.68111 0 1 -0.604826,2.68795 l -12.145973,15.32694 a 3.175,3.175 154.10968 0 1 -2.47863,1.20304 z"
+           inkscape:transform-center-x="-0.00091401786"
+           inkscape:transform-center-y="-1.2859785"
+           inkscape:path-effect="#path-effect3542"
+           transform="rotate(0.2,2199.3965,5058.3309)" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         id="path4353"
+         d="m 59.20602,295.48257 c -0.207887,-0.0959 -0.474733,-0.27962 -0.592992,-0.40817 -0.208541,-0.22669 -10.227127,-24.75626 -10.362028,-25.37045 -0.168328,-0.7664 0.521645,-1.7846 1.365499,-2.01509 0.732496,-0.20008 1.692369,0.19629 2.019159,0.83378 0.07189,0.14024 1.948805,4.74108 4.170928,10.2241 2.222123,5.48301 4.068721,10.00147 4.103552,10.04101 0.03483,0.0395 1.821778,-4.38278 3.970994,-9.82738 2.149215,-5.4446 3.986874,-10.0593 4.083687,-10.25489 0.362361,-0.73208 1.359717,-1.16701 2.109036,-0.91972 0.421561,0.13913 0.948178,0.58738 1.151111,0.97981 0.37275,0.72082 0.508716,0.33147 -4.766134,13.64815 -3.076063,7.7657 -4.998617,12.49872 -5.138858,12.65104 -0.305765,0.33209 -0.902307,0.59226 -1.358001,0.59226 -0.207887,0 -0.548066,-0.0785 -0.755953,-0.17445 z"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:1.34464288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+  </g>
+</svg>

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -488,8 +488,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.metrics_api_port = "5432";
       $scope.emsCommonModel.default_api_port = $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
       $scope.emsCommonModel.metrics_database_name = "ovirt_engine_history";
-    } else if ($scope.emsCommonModel.emstype === 'kubevirt') {
-      $scope.emsCommonModel.default_api_port = "8443";
     } else if ($scope.emsCommonModel.emstype === 'vmware_cloud') {
       $scope.emsCommonModel.default_api_port = "443";
       $scope.emsCommonModel.event_stream_selection = "none";

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -293,7 +293,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
        $scope.emsCommonModel.emstype == "openstack_infra" && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "nuage_network"  && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "rhevm" && $scope.emsCommonModel.default_hostname ||
-       $scope.emsCommonModel.emstype == "kubevirt" && $scope.emsCommonModel.default_hostname ||
+       $scope.emsCommonModel.emstype === "kubevirt" && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "vmwarews" && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "vmware_cloud" && $scope.emsCommonModel.default_hostname) &&
       ($scope.emsCommonModel.default_userid != '' && $scope.angularForm.default_userid.$valid &&
@@ -353,7 +353,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       ($scope.currentTab == "default" ||
       ($scope.currentTab == "service_account" && $scope.emsCommonModel.service_account != ''))) {
       return true;
-    } else if($scope.emsCommonModel.emstype == "kubevirt") {
+    } else if($scope.emsCommonModel.emstype === "kubevirt") {
       return true;
     } else {
       return false;

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -120,8 +120,7 @@ class EmsContainerController < ApplicationController
   end
 
   def retrieve_virtualization_selection
-    return "disabled" if @ems.connection_configurations.try(:kubevirt).nil?
-    "kubevirt"
+    @ems.connection_configurations.try(:kubevirt).nil? ? "disabled" : "kubevirt"
   end
 
   private

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -72,6 +72,7 @@ class EmsContainerController < ApplicationController
                  else
                    params[:metrics_selection]
                  end
+
     route, project = OPENSHIFT_ROUTES[route_type]
     verify_ems ||= find_record_with_rbac(model, params[:id])
     set_ems_record_vars(verify_ems, :validate)
@@ -116,6 +117,11 @@ class EmsContainerController < ApplicationController
   def retrieve_alerts_selection
     return "disabled" if @ems.connection_configurations.try(:prometheus_alerts).nil?
     "prometheus"
+  end
+
+  def retrieve_virtualization_selection
+    return "disabled" if @ems.connection_configurations.try(:kubevirt).nil?
+    "kubevirt"
   end
 
   private

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -35,6 +35,11 @@ class EmsInfraController < ApplicationController
     redirect_to :action => 'show_list'
   end
 
+  def new
+    @disabled_ems_infra_types = [['KubeVirt', 'kubevirt']]
+    super
+  end
+
   def scaling
     assert_privileges("ems_infra_scale")
 

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -154,6 +154,14 @@ module Mixins
           :metrics_port     => params[:metrics_api_port],
           :metrics_database => params[:metrics_database_name],
         }]
+      when 'ManageIQ::Providers::Kubevirt::InfraManager'
+        [{
+          :password   => params[:kubevirt_password],
+          :server     => params[:kubevirt_hostname],
+          :port       => params[:kubevirt_api_port],
+          :verify_ssl => params[:kubevirt_tls_verify] == 'on' ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE,
+          :ca_certs   => params[:kubevirt_tls_ca_certs],
+        }]
       when 'ManageIQ::Providers::Vmware::InfraManager'
         [{:pass => password, :user => user, :ip => params[:default_hostname], :use_broker => false}]
       when 'ManageIQ::Providers::Nuage::NetworkManager'
@@ -219,6 +227,12 @@ module Mixins
       prometheus_alerts_api_port = ""
       prometheus_alerts_security_protocol = security_protocol_default
       prometheus_alerts_tls_ca_certs = ""
+      kubevirt_hostname = ""
+      kubevirt_api_port = ""
+      kubevirt_security_protocol = default_security_protocol
+      kubevirt_tls_ca_certs = ""
+      kubevirt_password = ""
+      kubevirt_tls_verify = false
 
       provider_options = @ems.options || {}
 
@@ -285,6 +299,16 @@ module Mixins
         prometheus_alerts_security_protocol = @ems.connection_configurations.prometheus_alerts.endpoint.security_protocol
         prometheus_alerts_security_protocol ||= security_protocol_default
         prometheus_alerts_tls_ca_certs = @ems.connection_configurations.prometheus_alerts.endpoint.certificate_authority
+      end
+
+      if @ems.connection_configurations.kubevirt.try(:endpoint)
+        kubevirt_hostname = @ems.connection_configurations.kubevirt.endpoint.hostname
+        kubevirt_api_port = @ems.connection_configurations.kubevirt.endpoint.port
+        kubevirt_auth_status = @ems.authentication_status_ok?(:kubevirt)
+        kubevirt_security_protocol = @ems.connection_configurations.kubevirt.endpoint.security_protocol
+        kubevirt_security_protocol ||= default_security_protocol
+        kubevirt_tls_ca_certs = @ems.connection_configurations.kubevirt.endpoint.certificate_authority
+        kubevirt_tls_verify = @ems.connection_configurations.kubevirt.endpoint.verify_ssl
       end
 
       if @ems.connection_configurations.default.try(:endpoint)
@@ -387,7 +411,15 @@ module Mixins
                         :default_auth_status           => default_auth_status,
                         :console_auth_status           => console_auth_status,
                         :metrics_auth_status           => metrics_auth_status.nil? ? true : metrics_auth_status,
-                        :ssh_keypair_auth_status       => ssh_keypair_auth_status.nil? ? true : ssh_keypair_auth_status
+                        :ssh_keypair_auth_status       => ssh_keypair_auth_status.nil? ? true : ssh_keypair_auth_status,
+                        :kubevirt_api_port             => kubevirt_api_port,
+                        :kubevirt_hostname             => kubevirt_hostname,
+                        :kubevirt_security_protocol    => kubevirt_security_protocol,
+                        :kubevirt_tls_verify           => kubevirt_tls_verify,
+                        :kubevirt_tls_ca_certs         => kubevirt_tls_ca_certs,
+                        :kubevirt_auth_status          => kubevirt_auth_status,
+                        :kubevirt_password             => kubevirt_password,
+                        :kubevirt_password_exists      => @ems.authentication_token(:kubevirt).nil? ? false : true,
       } if controller_name == "ems_infra"
 
       if controller_name == "ems_container"
@@ -419,7 +451,17 @@ module Mixins
                          :prometheus_alerts_tls_ca_certs      => prometheus_alerts_tls_ca_certs,
                          :prometheus_alerts_auth_status       => prometheus_alerts_auth_status,
                          :provider_options                    => provider_options,
-                         :alerts_selection                    => retrieve_alerts_selection}
+                         :alerts_selection                    => retrieve_alerts_selection,
+                         :kubevirt_api_port                   => kubevirt_api_port,
+                         :kubevirt_hostname                   => kubevirt_hostname,
+                         :kubevirt_security_protocol          => kubevirt_security_protocol,
+                         :kubevirt_tls_verify                 => kubevirt_tls_verify,
+                         :kubevirt_tls_ca_certs               => kubevirt_tls_ca_certs,
+                         :kubevirt_auth_status                => kubevirt_auth_status,
+                         :kubevirt_password                   => kubevirt_password,
+                         :kubevirt_password_exists            => @ems.authentication_token(:kubevirt).nil? ? false : true,
+                         :provider_options                    => provider_options,
+                         :virtualization_selection            => retrieve_virtualization_selection}
       end
 
       if controller_name == "ems_middleware"
@@ -486,6 +528,10 @@ module Mixins
       prometheus_alerts_hostname = params[:prometheus_alerts_hostname].strip if params[:prometheus_alerts_hostname]
       prometheus_alerts_api_port = params[:prometheus_alerts_api_port].strip if params[:prometheus_alerts_api_port]
       prometheus_alerts_security_protocol = params[:prometheus_alerts_security_protocol].strip if params[:prometheus_alerts_security_protocol]
+      kubevirt_tls_ca_certs = params[:kubevirt_tls_ca_certs].strip if params[:kubevirt_tls_ca_certs]
+      kubevirt_hostname = params[:kubevirt_hostname].strip if params[:kubevirt_hostname]
+      kubevirt_api_port = params[:kubevirt_api_port].strip if params[:kubevirt_api_port]
+      kubevirt_security_protocol = ems.security_protocol
       default_endpoint = {}
       amqp_endpoint = {}
       amqp_fallback_endpoint1 = {}
@@ -496,6 +542,7 @@ module Mixins
       hawkular_endpoint = {}
       prometheus_endpoint = {}
       prometheus_alerts_endpoint = {}
+      kubevirt_endpoint = {}
 
       if ems.kind_of?(ManageIQ::Providers::Openstack::CloudManager) || ems.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
         default_endpoint = {:role => :default, :hostname => hostname, :port => port, :security_protocol => ems.security_protocol}
@@ -522,6 +569,16 @@ module Mixins
                              :hostname => metrics_hostname,
                              :port     => metrics_port,
                              :path     => metrics_database_name }
+      end
+
+      if ems.kind_of?(ManageIQ::Providers::Kubevirt::InfraManager)
+        kubevirt_endpoint = {
+          :role                  => :kubevirt,
+          :hostname              => kubevirt_hostname,
+          :port                  => kubevirt_api_port,
+        }
+
+        kubevirt_endpoint.merge!(endpoint_security_options(kubevirt_security_protocol, kubevirt_tls_ca_certs))
       end
 
       if ems.kind_of?(ManageIQ::Providers::Google::CloudManager)
@@ -569,6 +626,11 @@ module Mixins
           prometheus_alerts_endpoint = {:role => :prometheus_alerts, :hostname => prometheus_alerts_hostname, :port => prometheus_alerts_api_port}
           prometheus_alerts_endpoint.merge!(endpoint_security_options(prometheus_alerts_security_protocol, prometheus_alerts_tls_ca_certs))
         end
+
+        if params[:virtualization_selection] == 'kubevirt'
+          kubevirt_endpoint = {:role => :kubevirt, :hostname => kubevirt_hostname, :port => kubevirt_api_port}
+          kubevirt_endpoint.merge!(endpoint_security_options(kubevirt_security_protocol, kubevirt_tls_ca_certs))
+        end
       end
 
       if ems.kind_of?(ManageIQ::Providers::Nuage::NetworkManager)
@@ -612,7 +674,8 @@ module Mixins
                    :metrics           => metrics_endpoint,
                    :hawkular          => hawkular_endpoint,
                    :prometheus        => prometheus_endpoint,
-                   :prometheus_alerts => prometheus_alerts_endpoint}
+                   :prometheus_alerts => prometheus_alerts_endpoint,
+                   :kubevirt          => kubevirt_endpoint}
 
       build_connection(ems, endpoints, mode)
     end
@@ -629,7 +692,7 @@ module Mixins
       authentications = build_credentials(ems, mode)
       configurations = []
 
-      [:default, :ceilometer, :amqp, :amqp_fallback1, :amqp_fallback2, :console, :smartstate_docker, :ssh_keypair, :metrics, :hawkular, :prometheus, :prometheus_alerts].each do |role|
+      [:default, :ceilometer, :amqp, :amqp_fallback1, :amqp_fallback2, :console, :smartstate_docker, :ssh_keypair, :metrics, :hawkular, :prometheus, :prometheus_alerts, :kubevirt].each do |role|
         configurations << build_configuration(ems, authentications, endpoints, role)
       end
 
@@ -676,6 +739,12 @@ module Mixins
         metrics_password = params[:metrics_password] ? params[:metrics_password] : ems.authentication_password(:metrics)
         creds[:metrics] = {:userid => params[:metrics_userid], :password => metrics_password, :save => (mode != :validate)}
       end
+      if ems.kind_of?(ManageIQ::Providers::Kubevirt::InfraManager)
+        creds[:kubevirt] = {
+          :auth_key => params[:kubevirt_password] ? params[:kubevirt_password] : ems.authentication_token(:kubevirt),
+          :save     => mode != :validate,
+        }
+      end
       if ems.supports_authentication?(:auth_key) && params[:service_account]
         creds[:default] = {:auth_key => params[:service_account], :userid => "_", :save => (mode != :validate)}
       end
@@ -698,6 +767,10 @@ module Mixins
         end
         if params[:alerts_selection] == 'prometheus'
           creds[:prometheus_alerts] = {:auth_key => default_key, :save => (mode != :validate)}
+        end
+        if params[:virtualization_selection] == 'kubevirt'
+          kubevirt_key = params[:kubevirt_password] ? params[:kubevirt_password] : default_key
+          creds[:kubevirt] = { :auth_key => kubevirt_key, :save => (mode != :validate) }
         end
         creds[:bearer] = {:auth_key => default_key, :save => (mode != :validate)}
         creds.delete(:default)

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -460,7 +460,6 @@ module Mixins
                          :kubevirt_auth_status                => kubevirt_auth_status,
                          :kubevirt_password                   => kubevirt_password,
                          :kubevirt_password_exists            => @ems.authentication_token(:kubevirt).nil? ? false : true,
-                         :provider_options                    => provider_options,
                          :virtualization_selection            => retrieve_virtualization_selection}
       end
 
@@ -573,9 +572,9 @@ module Mixins
 
       if ems.kind_of?(ManageIQ::Providers::Kubevirt::InfraManager)
         kubevirt_endpoint = {
-          :role                  => :kubevirt,
-          :hostname              => kubevirt_hostname,
-          :port                  => kubevirt_api_port,
+          :role     => :kubevirt,
+          :hostname => kubevirt_hostname,
+          :port     => kubevirt_api_port,
         }
 
         kubevirt_endpoint.merge!(endpoint_security_options(kubevirt_security_protocol, kubevirt_tls_ca_certs))

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -105,6 +105,10 @@ module EmsContainerHelper::TextualSummary
       :prometheus_alerts => {
         :name => _("Alerts"),
         :type => _("prometheus"),
+      },
+      :kubevirt          => {
+        :name => _("Virtualization"),
+        :type => _("kubevirt"),
       }
     }
 

--- a/app/services/ui_service_mixin.rb
+++ b/app/services/ui_service_mixin.rb
@@ -31,6 +31,7 @@ module UiServiceMixin
       :Azure                   => {:type => "image", :icon => provider_icon(:Azure)},
       :Google                  => {:type => "image", :icon => provider_icon(:Google)},
       :Kubernetes              => {:type => "image", :icon => provider_icon(:Kubernetes)},
+      :Kubevirt                => {:type => "image", :icon => provider_icon(:Kubevirt)},
       :Lenovo                  => {:type => "image", :icon => provider_icon(:Lenovo)},
       :Microsoft               => {:type => "image", :icon => provider_icon(:Microsoft)},
       :Nuage                   => {:type => "image", :icon => provider_icon(:Nuage_Network)},

--- a/app/views/ems_container/_form.html.haml
+++ b/app/views/ems_container/_form.html.haml
@@ -84,6 +84,17 @@
                      "checkchange"                 => "",
                      "required"                    => "",
                      "selectpicker-for-select-tag" => "")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.virtualization.$invalid}"}
+      %label.col-md-2.control-label{"for" => "prov_virtualization"}
+        = _("Virtualization")
+      .col-md-8
+        = select_tag('virtualization_selection', options_for_select([[_("Disabled"), "disabled"], [_("KubeVirt"), "kubevirt"]]),
+                        "ng-model"                    => "emsCommonModel.virtualization_selection",
+                        "ng-change"                   => "virtualizationSelectionChanged()",
+                        "checkchange"                 => "",
+                        "required"                    => "",
+                        "selectpicker-for-select-tag" => "")
     %input{:type      => 'text',
            :id        => "current_tab",
            :name      => "current_tab",

--- a/app/views/ems_infra/_form.html.haml
+++ b/app/views/ems_infra/_form.html.haml
@@ -24,7 +24,7 @@
         = _('Type')
       .col-md-8
         = select_tag('emstype',
-                     options_for_select([["<#{_('Choose')}>", nil]] + @ems_types, disabled: ["<#{_('Choose')}>", nil]),
+                     options_for_select([["<#{_('Choose')}>", nil]] + (@ems_types - Array(@disabled_ems_infra_types)), disabled: ["<#{_('Choose')}>", nil] || []),
                      "ng-if"                       => "newRecord",
                      "ng-model"                    => "emsCommonModel.emstype",
                      "ng-change"                   => "providerTypeChanged()",

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -18,7 +18,7 @@
                             "(emsCommonModel.emstype == 'vmware_cloud' && '#{prefix}' === 'amqp') || " |
                             "emsCommonModel.emstype == 'scvmm' || " +                                  |
                             "emsCommonModel.ems_controller == 'ems_container' || " +                   |
-                            "emsCommonModel.emstype == 'kubevirt' || " +                               |
+                            "emsCommonModel.emstype === 'kubevirt' || " +                              |
                             "emsCommonModel.emstype == 'hawkular'"}                                    |
     %label.col-md-2.control-label{"for" => "#{prefix}_security_protocol"}
       = _('Security Protocol')
@@ -50,7 +50,7 @@
                        "selectpicker-for-select-tag" => "",
                        "prefix"                      => prefix.to_s,
                        "reset-validation-status"     => "#{prefix}_auth_status")
-    .col-md-8{"ng-if" => "emsCommonModel.ems_controller == 'ems_container' || emsCommonModel.emstype == 'kubevirt'"}
+    .col-md-8{"ng-if" => "emsCommonModel.ems_controller == 'ems_container' || emsCommonModel.emstype === 'kubevirt'"}
       = select_tag("#{prefix}_security_protocol",
                        options_for_select([["<#{_('Choose')}>", nil]] + @container_security_protocols, :disabled => ["<#{_('Choose')}>", nil]),
                        "disabled"                    => ng_readonly_ems_container_security_protocol,
@@ -157,7 +157,7 @@
                          "emsCommonModel.emstype == 'openstack_infra'        || " + |
                          "emsCommonModel.emstype == 'nuage_network'          || " + |
                          "emsCommonModel.emstype == 'rhevm'                  || " + |
-                         "emsCommonModel.emstype == 'kubevirt'               || " + |
+                         "emsCommonModel.emstype === 'kubevirt'              || " + |
                          "emsCommonModel.emstype == 'vmware_cloud'           || " + |
                          "emsCommonModel.emstype == 'hawkular'               || " + |
                          "emsCommonModel.emstype == 'lenovo_ph_infra'        || " + |
@@ -227,7 +227,7 @@
 %div{"ng-if" => defined?(tls_ca_certs_hide) ? false : true}
   .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm' || " +                                             |
                         "((emsCommonModel.ems_controller == 'ems_container' || " +                            |
-                        " emsCommonModel.emstype == 'kubevirt') && " +                                        |
+                        " emsCommonModel.emstype === 'kubevirt') && " +                                       |
                         " emsCommonModel.#{prefix}_security_protocol == 'ssl-with-validation-custom-ca') || " |
                         "(emsCommonModel.emstype == 'hawkular' && " +                                         |
                         " emsCommonModel.#{prefix}_security_protocol == 'ssl-with-validation-custom-ca')"}    |

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -4,6 +4,11 @@
 - ng_reqd_api_port ||= true
 - ng_reqd_db_name ||= false
 - detection ||= false
+- ng_readonly_hostname ||= false
+- ng_readonly_api_port ||= false
+- ng_readonly_ems_container_security_protocol ||= false
+- ng_readonly_tls_verify ||= false
+- ng_readonly_tls_ca_certs ||= false
 
 %div{"ng-if" => defined?(security_protocol_hide) ? false : true}
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_security_protocol.$invalid}",
@@ -13,6 +18,7 @@
                             "(emsCommonModel.emstype == 'vmware_cloud' && '#{prefix}' === 'amqp') || " |
                             "emsCommonModel.emstype == 'scvmm' || " +                                  |
                             "emsCommonModel.ems_controller == 'ems_container' || " +                   |
+                            "emsCommonModel.emstype == 'kubevirt' || " +                               |
                             "emsCommonModel.emstype == 'hawkular'"}                                    |
     %label.col-md-2.control-label{"for" => "#{prefix}_security_protocol"}
       = _('Security Protocol')
@@ -44,9 +50,10 @@
                        "selectpicker-for-select-tag" => "",
                        "prefix"                      => prefix.to_s,
                        "reset-validation-status"     => "#{prefix}_auth_status")
-    .col-md-8{"ng-if" => "emsCommonModel.ems_controller == 'ems_container'"}
+    .col-md-8{"ng-if" => "emsCommonModel.ems_controller == 'ems_container' || emsCommonModel.emstype == 'kubevirt'"}
       = select_tag("#{prefix}_security_protocol",
                        options_for_select([["<#{_('Choose')}>", nil]] + @container_security_protocols, :disabled => ["<#{_('Choose')}>", nil]),
+                       "disabled"                    => ng_readonly_ems_container_security_protocol,
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "required"                    => "",
@@ -73,6 +80,7 @@
                           "id"                      => "#{prefix}_hostname",
                           "name"                    => "#{prefix}_hostname",
                           "ng-model"                => "#{ng_model}.#{prefix}_hostname",
+                          "ng-readonly"             => ng_readonly_hostname,
                           "maxlength"               => ViewHelper::MAX_NAME_LEN.to_s,
                           "ng-required"             => ng_reqd_hostname.to_s,
                           "ng-trim"                 => false,
@@ -149,6 +157,7 @@
                          "emsCommonModel.emstype == 'openstack_infra'        || " + |
                          "emsCommonModel.emstype == 'nuage_network'          || " + |
                          "emsCommonModel.emstype == 'rhevm'                  || " + |
+                         "emsCommonModel.emstype == 'kubevirt'               || " + |
                          "emsCommonModel.emstype == 'vmware_cloud'           || " + |
                          "emsCommonModel.emstype == 'hawkular'               || " + |
                          "emsCommonModel.emstype == 'lenovo_ph_infra'        || " + |
@@ -162,6 +171,7 @@
                           "ng-model"                    => "#{ng_model}.#{prefix}_api_port",
                           "maxlength"                   => 15,
                           "ng-required"                 => ng_reqd_api_port.to_s,
+                          "ng-readonly"                 => ng_readonly_api_port,
                           "checkchange"                 => "",
                           "ng-trim"                     => false,
                           "detect-spaces"               => "",
@@ -205,6 +215,7 @@
       %input{"type"            => "checkbox",
              "id"              => "#{prefix}_tls_verify",
              "name"            => "#{prefix}_tls_verify",
+             "ng-readonly"     => ng_readonly_tls_verify,
              "bs-switch"       => "",
              "switch-on-text"  => _("Yes"),
              "switch-off-text" => _("No"),
@@ -215,7 +226,8 @@
 
 %div{"ng-if" => defined?(tls_ca_certs_hide) ? false : true}
   .form-group{"ng-if"=> "emsCommonModel.emstype == 'rhevm' || " +                                             |
-                        "(emsCommonModel.ems_controller == 'ems_container' && " +                             |
+                        "((emsCommonModel.ems_controller == 'ems_container' || " +                            |
+                        " emsCommonModel.emstype == 'kubevirt') && " +                                        |
                         " emsCommonModel.#{prefix}_security_protocol == 'ssl-with-validation-custom-ca') || " |
                         "(emsCommonModel.emstype == 'hawkular' && " +                                         |
                         " emsCommonModel.#{prefix}_security_protocol == 'ssl-with-validation-custom-ca')"}    |
@@ -226,6 +238,7 @@
                              "name"        => "#{prefix}_tls_ca_certs",
                              "ng-model"    => "#{ng_model}.#{prefix}_tls_ca_certs",
                              "ng-disabled" => "emsCommonModel.emstype == 'rhevm' && !#{ng_model}.#{prefix}_tls_verify",
+                             "ng-readonly" => ng_readonly_tls_ca_certs,
                              "ng-required" => false,
                              "ng-trim"     => false,
                              "prefix"      => prefix.to_s,

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -103,7 +103,7 @@
                                                 :id                     => record.id,
                                                 :prefix                 => "default",
                                                 :ng_reqd_api_port       => "false"}
-          %div{"ng-if" => "#{ng_model}.ems_controller == 'ems_infra' && #{ng_model}.emstype == 'kubevirt'"}
+          %div{"ng-if" => "#{ng_model}.ems_controller == 'ems_infra' && #{ng_model}.emstype === 'kubevirt'"}
             = render :partial => "layouts/angular-bootstrap/endpoints_angular",
                                    :locals  => {:ng_show                                     => "true",
                                                 :ng_model                                    => ng_model.to_s,
@@ -408,7 +408,7 @@
                                       :basic_info_needed => true}
 
       = miq_tab_content('virtualization', 'default') do
-        %div{"ng-if" => "emsCommonModel.virtualization_selection == 'kubevirt'" }
+        %div{"ng-if" => "emsCommonModel.virtualization_selection === 'kubevirt'" }
           .form-group
             .col-md-12
             = render :partial => "layouts/angular-bootstrap/endpoints_angular",
@@ -528,7 +528,7 @@
     miq_tabs_show_hide("#smartstate_docker_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
-%div{"ng-if" => "#{ng_model}.emstype == 'kubevirt'"}
+%div{"ng-if" => "#{ng_model}.emstype === 'kubevirt'"}
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", false);

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -3,7 +3,6 @@
 - vm_scope   ||= false
 - main_scope  = vm_scope ? "$parent.vm" : "$parent"
 
-
 #auth_tabs
   %h3
     = legendtext
@@ -37,6 +36,10 @@
         %div{"ng-if" => "emsCommonModel.alerts_selection == 'prometheus'"}
           %i{"error-on-tab" => "prometheus_alerts", :style => "color:#cc0000"}
           = _("Alerts")
+      = miq_tab_header('virtualization', nil, 'ng-click' => "changeAuthTabToVirtualization('virtualization')") do
+        %div{"ng-if" => "emsCommonModel.virtualization_selection == 'kubevirt'"}
+          %i{"error-on-tab" => "kubevirt", :style => "color:#cc0000"}
+          = _("Virtualization")
     - elsif controller_name == "host"
       = miq_tab_header('remote', nil, {'ng-click' => "changeAuthTab('remote')"}) do
         = _("Remote Login")
@@ -87,7 +90,7 @@
                                             :prefix                 => "service_account",
                                             :basic_info_needed      => true}
         .col-md-12{"ng-if" => "#{ng_model}.emstype != 'gce' && #{ng_model}.emstype != 'ec2'" || "#{ng_model}" != "emsCommonModel"}
-          %div{"ng-if" => "#{ng_model}.emstype == 'openstack' || (#{ng_model}.ems_controller == 'ems_infra' && #{ng_model}.emstype != 'rhevm')  || #{ng_model}.emstype == 'vmware_cloud'"}
+          %div{"ng-if" => "#{ng_model}.emstype == 'openstack' || (#{ng_model}.ems_controller == 'ems_infra' && #{ng_model}.emstype != 'rhevm' && #{ng_model}.emstype != 'kubevirt')  || #{ng_model}.emstype == 'vmware_cloud'"}
             = render :partial => "layouts/angular-bootstrap/endpoints_angular",
                                    :locals  => {:ng_show                => true,
                                                 :ng_model               => "#{ng_model}",
@@ -100,7 +103,38 @@
                                                 :id                     => record.id,
                                                 :prefix                 => "default",
                                                 :ng_reqd_api_port       => "false"}
-          %div{"ng-if" => controller_name != "ems_container"}
+          %div{"ng-if" => "#{ng_model}.ems_controller == 'ems_infra' && #{ng_model}.emstype == 'kubevirt'"}
+            = render :partial => "layouts/angular-bootstrap/endpoints_angular",
+                                   :locals  => {:ng_show                                     => "true",
+                                                :ng_model                                    => ng_model.to_s,
+                                                :id                                          => record.id,
+                                                :ng_reqd_hostname                            => "true",
+                                                :ng_reqd_api_port                            => "true",
+                                                :prefix                                      => "kubevirt",
+                                                :detection                                   => false,
+                                                :ng_readonly_hostname                        => true,
+                                                :ng_readonly_api_port                        => true,
+                                                :ng_readonly_ems_container_security_protocol => true,
+                                                :ng_readonly_tls_verify                      => true,
+                                                :ng_readonly_tls_ca_certs                    => true,
+                                                }
+            = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                                   :locals  => {:ng_show                => "true",
+                                                :ng_model               => "#{ng_model}",
+                                                :validate_url           => validate_url,
+                                                :id                     => record.id,
+                                                :prefix                 => "kubevirt",
+                                                :ng_show_password       => "true",
+                                                :ng_show_userid         => "false",
+                                                :ng_reqd_password       => "true",
+                                                :userid_disabled        => false,
+                                                :password_label         => _("Token"),
+                                                :verify_label           => _("Confirm Token"),
+                                                :passwd_mismatch        => _("Tokens do not match"),
+                                                :change_stored_password => _("Change stored token"),
+                                                :cancel_password_change => _("Cancel stored token"),
+                                                :basic_info_needed      => true}
+          %div{"ng-if" => controller_name != "ems_container" && "#{ng_model}.emstype != 'kubevirt'"}
             = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                    :locals  => {:ng_show           => "true",
                                                 :ng_model          => "#{ng_model}",
@@ -133,7 +167,7 @@
         .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'gce'"}
           %span{:style => "color:black"}
             = _("Used to authenticate as a service account against your provider.")
-        .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype != 'gce'" && "#{ng_model}.ems_controller != 'ems_container'"}
+        .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype != 'gce'" && "#{ng_model}.ems_controller != 'ems_container'" && "#{ng_model}.emstype != 'kubevirt'"}
           %span{:style => "color:black"}
             = _("Required. Should have privileged access, such as root or administrator.")
         .col-md-12{"ng-if" => "#{ng_model}.ems_controller == 'ems_container'"}
@@ -372,6 +406,40 @@
                                       :prefix            => "prometheus_alerts",
                                       :verify_title_off  => _("prometheus URL and API port fields are needed to perform validation."),
                                       :basic_info_needed => true}
+
+      = miq_tab_content('virtualization', 'default') do
+        %div{"ng-if" => "emsCommonModel.virtualization_selection == 'kubevirt'" }
+          .form-group
+            .col-md-12
+            = render :partial => "layouts/angular-bootstrap/endpoints_angular",
+                                   :locals  => {:ng_show                                     => true,
+                                                :ng_model                                    => ng_model.to_s,
+                                                :id                                          => record.id,
+                                                :ng_reqd_hostname                            => "true",
+                                                :ng_reqd_api_port                            => "true",
+                                                :prefix                                      => "kubevirt",
+                                                :detection                                   => false,
+                                                :ng_readonly_hostname                        => true,
+                                                :ng_readonly_api_port                        => true,
+                                                :ng_readonly_ems_container_security_protocol => true,
+                                                :ng_readonly_tls_verify                      => true,
+                                                :ng_readonly_tls_ca_certs                    => true}
+            = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                         :locals  => {:ng_show                => true,
+                                      :ng_model               => ng_model.to_s,
+                                      :main_scope             => main_scope,
+                                      :ng_show_userid         => "false",
+                                      :ng_reqd_password       => true,
+                                      :password_label         => _("Token"),
+                                      :verify_label           => _("Confirm Token"),
+                                      :passwd_mismatch        => _("Tokens do not match"),
+                                      :change_stored_password => _("Change stored token"),
+                                      :cancel_password_change => _("Cancel stored token"),
+                                      :validate_url           => validate_url,
+                                      :id                     => record.id,
+                                      :prefix                 => "kubevirt",
+                                      :verify_title_off       => _("kubevirt URL and API port fields are needed to perform validation."),
+                                      :basic_info_needed      => true}
     - elsif controller_name == "host"
       = miq_tab_content('remote', 'default') do
         .form-group
@@ -427,6 +495,7 @@
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", false);
+    miq_tabs_show_hide("#virtualization_tab", false);
     miq_tabs_show_hide("#console_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
     miq_tabs_show_hide("#smartstate_docker_tab", false);
@@ -459,6 +528,13 @@
     miq_tabs_show_hide("#smartstate_docker_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
+%div{"ng-if" => "#{ng_model}.emstype == 'kubevirt'"}
+  :javascript
+    miq_tabs_show_hide("#amqp_tab", false);
+    miq_tabs_show_hide("#metrics_tab", false);
+    miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_init('#auth_tabs');
+    $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'vmware_cloud'"}
   :javascript
     miq_tabs_show_hide("#amqp_tab", true);
@@ -486,6 +562,7 @@
 %div{"ng-if" => "#{ng_model}.ems_controller == 'ems_container'"}
   :javascript
     miq_tabs_show_hide("#metrics_tab", true);
+    miq_tabs_show_hide("#virtualization_tab", true);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -843,6 +843,69 @@ describe('emsCommonFormController in the context of ems infra provider', functio
       expect($scope.emsCommonModel.default_api_port).toEqual('');
     });
   });
+
+  describe('when the emsCommonFormId is a Kubevirt Id', function () {
+    var emsCommonFormResponse = {
+      id: 12345,
+      name: 'myKubevirt',
+      kubevirt_hostname: '10.22.33.44',
+      emstype: 'kubevirt',
+      zone: 'default',
+      kubevirt_api_port: '8443',
+      kubevirt_password_exists: true,
+      kubevirt_security_protocol: 'ssl-with-validation-custom-ca',
+      kubevirt_tls_ca_certs: '-----BEGIN DUMMY...',
+    };
+
+    beforeEach(inject(function (_$controller_) {
+      $httpBackend.whenGET('/ems_infra/ems_infra_form_fields/12345').respond(emsCommonFormResponse);
+
+      $controller = _$controller_('emsCommonFormController',
+        {
+          $scope: $scope,
+          $attrs: {
+            'formFieldsUrl': '/ems_infra/ems_infra_form_fields/',
+            'updateUrl': '/ems_infra/update/'
+          },
+          emsCommonFormId: 12345,
+          miqService: miqService,
+          API: API
+        });
+      $httpBackend.flush();
+    }));
+
+    it('sets the name to the Kubevirt Provider', function () {
+      expect($scope.emsCommonModel.name).toEqual('myKubevirt');
+    });
+
+    it('sets the type to kubevirt', function () {
+      expect($scope.emsCommonModel.emstype).toEqual('kubevirt');
+    });
+
+    it('sets the hostname', function () {
+      expect($scope.emsCommonModel.kubevirt_hostname).toEqual('10.22.33.44');
+    });
+
+    it('sets the zone to default', function () {
+      expect($scope.emsCommonModel.zone).toEqual('default');
+    });
+
+    it('sets the password', function () {
+      expect($scope.emsCommonModel.kubevirt_password).toEqual(miqService.storedPasswordPlaceholder);
+    });
+
+    it('sets the kubevirt api port', function () {
+      expect($scope.emsCommonModel.kubevirt_api_port).toEqual('8443');
+    });
+
+    it('sets the kubevirt security protocol', function () {
+      expect($scope.emsCommonModel.kubevirt_security_protocol).toEqual('ssl-with-validation-custom-ca');
+    });
+
+    it('sets the kubevirt certificate', function () {
+      expect($scope.emsCommonModel.kubevirt_tls_ca_certs).toEqual('-----BEGIN DUMMY...');
+    });
+  });
 });
 
 describe('emsCommonFormController in the context of ems middleware provider', function () {


### PR DESCRIPTION
kubevirt provider is added as a secondary provider to be
managed by the openshift/kubernetes provider.

It will have also representation as an infrastructure provider, but its
management will be done under  openshift/kubernetes, as it shares the
same endpoint, and might differ only by its token.

The token might be different than the default token in order to allow
the specific virtualization capabilities.

Since kubevirt share the same endpoint as the parent provider,
the 'detection' button will not be shown.

The virtualization label for the kubevirt provider:
![container_manager_virtualization_drop_down_list](https://user-images.githubusercontent.com/316242/34403076-910d9dcc-ebae-11e7-8c12-daf0938dc585.png)

The virtualization tab for the kubevirt provider:
![container_manager_virtualization_tab](https://user-images.githubusercontent.com/316242/34403099-bbea79a2-ebae-11e7-9e55-25cb7ff9deee.png)

Changing token for the virtualization manager:
![container_manager_virtualization_tab_change_token](https://user-images.githubusercontent.com/316242/34403111-dca078e0-ebae-11e7-90af-f7f2373510b2.png)

'Add provider' drop-down list without 'kubevirt':
![add_provider_list](https://user-images.githubusercontent.com/316242/36443707-324dd758-1682-11e8-873f-6c084a3bfa16.png)

