### PR TITLE
Adding default labels 'com.redhat.component' to chargback assignments

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -747,10 +747,17 @@ class ChargebackController < ApplicationController
     classification.entries.each { |e| @edit[:cb_assign][:tags][e.id.to_s] = e.description } if classification
   end
 
+  DEFAULT_CHARGEBACK_LABELS = ["com.redhat.component"].freeze
+
   def get_docker_labels_all_keys
     @edit[:cb_assign][:docker_label_keys] = {}
+    @edit[:cb_assign][:docker_label_default_keys] = {}
     CustomAttribute.where(:section => "docker_labels").pluck(:id, :name).uniq(&:second).each do |label|
-      @edit[:cb_assign][:docker_label_keys][label.first.to_s] = label.second
+      if DEFAULT_CHARGEBACK_LABELS.include?(label.second)
+        @edit[:cb_assign][:docker_label_default_keys][label.first.to_s] = label.second
+      else
+        @edit[:cb_assign][:docker_label_keys][label.first.to_s] = label.second
+      end
     end
   end
 

--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -15,7 +15,12 @@
                     "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")
       :javascript
         miqInitSelectPicker();
-        miqSelectPickerEvent("cbshow_typ", "#{url}")
+        miqSelectPickerEvent("cbshow_typ", "#{url}", {callback: function() {
+          if ($('#cbshow_typ').val() == "container_image-labels") {
+            // trigger dropdown change for when container_image-labels is picked so that the default image will be loaded to the view.
+            $("#cblabel_key").trigger('change');
+          }
+        }});
     - if !@edit[:new][:cbshow_typ].blank? && @edit[:new][:cbshow_typ].ends_with?("-tags")
       .form-group
         %label.col-md-2.control-label
@@ -32,8 +37,9 @@
         %label.col-md-2.control-label
           = _('Image Labels')
         .col-md-8
+          - default_options = Array(@edit[:cb_assign][:docker_label_default_keys].invert).sort_by { |a| a.first.downcase }
           - options = Array(@edit[:cb_assign][:docker_label_keys].invert).sort_by { |a| a.first.downcase }
-          = select_tag("cblabel_key", options_for_select([["<#{_('Choose a Label')}>", ""]] + options, @edit[:new][:cblabel_key].to_s),
+          = select_tag("cblabel_key", options_for_select(default_options  + options, @edit[:new][:cblabel_key].to_s),
                       "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")
         :javascript
           miqInitSelectPicker();


### PR DESCRIPTION
**What This Does**
Makes the label `com.redhat.component`  as default label for docker container images in chargback assignments screen.

**Why**
This makes it easier for customers to leverage RH product labels, instead of scanning through what could be large number of image labels.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1417236
GIF:
![default_labels](https://user-images.githubusercontent.com/8366181/34561734-1dcfc3a2-f154-11e7-95ae-0554427e6cdf.gif)

cc: @himdel , @zeari 
  