### PR TITLE
Fix ReferenceError: jasmine is not defined

### DIFF
--- a/app/javascript/miq-redux/index.ts
+++ b/app/javascript/miq-redux/index.ts
@@ -9,7 +9,7 @@ const initialState = {};
 configureNgReduxStore(app, initialState);
 
 // allow unit-testing specific module exports
-if (jasmine) {
+if (window['jasmine']) {
   app.constant('_rootReducer', rootReducer);
   app.constant('_addReducer', addReducer);
   app.constant('_clearReducers', clearReducers);


### PR DESCRIPTION
introduced in #2504

causes

```
Uncaught ReferenceError: jasmine is not defined
    at eval (index.ts?37df:8)
    at Object.<anonymous> (miq-redux-common.js:183)
    at __webpack_require__ (miq-redux-common.js:20)
    at eval (miq-redux-common.js?4cb0:1)
    at Object.<anonymous> (miq-redux-common.js:171)
    at __webpack_require__ (miq-redux-common.js:20)
    at miq-redux-common.js:63
    at miq-redux-common.js:66
```

in the browser console.

Cc @vojtechszocs 