### PR TITLE
[FINE] Use container instead of containers for the product feature

### DIFF
--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -42,7 +42,7 @@ module ContainerSummaryHelper
   end
 
   def textual_containers
-    textual_link(@record.containers, :feature => "containers") # should it be container_show_list?
+    textual_link(@record.containers, :feature => "container") # should it be container_show_list?
   end
 
   def textual_container_nodes

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -165,8 +165,8 @@ describe DashboardController do
       MiqShortcut.seed
       allow_any_instance_of(described_class).to receive(:set_user_time_zone)
       allow(controller).to receive(:check_privileges).and_return(true)
-      EvmSpecHelper.seed_specific_product_features("containers")
-      feature_id = MiqProductFeature.find_all_by_identifier(["containers"])
+      EvmSpecHelper.seed_specific_product_features("container")
+      feature_id = MiqProductFeature.find_all_by_identifier(["container"])
       user = FactoryGirl.create(:user, :features => feature_id)
       allow(User).to receive(:authenticate).and_return(user)
       validation = controller.send(:validate_user, user)


### PR DESCRIPTION
The feature was renamed from `containers` to `container` in https://github.com/ManageIQ/manageiq/pull/16658

Looks like these 3 were missed.

Cc @h-kataria 

---

Fixes fine travis like https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/318220713#L1929

```
  1) DashboardController#validate_user returns url for the user with access to only Containers maintab
     Failure/Error: children = hash.delete(:children) || []
     
     NoMethodError:
       undefined method `delete' for nil:NilClass
     # ./spec/manageiq/app/models/miq_product_feature.rb:123:in `seed_from_hash'
     # ./spec/manageiq/spec/support/evm_spec_helper.rb:100:in `seed_specific_product_features'
     # ./spec/controllers/dashboard_controller_spec.rb:168:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:75:in `block (3 levels) in <top (required)>'
     # ./spec/manageiq/spec/support/evm_spec_helper.rb:34:in `clear_caches'
     # ./spec/spec_helper.rb:75:in `block (2 levels) in <top (required)>'
```