### PR TITLE
[WIP] JS logout - save the url

### DIFF
--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -1,4 +1,4 @@
-/* global miqDeferred, add_flash */
+/* global miqDeferred, add_flash, miqRelativeUrl */
 
 /* functions to use the API from our JS/Angular:
  *
@@ -200,7 +200,8 @@
       if ((response.status === 401) && !options.skipLoginRedirect) {
         // Unauthorized - always redirect to dashboard#login
         add_flash(__('API logged out, redirecting to the login page'), 'warning');
-        window.document.location.href = '/dashboard/login?timeout=true';
+
+        window.document.location.href = '/dashboard/login?timeout=true&last_url=' + encodeURIComponent(miqRelativeUrl());
 
         return ret;
       }

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1695,7 +1695,14 @@ function miqUncompressedId(id) {
   return id;
 }
 
-function queryParam(name) { return QS(window.location.href).get(name); }
+function queryParam(name) {
+  return QS(window.location.href).get(name);
+}
+
+function miqRelativeUrl() {
+  var location = window.document.location;
+  return location.pathname + location.search;
+}
 
 function miqFormatNotification(text, bindings) {
   if (! text) {

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -431,6 +431,8 @@ class DashboardController < ApplicationController
       session[:user_validation_error] = nil
     end
 
+    session[:login_redirect_url] = params[:last_url]
+
     render :layout => "login"
   end
 
@@ -543,10 +545,12 @@ class DashboardController < ApplicationController
       # noop, page content already set by initiate_wait_for_task
     when :pass
       miq_api_token = require_api_token ? generate_ui_api_token(user[:name]) : nil
+      url = session.delete(:login_redirect_url) || validation.url
+
       render :update do |page|
         page << javascript_prologue
         page << "localStorage.miq_token = '#{j_str miq_api_token}';" if miq_api_token
-        page.redirect_to(validation.url)
+        page.redirect_to(url)
       end
     when :fail
       clear_current_user


### PR DESCRIPTION
When logging out because the API token expired, we should save the last URL, so that we can return the user there after they log in again.


TODO: do the same for saml login, check the names, try merging with the server side logic that does the same