### PR TITLE
Availability Zone has only Management Events in Timelines

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1763,4 +1763,8 @@ module ApplicationHelper
                         :flash_msg   => @flash_array[0][:message],
                         :flash_error => @flash_array[0][:level] == :error
   end
+
+  def accessible_select_event_types
+    ApplicationController::Timelines::SELECT_EVENT_TYPE.map {|key, value| [_(key), value]}
+  end
 end

--- a/app/helpers/availability_zone_helper.rb
+++ b/app/helpers/availability_zone_helper.rb
@@ -1,3 +1,7 @@
 module AvailabilityZoneHelper
   include_concern 'TextualSummary'
+
+  def accessible_select_event_types
+    [[_('Management Events'), 'timeline']]
+  end
 end

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -17,7 +17,7 @@
             .form-group
               %div{'class' => 'timeline-filterbar'}
                 = select_tag("tl_show",
-                  options_for_select(ApplicationController::Timelines::SELECT_EVENT_TYPE.map {|key, value| [_(key), value]}, nil),
+                  options_for_select(accessible_select_event_types, nil),
                   'ng-model'                    => 'reportModel.tl_show',
                   "selectpicker-for-select-tag" => '',
                   :class                        => 'selectpicker',

--- a/spec/helpers/availability_zone_helper_spec.rb
+++ b/spec/helpers/availability_zone_helper_spec.rb
@@ -1,0 +1,8 @@
+describe AvailabilityZoneHelper do
+
+  context "#accessible_select_event_types" do
+    it 'returns only Management Events' do
+      expect(accessible_select_event_types).to eq([['Management Events', 'timeline']])
+    end
+  end
+end


### PR DESCRIPTION
As Policy Events are not yet implemented for Availability Zones this hides them until they will be implemented. And it's present in Darga as well.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1523663

Compute -> Cloud -> Availability Zone -> select one that has timelines -> Monitoring -> Timelines 

Before:
![image](https://user-images.githubusercontent.com/9210860/34522317-528739a8-f092-11e7-9010-a4f50b7343ee.png)
*After applying Policy Events*
![image](https://user-images.githubusercontent.com/9210860/34522303-4800b6f8-f092-11e7-8731-fd263b4b1cae.png)
After:
![image](https://user-images.githubusercontent.com/9210860/34522198-d0da43e6-f091-11e7-9653-bdce35f0fd44.png)

@miq-bot add_label bug, blocker, compute/cloud, gaprindashvili/yes, euwe/yes, darga/yes
  