### PR TITLE
Fix typo in get_view_where_clause

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1592,7 +1592,7 @@ class ApplicationController < ActionController::Base
 
       if chart_click.type == "bytag"
         ["\"#{model_downcase.pluralize}\".id IN (?)",
-         data_row["assoc_ids_#{report.extras[:group_by_tags][chart_click.legend_idx]}"][model_downcase.to_sym][:on]]
+         data_row["assoc_ids_#{report.extras[:group_by_tags][chart_click.legend_index]}"][model_downcase.to_sym][:on]]
       else
         ["\"#{model_downcase.pluralize}\".id IN (?)",
          data_row["assoc_ids"][model_downcase.to_sym][chart_click.type.to_sym]]


### PR DESCRIPTION
Fix typo in `get_view_where_clause`. Chart code is shared for all entities, so it fixes all three BZs.
Title and text in the chart menu is still wrong, but since it is blocker, it could be fixed in separate PR.

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1530208
https://bugzilla.redhat.com/show_bug.cgi?id=1530296
https://bugzilla.redhat.com/show_bug.cgi?id=1530226

Screenshots
-------------------------------

![screencast from 2018-01-03 15-49-19](https://user-images.githubusercontent.com/9535558/34525550-a84d4d8e-f09f-11e7-9f83-85dfa40bf4fc.gif)
![screencast from 2018-01-03 16-02-06](https://user-images.githubusercontent.com/9535558/34525557-ad4d356a-f09f-11e7-908e-40adfb653281.gif)

  
  