### PR TITLE
Fix displaying Services after removing one of them

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -269,11 +269,12 @@ class ServiceController < ApplicationController
     assert_privileges("service_delete")
     @explorer = true
     elements = []
-    if params[:id]
+    if params[:id] # delete service from its details page
       elements.push(params[:id])
+      deleted_service = Service.find(params[:id].to_i) # service which is going to be deleted
       process_elements(elements, Service, 'destroy') unless elements.empty?
-      self.x_node = "root"
-    else # showing 1 element, delete it
+      self.x_node = deleted_service.retired ? "xx-rsrv" : "xx-asrv" # set x_node for returning to Active or Retired Services
+    else # delete choosen service(s), choosen by checking appropriate checkbox(es)
       elements = find_checked_items
       if elements.empty?
         add_flash(_("No Services were selected for deletion"), :error)

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -45,6 +45,26 @@ describe ServiceController do
       expect(flash_message[:message]).to include("Delete successful")
       expect(flash_message[:level]).to be(:success)
     end
+
+    context 'setting x_node properly after deleting a service from its details page' do
+      let(:service) { FactoryGirl.create(:service) }
+
+      before do
+        allow(controller).to receive(:replace_right_cell)
+        controller.instance_variable_set(:@_params, :id => service.id)
+      end
+
+      it 'sets x_node to return to Active Services' do
+        controller.send(:service_delete)
+        expect(controller.x_node).to eq("xx-asrv")
+      end
+
+      it 'sets x_node to return to Retired Services' do
+        service.update_attributes(:retired => true)
+        controller.send(:service_delete)
+        expect(controller.x_node).to eq("xx-rsrv")
+      end
+    end
   end
 
   describe 'x_button' do

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -5,7 +5,7 @@ describe ServiceController do
     stub_user(:features => :all)
   end
 
-  context "#service_delete" do
+  describe "#service_delete" do
     it "display flash message with description of deleted Service" do
       st  = FactoryGirl.create(:service_template)
       svc = FactoryGirl.create(:service, :service_template => st, :name => "GemFire", :description => "VMware vFabric GEMFIRE")
@@ -30,6 +30,21 @@ describe ServiceController do
 
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
+
+    it "replaces right cell after service is deleted" do
+      service = FactoryGirl.create(:service)
+      allow(controller).to receive(:x_build_tree)
+      controller.instance_variable_set(:@settings, {})
+      controller.instance_variable_set(:@sb, {})
+      controller.instance_variable_set(:@_params, :id => service.id)
+      expect(controller).to receive(:render)
+      expect(response.status).to eq(200)
+      controller.send(:service_delete)
+
+      flash_message = assigns(:flash_array).first
+      expect(flash_message[:message]).to include("Delete successful")
+      expect(flash_message[:level]).to be(:success)
+    end
   end
 
   describe 'x_button' do
@@ -49,23 +64,6 @@ describe ServiceController do
     it 'exception is raised for unknown action' do
       get :x_button, :params => { :pressed => 'random_dude', :format => :html }
       expect(response).to render_template('layouts/exception')
-    end
-  end
-
-  context "#service_delete" do
-    it "replaces right cell after service is deleted" do
-      service = FactoryGirl.create(:service)
-      allow(controller).to receive(:x_build_tree)
-      controller.instance_variable_set(:@settings, {})
-      controller.instance_variable_set(:@sb, {})
-      controller.instance_variable_set(:@_params, :id => service.id)
-      expect(controller).to receive(:render)
-      expect(response.status).to eq(200)
-      controller.send(:service_delete)
-
-      flash_message = assigns(:flash_array).first
-      expect(flash_message[:message]).to include("Delete successful")
-      expect(flash_message[:level]).to be(:success)
     end
   end
 


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1528347

Fix displaying _Active_ or _Retired Services_ after removing one of them **from
its details page** by choosing '_Remove Service from inventory_' in _Services_
_-> My Services_ page.
Fix also GTL view which broke after removing a service the same way (after
deleting the service, it was not possible to change the view).

**Before:**
![service_before](https://user-images.githubusercontent.com/13417815/34529584-d3c57790-f0ac-11e7-995f-eb8f56e8e463.png)
![service_before2](https://user-images.githubusercontent.com/13417815/34529585-d5b2d2d2-f0ac-11e7-87ff-a80ca0a94e83.png)
![service_before3](https://user-images.githubusercontent.com/13417815/34529595-d78e3614-f0ac-11e7-8664-370c6e439e4d.png)

**After:**
![service_after](https://user-images.githubusercontent.com/13417815/34529603-dc31d4fa-f0ac-11e7-97e6-b791f8b3030f.png)
![service_remove](https://user-images.githubusercontent.com/13417815/34529608-dedad79c-f0ac-11e7-946f-6aaac66f7747.png)
![service_after2](https://user-images.githubusercontent.com/13417815/34529612-e0dea51e-f0ac-11e7-8a55-5688cd66f4da.png)

