### PR TITLE
 Fix alignment of font icons on summary screens

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -219,16 +219,17 @@ body#dashboard .blank-slate-pf {
 }
 
 table.table-summary-screen i { /* font icon styling in table view (equivalent to fa-lg) */
-  padding-left: 2px;
+  display: inline-block; 
   font-size: 1.333em;
   line-height: 0.75em;
+  text-align:center;
   vertical-align: -15%;
-  margin-right: 3px;
+  width: 1.25em;
 }
 
 table.table.table-summary-screen tbody td img {
-  margin-left: 2px;
   height: 16px;
+  margin: 0 2px 0 2px;
   width: 16px;
 }
 


### PR DESCRIPTION
This PR adjusts the width of font icons in the summary screen tables so that text to the right is properly aligned. It also syncs the alignment of the font icons with the SVGs.

https://bugzilla.redhat.com/show_bug.cgi?id=1528182

<img width="878" alt="screen shot 2018-01-03 at 1 56 52 pm" src="https://user-images.githubusercontent.com/1287144/34534917-18108670-f08e-11e7-9383-ec278bb2847b.png">
<img width="877" alt="screen shot 2018-01-03 at 1 41 04 pm" src="https://user-images.githubusercontent.com/1287144/34534929-23058102-f08e-11e7-9553-21bbcd44e7aa.png">

