### PR TITLE
Update message for the zone name uniqueness validation test

### DIFF
--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -166,7 +166,7 @@ describe OpsController do
         controller.send(:zone_edit)
 
         expect(controller.send(:flash_errors?)).to be_truthy
-        expect(assigns(:flash_array).first[:message]).to include("Name has already been taken")
+        expect(assigns(:flash_array).first[:message]).to include("Name is not unique within region")
       end
     end
 


### PR DESCRIPTION
Update the spec for the zone name uniqueness test after https://github.com/ManageIQ/manageiq/pull/16731

  
  