### PR TITLE
Enable to add a new Group after first unsuccessful adding

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -726,7 +726,7 @@ module OpsController::OpsRbac
     when :group then
       record = @edit[:group_id] ? MiqGroup.find_by(:id => @edit[:group_id]) : MiqGroup.new
       validated = rbac_group_validate?
-      rbac_group_set_record_vars(record)
+      rbac_group_set_record_vars(record) if validated
     when :role  then
       record = @edit[:role_id] ? MiqUserRole.find_by(:id => @edit[:role_id]) : MiqUserRole.new
       validated = rbac_role_validate?
@@ -1421,6 +1421,7 @@ module OpsController::OpsRbac
 
   # Validate some of the role fields
   def rbac_group_validate?
+    return false if @edit[:new][:description].nil?
     @assigned_filters = [] if @edit[:new][:filters].empty? || @edit[:new][:use_filter_expression]
     @filter_expression = [] if @edit[:new][:filter_expression].empty? || @edit[:new][:use_filter_expression] == false
     if @edit[:new][:role].nil? || @edit[:new][:role] == ""


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1523214

Enable to add a new Group after first unsuccessful adding of the Group because
of missing Name, in _Administrator > Configuration, Access Control_ tab > _Groups_.

---
**Explanation:**
The two simple conditions were added to prevent the error (see the BZ above), which was caused here:
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ops_controller/ops_rbac.rb#L1425
`@edit[:new][:filter_expression]` was `nil`, so the error occurred. It was set to `nil` here:
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ops_controller/ops_rbac.rb#L1252
The method `rbac_group_set_record_vars` is called right after the validation (see https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ops_controller/ops_rbac.rb#L728) and even if it is not known if the validation was successful, the group record variables are set to new values, which is good only after successful validation (because of the _if-else_ conditions in `rbac_group_set_record_vars` which are very specific). So the condition https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Add_Group_empty_name_validate?expand=1#diff-8078c760e06b820719715450b2a112e0R729 was added and also validation was extended by adding one simple line https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Add_Group_empty_name_validate?expand=1#diff-8078c760e06b820719715450b2a112e0R1424 to consider also the name of a new group.

This solution is simple and we don't have to reset variables `@edit[:new][:filters]` and `@edit[:new][:filter_expression]` (changed in `rbac_group_set_record_vars` method), if validation is not successful or if anything else breaks when creating/adding a new group (and we don't have to remember their values: we had to remember/save them, if we wanted to reset the variables after unsuccessful adding a group). And also none of the variables in the method are set (using fix in this PR) if `rbac_group_validate?` returns `false`, which is good. They are still set in the next try of adding a new group, after successful validation.

![group_add](https://user-images.githubusercontent.com/13417815/34604673-06f24398-f209-11e7-8ff2-688b1831910c.png)

**Before:**
![group_before](https://user-images.githubusercontent.com/13417815/34604939-e3c927f0-f209-11e7-9120-79544293dece.png)

**After:**  
![group_after](https://user-images.githubusercontent.com/13417815/34605038-35088b7e-f20a-11e7-9d12-a2d50810372e.png)


