### PR TITLE
Require privilege network providers and cloud tenants for new cloud network, cloud subnet, network router form

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -150,6 +150,7 @@ class CloudNetworkController < ApplicationController
   def new
     assert_privileges("cloud_network_new")
     assert_privileges("ems_network_show_list")
+    assert_privileges("cloud_tenant_show_list")
 
     @network = CloudNetwork.new
     @in_a_form = true

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -149,6 +149,8 @@ class CloudNetworkController < ApplicationController
 
   def new
     assert_privileges("cloud_network_new")
+    assert_privileges("ems_network_show_list")
+
     @network = CloudNetwork.new
     @in_a_form = true
     @network_ems_provider_choices = {}

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -43,6 +43,8 @@ class CloudSubnetController < ApplicationController
 
   def new
     assert_privileges("cloud_subnet_new")
+    assert_privileges("ems_network_show_list")
+
     @subnet = CloudSubnet.new
     @in_a_form = true
     @network_provider_choices = {}

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -44,6 +44,7 @@ class CloudSubnetController < ApplicationController
   def new
     assert_privileges("cloud_subnet_new")
     assert_privileges("ems_network_show_list")
+    assert_privileges("cloud_tenant_show_list")
 
     @subnet = CloudSubnet.new
     @in_a_form = true

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -95,6 +95,7 @@ class NetworkRouterController < ApplicationController
     @router = NetworkRouter.new
     assert_privileges("network_router_new")
     assert_privileges("ems_network_show_list")
+    assert_privileges("cloud_tenant_show_list")
 
     @in_a_form = true
     @network_provider_choices = {}

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -94,6 +94,8 @@ class NetworkRouterController < ApplicationController
   def new
     @router = NetworkRouter.new
     assert_privileges("network_router_new")
+    assert_privileges("ems_network_show_list")
+
     @in_a_form = true
     @network_provider_choices = {}
     network_managers.each do |network_manager|

--- a/app/helpers/application_helper/button/cloud_network_new.rb
+++ b/app/helpers/application_helper/button/cloud_network_new.rb
@@ -1,13 +1,10 @@
 class ApplicationHelper::Button::CloudNetworkNew < ApplicationHelper::Button::ButtonNewDiscover
-  def calculate_properties
-    super
-    if disabled?
-      self[:title] = _("No cloud providers support creating cloud networks.")
-    end
+  def supports_button_action?
+    ::EmsNetwork.all.any? { |ems| CloudNetwork.class_by_ems(ems).supports_create? }
   end
 
-  # disable button if no active providers support create action
   def disabled?
-    ::EmsNetwork.all.none? { |ems| CloudNetwork.class_by_ems(ems).supports_create? }
+    @error_message = _("No cloud providers support creating cloud networks.") unless supports_button_action?
+    super || @error_message.present?
   end
 end

--- a/app/helpers/application_helper/button/cloud_network_new.rb
+++ b/app/helpers/application_helper/button/cloud_network_new.rb
@@ -3,6 +3,10 @@ class ApplicationHelper::Button::CloudNetworkNew < ApplicationHelper::Button::Bu
     ::EmsNetwork.all.any? { |ems| CloudNetwork.class_by_ems(ems).supports_create? }
   end
 
+  def role_allows_feature?
+    role_allows?(:feature => 'ems_network_show_list')
+  end
+
   def disabled?
     @error_message = _("No cloud providers support creating cloud networks.") unless supports_button_action?
     super || @error_message.present?

--- a/app/helpers/application_helper/button/cloud_network_new.rb
+++ b/app/helpers/application_helper/button/cloud_network_new.rb
@@ -4,7 +4,7 @@ class ApplicationHelper::Button::CloudNetworkNew < ApplicationHelper::Button::Bu
   end
 
   def role_allows_feature?
-    role_allows?(:feature => 'ems_network_show_list') && role_allows?(:feature => 'cloud_tenant_show_list')
+    super && role_allows?(:feature => 'ems_network_show_list') && role_allows?(:feature => 'cloud_tenant_show_list')
   end
 
   def disabled?

--- a/app/helpers/application_helper/button/cloud_network_new.rb
+++ b/app/helpers/application_helper/button/cloud_network_new.rb
@@ -4,7 +4,7 @@ class ApplicationHelper::Button::CloudNetworkNew < ApplicationHelper::Button::Bu
   end
 
   def role_allows_feature?
-    role_allows?(:feature => 'ems_network_show_list')
+    role_allows?(:feature => 'ems_network_show_list') && role_allows?(:feature => 'cloud_tenant_show_list')
   end
 
   def disabled?

--- a/app/helpers/application_helper/button/cloud_subnet_new.rb
+++ b/app/helpers/application_helper/button/cloud_subnet_new.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Button::CloudSubnetNew < ApplicationHelper::Button::But
   end
 
   def role_allows_feature?
-    role_allows?(:feature => 'ems_network_show_list')
+    role_allows?(:feature => 'ems_network_show_list') && role_allows?(:feature => 'cloud_tenant_show_list')
   end
 
   # disable button if no active providers support create action

--- a/app/helpers/application_helper/button/cloud_subnet_new.rb
+++ b/app/helpers/application_helper/button/cloud_subnet_new.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Button::CloudSubnetNew < ApplicationHelper::Button::But
   end
 
   def role_allows_feature?
-    role_allows?(:feature => 'ems_network_show_list') && role_allows?(:feature => 'cloud_tenant_show_list')
+    super && role_allows?(:feature => 'ems_network_show_list') && role_allows?(:feature => 'cloud_tenant_show_list')
   end
 
   # disable button if no active providers support create action

--- a/app/helpers/application_helper/button/cloud_subnet_new.rb
+++ b/app/helpers/application_helper/button/cloud_subnet_new.rb
@@ -6,6 +6,10 @@ class ApplicationHelper::Button::CloudSubnetNew < ApplicationHelper::Button::But
     end
   end
 
+  def role_allows_feature?
+    role_allows?(:feature => 'ems_network_show_list')
+  end
+
   # disable button if no active providers support create action
   def disabled?
     ::EmsNetwork.all.none? { |ems| CloudSubnet.class_by_ems(ems).supports_create? }

--- a/app/helpers/application_helper/button/network_router_new.rb
+++ b/app/helpers/application_helper/button/network_router_new.rb
@@ -6,6 +6,10 @@ class ApplicationHelper::Button::NetworkRouterNew < ApplicationHelper::Button::B
     end
   end
 
+  def role_allows_feature?
+    role_allows?(:feature => 'ems_network_show_list')
+  end
+
   # disable button if no active providers support create action
   def disabled?
     ::EmsNetwork.all.none? { |ems| NetworkRouter.class_by_ems(ems).supports_create? }

--- a/app/helpers/application_helper/button/network_router_new.rb
+++ b/app/helpers/application_helper/button/network_router_new.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Button::NetworkRouterNew < ApplicationHelper::Button::B
   end
 
   def role_allows_feature?
-    role_allows?(:feature => 'ems_network_show_list') && role_allows?(:feature => 'cloud_tenant_show_list')
+    super && role_allows?(:feature => 'ems_network_show_list') && role_allows?(:feature => 'cloud_tenant_show_list')
   end
 
   # disable button if no active providers support create action

--- a/app/helpers/application_helper/button/network_router_new.rb
+++ b/app/helpers/application_helper/button/network_router_new.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Button::NetworkRouterNew < ApplicationHelper::Button::B
   end
 
   def role_allows_feature?
-    role_allows?(:feature => 'ems_network_show_list')
+    role_allows?(:feature => 'ems_network_show_list') && role_allows?(:feature => 'cloud_tenant_show_list')
   end
 
   # disable button if no active providers support create action

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -70,6 +70,28 @@ describe CloudNetworkController do
     end
   end
 
+  describe "#new" do
+    let(:feature) { MiqProductFeature.find_all_by_identifier(%w(cloud_network_new)) }
+    let(:role)    { FactoryGirl.create(:miq_user_role, :miq_product_features => feature) }
+    let(:group)   { FactoryGirl.create(:miq_group, :miq_user_role => role) }
+    let(:user)    { FactoryGirl.create(:user, :miq_groups => [group]) }
+
+    before do
+      bypass_rescue
+
+      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.seed_specific_product_features(%w(cloud_network_new))
+
+      allow(User).to receive(:current_user).and_return(user)
+      allow(Rbac).to receive(:role_allows?).and_call_original
+      login_as user
+    end
+
+    it "raises exception when user don't have privilege" do
+      expect { post :new, :params => { :button => "new", :format => :js } }.to raise_error(MiqException::RbacPrivilegeException)
+    end
+  end
+
   describe "#create" do
     before do
       stub_user(:features => :all)

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -80,7 +80,7 @@ describe CloudNetworkController do
       bypass_rescue
 
       EvmSpecHelper.create_guid_miq_server_zone
-      EvmSpecHelper.seed_specific_product_features(%w(cloud_network_new))
+      EvmSpecHelper.seed_specific_product_features(%w(cloud_network_new ems_network_show_list))
 
       allow(User).to receive(:current_user).and_return(user)
       allow(Rbac).to receive(:role_allows?).and_call_original
@@ -89,6 +89,14 @@ describe CloudNetworkController do
 
     it "raises exception when user don't have privilege" do
       expect { post :new, :params => { :button => "new", :format => :js } }.to raise_error(MiqException::RbacPrivilegeException)
+    end
+
+    context "user don't have privilege for cloud tenants" do
+      let(:feature) { MiqProductFeature.find_all_by_identifier(%w(cloud_network_new ems_network_show_list)) }
+
+      it "raises exception" do
+        expect { post :new, :params => { :button => "new", :format => :js } }.to raise_error(MiqException::RbacPrivilegeException)
+      end
     end
   end
 

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -80,7 +80,7 @@ describe CloudSubnetController do
       bypass_rescue
 
       EvmSpecHelper.create_guid_miq_server_zone
-      EvmSpecHelper.seed_specific_product_features(%w(cloud_subnet_new))
+      EvmSpecHelper.seed_specific_product_features(%w(cloud_subnet_new ems_network_show_list))
 
       allow(User).to receive(:current_user).and_return(user)
       allow(Rbac).to receive(:role_allows?).and_call_original
@@ -89,6 +89,14 @@ describe CloudSubnetController do
 
     it "raises exception wheh used have not privilege" do
       expect { post :new, :params => { :button => "new", :format => :js } }.to raise_error(MiqException::RbacPrivilegeException)
+    end
+
+    context "user don't have privilege for cloud tenants" do
+      let(:feature) { MiqProductFeature.find_all_by_identifier(%w(cloud_subnet_new ems_network_show_list)) }
+
+      it "raises exception" do
+        expect { post :new, :params => { :button => "new", :format => :js } }.to raise_error(MiqException::RbacPrivilegeException)
+      end
     end
   end
 

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -70,6 +70,28 @@ describe NetworkRouterController do
     end
   end
 
+  describe "#new" do
+    let(:feature) { MiqProductFeature.find_all_by_identifier(%w(network_router_new)) }
+    let(:role)    { FactoryGirl.create(:miq_user_role, :miq_product_features => feature) }
+    let(:group)   { FactoryGirl.create(:miq_group, :miq_user_role => role) }
+    let(:user)    { FactoryGirl.create(:user, :miq_groups => [group]) }
+
+    before do
+      bypass_rescue
+
+      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.seed_specific_product_features(%w(network_router_new))
+
+      allow(User).to receive(:current_user).and_return(user)
+      allow(Rbac).to receive(:role_allows?).and_call_original
+      login_as user
+    end
+
+    it "raises exception wheh used have not privilege" do
+      expect { post :new, :params => { :button => "new", :format => :js } }.to raise_error(MiqException::RbacPrivilegeException)
+    end
+  end
+
   describe "#create" do
     before do
       stub_user(:features => :all)

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -80,7 +80,7 @@ describe NetworkRouterController do
       bypass_rescue
 
       EvmSpecHelper.create_guid_miq_server_zone
-      EvmSpecHelper.seed_specific_product_features(%w(network_router_new))
+      EvmSpecHelper.seed_specific_product_features(%w(network_router_new ems_network_show_list))
 
       allow(User).to receive(:current_user).and_return(user)
       allow(Rbac).to receive(:role_allows?).and_call_original
@@ -89,6 +89,14 @@ describe NetworkRouterController do
 
     it "raises exception wheh used have not privilege" do
       expect { post :new, :params => { :button => "new", :format => :js } }.to raise_error(MiqException::RbacPrivilegeException)
+    end
+
+    context "user don't have privilege for cloud tenants" do
+      let(:feature) { MiqProductFeature.find_all_by_identifier(%w(network_router_new ems_network_show_list)) }
+
+      it "raises exception" do
+        expect { post :new, :params => { :button => "new", :format => :js } }.to raise_error(MiqException::RbacPrivilegeException)
+      end
     end
   end
 


### PR DESCRIPTION
imagine that you are the user without allowed section network providers.
then  when you go to `Network -> Networks|Subnets|Network Routers-> Add new` and select any network provider, it will end with error(there is video in BZ)

so I am adding the assert for this feature and I am adding the method role_allows - it check if user has feature related to Network Providers(ems_network_show_list)

@miq-bot assign @himdel 
@miq-bot add_label bug, blocker, gaprindashvili/yes

## Links 
https://bugzilla.redhat.com/show_bug.cgi?id=1526803


  
  