### PR TITLE
Scan Storage via EMS not Host

### DIFF
--- a/app/helpers/application_helper/button/storage_scan.rb
+++ b/app/helpers/application_helper/button/storage_scan.rb
@@ -4,26 +4,4 @@ class ApplicationHelper::Button::StorageScan < ApplicationHelper::Button::Generi
   def visible?
     true
   end
-
-  def disabled?
-    disabled = super
-    unless disabled
-      if no_active_hosts?
-        @error_message = _('SmartState Analysis cannot be performed when there is no active Host')
-      elsif without_valid_credentials_for_datastores?
-        @error_message = _('There are no running Hosts with valid credentials for this Datastore')
-      end
-    end
-    @error_message.present?
-  end
-
-  private
-
-  def no_active_hosts?
-    @record.active_hosts.empty?
-  end
-
-  def without_valid_credentials_for_datastores?
-    @record.active_hosts_with_authentication_status_ok.empty?
-  end
 end

--- a/spec/helpers/application_helper/buttons/storage_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/storage_scan_spec.rb
@@ -1,14 +1,15 @@
 describe ApplicationHelper::Button::StorageScan do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:host) { FactoryGirl.create(:host, :state => 'on') }
-  let(:hosts) { [host] }
-  let(:authenticated_hosts) { hosts }
-  let(:record) { FactoryGirl.create(:storage, :hosts => hosts) }
+  let(:record) { FactoryGirl.create(:storage) }
   let(:feature) { :smartstate_analysis }
   let(:props) { {:options => {:feature => feature}} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
+  let(:ems)                  { FactoryGirl.create(:ems_vmware) }
+  let(:emss)                 { [ems] }
+  let(:emss_with_valid_auth) { [ems] }
 
-  before { allow(record).to receive(:active_hosts_with_authentication_status_ok).and_return(authenticated_hosts) }
+  before { allow(record).to receive(:ext_management_systems).and_return(emss) }
+  before { allow(record).to receive(:ext_management_systems_with_authentication_status_ok).and_return(emss_with_valid_auth) }
 
   it_behaves_like 'a generic feature button after initialization'
 
@@ -19,22 +20,19 @@ describe ApplicationHelper::Button::StorageScan do
   context 'when feature is supported' do
     describe '#calculate_properties' do
       before do
-        allow(record).to receive(:supports?).and_return(true)
         button.calculate_properties
       end
 
-      context 'and there are active hosts' do
-        context 'but none has valid credentials for the Datastore' do
-          let(:authenticated_hosts) { [] }
-          it_behaves_like 'a disabled button', 'There are no running Hosts with valid credentials for this Datastore'
-        end
-        context 'with valid credentials for this Datastore' do
-          it_behaves_like 'an enabled button'
-        end
+      context 'but no EMSs are present' do
+        let(:emss) { [] }
+        it_behaves_like 'a disabled button', 'Smartstate Analysis cannot be performed on selected Datastore'
       end
-      context 'and there are no active hosts' do
-        let(:host) { FactoryGirl.create(:host, :state => 'off') }
-        it_behaves_like 'a disabled button', 'SmartState Analysis cannot be performed when there is no active Host'
+      context 'but no EMS has valid credentials for the Datastore' do
+        let(:emss_with_valid_auth) { [] }
+        it_behaves_like 'a disabled button', 'There are no EMSs with valid credentials for this Datastore'
+      end
+      context 'with valid credentials for this Datastore' do
+        it_behaves_like 'an enabled button'
       end
     end
   end


### PR DESCRIPTION
Remove the requirement for hosts with valid credentials to be able to
run storage smartstate.  The valid unsupported reasons will be moved to
the Storage model.

Depends https://github.com/ManageIQ/manageiq/pull/16743

https://bugzilla.redhat.com/show_bug.cgi?id=1529725
  