### PR TITLE
Removed fixed height for table-compressed

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -251,7 +251,6 @@ table.table.table-summary-screen tbody td img {
   }
 
   table.table-compressed thead tr th {
-    height: 150px !important;
     width: 26px !important;
     text-align: center;
     white-space: nowrap;


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/556

![screencast from 2018-01-05 10-54-06](https://user-images.githubusercontent.com/1187051/34604080-dd3f40ca-f206-11e7-803a-754c65bfdde9.gif)
