### PR TITLE
Fix cut-off dropdowns on Provisioning screens

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -33,6 +33,7 @@
                          :style                 => "width: auto;",
                          "data-miq_sparkle_on"  => true,
                          "data-miq_sparkle_off" => true,
+                         "data-container"       => "body",
                          :class                 => "selectpicker")
             :javascript
               miqInitSelectPicker();
@@ -179,6 +180,7 @@
                           :disabled              => disabled,
                           "data-miq_sparkle_on"  => true,
                           "data-miq_sparkle_off" => true,
+                          "data-container"       => "body",
                           :class    => "selectpicker")
             :javascript
               miqInitSelectPicker();
@@ -220,6 +222,7 @@
                          :style                 => "width:auto;",
                          "data-miq_sparkle_on"  => true,
                          "data-miq_sparkle_off" => true,
+                         "data-container"       => "body",
                          :class                 => "selectpicker")
             :javascript
               miqInitSelectPicker();
@@ -268,6 +271,7 @@
                          :disabled              => disabled,
                          "data-miq_sparkle_on"  => true,
                          "data-miq_sparkle_off" => true,
+                         "data-container"       => "body",
                          :class                 => "selectpicker")
             :javascript
               miqInitSelectPicker();
@@ -361,6 +365,7 @@
                            :style                 => "width: auto;",
                            "data-miq_sparkle_on"  => true,
                            "data-miq_sparkle_off" => true,
+                           "data-container"       => "body",
                            :class                 => "selectpicker")
               :javascript
                 miqInitSelectPicker();
@@ -405,6 +410,7 @@
                          :disabled              => disabled,
                          "data-miq_sparkle_on"  => true,
                          "data-miq_sparkle_off" => true,
+                         "data-container"       => "body",
                          :class                 => "selectpicker")
             :javascript
               miqInitSelectPicker();
@@ -474,7 +480,8 @@
             -# Allow editing of the text field
             = select_tag("start_hour",
                          options_for_select((0..23).to_a, options[:start_hour].to_i),
-                         :class    => "selectpicker selectWidth")
+                         "data-container" => "body",
+                         :class           => "selectpicker selectWidth")
             %span h
             :javascript
               miqInitSelectPicker();


### PR DESCRIPTION
This PR fixes a problem where the bootstrap-select dropdowns were conflicting with the GTL #main_div by setting the data-container to "body."

https://bugzilla.redhat.com/show_bug.cgi?id=1530966

Old
<img width="984" alt="screen shot 2018-01-05 at 11 11 02 am" src="https://user-images.githubusercontent.com/1287144/34617396-45f6256e-f209-11e7-82e5-e7793270e799.png">

New
<img width="999" alt="screen shot 2018-01-05 at 11 07 38 am" src="https://user-images.githubusercontent.com/1287144/34617397-4604283a-f209-11e7-8e0c-f90fa9ea887e.png">

