### PR TITLE
Add rbac checks for cloud 'new' screens

### DIFF
--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -46,7 +46,7 @@ class CloudSubnetController < ApplicationController
     @subnet = CloudSubnet.new
     @in_a_form = true
     @network_provider_choices = {}
-    ExtManagementSystem.where(:type => ['ManageIQ::Providers::Openstack::NetworkManager', 'ManageIQ::Providers::Redhat::NetworkManager']).find_each do |ems|
+    Rbac::Filterer.filtered(ExtManagementSystem.where(:type => ['ManageIQ::Providers::Openstack::NetworkManager', 'ManageIQ::Providers::Redhat::NetworkManager'])).find_each do |ems|
       @network_provider_choices[ems.name] = ems.id
     end
     drop_breadcrumb(

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -54,11 +54,11 @@ class CloudTenantController < ApplicationController
     @tenant = CloudTenant.new
     @in_a_form = true
     @ems_choices = {}
-    ManageIQ::Providers::Openstack::CloudManager.all.each do |ems|
+    Rbac::Filterer.filtered(ManageIQ::Providers::Openstack::CloudManager).each do |ems|
       @ems_choices[ems.name] = ems.id
       # keystone v3 allows for hierarchical tenants
       if ems.api_version == "v3"
-        ems.cloud_tenants.each do |ems_cloud_tenant|
+        Rbac::Filterer.filtered(ems.cloud_tenants).each do |ems_cloud_tenant|
           tenant_choice_name = ems.name + " (" + ems_cloud_tenant.name + ")"
           tenant_choice_id = ems.id.to_s + ":" + ems_cloud_tenant.id.to_s
           @ems_choices[tenant_choice_name] = tenant_choice_id

--- a/app/controllers/flavor_controller.rb
+++ b/app/controllers/flavor_controller.rb
@@ -30,7 +30,7 @@ class FlavorController < ApplicationController
 
   def ems_list
     assert_privileges('flavor_create')
-    ems_list = ManageIQ::Providers::CloudManager.select do |ems|
+    ems_list = Rbac::Filterer.filtered(ManageIQ::Providers::CloudManager).select do |ems|
       ems.class::Flavor.supports?(:create)
     end
     ems_list.each do |ems|

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -105,7 +105,7 @@ class HostAggregateController < ApplicationController
     @host_aggregate = HostAggregate.new
     @in_a_form = true
     @ems_choices = {}
-    ManageIQ::Providers::CloudManager.select { |ems| ems.supports?(:create_host_aggregate) }.each do |ems|
+    Rbac::Filterer.filtered(ManageIQ::Providers::CloudManager).select { |ems| ems.supports?(:create_host_aggregate) }.each do |ems|
       @ems_choices[ems.name] = ems.id
     end
 


### PR DESCRIPTION
there were couple places in new cloud form without RBAC filtering and this PRs is adding RBAC here.

Affected screen new form screens:
Host Aggregates,
Tenant,
Flavour,
Subnets

Cloud Network is missing(regard to the description in BZ) but there is already RBAC check.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1516229

@miq-bot add_label gaprindashvili/yes, bug

@miq-bot assign @martinpovolny 
cc @mzazrivec 


  