### PR TITLE
Remove replacement of whole right cell and instead render flash message div so flash message isn't doubled

### DIFF
--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -86,7 +86,7 @@ module MiqPolicyController::Conditions
         condition.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
         end
-        replace_right_cell(:nodetype => "co")
+        javascript_flash
       end
     when "expression", "applies_to_exp"
       session[:changed] = (@edit[:new] != @edit[:current])


### PR DESCRIPTION
With the right cell being replaced, the control policy description validation appears twice. This removes the replacement of the right cell per h-kataria's suggestion at the review that's at the bottom of this PR. 

Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1531469