### PR TITLE
Fix project main page showtype

### DIFF
--- a/app/controllers/container_project_controller.rb
+++ b/app/controllers/container_project_controller.rb
@@ -8,6 +8,7 @@ class ContainerProjectController < ApplicationController
   after_action :set_session_data
 
   def show_list
+    @showtype = "main"
     process_show_list(:named_scope => :active)
   end
 


### PR DESCRIPTION
**Description**

compute -> containers -> projects

Projects get a `showtype=dashboard` after visiting the dashboard view, this PR reset `showtype=main`, each time we return to main view.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1530610
Target: 5.9.1

**Screeshots**

Before:
![peek 2018-01-07 17-31](https://user-images.githubusercontent.com/2181522/34650882-bd3c0fee-f3d0-11e7-97ee-f9edbc16da34.gif)

After:
![peek 2018-01-07 16-52](https://user-images.githubusercontent.com/2181522/34650774-0381e476-f3cf-11e7-8b7f-980c07fbe59a.gif)




  
  