### PR TITLE
Delete unnecessary X.empty? check after calling find_record_with_rbac

### DIFF
--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -108,9 +108,6 @@ class CloudSubnetController < ApplicationController
   def delete_subnets
     assert_privileges("cloud_subnet_delete")
     subnets = find_records_with_rbac(CloudSubnet, checked_or_params)
-    if subnets.empty?
-      add_flash(_("No Cloud Subnet were selected for deletion."), :error)
-    end
 
     subnets_to_delete = []
     subnets.each do |subnet|

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -337,9 +337,6 @@ class CloudVolumeController < ApplicationController
   def delete_volumes
     assert_privileges("cloud_volume_delete")
     volumes = find_records_with_rbac(CloudVolume, checked_or_params)
-    if volumes.empty?
-      add_flash(_("No Cloud Volumes were selected for deletion."), :error)
-    end
 
     volumes_to_delete = []
     volumes.each do |volume|

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -214,11 +214,7 @@ module OpsController::Settings::Schedules
             _("The selected Schedules were disabled")
           end
     schedules = find_records_with_rbac(MiqSchedule, checked_or_params)
-    if schedules.empty?
-      add_flash(msg, :error)
-      javascript_flash
-    end
-    schedule_enable_disable(schedules, enable)  unless schedules.empty?
+    schedule_enable_disable(schedules, enable)
     add_flash(msg, :info, true) unless flash_errors?
     schedule_build_list
     settings_get_info("st")


### PR DESCRIPTION
Delete unnecessary X.empty? check after calling `find_record_with_rbac`. After #3131 `find_record_with_rbac` raises exception if it should return empty array.

Links
----------------
#3131 



  