### PR TITLE
Remove unnecessary, dead and duplicate code around reports_menu

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -132,7 +132,7 @@ class ReportController < ApplicationController
       return
     end
 
-    reports_menu_in_sb
+    populate_reports_menu("reports", "menu")
     build_accordions_and_trees
 
     self.x_active_tree = x_last_active_tree if x_last_active_tree
@@ -625,11 +625,6 @@ class ReportController < ApplicationController
     add_nodes = {:key => existing_node, :nodes => tree_add_child_nodes(existing_node)} if existing_node
     self.x_node = params[:id]
     add_nodes
-  end
-
-  def reports_menu_in_sb
-    @sb[:rpt_menu]  = populate_reports_menu("reports", "menu")
-    @sb[:grp_title] = reports_group_title
   end
 
   def replace_right_cell(options = {}) # :replace_trees key can be an array of tree symbols to be replaced

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -237,7 +237,7 @@ module ReportController::Reports
 
   # Build the main reports tree
   def build_reports_tree
-    reports_menu_in_sb
+    populate_reports_menu("reports", "menu")
     TreeBuilderReportReports.new('reports_tree', 'reports', @sb)
   end
 end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1332,7 +1332,7 @@ describe ReportController do
     end
   end
 
-  describe "#reports_menu_in_sb" do
+  describe "#populate_reports_menu" do
     let(:user) { FactoryGirl.create(:user_with_group) }
     subject! { FactoryGirl.create(:miq_report, :rpt_type => "Custom", :miq_group => user.current_group) }
 


### PR DESCRIPTION
I started to untangle the code around the reports_menu and after a few :boom: :boom: :boom: found some stuff to clean up. For example setting `@sb[:rpt_menu] and `@sb[:grp_title]` twice`:

```ruby
def reports_menu_in_sb		
  @sb[:rpt_menu]  = populate_reports_menu("reports", "menu")		
  @sb[:grp_title] = reports_group_title		
end

# ...

def populate_reports_menu(tree_type = 'reports', mode = 'menu')
  # ...
  @sb[:rpt_menu] = get_reports_menu(group, tree_type, mode)
end

# ...

def get_reports_menu
  # ...
  @sb[:grp_title] = reports_group_title
  # ...
end
```

After the cleanup the `reports_menu_in_sb` became an alias for `populate_reports_menu` and in its spec was misleading. So I decided to drop the method completely and rename the spec to `#populate_reports_menu` as it is actually testing that method.

@miq-bot add_label refactoring, cloud intel/reporting, gaprindashvili/no