### PR TITLE
Add capture metrics feature

### DIFF
--- a/app/controllers/ems_common_helper.rb
+++ b/app/controllers/ems_common_helper.rb
@@ -1,0 +1,82 @@
+module EmsCommonHelper
+  def add_task_flash(emss, action_name)
+    msg_params = {
+      :action_name => action_name,
+      :count       => emss.length,
+      :model       => _(table_name.humanize),
+      :models      => _(table_name.humanize.pluralize)
+    }
+    add_flash(n_("%<action_name>s initiated for one %<model>s",
+                 "%<action_name>s initiated for %<count>d %<models>s", emss.length) % msg_params)
+  end
+
+  def add_success_audit(emss, task)
+    msg_params = {
+      :task   => task,
+      :model  => _(table_name.humanize),
+      :models => _(table_name.humanize.pluralize),
+    }
+    msg = n_("'%<task>s' successfully initiated for %<model>s",
+             "'%<task>s' successfully initiated for %<models>s", emss.length) % msg_params
+    audit = {
+      :userid       => session[:userid],
+      :event        => "#{table_name}_#{task}",
+      :target_class => model.to_s,
+      :message      => msg,
+    }
+    AuditEvent.success(audit)
+  end
+
+  def find_ems_list_for_action(action_name)
+    emss = find_records_with_rbac(model, checked_or_params)
+    if emss.empty?
+      msg_params = {
+        :model       => _(table_name.humanize),
+        :action_name => action_name
+      }
+      add_flash(_("No %<model>s were selected for %<action_name>s") % msg_params, :error)
+      return
+    end
+
+    emss
+  end
+
+  def find_single_ems_for_action
+    ems = find_record_with_rbac(model, params[:id])
+    if ems.nil?
+      add_flash(_("%<record>s no longer exists") % { :record => _(table_name.humanize) }, :error)
+      return
+    end
+
+    ems
+  end
+
+  def find_emss_for_action(action_name)
+    if @lastaction == "show_list"
+      find_ems_list_for_action(action_name)
+    else
+      [find_single_ems_for_action]
+    end
+  end
+
+  def refresh_or_capture_emss(task, action_name)
+    emss = find_emss_for_action(action_name)
+    return if emss.compact.empty?
+
+    if task == "refresh_ems"
+      model.refresh_ems(emss, true)
+    elsif task == "capture_ems"
+      emss.each(&:queue_metrics_capture)
+    end
+
+    add_task_flash(emss, action_name)
+    add_success_audit(emss, task)
+
+    if @lastaction == "show_list"
+      show_list
+      @refresh_partial = "layouts/gtl"
+    else
+      params[:display] = @display
+    end
+  end
+end

--- a/app/helpers/application_helper/button/ems_capture_metrics.rb
+++ b/app/helpers/application_helper/button/ems_capture_metrics.rb
@@ -1,0 +1,32 @@
+class ApplicationHelper::Button::EmsCaptureMetrics < ApplicationHelper::Button::Basic
+  def disabled?
+    super
+    if @record
+      check_credentials
+      check_refresh
+      check_endpoint
+    end
+    check_role
+
+    @error_message.present?
+  end
+
+  def check_credentials
+    @error_message ||= _("Credentials must be valid to capture metrics") unless @record.authentication_status.downcase == "valid"
+  end
+
+  def check_refresh
+    @error_message ||= _("Please refresh provider before metrics capture") unless @record.last_refresh_error.nil?
+  end
+
+  def check_endpoint
+    @error_message ||= _("Metrics endpoint is not set") unless @record.supports_metrics?
+  end
+
+  def check_role
+    metrics_collection = ManageIQ::Providers::Kubernetes::ContainerManager.method_defined?(:queue_metrics_capture) &&
+                         MiqServer.my_server.zone.role_active?("ems_metrics_coordinator")
+
+    @error_message ||= _("Capacity & Utilization Coordinator role is off") unless metrics_collection
+  end
+end

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -18,6 +18,14 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
           N_('Refresh items and relationships'),
           :confirm => N_("Refresh items and relationships related to this Containers Provider?"),
           :klass   => ApplicationHelper::Button::EmsRefresh),
+        button(
+          :ems_container_capture_metrics,
+          'fa pficon-import fa-lg',
+          N_('Capture metrics related to this Containers Provider'),
+          N_('Capture metrics'),
+          :confirm => N_("Capture metrics related to this Containers Provider?"),
+          :klass   => ApplicationHelper::Button::EmsCaptureMetrics,
+        ),
         separator,
         button(
           :ems_container_edit,

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -16,6 +16,18 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
           :url_parms    => "main_div",
           :send_checked => true,
           :onwhen       => "1+"),
+        button(
+          :ems_container_capture_metrics,
+          'fa pficon-import fa-lg',
+          N_('Capture metrics for selected Containers Providers'),
+          N_('Capture metrics'),
+          :confirm      => N_("Capture metrics for selected Containers Providers?"),
+          :enabled      => false,
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :onwhen       => "1+",
+          :klass        => ApplicationHelper::Button::EmsCaptureMetrics,
+        ),
         separator,
         button(
           :ems_container_new,


### PR DESCRIPTION
**Description**

Compute -> Containers -> Providers

Add an options to force reading container performance metrics.

Schedules a metrics collection:
- On one container provider 
- On a list of selected container providers

Gray out button if:
- Core support is missing
- Metrics are disabled or not configured.
- Note: when multiple providers are selected, will try to schedule a readings even if none have metrics configured.
 
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1527877
Additional PRs:
ManageIQ/manageiq-providers-kubernetes#206
https://github.com/ManageIQ/manageiq/pull/16763

**Screenshot**

Queue metrics collection for one container:
![peek 2018-01-14 10-51](https://user-images.githubusercontent.com/2181522/34914412-5075aeec-f91b-11e7-9189-484a453b921c.gif)

C&U not enabled:
![peek 2018-01-14 11-11](https://user-images.githubusercontent.com/2181522/34914456-cea36eb2-f91b-11e7-9e82-51a765efb0a3.gif)




  