### PR TITLE
Require cloud tenant list permission for cloud volume

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -185,6 +185,8 @@ class CloudVolumeController < ApplicationController
 
   def new
     assert_privileges("cloud_volume_new")
+    assert_privileges("cloud_tenant_show_list")
+
     @volume = CloudVolume.new
     @in_a_form = true
     if params[:storage_manager_id]

--- a/app/helpers/application_helper/button/cloud_volume_new.rb
+++ b/app/helpers/application_helper/button/cloud_volume_new.rb
@@ -6,6 +6,10 @@ class ApplicationHelper::Button::CloudVolumeNew < ApplicationHelper::Button::But
     end
   end
 
+  def role_allows_feature?
+    role_allows?(:feature => 'cloud_tenant_show_list')
+  end
+
   # disable button if no active providers support create action
   def disabled?
     ExtManagementSystem.all.none? { |ems| CloudVolume.class_by_ems(ems).supports_create? }


### PR DESCRIPTION
similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/3165

@miq-bot add_label bug, blocker, gaprindashvili/yes

# Reproducer
1. Add user without permission list of Cloud Tenant
2. Go To Storage -> Block -> Volume -> Add new volume
3. You will see error.



# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1526804
similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/3165

@miq-bot assign @mzazrivec 

cc @martinpovolny 