### PR TITLE
Add both custom reports and custom report menu items to report menu

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -944,6 +944,8 @@ class ApplicationController < ActionController::Base
           folders.push([title[1], reports]) unless folders.include?([title[1], reports])
         end
       end
+
+      rptmenu = rptmenu.concat(group.settings[:report_menus]) if group.settings && group.settings[:report_menus] && mode == "default"
     else
       # Building custom reports array for super_admin/admin roles, it doesnt show up on menu if their menu was set which didnt contain custom folder in it
       temp = []

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -132,7 +132,7 @@ class ReportController < ApplicationController
       return
     end
 
-    populate_reports_menu("reports", "menu")
+    populate_reports_menu("reports", "default")
     build_accordions_and_trees
 
     self.x_active_tree = x_last_active_tree if x_last_active_tree

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -237,7 +237,7 @@ module ReportController::Reports
 
   # Build the main reports tree
   def build_reports_tree
-    populate_reports_menu("reports", "menu")
+    populate_reports_menu("reports", "default")
     TreeBuilderReportReports.new('reports_tree', 'reports', @sb)
   end
 end


### PR DESCRIPTION
The code is nearly unreadable and honestly, I don't see the bigger picture here and have no idea how this `get_reports_menu` should behave. The fix is an ugly hack and it might break everything in cases which I don't even know if exist at all. Writing tests around something I don't understand is IMHO meaningless and it might cause even more problems.

If you go to `Cloud Intel -> Reports (menu) -> Reports (accordion)`, you will see both the custom menus created under the `Edit Report Menus (accordion)` for the current user's group and the custom reports created (if any). Originally the manually edited report menus were not displayed, that has been fixed by #3098, that broke custom reports.

Because of #3187 there will be a merge conflict for `gaprindashvili` so I will create a separate PR for that.

@h-kataria could you please take a look at this? It might need some extra testing on each place where this is being used.

@miq-bot add_label bug, cloud intel/reports, gaprindashvili/yes
@miq-bot assign @h-kataria 

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1531600