### PR TITLE
RHSM form - use observe queue for submit

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -634,7 +634,14 @@ function miqAjax(url, serialize_fields, options) {
     complete: true,
   };
 
-  miqJqueryRequest(url, _.extend(defaultOptions, options || {}, { data: data }))
+  // miqAjaxButton with { observeQueue: true } will queue the request instead of sending directly
+  var requestFn = miqJqueryRequest;
+  if (options && options.observeQueue) {
+    delete options.observeQueue;
+    requestFn = miqObserveRequest;
+  }
+
+  return requestFn(url, _.extend(defaultOptions, options || {}, { data: data }))
     .catch(function(err) {
       add_flash(__('Error requesting data from server'), 'error');
       console.log(err);

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -451,6 +451,7 @@ class OpsController < ApplicationController
         record_id = @lt_map.try(:id)
       elsif @sb[:active_tab] == 'settings_rhn_edit'
         locals[:no_cancel] = false
+        locals[:observe_queue] = true
         action_url = "settings_update"
         record_id  = @sb[:active_tab].split("settings_").last
       else

--- a/app/views/layouts/_auth_credentials2.html.haml
+++ b/app/views/layouts/_auth_credentials2.html.haml
@@ -41,17 +41,15 @@
 - if validate
   .form-group
     .col-md-10{:align => 'right'}
-      = link_to(_('Validate'),
-                {:action => validate_url,
-                 :button => 'validate',
-                 :type   => prefix,
-                 :id     => record_id},
-                :class                => 'btn btn-primary btn-xs',
-                :alt                  => labels[:title],
-                :title                => labels[:title],
-                :remote               => true,
-                "data-method"         => :post,
-                'data-miq_sparkle_on' => true)
+      - url = url_for_only_path(:action => validate_url,
+                                :button => 'validate',
+                                :type   => prefix,
+                                :id     => record_id)
+      = button_tag(_('Validate'),
+                   :onclick => "miqAjaxButton('#{url}', undefined, { observeQueue: true, beforeSend: true, complete: false })",
+                   :class   => 'btn btn-primary btn-xs',
+                   :alt     => labels[:title],
+                   :title   => labels[:title])
       - if validate_note
         .note
           %b= validate_note

--- a/app/views/layouts/_x_edit_buttons.html.haml
+++ b/app/views/layouts/_x_edit_buttons.html.haml
@@ -37,6 +37,8 @@
 - export_button ||= nil
 -# need to pass this as true if need to send up serialized form data when save is pressed
 - serialize ||= false
+-# use miqAjaxButton with observeQueue: true (waits for miq-observe inputs first)
+- observe_queue ||= false
 
 
 %div{:style => 'padding-top: 5px'}
@@ -47,7 +49,7 @@
           :class   => "btn btn-primary",
           :alt     => t,
           :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => "add")}', #{serialize});")
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :button => "add")}', #{serialize}, #{observe_queue ? '{ observeQueue: true }' : 'null'});")
       - else
         - if apply_button
           = link_to(_("Apply"),
@@ -95,13 +97,13 @@
               :class   => "btn btn-primary",
               :alt     => save_text,
               :title   => save_text,
-              :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
+              :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize}, #{observe_queue ? '{ observeQueue: true }' : 'null'});")
           - else
             = button_tag(_('Save'),
               :class   => "btn btn-primary",
               :alt     => t = _("Save Changes"),
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
+              :onclick => "miqAjaxButton('#{url_for_only_path(:action => action_url, :id => record_id, :button => "save")}', #{serialize}, #{observe_queue ? '{ observeQueue: true }' : 'null'});")
 
         - unless no_reset
           = button_tag(_('Reset'),


### PR DESCRIPTION
Ops (Configuration) > Settings, select Region, tab Red Hat Updates
Edit Registration - fill out inputs too quickly and hit Register

clicking the Register button too fast would mean the attempt to save the form happened before the last input changed

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1532201
  