### PR TITLE
Fire new event when toolbar click finish

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -7,10 +7,19 @@
   var TREE_TABS_WITHOUT_PARENT = ['action_tree', 'alert_tree', 'schedules_tree'];
   var USE_TREE_ID = ['automation_manager'];
   var DEFAULT_VIEW = 'grid';
+  var TOOLBAR_CLICK_FINISH = 'TOOLBAR_CLICK_FINISH';
 
   function isAllowedParent(initObject) {
     return TREES_WITHOUT_PARENT.indexOf(ManageIQ.controller) === -1 &&
       TREE_TABS_WITHOUT_PARENT.indexOf(initObject.activeTree) === -1;
+  }
+
+  function tileViewSelector() {
+    return document.querySelector('miq-tile-view');
+  }
+
+  function tableViewSelector() {
+    return document.querySelector('miq-data-table');
   }
 
   function constructSuffixForTreeUrl(initObject, item) {
@@ -88,6 +97,8 @@
       } else if (event.unsubscribe && event.unsubscribe === CONTROLLER_NAME) {
         this.onUnsubscribe();
       } else if (event.toolbarEvent && (event.toolbarEvent === 'itemClicked')) {
+        this.setExtraClasses();
+      } else if (event.type === TOOLBAR_CLICK_FINISH && (tileViewSelector() || tableViewSelector())) {
         this.setExtraClasses(this.initObject.gtlType);
       } else if (event.refreshData && event.refreshData.name === CONTROLLER_NAME) {
         this.refreshData();
@@ -224,7 +235,7 @@
         }
         var url = prefix + itemId;
         $.post(url).always(function() {
-          this.setExtraClasses(this.initObject.gtlType);
+          this.setExtraClasses();
         }.bind(this));
       } else if (prefix !== "true") {
         var lastChar = prefix[prefix.length - 1];

--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -126,7 +126,9 @@
           }
 
           sendDataWithRx({toolbarEvent: 'itemClicked'});
-          miqToolbarOnClick.bind($event.delegateTarget)($event);
+          miqToolbarOnClick.bind($event.delegateTarget)($event).then(function(data) {
+            sendDataWithRx({type: 'TOOLBAR_CLICK_FINISH', payload: data});
+          });
         };
       })
       .value();

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1316,7 +1316,10 @@ function miqInitToolbars() {
   $('#toolbar:not(.miq-toolbar-menu) button:not(.dropdown-toggle), ' +
   '#toolbar:not(.miq-toolbar-menu) ul.dropdown-menu > li > a, '+
   '#toolbar:not(.miq-toolbar-menu) .toolbar-pf-view-selector > ul.list-inline > li > a'
-  ).click(miqToolbarOnClick);
+  ).click(function() {
+    miqToolbarOnClick.bind(this)();
+    return false;
+  });
 }
 
 // Function to run transactions when toolbar button is clicked
@@ -1432,8 +1435,7 @@ function miqToolbarOnClick(_e) {
     data: paramstring,
   };
 
-  miqJqueryRequest(tb_url, options);
-  return false;
+  return miqJqueryRequest(tb_url, options);
 
   function getParams(urlParms, sendChecked) {
     var params = [];


### PR DESCRIPTION
### Fixes present class on main div when clicked on GTL item
Class which was still present was `miq-sand-paper` which caused greyed content background. This PR fires new event when click on toolbar is finished and if such event is cought by report data it will check if any grid is present and if so, it will set `miq-sand-paper` back.

### Related issues/PRs
https://github.com/ManageIQ/manageiq-ui-classic/pull/3062

### BZ
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1530939