### PR TITLE
[WIP] Extract handling of common buttons, use GenericButtonMinix

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -22,6 +22,7 @@ module ApplicationController::CiProcessing
     include Mixins::Actions::HostActions::Discover
     include Mixins::Actions::HostActions::Power
     include Mixins::Actions::HostActions::Misc
+    include Mixins::Actions::HostActions::General
 
     include Mixins::Actions::ProviderActions::MassTransform
 

--- a/app/controllers/mixins/actions/host_actions/general.rb
+++ b/app/controllers/mixins/actions/host_actions/general.rb
@@ -1,0 +1,48 @@
+module Mixins
+  module Actions
+    module HostActions
+      module General
+        def host_buttons(pressed)
+          case pressed
+          when 'host_scan'
+            scanhosts
+          when 'host_analyze_check_compliance'
+            analyze_check_compliance_hosts
+          when 'host_check_compliance'
+            check_compliance_hosts
+          when 'host_refresh'
+            host_refresh
+          when 'host_protect'
+            assign_policies(Host)
+          when 'host_delete'
+            deletehosts
+          when 'host_edit'
+            edit_record
+            return true # no further handling
+          when 'storage_refresh'
+            refreshstorage
+            @refresh_div = 'main_div'
+            return false # unfinished
+          when 'storage_scan'
+            scanstorage
+            @refresh_div = 'main_div'
+            return false # unfinished
+          when 'storage_delete'
+            deletestorages
+            @refresh_div = 'main_div'
+            return false # unfinished
+          else
+            if host_power_button?(pressed)
+              handle_host_power_button(pressed)
+              return false
+            end
+          end
+
+          @refresh_div = "main_div"
+          @refresh_partial = "layouts/gtl"
+          false # no further processing
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -35,6 +35,8 @@ module Mixins
       when 'network_port_tag'                 then tag(NetworkPort)
       when 'network_router_tag'               then tag(NetworkRouter)
       when 'security_group_tag'               then tag(SecurityGroup)
+      when 'host_tag'                         then tag(Host)
+      when 'rp_tag'                           then tag(ResourcePool)
       end
 
       @flash_array.nil? ? :finished : :continue
@@ -42,7 +44,8 @@ module Mixins
 
     def button
       @edit = session[:edit] # Restore @edit for adv search box
-      params[:display] = @display if %w(vms images instances).include?(@display)
+      # FIXME: can the line below be replaced with a test agains display_message?
+      params[:display] = @display if %w(all_vms vms images instances hosts resource_pools).include?(@display)
       params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
 
       if params[:pressed] == "custom_button"

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -1,6 +1,7 @@
 class StorageController < ApplicationController
   include_concern 'StorageD'
   include_concern 'StoragePod'
+  include Mixins::GenericButtonMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
   include Mixins::MoreShowActions
@@ -66,67 +67,8 @@ class StorageController < ApplicationController
     true
   end
 
-  # handle buttons pressed on the button bar
-  def button
-    @edit = session[:edit] # Restore @edit for adv search box
-    params[:display] = @display if %w(all_vms vms hosts).include?(@display) # Were we displaying vms or hosts
-
-    if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
-                                     "miq_template_",
-                                     "guest_",
-                                     "host_")
-
-      scanhosts if params[:pressed] == "host_scan"
-      analyze_check_compliance_hosts if params[:pressed] == "host_analyze_check_compliance"
-      check_compliance_hosts if params[:pressed] == "host_check_compliance"
-      refreshhosts if params[:pressed] == "host_refresh"
-      tag(Host) if params[:pressed] == "host_tag"
-      assign_policies(Host) if params[:pressed] == "host_protect"
-      edit_record if params[:pressed] == "host_edit"
-      deletehosts if params[:pressed] == "host_delete"
-
-      pfx = pfx_for_vm_button_pressed(params[:pressed])
-      # Handle Host power buttons
-      if host_power_button?(params[:pressed])
-        handle_host_power_button(params[:pressed])
-      else
-        process_vm_buttons(pfx)
-        return if ["host_tag", "#{pfx}_policy_sim", "host_scan", "host_refresh", "host_protect",
-                   "#{pfx}_compare", "#{pfx}_tag", "#{pfx}_protect", "#{pfx}_retire",
-                   "#{pfx}_ownership", "#{pfx}_right_size", "#{pfx}_reconfigure"].include?(params[:pressed]) &&
-                  @flash_array.nil? # Tag screen is showing, so return
-
-        unless ["host_edit", "#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone", "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-          @refresh_div = "main_div"
-          @refresh_partial = "layouts/gtl"
-          show
-          @display = "vms"
-        end
-      end
-    else
-      @refresh_div = "main_div" # Default div for button.rjs to refresh
-      refreshstorage if params[:pressed] == "storage_refresh"
-      tag(Storage) if params[:pressed] == "storage_tag"
-      scanstorage if params[:pressed] == "storage_scan"
-      deletestorages if params[:pressed] == "storage_delete"
-      custom_buttons if params[:pressed] == "custom_button"
-    end
-
-    return if ["custom_button"].include?(params[:pressed]) # custom button screen, so return, let custom_buttons method handle everything
-    return if ["storage_tag"].include?(params[:pressed]) && @flash_array.nil? # Tag screen showing, so return
-
-    check_if_button_is_implemented
-
-    if single_delete_test
-      single_delete_redirect
-    elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
-                                                   "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-      render_or_redirect_partial(pfx)
-    elsif !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
-      replace_gtl_main_div
-    else
-      javascript_flash
-    end
+  def specific_buttons(pressed)
+    host_buttons(pressed)
   end
 
   def files


### PR DESCRIPTION
 * extract Host button handling
 * dedup `StorageController` `button` using `GenericButtonMixin`
 * dedup `EmsClusteController` `button` using `GenericButtonMixin`

I am not very sure about the setting of `params[:display]`. We should not be doing such things but seems there are places that depend on this bad practice :-(