### PR TITLE
Fix for orchestration stack retirement from summary page

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -273,7 +273,7 @@ module ApplicationController::CiProcessing
 
     # Either a list or coming from a different controller (e.g. from host screen, go to its vms)
     if @lastaction == "show_list" ||
-       !%w(service vm_cloud vm_infra vm miq_template vm_or_template).include?(controller_name)
+       !%w(service vm_cloud vm_infra vm miq_template vm_or_template orchestration_stack).include?(controller_name)
 
       # FIXME: retrieving vms from DB two times
       items = find_checked_ids_with_rbac(klass, task)

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -212,6 +212,14 @@ describe OrchestrationStackController do
         expect(response.status).to eq(200)
         expect(controller.send(:flash_errors?)).not_to be_truthy
       end
+
+      it "retires the orchestration stack now when called from the summary page" do
+        record = FactoryGirl.create(:orchestration_stack_cloud)
+        session[:orchestration_stack_lastaction] = 'show'
+        post :button, :params => {:id => record.id, :pressed => "orchestration_stack_retire_now"}
+        expect(response.status).to eq(200)
+        expect(controller.send(:flash_errors?)).not_to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
Fix for orchestration stack retirement from the summary page

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1531953

Steps for Testing/QA 
-------------------------------
1.Open stack details
2.Retire Now

  