### PR TITLE
Styling changes to the table component in Generic Object Definition screen

### DIFF
--- a/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-component.js
@@ -20,9 +20,9 @@ function genericObjectDefinitionFormController(API, miqService, $q) {
 
     vm.pictureReset = false;
 
-    vm.attributeTableHeaders = [__("Name"), __("Type")];
-    vm.associationTableHeaders = [__("Name"), __("Class")];
-    vm.methodTableHeaders = [__("Name")];
+    vm.attributeTableHeaders = [__("Name"), __("Type"), __("Actions")];
+    vm.associationTableHeaders = [__("Name"), __("Class"), __("Actions")];
+    vm.methodTableHeaders = [__("Name"), __("Actions")];
 
     vm.types = [];
     vm.classes = [];

--- a/app/assets/javascripts/components/generic_object/generic-object-table-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-table-component.js
@@ -28,8 +28,6 @@ function genericObjectTableController($timeout) {
   var vm = this;
 
   vm.$onInit = function() {
-    vm.tableHeaders.push('');
-
     vm.dupicatePropertyError = [];
     vm.invalidKeyName = __("Invalid name");
     vm.tableRendered = true;

--- a/app/assets/javascripts/components/generic_object/generic-object-table-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-table-component.js
@@ -35,11 +35,11 @@ function genericObjectTableController($timeout) {
     vm.tableRendered = true;
 
     if (vm.newRecord) {
-      vm.addRow(0, vm.keyType + '0', true);
+      vm.addRow(vm.keyType + '0', true);
     }
   };
 
-  vm.addRow = function(_currentRow, element, addFromOtherSource) {
+  vm.addRow = function(element, addFromOtherSource) {
     vm.keys.push('');
     vm.noOfRows = _.size(vm.keys);
 
@@ -60,7 +60,7 @@ function genericObjectTableController($timeout) {
     recalibrateDupes();
 
     if (vm.noOfRows === 0) {
-      vm.addRow(0, vm.keyType + '0', true);
+      vm.addRow(vm.keyType + '0', true);
     }
     checkIfTableChanged();
   };

--- a/app/assets/javascripts/components/generic_object/generic-object-table-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-table-component.js
@@ -3,6 +3,7 @@ ManageIQ.angular.app.component('genericObjectTableComponent', {
     keys: '=',
     values: '=',
     keyType: '@',
+    addRowText: '@',
     tableHeaders: '=',
     valueOptions: '<',
     newRecord: '<',
@@ -28,8 +29,6 @@ function genericObjectTableController($timeout) {
 
   vm.$onInit = function() {
     vm.tableHeaders.push('');
-
-    vm.addRowText = sprintf(__('Add %s'), vm.keyType);
 
     vm.dupicatePropertyError = [];
     vm.invalidKeyName = __("Invalid name");

--- a/app/assets/javascripts/components/generic_object/generic-object-table-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-table-component.js
@@ -27,7 +27,9 @@ function genericObjectTableController($timeout) {
   var vm = this;
 
   vm.$onInit = function() {
-    vm.tableHeaders.push('', '');
+    vm.tableHeaders.push('');
+
+    vm.addRowText = sprintf(__('Add %s'), vm.keyType);
 
     vm.dupicatePropertyError = [];
     vm.invalidKeyName = __("Invalid name");

--- a/app/assets/javascripts/components/generic_object/main-custom-button-form-component.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form-component.js
@@ -54,7 +54,7 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
     vm.button_types = [];
     vm.ae_instances = [];
 
-    vm.attributeValueTableHeaders = [__("Name"), __("Value")];
+    vm.attributeValueTableHeaders = [__("Name"), __("Value"), __("Actions")];
 
     vm.display_for = [
       {id: 'single', name: __('Single Entity')},

--- a/app/views/static/generic_object/generic_object_definition.html.haml
+++ b/app/views/static/generic_object/generic_object_definition.html.haml
@@ -38,6 +38,7 @@
       %generic-object-table-component{"keys"             => "vm.genericObjectDefinitionModel.attribute_names",
                                       "values"           => "vm.genericObjectDefinitionModel.attribute_types",
                                       "key-type"         => "Attribute",
+                                      "add-row-text"     => _("Add Attribute"),
                                       "table-headers"    => "vm.attributeTableHeaders",
                                       "orig-keys-values" => "vm.genericObjectDefinitionModel.properties.attributes",
                                       "table-changed"    => "vm.genericObjectDefinitionModel.attributesTableChanged",
@@ -55,6 +56,7 @@
       %generic-object-table-component{"keys"             => "vm.genericObjectDefinitionModel.association_names",
                                       "values"           => "vm.genericObjectDefinitionModel.association_classes",
                                       "key-type"         => "Association",
+                                      "add-row-text"     => _("Add Association"),
                                       "table-headers"    => "vm.associationTableHeaders",
                                       "orig-keys-values" => "vm.genericObjectDefinitionModel.properties.associations",
                                       "table-changed"    => "vm.genericObjectDefinitionModel.associationsTableChanged",
@@ -71,6 +73,7 @@
     .col-md-8
       %generic-object-table-component{"keys"             => "vm.genericObjectDefinitionModel.method_names",
                                       "key-type"         => "Method",
+                                      "add-row-text"     => _("Add Method"),
                                       "table-headers"    => "vm.methodTableHeaders",
                                       "orig-keys-values" => "vm.genericObjectDefinitionModel.properties.methods",
                                       "table-changed"    => "vm.genericObjectDefinitionModel.methodsTableChanged",

--- a/app/views/static/generic_object/generic_object_definition.html.haml
+++ b/app/views/static/generic_object/generic_object_definition.html.haml
@@ -3,6 +3,7 @@
                       "model"        => "vm.genericObjectDefinitionModel",
                       "ng-show"      => "vm.afterGet && vm.tableRendered",
                       "ng-cloak"     => "",
+                      "novalidate"   => true,
                       "form-changed" => true,
                       "miq-form"     => true}
   .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}

--- a/app/views/static/generic_object/generic_object_table.html.haml
+++ b/app/views/static/generic_object/generic_object_table.html.haml
@@ -2,7 +2,7 @@
   %span.input-group-btn
     %button.btn.btn-primary{:alt => t = _("Add Row"), :title => t, "ng-click" => "vm.addRow(vm.keyType + vm.noOfRows)"}
       {{vm.addRowText}}
-  %table.table.datatable.table-striped.table-bordered
+  %table.table.table-striped.table-bordered.dataTable
     %thead
       %tr
         %th{"ng-repeat" => "header in vm.tableHeaders track by $index"}{{header}}
@@ -52,7 +52,7 @@
                               "ng-model"    => "vm.values[$index]",
                               "ng-change"   => "vm.tableCellValueChanged()",
                               "maxlength"   => "#{ViewHelper::MAX_NAME_LEN}",}
-        %td{:align => "center", :style => "width: 50px"}
-          %span.input-group-btn
+        %td.table-view-pf-actions
+          .table-view-pf-btn
             .btn.btn-default{:alt => t = _("Delete Row"), :title => t, "ng-click" => "vm.deleteRow($index)"}
-              %i.fa.fa-minus
+              = _("Delete")

--- a/app/views/static/generic_object/generic_object_table.html.haml
+++ b/app/views/static/generic_object/generic_object_table.html.haml
@@ -1,6 +1,6 @@
 %add_row_div{:align => "right", :style => "width: 50px"}
   %span.input-group-btn
-    %button.btn.btn-primary{:alt => t = _("Add Row"), :title => t, "ng-click" => "vm.addRow($index, vm.keyType + vm.noOfRows)"}
+    %button.btn.btn-primary{:alt => t = _("Add Row"), :title => t, "ng-click" => "vm.addRow(vm.keyType + vm.noOfRows)"}
       {{vm.addRowText}}
   %table.table.datatable.table-striped.table-bordered
     %thead

--- a/app/views/static/generic_object/generic_object_table.html.haml
+++ b/app/views/static/generic_object/generic_object_table.html.haml
@@ -1,58 +1,58 @@
-%table.table.datatable.table-striped.table-bordered
-  %thead
-    %tr
-      %th{"ng-repeat" => "header in vm.tableHeaders track by $index"}{{header}}
-  %tbody
-    %tr{"ng-repeat" => "key in vm.keys track by $index"}
-      %td.form-group{"ng-class" => "{'has-error': vm.angularForm['{{vm.keyType}}{{$index}}'].$invalid}"}
-        %div{"ng-if" => "vm.noPattern"}
+%add_row_div{:align => "right", :style => "width: 50px"}
+  %span.input-group-btn
+    %button.btn.btn-primary{:alt => t = _("Add Row"), :title => t, "ng-click" => "vm.addRow($index, vm.keyType + vm.noOfRows)"}
+      {{vm.addRowText}}
+  %table.table.datatable.table-striped.table-bordered
+    %thead
+      %tr
+        %th{"ng-repeat" => "header in vm.tableHeaders track by $index"}{{header}}
+    %tbody
+      %tr{"ng-repeat" => "key in vm.keys track by $index"}
+        %td.form-group{"ng-class" => "{'has-error': vm.angularForm['{{vm.keyType}}{{$index}}'].$invalid}"}
+          %div{"ng-if" => "vm.noPattern"}
+            %input.form-control{"type"        => "text",
+                                "id"          => "{{vm.keyType}}{{$index}}",
+                                "name"        => "{{vm.keyType}}{{$index}}",
+                                "ng-required" => "vm.valueOptions && vm.values[$index] || {{vm.requiredRule}}",
+                                "ng-model"    => "vm.keys[$index]",
+                                "ng-change"   => "vm.tableCellValueChanged(vm.angularForm[vm.keyType+$index])",
+                                "title"       => "{{vm.angularForm[vm.keyType+$index].$error.pattern ? vm.invalidKeyName : ''}}",
+                                "maxlength"   => "#{ViewHelper::MAX_NAME_LEN}",}
+          %div{"ng-if" => "!vm.noPattern"}
+            %input.form-control{"type"        => "text",
+                                "id"          => "{{vm.keyType}}{{$index}}",
+                                "name"        => "{{vm.keyType}}{{$index}}",
+                                "ng-required" => "vm.valueOptions && vm.values[$index] || {{vm.requiredRule}}",
+                                "ng-model"    => "vm.keys[$index]",
+                                "ng-change"   => "vm.tableCellValueChanged(vm.angularForm[vm.keyType+$index])",
+                                "ng-pattern"  => "/^[a-z][a-zA-Z_0-9]*[!?]?$/",
+                                "title"       => "{{vm.angularForm[vm.keyType+$index].$error.pattern ? vm.invalidKeyName : ''}}",
+                                "maxlength"   => "#{ViewHelper::MAX_NAME_LEN}",}
+            %span.help-block{"ng-if" => "vm.angularForm[vm.keyType+$index].$error.pattern"}
+              %i.fa.fa-exclamation-circle{:style => "color:#cc0000"}
+                {{vm.invalidKeyName}}
+            %span.help-block{"ng-if" => "vm.angularForm[vm.keyType+$index].$error.duplicateProperty"}
+              %i.fa.fa-exclamation-circle{:style => "color:#cc0000"}
+                {{vm.dupicatePropertyError[vm.keyType+$index]}}
+        %td.form-group{"ng-if" => "vm.valueOptions", :style => "width: 50px", "ng-class" => "{'has-error': vm.angularForm['Value_{{vm.keyType}}{{$index}}'].$invalid}"}
+          %select{"name"                        => "Value_{{vm.keyType}}{{$index}}",
+                  "ng-required"                 => "vm.keys[$index] !== '' || {{vm.requiredRule}}",
+                  "ng-model"                    => "vm.values[$index]",
+                  "ng-change"                   => "vm.tableCellValueChanged()",
+                  "ng-options"                  => "valueOption.id as valueOption.name for valueOption in vm.valueOptions",
+                  "data-live-search"            => "true",
+                  "selectpicker-for-select-tag" => "",
+                  "pf-select"                   => true,}
+            %option{"value" => "", "disabled" => ""}
+              = "<#{_('Choose')}>"
+        %td.form-group{"ng-if" => "vm.addValueColumn", "ng-class" => "{'has-error': vm.angularForm['Value_{{vm.keyType}}{{$index}}'].$invalid}"}
           %input.form-control{"type"        => "text",
-                              "id"          => "{{vm.keyType}}{{$index}}",
-                              "name"        => "{{vm.keyType}}{{$index}}",
-                              "ng-required" => "vm.valueOptions && vm.values[$index] || {{vm.requiredRule}}",
-                              "ng-model"    => "vm.keys[$index]",
-                              "ng-change"   => "vm.tableCellValueChanged(vm.angularForm[vm.keyType+$index])",
-                              "title"       => "{{vm.angularForm[vm.keyType+$index].$error.pattern ? vm.invalidKeyName : ''}}",
+                              "id"          => "Value_{{vm.keyType}}{{$index}}",
+                              "name"        => "Value_{{vm.keyType}}{{$index}}",
+                              "ng-model"    => "vm.values[$index]",
+                              "ng-change"   => "vm.tableCellValueChanged()",
                               "maxlength"   => "#{ViewHelper::MAX_NAME_LEN}",}
-        %div{"ng-if" => "!vm.noPattern"}
-          %input.form-control{"type"        => "text",
-                              "id"          => "{{vm.keyType}}{{$index}}",
-                              "name"        => "{{vm.keyType}}{{$index}}",
-                              "ng-required" => "vm.valueOptions && vm.values[$index] || {{vm.requiredRule}}",
-                              "ng-model"    => "vm.keys[$index]",
-                              "ng-change"   => "vm.tableCellValueChanged(vm.angularForm[vm.keyType+$index])",
-                              "ng-pattern"  => "/^[a-z][a-zA-Z_0-9]*[!?]?$/",
-                              "title"       => "{{vm.angularForm[vm.keyType+$index].$error.pattern ? vm.invalidKeyName : ''}}",
-                              "maxlength"   => "#{ViewHelper::MAX_NAME_LEN}",}
-          %span.help-block{"ng-if" => "vm.angularForm[vm.keyType+$index].$error.pattern"}
-            %i.fa.fa-exclamation-circle{:style => "color:#cc0000"}
-              {{vm.invalidKeyName}}
-          %span.help-block{"ng-if" => "vm.angularForm[vm.keyType+$index].$error.duplicateProperty"}
-            %i.fa.fa-exclamation-circle{:style => "color:#cc0000"}
-              {{vm.dupicatePropertyError[vm.keyType+$index]}}
-      %td.form-group{"ng-if" => "vm.valueOptions", :style => "width: 50px", "ng-class" => "{'has-error': vm.angularForm['Value_{{vm.keyType}}{{$index}}'].$invalid}"}
-        %select{"name"                        => "Value_{{vm.keyType}}{{$index}}",
-                "ng-required"                 => "vm.keys[$index] !== '' || {{vm.requiredRule}}",
-                "ng-model"                    => "vm.values[$index]",
-                "ng-change"                   => "vm.tableCellValueChanged()",
-                "ng-options"                  => "valueOption.id as valueOption.name for valueOption in vm.valueOptions",
-                "data-live-search"            => "true",
-                "selectpicker-for-select-tag" => "",
-                "pf-select"                   => true,}
-          %option{"value" => "", "disabled" => ""}
-            = "<#{_('Choose')}>"
-      %td.form-group{"ng-if" => "vm.addValueColumn", "ng-class" => "{'has-error': vm.angularForm['Value_{{vm.keyType}}{{$index}}'].$invalid}"}
-        %input.form-control{"type"        => "text",
-                            "id"          => "Value_{{vm.keyType}}{{$index}}",
-                            "name"        => "Value_{{vm.keyType}}{{$index}}",
-                            "ng-model"    => "vm.values[$index]",
-                            "ng-change"   => "vm.tableCellValueChanged()",
-                            "maxlength"   => "#{ViewHelper::MAX_NAME_LEN}",}
-      %td{:align => "center", :style => "width: 50px"}
-        %span.input-group-btn
-          .btn.btn-default{:alt => t = _("Delete Row"), :title => t, "ng-click" => "vm.deleteRow($index)"}
-            %i.fa.fa-minus
-      %td{:align => "center", :style => "width: 50px"}
-        %span.input-group-btn
-          .btn.btn-default{:alt => t = _("Add Row"), :title => t, "ng-click" => "vm.addRow($index, vm.keyType + ($index + 1))", "ng-show" => "$index === vm.noOfRows - 1"}
-            %i.fa.fa-plus
+        %td{:align => "center", :style => "width: 50px"}
+          %span.input-group-btn
+            .btn.btn-default{:alt => t = _("Delete Row"), :title => t, "ng-click" => "vm.deleteRow($index)"}
+              %i.fa.fa-minus

--- a/app/views/static/generic_object/main_custom_button_form.html.haml
+++ b/app/views/static/generic_object/main_custom_button_form.html.haml
@@ -116,6 +116,7 @@
     .col-md-8
       %generic-object-table-component{"keys"             => "vm.customButtonModel.attribute_names",
                                       "values"           => "vm.customButtonModel.attribute_values",
+                                      "add-row-text"     => _("Add Attribute/Value Pair"),
                                       "key-type"         => "Attribute",
                                       "table-headers"    => "vm.attributeValueTableHeaders",
                                       "orig-keys-values" => "vm.customButtonModel.resource_action.ae_attributes",

--- a/app/views/static/generic_object/main_custom_button_form.html.haml
+++ b/app/views/static/generic_object/main_custom_button_form.html.haml
@@ -4,6 +4,7 @@
                       "ng-show"      => "vm.afterGet",
                       "ng-cloak"     => "",
                       "form-changed" => true,
+                      "novalidate"   => true,
                       "miq-form"     => true}
   .form-group{"ng-class" => "{'has-error': angularForm.button_type.$invalid}"}
     %label.col-md-2.control-label{"for" => "custom_button_button_type"}


### PR DESCRIPTION
As seen below, the '+' (Add Row) button was moved outside of the table to meet the UI/UX standards.

Before-
<img width="1407" alt="screen shot 2018-01-08 at 11 06 53 am" src="https://user-images.githubusercontent.com/1538216/34687596-1b58ca8e-f464-11e7-9a39-6ae487124aec.png">

After-
<img width="1411" alt="screen shot 2018-01-08 at 11 01 47 am" src="https://user-images.githubusercontent.com/1538216/34687622-2d6116aa-f464-11e7-90cd-33a6b63eade4.png">

The Change is also reflected in the Custom Button Editor screen where the same table component has been used -
<img width="1410" alt="screen shot 2018-01-08 at 11 36 34 am" src="https://user-images.githubusercontent.com/1538216/34688822-3d49511e-f468-11e7-85f5-f49939af10a7.png">






