### PR TITLE
Change Description to Name form label

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -10,7 +10,7 @@
   .form-horizontal
     .form-group
       %label.col-md-2.control-label
-        = _("Name")
+        = _("Description")
       .col-md-8
         - if !@edit
           = h(@group.description)

--- a/product/views/MiqGroup.yaml
+++ b/product/views/MiqGroup.yaml
@@ -38,7 +38,7 @@ col_order:
 
 # Column titles, in order
 headers:
-- Name
+- Description
 - Read Only
 - Number of Users
 - Role


### PR DESCRIPTION
**fixing** https://github.com/ManageIQ/manageiq-ui-classic/issues/3173

Change `Description` label of the form to `Name` when adding new Group
in _Administrator > Configuration > Access Control_ tab > _Groups_, to achieve
consistency with the table column of the DB.

**Before:**
![name](https://user-images.githubusercontent.com/13417815/34720977-283713a4-f541-11e7-8c8e-6e2b383291d6.png)
![name](https://user-images.githubusercontent.com/13417815/34821296-85726374-f6c3-11e7-9058-1b6b52598bdd.png)

**After:**
![description](https://user-images.githubusercontent.com/13417815/34821700-e783fc70-f6c4-11e7-8ab2-bb5cd61aea25.png)
![desc](https://user-images.githubusercontent.com/13417815/34821297-887624a2-f6c3-11e7-9573-825a039662be.png)
