### PR TITLE
Fix dropdown in tagging

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -215,7 +215,7 @@ module ApplicationController::Tags
     end
 
     # Set to first category, if not already set
-    @edit[:cat] ||= cats.min_by(&:description)
+    @edit[:cat] ||= cats.min_by(&:name)
 
     unless @object_ids.blank?
       @tagitems = @tagging.constantize.where(:id => @object_ids).sort_by { |t| t.name.try(:downcase).to_s }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1517285

Go to any tagging screen like Compute -> Infrastructure -> Virtual Machines -> Policy -> Edit Tags 
At load second dropdown is not correctly populated. After change it's correct.

Before:
![image](https://user-images.githubusercontent.com/9210860/34722381-fe720258-f546-11e7-9b68-7ff627a72b8f.png)

After:
![image](https://user-images.githubusercontent.com/9210860/34722132-e19ebcee-f545-11e7-9012-33f3096138fc.png)

IMPORTANT: Make sure that `Classification.categories.select(&:show).min_by(&:description)` and `Classification.categories.select(&:show).min_by(&:name)` are two different instances.

`Classification.categories.select(&:show).sort_by(&:name)[0]` that is used in layout as `@categories` is not equal to `Classification.categories.select(&:show).sort_by(&:name).min_by(&:description)` that is used as `@edit[:cat]` to generate its subcategories.
Replaced `:description` to `:name` to make it equal 😄 

@miq-bot add_label bug, gaprindashvili/yes, tagging
