### PR TITLE
GTL onItemClicked - ignore clicks on td with checkbox

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -203,38 +203,42 @@
     event.stopPropagation();
     event.preventDefault();
 
+    // nothing to do
+    if (! this.initObject.showUrl) {
+      return false;
+    }
+
     // clicks just outside the checkbox
     if ($(event.target).is('.is-checkbox-cell')) {
       return false;
     }
 
-    if (this.initObject.showUrl) {
-      var prefix = this.initObject.showUrl;
-      var splitUrl = this.initObject.showUrl.split('/');
-      if (item.parent_path && item.parent_id) {
-        miqSparkleOn();
-        this.$window.DoNav(item.parent_path + '/' + item.parent_id);
-      } else if (this.initObject.isExplorer && isCurrentControllerOrPolicies(splitUrl)) {
-        miqSparkleOn();
-        var itemId = item.id;
-        if (_.isString(this.initObject.showUrl) && this.initObject.showUrl.indexOf('?id=') !== -1) {
-          itemId = constructSuffixForTreeUrl(this.initObject, item);
-          this.activateNodeSilently(itemId);
-        }
-        if (itemId.indexOf('unassigned') !== -1) {
-          prefix = '/' + ManageIQ.controller + '/tree_select/?id=';
-        }
-        var url = prefix + itemId;
-        $.post(url).always(function() {
-          this.setExtraClasses();
-        }.bind(this));
-      } else if (prefix !== "true") {
-        miqSparkleOn();
-        var lastChar = prefix[prefix.length - 1];
-        prefix = (lastChar !== '/' && lastChar !== '=') ? prefix + '/' : prefix;
-        this.$window.DoNav(prefix + (item.long_id || item.id));
+    var prefix = this.initObject.showUrl;
+    var splitUrl = this.initObject.showUrl.split('/');
+    if (item.parent_path && item.parent_id) {
+      miqSparkleOn();
+      this.$window.DoNav(item.parent_path + '/' + item.parent_id);
+    } else if (this.initObject.isExplorer && isCurrentControllerOrPolicies(splitUrl)) {
+      miqSparkleOn();
+      var itemId = item.id;
+      if (_.isString(this.initObject.showUrl) && this.initObject.showUrl.indexOf('?id=') !== -1) {
+        itemId = constructSuffixForTreeUrl(this.initObject, item);
+        this.activateNodeSilently(itemId);
       }
+      if (itemId.indexOf('unassigned') !== -1) {
+        prefix = '/' + ManageIQ.controller + '/tree_select/?id=';
+      }
+      var url = prefix + itemId;
+      $.post(url).always(function() {
+        this.setExtraClasses();
+      }.bind(this));
+    } else if (prefix !== "true") {
+      miqSparkleOn();
+      var lastChar = prefix[prefix.length - 1];
+      prefix = (lastChar !== '/' && lastChar !== '=') ? prefix + '/' : prefix;
+      this.$window.DoNav(prefix + (item.long_id || item.id));
     }
+
     return false;
   };
 

--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -202,6 +202,12 @@
   ReportDataController.prototype.onItemClicked = function(item, event) {
     event.stopPropagation();
     event.preventDefault();
+
+    // clicks just outside the checkbox
+    if ($(event.target).is('.is-checkbox-cell')) {
+      return false;
+    }
+
     if (this.initObject.showUrl) {
       var prefix = this.initObject.showUrl;
       var splitUrl = this.initObject.showUrl.split('/');


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/ui-components/pull/230 (merged)

When clicking just outside the checkbox in a GTL list, usually the intent is to click the checkbox, not to open the detail screen.

This is to catch that :).
 
---
[diff -w](https://github.com/ManageIQ/manageiq-ui-classic/pull/3207/files?w=1) for better diff here :)