### PR TITLE
Fix rendering of flash message when running check compliance

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -431,6 +431,7 @@ module EmsCommon
     end
     process_emss(ids, "check_compliance")
     params[:display] = "main"
+    return if @display == 'dashboard'
     showlist ? show_list : show
   end
 

--- a/app/views/ems_infra/_show_dashboard.html.haml
+++ b/app/views/ems_infra/_show_dashboard.html.haml
@@ -1,3 +1,4 @@
+= render :partial => "layouts/flash_msg"
 .container-fluid.container-tiles-pf.ems-infra-dashboard
   .row.row-tile-pf
     = render :partial => "aggregate-status-card"

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -13,8 +13,10 @@ describe EmsInfraController do
 
     it "EmsInfra check compliance is called when Compliance is pressed" do
       ems_infra = FactoryGirl.create(:ems_vmware)
-      expect(controller).to receive(:check_compliance)
+      expect(controller).to receive(:check_compliance).and_call_original
       post :button, :params => {:pressed => "ems_infra_check_compliance", :format => :js, :id => ems_infra.id}
+      expect(controller.send(:flash_errors?)).not_to be_truthy
+      expect(assigns(:flash_array).first[:message]).to include('Check Compliance successfully initiated')
     end
 
     it "when VM Right Size Recommendations is pressed" do


### PR DESCRIPTION
Navigate to infra / container provider summary, switch to dashboard view, hit 'Check Compliance of Last known Configuration' button.

Previously, the button action would render full page (html). Now the action will render a javascript flash message. 

https://bugzilla.redhat.com/show_bug.cgi?id=1510340