### PR TITLE
Add missing condition for retrieving data on the provider topology pages

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -278,7 +278,7 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
       var url = '';
       if ($location.absUrl().match('show/$') || $location.absUrl().match('show$')) {
         url = controller.dataUrl;
-      } else if ($location.absUrl().match('show/[0-9]*\\?display=topology$') || $location.absUrl().match('show/[0-9]*\\?display=topology/$')) {
+      } else if ($location.absUrl().match('show/[0-9]*\\?display=topology/?$') || $location.absUrl().match('_topology/show/[0-9]+/?$')) {
         id = '/' + (/\/show\/(\d+)/.exec($location.absUrl())[1]);
         url = controller.detailUrl || controller.dataUrl;
         url += id;


### PR DESCRIPTION
When you go to a provider's (e.g. infra) summary screen and select the topology in the table view, the topology data are not being loaded onto the controller.

![screenshot from 2018-01-10 14-17-41](https://user-images.githubusercontent.com/649130/34774870-5fbb1c64-f611-11e7-94aa-dd49509a4176.png)

The problem was that the condition for building the URL did not cover this way of displaying a topology screen. I updated the condition to make this work, however, some refactoring should be done in the future. The code is too much spaghetti for adding any tests, but after @Hyperkid123 is finished with the refactoring, it should be easy. 

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1532404