### PR TITLE
Fix GO under services and fix services tagging

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -85,7 +85,7 @@ module ApplicationController::Explorer
   def x_button
     model, action = pressed2model_action(params[:pressed])
 
-    allowed_models = %w(common image instance vm miq_template provider storage configscript infra_networking automation_manager_provider configuration_manager_provider service)
+    allowed_models = %w(common image instance vm miq_template provider storage configscript infra_networking automation_manager_provider configuration_manager_provider)
     raise ActionController::RoutingError.new('invalid button action') unless
       allowed_models.include?(model)
 

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -16,7 +16,7 @@ module ApplicationController::Tags
     end
   end
 
-  def service_tag(_db = nil)
+  def service_tag
     tagging_edit('Service')
   end
 

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -5,13 +5,14 @@ module ApplicationController::Tags
   def tagging_edit(db = nil, assert = true)
     assert_privileges("#{controller_for_common_methods}_tag") if assert
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
+
+    @tagging = session[:tag_db] = params[:db] ? params[:db] : db if params[:db] || db
     case params[:button]
     when "cancel"
       tagging_edit_tags_cancel
     when "save", "add"
       tagging_edit_tags_save
     when "reset", nil # Reset or first time in
-      @tagging = session[:tag_db] = params[:db] ? params[:db] : db if params[:db] || db
       tagging_edit_tags_reset
     end
   end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -427,9 +427,8 @@ class ServiceController < ApplicationController
       elsif record_showing
         presenter.remove_sand
         if action
-          partial_locals[:item_id] = @item.id
           cb_tb = build_toolbar(Mixins::CustomButtons::Result.new(:single))
-          r[:partial => partial, :locals => partial_locals]
+          r[:partial => partial, :locals => {:item_id => @item.id}]
         else
           r[:partial => "service/svcs_show", :locals => {:controller => "service"}]
         end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -426,12 +426,7 @@ class ServiceController < ApplicationController
         r[:partial => 'layouts/x_gtl', :locals => {:controller => "vm", :action_url => @lastaction}]
       elsif record_showing
         presenter.remove_sand
-        if action
-          cb_tb = build_toolbar(Mixins::CustomButtons::Result.new(:single))
-          r[:partial => partial, :locals => {:item_id => @item.id}]
-        else
-          r[:partial => "service/svcs_show", :locals => {:controller => "service"}]
-        end
+        r[:partial => "service/svcs_show", :locals => {:controller => "service"}]
       else
         r[:partial => "layouts/x_gtl"]
       end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -51,8 +51,8 @@ class ServiceController < ApplicationController
 
     set_display
 
-    if self.class.display_methods.include?(@display)
-      nested_list_show
+    if @display == 'generic_objects'
+      show_generic_object
       return
     end
 
@@ -71,8 +71,12 @@ class ServiceController < ApplicationController
     @display ||= default_display unless pagination_or_gtl_request?
   end
 
-  def nested_list_show
-    params[:generic_object_id] ? generic_object : display_nested_list(@display)
+  def show_generic_object
+    if params[:generic_object_id]
+      show_single_generic_object
+    else
+      display_nested_list(@display)
+    end
   end
 
   def show_list
@@ -173,14 +177,15 @@ class ServiceController < ApplicationController
     }
   end
 
-  def generic_object
+  # display a single generic object
+  #
+  def show_single_generic_object
     return unless init_show_variables
 
     @lastaction = 'generic_object'
-    @item ||= @record.generic_objects.find(params[:generic_object_id]).first
-    drop_breadcrumb(:name => _("%{name} (All Generic Objects)") % {:name => @record.name},
-                    :url  => show_link(@record, :display => @display))
-    drop_breadcrumb(:name => @item.name, :url => "/#{controller_name}/show/#{@record.id}?display=generic_objects&generic_object_id=#{params[:generic_object_id]}")
+    @item = @record.generic_objects.find(params[:generic_object_id]).first
+    drop_breadcrumb(:name => _("%{name} (All Generic Objects)") % {:name => @record.name}, :url  => show_link(@record, :display => 'generic_objects'))
+    drop_breadcrumb(:name => @item.name, :url  => show_link(@record, :display => 'generic_objects', :generic_object_id => params[:generic_object_id]))
     @view = get_db_view(GenericObject)
     @sb[:rec_id] = params[:generic_object_id]
     show_item

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -370,7 +370,7 @@ class ServiceController < ApplicationController
       partial = "service_form"
       header = _("Editing Service \"%{name}\"") % {:name => @service.name}
       action = "service_edit"
-    when "tag"
+    when "tag", 'service_tag'
       partial = "layouts/tagging"
       header = _("Edit Tags for Service")
       action = "service_tag"
@@ -391,7 +391,7 @@ class ServiceController < ApplicationController
     partial, action_url, @right_cell_text = set_right_cell_vars(action) if action # Set partial name, action and cell header
     get_node_info(x_node) if !action && !@in_a_form && !params[:display]
     replace_trees = @replace_trees if @replace_trees  # get_node_info might set this
-    type, = parse_nodetype_and_id(x_node)
+    type, _ = parse_nodetype_and_id(x_node)
     record_showing = type && ["Service"].include?(TreeBuilder.get_model_for_prefix(type))
     if x_active_tree == :svcs_tree && !@in_a_form && !@sb[:action]
       if record_showing && @sb[:action].nil?
@@ -413,7 +413,7 @@ class ServiceController < ApplicationController
 
     # Replace right cell divs
     presenter.update(:main_div,
-      if ["dialog_provision", "ownership", "retire", "service_edit", "tag"].include?(action)
+      if %w(dialog_provision ownership retire service_edit tag service_tag).include?(action)
         r[:partial => partial, :locals => options[:dialog_locals]]
       elsif params[:display]
         r[:partial => 'layouts/x_gtl', :locals => {:controller => "vm", :action_url => @lastaction}]
@@ -424,14 +424,14 @@ class ServiceController < ApplicationController
         r[:partial => "layouts/x_gtl"]
       end
     )
-    if %w(dialog_provision ownership tag).include?(action)
+    if %w(dialog_provision ownership tag service_tag).include?(action)
       presenter.show(:form_buttons_div).hide(:pc_div_1, :toolbar).show(:paging_div)
       if action == "dialog_provision" && params[:pressed] == "service_reconfigure"
         presenter.update(:form_buttons_div, r[:partial => "layouts/x_dialog_buttons",
                                               :locals  => {:action_url => action_url,
                                                            :record_id  => @edit[:rec_id]}])
       else
-        if action == "tag"
+        if %w(tag service_tag).include?(action)
           locals = {:action_url => action_url}
           locals[:multi_record] = true    # need save/cancel buttons on edit screen even tho @record.id is not there
           locals[:record_id]    = @sb[:rec_id] || @edit[:object_ids] && @edit[:object_ids][0]

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -369,18 +369,6 @@ class ServiceController < ApplicationController
       partial = "layouts/tagging"
       header = _("Edit Tags for Service")
       action = "service_tag"
-    when "show_generic_object"
-      table = controller_name
-      partial = "layouts/item"
-      header = _("Generic Object \"%{item_name}\" for %{service} \"%{name}\"") % {
-        :service   => ui_lookup(:table => table),
-        :name      => @record.name,
-        :item_name => @item.name
-      }
-      x_history_add_item(:id     => x_node,
-                         :text   => header,
-                         :action => action,
-                         :item   => @item.id)
     else
       action = nil
     end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -184,8 +184,8 @@ class ServiceController < ApplicationController
 
     @lastaction = 'generic_object'
     @item = @record.generic_objects.find(params[:generic_object_id]).first
-    drop_breadcrumb(:name => _("%{name} (All Generic Objects)") % {:name => @record.name}, :url  => show_link(@record, :display => 'generic_objects'))
-    drop_breadcrumb(:name => @item.name, :url  => show_link(@record, :display => 'generic_objects', :generic_object_id => params[:generic_object_id]))
+    drop_breadcrumb(:name => _("%{name} (All Generic Objects)") % {:name => @record.name}, :url => show_link(@record, :display => 'generic_objects'))
+    drop_breadcrumb(:name => @item.name, :url => show_link(@record, :display => 'generic_objects', :generic_object_id => params[:generic_object_id]))
     @view = get_db_view(GenericObject)
     @sb[:rec_id] = params[:generic_object_id]
     show_item
@@ -412,7 +412,8 @@ class ServiceController < ApplicationController
     reload_trees_by_presenter(presenter, build_replaced_trees(replace_trees, %i(svcs)))
 
     # Replace right cell divs
-    presenter.update(:main_div,
+    presenter.update(
+      :main_div,
       if %w(dialog_provision ownership retire service_edit tag service_tag).include?(action)
         r[:partial => partial, :locals => options[:dialog_locals]]
       elsif params[:display]
@@ -434,7 +435,7 @@ class ServiceController < ApplicationController
       else
         if %w(tag service_tag).include?(action)
           locals = {:action_url => action_url}
-          locals[:multi_record] = true    # need save/cancel buttons on edit screen even tho @record.id is not there
+          locals[:multi_record] = true  # need save/cancel buttons on edit screen even tho @record.id is not there
           locals[:record_id]    = @sb[:rec_id] || @edit[:object_ids] && @edit[:object_ids][0]
         elsif action == "ownership"
           locals = {:action_url => action_url}

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -238,6 +238,12 @@ class ServiceController < ApplicationController
     replace_right_cell(:action => 'ownership')
   end
 
+  def service_tag_edit
+    @explorer = true
+    service_tag
+    replace_right_cell(:action => 'tag')
+  end
+
   def service_retire
     @explorer = true
     retirevms

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -418,6 +418,7 @@ class ServiceController < ApplicationController
       elsif params[:display]
         r[:partial => 'layouts/x_gtl', :locals => {:controller => "vm", :action_url => @lastaction}]
       elsif record_showing
+        @selected_ids = [] # FIXME: hack to hide checkboxes
         presenter.remove_sand
         r[:partial => "service/svcs_show", :locals => {:controller => "service"}]
       else

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -11,7 +11,7 @@ class ServiceController < ApplicationController
     'service_delete'      => :service_delete,
     'service_edit'        => :service_edit,
     'service_ownership'   => :service_ownership,
-    'service_tag'         => :service_tag,
+    'service_tag'         => :service_tag_edit,
     'service_retire'      => :service_retire,
     'service_retire_now'  => :service_retire_now,
     'service_reconfigure' => :service_reconfigure

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -448,7 +448,7 @@ class ServiceController < ApplicationController
         (@pages && (@items_per_page == ONE_MILLION || @pages[:items] == 0)))
       # Added so buttons can be turned off even tho div is not being displayed it still pops up Abandon changes box
       # when trying to change a node on tree after saving a record
-      presenter.hide(:buttons_on).show(:toolbar).hide(:paging_div)
+      presenter.hide(:form_buttons_div, :paging_div).show(:toolbar)
     else
       presenter.hide(:form_buttons_div).show(:pc_div_1, :toolbar, :paging_div)
     end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -34,6 +34,10 @@ class ServiceController < ApplicationController
     custom_buttons(ids, display_options)
   end
 
+  def x_button
+    generic_x_button(SERVICE_X_BUTTON_ALLOWED_ACTIONS)
+  end
+
   def title
     _("My Services")
   end
@@ -390,7 +394,6 @@ class ServiceController < ApplicationController
       return
     end
     action, replace_trees = options.values_at(:action, :replace_trees)
-    action = @sb[:action] if action.nil?
     @explorer = true
     partial, action_url, @right_cell_text = set_right_cell_vars(action) if action # Set partial name, action and cell header
     get_node_info(x_node) if !action && !@in_a_form && !params[:display]

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -499,7 +499,8 @@ class ServiceController < ApplicationController
   end
 
   def tagging_explorer_controller?
-    @explorer
+    # this controller behaves explorer-like for services and non-explorer-like for GO
+    @tagging == 'Service'
   end
 
   def get_session_data

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -946,7 +946,7 @@ module ApplicationHelper
   end
 
   def pressed2model_action(pressed)
-    pressed =~ /^(ems_cluster|miq_template|infra_networking|automation_manager_provider|configuration_manager_provider|service)_(.*)$/ ? [$1, $2] : pressed.split('_', 2)
+    pressed =~ /^(ems_cluster|miq_template|infra_networking|automation_manager_provider|configuration_manager_provider)_(.*)$/ ? [$1, $2] : pressed.split('_', 2)
   end
 
   def model_for_ems(record)

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -470,7 +470,7 @@ class ApplicationHelper::ToolbarChooser
         return "#{@display}_center"
       end
     elsif @display == 'generic_objects'
-      return "#{@display}_center"
+      return @lastaction == 'generic_object' ? nil : 'generic_objects_center'
     elsif @lastaction == "compare_miq" || @lastaction == "compare_compress"
       return "compare_center_tb"
     elsif @lastaction == "drift_history"

--- a/app/views/service/explorer.html.haml
+++ b/app/views/service/explorer.html.haml
@@ -2,6 +2,7 @@
   = render(:partial => "layouts/x_adv_searchbox")
   = render(:partial => 'layouts/quick_search')
 - if TreeBuilder.get_model_for_prefix(@nodetype) == "Service"
+  - @selected_ids = [] # FIXME: hack to hide checkboxes
   -# Showing a specific Service
   #main_div
     = render :partial => "svcs_show", :locals => {:controller => "service"}

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -5,11 +5,11 @@ describe ServiceController do
     stub_user(:features => :all)
   end
 
-  let(:go_definition) {
+  let(:go_definition) do
     FactoryGirl.create(:generic_object_definition, :properties => {:associations => {"vms" => "Vm", "services" => "Service"}})
-  }
+  end
 
-  let (:service_with_go) {
+  let(:service_with_go) do
     service = FactoryGirl.create(:service, :name => 'Services with a GO')
 
     go = FactoryGirl.create(
@@ -21,7 +21,7 @@ describe ServiceController do
     service.add_resource(go)
 
     service
-  }
+  end
 
   describe "#service_delete" do
     it "display flash message with description of deleted Service" do

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -5,6 +5,24 @@ describe ServiceController do
     stub_user(:features => :all)
   end
 
+  let(:go_definition) {
+    FactoryGirl.create(:generic_object_definition, :properties => {:associations => {"vms" => "Vm", "services" => "Service"}})
+  }
+
+  let (:service_with_go) {
+    service = FactoryGirl.create(:service, :name => 'Services with a GO')
+
+    go = FactoryGirl.create(
+      :generic_object,
+      :generic_object_definition => go_definition,
+      :name                      => 'go_assoc',
+      :services                  => [service]
+    )
+    service.add_resource(go)
+
+    service
+  }
+
   describe "#service_delete" do
     it "display flash message with description of deleted Service" do
       st  = FactoryGirl.create(:service_template)
@@ -102,20 +120,10 @@ describe ServiceController do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)
       controller.instance_variable_set(:@breadcrumbs, [])
-      service = FactoryGirl.create(:service, :name => "Abc")
-      definition = FactoryGirl.create(:generic_object_definition,
-                                      :properties => {:associations => {"vms" => "Vm", "services" => "Service"}})
-      go = FactoryGirl.create(
-        :generic_object,
-        :generic_object_definition => definition,
-        :name                      => 'go_assoc',
-        :services                  => [service]
-      )
-      service.add_resource(go)
 
-      get :show, :params => { :id => service.id, :display => 'generic_objects'}
+      get :show, :params => { :id => service_with_go.id, :display => 'generic_objects'}
       expect(response.status).to eq(200)
-      expect(assigns(:breadcrumbs)).to eq([{:name => "Abc (All Generic Objects)", :url => "/service/show/#{service.id}?display=generic_objects"}])
+      expect(assigns(:breadcrumbs)).to eq([{:name => "Services with a GO (All Generic Objects)", :url => "/service/show/#{service_with_go.id}?display=generic_objects"}])
     end
 
     it 'redirects to service detail page when Services maintab is clicked right after viewing the GO object' do
@@ -123,11 +131,9 @@ describe ServiceController do
       login_as FactoryGirl.create(:user)
       controller.instance_variable_set(:@breadcrumbs, [])
       service = FactoryGirl.create(:service, :name => "Abc")
-      definition = FactoryGirl.create(:generic_object_definition,
-                                      :properties => {:associations => {"vms" => "Vm", "services" => "Service"}})
       go = FactoryGirl.create(
         :generic_object,
-        :generic_object_definition => definition,
+        :generic_object_definition => go_definition,
         :name                      => 'GOTest',
         :services                  => [service]
       )
@@ -155,11 +161,9 @@ describe ServiceController do
 
       it "when Generic Object Tag is pressed for the generic object nested list" do
         service = FactoryGirl.create(:service, :name => "Service with Generic Objects")
-        definition = FactoryGirl.create(:generic_object_definition,
-                                        :properties => {:associations => {"vms" => "Vm", "services" => "Service"}})
         go = FactoryGirl.create(
           :generic_object,
-          :generic_object_definition => definition,
+          :generic_object_definition => go_definition,
           :name                      => 'go_assoc',
           :services                  => [service]
         )


### PR DESCRIPTION
Reverts:
https://github.com/ManageIQ/manageiq-ui-classic/pull/2680

Fixes:
https://github.com/ManageIQ/manageiq-ui-classic/pull/2636
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1528289 

related BZs:
https://bugzilla.redhat.com/show_bug.cgi?id=1532354
https://bugzilla.redhat.com/show_bug.cgi?id=1532355

### Testing
 1. c-n-p this gist into the `rails c` https://gist.github.com/martinpovolny/4d960e550a7838a9b04cb4d8396514b0 
 1. test services tagging (reset, cancel, save)
 1. test display of nested VM (no checkbox)
 1. test display of GO (single/list)
 1. test tagging of GO (only from the list now)

### TODO
 1. ~~fix the BZs~~
 2. tests
 3. what about the layout/item ?

### Bugz
 1. ~~VMs under a service are displayed with checkboxes (this breaks the tagging when a checkbox is checked)~~
 1. ~~tagging button is broken under GO~~
 1. ~~tagging is broken (at least reset)~~
 1. ~~tree is missing when displaying GO~~ (this is to stay that way for now per discussion with @dclarizio)
 1. breadcrumbs are broken (when displaying GO and going here and back) (NOT fixing that here)
 1. ~~tagging button is disabled when a single GO is displayed.~~ I REMOVED the toolbar in that context. It never worked and there's no nice way to fix that. It's messed up due to the fact that Services and GOs are displayed in a single controller.

