### PR TITLE
Use bypass_rescue instead of handle_exceptions = false in cloud_volume_controller_spec

### DIFF
--- a/app/helpers/application_helper/button/cloud_volume_new.rb
+++ b/app/helpers/application_helper/button/cloud_volume_new.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Button::CloudVolumeNew < ApplicationHelper::Button::But
   end
 
   def role_allows_feature?
-    role_allows?(:feature => 'cloud_tenant_show_list')
+    super && role_allows?(:feature => 'cloud_tenant_show_list')
   end
 
   # disable button if no active providers support create action

--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -99,7 +99,6 @@ describe CloudVolumeController do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       EvmSpecHelper.seed_specific_product_features(%w(cloud_volume_new))
-      ApplicationController.handle_exceptions = false
 
       allow(User).to receive(:current_user).and_return(user)
       allow(Rbac).to receive(:role_allows?).and_call_original
@@ -107,7 +106,10 @@ describe CloudVolumeController do
     end
 
     it "raises exception wheh used have not privilege" do
-      expect { post :new, :params => {:button => "new", :format => :js} }.to raise_error(MiqException::RbacPrivilegeException)
+      expect do
+        bypass_rescue
+        post :new, :params => {:button => "new", :format => :js}
+      end.to raise_error(MiqException::RbacPrivilegeException)
     end
   end
 


### PR DESCRIPTION
it looks that it is causing sporadic CI failures because of enabling/disabling handling an exception 
like this https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/327674115
in PR https://github.com/ManageIQ/manageiq-ui-classic/pull/3165

and address comment 
https://github.com/ManageIQ/manageiq-ui-classic/pull/3189/files/e37c91172b2182e7d8ba5d1914ba1b8c52d16af0#diff-7f61832948d751577adfa11885942a16

@miq-bot add_label bug, technical-debt
@miq-bot assign @himdel 

# Links 
caused by https://github.com/ManageIQ/manageiq-ui-classic/pull/3189
CI failure https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/327674115
