### PR TITLE
Remove nil elements from top_nodes array.

### DIFF
--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -44,8 +44,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
     %w(all_vm_rules api_exclusive sui).each do |additional_feature|
       top_nodes << MiqProductFeature.obj_features[additional_feature][:feature]
     end
-
-    count_only_or_objects(count_only, top_nodes)
+    count_only_or_objects(count_only, top_nodes.compact)
   end
 
   def x_get_tree_section_kids(parent, count_only = false)

--- a/spec/presenters/tree_builder_ops_rbac_features_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_features_spec.rb
@@ -43,10 +43,14 @@ describe TreeBuilderOpsRbacFeatures do
       expect(t['checkable']).to be false
     end
 
-    describe 'main sections' do
-      %w(aut compute con conf net opt set sto svc vi).each do |i|
+    describe 'main section keys are excluded from top_nodes if they do not exists in permissions.yml' do
+      %w(aut compute con conf mdl net opt set sto svc vi).each do |i|
         it "includes #{i}" do
-          expect(main_keys).to include("100000002___tab_#{i}")
+          if i == 'mdl'
+            expect(main_keys).not_to include("100000002___tab_#{i}")
+          else
+            expect(main_keys).to include("100000002___tab_#{i}")
+          end
         end
       end
 


### PR DESCRIPTION
Even when section was skipped in x_get_tree_roots method a nil was being added to top_nodes array that was causing undefined method `new' for nil:NilClass
in /app/presenters/tree_node.rb:9. This fix removes any nil elements from array before trying to build RBAC features tree.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1533391

@lgalis please test.