### PR TITLE
Replace 'Show costs by' option for Metering reports

### DIFF
--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -29,7 +29,10 @@
   - if @edit[:cb_users]
     .form-group
       %label.control-label.col-md-2
-        = _('Show Costs by')
+        - if @edit[:new][:model].include?('Metering')
+          = _('Show usage by')
+        - else
+          = _('Show Costs by')
       .col-md-8
         - opts = [["<#{_('Choose')}>", nil]]
         - if @edit[:new][:model] == "ChargebackContainerProject" || @edit[:new][:model] == "MeteringContainerProject"
@@ -172,7 +175,10 @@
 .form-horizontal
   .form-group
     %label.control-label.col-md-2
-      = _('Show Costs by')
+      - if @edit[:new][:model].include?('Metering')
+        = _('Show usage by')
+      - else
+        = _('Show Costs by')
     .col-md-8
       = select_tag("cb_interval",
         options_for_select([[_("Day"), "daily"], [_("Week"), "weekly"], [_("Month"), "monthly"]], @edit[:new][:cb_interval]),


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1533294

Replace `'Show costs by'` with `'Show usage by'` option under _Filter_ tab for **Metering reports**,
when adding a new Report in _Cloud Intel -> Reports -> Reports_ tab.

**Before:**
![costs](https://user-images.githubusercontent.com/13417815/34870059-3af10758-f789-11e7-9673-22975e239505.png)

**After:**
![metering](https://user-images.githubusercontent.com/13417815/34870054-357fcf3e-f789-11e7-8a78-005f1311c486.png)
![usage](https://user-images.githubusercontent.com/13417815/34870262-d99d36ec-f789-11e7-81bd-2b6e8ca8d789.png)
