### PR TITLE
Unable to select '<Choose a Group>' and change it to 'Choose one or more Groups'

### DIFF
--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -131,12 +131,12 @@
                 = h(group.description)
                 %br
           - else
-            - options = (@edit[:new][:group].present? ? [] : [[_("<Choose a Group>"), nil]]) + @edit[:groups]
             - select_groups = @edit[:new][:userid].blank? ? @edit[:new][:group] : groups.map(&:id)
             = select_tag('chosen_group',
-                         options_for_select(options, select_groups),
+                         options_for_select(@edit[:groups], select_groups),
                          :class    => "selectpicker",
                          :multiple => true,
+                         :title    => "&lt;#{_('Choose one or more Groups')}&gt;",
                          :style    => "overflow-x: scroll;")
             :javascript
               miqInitSelectPicker();


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1525122

Unable to select **"\<Choose a Group\>"** as a group from _Available Groups_,
when creating a User in _Configuration -> Access Control -> Users_.

**Before:**
![choose_before](https://user-images.githubusercontent.com/13417815/34871691-db7cd17a-f78e-11e7-8f44-f30fb89bb871.png)

**After:**
![choose](https://user-images.githubusercontent.com/13417815/34871697-de8b78a8-f78e-11e7-9fcc-163f9454d037.png)
