### PR TITLE
Fix uncheck of Host in HaC tree

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1124,9 +1124,9 @@ module OpsController::OpsRbac
       else # Belongsto tag checked
         class_prefix, id = parse_nodetype_and_id(params[:id])
         klass = TreeBuilder.get_model_for_prefix(class_prefix)
-        # If ExtManagementSystem is returned get specific class
-        if klass == 'ExtManagementSystem'
-          klass = ExtManagementSystem.find(from_cid(id)).class.to_s
+        # If ExtManagementSystem/Host is returned get specific class
+        if %w(ExtManagementSystem Host).include?(klass)
+          klass = find_record_with_rbac(klass.constantize, from_cid(id)).class.to_s
         end
         if params[:check] == "0" #   unchecked
           @edit[:new][:belongsto].delete("#{klass}_#{from_cid(id)}") # Remove the tag from the belongsto hash


### PR DESCRIPTION
Identificator for selected host in HaC tree uses name of specific class for host but deselection uses just `Host`. So it never finds correct record. This unifies it to use specific class.

https://bugzilla.redhat.com/show_bug.cgi?id=1511528

Configuration -> Access Control -> Groups -> Select one with checked Host as below
<img width="298" alt="screen shot 2018-01-12 at 11 06 44 am" src="https://user-images.githubusercontent.com/9210860/34870126-79de1438-f789-11e7-8a4c-ab5537da893a.png">
Edit the group -> Uncheck a Host -> Save
Before:
Host stays checked
After:
Host is unchecked

@miq-bot add_label bug, gaprindashvili/yes, fine/yes

