### PR TITLE
Need to call alert_profile_edit_load_edit when cancel is pressed

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -6,7 +6,7 @@ module MiqPolicyController::AlertProfiles
   end
 
   def alert_profile_edit_cancel
-    alert_profile_load
+    return unless alert_profile_edit_load_edit
     @edit = nil
     if @alert_profile && @alert_profile.id.blank?
       add_flash(_("Add of new Alert Profile was cancelled by the user"))

--- a/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
+++ b/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
@@ -71,5 +71,26 @@ describe MiqPolicyController do
         expect(controller.send(:flash_errors?)).not_to be_truthy
       end
     end
+
+    context "#alert_profile_edit" do
+      before :each do
+        controller.instance_variable_set(:@sb,
+                                         :trees       => {
+                                           :alert_profile_tree => {:active_node => "xx-Vm"}},
+                                         :active_tree => :alert_profile_tree)
+        allow(controller).to receive(:replace_right_cell)
+        edit = {
+          :key => "alert_profile_edit__new"
+        }
+        session[:edit] = edit
+      end
+
+      it "Test cancel button" do
+        controller.instance_variable_set(:@_params, :id => 'new', :button => "cancel")
+        controller.alert_profile_edit
+        expect(assigns(:flash_array).first[:message]).to include("Add of new Alert Profile was cancelled by the user")
+        expect(controller.send(:flash_errors?)).not_to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
alert_profile_edit_load_edit method loads `@edit` that's being used in alert_profile_load method. Issue was introduced during cleanup in https://github.com/ManageIQ/manageiq-ui-classic/pull/2026

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1533633

@dclarizio @martinpovolny please review.