### PR TITLE
Set the action parameter  replace_right_cell's  on button update and reset

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -493,7 +493,7 @@ module ApplicationController::Buttons
     @edit[:enablement_expression_table] = exp_build_table_or_nil(@edit[:new][:enablement_expression])
     @in_a_form = true
     @sb[:active_tab] = "ab_advanced_tab"
-    replace_right_cell(:nodetype => x_node)
+    replace_right_cell(:action => 'button_edit')
   end
 
   def ab_button_cancel(typ)
@@ -624,7 +624,7 @@ module ApplicationController::Buttons
     drop_breadcrumb(:name => _("Edit of Button"), :url => "/miq_ae_customization/button_edit")
     @lastaction = "automate_button"
     @layout = "miq_ae_automate_button"
-    replace_right_cell(:nodetype => "button_edit")
+    replace_right_cell(:action => "button_edit")
   end
 
   # Set form variables for button add/edit

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -135,6 +135,40 @@ describe ApplicationController do
         controller.send(:button_create_update, "add")
         expect(assigns(:sb)[:active_tab]).to eq("ab_advanced_tab")
       end
+
+      it "calls replace_right_cell with action='button_edit' when the edit expression button was pressed" do
+        custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
+        controller.instance_variable_set(:@_params, :button => "enablement_expression", :id => custom_button.id)
+        edit = {:new           => {},
+                :current       => {},
+                :custom_button => custom_button}
+        controller.instance_variable_set(:@edit, edit)
+        session[:edit] = edit
+        controller.instance_variable_set(:@sb,
+                                         :trees       => {:ab_tree => {:active_node => "-ub-Host"}},
+                                         :active_tree => :ab_tree)
+        allow(controller).to receive(:ab_get_node_info)
+        allow(controller).to receive(:exp_build_table_or_nil).and_return(nil)
+        expect(controller).to receive(:replace_right_cell).with(:action => 'button_edit')
+        controller.send(:button_create_update, "edit")
+      end
+
+      it "calls replace_right_cell with action='button_edit' when the edit expression button was pressed" do
+        custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
+        controller.instance_variable_set(:@_params, :button => "enablement_expression", :id => custom_button.id)
+        edit = {:new           => {},
+                :current       => {},
+                :custom_button => custom_button}
+        controller.instance_variable_set(:@edit, edit)
+        session[:edit] = edit
+        controller.instance_variable_set(:@sb,
+                                         :trees       => {:ab_tree => {:active_node => "-ub-Host"}},
+                                         :active_tree => :ab_tree)
+        allow(controller).to receive(:ab_get_node_info)
+        allow(controller).to receive(:exp_build_table_or_nil).and_return(nil)
+        expect(controller).to receive(:replace_right_cell).with(:action => 'button_edit')
+        controller.send(:button_create_update, "reset")
+      end
     end
   end
 


### PR DESCRIPTION
Set the action parameter  replace_right_cell's  on button update and reset

Links 
--------

https://bugzilla.redhat.com/show_bug.cgi?id=1533643

Steps for Testing/QA 
-----------------------------
1. Create a Custom Button in Button Group for Service Template  (Services->Catalogs->All Catalog Items -> Action ... )
2. Edit new Button -> click on 'Define Expression' -> enter some expression
 - or press Reset after other changes


Before:

![screenshot from 2018-01-12 14-46-06](https://user-images.githubusercontent.com/12769982/34892461-68c0ca92-f7a7-11e7-8219-5a181b383aff.png)

After:

![screenshot from 2018-01-12 14-35-00](https://user-images.githubusercontent.com/12769982/34892469-7136f9b2-f7a7-11e7-9024-a30a7d142926.png)

