### PR TITLE
Remove dead code from get_reports_menu in application controller

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -779,7 +779,6 @@ class DashboardController < ApplicationController
 
   # Gather information for the report accordians
   def build_timeline_listnav
-    populate_reports_menu("timeline", "menu")
     @timelines_tree = TreeBuilderTimelines.new(:timelines_tree, :timelines, @sb, true, :title => @sb[:grp_title])
   end
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -132,7 +132,7 @@ class ReportController < ApplicationController
       return
     end
 
-    populate_reports_menu("reports", "default")
+    populate_reports_menu("default")
     build_accordions_and_trees
 
     self.x_active_tree = x_last_active_tree if x_last_active_tree

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -10,7 +10,7 @@ module ReportController::Menus
       @rpt_menu = copy_array(@edit[:new])
     elsif @menu_lastaction == "default"
     else
-      populate_reports_menu("reports", "menu")
+      populate_reports_menu("menu")
       tree = build_menu_roles_tree
       @rpt_menu = tree.rpt_menu
     end
@@ -209,7 +209,7 @@ module ReportController::Menus
       get_tree_data
       replace_right_cell(:menu_edit_action => "menu_reset")
     elsif params[:button] == "default"
-      populate_reports_menu("reports", "default")
+      populate_reports_menu("default")
       @menu_roles_tree = build_menu_roles_tree
       @edit[:new]      = copy_array(@sb[:rpt_menu])
       @menu_lastaction = "default"

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -237,7 +237,7 @@ module ReportController::Reports
 
   # Build the main reports tree
   def build_reports_tree
-    populate_reports_menu("reports", "default")
+    populate_reports_menu("default")
     TreeBuilderReportReports.new('reports_tree', 'reports', @sb)
   end
 end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1345,7 +1345,7 @@ describe ReportController do
       controller.instance_variable_set(:@_params, :controller => "report", :action => "explorer")
       controller.instance_variable_set(:@sb, {})
       allow(controller).to receive(:get_node_info)
-      controller.send(:populate_reports_menu, "reports", "default")
+      controller.send(:populate_reports_menu, "default")
       rpt_menu = controller.instance_variable_get(:@sb)[:rpt_menu]
       expect(rpt_menu.first.first).to eq("#{user.current_tenant.name} (Group): #{user.current_group.name}")
     end


### PR DESCRIPTION
When on the `CI -> Reports -> Timelines` screen, the `populate_reports_menu` is being called unnecessarily as the `TreeBuilderTimelines` is building the tree without depending on `@sb[:rpt_menu]`. This allows to remove all the logic responsible for timelines in `get_reports_menu` and it will ease its future refactoring.

@miq-bot add_label refactoring, gaprindashvili/no, cloud intel/reporting