### PR TITLE
Embedded Ansible Automation Manager should not be shown in alert profile assignment screen 

### DIFF
--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -46,7 +46,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
           elsif @cat_tree
             @cat ? Classification.find(@cat).entries : []
           elsif @assign_to == "ext_management_system"
-            @assign_to.camelize.constantize.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager")
+            ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager")
           else
             @assign_to.camelize.constantize.all
           end

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -45,6 +45,8 @@ class TreeBuilderAlertProfileObj < TreeBuilder
             []
           elsif @cat_tree
             @cat ? Classification.find(@cat).entries : []
+          elsif @assign_to == "ext_management_system"
+            @assign_to.camelize.constantize.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager")
           else
             @assign_to.camelize.constantize.all
           end

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -64,7 +64,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     if @assign_to.present?
       count_only_or_objects(count_only, ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
     else
-      count_only_or_objects(count_only, ExtManagementSystem)
+      count_only_or_objects(count_only, ExtManagementSystem.all)
     end
   end
 

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -61,7 +61,11 @@ class TreeBuilderBelongsToHac < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    count_only_or_objects(count_only, ExtManagementSystem.all)
+    if @assign_to.present?
+      count_only_or_objects(count_only, ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
+    else
+      count_only_or_objects(count_only, ExtManagementSystem)
+    end
   end
 
   def x_get_provider_kids(parent, count_only)

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -81,6 +81,14 @@ describe TreeBuilderAlertProfileObj do
         expect(s).to eq([tag1a, tag2a, tag3a].sort_by { |o| (o.name.presence || o.description).downcase })
       end
     end
+
+    describe '#x_get_tree_roots for provider' do
+      it 'returns all ExtManagementSystems except the Embedded Ansible when @assign_to=ext_management_system' do
+        subject.instance_variable_set(:@cat_tree, nil)
+        subject.instance_variable_set(:@assign_to, "ext_management_system")
+        expect(subject.send(:x_get_tree_roots, false, nil)).to eq(ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
+      end
+    end
   end
 
   context 'tenant tree' do

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -97,6 +97,13 @@ describe TreeBuilderBelongsToHac do
     end
   end
 
+  describe '#x_get_tree_roots' do
+    it 'returns all ExtManagementSystems except the Embedded Ansible when @assign_to is present' do
+      subject.instance_variable_set(:@assign_to, "ems_folder")
+      expect(subject.send(:x_get_tree_roots, false, nil)).to eq(ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
+    end
+  end
+
   describe '#x_get_tree_provider_kids' do
     it 'returns datacenter or folder' do
       kids = subject.send(:x_get_provider_kids, ems_azure_network, false)


### PR DESCRIPTION
Embedded Ansible Automation Manager is removed from the alert profile assignment screen 

Npte - this PR will not show the Embedded Ansible in the Alet profile screen. I will open a GH Issue to obtain the filtered list from the model.

Links 
-------
https://bugzilla.redhat.com/show_bug.cgi?id=1533456

Steps for Testing
-------------------------------
1. Enable Embedded Ansible role.
2. Navigate to Control/Explorer, expand Alert Profiles accordion.
3. Create a "VM and Instance" alert profile and assign some alert.
4. Click on Configuration/Edit assignments for this Alert Profile.
5. In "Assign To" select "Selected Providers".


Before:
![screenshot from 2018-01-15 10-54-31](https://user-images.githubusercontent.com/12769982/34951747-4749fcd6-f9e5-11e7-8645-c2d3756e8974.png)
![screenshot from 2018-01-15 10-55-15](https://user-images.githubusercontent.com/12769982/34951748-475541f4-f9e5-11e7-8222-c98d34bcb333.png)

After:
![screenshot from 2018-01-15 11-14-13](https://user-images.githubusercontent.com/12769982/34951768-5264fae4-f9e5-11e7-9228-fa73f0ed8345.png)
![screenshot from 2018-01-15 11-14-21](https://user-images.githubusercontent.com/12769982/34951769-5274e58a-f9e5-11e7-8202-86cc1eaaba34.png)
