### PR TITLE
Move common initialization steps of topologies to topology service

### DIFF
--- a/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
@@ -1,32 +1,13 @@
 angular.module('ManageIQ').controller('cloudTopologyController', CloudTopologyCtrl);
-CloudTopologyCtrl.$inject = ['$scope', '$interval', 'topologyService'];
+CloudTopologyCtrl.$inject = ['$scope', 'topologyService'];
 
-function CloudTopologyCtrl($scope, $interval, topologyService) {
+function CloudTopologyCtrl($scope, topologyService) {
   var vm = this;
-
-  miqHideSearchClearButton();
   vm.vs = null;
   vm.icons = null;
   vm.dataUrl = '/cloud_topology/data';
-  var d3 = window.d3;
-  // NOTE: for search
-  vm.d3 = d3;
-  topologyService.mixinContextMenu(vm, vm);
 
-  vm.checkboxModel = {
-    value: false,
-  };
-
-  vm.legendTooltip = __('Click here to show/hide entities of this type');
-
-  $('input#box_display_names').click(topologyService.showHideNames(vm));
-  topologyService.mixinRefresh(vm, $scope);
-  topologyService.mixinGetIcon(vm);
-  vm.refresh();
-  var promise = $interval(vm.refresh, 1000 * 60 * 3);
-  $scope.$on('$destroy', function() {
-    $interval.cancel(promise);
-  });
+  topologyService.mixinTopology(vm, $scope);
 
   $scope.$on('render', function(ev, vertices, added) {
     /*
@@ -155,6 +136,4 @@ function CloudTopologyCtrl($scope, $interval, topologyService) {
         return defaultDimensions;
     }
   };
-
-  topologyService.mixinSearch(vm);
 }

--- a/app/assets/javascripts/controllers/topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/container_topology_controller.js
@@ -1,23 +1,11 @@
 angular.module('ManageIQ').controller('containerTopologyController', ContainerTopologyCtrl);
-ContainerTopologyCtrl.$inject = ['$scope', '$interval', 'topologyService'];
+ContainerTopologyCtrl.$inject = ['$scope', 'topologyService', 'topologyDetail'];
 
-function ContainerTopologyCtrl($scope, $interval, topologyService) {
-  ManageIQ.angular.scope = $scope;
-  miqHideSearchClearButton();
+function ContainerTopologyCtrl($scope, topologyService, topologyDetail) {
   var vm = this;
-  vm.dataUrl = '/container_topology/data';
-  vm.detailUrl = '/container_project_topology/data';
+  vm.dataUrl = topologyDetail ? '/container_project_topology/data' : '/container_topology/data';
   vm.vs = null;
   vm.icons = null;
-
-  var d3 = window.d3;
-  vm.d3 = d3;
-
-  topologyService.mixinContextMenu(vm, vm);
-
-  vm.checkboxModel = {
-    value: false
-  };
 
   vm.remove_hierarchy = [
     'Container',
@@ -31,15 +19,7 @@ function ContainerTopologyCtrl($scope, $interval, topologyService) {
     'ContainerManager'
   ];
 
-  vm.legendTooltip = __("Click here to show/hide entities of this type");
-  $('input#box_display_names').click(topologyService.showHideNames(vm));
-  topologyService.mixinRefresh(vm, $scope);
-  vm.refresh();
-  var promise = $interval(vm.refresh, 1000 * 60 * 3);
-
-  $scope.$on('$destroy', function() {
-    $interval.cancel(promise);
-  });
+  topologyService.mixinTopology(vm, $scope);
 
   $scope.$on("render", function(ev, vertices, added) {
     /*
@@ -151,10 +131,6 @@ function ContainerTopologyCtrl($scope, $interval, topologyService) {
     ev.preventDefault();
   });
 
-  vm.getIcon = function getIcon(d) {
-    return d.item.kind === 'ContainerManager' ? vm.icons[d.item.display_kind] : vm.icons[d.item.kind];
-  };
-
   vm.getDimensions = function getDimensions(d) {
     var defaultDimensions = topologyService.defaultElementDimensions();
     switch (d.item.kind) {
@@ -178,6 +154,4 @@ function ContainerTopologyCtrl($scope, $interval, topologyService) {
         return defaultDimensions;
     }
   };
-
-  topologyService.mixinSearch(vm);
 }

--- a/app/assets/javascripts/controllers/topology/infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/infra_topology_controller.js
@@ -1,33 +1,13 @@
 angular.module('ManageIQ').controller('infraTopologyController', InfraTopologyCtrl);
-InfraTopologyCtrl.$inject = ['$scope', '$interval', 'topologyService'];
+InfraTopologyCtrl.$inject = ['$scope', 'topologyService'];
 
-function InfraTopologyCtrl($scope, $interval, topologyService) {
-  ManageIQ.angular.scope = $scope;
-  miqHideSearchClearButton();
+function InfraTopologyCtrl($scope, topologyService) {
   var vm = this;
   vm.dataUrl = '/infra_topology/data';
   vm.vs = null;
   vm.icons = null;
 
-  var d3 = window.d3;
-  vm.d3 = d3;
-
-  topologyService.mixinContextMenu(vm, vm);
-  vm.checkboxModel = {
-    value: false
-  };
-
-  vm.legendTooltip = __("Click here to show/hide entities of this type");
-
-  $('input#box_display_names').click(topologyService.showHideNames(vm));
-  topologyService.mixinRefresh(vm, $scope);
-  topologyService.mixinGetIcon(vm);
-  vm.refresh();
-  var promise = $interval(vm.refresh, 1000 * 60 * 3);
-
-  $scope.$on('$destroy', function() {
-    $interval.cancel(promise);
-  });
+  topologyService.mixinTopology(vm, $scope);
 
   $scope.$on("render", function(ev, vertices, added) {
     /*
@@ -154,6 +134,4 @@ function InfraTopologyCtrl($scope, $interval, topologyService) {
         return defaultDimensions;
     }
   };
-
-  topologyService.mixinSearch(vm);
 }

--- a/app/assets/javascripts/controllers/topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/network_topology_controller.js
@@ -1,53 +1,13 @@
 angular.module('ManageIQ').controller('networkTopologyController', NetworkTopologyCtrl);
-NetworkTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService', 'miqService'];
+NetworkTopologyCtrl.$inject = ['$scope', 'topologyService'];
 
-function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyService, miqService) {
+function NetworkTopologyCtrl($scope, topologyService) {
   var vm = this;
-  ManageIQ.angular.scope = $scope;
-  miqHideSearchClearButton();
   vm.vs = null;
-  var icons = null;
+  vm.icons = null;
+  vm.dataUrl = '/network_topology/data';
 
-  var d3 = window.d3;
-  vm.d3 = d3;
-
-  topologyService.mixinContextMenu(this, vm);
-
-  listenToRx(function(event) {
-    if (event.name === 'refreshTopology') {
-      vm.refresh();
-    }
-  });
-
-
-  vm.refresh = function() {
-    var id;
-    if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
-      id = '';
-    } else {
-      id = '/' + (/network_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
-    }
-
-    var url = '/network_topology/data' + id;
-
-    $http.get(url)
-      .then(getNetworkTopologyData)
-      .catch(miqService.handleFailure);
-  };
-
-  vm.checkboxModel = {
-    value: false
-  };
-
-  vm.legendTooltip = __("Click here to show/hide entities of this type");
-
-  $('input#box_display_names').click(topologyService.showHideNames(vm));
-  vm.refresh();
-  var promise = $interval(vm.refresh, 1000 * 60 * 3);
-
-  $scope.$on('$destroy', function() {
-    $interval.cancel(promise);
-  });
+  topologyService.mixinTopology(vm, $scope);
 
   $scope.$on("render", function(ev, vertices, added) {
     /*
@@ -159,15 +119,6 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
     ev.preventDefault();
   });
 
-  this.getIcon = function getIcon(d) {
-    switch(d.item.kind) {
-      case 'NetworkManager':
-        return icons[d.item.display_kind];
-      default:
-        return icons[d.item.kind];
-    }
-  };
-
   this.getDimensions = function getDimensions(d) {
     var defaultDimensions = topologyService.defaultElementDimensions();
     switch (d.item.kind) {
@@ -186,20 +137,4 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
         return defaultDimensions;
     }
   };
-
-  function getNetworkTopologyData(response) {
-    var data = response.data;
-
-    var currentSelectedKinds = vm.kinds;
-    vm.items = data.data.items;
-    vm.relations = data.data.relations;
-    vm.kinds = $scope.kinds = data.data.kinds;
-    icons = data.data.icons;
-
-    if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !== Object.keys(vm.kinds).length)) {
-      vm.kinds = currentSelectedKinds;
-    }
-  }
-
-  topologyService.mixinSearch(vm);
 }

--- a/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
@@ -1,33 +1,13 @@
 angular.module('ManageIQ').controller('physicalInfraTopologyController', physicalInfraTopologyCtrl);
-physicalInfraTopologyCtrl.$inject = ['$scope', '$interval', 'topologyService'];
+physicalInfraTopologyCtrl.$inject = ['$scope', 'topologyService'];
 
-function physicalInfraTopologyCtrl($scope, $interval, topologyService) {
-  miqHideSearchClearButton();
+function physicalInfraTopologyCtrl($scope, topologyService) {
   var vm = this;
   vm.vs = null;
   vm.icons = null;
   vm.dataUrl = '/physical_infra_topology/data';
 
-  var d3 = window.d3;
-  vm.d3 = d3;
-
-  topologyService.mixinContextMenu(vm, vm);
-
-  vm.checkboxModel = {
-    value: false
-  };
-
-  vm.legendTooltip = __("Click here to show/hide entities of this type");
-
-  $('input#box_display_names').click(topologyService.showHideNames(vm));
-  topologyService.mixinRefresh(vm, $scope);
-  topologyService.mixinGetIcon(vm);
-  vm.refresh();
-  var promise = $interval(vm.refresh, 1000 * 60 * 3);
-
-  $scope.$on('$destroy', function() {
-    $interval.cancel(promise);
-  });
+  topologyService.mixinTopology(vm, $scope);
 
   $scope.$on("render", function(ev, vertices, added) {
     /*
@@ -154,5 +134,4 @@ function physicalInfraTopologyCtrl($scope, $interval, topologyService) {
         return defaultDimensions;
     }
   };
-  topologyService.mixinSearch(vm);
 }

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -35,7 +35,7 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
     };
   };
 
-  this.contextMenu = function(vm) {
+  this.minxContextMenu = function(vm) {
     var topologyService = this;
     vm.contextMenuShowing = false;
 
@@ -247,7 +247,7 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
     });
   };
 
-  this.refresh = function(controller, $scope) {
+  this.mixinRefresh = function(controller, $scope) {
     var topologyService = this;
     var getTopologyData = function(response) {
       var data = response.data;
@@ -295,7 +295,7 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
     });
   };
 
-  this.getIcon = function(controller) {
+  this.mixinGetIcon = function(controller) {
     controller.getIcon = function(d) {
       switch (d.item.kind) {
         case 'CloudManager':
@@ -319,9 +319,9 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
     vm.legendTooltip = __('Click here to show/hide entities of this type');
     $('input#box_display_names').click(this.showHideNames(vm));
 
-    this.contextMenu(vm);
-    this.refresh(vm, $scope);
-    this.getIcon(vm);
+    this.minxContextMenu(vm);
+    this.mixinRefresh(vm, $scope);
+    this.mixinGetIcon(vm);
     vm.refresh();
 
     var promise = $interval(vm.refresh, 1000 * 60 * 3);

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -35,7 +35,7 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
     };
   };
 
-  this.minxContextMenu = function(vm) {
+  this.mixinContextMenu = function(vm) {
     var topologyService = this;
     vm.contextMenuShowing = false;
 
@@ -210,7 +210,7 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
   };
 
   // this injects some common code in the controller - temporary pending a proper merge
-  this.search = function($scope) {
+  this.mixinSearch = function($scope) {
     var topologyService = this;
 
     var resetEvent = function() {
@@ -319,7 +319,7 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
     vm.legendTooltip = __('Click here to show/hide entities of this type');
     $('input#box_display_names').click(this.showHideNames(vm));
 
-    this.minxContextMenu(vm);
+    this.mixinContextMenu(vm);
     this.mixinRefresh(vm, $scope);
     this.mixinGetIcon(vm);
     vm.refresh();
@@ -328,6 +328,6 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
     $scope.$on('$destroy', function() {
       $interval.cancel(promise);
     });
-    this.search(vm);
+    this.mixinSearch(vm);
   };
 }]);

--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -55,4 +55,5 @@
   %kubernetes-topology-graph{:items => "vm.items", :relations => "vm.relations", :kinds => "vm.kinds"}
 
 :javascript
+  ManageIQ.angular.app.value('topologyDetail', #{params[:controller] == "container_project"});
   miq_bootstrap('.topology');

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -1,4 +1,4 @@
-- tooltipOptions = {"tooltip-placement" => "bottom", "uib-tooltip" => "{{legendTooltip}}"}
+- tooltipOptions = {"tooltip-placement" => "bottom", "uib-tooltip" => "{{vm.legendTooltip}}"}
 .topology{'ng-controller' => "networkTopologyController as vm"}
   .legend
     %label#selected

--- a/spec/javascripts/controllers/containers/container_topology_controller_spec.js
+++ b/spec/javascripts/controllers/containers/container_topology_controller_spec.js
@@ -50,6 +50,7 @@ describe('containerTopologyController', function() {
       ctrl = _$controller_('containerTopologyController',
         {
           $scope: scope,
+          topologyDetail: true,
         }
       );
       $httpBackend.flush();

--- a/spec/javascripts/services/topology_service_spec.js
+++ b/spec/javascripts/services/topology_service_spec.js
@@ -36,15 +36,14 @@ describe('topologyService', function() {
 
     beforeEach(function() {
       controller = {};
-      testService.mixinRefresh(controller);
+      testService.refresh(controller);
     });
 
     context('cloud', function() {
       beforeEach(function() {
         controller.dataUrl = '/cloud_topology/data';
-        controller.detailUrl = null;
 
-        testService.mixinRefresh(controller);
+        testService.refresh(controller);
       });
 
       it('Compute > Cloud > Topology', function() {
@@ -61,9 +60,7 @@ describe('topologyService', function() {
     context('container', function() {
       beforeEach(function() {
         controller.dataUrl = '/container_topology/data';
-        controller.detailUrl = '/container_project_topology/data';
-
-        testService.mixinRefresh(controller);
+        testService.refresh(controller);
       });
 
       it('Compute > Containers > Topology', function() {
@@ -79,10 +76,8 @@ describe('topologyService', function() {
 
     context('container project', function() {
       beforeEach(function() {
-        controller.dataUrl = '/container_topology/data';
-        controller.detailUrl = '/container_project_topology/data';
-
-        testService.mixinRefresh(controller);
+        controller.dataUrl = '/container_project_topology/data';
+        testService.refresh(controller);
       });
 
       it('Compute > Containers > Projects > detail > Topology', function() {
@@ -94,9 +89,8 @@ describe('topologyService', function() {
     context('infra', function() {
       beforeEach(function() {
         controller.dataUrl = '/infra_topology/data';
-        controller.detailUrl = null;
 
-        testService.mixinRefresh(controller);
+        testService.refresh(controller);
       });
 
       it('Compute > Infrastructure > Topology', function() {
@@ -113,9 +107,8 @@ describe('topologyService', function() {
     context('middleware', function() {
       beforeEach(function() {
         controller.dataUrl = '/middleware_topology/data';
-        controller.detailUrl = null;
 
-        testService.mixinRefresh(controller);
+        testService.refresh(controller);
       });
 
       it('Middleware > Topology', function() {
@@ -129,7 +122,12 @@ describe('topologyService', function() {
       });
     });
 
-    /** TODO: network, once converted
+    context('network', function() {
+      beforeEach(function () {
+        controller.dataUrl = '/network_topology/data';
+
+        testService.refresh(controller);
+      });
       it('Networks > Topology', function() {
         var url = controller.parseUrl('/network_topology/show');
         expect(url).toEqual('/network_topology/data');
@@ -139,14 +137,13 @@ describe('topologyService', function() {
         var url = controller.parseUrl('/network_topology/show/10000000000005');
         expect(url).toEqual('/network_topology/data/10000000000005');
       });
-    */
+    })
 
     context('physical infra', function() {
       beforeEach(function() {
         controller.dataUrl = '/physical_infra_topology/data';
-        controller.detailUrl = null;
 
-        testService.mixinRefresh(controller);
+        testService.refresh(controller);
       });
 
       it('Compute > Physical Infrastructure > Topology', function() {

--- a/spec/javascripts/services/topology_service_spec.js
+++ b/spec/javascripts/services/topology_service_spec.js
@@ -36,14 +36,14 @@ describe('topologyService', function() {
 
     beforeEach(function() {
       controller = {};
-      testService.refresh(controller);
+      testService.mixinRefresh(controller);
     });
 
     context('cloud', function() {
       beforeEach(function() {
         controller.dataUrl = '/cloud_topology/data';
 
-        testService.refresh(controller);
+        testService.mixinRefresh(controller);
       });
 
       it('Compute > Cloud > Topology', function() {
@@ -60,7 +60,7 @@ describe('topologyService', function() {
     context('container', function() {
       beforeEach(function() {
         controller.dataUrl = '/container_topology/data';
-        testService.refresh(controller);
+        testService.mixinRefresh(controller);
       });
 
       it('Compute > Containers > Topology', function() {
@@ -77,7 +77,7 @@ describe('topologyService', function() {
     context('container project', function() {
       beforeEach(function() {
         controller.dataUrl = '/container_project_topology/data';
-        testService.refresh(controller);
+        testService.mixinRefresh(controller);
       });
 
       it('Compute > Containers > Projects > detail > Topology', function() {
@@ -90,7 +90,7 @@ describe('topologyService', function() {
       beforeEach(function() {
         controller.dataUrl = '/infra_topology/data';
 
-        testService.refresh(controller);
+        testService.mixinRefresh(controller);
       });
 
       it('Compute > Infrastructure > Topology', function() {
@@ -108,7 +108,7 @@ describe('topologyService', function() {
       beforeEach(function() {
         controller.dataUrl = '/middleware_topology/data';
 
-        testService.refresh(controller);
+        testService.mixinRefresh(controller);
       });
 
       it('Middleware > Topology', function() {
@@ -126,7 +126,7 @@ describe('topologyService', function() {
       beforeEach(function () {
         controller.dataUrl = '/network_topology/data';
 
-        testService.refresh(controller);
+        testService.mixinRefresh(controller);
       });
       it('Networks > Topology', function() {
         var url = controller.parseUrl('/network_topology/show');
@@ -143,7 +143,7 @@ describe('topologyService', function() {
       beforeEach(function() {
         controller.dataUrl = '/physical_infra_topology/data';
 
-        testService.refresh(controller);
+        testService.mixinRefresh(controller);
       });
 
       it('Compute > Physical Infrastructure > Topology', function() {


### PR DESCRIPTION
Moving common code to topology service from all topology controllers.

### Folowing methods and code pieces were moved to topology service
- `miqHideSeachClearButton()`
- refresh setup
- context menu setup
- icon loading
- tooltip setup

Also the `/container_project_topology/data` and `/container_topology/data` URL decision was removed from topology service. Container topology controller is now picking the right URL based on the `topologyDetail` parameter (Once there is a component for topology URL will be parameter anyway...).


