### PR TITLE
Fix dashboard widget id

### DIFF
--- a/app/assets/javascripts/components/dropdown-menu.js
+++ b/app/assets/javascripts/components/dropdown-menu.js
@@ -1,6 +1,6 @@
 ManageIQ.angular.app.component('dropdownMenu', {
   bindings: {
-    id: '<',
+    widgetId: '@',
     buttonsData: '@',
   },
   controllerAs: 'vm',
@@ -8,7 +8,7 @@ ManageIQ.angular.app.component('dropdownMenu', {
     var vm = this;
 
     this.$onInit = function() {
-      vm.dropdown_id = 'btn_' + vm.id;
+      vm.dropdown_id = 'btn_' + vm.widgetId;
       vm.buttons = JSON.parse(vm.buttonsData);
     };
   },

--- a/app/views/dashboard/_widget.html.haml
+++ b/app/views/dashboard/_widget.html.haml
@@ -1,11 +1,10 @@
 -# Parameters:
 -# widget MiqWidget object
-- button_id = "btn_#{presenter.widget.id}"
 %div{:id => "w_#{presenter.widget.id}"}
   .card-pf.card-pf-view
     .card-pf-body
       .card-pf-heading-kebab
-        %dropdown-menu{:id => button_id, "buttons-data" => presenter.widget_buttons}
+        %dropdown-menu{"widget-id" => presenter.widget.id, "buttons-data" => presenter.widget_buttons}
         %h2.card-pf-title.sortable-handle{:style => "cursor:move"}
           = h(presenter.widget.title)
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1533792

Cloud Intel -> Dashboard -> any dashboard 

Problem is that`button` has `id = "btn_undefined"`. Removing `id` from `dropdown-menu` component because it's not needed and passing id down as `widget-id`.

Before:
<img width="655" alt="screen shot 2018-01-15 at 11 11 33 am" src="https://user-images.githubusercontent.com/9210860/34937344-bf4e6dda-f9e4-11e7-8413-31018747235c.png">
After:
<img width="654" alt="screen shot 2018-01-15 at 11 14 06 am" src="https://user-images.githubusercontent.com/9210860/34937420-15438c52-f9e5-11e7-821d-d5176052046d.png">

@miq-bot add_label bug, dashboards, gaprindashvili/yes, blocker
