### PR TITLE
Remove the middleware GTL icon exception from view_to_hash

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1059,7 +1059,6 @@ class ApplicationController < ActionController::Base
         image = "100/#{(@listicon || view.db).underscore}.png" if icon.nil? && image.nil? # TODO: we want to get rid of this
         # FIXME: adding exceptions here is a wrong approach
         icon = nil if params[:controller] == 'pxe'
-        icon = nil if params[:model] == 'MiddlewareServer'
         new_row[:cells] << {:title => _('View this item'),
                             :image   => ActionController::Base.helpers.image_path(image.to_s),
                             :picture => ActionController::Base.helpers.image_path(picture.to_s),

--- a/spec/controllers/ems_middleware_controller_spec.rb
+++ b/spec/controllers/ems_middleware_controller_spec.rb
@@ -101,24 +101,5 @@ describe EmsMiddlewareController do
     end
   end
 
-  describe '#report_data' do
-    context 'list of middleware servers related to a provider' do
-      let!(:provider) { FactoryGirl.create(:ems_hawkular) }
-      let!(:server) { FactoryGirl.create(:hawkular_middleware_server, :ext_management_system => provider) }
-
-      subject { assert_report_data_response }
-
-      it 'returns a single middleware server that has an image but not an icon' do
-        report_data_request(:model => 'MiddlewareServer', :parent_model => provider.type, :parent_id => provider.id, :explorer => false)
-
-        expect(subject["data"]["rows"].length).to eq(1)
-        expect(subject["data"]["rows"][0]["cells"][2]["text"]).to eq(server.name)
-
-        expect(subject["data"]["rows"][0]["cells"][1]["icon"]).to be_nil
-        expect(subject["data"]["rows"][0]["cells"][1]["image"]).not_to be_nil
-      end
-    end
-  end
-
   include_examples '#download_summary_pdf', :ems_hawkular
 end

--- a/spec/controllers/middleware_server_controller_spec.rb
+++ b/spec/controllers/middleware_server_controller_spec.rb
@@ -170,9 +170,7 @@ describe MiddlewareServerController do
 
         expect(subject["data"]["rows"].length).to eq(1)
         expect(subject["data"]["rows"][0]["cells"][2]["text"]).to eq(server.name)
-
-        expect(subject["data"]["rows"][0]["cells"][1]["icon"]).to be_nil
-        expect(subject["data"]["rows"][0]["cells"][1]["image"]).not_to be_nil
+        expect(subject["data"]["rows"][0]["cells"][1]["icon"]).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
This is a revert of #2994 as we no longer have the middleware code.