### PR TITLE
Fix ids in widgets

### DIFF
--- a/app/assets/javascripts/components/widget-chart.js
+++ b/app/assets/javascripts/components/widget-chart.js
@@ -1,6 +1,6 @@
 ManageIQ.angular.app.component('widgetChart', {
   bindings: {
-    id: '<',
+    widgetId: '@',
   },
   controllerAs: 'vm',
   controller: ['$http', 'miqService', '$sce', function($http, miqService, $sce) {
@@ -8,10 +8,10 @@ ManageIQ.angular.app.component('widgetChart', {
     vm.widgetChartModel = {};
 
     this.$onInit = function() {
-      $http.get('/dashboard/widget_chart_data/' + vm.id)
+      $http.get('/dashboard/widget_chart_data/' + vm.widgetId)
         .then(vm.getData)
         .catch(miqService.handleFailure);
-      vm.div_id = "dd_w" + vm.id + "_box";
+      vm.div_id = "dd_w" + vm.widgetId + "_box";
     };
 
     vm.getData = function(response) {

--- a/app/assets/javascripts/components/widget-menu.js
+++ b/app/assets/javascripts/components/widget-menu.js
@@ -1,6 +1,6 @@
 ManageIQ.angular.app.component('widgetMenu', {
   bindings: {
-    id: '<',
+    widgetId: '@',
   },
   controllerAs: 'vm',
   controller: ['$http', 'miqService', function($http, miqService) {
@@ -12,10 +12,10 @@ ManageIQ.angular.app.component('widgetMenu', {
     };
 
     this.$onInit = function() {
-      $http.get('/dashboard/widget_menu_data/' + vm.id)
+      $http.get('/dashboard/widget_menu_data/' + vm.widgetId)
         .then(function(response) { vm.widgetMenuModel = response.data; })
         .catch(miqService.handleFailure);
-      vm.div_id = 'dd_w' + vm.id + '_box';
+      vm.div_id = 'dd_w' + vm.widgetId + '_box';
     };
   }],
   template: [

--- a/app/assets/javascripts/components/widget-report.js
+++ b/app/assets/javascripts/components/widget-report.js
@@ -1,6 +1,6 @@
 ManageIQ.angular.app.component('widgetReport', {
   bindings: {
-    id: '<',
+    widgetId: '@',
   },
   controllerAs: 'vm',
   controller: ['$http', 'miqService', '$sce', function($http, miqService, $sce) {
@@ -8,10 +8,10 @@ ManageIQ.angular.app.component('widgetReport', {
     vm.widgetReportModel = {};
 
     this.$onInit = function() {
-      $http.get('/dashboard/widget_report_data/' + vm.id)
+      $http.get('/dashboard/widget_report_data/' + vm.widgetId)
         .then(function(response) { vm.widgetReportModel.content = $sce.trustAsHtml(response.data.content);})
         .catch(miqService.handleFailure);
-      vm.div_id = "dd_w" + vm.id + "_box";
+      vm.div_id = "dd_w" + vm.widgetId + "_box";
     };
 
     vm.contentPresent = function() {

--- a/app/assets/javascripts/components/widget-rss.js
+++ b/app/assets/javascripts/components/widget-rss.js
@@ -1,6 +1,6 @@
 ManageIQ.angular.app.component('widgetRss', {
   bindings: {
-    id: '<',
+    widgetId: '@',
   },
   controllerAs: 'vm',
   controller: ['$http', 'miqService', '$sce', function($http, miqService, $sce) {
@@ -8,10 +8,10 @@ ManageIQ.angular.app.component('widgetRss', {
     vm.widgetRssModel = {};
 
     this.$onInit = function() {
-      $http.get('/dashboard/widget_rss_data/' + vm.id)
+      $http.get('/dashboard/widget_rss_data/' + vm.widgetId)
         .then(function(response) { vm.widgetRssModel.content = $sce.trustAsHtml(response.data.content); })
         .catch(miqService.handleFailure);
-      vm.div_id = "dd_w" + vm.id + "_box";
+      vm.div_id = "dd_w" + vm.widgetId + "_box";
     };
 
     vm.contentPresent = function() {

--- a/app/views/dashboard/_widget.html.haml
+++ b/app/views/dashboard/_widget.html.haml
@@ -1,6 +1,5 @@
 -# Parameters:
 -# widget MiqWidget object
-- button_id = "btn_#{presenter.widget.id}"
 %div{:id => "w_#{presenter.widget.id}"}
   .card-pf.card-pf-view
     .card-pf-body
@@ -10,15 +9,15 @@
           = h(presenter.widget.title)
 
     - if presenter.widget.content_type == "menu"
-      %widget-menu{:id => presenter.widget.id}
+      %widget-menu{:id => presenter.widget.id, "widget-id" => presenter.widget.id}
     - elsif presenter.widget.contents_for_user(current_user).blank?
       = render :partial => 'widget_blank', :locals => {:widget => presenter.widget}
     - elsif presenter.widget.content_type == "report"
-      %widget-report{:id => presenter.widget.id}
+      %widget-report{:id => presenter.widget.id, "widget-id" => presenter.widget.id}
     - elsif presenter.widget.content_type == "chart"
-      %widget-chart{:id => presenter.widget.id}
+      %widget-chart{:id => presenter.widget.id, "widget-id" => presenter.widget.id}
     - elsif presenter.widget.content_type == "rss"
-      %widget-rss{:id => presenter.widget.id}
+      %widget-rss{:id => presenter.widget.id, "widget-id" => presenter.widget.id}
     - unless presenter.widget.content_type == "menu"
       = render :partial => 'widget_footer', :locals => {:widget => presenter.widget}
 


### PR DESCRIPTION
Use `@` instead of `<`. Never assume id is number, always a string.
Don't use `:id` in component bindings. It's not good practise.

@miq-bot add_label technical debt, dashboards, gaprindashvili/no
