### PR TITLE
Refactor _reports_menu methods in the ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -890,10 +890,10 @@ class ApplicationController < ActionController::Base
     session[:user_tz] = Time.zone = (user ? user.get_timezone : server_timezone)
   end
 
-  def populate_reports_menu(mode = 'menu')
+  def populate_reports_menu(hide_custom = false)
     # checking to see if group (used to be role) was selected in menu editor tree, or came in from reports/timeline tree calls
     group = !session[:role_choice].blank? ? MiqGroup.find_by(:description => session[:role_choice]) : current_group
-    @sb[:rpt_menu] = get_reports_menu(group, mode)
+    @sb[:rpt_menu] = get_reports_menu(hide_custom, group)
   end
 
   def reports_group_title
@@ -907,73 +907,26 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def get_reports_menu(group = current_group, mode = "menu")
-    rptmenu = []
-    reports = []
-    folders = []
-    user = current_user
-    @sb[:grp_title] = reports_group_title
-    data = []
-    if !group.settings || group.settings[:report_menus].blank? || mode == "default"
-      # array of all reports if menu not configured
-      data = MiqReport.for_user(current_user).where(:template_type => "report").order(:rpt_type, :filename, :name)
-      data.each do |r|
-        r_group = r.rpt_group == "Custom" ? "#{@sb[:grp_title]} - Custom" : r.rpt_group # Get the report group
-        title = r_group.reverse.split('-', 2).collect(&:reverse).collect(&:strip).reverse
-        next if mode == "menu" && title[1] == "Custom"
-        if @temp_title != title[0]
-          @temp_title = title[0]
-          reports = []
-          folders = []
-        end
-
-        if title[1].nil?
-          if title[0] == @temp_title
-            reports.push(r.name) unless reports.include?(r.name)
-            rptmenu.push([title[0], reports]) unless rptmenu.include?([title[0], reports])
-          end
-        else
-          if @temp_title1 != title[1]
-            reports.sort!
-            reports = []
-            @temp_title1 = title[1]
-          end
-          rptmenu.push([title[0], folders]) unless rptmenu.include?([title[0], folders])
-          reports.push(r.name) unless reports.include?(r.name)
-          folders.push([title[1], reports]) unless folders.include?([title[1], reports])
-        end
-      end
-
-      rptmenu = rptmenu.concat(group.settings[:report_menus]) if group.settings && group.settings[:report_menus] && mode == "default"
-    else
-      # Building custom reports array for super_admin/admin roles, it doesnt show up on menu if their menu was set which didnt contain custom folder in it
-      temp = []
-      subfolder = %w(Custom)
-      @custom_folder = [@sb[:grp_title]]
-      @custom_folder.push([subfolder]) unless @custom_folder.include?([subfolder])
-
-      custom = MiqReport.for_user(current_user).sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
-      rep = custom.select do |r|
-        r.rpt_type == "Custom" && (user.admin_user? || r.miq_group_id.to_i == current_group.try(:id))
-      end.map(&:name).uniq
-
-      subfolder.push(rep) unless subfolder.include?(rep)
-      temp.push(@custom_folder) unless temp.include?(@custom_folder)
-      temp2 = group.settings[:report_menus]
-      # don't add custom reports to rptmenu when building tree for menu editor form
-      rptmenu = mode == "menu" ? temp2 : temp.concat(temp2)
+  def default_reports_menu
+    # TODO: move this into a named scope
+    data = MiqReport.for_user(current_user).where(:template_type => "report").where.not(:rpt_type => 'Custom').order(:rpt_type, :name).pluck(:rpt_group, :name)
+    data.map { |grp, items| [grp.split(/ *- */), items].flatten }.group_by(&:first).map do |grp, items|
+      # Group the items by the secondary group and throw out the group names from the final items list
+      [grp, items.group_by(&:second).map { |subgroup, subitems| [subgroup, subitems.map(&:third)] }]
     end
-    # move Customs folder as last item in tree
-    rptmenu[0].each do |r|
-      next unless r.class == String && r == @sb[:grp_title]
+  end
 
-      @custom_folder = copy_array(rptmenu[0]) if @custom_folder.nil?
-      # Keeping My Company Reports folder on top of the menu tree only if user is on edit tab, else delete it from tree
-      # only add custom folder if it has any reports
-      rptmenu.push(rptmenu[0]) unless rptmenu[0][1][0][1].empty?
-      rptmenu.delete_at(0)
+  def get_reports_menu(hide_custom = false, group = current_group)
+    reports = group.try(:settings).try(:[], :report_menus) || default_reports_menu
+    # TODO: move this into a named scope
+    unless hide_custom
+      # TODO: move this into a named scope
+      @sb[:grp_title] = reports_group_title
+      custom = MiqReport.for_user(current_user).where(:template_type => "report", :rpt_type => 'Custom').order(:name).pluck(:name, :miq_group_id)
+      custom.select! { |item| item.second.to_i == current_group.try(:id) } unless current_user.admin_user?
+      reports.push([@sb[:grp_title], [[_("Custom"), custom.map(&:first)]]])
     end
-    rptmenu
+    reports
   end
 
   # Calculate controller name from job.target_class used in the Tasks GTL

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -132,7 +132,7 @@ class ReportController < ApplicationController
       return
     end
 
-    populate_reports_menu("default")
+    populate_reports_menu
     build_accordions_and_trees
 
     self.x_active_tree = x_last_active_tree if x_last_active_tree

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -10,7 +10,7 @@ module ReportController::Menus
       @rpt_menu = copy_array(@edit[:new])
     elsif @menu_lastaction == "default"
     else
-      populate_reports_menu("menu")
+      populate_reports_menu(true)
       tree = build_menu_roles_tree
       @rpt_menu = tree.rpt_menu
     end
@@ -209,7 +209,7 @@ module ReportController::Menus
       get_tree_data
       replace_right_cell(:menu_edit_action => "menu_reset")
     elsif params[:button] == "default"
-      populate_reports_menu("default")
+      @sb[:rpt_menu]   = default_reports_menu
       @menu_roles_tree = build_menu_roles_tree
       @edit[:new]      = copy_array(@sb[:rpt_menu])
       @menu_lastaction = "default"

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -237,7 +237,7 @@ module ReportController::Reports
 
   # Build the main reports tree
   def build_reports_tree
-    populate_reports_menu("default")
+    populate_reports_menu
     TreeBuilderReportReports.new('reports_tree', 'reports', @sb)
   end
 end

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -300,7 +300,7 @@ module ReportController::Schedules
     @edit[:new]      = {}
     @edit[:current]  = {}
     @edit[:key]      = "schedule_edit__#{@schedule.id || "new"}"
-    @menu            = get_reports_menu
+    @menu            = get_reports_menu(true)
     @menu.each { |r| @folders.push(r[0]) }
 
     @edit[:new][:name]        = @schedule.name

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -381,7 +381,7 @@ module ReportController::Widgets
       @edit[:schedule].name = @widget.resource.name
       @edit[:schedule].description = @widget.resource.title
       @edit[:rpt] = MiqReport.find_by_id(@widget.resource_id)
-      @menu = get_reports_menu(current_group, "default")
+      @menu = get_reports_menu
       if @sb[:wtype] == "r"
         @menu.each do |m|
           m[1].each do |f|
@@ -403,7 +403,7 @@ module ReportController::Widgets
       end
       @edit[:new][:repfilter] = @edit[:rpt].id
     elsif ["r", "c"].include?(@sb[:wtype])
-      @menu = get_reports_menu(current_group, "default")
+      @menu = get_reports_menu
       if @sb[:nodes][1] == "c"
         widget_graph_menus      # to build report pulldown with only reports with grpahs
       else

--- a/spec/controllers/miq_report_controller/menus_spec.rb
+++ b/spec/controllers/miq_report_controller/menus_spec.rb
@@ -1,23 +1,25 @@
 describe ReportController do
   describe "#menu_update" do
+    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:report) { FactoryGirl.create(:miq_report, :rpt_type => "Default", :rpt_group => 'foo - bar', :miq_group => user.current_group) }
+
     before do
       controller.instance_variable_set(:@edit, :new => {})
       controller.instance_variable_set(:@sb, :new => {})
       controller.instance_variable_set(:@_params, :button => "default")
-      tenant = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant, :name => "foo - bar", :subdomain => "foo - bar")
-      @user = FactoryGirl.create(:user_with_group, :tenant => tenant)
-      @report = FactoryGirl.create(:miq_report, :rpt_type => "Custom", :miq_group => @user.current_group)
-      allow(controller).to receive(:current_user).and_return(@user)
-      login_as @user
+      allow(controller).to receive(:current_user).and_return(user)
+      login_as user
+      report
     end
 
     it "set menus to default and sets correct title for custom reports" do
       expect(controller).to receive(:menu_get_form_vars)
+      expect(controller).to receive(:build_menu_roles_tree)
       expect(controller).to receive(:get_tree_data)
       expect(controller).to receive(:replace_right_cell)
 
       controller.menu_update
-      expect(assigns(:edit)[:new]).to eq([["foo - bar (Group): #{@user.current_group.description}", [["Custom", [@report.name]]]]])
+      expect(assigns(:edit)[:new]).to eq([["foo", [["bar", [report.name]]]]])
       expect(assigns(:flash_array).first[:message]).to include("default")
     end
   end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1334,20 +1334,58 @@ describe ReportController do
 
   describe "#populate_reports_menu" do
     let(:user) { FactoryGirl.create(:user_with_group) }
-    subject! { FactoryGirl.create(:miq_report, :rpt_type => "Custom", :miq_group => user.current_group) }
+    let(:sandbox) { {} }
 
     before do
       EvmSpecHelper.local_miq_server
       login_as user
     end
 
-    it "it returns correct name for custom folder" do
-      controller.instance_variable_set(:@_params, :controller => "report", :action => "explorer")
+    it 'sets the sandbox' do
+      controller.instance_variable_set(:@sb, sandbox)
+      expect(controller).to receive(:get_reports_menu).and_return('yay')
+      controller.send(:populate_reports_menu)
+      expect(sandbox[:rpt_menu]).to eq('yay')
+    end
+  end
+
+  describe '#get_reports_menu' do
+    let(:group) { FactoryGirl.create(:miq_group, :settings => settings) }
+    let(:settings) { {:report_menus => []} }
+
+    before do
       controller.instance_variable_set(:@sb, {})
-      allow(controller).to receive(:get_node_info)
-      controller.send(:populate_reports_menu, "default")
-      rpt_menu = controller.instance_variable_get(:@sb)[:rpt_menu]
-      expect(rpt_menu.first.first).to eq("#{user.current_tenant.name} (Group): #{user.current_group.name}")
+    end
+
+    context 'custom menus configured' do
+      it 'retrieves the custom menu' do
+        expect(controller).not_to receive(:default_reports_menu)
+        controller.send(:get_reports_menu, true, group)
+      end
+    end
+
+    context 'custom menus not configured' do
+      let(:settings) { nil }
+      it 'returns with the default menu' do
+        expect(controller).to receive(:default_reports_menu)
+        controller.send(:get_reports_menu, true, group)
+      end
+    end
+
+    context 'custom reports included' do
+      let(:user) { FactoryGirl.create(:user_with_group) }
+      let(:menu) { controller.instance_variable_get(:@sb)[:rpt_menu] }
+      subject { controller.send(:get_reports_menu, false, user.current_group) }
+
+      before do
+        EvmSpecHelper.local_miq_server
+        login_as user
+        FactoryGirl.create(:miq_report, :rpt_type => "Custom", :miq_group => user.current_group)
+      end
+
+      it 'returns with the correct name for custom folder' do
+        expect(subject.first.first).to eq("#{user.current_tenant.name} (Group): #{user.current_group.name}")
+      end
     end
   end
 


### PR DESCRIPTION
The `get_reports_menu` was implemented in a very unreadable and unmaintainable way. So I went through all the possible outputs of the code and reimplemented it in a much simpler pattern. Firstly I pulled out the `default_reports_menu` method that always returns with the default values for a given user. 

The base for the returned result is usually `group.settings[:report_menus]` and if not defined, it falls back to the `default_reports_menu`. On certain screens this output is concatenated with the custom reports that received its own separate query. There was one single exception under these rules under the `Edit Report Menus` screen when the menu is being reset back to default. I decided to do this step directly using `default_reports_menu`, instead of calling the `populate_reports_menu`. After these changes I cleaned up the arguments of all the methods.