### PR TITLE
Fix 'Managed/Unregistered VMs' count on Datastore summary screen

### DIFF
--- a/app/helpers/storage_helper/textual_summary.rb
+++ b/app/helpers/storage_helper/textual_summary.rb
@@ -117,7 +117,7 @@ module StorageHelper::TextualSummary
   end
 
   def textual_unregistered_vms
-    value = @record.total_managed_unregistered_vms
+    value = @record.total_unregistered_vms
     h = {:label => _("Managed/Unregistered VMs"),
          :icon  => "pficon pficon-virtual-machine",
          :value => value}

--- a/spec/helpers/storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/storage_helper/textual_summary_spec.rb
@@ -59,7 +59,7 @@ describe StorageHelper do
                                              :title => "Show all Managed/Registered VMs")
       end
       it 'returns correct Hash' do
-        allow(@record).to receive(:total_managed_unregistered_vms).and_return(1)
+        allow(@record).to receive(:total_unregistered_vms).and_return(1)
         expect(textual_unregistered_vms).to eq(:label => "Managed/Unregistered VMs",
                                                :icon  => "pficon pficon-virtual-machine",
                                                :value => 1,


### PR DESCRIPTION
@miq-bot add_labels bug, blocker, gaprindashvili/yes, compute/infrastructure

https://bugzilla.redhat.com/show_bug.cgi?id=1529269