### PR TITLE
Fix breadcrumb when navigating to service's ansible credential

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -93,6 +93,7 @@ class ServiceController < ApplicationController
       x_node_to_set = "#{nodetype}-#{to_cid(id)}"
     end
 
+    @breadcrumbs.clear if @breadcrumbs.present?
     build_accordions_and_trees(x_node_to_set)
 
     params.instance_variable_get(:@parameters).merge!(session[:exp_parms]) if session[:exp_parms]  # Grab any explorer parm overrides
@@ -288,6 +289,7 @@ class ServiceController < ApplicationController
     case TreeBuilder.get_model_for_prefix(@nodetype)
     when "Service"
       show_record(from_cid(id))
+      drop_breadcrumb(:name => _('Services'), :url => '/service/explorer') if @breadcrumbs.empty?
       @right_cell_text = _("%{model} \"%{name}\"") % {:name => @record.name, :model => ui_lookup(:model => 'Service')}
       @no_checkboxes = true
       @gtl_type = "grid"


### PR DESCRIPTION
1.  Create Ansible catalog item and provision it
2. Navigate to Services -> My Services -> [your service from above]
3. Navigate to Services -> Requests -> Click on some request
4. Navigate to Services -> My Services -> [your service from above should be selected]
5. Click on Provioning tab
6. Click on the ansible credential resource rendered in the textual summary

Before:
![breadcrumb-before](https://user-images.githubusercontent.com/6648365/34949893-c4f80d40-fa11-11e7-8d69-8b220d81da58.jpg)


After:
![breadcrumb-after](https://user-images.githubusercontent.com/6648365/34949887-c1437298-fa11-11e7-98d6-c812d0623085.jpg)

https://bugzilla.redhat.com/show_bug.cgi?id=1533071