### PR TITLE
Moving Spec::Support::ButtonHelper from ManageIQ/manageiq

### DIFF
--- a/spec/support/button_helper.rb
+++ b/spec/support/button_helper.rb
@@ -1,0 +1,12 @@
+module Spec
+  module Support
+    module ButtonHelper
+      def setup_view_context_with_sandbox(sandbox)
+        view_context = double('ApplicationHelper')
+        view_context.class.send(:include, ApplicationHelper)
+        view_context.instance_eval { @sb = sandbox }
+        view_context
+      end
+    end
+  end
+end


### PR DESCRIPTION
This method is only used in the ui-classic repo

https://github.com/ManageIQ/manageiq/pull/16821