### PR TITLE
[FINE] Corrects model and function names in New Subnet form

### DIFF
--- a/app/views/cloud_subnet/new.html.haml
+++ b/app/views/cloud_subnet/new.html.haml
@@ -16,9 +16,9 @@
       .col-md-8
         = select_tag("ems_id",
                       options_for_select([["<#{_('Choose')}>", nil]] + @network_provider_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
-                      "ng-model"                    => "cloudSubnetModel.ems_id",
+                      "ng-model"                    => "vm.cloudSubnetModel.ems_id",
                       "required"                    => "",
-                      "ng-change"                   => "filterNetworkManagerChanged(cloudSubnetModel.ems_id)",
+                      "ng-change"                   => "vm.filterNetworkManagerChanged(vm.cloudSubnetModel.ems_id)",
                       "selectpicker-for-select-tag" => "")
         %span.help-block{"ng-show" => "angularForm.ems_id.$error.required"}
           = _("Required")


### PR DESCRIPTION
solves https://bugzilla.redhat.com/show_bug.cgi?id=1533011

Steps for Testing/QA [taken from BZ linked above]
-------------------------------
Steps to Reproduce:
1. Add OpenStack provider.
2. Navigate to Network -> Subnets
3. Open add new subnet page
4. Check page UI

Results without patch:
Page is corrupted, network dropdown is missing

Results with patch (expected):
Network drop-down should be present on the page
