### PR TITLE
Fix applying a filter in My Services from Adv search

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -317,8 +317,8 @@ class ServiceController < ApplicationController
         process_show_list(:named_scope => [:retired, :displayed])
         @right_cell_text = _("Retired Services")
       end
-    when "MiqSearch"
-      load_adv_search # Select/load filter from Global/My Filters
+    when "MiqSearch", nil # nil if applying a filter from Advanced search - and @nodetype is root
+      load_adv_search unless @nodetype == "root" # Select/load filter from Global/My Filters
       process_show_list
       @right_cell_text = _("All Services")
     end


### PR DESCRIPTION
**Fixing** https://github.com/ManageIQ/manageiq-ui-classic/issues/3252

Fix applying a filter when clicking on _Apply_ button in Advanced
search when filtering services in _Services -> My Services_ page.

**TODO:**[RESOLVED]
- fix selecting the applied filter also in accordion
  (this issue is present in most of the explorer screens, for example in _Configuration > Management > Configured Systems_, not sure if this has ever worked. Do we need to fix this here and now?)

**Details:**
The problem is here: https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/application_controller/advanced_search.rb#L144 When `adv_search_button_apply` method is called, `x_node` is changed to _"root"_ node because we are in explorer screen. BUT there is **no root node in _My Services_**! (this fact is considered for example when clearing the applied search here: https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/application_controller/advanced_search.rb#L309 and the question is "why isn't this considered when applying a filter?") This could be fixed by adding simple condition to `adv_search_button_apply` method (so that _x_node_ wouldn't be changed to _"root"_). BUT this would lead to one of the cases in `get_node_info` method in service controller, for example here: https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/service_controller.rb#L313 which is slightly different to what we want. We want the same result as we get if we apply a filter by clicking on it in accordion, which is the case here: https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/service_controller.rb#L320 So I added `nil` to that case https://github.com/ManageIQ/manageiq-ui-classic/pull/3255/files#diff-e4046e1d448a629c478f2a2d28286089R320, which corresponds with root node set in `adv_search_button_apply` method. I also added a condition for `load_adv_search` method https://github.com/ManageIQ/manageiq-ui-classic/pull/3255/files#diff-e4046e1d448a629c478f2a2d28286089R321 because we need to call it only when clicking on a filter in accordion.

**Before:**
```
[1] pry(#<ServiceController>)> 
F, [2018-01-15T17:34:57.696713 #24064] FATAL -- : Error caught: [NoMethodError] undefined method `+' for nil:NilClass
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/service_controller.rb:328:in `get_node_info'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/service_controller.rb:397:in `replace_right_cell'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/advanced_search.rb:145:in `adv_search_button_apply'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/advanced_search.rb:254:in `adv_search_button'
```
![apply_issue](https://user-images.githubusercontent.com/13417815/34952848-5999fde2-fa1b-11e7-8013-80c020dce71f.png)

**After:**
![applied_after](https://user-images.githubusercontent.com/13417815/34999287-acd8f21c-fae1-11e7-997f-edbda1e56db3.png)
