### PR TITLE
Change VMware console api detection from vCenter to ESXi Host

### DIFF
--- a/app/helpers/application_helper/button/vm_console.rb
+++ b/app/helpers/application_helper/button/vm_console.rb
@@ -11,10 +11,6 @@ class ApplicationHelper::Button::VmConsole < ApplicationHelper::Button::Basic
     @record.ems_id
   end
 
-  def supported_vendor_api?
-    ExtManagementSystem.find(@record.ems_id).api_version.to_f < unsupported_vendor_api_version
-  end
-
   def console_supports_type?(supported_type)
     ::Settings.server.remote_console_type == supported_type ? @record.console_supported?(supported_type) : false
   end

--- a/app/helpers/application_helper/button/vm_vnc_console.rb
+++ b/app/helpers/application_helper/button/vm_vnc_console.rb
@@ -17,7 +17,11 @@ class ApplicationHelper::Button::VmVncConsole < ApplicationHelper::Button::VmCon
 
   private
 
-  def unsupported_vendor_api_version
+  def supported_vendor_api?
+    @record.host.vmm_version.to_f < unsupported_api_version
+  end
+
+  def unsupported_api_version
     6.5
   end
 end

--- a/app/helpers/application_helper/button/vm_webmks_console.rb
+++ b/app/helpers/application_helper/button/vm_webmks_console.rb
@@ -14,10 +14,10 @@ class ApplicationHelper::Button::VmWebmksConsole < ApplicationHelper::Button::Vm
   end
 
   def supported_vendor_api?
-    ExtManagementSystem.find(@record.ems_id).api_version.to_f >= min_required_api_version
+    @record.host.vmm_version.to_f > min_supported_api_version
   end
 
-  def min_required_api_version
+  def min_supported_api_version
     6.0
   end
 end

--- a/spec/helpers/application_helper/buttons/vm_vnc_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_vnc_console_spec.rb
@@ -30,8 +30,8 @@ describe ApplicationHelper::Button::VmVncConsole do
 
     context 'when record.vendor == vmware' do
       let(:power_state) { 'on' }
-      let(:ems) { FactoryGirl.create(:ems_vmware, :api_version => api_version) }
-      let(:record) { FactoryGirl.create(:vm_vmware, :ems_id => ems.id) }
+      let(:host) { FactoryGirl.create(:host_vmware_esx, :vmm_version => api_version) }
+      let(:record) { FactoryGirl.create(:vm_vmware, :host => host) }
 
       context 'and vendor api is not supported' do
         let(:api_version) { 6.5 }

--- a/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
@@ -26,8 +26,8 @@ describe ApplicationHelper::Button::VmWebmksConsole do
     context 'when record.vendor == vmware' do
       let(:power_state) { 'on' }
       let(:api_version) { 6.5 }
-      let(:ems) { FactoryGirl.create(:ems_vmware, :api_version => api_version) }
-      let(:record) { FactoryGirl.create(:vm_vmware, :ems_id => ems.id) }
+      let(:host) { FactoryGirl.create(:host_vmware_esx, :vmm_version => api_version) }
+      let(:record) { FactoryGirl.create(:vm_vmware, :host => host) }
 
       context 'and the power is on' do
         it_behaves_like 'vm_console_with_power_state_on_off',


### PR DESCRIPTION
This resolves an issue where a VM on a 5.5 Host was not reachable by a VNC console when the Host was in a cluster in vCenter 6.5.

@miq-bot add_labels compute/infrastructure, bug, wip

https://bugzilla.redhat.com/show_bug.cgi?id=1535167