### PR TITLE
Do not display toolbars in the CustomButton/Custom Group form

### DIFF
--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -210,7 +210,7 @@ class GenericObjectDefinitionController < ApplicationController
     presenter.replace(:main_div, r[:partial => form_partial])
     presenter.hide(:paging_div)
     presenter[:lock_sidebar] = true
-    build_toolbar("x_summary_view_tb")
+    presenter.set_visibility(false, :toolbar)
 
     render :json => presenter.for_render
   end

--- a/spec/controllers/generic_object_definition_controller_spec.rb
+++ b/spec/controllers/generic_object_definition_controller_spec.rb
@@ -96,4 +96,33 @@ describe GenericObjectDefinitionController do
       expect(toolbar_array[0][2][:url]).to eq('/show_list')
     end
   end
+
+  context "Render form/Toolbar" do
+    render_views
+
+    before do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+      ApplicationController.handle_exceptions = true
+      allow(controller).to receive(:build_tree)
+    end
+
+    it "does not display toolbar and paging div when custom button is edited" do
+      custom_button = FactoryGirl.create(:custom_button,
+                                         :applies_to_class => "GenericObjectDefinition",
+                                         :name             => "Default",
+                                         :options          => {
+                                           'button_icon'  => 'ff ff-view-expanded',
+                                           'button_color' => '#4727ff',
+                                           'display'      => true,
+                                         },)
+
+      allow(controller).to receive(:x_node) { "cb-#{custom_button.id}" }
+      post :tree_select, :params => {'id' => "cb-#{custom_button.id}"}
+
+      post :custom_button_edit, :params => {:id => custom_button.id, :format => :js}
+      expect(response.status).to eq(200)
+      expect(response.body).to include('"setVisibility":{"paging_div":false,"toolbar":false}')
+    end
+  end
 end


### PR DESCRIPTION
Set the visibility of toolbars to false while rendering forms.

Before (Toolbar visible in the form)
<img width="1437" alt="screen shot 2018-01-16 at 2 23 14 pm" src="https://user-images.githubusercontent.com/1538216/35015346-d8534168-fac8-11e7-8fb4-b90092f8324f.png">



After (Toolbar not displayed in the form)
<img width="1437" alt="screen shot 2018-01-16 at 2 18 27 pm" src="https://user-images.githubusercontent.com/1538216/35015358-e38a9784-fac8-11e7-82f0-f0df9e26e859.png">



https://bugzilla.redhat.com/show_bug.cgi?id=1534534