### PR TITLE
Move Spec::Support::MenuHelper from ManageIQ/manageiq

### DIFF
--- a/spec/support/menu_helper.rb
+++ b/spec/support/menu_helper.rb
@@ -1,0 +1,41 @@
+module Spec
+  module Support
+    module MenuHelper
+      SECTION_DEF = <<EOF
+type: section
+name: Red Hat
+id: redhat
+before: compute
+section_type: big_iframe
+href: http://www.redhat.com
+EOF
+
+      ITEM_DEF = <<EOF
+type: item
+name: courses
+id: rht2
+feature: redhat_forum
+rbac:
+  feature: redhat_forum
+parent: redhat
+href: http://www.redhat.com/en/services/training/all-courses-exams
+item_type: big_iframe
+EOF
+
+      def create_temp_file(content)
+        temp_file  = Tempfile.new('snafu')
+        temp_file << content
+        temp_file.close
+        temp_file
+      end
+
+      def section_file
+        create_temp_file(SECTION_DEF)
+      end
+
+      def item_file
+        create_temp_file(ITEM_DEF)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This doesn't belong in the main repo, so moving it here.