### PR TITLE
[GAPRINDASHVILI] Workers - send list of checked items

### DIFF
--- a/app/helpers/application_helper/toolbar/diagnostics_server_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_server_center.rb
@@ -105,6 +105,7 @@ class ApplicationHelper::Toolbar::DiagnosticsServerCenter < ApplicationHelper::T
           N_('Restart selected worker'),
           :confirm      => N_("Warning: Selected node will be restarted, do you want to continue?"),
           :klass        => ApplicationHelper::Button::RefreshWorkers,
+          :url_parms    => "unused_div",
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1"),


### PR DESCRIPTION
In master https://github.com/ManageIQ/manageiq-ui-classic/pull/2398 changed toolbar button handling from
"send checked items if url_parms matches /_div/" to
"send checked items if send_checked is true".

This is not backported to gaprindashvili, and this particular button didn't have url_parms (because it is no longer needed in master).

Adding. (Not sure we can backport that whole PR without breaking anything else now.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1533548
(comment 4)