### PR TITLE
Layouts - always create paging_div, hidden if needed

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -407,6 +407,11 @@
         $(pagingDiv).append(col);
         col[0].appendChild(pagination[0]);
       }
+
+      if (this.initObject.pages) {
+        $(pagingDiv).show();
+      }
+
       // calculates the height of main content from toolbar and footer, needed
       // to make sure the paginator is not off the screen
       miqInitMainContent();

--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -67,6 +67,7 @@ module GtlHelper
       :view                           => @view,
       :db                             => @db,
       :parent                         => @parent,
+      :pages                          => @pages,
 
       :report_data_additional_options => @report_data_additional_options,
     }
@@ -121,7 +122,8 @@ module GtlHelper
           isExplorer: '#{options[:explorer]}' === 'true' ? true : false,
           records: #{!options[:selected_records].nil? ? h(j_str(options[:selected_records].to_json)) : "\'\'"},
           hideSelect: #{options[:selected_records].kind_of?(Array)},
-          showUrl: '#{gtl_show_url(options)}'
+          showUrl: '#{gtl_show_url(options)}',
+          pages: #{options[:pages].to_json},
         }
       }});
 EOJ

--- a/app/views/layouts/_center_div_dashboard_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_dashboard_no_listnav.html.haml
@@ -4,7 +4,7 @@
     .col-sm-12
       - if @widgets_menu
         = render :partial => "layouts/angular/toolbar"
-  .row#main-content.miq-body
+  .row#main-content.miq-body.miq-layout-center_div_dashboard_no_listnav
     .col-md-12
       .spacer
       = render :partial => 'layouts/tabs'

--- a/app/views/layouts/_center_div_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_no_listnav.html.haml
@@ -6,7 +6,7 @@
         .row.toolbar-pf#toolbar
           .col-sm-12
             = render :partial => "layouts/angular/toolbar"
-      .row#main-content{:class => @lastaction == "show_dashboard" ? 'miq-sand-paper' : ''}
+      .row#main-content.miq-layout-center_div_no_listnav{:class => @lastaction == "show_dashboard" ? 'miq-sand-paper' : ''}
         .col-md-12
           = render :partial => "layouts/breadcrumbs"
         - if layout_uses_tabs?

--- a/app/views/layouts/_center_div_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_no_listnav.html.haml
@@ -14,5 +14,4 @@
             = render :partial => 'layouts/tabs'
         .col-md-12
           = yield
-      - if layout_uses_paging? && !@in_a_form
-        .row#paging_div
+      .row#paging_div{:style => (layout_uses_paging? && !@in_a_form) ? '' : 'display: none'}

--- a/app/views/layouts/_center_div_with_listnav.html.haml
+++ b/app/views/layouts/_center_div_with_listnav.html.haml
@@ -21,8 +21,7 @@
           .row
             .col-md-12
               = yield
-      - unless @in_a_form
-        .row#paging_div
+      .row#paging_div{:style => @in_a_form ? '' : 'display: none'}
 
     .col-sm-2.col-md-3.col-sm-pull-10.col-md-pull-9.sidebar-pf.sidebar-pf-left.max-height
       -# listnav_div

--- a/app/views/layouts/_center_div_with_listnav.html.haml
+++ b/app/views/layouts/_center_div_with_listnav.html.haml
@@ -8,7 +8,7 @@
         = render :partial => "layouts/angular/toolbar"
   .row.max-height
     .col-sm-10.col-md-9.col-sm-push-2.col-md-push-3.max-height
-      #main-content.row
+      #main-content.row.miq-layout-center_div_with_listnav
         .col-md-12
           .row
             .col-md-7

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -17,7 +17,7 @@
         = render :partial => "layouts/angular/toolbar"
     .row.max-height
       #right_div.resizable.max-height{:class => "col-md-#{maindiv} col-md-push-#{sidewidth}"}
-        #main-content.row
+        #main-content.row.miq-layout-content
           .col-md-12
             .row
               .col-md-7#explorer

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -44,7 +44,7 @@
                 = yield
         .col-md-12.no-padding
           = render :partial => 'layouts/x_form_buttons'
-          .row#paging_div
+          .row#paging_div{:style => saved_report_paging? ? "" : "display: none"}
             - if saved_report_paging?
               = render(:partial => 'layouts/saved_report_paging_bar',
                        :locals  => {:pages => @sb[:pages]})


### PR DESCRIPTION
content layout - always creates paging_div, after #main-content
center div with/no listnav - create paging_div conditionally, after #main-content
center div dashboard - no paging_div, but no ajax transitions to other screens either

this updates center div with/without listnav to always create paging_div, hidden if necessary

that way, ReportDataController.prototype.movePagination should always succeed, and the pagination will never appear above GTL.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1501035

(also https://bugzilla.redhat.com/show_bug.cgi?id=1535946 which is marked as a dup)
