### PR TITLE
Add scopes for MiqRequest

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -85,7 +85,7 @@
       } else if (event.type === TOOLBAR_CLICK_FINISH && (tileViewSelector() || tableViewSelector())) {
         this.setExtraClasses(this.initObject.gtlType);
       } else if (event.refreshData && event.refreshData.name === CONTROLLER_NAME) {
-        this.refreshData();
+        this.refreshData(event.data);
       }
 
       if (event.controller === CONTROLLER_NAME && this.apiFunctions && this.apiFunctions[event.action]) {
@@ -143,8 +143,8 @@
     vm.perPage = defaultPaging();
   };
 
-  ReportDataController.prototype.refreshData = function() {
-    this.initController(this.initObject);
+  ReportDataController.prototype.refreshData = function(data) {
+    this.initController(_.merge(this.initObject, data));
   };
 
   ReportDataController.prototype.setSort = function(headerId, isAscending) {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -373,8 +373,6 @@ class ApplicationController < ActionController::Base
     # handle exceptions
     if params[:model_name]
       options = case params[:model_name]
-                when 'MiqRequest'
-                  page_display_options
                 when 'miq_tasks'
                   jobs_info
                 when 'physical_servers_with_host'

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -102,7 +102,7 @@ module Spec
           'model_id'    => options[:parent_id],
           'explorer'    => explorer,
           'additional_options' => {
-            'named_scope'           => nil,
+            'named_scope'           => options[:named_scope],
             'gtl_dbname'            => options[:gtl_dbname],
             'model'                 => options[:model],
             'match_via_descendants' => nil,
@@ -118,7 +118,8 @@ module Spec
       # Fires a POST request to the current controller's /report_data action
       #
       def report_data_request(options)
-        post :report_data, :params => report_data_request_data(options)
+        request.headers['Content-Type'] = 'application/json'
+        post :report_data, report_data_request_data(options)
       end
 
       # Assert a valid /report_data response, parse the response.


### PR DESCRIPTION
Change the MiqRequest query builder to use `named_scopes` instead of `filter`.

Depends on: ~https://github.com/ManageIQ/manageiq/pull/16843~
Depends on: https://github.com/ManageIQ/manageiq/pull/16939
Depends on: https://github.com/ManageIQ/manageiq/pull/16950

- [x] Get rid of `filter`, use `scopes` instead
- [x] Investigate when the different branches in `page_display_options` are used (the first two seems redundant and the third seems unused)
- [x] Clean up and update testcases
- [x] Change `request_types_for_model` magic to something readible
