### PR TITLE
[FINE] Corrects sections and their names in New Subnet form

### DIFF
--- a/app/views/cloud_subnet/new.html.haml
+++ b/app/views/cloud_subnet/new.html.haml
@@ -24,12 +24,11 @@
           = _("Required")
 
   %h3
-    = _('Cloud Subnet details')
+    = _('Placement')
   .form-horizontal
     .form-group{"ng-if"    => "vm.cloudSubnetModel.ems_id",
                 "ng-class" => "{'has-error': angularForm.cloud_tenant_id.$invalid}"}
       %h3
-        = _('Placement')
       %label.col-md-2.control-label
         = _('Cloud Tenant')
       .col-md-8


### PR DESCRIPTION
solves https://bugzilla.redhat.com/show_bug.cgi?id=1535369

Steps for Testing/QA
-------------------------------
1. Add OpenStack provider
2. Networks > Subnets
3. Configuration > Add a new Cloud Subnet

Results without patch:
Form on page has wrong form section captions. Original BZ can describe little different parts b/c https://github.com/ManageIQ/manageiq-ui-classic/pull/3254 got merged in the meantime.

Results with patch (expected):
Form on page has "Network Provider", "Placement" and "Cloud Subnet details" sections.

Backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/3148