### PR TITLE
Add comment about leak in engine.rb

### DIFF
--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -31,8 +31,18 @@ module ManageIQ
   module UI
     module Classic
       class Engine < ::Rails::Engine
+
+        # NOTE:  If you are going to make changes to autoload_paths, please make
+        # sure they are all strings.  Rails will push these paths into the
+        # $LOAD_PATH.
+        #
+        # More info can be found in the ruby-lang bug:
+        #
+        #   https://bugs.ruby-lang.org/issues/14372
+        #
         config.autoload_paths << root.join('app', 'controllers', 'mixins').to_s
         config.autoload_paths << root.join('lib').to_s
+
         if Rails.env.production? || Rails.env.test?
           require 'uglifier'
           config.assets.js_compressor = Uglifier.new(


### PR DESCRIPTION
Provides comments and info regarding the changes to the `autoload_paths`. Specs to test this is not a problem can be found in the main repo in https://github.com/ManageIQ/manageiq/pull/16847

Links
-----

* https://github.com/ManageIQ/manageiq/pull/16847