### PR TITLE
Add line breaks below the Role Access dropdown in the Generic Object Definition CustomButton form

### DIFF
--- a/app/views/static/generic_object/main_custom_button_form.html.haml
+++ b/app/views/static/generic_object/main_custom_button_form.html.haml
@@ -139,6 +139,8 @@
               "pf-select"                   => true,}
       %span.help-block{"ng-show" => "angularForm.visibility.$error.required"}
         = _("Required")
+  %br
+  %br
   .form-group{"ng-if" => "vm.customButtonModel.current_visibility === 'role'"}
     %label.col-md-2.control-label{"for" => "custom_button_open_url"}
       = _("User Roles")


### PR DESCRIPTION
The below BZ describes a partial rendering issue in the bootstrap switch when the page is zoomed out.
The real issue however, is that the 'Role Access' dropdown that is at the end of the page, does not have enough room to expand. 
To resolve this, line breaks were added at the end, allowing the dropdown to display it's contents without the user having to zoom out the screen or scroll inside the dropdown.

https://bugzilla.redhat.com/show_bug.cgi?id=1534960

Before (`<By Role>` not visible in the dropdown) -
<img width="904" alt="screen shot 2018-01-18 at 2 51 09 pm" src="https://user-images.githubusercontent.com/1538216/35125597-11e43c24-fc5f-11e7-9ed6-5b5172ab86dd.png">

After (`<By Role>` visible in the dropdown) -
<img width="903" alt="screen shot 2018-01-18 at 2 49 08 pm" src="https://user-images.githubusercontent.com/1538216/35125608-1f85c672-fc5f-11e7-90a7-d6df71e020b7.png">






