### PR TITLE
[WIP]Fix miq_group custom button filter expression field selection

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1159,7 +1159,7 @@ module OpsController::OpsRbac
     @edit = {
       :new => {
         :filters     => {},
-        :filter_expression => {},
+        :group_filter_expression => {},
         :belongsto   => {},
         :description => @group.description,
       },
@@ -1202,7 +1202,7 @@ module OpsController::OpsRbac
     @edit[:projects_tenants].push(["Tenants", all_tenants]) unless all_tenants.blank?
     @edit[:new][:group_tenant] = @group.tenant_id
 
-    rbac_group_filter_expression_vars(:filter_expression, :filter_expression_table)
+    rbac_group_filter_expression_vars(:group_filter_expression, :group_filter_expression_table)
     @edit[:current] = copy_hash(@edit[:new])
 
     @right_cell_text = if @edit[:group_id]
@@ -1215,8 +1215,8 @@ module OpsController::OpsRbac
   end
 
   def rbac_group_filter_expression_vars(field_expression, field_expression_table)
-    if @group && @group.entitlement && @group.entitlement[field_expression].kind_of?(MiqExpression)
-      @edit[:new][field_expression] = @group.entitlement[field_expression].exp
+    if @group && @group.entitlement && @group.entitlement[:filter_expression].kind_of?(MiqExpression)
+      @edit[:new][field_expression] = @group.entitlement[:filter_expression].exp
     else
       @edit[:new][field_expression] = nil
     end
@@ -1248,8 +1248,8 @@ module OpsController::OpsRbac
     if @edit[:new][:use_filter_expression]
       @edit[:new][:filters].clear
     else
-      exp_remove_tokens(@edit[:new][:filter_expression])
-      @edit[:new][:filter_expression] = nil
+      exp_remove_tokens(@edit[:new][:group_filter_expression])
+      @edit[:new][:group_filter_expression] = nil
     end
 
     rbac_group_set_filters(group) # Go set the filters for the group
@@ -1260,7 +1260,7 @@ module OpsController::OpsRbac
     group.entitlement ||= Entitlement.new
     if @edit[:new][:use_filter_expression]
       group.entitlement.set_managed_filters(nil) if group.entitlement.get_managed_filters.present?
-      group.entitlement.filter_expression = @edit[:new][:filter_expression]["???"] ? nil : MiqExpression.new(@edit[:new][:filter_expression])
+      group.entitlement.filter_expression = @edit[:new][:group_filter_expression]["???"] ? nil : MiqExpression.new(@edit[:new][:group_filter_expression])
     else
       group.entitlement.filter_expression = nil if group.entitlement.filter_expression
       @set_filter_values = []
@@ -1423,7 +1423,7 @@ module OpsController::OpsRbac
   def rbac_group_validate?
     return false if @edit[:new][:description].nil?
     @assigned_filters = [] if @edit[:new][:filters].empty? || @edit[:new][:use_filter_expression]
-    @filter_expression = [] if @edit[:new][:filter_expression].empty? || @edit[:new][:use_filter_expression] == false
+    @filter_expression = [] if @edit[:new][:group_filter_expression].empty? || @edit[:new][:use_filter_expression] == false
     if @edit[:new][:role].nil? || @edit[:new][:role] == ""
       add_flash(_("A User Group must be assigned a Role"), :error)
       return false

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1215,11 +1215,8 @@ module OpsController::OpsRbac
   end
 
   def rbac_group_filter_expression_vars(field_expression, field_expression_table)
-    if @group && @group.entitlement && @group.entitlement[:filter_expression].kind_of?(MiqExpression)
-      @edit[:new][field_expression] = @group.entitlement[:filter_expression].exp
-    else
-      @edit[:new][field_expression] = nil
-    end
+    @edit[:new][field_expression]
+    @edit[:new][field_expression] = @group.entitlement[:filter_expression].exp if !@group.nil? && @group.entitlement && @group.entitlement[:filter_expression].kind_of?(MiqExpression)
     @edit[:new][:use_filter_expression] = true
     # Populate exp editor fields for the expression column
     @edit[field_expression] ||= ApplicationController::Filter::Expression.new

--- a/app/views/layouts/_exp_editor.html.haml
+++ b/app/views/layouts/_exp_editor.html.haml
@@ -109,4 +109,4 @@
             = token
 
   - if @edit[@expkey][:exp_token]
-    = render(:partial => 'layouts/exp_atom/editor')
+    = render(:partial => 'layouts/exp_atom/editor', :locals => { :expression_type => defined?(expression_type) ? expression_type : nil}  )

--- a/app/views/layouts/_filter_expression.html.haml
+++ b/app/views/layouts/_filter_expression.html.haml
@@ -8,7 +8,7 @@
         = title
       .col-md-8
         = _("Choose an element of the expression to edit")
-        = render :partial => 'layouts/exp_editor'
+        = render :partial => 'layouts/exp_editor', :locals => {:expression_type => expression_type || nil}
   - else
     .form-group
       %label.control-label.col-md-2

--- a/app/views/layouts/_group_filter_expression.html.haml
+++ b/app/views/layouts/_group_filter_expression.html.haml
@@ -8,7 +8,7 @@
       = render :partial => 'layouts/info_msg', :locals => {:message => _("No Filter Expression defined")}
 - else
   = render :partial => 'layouts/filter_expression',
-           :locals => {:expression_type => :filter_expression,
-                       :action          => "rbac_group_edit",
-                       :id              => @edit[:group_id] || 'new',
-                       :title           => _('Expression')}
+           :locals => {:expression_type        => :group_filter_expression,
+                       :action                 => "rbac_group_edit",
+                       :id                     => @edit[:group_id] || 'new',
+                       :title                   => _('Expression')}

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -54,8 +54,11 @@
           - unless @edit[@expkey].tags_for_display_filters.empty?
             - opts.push([_('Tag'), 'tag'])
         - when 'MiqGroup'
-          - opts = [[_('Tag'), 'tags']]
-          - @edit[@expkey][:exp_typ] = 'tags'
+          - if defined?(expression_type) && expression_type == :group_filter_expression
+            - opts = [[_('Tag'), 'tags']]
+            - @edit[@expkey][:exp_typ] = 'tags'
+          - else
+            - opts += exptypes
         - else
           - opts += exptypes
 

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -464,8 +464,8 @@ describe OpsController do
       edit[:filter_expression].history.reset(edit[:filter_expression][:expression])
       controller.instance_variable_set(:@edit, edit)
       controller.instance_variable_set(:@expkey, :filter_expression)
-      edit[:filter_expression][:exp_table] = controller.send(:exp_build_table, edit[:filter_expression][:expression])
-      edit[:filter_expression][:exp_model] = @group.class.to_s
+      edit[:group_filter_expression][:exp_table] = controller.send(:exp_build_table, edit[:group_filter_expression][:expression])
+      edit[:group_filter_expression][:exp_model] = @group.class.to_s
       session[:edit] = edit
       session[:expkey] = :filter_expression
       controller.instance_variable_set(:@edit, edit)

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -417,26 +417,26 @@ describe OpsController do
 
     it "saves the filters when use_filter_expression is false" do
       @group.entitlement = Entitlement.create!
-      controller.instance_variable_set(:@edit, :new => {:use_filter_expression => false,
-                                                        :name                  => 'Name',
-                                                        :description           => "Test",
-                                                        :role                  => @role.id,
-                                                        :filter_expression     => @exp.exp,
-                                                        :belongsto             => {},
-                                                        :filters               => {'managed/env' => '/managed/env'}})
+      controller.instance_variable_set(:@edit, :new => {:use_filter_expression   => false,
+                                                        :name                    => 'Name',
+                                                        :description             => "Test",
+                                                        :role                    => @role.id,
+                                                        :group_filter_expression => @exp.exp,
+                                                        :belongsto               => {},
+                                                        :filters                 => {'managed/env' => '/managed/env'}})
       controller.send(:rbac_group_set_record_vars, @group)
       expect(@group.entitlement.filter_expression).to be_nil
       expect(@group.entitlement.get_managed_filters).to match([["/managed/env"]])
     end
 
     it "saves the filter_expression when use_filter_expression true" do
-      controller.instance_variable_set(:@edit, :new => {:use_filter_expression => true,
-                                                        :name                  => 'Name',
-                                                        :description           => "Test",
-                                                        :role                  => @role.id,
-                                                        :filter_expression     => @exp.exp,
-                                                        :belongsto             => {},
-                                                        :filters               => {'managed/env' => '/managed/env'}})
+      controller.instance_variable_set(:@edit, :new => {:use_filter_expression   => true,
+                                                        :name                    => 'Name',
+                                                        :description             => "Test",
+                                                        :role                    => @role.id,
+                                                        :group_filter_expression => @exp.exp,
+                                                        :belongsto               => {},
+                                                        :filters                 => {'managed/env' => '/managed/env'}})
       controller.send(:rbac_group_set_record_vars, @group)
       expect(@group.entitlement.get_managed_filters).to eq([])
       expect(@group.entitlement.filter_expression.exp).to match(@exp.exp)
@@ -458,16 +458,16 @@ describe OpsController do
               :new      => new,
               :current  => new,
               :edit_exp => {:key => '???'}}
-      edit[:filter_expression] ||= ApplicationController::Filter::Expression.new
-      edit[:filter_expression][:expression] = {"???" => "???"}
-      edit[:new][:filter_expression] = copy_hash(edit[:filter_expression][:expression])
-      edit[:filter_expression].history.reset(edit[:filter_expression][:expression])
+      edit[:group_filter_expression] ||= ApplicationController::Filter::Expression.new
+      edit[:group_filter_expression][:expression] = {"???" => "???"}
+      edit[:new][:group_filter_expression] = copy_hash(edit[:group_filter_expression][:expression])
+      edit[:group_filter_expression].history.reset(edit[:group_filter_expression][:expression])
       controller.instance_variable_set(:@edit, edit)
-      controller.instance_variable_set(:@expkey, :filter_expression)
+      controller.instance_variable_set(:@expkey, :group_filter_expression)
       edit[:group_filter_expression][:exp_table] = controller.send(:exp_build_table, edit[:group_filter_expression][:expression])
       edit[:group_filter_expression][:exp_model] = @group.class.to_s
       session[:edit] = edit
-      session[:expkey] = :filter_expression
+      session[:expkey] = :group_filter_expression
       controller.instance_variable_set(:@edit, edit)
       session[:sandboxes] = {"ops" => {:active_tree => :rbac_tree}}
       allow(controller).to receive(:replace_right_cell)
@@ -480,13 +480,13 @@ describe OpsController do
     it "initializes the group record and tag tree when switching tabs" do
       controller.instance_variable_set(:@edit,
                                        :group_id => @group.id,
-                                       :new      => {:use_filter_expression => true,
-                                                     :name                  => 'Name',
-                                                     :description           => "Test",
-                                                     :role                  => @role.id,
-                                                     :filter_expression     => @exp.exp,
-                                                     :belongsto             => {},
-                                                     :filters               => {'managed/env' => '/managed/env'}})
+                                       :new      => {:use_filter_expression   => true,
+                                                     :name                    => 'Name',
+                                                     :description             => "Test",
+                                                     :role                    => @role.id,
+                                                     :group_filter_expression => @exp.exp,
+                                                     :belongsto               => {},
+                                                     :filters                 => {'managed/env' => '/managed/env'}})
       controller.instance_variable_set(:@sb, :active_rbac_group_tab => 'rbac_customer_tags')
       controller.instance_variable_set(:@_params, :use_filter_expression => "false", :id => @group.id)
       controller.send(:rbac_group_get_form_vars)


### PR DESCRIPTION
Fixes the expression editor for Group Custom buttons and Group enablement Expression

Links 
----------
https://bugzilla.redhat.com/show_bug.cgi?id=1535063

Steps for Testing/QA
-------------------------------

1. Add a custom button for a Group. The enablement expression will only allow the selection of tags without this PR.
2. With a Group custom button with an enablement expression added, an error occurs when selecting a group in Configuration->Access control 



