### PR TITLE
[WIP] Fix bug when navigating to tags of Job templates

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -15,7 +15,8 @@ module ApplicationController::AdvancedSearch
     @expkey = :expression # Reset to use default expression key
     if session.fetch_path(:adv_search, model.to_s)
       adv_search_model = session[:adv_search][model.to_s]
-      @edit ||= copy_hash(adv_search_model[@expkey] ? adv_search_model : session[:edit])
+      @edit ||= {}
+      @edit.merge!(copy_hash(adv_search_model[@expkey] ? adv_search_model : session[:edit]))
       adv_search_clear_default_search_if_cant_be_seen
       @edit.delete(:exp_token)                                          # Remove any existing atom being edited
     else                                                                # Create new exp fields


### PR DESCRIPTION
### FIXES navigating to Tags of Job template
Go to `Automation` -> `Ansible tower` -> `Explorer` select `Job Templates` from left menu, select any template and click on `Edit tags` from toolbar. This causes error, because `@edit` is set and it should be empty or contain specific `:expression` information which can be optained by calling `session[:adv_search][model.to_s]`. Avoid this by merging `@edit` and specific data from `session[:adv_search]`.

### UI changes
none 

### BZ
none