### PR TITLE
Networks > Floating IPs - fix uninitialized constant ApplicationHelper::Button::FloatingIpNew::EmsNetwork

### DIFF
--- a/app/helpers/application_helper/button/floating_ip_new.rb
+++ b/app/helpers/application_helper/button/floating_ip_new.rb
@@ -8,6 +8,6 @@ class ApplicationHelper::Button::FloatingIpNew < ApplicationHelper::Button::Butt
 
   # disable button if no active providers support create action
   def disabled?
-    EmsNetwork.all.none? { |ems| FloatingIp.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.none? { |ems| ::FloatingIp.class_by_ems(ems).supports_create? }
   end
 end


### PR DESCRIPTION
Go to `/floating_ip/show_list`

I'm seeing `uninitialized constant ApplicationHelper::Button::FloatingIpNew::EmsNetwork`.

Adding :: to use the right namespace

(I don't see the same problem in gaprindashvili, but the code is the same, YMMV.)

EDIT: this is only happening when reloading in devel mode, `gaprindashvili/no` then