### PR TITLE
Fix editing Tags for Cloud Subnets

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -30,6 +30,8 @@ class CloudNetworkController < ApplicationController
       javascript_redirect :action => "edit", :id => checked_item_id
     when "cloud_network_new"
       javascript_redirect :action => "new"
+    when "cloud_subnet_tag"
+      return tag("CloudSubnet")
     when "custom_button"
       custom_buttons
       return


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1534915

Fix editing Tags for Cloud Subnets when going to _Networks -> Networks_, choosing a network, selecting _Cloud Subnets_ in _Relationships_ table and selecting some subnets by checking the checkboxes in the list and clicking on _Edit Tags_ under _Policy_.

**Before:**

**After:**
