### PR TITLE
Implementing change password view

### DIFF
--- a/app/assets/javascripts/components/physical_infrastructures/change-password-component.js
+++ b/app/assets/javascripts/components/physical_infrastructures/change-password-component.js
@@ -1,0 +1,94 @@
+(function() {
+  ManageIQ.angular.app.component('changePasswordComponent', {
+    bindings: {
+      recordId: '@?',
+      recordName: '@?',
+      redirectUrl: '@',
+    },
+    controllerAs: 'vm',
+    controller: changePasswordFormController,
+    templateUrl: '/static/ems_physical_infra/change_password.html.haml',
+  });
+
+  changePasswordFormController.$inject = ['API', 'miqService'];
+
+  function changePasswordFormController(API, miqService) {
+    var vm = this;
+
+    vm.$onInit = function() {
+      vm.entity = 'Physical Provider';
+
+      vm.model = modelInit();
+      vm.modelCopy = angular.copy(vm.model);
+    };
+
+    vm.saveClicked = function() {
+      var saveMsg = sprintf(__('Requested password change for the %s \"%s\".'), vm.entity, vm.recordName);
+      vm.saveWithAPI('post', '/api/providers/' + vm.recordId, vm.model, saveMsg);
+    };
+
+    vm.saveWithAPI = function(method, url, saveObject, saveMsg) {
+      miqService.sparkleOn();
+      API[method](url, saveObject, {
+        skipErrors: [400],  // server-side validation
+      })
+        .then(miqService.redirectBack.bind(vm, saveMsg, 'success', vm.redirectUrl))
+        .catch(miqService.handleFailure);
+    };
+
+    vm.resetClicked = function() {
+      vm.model = modelInit();
+    };
+
+    vm.cancelClicked = function() {
+      miqService.sparkleOn();
+      miqService.redirectBack(sprintf(__('Edit of %s \"%s\" was canceled by the user.'), vm.entity, vm.recordName), 'warning', vm.redirectUrl);
+    };
+
+    vm.current_and_new_password_are_equals = function() {
+      return isFieldsEquals(vm.model.new_password, vm.model.current_password);
+    };
+
+    vm.confirmation_and_new_password_are_different = function() {
+      if (vm.model.confirm_password) {
+        return ! isFieldsEquals(vm.model.confirm_password, vm.model.new_password);
+      }
+      return false;
+    };
+
+    vm.saveable = function() {
+      return !! (vm.model.current_password
+            && vm.model.new_password
+            && vm.model.confirm_password
+            && ! vm.confirmation_and_new_password_are_different()
+            && ! vm.current_and_new_password_are_equals());
+    };
+  }
+
+  /**
+  * Compares two fields and see if they are equal.
+  *  If some field is empty it doesn't compares and just return false.
+  *
+  * @param {*} firstField - First field to be compared
+  * @param {*} secondField - Second field to be compared
+  *
+  * @return {Boolean} If one of the fields is empty, returns false
+  *                   if the fields are equal, returns true
+  *                   else return false.
+  */
+  function isFieldsEquals(firstField, secondField) {
+    if (firstField && secondField) {
+      return firstField === secondField;
+    }
+    return false;
+  }
+
+  function modelInit() {
+    return {
+      current_password: '',
+      new_password: '',
+      confirm_password: '',
+      action: 'change_password',
+    };
+  }
+})();

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -407,6 +407,8 @@ module EmsCommon
       javascript_redirect :controller => "network_router",
                           :action     => "remove_interface_select",
                           :id         => find_record_with_rbac(NetworkRouter, checked_or_params)
+    elsif params[:pressed] == 'ems_infra_change_password'
+      javascript_redirect(change_password_ems_physical_infra_path(checked_or_params.first))
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)

--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -61,6 +61,18 @@ class EmsPhysicalInfraController < ApplicationController
     javascript_open_window(@ems.console_url.to_s)
   end
 
+  def change_password_ems_physical_infra_path(id = nil)
+    "/ems_physical_infra/change_password/#{id}"
+  end
+
+  # This method handle view objects of page
+  # +/ems_physical_infra/change_password/<id>+
+  def change_password
+    @record = find_record_with_rbac(model, params[:id])
+    @title = _("Change Password for Physical Infrasctructure Provider '#{@record.name}'")
+    @in_a_form = true # to show the page on all content frame
+  end
+
   private
 
   ############################

--- a/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
@@ -104,6 +104,12 @@ class ApplicationHelper::Toolbar::EmsPhysicalInfraCenter < ApplicationHelper::To
       t,
       :items => [
         button(
+          :ems_infra_change_password,
+          'pficon pficon-edit fa-lg',
+          t = N_('Change password'),
+          t
+        ),
+        button(
           :ems_physical_infra_recheck_auth_status,
           'fa fa-search fa-lg',
           N_('Re-check Authentication Status for this Physical Infrastructure Provider'),

--- a/app/helpers/application_helper/toolbar/ems_physical_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_physical_infras_center.rb
@@ -102,6 +102,15 @@ class ApplicationHelper::Toolbar::EmsPhysicalInfrasCenter < ApplicationHelper::T
       :onwhen  => "1+",
       :items   => [
         button(
+          :ems_infra_change_password,
+          'pficon pficon-edit fa-lg',
+          N_('Select a single Infrastructure Provider to Change password'),
+          N_('Change Password'),
+          :send_checked => true,
+          :enabled      => false,
+          :onwhen       => "1"
+        ),
+        button(
           :ems_physical_infra_recheck_auth_status,
           'fa fa-search fa-lg',
           N_('Re-check Authentication Status for the selected Physical Infrastructure Providers'),

--- a/app/views/ems_physical_infra/change_password.html.haml
+++ b/app/views/ems_physical_infra/change_password.html.haml
@@ -1,0 +1,10 @@
+- @angular_form = true
+
+= render :partial => "layouts/flash_msg"
+
+%change-password-component{"record-id"    => @record.id,
+                           "record-name"  => @record.name,
+                           "redirect-url" => ems_physical_infra_path(@record),}
+
+:javascript
+  miq_bootstrap('change-password-component');

--- a/app/views/static/ems_physical_infra/change_password.html.haml
+++ b/app/views/static/ems_physical_infra/change_password.html.haml
@@ -1,0 +1,52 @@
+%form.form-horizontal{"name"         => "angularForm",
+                      "model-copy"   => "vm.modelCopy",
+                      "model"        => "vm.model",
+                      "ng-cloak"     => "",
+                      "form-changed" => true,
+                      "miq-form"     => true}
+
+  .form-group{"ng-class" => "{'has-error': angularForm.current_password.$invalid}"}
+    %label.col-md-2.control-label{"for" => "current_password"}
+      = _('Current Password')
+    .col-md-8
+      %input.form-control{"type"        => "password",
+                          "id"          => "current_password",
+                          "name"        => "current_password",
+                          "ng-model"    => "vm.model.current_password",
+                          "required"    => "true",
+                          "checkchange" => "",
+                          "auto-focus"  => ""}
+      %span.help-block{"ng-show" => "angularForm.current_password.$error.required"}
+        = _("Required")
+
+  .form-group{"ng-class" => "{'has-error': angularForm.new_password.$invalid || vm.current_and_new_password_are_equals()}"}
+    %label.col-md-2.control-label{"for" => "new_password"}
+      = _('New Password')
+    .col-md-8
+      %input.form-control{"type"        => "password",
+                          "id"          => "new_password",
+                          "name"        => "new_password",
+                          "ng-model"    => "vm.model.new_password",
+                          "required"    => "true",
+                          "checkchange" => ""}
+      %span.help-block{"ng-show" => "angularForm.new_password.$error.required"}
+        = _("Required")
+      %span.help-block{"ng-show" => "vm.current_and_new_password_are_equals()"}
+        = _("Current and new password must be different")
+
+  .form-group{"ng-class" => "{'has-error': angularForm.confirm_new_password.$invalid || vm.confirmation_and_new_password_are_different()}"}
+    %label.col-md-2.control-label{"for" => "confirm_new_password"}
+      = _('Confirm New Password')
+    .col-md-8
+      %input.form-control{"type"        => "password",
+                          "id"          => "confirm_new_password",
+                          "name"        => "confirm_new_password",
+                          "ng-model"    => "vm.model.confirm_password",
+                          "required"    => "true",
+                          "checkchange" => ""}
+      %span.help-block{"ng-show" => "angularForm.confirm_new_password.$error.required"}
+        = _("Required")
+      %span.help-block{"ng-show" => "vm.confirmation_and_new_password_are_different()"}
+        = _("Confirm password did not match")
+
+  = render :partial => "layouts/angular/generic_form_buttons"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1284,6 +1284,7 @@ Rails.application.routes.draw do
         protect
         show_list
         tagging_edit
+        change_password
       ) +
                compare_get,
       :post => %w(

--- a/spec/javascripts/components/physical_infrastructures/change-password-component_spec.js
+++ b/spec/javascripts/components/physical_infrastructures/change-password-component_spec.js
@@ -1,0 +1,50 @@
+describe('change-password-component', function() {
+  var $componentController, vm, miqService, API;
+
+  describe('load page', function() {
+    beforeEach(module('ManageIQ'));
+    beforeEach(inject(function(_$componentController_, _API_, _miqService_, $q) {
+      $componentController = _$componentController_;
+      API = _API_;
+      miqService = _miqService_;
+
+      spyOn(miqService.redirectBack, 'bind');
+      var deferred = $q.defer();
+      spyOn(API, 'post').and.callFake(function() {return deferred.promise;});
+
+      var bindings = {recordId: '1111', redirectUrl: '/controller/go_back', recordName: 'provider'};
+      vm = $componentController('changePasswordComponent', null, bindings);
+      vm.$onInit();
+    }));
+
+    it('sets saveable to false', function() {
+      expect(vm.saveable()).toBe(false);
+    });
+
+    it('identifies errors in user entries', function() {
+      vm.model.current_password = 'current_password';
+      vm.model.new_password = 'current_password';
+      vm.model.confirm_password = 'different_confirm_password';
+      vm.model.name = 'xyz';
+
+      expect(vm.confirmation_and_new_password_are_different()).toBe(true);
+      expect(vm.current_and_new_password_are_equals()).toBe(true);
+    });
+
+    it('saves the new password', function() {
+      vm.model.current_password = 'current_password';
+      vm.model.new_password = 'pass';
+      vm.model.confirm_password = 'pass';
+      vm.recordName = 'xyz';
+
+      expect(vm.confirmation_and_new_password_are_different()).toBe(false);
+      expect(vm.current_and_new_password_are_equals()).toBe(false);
+
+      vm.saveClicked();
+      expect(API.post).toHaveBeenCalledWith('/api/providers/1111', vm.model, {
+        skipErrors: [400],
+      });
+      expect(miqService.redirectBack.bind).toHaveBeenCalledWith(vm, 'Requested password change for the Physical Provider \"xyz\".', 'success', vm.redirectUrl);
+    });
+  });
+});


### PR DESCRIPTION
**This PR is able to:**
- Add a view to change password of a Physical Infra Provider

__ems_physical_infra/show_list__

![screenshot from 2018-04-27 09-05-35](https://user-images.githubusercontent.com/8550928/39361871-a690b918-49fa-11e8-9c4a-5d924e889f6b.png)

__ems_physical_infra/change_password/${id}__

![image](https://user-images.githubusercontent.com/8550928/39361919-da6af6ae-49fa-11e8-9096-ffd27d69fa30.png)

![image](https://user-images.githubusercontent.com/8550928/39362007-3a3cb1ee-49fb-11e8-85ba-c8cf4ffdad20.png)

![image](https://user-images.githubusercontent.com/8550928/39362032-5501094e-49fb-11e8-81c6-5a327e4aafd2.png)

__After click in save button__

![image](https://user-images.githubusercontent.com/8550928/39362070-6f59f062-49fb-11e8-8295-55e1c48a5c0a.png)

__The user can follow the change password request status in the tasks page__

![image](https://user-images.githubusercontent.com/8550928/39364517-9e30f4f4-4a04-11e8-8120-c34678633e79.png)


**This PR depends on:** 
* ~https://github.com/ManageIQ/manageiq/pull/16883~ - Merged
* ~https://github.com/ManageIQ/manageiq/pull/16895~ - Merged