### PR TITLE
[GAPRINDASHVILI] Fix Host provide controller method

### DIFF
--- a/app/controllers/mixins/actions/host_actions/misc.rb
+++ b/app/controllers/mixins/actions/host_actions/misc.rb
@@ -123,7 +123,7 @@ module Mixins
           end
         end
 
-        def process_host_provide(hosts, display_name)
+        def process_hosts_provide(hosts, display_name)
           each_host(hosts, display_name) do |host|
             if host.hardware.provision_state == "manageable"
               host.provide_queue(session[:userid])


### PR DESCRIPTION
Fix typo in Hosts controller misc module preventing Host registration in OSP provider.

Upstream has it fixed already by https://github.com/ManageIQ/manageiq-ui-classic/pull/2945

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536819
