### PR TITLE
[GAPRINDASHVILI] Widgets - fix get_reports_menu call to include missing arg

### DIFF
--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -381,7 +381,7 @@ module ReportController::Widgets
       @edit[:schedule].name = @widget.resource.name
       @edit[:schedule].description = @widget.resource.title
       @edit[:rpt] = MiqReport.find_by_id(@widget.resource_id)
-      @menu = get_reports_menu(current_group, "default")
+      @menu = get_reports_menu(current_group, "reports", "default")
       if @sb[:wtype] == "r"
         @menu.each do |m|
           m[1].each do |f|
@@ -403,7 +403,7 @@ module ReportController::Widgets
       end
       @edit[:new][:repfilter] = @edit[:rpt].id
     elsif ["r", "c"].include?(@sb[:wtype])
-      @menu = get_reports_menu(current_group, "default")
+      @menu = get_reports_menu(current_group, "reports", "default")
       if @sb[:nodes][1] == "c"
         widget_graph_menus      # to build report pulldown with only reports with grpahs
       else


### PR DESCRIPTION
between gaprindashvili and master, `get_reports_menu` changed signature:

gaprindashvili: `get_reports_menu(group = current_group, tree_type = "reports", mode = "menu")`
master: `get_reports_menu(group = current_group, mode = "menu")`

That means https://github.com/ManageIQ/manageiq-ui-classic/pull/3285 only worked in master, not gaprindashvili.

Fixing the signature - this should fix both https://bugzilla.redhat.com/show_bug.cgi?id=1537142 and failing travis.