### PR TITLE
Fix for dialog loading issue and wrong redirect

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -27,7 +27,8 @@ module VmCommon
 
     case params[:pressed]
     when 'custom_button'
-      custom_buttons
+      cancel_endpoint = "/#{params[:controller]}/explorer"
+      custom_buttons(nil, :cancel_endpoint => cancel_endpoint)
       return
     when 'perf_reload'
       perf_chart_chooser

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -91,7 +91,7 @@ class DialogLocalService
       cancel_endpoint = "/storage/explorer"
     when /Vm/
       api_collection_name = "vms"
-      cancel_endpoint = "/vm_infra/explorer"
+      cancel_endpoint = display_options[:cancel_endpoint] || "/vm_infra/explorer"
     end
 
     submit_endpoint = "/api/#{api_collection_name}/#{obj.id}"

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -1,4 +1,6 @@
 .row.wrapper{"ng-controller" => "dialogUserController as vm"}
+  .spinner{'ng-show' => "!vm.dialogLoaded"}
+
   .col-md-12.col-lg-12{'ng-if' => 'vm.dialog'}
     %dialog-user{"dialog" =>"vm.dialog", "refresh-field" => "vm.refreshField(field)", "on-update" => "vm.setDialogData(data)"}
 

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -222,20 +222,41 @@ describe DialogLocalService do
     end
 
     context "when the object is a Vm" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Vm, :id => 123) }
+      context "when there is a cancel endpoint in the display options" do
+        let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Vm, :id => 123) }
+        let(:display_options) { {:cancel_endpoint => "/vm_cloud/explorer"} }
 
-      it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
-          :resource_action_id     => 321,
-          :target_id              => 123,
-          :target_type            => 'vm',
-          :dialog_id              => 654,
-          :force_old_dialog_use   => false,
-          :api_submit_endpoint    => "/api/vms/123",
-          :api_action             => "custom-button-name",
-          :finish_submit_endpoint => "/vm_infra/explorer",
-          :cancel_endpoint        => "/vm_infra/explorer"
-        )
+        it "returns a hash" do
+          expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action, display_options)).to eq(
+            :resource_action_id     => 321,
+            :target_id              => 123,
+            :target_type            => 'vm',
+            :dialog_id              => 654,
+            :force_old_dialog_use   => false,
+            :api_submit_endpoint    => "/api/vms/123",
+            :api_action             => "custom-button-name",
+            :finish_submit_endpoint => "/vm_cloud/explorer",
+            :cancel_endpoint        => "/vm_cloud/explorer"
+          )
+        end
+      end
+
+      context "when there is not a cancel endpoint in the display options" do
+        let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Vm, :id => 123) }
+
+        it "returns a hash" do
+          expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
+            :resource_action_id     => 321,
+            :target_id              => 123,
+            :target_type            => 'vm',
+            :dialog_id              => 654,
+            :force_old_dialog_use   => false,
+            :api_submit_endpoint    => "/api/vms/123",
+            :api_action             => "custom-button-name",
+            :finish_submit_endpoint => "/vm_infra/explorer",
+            :cancel_endpoint        => "/vm_infra/explorer"
+          )
+        end
       end
     end
 


### PR DESCRIPTION
I had a small oversight where regardless of where the Vm instance was being shown (either on vm_infra or vm_cloud), when clicking on a custom button and then either cancelling or submitting we would be redirecting back to /vm_infra/explorer instead of the appropriate location.

This PR also adds a spinner to the dialog runner while it is loading.

https://bugzilla.redhat.com/show_bug.cgi?id=1536204

@miq-bot add_label gaprindashvili/yes, bug, blocker

@miq-bot assign @h-kataria 