### PR TITLE
Show alert labels in the `All Alerts` page

### DIFF
--- a/app/assets/javascripts/services/alerts_center_service.js
+++ b/app/assets/javascripts/services/alerts_center_service.js
@@ -409,7 +409,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
 
   _this.getAlertsData = function(limit, offset, filters, sortField, sortAscending) {
     var deferred = $q.defer();
-    var resourceOptions = '?expand=resources,alert_actions&attributes=assignee,resource&filter[]=resolved=false&filter[]=or+resolved=nil';
+    var resourceOptions = '?expand=resources,alert_actions&attributes=assignee,resource,labels&filter[]=resolved=false&filter[]=or+resolved=nil';
     var limitOptions = '';
     var offsetOptions = '';
     var sortOptions = '';
@@ -508,6 +508,7 @@ function alertsCenterService(API, $q, $timeout, $document, $modal, $http) {
       evaluated_on: convertApiTime(alertData.evaluated_on),
       severity: alertData.severity,
       alert_actions: alertData.alert_actions,
+      labels: alertData.labels,
     };
 
     if (newAlert.severity == 'error') {

--- a/app/views/shared/views/_alerts_list.html.haml
+++ b/app/views/shared/views/_alerts_list.html.haml
@@ -67,6 +67,29 @@
           .col-md-12
             %a{"ng-href" => '{{$parent.$parent.item.sopLink}}', "target" => "_blank", "ng-if" => "$parent.item.sopLink"}
               = _("View SOP")
+        .row{"ng-if" => "$parent.item.labels && $parent.item.labels.length > 0"}
+          .col-md-12
+            %span.header
+              = _("Labels")
+          .col-md-12
+            %table.table.table-striped.table-bordered.table-hover
+              %colgroup
+                %col.fixed-col
+                %col.grow-col
+              %thead
+                %tr
+                  %th
+                    = _("Name")
+                  %th
+                    = _("Value")
+              %tbody
+                %tr{"ng-repeat" => "label in $parent.$parent.item.labels"}
+                  %td
+                    .no-wrap
+                      {{label.name}}
+                  %td
+                    .no-wrap
+                      {{label.value}}
         .row
           .col-md-12
             %span.header


### PR DESCRIPTION
Currently the alerts displayed in the `All Alerts` page don't contain
the _labels_ that may be available if the alert is coming from a system
like Prometheus. That means that alerts that are different may appear
identical, because the only difference may be in the values of some
labels. To improve that this patch changes the user interface so that
the labels will be displayed when the button to display alert details is
clicked. The alerts will be displayed in a new _Labels_ table right
before the existing _History_ table:

```
> X The message of the alert  Updated: 2018-01-22 05:56:55
    theprovider                   Age: 5m 10s

Labels
+-------------------------+-----------------------+
| Name                    | Value                 |
+-------------------------+-----------------------+
| alertname               | The name of the alert |
| beta_kubernetes_io_arch | amd64                 |
| beta_kubernetes_io_os   | linux                 |
| instance                | openshift.local       |
| job                     | kubernetes-nodes      |
| kubernetes_io_hostname  | openshift.local       |
| openshift_infra         | apiserver             |
| region                  | infra                 |
+-------------------------+-----------------------+

History
+---------------------+--------+---------------+------+
| Time                | Action | User          | Note |
+---------------------+--------+---------------+------+
| 2018-01-22 05:56:55 | assign | Administrator |      |
+---------------------+--------+---------------+------+
```

The new _Labels_ table will only be shown if the alert contains at least
one label.

Fixes https://bugzilla.redhat.com/1520125

Note that this pull request depends on ManageIQ/manageiq/pull#16866,
which adds the `alert_labels` feature to the core.
