### PR TITLE
DialogEditor - remove code that changes fields to refresh from name to id

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -67,16 +67,6 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', '$http', '
           });
         });
       });
-
-      _.forEach(allFields, function(field) {
-        _.forEach(field.dialog_field_responders, function(responder, index) {
-          _.forEach(dynamicFields, function(dynamicField) {
-            if (responder === dynamicField.name) {
-              field.dialog_field_responders[index] = dynamicField.id;
-            }
-          });
-        });
-      });
     }
 
     translateResponderNamesToIds(dialog.content[0]);


### PR DESCRIPTION
Since https://github.com/ManageIQ/ui-components/pull/228 , we're using `name` instead of `id` in `fields_to_refresh`.

Previously, we used the `id` and this bit of code converted the names coming from the API to ids.
That's counter-productive now, removing :)

(This is a two-part fix, https://github.com/ManageIQ/ui-components/pull/238 should go first.)

Testing: go to `/miq_ae_customization/editor`, create a dynamic field and a non-dynamic field.
Edit the non-dynamic field's "Fields to Refresh" to use the dynamic field.
Save the dialog, edit it.
See the non-dynamic field's "Fields to Refresh".

before: empty, now: the value set when creating

Cc: @romanblanco @eclarizio 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536528