### PR TITLE
[FINE] Fix show top VM/Host in C&U chart grouped by some tag

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1606,7 +1606,7 @@ class ApplicationController < ActionController::Base
 
       if typ == "bytag"
         ["\"#{model.downcase.pluralize}\".id IN (?)",
-         data_row["assoc_ids_#{report.extras[:group_by_tags][legend_index]}"][model.downcase.to_sym][:on]]
+         data_row["assoc_ids_#{report.extras[:group_by_tags][legend_idx]}"][model.downcase.to_sym][:on]]
       else
         ["\"#{model.downcase.pluralize}\".id IN (?)",
          data_row["assoc_ids"][model.downcase.to_sym][typ.to_sym]]

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -201,7 +201,7 @@ module ApplicationController::Performance
     elsif cmd == "Chart" && model == "Selected"
       return if chart_selected(data_row, typ, ts)
     elsif cmd == "Chart" && typ.starts_with?("top") && @perf_options[:cat]
-      return if chart_top_by_tag(data_row, report, legend_idx, model, ts, bc_model)
+      return if chart_top_by_tag(data_row, report, legend_idx, typ, model, ts, bc_model)
     elsif cmd == "Chart" && typ.starts_with?("top")
       return if chart_top(data_row, typ, ts, model, bc_model)
     else
@@ -466,7 +466,7 @@ module ApplicationController::Performance
   end
 
   # create top chart for selected timestamp/model by tag
-  def chart_top_by_tag(data_row, report, legend_idx, model, ts, bc_model)
+  def chart_top_by_tag(data_row, report, legend_idx, typ, model, ts, bc_model)
     @record = identify_tl_or_perf_record
     @perf_record = @record.kind_of?(MiqServer) ? @record.vm : @record # Use related server vm record
     top_ids = data_row["assoc_ids_#{report.extras[:group_by_tags][legend_idx]}"][model.downcase.to_sym][:on]

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -187,7 +187,7 @@ module ApplicationController::Performance
       display_current_top(data_row)
       return
     elsif cmd == "Display" && typ == "bytag"
-      return if display_by_tag(data_row, report, ts, bc_model, model, legend_idx)
+      return if display_by_tag(data_row, report, ts, bc_model, model, legend_idx, typ)
     elsif cmd == "Display"
       return if display_selected(ts, typ, data_row, model, bc_model)
     elsif cmd == "Timeline" && model == "Current"
@@ -227,7 +227,7 @@ module ApplicationController::Performance
   end
 
   # display selected resources from a tag chart
-  def display_by_tag(data_row, report, ts, bc_model, model, legend_idx)
+  def display_by_tag(data_row, report, ts, bc_model, model, legend_idx, typ)
     dt = @perf_options[:typ] == "Hourly" ? "on #{ts.to_date} at #{ts.strftime("%H:%M:%S %Z")}" : "on #{ts.to_date}"
     top_ids = data_row["assoc_ids_#{report.extras[:group_by_tags][legend_idx]}"][model.downcase.to_sym][:on]
     bc_tag =  "#{Classification.find_by_name(@perf_options[:cat]).description}:#{report.extras[:group_by_tag_descriptions][legend_idx]}"

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -86,10 +86,10 @@ module Mixins
 
     # Find a record by model and ID.
     # Set flash errors for not found/not authorized.
-    def find_record_with_rbac_flash(model, id, resource_name = nil)
+    def find_record_with_rbac_flash(klass, id, resource_name = nil)
       tested_object = klass.find(id)
       if tested_object.nil?
-        record_name = resource_name ? "#{ui_lookup(:model => model)} '#{resource_name}'" : _("The selected record")
+        record_name = resource_name ? "#{ui_lookup(:model => klass)} '#{resource_name}'" : _("The selected record")
         add_flash(_("%{record_name} no longer exists in the database") % {:record_name => record_name}, :error)
         return nil
       end


### PR DESCRIPTION
 Fix show top VM/Host in C&U chart grouped by some tag. In `chart_top_by_tag` was used variable `typ` but it wasn't defined.

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1531619
https://bugzilla.redhat.com/show_bug.cgi?id=1531615

Steps for Testing/QA
-------------------------------
![screencast from 2018-01-23 13-06-31](https://user-images.githubusercontent.com/9535558/35275761-139a25f2-0041-11e8-9a8c-d6938333525c.gif)

