### PR TITLE
Remove more of middleware topology

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -146,9 +146,6 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
       case 'NetworkManager':
         entity_url = 'ems_network';
         break;
-      case 'MiddlewareManager':
-        entity_url = 'ems_middleware';
-        break;
       case 'InfraManager':
         entity_url = 'ems_infra';
         break;
@@ -182,20 +179,16 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
       case 'Running':
       case 'Succeeded':
       case 'Valid':
-      case 'Enabled':
         return 'success';
       case 'NotReady':
       case 'Failed':
       case 'Error':
       case 'Unreachable':
-      case 'Down':
       case 'Inactive':
         return 'error';
       case 'Warning':
       case 'Waiting':
       case 'Pending':
-      case 'Disabled':
-      case 'Reload required':
         return 'warning';
       case 'Unknown':
       case 'Terminated':

--- a/spec/javascripts/services/topology_service_spec.js
+++ b/spec/javascripts/services/topology_service_spec.js
@@ -1,17 +1,6 @@
 describe('topologyService', function() {
     var testService;
     var replicator = { id:"396086e5-7b0d-11e5-8286-18037327aaeb",  item:{display_kind:"Replicator", kind:"ContainerReplicator", id:"396086e5-7b0d-11e5-8286-18037327aaeb", miq_id:"10"}};
-    var mw_manager = {
-        id: "1", item: {
-            "name": "Hawkular",
-            "kind": "MiddlewareManager",
-            "miq_id": 1,
-            "status": "Unknown",
-            "display_kind": "Hawkular",
-            "icon": "vendor-hawkular",
-            "id": "1"
-        }
-    };
 
     beforeEach(module('ManageIQ'));
 
@@ -34,7 +23,6 @@ describe('topologyService', function() {
       it('to entity pages', function() {
         var d = { id:"2",  item:{display_kind:"Openshift", kind:"ContainerManager", id:"2", miq_id:"37"}};
         expect(testService.geturl(d)).toEqual("/ems_container/37");
-        expect(testService.geturl(mw_manager)).toEqual("/ems_middleware/1");
         d = { id:"3",  item:{display_kind:"Pod", kind:"ContainerGroup", id:"3", miq_id:"30"}};
         expect(testService.geturl(d)).toEqual("/container_group/show/30");
         d = { id:"4",  item:{display_kind:"VM", kind:"Vm", id:"4", miq_id:"25"}};


### PR DESCRIPTION
This removes some remaining code related to middleware topology that is not needed anymore.
Related to #3141.

Per BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1526791