### PR TITLE
Add note about vm restart for cpu hot plug change

### DIFF
--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -92,6 +92,8 @@
                           "selectpicker-for-select-tag" => "")
             - if @cores_options.length <= 1
               @cores_options[0]
+            %span.help-block{"ng-if" => "angularForm.cores_per_socket_count.$dirty"}
+              =_("Note: a restart of the virtual machine might be reuired for the changes to apply.")
         .form-group{"ng-class" => "{'has-error': angularForm.total_cpus.$invalid}"}
           %label.col-sm-2.control-label
             = _('Total Processors')


### PR DESCRIPTION
When the number of cores per sockets is changed in VM reconfigure
a restart of the VM might be required for the change to apply.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1534510

![selection_005](https://user-images.githubusercontent.com/3274731/35318448-19743f96-00e4-11e8-932e-6d9007af06b8.png)