### PR TITLE
Drop middleware provider condition from the add provider controller

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -573,11 +573,6 @@ module Mixins
         end
       end
 
-      if ems.kind_of?(ManageIQ::Providers::MiddlewareManager)
-        default_endpoint = {:role => :default, :hostname => hostname, :port => port}
-        default_endpoint.merge!(endpoint_security_options(ems.security_protocol, default_tls_ca_certs))
-      end
-
       if ems.kind_of?(ManageIQ::Providers::Nuage::NetworkManager)
         default_endpoint = {:role => :default, :hostname => hostname, :port => port, :security_protocol => ems.security_protocol}
         amqp_endpoint = {:role => :amqp, :hostname => amqp_hostname, :port => amqp_port, :security_protocol => amqp_security_protocol}


### PR DESCRIPTION
@borod108 [discovered](https://gitter.im/ManageIQ/manageiq/ui?at=5a68666fe01412265085e884) that adding a provider fails with a `NameError` due to the removal of the middleware provider.

@miq-bot add_label bug, gaprindashvili/no