### PR TITLE
Use Object.keys so we don't have to use newer version of node for build

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -66,7 +66,7 @@ module.exports = {
   resolve: {
     extensions: settings.extensions,
     modules: [resolve(settings.source_path)].concat(
-      Object.values(engines).map(engine => `${engine}/node_modules`)
+      Object.keys(engines).map(key => engines[key]).map(engine => `${engine}/node_modules`)
     ),
   },
 


### PR DESCRIPTION
### Fixes build problem for older version of node
Since we support current LTS version of Node (currently v 6) we can't use `Object.values`.

### Referenced PR
https://github.com/ManageIQ/manageiq-ui-classic/pull/2652