### PR TITLE
Remove Adv Search from Config mgmt Providers page

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -193,6 +193,10 @@ class ProviderForemanController < ApplicationController
     true
   end
 
+  def provider_active_tree?
+    x_active_tree == :configuration_manager_providers_tree
+  end
+
   private
 
   def textual_group_list
@@ -366,6 +370,13 @@ class ProviderForemanController < ApplicationController
     node
   end
 
+  def replace_search_box(presenter)
+    # Replace the searchbox
+    presenter.replace(:adv_searchbox_div,
+                      r[:partial => 'layouts/x_adv_searchbox',
+                        :locals  => {:nameonly => provider_active_tree?}])
+  end
+
   def update_partials(record_showing, presenter)
     if record_showing && valid_configured_system_record?(@configured_system_record)
       get_tagdata(@record)
@@ -390,6 +401,7 @@ class ProviderForemanController < ApplicationController
     else
       presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     end
+    replace_search_box(presenter)
   end
 
   def group_summary_tab_selected?

--- a/app/views/provider_foreman/explorer.html.haml
+++ b/app/views/provider_foreman/explorer.html.haml
@@ -1,5 +1,5 @@
 - content_for :search do
-  = render(:partial => "layouts/x_adv_searchbox")
+  = render(:partial => "layouts/x_adv_searchbox", :locals => {:nameonly => controller.provider_active_tree?})
   = render(:partial => 'layouts/quick_search')
 
 -# These are the initial divs that will go inside center_cell_div


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1536452

Remove _Advanced Search_ from _Configuration > Management > Providers_ page, as it is not supported, it never worked and only _Search_ remains in the page, which works well.

---

**Before:**
Adv search button present but not working properly:
![mgmt_provider_before1](https://user-images.githubusercontent.com/13417815/35342117-8e3bb9d8-0127-11e8-9926-34f94830e618.png)
![mgmt_provider_before2](https://user-images.githubusercontent.com/13417815/35342120-901a2122-0127-11e8-9557-9d3d00a21598.png)
When trying to use Adv search:
![mgmt_provider_before3](https://user-images.githubusercontent.com/13417815/35342473-7196afda-0128-11e8-9062-d4f042087dcc.png)
![mgmt_provider_before4](https://user-images.githubusercontent.com/13417815/35342483-75f550e0-0128-11e8-9988-a1186f94a031.png)
After clicking on _Apply_ button:
![mgmt_provider_before5](https://user-images.githubusercontent.com/13417815/35342489-7839372c-0128-11e8-89be-ac3f7cef724a.png)

---

**After:**
Adv Search NOT present, everything works well:
![mgmt_providers1](https://user-images.githubusercontent.com/13417815/35341484-19d961e0-0126-11e8-9adb-500515856fdf.png)
![mgmt_providers2](https://user-images.githubusercontent.com/13417815/35341492-1c3b9a48-0126-11e8-88af-72de6d022129.png)
![mgmt_providers3](https://user-images.githubusercontent.com/13417815/35341495-1e8d34be-0126-11e8-80f2-43e0c0fc475f.png)
