### PR TITLE
Remove vertical lines from gettext strings

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -528,7 +528,7 @@ module QuadiconHelper
              end
 
       output << content_tag(:div, :class => 'flobj') do
-        title = _("Name: %{name} | Hostname: %{hostname}") % {:name => h(item.name), :hostname => h(item.hostname)}
+        title = _("Name: %{name} Hostname: %{hostname}") % {:name => h(item.name), :hostname => h(item.hostname)}
 
         link_to(href, :title => title) do
           quadicon_reflection_img
@@ -617,7 +617,7 @@ module QuadiconHelper
       output << flobj_img_simple("layout/reflection.png")
     else
       output << content_tag(:div, :class => 'flobj') do
-        title = _("Name: %{name} | Hostname: %{hostname} | Refresh Status: %{status}") %
+        title = _("Name: %{name} Hostname: %{hostname} Refresh Status: %{status}") %
           {:name     => h(item.name),
            :hostname => h(item.hostname),
            :status   => h(item.last_refresh_status.titleize)}
@@ -810,7 +810,7 @@ module QuadiconHelper
 
   def quadicon_storage_img_options(item)
     opts = {
-      :title  => _("Name: %{name} | Datastore Type: %{storage_type}") % {:name => h(item.name), :storage_type => h(item.store_type)}
+      :title  => _("Name: %{name} Datastore Type: %{storage_type}") % {:name => h(item.name), :storage_type => h(item.store_type)}
     }
 
     opts

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -71,7 +71,7 @@ end
 
 RSpec.shared_examples :storage_name_type_title do
   it 'has a title with name and type' do
-    expect(subject).to include("Name: #{item.name} | Datastore Type: VMFS")
+    expect(subject).to include("Name: #{item.name} Datastore Type: VMFS")
   end
 end
 


### PR DESCRIPTION
Having `|` in gettext strings repeatedly causes problems with translators, who confuse this with a `Model|Attribute` string.