### PR TITLE
Fix missing i18n in notification drawer

### DIFF
--- a/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
+++ b/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
@@ -127,5 +127,9 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
     eventNotifications.clearAll(group);
   };
 
+  vm.customScope.unreadCountText = function(count) {
+    return sprintf(__("%d New"), count);
+  }
+
   refresh();
 }

--- a/app/views/static/notification_drawer/notification-subheading.html.haml
+++ b/app/views/static/notification_drawer/notification-subheading.html.haml
@@ -1,3 +1,2 @@
 %span.subheading-class
-  -# TODO: i18n
-  {{notificationGroup.unreadCount}} New
+  {{customScope.unreadCountText(notificationGroup.unreadCount)}}


### PR DESCRIPTION
The text `0 New` `1 New` `2 New` etc. in notification drawer wasn't being translated.

https://bugzilla.redhat.com/show_bug.cgi?id=1538087