### PR TITLE
Custom Button Add/Edit - stay on the Advanced tab when changing the System/Process field 

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -121,7 +121,7 @@ module ApplicationController::Buttons
     render :update do |page|
       page << javascript_prologue
       if [:instance_name, :other_name, :target_class, :button_type].any? { |k| params.key?(k) }
-        @sb[:active_tab] = "ab_options_tab"
+        @sb[:active_tab] = params[:instance_name] ? "ab_advanced_tab" : "ab_options_tab"
         page.replace("ab_form", :partial => "shared/buttons/ab_form")
       end
       if params[:visibility_typ]

--- a/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
@@ -74,5 +74,28 @@ describe MiqAeCustomizationController do
       expect(response.status).to eq(200)
       expect(response.body).to include('name=\"disabled_text\" id=\"disabled_text\" value=\"a_new_disabled_text\"')
     end
+
+    it "the active tab is Advanced when the System/process field is updated" do
+      @sb = {:active_tree => :ab_tree,
+             :trees       => {:ab_tree => {:tree => :ab_tree}},
+             :params      => {:instance_name => 'MiqEvent'}}
+      controller.instance_variable_set(:@sb, @sb)
+      controller.instance_variable_set(:@breadcrumbs, [])
+
+      edit = {:new               => {:button_images => %w(01 02 03), :available_dialogs => {:id => '01', :name => '02'},
+                                    :instance_name  => 'MiqEvent',
+                                    :attrs          => [%w(Attr1 01), %w(Attr2 02), %w(Attr3 03), %w(Attr4 04), %w(Attr5 05)],
+                                    :disabled_text  => 'a_disabled_text',
+                                    :visibility_typ => 'Type1'},
+              :instance_names    => %w(CustomButton_1 CustomButton_2),
+              :visibility_types  => %w(Type1 Type2),
+              :ansible_playbooks => [],
+              :current           => {}}
+      controller.instance_variable_set(:@edit, edit)
+      session[:edit] = edit
+      session[:resolve] = {}
+      post :automate_button_field_changed, :params => {:id => 'new', :instance_name => "Request"}
+      expect(assigns(:sb)[:active_tab]).to eq("ab_advanced_tab")
+    end
   end
 end


### PR DESCRIPTION
Custom Button Add/Edit - stay on the Advanced tab when changing the System/Process field


Links 
---------
https://bugzilla.redhat.com/show_bug.cgi?id=1501041

Steps for Testing/QA
-------------------------------
1.Go to Automation->Automate->Customization 
2.Add a new Button->Go to Advanced tab-> In Object Details  section
3.Change the System/Process type
