### PR TITLE
Fixed variable name

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1981,7 +1981,7 @@ class MiqAeClassController < ApplicationController
       @sb[:row_selected].each do |items|
         item = items.split('-')
         item = find_id_with_rbac(MiqAeInstance, item[1])
-        aeinstances.push(item[1])
+        aeinstances.push(item) if item
       end
     else
       node = x_node.split('-')
@@ -2008,7 +2008,7 @@ class MiqAeClassController < ApplicationController
       @sb[:row_selected].each do |items|
         item = items.split('-')
         item = find_id_with_rbac(MiqAeMethod, item[1])
-        aemethods.push(item[1])
+        aemethods.push(item) if item
       end
     else
       node = x_node.split('-')

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -958,4 +958,81 @@ describe MiqAeClassController do
       expect(tree_node).to eq(node_to_add)
     end
   end
+
+  context "#deleteinstances" do
+    before do
+      stub_user(:features => :all)
+      domain = FactoryGirl.create(:miq_ae_domain, :tenant => Tenant.seed)
+      @namespace = FactoryGirl.create(:miq_ae_namespace, :name => "foo_namespace", :parent => domain)
+      @ae_class = FactoryGirl.create(:miq_ae_class, :name => "foo_class", :namespace_id => @namespace.id)
+      controller.instance_variable_set(:@sb,
+                                       :trees       => {},
+                                       :active_tree => :ae_tree)
+      @instance = FactoryGirl.create(:miq_ae_instance, :name => "instance01", :class_id => @ae_class.id)
+      allow(controller).to receive(:replace_right_cell)
+    end
+
+    it "Should delete selected instance from details screen" do
+      controller.x_node = "aei-#{@instance.id}"
+      controller.instance_variable_set(:@_params,
+                                       :pressed => "miq_ae_instance_delete",
+                                       :id      => @instance.id)
+      controller.send(:deleteinstances)
+    end
+
+    it "Should delete selected instance in the list" do
+      controller.x_node = "aec-#{@ae_class.id}"
+      controller.instance_variable_set(:@_params,
+                                       :miq_grid_checks => "aei-#{@instance.id}",
+                                       :pressed         => "miq_ae_instance_delete",
+                                       :id              => @ae_class.id)
+      controller.send(:deleteinstances)
+    end
+
+    after(:each) do
+      flash_messages = assigns(:flash_array)
+      expect(flash_messages.first[:message]).to include("Automate Instance \"#{@instance.name}\": Delete successful")
+      expect(controller.x_node).to eq("aec-#{@ae_class.id}")
+    end
+  end
+
+  context "#deletemethods" do
+    before do
+      stub_user(:features => :all)
+      domain = FactoryGirl.create(:miq_ae_domain, :tenant => Tenant.seed)
+      @namespace = FactoryGirl.create(:miq_ae_namespace, :name => "foo_namespace", :parent => domain)
+      @ae_class = FactoryGirl.create(:miq_ae_class, :name => "foo_class", :namespace_id => @namespace.id)
+      controller.instance_variable_set(:@sb,
+                                       :trees       => {},
+                                       :active_tree => :ae_tree)
+      @method = FactoryGirl.create(:miq_ae_method, :name => "method01", :scope => "class",
+                                   :language => "ruby", :class_id => @ae_class.id, :data => "exit MIQ_OK", :location => "inline")
+      @method2 = FactoryGirl.create(:miq_ae_method, :name => "method012", :scope => "class",
+                                   :language => "ruby", :class_id => @ae_class.id, :data => "exit MIQ_OK", :location => "inline")
+      allow(controller).to receive(:replace_right_cell)
+    end
+
+    it "Should delete selected method from details screen" do
+      controller.x_node = "aem-#{@method.id}"
+      controller.instance_variable_set(:@_params,
+                                       :pressed => "miq_ae_method_delete",
+                                       :id      => @method.id)
+      controller.send(:deletemethods)
+    end
+
+    it "Should delete selected method in the list" do
+      controller.x_node = "aec-#{@ae_class.id}"
+      controller.instance_variable_set(:@_params,
+                                       :miq_grid_checks => "aem-#{@method.id},aem-#{@method2.id}",
+                                       :pressed         => "miq_ae_method_delete",
+                                       :id              => @ae_class.id)
+      controller.send(:deletemethods)
+    end
+
+    after(:each) do
+      flash_messages = assigns(:flash_array)
+      expect(flash_messages.first[:message]).to include("Automate Method \"#{@method.name}\": Delete successful")
+      expect(controller.x_node).to eq("aec-#{@ae_class.id}")
+    end
+  end
 end


### PR DESCRIPTION
- Fixed name of variable that is being pushed into aeinstances and aemethods arrays respectively. In both occurrences item[1] was being reset by item = find_xxx command.

- Added spec test to verify that both instance and method delete is successful from both list view and detail screens.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1532340

@mkanoor please test/review.