### PR TITLE
Fix typo in Container Provider Screen: 'Hakalur' to 'Hawkular'

### DIFF
--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -96,7 +96,7 @@ module EmsContainerHelper::TextualSummary
     endpoints_types = {
       :hawkular          => {
         :name => _("Metrics"),
-        :type => _("Hakular"),
+        :type => _("Hawkular"),
       },
       :prometheus        => {
         :name => _("Metrics"),


### PR DESCRIPTION
Fix typo in Container Provider Screen: 'Hakalur' to 'Hawkular'.
Screenshots:
Before:
![Before](https://user-images.githubusercontent.com/8366181/35482506-2e51c2ea-043f-11e8-9369-8b290c642b76.png)
After:
![After](https://user-images.githubusercontent.com/8366181/35482510-4adbe24c-043f-11e8-8da5-f8a520d8398c.png)
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1538948
cc: @yaacov @himdel 