### PR TITLE
Remove container statuses table from pod summary page

### DIFF
--- a/app/controllers/container_group_controller.rb
+++ b/app/controllers/container_group_controller.rb
@@ -15,7 +15,7 @@ class ContainerGroupController < ApplicationController
   def textual_group_list
     [
       %i(properties container_labels container_node_selectors volumes),
-      %i(relationships conditions smart_management container_statuses_summary)
+      %i(relationships conditions smart_management)
     ]
   end
   helper_method :textual_group_list

--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -123,22 +123,6 @@ module ContainerGroupHelper::TextualSummary
     TextualGroup.new(_("Container Statuses Summary"), %i(waiting running terminated))
   end
 
-  def container_statuses_summary
-    @container_statuses_summary ||= @record.container_states_summary
-  end
-
-  def textual_waiting
-    {:label => _('Waiting'), :value => container_statuses_summary[:waiting] || 0}
-  end
-
-  def textual_running
-    {:label => _('Running'), :value => container_statuses_summary[:running] || 0}
-  end
-
-  def textual_terminated
-    {:label => _('Terminated'), :value => container_statuses_summary[:terminated] || 0}
-  end
-
   def textual_compliance_history
     super(:title => _("Show Compliance History of this Replicator (Last 10 Checks)"))
   end


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1539370
This table usually doesnt help the user. In most cases its a constant `1/1 running containers` type of information.

Before:
![manageiq pods](https://user-images.githubusercontent.com/11256940/35504355-89124324-04eb-11e8-9f5d-b56a7ebd79ed.png)

After:
![screencapture-localhost-3000-container_group-show-16-1517219694413](https://user-images.githubusercontent.com/11256940/35504277-536b06a2-04eb-11e8-9b8c-a3a573cef95c.png)


@nimrodshn @yaacov Please review
cc @oourfali 

@miq-bot add_label compute/containers

