### PR TITLE
Add role(assert) check for cloud network in subnet new form

### DIFF
--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -45,6 +45,7 @@ class CloudSubnetController < ApplicationController
     assert_privileges("cloud_subnet_new")
     assert_privileges("ems_network_show_list")
     assert_privileges("cloud_tenant_show_list")
+    assert_privileges("cloud_network_show_list")
 
     @subnet = CloudSubnet.new
     @in_a_form = true

--- a/app/helpers/application_helper/button/cloud_subnet_new.rb
+++ b/app/helpers/application_helper/button/cloud_subnet_new.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Button::CloudSubnetNew < ApplicationHelper::Button::But
   end
 
   def role_allows_feature?
-    super && role_allows?(:feature => 'ems_network_show_list') && role_allows?(:feature => 'cloud_tenant_show_list')
+    super && role_allows?(:feature => 'ems_network_show_list') && role_allows?(:feature => 'cloud_tenant_show_list') && role_allows?(:feature => 'cloud_network_show_list')
   end
 
   # disable button if no active providers support create action

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -80,7 +80,7 @@ describe CloudSubnetController do
       bypass_rescue
 
       EvmSpecHelper.create_guid_miq_server_zone
-      EvmSpecHelper.seed_specific_product_features(%w(cloud_subnet_new ems_network_show_list))
+      EvmSpecHelper.seed_specific_product_features(%w(cloud_subnet_new ems_network_show_list cloud_network_show_list cloud_tenant_show_list))
 
       allow(User).to receive(:current_user).and_return(user)
       allow(Rbac).to receive(:role_allows?).and_call_original
@@ -93,6 +93,14 @@ describe CloudSubnetController do
 
     context "user don't have privilege for cloud tenants" do
       let(:feature) { MiqProductFeature.find_all_by_identifier(%w(cloud_subnet_new ems_network_show_list)) }
+
+      it "raises exception" do
+        expect { post :new, :params => { :button => "new", :format => :js } }.to raise_error(MiqException::RbacPrivilegeException)
+      end
+    end
+
+    context "user don't have privilege for cloud networks" do
+      let(:feature) { MiqProductFeature.find_all_by_identifier(%w(cloud_subnet_new ems_network_show_list cloud_tenant_show_list)) }
 
       it "raises exception" do
         expect { post :new, :params => { :button => "new", :format => :js } }.to raise_error(MiqException::RbacPrivilegeException)


### PR DESCRIPTION
Add role(assert) check for cloud network in subnet new form and for related toolbar.

User needs to have also `cloud_network_show_list` role feature to access this `new subnet screen`


# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1520651
This feature has been missed in https://github.com/ManageIQ/manageiq-ui-classic/pull/3165/commits/d68cd786a2b63d5915147c9761fcc08d4dfcc01d

# Reproducer

Networks -> Subnet -> add new (it can be hidden if user don't have permission)
cc @mzazrivec @himdel 
@miq-bot assign @martinpovolny 
@miq-bot add_label bug, blocker 


