### PR TITLE
Fix broken tagging in Datastores and My Services page

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -13,7 +13,7 @@ module ApplicationController::AdvancedSearch
   def adv_search_build(model)
     # Restore @edit hash if it's saved in @settings
     @expkey = :expression # Reset to use default expression key
-    if session.fetch_path(:adv_search, model.to_s)
+    if session.fetch_path(:adv_search, model.to_s) && %w(tag service_tag).exclude?(@sb[:action])
       adv_search_model = session[:adv_search][model.to_s]
       @edit ||= copy_hash(adv_search_model[@expkey] ? adv_search_model : session[:edit])
       adv_search_clear_default_search_if_cant_be_seen

--- a/spec/controllers/application_controller/advanced_search_spec.rb
+++ b/spec/controllers/application_controller/advanced_search_spec.rb
@@ -1,11 +1,11 @@
 describe ProviderForemanController, "::AdvancedSearch" do
-  before :each do
+  before do
     stub_user(:features => :all)
     controller.instance_variable_set(:@sb, {})
   end
 
   describe "#adv_search_redraw_left_div" do
-    before :each do
+    before do
       controller.instance_variable_set(:@sb, :active_tree => :configuration_manager_cs_filter_tree)
     end
 
@@ -14,6 +14,48 @@ describe ProviderForemanController, "::AdvancedSearch" do
 
       expect(controller).to receive(:build_configuration_manager_cs_filter_tree).once
       controller.send(:adv_search_redraw_left_div)
+    end
+  end
+end
+
+describe StorageController, "::AdvancedSearch" do
+  describe '#adv_search_build' do
+    let(:edit) { nil }
+    let(:model) { "Storage" }
+    let(:s) { {} }
+    let(:sandbox) { {} }
+
+    before do
+      allow(controller).to receive(:exp_build_table).and_call_original
+      allow(controller).to receive(:session).and_return(s)
+
+      controller.instance_variable_set(:@edit, edit)
+      controller.instance_variable_set(:@expkey, {})
+      controller.instance_variable_set(:@sb, sandbox)
+    end
+
+    subject { controller.instance_variable_get(:@edit)[controller.instance_variable_get(:@expkey)][:exp_table] }
+
+    context 'when session[:adv_search] is set, after using Advanced Search' do
+      let(:expr) { ApplicationController::Filter::Expression.new.tap { |e| e.expression = {"???" => "???"} } }
+      let(:s) { {:adv_search => {model => {:expression => expr}}} }
+
+      context 'tagging action' do
+        let(:edit) { {:new => {}} }
+        let(:sandbox) { {:action => "tag"} }
+
+        it 'sets @edit[@expkey] properly' do
+          controller.send(:adv_search_build, model)
+          expect(subject).not_to be_nil
+        end
+      end
+
+      context 'not tagging action' do
+        it 'sets @edit[@expkey] properly' do
+          controller.send(:adv_search_build, model)
+          expect(subject).not_to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**Fixes:** 
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1539614
Issue with more info: https://github.com/ManageIQ/manageiq-ui-classic/issues/3325

Fix broken tagging in _Compute -> Infrastructure -> Datastores_ which breaks after working with filters or Adv search because of wrong setting of `@edit`. The same for _My Services_ page.

---

**Before:**
![datastore_error](https://user-images.githubusercontent.com/13417815/35520403-396715da-0517-11e8-977e-252e58acea13.png)
```
I, [2018-01-29T17:04:55.688793 #12007]  INFO -- : Started POST "/storage/report_data" for ::1 at 2018-01-29 17:04:55 +0100
I, [2018-01-29T17:04:55.717036 #12007]  INFO -- : Processing by StorageController#report_data as HTML
I, [2018-01-29T17:04:55.717226 #12007]  INFO -- :   Parameters: {"model_name"=>"Storage", "model"=>"Storage", "active_tree"=>"storage_tree", "explorer"=>true, "records[]"=>[10000000000005], "records"=>[10000000000005], "additional_options"=>{"named_scope"=>nil, "gtl_dbname"=>nil, "model"=>"Storage", "match_via_descendants"=>nil, "parent_id"=>nil, "parent_class_name"=>nil, "parent_method"=>nil, "association"=>nil, "view_suffix"=>nil, "row_button"=>nil, "menu_click"=>nil, "sb_controller"=>nil, "listicon"=>nil, "embedded"=>nil, "showlinks"=>true, "policy_sim"=>nil, "in_a_form"=>nil, "lastaction"=>"show_list", "display"=>nil, "gtl_type"=>"grid", "supported_features_filter"=>nil, "clickable"=>nil}, "storage"=>{}}
F, [2018-01-29T17:04:55.729127 #12007] FATAL -- : Error caught: [NoMethodError] undefined method `[]' for nil:NilClass
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/advanced_search.rb:37:in `adv_search_build'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller.rb:1460:in `get_view'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller.rb:457:in `report_data'
```

**After:**
![datastore_edit_tags](https://user-images.githubusercontent.com/13417815/35520506-814f5d8a-0517-11e8-9ba0-b7e5e434afff.png)
