### PR TITLE
Fix tagging Instances

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -40,6 +40,10 @@ class CloudNetworkController < ApplicationController
     when "custom_button"
       custom_buttons
       return
+    when "instance_tag"
+      return tag("VmOrTemplate")
+    when "network_router_tag"
+      return tag("NetworkRouter")
     end
   end
 

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -22,8 +22,12 @@ class NetworkRouterController < ApplicationController
     @refresh_div = "main_div"
 
     case params[:pressed]
+    when "cloud_subnet_tag"
+      return tag("CloudSubnet")
     when "custom_button"
       custom_buttons
+    when "instance_tag"
+      return tag("VmOrTemplate")
     when "network_router_add_interface"
       javascript_redirect(:action => "add_interface_select", :id => checked_item_id)
     when "network_router_delete"

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -20,21 +20,22 @@ class NetworkRouterController < ApplicationController
     params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
 
     @refresh_div = "main_div"
-    return tag("NetworkRouter") if params[:pressed] == "network_router_tag"
-    delete_network_routers if params[:pressed] == 'network_router_delete'
 
-    if params[:pressed] == "network_router_edit"
-      javascript_redirect :action => "edit", :id => checked_item_id
-    elsif params[:pressed] == "network_router_new"
-      javascript_redirect :action => "new"
-    elsif params[:pressed] == "custom_button"
+    case params[:pressed]
+    when "custom_button"
       custom_buttons
-    elsif params[:pressed] == "network_router_add_interface"
-      javascript_redirect :action => "add_interface_select", :id => checked_item_id
-    elsif params[:pressed] == "network_router_remove_interface"
-      javascript_redirect :action => "remove_interface_select", :id => checked_item_id
-    elsif !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
-      replace_gtl_main_div
+    when "network_router_add_interface"
+      javascript_redirect(:action => "add_interface_select", :id => checked_item_id)
+    when "network_router_delete"
+      delete_network_routers
+    when "network_router_edit"
+      javascript_redirect(:action => "edit", :id => checked_item_id)
+    when "network_router_new"
+      javascript_redirect(:action => "new")
+    when "network_router_remove_interface"
+      javascript_redirect(:action => "remove_interface_select", :id => checked_item_id)
+    when "network_router_tag"
+      return tag("NetworkRouter")
     else
       render_flash
     end

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -23,9 +23,13 @@ class SecurityGroupController < ApplicationController
     @refresh_div = "main_div"
 
     case params[:pressed]
+    when "instance_tag"
+      return tag("VmOrTemplate")
+    when "network_port_tag"
+      return tag("NetworkPort")
     when "security_group_tag"
       return tag("SecurityGroup")
-    when 'security_group_delete'
+    when "security_group_delete"
       delete_security_groups
     when "security_group_edit"
       javascript_redirect :action => "edit", :id => checked_item_id(params)

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -212,4 +212,28 @@ describe CloudNetworkController do
       end
     end
   end
+
+  describe '#button' do
+    before do
+      controller.instance_variable_set(:@_params, params)
+    end
+
+    context 'tagging instances from a list of instances, accessed from the details page of a network' do
+      let(:params) { {:pressed => "instance_tag"} }
+
+      it 'calls tag method for tagging instances' do
+        expect(controller).to receive(:tag).with("VmOrTemplate")
+        controller.send(:button)
+      end
+    end
+
+    context 'tagging network routers from a list of routers, accessed from the details page of a network' do
+      let(:params) { {:pressed => "network_router_tag"} }
+
+      it 'calls tag method for tagging network routers' do
+        expect(controller).to receive(:tag).with("NetworkRouter")
+        controller.send(:button)
+      end
+    end
+  end
 end

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -307,4 +307,28 @@ describe NetworkRouterController do
       end
     end
   end
+
+  describe '#button' do
+    before do
+      controller.instance_variable_set(:@_params, params)
+    end
+
+    context 'tagging instances from a list of instances, accessed from the details page of a network router' do
+      let(:params) { {:pressed => "instance_tag"} }
+
+      it 'calls tag method for tagging instances' do
+        expect(controller).to receive(:tag).with("VmOrTemplate")
+        controller.send(:button)
+      end
+    end
+
+    context 'tagging cloud subnets from a list of subnets, accessed from the details page of a network router' do
+      let(:params) { {:pressed => "cloud_subnet_tag"} }
+
+      it 'calls tag method for tagging cloud subnets' do
+        expect(controller).to receive(:tag).with("CloudSubnet")
+        controller.send(:button)
+      end
+    end
+  end
 end

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -204,4 +204,28 @@ describe SecurityGroupController do
       end
     end
   end
+
+  describe '#button' do
+    before do
+      controller.instance_variable_set(:@_params, params)
+    end
+
+    context 'tagging instances from their list, accessed from the details page of a security group' do
+      let(:params) { {:pressed => "instance_tag"} }
+
+      it 'calls tag method for tagging instances' do
+        expect(controller).to receive(:tag).with("VmOrTemplate")
+        controller.send(:button)
+      end
+    end
+
+    context 'tagging network ports from their list, accessed from the details page of a security group' do
+      let(:params) { {:pressed => "network_port_tag"} }
+
+      it 'calls tag method for tagging network ports' do
+        expect(controller).to receive(:tag).with("NetworkPort")
+        controller.send(:button)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1539584

Fix **_tagging_** **Instances/Network Routers** from their list, accessed through _Networks -> Networks_, opening some network details page and clicking on _Instances/Network Routers_ under _Relationships_ table.

Fix tagging I**nstances/Cloud Subnets** from their list, accessed through _Networks -> Network Routers_, opening network router details page and clicking on _Instances/Cloud Subnets_ under _Relationships_ table.

Fix tagging **Instances/Network Ports** from their list, accessed through _Networks -> Security Groups_, opening security group details page and clicking on _Instances/Network Ports_ under _Relationships_ table.

The spec tests for the fixes above are also added in separate commits.

---

Accessing Instances/Network Routers list from some network details page:
![network_instances](https://user-images.githubusercontent.com/13417815/35566481-dc7cc1b6-05c1-11e8-9dec-7b8b138e8bf8.png)

Tagging some instance:
![instance_tagging](https://user-images.githubusercontent.com/13417815/35566607-3f860cd6-05c2-11e8-8008-6c3e6d63f53d.png)

**Before:**(nothing has happened after clicking on _Edit Tags_)
![instance_tagging_before](https://user-images.githubusercontent.com/13417815/35566799-f7d04ce8-05c2-11e8-9632-ba00b47d989e.png)

**After:**(tagging page has opened and it is possible to tag the instance)
![instance_tagging_after](https://user-images.githubusercontent.com/13417815/35566652-72f95d7a-05c2-11e8-965d-f40a87b38825.png)
