### PR TITLE
Fix for available expression fields for groups

### DIFF
--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -54,8 +54,11 @@
           - unless @edit[@expkey].tags_for_display_filters.empty?
             - opts.push([_('Tag'), 'tag'])
         - when 'MiqGroup'
-          - opts = [[_('Tag'), 'tags']]
-          - @edit[@expkey][:exp_typ] = 'tags'
+          - if @expkey == :filter_expression
+            - opts = [[_('Tag'), 'tags']]
+            - @edit[@expkey][:exp_typ] = 'tags'
+          -else
+            - opts += exptypes
         - else
           - opts += exptypes
 

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -57,7 +57,7 @@
           - if @expkey == :filter_expression
             - opts = [[_('Tag'), 'tags']]
             - @edit[@expkey][:exp_typ] = 'tags'
-          -else
+          - else
             - opts += exptypes
         - else
           - opts += exptypes

--- a/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
@@ -97,5 +97,40 @@ describe MiqAeCustomizationController do
       post :automate_button_field_changed, :params => {:id => 'new', :instance_name => "Request"}
       expect(assigns(:sb)[:active_tab]).to eq("ab_advanced_tab")
     end
+
+    it "uses available expression fields when editing the custom buttons expressions" do
+      allow(MiqAeClass).to receive_messages(:find_distinct_instances_across_domains => [double(:name => "foo")])
+
+      e_exp = MiqExpression.new("=" => {:field => "MiqGroup.name", :value => "TestEnablementExpression"}, :token => 1)
+
+      @sb = {:active_tree => :ab_tree,
+             :trees       => {:ab_tree => {:tree => :ab_tree}},
+             :params      => {:instance_name => 'CustomButton_1'}}
+      controller.instance_variable_set(:@sb, @sb)
+      controller.instance_variable_set(:@breadcrumbs, [])
+
+      edit = {:new               => {:button_images         => %w(01 02 03), :available_dialogs => {:id => '01', :name => '02'},
+                                     :instance_name         => 'CustomButton_1',
+                                     :attrs                 => [%w(Attr1 01), %w(Attr2 02), %w(Attr3 03), %w(Attr4 04), %w(Attr5 05)],
+                                     :enablement_expression => e_exp.exp},
+              :instance_names    => %w(CustomButton_1 CustomButton_2),
+              :exp_key           => 'foo',
+              :ansible_playbooks => [],
+              :current           => {}}
+      edit[:enablement_expression] ||= ApplicationController::Filter::Expression.new
+      edit[:enablement_expression][:expression] = {:test => "foo", :token => 1}
+      edit[:new][:enablement_expression] = copy_hash(edit[:enablement_expression][:expression])
+      edit[:enablement_expression].history.reset(edit[:enablement_expression][:expression])
+      controller.instance_variable_set(:@edit, edit)
+      controller.instance_variable_set(:@expkey, :enablement_expression)
+      edit[:enablement_expression][:exp_table] = controller.send(:exp_build_table, edit[:enablement_expression][:expression])
+      edit[:enablement_expression][:exp_model] = 'MiqGroup'
+      session[:edit] = edit
+      session[:expkey] = :enablement_expression
+      controller.instance_variable_set(:@edit, edit)
+      post :exp_token_pressed, :params => {:id => 'new', :token => 1}
+      @edit = controller.instance_variable_get(:@edit)
+      expect(@edit[:enablement_expression][:exp_typ]).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Fixes the expression editor for Group Custom buttons and Group enablement Expression

Links
-----------
https://bugzilla.redhat.com/show_bug.cgi?id=1535063

Steps for Testing/QA
-----------------------------
 - Add a custom button for a Group. The enablement expression will only allow the selection of tags without this PR.
-  With a Group custom button with an enablement expression added, an error occurs when selecting a group in Configuration->Access control


Before:

![screenshot from 2018-01-30 16-37-40](https://user-images.githubusercontent.com/12769982/35592810-2a5d09ee-05dc-11e8-93ae-dfa4e2df3eff.png)

After:
![screenshot from 2018-01-30 16-40-54](https://user-images.githubusercontent.com/12769982/35592877-5c768946-05dc-11e8-9997-22c331f75270.png)

