### PR TITLE
Fix Nuage provider update

### DIFF
--- a/app/controllers/ems_network_controller.rb
+++ b/app/controllers/ems_network_controller.rb
@@ -19,8 +19,7 @@ class EmsNetworkController < ApplicationController
   end
 
   def ems_path(*args)
-    path_hash = {:action => 'show', :id => args[0].id.to_s }
-    path_hash.merge(args[1])
+    ems_network_path(*args)
   end
 
   def new_ems_path

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -713,8 +713,9 @@ module Mixins
     end
 
     def retrieve_event_stream_selection
-      return "amqp" if @ems.connection_configurations.ceilometer.try(:endpoint).nil? && @ems.connection_configurations.amqp.try(:endpoint)
-      "ceilometer"
+      return 'amqp' if @ems.connection_configurations.amqp&.endpoint&.hostname&.present?
+      return 'ceilometer' if @ems.connection_configurations.ceilometer&.endpoint&.hostname&.present?
+      @ems.kind_of?(ManageIQ::Providers::Openstack::CloudManager) || @ems.kind_of?(ManageIQ::Providers::Openstack::InfraManager) ? 'ceilometer' : 'none'
     end
 
     def construct_edit_for_audit(ems)

--- a/spec/controllers/mixins/ems_common_angular_spec.rb
+++ b/spec/controllers/mixins/ems_common_angular_spec.rb
@@ -1,0 +1,57 @@
+describe Mixins::EmsCommonAngular do
+  context '.retrieve_event_stream_selection' do
+    let(:network_controller) { EmsNetworkController.new }
+    let(:ems_nuage) { FactoryGirl.create(:ems_nuage_network_with_authentication) }
+    let(:ems_openstack) { FactoryGirl.create(:ems_openstack_with_authentication) }
+
+    it 'when amqp' do
+      ems_nuage.endpoints << Endpoint.create(:role => 'amqp', :hostname => 'hostname')
+      network_controller.instance_variable_set(:@ems, ems_nuage)
+
+      expect(network_controller.send(:retrieve_event_stream_selection)).to eq('amqp')
+    end
+
+    it 'when ceilometer' do
+      ems_openstack.endpoints << Endpoint.create(:role => 'ceilometer', :hostname => 'hostname')
+      network_controller.instance_variable_set(:@ems, ems_openstack)
+
+      expect(network_controller.send(:retrieve_event_stream_selection)).to eq('ceilometer')
+    end
+
+    it 'when ceilometer and amqp has empty hostname' do
+      ems_nuage.endpoints << Endpoint.create(:role => 'ceilometer', :hostname => 'hostname')
+      ems_nuage.endpoints << Endpoint.create(:role => 'amqp')
+      network_controller.instance_variable_set(:@ems, ems_nuage)
+
+      expect(network_controller.send(:retrieve_event_stream_selection)).to eq('ceilometer')
+    end
+
+    it 'when amqp and ceilometer has empty hostname' do
+      ems_nuage.endpoints << Endpoint.create(:role => 'ceilometer')
+      ems_nuage.endpoints << Endpoint.create(:role => 'amqp', :hostname => 'hostname')
+      network_controller.instance_variable_set(:@ems, ems_nuage)
+
+      expect(network_controller.send(:retrieve_event_stream_selection)).to eq('amqp')
+    end
+
+    it 'none when amqp and ceilometer have empty hostnames' do
+      ems_nuage.endpoints << Endpoint.create(:role => 'ceilometer')
+      ems_nuage.endpoints << Endpoint.create(:role => 'amqp')
+      network_controller.instance_variable_set(:@ems, ems_nuage)
+
+      expect(network_controller.send(:retrieve_event_stream_selection)).to eq('none')
+    end
+
+    it 'ceilometer when openstack provider when amqp and ceilometer have nil endpoints' do
+      network_controller.instance_variable_set(:@ems, ems_openstack)
+
+      expect(network_controller.send(:retrieve_event_stream_selection)).to eq('ceilometer')
+    end
+
+    it 'when none' do
+      network_controller.instance_variable_set(:@ems, ems_nuage)
+
+      expect(network_controller.send(:retrieve_event_stream_selection)).to eq('none')
+    end
+  end
+end


### PR DESCRIPTION
There were two problems when editing Nuage network provider. If
network that you edited had no event, there would still be AMQP
selected under the Events tab. That made Save button disabled
since hostname must not be empty and everything has to be verified.
Now None is selected in case of no event.
The second problem was that when a network was updated error occurred
while redirecting, since you would only get one argument and
`ems_path` required two. Now `ems_path` works same as
in the cloud provider controller.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1534457
