### PR TITLE
Use correct role feature check for block|object storage summary page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1206,8 +1206,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def handle_generic_rbac
-    pass = check_generic_rbac
+  def handle_generic_rbac(pass)
     unless pass
       if request.xml_http_request?
         javascript_redirect :controller => 'dashboard', :action => 'auth_error'
@@ -1228,7 +1227,7 @@ class ApplicationController < ActionController::Base
 
     return if action_name == 'auth_error'
 
-    pass = %w(button x_button).include?(action_name) ? handle_button_rbac : handle_generic_rbac
+    pass = %w(button x_button).include?(action_name) ? handle_button_rbac : handle_generic_rbac(check_generic_rbac)
     $audit_log.failure("Username [#{current_userid}], Role ID [#{current_user.miq_user_role.try(:id)}] attempted to access area [#{controller_name}], type [Action], task [#{action_name}]") unless pass
   end
 

--- a/app/controllers/ems_storage_controller.rb
+++ b/app/controllers/ems_storage_controller.rb
@@ -31,6 +31,37 @@ class EmsStorageController < ApplicationController
     ems_form_fields
   end
 
+  TYPE_CHECK_SHOW_IDENTIFIERS = %w(ems_storage_show).freeze
+
+  def check_generic_rbac
+    ident = "#{controller_name}_#{action_name == 'report_data' ? 'show_list' : action_name}"
+    return true if TYPE_CHECK_SHOW_IDENTIFIERS.include?(ident)
+
+    super
+  end
+
+  def type_feature_role_check
+    return true unless TYPE_CHECK_SHOW_IDENTIFIERS.include?("#{controller_name}_#{action_name}") && respond_to?(:feature_role)
+
+    handle_generic_rbac(role_allows?(:feature => feature_role(@record)))
+  end
+
+  def init_show(model_class = self.class.model)
+    @record = identify_record(params[:id], model_class)
+
+    return true unless type_feature_role_check
+
+    super
+  end
+
+  def feature_role(record)
+    if record.supports_object_storage?
+      'ems_object_storage_show'
+    elsif record.supports_block_storage?
+      'ems_block_storage_show'
+    end
+  end
+
   menu_section :sto
   has_custom_buttons
 end

--- a/spec/controllers/ems_storage_controller_spec.rb
+++ b/spec/controllers/ems_storage_controller_spec.rb
@@ -2,4 +2,35 @@ describe EmsStorageController do
   include_examples :shared_examples_for_ems_storage_controller, %w(openstack)
 
   it_behaves_like "controller with custom buttons"
+
+  describe "#check_generic_rbac" do
+    let(:feature)        { MiqProductFeature.find_all_by_identifier(%w(ems_block_storage_show ems_block_storage_show_list)) }
+    let(:role)           { FactoryGirl.create(:miq_user_role, :miq_product_features => feature) }
+    let(:group)          { FactoryGirl.create(:miq_group, :miq_user_role => role) }
+    let(:user)           { FactoryGirl.create(:user, :miq_groups => [group]) }
+    let(:object_storage) { FactoryGirl.create(:ems_swift) }
+    let(:block_storage)  { FactoryGirl.create(:ems_cinder) }
+
+    before(:each) do
+      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.seed_specific_product_features(%w(ems_block_storage_show ems_block_storage_show_list))
+
+      allow(User).to receive(:current_user).and_return(user)
+      allow(Rbac).to receive(:role_allows?).and_call_original
+      login_as user
+    end
+
+    it "allows access for block_storage" do
+      controller.action_name = 'show'
+      controller.instance_variable_set(:@record, block_storage)
+      expect(controller.send(:type_feature_role_check)).to be_truthy
+    end
+
+    it "denies access for object_storage" do
+      controller.action_name = 'show'
+      allow(controller).to receive(:redirect_to)
+      controller.instance_variable_set(:@record, object_storage)
+      expect(controller.send(:type_feature_role_check)).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
User correct role feature check for block|object storage summary page
For summary page of storage manager is used ems_storage controller.
And it fails with automatic inheritance feature role for block and object
storage manager.

This change consider feature role regard to type(block, storage) of manager.
So if user is going on block storage manager summary page
ems_block_storage_show feature role is checked
instead of ems_storage_show.


## Reproducer
I have user with this role
<img width="891" alt="screen shot 2018-02-15 at 16 12 42" src="https://user-images.githubusercontent.com/14937244/36263840-670b614c-126b-11e8-9ead-2967c5bfeaee.png">
but I can't access the storage provider

![smgl306xql](https://user-images.githubusercontent.com/14937244/36264009-e34c5b58-126b-11e8-85c8-d6be746110db.gif)

## What I think.
I think that there should be block|storage related controllers like -  ems_block_storage_controller **also for summary page.** Then we can inherit automatically role check.

@miq-bot add_label bug

@miq-bot assign @martinpovolny 
cc @himdel 

# Links

https://bugzilla.redhat.com/show_bug.cgi?id=1538003
