### PR TITLE
Taking back a change of 'vm_clone' toolbar button class

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -605,6 +605,12 @@ module ApplicationController::CiProcessing
   #   operation   - a block with a operation, specific to the type of action
   #                 on a record
   #   options     - other optional parameters
+  #               - :redirect => :controller
+  #                           => :action
+  #                 :refresh_partial
+  #                 used by #screen_redirection
+  #               - :specific_requirements
+  #                 used by #specific_requirements_fullfiled?
   def generic_button_operation(action, action_name, operation, options = {})
     records = find_records_with_rbac(get_rec_cls, checked_or_params)
     if (testable_action?(action) && !records_support_feature?(records, action_to_feature(action))) ||

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -383,12 +383,32 @@ module ApplicationController::CiProcessing
   # Import info for all selected or single displayed vm(s)
   def scanvms
     assert_privileges(params[:pressed])
-    generic_button_operation('scan', _('Analysis'), vm_button_action)
+    generic_button_operation('scan', _('Analysis'), vm_button_action,
+                             :specific_requirements => :scanvms_vmware_requirements?)
   end
   alias_method :image_scan, :scanvms
   alias_method :instance_scan, :scanvms
   alias_method :vm_scan, :scanvms
   alias_method :miq_template_scan, :scanvms
+
+  # Method tests requirements specific for Vmware provider.
+  #
+  # All the selected records are tested whether they are an instance of
+  # VMWare provider and fullfill the requirements for SmartState Analysis
+  # (tested by method #has_active_proxy?).
+  #
+  # Params:
+  #   records - records selected for SmartState Analysis
+  # Returns:
+  #   boolean - true, if all the records are instances of VMware provider and
+  #             fullfill the requirements or are instances of any other
+  #             provider
+  #           - false otherwise
+  def scanvms_vmware_requirements?(records)
+    records.all? do |record|
+      !record.instance_of?(ManageIQ::Providers::Vmware::InfraManager::Vm) || record.has_active_proxy?
+    end
+  end
 
   # Immediately retire items
   def retirevms_now

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -607,7 +607,8 @@ module ApplicationController::CiProcessing
   #   options     - other optional parameters
   def generic_button_operation(action, action_name, operation, options = {})
     records = find_records_with_rbac(get_rec_cls, checked_or_params)
-    if testable_action(action) && !records_support_feature?(records, action_to_feature(action))
+    if (testable_action?(action) && !records_support_feature?(records, action_to_feature(action))) ||
+       !specific_requirements_fullfiled?(records, options[:specific_requirements])
       javascript_flash(
         :text       => _("%{action_name} action does not apply to selected items") % {:action_name => action_name},
         :severity   => :error,
@@ -618,6 +619,21 @@ module ApplicationController::CiProcessing
     operation.call(records.map(&:id), action, action_name)
     @single_delete = action == 'destroy' && !flash_errors?
     screen_redirection(options)
+  end
+
+  # Tests requirements specific for different providers that are not
+  # tested by SupportsFeatureMixin
+  #
+  # Params:
+  #   records             - selected records
+  #   requirements_method - symbol with a name of the method to be ran
+  # Returns:
+  #   boolean - true, if all the requirements are fullfilled (called method returns
+  #             true as well) or no requirements method is specified
+  #           - false if the requirements are not fullfilled
+  def specific_requirements_fullfiled?(records, requirements_method)
+    return true if requirements_method.nil?
+    method(requirements_method).call(records)
   end
 
   # Some of the tasks are not testable by SupportsFeatureMixin
@@ -632,7 +648,7 @@ module ApplicationController::CiProcessing
   #   boolean - true, if the action should not skip the test for records
   #             support for the action
   #           - false otherwise
-  def testable_action(action)
+  def testable_action?(action)
     controller = params[:controller]
     vm_infra_untestable_actions = %w(
       reboot_guest stop start check_compliance_queue destroy

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -179,7 +179,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1",
-          :klass        => ApplicationHelper::Button::BasicImage),
+          :klass        => ApplicationHelper::Button::VmInstanceTemplateScan),
         button(
           :vm_publish,
           'pficon pficon-export fa-lg',


### PR DESCRIPTION
In this PR I'm trying to fix the error described in BZ https://bugzilla.redhat.com/show_bug.cgi?id=1537989. 

I'd need someone, who knows the background for the BZ more than I do, to take a look, if the change really fixes the issue.

It **doesn't** seem right to me, that the suggested change could fix the issue. The toolbar button class is used only to decide, whether the button should be **visible** or **disabled**. From the BZ description, it doesn't look like there would be a problem with the button's visibility.

---

Just to mention, the button's class is not the same as at the time of the change, but basically should work the same.

At the time of commit 2f82941d7fd4cb58a145d2b1f9b919825a80969c, the method deciding the buttons visibility looked like this:

  ```ruby
  def skip? # (not displayed -> not visible)
    return false if @record.kind_of?(OrchestrationStack) && @display == "instances"
    !(@record.is_available?(:smartstate_analysis) ||
      @record.is_available_now_error_message(:smartstate_analysis)) ||
    !@record.has_proxy?
  end
  ```

Now, it does pretty much the same, so if the bug is really in the button's class, the fix should be correct:

  ```ruby
  def visible?
    @record.supports?(:smartstate_analysis) && @record.has_proxy?
  end
  ```

---

Links
----------------

* BZ ticket: https://bugzilla.redhat.com/show_bug.cgi?id=1537989
* Suggested mistake https://github.com/ManageIQ/manageiq-ui-classic/commit/2f82941d7fd4cb58a145d2b1f9b919825a80969c#diff-2c30213bb5a34102bc5f4c35680fdda1R159
* `vm_instance_scan` class at the time of change https://github.com/ManageIQ/manageiq-ui-classic/blob/2f82941d7fd4cb58a145d2b1f9b919825a80969c/app/helpers/application_helper/button/vm_instance_scan.rb

Steps for Testing/QA
-------------------------------

I've tried to watch the `evm.log` for the error described in the BZ:

```log
    Could not open library 'vixDiskLib.so.6.5.0': vixDiskLib.so.6.5.0: cannot open shared object file: No such file or directory.

<...ommitting other vixDiskLib versions checked and not found...>
```

but the only error messages I've received were these:

```log
• ~/devel/manageiq/ master tail -f log/evm.log | egrep 'ERROR|FATAL|vixDiskLib' --color

[----] E, [2018-01-30T19:45:46.077672 #7546:2aabc7cb0f78] ERROR -- : MIQ(ManageIQ::Providers::Vmware::InfraManager::Provision#provision_error) [[Handsoap::Fault]: Handsoap::Fault { :code => 'ServerFaultCode', :reason => 'Cannot complete login due to an incorrect user name or password.' }] encountered during phase [start_clone_task]
[----] E, [2018-01-30T19:45:46.077733 #7546:2aabc7cb0f78] ERROR -- : /home/rblanco/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/handsoap-b1247a733ca3/lib/handsoap/service.rb:217:in `on_fault'
[----] E, [2018-01-30T19:45:57.008989 #7546:2aabc7cb0f78] ERROR -- : MIQ(MiqAeEngine.deliver) Error delivering {"request"=>"vm_provision"} for object [ManageIQ::Providers::Vmware::InfraManager::Provision.10000000001156] with state [CheckProvisioned] to Automate:
```

but I might not have everything setup correctly to test this.

@h-kataria @jerryk55, please take a look