### PR TITLE
Sort tag by descriptions not by name

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -192,7 +192,7 @@ module ApplicationController::Tags
   def tag_edit_build_screen
     @showlinks = true
 
-    cats = Classification.categories.select(&:show).sort_by(&:name) # Get the categories, sort by name
+    cats = Classification.categories.select(&:show).sort_by(&:description) # Get the categories, sort by description
     @categories = {}    # Classifications array for first chooser
     cats.delete_if { |c| c.read_only? || c.entries.length == 0 }  # Remove categories that are read only or have no entries
     cats.each do |c|
@@ -214,7 +214,7 @@ module ApplicationController::Tags
     end
 
     # Set to first category, if not already set
-    @edit[:cat] ||= cats.min_by(&:name)
+    @edit[:cat] ||= cats.min_by(&:description)
 
     unless @object_ids.blank?
       @tagitems = @tagging.constantize.where(:id => @object_ids).sort_by { |t| t.name.try(:downcase).to_s }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1517285

Tags are always sorted by `:description`.

Have a Tag that has `:description` that will be the first one in Tags but `:name` that will be not.

Before:
<img width="887" alt="screen shot 2018-01-31 at 9 42 51 am" src="https://user-images.githubusercontent.com/9210860/35613044-2437029c-066b-11e8-87cd-92b1bd975ab4.png">

After:
<img width="884" alt="screen shot 2018-01-31 at 9 40 55 am" src="https://user-images.githubusercontent.com/9210860/35613050-2743d17c-066b-11e8-8240-8e3e2c84eb45.png">

@miq-bot add_label bug, tagging, gaprindashvili/yes
