### PR TITLE
Disable cloud network editing and deletion for list view.

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud_networks_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_networks_center.rb
@@ -15,27 +15,6 @@ class ApplicationHelper::Toolbar::CloudNetworksCenter < ApplicationHelper::Toolb
             t,
             :klass => ApplicationHelper::Button::CloudNetworkNew
           ),
-          separator,
-          button(
-            :cloud_network_edit,
-            'pficon pficon-edit fa-lg',
-            t = N_('Edit selected Cloud Network'),
-            t,
-            :url_parms    => 'main_div',
-            :enabled      => false,
-            :onwhen       => '1',
-            :send_checked => true
-          ),
-          button(
-            :cloud_network_delete,
-            'pficon pficon-delete fa-lg',
-            t = N_('Delete selected Cloud Networks'),
-            t,
-            :url_parms => 'main_div',
-            :send_checked => true,
-            :confirm   => N_('Warning: The selected Cloud Networks and ALL of their components will be removed!'),
-            :enabled   => false,
-            :onwhen    => '1+')
         ]
       )
     ]


### PR DESCRIPTION
Network editing is only implemented for OpenStack. So it needs to be
disabled for the general case.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1539723


@miq-bot add_label gaprindashvili/yes
@miq-bot add_label bug
@miq-bot add_label networks