### PR TITLE
Add  to providers for toolbar and use it to resolve promise from toolbarClick

### DIFF
--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -126,7 +126,7 @@
           }
 
           sendDataWithRx({toolbarEvent: 'itemClicked'});
-          miqToolbarOnClick.bind($event.delegateTarget)($event).then(function(data) {
+          Promise.resolve(miqToolbarOnClick.bind($event.delegateTarget)($event)).then(function(data) {
             sendDataWithRx({type: 'TOOLBAR_CLICK_FINISH', payload: data});
           });
         };


### PR DESCRIPTION
### Fixes #3348 
When clicking on toolbar items which does not return promise UI console would throw error which was silenced with reload of page. This PR wrap return object in `$q.resolve()` which works for checking if the return value of `miqToolbarOnClick` is really promise like object. If not, `TOOLBAR_CLICK_FINISH` is still sent from toolbarController (it will be sent emediately no need to wait for promise reolve).

### UI changes
none
