### PR TITLE
Fix Reset button when tagging vms, templates, instances, images

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -7,6 +7,7 @@ module ApplicationController::Tags
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
     @tagging = session[:tag_db] = params[:db] ? params[:db] : db if params[:db] || db
+    @tagging ||= session[:tag_db] if session[:tag_db]
     case params[:button]
     when "cancel"
       tagging_edit_tags_cancel

--- a/spec/controllers/application_controller/tags_spec.rb
+++ b/spec/controllers/application_controller/tags_spec.rb
@@ -85,4 +85,30 @@ describe ApplicationController do
         .to eq(convert_to_region_id(assigns(:entries)['Bishop']))
     end
   end
+
+  describe '#tagging_edit' do
+    let(:params) { nil }
+    let(:s) { nil }
+
+    before do
+      allow(controller).to receive(:assert_privileges)
+      allow(controller).to receive(:session).and_return(s)
+
+      controller.instance_variable_set(:@_params, params)
+    end
+
+    context 'resetting changes' do
+      let(:params) { {:button => "reset"} }
+      let(:s) { {:tag_db => VmOrTemplate} }
+
+      before do
+        allow(controller).to receive(:tagging_edit_tags_reset)
+      end
+
+      it 'sets @tagging properly' do
+        controller.send(:tagging_edit)
+        expect(controller.instance_variable_get(:@tagging)).not_to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1470636

Fix _Reset_ button when tagging VMs, Templates, Instances or Images, in _Compute > Clouds > Instances_ or _Compute > Infrastructure > Virtual Machines_.

Also the spec test was added to this PR to check if `@tagging` was properly set.

**Details:**
`@tagging` was not set properly, it was set to `nil` in `tagging_edit` method in _app/controllers/application_controller/tags.rb_, so then `find_records_with_rbac` method failed when it was called from `get_tag_items` method, which was called from `tagging_edit_tags_reset`, when reaching `"reset", nil` case in `tagging_edit` method. The line https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Reset_button_tag_vms_templates_instances?expand=1#diff-32a1920bfa43ecfb0853173babda0f8aR9 sets `@tagging` only if `db` or `params[:db]` is present so another condition for setting `@tagging` properly was added, and it works well.

Just before clicking on _Reset_ button:
![reset_tags](https://user-images.githubusercontent.com/13417815/35629114-1c40b12c-069e-11e8-94fc-c1ac62bfcf1d.png)

**Before:** (no change in the edit tag page after clicking on Reset button + error in log)
```
I, [2018-01-31T15:45:22.233279 #22674]  INFO -- : Started POST "/vm_infra/tagging_edit/10000000002164?button=reset" for ::1 at 2018-01-31 15:45:22 +0100
I, [2018-01-31T15:45:22.258548 #22674]  INFO -- : Processing by VmInfraController#tagging_edit as JS
I, [2018-01-31T15:45:22.258664 #22674]  INFO -- :   Parameters: {"button"=>"reset", "id"=>"10000000002164"}
W, [2018-01-31T15:45:22.273129 #22674]  WARN -- : DEPRECATION WARNING: Method each_with_object is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.6/classes/ActionController/Parameters.html (called from find_checked_items at /home/hstastna/manageiq/manageiq-ui-classic/app/controllers/mixins/checked_id_mixin.rb:17)
F, [2018-01-31T15:45:22.274136 #22674] FATAL -- : Error caught: [NoMethodError] undefined method `where' for nil:NilClass
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/mixins/checked_id_mixin.rb:126:in `find_records_with_rbac'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/tags.rb:88:in `get_tag_items'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/tags.rb:97:in `tagging_edit_tags_reset'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/tags.rb:16:in `tagging_edit'

```
**After:**
![reset_tags_after](https://user-images.githubusercontent.com/13417815/35629173-39020cca-069e-11e8-8ae4-17367e88b1fd.png)
