### PR TITLE
Render flash message or reload list view after Delete is pressed.

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -26,6 +26,11 @@ class CloudNetworkController < ApplicationController
       return tag("CloudNetwork")
     when 'cloud_network_delete'
       delete_networks
+      if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
+        replace_gtl_main_div
+      else
+        render_flash
+      end
     when "cloud_network_edit"
       javascript_redirect :action => "edit", :id => checked_item_id
     when "cloud_network_new"
@@ -35,12 +40,6 @@ class CloudNetworkController < ApplicationController
     when "custom_button"
       custom_buttons
       return
-    else
-      if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
-        replace_gtl_main_div
-      else
-        render_flash
-      end
     end
   end
 


### PR DESCRIPTION
Fixed code alignment to fix an issue where flash messages were not being displayed at all after Delete Cloud Networks button was pressed from list of Cloud Networks. Noticed a message in log "No template found for CloudNetworkController#button, rendering head :no_content"

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1539718

@bronaghs please test/review. Delete button is not present on Cloud network summary screen when selected Network does not support delete task. This PR fixes an issue where it should show appropriate flash message after one or more Networks are selected to Delete.

after fix:
![after](https://user-images.githubusercontent.com/3450808/35635696-003025d8-067d-11e8-9e2d-b1fb3de00bf9.png)
