### PR TITLE
Fixed code to display dialog form buttons when loading old dialog runner

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1302,7 +1302,7 @@ module VmCommon
         # these subviews use angular, so they need to use a special partial
         # so the form buttons on the outer frame can be updated.
         if @sb[:action] == 'dialog_provision'
-          if Settings.product.old_dialog_user_ui
+          if params[:pressed] == 'vm_transform_mass' || Settings.product.old_dialog_user_ui
             presenter.update(:form_buttons_div, r[
               :partial => 'layouts/x_dialog_buttons',
               :locals  => {
@@ -1310,6 +1310,9 @@ module VmCommon
                 :record_id  => @edit[:rec_id],
               }
             ])
+          else
+            presenter.update(:form_buttons_div, '')
+            presenter.remove_paging.hide(:form_buttons_div)
           end
         elsif %w(attach detach live_migrate resize evacuate ownership add_security_group remove_security_group
                  associate_floating_ip disassociate_floating_ip).include?(@sb[:action])


### PR DESCRIPTION
Transform screen still uses old dialog runner, fixed code to show form buttons on transform VMs screen.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540159

@eclarizio please review/test, i have tried combinations of Settings.product.old_dialog_user_ui setting with old/new dialogs, seems to work for me.

before:
![before](https://user-images.githubusercontent.com/3450808/35694792-746affbc-0750-11e8-81cd-8f13e3ad4c6e.png)

after:
![after](https://user-images.githubusercontent.com/3450808/35694788-713a13d2-0750-11e8-8fdc-8fe296eeae70.png)
