### PR TITLE
Remove openstack infra provider from network actions

### DIFF
--- a/app/controllers/application_controller/network.rb
+++ b/app/controllers/application_controller/network.rb
@@ -2,7 +2,8 @@ module ApplicationController::Network
   extend ActiveSupport::Concern
 
   def network_managers
-    openstack_network_manager = Rbac::Filterer.filtered(ManageIQ::Providers::Openstack::NetworkManager).select(:id, :name, :parent_ems_id)
+    ems_clouds = ManageIQ::Providers::Openstack::NetworkManager.joins(:parent_manager).where(:parent_managers_ext_management_systems=>{:type=>'ManageIQ::Providers::Openstack::CloudManager'})
+    openstack_network_manager = Rbac::Filterer.filtered(ems_clouds).select(:id, :name, :parent_ems_id)
     redhat_network_manager = Rbac::Filterer.filtered(ManageIQ::Providers::Redhat::NetworkManager).select(:id, :name, :parent_ems_id)
     openstack_network_manager + redhat_network_manager
   end


### PR DESCRIPTION
This PR removes infra provider from filtered result, because actions like creating networks, assigning FIP, etc. do not work for OpenStack infra provider.

Not sure if removing from filtered result should be done here or should be moved inside controllers.
ping @lpichler @aufi 
https://github.com/ManageIQ/manageiq-ui-classic/pull/3367/files