### PR TITLE
Merged Container Providers with all other providers in the list

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -673,11 +673,9 @@ class ChargebackController < ApplicationController
     @edit[:current_assignment] = ChargebackRate.get_assignments(x_node.split('-').last)
     unless @edit[:current_assignment].empty?
       @edit[:new][:cbshow_typ] =  case @edit[:current_assignment][0][:object]
-                                  when ManageIQ::Providers::ContainerManager
-                                    "ems_container"
                                   when EmsCluster
                                     "ems_cluster"
-                                  when ExtManagementSystem
+                                  when ExtManagementSystem, ManageIQ::Providers::ContainerManager
                                     "ext_management_system"
                                   when MiqEnterprise
                                     "enterprise"
@@ -784,9 +782,7 @@ class ChargebackController < ApplicationController
       if klass == "enterprise"
         MiqEnterprise.all
       elsif klass == "ext_management_system"
-        ExtManagementSystem.all.reject { |prov| prov.kind_of? ManageIQ::Providers::ContainerManager }
-      elsif klass == "ems_container"
-        ManageIQ::Providers::ContainerManager.all
+        ExtManagementSystem.all
       else
         klass.classify.constantize.all
       end

--- a/app/helpers/term_of_service_helper.rb
+++ b/app/helpers/term_of_service_helper.rb
@@ -24,7 +24,6 @@ module TermOfServiceHelper
       "enterprise"    => N_("The Enterprise"),
       "storage"       => N_("Selected Datastores"),
       "storage-tags"  => N_("Tagged Datastores"),
-      "ems_container" => N_("Selected Containers Providers"),
       "tenant"        => N_("Tenants")
     },
     "MiqServer" => {
@@ -42,7 +41,6 @@ module TermOfServiceHelper
       "enterprise"             => N_("The Enterprise"),
       "ext_management_system"  => N_("Selected Providers"),
       "ems_cluster"            => N_("Selected Cluster / Deployment Roles"),
-      "ems_container"          => N_("Selected Containers Providers"),
       "vm-tags"                => N_("Tagged VMs and Instances"),
       "container_image-tags"   => N_("Tagged Container Images"),
       "container_image-labels" => N_("Labeled Container Images"),


### PR DESCRIPTION
Need to merge and keep all kind of providers under same entry to be able ot save chargeback assignments for different types of providers together.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1505335

before:
![before](https://user-images.githubusercontent.com/3450808/35743319-43607e4a-080b-11e8-8c5b-6ccfa906ff5b.png)
![before1](https://user-images.githubusercontent.com/3450808/35743323-4592c47a-080b-11e8-94ce-8bc878adc150.png)

after:
![after](https://user-images.githubusercontent.com/3450808/35743226-e8117972-080a-11e8-9fca-6bf9aa8a9b40.png)
