### PR TITLE
Added column 'status' to replication screen

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -280,7 +280,8 @@ module OpsController::Settings::Common
         :password        => '●●●●●●●●',
         :port            => sub.port,
         :provider_region => sub.provider_region,
-        :backlog         => number_to_human_size(sub.backlog)
+        :backlog         => number_to_human_size(sub.backlog),
+        :status          => sub.status
       }
     end
   end

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -36,6 +36,7 @@
           %th= _('Password')
           %th= _('Port')
           %th= _('Backlog')
+          %th= _('Status')
           %th{:colspan => 2}=_('Actions')
         %tbody
           %tr{"ng-if" => "pglogicalReplicationModel.addEnabled"}
@@ -73,6 +74,7 @@
                                   "id"          => "port",
                                   "name"        => "port",
                                   "ng-model"    => "pglogicalReplicationModel.port"}
+            %td
             %td
             %td{:class => "action-cell"}
               %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-disabled" => "!subscriptionValid()",  "ng-click" => "addSubscription()"}= _('Accept')
@@ -144,6 +146,8 @@
 
             %td
               {{subscription.backlog}}
+            %td
+              {{subscription.status}}
             %td{:class => "action-cell", "ng-show" => "showCancelDelete($index)"}
               %button.btn.btn-default.btn-sm{:type => "button", "ng-click" => "cancelDelete($index)"}= _('Cancel Delete')
 


### PR DESCRIPTION
related BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1540688

Issue described in BZ: replication screen throws error if replication on one of remote server was not set-up correctly.
After merging https://github.com/ManageIQ/pg-pglogical/pull/20 corrupted subscription would be shown but without any indication that replication set-up is invalid

This PR adding column `status` to UI which would have value `down` in for not working subscriptions


**BEFORE:**
<img width="1249" alt="after" src="https://user-images.githubusercontent.com/6556758/35756927-1190a766-083b-11e8-987c-a21c1cbb9fe4.png">

**AFTER:**
![aftrer2](https://user-images.githubusercontent.com/6556758/35756979-3d3238e4-083b-11e8-984e-733925be9c61.png)

@miq-bot add-label replication, enhancement, gaprindashvili/yes

\cc @carbonin @martinpovolny 
