### PR TITLE
Fix for different behavior of items in regards to default values on dialog sample page

### DIFF
--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -31,7 +31,7 @@
                           = text_field_tag(field_id, field.sample_text, :maxlength => 20, :disabled => true)
 
                       - when "DialogFieldCheckBox"
-                        = check_box_tag(field_id, "1", false, :disabled => true)
+                        = check_box_tag(field_id, "1", field.default_value == 't', :disabled => true)
                       - when "DialogFieldDateControl", "DialogFieldDateTimeControl"
                         - if field.show_past_dates
                           :javascript
@@ -90,8 +90,10 @@
 
                             - else
                               - val.each_with_index do |rb, i|
-                                %input{:type => "radio", :disabled => true, :checked => (field.default_value == rb[0]),
-                                  :id => rb[0], :value => rb[1], :name => rb[0]}
+                                %input{:type     => "radio",
+                                       :disabled => true,
+                                       :checked  => (field.default_value == rb[0]),
+                                       :value    => rb[0]}
                                 &nbsp;
                                 = rb[1]
                                 &nbsp;


### PR DESCRIPTION
This is a simple change to the sample page of a dialog (when you click on it in the accordion list and it shows some basic sample of what it's going to look like in the right cell). We're merely taking into account default values that were not being utilized before. The radio button sample was also just completely incorrect and needed to be modified.

This fixes part of https://bugzilla.redhat.com/show_bug.cgi?id=1540273, the fix for the timepicker not showing up in the service-ui will likely be needed in the ui-components repo.

@miq-bot add_label gaprindashvili/yes, bug, blocker
@miq-bot assign @dclarizio 