### PR TITLE
Disable group_by options when there is no daily data 

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -69,8 +69,10 @@ module ApplicationController::Performance
         page << Charting.js_load_statement
       end
       page << 'miqSparkle(false);'
-      if request.parameters["controller"] == "storage" && @perf_options[:cat]
-        page << javascript_disable_field('perf_typ')
+
+      if request.parameters["controller"] == "storage"
+        page << javascript_disable_field('perf_typ') if @perf_options[:cat]
+        page << javascript_disable_field('perf_cat') if @perf_options[:typ] == 'Daily' && @perf_options[:no_daily]
       end
     end
   end


### PR DESCRIPTION
Disable the group_by option when the @perf_options[:no_daily] is set to true for Datastores performance charts with 'Daily' selection

Links 
------------
https://bugzilla.redhat.com/show_bug.cgi?id=1540129

Steps for Testing/QA [Optional]
-------------------------------

- make sure there is no daily data
-------------------
1. Navigate to Datastore C&U graphs
2. Select Intervel> Daily
3. check for No daily data available
4. select Group By> any VM tag

Before - error when selecting group_by:
![screenshot from 2018-02-05 14-41-08](https://user-images.githubusercontent.com/12769982/35825027-a0045292-0a82-11e8-8acf-06c8cb46542b.png)


After - Group_by not selectable

![screenshot from 2018-02-05 14-34-57](https://user-images.githubusercontent.com/12769982/35824913-5aa40dfa-0a82-11e8-8a77-51c90d4b13df.png)
