### PR TITLE
Fixes Azure Instance container display of file name and mode descriptions

### DIFF
--- a/app/helpers/textual_mixins/textual_devices.rb
+++ b/app/helpers/textual_mixins/textual_devices.rb
@@ -42,16 +42,21 @@ module TextualMixins::TextualDevices
 
     # HDDs
     disks = @record.hardware.hard_disks.map do |disk|
-      ctrl_type = disk.controller_type.upcase
-      location = disk.location
-      size = disk.size
-      prov = disk.size_on_disk.nil? ? 'N/A' : disk.used_percent_of_provisioned
-      device_name = _("Hard Disk (%{controller_type} %{location}), Size %{size}, " \
-                      "Percent Used Provisioned Space %{space}") % {:controller_type => ctrl_type,
-                                                                    :location        => location,
-                                                                    :size            => size,
-                                                                    :space           => prov}
-      description = _("%{filename}, Mode: %{mode}") % {:filename => disk.filename, :mode => disk.mode}
+      device_name = _("Hard Disk")
+
+      hd_name = disk.device_name.upcase
+      location = disk.location.presence || _("N/A")
+      size = disk.size.presence || _("N/A")
+      pct_prov = disk.size_on_disk.nil? ? _("N/A") : disk.used_percent_of_provisioned
+      filename = disk.filename.presence || _("N/A")
+      mode = disk.mode.presence || _("N/A")
+      description = _("Name: %{hd_name}, Location: %{location}, Size: %{size}, Percent Used Provisioned Space: %{prov}, " \
+                      "Filename: %{filename}, Mode: %{mode}") % {:hd_name  => hd_name,
+                                                                 :location => location,
+                                                                 :size     => size,
+                                                                 :prov     => pct_prov,
+                                                                 :filename => filename,
+                                                                 :mode     => mode}
       Device.new(device_name, description, nil, :disk)
     end
 

--- a/spec/helpers/textual_mixins/textual_devices_spec.rb
+++ b/spec/helpers/textual_mixins/textual_devices_spec.rb
@@ -31,6 +31,7 @@ describe TextualMixins::TextualDevices do
         FactoryGirl.create(:hardware,
                            :disks => [FactoryGirl.create(:disk,
                                                          :device_type     => "disk",
+                                                         :device_name     => "HD01",
                                                          :controller_type => "scsi")])
       end
       it { is_expected.not_to be_empty }
@@ -41,10 +42,37 @@ describe TextualMixins::TextualDevices do
         FactoryGirl.create(:hardware,
                            :disks => [FactoryGirl.create(:disk,
                                                          :device_type     => "disk",
+                                                         :device_name     => "HD01",
                                                          :size            => "1072693248",
                                                          :controller_type => "AZURE")])
       end
-      it { expect(subject[0][:name]).to include("Hard Disk (AZURE ), Size 1072693248, Percent Used Provisioned Space N/A") }
+      it { expect(subject[0][:name]).to include("Hard Disk") }
+      it { expect(subject[0][:description]).to include("Name: HD01, Location: N/A, Size: 1072693248, Percent Used Provisioned Space: N/A, Filename: N/A, Mode: N/A") }
+    end
+
+    context "with hdd with size_on_disk and percent provisioned collected (AZURE)" do
+      let(:hw) do
+        FactoryGirl.create(:hardware,
+                           :disks => [FactoryGirl.create(:disk,
+                                                         :device_type     => "disk",
+                                                         :device_name     => "CLIA566D60F38FB9ECC",
+                                                         :location        => "https://jdg.blob.core.windows.net/vhds/clia566d60f38fb9ecc.vhd",
+                                                         :size            => "1072693248",
+                                                         :size_on_disk    => "357564416",
+                                                         :controller_type => "AZURE")])
+      end
+      it { expect(subject[0][:name]).to include("Hard Disk") }
+
+      it "expect hard disk description with percent provisioned " do
+        expected_description = "Name: CLIA566D60F38FB9ECC, " \
+                               "Location: https://jdg.blob.core.windows.net/vhds/clia566d60f38fb9ecc.vhd, " \
+                               "Size: 1072693248, " \
+                               "Percent Used Provisioned Space: 33.3, " \
+                               "Filename: N/A, " \
+                               "Mode: N/A"
+
+        expect(subject[0][:description]).to include(expected_description)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes display of container hard drive filename and mode descriptions for Azure Instances, as well as other providers. Code now accounts for when values/settings are either nil or blank (text) strings. All hard drive parameters were shifted to display in the right hand column on the page for display consistency and viewing legibility. See screen shots bellow.

https://bugzilla.redhat.com/show_bug.cgi?id=1536681

Screen shot before code fix:
![azure instance container file name and mode display prior to code fix](https://user-images.githubusercontent.com/552686/35833114-a71e9cb6-0a84-11e8-95c7-2b9a1a3539aa.png)

Screen shot of Azure Instance post code fix:
![azure instance container post code fix](https://user-images.githubusercontent.com/552686/35889133-24e2b2e8-0b4f-11e8-96f0-8ab6585069f7.png)

Screen shot of Amazon Instance display post fix:
![amazon instance container post code fix](https://user-images.githubusercontent.com/552686/35889154-3cb70536-0b4f-11e8-9da2-82f3dab48d76.png)

Screen shot of OpenStack Instance display post code fix, notice 2 hard drives listed:
![openstack instance container with 2 hard drives post code fix](https://user-images.githubusercontent.com/552686/35889177-566f4e16-0b4f-11e8-87ad-1c961797c6ae.png)

