### PR TITLE
Adding Authentication Status to the information given on quadicon

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -617,10 +617,11 @@ module QuadiconHelper
       output << flobj_img_simple("layout/reflection.png")
     else
       output << content_tag(:div, :class => 'flobj') do
-        title = _("Name: %{name} Hostname: %{hostname} Refresh Status: %{status}") %
-          {:name     => h(item.name),
-           :hostname => h(item.hostname),
-           :status   => h(item.last_refresh_status.titleize)}
+        title = _("Name: %{name} Hostname: %{hostname} Refresh Status: %{status} Authentication Status: %{auth_status}") %
+          {:name        => h(item.name),
+           :hostname    => h(item.hostname),
+           :status      => h(item.last_refresh_status.titleize),
+           :auth_status => h(item.authentication_status)}
 
         link_to(url_for_record(item), :title => title) do
           quadicon_reflection_img


### PR DESCRIPTION
Currently when hovering over a quadicon in the providers screen it is somewhat confusing if the quad is showing an issue due to Authentication Status not "Valid". In this PR we add this information upon mouseover.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1537200

![screenshot from 2018-02-06 14-33-26](https://user-images.githubusercontent.com/8366181/35860029-1edbf2fa-0b4b-11e8-8585-d8e87f173647.png)

cc: @himdel 