### PR TITLE
Fix tag CU chart when there are no daily data

### DIFF
--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -92,6 +92,7 @@ module ReportFormatter
           mri.chart[:legend] = {:position => 'bottom'}
         end
 
+        return if mri.graph[:columns].blank?
         column = grouped_by_tag_category? ? mri.graph[:columns][0].split(/_+/)[0..-2].join('_') : mri.graph[:columns][0]
         format, options = javascript_format(column, nil)
         return unless format


### PR DESCRIPTION
Fix tag CU chart when there are not enough daily data.
I think, that source of this problem is hidden in generating reports, but because i think it is related to blocker bz, I just fix consequences and return to it later.

Links [Optional]
----------------
Related(ish) with https://bugzilla.redhat.com/show_bug.cgi?id=1540129

Steps for Testing/QA [Optional]
-------------------------------
Select host with some C&U data, but not for all day.
Utilization -> Group By (tag) -> Daily

Screenshots
-------------------------------

Before:
![screencapture-localhost-3000-host-show-10000000000014-1517923395930](https://user-images.githubusercontent.com/9535558/35861807-a95336ca-0b49-11e8-9788-eef7ab1699b7.png)


After:
![screencapture-localhost-3000-host-show-10000000000014-1517923046039](https://user-images.githubusercontent.com/9535558/35861810-ac4c7382-0b49-11e8-9726-07cf2c7d2c05.png)
