### PR TITLE
[WIP] Fix assigning global filter in SSA scheduler

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -311,6 +311,8 @@ module OpsController::Settings::Schedules
     when "global"
       if action_type == "miq_template"
         action_type = action_type.camelize
+      elsif action_type == "vm"
+        action_type = "VmInfra"
       else
         action_type = action_type.split("_").first.capitalize
       end


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1534633

Fix assigning global filter in SSA scheduler when creating a schedule in _Configuration -> Settings_ tab -> _Schedules_.

**Details:**
The problem was wrong db when looking for appropriate filters for VMs in https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Assign_global_filter_SSA_scheduler?expand=1#diff-27e8e9795d5f4a9a5087545e103d4e51R319

**Before:**
![filters_vms](https://user-images.githubusercontent.com/13417815/35915261-6f130fcc-0c06-11e8-8199-3a08ad487d69.png)
**After:**
![all_filters_vms](https://user-images.githubusercontent.com/13417815/35915257-6cad4360-0c06-11e8-9987-4277e108a9b0.png)

