### PR TITLE
Added vm_transform button pressed id to the list

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1302,7 +1302,7 @@ module VmCommon
         # these subviews use angular, so they need to use a special partial
         # so the form buttons on the outer frame can be updated.
         if @sb[:action] == 'dialog_provision'
-          if params[:pressed] == 'vm_transform_mass' || Settings.product.old_dialog_user_ui
+          if %w(vm_transform vm_transform_mass).include?(params[:pressed]) || Settings.product.old_dialog_user_ui
             presenter.update(:form_buttons_div, r[
               :partial => 'layouts/x_dialog_buttons',
               :locals  => {


### PR DESCRIPTION
Added vm_transform button pressed id to the list that uses old dialog runner.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540159