### PR TITLE
Fix title of the page to be updated when searching text in Datastores and other pages 

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -242,6 +242,9 @@ class AutomationManagerController < ApplicationController
     else
       default_node
     end
+
+    # Edit right cell text if searching text
+    @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present? && %w(ConfiguredSystem ConfigurationScript).exclude?(model)
     # Edit right cell text if using filter
     @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && filtering? && @edit && @edit[:adv_search_applied]
 

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -551,6 +551,7 @@ class MiqPolicyController < ApplicationController
 
       presenter.update(:main_div, r[:partial => partial_name])
       right_cell_text = _("All %{models}") % {:models => model}
+      right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present? && %w(alert_profile_tree condition_tree policy_tree).exclude?(x_active_tree.to_s)
     when 'pp'
       presenter.update(:main_div, r[:partial => 'profile_details'])
       right_cell_text =
@@ -588,6 +589,7 @@ class MiqPolicyController < ApplicationController
           r[:partial => 'alert_profile_list']
         end
       )
+      right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present? && !@folders
     when 'p'
       presenter.update(:main_div, r[:partial => 'policy_details', :locals => {:read_only => true}])
       model_name = ui_lookup(:model => @sb[:nodeid].try(:camelize))

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -260,6 +260,7 @@ class ProviderForemanController < ApplicationController
                   default_node
                 end
               end
+    @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present?
     @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && x_tree[:type] == :configuration_manager_cs_filter && @edit && @edit[:adv_search_applied]
 
     if @edit && @edit.fetch_path(:adv_search_applied, :qs_exp) # If qs is active, save it in history

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -324,6 +324,7 @@ class ServiceController < ApplicationController
       process_show_list
       @right_cell_text = _("All Services")
     end
+    @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present?
     @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && @edit && @edit[:adv_search_applied]
 
     if @edit && @edit.fetch_path(:adv_search_applied, :qs_exp) # If qs is active, save it in history

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -339,6 +339,7 @@ class StorageController < ApplicationController
     when :storage_tree     then storage_get_node_info(node)
     when :storage_pod_tree then storage_pod_get_node_info(node)
     end
+    @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present?
     @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && x_tree[:type] == :storage && @edit && @edit[:adv_search_applied]
 
     if @edit && @edit.fetch_path(:adv_search_applied, :qs_exp) # If qs is active, save it in history

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -243,6 +243,19 @@ describe AutomationManagerController do
       right_cell_text = controller.instance_variable_get(:@right_cell_text)
       expect(right_cell_text).to eq("All Ansible Tower Providers")
     end
+
+    context 'searching text' do
+      let(:search) { "some_text" }
+
+      before do
+        controller.instance_variable_set(:@search_text, search)
+      end
+
+      it 'updates right cell text according to search text' do
+        controller.send(:get_node_info, "root")
+        expect(controller.instance_variable_get(:@right_cell_text)).to eq("All Ansible Tower Providers (Names with \"#{search}\")")
+      end
+    end
   end
 
   it "builds ansible tower child tree" do

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -233,6 +233,38 @@ describe MiqPolicyController do
       expect(presenter[:right_cell_text]).not_to equal('foo')
       expect(presenter[:right_cell_text]).to_not be_nil
     end
+
+    context 'searching text' do
+      let(:search) { "some_text" }
+
+      before do
+        allow(controller).to receive(:params).and_return(:action => 'x_search_by_name')
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@conditions, {})
+        controller.instance_variable_set(:@sb, tree)
+        controller.instance_variable_set(:@search_text, search)
+      end
+
+      subject { controller.instance_variable_get(:@right_cell_text) }
+
+      context 'policy profiles root node' do
+        let(:tree) { {:active_tree => :policy_profile_tree} }
+
+        it 'updates right cell text according to search text' do
+          controller.send(:replace_right_cell, :nodetype => 'root')
+          expect(subject).to eq("All Policy Profiles (Names with \"#{search}\")")
+        end
+      end
+
+      context 'conditions node' do
+        let(:tree) { {:active_tree => :condition_tree, :folder => "host"} }
+
+        it 'updates right cell text according to search text' do
+          controller.send(:replace_right_cell, :nodetype => 'xx')
+          expect(subject).to eq("All Host / Node Conditions (Names with \"#{search}\")")
+        end
+      end
+    end
   end
 
   describe 'x_button' do

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -718,6 +718,22 @@ describe ProviderForemanController do
     end
   end
 
+  describe '#get_node_info' do
+    before do
+      controller.instance_variable_set(:@right_cell_text, "")
+      controller.instance_variable_set(:@search_text, search)
+    end
+
+    context 'searching text' do
+      let(:search) { "some_text" }
+
+      it 'updates right cell text according to search text' do
+        controller.send(:get_node_info, "root")
+        expect(controller.instance_variable_get(:@right_cell_text)).to eq(" (Names with \"#{search}\")")
+      end
+    end
+  end
+
   def user_with_feature(features)
     features = EvmSpecHelper.specific_product_features(*features)
     FactoryGirl.create(:user, :features => features)

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -327,6 +327,19 @@ describe ServiceController do
           controller.send(:get_node_info, "root")
           expect(controller.instance_variable_get(:@right_cell_text)).to eq("All Services - Filtered by Filter1")
         end
+
+        context 'searching text' do
+          let(:search) { "Service" }
+
+          before do
+            controller.instance_variable_set(:@search_text, search)
+          end
+
+          it 'updates right cell text properly' do
+            controller.send(:get_node_info, "root")
+            expect(controller.instance_variable_get(:@right_cell_text)).to eq("All Services (Names with \"#{search}\")")
+          end
+        end
       end
     end
   end

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -356,6 +356,22 @@ describe StorageController do
     end
   end
 
+  describe '#get_node_info' do
+    before do
+      controller.instance_variable_set(:@right_cell_text, "")
+      controller.instance_variable_set(:@search_text, search)
+    end
+
+    context 'searching text' do
+      let(:search) { "Datastore" }
+
+      it 'updates right cell text according to search text' do
+        controller.send(:get_node_info, "root")
+        expect(controller.instance_variable_get(:@right_cell_text)).to eq(" (Names with \"#{search}\")")
+      end
+    end
+  end
+
   include_examples '#download_summary_pdf', :storage
 
   it_behaves_like "controller with custom buttons"


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1540613

Fix title of the page to be updated according to search text in _Compute > Infrastructure > Datastores_ page and in another pages.

**Details** (for _Datastores_):
The title of the page was not updated when searching text in _Datastores_, because it was not implemented in storage controller. In other pages, for example _VMs_, it is implemented in `get_node_info` method (like this: https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/vm_common.rb#L1155). The title which was changed according to search text in _Datastores_ page, is stored in `@title` variable, updated in application controller (here: https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller.rb#L1199), but this variable is used for title in other pages, not in _Datastores_ (and also it was set to just _"Datastores"_, and we need _"All Datastores"_). For _Datastores_ we see the title in the page, which is stored in `@right_cell_text`, so I added the line for updating `@right_cell_text` according to what is in `@search_text` to storage controller, to `get_node_info` method (as it is in other controllers, where it works).

Another note:
I've added the line for updating  `@right_cell_text` to controllers BEFORE the name of a filter is added to the title here https://github.com/ManageIQ/manageiq-ui-classic/pull/3385/files#diff-deaa0e49bde4dd95612b5e0b14568aa6R343 (if some filter is applied). The reason is _"clear"_:
![datastores_good](https://user-images.githubusercontent.com/13417815/35978492-337e7506-0ce6-11e8-8032-f181f4fb519c.png)
vs this:
![datastores_not_good](https://user-images.githubusercontent.com/13417815/35978495-35f5d9d2-0ce6-11e8-91e0-186354c2ee7a.png)

**Done:** fixing the title in 
-- _Compute > Infrastructure > Datastores_ 
-- _Services > My Services_
-- _Configuration > Management_
-- _Control > Explorer_
-- _Automation > Ansible Tower > Explorer_
-- spec tests for all of the changes in all of the controllers

---

**Before searching text in Datastores:**
![datastores](https://user-images.githubusercontent.com/13417815/35976362-270f930a-0ce0-11e8-8d29-69a6ed97ee01.png)

**Before fixing title in Datastores:**
![datastores_before1](https://user-images.githubusercontent.com/13417815/35976939-f3a1f4fc-0ce1-11e8-9fda-9da529cc368e.png)
![datastores_before2](https://user-images.githubusercontent.com/13417815/35976945-f5cfc344-0ce1-11e8-8b77-93552482adee.png)

**After fixing title in Datastores:**
![datastores_after1](https://user-images.githubusercontent.com/13417815/35976472-80e4ab0e-0ce0-11e8-92a9-3ae67ef57f85.png)
