### PR TITLE
[FINE] Render flash messages when deleting cloud tenants

### DIFF
--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -214,6 +214,7 @@ class CloudTenantController < ApplicationController
     # refresh the list if applicable
     if @lastaction == "show_list"
       show_list
+      render_flash
       @refresh_partial = "layouts/gtl"
     elsif @lastaction == "show" && @layout == "cloud_tenant"
       # deleting from 'show' so we:


### PR DESCRIPTION
Cause flash messages to be rendered after attempting to delete one or more cloud tenants. This is a fix for the superficial issue described in https://bugzilla.redhat.com/show_bug.cgi?id=1541713, but this does not resolve the bug on its own.