### PR TITLE
Bower to npm - fix paths to really be able to differentiate between bower and npm packages

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "vendor/assets/bower_components"
+  "directory": "vendor/assets/bower/bower_components"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ tmp/
 .vscode/
 .ruby-version
 vendor/assets/bower_components/
+vendor/assets/bower/bower_components/
 node_modules/
 config/webpack/paths.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   bundler: true
   yarn: true
   directories:
-  - vendor/assets/bower_components
+  - vendor/assets/bower/bower_components
 addons:
   postgresql: '9.4'
 env:
@@ -21,7 +21,7 @@ before_install: source tools/ci/before_install.sh
 before_script: bundle exec rake $TEST_SUITE:setup
 script: bundle exec rake $TEST_SUITE
 before_cache:
-- cp bower.json vendor/assets/bower_components
+- cp bower.json vendor/assets/bower/bower_components
 after_script: source tools/ci/after_install.sh
 notifications:
   webhooks:

--- a/app/assets/javascripts/remote_consoles/spice.js
+++ b/app/assets/javascripts/remote_consoles/spice.js
@@ -1,5 +1,5 @@
-//= require jquery
-//= require spice-html5-bower
+//= require bower_components/jquery/dist/jquery
+//= require bower_components/spice-html5-bower/spice-html5-rails
 //= require_tree ../locale
 //= require gettext/all
 

--- a/app/assets/javascripts/remote_consoles/vnc.js
+++ b/app/assets/javascripts/remote_consoles/vnc.js
@@ -1,4 +1,4 @@
-//= require jquery
+//= require bower_components/jquery/dist/jquery
 //= require novnc-rails
 //= require_tree ../locale
 //= require gettext/all

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "node_modules",
     "bower_components",
     "vendor/assets/bower_components",
+    "vendor/assets/bower/bower_components",
     "test",
     "tests"
   ],

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,6 +10,7 @@ Rails.application.config.assets.precompile += %w(
   bower_components/codemirror/themes/*.css
   bower_components/jquery/dist/jquery.js
   bower_components/jquery-ui/jquery-ui.js
+  bower_components/tota11y/build/tota11y.js
 
   jquery_overrides.js
   remote_consoles/*.js

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,4 +1,4 @@
-Rails.application.config.assets.paths << ManageIQ::UI::Classic::Engine.root.join('vendor', 'assets') # all bower deps need to be prefixed by bower_components/
+Rails.application.config.assets.paths << ManageIQ::UI::Classic::Engine.root.join('vendor', 'assets', 'bower') # all bower deps need to be prefixed by bower_components/, but vendor/assets/* can't be removed from paths :(
 Rails.application.config.assets.paths << ManageIQ::UI::Classic::Engine.root.join('node_modules')
 
 Rails.application.config.assets.precompile << proc do |filename, path|

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -14,7 +14,14 @@ namespace :update do
     end
   end
 
-  task :ui => ['update:bower', 'update:yarn', 'webpack:compile']
+  task :clean do
+    Dir.chdir ManageIQ::UI::Classic::Engine.root do
+      # clean up old bower install to prevent it from winning over npm
+      system("rm -rf vendor/assets/bower_components")
+    end
+  end
+
+  task :ui => ['update:clean', 'update:bower', 'update:yarn', 'webpack:compile']
 end
 
 namespace :webpack do

--- a/tools/ci/setup_js_env.sh
+++ b/tools/ci/setup_js_env.sh
@@ -1,11 +1,11 @@
 which bower || npm install -g bower
 
 # Check if the bower cache is valid, otherwise delete it
-if ! cmp --silent bower.json vendor/assets/bower_components/bower.json; then
-  rm -rf vendor/assets/bower_components
+if ! cmp --silent bower.json vendor/assets/bower/bower_components/bower.json; then
+  rm -rf vendor/assets/bower/bower_components
 fi
 
-if [ -d vendor/assets/bower_components ]; then
+if [ -d vendor/assets/bower/bower_components ]; then
   # Using bower_components from cache
   echo "bower assets installed... moving on."
 else
@@ -15,7 +15,7 @@ else
 
   # fail the whole test suite if bower install failed
   [ $STATUS = 0 ] || exit 1
-  [ -d vendor/assets/bower_components ] || exit 1
+  [ -d vendor/assets/bower/bower_components ] || exit 1
 fi
 
 # make sure yarn is installed, in the right version

--- a/tools/ci/setup_js_env.sh
+++ b/tools/ci/setup_js_env.sh
@@ -1,5 +1,10 @@
 which bower || npm install -g bower
 
+# Clean up old bower_components location
+if [ -d vendor/assets/bower_components ]; then
+  rm -rf vendor/assets/bower_components
+fi
+
 # Check if the bower cache is valid, otherwise delete it
 if ! cmp --silent bower.json vendor/assets/bower/bower_components/bower.json; then
   rm -rf vendor/assets/bower/bower_components


### PR DESCRIPTION
Railties adds `vendor/assets/*` to asset path - https://github.com/rails/rails/blob/20c91119903f70eb19aed33fe78417789dbf070f/railties/lib/rails/engine/configuration.rb#L65

Engine initializer can't remove it because at the point it's running, the array is empty.

Rails asset pipeline can't differentiate between `vendor/assets/bower_components/foo` and `node_modules/foo` because both are in assets path (what #3343 tried to change).

Being able to differentiate is a necessary step when moving off bower.

---

So.. moving bower_components to a subdirectory to get the right semantics:

  * `vendor/assets/bower_components` - old location, will be deleted during `bin/update`
  * `vendor/assets/bower/bower_components` - new location