### PR TITLE
Fix logic error preventing WebMKS console access on 6.0 Hosts

### DIFF
--- a/app/helpers/application_helper/button/vm_webmks_console.rb
+++ b/app/helpers/application_helper/button/vm_webmks_console.rb
@@ -14,7 +14,7 @@ class ApplicationHelper::Button::VmWebmksConsole < ApplicationHelper::Button::Vm
   end
 
   def supported_vendor_api?
-    @record.host.vmm_version.to_f > min_supported_api_version
+    @record.host.vmm_version.to_f >= min_supported_api_version
   end
 
   def min_supported_api_version

--- a/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
@@ -25,7 +25,6 @@ describe ApplicationHelper::Button::VmWebmksConsole do
 
     context 'when record.vendor == vmware' do
       let(:power_state) { 'on' }
-      let(:api_version) { 6.5 }
       let(:host) { FactoryGirl.create(:host_vmware_esx, :vmm_version => api_version) }
       let(:record) { FactoryGirl.create(:vm_vmware, :host => host) }
 
@@ -40,8 +39,11 @@ describe ApplicationHelper::Button::VmWebmksConsole do
           it_behaves_like 'a disabled button',
                           'The web-based WebMKS console is not available because the VM does not support the minimum required vSphere API version.'
         end
-        context 'is >= 6' do
-          it_behaves_like 'an enabled button'
+        [6.0, 6.5].each do |ver|
+          context "is #{ver}" do
+            let(:api_version) { ver }
+            it_behaves_like 'an enabled button'
+          end
         end
       end
     end

--- a/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
@@ -25,6 +25,7 @@ describe ApplicationHelper::Button::VmWebmksConsole do
 
     context 'when record.vendor == vmware' do
       let(:power_state) { 'on' }
+      let(:api_version) { 6.5 }
       let(:host) { FactoryGirl.create(:host_vmware_esx, :vmm_version => api_version) }
       let(:record) { FactoryGirl.create(:vm_vmware, :host => host) }
 


### PR DESCRIPTION
`>` instead of `>=` was disabling the VM Console button on 6.0 Hosts incorrectly.  Updated tests to catch this regression in the future.

@miq-bot add_labels bug, blocker, gaprindashvili/yes, fine/yes, compute/infrastructure

https://bugzilla.redhat.com/show_bug.cgi?id=1543106