### PR TITLE
Add tota11y to precompiled assets in development

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,3 +15,9 @@ Rails.application.config.assets.precompile += %w(
   remote_consoles/*.js
   remote_console.js
 )
+
+if Rails.env.development?
+  Rails.application.config.assets.precompile += %w(
+    bower_components/tota11y/build/tota11y.js
+  )
+end


### PR DESCRIPTION
to prevent

```
F, [2018-02-09T15:52:12.518414 #6652] FATAL -- : ActionView::Template::Error (Asset was not declared to be precompiled in production.
Add `Rails.application.config.assets.precompile += %w( bower_components/tota11y/build/tota11y.js )` to `config/initializers/assets.rb` and restart your server):
F, [2018-02-09T15:52:12.518489 #6652] FATAL -- :     3:   %script{:defer => "defer", :type => "text/javascript"}
    4:     miqOnLoad();
    5: - if Rails.env.development?
    6:   = javascript_include_tag 'bower_components/tota11y/build/tota11y'
F, [2018-02-09T15:52:12.518526 #6652] FATAL -- :
F, [2018-02-09T15:52:12.518623 #6652] FATAL -- : sprockets-rails (3.2.1) lib/sprockets/rails/helper.rb:363:in `raise_unless_precompiled_asset'
sprockets-rails (3.2.1) lib/sprockets/rails/helper.rb:348:in `find_debug_asset'
sprockets-rails (3.2.1) lib/sprockets/rails/helper.rb:229:in `block in lookup_debug_asset'
sprockets-rails (3.2.1) lib/sprockets/rails/helper.rb:242:in `block in resolve_asset'
sprockets-rails (3.2.1) lib/sprockets/rails/helper.rb:241:in `each'
sprockets-rails (3.2.1) lib/sprockets/rails/helper.rb:241:in `detect'
sprockets-rails (3.2.1) lib/sprockets/rails/helper.rb:241:in `resolve_asset'
sprockets-rails (3.2.1) lib/sprockets/rails/helper.rb:228:in `lookup_debug_asset'
sprockets-rails (3.2.1) lib/sprockets/rails/helper.rb:141:in `block in javascript_include_tag'
sprockets-rails (3.2.1) lib/sprockets/rails/helper.rb:140:in `map'
sprockets-rails (3.2.1) lib/sprockets/rails/helper.rb:140:in `javascript_include_tag'
/home/himdel/manageiq-ui-classic/app/views/layouts/_footer.html.haml:6:in `__home_himdel_manageiq_ui_classic_app_views_layouts__footer_html_haml__2844698119039625782_70304539162540
```

presumably related to #3343 where it changed..

```diff
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -3,4 +3,4 @@
   %script{:defer => "defer", :type => "text/javascript"} 
     miqOnLoad();
 - if Rails.env.development?
-  = javascript_include_tag 'tota11y'
+  = javascript_include_tag 'bower_components/tota11y/build/tota11y'
```


Cc @mzazrivec, @skateman 