### PR TITLE
Better handling of responses from validation

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -610,17 +610,23 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     $scope.authType = authType;
     miqService.validateWithREST($event, authType, $scope.actionUrl, formSubmit)
       .then(function success(data) {
-        $timeout(function() {
-          $scope.$apply(function() {
-            if(data.level == "error") {
-              $scope.updateAuthStatus(false);
-            } else {
-              $scope.updateAuthStatus(true);
-            }
-            miqService.miqFlash(data.level, data.message, data.options);
-            miqSparkleOff();
+        // check if data object is a JSON, otherwise (recieved JS or HTML) output a warning to the user.
+        if (data === Object(data)) {
+          $timeout(function() {
+            $scope.$apply(function() {
+              if(data.level == "error") {
+                $scope.updateAuthStatus(false);
+              } else {
+                $scope.updateAuthStatus(true);
+              }
+              miqService.miqFlash(data.level, data.message, data.options);
+              miqSparkleOff();
+            });
           });
-        });
+        } else {
+          miqService.miqFlash("error", __('Something went wrong, please check the logs for more information.'));
+          miqSparkleOff();
+        }
       });
   };
 


### PR DESCRIPTION
Currently if the response returned from `validate` in the add/edit provider screen is **not** json (i.e javascript / html) we output a green warning with no description (see screenshot).
In this PR we try and catch this scenario and output a warning to the user.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1541744

Screenshot:
Before:
![screenshot from 2018-02-08 16-01-11](https://user-images.githubusercontent.com/8366181/36088794-495e09ba-0fe1-11e8-91c3-7e0652dd5ed1.png)
After:
![screenshot from 2018-02-14 10-58-08](https://user-images.githubusercontent.com/8366181/36195447-2c872f24-1176-11e8-999f-e7ebdd5eab77.png)

cc: @himdel 
 