### PR TITLE
Disable editing of NetworkProviders except Nuage

### DIFF
--- a/app/helpers/application_helper/button/ems_network.rb
+++ b/app/helpers/application_helper/button/ems_network.rb
@@ -1,5 +1,9 @@
 class ApplicationHelper::Button::EmsNetwork < ApplicationHelper::Button::Basic
   def visible?
-    ::Settings.product.nuage
+    # Nuage is only provider that supports adding NetworkProvider manually
+    # therefore we hide drop-down option completely unless Nuage is enabled.
+    return ::Settings.product.nuage unless @record # add new
+
+    @record.supports?(:ems_network_new) # edit
   end
 end

--- a/spec/helpers/application_helper/toolbar/ems_network_center_spec.rb
+++ b/spec/helpers/application_helper/toolbar/ems_network_center_spec.rb
@@ -1,0 +1,26 @@
+describe ApplicationHelper::Toolbar::EmsNetworkCenter do
+  let(:ems_network_vmdb)        { described_class.definition['ems_network_vmdb'] }
+  let(:ems_network_vmdb_choice) { ems_network_vmdb.buttons.detect { |b| b[:id] == 'ems_network_vmdb_choice' } }
+
+  describe 'Edit this Network Provider' do
+    let(:button_hash)   { ems_network_vmdb_choice[:items].detect { |b| b[:id] == 'ems_network_edit' } }
+    let(:button_klass)  { button_hash[:klass] }
+    let(:button)        { button_klass.new(nil, nil, {}, {}) }
+    let(:ems_nuage)     { FactoryGirl.create(:ems_nuage_network) }
+    let(:ems_openstack) { FactoryGirl.create(:ems_openstack) }
+
+    it 'appropriate button class' do
+      expect(button_klass).to eq(ApplicationHelper::Button::EmsNetwork)
+    end
+
+    it 'visible for nuage provider' do
+      button.instance_variable_set(:@record, ems_nuage)
+      expect(button.visible?).to eq(true)
+    end
+
+    it 'not visible for openstack provider' do
+      button.instance_variable_set(:@record, ems_openstack)
+      expect(button.visible?).to eq(false)
+    end
+  end
+end

--- a/spec/helpers/application_helper/toolbar/ems_networks_center_spec.rb
+++ b/spec/helpers/application_helper/toolbar/ems_networks_center_spec.rb
@@ -1,0 +1,24 @@
+describe ApplicationHelper::Toolbar::EmsNetworksCenter do
+  let(:ems_network_vmdb)        { described_class.definition['ems_network_vmdb'] }
+  let(:ems_network_vmdb_choice) { ems_network_vmdb.buttons.detect { |b| b[:id] == 'ems_network_vmdb_choice' } }
+
+  describe 'Add a New Network Provider' do
+    let(:button_hash)   { ems_network_vmdb_choice[:items].detect { |b| b[:id] == 'ems_network_new' } }
+    let(:button_klass)  { button_hash[:klass] }
+    let(:button)        { button_klass.new(nil, nil, {}, {}) }
+
+    it 'appropriate button class' do
+      expect(button_klass).to eq(ApplicationHelper::Button::EmsNetworkNew)
+    end
+
+    it 'visible when nuage provider enabled' do
+      allow(::Settings.product).to receive(:nuage).and_return(true)
+      expect(button.visible?).to eq(true)
+    end
+
+    it 'hidden when nuage provider disabled' do
+      allow(::Settings.product).to receive(:nuage).and_return(false)
+      expect(button.visible?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
With this commit we hide option "Edit this Network Provider" for any other NetworkProvider than Nuage. Editing NetworkProviders was disabled prior integrating Nuage into MIQ when we accidently enabled it for all of them. Well not any more, we hide it back for other providers while keeping it for Nuage.

@AparnaKarve this is the followup PR as promised [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/3337#issuecomment-362512635).

@miq-bot assign @AparnaKarve 
@miq-bot add_label enhancement,gaprindashvili/yes