### PR TITLE
[WIP] Fix displaying services after applying a filter

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -300,6 +300,7 @@ class ServiceController < ApplicationController
     @nodetype, id = parse_nodetype_and_id(valid_active_node(treenodeid))
     # resetting action that was stored during edit to determine what is being edited
     @sb[:action] = nil
+    @edit = session[:adv_search]["Service"] if session[:adv_search].present? && @nodetype != "s"
 
     case TreeBuilder.get_model_for_prefix(@nodetype)
     when "Service"


### PR DESCRIPTION
**fixing the issue** https://github.com/ManageIQ/manageiq-ui-classic/issues/3261

Fix displaying services **_after applying a filter and clicking on an other node in the tree_**, in _Services > My Services_ page.

---

Active Services, before applying filtering:
![all_services_no_filter](https://user-images.githubusercontent.com/13417815/36100580-03530922-1007-11e8-9145-ec1766855718.png)


Right after applying a filter by clicking on the filter in accordion:
![all_services](https://user-images.githubusercontent.com/13417815/36100306-191df83a-1006-11e8-8270-737c1d495fc3.png)

**Before fixing the issue:** (clicking on Active/Retired Services after applying the filter on all services: we see filtered Active Services, not all Active Services, filter is still applied but "Filtered by ..." is missing)
![active_services_before](https://user-images.githubusercontent.com/13417815/36100180-ab9175b2-1005-11e8-9d8a-6e008f7304a3.png)
![retired_services_before](https://user-images.githubusercontent.com/13417815/36100183-ae057212-1005-11e8-89cc-051eaac404b8.png)

**After fixing the issue:**
(added _Filtered by ..._ to match the title with the items under it)
![active_services_after](https://user-images.githubusercontent.com/13417815/36100736-8ec96f6e-1007-11e8-9062-680cfda0a711.png)
![retired_services_after](https://user-images.githubusercontent.com/13417815/36100737-913e3fe0-1007-11e8-814b-94f400665dc4.png)

---

**Details:** (check also the issue with the link above)
After applying a filter in _My Services_, there is _"Filtered by <name_of_applied_filter>."_ in the title. When clicking on _Active Services_ node in the tree (or _Retired Services_) after applying a filter, _"Filtered by..."_ disappears but services remain filtered! It was because @edit was nil so `@right_cell_text` was not updated (it depends on `@edit`) in `get_node_info` method in service controller. Setting `@edit` according to session fixes this issue. I also had to consider some specific situations, when fixing the issue: what if user clicks on some specific service from the list of services (we don't wanna see _"Filtered by.. "_ in this situation in the title) and also what if user clicks on Active Services again, after clicking on some specific service (session[:edit] would be nil in this case so it wouldn't work and the same problem would occur so I had to use `session[:adv_search]` to set `@edit` properly because only `session[:adv_search]` stores the right info in all of the situations). In some other pages, I saw that we have this feature: filtering applies on a selected node, not just on a node where we actually were when we were applying a filter on some items, so I assume that only _"Filtered by..."_ was missing in the title if we talk about the core of the issue.

Another solution would be some change in app controller, where `adv_search_build` method is NOT called, when clicking on an other node after applying some filter, because `action_name` is set to `tree_select` (and `adv_search_build` sets `@edit`, so this is why `@edit` was not set when we needed it, because https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller.rb#L1411). I avoid making changes in app controller as this could cause unexpected behavior in other pages/situations, as many pages use app controller, so I made change specifically in service controller.