### PR TITLE
Change the way that network device details are displayed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -137,6 +137,7 @@ class ApplicationController < ActionController::Base
       :emscluster                               => "grid",
       :emscontainer                             => "grid",
       :filesystem                               => "list",
+      :guestdevice                              => "list",
       :flavor                                   => "list",
       :host                                     => "grid",
       :job                                      => "list",

--- a/app/controllers/guest_device_controller.rb
+++ b/app/controllers/guest_device_controller.rb
@@ -1,0 +1,38 @@
+class GuestDeviceController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
+  include Mixins::GenericSessionMixin
+  include Mixins::MoreShowActions
+
+  before_action :check_privileges
+  before_action :session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def self.model
+    @model ||= "GuestDevice".safe_constantize
+  end
+
+  def title
+    _('Guest Devices')
+  end
+
+  def model
+    self.class.model
+  end
+
+  def self.table_name
+    @table_name ||= "guest_devices"
+  end
+
+  def session_data
+    @title  = _("Guest Devices")
+    @layout = "guest_device"
+    @lastaction = session[:guest_device_lastaction]
+  end
+
+  def set_session_data
+    session[:layout] = @layout
+    session[:guest_device_lastaction] = @lastaction
+  end
+end

--- a/app/controllers/guest_device_controller.rb
+++ b/app/controllers/guest_device_controller.rb
@@ -36,11 +36,6 @@ class GuestDeviceController < ApplicationController
     session[:guest_device_lastaction] = @lastaction
   end
 
-  def show_list
-    options = {:model => "GuestDevice", :named_scope => [:with_ethernet_type]}
-    process_show_list(options)
-  end
-
   def textual_group_list
     [
       %i(properties ports firmware),

--- a/app/controllers/guest_device_controller.rb
+++ b/app/controllers/guest_device_controller.rb
@@ -35,4 +35,9 @@ class GuestDeviceController < ApplicationController
     session[:layout] = @layout
     session[:guest_device_lastaction] = @lastaction
   end
+
+  def show_list
+    options = {:model => "GuestDevice", :named_scope => [:with_ethernet_type]}
+    process_show_list(options)
+  end
 end

--- a/app/controllers/guest_device_controller.rb
+++ b/app/controllers/guest_device_controller.rb
@@ -40,4 +40,11 @@ class GuestDeviceController < ApplicationController
     options = {:model => "GuestDevice", :named_scope => [:with_ethernet_type]}
     process_show_list(options)
   end
+
+  def textual_group_list
+    [
+      %i(properties ports firmware),
+    ]
+  end
+  helper_method(:textual_group_list)
 end

--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -13,8 +13,8 @@ class PhysicalServerController < ApplicationController
     %w(guest_devices)
   end
 
-  def display_guest_devices  
-    nested_list(GuestDevice, {:named_scope => :with_ethernet_type})
+  def display_guest_devices
+    nested_list(GuestDevice, :named_scope => :with_ethernet_type)
   end
 
   def self.table_name

--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -36,7 +36,7 @@ class PhysicalServerController < ApplicationController
 
   def textual_group_list
     [
-      %i(properties networks relationships power_management assets firmware_details network_adapters smart_management),
+      %i(properties networks relationships power_management assets firmware_details smart_management),
     ]
   end
   helper_method(:textual_group_list)

--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -9,6 +9,14 @@ class PhysicalServerController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  def self.display_methods
+    %w(guest_devices)
+  end
+
+  def display_guest_devices  
+    nested_list(GuestDevice, {:named_scope => :with_ethernet_type})
+  end
+
   def self.table_name
     @table_name ||= "physical_servers"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1342,6 +1342,7 @@ module ApplicationHelper
                         floating_ip
                         generic_object
                         generic_object_definition
+                        guest_device
                         host
                         host_aggregate
                         load_balancer
@@ -1442,6 +1443,7 @@ module ApplicationHelper
           flavor
           floating_ip
           generic_object_definition
+          guest_device
           host
           load_balancer
           middleware_deployment
@@ -1510,6 +1512,7 @@ module ApplicationHelper
              flavor
              floating_ip
              generic_object_definition
+             guest_device
              host
              host_aggregate
              load_balancer

--- a/app/helpers/application_helper/toolbar/guest_device_center.rb
+++ b/app/helpers/application_helper/toolbar/guest_device_center.rb
@@ -1,0 +1,2 @@
+class ApplicationHelper::Toolbar::GuestDeviceCenter < ApplicationHelper::Toolbar::Basic
+end

--- a/app/helpers/application_helper/toolbar/guest_devices_center.rb
+++ b/app/helpers/application_helper/toolbar/guest_devices_center.rb
@@ -1,0 +1,2 @@
+class ApplicationHelper::Toolbar::GuestDevicesCenter < ApplicationHelper::Toolbar::Basic
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -441,7 +441,7 @@ class ApplicationHelper::ToolbarChooser
                     load_balancers network_ports network_routers orchestration_stacks resource_pools
                     security_groups storages middleware_deployments
                     middleware_servers)
-    to_display_center = %w(stack_orchestration_template topology cloud_object_store_objects generic_objects physical_servers)
+    to_display_center = %w(stack_orchestration_template topology cloud_object_store_objects generic_objects physical_servers guest_devices)
     performance_layouts = %w(vm host ems_container)
     if @lastaction == 'show' && (@view || @display != 'main') && !@layout.starts_with?("miq_request")
       if @display == "vms" || @display == "all_vms"
@@ -530,6 +530,7 @@ class ApplicationHelper::ToolbarChooser
               ems_object_storage
               timeline
               usage
+              guest_device
               generic_object_definition).include?(@layout)
           if ["show_list"].include?(@lastaction)
             return "#{@layout.pluralize}_center_tb"

--- a/app/helpers/guest_device_helper.rb
+++ b/app/helpers/guest_device_helper.rb
@@ -1,0 +1,3 @@
+module GuestDeviceHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/guest_device_helper/textual_summary.rb
+++ b/app/helpers/guest_device_helper/textual_summary.rb
@@ -1,0 +1,54 @@
+module GuestDeviceHelper::TextualSummary
+  def textual_group_properties
+    TextualGroup.new(
+      _("Properties"),
+      %i(device_name location manufacturer field_replaceable_unit)
+    )
+  end
+
+  def textual_group_ports
+    ports = {:labels => [_("Name"), _("MAC Address")]}
+    ports[:values] = @record.child_devices.collect do |port|
+      [
+        port.name,
+        port.address
+      ]
+    end
+
+    TextualMultilabel.new(
+      _("Ports"),
+      ports
+    )
+  end
+
+  def textual_group_firmware
+    firmware = {:labels => [_("Name"), _("Version")]}
+    firmware[:values] = @record.firmwares.collect do |fw|
+      [
+        fw.name,
+        fw.version
+      ]
+    end
+
+    TextualMultilabel.new(
+      _("Firmware"),
+      firmware
+    )
+  end
+
+  def textual_device_name
+    {:label => _("Name"), :value => @record.device_name}
+  end
+
+  def textual_manufacturer
+    {:label => _("Manufacturer"), :value => @record.manufacturer}
+  end
+
+  def textual_location
+    {:label => _("Location"), :value => @record.location}
+  end
+
+  def textual_field_replaceable_unit
+    {:label => _("FRU"), :value => @record.field_replaceable_unit}
+  end
+end

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -156,9 +156,10 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_network_devices
-    device = {:label => _("Network Devices"), :value => @record.hardware.nics.count, :icon => "ff ff-network-card"}
-    unless @record.hardware.nics.nil?
-      device.update(:link => "/physical_server/show/#{@record.id}?display=guest_devices")
+    hardware_nics_count = @record.hardware.nics.count
+    device = {:label => _("Network Devices"), :value => hardware_nics_count, :icon => "ff ff-network-card"}
+    if hardware_nics_count > 0
+      device[:link] = "/physical_server/show/#{@record.id}?display=guest_devices"
     end
     device
   end

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -158,7 +158,7 @@ module PhysicalServerHelper::TextualSummary
   def textual_network_devices
     hardware_nics_count = @record.hardware.nics.count
     device = {:label => _("Network Devices"), :value => hardware_nics_count, :icon => "ff ff-network-card"}
-    if hardware_nics_count > 0
+    if hardware_nics_count.positive?
       device[:link] = "/physical_server/show/#{@record.id}?display=guest_devices"
     end
     device

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -158,7 +158,7 @@ module PhysicalServerHelper::TextualSummary
   def textual_network_devices
     device = {:label => _("Network Devices"), :value => @record.hardware.nics.count, :icon => "ff ff-network-card"}
     unless @record.hardware.nics.nil?
-      device.update(:link => url_for(:controller => 'guest_device', :action => 'show_list'))
+      device.update(:link => "/physical_server/show/#{@record.id}?display=guest_devices")
     end
     device
   end

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -2,7 +2,7 @@ module PhysicalServerHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i(name model product_name manufacturer machine_type serial_number ems_ref capacity memory cores health_state loc_led_state)
+      %i(name model product_name manufacturer machine_type serial_number ems_ref capacity memory cores network_devices health_state loc_led_state)
     )
   end
 
@@ -39,14 +39,6 @@ module PhysicalServerHelper::TextualSummary
       _("Firmware"),
       "textual_firmware_table",
       %i(fw_details)
-    )
-  end
-
-  def textual_group_network_adapters
-    TextualCustom.new(
-      _("Network Devices"),
-      "textual_network_adapter_table",
-      %i(network_adapter)
     )
   end
 
@@ -163,6 +155,14 @@ module PhysicalServerHelper::TextualSummary
     {:label => _("Health State"), :value => @record.health_state}
   end
 
+  def textual_network_devices
+    device = {:label => _("Network Devices"), :value => @record.hardware.nics.count, :icon => "ff ff-network-card"}
+    unless @record.hardware.nics.nil?
+      device.update(:link => url_for(:controller => 'guest_device', :action => 'show_list'))
+    end
+    device
+  end
+
   def textual_fw_details
     fw_details = []
     @record.hardware.firmwares.each do |fw|
@@ -170,30 +170,5 @@ module PhysicalServerHelper::TextualSummary
     end
 
     {:value => fw_details}
-  end
-
-  def textual_network_adapter
-    network_adapters = []
-
-    @record.hardware.nics.each do |nic|
-      port_names = []
-      mac_addresses = []
-
-      child_devices = nic.child_devices.sort_by(&:device_name)
-
-      child_devices.each do |child_device|
-        port_names.push(child_device.device_name)
-        mac_addresses.push(child_device.address)
-      end
-
-      network_adapters.push(:location      => nic.location,
-                            :adapter_name  => nic.device_name,
-                            :manufacturer  => nic.manufacturer,
-                            :fru           => nic.field_replaceable_unit,
-                            :port_names    => port_names,
-                            :mac_addresses => mac_addresses)
-    end
-
-    {:value => network_adapters}
   end
 end

--- a/app/views/guest_device/show.html.haml
+++ b/app/views/guest_device/show.html.haml
@@ -1,0 +1,7 @@
+#main_div
+  - if %w(guest_devices).include?(@display)
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  - else
+    - case @showtype
+    - when "main"
+      = render :partial => 'layouts/textual_groups_generic'

--- a/app/views/guest_device/show_list.html.haml
+++ b/app/views/guest_device/show_list.html.haml
@@ -1,0 +1,2 @@
+#main_div
+= render :partial => 'layouts/gtl'

--- a/app/views/physical_server/show.html.haml
+++ b/app/views/physical_server/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(physical_servers).include?(@display)
+  - if %w(guest_devices physical_servers).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
     - case @showtype

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1342,6 +1342,22 @@ Rails.application.routes.draw do
           save_post
     },
 
+    :guest_device    =>  {
+      :get  =>  %w(
+        show_list
+        show
+        quick_search
+      ) + compare_get,
+
+      :post   =>  %w(
+        button
+        show_list
+      ) +
+          adv_search_post +
+          exp_post +
+          save_post
+    },
+
     :ems_physical_infra_dashboard      => {
       :get => %w(
         show

--- a/product/views/GuestDevice.yaml
+++ b/product/views/GuestDevice.yaml
@@ -11,7 +11,6 @@ db: GuestDevice
 # Columns to fetch from main table
 cols:
 - device_name
-- device_type
 - location
 - manufacturer
 - field_replaceable_unit
@@ -26,7 +25,6 @@ include_for_find:
 
 col_order:
 - device_name
-- device_type
 - location
 - manufacturer
 - field_replaceable_unit
@@ -35,7 +33,6 @@ col_formats:
 
 headers:
 - Device Name
-- Device Type
 - Location
 - Manufacturer
 - Field Replaceable Unit

--- a/product/views/GuestDevice.yaml
+++ b/product/views/GuestDevice.yaml
@@ -1,0 +1,59 @@
+#Report title
+title: Guest Devices
+
+#Menu name
+name: Guest Device
+
+
+db: GuestDevice
+
+
+# Columns to fetch from main table
+cols:
+- device_name
+- device_type
+- location
+- manufacturer
+- field_replaceable_unit
+
+
+include:
+
+
+include_for_find:
+  :ext_management_system: {}
+
+
+col_order:
+- device_name
+- device_type
+- location
+- manufacturer
+- field_replaceable_unit
+
+col_formats:
+
+headers:
+- Device Name
+- Device Type
+- Location
+- Manufacturer
+- Field Replaceable Unit
+
+
+conditions:
+
+
+order: Ascending
+
+
+sortby:
+- device_name
+
+group: n
+
+
+graph:
+
+
+dims:

--- a/spec/controllers/guest_device_controller_spec.rb
+++ b/spec/controllers/guest_device_controller_spec.rb
@@ -1,0 +1,49 @@
+describe GuestDeviceController do
+  render_views
+
+  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+  let(:zone) { FactoryGirl.build(:zone) }
+
+  before(:each) do
+    stub_user(:features => :all)
+    EvmSpecHelper.create_guid_miq_server_zone
+    login_as FactoryGirl.create(:user)
+    @guest_device = FactoryGirl.create(:guest_device, :id => 1)
+  end
+
+  describe "#show_list" do
+    before(:each) do
+      FactoryGirl.create(:guest_device)
+    end
+
+    subject { get :show_list }
+
+    it do
+      is_expected.to have_http_status 200
+      is_expected.to render_template(:partial => "layouts/_gtl")
+    end
+  end
+
+  describe "#show" do
+    context "with valid id" do
+      subject { get :show, :params => {:id => @guest_device.id} }
+
+      it "should respond to show" do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/_textual_groups_generic")
+      end
+    end
+
+    context "with invalid id" do
+      subject { get :show, :params => {:id => (@guest_device.id + 1) } }
+
+      it "should redirect to #show_list" do
+        is_expected.to have_http_status 302
+        is_expected.to redirect_to(:action => :show_list)
+
+        flash_messages = assigns(:flash_array)
+        expect(flash_messages.first[:message]).to include("Can't access selected records")
+      end
+    end
+  end
+end

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -61,6 +61,15 @@ describe PhysicalServerController do
         expect(controller.send(:flash_errors?)).to be_falsey
       end
     end
+
+    context "display=guest_devices" do
+      it do
+        post :show, :params => {:id => @physical_server.id, :display => "guest_devices"}
+        expect(response.status).to eq 200
+        is_expected.to render_template(:partial => "layouts/_gtl")
+        expect(controller.send(:flash_errors?)).to be_falsey
+      end
+    end
   end
 
   describe "#button" do


### PR DESCRIPTION
This PR changes the way that network device details are displayed on the physical server summary page. The existing _Network Devices_ table was removed, and a new row named _Network Devices_ was added to the _Properties_ table. In this new row, the number of network devices a server has is displayed, and this row can be clicked on to go to a page displaying all network devices. Clicking on an entry on the network devices page takes the user to the network device summary page for that device.

This PR depends on changes made in https://github.com/ManageIQ/manageiq/pull/16996

![image](https://user-images.githubusercontent.com/23690141/36504082-5009c5b8-171d-11e8-8520-ec1a76dea36f.png)
![image](https://user-images.githubusercontent.com/23690141/36503888-b5b190a4-171c-11e8-9847-071e738df6dd.png)
![image](https://user-images.githubusercontent.com/23690141/36503953-e936b2ec-171c-11e8-9f25-6d3540ee8d22.png)

