### PR TITLE
Fix folding of accordion after adding a schedule

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -184,7 +184,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
 
   if (_.isString(data.clearTreeCookies)) { miqDeleteTreeCookies(data.clearTreeCookies); }
 
-  if (_.isString(data.accordionSwap)) {
+  if (_.isString(data.accordionSwap) && ! data.activateNode.activeTree.includes(data.accordionSwap)) {
     miqAccordionSwap('#accordion .panel-collapse.collapse.in', '#' + data.accordionSwap + '_accord');
   }
 


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1441101

Fix folding of accordion after adding or editing a schedule in _Cloud Intel > Reports > Schedules_.

**Before:** (_Schedules_ accordion closes after adding a new schedule)
![add_schedule_before](https://user-images.githubusercontent.com/13417815/36157670-a23ca470-10da-11e8-9645-2e54a681b61d.png)

**After:** (_Schedules_ accordion remains open after adding a new schedule)
![add_schedule_after](https://user-images.githubusercontent.com/13417815/36157524-44d72878-10da-11e8-8279-ab52cd29d04f.png)

@skateman Could you please look at it? Thanks a lot! ;)

Some details:
I've added a condition to check active tree (which is set in explorer presenter) and if we are in the same tree as accordion we want to collapse, it just does not happen.