### PR TITLE
Copy nodes object to fix iteration when adding new tree items

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -59,7 +59,7 @@ function miqTreeResetState(treename) {
 function miqRemoveNodeChildren(treename, key) {
   var node = miqTreeFindNodeByKey(treename, key);
   if (node.nodes) {
-    node.nodes.forEach(function(child) {
+    node.nodes.slice().forEach(function(child) {
       miqTreeObject(treename).removeNode(child);
     });
   }


### PR DESCRIPTION
We need a copy of the `node.nodes` to iterate through them with deletion, credit goes to @himdel. For the actual issue and steps to reproduce see the GH issue below.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544844
Fixes https://github.com/ManageIQ/manageiq/issues/15743