### PR TITLE
Deactivate Add button when name field is cleared

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -814,6 +814,7 @@ module OpsController::OpsRbac
     if rec_type == "group"
       bad = (@edit[:new][:role].blank? || @edit[:new][:group_tenant].blank?)
     end
+    bad = @edit[:new][:name].blank? if rec_type == 'role'
 
     render :update do |page|
       page << javascript_prologue


### PR DESCRIPTION
Prevents the Add button from remaining active when populating the Name field and then clearing the Name field.

@miq-bot add_labels bug, settings, gaprindashvili/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1486681