### PR TITLE
 Instances without tenants should not cause navigation to fail on InstanceAttach checks

### DIFF
--- a/app/helpers/application_helper/button/instance_attach.rb
+++ b/app/helpers/application_helper/button/instance_attach.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::InstanceAttach < ApplicationHelper::Button::Basic
   def disabled?
-    if @record.cloud_tenant.cloud_volumes.where(:status => 'available').count.zero?
+    if @record.cloud_tenant.nil? || @record.cloud_tenant.cloud_volumes.where(:status => 'available').count.zero?
       @error_message = _("There are no Cloud Volumes available to attach to this Instance.")
     end
     @error_message.present?


### PR DESCRIPTION
Fixes the UI bug in https://bugzilla.redhat.com/show_bug.cgi?id=1544732