### PR TITLE
Allow the ownership to be set to 'No group'

### DIFF
--- a/app/views/shared/views/_ownership.html.haml
+++ b/app/views/shared/views/_ownership.html.haml
@@ -32,11 +32,13 @@
         = _('Select a Group:')
       .col-md-8
         - if @ownershipitems.length > 1
-          - opts = [["<#{_("Don't change")}>", 'dont-change']] + @groups.sort
+          - opts = [["<#{_("Don't change")}>", 'dont-change'], ["<#{_('No User Group')}>", '']] + @groups.sort
         - else
-          - opts = @groups.sort
+          - user_group = MiqGroup.find_by(:id => @group).tenant_group? ? @group : ''
+          - opts =  [["<#{_('No User Group')}>", user_group]]
+        - opts += @groups.sort
         = select_tag("group",
-                      options_for_select(opts, @group),
+                      options_for_select(opts, user_group),
                       "ng-model"                    => "vm.ownershipModel.group",
                       "id"                          => "group_name",
                       "checkchange"                 => "",

--- a/spec/views/shared/views/_ownership.html.haml_spec.rb
+++ b/spec/views/shared/views/_ownership.html.haml_spec.rb
@@ -1,0 +1,33 @@
+describe "shared/views/_ownership" do
+  let(:root_tenant) do
+    Tenant.seed
+  end
+
+  let(:default_tenant) do
+    root_tenant
+    Tenant.default_tenant
+  end
+  let(:user)         { FactoryGirl.create(:user, :userid => 'user', :miq_groups => [tenant_group]) }
+  let(:tenant)       { FactoryGirl.build(:tenant, :parent => default_tenant) }
+  let(:tenant_users) { FactoryGirl.create(:miq_user_role, :name => "tenant-users") }
+  let(:tenant_group) { FactoryGirl.create(:miq_group, :miq_user_role => tenant_users, :tenant => tenant) }
+  let(:user_role)    { FactoryGirl.create(:miq_user_role) }
+  let(:user_group)   { FactoryGirl.create(:miq_group, :miq_user_role => user_role) }
+
+  before do
+    set_controller_for_view("vm_infra")
+    set_controller_for_view_to_be_nonrestful
+  end
+
+  it "the ownership group dropdown includes the no group option" do
+    vm = FactoryGirl.create(:vm_vmware, :miq_group => tenant_group)
+    allow(view).to receive(:ownership_user_options).and_return([user.id])
+    allow(view).to receive(:settings).and_return('list')
+    allow(view).to receive(:render_gtl_outer)
+    @groups = [tenant_group.id, user_group.id]
+    @origin_ownership_items = @ownershipitems = Vm.where(:id => vm.id)
+    @group = vm.miq_group
+    render
+    expect(rendered).to include('No User Group')
+  end
+end


### PR DESCRIPTION
Add back the option of 'No User Group' ownership ( No group will default to the tenant group of the root tenant). If the owner group is set to a tenant group, the dropdown will show 'No User Group'.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1483512

Before:
![screenshot from 2018-02-15 14-07-11](https://user-images.githubusercontent.com/12769982/36276132-ef0f6e96-125a-11e8-93a0-6500a8d00394.png)



After:
![screenshot from 2018-02-15 13-41-49](https://user-images.githubusercontent.com/12769982/36274584-2f287946-1256-11e8-9f04-27db8890b21c.png)
