### PR TITLE
Remove tota11y

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -2,5 +2,3 @@
 - if is_browser_ie?
   %script{:defer => "defer", :type => "text/javascript"}
     miqOnLoad();
-- if Rails.env.development?
-  = javascript_include_tag 'bower_components/tota11y/build/tota11y'

--- a/bower.json
+++ b/bower.json
@@ -50,7 +50,6 @@
     "spice-html5-bower": "himdel/spice-html5-bower#~1.7.1",
     "spin.js": "~2.3.2",
     "sprintf": "~1.0.3",
-    "tota11y": "~0.1.6",
     "xml_display": "~0.1.1"
   },
   "resolutions": {

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,7 +10,6 @@ Rails.application.config.assets.precompile += %w(
   bower_components/codemirror/themes/*.css
   bower_components/jquery/dist/jquery.js
   bower_components/jquery-ui/jquery-ui.js
-  bower_components/tota11y/build/tota11y.js
 
   jquery_overrides.js
   remote_consoles/*.js


### PR DESCRIPTION
A dev-only library that doesn't appear to be used now.

Introduced in ManageIQ/manageiq#8387.

See #3391 for more details :).
