### PR TITLE
Add redirect to request show_list page

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -421,13 +421,7 @@ module ApplicationController::CiProcessing
 
     options = {:ids => objs, :task => task, :userid => session[:userid]}
     options[:snap_selected] = session[:snap_selected] if task == "remove_snapshot" || task == "revert_to_snapshot"
-
-    if task == 'retire_now'
-      options = {:task => task, :userid => session[:userid], :ids => objs, :src_ids => objs}
-      (klass.to_s + "RetireRequest").constantize.make_request(@request_id, options, current_user)
-    else
-      klass.process_tasks(options)
-    end
+    klass.process_tasks(options)
   rescue => err
     add_flash(_("Error during '%{task}': %{error_message}") % {:task => task, :error_message => err.message}, :error)
   else

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -94,6 +94,7 @@ class OrchestrationStackController < ApplicationController
         orchestration_stack_retire
       when "orchestration_stack_retire_now"
         orchestration_stack_retire_now
+        return
       when "orchestration_stack_tag"
         tag(OrchestrationStack)
       when params[:pressed] == "custom_button"

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -261,6 +261,7 @@ class ServiceController < ApplicationController
   def service_retire
     @explorer = true
     retirevms
+    replace_right_cell(:action => 'retire')
   end
 
   def service_retire_now

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -261,13 +261,11 @@ class ServiceController < ApplicationController
   def service_retire
     @explorer = true
     retirevms
-    replace_right_cell(:action => 'retire')
   end
 
   def service_retire_now
     @explorer = true
     retirevms_now
-    replace_right_cell
   end
 
   def service_set_record_vars(svc)

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -872,6 +872,8 @@ describe ServiceController do
                                    )
       service.update_attribute(:id, template.id)
       service.reload
+      login_as FactoryGirl.create(:user_admin)
+      allow(User).to receive_messages(:server_timezone => "UTC")
       controller.instance_variable_set(:@_params, :miq_grid_checks => service.id.to_s)
       expect(controller).to receive(:show_list)
       controller.send(:vm_button_operation, 'retire_now', "Retirement")
@@ -945,6 +947,8 @@ describe VmOrTemplateController do
         :storage               => FactoryGirl.create(:storage)
       )
 
+      login_as FactoryGirl.create(:user_admin)
+      allow(User).to receive_messages(:server_timezone => "UTC")
       controller.instance_variable_set(:@_params, :miq_grid_checks => vm.id.to_s)
       expect(controller).to receive(:show_list)
       controller.send(:vm_button_operation, 'retire_now', "Retirement")

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -872,8 +872,6 @@ describe ServiceController do
                                    )
       service.update_attribute(:id, template.id)
       service.reload
-      login_as FactoryGirl.create(:user_admin)
-      allow(User).to receive_messages(:server_timezone => "UTC")
       controller.instance_variable_set(:@_params, :miq_grid_checks => service.id.to_s)
       expect(controller).to receive(:show_list)
       controller.send(:vm_button_operation, 'retire_now', "Retirement")
@@ -947,8 +945,6 @@ describe VmOrTemplateController do
         :storage               => FactoryGirl.create(:storage)
       )
 
-      login_as FactoryGirl.create(:user_admin)
-      allow(User).to receive_messages(:server_timezone => "UTC")
       controller.instance_variable_set(:@_params, :miq_grid_checks => vm.id.to_s)
       expect(controller).to receive(:show_list)
       controller.send(:vm_button_operation, 'retire_now', "Retirement")

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -208,16 +208,16 @@ describe OrchestrationStackController do
       it "retires the orchestration stack now" do
         record = FactoryGirl.create(:orchestration_stack_cloud)
         session[:orchestration_stack_lastaction] = 'show_list'
+        expect(controller).to receive(:render).at_least(:once)
         post :button, :params => {:miq_grid_checks => record.id, :pressed => "orchestration_stack_retire_now"}
-        expect(response.status).to eq(200)
         expect(controller.send(:flash_errors?)).not_to be_truthy
       end
 
       it "retires the orchestration stack now when called from the summary page" do
         record = FactoryGirl.create(:orchestration_stack_cloud)
         session[:orchestration_stack_lastaction] = 'show'
+        expect(controller).to receive(:render).at_least(:once)
         post :button, :params => {:id => record.id, :pressed => "orchestration_stack_retire_now"}
-        expect(response.status).to eq(200)
         expect(controller.send(:flash_errors?)).not_to be_truthy
       end
     end

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -320,8 +320,9 @@ describe VmInfraController do
     post :explorer
     expect(response.status).to eq(200)
 
+    expect(controller).to receive(:render).at_least(:once)
     post :x_button, :params => {:pressed => 'vm_retire_now', :id => vm_vmware.id}
-    expect(response.status).to eq(200)
+    expect(response).to render_template(:partial => 'layouts/_flash_msg')
   end
 
   it 'can reset selected items' do


### PR DESCRIPTION
VM retirement should be a request. This redirects to the request list page after hitting the retire_now option on a VM. 
## Related to:
~~https://github.com/ManageIQ/manageiq-automation_engine/pull/157~~
~~https://github.com/ManageIQ/manageiq-content/pull/262~~

## Depends on:
~~https://github.com/ManageIQ/manageiq/pull/16933~~
