### PR TITLE
Use the top-level dialogEditor component and drop unnecessary code

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -3,16 +3,10 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'miqServic
 
   vm.saveDialogDetails = saveDialogDetails;
   vm.dismissChanges = dismissChanges;
-  vm.setupModalOptions = setupModalOptions;
 
   // treeSelector related
   vm.lazyLoad = DialogEditorHttp.treeSelectorLazyLoadData;
-  vm.onSelect = onSelect;
-  vm.showFullyQualifiedName = showFullyQualifiedName;
   vm.node = {};
-  vm.treeSelectorToggle = treeSelectorToggle;
-  vm.treeSelectorIncludeDomain = false;
-  vm.treeSelectorShow = false;
   DialogEditorHttp.treeSelectorLoadData().then(function(data) {
     vm.treeSelectorData = data;
   });
@@ -72,48 +66,6 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'miqServic
     vm.dialog = dialog;
     vm.DialogValidation = DialogValidation;
     vm.DialogEditor = DialogEditor;
-  }
-
-  function setupModalOptions(type, tab, box, field) {
-    var components = {
-      tab: 'dialog-editor-modal-tab',
-      box: 'dialog-editor-modal-box',
-      field: 'dialog-editor-modal-field'
-    };
-    vm.modalOptions = {
-      component: components[type],
-      size: 'lg',
-    };
-    vm.elementInfo = { type: type, tabId: tab, boxId: box, fieldId: field };
-    vm.visible = true;
-  }
-
-
-  function onSelect(node, elementData) {
-    var fqname = node.fqname.split('/');
-    if (vm.treeSelectorIncludeDomain === false) {
-      fqname.splice(1, 1);
-    }
-    elementData.resource_action.ae_instance = fqname.pop();
-    elementData.resource_action.ae_class = fqname.pop();
-    elementData.resource_action.ae_namespace = fqname.filter(String).join('/');
-    vm.treeSelectorShow = false;
-  }
-
-  function showFullyQualifiedName(resourceAction) {
-    if (typeof resourceAction.ae_namespace === 'undefined' ||
-        typeof resourceAction.ae_class === 'undefined' ||
-        typeof resourceAction.ae_instance === 'undefined') {
-      return '';
-    }
-    var fqname = resourceAction.ae_namespace
-      + '/' + resourceAction.ae_class
-      + '/' + resourceAction.ae_instance;
-    return fqname;
-  }
-
-  function treeSelectorToggle() {
-    vm.treeSelectorShow = ! vm.treeSelectorShow;
   }
 
   var beingCloned = null; // hack that solves recursion problem for cloneDeep

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -17,25 +17,7 @@
             %textarea#description{"ng-model" => "vm.dialog.content[0].description",
               :title => _("Dialog's description")}
               {{ vm.dialog.content[0].description }}
-    .dialog-designer-container
-      %dialog-editor-modal{"modal-options" => "vm.modalOptions",
-                           "element-info" => "vm.elementInfo",
-                           "lazy-load" => "vm.lazyLoad",
-                           "on-select" => "vm.onSelect",
-                           "show-fully-qualified-name" => "vm.showFullyQualifiedName",
-                           "tree-selector-data" => "vm.treeSelectorData",
-                           "tree-selector-include-domain" => "vm.treeSelectorIncludeDomain",
-                           "tree-selector-show" => "vm.treeSelectorShow",
-                           "tree-selector-toggle" => "vm.treeSelectorToggle",
-                           :visible => "vm.modalVisible"}
-      .toolbox-container
-        #toolbox.static-field-container
-          .draggable
-            %dialog-editor-field-static
-        .editable-fields-container
-          %dialog-editor-tabs{"setup-modal-options" => "vm.setupModalOptions(type, tab, box, field)"}
-          %dialog-editor-boxes{"setup-modal-options" => "vm.setupModalOptions(type, tab, box, field)"}
-
+    %dialog-editor{'tree-selector-data' => 'vm.treeSelectorData', 'tree-selector-lazy-load' => 'vm.lazyLoad'}
     .pull-right
       %button.btn.btn-default{"ng-click" => "vm.dismissChanges()",
                               :type => "button"}= _("Cancel")


### PR DESCRIPTION
There's a lot of spaghetti code in the `dialog_editor_controller.js` that shouldn't even be there. I'm creating a top-level `dialogEditor` component in ui-components that will take over some functionalities from this controller. In the future these methods should be moved down into the related sub-components.

Depends on: https://github.com/ManageIQ/ui-components/pull/257

@miq-bot assign @romanblanco 