### PR TITLE
bin/update: run update_ui

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -11,4 +11,6 @@ else
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
-ManageIQ::Environment.manageiq_plugin_update
+ManageIQ::Environment.manageiq_plugin_update(gem_root)
+
+ManageIQ::Environment.update_ui


### PR DESCRIPTION
right now, only manageiq `bin/update` regenerates UI assets, installs bower & npm deps, etc.

it makes sense to me that ui-classic's `bin/update` should do the same thing (because people tend to use it sometimes and expect it to work :))

@bdunne WDYT?