### PR TITLE
[FINE] - Show custom reports in menu editor as available reports.

### DIFF
--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -10,7 +10,7 @@ module ReportController::Menus
       @rpt_menu = copy_array(@edit[:new])
     elsif @menu_lastaction == "default"
     else
-      populate_reports_menu("reports", "menu")
+      populate_reports_menu(true)
       tree = build_menu_roles_tree
       @rpt_menu = tree.rpt_menu
     end
@@ -211,7 +211,7 @@ module ReportController::Menus
       get_tree_data
       replace_right_cell(:menu_edit_action => "menu_reset")
     elsif params[:button] == "default"
-      populate_reports_menu("reports", "default")
+      @sb[:rpt_menu]   = default_reports_menu
       @menu_roles_tree = build_menu_roles_tree
       @edit[:new]      = copy_array(@sb[:rpt_menu])
       @menu_lastaction = "default"
@@ -265,7 +265,7 @@ module ReportController::Menus
     current_group_id = current_user.current_group.try(:id).to_i
     id = session[:node_selected].split('__')
     @selected = id[1].split(':')
-    all = MiqReport.for_user(current_user).sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
+    all = MiqReport.all.sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
     @all_reports = []
     all.each do |r|
       next if r.template_type != "report" && !r.template_type.blank?

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -314,7 +314,7 @@ module ReportController::Schedules
     @edit[:new]      = {}
     @edit[:current]  = {}
     @edit[:key]      = "schedule_edit__#{@schedule.id || "new"}"
-    @menu            = get_reports_menu
+    @menu            = get_reports_menu(true)
     @menu.each { |r| @folders.push(r[0]) }
 
     @edit[:new][:name]        = @schedule.name

--- a/spec/controllers/miq_report_controller/menus_spec.rb
+++ b/spec/controllers/miq_report_controller/menus_spec.rb
@@ -1,23 +1,25 @@
 describe ReportController do
   describe "#menu_update" do
+    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:report) { FactoryGirl.create(:miq_report, :rpt_type => "Default", :rpt_group => 'foo - bar', :miq_group => user.current_group) }
+
     before do
       controller.instance_variable_set(:@edit, :new => {})
       controller.instance_variable_set(:@sb, :new => {})
       controller.instance_variable_set(:@_params, :button => "default")
-      tenant = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant, :name => "foo - bar", :subdomain => "foo - bar")
-      @user = FactoryGirl.create(:user_with_group, :tenant => tenant)
-      @report = FactoryGirl.create(:miq_report, :rpt_type => "Custom", :miq_group => @user.current_group)
-      allow(controller).to receive(:current_user).and_return(@user)
-      login_as @user
+      allow(controller).to receive(:current_user).and_return(user)
+      login_as user
+      report
     end
 
     it "set menus to default and sets correct title for custom reports" do
       expect(controller).to receive(:menu_get_form_vars)
+      expect(controller).to receive(:build_menu_roles_tree)
       expect(controller).to receive(:get_tree_data)
       expect(controller).to receive(:replace_right_cell)
 
       controller.menu_update
-      expect(assigns(:edit)[:new]).to eq([["foo - bar (EVM Group): #{@user.current_group.description}", [["Custom", [@report.name]]]]])
+      expect(assigns(:edit)[:new]).to eq([["foo", [["bar", [report.name]]]]])
       expect(assigns(:flash_array).first[:message]).to include("default")
     end
   end

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -194,7 +194,7 @@ describe ReportController do
       end
 
       it 'renders form to edit Role in Roles tree' do
-        FactoryGirl.create(:miq_report)
+        FactoryGirl.create(:miq_report, :name => "VM 1", :rpt_group => "Configuration Management - Folder Foo", :rpt_type => "Default")
         user = FactoryGirl.create(:user_with_group)
         login_as user
         post :tree_select, :params => { :id => "g-#{user.current_group.id}", :format => :js, :accord => 'roles' }


### PR DESCRIPTION
Fixed code to show Custom reports in Available Reports box in menu editor. Code has been refactored and fixed on Upstream and G release, this is a Fine specific fix.

backported changes from https://github.com/ManageIQ/manageiq-ui-classic/pull/3245 to fix issues in menu editor/reports accordion tree.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1496924
https://bugzilla.redhat.com/show_bug.cgi?id=1545441
https://bugzilla.redhat.com/show_bug.cgi?id=1535023

@dclarizio please review.

before:
![before](https://user-images.githubusercontent.com/3450808/36278569-3a9bd938-1262-11e8-8685-b917d5571086.png)

after:
![after](https://user-images.githubusercontent.com/3450808/36278587-458d7dd8-1262-11e8-80c3-bdb599c749a5.png)

