### PR TITLE
Fix logic for selecting radio button on Catalog Item edit screen

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -16,7 +16,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       provisioning_cloud_credential_id: '',
       provisioning_execution_ttl: '',
       provisioning_inventory: 'localhost',
-      provisioning_dialog_existing: 'existing',
+      provisioning_dialog_existing: '',
       provisioning_dialog_id: '',
       provisioning_dialog_name: '',
       provisioning_key: '',


### PR DESCRIPTION
The 'Use Existing' Dialog radio button was not cooperating when it should have been checked by default. 

@miq-bot add_labels bug, services

https://bugzilla.redhat.com/show_bug.cgi?id=1543136