### PR TITLE
Extract all API/HTTP calls from dialogEditorController to a service

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -1,7 +1,6 @@
 ManageIQ.angular.app.controller('dialogEditorController', ['$window', '$http', 'API', 'miqService', 'DialogEditor', 'DialogValidation', 'dialogIdAction', function($window, $http, API, miqService, DialogEditor, DialogValidation, dialogIdAction) {
   var vm = this;
 
-  vm.cache = {};
   vm.$http = $http;
 
   vm.saveDialogDetails = saveDialogDetails;
@@ -99,7 +98,6 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', '$http', '
   function lazyLoad(node) {
     return vm.$http.get('/tree/automate_entrypoint?id=' + encodeURIComponent(node.key))
     .then(function(response) {
-      vm.cache[node.key] = response.data;
       return response.data;
     });
   }

--- a/app/assets/javascripts/services/dialog_editor_http_service.js
+++ b/app/assets/javascripts/services/dialog_editor_http_service.js
@@ -1,0 +1,26 @@
+ManageIQ.angular.app.service('DialogEditorHttp', ['$http', 'API', function($http, API) {
+  this.loadDialog = function(id) {
+    return API.get('/api/service_dialogs/' + id + '?attributes=content,buttons,label');
+  };
+
+  this.saveDialog = function(id, action, data) {
+    return API.post('/api/service_dialogs' + id, {
+      action: action,
+      resource: data,
+    }, {
+      skipErrors: [400],
+    });
+  };
+
+  this.treeSelectorLoadData = function() {
+    return $http.get('/tree/automate_entrypoint').then(function(response) {
+      return response.data;
+    });
+  };
+
+  this.treeSelectorLazyLoadData = function(node) {
+    return $http.get('/tree/automate_entrypoint?id=' + encodeURIComponent(node.key)).then(function(response) {
+      return response.data;
+    });
+  };
+}]);


### PR DESCRIPTION
I am moving out all the MiQ-related API/HTTP calls to a single service. I also found out that the caching feature is just copy-pasted from [my example](https://github.com/ManageIQ/manageiq-ui-classic/pull/2091) but not being actually used, so deleting that too.

My long-term plan is to have an interface specified for this service that would allow to easily re-use the dialog editor elsewhere.

@miq-bot assign @romanblanco 