### PR TITLE
Menu::Manager - support adding to existing sections

### DIFF
--- a/app/presenters/menu/manager.rb
+++ b/app/presenters/menu/manager.rb
@@ -73,6 +73,12 @@ module Menu
 
     def merge_sections(sections)
       sections.each do |section|
+        duplicate = @menu.find { |existing_section| existing_section.id == section.id }
+        if duplicate
+          duplicate.items.push(*section.items)
+          next
+        end
+
         position = nil
         if section.before
           position = @menu.index { |existing_section| existing_section.id == section.before }


### PR DESCRIPTION
Right now, plugins can add new sections and items in the menu, but can't append to existing sections.

Menu sections already have ids, with this PR, if you create an already existing section in a plugin, it will get merged with the existing one.

Cc @ZitaNemeckova, @priley86
@martinpovolny please review

This is so that v2v can replace https://github.com/priley86/manageiq-ui-classic/commit/5367072f6a10ae806da3a62f000a754d6f89ed26 with an in-plugin solution.