### PR TITLE
Remove dead build_*_tree methods

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -205,19 +205,6 @@ class AutomationManagerController < ApplicationController
     ]
   end
 
-  def build_automation_manager_tree(type, name)
-    tree = case name
-           when :automation_manager_providers_tree
-             TreeBuilderAutomationManagerProviders.new(name, type, @sb)
-           when :automation_manager_cs_filter_tree
-             TreeBuilderAutomationManagerConfiguredSystems.new(name, type, @sb)
-           else
-             TreeBuilderAutomationManagerConfigurationScripts.new(name, type, @sb)
-           end
-    instance_variable_set :"@#{name}", tree.tree_nodes
-    tree
-  end
-
   def get_node_info(treenodeid, _show_list = true)
     @sb[:action] = nil
     @nodetype, id = parse_nodetype_and_id(valid_active_node(treenodeid))

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -205,15 +205,6 @@ class InfraNetworkingController < ApplicationController
     end
   end
 
-  def build_infra_networking_tree(type, name)
-    tree = case name
-           when :infra_networking_tree
-             TreeBuilderConfigurationManager.new(name, type, @sb)
-           end
-    instance_variable_set :"@#{name}", tree.tree_nodes
-    tree
-  end
-
   def get_node_info(treenodeid, show_list = true)
     @sb[:action] = nil
     @nodetype, id = parse_nodetype_and_id(valid_active_node(treenodeid))


### PR DESCRIPTION
Closes #1922 

The only way to call a `build_*_tree` method without actually invoking the name is via 
`try_build_tree`, but that one only passes 1 or 0 arguments.

Thus, any `build_*_tree` method which relies on the second argument and is not called directly is not called at all.

By coincidence those are exactly the methods which still use `instance_variable_set(:"@#{name}")` :fire: 

Removing those :)