### PR TITLE
Make view selector of All Generic Objects page work

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -69,6 +69,7 @@ class ServiceController < ApplicationController
   def set_display
     @display = params[:display]
     @display ||= default_display unless pagination_or_gtl_request?
+    @display ||= 'generic_objects' if role_allows?(:feature => "generic_object_view") && @record.number_of(:generic_objects).positive?
   end
 
   def show_generic_object


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1545296

Make view selector of _All Generic Objects_ page work, when attaching GO to a service
and navigating to _Services > My Services_ > service with GO and clicking on _Instances_
from _Generic Objects_ table (where we can change the view from tile also to grid/list).

Right before changing the view in  _All Generic Objects_ page (now default Tile view):
![service_go](https://user-images.githubusercontent.com/13417815/36377500-b0af5614-1577-11e8-90fd-d3df74be79ab.png)

**Before:** (after clicking on Grid/List view from _All Generic Objects_ page)
![service_go_before](https://user-images.githubusercontent.com/13417815/36377728-76bed604-1578-11e8-9b69-7017eec7e442.png)

**After:**
![service_go_grid](https://user-images.githubusercontent.com/13417815/36377632-1fb15792-1578-11e8-9ab6-3d779746fc0c.png)
![service_go_list](https://user-images.githubusercontent.com/13417815/36377639-2202627a-1578-11e8-8224-3fbe963bea5c.png)
