### PR TITLE
Custom button group - validate required fields before enabling buttons

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -440,7 +440,7 @@ module ApplicationController::Buttons
         replace_right_cell(:nodetype => x_node, :replace_trees => x_active_tree == :ab_tree ? [:ab] : [:sandt])
       else
         @custom_button_set.errors.each do |field, msg|
-          add_flash(_("Error during 'add': %{field_name} %{error_name}") %
+          add_flash(_("Error during 'add': %{field_name} %{error_message}") %
             {:field_name => field.to_s.capitalize, :error_message => msg}, :error)
         end
         @lastaction = "automate_button"

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -186,19 +186,29 @@ module ApplicationController::Buttons
     button_create_update("create")
   end
 
+  def group_form_valid
+    required = %i(name description button_icon)
+
+    required.none? do |field|
+      @edit[:new][field].blank?
+    end
+  end
+
   # AJAX driven routine to check for changes in ANY field on the form
   def group_form_field_changed
     return unless load_edit("bg_edit__#{params[:id]}", "replace_cell__explorer")
     group_get_form_vars
     @custom_button_set = @edit[:custom_button_set_id] ? CustomButtonSet.find_by_id(@edit[:custom_button_set_id]) : CustomButtonSet.new
     @changed = (@edit[:new] != @edit[:current])
+    valid = group_form_valid
+
     render :update do |page|
       page << javascript_prologue
       page.replace(@refresh_div, :partial => "shared/buttons/#{@refresh_partial}") if @refresh_div
       if @flash_array
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       else
-        page << javascript_for_miq_button_visibility(@changed)
+        page << javascript_for_miq_button_visibility(@changed && valid)
       end
     end
   end


### PR DESCRIPTION
Automation > Automate > Customization, Buttons accordion, select object type, Configuration > Add Button Group

Right now, it's apparently possible to submit the form before all the input changes made it to the server.

This enables server-side validation for the required fields.
Fixing this properly will probably mean an angular/react rewrite of the screen.

(+ a fix for the error message when it goes wrong :))

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536670