### PR TITLE
Extract categories API call from dialog editor into DEHttpService

### DIFF
--- a/app/assets/javascripts/services/dialog_editor_http_service.js
+++ b/app/assets/javascripts/services/dialog_editor_http_service.js
@@ -23,4 +23,11 @@ ManageIQ.angular.app.service('DialogEditorHttp', ['$http', 'API', function($http
       return response.data;
     });
   };
+
+  // Load categories data from API.
+  this.loadCategories = function() {
+    return API.get('/api/categories' +
+                        '?expand=resources' +
+                        '&attributes=description,single_value,children');
+  };
 }]);


### PR DESCRIPTION
Continuing the effort started in https://github.com/ManageIQ/ui-components/issues/219 and #3414, @romanblanco found an [API call](https://github.com/ManageIQ/ui-components/blob/f816998ade87ef8a4a018fb4fb84b49ed684535a/src/dialog-editor/components/modal/modalComponent.ts#L100) in `ui-components`. 