### PR TITLE
[WIP] Rename "Global Filters" to "Default Filters"

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -603,7 +603,7 @@ module OpsController::Settings::Schedules
       [_("All VMs for Host"), "host"],
       [_("A single VM"), "vm"]
     ] +
-                             (@vm_global_filters.empty? ? [] : [[_("Global Filters"), "global"]]) +
+                             (@vm_global_filters.empty? ? [] : [[_("Default Filters"), "global"]]) +
                              (@vm_my_filters.empty? ? [] : [[_("My Filters"), "my"]])
 
     @template_options_for_select = [
@@ -613,7 +613,7 @@ module OpsController::Settings::Schedules
       [_("All Templates for Host"), "host"],
       [_("A single Template"), "miq_template"]
     ] +
-                                   (@miq_template_global_filters.empty? ? [] : [[_("Global Filters"), "global"]]) +
+                                   (@miq_template_global_filters.empty? ? [] : [[_("Default Filters"), "global"]]) +
                                    (@miq_template_my_filters.empty? ? [] : [[_("My Filters"), "my"]])
 
     @host_options_for_select = [
@@ -622,7 +622,7 @@ module OpsController::Settings::Schedules
       [_("All Hosts for Clusters / Deployment Roles"), "cluster"],
       [_("A single Host"), "host"]
     ] +
-                               (@host_global_filters.empty? ? [] : [[_("Global Filters"), "global"]]) +
+                               (@host_global_filters.empty? ? [] : [[_("Default Filters"), "global"]]) +
                                (@host_my_filters.empty? ? [] : [[_("My Filters"), "my"]])
 
     # to do, add scheduling by project
@@ -637,7 +637,7 @@ module OpsController::Settings::Schedules
       [_("All Clusters for Infrastructure Provider"), "ems"],
       [_("A single Cluster"), "cluster"]
     ] +
-                                  (@cluster_global_filters.empty? ? [] : [[_("Global Filters"), "global"]]) +
+                                  (@cluster_global_filters.empty? ? [] : [[_("Default Filters"), "global"]]) +
                                   (@cluster_my_filters.empty? ? [] : [[_("My Filters"), "my"]])
 
     @storage_options_for_select = [
@@ -646,7 +646,7 @@ module OpsController::Settings::Schedules
       [_("All Datastores for Infrastructure Provider"), "ems"],
       [_("A single Datastore"), "storage"]
     ] +
-                                  (@storage_global_filters.empty? ? [] : [[_("Global Filters"), "global"]]) +
+                                  (@storage_global_filters.empty? ? [] : [[_("Default Filters"), "global"]]) +
                                   (@storage_my_filters.empty? ? [] : [[_("My Filters"), "my"]])
 
     build_db_options_for_select

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -30,9 +30,9 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
     end
 
     objects.push(:id         => "global",
-                 :text       => _("Global Filters"),
+                 :text       => _("Default Filters"),
                  :icon       => "pficon pficon-folder-close",
-                 :tip        => _("Global Shared Filters"),
+                 :tip        => _("Default Shared Filters"),
                  :selectable => false)
     objects.push(:id         => "my",
                  :text       => _("My Filters"),

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -14,7 +14,7 @@ class TreeBuilderConfiguredSystems < TreeBuilder
 
   def x_get_search_results(object, leaf)
     case object[:id]
-    when "global" # Global filters
+    when "global" # Default filters
       x_get_global_filter_search_results(leaf)
     when "my"     # My filters
       x_get_my_filter_search_results(leaf)
@@ -35,9 +35,9 @@ class TreeBuilderConfiguredSystems < TreeBuilder
     objects = []
     objects.push(configured_systems)
     objects.push(:id         => "global",
-                 :text       => _("Global Filters"),
+                 :text       => _("Default Filters"),
                  :icon       => "pficon pficon-folder-close",
-                 :tip        => _("Global Shared Filters"),
+                 :tip        => _("Default Shared Filters"),
                  :selectable => false)
     objects.push(:id         => "my",
                  :text       => _("My Filters"),

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -41,7 +41,7 @@ class TreeBuilderServices < TreeBuilder
     objects = [
       services_root('asrv', _('Active Services'),  _('Active Services')),
       services_root('rsrv', _('Retired Services'), _('Retired Services')),
-      filter_root('global', _('Global Filters'),   _('Global Shared Filters')),
+      filter_root('global', _('Default Filters'),   _('Default Shared Filters')),
       filter_root('my',     _('My Filters'),       _('My Personal Filters'))
     ]
     count_only_or_objects(count_only, objects)
@@ -50,7 +50,7 @@ class TreeBuilderServices < TreeBuilder
   def x_get_tree_custom_kids(object, count_only, options)
     case object[:id]
     when 'my', 'global'
-      # Get My Filters and Global Filters
+      # Get My Filters and Default Filters
       count_only_or_objects(count_only, x_get_search_results(object, options[:leaf]))
     when 'asrv', 'rsrv'
       retired = object[:id] != 'asrv'
@@ -64,7 +64,7 @@ class TreeBuilderServices < TreeBuilder
 
   def x_get_search_results(object, leaf)
     case object[:id]
-    when "global" # Global filters
+    when "global" # Default filters
       x_get_global_filter_search_results(leaf)
     when "my"     # My filters
       x_get_my_filter_search_results(leaf)

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -20,7 +20,7 @@ class TreeBuilderStorage < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     objects =
       [
-        {:id => "global", :text => _("Global Filters"), :icon => "pficon pficon-folder-close", :tip => _("Global Shared Filters"), :selectable => false},
+        {:id => "global", :text => _("Default Filters"), :icon => "pficon pficon-folder-close", :tip => _("Default Shared Filters"), :selectable => false},
         {:id => "my",     :text => _("My Filters"),     :icon => "pficon pficon-folder-close", :tip => _("My Personal Filters"),   :selectable => false}
       ]
     count_only_or_objects(count_only, objects)

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -21,7 +21,7 @@ class TreeBuilderVmsFilter < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     objects =
       [
-        {:id => "global", :text => _("Global Filters"), :icon => "pficon pficon-folder-close", :tip => _("Global Shared Filters"), :selectable => false},
+        {:id => "global", :text => _("Default Filters"), :icon => "pficon pficon-folder-close", :tip => _("Default Shared Filters"), :selectable => false},
         {:id => "my",     :text => _("My Filters"),     :icon => "pficon pficon-folder-close", :tip => _("My Personal Filters"),   :selectable => false}
       ]
     count_only_or_objects(count_only, objects)


### PR DESCRIPTION
This PR renames "Global Filters" to "Default Filters" as suggested in Issue 1 here: http://talk.manageiq.org/t/ux-feedback-expression-editor/2927