### PR TITLE
Button Group: Fix 'Display on Button' checkbox visibility

### DIFF
--- a/app/views/shared/buttons/_ab_list.html.haml
+++ b/app/views/shared/buttons/_ab_list.html.haml
@@ -70,7 +70,7 @@
           = _('Text')
         .col-md-8
           = @record.name.split('|').first
-          - display = @record.set_data.key?(:display) && @record.set_data[:display] == '1'
+          - display = @record.set_data.present? && [true, "1"].include?(@record.set_data[:display])
           &nbsp;
           .checkbox-inline
             %label{:style => "font-weight: normal"}

--- a/app/views/shared/buttons/_group_form.html.haml
+++ b/app/views/shared/buttons/_group_form.html.haml
@@ -15,7 +15,7 @@
                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           .input-group-addon
             %label.checkbox-inline
-              - display = @record.set_data.key?(:display) && @record.set_data[:display] == '1'
+              - display = @record.set_data.present? ? [true, "1"].include?(@record.set_data[:display]) : @edit[:new][:display]
               = check_box_tag("display", "1", display,
                               "data-miq_observe_checkbox" => {:url => url}.to_json)
               = _('Display on Button')


### PR DESCRIPTION
This is addressing problem described in https://github.com/ManageIQ/manageiq-ui-classic/pull/3383#issuecomment-366679735 and https://github.com/ManageIQ/manageiq-ui-classic/pull/3424#issuecomment-366688854

1. Add / Edit of a Button Group should not produce error
2. `Display on Button` checkbox should be consistent in both the edit & details screen.

`[true, "1"]` because historically you'll find both in the database.

@himdel 