### PR TITLE
Remove setPristine from save/add

### DIFF
--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -49,7 +49,6 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
 
   vm.saveClicked = function() {
     keyPairEditButtonClicked('save', true);
-    $scope.angularForm.$setPristine(true);
   };
 
   vm.addClicked = vm.saveClicked;

--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -179,7 +179,6 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       redirectUrl + '?button=save',
       setConfigInfo(vm.catalogItemModel),
       successMsg);
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.addClicked = function($event, _formSubmit) {
@@ -188,7 +187,6 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       redirectUrl + '?button=add',
       setConfigInfo(vm.catalogItemModel),
       successMsg);
-    $scope.angularForm.$setPristine(true);
   };
 
   var formatExtraVars = function(extraVars) {

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -378,7 +378,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     if (formSubmit) {
       angular.element('#button_name').val('save');
       emsCommonEditButtonClicked('save', true, $event);
-      $scope.angularForm.$setPristine(true);
     } else {
       $event.preventDefault();
     }
@@ -388,7 +387,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     if (formSubmit) {
       angular.element('#button_name').val('add');
       emsCommonAddButtonClicked('add', true, $event);
-      $scope.angularForm.$setPristine(true);
     } else {
       $event.preventDefault();
     }

--- a/app/assets/javascripts/controllers/miq_ae_class/ae_method_form_controller.js
+++ b/app/assets/javascripts/controllers/miq_ae_class/ae_method_form_controller.js
@@ -126,12 +126,10 @@ function aeMethodFormController($http, $scope, aeMethodFormId, currentRegion, mi
 
   vm.saveClicked = function() {
     methodEditButtonClicked('save');
-    $scope.angularForm.$setPristine(true);
   };
 
   vm.addClicked = function() {
     methodEditButtonClicked('add');
-    $scope.angularForm.$setPristine(true);
   };
 
   var setConfigInfo = function(configData) {

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -50,7 +50,6 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
       'subscriptions' : $scope.pglogicalReplicationModel.subscriptions,
       'exclusion_list' : updated_exclusion_list
     });
-    $scope.angularForm.$setPristine(true);
   };
 
   // check if subscription values have been changed

--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -57,7 +57,6 @@ ManageIQ.angular.app.controller('tenantQuotaFormController', ['$http', '$scope',
       }
     }
     tenantManageQuotasButtonClicked('save', { 'quotas' : data});
-    $scope.angularForm.$setPristine(true);
   };
 
   vm.check_quotas_changed = function() {

--- a/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
+++ b/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
@@ -57,7 +57,6 @@ ManageIQ.angular.app.controller('ownershipFormController', ['$http', '$scope', '
 
   $scope.saveClicked = function() {
     ownershipEditButtonClicked('save', true);
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.addClicked = function() {

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -318,7 +318,6 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
   vm.submitClicked = function() {
     // change memory value based ontype
     reconfigureEditButtonClicked('submit', true);
-    $scope.angularForm.$setPristine(true);
   };
 
   vm.addClicked = function() {

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -345,7 +345,6 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
 
   $scope.saveClicked = function() {
     scheduleEditButtonClicked('save', true);
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.addClicked = function() {


### PR DESCRIPTION
`setPristine(true)` marks the angular form as pristine, unchanged by the user

this makes sense when clicking Reset (kept)
this *may* make sense when clicking Cancel sometimes (kept)
but for add/save, all this does is make the user unable to submit the form again

In cases where submitting again is needed (temporary errors, changes in other tabs), this breaks - removing.

Closes #3425

Cc @lpichler 