### PR TITLE
Make filters saved in Workloads displayed in accordion

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -193,8 +193,13 @@ module ApplicationController::AdvancedSearch
       tree_type = x_active_tree.to_s.sub(/_tree/, '').to_sym
       builder = TreeBuilder.class_for_type(tree_type)
       tree = builder.new(x_active_tree, tree_type, @sb)
-      adv_search_redraw_tree_and_main(tree)
-      return
+      if tree_for_building_accordions?
+        @explorer = true
+        build_accordions_and_trees
+      else
+        adv_search_redraw_tree_and_main(tree)
+        return
+      end
     elsif %w(ems_cloud ems_infra).include?(@layout)
       build_listnav_search_list(@view.db)
     else
@@ -202,6 +207,18 @@ module ApplicationController::AdvancedSearch
     end
 
     adv_search_redraw_listnav_and_main
+  end
+
+  def tree_for_building_accordions?
+    %w(automation_manager_cs_filter_tree
+       configuration_scripts_tree
+       images_filter_tree
+       instances_filter_tree
+       svcs_tree
+       storage_tree
+       templates_filter_tree
+       vms_filter_tree
+       vms_instances_filter_tree).include?(x_active_tree.to_s)
   end
 
   def adv_search_redraw_search_partials(display_mode = nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1460,7 +1460,6 @@ module ApplicationHelper
           retired
           security_group
           service
-          storage
           templates
           vm).include?(@layout) && !@in_a_form
       "show_list"


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1536625

Make filters saved in _Advanced Search_ in _Workloads_ displayed in accordion right after creating them. Make filters saved in Adv Search displayed also in another screens like _My Services, Datastores, VMS, Images,_ etc.

**Before:**
![workloads_before](https://user-images.githubusercontent.com/13417815/36436206-efcced10-1663-11e8-8bef-e019e72c3850.png)

**After:**
![workloads_after](https://user-images.githubusercontent.com/13417815/36434788-2e38bdbc-1660-11e8-8df0-9224c9fa2fcd.png)

---

**Details:**
Actually, `build_accordions_and_trees` and `adv_search_redraw_listnav_and_main` methods in `adv_search_redraw_left_div` https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/advanced_search.rb#L187 do what we need to properly display the tree and the filters, after saving a new filter (see the changes of this PR). I've tested many screens, fixed all of the screens with `x_active_tree` like https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Filters_Workloads_display_until_refresh?expand=1#diff-3bd60fe6d117a9261fe45876c3ba51c9R213. Anyway, I think that maybe we could remove `adv_search_redraw_tree_and_main(tree)` method from `adv_search_redraw_left_div` and so from _advanced_search.rb_ (I mean, the whole "else" part of if/else block https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Filters_Workloads_display_until_refresh?expand=1#diff-3bd60fe6d117a9261fe45876c3ba51c9R199) because I have not found any situation when it would enter the "else" part of the block; I just kept it there for now, to be sure that nothing else breaks. I think that we don't need that method, it never worked as expected, as I remember.

I also removed "storage" from `render_listnav_filename`, because this method is called only from https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/layouts/_listnav.html.haml#L2, and for Datastores this place is accessed only when saving/deleting some filter and it does not work, of course, because we need "explorer" as `filename` in that haml, not "show_list" (as a result of `render_listnav_filename` method) to make everything displayed properly (normally, it is "explorer", if we are in the page for the first time or if we reload the page).

Btw, when we refresh the pages with the issue (BZ), filters are properly displayed and `build_accordions_and_trees` and `adv_search_redraw_listnav_and_main` methods are normally called so why to call different methods when saving/deleting filters? This is the idea which lead to my fix. Yes, the fix also works well if we delete some filter: the filter immediately disappears from accordion, and that is right behavior (this also did not work). Maybe this fix is not the best, but it works well and I haven't found any simpler solution which wouldn't affect other screens/situations in a negative way.
