### PR TITLE
Use new dialog-user feature for custom buttons for more object types

### DIFF
--- a/app/controllers/mixins/custom_button_dialog_form_mixin.rb
+++ b/app/controllers/mixins/custom_button_dialog_form_mixin.rb
@@ -1,24 +1,35 @@
 module Mixins
   module CustomButtonDialogFormMixin
-    def set_custom_button_dialog_presenter
+    def set_custom_button_dialog_presenter(options)
       presenter ||= ExplorerPresenter.new(
         :active_tree => x_active_tree,
       )
       presenter.show(:default_left_cell).hide(:custom_left_cell)
-      presenter.update(:main_div, r[:partial => "shared/dialogs/dialog_provision"])
-      presenter.update(:form_buttons_div, r[
-        :partial => 'layouts/x_dialog_buttons',
-        :locals  => {
-          :action_url => "dialog_form_button_pressed",
-          :record_id  => @edit[:rec_id],
-        }
+      presenter.update(:main_div, r[
+        :partial => "shared/dialogs/dialog_provision",
+        :locals  => options[:dialog_locals]
       ])
-      presenter.show(:form_buttons_div)
+      unless using_new_dialog_runner?(options)
+        presenter.update(:form_buttons_div, r[
+          :partial => 'layouts/x_dialog_buttons',
+          :locals  => {
+            :action_url => "dialog_form_button_pressed",
+            :record_id  => @edit[:rec_id],
+          }
+        ])
+        presenter.show(:form_buttons_div)
+      end
       presenter[:right_cell_text] = @right_cell_text
       presenter.set_visibility(false, :toolbar)
       presenter.set_visibility(false, :adv_searchbox_div)
       presenter[:lock_sidebar] = true
       presenter
+    end
+
+    private
+
+    def using_new_dialog_runner?(options)
+      options[:dialog_locals].present? && options[:dialog_locals][:force_old_dialog_use].to_s == "false"
     end
   end
 end

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -537,7 +537,7 @@ class OpsController < ApplicationController
   def replace_right_cell(options = {}) # replace_trees can be an array of tree symbols to be replaced
     nodetype, replace_trees = options.values_at(:nodetype, :replace_trees)
     if params[:pressed] == "custom_button"
-      presenter = set_custom_button_dialog_presenter
+      presenter = set_custom_button_dialog_presenter(options)
       render :json => presenter.for_render
       return
     end

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -1,5 +1,8 @@
 class DialogLocalService
   NEW_DIALOG_USERS = %w(
+    CloudNetwork
+    CloudObjectStoreContainer
+    CloudSubnet
     CloudTenant
     CloudVolume
     ContainerNode
@@ -7,9 +10,12 @@ class DialogLocalService
     GenericObject
     Host
     InfraManager
+    MiqGroup
     MiqTemplate
     Service
     Storage
+    Tenant
+    User
     Vm
   ).freeze
 
@@ -55,6 +61,15 @@ class DialogLocalService
 
   def determine_api_endpoints(obj, display_options = {})
     case obj.class.name.demodulize
+    when /CloudNetwork/
+      api_collection_name = "cloud_networks"
+      cancel_endpoint = "/cloud_network"
+    when /CloudObjectStoreContainer/
+      api_collection_name = "cloud_object_store_containers"
+      cancel_endpoint = "/cloud_object_store_container"
+    when /CloudSubnet/
+      api_collection_name = "cloud_subnets"
+      cancel_endpoint = "/cloud_subnet"
     when /CloudTenant/
       api_collection_name = "cloud_tenants"
       cancel_endpoint = "/cloud_tenant"
@@ -80,6 +95,9 @@ class DialogLocalService
     when /InfraManager/
       api_collection_name = "providers"
       cancel_endpoint = "/ems_infra"
+    when /MiqGroup/
+      api_collection_name = "groups"
+      cancel_endpoint = "/ops/explorer"
     when /MiqTemplate/
       api_collection_name = "templates"
       cancel_endpoint = "/vm_or_template/explorer"
@@ -89,6 +107,12 @@ class DialogLocalService
     when /Storage/
       api_collection_name = "datastores"
       cancel_endpoint = "/storage/explorer"
+    when /Tenant/
+      api_collection_name = "tenants"
+      cancel_endpoint = "/ops/explorer"
+    when /User/
+      api_collection_name = "users"
+      cancel_endpoint = "/ops/explorer"
     when /Vm/
       api_collection_name = "vms"
       cancel_endpoint = display_options[:cancel_endpoint] || "/vm_infra/explorer"

--- a/spec/controllers/mixins/custom_button_dialog_form_mixin_spec.rb
+++ b/spec/controllers/mixins/custom_button_dialog_form_mixin_spec.rb
@@ -1,0 +1,95 @@
+class CustomButtonDialogFormMixinTestClass
+  attr_accessor :edit
+  include Mixins::CustomButtonDialogFormMixin
+
+  def x_active_tree
+    "test_active_tree"
+  end
+
+  # This is only here for simplicity of testing. Normally this method
+  # renders the entire haml template
+  def r
+    @r ||= proc do |options|
+      if options[:partial] == "shared/dialogs/dialog_provision"
+        if options[:locals].present? && options[:locals][:force_old_dialog_use].to_s == "false"
+          "main_div_with_new_dialog_runner"
+        else
+          "main_div"
+        end
+      else
+        "form_buttons_div"
+      end
+    end
+  end
+end
+
+describe Mixins::CustomButtonDialogFormMixin do
+  let(:mixin) { CustomButtonDialogFormMixinTestClass.new }
+
+  describe "#set_custom_button_dialog_presenter" do
+    let(:presenter) { instance_double("ExplorerPresenter") }
+
+    before do
+      mixin.edit = {:rec_id => 123}
+      allow(ExplorerPresenter).to receive(:new).and_return(presenter)
+      allow(presenter).to receive(:show).and_return(presenter)
+      allow(presenter).to receive(:hide)
+      allow(presenter).to receive(:update)
+      allow(presenter).to receive(:set_visibility)
+      allow(presenter).to receive(:[]=)
+    end
+
+    context "when dialog locals are present" do
+      context "when force_old_dialog_use is false" do
+        let(:options) { {:dialog_locals => {:force_old_dialog_use => false}} }
+
+        it "passes the locals through the render method" do
+          allow(presenter).to receive(:update) do |_div, render_method|
+            expect(render_method).to eq("main_div_with_new_dialog_runner")
+          end
+          mixin.set_custom_button_dialog_presenter(options)
+        end
+
+        it "does not update the form buttons div and does not show it" do
+          mixin.set_custom_button_dialog_presenter(options)
+          expect(presenter).not_to have_received(:update).with(:form_buttons_div, instance_of(String)).ordered
+          expect(presenter).not_to have_received(:show).with(:form_buttons_div).ordered
+        end
+      end
+
+      context "when force_old_dialog_use is true" do
+        let(:options) { {:dialog_locals => {:force_old_dialog_use => true}} }
+
+        before do
+          mixin.set_custom_button_dialog_presenter(options)
+        end
+
+        it "updates the main div" do
+          expect(presenter).to have_received(:update).with(:main_div, "main_div").ordered
+        end
+
+        it "updates the form_buttons_div and shows it" do
+          expect(presenter).to have_received(:update).with(:form_buttons_div, "form_buttons_div").ordered
+          expect(presenter).to have_received(:show).with(:form_buttons_div).ordered
+        end
+      end
+    end
+
+    context "when dialog locals are not present" do
+      let(:options) { {} }
+
+      before do
+        mixin.set_custom_button_dialog_presenter(options)
+      end
+
+      it "updates the main div" do
+        expect(presenter).to have_received(:update).with(:main_div, "main_div").ordered
+      end
+
+      it "updates the form_buttons_div and shows it" do
+        expect(presenter).to have_received(:update).with(:form_buttons_div, "form_buttons_div").ordered
+        expect(presenter).to have_received(:show).with(:form_buttons_div).ordered
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related to #2671, this just adds a few more object types that will use the new dialog runner and changes some of the mixin logic these object types go through to handle the extra dialog locals that are getting passed down.

Object types that will use the new dialog-user ui-component after this PR:
`CloudNetwork`
`CloudObjectStoreContainer`
`CloudSubnet`
`MiqGroup`
`Tenant`
`User`

/cc @gmcculloug
@d-m-u @syncrou Can you review, please?
@himdel Can you also review or tag someone to review, please?

If anyone has any good ideas on how to best extract/simplify the big case statement within `#determine_api_endpoints` I'm all ears. Right now it's really simple to add to it, but it is definitely pretty ugly. The main problem I see is that for some of the object types the collection name and the cancel endpoint are predictable, but for others they aren't. Ultimately maybe it isn't even worth it to refactor right now.

@miq-bot assign @h-kataria
@miq-bot add_label enhancement, automation/automate