### PR TITLE
Add keymap support for WebMKS remote consoles

### DIFF
--- a/app/helpers/vmware_console_helper.rb
+++ b/app/helpers/vmware_console_helper.rb
@@ -1,4 +1,16 @@
 module VmwareConsoleHelper
+  KEYBOARD_LAYOUTS = [
+    ['English', "en-US"],
+    ['Japanese', "ja-JP_106/109"],
+    ['German', "de-DE"],
+    ['Italian', "it-IT"],
+    ['Spanish', "es-ES"],
+    ['Portuguese', "pt-PT"],
+    ['French', "fr-FR"],
+    ['Swiss‐French', "fr-CH"],
+    ['Swiss‐German', "de-CH"]
+  ].freeze
+
   # Helper method for retrieving vmware remote console options for a <select> field
   def vmware_remote_console_items(webmks)
     items = [[_("VNC"), "VNC"], [_("VMware VMRC Plugin"), "VMRC"]]

--- a/app/views/shared/_remote_console_footer.haml
+++ b/app/views/shared/_remote_console_footer.haml
@@ -3,6 +3,8 @@
     %span#console-type.label.label-info= j console_type.to_s
     %span#connection-status.label.label-warning= _('Connecting')
   .pull-right
+    - if console_type == 'WebMKS'
+      = select_tag(:keymap, options_for_select(VmwareConsoleHelper::KEYBOARD_LAYOUTS), :id => 'keymap')
     %button#ctrlaltdel.btn.btn-default{:title => _('Send CTRL+ALT+DEL')}
       %i.fa.fa-keyboard-o
     %button#fullscreen.btn.btn-default{:title => _('Toggle Fullscreen')}

--- a/app/views/vm_common/console_webmks.html.haml
+++ b/app/views/vm_common/console_webmks.html.haml
@@ -28,6 +28,10 @@
         $('#ctrlaltdel').on('click', function() {
           wmks.sendCAD();
         });
+
+        $('#keymap').on('change', function() {
+          wmks.setOption('keyboardLayoutId', this.value);
+        });
       });
 
   %body


### PR DESCRIPTION
I looked into the [VMware HTML Console Programming Guide](https://www.vmware.com/support/developer/html-console/html-console-sdk-200-programmer-guide.pdf) and on page 8 found that WebMKS has support for key mapping between a few keyboard types. It is not a universal solution, but solves the problem of special characters if both the VM's and the client's keyboard layout is one of the supported keyboards. 

![screenshot from 2018-02-21 13-44-48](https://user-images.githubusercontent.com/649130/36480702-924ff736-170d-11e8-97ee-a25988782fa1.png)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1545927

@bmclaughlin can you test this please? 
@miq-bot add_label gaprindashvili/yes, fine/yes, bug, consoles