### PR TITLE
Fix closing dialog window when applying filter in Workloads

### DIFF
--- a/app/views/layouts/_user_input_filter.html.haml
+++ b/app/views/layouts/_user_input_filter.html.haml
@@ -94,6 +94,7 @@
                         "data-miq_sparkle_on"  => true,
                         "data-miq_sparkle_off" => true,
                         :remote                => true,
+                        "data-dismiss"         => "modal",
                         "data-method"          => :post,
                         :id                    => "apply_button",
                         :title                 => t)


### PR DESCRIPTION
**Fixes issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/499

Fix closing dialog window when applying a filter after user inputs the value and clicks on _Apply_ button, in _Services > Workloads_ and other explorer screens, where this issue also occurs.

Right before applying a filter if user inputs the value:
![workloads_apply](https://user-images.githubusercontent.com/13417815/36484623-2747dabe-171a-11e8-8539-3908de16dd58.png)

**Before:** (filter is applied but dialog window did not close, after clicking on _Apply_ button)
![workloads_apply_bad](https://user-images.githubusercontent.com/13417815/36484761-97858812-171a-11e8-88da-2204b9cc8667.png)

**After:** (dialog window has closed and everything looks good)
![workloads_apply_ok](https://user-images.githubusercontent.com/13417815/36484960-2927ffde-171b-11e8-8060-712b60dbb785.png)
