### PR TITLE
[FINE] Remove duplicate flash message on tag reset

### DIFF
--- a/app/views/layouts/_tag_edit_items.html.haml
+++ b/app/views/layouts/_tag_edit_items.html.haml
@@ -6,5 +6,6 @@
 
   - if @tagitems
     - @quadicon_no_url = true
+    - @embedded = true
     - @gtl_type ||= settings(:views, :tagging)
     = render :partial => "layouts/gtl"


### PR DESCRIPTION
Remove duplicate flash message on tag reset
This issue exists only on the Fine branch, it was already fixed upstream. 

Links
-----------

https://bugzilla.redhat.com/show_bug.cgi?id=1533082

Before:

![screenshot from 2018-02-21 10-10-36](https://user-images.githubusercontent.com/12769982/36487664-7ce9d826-16ef-11e8-90e6-0ee6cc377548.png)

After:
![screenshot from 2018-02-21 10-00-15](https://user-images.githubusercontent.com/12769982/36487544-2caf296a-16ef-11e8-9cbe-a838a1a226b9.png)

