### PR TITLE
Update Expression Editor Styling

### DIFF
--- a/app/views/layouts/exp_atom/_edit_count.html.haml
+++ b/app/views/layouts/exp_atom/_edit_count.html.haml
@@ -4,6 +4,7 @@
   Parameters:
     exp_model       Model in use for this expression
 
+.spacer
 = select_tag('chosen_count',
   options_for_select(["<#{_('Choose')}>"] + MiqExpression.miq_adv_search_lists(exp_model, :exp_available_counts), @edit[@expkey][:exp_count]),
   :multiple              => false,
@@ -12,7 +13,6 @@
   "data-miq_sparkle_off" => true)
 
 - if adv_search_show_alias_checkbox? && !@edit[@expkey][:exp_count].blank?
-  %br
   = check_box_tag("use_alias", "1", !@edit[@expkey][:alias].blank?,
     :style                      => "width: 20px; margin-top:5px; margin-bottom: 5px;",
     "data-miq_sparkle_on"       => true,
@@ -25,7 +25,7 @@
       "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
 
 - if @edit[@expkey][:exp_count]
-  %br
+  .spacer
   = select_tag('chosen_key',
     options_for_select(MiqExpression.get_col_operators(:count), @edit[@expkey][:exp_key]),
     :multiple              => false,
@@ -33,7 +33,7 @@
     "data-miq_sparkle_on"  => true,
     "data-miq_sparkle_off" => true,
     "data-miq_observe"     => {:url => url}.to_json)
-  %br
+  .spacer
   - if @edit[@expkey][:exp_value] == :user_input
     = "<#{_('user input')}>"
   - else

--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -3,7 +3,7 @@
 -# Parameters:
 -# exp_model    Model in use for this expression
 
-%br
+.spacer
 - opts = ["<#{_('Choose')}>"]
 - if exp_model == "_display_filter_"
   -# Use list in @edit for reporting display filter
@@ -21,7 +21,6 @@
   'data-miq_sparkle_off' => true)
 
 - if adv_search_show_alias_checkbox? && !@edit[@expkey][:exp_field].blank?
-  %br
   = check_box_tag("use_alias", "1", !@edit[@expkey][:alias].blank?,
     :style                      => "width: 20px",
     "data-miq_sparkle_on"       => true,
@@ -34,7 +33,7 @@
       "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
 
 - if @edit[@expkey][:exp_field]
-  %br
+  .spacer
   - if @edit[@expkey][:exp_key] == "CONTAINS"
     %font{:color => "black"}
       = h(@edit[@expkey][:exp_key])
@@ -46,7 +45,7 @@
       "data-miq_sparkle_on"   => true,
       "data-miq_sparkle_off"  => true)
   - unless @edit[@expkey][:exp_key].include?("NULL") || @edit[@expkey][:exp_key].include?("EMPTY")
-    %br
+    .spacer
     %span#chosen_value_span
       - if @edit[@expkey][:val1][:type] == :boolean
         - if @edit[@expkey][:exp_value] == :user_input
@@ -86,9 +85,9 @@
             "data-miq_sparkle_off" => true)
 
         - if @edit[@expkey][:exp_key] == ApplicationController::Filter::EXP_FROM && @edit[@expkey][:exp_value][0]
-          %br
+          .spacer
           = _('THROUGH')
-          %br
+          .spacer
           - if @edit[@expkey][:val1][:date_format] == 's'
             = datepicker_input_tag("miq_date_1_1",
               @edit[@expkey][:exp_value][1] ? @edit[@expkey][:exp_value][1].split(" ").first : "",

--- a/app/views/layouts/exp_atom/_edit_find.html.haml
+++ b/app/views/layouts/exp_atom/_edit_find.html.haml
@@ -3,7 +3,7 @@
 -# Parameters:
 -# exp_model      Model in use for this expression
 
-%br
+.spacer
 
 = select_tag('chosen_field',
   options_for_select(["<#{_('Choose')}>"] + MiqExpression.miq_adv_search_lists(exp_model, :exp_available_finds), @edit[@expkey][:exp_field]),
@@ -14,7 +14,6 @@
   "data-miq_sparkle_off" => true)
 
 - if adv_search_show_alias_checkbox? && !@edit[@expkey][:exp_field].blank?
-  %br
   = check_box_tag("use_alias", "1", !@edit[@expkey][:alias].blank?,
     :style                      => "width: 20px",
     "data-miq_sparkle_on"       => true,
@@ -27,7 +26,7 @@
       "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
 
 - if @edit[@expkey][:exp_field]
-  %br
+  .spacer
   = select_tag('chosen_skey',
     options_for_select(MiqExpression.get_col_operators(@edit[@expkey][:exp_field]), @edit[@expkey][:exp_skey]),
     :multiple              => false,
@@ -126,7 +125,7 @@
             :class                 => 'selectpicker',
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true)
-  %br
+  .spacer
   - opts = [[_("Check All"), "checkall"], [_("Check Any"), "checkany"], [_("Check Count"), "checkcount"]]
   = select_tag('chosen_check',
     options_for_select(opts, @edit[@expkey][:exp_check]),

--- a/app/views/layouts/exp_atom/_edit_tag.html.haml
+++ b/app/views/layouts/exp_atom/_edit_tag.html.haml
@@ -7,7 +7,7 @@
 - opts = ["<#{_('Choose')}>"]
 - opts += @edit[@expkey].tags_for_display_filters
 
-%br
+.spacer
 
 = select_tag('chosen_tag', options_for_select(opts, @edit[@expkey][:exp_tag]),
   :multiple              => false,
@@ -17,7 +17,6 @@
   'data-miq_sparkle_off' => true)
 
 - if adv_search_show_alias_checkbox? && !@edit[@expkey][:exp_tag].blank?
-  %br
   = check_box_tag("use_alias", "1", !@edit[@expkey][:alias].blank?,
     :style                      => "width: 20px",
     "data-miq_sparkle_on"       => true,
@@ -31,10 +30,10 @@
       "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
 
 - if @edit[@expkey][:exp_tag]
-  %br
+  .spacer
   %font{:color => "black"}
     = h(@edit[@expkey][:exp_key])
-  %br
+  .spacer
   - if @edit[@expkey][:exp_value] == :user_input
     = "<#{_('user input')}>"
   - else


### PR DESCRIPTION
This PR adds vertical spacing between rows containing dropdowns and input fields. It also moves the "Use Alias" checkbox next to the dropdown.

Old
<img width="1217" alt="screen shot 2018-02-21 at 10 41 32 am" src="https://user-images.githubusercontent.com/1287144/36489384-e87b1754-16f3-11e8-857b-dbacb3738e56.png">

New
<img width="1219" alt="screen shot 2018-02-21 at 11 05 41 am" src="https://user-images.githubusercontent.com/1287144/36490829-34f3c588-16f7-11e8-8128-22bc96cacc38.png">


Issue # 6 here: http://talk.manageiq.org/t/ux-feedback-expression-editor/2927
and
https://bugzilla.redhat.com/show_bug.cgi?id=1394263
