### PR TITLE
Fix Chargeback Rates page title

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -381,7 +381,7 @@ class ChargebackController < ApplicationController
     if x_active_tree == :cb_rates_tree
       if node == "root"
         @record = nil
-        @right_cell_text = _("All Chargeback Rate")
+        @right_cell_text = _("All Chargeback Rates")
       elsif ["xx-Compute", "xx-Storage"].include?(node)
         @record = nil
         @right_cell_text = case node

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -662,4 +662,21 @@ describe ChargebackController do
       end
     end
   end
+
+  describe '#get_node_info' do
+    let(:sandbox) { {:active_tree => :cb_rates_tree, :trees => {:cb_rates_tree => {:active_node => node}}} }
+
+    before do
+      controller.instance_variable_set(:@sb, sandbox)
+    end
+
+    context 'root node' do
+      let(:node) { "root" }
+
+      it 'sets right cell text properly' do
+        controller.send(:get_node_info, node)
+        expect(controller.instance_variable_get(:@right_cell_text)).to eq("All Chargeback Rates")
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1532701
Caused by: https://github.com/ManageIQ/manageiq-ui-classic/pull/2347

Fix Chargeback Rates page title in _Cloud Intel > Chargeback > Rates > Rates_ folder.

**Note:**
The BZ is not reproducible the exact way it is written in bugzilla, on master branch, because of https://github.com/ManageIQ/manageiq-ui-classic/pull/3215 (I fixed two "title-plural" issues with that PR, but that PR was not backported to Gaprindashvili yet so the BZ is fully reproducible only in Gaprindashvili). So how to reproduce the bug now on master? Simply:
1. Go to _Cloud Intel > Chargeback > Rates > Rates_ folder
and you will see: _All Chargeback Rate_ in the title of the page, instead of _All Chargeback Rate**s**_,
no need to create/delete any of the rates to reproduce the bug.

_Before:_
![all_rate](https://user-images.githubusercontent.com/13417815/36490420-7eb8daf6-1728-11e8-99e6-f2ecb8a2c7ea.png)

_After:_
![all_rates](https://user-images.githubusercontent.com/13417815/36490428-819f80ee-1728-11e8-94b6-b2aa8e8e5e30.png)
