### PR TITLE
jquery - move to npm

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,7 +2,7 @@
 //= require bower_components/es6-shim/es6-shim
 //= require bower_components/array-includes/array-includes
 //= require bower_components/fetch/fetch
-//= require bower_components/jquery/dist/jquery
+//= require jquery
 //= require ./jquery_overrides
 //= require ./i18n
 //= require bower_components/patternfly/dist/js/patternfly

--- a/app/assets/javascripts/remote_consoles/spice.js
+++ b/app/assets/javascripts/remote_consoles/spice.js
@@ -1,4 +1,4 @@
-//= require bower_components/jquery/dist/jquery
+//= require jquery
 //= require bower_components/spice-html5-bower/spice-html5-rails
 //= require_tree ../locale
 //= require gettext/all

--- a/app/assets/javascripts/remote_consoles/vnc.js
+++ b/app/assets/javascripts/remote_consoles/vnc.js
@@ -1,4 +1,4 @@
-//= require bower_components/jquery/dist/jquery
+//= require jquery
 //= require novnc-rails
 //= require_tree ../locale
 //= require gettext/all

--- a/app/views/layouts/remote_console.html.haml
+++ b/app/views/layouts/remote_console.html.haml
@@ -6,7 +6,7 @@
     = favicon_link_tag
     = stylesheet_link_tag 'application'
     -# Load the required JS based on the console type
-    = javascript_include_tag 'bower_components/jquery/dist/jquery.js', "remote_consoles/#{@console[:type]}", 'remote_console'
+    = javascript_include_tag 'jquery', "remote_consoles/#{@console[:type]}", 'remote_console'
   %body
     #remote-console{'data-url' => @console[:url], 'data-secret' => @console[:secret]}
     = render :partial => 'shared/remote_console_footer', :layout   => false, :locals   => { :console_type => @console[:type].upcase }

--- a/app/views/vm_common/console_vmrc.html.haml
+++ b/app/views/vm_common/console_vmrc.html.haml
@@ -2,7 +2,7 @@
 %html{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
     = favicon_link_tag
-    = javascript_include_tag 'bower_components/jquery/dist/jquery.js'
+    = javascript_include_tag 'jquery'
     :javascript
       // INITIALIZE
       $(document).ready(function(){

--- a/app/views/vm_common/console_webmks.html.haml
+++ b/app/views/vm_common/console_webmks.html.haml
@@ -5,7 +5,7 @@
       = _('%{product_name} WebMKS Remote Console') % {:product_name => Vmdb::Appliance.PRODUCT_NAME}
     = favicon_link_tag
     = stylesheet_link_tag '/webmks/css/wmks-all.css', 'application'
-    = javascript_include_tag 'bower_components/jquery/dist/jquery.js', 'bower_components/jquery-ui/jquery-ui.js', '/webmks/wmks.min.js', 'remote_console'
+    = javascript_include_tag 'jquery', 'bower_components/jquery-ui/jquery-ui.js', '/webmks/wmks.min.js', 'remote_console'
     :javascript
       $(function () {
         var wmks = WMKS.createWMKS('remote-console', {}).register(WMKS.CONST.Events.CONNECTION_STATE_CHANGE, function (event,data) {

--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,6 @@
     "es6-shim": "~0.35.1",
     "fetch": "~1.0.0",
     "jasmine-jquery": "~2.1.1",
-    "jquery": "~2.2.4",
     "jquery-ui": "jqueryui#~1.12.1",
     "jquery-ujs": "~1.2.2",
     "jquery.observe_field": "himdel/jquery.observe_field#~0.1.0",

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,7 +8,7 @@ end
 Rails.application.config.assets.precompile += %w(
   bower_components/codemirror/modes/*.js
   bower_components/codemirror/themes/*.css
-  bower_components/jquery/dist/jquery.js
+  jquery.js
   bower_components/jquery-ui/jquery-ui.js
 
   jquery_overrides.js

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "angular-mocks": "~1.6.6",
     "angular-sanitize": "~1.6.6",
     "core-js": "~2.4.1",
+    "jquery": "~2.2.4",
     "lodash": "^4.17.4",
     "ng-redux": "^3.5.2",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
Moves jquery from bower to npm. That's it :).

(intentionally not removed from bower resolutions (to prevent it automagically adding >=1.6)

Cc @skateman 