### PR TITLE
Serializing schedule model instead of values from html while saving.

### DIFF
--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -312,7 +312,6 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
 
   $scope.cancelClicked = function() {
     scheduleEditButtonClicked('cancel');
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.resetClicked = function() {
@@ -344,7 +343,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
   };
 
   $scope.saveClicked = function() {
-    scheduleEditButtonClicked('save', true);
+    scheduleEditButtonClicked('save', $scope.scheduleModel);
   };
 
   $scope.addClicked = function() {

--- a/app/views/ops/_schedule_form_filter.html.haml
+++ b/app/views/ops/_schedule_form_filter.html.haml
@@ -82,7 +82,6 @@
                                  "ng-required"                => "!automateRequest() && filterValueRequired(scheduleModel.filter_value)",
                                  "checkchange"                => ""}
               %option{"disabled" => "", "value" => ""} &lt;Choose&gt;
-            %input{"type" => "hidden", "name" => "filter_value", "value" => "{{scheduleModel.filter_value}}"}
 
         = render :partial => "layouts/angular-bootstrap/ae_resolve_options",
                  :locals  => {:ng_show => "automateRequest()"}

--- a/app/views/ops/_schedule_form_timer.html.haml
+++ b/app/views/ops/_schedule_form_timer.html.haml
@@ -20,7 +20,6 @@
                               "ng-options"                => "timerItem.value as timerItem.text for timerItem in timer_items",
                               "timer-hide"                => "timerTypeOnce",
                               "checkchange"               => ""}
-          %input{"type" => "hidden", "ng-value" => "scheduleModel.timer_value", "name" => "timer_value"}
       .form-group
         %label.col-md-2.control-label{"for" => "time_zone"}
           = _("Time Zone")

--- a/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
+++ b/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
@@ -331,7 +331,7 @@ describe('scheduleFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=save', true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=save', $scope.scheduleModel);
     });
   });
 
@@ -348,7 +348,7 @@ describe('scheduleFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=save', true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=save', $scope.scheduleModel);
     });
   });
 


### PR DESCRIPTION
In preparation for 'schedule_form_controller' refactoring, this change is required for new components which will replace existing partials.

refactoring PR: #2766 

This change cause one minor difference. While adding/saving `automation task` the post form values are different. But the form values are for some reason being send in URL as query parameter and these are exactly same as before. Some further investigation is required, but i suspect  that it won't break anything. 

I also think that sending form data in URL is not good and it should be send via POST