### PR TITLE
Remove gettext from audit.log messages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1686,9 +1686,9 @@ class ApplicationController < ActionController::Base
   def build_saved_audit_hash_angular(old_record_attributes, new_record, add)
     name  = new_record.respond_to?(:name) ? new_record.name : new_record.description
     msg   = if add
-              _("[%{name}] Record added (") % {:name => name}
+              "[#{name}] Record added ("
             else
-              _("[%{name}] Record updated (") % {:name => name}
+              "[#{name}] Record updated ("
             end
     event = "#{new_record.class.to_s.downcase}_record_#{add ? "add" : "update"}"
 
@@ -1698,7 +1698,7 @@ class ApplicationController < ActionController::Base
     difference_messages = []
 
     attribute_difference.each do |key, value|
-      difference_messages << _("%{key} changed to %{value}") % {:key => key, :value => value}
+      difference_messages << "#{key} changed to #{value}"
     end
 
     msg = msg + difference_messages.join(", ") + ")"

--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -195,7 +195,7 @@ module ApplicationController::PolicySupport
 
   # Create policy assignment audit record
   def protect_audit(pp, mode, db, recs)
-    msg = _("[%{name}] Policy Profile %{mode} (db:[%{db}]") % {:name => pp.name, :mode => mode, :db => db}
+    msg = "[#{pp.name}] Policy Profile #{mode} (db:[#{db}]"
     msg += ", ids:[#{recs.sort_by(&:to_i).join(',')}])"
     event = "policyset_" + mode
     audit = {:event => event, :target_id => pp.id, :target_class => pp.class.base_class.name, :userid => session[:userid], :message => msg}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -624,7 +624,7 @@ class CatalogController < ApplicationController
       id = st.id
       st_name = st.name
       audit = {:event        => "st_record_delete",
-               :message      => _("[%{name}] Record deleted") % {:name => st_name},
+               :message      => "[#{st_name}] Record deleted",
                :target_id    => id,
                :target_class => "ServiceTemplate",
                :userid       => session[:userid]}

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -536,7 +536,7 @@ module EmsCommon
         id = ems.id
         ems_name = ems.name
         audit = {:event        => "ems_record_delete_initiated",
-                 :message      => _("[%{name}] Record delete initiated") % {:name => ems_name},
+                 :message      => "[#{ems_name}] Record delete initiated",
                  :target_id    => id,
                  :target_class => model.to_s,
                  :userid       => session[:userid]}
@@ -555,7 +555,7 @@ module EmsCommon
         id = ems.id
         ems_name = ems.name
         audit = {:event        => "ems_record_#{action}_initiated",
-                 :message      => _("[%{name}] Record #{action} initiated") % {:name => ems_name},
+                 :message      => "[#{ems_name}] Record #{action} initiated",
                  :target_id    => id,
                  :target_class => model.to_s,
                  :userid       => session[:userid]}
@@ -573,14 +573,15 @@ module EmsCommon
         rescue => bang
           add_flash(_("%{model} \"%{name}\": Error during '%{task}': %{error_message}") %
             {:model => ui_lookup(:table => @table_name), :name => ems_name, :task => _(task.titleize), :error_message => bang.message}, :error)
-          AuditEvent.failure(:userid => session[:userid], :event => "#{table_name}_#{task}",
-            :message      => _("%{name}: Error during '%{task}': %{message}") %
-                          {:name => ems_name, :task => task, :message => bang.message},
-            :target_class => model.to_s, :target_id => id)
+          AuditEvent.failure(:userid       => session[:userid],
+                             :event        => "#{table_name}_#{task}",
+                             :message      => "#{ems_name}: Error during '#{task}': #{bang.message}",
+                             :target_class => model.to_s, :target_id => id)
         else
           add_flash(_("%{model} \"%{name}\": %{task} successfully initiated") % {:model => ui_lookup(:table => @table_name), :name => ems_name, :task => _(task.titleize)})
-          AuditEvent.success(:userid => session[:userid], :event => "#{table_name}_#{task}",
-                             :message      => _("%{name}: '%{task}' successfully initiated") % {:name => ems_name, :task => task},
+          AuditEvent.success(:userid       => session[:userid],
+                             :event        => "#{table_name}_#{task}",
+                             :message      => "#{ems_name}: '#{task}' successfully initiated",
                              :target_class => model.to_s, :target_id => id)
         end
       end

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -307,7 +307,7 @@ class MiqPolicyController < ApplicationController
               :filename => "policy.log")
     AuditEvent.success(:userid  => session[:userid],
                        :event   => "download_policy_log",
-                       :message => _("Policy log downloaded"))
+                       :message => "Policy log downloaded")
   end
 
   private

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -108,8 +108,7 @@ module MiqPolicyController::Conditions
                        :target_id    => policy.id,
                        :target_class => "MiqPolicy",
                        :userid       => session[:userid],
-                       :message      => _("Condition record ID %{param_id} was removed from Policy ID %{policy_id}") %
-                                          {:param_id => params[:id], :policy_id => policy.id})
+                       :message      => "Condition record ID #{params[:id]} was removed from Policy ID #{policy.id}")
     add_flash(_("Condition \"%{cond_name}\" has been removed from Policy \"%{pol_name}\"") % {:cond_name => cdesc, :pol_name => policy.description})
     policy_get_info(policy)
     @nodetype = "p"

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -495,7 +495,7 @@ class MiqRequestController < ApplicationController
     miq_requests.each do |miq_request|
       request_name = miq_request.description
       audit = {:event        => "MiqRequest_record_delete",
-               :message      => _("[%{name}] Record deleted") % {:name => request_name},
+               :message      => "[#{request_name}] Record deleted",
                :target_id    => miq_request.id,
                :target_class => "MiqRequest",
                :userid       => session[:userid]}

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -127,8 +127,7 @@ class MiqTaskController < ApplicationController
     task = MiqTask.find_by(:id => taskid)
     if task
       MiqTask.delete_older(task.updated_on, tasks_condition(@tasks_options[@tabform], false))
-      message = _("Delete started for records older than %{date}, conditions: %{conditions}") %
-                {:date => task.updated_on, :conditions => @tasks_options[@tabform].inspect}
+      message = "Delete started for records older than #{task.updated_on}, conditions: #{@tasks_options[@tabform].inspect}"
       AuditEvent.success(:userid       => session[:userid],
                          :event        => "Delete older tasks",
                          :message      => message,
@@ -223,7 +222,7 @@ class MiqTaskController < ApplicationController
       MiqTask.delete_by_id(task_ids)
       AuditEvent.success(:userid       => session[:userid],
                          :event        => event_message,
-                         :message      => _("Delete started for record ids: %{id}") % {:id => task_ids.inspect},
+                         :message      => "Delete started for record ids: #{task_ids.inspect}",
                          :target_class => "MiqTask")
       add_flash(n_("Delete initiated for %{count} Task from the %{product} Database",
                    "Delete initiated for %{count} Tasks from the %{product} Database",

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -28,7 +28,7 @@ module OpsController::Diagnostics
       add_flash(_("Error during 'Appliance restart': %{message}") % {:message => bang.message}, :error)
     else
       audit = {:event        => "restart_server",
-               :message      => _("Server '%{name}' restarted") % {:name => svr.name},
+               :message      => "Server '#{svr.name}' restarted",
                :target_id    => svr.id,
                :target_class => "MiqServer",
                :userid       => session[:userid]}
@@ -54,7 +54,7 @@ module OpsController::Diagnostics
         add_flash(_("Error during 'workers restart': %{message}") % {:message => bang.message}, :error)
       else
         audit = {:event        => "restart_workers",
-                 :message      => _("Worker on Server '%{name}' restarted") % {:name => svr.name},
+                 :message      => "Worker on Server '#{svr.name}' restarted",
                  :target_id    => svr.id,
                  :target_class => "MiqWorker",
                  :userid       => session[:userid]}
@@ -152,7 +152,7 @@ module OpsController::Diagnostics
     disable_client_cache
     send_data($log.contents(nil, nil),
               :filename => "evm.log")
-    AuditEvent.success(:userid => session[:userid], :event => "download_evm_log", :message => _("EVM log downloaded"))
+    AuditEvent.success(:userid => session[:userid], :event => "download_evm_log", :message => "EVM log downloaded")
   end
 
   # Send the audit log in text format
@@ -163,7 +163,7 @@ module OpsController::Diagnostics
               :filename => "audit.log")
     AuditEvent.success(:userid  => session[:userid],
                        :event   => "download_audit_log",
-                       :message => _("Audit log downloaded"))
+                       :message => "Audit log downloaded")
   end
 
   # Send the production log in text format
@@ -174,7 +174,7 @@ module OpsController::Diagnostics
               :filename => "#{@sb[:rails_log].downcase}.log")
     AuditEvent.success(:userid  => session[:userid],
                        :event   => "download_#{@sb[:rails_log].downcase}_log",
-                       :message => _("%{log_description} log downloaded") % {:log_description => @sb[:rails_log]})
+                       :message => "#{@sb[:rails_log]} log downloaded")
   end
 
   def refresh_log
@@ -388,7 +388,7 @@ module OpsController::Diagnostics
     javascript_flash(:spinner_off => true)
   else
     audit = {:event        => "orphaned_record_delete",
-             :message      => _("Orphaned Records deleted for userid [%{number}]") % {:number => params[:userid]},
+             :message      => "Orphaned Records deleted for userid [#{params[:userid]}]",
              :target_id    => params[:userid],
              :target_class => "MiqReport",
              :userid       => session[:userid]}
@@ -482,7 +482,7 @@ module OpsController::Diagnostics
         add_flash(_("Error during 'Clear Connection Broker cache': %{message}") % {:message => bang.message}, :error)
       else
         audit = {:event        => "reset_broker",
-                 :message      => _("Connection Broker cache cleared successfully"),
+                 :message      => "Connection Broker cache cleared successfully",
                  :target_id    => ms.id,
                  :target_class => "ExtManagementSystem",
                  :userid       => session[:userid]}
@@ -602,7 +602,7 @@ module OpsController::Diagnostics
   else
     AuditEvent.success(
       :event        => "svr_record_delete",
-      :message      => _("[%{name}] Record deleted") % {:name => server.name},
+      :message      => "[#{server.name}] Record deleted",
       :target_id    => server.id,
       :target_class => "MiqServer",
       :userid       => session[:userid]

--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -165,7 +165,7 @@ module OpsController::Settings::AnalysisProfiles
 
   # Build the audit object when a record is created, including all of the new fields
   def ap_build_created_audit_set(scanitemset)
-    msg = _("[%{name}] Record created (") % {:name => scanitemset.name}
+    msg = "[#{scanitemset.name}] Record created ("
     event = "scanitemset_record_add"
     i = 0
     @edit[:new].each_key do |k|
@@ -183,7 +183,7 @@ module OpsController::Settings::AnalysisProfiles
 
   # Build the audit object when a record is saved, including all of the changed fields
   def ap_build_saved_audit(scanitemset)
-    msg = _("[%{name}] Record updated (") % {:name => scanitemset.name}
+    msg = "[#{scanitemset.name}] Record updated ("
     event = "scanitemset_record_update"
     i = 0
     @edit[:new].each_key do |k|

--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -15,7 +15,7 @@ module OpsController::Settings::Tags
     category = Classification.find(params[:id])
     c_name = category.name
     audit = {:event        => "category_record_delete",
-             :message      => _("[%{name}] Record deleted") % {:name => c_name},
+             :message      => "[#{c_name}] Record deleted",
              :target_id    => category.id,
              :target_class => "Classification",
              :userid       => session[:userid]}

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -97,8 +97,7 @@ module ReportController::Schedules
       MiqSchedule.queue_scheduled_work(schedule.id, nil, Time.now.utc.to_i, nil)
       audit = {
         :event        => "queue_scheduled_work",
-        :message      => _("Schedule [%{schedule}] queued to run from the UI by user %{user}") %
-                          { :schedule => schedule.name, :user => current_user.name },
+        :message      => "Schedule [#{schedule.name}] queued to run from the UI by user #{current_user.name}",
         :target_id    => schedule.id,
         :target_class => "MiqSchedule",
         :userid       => session[:userid]


### PR DESCRIPTION
Messages that are meant to end up in `audit.log` have to stay in English. Translating them makes no sense.

https://bugzilla.redhat.com/show_bug.cgi?id=1548389