### PR TITLE
BZ1544764: Fix evacuate host param handling in controller

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/evacuate.rb
+++ b/app/controllers/mixins/actions/vm_actions/evacuate.rb
@@ -76,9 +76,9 @@ module Mixins
           @evacuate_items.each do |vm|
             if vm.supports_evacuate?
               options = {
-                :hostname          => params['auto_select_host']  == 'on' ? nil : params['destination_host'],
-                :on_shared_storage => params['on_shared_storage'] == 'on',
-                :admin_password    => params['on_shared_storage'] == 'on' ? nil : params['admin_password']
+                :hostname          => params['auto_select_host']  == 'true' ? nil : params['destination_host'],
+                :on_shared_storage => params['on_shared_storage'] == 'true',
+                :admin_password    => params['on_shared_storage'] == 'true' ? nil : params['admin_password']
               }
               task_id = vm.class.evacuate_queue(session[:userid], vm, options)
               add_flash(_("Instance evacuation task failed."), :error) unless task_id.kind_of?(Integer)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1544764

Fix mismatch in param value expectations for handling 'evacuate host'
controller action.

A related fix will be needed in fog-openstack to fix the on_shared_storage==false
use case, but this should handle the 'true' use case.


