### PR TITLE
Fix Bottlenecks timeline no data message

### DIFF
--- a/app/controllers/bottlenecks_controller.rb
+++ b/app/controllers/bottlenecks_controller.rb
@@ -196,7 +196,7 @@ class BottlenecksController < ApplicationController
     @timeline = true
     if @sb[:report].table.data.empty?
       @flash_array = nil
-      add_flash(_("No records found for this timeline"), :warning)
+      add_flash(_("No records found for this timeline"), :info)
     else
       tz = @sb[:report].tz ? @sb[:report].tz : Time.zone
       @sb[:report].extras[:browser_name] = browser_info(:name)


### PR DESCRIPTION
Fixes Bottlenecks timeline data not available message display from warning to information. 

**Note**: Originating BZ request states that an error message, in red, is being displayed. The message and background appear to be "reddish", but in fact are "yellow" per **Patternfly** use and definition. Message itself has been refactored to be an info type to alleviate any visual confusion. 

https://bugzilla.redhat.com/show_bug.cgi?id=1540695


Screen shot prior to fix:
![bottlenecks no tm data warning msg prior to code fix](https://user-images.githubusercontent.com/552686/36560715-704ddfae-17c6-11e8-8fc2-d8e10ba58a3b.png)

Screen shot post code fix, note Info message display:
![bottlenecks no tm data info msg post code fix](https://user-images.githubusercontent.com/552686/36560886-f3c9d112-17c6-11e8-9e98-e81914c8e804.png)



