### PR TITLE
Add accessors for DialogFieldVisibilityService.

### DIFF
--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -1,4 +1,16 @@
 class DialogFieldVisibilityService
+  attr_accessor :auto_placement_visibility_service
+  attr_accessor :number_of_vms_visibility_service
+  attr_accessor :service_template_fields_visibility_service
+  attr_accessor :network_visibility_service
+  attr_accessor :sysprep_auto_logon_visibility_service
+  attr_accessor :retirement_visibility_service
+  attr_accessor :customize_fields_visibility_service
+  attr_accessor :sysprep_custom_spec_visibility_service
+  attr_accessor :request_type_visibility_service
+  attr_accessor :pxe_iso_visibility_service
+  attr_accessor :linked_clone_visibility_service
+
   def initialize(
     auto_placement_visibility_service = AutoPlacementVisibilityService.new,
     number_of_vms_visibility_service = NumberOfVmsVisibilityService.new,
@@ -39,33 +51,33 @@ class DialogFieldVisibilityService
     @field_names_to_edit = []
     @field_names_to_show = []
 
-    add_to_visibility_arrays(@service_template_fields_visibility_service, options[:service_template_request])
-    add_to_visibility_arrays(@auto_placement_visibility_service, options[:auto_placement_enabled])
-    add_to_visibility_arrays(@number_of_vms_visibility_service, options[:number_of_vms], options[:platform])
+    add_to_visibility_arrays(service_template_fields_visibility_service, options[:service_template_request])
+    add_to_visibility_arrays(auto_placement_visibility_service, options[:auto_placement_enabled])
+    add_to_visibility_arrays(number_of_vms_visibility_service, options[:number_of_vms], options[:platform])
 
     add_to_visibility_arrays(
-      @network_visibility_service,
+      network_visibility_service,
       options[:sysprep_enabled],
       options[:supports_pxe],
       options[:supports_iso],
       options[:addr_mode]
     )
 
-    add_to_visibility_arrays(@sysprep_auto_logon_visibility_service, options[:sysprep_auto_logon])
-    add_to_visibility_arrays(@retirement_visibility_service, options[:retirement])
+    add_to_visibility_arrays(sysprep_auto_logon_visibility_service, options[:sysprep_auto_logon])
+    add_to_visibility_arrays(retirement_visibility_service, options[:retirement])
 
     add_to_visibility_arrays(
-      @customize_fields_visibility_service,
+      customize_fields_visibility_service,
       options[:platform],
       options[:supports_customization_template],
       options[:customize_fields_list]
     )
 
-    add_to_visibility_arrays(@sysprep_custom_spec_visibility_service, options[:sysprep_custom_spec])
-    add_to_visibility_arrays(@request_type_visibility_service, options[:request_type])
-    add_to_visibility_arrays(@pxe_iso_visibility_service, options[:supports_iso], options[:supports_pxe])
+    add_to_visibility_arrays(sysprep_custom_spec_visibility_service, options[:sysprep_custom_spec])
+    add_to_visibility_arrays(request_type_visibility_service, options[:request_type])
+    add_to_visibility_arrays(pxe_iso_visibility_service, options[:supports_iso], options[:supports_pxe])
     add_to_visibility_arrays(
-      @linked_clone_visibility_service,
+      linked_clone_visibility_service,
       options[:provision_type],
       options[:linked_clone],
       options[:snapshot_count]

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -1,6 +1,63 @@
 describe DialogFieldVisibilityService do
   let(:subject) { described_class.new }
 
+  context "accessors" do
+    it "defines an auto_placement_visibility_service accessor" do
+      expect(subject).to respond_to(:auto_placement_visibility_service)
+      expect(subject).to respond_to(:auto_placement_visibility_service=)
+    end
+
+    it "defines an number_of_vms_visibility_service accessor" do
+      expect(subject).to respond_to(:number_of_vms_visibility_service)
+      expect(subject).to respond_to(:number_of_vms_visibility_service=)
+    end
+
+    it "defines an service_template_fields_visibility_service accessor" do
+      expect(subject).to respond_to(:service_template_fields_visibility_service)
+      expect(subject).to respond_to(:service_template_fields_visibility_service=)
+    end
+
+    it "defines an network_visibility_service accessor" do
+      expect(subject).to respond_to(:network_visibility_service)
+      expect(subject).to respond_to(:network_visibility_service=)
+    end
+
+    it "defines an sysprep_auto_logon_visibility_service accessor" do
+      expect(subject).to respond_to(:sysprep_auto_logon_visibility_service)
+      expect(subject).to respond_to(:sysprep_auto_logon_visibility_service=)
+    end
+
+    it "defines an retirement_visibility_service accessor" do
+      expect(subject).to respond_to(:retirement_visibility_service)
+      expect(subject).to respond_to(:retirement_visibility_service=)
+    end
+
+    it "defines an customize_fields_visibility_service accessor" do
+      expect(subject).to respond_to(:customize_fields_visibility_service)
+      expect(subject).to respond_to(:customize_fields_visibility_service=)
+    end
+
+    it "defines an sysprep_custom_spec_visibility_service accessor" do
+      expect(subject).to respond_to(:sysprep_custom_spec_visibility_service)
+      expect(subject).to respond_to(:sysprep_custom_spec_visibility_service=)
+    end
+
+    it "defines an request_type_visibility_service accessor" do
+      expect(subject).to respond_to(:request_type_visibility_service)
+      expect(subject).to respond_to(:request_type_visibility_service=)
+    end
+
+    it "defines an pxe_iso_visibility_service accessor" do
+      expect(subject).to respond_to(:pxe_iso_visibility_service)
+      expect(subject).to respond_to(:pxe_iso_visibility_service=)
+    end
+
+    it "defines an linked_clone_visibility_service accessor" do
+      expect(subject).to respond_to(:linked_clone_visibility_service)
+      expect(subject).to respond_to(:linked_clone_visibility_service=)
+    end
+  end
+
   describe "#determine_visibility" do
     let(:subject) do
       described_class.new(


### PR DESCRIPTION
Currently the DialogFieldVisibilityService sets several instance variables for the constructor arguments, but does not create accessors for them. This PR adds them and has the internal code reference the methods instead of the instance variables directly.

The current code makes subclassing  a pain, where we may want to define our own service classes, and set the instance ourselves for individual providers.

For example, in https://github.com/ManageIQ/manageiq-providers-azure/pull/210, I am forced to redefine the constructor in order to make it use a subclass of `NumberOfVmsVisibilityService`. Whereas if I had an accessor, I could simply do:
```
d = DialogFieldVisibilityService.new
d.number_of_vms_visibility_service = ManageIQ::Providers::Azure::NumberOfVmsVisibilityService.new
```

As for testing, there's not much to do but fire up the Rails console and check to see if the accessors are defined. That, or just trust the specs.