### PR TITLE
Render GO summary screen in Service Explorer.

### DIFF
--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -33,7 +33,7 @@ class GenericObjectController < ApplicationController
   private
 
   def textual_group_list
-    [%i(properties attribute_details_list associations methods)]
+    [%i(go_properties attribute_details_list associations methods)]
   end
 
   helper_method :textual_group_list

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -189,6 +189,7 @@ class ServiceController < ApplicationController
     drop_breadcrumb(:name => @item.name, :url => show_link(@record, :display => 'generic_objects', :generic_object_id => params[:generic_object_id]))
     @view = get_db_view(GenericObject)
     @sb[:rec_id] = params[:generic_object_id]
+    @record = @item
     show_item
   end
 
@@ -217,7 +218,9 @@ class ServiceController < ApplicationController
   helper_method :sanitize_output
 
   def textual_group_list
-    if @record.type == "ServiceAnsiblePlaybook"
+    if @item && @item.kind_of?(GenericObject)
+      [%i(go_properties attribute_details_list methods)]
+    elsif @record.type == "ServiceAnsiblePlaybook"
       [%i(properties), %i(lifecycle tags generic_objects)]
     else
       [%i(properties lifecycle relationships generic_objects miq_custom_attributes), %i(vm_totals tags)]

--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -1,12 +1,12 @@
 module GenericObjectHelper::TextualSummary
   include TextualMixins::TextualName
 
-  def textual_group_properties
-    TextualGroup.new(_("Properties"), %i(name created updated))
+  def textual_group_go_properties
+    TextualGroup.new(_("Properties"), %i(definition created updated))
   end
 
-  def textual_name
-    {:label => _("Name"), :value => @record.name}
+  def textual_definition
+    {:label => _("Definition"), :value => @record.generic_object_definition_name}
   end
 
   def textual_created

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -2,6 +2,8 @@ module ServiceHelper::TextualSummary
   include TextualMixins::TextualDescription
   include TextualMixins::TextualGroupTags
   include TextualMixins::TextualName
+  include GenericObjectHelper::TextualSummary
+
   #
   # Groups
   #

--- a/app/views/service/show.html.haml
+++ b/app/views/service/show.html.haml
@@ -1,7 +1,7 @@
 #main_div
   - if %w(generic_objects).include?(@display)
     - if @lastaction == 'generic_object' && @item
-      = render :partial => "layouts/item", :locals => {:action_url => "show/#{@item}"}
+      = render :partial => 'layouts/textual_groups_generic'
     - else
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -140,7 +140,6 @@ describe ServiceController do
       expect(response.status).to eq(200)
       expect(assigns(:breadcrumbs)).to eq([{:name => "Abc (All Generic Objects)", :url => "/service/show/#{service.id}?display=generic_objects"},
                                            {:name => "GOTest", :url => "/service/show/#{service.id}?display=generic_objects&generic_object_id=#{go.id}"}])
-      is_expected.to render_template("layouts/_item")
       is_expected.to render_template("service/show")
 
       get :show, :params => { :id => service.id}


### PR DESCRIPTION
Render GO summary screen when browsing to that thru list of generic objects from service summary screen

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1515857

before:
![before](https://user-images.githubusercontent.com/3450808/36568549-69015780-17f8-11e8-81e9-54ac12b65a21.png)

after:
![after](https://user-images.githubusercontent.com/3450808/36608867-2002651e-1899-11e8-8180-ebbf946012d8.png)


@dclarizio please review, this one renders GO textual summary screen to show more information on the screen when browsing to GO object from within Services explorer.
