### PR TITLE
Remove Adv Search from Ansible Tower Providers page

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -171,6 +171,10 @@ class AutomationManagerController < ApplicationController
     true
   end
 
+  def providers_active_tree?
+    x_active_tree == :automation_manager_providers_tree
+  end
+
   private
 
   def textual_group_list
@@ -257,7 +261,7 @@ class AutomationManagerController < ApplicationController
     elsif x_active_tree == :configuration_scripts_tree
       cs_provider_node(provider)
     else
-      @show_adv_search = true
+      @show_adv_search = false
       @no_checkboxes = true
       options = {:model                 => "ManageIQ::Providers::AutomationManager::InventoryRootGroup",
                  :match_via_descendants => 'ConfiguredSystem',
@@ -287,7 +291,7 @@ class AutomationManagerController < ApplicationController
       self.x_node = "root"
       get_node_info("root")
     else
-      @show_adv_search = true
+      @show_adv_search = false
       options = {:model                 => "ConfiguredSystem",
                  :match_via_descendants => 'ConfiguredSystem',
                  :named_scope           => [[:with_inventory_root_group, @inventory_group_record.id]],
@@ -404,6 +408,13 @@ class AutomationManagerController < ApplicationController
     else
       presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     end
+    replace_search_box(presenter)
+  end
+
+  def replace_search_box(presenter)
+    presenter.replace(:adv_searchbox_div,
+                      r[:partial => 'layouts/x_adv_searchbox',
+                        :locals  => {:nameonly => providers_active_tree?}])
   end
 
   def group_summary_tab_selected?

--- a/app/views/automation_manager/explorer.html.haml
+++ b/app/views/automation_manager/explorer.html.haml
@@ -1,5 +1,5 @@
 - content_for :search do
-  = render(:partial => "layouts/x_adv_searchbox", :locals => {:nameonly => x_active_tree == :configuration_manager_providers_tree})
+  = render(:partial => "layouts/x_adv_searchbox", :locals => {:nameonly => controller.providers_active_tree?})
   = render(:partial => 'layouts/quick_search')
 
 -# These are the initial divs that will go inside center_cell_div


### PR DESCRIPTION
**Fixes issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/3433

Remove _Advanced Search_ from _All Ansible Tower Providers_ page in _Automation -> Ansible Tower -> Explorer -> Providers_ accordion, as it is not supported there (see the issue for more info) and only _Search_ remains in the page, which works well.

---

**Before:** (Adv Search present)
![automation_providers_before](https://user-images.githubusercontent.com/13417815/36594164-59241ca8-189d-11e8-9c55-2c11f68917c3.png)

**After:** (Adv Search NOT present, everything works well)
![amutomation_providers_after](https://user-images.githubusercontent.com/13417815/36594608-1ebb5912-189f-11e8-9801-1a8fcd25e16e.png)
