### PR TITLE
MiqPolicy - remove form buttons when cancelling a form or sucessfully saving/adding

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -689,8 +689,10 @@ class MiqPolicyController < ApplicationController
     else
       # Added so buttons can be turned off even tho div is not being displayed it still pops up
       # Abandon changes box when trying to change a node on tree after saving a record
-      presenter.hide(:button_on).show(:toolbar).hide(:paging_div)
+      presenter.hide(:buttons_on).show(:toolbar).hide(:paging_div)
     end
+
+    presenter.hide(:form_buttons_div) if options[:remove_form_buttons]
 
     # Replace the searchbox
     presenter.replace(:adv_searchbox_div, r[:partial => 'layouts/x_adv_searchbox', :locals => {:nameonly => true}])

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -61,7 +61,7 @@ module MiqPolicyController::AlertProfiles
     @edit = nil
     self.x_node = @new_alert_profile_node = "xx-#{alert_profile.mode}_ap-#{alert_profile.id}"
     get_node_info(@new_alert_profile_node)
-    replace_right_cell(:nodetype => "ap", :replace_trees => [:alert_profile], :remove_form_buttons => true)
+    replace_right_cell(:nodetype => "ap", :replace_trees => %i(alert_profile), :remove_form_buttons => true)
   end
 
   def alert_profile_edit_move
@@ -142,7 +142,7 @@ module MiqPolicyController::AlertProfiles
     nodes.pop
     self.x_node = nodes.join("_")
     get_node_info(x_node)
-    replace_right_cell(:nodetype => "xx", :replace_trees => [:alert_profile])
+    replace_right_cell(:nodetype => "xx", :replace_trees => %i(alert_profile))
   end
 
   def alert_profile_field_changed

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -14,7 +14,7 @@ module MiqPolicyController::AlertProfiles
       add_flash(_("Edit of Alert Profile \"%{name}\" was cancelled by the user") % {:name => @alert_profile.description})
     end
     get_node_info(x_node)
-    replace_right_cell(:nodetype => @nodetype)
+    replace_right_cell(:nodetype => @nodetype, :remove_form_buttons => true)
   end
 
   def alert_profile_edit_reset
@@ -61,7 +61,7 @@ module MiqPolicyController::AlertProfiles
     @edit = nil
     self.x_node = @new_alert_profile_node = "xx-#{alert_profile.mode}_ap-#{alert_profile.id}"
     get_node_info(@new_alert_profile_node)
-    replace_right_cell(:nodetype => "ap", :replace_trees => [:alert_profile])
+    replace_right_cell(:nodetype => "ap", :replace_trees => [:alert_profile], :remove_form_buttons => true)
   end
 
   def alert_profile_edit_move

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -10,7 +10,7 @@ module MiqPolicyController::Alerts
       add_flash(_("Edit of Alert \"%{name}\" was cancelled by the user") % {:name => @alert.description})
     end
     get_node_info(x_node)
-    replace_right_cell(:nodetype => @nodetype)
+    replace_right_cell(:nodetype => @nodetype, :remove_form_buttons => true)
   end
 
   def alert_edit_save_add
@@ -35,7 +35,7 @@ module MiqPolicyController::Alerts
     @edit = nil
     @nodetype = "al"
     @new_alert_node = "al-#{alert.id}"
-    replace_right_cell(:nodetype => "al", :replace_trees => [:alert_profile, :alert])
+    replace_right_cell(:nodetype => "al", :replace_trees => [:alert_profile, :alert], :remove_form_buttons => true)
   end
 
   def alert_edit_reset

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -35,7 +35,7 @@ module MiqPolicyController::Alerts
     @edit = nil
     @nodetype = "al"
     @new_alert_node = "al-#{alert.id}"
-    replace_right_cell(:nodetype => "al", :replace_trees => [:alert_profile, :alert], :remove_form_buttons => true)
+    replace_right_cell(:nodetype => "al", :replace_trees => %i(alert_profile alert), :remove_form_buttons => true)
   end
 
   def alert_edit_reset
@@ -77,7 +77,7 @@ module MiqPolicyController::Alerts
     process_alerts(alerts, "destroy") unless alerts.empty?
     @new_alert_node = self.x_node = "root"
     get_node_info(x_node)
-    replace_right_cell(:nodetype => "root", :replace_trees => [:alert_profile, :alert])
+    replace_right_cell(:nodetype => "root", :replace_trees => %i(alert_profile alert))
   end
 
   def alert_field_changed

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -14,7 +14,7 @@ module MiqPolicyController::Conditions
       end
       @edit = nil
       get_node_info(x_node)
-      replace_right_cell(:nodetype => @nodetype)
+      replace_right_cell(:nodetype => @nodetype, :remove_form_buttons => true)
       return
     when "reset", nil # Reset or first time in
       condition_build_edit_screen
@@ -68,19 +68,19 @@ module MiqPolicyController::Conditions
           case x_active_tree
           when :condition_tree
             @new_condition_node = "xx-#{condition.towhat.downcase}_co-#{condition.id}"
-            replace_right_cell(:nodetype => "co", :replace_trees => [:condition])
+            replace_right_cell(:nodetype => "co", :replace_trees => [:condition], :remove_form_buttons => true)
           when :policy_tree
             node_ids = @sb[:node_ids][x_active_tree]  # Get the selected node ids
             @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.downcase}_p-#{node_ids["p"]}_co-#{condition.id}"
-            replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition])
+            replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition], :remove_form_buttons => true)
           when :policy_profile_tree
             node_ids = @sb[:node_ids][x_active_tree]  # Get the selected node ids
             @new_profile_node = "pp-#{node_ids["pp"]}_p-#{node_ids["p"]}_co-#{condition.id}"
-            replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition])
+            replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition], :remove_form_buttons => true)
           end
         else
           condition_get_info(Condition.find(condition.id))
-          replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition])
+          replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition], :remove_form_buttons => true)
         end
       else
         condition.errors.each do |field, msg|

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -68,19 +68,19 @@ module MiqPolicyController::Conditions
           case x_active_tree
           when :condition_tree
             @new_condition_node = "xx-#{condition.towhat.downcase}_co-#{condition.id}"
-            replace_right_cell(:nodetype => "co", :replace_trees => [:condition], :remove_form_buttons => true)
+            replace_right_cell(:nodetype => "co", :replace_trees => %i(condition), :remove_form_buttons => true)
           when :policy_tree
             node_ids = @sb[:node_ids][x_active_tree]  # Get the selected node ids
             @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.downcase}_p-#{node_ids["p"]}_co-#{condition.id}"
-            replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition], :remove_form_buttons => true)
+            replace_right_cell(:nodetype => "co", :replace_trees => %i(policy_profile policy condition), :remove_form_buttons => true)
           when :policy_profile_tree
             node_ids = @sb[:node_ids][x_active_tree]  # Get the selected node ids
             @new_profile_node = "pp-#{node_ids["pp"]}_p-#{node_ids["p"]}_co-#{condition.id}"
-            replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition], :remove_form_buttons => true)
+            replace_right_cell(:nodetype => "co", :replace_trees => %i(policy_profile policy condition), :remove_form_buttons => true)
           end
         else
           condition_get_info(Condition.find(condition.id))
-          replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition], :remove_form_buttons => true)
+          replace_right_cell(:nodetype => "co", :replace_trees => %i(policy_profile policy condition), :remove_form_buttons => true)
         end
       else
         condition.errors.each do |field, msg|
@@ -116,7 +116,7 @@ module MiqPolicyController::Conditions
     nodes = x_node.split("_")
     nodes.pop
     @new_policy_node = self.x_node = nodes.join("_")
-    replace_right_cell(:nodetype => "p", :replace_trees => [:policy_profile, :policy])
+    replace_right_cell(:nodetype => "p", :replace_trees => %i(policy_profile policy))
   end
 
   def condition_delete
@@ -132,7 +132,7 @@ module MiqPolicyController::Conditions
     end
     process_conditions(conditions, "destroy") unless conditions.empty?
     get_node_info(@new_condition_node)
-    replace_right_cell(:nodetype => "xx", :replace_trees => [:condition])
+    replace_right_cell(:nodetype => "xx", :replace_trees => %i(condition))
   end
 
   def condition_field_changed

--- a/app/controllers/miq_policy_controller/events.rb
+++ b/app/controllers/miq_policy_controller/events.rb
@@ -44,7 +44,7 @@ module MiqPolicyController::Events
       @nodetype = "ev"
       event_get_info(MiqEventDefinition.find(event.id))
       @edit = nil
-      replace_right_cell(:nodetype => "ev", :replace_trees => [:policy_profile, :policy], :remove_form_buttons => true)
+      replace_right_cell(:nodetype => "ev", :replace_trees => %i(policy_profile policy), :remove_form_buttons => true)
     when "true_right", "true_left", "true_allleft", "true_up", "true_down", "true_sync", "true_async"
       handle_selection_buttons(:actions_true, :members_chosen_true, :choices_true, :choices_chosen_true)
       session[:changed] = (@edit[:new] != @edit[:current])

--- a/app/controllers/miq_policy_controller/events.rb
+++ b/app/controllers/miq_policy_controller/events.rb
@@ -8,7 +8,7 @@ module MiqPolicyController::Events
       @edit = nil
       add_flash(_("Edit Event cancelled by user"))
       get_node_info(x_node)
-      replace_right_cell(:nodetype => @nodetype)
+      replace_right_cell(:nodetype => @nodetype, :remove_form_buttons => true)
       return
     when "reset", nil # Reset or first time in
       event_build_edit_screen
@@ -44,7 +44,7 @@ module MiqPolicyController::Events
       @nodetype = "ev"
       event_get_info(MiqEventDefinition.find(event.id))
       @edit = nil
-      replace_right_cell(:nodetype => "ev", :replace_trees => [:policy_profile, :policy])
+      replace_right_cell(:nodetype => "ev", :replace_trees => [:policy_profile, :policy], :remove_form_buttons => true)
     when "true_right", "true_left", "true_allleft", "true_up", "true_down", "true_sync", "true_async"
       handle_selection_buttons(:actions_true, :members_chosen_true, :choices_true, :choices_chosen_true)
       session[:changed] = (@edit[:new] != @edit[:current])

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -51,7 +51,7 @@ module MiqPolicyController::MiqActions
         @edit = nil
         @nodetype = "a"
         @new_action_node = "a-#{action.id}"
-        replace_right_cell(:nodetype => "a", :replace_trees => params[:button] == "save" ? [:policy_profile, :policy, :action] : [:action], :remove_form_buttons => true)
+        replace_right_cell(:nodetype => "a", :replace_trees => params[:button] == "save" ? %i(policy_profile policy action) : %i(action), :remove_form_buttons => true)
         @sb[:action] = nil
       else
         action.errors.each do |field, msg|
@@ -78,7 +78,7 @@ module MiqPolicyController::MiqActions
     process_actions(actions, "destroy") unless actions.empty?
     @new_action_node = self.x_node = "root"
     get_node_info(x_node)
-    replace_right_cell(:nodetype => "root", :replace_trees => [:action])
+    replace_right_cell(:nodetype => "root", :replace_trees => %i(action))
   end
 
   def action_field_changed

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -14,7 +14,7 @@ module MiqPolicyController::MiqActions
       end
       @sb[:action] = nil
       get_node_info(x_node)
-      replace_right_cell(:nodetype => @nodetype)
+      replace_right_cell(:nodetype => @nodetype, :remove_form_buttons => true)
       return
     when "reset", nil # Reset or first time in
       action_build_edit_screen
@@ -51,7 +51,7 @@ module MiqPolicyController::MiqActions
         @edit = nil
         @nodetype = "a"
         @new_action_node = "a-#{action.id}"
-        replace_right_cell(:nodetype => "a", :replace_trees => params[:button] == "save" ? [:policy_profile, :policy, :action] : [:action])
+        replace_right_cell(:nodetype => "a", :replace_trees => params[:button] == "save" ? [:policy_profile, :policy, :action] : [:action], :remove_form_buttons => true)
         @sb[:action] = nil
       else
         action.errors.each do |field, msg|

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -12,7 +12,7 @@ module MiqPolicyController::Policies
     end
     @edit = nil
     get_node_info(x_node)
-    replace_right_cell(:nodetype => @nodetype)
+    replace_right_cell(:nodetype => @nodetype, :remove_form_buttons => true)
   end
 
   def policy_edit_reset
@@ -74,14 +74,14 @@ module MiqPolicyController::Policies
 
     case x_active_tree
     when :policy_profile_tree
-      replace_right_cell(:nodetype => "p", :replace_trees => [:policy_profile, :policy])
+      replace_right_cell(:nodetype => "p", :replace_trees => [:policy_profile, :policy], :remove_form_buttons => true)
     when :policy_tree
       @nodetype = "p"
       if params[:button] == "add"
         self.x_node = @new_policy_node = policy_node(policy)
         get_node_info(@new_policy_node)
       end
-      replace_right_cell(:nodetype => "p", :replace_trees => params[:button] == "save" ? [:policy_profile, :policy] : [:policy])
+      replace_right_cell(:nodetype => "p", :replace_trees => params[:button] == "save" ? [:policy_profile, :policy] : [:policy], :remove_form_buttons => true)
     end
   end
 

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -74,14 +74,14 @@ module MiqPolicyController::Policies
 
     case x_active_tree
     when :policy_profile_tree
-      replace_right_cell(:nodetype => "p", :replace_trees => [:policy_profile, :policy], :remove_form_buttons => true)
+      replace_right_cell(:nodetype => "p", :replace_trees => %i(policy_profile policy), :remove_form_buttons => true)
     when :policy_tree
       @nodetype = "p"
       if params[:button] == "add"
         self.x_node = @new_policy_node = policy_node(policy)
         get_node_info(@new_policy_node)
       end
-      replace_right_cell(:nodetype => "p", :replace_trees => params[:button] == "save" ? [:policy_profile, :policy] : [:policy], :remove_form_buttons => true)
+      replace_right_cell(:nodetype => "p", :replace_trees => params[:button] == "save" ? %i(policy_profile policy) : %i(policy), :remove_form_buttons => true)
     end
   end
 
@@ -132,7 +132,7 @@ module MiqPolicyController::Policies
       add_flash(_("Policy \"%{name}\" was added") % {:name => new_desc})
       @new_policy_node = policy_node(policy)
       get_node_info(@new_policy_node)
-      replace_right_cell(:nodetype => "p", :replace_trees => [:policy])
+      replace_right_cell(:nodetype => "p", :replace_trees => %i(policy))
     end
   end
 
@@ -154,7 +154,7 @@ module MiqPolicyController::Policies
     process_policies(policies, "destroy") unless policies.empty?
     add_flash(_("The selected Policies were deleted")) if @flash_array.nil?
     get_node_info(@new_policy_node)
-    replace_right_cell(:nodetype => "xx", :replace_trees => [:policy, :policy_profile])
+    replace_right_cell(:nodetype => "xx", :replace_trees => %i(policy policy_profile))
   end
 
   def policy_field_changed

--- a/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -12,7 +12,7 @@ module MiqPolicyController::PolicyProfiles
         add_flash(_("Edit of Policy Profile \"%{name}\" was cancelled by the user") % {:name => @profile.description})
       end
       get_node_info(x_node)
-      replace_right_cell(:nodetype => @nodetype)
+      replace_right_cell(:nodetype => @nodetype, :remove_form_buttons => true)
       return
     when "reset", nil # Reset or first time in
       profile_build_edit_screen
@@ -58,7 +58,7 @@ module MiqPolicyController::PolicyProfiles
         @edit = nil
         @nodetype = "pp"
         @new_profile_node = "pp-#{profile.id}"
-        replace_right_cell(:nodetype => "pp", :replace_trees => [:policy_profile])
+        replace_right_cell(:nodetype => "pp", :replace_trees => [:policy_profile], :remove_form_buttons => true)
       else
         profile.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)

--- a/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -58,7 +58,7 @@ module MiqPolicyController::PolicyProfiles
         @edit = nil
         @nodetype = "pp"
         @new_profile_node = "pp-#{profile.id}"
-        replace_right_cell(:nodetype => "pp", :replace_trees => [:policy_profile], :remove_form_buttons => true)
+        replace_right_cell(:nodetype => "pp", :replace_trees => %i(policy_profile), :remove_form_buttons => true)
       else
         profile.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -85,7 +85,7 @@ module MiqPolicyController::PolicyProfiles
     add_flash(_("The selected Policy Profile was deleted")) if @flash_array.nil?
     self.x_node = @new_profile_node = 'root'
     get_node_info('root')
-    replace_right_cell(:nodetype => 'root', :replace_trees => [:policy_profile])
+    replace_right_cell(:nodetype => 'root', :replace_trees => %i(policy_profile))
   end
 
   def profile_field_changed


### PR DESCRIPTION
Go to any accordion under Control > Explorer (all of them),
Configure > Add a new $thing,
Cancel (or sucessfully save)

Before: you will see the Add/Cancel buttons hanging around on the "list" screen
After: no add/cancel buttons

---

Done so explicitly by passing `:remove_form_buttons => true` to `replace_right_cell`.

Not seeing any previous mechanism to handle this in miq_policy, the `handle_bottom_cell` mechanism used elsewhere doesn't work when transitiononing to a non-GTL screen.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1530971