### PR TITLE
GTL: Hide pagination on no records

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -323,10 +323,16 @@
         }
         this.setDefaults();
         this.movePagination();
+
+        // pagination doesn't update on no records (components/data-table/data-table.html:4:99), hide it instead
+        if (! this.gtlData.rows.length) {
+          this.setExtraClasses();
+        }
+
         this.$timeout(function() {
           this.$window.ManageIQ.gtl.loading = false;
           this.$window.ManageIQ.gtl.isFirst = this.settings.current === 1;
-          this.$window.ManageIQ.gtl.isLast = this.settings.current === this.settings.totla;
+          this.$window.ManageIQ.gtl.isLast = this.settings.current === this.settings.total;
         }.bind(this));
         return data;
       }.bind(this));


### PR DESCRIPTION
when transitioning from a GTL screen to another,
and the target screen has no records,
the paging toolbar doesn't update and keeps showing the old data.

Hiding on 0 rows.

Cc @karelhala 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1548121