### PR TITLE
Edit log depot settings component

### DIFF
--- a/app/assets/javascripts/components/edit-log-depot-settings/edit-log-depot-settings-component.js
+++ b/app/assets/javascripts/components/edit-log-depot-settings/edit-log-depot-settings-component.js
@@ -8,9 +8,7 @@ ManageIQ.angular.app.component('editLogDepotSettings', {
     depotUri: '<',
     depotUriPrefix: '<',
     depotUriPrefixDisplay: '<',
-    depotUriChanged: '&'
-  },
-  controller: function () {
+    depotUriChanged: '&',
   },
   templateUrl: '/static/edit_log_depot_settings/edit-log-depot-settings-component.html.haml',
 });

--- a/app/assets/javascripts/components/edit-log-depot-settings/edit-log-depot-settings-component.js
+++ b/app/assets/javascripts/components/edit-log-depot-settings/edit-log-depot-settings-component.js
@@ -1,0 +1,16 @@
+ManageIQ.angular.app.component('editLogDepotSettings', {
+  bindings: {
+    depotNameRequired: "<",
+    depotName: '<',
+    readonly: '<',
+    depotNameChanged: '&',
+    depotUriRequired: '<',
+    depotUri: '<',
+    depotUriPrefix: '<',
+    depotUriPrefixDisplay: '<',
+    depotUriChanged: '&'
+  },
+  controller: function () {
+  },
+  templateUrl: '/static/edit_log_depot_settings/edit-log-depot-settings-component.html.haml',
+});

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -364,9 +364,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
   };
 
   $scope.isBasicInfoValid = function() {
-    return ($scope.angularForm.depot_name.$valid &&
-      $scope.angularForm.uri.$valid &&
-      $scope.angularForm.log_userid.$valid &&
+    return ($scope.angularForm.log_userid.$valid &&
       $scope.angularForm.log_password.$valid);
   };
 
@@ -391,9 +389,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
   };
 
   $scope.validateFieldsDirty = function() {
-    return ($scope.angularForm.depot_name.$dirty ||
-        $scope.angularForm.uri.$dirty ||
-        $scope.angularForm.log_userid.$dirty ||
+    return ($scope.angularForm.log_userid.$dirty ||
         $scope.angularForm.log_password.$dirty);
   };
 
@@ -411,6 +407,14 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
 
   $scope.setTargetId = function(targetId) {
     $scope.scheduleModel.target_id = targetId;
+  };
+
+  $scope.setDepotName = function(depotName) {;
+    $scope.scheduleModel.depot_name = depotName;
+  };
+
+  $scope.setDepotUri = function(depotUri) {
+    $scope.scheduleModel.uri = depotUri;
   };
 
   init();

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -409,7 +409,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     $scope.scheduleModel.target_id = targetId;
   };
 
-  $scope.setDepotName = function(depotName) {;
+  $scope.setDepotName = function(depotName) {
     $scope.scheduleModel.depot_name = depotName;
   };
 

--- a/app/views/ops/_schedule_form_filter.html.haml
+++ b/app/views/ops/_schedule_form_filter.html.haml
@@ -82,7 +82,7 @@
                                  "ng-required"                => "!automateRequest() && filterValueRequired(scheduleModel.filter_value)",
                                  "checkchange"                => ""}
               %option{"disabled" => "", "value" => ""} &lt;Choose&gt;
-        
+
         %ae-resolve-options{"ng-if"                 => "automateRequest()",
                             "instance-name"         => "scheduleModel.instance_name",
                             "instance-options"      => "scheduleModel.instance_names",
@@ -99,14 +99,15 @@
                             "target-id-change"      => "setTargetId(targetId)",
                             "ui-attrs"              => "scheduleModel.ui_attrs"}
 
-        = render :partial => "layouts/angular-bootstrap/edit_log_depot_settings_angular_bootstrap",
-                 :locals  => {:ng_show             => "dbBackup()",
-                              :ng_reqd_depot_name  => "dbRequired(scheduleModel.depot_name)",
-                              :ng_model_depot_name => "scheduleModel.depot_name",
-                              :ng_reqd_uri         => "dbRequired(scheduleModel.uri)",
-                              :ng_model_uri        => "scheduleModel.uri",
-                              :ng_model_uri_prefix => "scheduleModel.uri_prefix",
-                              :uri_prefix_display  =>  "{{scheduleModel.uri_prefix}}://"}
+        %edit-log-depot-settings{ "ng-if"                    => "dbBackup()",
+                                  "depot-name-required"      => "dbRequired(scheduleModel.depot_name)",
+                                  "depot-name"               => "scheduleModel.depot_name",
+                                  "readonly"                 => false,
+                                  "depot-name-changed"       => "setDepotName(depotName)",
+                                  "depot-uri-required"       => "dbRequired(scheduleModel.uri)",
+                                  "depot-uri"                => "scheduleModel.uri",
+                                  "depot-uri-prefix"         => "scheduleModel.uri_prefix",
+                                  "depot-uri-changed"        => "setDepotUri(depotUri)"}
 
         = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                  :locals  => {:ng_show           => "sambaBackup()",

--- a/app/views/static/edit_log_depot_settings/edit-log-depot-settings-component.html.haml
+++ b/app/views/static/edit_log_depot_settings/edit-log-depot-settings-component.html.haml
@@ -1,0 +1,33 @@
+%ng-form{'name'         => 'editLogDepotSettingsForm',
+         'form-changed' => ''}
+  .form-group{'ng-class' => "{'has-error': editLogDepotSettingsForm.depotName.$invalid}"}
+    %label.col-md-2.control-label{'for' => 'depotName'}
+      = _('Depot Name')
+    .col-md-8
+      %input.form-control{'type'        => 'text',
+                          'id'          => 'depotName',
+                          'ng-required' => '$ctrl.depotNameRequired',
+                          'ng-model'    => '$ctrl.depotName',
+                          'name'        => 'depotName',
+                          'auto-focus'  => 'reactiveFocus',
+                          'ng-readonly' => '$ctrl.readOnly',
+                          'ng-change'   => '$ctrl.depotNameChanged({depotName: $ctrl.depotName})'}
+      %span.help-block{"ng-show" => "editLogDepotSettingsForm.depotName.$invalid"}
+        = _("Required")
+  .form-group{"ng-class" => "{'has-error': editLogDepotSettingsForm.depotUri.$invalid}"}
+    %label.col-md-2.control-label{"for" => "depotUri"}
+      = _("URI")
+    .col-md-8
+      .input-group
+        %span.input-group-addon
+          {{$ctrl.depotUriPrefix + '://'}}
+        %input.uri-input.form-control{"type"        => "text",
+                                      "id"          => "depotUri",
+                                      "ng-required" => "$ctrl.depotUriRequired",
+                                      "name"        => "depotUri",
+                                      "ng-model"    => "$ctrl.depotUri",
+                                      "ng-readonly" => "$ctrl.readonly",
+                                      "ng-change"   => '$ctrl.depotUriChanged({depotUri: $ctrl.depotUri})'}
+      %span.help-block{"ng-show" => "editLogDepotSettingsForm.depotUri.$invalid"}
+        = _("Required")
+      %input{"type" => "hidden", "name" => "uriPrefix", "ng-value" => "$ctrl.depotUriPrefix"}


### PR DESCRIPTION
This PR replaces partial for scheduleForm #2766 with angular component.

Configuration -> Settings -> Schedules ->Configuration -> Add new Schedule / Edit the selected Schedule

select action "Database Backup"
Depot name and uri are now inside component instead of partial.

partial `app/views/layouts/angular-bootstrap/_edit_log_depot_settings_angular_bootstrap.html.haml`

this partial is also used in `app/views/ops/_diagnostics_database_tab.html.haml` and `app/views/ops/_log_collection.html.haml` and should be replaced in future