### PR TITLE
Hide region from add provider forms if it's not required

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -469,7 +469,7 @@ module EmsCommon
   end
 
   def retrieve_provider_regions
-    managers = model.supported_subclasses.select(&:supports_regions?)
+    managers = model.supported_subclasses.select { |s| s.supports_regions? && s.try(:region_required?) != false }
     managers.each_with_object({}) do |manager, provider_regions|
       regions = manager.parent::Regions.all.sort_by { |r| r[:description] }
       provider_regions[manager.ems_type] = regions.map do |region|


### PR DESCRIPTION
If a provider clearly states `:reqion_required?` as false, don't
show the Region dropdown in add provider dialogue.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1433062
Before:
```
ng-if="["ec2","azure","gce"].includes(emsCommonModel.emstype)"
```
![image](https://user-images.githubusercontent.com/7453394/36673920-c2474340-1b04-11e8-9e4b-aa4d93f5259b.png)

After:
```
ng-if="["ec2","azure"].includes(emsCommonModel.emstype)"
```
![image](https://user-images.githubusercontent.com/7453394/36673255-79791294-1b02-11e8-8360-b82b8b49db26.png)

@miq-bot add_label compute/cloud, bug
