### PR TITLE
Add <none> field to security groups

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -255,7 +255,7 @@
                 - else
                   - opts = [["<#{_('Choose')}>", nil]]
               - else
-                - opts = multiple ? [] : [["<#{_('None')}>", nil]]
+                - opts = [["<#{_('None')}>", nil]]
               - if field_hash[:sort_by] == :none
                 - opts += Array(field_hash[:values].invert)
               - elsif field_hash[:data_type] == :integer


### PR DESCRIPTION
This PR add <None> field to security groups in provisioning, because security group field is not required to provision a Vm.
Should fix this issue https://github.com/ManageIQ/manageiq-providers-openstack/issues/178

ping @martinpovolny @aufi @mansam 