### PR TITLE
Fix Network Router form styling

### DIFF
--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -81,8 +81,8 @@
           = _("Required")
 
     %h3
-    .form-horizontal{"ng-if" => "vm.networkRouterModel.cloud_network_id"}
       = _('Fixed IPs')
+    .form-horizontal{"ng-if" => "vm.networkRouterModel.cloud_network_id"}
       .form-group
         %label.col-md-2.control-label
           = _('Subnet')


### PR DESCRIPTION
This PR moves the section title out of the form-horizontal div

follow-up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/3464

https://bugzilla.redhat.com/show_bug.cgi?id=1547878