### PR TITLE
Fix nil @title in TreeBuilderTimelines

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -779,7 +779,7 @@ class DashboardController < ApplicationController
 
   # Gather information for the report accordians
   def build_timeline_listnav
-    @timelines_tree = TreeBuilderTimelines.new(:timelines_tree, :timelines, @sb, true, :title => @sb[:grp_title])
+    @timelines_tree = TreeBuilderTimelines.new(:timelines_tree, :timelines, @sb, true, :title => reports_group_title)
   end
 
   def build_timeline


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1548160

Go to Cloud Intel -> Timelines

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/3238

Before:
<img width="1147" alt="screen shot 2018-02-26 at 4 06 58 pm" src="https://user-images.githubusercontent.com/9210860/36677686-1e3944aa-1b0f-11e8-9166-253a23277d85.png">
```
F, [2018-02-26T16:06:41.241759 #5449] FATAL -- : Error caught: [ArgumentError] comparison of NilClass with String failed
/ManageIQ/manageiq-ui-classic/app/presenters/tree_builder_timelines.rb:51:in `sort'
/ManageIQ/manageiq-ui-classic/app/presenters/tree_builder_timelines.rb:51:in `x_get_tree_roots'
/ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:240:in `x_get_tree_objects'
/ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:207:in `x_build_tree'
/ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:141:in `build_tree'
/ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:24:in `initialize'
/ManageIQ/manageiq-ui-classic/app/presenters/tree_builder_timelines.rb:34:in `initialize'
/ManageIQ/manageiq-ui-classic/app/controllers/dashboard_controller.rb:782:in `new'
/ManageIQ/manageiq-ui-classic/app/controllers/dashboard_controller.rb:782:in `build_timeline_listnav'
/ManageIQ/manageiq-ui-classic/app/controllers/dashboard_controller.rb:581:in `timeline'

```
After:
<img width="1206" alt="screen shot 2018-02-26 at 4 05 59 pm" src="https://user-images.githubusercontent.com/9210860/36677637-f95dd2f4-1b0e-11e8-8b84-fc70380479c7.png">

@miq-bot add_label trees, bug, gaprindashvili/yes, blocker, wip
