### PR TITLE
Remove duplicate main_div from control action list view

### DIFF
--- a/app/views/miq_policy/_action_list.html.haml
+++ b/app/views/miq_policy/_action_list.html.haml
@@ -1,3 +1,2 @@
 #action_list_div
-  #main_div
-    = render :partial => 'layouts/gtl', :locals  => {:action_url => "action_get_all", :button_div => 'policy_bar'}
+  = render :partial => 'layouts/gtl', :locals  => {:action_url => "action_get_all", :button_div => 'policy_bar'}


### PR DESCRIPTION
The partial is included from `miq_policy/explorer.html.haml` -- used when rendering the whole page or the partial is rendered via `presenter.update()` when clicking on accordions. In either case, the `main_div` is already there and doesn't need to be rendered again.