### PR TITLE
Remove duplicate main_div from policies list view

### DIFF
--- a/app/views/miq_policy/_policy_list.html.haml
+++ b/app/views/miq_policy/_policy_list.html.haml
@@ -1,3 +1,2 @@
 #policy_list_div
-  #main_div
-    = render :partial => 'layouts/gtl', :locals => {:action_url => "policy_get_all", :button_div => 'policy_bar'}
+  = render :partial => 'layouts/gtl', :locals => {:action_url => "policy_get_all", :button_div => 'policy_bar'}


### PR DESCRIPTION
The partial is either included from `miq_policy/explorer.html.haml` when rendering the whole page or is rendered via presenter when clicking on the nodes of the tree of the Policies accordion.