### PR TITLE
Remove duplicate main_div from alerts list view

### DIFF
--- a/app/views/miq_policy/_alert_list.html.haml
+++ b/app/views/miq_policy/_alert_list.html.haml
@@ -1,3 +1,2 @@
 #alert_list_div
-  #main_div
-    = render :partial => 'layouts/gtl', :locals  => {:action_url => "alert_get_all", :button_div => 'policy_bar'}
+  = render :partial => 'layouts/gtl', :locals  => {:action_url => "alert_get_all", :button_div => 'policy_bar'}


### PR DESCRIPTION
The partial is included from `miq_policy/explorer.html.haml` when rendering the whole page or it is rendered via presenter's update when clicking on the Alerts accordion.