### PR TITLE
Fix Default Views settings for Service Catalogs

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -964,6 +964,7 @@ class CatalogController < ApplicationController
                        :function => "miqOrderService",
                        :title    => _("Order this Service")} # Show a button instead of the checkbox
       end
+      options[:gtl_dbname] = :catalog
     end
     options[:named_scope] = scope
     process_show_list(options)

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1079,4 +1079,21 @@ describe CatalogController do
       end
     end
   end
+
+  describe '#service_template_list' do
+    let(:sandbox) { {:active_tree => tree} }
+
+    before do
+      controller.instance_variable_set(:@sb, sandbox)
+    end
+
+    context 'Service Catalogs accordion' do
+      let(:tree) { :svccat_tree }
+
+      it 'sets options for rendering proper type of view' do
+        expect(controller).to receive(:process_show_list).with(:gtl_dbname => :catalog, :named_scope => {})
+        controller.send(:service_template_list, {})
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1404207
**More info:** https://github.com/ManageIQ/manageiq-ui-classic/issues/3469

---

Fix Default Views settings for _Services > Catalogs > Service Catalogs_ accordion.

Setting up new Default Views settings for _Service Catalogs_ (tile view):
![service_cat_tile](https://user-images.githubusercontent.com/13417815/36739412-1bcbf5ba-1be0-11e8-92e4-6ae13c3b3936.png)

**Before:** (still list view)
![service_cat_bad](https://user-images.githubusercontent.com/13417815/36739559-881dde54-1be0-11e8-88dc-3773812c638c.png)

**After:**(tile view as expected)
![service_cat_ok](https://user-images.githubusercontent.com/13417815/36739222-b7109bf8-1bdf-11e8-9a82-fc4945352d25.png)

**Note:**
Changing between views in _Service Catalogs_ now also works properly.
