### PR TITLE
Policy shield should not be visible for items which have no policies

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -199,7 +199,7 @@ module QuadiconHelper
     if item.kind_of?(VmOrTemplate) && quadicon_policy_sim? && !session[:policies].empty?
       output << flobj_img_small(img_for_compliance(item), "e72")
     end
-    output << flobj_img_simple('100/shield.png', "g72") unless item.try(:get_policies).try(:empty?)
+    output << flobj_img_simple('100/shield.png', "g72") if item.try(:get_policies).present?
     output << flobj_img_simple(quad_image(item), "e72")
   end
 
@@ -209,9 +209,7 @@ module QuadiconHelper
     output = []
     output << flobj_img_simple("layout/base.svg")
     output.concat(transform_quadicon(quad))
-    if item.try(:get_policies) && !item.try(:get_policies).try(:empty?)
-      output << flobj_img_simple('100/shield.png', "g72")
-    end
+    output << flobj_img_simple('100/shield.png', "g72") if item.try(:get_policies).present?
     output
   end
 


### PR DESCRIPTION
### Fixes visible shield for all items
When item hasn't enabled policies, and displays single quad policy shield is visible. That is incorrect, this PR addresses such issue by checking if item can use function `get_policies`

### UI changes
#### Before
![screenshot from 2018-02-27 17-58-59](https://user-images.githubusercontent.com/3439771/36742571-51d9f208-1be8-11e8-9dd7-436ad0fa6626.png)
#### After
![screenshot from 2018-02-27 17-57-50](https://user-images.githubusercontent.com/3439771/36742581-53a11be8-1be8-11e8-9c19-471193f9d3da.png)
