### PR TITLE
Enable quadicon image for switch

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -201,7 +201,6 @@ module ApplicationHelper
       MiqTask
       MiqRequest
       PxeServer
-      Switch
     ).include? type
   end
 


### PR DESCRIPTION
### Fixes missing switch icon
This PR removes `Switch` from disabled quadicon members bacause we want to show quadicon (single quad) for switches.

### UI changes
#### Before
![actual 3](https://user-images.githubusercontent.com/3439771/36742830-f6195732-1be8-11e8-9a84-ca9fe8a71561.jpg)

#### After
![screenshot from 2018-02-27 17-57-50](https://user-images.githubusercontent.com/3439771/36742820-ee73e308-1be8-11e8-9130-5826db8a651f.png)


### BZ
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1546729