### PR TITLE
[GAPRINDASHVILI] Fix tool tip while setting the ownership for vm's

### DIFF
--- a/bower-locker.bower.json
+++ b/bower-locker.bower.json
@@ -55,7 +55,8 @@
     "spin.js": "~2.3.2",
     "sprintf": "~1.0.3",
     "tota11y": "~0.1.6",
-    "xml_display": "~0.1.1"
+    "xml_display": "~0.1.1",
+    "bootstrap-select": "1.12.2"
   },
   "resolutions": {
     "d3": "~3.5.0",

--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "bootstrap-filestyle": "https://github.com/markusslima/bootstrap-filestyle.git#30e9f0b996ab811d468bf0211a0b212cc9cf30fe",
     "bootstrap-hover-dropdown": "https://github.com/CWSpear/twitter-bootstrap-hover-dropdown.git#df0359b25cc8520b6ee6f1b56daf8e18504f8165",
     "bootstrap-sass": "https://github.com/twbs/bootstrap-sass.git#6620202b137a877dc614dd87bf7f81f895af8024",
-    "bootstrap-select": "https://github.com/silviomoreto/bootstrap-select.git#a1b3d496e7ea13054451ddaa941fa217898b8ce4",
+    "bootstrap-select": "https://github.com/silviomoreto/bootstrap-select.git#4eb040b7097fd8eab8184e54efe973ce8468e9b2",
     "bootstrap-switch": "https://github.com/nostalgiaz/bootstrap-switch.git#02721b769a6ac83eabe733fd9f08a2ddc7320756",
     "bootstrap-touchspin": "https://github.com/istvan-ujjmeszaros/bootstrap-touchspin.git#b87fa994778f11285975b5013c761b0376fe6f21",
     "c3": "https://github.com/masayuki0812/c3.git#69f975cfcf54626a36566a8b8236f63aec001951",
@@ -97,7 +97,7 @@
     "bootstrap-filestyle": "30e9f0b996ab811d468bf0211a0b212cc9cf30fe",
     "bootstrap-hover-dropdown": "df0359b25cc8520b6ee6f1b56daf8e18504f8165",
     "bootstrap-sass": "6620202b137a877dc614dd87bf7f81f895af8024",
-    "bootstrap-select": "a1b3d496e7ea13054451ddaa941fa217898b8ce4",
+    "bootstrap-select": "4eb040b7097fd8eab8184e54efe973ce8468e9b2",
     "bootstrap-switch": "02721b769a6ac83eabe733fd9f08a2ddc7320756",
     "bootstrap-touchspin": "b87fa994778f11285975b5013c761b0376fe6f21",
     "c3": "69f975cfcf54626a36566a8b8236f63aec001951",
@@ -141,7 +141,7 @@
     "xml_display": "ed5fb8e5dc10f4d66e05c6c27a50defff14672e4"
   },
   "bowerLocker": {
-    "lastUpdated": "2018-02-21T18:17:09.795Z",
+    "lastUpdated": "2018-03-09T10:19:48.720Z",
     "lockedVersions": {
       "angular": "1.6.6",
       "angular-animate": "1.6.6",
@@ -161,7 +161,7 @@
       "bootstrap-filestyle": "1.2.3",
       "bootstrap-hover-dropdown": "2.2.1",
       "bootstrap-sass": "3.3.7",
-      "bootstrap-select": "1.10.0",
+      "bootstrap-select": "1.12.2",
       "bootstrap-switch": "3.3.4",
       "bootstrap-touchspin": "3.1.2",
       "c3": "0.4.18",


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1549722

Fix tool tip which displayed html code while setting the ownership
for multiple vm's, in _Compute > Infrastructure > Virtual Machines_.

---

**Note:** The bug was originally fixed for master by updating PatternFly to v3.31.1:https://github.com/ManageIQ/manageiq-ui-classic/pull/2989, and I was told that we did not want to backport the whole PR to Gaprindashvili, so I created this PR with only the changes really needed for the fix.

**Before:**
User dropdown (the same for Group dropdown):
![tool_tip_before](https://user-images.githubusercontent.com/13417815/36793635-31a0bac4-1c9e-11e8-9746-109aaf323f10.png)
User dropdown - No Owner:
![tool_tip_before2](https://user-images.githubusercontent.com/13417815/36793640-3425d7b6-1c9e-11e8-9517-033960a4ea43.png)

**After:**
User dropdown (the same for Group dropdown):
![tool_tip_after](https://user-images.githubusercontent.com/13417815/36793646-36deff00-1c9e-11e8-9f3e-5691d3050b61.png)
User dropdown - No Owner:
![tool_tip_after2](https://user-images.githubusercontent.com/13417815/36793649-3916c9a6-1c9e-11e8-803a-2e538f7a8a2d.png)
