### PR TITLE
Fix FontFabulous icon reference

### DIFF
--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -118,7 +118,7 @@ module OrchestrationStackHelper::TextualSummary
 
   def textual_outputs
     num   = @record.number_of(:outputs)
-    h     = {:label => _("Outputs"), :icon => "ff ff-output", :value => num}
+    h     = {:label => _("Outputs"), :icon => "ff ff-file-output-o", :value => num}
     if num > 0
       h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'outputs', :id => @record)
       h[:title] = _("Show all outputs")


### PR DESCRIPTION
This PR corrects the reference to the FontFabulous "output" icon.

https://bugzilla.redhat.com/show_bug.cgi?id=1549165

Old
<img width="385" alt="screen shot 2018-02-28 at 1 23 58 pm" src="https://user-images.githubusercontent.com/1287144/36805178-b1b842d6-1c8a-11e8-976a-ee8fb08317c1.png">

New
<img width="436" alt="screen shot 2018-02-28 at 1 23 22 pm" src="https://user-images.githubusercontent.com/1287144/36805179-b1c47aba-1c8a-11e8-98f5-f2e9155b49e5.png">

