### PR TITLE
Add user tags to ems when ems is created

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -176,6 +176,7 @@ module Mixins
       ems = model.model_from_emstype(params[:emstype]).new
       set_ems_record_vars(ems) unless @flash_array
       if ems.valid? && ems.save
+        ems.add_current_user_tags if ems.respond_to?(:add_current_user_tags)
         construct_edit_for_audit(ems)
         AuditEvent.success(build_created_audit(ems, @edit))
         add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:tables => table_name), :name => ems.name})


### PR DESCRIPTION
- [ ] merge backend PR https://github.com/ManageIQ/manageiq/pull/17022

-----
when ems is created by tag-restricted user then the newly
created object is hidden for him - so this fix will copy
tags from current user's current group to object. 
There is only call of method from backend PR https://github.com/ManageIQ/manageiq/pull/17022

**Before/After**
User's group have 3 tags:
![screen shot 2018-02-19 at 19 38 19](https://user-images.githubusercontent.com/14937244/36392628-781b73e8-15ac-11e8-8194-e43edbcd625c.png)


**Before**
![ctdmwphybh](https://user-images.githubusercontent.com/14937244/36392593-4bfb42d4-15ac-11e8-9db2-4c1936c29de1.gif)


**After**
![ynux7otlnt](https://user-images.githubusercontent.com/14937244/36392452-7fe62e16-15ab-11e8-8948-ab458a7dbc6b.gif)

@miq-bot add_label bug
# Links
https://github.com/ManageIQ/manageiq/pull/17022