### PR TITLE
[FINE] Embedded Ansible: fix gtl sorting of playbooks for given repository

### DIFF
--- a/app/views/layouts/_list_grid.html.haml
+++ b/app/views/layouts/_list_grid.html.haml
@@ -16,6 +16,8 @@
       ManageIQ.record.parentClass = "policy";
     } else if (ManageIQ.record.parentClass == "ext_management_system") {
       ManageIQ.record.parentClass = "#{j layout}";
+    } else if (ManageIQ.record.parentClass == "configuration_script_source") {
+      ManageIQ.record.parentClass = "ansible_repository";
     }
 
 - if options[:action_url]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2062,6 +2062,7 @@ Rails.application.routes.draw do
         edit
         new
         repository_refresh
+        show
         show_list
       )
     },


### PR DESCRIPTION
1. Embedded Ansible -> Repositories -> Repo Summary -> List of its playbooks
2. Click on table headers (e.g. Description) to trigger new table sort

You'll see an error in console, the click would trigger post to an incorrect URL.

This is fine only. The problem in current master won't show, since GTLs have been remodeled significantly since fine.

https://bugzilla.redhat.com/show_bug.cgi?id=1549105