### PR TITLE
[WIP] Replace auth credentials partial in schedule_form_filter partial with angular component

### DIFF
--- a/app/assets/javascripts/components/auth-credentials.js
+++ b/app/assets/javascripts/components/auth-credentials.js
@@ -14,6 +14,8 @@ ManageIQ.angular.app.component('authCredentials', {
     postValidationModelRegistry: '<?',
     postValidationModel: '<?',
     checkAuthentication: '<?',
+    userDisabled: '<?',
+    passwordDisabled: '<?'
   },
   controllerAs: 'vm',
   controller: ['$scope', function($scope) {

--- a/app/assets/javascripts/components/auth-credentials.js
+++ b/app/assets/javascripts/components/auth-credentials.js
@@ -15,7 +15,7 @@ ManageIQ.angular.app.component('authCredentials', {
     postValidationModel: '<?',
     checkAuthentication: '<?',
     userDisabled: '<?',
-    passwordDisabled: '<?'
+    passwordDisabled: '<?',
   },
   controllerAs: 'vm',
   controller: ['$scope', function($scope) {

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -411,5 +411,9 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     $scope.scheduleModel.target_id = targetId;
   };
 
+  $scope.validateClicked = function() {
+    miqService.miqAjaxButton($scope.validationUrl, $scope.scheduleModel, true);
+  };
+
   init();
 }]);

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -22,9 +22,9 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     $scope.date_from = new Date();
     $scope.formId = scheduleFormId;
     $scope.afterGet = false;
-    $scope.validateClicked = miqService.validateWithAjax;
     $scope.modelCopy = angular.copy( $scope.scheduleModel );
     $scope.model = "scheduleModel";
+    $scope.validationUrl = '/ops/log_depot_validate/' + scheduleFormId + '?button=validate&type=log';
 
     ManageIQ.angular.scope = $scope;
 
@@ -365,9 +365,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
 
   $scope.isBasicInfoValid = function() {
     return ($scope.angularForm.depot_name.$valid &&
-      $scope.angularForm.uri.$valid &&
-      $scope.angularForm.log_userid.$valid &&
-      $scope.angularForm.log_password.$valid);
+      $scope.angularForm.uri.$valid);
   };
 
   $scope.setTimerType = function() {

--- a/app/views/ops/_schedule_form_filter.html.haml
+++ b/app/views/ops/_schedule_form_filter.html.haml
@@ -108,14 +108,14 @@
                               :ng_model_uri_prefix => "scheduleModel.uri_prefix",
                               :uri_prefix_display  =>  "{{scheduleModel.uri_prefix}}://"}
 
-        = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
-                 :locals  => {:ng_show           => "sambaBackup()",
-                              :ng_model          => "scheduleModel",
-                              :ng_reqd_userid    => "sambaRequired(scheduleModel.log_userid)",
-                              :ng_reqd_password  => "sambaRequired(scheduleModel.log_password)",
-                              :userid_disabled   => "scheduleModel.uri_prefix == 'nfs'",
-                              :password_disabled => "scheduleModel.uri_prefix == 'nfs'",
-                              :validate_url      => "log_depot_validate",
-                              :id                => @schedule.id || "new",
-                              :valtype           => "log",
-                              :basic_info_needed => true}
+        %auth-credentials{"ng-if"                 => "sambaBackup()",
+                          "form-model"            => "scheduleModel",
+                          "model-copy"            => "modelCopy",
+                          "prefix"                => "log",
+                          "user-required"         => "sambaRequired(scheduleModel.log_userid)",
+                          "password-required"     => "sambaRequired(scheduleModel.log_password)",
+                          "user-disabled"         => "scheduleModel.uri_prefix == 'nfs'",
+                          "password-disabled"     => "scheduleModel.uri_prefix == 'nfs'",
+                          "enable-valid-button"   => "canValidateBasicInfo()",
+                          "new-record"            => @schedule.id || "new",
+                          "validate"              => "validateClicked"}

--- a/app/views/static/auth-credentials.html.haml
+++ b/app/views/static/auth-credentials.html.haml
@@ -7,6 +7,7 @@
         {{ vm.userIdLabel }}
       .col-md-4
         %input.form-control{"type"                    => "text",
+                            "ng-disabled"             => "vm.userDisabled",
                             "ng-attr-name"            => "{{vm.prefix}}_userid",
                             "ng-attr-id"              => "{{vm.prefix}}_userid",
                             "ng-required"             => 'vm.userRequired',
@@ -33,6 +34,7 @@
           {{ vm.newPasswordLabel }}
       .col-md-4
         %input.form-control{"type"                    => "password",
+                            "ng-disabled"             => "vm.passwordDisabled",
                             "ng-model"                => "vm.formModel[vm.prefix + '_password']",
                             "ng-disabled"             => "!vm.showVerify(vm.prefix + '_userid')",
                             "ng-attr-name"            => "{{vm.prefix}}_password",


### PR DESCRIPTION
This PR replaces partial for scheduleForm #2766 with angular component.
Configuration -> Settings -> Schedules ->Configuration -> Add new Schedule / Edit the selected Schedule
select action: `Database backup`
select type: `Samba`

new component is handling user credentials and their validation.

partial `app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml`
this partial is still used in `multi_auth_credentials.html.haml`
