### PR TITLE
babelrc - explicitly mention browser support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,19 @@
 {
-  "presets": [["env", { "modules": false }], "react"],
+  "presets": [
+    ["env", {
+      "modules": false,
+      "targets": {
+        "browsers": [
+          "> 1%",
+          "last 2 versions",
+          "Firefox ESR",
+          "IE 10",
+          "IE 11",
+        ],
+      },
+    }],
+    "react",
+  ],
   "env": {
     "test": {
       "plugins": ["transform-es2015-modules-commonjs"]


### PR DESCRIPTION
This doesn't actually change the compiled bundle in any way right now, but we should probably make the list of supported browsers explicit.

(The idea is, babel can change the default list of supported browsers, so we may not necessarily be able to rely on the defaults matching our needs.)

@dclarizio Do we still need IE10 for the hammer release?

