### PR TITLE
Add RBAC and Tagging Support to Ansible Credentials

### DIFF
--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -26,12 +26,15 @@ class AnsibleCredentialController < ApplicationController
   end
 
   def button
-    if params[:pressed] == 'embedded_automation_manager_credentials_add'
+    case params[:pressed]
+    when 'embedded_automation_manager_credentials_add'
       javascript_redirect :action => 'new'
-    elsif params[:pressed] == 'embedded_automation_manager_credentials_edit'
+    when 'embedded_automation_manager_credentials_edit'
       javascript_redirect :action => 'edit', :id => params[:miq_grid_checks]
-    elsif params[:pressed] == 'embedded_automation_manager_credentials_delete'
+    when 'embedded_automation_manager_credentials_delete'
       delete_credentials
+    when 'ansible_credential_tag'
+      tag(self.class.model)
     end
   end
 

--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -57,7 +57,7 @@ class AnsibleCredentialController < ApplicationController
   private
 
   def textual_group_list
-    [%i(properties relationships options)]
+    [%i(properties relationships options smart_management)]
   end
   helper_method :textual_group_list
 

--- a/app/helpers/ansible_credential_helper/textual_summary.rb
+++ b/app/helpers/ansible_credential_helper/textual_summary.rb
@@ -29,6 +29,10 @@ module AnsibleCredentialHelper::TextualSummary
     TextualGroup.new(_("Credential Options"), options)
   end
 
+  def textual_group_smart_management
+    TextualTags.new(_("Smart Management"), %i(tags))
+  end
+
   def textual_type
     {:label => _("Authentication Type"), :value => ui_lookup(:model => @record.type)}
   end

--- a/app/helpers/application_helper/toolbar/ansible_credential_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_credential_center.rb
@@ -24,4 +24,20 @@ class ApplicationHelper::Toolbar::AnsibleCredentialCenter < ApplicationHelper::T
       ]
     ),
   ])
+  button_group('embedded_ansible_credentials_policy', [
+                 select(
+                   :embedded_ansible_credentials_policy_choice,
+                   'fa fa-shield fa-lg',
+                   t = N_('Policy'),
+                   t,
+                   :items => [
+                     button(
+                       :ansible_credential_tag,
+                       'pficon pficon-edit fa-lg',
+                       N_('Edit Tags for the selected Ansible Credentials'),
+                       N_('Edit Tags'),
+                     ),
+                   ]
+                 )
+               ])
 end

--- a/app/helpers/application_helper/toolbar/ansible_credentials_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_credentials_center.rb
@@ -38,4 +38,26 @@ class ApplicationHelper::Toolbar::AnsibleCredentialsCenter < ApplicationHelper::
       ]
     )
   ])
+  button_group('embedded_ansible_credentials_policy', [
+                 select(
+                   :embedded_ansible_credentials_policy_choice,
+                   'fa fa-shield fa-lg',
+                   t = N_('Policy'),
+                   t,
+                   :enabled => false,
+                   :onwhen  => "1+",
+                   :items   => [
+                     button(
+                       :ansible_credential_tag,
+                       'pficon pficon-edit fa-lg',
+                       N_('Edit Tags for the selected Ansible Credentials'),
+                       N_('Edit Tags'),
+                       :url_parms    => "main_div",
+                       :send_checked => true,
+                       :enabled      => false,
+                       :onwhen       => "1+"
+                     ),
+                   ]
+                 )
+               ])
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2069,10 +2069,13 @@ Rails.application.routes.draw do
         new
         show
         show_list
+        tagging_edit
       ),
       :post => %w(
         button
         show_list
+        tag_edit_form_field_changed
+        tagging_edit
       )
     },
 

--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -4,7 +4,7 @@ describe AnsibleCredentialController do
     login_as FactoryGirl.create(:user_admin)
   end
 
-  context "#show" do
+  describe "#show" do
     let(:machine_credential) { FactoryGirl.create(:embedded_ansible_scm_credential, :options=>{}) }
     subject { get :show, :params => {:id => machine_credential.id} }
     render_views
@@ -17,7 +17,7 @@ describe AnsibleCredentialController do
     end
   end
 
-  context "#show_list" do
+  describe "#show_list" do
     subject { get :show_list, :params => {} }
     render_views
 
@@ -27,6 +27,48 @@ describe AnsibleCredentialController do
 
     it "renders correct template" do
       is_expected.to render_template(:partial => "layouts/_gtl")
+    end
+  end
+
+  describe '#button' do
+    before do
+      controller.instance_variable_set(:@_params, params)
+    end
+
+    context 'adding a new ansible credential' do
+      let(:params) { {:pressed => "embedded_automation_manager_credentials_add"} }
+
+      it 'redirects to action new' do
+        expect(controller).to receive(:javascript_redirect).with(:action => 'new')
+        controller.send(:button)
+      end
+    end
+
+    context 'editing one or more ansible credentials' do
+      let(:params) { {:pressed => "embedded_automation_manager_credentials_edit"} }
+
+      it 'redirects to action edit' do
+        expect(controller).to receive(:javascript_redirect).with(:action => 'edit', :id => params[:miq_grid_checks])
+        controller.send(:button)
+      end
+    end
+
+    context 'deleting one or more ansible credentials from inventory' do
+      let(:params) { {:pressed => "embedded_automation_manager_credentials_delete"} }
+
+      it 'calls delete_credentials method' do
+        expect(controller).to receive(:delete_credentials)
+        controller.send(:button)
+      end
+    end
+
+    context 'tagging one or more ansible credentials' do
+      let(:params) { {:pressed => "ansible_credential_tag"} }
+
+      it 'calls tag method' do
+        expect(controller).to receive(:tag).with(controller.class.model)
+        controller.send(:button)
+      end
     end
   end
 end


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1526219
**Needs to merge with:** https://github.com/ManageIQ/manageiq/pull/17079

---

**Done:**
- add _Policy_ toolbar button to access tagging in _Automation > Ansible > Credentials_
(_Policy > Edit Tags_)
- add `tagging_edit` and `tag_edit_form_field_changed` to routes to enable tagging for Ansible Credentials or for proper rendering of tagging screen
- add calling `tag` method to `button` method in ansible credential controller and also small refactoring of `button` method, in that controller
- display tags in the table in summary page of any credential
- make tagging work also from summary page of any credential
- check if RBAC works
- spec test for `button` method in ansible credential controller

**Before:**
![credential_before](https://user-images.githubusercontent.com/13417815/36902569-3eb7cd4a-1e2b-11e8-8b39-09dd0fa5a2ac.png)

**After:**
![edit_tags_credential](https://user-images.githubusercontent.com/13417815/36901918-1bbbeb0c-1e29-11e8-997f-de612c6cd1f9.png)
![credential_tag](https://user-images.githubusercontent.com/13417815/36910125-1f671684-1e40-11e8-9a24-f24060d0a9e0.png)
![credential_tag_success](https://user-images.githubusercontent.com/13417815/36911822-0dbd8198-1e45-11e8-8ad4-f44a0ca9396f.png)
![credential_summary](https://user-images.githubusercontent.com/13417815/36968159-fba4aa76-2061-11e8-9548-16e975ce8b0e.png)

**Note:**
_How to check RBAC support (one of possible scenarios):_
1. as an admin, tag some credential(s) from _Automation > Ansible > Credentials_,
remember those tags
2. in _Configuration > Access Control > Groups_, create a group so that under _Assigned Filters_ in the first tab called _My Company Tags_, you choose the same tags from step 1.
3. set _EvmRole-administrator_ as a role of that group (not super administrator!) and save the group
4. create a user with that group from step 3.
5. logout and login as the user from step 4.
6. go to  _Automation > Ansible > Credentials_ and you should see only credentials with the same tags as from step 2.


