### PR TITLE
Revert "Hide region from Cloud provider forms if it's not required"

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -469,7 +469,7 @@ module EmsCommon
   end
 
   def retrieve_provider_regions
-    managers = model.supported_subclasses.select { |s| s.supports_regions? && s.try(:region_required?) != false }
+    managers = model.supported_subclasses.select(&:supports_regions?)
     managers.each_with_object({}) do |manager, provider_regions|
       regions = manager.parent::Regions.all.sort_by { |r| r[:description] }
       provider_regions[manager.ems_type] = regions.map do |region|


### PR DESCRIPTION
This reverts commit 34a42833db416d644fa9350eda1162462e100df7.

We figured out the regions are completely useless in GCE and since that's the only place where this flag is used at all, it would be nice of me to clean up the mess I've donated to UI. Sorry

Reverts: https://github.com/ManageIQ/manageiq-ui-classic/pull/3471
Related: https://github.com/ManageIQ/manageiq-providers-google/pull/52

@miq-bot add_label bug, compute/cloud