### PR TITLE
FormButtons component, with redux

### DIFF
--- a/app/javascript/forms/form-buttons-redux.jsx
+++ b/app/javascript/forms/form-buttons-redux.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { combineReducers } from 'redux';
+
+import FormButtons from './form-buttons';
+
+function FormButtonsRedux(props) {
+  initReducer();
+
+  return <FormButtons {...props} />;
+}
+
+FormButtonsRedux.propTypes = {
+};
+
+FormButtonsRedux.defaultProps = {
+};
+
+
+function mapStateToProps(state) {
+  return {...state.FormButtons};
+}
+
+export default connect(mapStateToProps)(FormButtonsRedux);
+
+function initReducer() {
+  if (! ManageIQ.redux || ! ManageIQ.redux.addReducer) {
+    // login screen
+    return;
+  }
+  if (initReducer.done) {
+    // don't init twice
+    return;
+  }
+  initReducer.done = true;
+
+
+  const initialState = {
+    customLabel: '',
+    newRecord: false,
+    pristine: false,
+    saveable: true,
+  };
+
+  const actions = {
+    'FormButtons.init': (_state, payload) => ({ ...initialState, ...payload }),
+    'FormButtons.customLabel': (state, payload) => ({ ...state, customLabel: payload || ''}),
+    'FormButtons.newRecord': (state, payload) => ({ ...state, newRecord: !! payload }),
+    'FormButtons.pristine': (state, payload) => ({ ...state, pristine: !! payload }),
+    'FormButtons.saveable': (state, payload) => ({ ...state, saveable: !! payload }),
+
+    'FormButtons.callbacks': (state, payload) => ({ ...state, ...payload }),
+  };
+
+
+  ManageIQ.redux.addReducer(combineReducers({
+    FormButtons: function FormButtonsReducer(state = initialState, action) {
+
+      if (actions[action.type]) {
+        return actions[action.type](state, action.payload);
+      } else if (action.type.match(/^FormButtons\./)) {
+        console.warn(`FormButtonsReducer - unknown action type: ${action.type}`, action);
+      }
+
+      return state;
+    },
+  }));
+}

--- a/app/javascript/forms/form-buttons-redux.jsx
+++ b/app/javascript/forms/form-buttons-redux.jsx
@@ -12,14 +12,29 @@ function FormButtonsRedux(props) {
 }
 
 FormButtonsRedux.propTypes = {
+  callbackOverrides: PropTypes.object,
 };
 
 FormButtonsRedux.defaultProps = {
+  callbackOverrides: {},
 };
 
 
-function mapStateToProps(state) {
-  return {...state.FormButtons};
+function mapStateToProps(state, ownProps) {
+  let props = {...state.FormButtons};
+
+  if (state.FormButtons && ownProps.callbackOverrides) {
+    // allow overriding click handlers
+    // the original handler is passed as the only argument to the new one
+    Object.keys(ownProps.callbackOverrides).forEach((name) => {
+      props[name] = () => {
+        let origHandler = state.FormButtons[name];
+        ownProps.callbackOverrides[name](origHandler);
+      };
+    });
+  }
+
+  return props;
 }
 
 export default connect(mapStateToProps)(FormButtonsRedux);
@@ -36,12 +51,7 @@ function initReducer() {
   initReducer.done = true;
 
 
-  const initialState = {
-    customLabel: '',
-    newRecord: false,
-    pristine: false,
-    saveable: true,
-  };
+  const initialState = {...FormButtons.defaultProps};
 
   const actions = {
     'FormButtons.init': (_state, payload) => ({ ...initialState, ...payload }),

--- a/app/javascript/forms/form-buttons.jsx
+++ b/app/javascript/forms/form-buttons.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import MiqButton from './miq-button';
+
+function FormButtons(props) {
+  let primaryTitle = props.customLabel || (props.newRecord ? __('Add') : __('Save'));
+  let primaryHandler = (props.newRecord ? props.addClicked : props.saveClicked) || props.addClicked || props.saveClicked;
+
+  let resetTitle = __("Reset");
+  let cancelTitle = __("Cancel");
+
+  return (
+    <React.Fragment>
+      <div className="clearfix"></div>
+      <div className="pull-right button-group edit_buttons">
+        <MiqButton name={primaryTitle} title={primaryTitle} enabled={props.saveable} onClick={primaryHandler} primary={true} />
+        {props.newRecord || <MiqButton name={resetTitle} title={resetTitle} enabled={! props.pristine} onClick={props.resetClicked} />}
+        <MiqButton name={cancelTitle} title={cancelTitle} enabled={true} onClick={props.cancelClicked} />
+
+      </div>
+    </React.Fragment>
+  );
+}
+
+FormButtons.propTypes = {
+  newRecord: PropTypes.bool,
+  customLabel: PropTypes.string,
+  saveable: PropTypes.bool,
+  pristine: PropTypes.bool,
+  addClicked: PropTypes.func,
+  saveClicked: PropTypes.func,
+  resetClicked: PropTypes.func,
+  cancelClicked: PropTypes.func,
+};
+
+const noop = () => null;
+
+FormButtons.defaultProps =  {
+  newRecord: false,
+  customLabel: '',
+  saveable: false,
+  pristine: true,
+  addClicked: noop,
+  saveClicked: noop,
+  resetClicked: noop,
+  cancelClicked: noop,
+}
+
+export default FormButtons;

--- a/app/javascript/forms/miq-button.jsx
+++ b/app/javascript/forms/miq-button.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ClassNames from 'classnames';
+
+function MiqButton(props) {
+  let title = props.title;
+  if (props.enabled && props.enabledTitle) {
+    title = props.enabledTitle;
+  }
+  if (! props.enabled && props.disabledTitle) {
+    title = props.disabledTitle;
+  }
+
+  let klass = ClassNames({
+    'btn': true,
+    'btn-xs': props.xs,
+    'btn-primary': props.primary,
+    'btn-default': !props.primary,
+    'disabled': !props.enabled,
+  });
+
+  let buttonClicked = (event) => {
+    if (props.enabled) {
+      props.onClick();
+    }
+
+    event.preventDefault();
+    event.target.blur();
+  };
+
+  return (
+    <button className={klass}
+      onClick={buttonClicked}
+      title={title}
+      alt={title}>
+      {props.name}
+    </button>
+  );
+}
+
+MiqButton.propTypes = {
+  name: PropTypes.string.isRequired,
+  enabled: PropTypes.bool.isRequired,
+  title: PropTypes.string,
+  enabledTitle: PropTypes.string,
+  disabledTitle: PropTypes.string,
+  primary: PropTypes.bool,
+  xs: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
+};
+
+MiqButton.defaultProps = {
+  title: '',
+  enabledTitle: '',
+  disabledTitle: '',
+  primary: false,
+  xs: false,
+};
+
+export default MiqButton;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -5,6 +5,7 @@ import TableListViewWrapper from '../react/table_list_view_wrapper';
 import GenericGroupWrapper from '../react/generic_group_wrapper';
 import { addReact } from '../miq-component/helpers';
 import VmSnapshotFormComponent from '../components/vm-snapshot-form-component';
+import FormButtonsRedux from '../forms/form-buttons-redux';
 
 /**
 * Add component definitions to this file.
@@ -19,3 +20,4 @@ addReact('GenericGroup', GenericGroup);
 addReact('GenericGroupWrapper', GenericGroupWrapper);
 addReact('TextualSummaryWrapper', TextualSummaryWrapper);
 addReact('VmSnapshotFormComponent', VmSnapshotFormComponent);
+addReact('FormButtonsRedux', FormButtonsRedux);

--- a/app/javascript/provider-dialogs/modal.js
+++ b/app/javascript/provider-dialogs/modal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Button, Icon, Modal } from 'patternfly-react';
+import { Provider } from 'react-redux';
 import FormButtonsRedux from '../forms/form-buttons-redux';
 
 function closeModal(id) {
@@ -40,29 +41,31 @@ function modal(title, Inner, closed, removeId) {
   };
 
   return (
-    <Modal
-      show={true}
-      onHide={closed}
-      onExited={closed}
-    >
-      <Modal.Header>
-        <button
-          className="close"
-          onClick={closed}
-          aria-hidden="true"
-          aria-label="Close"
-        >
-          <Icon type="pf" name="close" />
-        </button>
-        <Modal.Title>{title}</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <Inner />
-        <div id={/* see closeModal */ removeId}></div>
-      </Modal.Body>
-      <Modal.Footer>
-        <FormButtonsRedux callbackOverrides={overrides} />
-      </Modal.Footer>
-    </Modal>
+    <Provider store={ManageIQ.redux.store}>
+      <Modal
+        show={true}
+        onHide={closed}
+        onExited={closed}
+      >
+        <Modal.Header>
+          <button
+            className="close"
+            onClick={closed}
+            aria-hidden="true"
+            aria-label="Close"
+          >
+            <Icon type="pf" name="close" />
+          </button>
+          <Modal.Title>{title}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Inner />
+          <div id={/* see closeModal */ removeId}></div>
+        </Modal.Body>
+        <Modal.Footer>
+          <FormButtonsRedux callbackOverrides={overrides} />
+        </Modal.Footer>
+      </Modal>
+    </Provider>
   );
 }

--- a/app/javascript/provider-dialogs/modal.js
+++ b/app/javascript/provider-dialogs/modal.js
@@ -29,13 +29,13 @@ export default function renderModal(title = __("Modal"), Inner = () => <div>Empt
 function modal(title, Inner, closed, removeId) {
   const overrides = {
     addClicked: function(orig) {
-      Promise.when(orig()).then(closed);
+      Promise.resolve(orig()).then(closed);
     },
     saveClicked: function(orig) {
-      Promise.when(orig()).then(closed);
+      Promise.resolve(orig()).then(closed);
     },
     cancelClicked: function(orig) {
-      Promise.when(orig()).then(closed);
+      Promise.resolve(orig()).then(closed);
     },
     // don't close on reset
   };

--- a/app/javascript/provider-dialogs/modal.js
+++ b/app/javascript/provider-dialogs/modal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Button, Icon, Modal } from 'patternfly-react';
+import FormButtonsRedux from '../forms/form-buttons-redux';
 
 function closeModal(id) {
   // this should have been div.remove();
@@ -25,6 +26,19 @@ export default function renderModal(title = __("Modal"), Inner = () => <div>Empt
 }
 
 function modal(title, Inner, closed, removeId) {
+  const overrides = {
+    addClicked: function(orig) {
+      Promise.when(orig()).then(closed);
+    },
+    saveClicked: function(orig) {
+      Promise.when(orig()).then(closed);
+    },
+    cancelClicked: function(orig) {
+      Promise.when(orig()).then(closed);
+    },
+    // don't close on reset
+  };
+
   return (
     <Modal
       show={true}
@@ -47,13 +61,7 @@ function modal(title, Inner, closed, removeId) {
         <div id={/* see closeModal */ removeId}></div>
       </Modal.Body>
       <Modal.Footer>
-        <Button
-          bsStyle="primary"
-          onClick={closed}
-          autoFocus
-        >
-          {__('Close')}
-        </Button>
+        <FormButtonsRedux callbackOverrides={overrides} />
       </Modal.Footer>
     </Modal>
   );

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "angular.validators": "~4.4.2",
     "base64-js": "~1.2.3",
     "bootstrap-switch": "~3.3.4",
+    "classnames": "^2.2.5",
     "graphiql": "^0.11.11",
     "graphql": "^0.13.2",
     "jquery": "~2.2.4",


### PR DESCRIPTION
This is in preparation of having React forms in ui-classic, and adds several components:

* `MiqButton` - a react reimplementation of our angular miqButton (1:1 except `alt` is implied when `title` is set) - shows a button with enabled/disabled, titles, and actions

* `FormButtons` - a react implementation of our angular `generic_form_buttons` partial - does not deal with finding out the form state but when it gets it, it renders the buttons

* `FormButtonsRedux` - a wrapper for FormButtons which uses Redux for state management (so that we can trigger actions from anywhere, including angular forms)

---

The idea is that `FormButtonsRedux` will live in the "paging" toolbar, and the forms will be sending redux actions to tell the buttons what to show, and those buttons will be sending back actions like saveClicked, resetClicked, cancelClicked so that the form can handle them.

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1437800

---

* reset form buttons to initial state
    
        ManageIQ.redux.store.dispatch({ type: 'FormButtons.init', payload: {} })
    
* change the default Add/Save label
    
        ManageIQ.redux.store.dispatch({ type: 'FormButtons.customLabel', payload: __('Magic') })
    
* set newRecord - if true, the Add button is shown (and addClicked called), else the Save and Reset buttons are shown (and saveClicked, resetClicked called)
    
        ManageIQ.redux.store.dispatch({ type: 'FormButtons.newRecord', payload: true })
    
* set pristine - pristine form can't be reset (and shouldn't be saveable)
    
        ManageIQ.redux.store.dispatch({ type: 'FormButtons.pristine', payload: false })
    
* set saveable - means no validation error, the submit button will be enabled based on this
    
        ManageIQ.redux.store.dispatch({ type: 'FormButtons.saveable', payload: false })
    
* set callbacks - an object of functions - addClicked, saveClicked, resetClicked and cancelClicked are accepted
    
        ManageIQ.redux.store.dispatch({ type: 'FormButtons.callbacks', payload: {
          addClicked: () => console.log('add'),
          cancelClicked: () => console.log('cancel'),
          resetClicked: () => console.log('reset'),
          saveClicked: () => console.log('save'),
        }})


Cc @ZitaNemeckova, @Hyperkid123 , @martinpovolny 