### PR TITLE
Hide disabled tabs

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -220,6 +220,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
       miqService.sparkleOff();
 
+      $scope.hideDisabledTabs();
+
       $scope.emsOptionsModel.provider_options_original_values = data.provider_options;
       $scope.updateProviderOptionsDescription();
     }
@@ -262,11 +264,25 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.kubevirt_password               = data.kubevirt_password;
 
       miqService.sparkleOff();
-
+      $scope.hideDisabledTabs();
       $scope.afterGet  = true;
       $scope.modelCopy = angular.copy( $scope.emsCommonModel );
     }
   };
+
+  $scope.hideDisabledTabs = function() {
+    if ($scope.emsCommonModel.alerts_selection === 'disabled') {
+      angular.element("#alerts_tab").hide();
+    }
+
+    if ($scope.emsCommonModel.metrics_selection === 'disabled') {
+      angular.element("#container_metrics_tab").hide();
+    }
+
+    if ($scope.emsCommonModel.virtualization_selection === 'disabled') {
+      angular.element("#virtualization_tab").hide();
+    }
+  }
 
   $scope.changeAuthTab = function(id) {
     $scope.currentTab = id;
@@ -444,7 +460,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.metricSelectionChanged = function() {
-    $scope.tabSelectionChanged("#metrics_tab", $scope.emsCommonModel.metrics_selection);
+    $scope.tabSelectionChanged("#container_metrics_tab", $scope.emsCommonModel.metrics_selection);
   };
 
   $scope.alertsSelectionChanged = function() {

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -28,7 +28,7 @@
           %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
           = _("SmartState Docker")
     - elsif controller_name == "ems_container"
-      = miq_tab_header('metrics', nil, 'ng-click' => "changeAuthTab('metrics')") do
+      = miq_tab_header('container_metrics', nil, 'ng-click' => "changeAuthTab('container_metrics')") do
         %div{"ng-if" => "emsCommonModel.metrics_selection == 'prometheus' || emsCommonModel.metrics_selection == 'hawkular'"}
           %i{"error-on-tab" => "metrics", :style => "color:#cc0000"}
           = _("Metrics")
@@ -334,7 +334,7 @@
             %span{:style => "color:black"}
               = _("Used for VMRC connections to all VMs in this provider. If not set, the credentials from the Default tab will be used.")
     - elsif controller_name == "ems_container"
-      = miq_tab_content('metrics', 'default') do
+      = miq_tab_content('container_metrics', 'default') do
         .form-group
           .col-md-12.col-md-12
             %div{"ng-if" => "emsCommonModel.metrics_selection == 'hawkular'"}
@@ -494,7 +494,8 @@
                 "#{ng_model}.emstype == 'hawkular'"}                    |
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
-    miq_tabs_show_hide("#metrics_tab", false);
+    miq_tabs_show_hide("#alerts_tab", false);
+    miq_tabs_show_hide("#container_metrics_tab", false);
     miq_tabs_show_hide("#virtualization_tab", false);
     miq_tabs_show_hide("#console_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
@@ -561,7 +562,8 @@
     $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.ems_controller == 'ems_container'"}
   :javascript
-    miq_tabs_show_hide("#metrics_tab", true);
+    miq_tabs_show_hide("#alerts_tab", true);
+    miq_tabs_show_hide("#container_metrics_tab", true);
     miq_tabs_show_hide("#virtualization_tab", true);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();


### PR DESCRIPTION
The metrics & alerts tabs where partially visible.
Those tabs become more visible if the virtualization manager is
selected.

This PR hides any of the tabs if aren't used in Add/Edit provider.

Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/3498
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1550405

![selection_351](https://user-images.githubusercontent.com/316242/36950965-49e5b7cc-2006-11e8-87fe-2457a90939e2.png)
