### PR TITLE
Do not inherit decorators from other than MiqDecorator

### DIFF
--- a/app/decorators/manageiq/providers/cloud_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager_decorator.rb
@@ -1,18 +1,28 @@
-module ManageIQ::Providers
-  class CloudManagerDecorator < ExtManagementSystemDecorator
-    def quadicon(_n = nil)
-      {
-        :top_left     => {:text => total_vms},
-        :top_right    => {:text => total_miq_templates},
-        :bottom_left  => {
-          :fileicon => fileicon,
-          :tooltip  => type
-        },
-        :bottom_right => {
-          :fileicon => status_img(self),
-          :tooltip  => authentication_status
-        }
+class ManageIQ::Providers::CloudManagerDecorator < ExtManagementSystemDecorator
+  def self.fonticon
+    'pficon pficon-server'
+  end
+
+  def fonticon
+    nil
+  end
+
+  def fileicon
+    "svg/vendor-#{image_name}.svg"
+  end
+
+  def quadicon(_n = nil)
+    {
+      :top_left     => {:text => total_vms},
+      :top_right    => {:text => total_miq_templates},
+      :bottom_left  => {
+        :fileicon => fileicon,
+        :tooltip  => type
+      },
+      :bottom_right => {
+        :fileicon => status_img(self),
+        :tooltip  => authentication_status
       }
-    end
+    }
   end
 end

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -1,18 +1,28 @@
-module ManageIQ::Providers
-  class ContainerManagerDecorator < MiqDecorator
-    def quadicon(_n = nil)
-      {
-        :top_left     => {:text => container_nodes.size},
-        :top_right    => {:state_icon => enabled? ? "on" : "paused"},
-        :bottom_left  => {
-          :fileicon => fileicon,
-          :tooltip  => type
-        },
-        :bottom_right => {
-          :fileicon => status_img(self),
-          :tooltip  => authentication_status
-        }
+class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-server'
+  end
+
+  def fonticon
+    nil
+  end
+
+  def fileicon
+    "svg/vendor-#{image_name}.svg"
+  end
+
+  def quadicon(_n = nil)
+    {
+      :top_left     => {:text => container_nodes.size},
+      :top_right    => {:state_icon => enabled? ? "on" : "paused"},
+      :bottom_left  => {
+        :fileicon => fileicon,
+        :tooltip  => type
+      },
+      :bottom_right => {
+        :fileicon => status_img(self),
+        :tooltip  => authentication_status
       }
-    end
+    }
   end
 end

--- a/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
@@ -1,30 +1,28 @@
-module ManageIQ::Providers::Hawkular
-  class MiddlewareManagerDecorator < MiqDecorator
-    def self.fonticon
-      nil
-    end
+class ManageIQ::Providers::Hawkular::MiddlewareManagerDecorator < MiqDecorator
+  def self.fonticon
+    nil
+  end
 
-    def self.fileicon
-      "svg/vendor-hawkular.svg"
-    end
+  def self.fileicon
+    "svg/vendor-hawkular.svg"
+  end
 
-    def quadicon(_n = nil)
-      {
-        :top_left     => {
-          :text => middleware_domains.size
-        },
-        :top_right    => {
-          :text => middleware_servers.size
-        },
-        :bottom_left  => {
-          :fileicon => fileicon,
-          :tooltip  => type
-        },
-        :bottom_right => {
-          :fileicon => status_img(self),
-          :tooltip  => authentication_status
-        }
+  def quadicon(_n = nil)
+    {
+      :top_left     => {
+        :text => middleware_domains.size
+      },
+      :top_right    => {
+        :text => middleware_servers.size
+      },
+      :bottom_left  => {
+        :fileicon => fileicon,
+        :tooltip  => type
+      },
+      :bottom_right => {
+        :fileicon => status_img(self),
+        :tooltip  => authentication_status
       }
-    end
+    }
   end
 end

--- a/app/decorators/manageiq/providers/infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/infra_manager_decorator.rb
@@ -1,18 +1,28 @@
-module ManageIQ::Providers
-  class InfraManagerDecorator < ExtManagementSystemDecorator
-    def quadicon(_n = nil)
-      {
-        :top_left     => {:text => hosts.size},
-        :top_right    => {:text => total_vms},
-        :bottom_left  => {
-          :fileicon => fileicon,
-          :tooltip  => type
-        },
-        :bottom_right => {
-          :fileicon => status_img(self),
-          :tooltip  => authentication_status
-        }
+class ManageIQ::Providers::InfraManagerDecorator < ExtManagementSystemDecorator
+  def self.fonticon
+    'pficon pficon-server'
+  end
+
+  def fonticon
+    nil
+  end
+
+  def fileicon
+    "svg/vendor-#{image_name}.svg"
+  end
+
+  def quadicon(_n = nil)
+    {
+      :top_left     => {:text => hosts.size},
+      :top_right    => {:text => total_vms},
+      :bottom_left  => {
+        :fileicon => fileicon,
+        :tooltip  => type
+      },
+      :bottom_right => {
+        :fileicon => status_img(self),
+        :tooltip  => authentication_status
       }
-    end
+    }
   end
 end

--- a/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
@@ -1,18 +1,28 @@
-module ManageIQ::Providers
-  class PhysicalInfraManagerDecorator < ExtManagementSystemDecorator
-    def quadicon(_n = nil)
-      {
-        :top_left     => {:text => physical_servers.size},
-        :top_right    => {:text => ""},
-        :bottom_left  => {
-          :fileicon => fileicon,
-          :tooltip  => type
-        },
-        :bottom_right => {
-          :fileicon => status_img(self),
-          :tooltip  => authentication_status
-        }
+class ManageIQ::Providers::PhysicalInfraManagerDecorator < ExtManagementSystemDecorator
+  def self.fonticon
+    'pficon pficon-server'
+  end
+
+  def fonticon
+    nil
+  end
+
+  def fileicon
+    "svg/vendor-#{image_name}.svg"
+  end
+
+  def quadicon(_n = nil)
+    {
+      :top_left     => {:text => physical_servers.size},
+      :top_right    => {:text => ""},
+      :bottom_left  => {
+        :fileicon => fileicon,
+        :tooltip  => type
+      },
+      :bottom_right => {
+        :fileicon => status_img(self),
+        :tooltip  => authentication_status
       }
-    end
+    }
   end
 end


### PR DESCRIPTION
Code sharing is nice, DRY is even nicer, but not in decorator by a convention. Some provider decorators were inherited from the `ExtManagementSystemDecorator˙ and this was wrong, cleaning it up.