### PR TITLE
Fix tool tip when tagging Ansible Credential from its summary page

### DIFF
--- a/app/helpers/application_helper/toolbar/ansible_credential_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_credential_center.rb
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::AnsibleCredentialCenter < ApplicationHelper::T
                      button(
                        :ansible_credential_tag,
                        'pficon pficon-edit fa-lg',
-                       N_('Edit Tags for the selected Ansible Credentials'),
+                       N_('Edit Tags for this Ansible Credential'),
                        N_('Edit Tags'),
                      ),
                    ]


### PR DESCRIPTION
Fix tool tip when tagging Ansible Credential from its summary page, in _Automation > Ansible > Credentials._

This little issue was caused by: https://github.com/ManageIQ/manageiq-ui-classic/pull/3507

**Before:**
![tool_tip_bad](https://user-images.githubusercontent.com/13417815/37030268-a8288e6a-213a-11e8-9395-3c7a8a648546.png)

**After:**
![tool_tip_ok](https://user-images.githubusercontent.com/13417815/37030277-acd20cd4-213a-11e8-869c-a42469935cea.png)
