### PR TITLE
Drop middleware decorator quadicon definition

### DIFF
--- a/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
@@ -6,23 +6,4 @@ class ManageIQ::Providers::Hawkular::MiddlewareManagerDecorator < MiqDecorator
   def self.fileicon
     "svg/vendor-hawkular.svg"
   end
-
-  def quadicon(_n = nil)
-    {
-      :top_left     => {
-        :text => middleware_domains.size
-      },
-      :top_right    => {
-        :text => middleware_servers.size
-      },
-      :bottom_left  => {
-        :fileicon => fileicon,
-        :tooltip  => type
-      },
-      :bottom_right => {
-        :fileicon => status_img(self),
-        :tooltip  => authentication_status
-      }
-    }
-  end
 end


### PR DESCRIPTION
We don't need this, so :scissors: :scissors: :toilet: :fire: 