### PR TITLE
Do not use try unnecessarily on EMS decorator type/auth_status

### DIFF
--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -13,15 +13,15 @@ class ExtManagementSystemDecorator < MiqDecorator
 
   def quadicon(_n = nil)
     {
-      :top_left     => {:text => try(:hosts).try(:size) || 0},
+      :top_left     => {:text => try(:hosts).try(:size).to_i},
       :top_right    => {:text => ""},
       :bottom_left  => {
         :fileicon => fileicon,
-        :tooltip  => try(:type)
+        :tooltip  => type
       },
       :bottom_right => {
         :fileicon => status_img(self),
-        :tooltip  => try(:authentication_status)
+        :tooltip  => authentication_status
       }
     }
   end


### PR DESCRIPTION
There is always a `type` and an `authentication_status` in the affected records. Also simplified a `(N || nil) || 0` clause to a `N.to_i`.

@miq-bot assign @mzazrivec 