### PR TITLE
Show policy status when running policy simulation

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -85,6 +85,7 @@ module ApplicationController::PolicySupport
                     :url  => "/#{request.parameters["controller"]}/policy_sim?continue=true")
     session[:policies] = {} unless params[:continue]  # Clear current policies, unless continuing previous simulation
     records = session[:tag_items] if records.empty? && session[:tag_items].present?
+    session[:tag_items] = records
     policy_sim_build_screen(records)
 
     if @explorer
@@ -228,7 +229,7 @@ module ApplicationController::PolicySupport
   # Build the policy simulation screen
   def policy_sim_build_screen(records = [])
     @edit ||= {}
-    @tagitems = records ? records : session[:tag_db].find(session[:tag_items]) # Get the db records that are being tagged
+    @tagitems = records.presence || session[:tag_items] # Get the db records that are being tagged
     @tagitems = @tagitems.sort_by(&:name)
     @edit[:pol_items] = session[:tag_items]
     @catinfo = {}
@@ -248,6 +249,7 @@ module ApplicationController::PolicySupport
     else
       @all_profs["<select>"] = _("No Policy Profiles are available")
     end
+    @gtl_type = "grid"
     build_targets_hash(@tagitems)
   end
 end

--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -8,6 +8,7 @@ class MiqTemplateDecorator < MiqDecorator
   end
 
   def quadicon(settings = {})
+    show_compliance = settings[:show_compliance] && settings[:policies].present?
     {
       :top_left     => {
         :fileicon => os_image,
@@ -21,7 +22,7 @@ class MiqTemplateDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => type
       },
-      :bottom_right => settings[:show_compliance] ? compliance_image(settings[:policies]) : total_snapshots
+      :bottom_right => show_compliance ? compliance_image(settings[:policies].keys) : total_snapshots
     }
   end
 

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -12,6 +12,7 @@ class VmOrTemplateDecorator < MiqDecorator
   end
 
   def quadicon(settings = {})
+    show_compliance = settings[:show_compliance] && settings[:policies].present?
     {
       :top_left     => {
         :fileicon => os_image,
@@ -25,7 +26,7 @@ class VmOrTemplateDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => type
       },
-      :bottom_right => settings[:show_compliance] ? compliance_image(settings[:policies]) : total_snapshots
+      :bottom_right => show_compliance ? compliance_image(settings[:policies].keys) : total_snapshots
     }
   end
 


### PR DESCRIPTION
### Policy simulation status
When in policy simulation and user changes Policy Profile no status is visible because quadicon is not used in this list.

This PR fixes such issue so when selecting Policy Profiles user sees status of policy simulation. If no policy simulation is visible show number of total snapshots

### UI changes
#### Before
![screenshot from 2018-03-01 10-56-04 1](https://user-images.githubusercontent.com/3439771/37092304-a8f09190-220b-11e8-9c0e-f8046d9791db.png)

#### After
**No policy profile selected**
![screenshot from 2018-03-07 13-27-17](https://user-images.githubusercontent.com/3439771/37092324-bb21a912-220b-11e8-9d4d-07cf24a9f967.png)
**Policiy profile selected, but different policy assigned**
![screenshot from 2018-03-07 13-27-24](https://user-images.githubusercontent.com/3439771/37092325-bb3a6b46-220b-11e8-9063-f114b5c53cc2.png)

### BZ
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1550503