### PR TITLE
Allow datetime (existence of Resource) fields in report definition of chargeback for VM/Container/...* report 

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -21,6 +21,11 @@ module ReportController::Reports::Editor
     -vm_uid
   ).freeze
 
+  METERING_VM_ALLOWED_FIELD_SUFFIXES = %w(
+    -beginning_of_resource_existence_in_report_interval
+    -end_of_resource_existence_in_report_interval
+  ).freeze
+
   MAX_REPORT_COLUMNS = 100 # Default maximum number of columns in a report
   GRAPH_MAX_COUNT = 10
 


### PR DESCRIPTION
Need to merge first

- [x] https://github.com/ManageIQ/manageiq/pull/17100


![screen shot 2018-03-07 at 15 01 37](https://user-images.githubusercontent.com/14937244/37096295-7e9db08c-2218-11e8-8dec-bb9321037c11.png)

Links
----------------

* https://github.com/ManageIQ/manageiq/pull/17100 (backend PR)
* https://bugzilla.redhat.com/show_bug.cgi?id=1505115


@miq-bot assign @mzazrivec  
@miq-bot add_label gaprindashvili/yes, enhancement
