### PR TITLE
Untangling QuadiconHelper::Decorator and its shared methods

### DIFF
--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -20,7 +20,7 @@ class ExtManagementSystemDecorator < MiqDecorator
         :tooltip  => type
       },
       :bottom_right => {
-        :fileicon => status_img(self),
+        :fileicon => QuadiconHelper::Decorator.status_img(authentication_status),
         :tooltip  => authentication_status
       }
     }

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -16,7 +16,7 @@ class HostDecorator < MiqDecorator
         :tooltip  => type
       },
       :bottom_right => {
-        :fileicon => status_img(self),
+        :fileicon => QuadiconHelper::Decorator.status_img(authentication_status),
         :tooltip  => authentication_status
       }
     }

--- a/app/decorators/manageiq/providers/cloud_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager_decorator.rb
@@ -20,7 +20,7 @@ class ManageIQ::Providers::CloudManagerDecorator < MiqDecorator
         :tooltip  => type
       },
       :bottom_right => {
-        :fileicon => status_img(self),
+        :fileicon => QuadiconHelper::Decorator.status_img(authentication_status),
         :tooltip  => authentication_status
       }
     }

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -20,7 +20,7 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
         :tooltip  => type
       },
       :bottom_right => {
-        :fileicon => status_img(self),
+        :fileicon => QuadiconHelper::Decorator.status_img(authentication_status),
         :tooltip  => authentication_status
       }
     }

--- a/app/decorators/manageiq/providers/infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/infra_manager_decorator.rb
@@ -20,7 +20,7 @@ class ManageIQ::Providers::InfraManagerDecorator < ExtManagementSystemDecorator
         :tooltip  => type
       },
       :bottom_right => {
-        :fileicon => status_img(self),
+        :fileicon => QuadiconHelper::Decorator.status_img(authentication_status),
         :tooltip  => authentication_status
       }
     }

--- a/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
@@ -20,7 +20,7 @@ class ManageIQ::Providers::PhysicalInfraManagerDecorator < ExtManagementSystemDe
         :tooltip  => type
       },
       :bottom_right => {
-        :fileicon => status_img(self),
+        :fileicon => QuadiconHelper::Decorator.status_img(authentication_status),
         :tooltip  => authentication_status
       }
     }

--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -31,4 +31,12 @@ class MiqTemplateDecorator < MiqDecorator
   def os_image
     "svg/os-#{ERB::Util.h(os_image_name.downcase)}.svg"
   end
+
+  # FIXME: this will be unnecessary after the conditional policies are dropped from the decorators
+  def compliance_image(policies)
+    {
+      :fileicon => QuadiconHelper::Decorator.compliance_img(passes_profiles?(policies)),
+      :tooltip  => passes_profiles?(get_policies)
+    }
+  end
 end

--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -22,7 +22,7 @@ class MiqTemplateDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => type
       },
-      :bottom_right => show_compliance ? compliance_image(settings[:policies].keys) : total_snapshots
+      :bottom_right => show_compliance ? compliance_image(settings[:policies].keys) : {:text => ERB::Util.h(v_total_snapshots)}
     }
   end
 

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -19,9 +19,20 @@ class PhysicalServerDecorator < MiqDecorator
         :tooltip  => type
       },
       :bottom_right => {
-        :fileicon => health_state_img(self),
+        :fileicon => health_state_img,
         :tooltip  => health_state
       }
     }
+  end
+
+  private
+
+  def health_state_img
+    case health_state
+    when "Valid"    then "svg/healthstate-normal.svg"
+    when "Critical" then "svg/healthstate-critical.svg"
+    when "Warning"  then "100/warning.png"
+    else "svg/healthstate-unknown.svg"
+    end
   end
 end

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -35,4 +35,12 @@ class VmOrTemplateDecorator < MiqDecorator
   def os_image
     "svg/os-#{ERB::Util.h(os_image_name.downcase)}.svg"
   end
+
+  # FIXME: this will be unnecessary after the conditional policies are dropped from the decorators
+  def compliance_image(policies)
+    {
+      :fileicon => QuadiconHelper::Decorator.compliance_img(passes_profiles?(policies)),
+      :tooltip  => passes_profiles?(get_policies)
+    }
+  end
 end

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -26,7 +26,7 @@ class VmOrTemplateDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => type
       },
-      :bottom_right => show_compliance ? compliance_image(settings[:policies].keys) : total_snapshots
+      :bottom_right => show_compliance ? compliance_image(settings[:policies].keys) : {:text => ERB::Util.h(v_total_snapshots)}
     }
   end
 

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -236,7 +236,7 @@ module QuadiconHelper
   end
 
   def img_for_compliance(item)
-    compliance_img(item, session[:policies])
+    QuadiconHelper::Decorator.compliance_img(item.passes_profiles?(session[:policies]))
   end
 
   def img_for_vendor(item)

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -73,6 +73,10 @@ module QuadiconHelper
     @view.db == "Vm"
   end
 
+  def quadicon_policy_sim?
+    !!@policy_sim
+  end
+
   def quadicon_service_ctrlr_and_vm_view_db?
     quadicon_in_service_controller? && quadicon_view_db_is_vm?
   end
@@ -216,7 +220,7 @@ module QuadiconHelper
   def quadicon_for_item(item)
     quad_settings = if item.kind_of?(VmOrTemplate)
                       {
-                        :show_compliance => quadicon_lastaction_is_policy_sim? || quadicon_policy_sim?,
+                        :show_compliance => @lastaction == "policy_sim" || quadicon_policy_sim?,
                         :policies        => session[:policies]
                       }
                     else

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -19,8 +19,6 @@ module QuadiconHelper
   # session[:policies]
   # request.parameters[:controller]
 
-  include QuadiconHelper::Decorator
-
   def quadicon_truncate_mode
     @settings.fetch_path(:display, :quad_truncate) || 'm'
   end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -244,7 +244,7 @@ module QuadiconHelper
   end
 
   def img_for_auth_status(item)
-    status_img(item)
+    QuadiconHelper::Decorator.status_img(item.authentication_status)
   end
 
   def render_quadicon_text(item, row)

--- a/app/helpers/quadicon_helper/decorator.rb
+++ b/app/helpers/quadicon_helper/decorator.rb
@@ -17,12 +17,4 @@ module QuadiconHelper::Decorator
       end
     end
   end
-
-  def quadicon_lastaction_is_policy_sim?
-    @lastaction == "policy_sim"
-  end
-
-  def quadicon_policy_sim?
-    !!@policy_sim
-  end
 end

--- a/app/helpers/quadicon_helper/decorator.rb
+++ b/app/helpers/quadicon_helper/decorator.rb
@@ -1,12 +1,12 @@
 module QuadiconHelper::Decorator
-  private
-
-  def status_img(item = nil)
-    case item.authentication_status
-    when "Invalid" then "100/x.png"
-    when "Valid"   then "100/checkmark.png"
-    when "None"    then "100/unknown.png"
-    else                "100/exclamationpoint.png"
+  class << self
+    def status_img(status)
+      case status
+      when "Invalid" then "100/x.png"
+      when "Valid"   then "100/checkmark.png"
+      when "None"    then "100/unknown.png"
+      else                "100/exclamationpoint.png"
+      end
     end
   end
 

--- a/app/helpers/quadicon_helper/decorator.rb
+++ b/app/helpers/quadicon_helper/decorator.rb
@@ -10,15 +10,6 @@ module QuadiconHelper::Decorator
     end
   end
 
-  def health_state_img(item = nil)
-    case item.health_state
-    when "Valid"    then "svg/healthstate-normal.svg"
-    when "Critical" then "svg/healthstate-critical.svg"
-    when "Warning"  then "100/warning.png"
-    else "svg/healthstate-unknown.svg"
-    end
-  end
-
   def compliance_img(item, policies = {})
     case item.passes_profiles?(policies)
     when true  then '100/check.png'

--- a/app/helpers/quadicon_helper/decorator.rb
+++ b/app/helpers/quadicon_helper/decorator.rb
@@ -8,13 +8,13 @@ module QuadiconHelper::Decorator
       else                "100/exclamationpoint.png"
       end
     end
-  end
 
-  def compliance_img(item, policies = {})
-    case item.passes_profiles?(policies)
-    when true  then '100/check.png'
-    when 'N/A' then '100/na.png'
-    else            '100/x.png'
+    def compliance_img(status)
+      case status
+      when true  then '100/check.png'
+      when 'N/A' then '100/na.png'
+      else            '100/x.png'
+      end
     end
   end
 

--- a/lib/miq_decorator.rb
+++ b/lib/miq_decorator.rb
@@ -20,15 +20,6 @@ class MiqDecorator < SimpleDelegator
   # Call the class methods with identical names if these are not set
   delegate :fonticon, :to => :class
   delegate :fileicon, :to => :class
-
-  protected
-
-  def compliance_image(policies)
-    {
-      :fileicon => QuadiconHelper::Decorator.compliance_img(passes_profiles?(policies)),
-      :tooltip  => QuadiconHelper::Decorator.passes_profiles?(get_policies)
-    }
-  end
 end
 
 module MiqDecorator::Instance

--- a/lib/miq_decorator.rb
+++ b/lib/miq_decorator.rb
@@ -1,6 +1,4 @@
 class MiqDecorator < SimpleDelegator
-  include QuadiconHelper::Decorator
-
   class << self
     def for(klass)
       decorator = nil

--- a/lib/miq_decorator.rb
+++ b/lib/miq_decorator.rb
@@ -25,8 +25,8 @@ class MiqDecorator < SimpleDelegator
 
   def compliance_image(policies)
     {
-      :fileicon => compliance_img(self, policies),
-      :tooltip  => passes_profiles?(get_policies)
+      :fileicon => QuadiconHelper::Decorator.compliance_img(passes_profiles?(policies)),
+      :tooltip  => QuadiconHelper::Decorator.passes_profiles?(get_policies)
     }
   end
 end

--- a/lib/miq_decorator.rb
+++ b/lib/miq_decorator.rb
@@ -29,12 +29,6 @@ class MiqDecorator < SimpleDelegator
       :tooltip  => passes_profiles?(get_policies)
     }
   end
-
-  def total_snapshots
-    {
-      :text => ERB::Util.h(v_total_snapshots)
-    }
-  end
 end
 
 module MiqDecorator::Instance


### PR DESCRIPTION
This is a required step for the new quadicons, also we still don't like unnecessary things in decorators. I tried to make self-descriptive commit messages, so please read this commit by commit when reviewing. 

Including the `QuadiconHelper::Decorator` in all decorators is unnecessary as it is being used in only a few places. I changed all the method calls to the static `QuadiconHelper::Decorator.method()` form. Also passing the whole object to these methods is not necessary, so from now on just sending the necessary stuff. Methods that are being called just on a single place have been moved into the place of call.

The policies part is a bit tricky, eventually I would like to get rid of the policy alteration of quadicons from the decorators, so we can have all of them consistent. This can not be done in this PR, so I just prepared the code into an easy-to-remove-but-still-working form.

@martinpovolny @karelhala 