### PR TITLE
Enable to add tag for configuration provider

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -144,7 +144,7 @@ class ProviderForemanController < ApplicationController
     when "cp", "cs" then ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem
     when "xx"       then
       case nodes.second
-      when "fr" then ManageIQ::Providers::Foreman::ConfigurationManager
+      when "fr" then ManageIQ::Providers::ConfigurationManager
       when "csf" then ConfiguredSystem
       end
     else


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1549488

Enable to add tag for configuration provider from 'All Rad Hat Satellites
Providers', in _Configuration > Management > Providers_ accordion.

**Important:** the problem in the screen occurs right AFTER clicking on _Save_ button in tagging screen, so it means that tagging screen opens without problems, it is possible to edit tags in the screen, but not to save them properly.

---

**Before:** (right after saving tags)
![provider_tag_bad](https://user-images.githubusercontent.com/13417815/37103074-b1aaafb4-2229-11e8-99b6-0966501c81d5.png)

Original screenshot from the BZ, for better understanding/reproducing the problem:
![1519722340014](https://user-images.githubusercontent.com/13417815/37102985-7a12f674-2229-11e8-8c7a-9f9293f6db99.jpg)

**After:**
![provider_edit_tags](https://user-images.githubusercontent.com/13417815/37102915-44e144ba-2229-11e8-95f3-b43a73cf8b76.png)
![provider_tag_success](https://user-images.githubusercontent.com/13417815/37102871-2c0f716e-2229-11e8-95c1-41c003ba4a8b.png)

**Details:**
If we go to _Configuration > Management > Providers_ accordion, we are normally on `root` node, it is _All Configuration Manager Providers_ node, in the tree. After selecting some provider(s) in the list and clicking on _Edit Tags_ (under _Configuration_), we are able to tag the provider and **save** the changes we made, without any problems. During this process (saving the tags), we enter `class_for_provider_node` method in provider foreman controller, which returns `ManageIQ::Providers::ConfigurationManager`. So we know that this works, when tagging a provider. BUT if we enter other node in the tree, for example _All Red Hat Satellites Providers_ or _Foreman Providers_ node (as in my screenshots above), we are no longer on root node so `class_for_provider_node` returns wrong class (but only when saving tags; ). It looks like it has never worked with that class. If we just enter tagging screen (after clicking on _Edit Tags_), `tagging_edit` method gets different `db` as an argument, comparing to what it gets when saving the tags!