### PR TITLE
Fixing bug while try to perform a physical server action

### DIFF
--- a/app/assets/javascripts/components/physical_infrastructures/physical-server-toolbar.js
+++ b/app/assets/javascripts/components/physical_infrastructures/physical-server-toolbar.js
@@ -12,6 +12,10 @@ function physicalServerToolbarController(API, miqService) {
   var toolbar = this;
 
   ManageIQ.angular.rxSubject.subscribe(function(event) {
+    if (event.controller !== 'physicalServerToolbarController') {
+      return;
+    }
+
     toolbar.action = event.type;
 
     if (toolbar.action) {

--- a/spec/javascripts/components/physical_infrastructures/physical-server-toolbar_spec.js
+++ b/spec/javascripts/components/physical_infrastructures/physical-server-toolbar_spec.js
@@ -15,7 +15,7 @@ describe('physical-server-toolbar', function() {
       var bindings = {physicalServerId: 1};
       toolbar = $componentController('physicalServerToolbar', null, bindings);
 
-      sendDataWithRx({type: 'power_on'});
+      sendDataWithRx({type: 'power_on', controller: 'physicalServerToolbarController'});
     }));
 
     it('sets action to "power_on"', function () {
@@ -46,9 +46,9 @@ describe('physical-server-toolbar', function() {
       ManageIQ.gridChecks = [1,2];
       toolbar = $componentController('physicalServerToolbar', null, {});
 
-      sendDataWithRx({type: 'blink_loc_led'});
+      sendDataWithRx({type: 'blink_loc_led', controller: 'physicalServerToolbarController'});
     }));
-    
+
     it('sets action to "blink_loc_led"', function () {
       expect(toolbar.action).toEqual('blink_loc_led');
     });


### PR DESCRIPTION
Bug fix
=====

This PR fixes a bug while try to perform some physical server action from toolbar.

__now__: Error messages is shown to user;
![screenshot from 2018-03-07 16-44-36](https://user-images.githubusercontent.com/8550928/37115420-d47038fc-2229-11e8-924f-dce7b6ecc411.png)

__fix__: Prevent to execute some action for some MiQ UI event that doesn't explicit the `physicalServerToolbarController` to responde for.

This bug was caused as side effect of this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/3351

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1552866