### PR TITLE
Fix CI specs by adding persistent user|group|role object

### DIFF
--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -591,14 +591,14 @@ describe OpsController do
       expect(controller.instance_variable_get(:@users_count)).to eq(1)
     end
 
-    it "displays the access object count for the current tenant" do
+    it "displays the access object count for the current user" do
       login_as @u2a
       session[:sandboxes] = {"ops" => {:active_tree => :rbac_tree}}
       allow(controller).to receive(:replace_right_cell)
       post :tree_select, :params => { :id => 'root', :format => :js }
-      expect(controller.instance_variable_get(:@groups_count)).to eq(2)
+      expect(controller.instance_variable_get(:@groups_count)).to eq(1)
       expect(controller.instance_variable_get(:@tenants_count)).to eq(1)
-      expect(controller.instance_variable_get(:@users_count)).to eq(5)
+      expect(controller.instance_variable_get(:@users_count)).to eq(2)
     end
   end
 

--- a/spec/helpers/application_helper/views_shared_spec.rb
+++ b/spec/helpers/application_helper/views_shared_spec.rb
@@ -17,7 +17,7 @@ describe ApplicationHelper do
     end
     let!(:admin_user)             { FactoryGirl.create(:user_admin) }
     let!(:child_user)             { FactoryGirl.create(:user, :miq_groups => [child_group]) }
-    let!(:grand_child_user)       { FactoryGirl.create(:user, :miq_groups => [grand_child_group]) }
+    let!(:grand_child_user)       { FactoryGirl.create(:user, :miq_groups => [grand_child_group, great_grand_child_group]) }
     let!(:great_grand_child_user) { FactoryGirl.create(:user, :miq_groups => [great_grand_child_group]) }
 
     subject { helper.ownership_user_options }
@@ -30,11 +30,10 @@ describe ApplicationHelper do
     end
 
     context 'a tenant user' do
-      it 'lists users in that tenant' do
+      it 'lists users in his group' do
         allow(User).to receive(:server_timezone).and_return('UTC')
         allow(User).to receive(:current_user).and_return(grand_child_user)
-
-        ids = [great_grand_child_tenant, grand_child_tenant].collect(&:user_ids).flatten
+        ids = grand_child_user.miq_groups.collect(&:user_ids).flatten.uniq
         expect(subject.values(&:id).map(&:to_i)).to match_array(ids)
       end
     end

--- a/spec/presenters/tree_builder_ops_rbac_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_spec.rb
@@ -46,7 +46,7 @@ describe TreeBuilderOpsRbac do
 
   describe "#x_get_tree_custom_kids" do
     let(:group) { FactoryGirl.create(:miq_group) }
-    let(:user) { FactoryGirl.create(:user, :miq_groups => [group]) }
+    let(:user) { FactoryGirl.create(:user, :miq_groups => [group, other_group]) }
     let(:other_group) { FactoryGirl.create(:miq_group) }
     let(:other_user) { FactoryGirl.create(:user, :miq_groups => [other_group]) }
 
@@ -60,7 +60,7 @@ describe TreeBuilderOpsRbac do
       expect(objects).to match_array(expected_objects)
     end
 
-    it "is listing all users" do
+    it "is listing all users from current user's groups" do
       x_get_tree_custom_kids_for_and_expect_objects("u", [user, other_user])
     end
 
@@ -69,9 +69,10 @@ describe TreeBuilderOpsRbac do
     end
 
     context "User with self service user" do
-      before :each do
-        allow_any_instance_of(User).to receive_messages(:self_service? => true)
-      end
+      let(:self_service_role) { FactoryGirl.create(:miq_user_role, :settings => {:restrictions => {:vms => :user}}) }
+      let(:group)             { FactoryGirl.create(:miq_group, :miq_user_role => self_service_role) }
+      let(:other_group)       { FactoryGirl.create(:miq_group, :miq_user_role => self_service_role) }
+      let(:user)              { FactoryGirl.create(:user, :miq_groups => [group, other_group], :role => 'user_self_service') }
 
       it "is listing only current user" do
         x_get_tree_custom_kids_for_and_expect_objects("u", [user])


### PR DESCRIPTION
We are not using users|groups|role with establishing relations them and we are using for some specs objects created from these models but only in memory, without ids. And it is causing problems.


CI failure:
https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/350401089

Links
----------------
* caused by https://github.com/ManageIQ/manageiq/pull/17061

Progress

fixed:

- [x] /spec/controllers/ops_controller_spec.rb
- [x] /spec/helpers/application_helper/views_shared_spec.rb
- [x] /spec/presenters/tree_builder_ops_rbac_spec.rb
- [x] /spec/controllers/ops_controller/ops_rbac_spec.rb



