### PR TITLE
Delete dead methods

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -497,10 +497,6 @@ module Mixins
       self.class.table_name
     end
 
-    def no_blank(thing)
-      thing.blank? ? nil : thing
-    end
-
     def set_ems_record_vars(ems, mode = nil)
       ems.name                   = params[:name].strip if params[:name]
       ems.provider_region        = params[:provider_region] if params[:provider_region]

--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -344,11 +344,6 @@ module PxeController::PxeServers
     wimg.pxe_image_type = @edit[:new][:img_type].blank? ? nil : PxeImageType.find_by_id(@edit[:new][:img_type])
   end
 
-  # Delete all selected or single displayed PXE Server(s)
-  def deletepxes
-    pxe_button_operation('destroy', 'deletion')
-  end
-
   def pxe_server_set_record_vars(pxe, mode = nil)
     pxe.name = @edit[:new][:name]
     pxe.access_url = @edit[:new][:access_url]


### PR DESCRIPTION
Removing dead methods ✂️ ✂️ ✂️ 

`no_blank` was introduced and never used in https://github.com/ManageIQ/manageiq/pull/4189

`deletepxes` is present since init commit.

@miq-bot add_label technical debt, gaprindashvili/no

