### PR TITLE
Use fileicon instead of the newly introduced state_icon in decorators

### DIFF
--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -10,7 +10,7 @@ class HostDecorator < MiqDecorator
   def quadicon(_n = nil)
     {
       :top_left     => {:text => vms.size},
-      :top_right    => {:state_icon => normalized_state.downcase},
+      :top_right    => {:fileicon => "svg/currentstate-#{ERB::Util.h(normalized_state.downcase)}.svg"},
       :bottom_left  => {
         :fileicon => fileicon,
         :tooltip  => type

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -14,7 +14,7 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
   def quadicon(_n = nil)
     {
       :top_left     => {:text => container_nodes.size},
-      :top_right    => {:state_icon => enabled? ? "on" : "paused"},
+      :top_right    => {:state_icon => "svg/currentstate-#{enabled? ? 'on' : 'paused'}.svg"},
       :bottom_left  => {
         :fileicon => fileicon,
         :tooltip  => type

--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -14,7 +14,7 @@ class MiqTemplateDecorator < MiqDecorator
         :tooltip  => os_image_name.humanize.downcase
       },
       :top_right    => {
-        :state_icon => normalized_state.downcase,
+        :fileicon   => "svg/currentstate-#{ERB::Util.h(normalized_state.downcase)}.svg",
         :tooltip    => normalized_state
       },
       :bottom_left  => {

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -18,7 +18,7 @@ class VmOrTemplateDecorator < MiqDecorator
         :tooltip  => os_image_name.humanize.downcase
       },
       :top_right    => {
-        :state_icon => normalized_state.downcase,
+        :fileicon   => "svg/currentstate-#{ERB::Util.h(normalized_state.downcase)}.svg",
         :tooltip    => normalized_state
       },
       :bottom_left  => {

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -528,13 +528,6 @@ module QuadiconHelper
     output.collect(&:html_safe).join('').html_safe
   end
 
-  def currentstate_icon(state)
-    path = "svg/currentstate-#{h(state)}.svg"
-    content_tag(:div, :class => "flobj b72") do
-      content_tag(:div, '', :class => "stretch", :style => "background-image: url('#{encodable_image_source(path)}')")
-    end
-  end
-
   # Renders a quadicon for hosts
   #
   def render_host_quadicon(item, options)
@@ -609,8 +602,6 @@ module QuadiconHelper
     quadicon.map do |key, value|
       if value.try(:[], :text)
         render_quad_text(value[:text], POSITION_MAPPER[key])
-      elsif value.try(:[], :state_icon)
-        currentstate_icon(value[:state_icon])
       elsif value.try(:[], :fileicon)
         render_quad_image(value.try(:[], :fileicon), POSITION_MAPPER[key], value.try(:type))
       else


### PR DESCRIPTION
The `:state_icon` has been introduced unnecessarily and it is not compatible with the new quadicon component's [input specification](https://github.com/ManageIQ/ui-components/pull/243). So changing it to a normal `:fileicon`.