### PR TITLE
update:ui - ensure we always see all the js engines

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -35,10 +35,14 @@ namespace :update do
   task :ui do
     # when running update:ui from ui-classic, asset_engines won't see the other engines
     # the same goes for Rake::Task#invoke
-    Dir.chdir Rails.root do
-      Bundler.with_clean_env do
-        system("bundle exec rake update:actual_ui")
+    if defined?(ENGINE_ROOT)
+      Dir.chdir Rails.root do
+        Bundler.with_clean_env do
+          system("bundle exec rake update:actual_ui")
+        end
       end
+    else
+      Rake::Task['update:actual_ui'].invoke
     end
   end
 end

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -21,7 +21,17 @@ namespace :update do
     end
   end
 
-  task :ui => ['update:clean', 'update:bower', 'update:yarn', 'webpack:compile']
+  task :actual_ui => ['update:clean', 'update:bower', 'update:yarn', 'webpack:compile']
+
+  task :ui do
+    # when running update:ui from ui-classic, asset_engines won't see the other engines
+    # the same goes for Rake::Task#invoke
+    Dir.chdir Rails.root do
+      Bundler.with_clean_env do
+        system("bundle exec rake update:actual_ui")
+      end
+    end
+  end
 end
 
 namespace :webpack do

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -85,7 +85,7 @@ end
 # compile and clobber when running assets:* tasks
 if Rake::Task.task_defined?("assets:precompile")
   Rake::Task["assets:precompile"].enhance do
-    Rake::Task["webpack:compile"].invoke
+    Rake::Task["webpack:compile"].invoke unless ENV["TRAVIS"]
   end
 
   Rake::Task["assets:precompile"].actions.each do |action|
@@ -97,7 +97,7 @@ end
 
 if Rake::Task.task_defined?("assets:clobber")
   Rake::Task["assets:clobber"].enhance do
-    Rake::Task["webpack:clobber"].invoke
+    Rake::Task["webpack:clobber"].invoke unless ENV["TRAVIS"]
   end
 
   Rake::Task["assets:clobber"].actions.each do |action|

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -35,7 +35,7 @@ namespace :update do
   task :ui do
     # when running update:ui from ui-classic, asset_engines won't see the other engines
     # the same goes for Rake::Task#invoke
-    if defined?(ENGINE_ROOT)
+    if defined?(ENGINE_ROOT) && !ENV["TRAVIS"]
       Dir.chdir Rails.root do
         Bundler.with_clean_env do
           system("bundle exec rake update:actual_ui")

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -21,7 +21,16 @@ namespace :update do
     end
   end
 
-  task :actual_ui => ['update:clean', 'update:bower', 'update:yarn', 'webpack:compile']
+  task :debug_engines do
+    print "\n"
+    puts "JS plugins:"
+    asset_engines.each_pair do |k, v|
+      puts "  #{k}: #{v}"
+    end
+    print "\n"
+  end
+
+  task :actual_ui => ['update:clean', 'update:bower', 'update:yarn', 'webpack:compile', 'update:debug_engines']
 
   task :ui do
     # when running update:ui from ui-classic, asset_engines won't see the other engines

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "angular-animate": "~1.6.6",
     "angular-sanitize": "~1.6.6",
     "core-js": "~2.4.1",
-    "graphiql": "^0.11.11",
     "jquery": "~2.2.4",
     "lodash": "^4.17.4",
     "ng-redux": "^3.5.2",

--- a/tools/ci/setup_js_env.sh
+++ b/tools/ci/setup_js_env.sh
@@ -26,8 +26,5 @@ fi
 # make sure yarn is installed, in the right version
 bundle exec rake webpacker:check_yarn || npm install -g yarn
 
-# install npm dependencies
-yarn
-
-# compile webpacker assets
-bundle exec rake webpack:compile
+# install & compile dependencies
+bundle exec rake update:ui


### PR DESCRIPTION
This reverts the temporary fix from https://github.com/ManageIQ/manageiq-ui-classic/pull/3523,
to fix the problem with https://github.com/ManageIQ/manageiq-graphql/pull/44.

The `update:ui` task is supposed to find all the engines, run `yarn` in all of them, and then webpack the thing :). 

Except thanks to the magic of engines, running the task from ui-classic will only find ui-classic, and not the others - thus forcing `update:ui` to always run from `Rails.root`.