### PR TITLE
Remove default endpoints for :ems_nuage_network_with_authentication

### DIFF
--- a/spec/controllers/mixins/ems_common_angular_spec.rb
+++ b/spec/controllers/mixins/ems_common_angular_spec.rb
@@ -5,6 +5,8 @@ describe Mixins::EmsCommonAngular do
     let(:ems_openstack) { FactoryGirl.create(:ems_openstack_with_authentication) }
 
     it 'when amqp' do
+      # remove default endpoints
+      ems_nuage.endpoints = []
       ems_nuage.endpoints << Endpoint.create(:role => 'amqp', :hostname => 'hostname')
       network_controller.instance_variable_set(:@ems, ems_nuage)
 
@@ -19,6 +21,8 @@ describe Mixins::EmsCommonAngular do
     end
 
     it 'when ceilometer and amqp has empty hostname' do
+      # remove default endpoints
+      ems_nuage.endpoints = []
       ems_nuage.endpoints << Endpoint.create(:role => 'ceilometer', :hostname => 'hostname')
       ems_nuage.endpoints << Endpoint.create(:role => 'amqp')
       network_controller.instance_variable_set(:@ems, ems_nuage)
@@ -27,6 +31,8 @@ describe Mixins::EmsCommonAngular do
     end
 
     it 'when amqp and ceilometer has empty hostname' do
+      # remove default endpoints
+      ems_nuage.endpoints = []
       ems_nuage.endpoints << Endpoint.create(:role => 'ceilometer')
       ems_nuage.endpoints << Endpoint.create(:role => 'amqp', :hostname => 'hostname')
       network_controller.instance_variable_set(:@ems, ems_nuage)
@@ -35,6 +41,8 @@ describe Mixins::EmsCommonAngular do
     end
 
     it 'none when amqp and ceilometer have empty hostnames' do
+      # remove default endpoints
+      ems_nuage.endpoints = []
       ems_nuage.endpoints << Endpoint.create(:role => 'ceilometer')
       ems_nuage.endpoints << Endpoint.create(:role => 'amqp')
       network_controller.instance_variable_set(:@ems, ems_nuage)
@@ -49,6 +57,8 @@ describe Mixins::EmsCommonAngular do
     end
 
     it 'when none' do
+      # remove default endpoints
+      ems_nuage.endpoints = []
       network_controller.instance_variable_set(:@ems, ems_nuage)
 
       expect(network_controller.send(:retrieve_event_stream_selection)).to eq('none')


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-providers-nuage/pull/69 adds default enpoint to `:ems_nuage_network_with_authentication` factory. Removing that default endpoint.

Before:
```
Failures:

  1) Mixins::EmsCommonAngular.retrieve_event_stream_selection none when amqp and ceilometer have empty hostnames
     Failure/Error: expect(network_controller.send(:retrieve_event_stream_selection)).to eq('none')

       expected: "none"
            got: "amqp"

       (compared using ==)
     # ./spec/controllers/mixins/ems_common_angular_spec.rb:46:in `block (3 levels) in <top (required)>'

  2) Mixins::EmsCommonAngular.retrieve_event_stream_selection when ceilometer and amqp has empty hostname
     Failure/Error: expect(network_controller.send(:retrieve_event_stream_selection)).to eq('ceilometer')

       expected: "ceilometer"
            got: "amqp"

       (compared using ==)
     # ./spec/controllers/mixins/ems_common_angular_spec.rb:28:in `block (3 levels) in <top (required)>'

  3) Mixins::EmsCommonAngular.retrieve_event_stream_selection when none
     Failure/Error: expect(network_controller.send(:retrieve_event_stream_selection)).to eq('none')

       expected: "none"
            got: "amqp"

       (compared using ==)
     # ./spec/controllers/mixins/ems_common_angular_spec.rb:60:in `block (3 levels) in <top (required)>'

Finished in 4 minutes 54.7 seconds (files took 8.56 seconds to load)
7 examples, 3 failures

Failed examples:

rspec ./spec/controllers/mixins/ems_common_angular_spec.rb:39 # Mixins::EmsCommonAngular.retrieve_event_stream_selection none when amqp and ceilometer have empty hostnames
rspec ./spec/controllers/mixins/ems_common_angular_spec.rb:21 # Mixins::EmsCommonAngular.retrieve_event_stream_selection when ceilometer and amqp has empty hostname
rspec ./spec/controllers/mixins/ems_common_angular_spec.rb:55 # Mixins::EmsCommonAngular.retrieve_event_stream_selection when none
```
After:
Specs are green again :)

@miq-bot add_label gaprindashvili/yes