### PR TITLE
Add view selector to Ansible Repositories

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1347,6 +1347,7 @@ module ApplicationHelper
                         load_balancer
                         manageiq/providers/embedded_ansible/automation_manager/playbook
                         manageiq/providers/embedded_automation_manager/authentication
+                        manageiq/providers/embedded_automation_manager/configuration_script_source
                         middleware_deployment
                         middleware_domain
                         middleware_server


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/3536

Add view selector to _Automation > Ansible > Repositories_ page,
as the other pages under _Automation > Ansible_ already have it.

**Before:**
![repos-actual](https://user-images.githubusercontent.com/13417815/37156702-22eb1908-22e7-11e8-8665-fbb6243f0dc0.png)

**After:**
Grid View:
![repos_grid](https://user-images.githubusercontent.com/13417815/37156927-b2bd3e80-22e7-11e8-905a-6868eed98ede.png)
Tile View:
![repos_tile](https://user-images.githubusercontent.com/13417815/37156941-b952c9d6-22e7-11e8-827b-3a6fed127932.png)
List View:
![repos_list](https://user-images.githubusercontent.com/13417815/37156948-bc0fdba0-22e7-11e8-8d16-ca9e815a1380.png)

**Note:** I've also checked tagging support and it works fine when changing views in the page.