### PR TITLE
asset_data_uri - fix bower_components paths

### DIFF
--- a/app/assets/stylesheets/pdf/_fontawesome.scss.erb
+++ b/app/assets/stylesheets/pdf/_fontawesome.scss.erb
@@ -4,7 +4,7 @@
 
 @font-face {
   font-family: 'FontAwesome';
-  src: url(<%= asset_data_uri("font-awesome/fontawesome-webfont.ttf") %>);
+  src: url(<%= asset_data_uri("bower_components/font-awesome/fontawesome-webfont.ttf") %>);
   font-weight: normal;
   font-style: normal;
 }

--- a/app/assets/stylesheets/pdf/_fontawesome.scss.erb
+++ b/app/assets/stylesheets/pdf/_fontawesome.scss.erb
@@ -4,7 +4,7 @@
 
 @font-face {
   font-family: 'FontAwesome';
-  src: url(<%= asset_data_uri("bower_components/font-awesome/fontawesome-webfont.ttf") %>);
+  src: url(<%= asset_data_uri("bower_components/font-awesome/fonts/fontawesome-webfont.ttf") %>);
   font-weight: normal;
   font-style: normal;
 }

--- a/app/assets/stylesheets/pdf/_patternfly.scss.erb
+++ b/app/assets/stylesheets/pdf/_patternfly.scss.erb
@@ -4,7 +4,7 @@
 
 @font-face {
   font-family: "PatternFlyIcons-webfont";
-  src: url(<%= asset_data_uri("patternfly/dist/fonts/PatternFlyIcons-webfont.ttf") %>);
+  src: url(<%= asset_data_uri("bower_components/patternfly/dist/fonts/PatternFlyIcons-webfont.ttf") %>);
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
this was overlooked in #3343

bower deps using `asset_data_uri` also need the `bower_components/` prefix now

Fixes #3542 

Cc @hstastna can you test please?
Cc @skateman 