### PR TITLE
ProviderForeman - fix overriden list_row_id to return string id

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -431,7 +431,7 @@ class ProviderForemanController < ApplicationController
     if row['name'] == _("Unassigned Profiles Group") && row['id'].nil?
       "-#{row['manager_id']}-unassigned"
     else
-      row['id']
+      row['id'].to_s
     end
   end
 


### PR DESCRIPTION
Fixes #3530

By overriding `list_row_id` in ProviderForeman, it didn't get the `to_s` fix needed when moving from compressed ids to actual ids, making it impossible to actually click a foreman manager in GTL.

Adding :)

Cc @hstastna can you test please? :)