### PR TITLE
$http - redirect to login on 401, same as API

### DIFF
--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -37,6 +37,12 @@ function miqHttpInject(angular_app) {
     $httpProvider.interceptors.push(['$q', function($q) {
       return {
         responseError: function(err) {
+          if (err.status === 401) {
+            // Unauthorized - always redirect to dashboard#login
+            redirectLogin(__('$http session timed out, redirecting to the login page'));
+            return $q.reject(err);
+          }
+
           sendDataWithRx({
             serverError: err,
             source: '$http',

--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -199,9 +199,7 @@
 
       if ((response.status === 401) && !options.skipLoginRedirect) {
         // Unauthorized - always redirect to dashboard#login
-        add_flash(__('API logged out, redirecting to the login page'), 'warning');
-        window.document.location.href = '/dashboard/login?timeout=true';
-
+        redirectLogin(__('API logged out, redirecting to the login page'));
         return ret;
       }
 

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1728,3 +1728,8 @@ var fontIconChar = _.memoize(function(klass) {
   }
   return {font: font, char: char};
 });
+
+function redirectLogin(msg) {
+  add_flash(msg, 'warning');
+  window.document.location.href = '/dashboard/login?timeout=true';
+}


### PR DESCRIPTION
this just takes the API "redirect to login on 401" functionality
and adds it for $http requests as well

(since we never authenticate using $http, we can omit the special case for skipping the redirect on login-related requests)

Cc @martinpovolny you asked for it :)

But turns out, in most cases, when talking to actual rails controllers, you never get a 401, you'll get a 200 instead with some javascript to replace main_div with an error message. So.. we will need a server-side change to actually get those 401 in that case.