### PR TITLE
StaticController - add ApplicationHelper for helpers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,6 +50,8 @@ class StaticOrHaml
     scope.controller = ActionController::Base.new
     scope.view_paths << File.expand_path("../app/views", __FILE__)
 
+    scope.extend(ApplicationHelper)
+
     compiled = Haml::Engine.new(raw).render(scope)
 
     [200, {"Content-Type" => "text/html"}, [compiled]]

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -5,4 +5,5 @@ class StaticController < ActionController::Base
   protect_from_forgery :with => :exception
 
   include HighVoltage::StaticPage
+  helper ApplicationHelper
 end

--- a/app/views/static/test_haml.html.haml
+++ b/app/views/static/test_haml.html.haml
@@ -1,2 +1,4 @@
 .testclass
   Test
+
+= datepicker_input_tag("test_date")


### PR DESCRIPTION
right now, /static templates are limited to rails helpers, because ApplicationHelper is not included

if one wants to use, say, `datepicker_input_tag`, you get an ugly error instead.
Adding ApplicationHelper so we can use those.

EDIT: Also updated the /static route in jasmine config to use ApplicationHelper

Testing:

1. have the `test_haml` change in, but not the `static_controller` one
1. access `localhost:3000/static/test_haml.html.haml`
1. see an error screen
1. add the `static_controller` change
1. access `localhost:3000/static/test_haml.html.haml`
1. see text & an empty input