### PR TITLE
.travis.yml - only run ruby specs in all ruby versions, js once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,14 @@ env:
   - TEST_SUITE=spec:javascript
   - TEST_SUITE=spec:compile
   - TEST_SUITE=spec:jest
+matrix:
+  exclude:
+  - rvm: '2.4.2'
+    env: TEST_SUITE=spec:javascript
+  - rvm: '2.4.2'
+    env: TEST_SUITE=spec:compile
+  - rvm: '2.4.2'
+    env: TEST_SUITE=spec:jest
 bundler_args: --no-deployment
 before_install: source tools/ci/before_install.sh
 before_script: bundle exec rake $TEST_SUITE:setup


### PR DESCRIPTION
since `spec:javascript` is currently failing sporadically,
we want to halve the number of PRs where restarting jasmine is needed.

Not running non-ruby tests in each ruby version seems like a way to do that :).

Before:

* Ruby: 2.3.1 ; TEST_SUITE=spec
* Ruby: 2.3.1 ; TEST_SUITE=spec:javascript
* Ruby: 2.3.1 ; TEST_SUITE=spec:compile
* Ruby: 2.3.1 ; TEST_SUITE=spec:jest
* Ruby: 2.4.2 ; TEST_SUITE=spec
* Ruby: 2.4.2 ; TEST_SUITE=spec:javascript
* Ruby: 2.4.2 ; TEST_SUITE=spec:compile
* Ruby: 2.4.2 ; TEST_SUITE=spec:jest

After:

* Ruby: 2.3.1 ; TEST_SUITE=spec
* Ruby: 2.3.1 ; TEST_SUITE=spec:javascript
* Ruby: 2.3.1 ; TEST_SUITE=spec:compile
* Ruby: 2.3.1 ; TEST_SUITE=spec:jest
* Ruby: 2.4.2 ; TEST_SUITE=spec
