### PR TITLE
Fix for the infinte spinner on Playbook Catalog Item Edit Form Reset

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -168,6 +168,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     vm.catalogItemModel = angular.copy(vm.modelCopy);
     playbookReusableCodeMixin.formOptions(vm);
     playbookReusableCodeMixin.cloudCredentialsList(vm, vm.catalogItemModel.provisioning_cloud_credential_id, vm.catalogItemModel.retirement_cloud_credential_id);
+    playbookReusableCodeMixin.checkFormDataRetrieval(vm);
     $scope.angularForm.$setUntouched(true);
     $scope.angularForm.$setPristine(true);
     miqService.miqFlash('warn', __('All changes have been reset'));

--- a/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
+++ b/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
@@ -174,6 +174,10 @@ function playbookReusableCodeMixin(API, $q, miqService) {
       })
       .catch(miqService.handleFailure)
     );
+    checkFormDataRetrieval(vm);
+  };
+
+  var checkFormDataRetrieval = function(vm) {
     $q.all(allApiPromises)
       .then(retrievedFormData(vm));
   };
@@ -242,5 +246,6 @@ function playbookReusableCodeMixin(API, $q, miqService) {
     formCloudCredentials: formCloudCredentials,
     repositoryChanged: repositoryChanged,
     setIfDefined: setIfDefined,
+    checkFormDataRetrieval: checkFormDataRetrieval,
   };
 }


### PR DESCRIPTION
Add a check for the data and stop the spinner when the Reset button is pressed on the Ansible Playbook Catalog Item edit form.

Links
-----------

https://bugzilla.redhat.com/show_bug.cgi?id=1553785

Steps for Testing/QA 
-------------------------------
1. Edit a Playbook Catalog Item 
2. Make a change and press Reset 
 - infinite spinner before this change