### PR TITLE
Enable grid as view model for policy assignment screens

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -3,6 +3,7 @@ module ApplicationController::PolicySupport
 
   # Assign/unassign policies to/from a set of objects
   def protect
+    @gtl_type  = "grid"
     @display   = nil
     @edit      = session[:edit]
     profile_id = params[:id].to_i


### PR DESCRIPTION
### Changes view type for policy assignment
When assigning policy for any items table (list) view is visible. This is not correct since we users expect quadicons. This PR fixes such issue adding `@gtl_type` to proctect method, same applies for explorer screens.
### UI changes
#### Before
![screenshot from 2018-03-09 10-55-28](https://user-images.githubusercontent.com/3439771/37201714-bb668ebe-2388-11e8-90c5-1f4870f88f1f.png)
#### After
![screenshot from 2018-03-09 10-53-28](https://user-images.githubusercontent.com/3439771/37201484-24a3601a-2388-11e8-8b0f-4208563d5207.png)

### BZ
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1553071