### PR TITLE
Load the custom.css that bypasses the asset pipeline on every screen

### DIFF
--- a/app/views/dashboard/saml_login.html.haml
+++ b/app/views/dashboard/saml_login.html.haml
@@ -2,6 +2,7 @@
   %head
     = favicon_link_tag
     = stylesheet_link_tag 'application'
+    = stylesheet_link_tag '/custom.css'
     = javascript_include_tag 'application'
 
   %body

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,6 +10,7 @@
 
     = favicon_link_tag
     = stylesheet_link_tag 'application'
+    = stylesheet_link_tag '/custom.css'
     = render :partial => "stylesheets/template50"
     = javascript_include_tag 'application'
     - if Rails.env.development?

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -5,6 +5,7 @@
       = h productized_title(_(": Login"))
     = favicon_link_tag
     = stylesheet_link_tag 'application'
+    = stylesheet_link_tag '/custom.css'
     = javascript_include_tag 'application'
     - if Rails.env.development?
       = javascript_include_tag 'miq_debug'

--- a/app/views/layouts/remote_console.html.haml
+++ b/app/views/layouts/remote_console.html.haml
@@ -5,6 +5,7 @@
       = _('%{product_name} HTML5 Remote Console') % {:product_name => Vmdb::Appliance.PRODUCT_NAME}
     = favicon_link_tag
     = stylesheet_link_tag 'application'
+    = stylesheet_link_tag '/custom.css'
     -# Load the required JS based on the console type
     = javascript_include_tag 'jquery', "remote_consoles/#{@console[:type]}", 'remote_console'
   %body

--- a/app/views/layouts/report_only.html.haml
+++ b/app/views/layouts/report_only.html.haml
@@ -5,6 +5,7 @@
       = "%{product}: %{title}" % {:product => Vmdb::Appliance.PRODUCT_NAME, :title => @report.title}
     = favicon_link_tag
     = stylesheet_link_tag 'application'
+    = stylesheet_link_tag '/custom.css'
     = javascript_include_tag 'application'
     - if Rails.env.development?
       = javascript_include_tag 'miq_debug'


### PR DESCRIPTION
Asset precompilation on appliances is no longer possible, however, in some cases it is necessary to have custom styling applied on a running appliance. This can only be done by bypassing the asset pipeline and loading a CSS file directly from the `public` folder. To avoid 404 errors an empty CSS file has been created in the core repo.

Depends on: https://github.com/ManageIQ/manageiq/pull/17127
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1553353

@miq-bot add_label pending core