### PR TITLE
[WIP] Do not display checkboxes if they should not be visible in GTL

### DIFF
--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -24,6 +24,7 @@ class ApplicationController
     :gtl_type,
     :supported_features_filter,
     :clickable,
+    :no_checkboxes,
   ) do
     def self.from_options(options)
       additional_options = new
@@ -69,6 +70,10 @@ class ApplicationController
 
     def with_model(curr_model)
       self.model = curr_model.kind_of?(String) ? curr_model : curr_model.name
+    end
+
+    def with_no_checkboxes(no_checkboxes)
+      self.no_checkboxes = no_checkboxes
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1642,6 +1642,7 @@ module ApplicationHelper
     @report_data_additional_options.with_menu_click(params[:menu_click]) if params[:menu_click]
     @report_data_additional_options.with_sb_controller(params[:sb_controller]) if params[:sb_controller]
     @report_data_additional_options.with_model(curr_model) if curr_model
+    @report_data_additional_options.with_no_checkboxes(@no_checkboxes) if @no_checkboxes
     # FIXME: we would like to freeze here, but the @gtl_type is calculated no sooner than in view templates.
     # So until that if fixed we cannot freeze.
     # @report_data_additional_options.freeze
@@ -1658,6 +1659,7 @@ module ApplicationHelper
     end
 
     @row_button = additional_options[:row_button]
+    @no_checkboxes = additional_options[:no_checkboxes]
 
     additional_options
   end


### PR DESCRIPTION
### Do not display checkboxes if no action is needed
When in Policies, Actions or Alers checkboxes are visible. This is incorrect since there is no action with one or all items. This PR fixes such issue by adding new property to report_data_additional_options and when such data are loaded it sets `no_checkboxes` variable.
### UI changes
#### Before
![screenshot from 2018-03-09 14-27-22](https://user-images.githubusercontent.com/3439771/37209559-ffbddb90-23a5-11e8-9ed7-73d432cc5590.png)

#### After
![screenshot from 2018-03-09 14-22-55](https://user-images.githubusercontent.com/3439771/37209513-d6ced054-23a5-11e8-9df1-0d23a18d2723.png)

### Pending [ui-components](https://github.com/manageIq/ui-components)
* [ ] Merge after https://github.com/ManageIQ/ui-components/pull/267

### BZ
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1553157