### PR TITLE
Enable jsx to be loaded from js tests in jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,11 +8,13 @@ module.exports = {
   setupFiles: ['./config/jest.setup.js'],
   testRegex: '(/__tests__/.*|(\\.|_|/)(test|spec))\\.(jsx?|tsx?)$',
   transform: {
-    '^.+\\.js$': 'babel-jest',
+    '^.+\\.jsx?$': 'babel-jest',
     '.(ts|tsx)': 'ts-jest'
   },
   moduleFileExtensions: [
     'ts',
-    'js'
+    'tsx',
+    'js',
+    'jsx'
   ],
 };


### PR DESCRIPTION
### Load JSX files from JS tests
When loading JSX file from JS test it throws error that such file was not loaded. This PR fixes such issue adding JSX and TSX into list of extensions.

### UI changes
**none**

### BZ
**none**