### PR TITLE
Adds hypervisor_hostname to details and list view for OS Infra Host

### DIFF
--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -12,7 +12,7 @@ module HostHelper::TextualSummary
     TextualGroup.new(
       _("Properties"),
       %i(
-        hostname ipaddress ipmi_ipaddress custom_1 vmm_info model asset_tag service_tag osinfo
+        hostname ipaddress ipmi_ipaddress hypervisor_hostname custom_1 vmm_info model asset_tag service_tag osinfo
         power_state lockdown_mode maintenance_mode devices network storage_adapters num_cpu num_cpu_cores
         cpu_cores_per_socket memory guid
       )
@@ -131,6 +131,10 @@ module HostHelper::TextualSummary
 
   def textual_ipmi_ipaddress
     {:label => _("IPMI IP Address"), :value => @record.ipmi_address.to_s}
+  end
+
+  def textual_hypervisor_hostname
+    {:label => _("Hypervisor Hostname"), :value => @record.hypervisor_hostname.to_s}
   end
 
   def textual_custom_1

--- a/product/views/Host.yaml
+++ b/product/views/Host.yaml
@@ -20,6 +20,7 @@ db: Host
 # Columns to fetch from the main table
 cols:
 - name
+- hypervisor_hostname
 - ipaddress
 - v_owning_cluster
 - v_total_vms
@@ -44,6 +45,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- hypervisor_hostname
 - ipaddress
 - v_owning_cluster
 - v_total_vms
@@ -59,6 +61,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Hypervisor Hostname
 - IP Address
 - Cluster
 - Total VMs


### PR DESCRIPTION
Solves https://bugzilla.redhat.com/show_bug.cgi?id=1400314

Steps for Testing/QA
-------------------------------

1. Have OS undercloud in ManageIQ as Infra manager
2. Go to COMPUTE > INFRASTRUCTURE > NODES > Any node
3. Detail view should display Hypervisor Hostname
4. Go to COMPUTE > INFRASTRUCTURE > NODES > List view
5. Table should contain Hypervisor Hostname column
