### PR TITLE
Support for hidden columns in reports and views

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -962,6 +962,9 @@ class ApplicationController < ActionController::Base
     end
 
     view.headers.each_with_index do |h, i|
+      col = view.col_order[i]
+      next if view.column_is_hidden?(col)
+
       align = [:fixnum, :integer, :Fixnum, :float].include?(column_type(view.db, view.col_order[i])) ? 'right' : 'left'
 
       root[:head] << {:text    => h,
@@ -1020,6 +1023,8 @@ class ApplicationController < ActionController::Base
       end
 
       view.col_order.each_with_index do |col, col_idx|
+        next if view.column_is_hidden?(col)
+
         celltext = nil
 
         case view.col_order[col_idx]

--- a/lib/report_formatter/text.rb
+++ b/lib/report_formatter/text.rb
@@ -73,6 +73,10 @@ module ReportFormatter
 
       return if mri.headers.empty?
       c = mri.headers.dup
+      # Remove headers of hidden columns
+      mri.col_order.each_with_index do |f, i|
+        c.delete_at(i) if mri.column_is_hidden?(f)
+      end
       c.each_with_index do |f, i|
         c[i] = f.to_s.center(@max_col_width[i])
       end
@@ -107,6 +111,8 @@ module ReportFormatter
         end
         mri.col_formats ||= []                 # Backward compat - create empty array for formats
         mri.col_order.each_with_index do |f, i|
+          next if mri.column_is_hidden?(f)
+
           unless ["<compare>", "<drift>"].include?(mri.db)
             data = mri.format(f,
                               r[f],

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -21,34 +21,32 @@ describe HostController do
     it "renders show_list and does not include hidden column" do
       allow(controller).to receive(:render)
       report = FactoryGirl.create(:miq_report,
-                                  :name => 'Hosts',
-                                  :title => 'Hosts',
-                                  :cols => ['name', 'ipaddress', 'v_total_vms'],
-                                  :col_order => ['name', 'ipaddress', 'v_total_vms'],
-                                  :headers => ['Name', 'IP Address', 'VMs'],
-                                  :col_options => {"name" => {:hidden=>true}}
-      )
+                                  :name        => 'Hosts',
+                                  :title       => 'Hosts',
+                                  :cols        => %w(name ipaddress v_total_vms),
+                                  :col_order   => %w(name ipaddress v_total_vms),
+                                  :headers     => %w(Name IP\ Address VMs),
+                                  :col_options => {"name" => {:hidden => true}})
       expect(controller).to receive(:get_db_view).and_return(report)
       controller.send(:report_data)
       view_hash = controller.send(:view_to_hash, assigns(:view))
-      expect(view_hash[:head]).not_to include({:text => "Name", :sort => "str", :col_idx => 0, :align => "left"})
-      expect(view_hash[:head]).to include({:text => "IP Address", :sort => "str", :col_idx => 1, :align => "left"})
+      expect(view_hash[:head]).not_to include(:text => "Name", :sort => "str", :col_idx => 0, :align => "left")
+      expect(view_hash[:head]).to include(:text => "IP Address", :sort => "str", :col_idx => 1, :align => "left")
     end
 
     it "renders show_list and includes all columns" do
       allow(controller).to receive(:render)
       report = FactoryGirl.create(:miq_report,
-                                  :name => 'Hosts',
-                                  :title => 'Hosts',
-                                  :cols => ['name', 'ipaddress', 'v_total_vms'],
-                                  :col_order => ['name', 'ipaddress', 'v_total_vms'],
-                                  :headers => ['Name', 'IP Address', 'VMs']
-      )
+                                  :name      => 'Hosts',
+                                  :title     => 'Hosts',
+                                  :cols      => %w(name ipaddress v_total_vms),
+                                  :col_order => %w(name ipaddress v_total_vms),
+                                  :headers   => %w(Name IP\ Address VMs))
       expect(controller).to receive(:get_db_view).and_return(report)
       controller.send(:report_data)
       view_hash = controller.send(:view_to_hash, assigns(:view))
-      expect(view_hash[:head]).to include({:text => "Name", :sort => "str", :col_idx => 0, :align => "left"})
-      expect(view_hash[:head]).to include({:text => "IP Address", :sort => "str", :col_idx => 1, :align => "left"})
+      expect(view_hash[:head]).to include(:text => "Name", :sort => "str", :col_idx => 0, :align => "left")
+      expect(view_hash[:head]).to include(:text => "IP Address", :sort => "str", :col_idx => 1, :align => "left")
     end
 
     it 'edit renders GTL grid with selected Host records' do


### PR DESCRIPTION
Columns, including headers with MiqReport#col_options[<column_name>][:hidden] = true should not
are included in html, pdf, text output formats and only be included in csv

Depends on https://github.com/ManageIQ/manageiq/pull/17133

/cc @dclarizio 