### PR TITLE
Generic Object - fix extra vm.angularForm and nonused angularForm

### DIFF
--- a/app/views/static/generic_object/custom-image-component.html.haml
+++ b/app/views/static/generic_object/custom-image-component.html.haml
@@ -19,7 +19,7 @@
                   :title     => t,
                   :alt       => t,
                   :enabled   => "true",
-                  'on-click' => "vm.uploadClicked(angularForm)"}
+                  'on-click' => "vm.uploadClicked()"}
 .form-group{'ng-if' => "vm.pictureUrlPath !== '' && !vm.changeImage && !vm.pictureRemove"}
   %label.col-md-2.control-label{"for" => "custom_image"}
     = _("Current Custom Image File")

--- a/app/views/static/generic_object/main_custom_button_form.html.haml
+++ b/app/views/static/generic_object/main_custom_button_form.html.haml
@@ -36,7 +36,7 @@
           = "<#{_('Choose')}>"
       %span.help-block{"ng-show" => "angularForm.dialog_id.$error.required"}
         = _("Required")
-  .form-group{"ng-class" => "{'has-error': vm.angularForm.display.$invalid}"}
+  .form-group{"ng-class" => "{'has-error': angularForm.display.$invalid}"}
     %label.col-md-2.control-label{"for" => "custom_button_open_url"}
       = _("Open URL")
     .col-md-8


### PR DESCRIPTION
main custom button form contains the actual form, does not get angularForm via bindings, so should not use vm

custom image component *should* use vm, but the function does not actually take args

(noticed these while looking at network controllers, where `vm.angularForm` is never right)

Cc @AparnaKarve 