### PR TITLE
Provisioning properties tab should reflect that tenant will be chosen automatically

### DIFF
--- a/app/views/miq_request/_prov_dialog_cloud_quota.html.haml
+++ b/app/views/miq_request/_prov_dialog_cloud_quota.html.haml
@@ -7,6 +7,7 @@
   - cloud_tenant_name = @edit[:new][:cloud_tenant][1]
   - cloud_tenant_id   = @edit[:new][:cloud_tenant][0]
   - instance_type     = @edit[:new][:instance_type][1]
+  - placement_auto    = @edit[:new][:placement_auto][0]
   -# [:service, :quota_name, "label"]
   - quotas = [[:compute, :instances, _("instances")], [:compute, :cores, _("vcpus")], [:compute, :ram, _("(MB) memory")]]
   - quotas = quotas.each_with_object({}) { |q, h| h[q[2]] = lookup_quota(cloud_tenant_id, q[0], q[1]) }
@@ -14,7 +15,11 @@
 #cloud_quota
   %p{:class => "legend"}
     = _("Cloud Quota")
-  - if cloud_tenant_name
+  - if placement_auto
+    = _("Cloud Tenant:")
+    %strong
+      = _("Automatic Placement")
+  - elsif cloud_tenant_name
     = _("Cloud Tenant:")
     %strong
       = cloud_tenant_name


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1519496 by indicating on the Properties tab whether automatic placement was selected on the Environment tab.

![automaticplacement](https://user-images.githubusercontent.com/628956/37232450-0e0815be-23bd-11e8-86d0-789ce13ec311.png)
