### PR TITLE
Fixed code that displays values saved for NTP Servers for selected zone

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1194,6 +1194,8 @@ module OpsController::Settings::Common
     when "z"
       @servers = []
       @record = @zone = @selected_zone = Zone.find(nodes.last)
+      @ntp_servers = @selected_zone&.settings_for_resource&.ntp ?
+        @selected_zone.settings_for_resource.ntp.to_h[:server].join(", ") : ''
       @right_cell_text = my_zone_name == @selected_zone.name ?
           _("Settings %{model} \"%{name}\" (current)") % {:name  => @selected_zone.description,
                                                           :model => ui_lookup(:model => @selected_zone.class.to_s)} :

--- a/app/views/ops/_settings_evm_servers_tab.html.haml
+++ b/app/views/ops/_settings_evm_servers_tab.html.haml
@@ -26,7 +26,7 @@
           = _("NTP Servers")
         .col-md-8
           %p.form-control-static
-            = @selected_zone.settings[:ntp] ? @selected_zone.settings[:ntp][:server].join(", ") : ''
+            = @ntp_servers
 
       .form-group
         %label.col-md-2.control-label

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -231,6 +231,18 @@ describe OpsController do
           expect(edit[:new]).to eq(edit[:current])
         end
       end
+
+      context 'zone node' do
+        it 'sets ntp server info for display' do
+          controller.instance_variable_set(:@sb, :active_tab => 'settings_zone')
+          controller.instance_variable_set(:@edit, :new => {:ntp => {:server => ["example1.com", "example2.com"]}})
+          _guid, miq_server, zone = EvmSpecHelper.local_guid_miq_server_zone
+          controller.send(:zone_save_ntp_server_settings, zone)
+          allow(MiqServer).to receive(:my_server).and_return(miq_server)
+          controller.send(:settings_get_info, "z-#{zone.id}")
+          expect(assigns(:ntp_servers)).to eq("example1.com, example2.com")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1553771

before:
![before](https://user-images.githubusercontent.com/3450808/37232452-0ee4183e-23bd-11e8-8c2b-b64fb5f3cf55.png)

after:
![after](https://user-images.githubusercontent.com/3450808/37232448-0ba71ee6-23bd-11e8-9051-13f5c384f0bb.png)

@bdunne @chrisarcand please review, fixed to display NTP servers values for a Zone, this issue was introduced by changes in following 2 PRs
https://github.com/ManageIQ/manageiq-ui-classic/pull/2720
https://github.com/ManageIQ/manageiq-ui-classic/pull/2359 (fixes saving of NTP servers from UI)

@dclarizio please review.