### PR TITLE
Fixed CSP for webmks Console

### DIFF
--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -28,7 +28,7 @@ module VmRemote
     options = case console_type
               when "webmks"
                 # TODO: move this part to the launch_html5_console method
-                override_content_security_policy_directives(:connect_src => ["'self'", websocket_origin], :img_src => %w(data: self))
+                override_content_security_policy_directives(:connect_src => ["'self'", websocket_origin], :img_src => %w(data: 'self'))
                 %i(secret url).each { |p| params.require(p) }
                 @console = {
                   :url    => j(params[:url]),


### PR DESCRIPTION
Images from the webmks css causes CSP errors in browser console and evm.log
Was already fixed for HTML5 console (https://github.com/ManageIQ/manageiq-ui-classic/pull/2833)