### PR TITLE
tsconfig - enable allowJs, jsx:"react"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,9 @@
     "target": "es5",
     "typeRoots": [
       "app/javascript/typings"
-    ]
+    ],
+    "allowJs": true,
+    "jsx": "react"
   },
   "exclude": [
     "**/*.spec.ts",


### PR DESCRIPTION
`jsx: "react"` is needed when importing a jsx file from typescript, or using tsx
`allowJs: true` is needed when importing a js/jsx file from typescript

Cc @karelhala, @martinpovolny 

Extracted from https://github.com/ManageIQ/manageiq-ui-classic/pull/3517
Needed by https://github.com/ManageIQ/manageiq-ui-classic/pull/3228