### PR TITLE
Webpack - CommonsChunkPlugin - force for node_modules

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -60,6 +60,7 @@ module.exports = {
     }),
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
+      minChunks: module => /node_modules/.test(module.resource),
     }),
   ],
 


### PR DESCRIPTION
CommonsChunkPlugin defaults to only putting libraries in vendor.js if they are used at least twice.

What we really want instead is to put only external dependencies in vendor.js, regardless of how many times they are used.

This ensures anything under `node_modules` will get in vendor.js

Extracted from https://github.com/ManageIQ/manageiq-ui-classic/pull/3517
([docs](https://webpack.js.org/plugins/commons-chunk-plugin/#passing-the-minchunks-property-a-function))