### PR TITLE
webpacker.yml - remove .vue

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -10,7 +10,6 @@ default: &default
   - .jsx
   - .ts
   - .tsx
-  - .vue
   - .sass
   - .scss
   - .css


### PR DESCRIPTION
removed .vue from webpacker.yml, just because we're not using vue :)

Extracted from https://github.com/ManageIQ/manageiq-ui-classic/pull/3517