### PR TITLE
ManageIQ global cleanup, use for (old) component registry

### DIFF
--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -5,45 +5,45 @@ if (! window.ManageIQ) {
     afterOnload: null, // JS code to be evaluated after onload
     angular: {
       app: null, // angular application
-      scope: null,  // helper scope, pending refactor
-      rxSubject: null,  // an observable
       eventNotificationsData: null, // used by the notification drawer
+      rxSubject: null,  // an observable
+      scope: null,  // helper scope, pending refactor
     },
     browser: null, // browser name
-    controller: null, // stored controller, used to build URL
-    changes: null, // indicate if there are unsaved changes
-    editor: null, // instance of CodeMirror editor
-    toolbars: null, // toolbars
-    oneTransition: {
-      IEButtonPressed: false, // pressed save/reset button identificator
-      oneTrans: null, // used to generate Ajax request only once for a drawn screen
-    },
-    noCollapseEvent: false, // enable/disable events fired after collapsing an accordion
-    expEditor: {
-      prefillCount: 0, //
-      first: {
-        title: null, //
-        type: null, //
-      },
-      second: {
-        title: null, //
-        type: null, //
-      },
-    },
     calendar: { // TODO about to be removed
       calDateFrom: null, // to limit calendar starting
       calDateTo: null, // to limit calendar ending
       calSkipDays: null,  // to disable specific days of week
     },
+    changes: null, // indicate if there are unsaved changes
     charts: {
-      provider: null, // name of charting provider for provider-specific code
-      chartData: null, // data for charts
-      formatters: {}, // functions corresponding to MiqReport::Formatting
       c3: {}, // C3 charts by id
       c3config: null, // C3 chart configuration
+      chartData: null, // data for charts
+      formatters: {}, // functions corresponding to MiqReport::Formatting
+      provider: null, // name of charting provider for provider-specific code
+    },
+    controller: null, // stored controller, used to build URL
+    editor: null, // instance of CodeMirror editor
+    expEditor: {
+      first: {
+        title: null,
+        type: null,
+      },
+      prefillCount: 0,
+      second: {
+        title: null,
+        type: null,
+      },
     },
     explorer: {}, // methods to manipulate explorer screens through ExplorerPresenter
+    gridChecks: [], // list of checked checkboxes in current list grid
     grids: {}, // stored grids on the screen
+    gtl: {
+      isFirst: null,
+      isLast: null,
+      loading: null,
+    },
     i18n: {
       mark_translated_strings: false,
     },
@@ -51,39 +51,39 @@ if (! window.ManageIQ) {
       x: null, // mouse X coordinate for popup menu
       y: null, // mouse Y coordinate for popup menu
     },
+    noCollapseEvent: false, // enable/disable events fired after collapsing an accordion
+    observe: { // keeping track of data-miq_observe requests
+      processing: false, // is a request currently being processed?
+      queue: [], // a queue of pending requests
+    },
+    oneTransition: {
+      IEButtonPressed: false, // pressed save/reset button identificator
+      oneTrans: null, // used to generate Ajax request only once for a drawn screen
+    },
+    qe: {
+      autofocus: 0, // counter of pending autofocus fields
+      debounce_counter: 1,
+      debounced: {}, // running debounces
+    },
     record: {
       parentClass: null, // parent record ID for JS function miqGridSort to build URL
       parentId: null, // parent record ID for JS function miqGridSort to build URL
       recordId: null, // record being displayed or edited
     },
+    redux: null, // Redux API - app/javascript/miq-redux
     reportEditor: {
-      valueStyles: null,
       prefillCount: 0,
+      valueStyles: null,
+    },
+    toolbars: null,
+    tree: {
+      checkUrl: null,
+      clickUrl: null,
+      expandAll: true,
     },
     widget: {
       dashboardUrl: null, // set dashboard widget drag drop url
       menuXml: null,
     },
-    tree: {
-      expandAll: true,
-      clickUrl: null,
-      checkUrl: null
-    },
-    gtl: {
-      loading: null,
-      isLast: null,
-      isFirst: null
-    },
-    gridChecks: [], // list of checked checkboxes in current list grid
-    observe: { // keeping track of data-miq_observe requests
-      processing: false, // is a request currently being processed?
-      queue: [], // a queue of pending requests
-    },
-    qe: {
-      autofocus: 0, // counter of pending autofocus fields
-      debounced: {}, // running debounces
-      debounce_counter: 1,
-    },
-    redux: null // Redux API
   };
 }

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -65,6 +65,10 @@ if (! window.ManageIQ) {
       debounce_counter: 1,
       debounced: {}, // running debounces
     },
+    react: { // react component registry
+      mount: null, // mounter function
+      componentRegistry: null,  // registry
+    },
     record: {
       parentClass: null, // parent record ID for JS function miqGridSort to build URL
       parentId: null, // parent record ID for JS function miqGridSort to build URL

--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -1,7 +1,7 @@
 module ReactjsHelper
   def mount_react_component(name, selector, data = [])
     javascript_tag(:defer => 'defer') do
-      "$(MiqReact.mount('#{name}', '#{selector}', #{data.to_json}));".html_safe
+      "$(ManageIQ.react.mount('#{name}', '#{selector}', #{data.to_json}));".html_safe
     end
   end
 end

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -8,7 +8,7 @@
 import { mount } from '../react/mounter';
 import componentRegistry from '../react/componentRegistry';
 
-ManageIQ.react = Object.assign(ManageIQ.react || {}, {
-  mount: mount,
-  componentRegistry: componentRegistry,
-});
+ManageIQ.react = {
+  mount,
+  componentRegistry,
+};

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -8,8 +8,7 @@
 import { mount } from '../react/mounter';
 import componentRegistry from '../react/componentRegistry';
 
-// TODO: use ManageIQ object, once race conditions are fixed
-window.MiqReact = Object.assign(window.MiqReact || {}, {
+ManageIQ.react = Object.assign(ManageIQ.react || {}, {
   mount: mount,
-  componentRegistry: componentRegistry
+  componentRegistry: componentRegistry,
 });


### PR DESCRIPTION
This re-sorts the `ManageIQ` global def, makes sure it is always loaded first (already was), 
and renames `MiqReact` to `ManageIQ.react` as it should be :).

(It even contained a comment `TODO: use ManageIQ object, once race conditions are fixed`.)