### PR TITLE
Do not use .scss.erb for loading assets as there's asset_url in SASS

### DIFF
--- a/app/assets/stylesheets/pdf/_fontawesome.scss
+++ b/app/assets/stylesheets/pdf/_fontawesome.scss
@@ -4,7 +4,7 @@
 
 @font-face {
   font-family: 'FontAwesome';
-  src: url(<%= asset_data_uri("bower_components/font-awesome/fonts/fontawesome-webfont.ttf") %>);
+  src: asset_url("bower_components/font-awesome/fonts/fontawesome-webfont.ttf");
   font-weight: normal;
   font-style: normal;
 }

--- a/app/assets/stylesheets/pdf/_patternfly.scss
+++ b/app/assets/stylesheets/pdf/_patternfly.scss
@@ -4,7 +4,7 @@
 
 @font-face {
   font-family: "PatternFlyIcons-webfont";
-  src: url(<%= asset_data_uri("PatternFlyIcons-webfont.ttf") %>);
+  src: asset_url("PatternFlyIcons-webfont.ttf");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Using `css.erb` can be forgiven, but `scss.erb` is totally unnecessary as there's an `asset_url` helper in `sass-rails`. Merge after: #3571