### PR TITLE
Remove caching

### DIFF
--- a/app/helpers/ops_helper/my_server.rb
+++ b/app/helpers/ops_helper/my_server.rb
@@ -4,6 +4,6 @@ module OpsHelper::MyServer
   end
 
   def my_server
-    @my_server ||= MiqServer.my_server(true)
+    MiqServer.my_server
   end
 end


### PR DESCRIPTION
[MiqServer.my_server in the model is a cache](https://github.com/ManageIQ/manageiq/blob/f7662924f46afacd1eae42d5cefa06c2a2abba34/app/models/miq_server.rb#L547), we shouldn't need to cache it again here.  I found this while [fixing a zone issue](https://github.com/ManageIQ/manageiq/pull/17139) for https://github.com/ManageIQ/manageiq-ui-classic/pull/3582