### PR TITLE
Do not display policy shield on single quads in GTL view

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -199,7 +199,6 @@ module QuadiconHelper
     if item.kind_of?(VmOrTemplate) && quadicon_policy_sim? && !session[:policies].empty?
       output << flobj_img_small(img_for_compliance(item), "e72")
     end
-    output << flobj_img_simple('100/shield.png', "g72") if item.try(:get_policies).present?
     output << flobj_img_simple(quad_image(item), "e72")
   end
 

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -736,8 +736,6 @@ describe QuadiconHelper do
     let(:options) { {:mode => :icon} }
     subject(:quadicon) { helper.render_resource_pool_quadicon(item, options) }
 
-    include_examples :shield_img_with_policies
-
     it 'has a vapp image when vapp' do
       item.vapp = true
 


### PR DESCRIPTION
I looked into older versions of ManageIQ and found out that the policy shield is not being displayed on single quads. Also it doesn't even look good, so :scissors: :fire: :wastebasket: 

**Before:**
![screenshot from 2018-03-13 09-37-46](https://user-images.githubusercontent.com/649130/37330831-940f8a92-26a2-11e8-9fb1-92e98e2c6ec5.png)

**After:**
![screenshot from 2018-03-13 09-38-30](https://user-images.githubusercontent.com/649130/37330845-99c73a34-26a2-11e8-8f4b-cc8bb087362a.png)

@miq-bot assign @epwinchell 
cc @martinpovolny, @karelhala, @dclarizio 