### PR TITLE
Revert "Update description on VMRC configuration tab"

### DIFF
--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -332,7 +332,7 @@
         .form-group
           .col-md-12
             %span{:style => "color:black"}
-              = _("Used for VMRC connections to all VMs on this provider.")
+              = _("Used for VMRC connections to all VMs on this provider. If not set, the VMRC console access will be disabled for this provider.")
     - elsif controller_name == "ems_container"
       = miq_tab_content('container_metrics', 'default') do
         .form-group


### PR DESCRIPTION
This is unnecessary as the description is valid...

This reverts commit 7e1e8c8de57995af3fbfc0935a418f174f555fc6.

https://bugzilla.redhat.com/show_bug.cgi?id=1552147

@miq-bot assign @mzazrivec 
FYI @bmclaughlin 