### PR TITLE
Drop the unnecessary argument from the quadicon decorator methods

### DIFF
--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -11,7 +11,7 @@ class ExtManagementSystemDecorator < MiqDecorator
     "svg/vendor-#{image_name}.svg"
   end
 
-  def quadicon(_n = nil)
+  def quadicon
     {
       :top_left     => {:text => try(:hosts).try(:size).to_i},
       :top_right    => {:text => ""},

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -7,7 +7,7 @@ class HostDecorator < MiqDecorator
     "svg/vendor-#{vmm_vendor_display.downcase}.svg"
   end
 
-  def quadicon(_n = nil)
+  def quadicon
     {
       :top_left     => {:text => vms.size},
       :top_right    => {:fileicon => "svg/currentstate-#{ERB::Util.h(normalized_state.downcase)}.svg"},

--- a/app/decorators/manageiq/providers/cloud_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager_decorator.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::CloudManagerDecorator < MiqDecorator
     "svg/vendor-#{image_name}.svg"
   end
 
-  def quadicon(_n = nil)
+  def quadicon
     {
       :top_left     => {:text => total_vms},
       :top_right    => {:text => total_miq_templates},

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
     "svg/vendor-#{image_name}.svg"
   end
 
-  def quadicon(_n = nil)
+  def quadicon
     {
       :top_left     => {:text => container_nodes.size},
       :top_right    => {:state_icon => "svg/currentstate-#{enabled? ? 'on' : 'paused'}.svg"},

--- a/app/decorators/manageiq/providers/infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/infra_manager_decorator.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::InfraManagerDecorator < ExtManagementSystemDecorator
     "svg/vendor-#{image_name}.svg"
   end
 
-  def quadicon(_n = nil)
+  def quadicon
     {
       :top_left     => {:text => hosts.size},
       :top_right    => {:text => total_vms},

--- a/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::PhysicalInfraManagerDecorator < ExtManagementSystemDe
     "svg/vendor-#{image_name}.svg"
   end
 
-  def quadicon(_n = nil)
+  def quadicon
     {
       :top_left     => {:text => physical_servers.size},
       :top_right    => {:text => ""},

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -7,7 +7,7 @@ class PhysicalServerDecorator < MiqDecorator
     'pficon pficon-server'
   end
 
-  def quadicon(_n = nil)
+  def quadicon
     {
       :top_left     => {:text => (host ? 1 : 0)},
       :top_right    => {

--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -8,7 +8,7 @@ class StorageDecorator < MiqDecorator
     "100/piecharts/datastore-#{percent}.png"
   end
 
-  def quadicon(_n = nil)
+  def quadicon
     {
       :top_left     => {
         :fileicon => store_type_icon,

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -215,15 +215,12 @@ module QuadiconHelper
   end
 
   def quadicon_for_item(item)
-    quad_settings = if item.kind_of?(VmOrTemplate)
-                      {
-                        :show_compliance => @lastaction == "policy_sim" || quadicon_policy_sim?,
-                        :policies        => session[:policies]
-                      }
-                    else
-                      {}
-                    end
-    quadicon = item.decorate.try(:quadicon, quad_settings)
+    quadicon = if item.kind_of?(VmOrTemplate)
+                 item.decorate.try(:quadicon, :show_compliance => @lastaction == "policy_sim" || quadicon_policy_sim?,
+                                              :policies        => session[:policies])
+               else
+                 item.decorate.try(:quadicon)
+               end
     if quadicons_from_settings(calculate_quad_db(item)) && quadicon
       quad_decorator(quadicon, item)
     else


### PR DESCRIPTION
Single quadicons will be declared as separate methods for each decorator, so the `_n` argument is not necessary.

@miq-bot add_label cleanup, gtls, gaprindashvili/no
@miq-bot assign @mzazrivec 