### PR TITLE
Unify fileicon and free_space_fileicon for StorageDecorator

### DIFF
--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -4,8 +4,8 @@ class StorageDecorator < MiqDecorator
   end
 
   def fileicon
-    percent = (used_space_percent_of_total.to_i + 9) / 10
-    "100/piecharts/datastore-#{percent}.png"
+    percent = v_free_space_percent_of_total == 100 ? 20 : ((v_free_space_percent_of_total + 2) / 5.25).round # val is the percentage value of free space
+    "100/piecharts/datastore/#{percent}.png"
   end
 
   def quadicon(_n = nil)
@@ -17,7 +17,7 @@ class StorageDecorator < MiqDecorator
       :top_right    => {:text => v_total_vms},
       :bottom_left  => {:text => v_total_hosts},
       :bottom_right => {
-        :fileicon => free_space_fileicon
+        :fileicon => fileicon
       }
     }
   end
@@ -26,10 +26,5 @@ class StorageDecorator < MiqDecorator
 
   def store_type_icon
     "100/storagetype-#{store_type.nil? ? "unknown" : ERB::Util.h(store_type.to_s.downcase)}.png"
-  end
-
-  def free_space_fileicon
-    percent = v_free_space_percent_of_total == 100 ? 20 : ((v_free_space_percent_of_total + 2) / 5.25).round # val is the percentage value of free space
-    "100/piecharts/datastore/#{percent}.png"
   end
 end

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -1033,7 +1033,7 @@ describe QuadiconHelper do
 
     context "when @settings does not include :storage" do
       it 'shows used space' do
-        expect(storage_quad).to have_selector("img[src*='datastore-8']")
+        expect(storage_quad).to have_selector("img[src*='datastore/5']")
       end
 
       it 'includes the base-single img' do


### PR DESCRIPTION
These two methods produce inverted results. The `fileicon` was producing an error but as we never noticed it, I think it has been never used. So overwriting the `fileicon` with the `free_space_fileicon`.

@miq-bot add_label gtls, gaprindashvili/no, cleanup
@miq-bot assign @epwinchell 