### PR TITLE
Hide "Hide Deprecated" checkbox and remove "Deprecated" column when provisioning infra VM

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -152,7 +152,7 @@ module ApplicationController::MiqRequestMethods
     @edit[:vm_sortdir] ||= "ASC"
     @edit[:vm_sortcol] ||= "name"
     @edit[:prov_type] = "VM Provision"
-    @edit[:hide_deprecated_templates] = true
+    @edit[:hide_deprecated_templates] = true if request.parameters[:controller] == "vm_cloud"
     unless %w(image_miq_request_new miq_template_miq_request_new).include?(params[:pressed])
       @edit[:template_kls] = get_template_kls
       templates = Rbac.filtered(@edit[:template_kls].eligible_for_provisioning).sort_by { |a| a.name.downcase }
@@ -404,10 +404,11 @@ module ApplicationController::MiqRequestMethods
       "cpu_total_cores"               => _("CPUs"),
       "mem_cpu"                       => _("Memory"),
       "allocated_disk_storage"        => _("Disk Size"),
-      "deprecated"                    => _("Deprecated"),
       "ext_management_system.name"    => _("Provider"),
       "v_total_snapshots"             => _("Snapshots"),
     }
+
+    headers["deprecated"] = _("Deprecated") if request.parameters[:controller] == "vm_cloud"
 
     # add tenant column header to cloud workflows only
     headers["cloud_tenant"] = _("Tenant") if vms.any? { |vm| vm.respond_to?(:cloud_tenant) }

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -5,10 +5,11 @@
     = _("Provision %{what} based on the selected %{type}") % {:what => ui_lookup(:tables => request.parameters[:controller]), :type => typ}
   %label
     - id = @edit[:req_id] || "new"
-    %input{:type => "checkbox",
-           :onclick => "miqAjax('" + url_for_only_path({:action => "vm_pre_prov", :id => id.to_s, :hide_deprecated_templates => !@edit[:hide_deprecated_templates]}) + "')",
-           :checked => @edit[:hide_deprecated_templates]}
-      = _('Hide deprecated')
+    - unless @edit[:hide_deprecated_templates].nil?
+      %input{:type => "checkbox",
+             :onclick => "miqAjax('" + url_for_only_path({:action => "vm_pre_prov", :id => id.to_s, :hide_deprecated_templates => !@edit[:hide_deprecated_templates]}) + "')",
+             :checked => @edit[:hide_deprecated_templates]}
+        = _('Hide deprecated')
   %table.table.table-bordered.table-hover.table-striped.table-selectable
     %thead
       %tr

--- a/app/views/miq_request/_pre_prov_images.html.haml
+++ b/app/views/miq_request/_pre_prov_images.html.haml
@@ -17,8 +17,9 @@
     = h(number_to_human_size(row.mem_cpu.to_i * 1024 * 1024))
   %td
     = h(number_to_human_size(row.allocated_disk_storage))
-  %td
-    = h(row.deprecated ? _("true") : _("false"))
+  - if @edit[:vm_headers].key?('deprecated')
+    %td
+      = h(row.deprecated ? _("true") : _("false"))
   %td
     - if row.ext_management_system
       = h(row.ext_management_system.name)

--- a/app/views/miq_request/_prov_vm_grid.html.haml
+++ b/app/views/miq_request/_prov_vm_grid.html.haml
@@ -52,8 +52,9 @@
               = h(number_to_human_size(row.mem_cpu.to_i * 1024 * 1024))
             %td
               = h(number_to_human_size(row.allocated_disk_storage))
-            %td
-              = h(row.deprecated ? _("true") : _("false"))
+            - if @edit[:vm_headers].key?('deprecated')
+              %td
+                = h(row.deprecated ? _("true") : _("false"))
             %td
               - if row.ext_management_system
                 = h(row.ext_management_system.name)
@@ -85,8 +86,9 @@
             = h(number_to_human_size(@vm.mem_cpu.to_i * 1024 * 1024))
           %td
             = h(number_to_human_size(@vm.allocated_disk_storage))
-          %td
-            = h(@vm.deprecated ? _("true") : _("false"))
+          - if @edit[:vm_headers].key?('deprecated')
+            %td
+              = h(@vm.deprecated ? _("true") : _("false"))
           %td
             - if @vm.ext_management_system
               = h(@vm.ext_management_system.name)


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1399378

On pre provisioning screen, hide _"Hide Deprecated"_ checkbox and remove _"Deprecated"_ column from the table when user is submitting a provisioning request for **Infrastructure** VM, as those (the checkbox and the column) apply only to **_cloud_** provisioning. Cloud provisioning remains unchanged.

---

**Before:**
![infra_prov_before1](https://user-images.githubusercontent.com/13417815/37361083-5001ff42-26f2-11e8-973e-944e388096b8.png)
![infra_prov_before2](https://user-images.githubusercontent.com/13417815/37361089-534e09a2-26f2-11e8-9fcb-8ef17fc6cdcd.png)

**After:**
![infra_prov1](https://user-images.githubusercontent.com/13417815/37360742-648e051a-26f1-11e8-9c04-810fb5ef279a.png)
![infra_prov2](https://user-images.githubusercontent.com/13417815/37360749-69af9018-26f1-11e8-99e6-2801edc57cd8.png)


