### PR TITLE
Define single_quad methods for each model decorator that has a quadicon

### DIFF
--- a/app/decorators/availability_zone_decorator.rb
+++ b/app/decorators/availability_zone_decorator.rb
@@ -6,4 +6,10 @@ class AvailabilityZoneDecorator < MiqDecorator
   def self.fileicon
     '100/availability_zone.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/cloud_network_decorator.rb
+++ b/app/decorators/cloud_network_decorator.rb
@@ -6,4 +6,10 @@ class CloudNetworkDecorator < MiqDecorator
   def self.fileicon
     '100/cloud_network.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/cloud_object_store_container_decorator.rb
+++ b/app/decorators/cloud_object_store_container_decorator.rb
@@ -6,4 +6,10 @@ class CloudObjectStoreContainerDecorator < MiqDecorator
   def self.fileicon
     '100/cloud_object_store_container.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/cloud_object_store_object_decorator.rb
+++ b/app/decorators/cloud_object_store_object_decorator.rb
@@ -6,4 +6,10 @@ class CloudObjectStoreObjectDecorator < MiqDecorator
   def self.fileicon
     '100/cloud_object_store_container.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/cloud_subnet_decorator.rb
+++ b/app/decorators/cloud_subnet_decorator.rb
@@ -6,4 +6,10 @@ class CloudSubnetDecorator < MiqDecorator
   def self.fileicon
     '100/cloud_subnet.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/cloud_tenant_decorator.rb
+++ b/app/decorators/cloud_tenant_decorator.rb
@@ -6,4 +6,10 @@ class CloudTenantDecorator < MiqDecorator
   def self.fileicon
     '100/cloud_tenant.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/cloud_volume_backup_decorator.rb
+++ b/app/decorators/cloud_volume_backup_decorator.rb
@@ -6,4 +6,10 @@ class CloudVolumeBackupDecorator < MiqDecorator
   def self.fileicon
     '100/cloud_volume.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/cloud_volume_decorator.rb
+++ b/app/decorators/cloud_volume_decorator.rb
@@ -6,4 +6,10 @@ class CloudVolumeDecorator < MiqDecorator
   def self.fileicon
     '100/cloud_volume.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/cloud_volume_snapshot_decorator.rb
+++ b/app/decorators/cloud_volume_snapshot_decorator.rb
@@ -6,4 +6,10 @@ class CloudVolumeSnapshotDecorator < MiqDecorator
   def self.fileicon
     '100/cloud_volume_snapshot.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_build_decorator.rb
+++ b/app/decorators/container_build_decorator.rb
@@ -6,4 +6,10 @@ class ContainerBuildDecorator < MiqDecorator
   def self.fileicon
     '100/container_build.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_decorator.rb
+++ b/app/decorators/container_decorator.rb
@@ -6,4 +6,10 @@ class ContainerDecorator < MiqDecorator
   def self.fileicon
     '100/container.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_group_decorator.rb
+++ b/app/decorators/container_group_decorator.rb
@@ -6,4 +6,10 @@ class ContainerGroupDecorator < MiqDecorator
   def self.fileicon
     '100/container_group.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_image_decorator.rb
+++ b/app/decorators/container_image_decorator.rb
@@ -6,4 +6,10 @@ class ContainerImageDecorator < MiqDecorator
   def self.fileicon
     '100/container_image.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_image_registry_decorator.rb
+++ b/app/decorators/container_image_registry_decorator.rb
@@ -6,4 +6,10 @@ class ContainerImageRegistryDecorator < MiqDecorator
   def self.fileicon
     '100/container_image_registry.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_node_decorator.rb
+++ b/app/decorators/container_node_decorator.rb
@@ -6,4 +6,10 @@ class ContainerNodeDecorator < MiqDecorator
   def self.fileicon
     '100/container_node.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_project_decorator.rb
+++ b/app/decorators/container_project_decorator.rb
@@ -6,4 +6,10 @@ class ContainerProjectDecorator < MiqDecorator
   def self.fileicon
     '100/container_project.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_replicator_decorator.rb
+++ b/app/decorators/container_replicator_decorator.rb
@@ -6,4 +6,10 @@ class ContainerReplicatorDecorator < MiqDecorator
   def self.fileicon
     '100/container_replicator.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_route_decorator.rb
+++ b/app/decorators/container_route_decorator.rb
@@ -6,4 +6,10 @@ class ContainerRouteDecorator < MiqDecorator
   def self.fileicon
     '100/container_route.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_service_decorator.rb
+++ b/app/decorators/container_service_decorator.rb
@@ -6,4 +6,10 @@ class ContainerServiceDecorator < MiqDecorator
   def self.fileicon
     '100/container_service.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_template_decorator.rb
+++ b/app/decorators/container_template_decorator.rb
@@ -6,4 +6,10 @@ class ContainerTemplateDecorator < MiqDecorator
   def self.fileicon
     '100/container_template.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/container_volume_decorator.rb
+++ b/app/decorators/container_volume_decorator.rb
@@ -2,4 +2,10 @@ class ContainerVolumeDecorator < MiqDecorator
   def self.fonticon
     'pficon pficon-volume'
   end
+
+  def single_quad
+    {
+      :fileicon => '100/container_volume.png'
+    }
+  end
 end

--- a/app/decorators/ems_cluster_decorator.rb
+++ b/app/decorators/ems_cluster_decorator.rb
@@ -6,4 +6,10 @@ class EmsClusterDecorator < MiqDecorator
   def self.fileicon
     '100/ems_cluster.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -25,4 +25,10 @@ class ExtManagementSystemDecorator < MiqDecorator
       }
     }
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/flavor_decorator.rb
+++ b/app/decorators/flavor_decorator.rb
@@ -6,4 +6,10 @@ class FlavorDecorator < MiqDecorator
   def self.fileicon
     '100/flavor.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/floating_ip_decorator.rb
+++ b/app/decorators/floating_ip_decorator.rb
@@ -6,4 +6,10 @@ class FloatingIpDecorator < MiqDecorator
   def self.fileicon
     '100/floating_ip.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/host_aggregate_decorator.rb
+++ b/app/decorators/host_aggregate_decorator.rb
@@ -1,0 +1,5 @@
+class HostAggregateDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-screen'
+  end
+end

--- a/app/decorators/host_aggregate_decorator.rb
+++ b/app/decorators/host_aggregate_decorator.rb
@@ -2,4 +2,10 @@ class HostAggregateDecorator < MiqDecorator
   def self.fonticon
     'pficon pficon-screen'
   end
+
+  def single_quad
+    {
+      :fileicon => '100/host_aggregate.png'
+    }
+  end
 end

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -21,4 +21,10 @@ class HostDecorator < MiqDecorator
       }
     }
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/load_balancer_decorator.rb
+++ b/app/decorators/load_balancer_decorator.rb
@@ -6,4 +6,10 @@ class LoadBalancerDecorator < MiqDecorator
   def self.fileicon
     '100/load_balancer.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/manageiq/providers/cloud_manager/auth_key_pair_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager/auth_key_pair_decorator.rb
@@ -3,5 +3,11 @@ module ManageIQ::Providers
     def self.fileicon
       '100/auth_key_pair.png'
     end
+
+    def single_quad
+      {
+        :fileicon => fileicon
+      }
+    end
   end
 end

--- a/app/decorators/manageiq/providers/cloud_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager_decorator.rb
@@ -25,4 +25,10 @@ class ManageIQ::Providers::CloudManagerDecorator < MiqDecorator
       }
     }
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/manageiq/providers/configuration_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/configuration_manager_decorator.rb
@@ -7,5 +7,11 @@ module ManageIQ::Providers
     def fileicon
       "svg/vendor-#{image_name.downcase}.svg"
     end
+
+    def single_quad
+      {
+        :fileicon => fileicon
+      }
+    end
   end
 end

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -25,4 +25,10 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
       }
     }
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/manageiq/providers/infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/infra_manager_decorator.rb
@@ -25,4 +25,10 @@ class ManageIQ::Providers::InfraManagerDecorator < ExtManagementSystemDecorator
       }
     }
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
@@ -25,4 +25,10 @@ class ManageIQ::Providers::PhysicalInfraManagerDecorator < ExtManagementSystemDe
       }
     }
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -26,6 +26,12 @@ class MiqTemplateDecorator < MiqDecorator
     }
   end
 
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
+
   private
 
   def os_image

--- a/app/decorators/network_port_decorator.rb
+++ b/app/decorators/network_port_decorator.rb
@@ -6,4 +6,10 @@ class NetworkPortDecorator < MiqDecorator
   def self.fileicon
     '100/network_port.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/network_router_decorator.rb
+++ b/app/decorators/network_router_decorator.rb
@@ -6,4 +6,10 @@ class NetworkRouterDecorator < MiqDecorator
   def self.fileicon
     '100/network_router.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/orchestration_stack_decorator.rb
+++ b/app/decorators/orchestration_stack_decorator.rb
@@ -2,4 +2,10 @@ class OrchestrationStackDecorator < MiqDecorator
   def self.fonticon
     'ff ff-stack'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -25,7 +25,11 @@ class PhysicalServerDecorator < MiqDecorator
     }
   end
 
-  alias_method :single_quad, :fileicon
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 
   private
 

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -25,6 +25,8 @@ class PhysicalServerDecorator < MiqDecorator
     }
   end
 
+  alias_method :single_quad, :fileicon
+
   private
 
   def health_state_img

--- a/app/decorators/resource_pool_decorator.rb
+++ b/app/decorators/resource_pool_decorator.rb
@@ -6,4 +6,10 @@ class ResourcePoolDecorator < MiqDecorator
   def fileicon
     vapp ? '100/vapp.png' : '100/resource_pool.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/security_group_decorator.rb
+++ b/app/decorators/security_group_decorator.rb
@@ -6,4 +6,10 @@ class SecurityGroupDecorator < MiqDecorator
   def self.fileicon
     '100/security_group.png'
   end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
 end

--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -22,6 +22,12 @@ class StorageDecorator < MiqDecorator
     }
   end
 
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
+
   private
 
   def store_type_icon

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -30,6 +30,12 @@ class VmOrTemplateDecorator < MiqDecorator
     }
   end
 
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
+
   private
 
   def os_image


### PR DESCRIPTION
All quadicons can be rendered as a single-quad, so moving the definition of these quads into the decorators. In the future it will be possible to choose between `quadicon` or `single_quad` based on the user settings or what is available.

@miq-bot add_label gtls, gaprindashvili/no