### PR TITLE
Do not display GTL toolbars on non-GTL screens when navigating from the list

### DIFF
--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -23,8 +23,8 @@ class GenericObjectDefinitionController < ApplicationController
     self.x_active_tree ||= :generic_object_definitions_tree
     self.x_node ||= 'root'
     build_tree
-    node_info(x_node)
     process_show_list
+    node_info(x_node)
   end
 
   def show
@@ -179,6 +179,7 @@ class GenericObjectDefinitionController < ApplicationController
     @center_toolbar = 'generic_object_definition'
     @record = GenericObjectDefinition.find(node.split('-').last)
     @right_cell_text = _("Generic Object Class %{record_name}") % {:record_name => @record.name}
+    @gtl_type = nil
   end
 
   def actions_node_info(node)
@@ -186,6 +187,7 @@ class GenericObjectDefinitionController < ApplicationController
     @center_toolbar = 'generic_object_definition_actions_node'
     @record = GenericObjectDefinition.find(node.split('-').last)
     @right_cell_text = _("Actions for %{model}") % {:model => _("Generic Object Class")}
+    @gtl_type = nil
   end
 
   def custom_button_group_node_info(node)
@@ -193,6 +195,7 @@ class GenericObjectDefinitionController < ApplicationController
     @center_toolbar = 'generic_object_definition_button_group'
     @record = CustomButtonSet.find(node.split("-").last)
     @right_cell_text = _("Custom Button Set %{record_name}") % {:record_name => @record.name}
+    @gtl_type = nil
   end
 
   def custom_button_node_info(node)
@@ -200,6 +203,7 @@ class GenericObjectDefinitionController < ApplicationController
     @center_toolbar = 'generic_object_definition_button'
     @record = CustomButton.find(node.split("-").last)
     @right_cell_text = _("Custom Button %{record_name}") % {:record_name => @record.name}
+    @gtl_type = nil
   end
 
   def render_form(title, form_partial)

--- a/spec/controllers/generic_object_definition_controller_spec.rb
+++ b/spec/controllers/generic_object_definition_controller_spec.rb
@@ -92,6 +92,54 @@ describe GenericObjectDefinitionController do
 
       expect(toolbar_array[0][2][:id]).to eq('view_list')
       expect(toolbar_array[0][2][:url]).to eq('/show_list')
+
+      gtl_type = controller.instance_variable_get(:@gtl_type)
+      expect(gtl_type).to eq('list')
+    end
+  end
+
+  context "GTL rendering for various node types" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as FactoryGirl.create(:user)
+      @generic_obj_defn = FactoryGirl.create(:generic_object_definition)
+    end
+
+    it "renders the toolbar for root node with gtl icons" do
+      allow(controller).to receive(:x_node).and_return("root")
+      controller.send(:show_list)
+      gtl_type = controller.instance_variable_get(:@gtl_type)
+      expect(gtl_type).to eq('list')
+    end
+
+    it "renders the toolbar for god node with no gtl icons" do
+      allow(controller).to receive(:x_node).and_return("god-#{@generic_obj_defn.id}")
+      controller.send(:show_list)
+      gtl_type = controller.instance_variable_get(:@gtl_type)
+      expect(gtl_type).to eq(nil)
+    end
+
+    it "renders the toolbar for actions node with no gtl icons" do
+      allow(controller).to receive(:x_node).and_return("xx-#{@generic_obj_defn.id}")
+      controller.send(:show_list)
+      gtl_type = controller.instance_variable_get(:@gtl_type)
+      expect(gtl_type).to eq(nil)
+    end
+
+    it "renders the toolbar for custom_button_group node with no gtl icons" do
+      custom_button_set = FactoryGirl.create(:custom_button_set, :description => "custom button set description")
+      allow(controller).to receive(:x_node).and_return("cbg-#{custom_button_set.id}")
+      controller.send(:show_list)
+      gtl_type = controller.instance_variable_get(:@gtl_type)
+      expect(gtl_type).to eq(nil)
+    end
+
+    it "renders the toolbar for custom_button node with no gtl icons" do
+      custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "GenericObjectDefinition", :name => "Some Name")
+      allow(controller).to receive(:x_node).and_return("cb-#{custom_button.id}")
+      controller.send(:show_list)
+      gtl_type = controller.instance_variable_get(:@gtl_type)
+      expect(gtl_type).to eq(nil)
     end
   end
 


### PR DESCRIPTION
Currently, when navigating from the GO Definition list, the GTL buttons are displayed in the GO Definition Summary screen, which is not correct. 
This issue is also visible on other summary screens like Custom Button, Custom Group(non-GTL screens) when the view is reloaded.
Navigating from the tree, however, displays the correct toolbar with no GTL buttons.

The PR fixes this inconsistency.

Before (List navigation shows GTL buttons in Summary screen) -
<img width="1330" alt="screen shot 2018-03-13 at 10 35 49 am" src="https://user-images.githubusercontent.com/1538216/37361703-bffccc24-26b0-11e8-8244-4a0a1421c7aa.png">


After (List navigation does not show GTL buttons in Summary screen) -
<img width="1233" alt="screen shot 2018-03-13 at 11 14 30 am" src="https://user-images.githubusercontent.com/1538216/37361757-e3a88cda-26b0-11e8-9d65-130eb9dac325.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1545835