### PR TITLE
Ops Database: do not store vmdb_tables in the session.

### DIFF
--- a/app/helpers/ops_helper/textual_summary.rb
+++ b/app/helpers/ops_helper/textual_summary.rb
@@ -150,7 +150,7 @@ module OpsHelper::TextualSummary
         :value    => typ == :rows ? number_with_delimiter(row.latest_hourly_metric.send(typ.to_s), :delimeter => ',') :
                                  number_to_human_size(row.latest_hourly_metric.send(typ.to_s), :precision => 1),
         :explorer => true,
-        :link     => "miqTreeActivateNode('vmdb_tree', 'tb-#{@sb[:vmdb_tables][row.name]}');"
+        :link     => "miqTreeActivateNode('vmdb_tree', 'tb-#{row.id}');"
       }
     end
   end

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -26,11 +26,6 @@ class TreeBuilderOpsVmdb < TreeBuilderOps
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
     objects = Rbac.filtered(VmdbDatabase.my_database.try(:evm_tables).to_a).to_a
-    # storing table names and their id in hash so they can be used to build links on summary screen in top 5 boxes
-    @sb[:vmdb_tables] = {}
-    objects.each do |o|
-      @sb[:vmdb_tables][o.name] = o.id
-    end
     count_only_or_objects(count_only, objects, "name")
   end
 


### PR DESCRIPTION
Don't store `@sb[:vmdb_tables]`.

It's only used once, that that use is a non-sense as the `rows` --> `row` already includes the `:id`.

Ping @skateman, @lpichler 