### PR TITLE
Move out the policy simulation result logic from the related quads

### DIFF
--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -7,8 +7,7 @@ class MiqTemplateDecorator < MiqDecorator
     "svg/vendor-#{vendor.downcase}.svg"
   end
 
-  def quadicon(settings = {})
-    show_compliance = settings[:show_compliance] && settings[:policies].present?
+  def quadicon
     {
       :top_left     => {
         :fileicon => os_image,
@@ -22,7 +21,9 @@ class MiqTemplateDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => type
       },
-      :bottom_right => show_compliance ? compliance_image(settings[:policies].keys) : {:text => ERB::Util.h(v_total_snapshots)}
+      :bottom_right => {
+        :text => ERB::Util.h(v_total_snapshots)
+      }
     }
   end
 
@@ -30,13 +31,5 @@ class MiqTemplateDecorator < MiqDecorator
 
   def os_image
     "svg/os-#{ERB::Util.h(os_image_name.downcase)}.svg"
-  end
-
-  # FIXME: this will be unnecessary after the conditional policies are dropped from the decorators
-  def compliance_image(policies)
-    {
-      :fileicon => QuadiconHelper::Decorator.compliance_img(passes_profiles?(policies)),
-      :tooltip  => passes_profiles?(get_policies)
-    }
   end
 end

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -11,8 +11,7 @@ class VmOrTemplateDecorator < MiqDecorator
     "svg/vendor-#{vendor.downcase}.svg"
   end
 
-  def quadicon(settings = {})
-    show_compliance = settings[:show_compliance] && settings[:policies].present?
+  def quadicon
     {
       :top_left     => {
         :fileicon => os_image,
@@ -26,7 +25,9 @@ class VmOrTemplateDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => type
       },
-      :bottom_right => show_compliance ? compliance_image(settings[:policies].keys) : {:text => ERB::Util.h(v_total_snapshots)}
+      :bottom_right => {
+        :text => ERB::Util.h(v_total_snapshots)
+      }
     }
   end
 
@@ -34,13 +35,5 @@ class VmOrTemplateDecorator < MiqDecorator
 
   def os_image
     "svg/os-#{ERB::Util.h(os_image_name.downcase)}.svg"
-  end
-
-  # FIXME: this will be unnecessary after the conditional policies are dropped from the decorators
-  def compliance_image(policies)
-    {
-      :fileicon => QuadiconHelper::Decorator.compliance_img(passes_profiles?(policies)),
-      :tooltip  => passes_profiles?(get_policies)
-    }
   end
 end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -215,12 +215,15 @@ module QuadiconHelper
   end
 
   def quadicon_for_item(item)
-    quadicon = if item.kind_of?(VmOrTemplate)
-                 item.decorate.try(:quadicon, :show_compliance => @lastaction == "policy_sim" || quadicon_policy_sim?,
-                                              :policies        => session[:policies])
-               else
-                 item.decorate.try(:quadicon)
-               end
+    quadicon = item.decorate.try(:quadicon)
+
+    if item.kind_of?(VmOrTemplate) && (@lastaction == "policy_sim" || quadicon_policy_sim?) && session[:policies].present?
+      quadicon[:bottom_right] = {
+        :fileicon => QuadiconHelper::Decorator.compliance_img(item.passes_profiles?(session[:policies].keys)),
+        :tooltip  => item.passes_profiles?(session[:policies].keys)
+      }
+    end
+
     if quadicons_from_settings(calculate_quad_db(item)) && quadicon
       quad_decorator(quadicon, item)
     else


### PR DESCRIPTION
Decorators should not depend on external data, i.e. should not accept external arguments. For now the decorator was responsible for changing the `bottom_right` quadrant of a vm or template quadicon to the policy simulation result. This PR moves out the feature to the quadicon helper and so removes the need for an argument on the `quadicon` method. 

Steps to test:
* Go to `Compute -> Infrastructure -> Virtual Machines`
* Check at least one VM or template
* In the toolbar open `Policy -> Policy Simulation`
* Select some policies from the dropdown and watch the bottom-right quadrant(s)

@miq-bot add_label refactoring, gaprindashvili/no, GTLs