### PR TITLE
Fix displaying 'CPU' and 'CPU Cores' when creating chargeback rate

### DIFF
--- a/app/helpers/chargeback_helper.rb
+++ b/app/helpers/chargeback_helper.rb
@@ -1,12 +1,13 @@
 module ChargebackHelper
   def rate_detail_group(rd_group)
     rd_groups = {
-      'cpu'     => _('CPU'),
-      'disk_io' => _('Disk I/O'),
-      'fixed'   => _('Fixed'),
-      'memory'  => _('Memory'),
-      'net_io'  => _('Network I/O'),
-      'storage' => _('Storage')
+      'cpu'       => _('CPU'),
+      'cpu_cores' => _('CPU Cores'),
+      'disk_io'   => _('Disk I/O'),
+      'fixed'     => _('Fixed'),
+      'memory'    => _('Memory'),
+      'net_io'    => _('Network I/O'),
+      'storage'   => _('Storage')
     }
     rd_groups[rd_group] || rd_group.titleize
   end

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -6,7 +6,7 @@
 
 %tr.rdetail{:id => "rate_detail_row_#{i}_0"}
   %td{:rowspan => n.to_s}
-    = Dictionary.gettext(r[:group], :type => :rate_detail_group, :notfound => :titleize)
+    = h(rate_detail_group(r[:group]))
   %td{:rowspan => n.to_s}
     = r[:description]
     - if breakdown_present


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1521113

**Done:**
- fix displaying _**CPU** Cores_ instead of _Cpu Cores_ under the _Group_ column for
_Allocated CPU Cores_/_Used CPU Cores_, when creating a new chargeback rate
- fix displaying _**CPU**_ instead of _Cpu_ under the _Group_ column for _Allocated CPU Count_/_Used CPU_,
when adding a new `tier` (row under the _CPU_ Group), when creating a new chargeback rate
- similarly for _Disk **I/O**_ (which changes to _Disk Io_ when adding a new tier and we don't want this)
-  similarly for _**Network I/O**_ (->  _Net Io_).

**Note:** I used the same way (and working!) of displaying a group in the table as it is in more other places, for example:
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/chargeback/_cb_rate_edit_table.html.haml#L33
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/chargeback/_cb_rate_show.html.haml#L41
so I consider the code (2nd commit in this PR) more consistent than it was before

**Note 2:** We create new Compute or Storage chargeback rates under _Cloud Intel > Chargeback > Rates_ accordion.

---

**Before:**
Displaying _Cpu Cores_:
![cpu_cores_before](https://user-images.githubusercontent.com/13417815/37406079-97f77d82-2796-11e8-8210-5d7309036b81.png)
Displaying _Cpu_, _Disk Io_, _Net Io_, after adding a new tier:
![cpu_bad](https://user-images.githubusercontent.com/13417815/37418142-cd23dd6e-27b1-11e8-8209-5d3c7baa8f53.png)

**After:**
Displaying _**CPU** Cores_:
![cpu_cores_after](https://user-images.githubusercontent.com/13417815/37408754-0c94b406-279d-11e8-8b56-7911c0101508.png)
Displaying _**CPU**_, _Disk **I/O**_, _**Network I/O**_, after adding a new tier:
![cpu_fixed](https://user-images.githubusercontent.com/13417815/37416478-301ec8d8-27ae-11e8-8110-e16043bbaa8d.png)
