### PR TITLE
Support single quad for Physical Infrastructure Provider quadicons

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -93,15 +93,16 @@ class ApplicationController < ActionController::Base
   # Default UI settings
   DEFAULT_SETTINGS = {
     :quadicons => { # Show quad icons, by resource type
-      :service         => true,
-      :ems             => true,
-      :ems_cloud       => true,
-      :host            => true,
-      :miq_template    => true,
-      :physical_server => true,
-      :storage         => true,
-      :vm              => true,
-      :ems_container   => true
+      :service            => true,
+      :ems                => true,
+      :ems_cloud          => true,
+      :ems_physical_infra => true,
+      :host               => true,
+      :miq_template       => true,
+      :physical_server    => true,
+      :storage            => true,
+      :vm                 => true,
+      :ems_container      => true
     },
     :views     => { # List view setting, by resource type
       :authkeypaircloud                                                       => "list",

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -553,6 +553,7 @@ class ConfigurationController < ApplicationController
       @edit[:new][:quadicons][:host] = params[:quadicons_host] == "true" if params[:quadicons_host]
       @edit[:new][:quadicons][:vm] = params[:quadicons_vm] == "true" if params[:quadicons_vm]
       @edit[:new][:quadicons][:physical_server] = params[:quadicons_physical_server] == "true" if params[:quadicons_physical_server]
+      @edit[:new][:quadicons][:ems_physical_infra] = params[:quadicons_ems_physical_infra] == "true" if params[:quadicons_ems_physical_infra]
       @edit[:new][:quadicons][:miq_template] = params[:quadicons_miq_template] == "true" if params[:quadicons_miq_template]
       if ::Settings.product.proto # Hide behind proto setting - Sprint 34
         @edit[:new][:quadicons][:service] = params[:quadicons_service] == "true" if params[:quadicons_service]

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -552,9 +552,10 @@ module QuadiconHelper
 
   def db_for_quadicon
     case @layout
-    when "ems_infra" then :ems
-    when "ems_cloud" then :ems_cloud
-    else                  :ems_container
+    when "ems_infra"          then :ems
+    when "ems_cloud"          then :ems_cloud
+    when "ems_physical_infra" then :ems_physical_infra
+    else :ems_container
     end
   end
 

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -11,16 +11,17 @@
         %fieldset
           %h3
             = _('Grid/Tile Icons')
-          -# render condition                                 title                                      check_box label & checked T/F
+          -# render condition                                           title                          check_box label & checked T/F
           -# Host Item is commented (condition set as false) until we have host item quads
-          - [[role_allows?(:feature => "ems_infra_show_list"), _("Infrastructure Provider"),              "ems"],
-             [role_allows?(:feature => "ems_cloud_show_list"), _("Cloud Provider"),                       "ems_cloud"],
-             [role_allows?(:feature => "ems_container_show_list"), _("Containers Provider"),              "ems_container"],
-             [role_allows?(:feature => "host_show_list"),      _("Host"),                                 "host"],
-             [role_allows?(:feature => "storage_show_list"),   _("Datastores"),                           "storage"],
-             [true,                                           _("VM"),                                   "vm"],
-             [true,                                           _("Physical Server"),                                   "physical_server"],
-             [true,                                           _("Template"),                             "miq_template"]].each do |icons_checkbox|
+          - [[role_allows?(:feature => "ems_infra_show_list"),          _("Infrastructure Provider"), "ems"],
+             [role_allows?(:feature => "ems_cloud_show_list"),          _("Cloud Provider"),          "ems_cloud"],
+             [role_allows?(:feature => "ems_container_show_list"),      _("Containers Provider"),     "ems_container"],
+             [role_allows?(:feature => "ems_physical_infra_show_list"), _("Physical Infra Provider"), "ems_physical_infra"],
+             [role_allows?(:feature => "host_show_list"),               _("Host"),                    "host"],
+             [role_allows?(:feature => "storage_show_list"),            _("Datastores"),              "storage"],
+             [true,                                                     _("VM"),                      "vm"],
+             [true,                                                     _("Physical Server"),         "physical_server"],
+             [true,                                                     _("Template"),                "miq_template"]].each do |icons_checkbox|
             - if icons_checkbox[0]
               .form-group
                 %label.col-md-3.control-label


### PR DESCRIPTION
All 4-view quadicons allow a single icon view and this can be configured per-user under `My Settings`. The physical infrastructure provider doesn't have this feature. However, we :heart: consistency so adding it now!

![screenshot from 2018-03-14 16-28-25](https://user-images.githubusercontent.com/649130/37412194-bd2f4b30-27a4-11e8-8b1b-d25498fb91b7.png)

![screenshot from 2018-03-14 16-24-07](https://user-images.githubusercontent.com/649130/37412192-bd0ae18c-27a4-11e8-868e-1100cd69b3ce.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1555389

@miq-bot add_label gaprindashvili/yes, bug, gtls