### PR TITLE
Respect RBAC rules for physical server quadicon settings

### DIFF
--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -20,7 +20,7 @@
              [role_allows?(:feature => "host_show_list"),               _("Host"),                    "host"],
              [role_allows?(:feature => "storage_show_list"),            _("Datastores"),              "storage"],
              [true,                                                     _("VM"),                      "vm"],
-             [true,                                                     _("Physical Server"),         "physical_server"],
+             [role_allows?(:feature => "physical_server_show_list"),    _("Physical Server"),         "physical_server"],
              [true,                                                     _("Template"),                "miq_template"]].each do |icons_checkbox|
             - if icons_checkbox[0]
               .form-group


### PR DESCRIPTION
When having a user without access to physical servers, it should not see the quadicon switch under `My Settings`.

**Before:**
![screenshot from 2018-03-14 16-32-20](https://user-images.githubusercontent.com/649130/37413865-39d4e980-27a8-11e8-9b39-5de5abdfd9ec.png)

**After:**
![screenshot from 2018-03-14 16-52-42](https://user-images.githubusercontent.com/649130/37413857-36256a30-27a8-11e8-9659-becaf2c5dcba.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1555400

@miq-bot add_label bug, gaprindashvili/yes