### PR TITLE
Display flash message after Cloud Network delete is initiated.

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -26,11 +26,7 @@ class CloudNetworkController < ApplicationController
       return tag("CloudNetwork")
     when 'cloud_network_delete'
       delete_networks
-      if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
-        replace_gtl_main_div
-      else
-        render_flash
-      end
+      javascript_redirect(previous_breadcrumb_url)
     when "cloud_network_edit"
       javascript_redirect :action => "edit", :id => checked_item_id
     when "cloud_network_new"
@@ -135,7 +131,6 @@ class CloudNetworkController < ApplicationController
         add_flash(_("The selected Cloud Network was deleted"))
       end
       session[:flash_msgs] = @flash_array.dup if @flash_array
-      javascript_redirect(previous_breadcrumb_url)
     end
   end
 

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -208,7 +208,17 @@ describe CloudNetworkController do
       end
       it "queues the delete action" do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :button, :params => { :id => @network.id, :pressed => "cloud_network_delete", :format => :js }
+        controller.instance_variable_set(:@_params,
+                                         :pressed => "cloud_network_delete",
+                                         :id      => @network.id)
+        allow(controller).to receive(:find_checked_ids_with_rbac).and_return([@network])
+        allow(controller).to receive(:find_id_with_rbac).and_return([@network])
+        controller.instance_variable_set(:@breadcrumbs, [{:url => "cloud_network/show_list"}, 'placeholder'])
+        expect(controller).to receive(:render)
+        controller.send(:button)
+        flash_messages = assigns(:flash_array)
+        expect(flash_messages.first).to eq(:message => "Delete initiated for 1 Cloud Network.",
+                                           :level   => :success)
       end
     end
   end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1549564

@dclarizio please review.

after:
![after](https://user-images.githubusercontent.com/3450808/37428609-2d8299e8-27a3-11e8-9954-7a9447d053eb.png)
