### PR TITLE
Support single quad for Network Provider quadicons

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,6 +97,7 @@ class ApplicationController < ActionController::Base
       :ems                => true,
       :ems_cloud          => true,
       :ems_physical_infra => true,
+      :ems_network        => true,
       :host               => true,
       :miq_template       => true,
       :physical_server    => true,

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -554,6 +554,7 @@ class ConfigurationController < ApplicationController
       @edit[:new][:quadicons][:vm] = params[:quadicons_vm] == "true" if params[:quadicons_vm]
       @edit[:new][:quadicons][:physical_server] = params[:quadicons_physical_server] == "true" if params[:quadicons_physical_server]
       @edit[:new][:quadicons][:ems_physical_infra] = params[:quadicons_ems_physical_infra] == "true" if params[:quadicons_ems_physical_infra]
+      @edit[:new][:quadicons][:ems_network] = params[:quadicons_ems_network] == "true" if params[:quadicons_ems_network]
       @edit[:new][:quadicons][:miq_template] = params[:quadicons_miq_template] == "true" if params[:quadicons_miq_template]
       if ::Settings.product.proto # Hide behind proto setting - Sprint 34
         @edit[:new][:quadicons][:service] = params[:quadicons_service] == "true" if params[:quadicons_service]

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -558,6 +558,7 @@ module QuadiconHelper
     when "ems_infra"          then :ems
     when "ems_cloud"          then :ems_cloud
     when "ems_physical_infra" then :ems_physical_infra
+    when "ems_network"        then :ems_network
     else :ems_container
     end
   end

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -17,6 +17,7 @@
              [role_allows?(:feature => "ems_cloud_show_list"),          _("Cloud Provider"),          "ems_cloud"],
              [role_allows?(:feature => "ems_container_show_list"),      _("Containers Provider"),     "ems_container"],
              [role_allows?(:feature => "ems_physical_infra_show_list"), _("Physical Infra Provider"), "ems_physical_infra"],
+             [role_allows?(:feature => "ems_network_show_list"),        _("Network Provider"),        "ems_network"],
              [role_allows?(:feature => "host_show_list"),               _("Host"),                    "host"],
              [role_allows?(:feature => "storage_show_list"),            _("Datastores"),              "storage"],
              [true,                                                     _("VM"),                      "vm"],


### PR DESCRIPTION
Analogous with #3624, adding optional single view for network provider icons.

![screenshot from 2018-03-15 13-32-43](https://user-images.githubusercontent.com/649130/37463877-d9634a9c-2856-11e8-97a9-a255c717115d.png)

![screenshot from 2018-03-15 13-33-24](https://user-images.githubusercontent.com/649130/37463880-dc306b2e-2856-11e8-8f07-5522c927ed2d.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1556883

@miq-bot add_label bug, gaprindashvili/yes, gtls