### PR TITLE
Fix storage_controller to show custom buttons

### DIFF
--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -479,8 +479,9 @@ class StorageController < ApplicationController
     c_tb = build_toolbar(center_toolbar_filename) unless @in_a_form
     h_tb = build_toolbar('x_history_tb')
     v_tb = build_toolbar('x_gtl_view_tb') unless record_showing || (x_active_tree == :storage_pod_tree && x_node == 'root') || @in_a_form
+    cb_tb = build_toolbar(custom_toolbar_explorer)
 
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb)
+    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb, :custom => cb_tb)
     presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.present?, :toolbar)
     presenter[:record_id] = @record.try(:id)
 
@@ -523,6 +524,10 @@ class StorageController < ApplicationController
     ]
   end
   helper_method :textual_group_list
+
+  def custom_toolbar_explorer
+    @record.present? ? Mixins::CustomButtons::Result.new(:single) : Mixins::CustomButtons::Result.new(:list)
+  end
 
   menu_section :inf
   has_custom_buttons


### PR DESCRIPTION
Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/996

Steps to reproduce:

- Go to Automation > Automate > Customization, Buttons accordion
- pick Datastore in the tree
- create a group, and a custom button
- then go to Compute > Infrastructure > Datastores
- click on a datastore
Before:
<img width="1207" alt="screen shot 2018-03-15 at 2 26 24 pm" src="https://user-images.githubusercontent.com/9210860/37465963-df1e296a-285c-11e8-9150-343eb5d306d1.png">
<img width="1205" alt="screen shot 2018-03-15 at 2 26 16 pm" src="https://user-images.githubusercontent.com/9210860/37465964-df389106-285c-11e8-95c7-8a3166945686.png">

After:
<img width="1197" alt="screen shot 2018-03-15 at 2 17 45 pm" src="https://user-images.githubusercontent.com/9210860/37465882-a782835c-285c-11e8-9bed-e00e1d205f65.png">
<img width="1210" alt="screen shot 2018-03-15 at 2 17 31 pm" src="https://user-images.githubusercontent.com/9210860/37465883-a79b3b0e-285c-11e8-847e-6e7afab4995b.png">


It cannot rely on `@lastaction == "show_list"` because it's always `"explorer"`. Introduced in https://github.com/ManageIQ/manageiq/pull/11793

@miq-bot add_label bug, toolbars, gaprindashvili/yes

