### PR TITLE
Use keys for policySimulation when single quad is rendered

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -237,7 +237,7 @@ module QuadiconHelper
   end
 
   def img_for_compliance(item)
-    QuadiconHelper::Decorator.compliance_img(item.passes_profiles?(session[:policies]))
+    QuadiconHelper::Decorator.compliance_img(item.passes_profiles?(session[:policies].keys))
   end
 
   def img_for_vendor(item)


### PR DESCRIPTION
### Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/3599
When running policySimulation for single quad items error is thrown. This PR fixes such issue by running policy simulation with stored policie's keys.

### UI changes
#### Before
![649130/37330521-a2b12fca-26a1-11e8-9b76-a76bbed2ffe7.png](https://user-images.githubusercontent.com/649130/37330521-a2b12fca-26a1-11e8-9b76-a76bbed2ffe7.png)
#### After
![screenshot from 2018-03-15 15-02-28](https://user-images.githubusercontent.com/3439771/37467989-015494f6-2862-11e8-8a86-eae3c4986982.png)
