### PR TITLE
Use fileicon instead state_icon in container provider powerstate quad

### DIFF
--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -14,7 +14,7 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
   def quadicon
     {
       :top_left     => {:text => container_nodes.size},
-      :top_right    => {:state_icon => "svg/currentstate-#{enabled? ? 'on' : 'paused'}.svg"},
+      :top_right    => {:fileicon => "svg/currentstate-#{enabled? ? 'on' : 'paused'}.svg"},
       :bottom_left  => {
         :fileicon => fileicon,
         :tooltip  => type


### PR DESCRIPTION
Missed this one from #3537

**Before:**
![screenshot from 2018-03-15 15-07-32](https://user-images.githubusercontent.com/649130/37468212-9d4aee28-2862-11e8-8e1a-175a5857df14.png)

**After:**
![screenshot from 2018-03-15 15-05-54](https://user-images.githubusercontent.com/649130/37468133-6652a8d4-2862-11e8-8a68-ff8c8db10450.png)

@miq-bot add_label bug, gaprindashvili/no, gtls