### PR TITLE
Add Keystone Domain to EmsInfra form

### DIFF
--- a/app/views/ems_infra/_form.html.haml
+++ b/app/views/ems_infra/_form.html.haml
@@ -94,6 +94,18 @@
                             "maxlength"   => 6,
                             "checkchange" => ""}
 
+    .form-group{"ng-class" => "{'has-error': angularForm.keystone_v3_domain_id.$invalid}", "ng-if" => "emsCommonModel.api_version == 'v3' && (emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra')"}
+      %label.col-md-2.control-label{"for" => "ems_keystone_domain_id"}
+        = _('Keystone V3 Domain ID')
+      .col-md-4
+        %input.form-control{"type"        => "text",
+                            "id"          => "ems_keystone_domain_id",
+                            "name"        => "keystone_v3_domain_id",
+                            "ng-model"    => "emsCommonModel.keystone_v3_domain_id",
+                            "required"    => true,
+                            "checkchange" => ""}
+
+
   %hr
   - if controller_name == "ems_container"
     = render :partial => "/layouts/container_auth", :locals  => {:record => @ems}


### PR DESCRIPTION
Keystone v2 can be disabled on newer OpenStack versions, we need allow Keystone v3
auth for EmsInfra. The missing thing was unspecified domain_id parameter.

Adding the keystone_domain_id field to make Keystone v3 auth working on Infra providers.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1554329
