### PR TITLE
Add new JS component API (from #3228)

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1685,6 +1685,11 @@ function correctPatternflyOptions(config) {
 }
 
 $(function() {
+  if (window.__testing__) {
+    // in a jest test
+    return;
+  }
+
   $(window).on('resize', miqInitAccordions);
   $(window).on('resize', miqInitMainContent);
   $(window).on('resize', _.debounce(miqResetSizeTimer, 1000));

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -24,6 +24,7 @@ if (! window.ManageIQ) {
       provider: null, // name of charting provider for provider-specific code
     },
     controller: null, // stored controller, used to build URL
+    component: null, // Component API - app/javascript/miq-component
     editor: null, // instance of CodeMirror editor
     expEditor: {
       first: {

--- a/app/javascript/miq-component/component-typings.ts
+++ b/app/javascript/miq-component/component-typings.ts
@@ -1,0 +1,213 @@
+/**
+ * Props are component's inputs, containing data and/or callbacks.
+ *
+ * Props should be treated as immutable if possible, which greatly simplifies
+ * the data flow in your application, making it easier to understand and change.
+ */
+export interface ComponentProps {
+  [key: string]: any;
+}
+
+/**
+ * Represents a single instance of the underlying technology specific component.
+ */
+export interface BasicComponentInstance {
+
+  /**
+   * Instance `id` is used to distinguish between individual component instances.
+   *
+   * Instance `id` must be unique across all instances of the given component.
+   * Attempts to create new instances with an already taken `id` will throw an
+   * error.
+   *
+   * If not defined or not a string, the value will be auto-generated as part of
+   * the `newInstance` method.
+   */
+  id?: string;
+
+  /**
+   * Interface for component interaction.
+   *
+   * The value is entirely component specific and optional.
+   */
+  interact?: any;
+
+}
+
+/**
+ * Component instance created through (and managed by) the component API.
+ */
+export interface ManagedComponentInstance extends BasicComponentInstance {
+
+  /**
+   * Current component props.
+   *
+   * The value is initialized based on the `initialProps` parameter. Every time
+   * `instance.update` is called, the `props` value gets updated.
+   */
+  props: ComponentProps;
+
+  /**
+   * Update the component instance.
+   *
+   * This method creates new props by merging current props with `newProps` and
+   * then calls the `blueprint.update` method; any properties present in current
+   * props but missing in `newProps` will be retained.
+   *
+   * @param newProps New props to use.
+   */
+  update(
+    newProps: ComponentProps
+  ): void;
+
+  /**
+   * Destroy and unmount the component instance.
+   *
+   * Once destroyed, attempts to access properties of the instance other than `id`
+   * will throw an error.
+   */
+  destroy(
+  ): void;
+
+}
+
+export type AnyComponentInstance = BasicComponentInstance | ManagedComponentInstance;
+
+/**
+ * Blueprint used to manage component instances.
+ */
+export interface ComponentBlueprint {
+
+  /**
+   * Recipe for creating new instances.
+   *
+   * If not defined, the `newInstance` method will have no effect for the given
+   * component.
+   *
+   * Returning a reference to an existing component instance will cause the
+   * `newInstance` method to throw an error.
+   *
+   * @param props Props to use when creating the component instance.
+   * @param mountTo DOM element to mount the component instance to.
+   *
+   * @returns Object that represents the actual component instance.
+   */
+  create?(
+    props: ComponentProps,
+    mountTo?: HTMLElement
+  ): BasicComponentInstance;
+
+  /**
+   * Recipe for updating instances.
+   *
+   * If not defined, the `instance.update` method will have no effect.
+   *
+   * @param newProps New props to use.
+   * @param mountedTo DOM element to which the component instance is mounted.
+   */
+  update?(
+    newProps: ComponentProps,
+    mountedTo?: HTMLElement
+  ): void;
+
+  /**
+   * Recipe for destroying instances.
+   *
+   * Component instance that was previously mounted to a DOM element should be
+   * unmounted as part of this method.
+   *
+   * _To prevent memory leaks, components that require DOM context (have their
+   * instances mounted to a DOM element upon creation) must have their blueprint
+   * implement both `create` and `destroy` methods. Avoid leaky blueprints!_
+   *
+   * @param instance Component instance to destroy.
+   * @param unmountFrom DOM element from which to unmount the component instance.
+   */
+  destroy?(
+    instance: ManagedComponentInstance,
+    unmountFrom?: HTMLElement
+  ): void;
+
+}
+
+/**
+ * `ManageIQ.component` API.
+ */
+export interface ComponentApi {
+
+  /**
+   * Define new component.
+   *
+   * Each component has a unique `name`. Attempts to define new component with
+   * an already taken `name` will have no effect.
+   *
+   * @param name Component name.
+   * @param blueprint Blueprint used to manage component instances.
+   * @param instances Existing instances to associate with this component.
+   */
+  define(
+    name: string,
+    blueprint: ComponentBlueprint,
+    instances?: BasicComponentInstance[]
+  ): void;
+
+  /**
+   * Create new component instance and mount it to the given DOM element as
+   * necessary.
+   *
+   * Each component must be defined before creating its instances. Attempts to
+   * instantiate a component that isn't already defined will have no effect.
+   *
+   * This method delegates to component's blueprint. If the blueprint doesn't
+   * support creating new instances (`blueprint.create`), this method will have
+   * no effect.
+   *
+   * The `initialProps` object will be proxied in order to allow intercepting
+   * writes to its properties. Calling `props.foo = newValue` on the resulting
+   * props will trigger an update of the component instance. With that in mind,
+   * always treat props as immutable if possible, i.e. always prefer calling
+   * `instance.update` over current props modification.
+   *
+   * Note that the `mountTo` parameter is optional. This allows for definition
+   * of components that don't require DOM context.
+   *
+   * _Make sure to destroy component instances once they're no longer needed to
+   * prevent memory leaks._
+   *
+   * @param name Component name.
+   * @param initialProps Initial props to use when creating the instance.
+   * @param mountTo DOM element to mount the component instance to.
+   *
+   * @returns New component instance or `undefined` if it couldn't be created.
+   */
+  newInstance(
+    name: string,
+    initialProps: ComponentProps,
+    mountTo?: HTMLElement
+  ): ManagedComponentInstance | undefined;
+
+  /**
+   * Get existing component instance by its `id`.
+   *
+   * @param name Component name.
+   * @param id Component instance `id`.
+   *
+   * @returns Matching component instance or `undefined` if not found.
+   */
+  getInstance(
+    name: string,
+    id: string
+  ): AnyComponentInstance | undefined;
+
+  /**
+   * Check if a component with the given `name` is defined.
+   *
+   * @param name Component name.
+   *
+   * @returns `true` if the component is defined, `false` otherwise.
+   */
+  isDefined(
+    name: string
+  ): boolean;
+
+}

--- a/app/javascript/miq-component/helpers.js
+++ b/app/javascript/miq-component/helpers.js
@@ -1,0 +1,6 @@
+import * as registry from '../miq-component/registry';
+import reactBlueprint from '../miq-component/react-blueprint';
+
+export function addReact(name, component) {
+  return registry.define(name, reactBlueprint(component));
+}

--- a/app/javascript/miq-component/miq-component.spec.js
+++ b/app/javascript/miq-component/miq-component.spec.js
@@ -1,0 +1,494 @@
+import {
+  getDefinition,
+  sanitizeAndFreezeInstanceId,
+  validateInstance,
+  define,
+  newInstance,
+  getInstance,
+  isDefined,
+  getComponentNames,
+  getComponentInstances,
+  clearRegistry
+} from './registry';
+
+import {
+  writeProxy,
+  lockInstanceProperties
+} from './utils';
+
+describe('Component API', () => {
+  afterEach(() => {
+    clearRegistry();
+  });
+
+  it('define method can be used to register new components', () => {
+    define('FooComponent', {});
+    define('BarComponent', {}, [{}]);
+    expect(isDefined('FooComponent')).toBe(true);
+    expect(isDefined('BarComponent')).toBe(true);
+    expect(getComponentNames()).toEqual(['FooComponent', 'BarComponent']);
+  });
+
+  it('define method does nothing if the component name is already taken', () => {
+    define('FooComponent', {});
+    define('FooComponent', {});
+    expect(getComponentNames()).toEqual(['FooComponent']);
+  });
+
+  it('define method does nothing if the component name is not a string', () => {
+    define(123, {});
+    expect(isDefined(123)).toBe(false);
+    expect(getComponentNames()).toEqual([]);
+  });
+
+  it('define method can be used associate existing instances with the new component', () => {
+    var testInstances = [
+      { id: 'first' }, { id: 'second' }
+    ];
+
+    define('FooComponent', {}, testInstances);
+    expect(getInstance('FooComponent', 'first')).toBe(testInstances[0]);
+    expect(getInstance('FooComponent', 'second')).toBe(testInstances[1]);
+  });
+
+  it('when passing existing instances, define method ensures a sane instance id', () => {
+    var testInstances = [
+      { id: 'first' }, { id: 123 }, {}
+    ];
+
+    define('FooComponent', {}, testInstances);
+
+    var registeredInstances = getComponentInstances('FooComponent');
+    expect(registeredInstances.length).toBe(3);
+    expect(registeredInstances[0].id).toBe('first');
+    expect(registeredInstances[1].id).toBe('FooComponent-1');
+    expect(registeredInstances[2].id).toBe('FooComponent-2');
+  });
+
+  it('when passing existing instances, define method ensures that instance id is frozen', () => {
+    var testInstances = [
+      { id: 'first' }
+    ];
+
+    define('FooComponent', {}, testInstances);
+    expect(() => {
+      testInstances[0].id = 'second';
+    }).toThrow();
+  });
+
+  it('when passing existing instances, define method skips falsy values', () => {
+    var testInstances = [
+      false, '', null, undefined, {}
+    ];
+
+    define('FooComponent', {}, testInstances);
+
+    var registeredInstances = getComponentInstances('FooComponent');
+    expect(registeredInstances.length).toBe(1);
+    expect(registeredInstances[0].id).toBe('FooComponent-0');
+  });
+
+  it('when passing existing instances, define method throws in case of reference duplicity', () => {
+    var testInstance = { id: 'first' };
+
+    expect(() => {
+      define('FooComponent', {}, [testInstance, testInstance]);
+    }).toThrow();
+  });
+
+  it('when passing existing instances, define method throws in case of id duplicity', () => {
+    var testInstances = [
+      { id: 'first' }, { id: 'first' }
+    ];
+
+    expect(() => {
+      define('FooComponent', {}, testInstances);
+    }).toThrow();
+  });
+
+  it('newInstance method can be used to create new component instances', () => {
+    var testInstances = [
+      { id: 'first' }, { id: 'second' }
+    ];
+
+    var testBlueprint = {
+      create: jest.fn().mockName('testBlueprint.create')
+                .mockImplementationOnce(() => testInstances[0])
+                .mockImplementationOnce(() => testInstances[1])
+    };
+
+    define('FooComponent', testBlueprint);
+
+    var mountFirstInstanceTo = document.createElement('div');
+    var resultingInstances = [
+      newInstance('FooComponent', { bar: 123 }, mountFirstInstanceTo),
+      newInstance('FooComponent', { baz: true })
+    ];
+
+    expect(testBlueprint.create).toHaveBeenCalledTimes(2);
+    expect(testBlueprint.create.mock.calls[0]).toEqual([
+      { bar: 123 },
+      mountFirstInstanceTo
+    ]);
+    expect(testBlueprint.create.mock.calls[1]).toEqual([
+      { baz: true },
+      undefined
+    ]);
+
+    expect(resultingInstances[0]).toBe(testInstances[0]);
+    expect(resultingInstances[1]).toBe(testInstances[1]);
+
+    expect(resultingInstances[0].id).toBe('first');
+    expect(resultingInstances[1].id).toBe('second');
+
+    expect(resultingInstances[0].props).toEqual({ bar: 123 });
+    expect(resultingInstances[1].props).toEqual({ baz: true });
+
+    resultingInstances.forEach(instance => {
+      expect(instance.update).toEqual(expect.any(Function));
+      expect(instance.destroy).toEqual(expect.any(Function));
+    });
+
+    var registeredInstances = getComponentInstances('FooComponent');
+    expect(registeredInstances.length).toBe(2);
+    expect(registeredInstances[0]).toBe(resultingInstances[0]);
+    expect(registeredInstances[1]).toBe(resultingInstances[1]);
+  });
+
+  it('newInstance method does nothing if the component is not already defined', () => {
+    var resultingInstance = newInstance('FooComponent', { bar: 123 });
+    expect(resultingInstance).toBeUndefined();
+  });
+
+  it('newInstance method does nothing if blueprint.create is not a function', () => {
+    define('FooComponent', {});
+
+    var resultingInstance = newInstance('FooComponent', { bar: 123 });
+    expect(resultingInstance).toBeUndefined();
+  });
+
+  it('newInstance method throws if blueprint.create returns a falsy value', () => {
+    define('FooComponent', {
+      create() { return null; }
+    });
+
+    expect(() => {
+      newInstance('FooComponent', { bar: 123 });
+    }).toThrow();
+  });
+
+  it('newInstance method ensures a sane instance id', () => {
+    define('FooComponent', {
+      create: jest.fn().mockName('testBlueprint.create')
+                .mockImplementationOnce(() => ({ id: 'first' }))
+                .mockImplementationOnce(() => ({ id: 123 }))
+                .mockImplementationOnce(() => ({}))
+    });
+
+    var resultingInstances = [
+      newInstance('FooComponent', { bar: 123 }),
+      newInstance('FooComponent', { baz: true }),
+      newInstance('FooComponent', { qux: ['1337'] })
+    ];
+
+    expect(resultingInstances[0].id).toBe('first');
+    expect(resultingInstances[1].id).toBe('FooComponent-1');
+    expect(resultingInstances[2].id).toBe('FooComponent-2');
+  });
+
+  it('newInstance method ensures that instance id is frozen', () => {
+    define('FooComponent', {
+      create: jest.fn().mockName('testBlueprint.create')
+                .mockImplementationOnce(() => ({ id: 'first' }))
+    });
+
+    var resultingInstance = newInstance('FooComponent', { bar: 123 });
+    expect(() => {
+      resultingInstance.id = 'second';
+    }).toThrow();
+  });
+
+  it('newInstance method throws if blueprint.create returns the same instance', () => {
+    var testInstance = { id: 'first' };
+
+    define('FooComponent', {
+      create: jest.fn().mockName('testBlueprint.create')
+                .mockImplementationOnce(() => testInstance)
+                .mockImplementationOnce(() => testInstance)
+    });
+
+    newInstance('FooComponent', { bar: 123 });
+
+    expect(() => {
+      newInstance('FooComponent', { bar: 123 });
+    }).toThrow();
+  });
+
+  it('newInstance method throws if blueprint.create returns an instance with id already taken', () => {
+    define('FooComponent', {
+      create: jest.fn().mockName('testBlueprint.create')
+                .mockImplementationOnce(() => ({ id: 'first' }))
+                .mockImplementationOnce(() => ({ id: 'first' }))
+    });
+
+    newInstance('FooComponent', { bar: 123 });
+
+    expect(() => {
+      newInstance('FooComponent', { bar: 123 });
+    }).toThrow();
+  });
+
+  it('trying to rewrite instance props throws an error', () => {
+    define('FooComponent', {
+      create() { return {}; }
+    });
+
+    var resultingInstance = newInstance('FooComponent', { bar: 123 });
+    expect(() => {
+      resultingInstance.props = {};
+    }).toThrow();
+  });
+
+  it('instance.update merges props and delegates to blueprint.update', () => {
+    var testBlueprint = {
+      create() { return {}; },
+      update: jest.fn().mockName('testBlueprint.update')
+    };
+
+    define('FooComponent', testBlueprint);
+
+    var mountFirstInstanceTo = document.createElement('div');
+    var resultingInstances = [
+      newInstance('FooComponent', { bar: 123 }, mountFirstInstanceTo),
+      newInstance('FooComponent', { baz: true })
+    ];
+
+    resultingInstances[0].update({ baz: true, qux: ['1337'] });
+    resultingInstances[1].update({ baz: false });
+
+    expect(testBlueprint.update).toHaveBeenCalledTimes(2);
+    expect(testBlueprint.update.mock.calls[0]).toEqual([
+      { bar: 123, baz: true, qux: ['1337'] },
+      mountFirstInstanceTo
+    ]);
+    expect(testBlueprint.update.mock.calls[1]).toEqual([
+      { baz: false },
+      undefined
+    ]);
+
+    expect(resultingInstances[0].props).toEqual({
+      bar: 123, baz: true, qux: ['1337']
+    });
+    expect(resultingInstances[1].props).toEqual({
+      baz: false
+    });
+  });
+
+  it('instance.update does nothing if blueprint.update is not a function', () => {
+    define('FooComponent', {
+      create() { return {}; }
+    });
+
+    var resultingInstance = newInstance('FooComponent', { bar: 123 });
+    resultingInstance.update({ baz: true, qux: ['1337'] });
+
+    expect(resultingInstance.props).toEqual({ bar: 123 });
+  });
+
+  it('multiple props modifications will trigger single instance.update', (done) => {
+    var testBlueprint = {
+      create() { return {}; },
+      update: jest.fn().mockName('testBlueprint.update')
+    };
+
+    define('FooComponent', testBlueprint);
+
+    var resultingInstance = newInstance('FooComponent', { bar: 123 });
+    resultingInstance.update = jest.fn().mockName('resultingInstance.update');
+
+    resultingInstance.props.baz = true;
+    resultingInstance.props.qux = ['1337'];
+
+    setTimeout(() => {
+      expect(resultingInstance.update).toHaveBeenCalledWith(
+        { baz: true, qux: ['1337'] }
+      );
+      done();
+    });
+  });
+
+  it('instance.destroy delegates to blueprint.destroy', () => {
+    var testBlueprint = {
+      create() { return {}; },
+      destroy: jest.fn().mockName('testBlueprint.destroy')
+    };
+
+    define('FooComponent', testBlueprint);
+
+    var mountFirstInstanceTo = document.createElement('div');
+    var resultingInstances = [
+      newInstance('FooComponent', { bar: 123 }, mountFirstInstanceTo),
+      newInstance('FooComponent', { baz: true })
+    ];
+
+    resultingInstances[0].destroy();
+    resultingInstances[1].destroy();
+
+    expect(testBlueprint.destroy).toHaveBeenCalledTimes(2);
+    expect(testBlueprint.destroy.mock.calls[0]).toEqual([
+      resultingInstances[0],
+      mountFirstInstanceTo
+    ]);
+    expect(testBlueprint.destroy.mock.calls[0][0]).toBe(resultingInstances[0]);
+    expect(testBlueprint.destroy.mock.calls[1]).toEqual([
+      resultingInstances[1],
+      undefined
+    ]);
+    expect(testBlueprint.destroy.mock.calls[1][0]).toBe(resultingInstances[1]);
+  });
+
+  it('instance.destroy removes the component instance', () => {
+    define('FooComponent', {
+      create: jest.fn().mockName('testBlueprint.create')
+                .mockImplementationOnce(() => ({ id: 'first' }))
+    });
+
+    var resultingInstance = newInstance('FooComponent', { bar: 123 });
+    resultingInstance.destroy();
+
+    expect(getInstance('FooComponent', 'first')).toBeUndefined();
+    expect(getComponentInstances('FooComponent')).toEqual([]);
+  });
+
+  it('instance.destroy prevents access to existing instance properties except for id', () => {
+    define('FooComponent', {
+      create() { return {}; }
+    });
+
+    var resultingInstance = newInstance('FooComponent', { bar: 123 });
+    resultingInstance.destroy();
+
+    Object.keys(resultingInstance)
+      .filter(propName => propName !== 'id')
+      .forEach(propName => {
+        expect(() => {
+          resultingInstance[propName];
+        }).toThrow();
+        expect(() => {
+          resultingInstance[propName] = ['1337'];
+        }).toThrow();
+      });
+  });
+
+  it('getInstance method can be used to obtain existing component instances', () => {
+    define('FooComponent', {
+      create: jest.fn().mockName('testBlueprint.create')
+                .mockImplementationOnce(() => ({ id: 'first' }))
+    });
+
+    var resultingInstance = newInstance('FooComponent', { bar: 123 });
+    var obtainedInstance = getInstance('FooComponent', 'first');
+    expect(obtainedInstance).toBe(resultingInstance);
+    expect(getInstance('FooComponent', 'second')).toBeUndefined();
+  });
+
+  it('isDefined method can be used to determine whether a component is already defined', () => {
+    define('FooComponent', {});
+    expect(isDefined('FooComponent')).toBe(true);
+    expect(isDefined('BarComponent')).toBe(false);
+  });
+
+  it('getDefinition returns the correct component definition', () => {
+    var testBlueprint = {};
+    define('FooComponent', testBlueprint);
+
+    var definition = getDefinition('FooComponent');
+    expect(definition.name).toBe('FooComponent');
+    expect(definition.blueprint).toBe(testBlueprint);
+
+    expect(getDefinition('BarComponent')).toBeUndefined();
+  });
+
+  it('sanitizeAndFreezeInstanceId ensures the instance id is sane and cannot be changed', () => {
+    var testInstances = [
+      { id: 'first' }, { id: 123 }, {}
+    ];
+
+    define('FooComponent', {});
+    var definition = getDefinition('FooComponent');
+
+    testInstances.forEach(instance => {
+      sanitizeAndFreezeInstanceId(instance, definition);
+    });
+
+    expect(testInstances[0].id).toBe('first');
+    expect(testInstances[1].id).toBe('FooComponent-0');
+    expect(testInstances[2].id).toBe('FooComponent-0');
+
+    testInstances.forEach(instance => {
+      expect(() => {
+        instance.id = 'second';
+      }).toThrow();
+    });
+  });
+
+  it('validateInstance performs the necessary instance validations', () => {
+    define('FooComponent', {
+      create: jest.fn().mockName('testBlueprint.create')
+                .mockImplementationOnce(() => ({ id: 'first' }))
+    });
+
+    var firstInstance = newInstance('FooComponent', { bar: 123 });
+    var definition = getDefinition('FooComponent');
+
+    expect(() => {
+      validateInstance({ id: 'second' }, definition);
+    }).not.toThrow();
+
+    expect(() => {
+      validateInstance(firstInstance, definition);
+    }).toThrow();
+
+    expect(() => {
+      validateInstance({ id: 'first' }, definition);
+    }).toThrow();
+  });
+
+  it('writeProxy can be used to proxy writes to properties of the given object', () => {
+    var object = { bar: 123, baz: true };
+    var onWrite = jest.fn().mockName('onWrite');
+
+    var resultingObject = writeProxy(object, onWrite);
+    expect(resultingObject).toEqual(object);
+
+    resultingObject.bar = 456;
+    resultingObject.qux = ['1337'];
+
+    expect(resultingObject).toEqual(object);
+    expect(object).toEqual({ bar: 456, baz: true, qux: ['1337'] });
+
+    expect(onWrite).toHaveBeenCalledTimes(2);
+    expect(onWrite.mock.calls[0]).toEqual([
+      'bar', 456
+    ]);
+    expect(onWrite.mock.calls[1]).toEqual([
+      'qux', ['1337']
+    ]);
+  });
+
+  it('lockInstanceProperties prevents access to existing instance properties except for id', () => {
+    var testInstance = { id: 'first', bar: 123, baz: true };
+
+    var resultingInstance = lockInstanceProperties(testInstance);
+    expect(resultingInstance.id).toBe('first');
+
+    ['bar', 'baz'].forEach(propName => {
+      expect(() => {
+        resultingInstance[propName];
+      }).toThrow();
+      expect(() => {
+        resultingInstance[propName] = ['1337'];
+      }).toThrow();
+    });
+  });
+});

--- a/app/javascript/miq-component/react-blueprint.tsx
+++ b/app/javascript/miq-component/react-blueprint.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+import {
+  ComponentProps,
+  BasicComponentInstance,
+  ManagedComponentInstance,
+  ComponentBlueprint
+} from '../miq-component/component-typings'
+
+// TODO(vs) importing from @types/react and @types/react-dom causes TypeScript
+// compiler to generate tons of errors, updating TypeScript related dependencies
+// should fix the problem
+
+export default (
+  reactElementCreator: (props: ComponentProps) => any /* ReactElement */,
+  mapPropsToInteract: (props: ComponentProps) => any = () => undefined
+): ComponentBlueprint => {
+  function render(props: ComponentProps, container: HTMLElement) {
+    ReactDOM.render(
+      <Provider store={ManageIQ.redux.store}>
+        {reactElementCreator(props)}
+      </Provider>,
+      container
+    );
+  }
+
+  return {
+    create(props, mountTo) {
+      render(props, mountTo);
+      return { interact: mapPropsToInteract(props) };
+    },
+
+    update(newProps, mountedTo) {
+      render(newProps, mountedTo);
+    },
+
+    destroy(instance, unmountFrom) {
+      ReactDOM.unmountComponentAtNode(unmountFrom);
+    }
+  };
+}

--- a/app/javascript/miq-component/registry.ts
+++ b/app/javascript/miq-component/registry.ts
@@ -1,0 +1,234 @@
+import {
+  ComponentProps,
+  BasicComponentInstance,
+  ManagedComponentInstance,
+  AnyComponentInstance,
+  ComponentBlueprint
+} from './component-typings';
+
+import { writeProxy, lockInstanceProperties } from './utils';
+
+interface ComponentDefinition {
+  name: string;
+  blueprint: ComponentBlueprint;
+}
+
+const registry: Map<ComponentDefinition, Set<AnyComponentInstance>> = new Map();
+
+/**
+ * Get definition of a component with the given `name`.
+ */
+export function getDefinition(
+  name: string
+): ComponentDefinition | undefined {
+  return Array.from(registry.keys()).find(definition => definition.name === name);
+}
+
+/**
+ * Make sure the instance `id` is sane and cannot be changed.
+ */
+export function sanitizeAndFreezeInstanceId(
+  instance: AnyComponentInstance,
+  definition: ComponentDefinition
+): void {
+  const id = typeof instance.id === 'string'
+    ? instance.id
+    : `${definition.name}-${registry.get(definition).size}`;
+
+  Object.defineProperty(instance, 'id', {
+    get() {
+      return id;
+    },
+    set() {
+      throw new Error(`Attempt to modify id of instance ${instance.id}`);
+    },
+    enumerable: true
+  });
+}
+
+/**
+ * Check the following:
+ * - the given instance isn't already in the registry
+ * - the given instance `id` isn't already taken
+ */
+export function validateInstance(
+  instance: AnyComponentInstance,
+  definition: ComponentDefinition
+): void {
+  if (Array.from(registry.get(definition)).find(existingInstance => existingInstance === instance)) {
+    throw new Error('Instance already present, check your blueprint.create implementation');
+  }
+
+  if (getInstance(definition.name, instance.id)) {
+    throw new Error(`Instance with id ${instance.id} already present`);
+  }
+}
+
+/**
+ * Implementation of the `ComponentApi.define` method.
+ */
+export function define(
+  name: string,
+  blueprint: ComponentBlueprint = {},
+  instances?: BasicComponentInstance[]
+): void {
+  // validate inputs
+  if (typeof name !== 'string' || isDefined(name)) {
+    return;
+  }
+
+  // add new definition to the registry
+  const newDefinition: ComponentDefinition = { name, blueprint };
+  registry.set(newDefinition, new Set());
+
+  // add existing instances to the registry
+  if (Array.isArray(instances)) {
+    instances.filter(instance => !!instance)
+      .forEach(instance => {
+        sanitizeAndFreezeInstanceId(instance, newDefinition);
+        validateInstance(instance, newDefinition);
+        registry.get(newDefinition).add(instance);
+      });
+  }
+}
+
+/**
+ * Implementation of the `ComponentApi.newInstance` method.
+ */
+export function newInstance(
+  name: string,
+  initialProps: ComponentProps = {},
+  mountTo?: HTMLElement
+): ManagedComponentInstance | undefined {
+  // validate inputs
+  const definition = getDefinition(name);
+  if (!definition) {
+    return;
+  }
+
+  // check if the blueprint supports instance creation
+  const blueprint = definition.blueprint;
+  if (typeof blueprint.create !== 'function') {
+    return;
+  }
+
+  // multiple props modifications will trigger single instance update
+  let newPropsForUpdate = {};
+  function handlePropUpdate(propName, value) {
+    if (typeof blueprint.update !== 'function') {
+      return;
+    }
+
+    if (Object.keys(newPropsForUpdate).length === 0) {
+      setTimeout(() => {
+        newInstance.update(newPropsForUpdate);
+        newPropsForUpdate = {};
+      });
+    }
+    newPropsForUpdate[propName] = value;
+  }
+
+  // proxy props to handle instance update upon props modification
+  let actualProps = writeProxy(Object.assign({}, initialProps), handlePropUpdate);
+
+  // create new instance
+  let newInstance = blueprint.create(actualProps, mountTo) as ManagedComponentInstance;
+  if (!newInstance) {
+    throw new Error(`blueprint.create returned falsy value when trying to instantiate ${name}`);
+  }
+
+  // make sure the instance id is sane and cannot be changed
+  sanitizeAndFreezeInstanceId(newInstance, definition);
+
+  // validate the instance
+  validateInstance(newInstance, definition);
+
+  // provide access to current props
+  Object.defineProperty(newInstance, 'props', {
+    get() {
+      return actualProps;
+    },
+    set() {
+      throw new Error(`Attempt to rewrite props associated with instance ${newInstance.id}`);
+    },
+    enumerable: true,
+    configurable: true
+  });
+
+  // provide instance update method
+  newInstance.update = (newProps) => {
+    if (typeof blueprint.update !== 'function') {
+      return;
+    }
+
+    // update current props and delegate to blueprint
+    actualProps = writeProxy(Object.assign({}, actualProps, newProps), handlePropUpdate);
+    blueprint.update(actualProps, mountTo);
+  };
+
+  // provide instance destroy method
+  newInstance.destroy = () => {
+    // delegate to blueprint
+    if (typeof blueprint.destroy === 'function') {
+      blueprint.destroy(newInstance, mountTo);
+    }
+
+    // remove instance from the registry
+    registry.get(definition).delete(newInstance);
+
+    // prevent access to existing instance properties except for id
+    lockInstanceProperties(newInstance);
+
+    // clear instance reference
+    newInstance = null;
+  };
+
+  // add instance to the registry
+  registry.get(definition).add(newInstance);
+
+  return newInstance;
+}
+
+/**
+ * Implementation of the `ComponentApi.getInstance` method.
+ */
+export function getInstance(
+  name: string,
+  id: string
+): AnyComponentInstance | undefined {
+  const definition = getDefinition(name);
+  return definition && Array.from(registry.get(definition)).find(instance => instance.id === id);
+}
+
+/**
+ * Implementation of the `ComponentApi.isDefined` method.
+ */
+export function isDefined(
+  name: string
+): boolean {
+  return getDefinition(name) ? true : false;
+}
+
+/**
+ * Test helper: get names of all components.
+ */
+export function getComponentNames(): string[] {
+  return Array.from(registry.keys()).map(definition => definition.name);
+}
+
+/**
+ * Test helper: get all instances of the given component.
+ */
+export function getComponentInstances(
+  name: string
+): AnyComponentInstance[] {
+  const definition = getDefinition(name);
+  return definition ? Array.from(registry.get(definition).values()) : [];
+}
+
+/**
+ * Test helper: remove all component data.
+ */
+export function clearRegistry(): void {
+  registry.clear();
+}

--- a/app/javascript/miq-component/utils.ts
+++ b/app/javascript/miq-component/utils.ts
@@ -1,0 +1,42 @@
+import { AnyComponentInstance } from './component-typings';
+
+/**
+ * Proxy writes to properties of the given object.
+ */
+export function writeProxy<T extends object>(
+  object: T,
+  onWrite: (propName, value) => void
+): T {
+  return new Proxy<T>(object, {
+    set(target, prop, value): boolean {
+      target[prop] = value;
+      onWrite(prop, value);
+      return true;
+    }
+  });
+}
+
+/**
+ * Prevent access to existing instance properties except for `id`.
+ */
+export function lockInstanceProperties(
+  instance: AnyComponentInstance
+): AnyComponentInstance {
+  const descriptors = {};
+
+  Object.keys(instance)
+    .filter(propName => propName !== 'id')
+    .forEach(propName => {
+      descriptors[propName] = {
+        get() {
+          throw new Error(`Tried to read property ${propName} of destroyed instance ${instance.id}`);
+        },
+        set() {
+          throw new Error(`Tried to write property ${propName} of destroyed instance ${instance.id}`);
+        },
+        enumerable: true
+      };
+    });
+
+  return Object.defineProperties(instance, descriptors);
+}

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -11,7 +11,15 @@ import 'proxy-polyfill';
 import { mount } from '../react/mounter';
 import componentRegistry from '../react/componentRegistry';
 
+import * as newRegistry from '../miq-component/registry';
+import reactBlueprint from '../miq-component/react-blueprint';
+
 ManageIQ.react = {
   mount,
   componentRegistry,
+};
+
+ManageIQ.component = {
+  ...newRegistry,
+  reactBlueprint,
 };

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -5,6 +5,9 @@
 //
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
+
+import 'proxy-polyfill';
+
 import { mount } from '../react/mounter';
 import componentRegistry from '../react/componentRegistry';
 

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -13,6 +13,7 @@ import componentRegistry from '../react/componentRegistry';
 
 import * as newRegistry from '../miq-component/registry';
 import reactBlueprint from '../miq-component/react-blueprint';
+import * as helpers from '../miq-component/helpers';
 
 ManageIQ.react = {
   mount,
@@ -22,4 +23,5 @@ ManageIQ.react = {
 ManageIQ.component = {
   ...newRegistry,
   reactBlueprint,
+  ...helpers,
 };

--- a/app/javascript/typings/globals.d.ts
+++ b/app/javascript/typings/globals.d.ts
@@ -1,5 +1,5 @@
 import { IModule } from 'angular';
-
+import { ComponentApi } from '../miq-component/component-typings';
 import { ReduxApi } from '../miq-redux/redux-typings';
 
 interface MiqAngular {
@@ -10,7 +10,8 @@ declare global {
   // `ManageIQ` runtime global, holding application-specific objects.
   namespace ManageIQ {
     const angular: MiqAngular;
-    let redux: ReduxApi; // initialized by miq-redux pack
+    let component: ComponentApi;
+    let redux: ReduxApi;
   }
 
   // This global is available when running tests with Jasmine.

--- a/app/javascript/typings/globals.d.ts
+++ b/app/javascript/typings/globals.d.ts
@@ -7,18 +7,15 @@ interface MiqAngular {
 }
 
 declare global {
-
-  /**
-   * `ManageIQ` runtime global, holding application-specific objects.
-   */
+  // `ManageIQ` runtime global, holding application-specific objects.
   namespace ManageIQ {
     const angular: MiqAngular;
     let redux: ReduxApi; // initialized by miq-redux pack
   }
 
-  /**
-   * This global is available when running tests with Jasmine.
-   */
+  // This global is available when running tests with Jasmine.
   const jasmine: any;
 
+  // Truthy value means the code runs in a test environment.
+  const __testing__: boolean;
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lodash": "^4.17.4",
     "ng-redux": "^3.5.2",
     "prop-types": "^15.6.0",
+    "proxy-polyfill": "^0.1.7",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "redux-devtools-extension": "^2.13.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "proxy-polyfill": "^0.1.7",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-redux": "^5.0.7",
     "redux-devtools-extension": "^2.13.2",
     "rxjs": "~5.3.0",
     "ui-select": "0.19.8",


### PR DESCRIPTION
Most of the code is taken directly from #3228, with the following changes:

* rebased, split into commits, removed some unnecessary changes
* `ManageIQ.component` is set in the pack, not as part of miq-component
* merged `miq-component` and `miq-component-react` .. this is just one extra file, no need to split into directories
* `blueprint` is now exposed under `ManageIQ.component.reactBlueprint`
* this does *not* remove the other registry yet (I will do a separate PR to make both use the same underlying implementation while keeping the API used in plugins)
* added a simple react component helper so we can add react components easily

All the documentation in https://github.com/ManageIQ/manageiq-ui-classic/pull/3228 is still valid,
except for the simple case, you can do `ManageIQ.component.addReact('foo', Foo)` instead of `ManageIQ.component.define('foo', ManageIQ.component.reactBlueprint(Foo))`.

All the features were written by @vojtechszocs , the bugs are all mine :).

Cc @martinpovolny 