### PR TITLE
Fix for the feature tree role selection in the Add User Role form

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1292,11 +1292,11 @@ module OpsController::OpsRbac
     @edit[:new][:name] = @record.name
     vmr = @record.settings.fetch_path(:restrictions, :vms) if @record.settings
     @edit[:new][:vm_restriction] = vmr || :none
-    @edit[:new][:features] = rbac_expand_features(@record.feature_identifiers).sort
+    @edit[:new][:features] = rbac_expand_features(@record.miq_product_features.map(&:identifier)).sort
 
     @edit[:current] = copy_hash(@edit[:new])
 
-    @role_features = @record.feature_identifiers.sort
+    @role_features = @edit[:new][:features]
     @rbac_menu_tree = build_rbac_feature_tree
 
     @right_cell_text = if @edit[:role_id]


### PR DESCRIPTION
Fix for the feature tree role selection in the Add User Form

There is a disconnect between the selection of the features as shown in the tree and the controller features selection.
pluck does not work on proxy associations for new records. ( feature_identifiers now returns an empty array for new records )

* the alternative to this PR is to revert the backend change for feature_identifiers back to map from pluck
 
Links 
----------
- caused by this PR
https://github.com/ManageIQ/manageiq/pull/17008

Steps for Testing/QA 
-------------------------------

1. Configuration -> Access Control ->  Add Role
2. Unselect a feature from the tree.
3. When trying to save the role, an error message indicates that at least a feature must be selected.


