### PR TITLE
Fix for role features when adding a new role

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1292,7 +1292,7 @@ module OpsController::OpsRbac
     @edit[:new][:name] = @record.name
     vmr = @record.settings.fetch_path(:restrictions, :vms) if @record.settings
     @edit[:new][:vm_restriction] = vmr || :none
-    @edit[:new][:features] = rbac_expand_features(@record.feature_identifiers).sort
+    @edit[:new][:features] = rbac_expand_features(@record.miq_product_features.collect(&:identifier)).sort
 
     @edit[:current] = copy_hash(@edit[:new])
 


### PR DESCRIPTION
1. try to add a new role, notice the feature tree is checked at its root (i.e. every feature is selected)
2. Hit `Add` button.
3. Notice the flash message telling you that you need at least one product feature selected.

We need to use `.miq_product_features.collect(&:identifier)` rather than `.feature_identifiers()` when adding a new role, since `.feature_identifiers()` won't work for a newly added role (it uses `pluck()`, which works only for saved objects).