### PR TITLE
Fix the custom button group enablement for list and single targets

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -302,7 +302,7 @@ class ApplicationHelper::ToolbarBuilder
       enabled = if cb_enabled_for_nested
                   cb_enabled_value_for_nested
                 else
-                  record ? true : buttons.all? { |button| button[:enabled] }
+                  buttons.any? { |button| button[:enabled] }
                 end
       props = {
         :id      => "custom_#{group[:id]}",


### PR DESCRIPTION
Fix the custom button group enablement for list and single targets
Thank you for a new Pull Request!

Links [Optional]
----------------

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535208


Steps for Testing/QA
-------------------------------

Issue 1:

Custom buttons displayed on lists - the group was disabled before the fix if only one of the buttons belonging to it was disabled.

Issue 2:

Custom buttons displayed on single target summary page - the custom button group was enabled even when none of its buttons were enabled.

After: 
![screenshot from 2018-03-16 14-25-29](https://user-images.githubusercontent.com/12769982/37538466-132b337c-2927-11e8-8821-ebfab73214f6.png)
![screenshot from 2018-03-16 14-25-56](https://user-images.githubusercontent.com/12769982/37538467-13411d22-2927-11e8-929d-6b3ee08a3817.png)
