### PR TITLE
Fix mismatching categories with values when assigning tags

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -215,7 +215,7 @@ module ApplicationController::Tags
     end
 
     # Set to first category, if not already set
-    @edit[:cat] ||= cats.min_by(&:description)
+    @edit[:cat] ||= cats.first
 
     unless @object_ids.blank?
       @tagitems = @tagging.constantize.where(:id => @object_ids).sort_by { |t| t.name.try(:downcase).to_s }

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -193,7 +193,7 @@ module ApplicationController::Tags
   def tag_edit_build_screen
     @showlinks = true
 
-    cats = Classification.categories.select(&:show).sort_by(&:description) # Get the categories, sort by description
+    cats = Classification.categories.select(&:show).sort_by { |t| t.description.try(:downcase) } # Get the categories, sort by description
     @categories = {}    # Classifications array for first chooser
     cats.delete_if { |c| c.read_only? || c.entries.length == 0 }  # Remove categories that are read only or have no entries
     cats.each do |c|

--- a/app/views/layouts/_tag_edit.html.haml
+++ b/app/views/layouts/_tag_edit.html.haml
@@ -15,7 +15,7 @@
             - if session[:assigned_filters].include?(cat_key.downcase)
               - @categories.delete(cat_key)
           = select_tag("tag_cat",
-            options_for_select(@categories.sort_by{|key, _| key.downcase}, @edit[:cat].name),
+            options_for_select(@categories, @edit[:cat].name),
             "data-miq_observe"     => {:url => url}.to_json,
             "data-live-search"     => "true",
             "data-container"       => "body",


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1556984

**Partially caused by:**
[1] https://github.com/ManageIQ/manageiq/pull/5598
[2] https://github.com/ManageIQ/manageiq/pull/9234

**Done:**
- fix sorting of categories by `:description` for assigning tags so that `downcase` method is added, to sort items of the array properly (not sorting only right before displaying the categories like in [2] because for example `@edit[:cat]` depends on what is in the first position of the array for categories, like here: https://github.com/ManageIQ/manageiq-ui-classic/pull/3644/files#diff-32a1920bfa43ecfb0853173babda0f8aL218)
- fix setting `@edit[:cat]` to first category so that `min_by` method is replaced by `first` method, to really get the first item of the categories' array (see the comment: https://github.com/ManageIQ/manageiq-ui-classic/pull/3644/files#diff-32a1920bfa43ecfb0853173babda0f8aR217; `min_by` does not always return what we expect, we simply need the first item of the array)
- remove sorting of the array with categories for assigning tags from haml as it no longer makes sense to be there because proper sorting is already implemented in `tag_edit_build_screen` method (see https://github.com/ManageIQ/manageiq-ui-classic/pull/3644/files#diff-32a1920bfa43ecfb0853173babda0f8aR196)

**Notes:**
- this bug occurred everywhere where tagging is supported
- it was not easy to reproduce the bug, but after deleting some category (I deleted some of the first categories from my tagging categories) the bug occurred

---

**Before:**
![tag_category_before](https://user-images.githubusercontent.com/13417815/37591830-0a6c2c80-2b6d-11e8-97da-1b9617b95aef.png)
![tag_category_before2](https://user-images.githubusercontent.com/13417815/37591877-37845ff8-2b6d-11e8-8755-185c07daa2d0.png)

**After:**
![tag_category_after](https://user-images.githubusercontent.com/13417815/37591093-a746cc8e-2b6a-11e8-9290-2de86b9d62c7.png)
