### PR TITLE
Fix untranslated entry when adding a new Schedule

### DIFF
--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -164,7 +164,6 @@ module ReportController::Schedules
         page.replace("edit_email_div",
                      :partial => "layouts/edit_email",
                      :locals  => {:action_url => "schedule_form_field_changed",
-                                  :box_title  => "E-Mail after Running",
                                   :record     => @schedule})
         page.replace("schedule_email_options_div", :partial => "schedule_email_options")
       end

--- a/app/views/layouts/_edit_email.html.haml
+++ b/app/views/layouts/_edit_email.html.haml
@@ -3,6 +3,10 @@
   - url = url_for_only_path(:action => action_url, :id => (record.id || "new"))
 #edit_email_div
   %h3
+    - if x_active_accord == :schedules
+      = _("E-Mail after Running")
+    - else
+      = _("E-mail")
   .form-horizontal
     .form-group
       %label.control-label.col-md-2

--- a/app/views/layouts/_edit_email.html.haml
+++ b/app/views/layouts/_edit_email.html.haml
@@ -1,10 +1,8 @@
-- box_title ||= _("E-mail")
 - action_url ||= "form_field_changed"
 - if @edit
   - url = url_for_only_path(:action => action_url, :id => (record.id || "new"))
 #edit_email_div
   %h3
-    = box_title
   .form-horizontal
     .form-group
       %label.control-label.col-md-2

--- a/app/views/report/_schedule_form.html.haml
+++ b/app/views/report/_schedule_form.html.haml
@@ -31,7 +31,6 @@
   = render :partial => "schedule_form_filter"
   = render :partial => "schedule_form_timer", :locals => {:action_url => "schedule_form_field_changed", :record => @schedule}
   = render(:partial => "layouts/edit_email",
-           :locals  => {:box_title  => _("E-mail after Running"),
-                        :action_url => "schedule_form_field_changed",
+           :locals  => {:action_url => "schedule_form_field_changed",
                         :record     => @schedule})
   = render :partial => "schedule_email_options"


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1394217

The problem was caused by `box_title` variable in haml. If the title is represented the way like https://github.com/ManageIQ/manageiq-ui-classic/pull/3647/files#diff-0f738269de482d765f5a66dd8c9fabe5L7, it is simply not translated and is displayed just as it is set. We could fix this by more possibilities. I chose to remove the variable, also because it is used only in a few places. In the second commit of this PR, I am trying also to keep https://github.com/ManageIQ/manageiq-ui-classic/pull/3647/files#diff-0f738269de482d765f5a66dd8c9fabe5L1 because the haml is not used only for schedules. The second commit also ensures us that `E-mail` will also be translated properly. No need to add anything else anywhere else.

---

**Before:**
![email_before](https://user-images.githubusercontent.com/13417815/37598505-aa87c50c-2b82-11e8-9311-4b4783022809.png)

**After:**
![email_after](https://user-images.githubusercontent.com/13417815/37598249-02c67e58-2b82-11e8-99c0-24f2d57a426c.png)
