### PR TITLE
Remove delete button for PhysicalServer

### DIFF
--- a/app/helpers/application_helper/toolbar/physical_server_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_server_center.rb
@@ -19,15 +19,6 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
             :confirm => N_("Refresh relationships and power states for all items related to the selected Physical Servers?"),
             :options => {:feature => :refresh}
           ),
-          button(
-            :physical_server_delete,
-            'pficon pficon-delete fa-lg',
-            N_('Remove selected Physical Servers from Inventory'),
-            N_('Remove Physical Servers from Inventory'),
-            :url_parms    => "main_div",
-            :send_checked => true,
-            :confirm      => N_("Warning: The selected Physical Servers and ALL of their components will be permanently removed!"),
-          )
         ]
       ),
     ]

--- a/app/helpers/application_helper/toolbar/physical_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_servers_center.rb
@@ -21,17 +21,6 @@ class ApplicationHelper::Toolbar::PhysicalServersCenter < ApplicationHelper::Too
             :onwhen  => "1+",
             :options => {:feature => :refresh}
           ),
-          button(
-            :physical_server_delete,
-            'pficon pficon-delete fa-lg',
-            N_('Remove selected Physical Servers from Inventory'),
-            N_('Remove Physical Servers from Inventory'),
-            :url_parms    => "main_div",
-            :send_checked => true,
-            :confirm      => N_("Warning: The selected Physical Servers and ALL of their components will be permanently removed!"),
-            :enabled      => false,
-            :onwhen       => "1+"
-          ),
         ]
       ),
     ]


### PR DESCRIPTION
This PR is able to
 * Remove the delete button from physical servers, because editing Physical Servers is pointless since all 
    info are retrieved from a refresh. So if I delete a physical server, it will be retrieved again in the next 
    refresh