### PR TITLE
Add physical server dashboard widgets

### DIFF
--- a/app/assets/javascripts/controllers/ems_physical_infra_dashboard/charts-mixin.js
+++ b/app/assets/javascripts/controllers/ems_physical_infra_dashboard/charts-mixin.js
@@ -1,0 +1,62 @@
+angular.module('miq.util').factory('chartsMixin', ['$document', function($document) {
+  'use strict';
+
+  var dailyTimeTooltip = function(data) {
+    var theMoment = moment(data[0].x);
+    return _.template('<div class="tooltip-inner"><%- col1 %>  <%- col2 %></div>')({
+      col1: theMoment.format('MM/DD/YYYY'),
+      col2: data[0].value + ' ' + data[0].name,
+    });
+  };
+
+  var lineChartTooltipPositionFactory = function(chartId) {
+    var elementQuery = '#' + chartId + 'lineChart';
+
+    return function(_data, width, height, element) {
+      try {
+        var center = parseInt(element.getAttribute('x'), 10);
+        var top = parseInt(element.getAttribute('y'), 10);
+        var chartBox = $document[0].querySelector(elementQuery).getBoundingClientRect();
+        var graphOffsetX = $document[0].querySelector(elementQuery + ' g.c3-axis-y').getBoundingClientRect().right;
+
+        var x = Math.max(0, center + graphOffsetX - chartBox.left - Math.floor(width / 2));
+
+        return {
+          top: top - height,
+          left: Math.min(x, chartBox.width - width),
+        };
+      } catch (_e) {
+        return null;
+      }
+    };
+  };
+
+  var chartConfig = {
+    recentServersConfig: {
+      chartId: 'recentServersChart',
+      tooltip: {
+        contents: dailyTimeTooltip,
+        position: lineChartTooltipPositionFactory('recentServersChart'),
+      },
+      point: {r: 1},
+      size: {height: 145},
+      grid: {y: {show: false}},
+      setAreaChart: true,
+    },
+  };
+
+  var processData = function(data, xDataLabel, yDataLabel) {
+    if (! data) {
+      return { dataAvailable: false };
+    }
+    data.xData.unshift(xDataLabel);
+    data.yData.unshift(yDataLabel);
+    return data;
+  };
+
+  return {
+    chartConfig: chartConfig,
+    processData: processData,
+    dailyTimeTooltip: dailyTimeTooltip
+  };
+}]);

--- a/app/assets/javascripts/controllers/ems_physical_infra_dashboard/recent_servers_line_chart_controller.js
+++ b/app/assets/javascripts/controllers/ems_physical_infra_dashboard/recent_servers_line_chart_controller.js
@@ -1,0 +1,33 @@
+/* global miqHttpInject */
+angular.module( 'patternfly.charts' ).controller( 'recentServersLineChartController', ['$q', 'providerId', '$http', 'chartsMixin', 'miqService', function($q, providerId, $http, chartsMixin, miqService) {
+  var vm = this;
+  vm.id = "recentServersLineChart_" + providerId;
+  var init = function() {
+    ManageIQ.angular.scope = vm;
+    vm.loadingDone = false;
+    vm.config = chartsMixin.chartConfig.recentServersConfig;
+    vm.timeframeLabel = __('Last 30 Days');
+    var url = '/ems_physical_infra_dashboard/recent_servers_data/' + providerId;
+    var serversDataPromise = $http.get(url)
+      .then(function(response) {
+        vm.data = response.data.data;
+      })
+      .catch(miqService.handleFailure);
+
+    $q.all([serversDataPromise]).then(function() {
+      if (vm.data.recentServers.dataAvailable === false) {
+        vm.data.dataAvailable = false;
+      } else {
+        vm.data = chartsMixin.processData(vm.data.recentServers, 'dates', vm.data.recentServers.config.label);
+      }
+      Object.assign(vm.config, vm.data);
+      vm.loadingDone = true;
+    });
+
+    vm.custShowXAxis = false;
+    vm.custShowYAxis = false;
+    vm.custAreaChart = true;
+  };
+
+  init();
+}]);

--- a/app/controllers/ems_physical_infra_dashboard_controller.rb
+++ b/app/controllers/ems_physical_infra_dashboard_controller.rb
@@ -1,0 +1,32 @@
+class EmsPhysicalInfraDashboardController < ApplicationController
+  extend ActiveSupport::Concern
+
+  before_action :check_privileges
+  before_action :get_session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def show
+    if params[:id].nil?
+      @breadcrumbs.clear
+    end
+  end
+
+  def recent_servers_data
+    render :json => {:data => recent_servers(params[:id])}
+  end
+
+  private
+
+  def recent_servers(ems_id)
+    EmsPhysicalInfraDashboardService.new(ems_id, self).recent_servers_data
+  end
+
+  def get_session_data
+    @layout = "ems_physical_infra_dashboard"
+  end
+
+  def set_session_data
+    session[:layout] = @layout
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -710,6 +710,7 @@ module ApplicationHelper
       chargeback
       container_dashboard
       ems_infra_dashboard
+      ems_physical_infra_dashboard
       exception
       miq_ae_automate_button
       miq_ae_class
@@ -1334,6 +1335,7 @@ module ApplicationHelper
                         ems_middleware
                         ems_network
                         ems_physical_infra
+                        ems_physical_infra_dashboard
                         ems_storage
                         infra_topology
                         event

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -9,6 +9,7 @@ module ApplicationHelper::PageLayouts
       container_dashboard
       container_topology
       ems_infra_dashboard
+      ems_physical_infra_dashboard
       infra_topology
       network_topology
       cloud_topology
@@ -71,7 +72,7 @@ module ApplicationHelper::PageLayouts
        (@layout == 'vm' && controller.action_name == 'edit') ||
        (@layout == "report" && ["new", "create", "edit", "copy", "update", "explorer"].include?(controller.action_name))
       return false
-    elsif %w(container_dashboard dashboard ems_infra_dashboard).include?(@layout) ||
+    elsif %w(container_dashboard dashboard ems_infra_dashboard ems_physical_infra_dashboard).include?(@layout) ||
           (%w(dashboard).include?(@showtype) && @lastaction.to_s.ends_with?("_dashboard")) ||
           %w(topology).include?(@showtype)
       # Dashboard tabs are located in taskbar because they are otherwise hidden behind the taskbar regardless of z-index

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -235,7 +235,7 @@ class ApplicationHelper::ToolbarBuilder
       !name.starts_with?("miq_dialog") && !name.starts_with?("custom_button") &&
       !name.starts_with?("instance_") && !name.starts_with?("image_")) &&
        !%w(record_summary summary_main summary_download tree_main
-           x_edit_view_tb history_main ems_container_dashboard ems_infra_dashboard infra_networking_policy).include?(name)
+           x_edit_view_tb history_main ems_container_dashboard ems_infra_dashboard infra_networking_policy ems_physical_infra_dashboard).include?(name)
   end
 
   def cb_send_checked_list

--- a/app/services/ems_physical_infra_dashboard_service.rb
+++ b/app/services/ems_physical_infra_dashboard_service.rb
@@ -1,0 +1,42 @@
+class EmsPhysicalInfraDashboardService < DashboardService
+  include UiServiceMixin
+
+  def initialize(ems_id, controller)
+    @ems_id = ems_id
+    @ems = EmsPhysicalInfra.find(@ems_id) if @ems_id.present?
+    @controller = controller
+  end
+
+  def recent_servers_data
+    {
+      :recentHosts => recent_servers
+    }.compact
+  end
+
+  def recent_servers
+    # Get recent hosts
+    all_servers = recent_records(PhysicalServer)
+    config = {
+      :title => _('Recent Servers'),
+      :label => _('Servers')
+    }
+    return { :dataAvailable => false, :config => config} if all_servers.blank?
+    {
+      :dataAvailable => true,
+      :xData         => all_servers.keys,
+      :yData         => all_servers.values.map,
+      :config        => config
+    }
+  end
+
+  def recent_records(model)
+    all_records = Hash.new(0)
+    records = model.where('created_on > ? and ems_id = ?', 30.days.ago.utc, @ems.id)
+    records = records.includes(:resource => [:ext_management_system]) if @ems.blank?
+    records.sort_by { |r| r.created_on }.uniq.each do |r|
+      date = r.created_on.strftime("%Y-%m-%d")
+      all_records[date] += model.where('created_on = ?', r.created_on).count
+    end
+    all_records
+  end
+end

--- a/app/views/ems_physical_infra/_recent-servers-line-chart.html.haml
+++ b/app/views/ems_physical_infra/_recent-servers-line-chart.html.haml
@@ -1,0 +1,9 @@
+%div{'ng-controller' => "recentServersLineChartController as vm"}
+  .card-pf
+    .card-pf-heading
+      %h2.card-pf-title
+        {{vm.data.config.title}}
+    .card-pf-body
+      %pf-line-chart{'ng-if' => "vm.loadingDone", 'ng-attr-id' => "{{vm.id}}", 'config' => "vm.config", 'chart-data' => "vm.data", 'set-area-chart' => "vm.custAreaChart", 'show-x-axis' => "vm.custShowXAxis", 'show-y-axis' => "vm.custShowYAxis"}
+      %span.trend-footer-pf{"ng-class" => "{ 'chart-transparent-text': vm.data.dataAvailable === false }"}
+        {{vm.timeframeLabel}}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1363,6 +1363,7 @@ Rails.application.routes.draw do
       :get => %w(
         show
         data
+        recent_servers_data
       )
     },
 


### PR DESCRIPTION
This PR adds new physical server dashboard widgets.

Recently Discovered Physical Servers Widget:
![image](https://user-images.githubusercontent.com/23690141/37622072-1c502efe-2b97-11e8-937c-9eb03f2dd338.png)

Physical Server Health Widget:
![image](https://user-images.githubusercontent.com/23690141/37779414-b47ab1b8-2dc2-11e8-8b3b-2a598cda9cb8.png)

Physical Server Availability Widget (How many servers are associated with a host vs those that are not):
![image](https://user-images.githubusercontent.com/23690141/38111694-b2cd964a-336d-11e8-86b6-bfe7fa62734a.png)

This PR depends on https://github.com/ManageIQ/manageiq/pull/17172