### PR TITLE
[GAPRINDASHVILI] Follow-up to Restore server delete button in Diagnostics

### DIFF
--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -8,7 +8,8 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
   end
 
   def override(node, _object, _pid, _options)
-    if @sb[:diag_selected_id] && node[:key] == "svr-#{@sb[:diag_selected_id]}"
+    prefix = TreeBuilder.get_prefix_for_model('MiqServer')
+    if @sb[:diag_selected_id] && node[:key] == "#{prefix}-#{to_cid(@sb[:diag_selected_id])}"
       node[:highlighted] = true
     end
   end


### PR DESCRIPTION
Use from_cid when highlighting server in the diagnostics server_by_role tree
- follow up for https://github.com/ManageIQ/manageiq-ui-classic/pull/2213


Links 
----------------

Upstream PR https://github.com/ManageIQ/manageiq-ui-classic/pull/2213
