### PR TITLE
Fix displaying services after applying a filter (2)

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -304,6 +304,9 @@ class ServiceController < ApplicationController
     # resetting action that was stored during edit to determine what is being edited
     @sb[:action] = nil
 
+    # Reset session to same values as first time in
+    session[:adv_search]["Service"] = session[:edit] = nil if session[:adv_search] && params[:action] != 'x_search_by_name'
+
     case TreeBuilder.get_model_for_prefix(@nodetype)
     when "Service"
       show_record(id)

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -103,7 +103,7 @@ describe ServiceController do
     end
   end
 
-  context "#show" do
+  describe "#show" do
     render_views
 
     it 'contains the associated tags for the ansible service template' do
@@ -182,7 +182,7 @@ describe ServiceController do
       expect(response).to redirect_to(:action => 'explorer', :id => "s-#{service.id}")
     end
 
-    context "#button" do
+    describe "#button" do
       render_views
 
       before(:each) do
@@ -211,7 +211,7 @@ describe ServiceController do
     end
   end
 
-  context "#sanitize_output" do
+  describe "#sanitize_output" do
     it "escapes characters in the output string" do
       output = controller.send(:sanitize_output, "I'm \"\\'Fred\\'\" {{Flintstone}}")
       expect(output).to eq("I\\'m \\\"\\'Fred\\'\\\" \\{\\{Flintstone\\}\\}")
@@ -374,6 +374,30 @@ describe ServiceController do
             expect(controller.instance_variable_get(:@right_cell_text)).to eq("All Services (Names with \"#{search}\")")
           end
         end
+      end
+    end
+  end
+
+  context 'clicking on Active/Retired Services node in the tree, after applying a filter' do
+    describe '#get_node_info' do
+      let(:s) { {:adv_search => {"Service" => {:expression => {}}}, :edit => {:expression => {}}} }
+
+      before do
+        allow(controller).to receive(:session).and_return(s)
+        controller.instance_variable_set(:@_params, :action => 'tree_select')
+        controller.instance_variable_set(:@sb, {})
+      end
+
+      it 'resets session to same values as first time in, for Active Services' do
+        controller.send(:get_node_info, 'xx-asrv')
+        expect(controller.session[:edit]).to be_nil
+        expect(controller.session[:adv_search]["Service"]).to be_nil
+      end
+
+      it 'resets session to same values as first time in, for Retired Services' do
+        controller.send(:get_node_info, 'xx-rsrv')
+        expect(controller.session[:edit]).to be_nil
+        expect(controller.session[:adv_search]["Service"]).to be_nil
       end
     end
   end


### PR DESCRIPTION
**fixing issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/3261
**more info:** https://github.com/ManageIQ/manageiq-ui-classic/pull/3395

Fix displaying services after applying a filter and clicking on an other node in tree (_Active/Retired Services_ folder), in _Services > My Services_ page so that Active/Retired services **without filtering** are displayed.

---

**Details of a problem:**
There is an issue in _My Services_ page, after applying/clicking on some filter from _Global/My Filters_ in accordion: if we click on an other node in tree, for example _Active Services_ (or _Retired Services_), services are not displayed properly: there is inconsistency between displayed services and the title of the page, filter is applied on Active or Retired services, not on all of the services.

**Steps to reproduce:**
1. Go to _Services > My Services_ page
2. Click on some filter from accordion (from _Global/My Filters_ folder)
and you will see that filtering is applied on **all** of the services (this works right)
3. Click on _Active Services_ (or _Retired Services_) node in the tree in accordion
=> you will see active (or retired) services, filtered by previously selected filter, without any " - _Filtered by name_of_filter"_

Step 2:
![filtered_active](https://user-images.githubusercontent.com/13417815/35041989-157dcf22-fb87-11e7-8559-ee061e03d961.png)

**Before:** (step 3)
![active](https://user-images.githubusercontent.com/13417815/35042011-2a71fe1c-fb87-11e7-97f4-f30a155655b3.png)
![retired](https://user-images.githubusercontent.com/13417815/35042021-3611e9d0-fb87-11e7-8a88-9da7048d72e2.png)

**After:** (the title is consistent with services displayed on the page)
![active](https://user-images.githubusercontent.com/13417815/37662277-078138ae-2c57-11e8-86da-076bf00d73ee.png)
![retired](https://user-images.githubusercontent.com/13417815/37662294-0b03a14c-2c57-11e8-932c-367e02c082c7.png)

**Notes:** When fixing the problem, I also had to deal with normal _Search_ - to keep it working without any changes which lead to adding a necessary condition to resetting some values of `session` in `get_node_info`.