### PR TITLE
Fix title in service details page when searching text

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -327,7 +327,7 @@ class ServiceController < ApplicationController
       process_show_list
       @right_cell_text = _("All Services")
     end
-    @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present?
+    @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present? && @nodetype != 's'
     @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && @edit && @edit[:adv_search_applied]
 
     if @edit && @edit.fetch_path(:adv_search_applied, :qs_exp) # If qs is active, save it in history


### PR DESCRIPTION
**issue with more info:** https://github.com/ManageIQ/manageiq-ui-classic/issues/3655

Fix title in service details page in _Services > My Services_ when searching by text and then displaying some service details page (by clicking on a service name). The title contained unnecessary string _"(Names with <search_text>)"_.

---

**Before:**
![deploy_before](https://user-images.githubusercontent.com/13417815/37663792-457b2b44-2c5a-11e8-8a95-f8c6557a299c.png)

**After:**
![deploy_after](https://user-images.githubusercontent.com/13417815/37664020-c8a5c678-2c5a-11e8-864a-b410ebc7736d.png)

**Note:** 
I've added simple condition for not editing `@right_cell_text` when displaying service details page.
