### PR TITLE
Display filters in accordion in Host Aggregates page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1445,6 +1445,7 @@ module ApplicationHelper
           generic_object_definition
           guest_device
           host
+          host_aggregate
           load_balancer
           middleware_deployment
           middleware_domain

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,6 +253,7 @@ Rails.application.routes.draw do
         add_host
         add_host_select
         button
+        listnav_search_selected
         create
         quick_search
         remove_host
@@ -265,7 +266,7 @@ Rails.application.routes.draw do
         tl_chooser
         update
         wait_for_task
-      ) + adv_search_post + compare_post + exp_post + perf_post
+      ) + adv_search_post + compare_post + exp_post + perf_post + save_post
     },
 
     :catalog                  => {


### PR DESCRIPTION
**fixing issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/3429

Display filters in accordion in _Compute > Clouds > Host Aggregates_ page as there is working _Advanced Search_ in the page, but no filters are shown in accordion.

**Before:**
![host_agg_no_accord](https://user-images.githubusercontent.com/13417815/36391080-47accda8-15a5-11e8-8587-c299a6d4a808.png)

**After:**
![aggregate_filters](https://user-images.githubusercontent.com/13417815/37669995-7a097538-2c68-11e8-82b6-06862673504b.png)
![aggregate_filters2](https://user-images.githubusercontent.com/13417815/37670072-af843c7a-2c68-11e8-8239-001e1219ef0d.png)
