### PR TITLE
Generalizing methods for button operation handling

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -558,7 +558,7 @@ module ApplicationController::CiProcessing
     assert_privileges(params[:pressed])
     action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'remove_all_snapshots', _('Delete All Snapshots'), action,
-                             :partial_after_single_selection => 'vm_common/config'
+                             :refresh_partial => 'vm_common/config' if !@explorer
   end
   alias_method :vm_snapshot_delete_all, :deleteallsnapsvms
 
@@ -567,7 +567,7 @@ module ApplicationController::CiProcessing
     assert_privileges(params[:pressed])
     action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'remove_snapshot', _('Delete Snapshot'), action,
-                             :partial_after_single_selection => 'vm_common/config'
+                             :refresh_partial => 'vm_common/config' if !@explorer
   end
   alias_method :vm_snapshot_delete, :deletesnapsvms
 
@@ -576,7 +576,7 @@ module ApplicationController::CiProcessing
     assert_privileges(params[:pressed])
     action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'revert_to_snapshot', _('Revert to a Snapshot'), action,
-                             :partial_after_single_selection => 'vm_common/config'
+                             :refresh_partial => 'vm_common/config' if !@explorer
   end
   alias_method :vm_snapshot_revert, :revertsnapsvms
 
@@ -708,17 +708,21 @@ module ApplicationController::CiProcessing
         :severity => :error,
         :scroll_top => true)
     end
-    # explorer or non-explorer redirection
-    # TODO: this should be generalized
+    screen_redirection(options)
+  end
+
+  # Explorer or non-explorer screen redirection.
+  #
+  # Params:
+  #   options - specific partial to render
+  def screen_redirection(options)
     if @lastaction == "show_list"
       show_list unless @explorer
       @refresh_partial = "layouts/gtl"
     end
-    # TODO: this should be generalized
-    #       now it only applies for snapshots delete/revert action
-    if options[:partial_after_single_selection].present? && !@explorer
+    if options[:refresh_partial].present?
       show
-      @refresh_partial = options[:partial_after_single_selection]
+      @refresh_partial = options[:refresh_partial]
     end
   end
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -474,7 +474,8 @@ module ApplicationController::CiProcessing
   # Delete all selected or single displayed VM(s)
   def deletevms
     assert_privileges(params[:pressed])
-    vm_button_operation('destroy', _('Delete'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'destroy', _('Delete'), action
   end
   alias_method :image_delete, :deletevms
   alias_method :instance_delete, :deletevms
@@ -484,7 +485,8 @@ module ApplicationController::CiProcessing
   # Import info for all selected or single displayed vm(s)
   def syncvms
     assert_privileges(params[:pressed])
-    vm_button_operation('sync', _('Virtual Black Box synchronization'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'sync', _('Virtual Black Box synchronization'), action
   end
 
   DEFAULT_PRIVILEGE = Object.new # :nodoc:
@@ -498,7 +500,8 @@ module ApplicationController::CiProcessing
       privilege = params[:pressed]
     end
     assert_privileges(privilege)
-    vm_button_operation('refresh_ems', _('Refresh Provider'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'refresh_ems', _('Refresh Provider'), action
   end
   alias_method :image_refresh, :refreshvms
   alias_method :instance_refresh, :refreshvms
@@ -508,7 +511,8 @@ module ApplicationController::CiProcessing
   # Import info for all selected or single displayed vm(s)
   def scanvms
     assert_privileges(params[:pressed])
-    vm_button_operation('scan', _('Analysis'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'scan', _('Analysis'), action
   end
   alias_method :image_scan, :scanvms
   alias_method :instance_scan, :scanvms
@@ -518,7 +522,8 @@ module ApplicationController::CiProcessing
   # Immediately retire items
   def retirevms_now
     assert_privileges(params[:pressed])
-    vm_button_operation('retire_now', _('Retirement'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'retire_now', _('Retirement'), action
   end
   alias_method :instance_retire_now, :retirevms_now
   alias_method :vm_retire_now, :retirevms_now
@@ -526,7 +531,8 @@ module ApplicationController::CiProcessing
 
   def check_compliance_vms
     assert_privileges(params[:pressed])
-    vm_button_operation('check_compliance_queue', _('Check Compliance'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'check_compliance_queue', _('Check Compliance'), action
   end
   alias_method :image_check_compliance, :check_compliance_vms
   alias_method :instance_check_compliance, :check_compliance_vms
@@ -536,7 +542,8 @@ module ApplicationController::CiProcessing
   # Collect running processes for all selected or single displayed vm(s)
   def getprocessesvms
     assert_privileges(params[:pressed])
-    vm_button_operation('collect_running_processes', _('Collect Running Processes'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'collect_running_processes', _('Collect Running Processes'), action
   end
   alias_method :instance_collect_running_processes, :getprocessesvms
   alias_method :vm_collect_running_processes, :getprocessesvms
@@ -544,7 +551,8 @@ module ApplicationController::CiProcessing
   # Start all selected or single displayed vm(s)
   def startvms
     assert_privileges(params[:pressed])
-    vm_button_operation('start', _('Start'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'start', _('Start'), action
   end
   alias_method :instance_start, :startvms
   alias_method :vm_start, :startvms
@@ -552,7 +560,8 @@ module ApplicationController::CiProcessing
   # Suspend all selected or single displayed vm(s)
   def suspendvms
     assert_privileges(params[:pressed])
-    vm_button_operation('suspend', _('Suspend'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'suspend', _('Suspend'), action
   end
   alias_method :instance_suspend, :suspendvms
   alias_method :vm_suspend, :suspendvms
@@ -560,7 +569,8 @@ module ApplicationController::CiProcessing
   # Pause all selected or single displayed vm(s)
   def pausevms
     assert_privileges(params[:pressed])
-    vm_button_operation('pause', _('Pause'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'pause', _('Pause'), action
   end
   alias_method :instance_pause, :pausevms
   alias_method :vm_pause, :pausevms
@@ -568,14 +578,16 @@ module ApplicationController::CiProcessing
   # Terminate all selected or single displayed vm(s)
   def terminatevms
     assert_privileges(params[:pressed])
-    vm_button_operation('vm_destroy', _('Terminate'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'vm_destroy', _('Terminate'), action
   end
   alias_method :instance_terminate, :terminatevms
 
   # Stop all selected or single displayed vm(s)
   def stopvms
     assert_privileges(params[:pressed])
-    vm_button_operation('stop', _('Stop'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'stop', _('Stop'), action
   end
   alias_method :instance_stop, :stopvms
   alias_method :vm_stop, :stopvms
@@ -583,7 +595,8 @@ module ApplicationController::CiProcessing
   # Shelve all selected or single displayed vm(s)
   def shelvevms
     assert_privileges(params[:pressed])
-    vm_button_operation('shelve', _('Shelve'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'shelve', _('Shelve'), action
   end
   alias_method :instance_shelve, :shelvevms
   alias_method :vm_shelve, :shelvevms
@@ -591,7 +604,8 @@ module ApplicationController::CiProcessing
   # Shelve all selected or single displayed vm(s)
   def shelveoffloadvms
     assert_privileges(params[:pressed])
-    vm_button_operation('shelve_offload', _('Shelve Offload'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'shelve_offload', _('Shelve Offload'), action
   end
   alias_method :instance_shelve_offload, :shelveoffloadvms
   alias_method :vm_shelve_offload, :shelveoffloadvms
@@ -599,7 +613,8 @@ module ApplicationController::CiProcessing
   # Reset all selected or single displayed vm(s)
   def resetvms
     assert_privileges(params[:pressed])
-    vm_button_operation('reset', _('Reset'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'reset', _('Reset'), action
   end
   alias_method :instance_reset, :resetvms
   alias_method :vm_reset, :resetvms
@@ -607,20 +622,23 @@ module ApplicationController::CiProcessing
   # Shutdown guests on all selected or single displayed vm(s)
   def guestshutdown
     assert_privileges(params[:pressed])
-    vm_button_operation('shutdown_guest', _('Shutdown Guest'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'shutdown_guest', _('Shutdown Guest'), action
   end
   alias_method :vm_guest_shutdown, :guestshutdown
 
   # Standby guests on all selected or single displayed vm(s)
   def gueststandby
     assert_privileges(params[:pressed])
-    vm_button_operation('standby_guest', _('Standby Guest'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'standby_guest', _('Standby Guest'), action
   end
 
   # Restart guests on all selected or single displayed vm(s)
   def guestreboot
     assert_privileges(params[:pressed])
-    vm_button_operation('reboot_guest', _('Restart Guest'))
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'reboot_guest', _('Restart Guest'), action
   end
   alias_method :instance_guest_restart, :guestreboot
   alias_method :vm_guest_restart, :guestreboot
@@ -628,21 +646,27 @@ module ApplicationController::CiProcessing
   # Delete all snapshots for vm(s)
   def deleteallsnapsvms
     assert_privileges(params[:pressed])
-    vm_button_operation('remove_all_snapshots', _('Delete All Snapshots'), 'vm_common/config')
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'remove_all_snapshots', _('Delete All Snapshots'), action,
+                             :partial_after_single_selection => 'vm_common/config'
   end
   alias_method :vm_snapshot_delete_all, :deleteallsnapsvms
 
   # Delete selected snapshot for vm
   def deletesnapsvms
     assert_privileges(params[:pressed])
-    vm_button_operation('remove_snapshot', _('Delete Snapshot'), 'vm_common/config')
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'remove_snapshot', _('Delete Snapshot'), action,
+                             :partial_after_single_selection => 'vm_common/config'
   end
   alias_method :vm_snapshot_delete, :deletesnapsvms
 
   # Delete selected snapshot for vm
   def revertsnapsvms
     assert_privileges(params[:pressed])
-    vm_button_operation('revert_to_snapshot', _('Revert to a Snapshot'), 'vm_common/config')
+    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    generic_button_operation 'revert_to_snapshot', _('Revert to a Snapshot'), action,
+                             :partial_after_single_selection => 'vm_common/config'
   end
   alias_method :vm_snapshot_revert, :revertsnapsvms
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -702,7 +702,10 @@ module ApplicationController::CiProcessing
     screen_redirection(options)
   end
 
-  # In case a record does not support the feature, it won't be ran for
+  # Some of the tasks are not testable by SupportsFeatureMixin
+  # nor AvailabilityMixin.
+  #
+  # In case a record does not support the feature, the test won't be ran for
   # any of selected records.
   #
   # Params:
@@ -713,11 +716,13 @@ module ApplicationController::CiProcessing
   #           - false otherwise
   def testable_action(action)
     controller = params[:controller]
-    vm_infra_actions = %w(
-      reboot_guest stop start check_compliance_queue
+    vm_infra_untestable_actions = %w(
+      reboot_guest stop start check_compliance_queue destroy
       refresh_ems vm_miq_request_new suspend reset shutdown_guest
     )
-    return vm_infra_actions.exclude?(action) if controller == "vm_infra"
+    if controller == "vm_infra"
+      return vm_infra_untestable_actions.exclude?(action)
+    end
     true
   end
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -261,8 +261,6 @@ module ApplicationController::CiProcessing
     return false if task == 'retire_now' && !check_retire_requirements(items)
     return false if task == 'scan' && !check_scan_requirements(items)
     return false if task == 'reset' && !check_reset_requirements(items)
-    return false unless check_non_empty(items, display_name)
-
     process_objects(items, task, display_name)
     true
   end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -686,13 +686,13 @@ module ApplicationController::CiProcessing
     records = find_records_with_rbac(get_rec_cls, checked_or_params)
     if records_support_feature?(records, feature)
       action.call(records.map(&:id), feature, action_name)
-      @single_delete = feature == 'destroy' && !flash_errors?
     else
       javascript_flash(
         :text => _("#{action_name} action does not apply to selected items"),
         :severity => :error,
         :scroll_top => true)
     end
+    @single_delete = feature == 'destroy' && !flash_errors?
     screen_redirection(options)
   end
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -388,7 +388,7 @@ module ApplicationController::CiProcessing
   # Delete all selected or single displayed VM(s)
   def deletevms
     assert_privileges(params[:pressed])
-    generic_button_operation 'destroy', _('Delete'), vm_button_action
+    generic_button_operation('destroy', _('Delete'), vm_button_action)
   end
   alias_method :image_delete, :deletevms
   alias_method :instance_delete, :deletevms
@@ -398,7 +398,7 @@ module ApplicationController::CiProcessing
   # Import info for all selected or single displayed vm(s)
   def syncvms
     assert_privileges(params[:pressed])
-    generic_button_operation 'sync', _('Virtual Black Box synchronization'), vm_button_action
+    generic_button_operation('sync', _('Virtual Black Box synchronization'), vm_button_action)
   end
 
   DEFAULT_PRIVILEGE = Object.new # :nodoc:
@@ -412,7 +412,7 @@ module ApplicationController::CiProcessing
       privilege = params[:pressed]
     end
     assert_privileges(privilege)
-    generic_button_operation 'refresh_ems', _('Refresh Provider'), vm_button_action
+    generic_button_operation('refresh_ems', _('Refresh Provider'), vm_button_action)
   end
   alias_method :image_refresh, :refreshvms
   alias_method :instance_refresh, :refreshvms
@@ -422,7 +422,7 @@ module ApplicationController::CiProcessing
   # Import info for all selected or single displayed vm(s)
   def scanvms
     assert_privileges(params[:pressed])
-    generic_button_operation 'scan', _('Analysis'), vm_button_action
+    generic_button_operation('scan', _('Analysis'), vm_button_action)
   end
   alias_method :image_scan, :scanvms
   alias_method :instance_scan, :scanvms
@@ -432,11 +432,14 @@ module ApplicationController::CiProcessing
   # Immediately retire items
   def retirevms_now
     assert_privileges(params[:pressed])
-    generic_button_operation 'retire_now', _('Retirement'), vm_button_action,
-     :redirect => {
-      :controller => 'miq_request',
-      :action => 'show_list'
-    } if role_allows?(:feature => "miq_request_show_list")
+    redirect = {
+      :redirect => {
+        :controller => 'miq_request',
+        :action => 'show_list'
+      }
+    }
+    generic_button_operation('retire_now', _('Retirement'), vm_button_action,
+      role_allows?(:feature => "miq_request_show_list") ? redirect : nil)
   end
   alias_method :instance_retire_now, :retirevms_now
   alias_method :vm_retire_now, :retirevms_now
@@ -444,7 +447,7 @@ module ApplicationController::CiProcessing
 
   def check_compliance_vms
     assert_privileges(params[:pressed])
-    generic_button_operation 'check_compliance_queue', _('Check Compliance'), vm_button_action
+    generic_button_operation('check_compliance_queue', _('Check Compliance'), vm_button_action)
   end
   alias_method :image_check_compliance, :check_compliance_vms
   alias_method :instance_check_compliance, :check_compliance_vms
@@ -454,7 +457,7 @@ module ApplicationController::CiProcessing
   # Collect running processes for all selected or single displayed vm(s)
   def getprocessesvms
     assert_privileges(params[:pressed])
-    generic_button_operation 'collect_running_processes', _('Collect Running Processes'), vm_button_action
+    generic_button_operation('collect_running_processes', _('Collect Running Processes'), vm_button_action)
   end
   alias_method :instance_collect_running_processes, :getprocessesvms
   alias_method :vm_collect_running_processes, :getprocessesvms
@@ -462,7 +465,7 @@ module ApplicationController::CiProcessing
   # Start all selected or single displayed vm(s)
   def startvms
     assert_privileges(params[:pressed])
-    generic_button_operation 'start', _('Start'), vm_button_action
+    generic_button_operation('start', _('Start'), vm_button_action)
   end
   alias_method :instance_start, :startvms
   alias_method :vm_start, :startvms
@@ -470,7 +473,7 @@ module ApplicationController::CiProcessing
   # Suspend all selected or single displayed vm(s)
   def suspendvms
     assert_privileges(params[:pressed])
-    generic_button_operation 'suspend', _('Suspend'), vm_button_action
+    generic_button_operation('suspend', _('Suspend'), vm_button_action)
   end
   alias_method :instance_suspend, :suspendvms
   alias_method :vm_suspend, :suspendvms
@@ -478,7 +481,7 @@ module ApplicationController::CiProcessing
   # Pause all selected or single displayed vm(s)
   def pausevms
     assert_privileges(params[:pressed])
-    generic_button_operation 'pause', _('Pause'), vm_button_action
+    generic_button_operation('pause', _('Pause'), vm_button_action)
   end
   alias_method :instance_pause, :pausevms
   alias_method :vm_pause, :pausevms
@@ -486,14 +489,14 @@ module ApplicationController::CiProcessing
   # Terminate all selected or single displayed vm(s)
   def terminatevms
     assert_privileges(params[:pressed])
-    generic_button_operation 'vm_destroy', _('Terminate'), vm_button_action
+    generic_button_operation('vm_destroy', _('Terminate'), vm_button_action)
   end
   alias_method :instance_terminate, :terminatevms
 
   # Stop all selected or single displayed vm(s)
   def stopvms
     assert_privileges(params[:pressed])
-    generic_button_operation 'stop', _('Stop'), vm_button_action
+    generic_button_operation('stop', _('Stop'), vm_button_action)
   end
   alias_method :instance_stop, :stopvms
   alias_method :vm_stop, :stopvms
@@ -501,7 +504,7 @@ module ApplicationController::CiProcessing
   # Shelve all selected or single displayed vm(s)
   def shelvevms
     assert_privileges(params[:pressed])
-    generic_button_operation 'shelve', _('Shelve'), vm_button_action
+    generic_button_operation('shelve', _('Shelve'), vm_button_action)
   end
   alias_method :instance_shelve, :shelvevms
   alias_method :vm_shelve, :shelvevms
@@ -509,7 +512,7 @@ module ApplicationController::CiProcessing
   # Shelve all selected or single displayed vm(s)
   def shelveoffloadvms
     assert_privileges(params[:pressed])
-    generic_button_operation 'shelve_offload', _('Shelve Offload'), vm_button_action
+    generic_button_operation('shelve_offload', _('Shelve Offload'), vm_button_action)
   end
   alias_method :instance_shelve_offload, :shelveoffloadvms
   alias_method :vm_shelve_offload, :shelveoffloadvms
@@ -517,7 +520,7 @@ module ApplicationController::CiProcessing
   # Reset all selected or single displayed vm(s)
   def resetvms
     assert_privileges(params[:pressed])
-    generic_button_operation 'reset', _('Reset'), vm_button_action
+    generic_button_operation('reset', _('Reset'), vm_button_action)
   end
   alias_method :instance_reset, :resetvms
   alias_method :vm_reset, :resetvms
@@ -525,20 +528,20 @@ module ApplicationController::CiProcessing
   # Shutdown guests on all selected or single displayed vm(s)
   def guestshutdown
     assert_privileges(params[:pressed])
-    generic_button_operation 'shutdown_guest', _('Shutdown Guest'), vm_button_action
+    generic_button_operation('shutdown_guest', _('Shutdown Guest'), vm_button_action)
   end
   alias_method :vm_guest_shutdown, :guestshutdown
 
   # Standby guests on all selected or single displayed vm(s)
   def gueststandby
     assert_privileges(params[:pressed])
-    generic_button_operation 'standby_guest', _('Standby Guest'), vm_button_action
+    generic_button_operation('standby_guest', _('Standby Guest'), vm_button_action)
   end
 
   # Restart guests on all selected or single displayed vm(s)
   def guestreboot
     assert_privileges(params[:pressed])
-    generic_button_operation 'reboot_guest', _('Restart Guest'), vm_button_action
+    generic_button_operation('reboot_guest', _('Restart Guest'), vm_button_action)
   end
   alias_method :instance_guest_restart, :guestreboot
   alias_method :vm_guest_restart, :guestreboot
@@ -546,24 +549,24 @@ module ApplicationController::CiProcessing
   # Delete all snapshots for vm(s)
   def deleteallsnapsvms
     assert_privileges(params[:pressed])
-    generic_button_operation 'remove_all_snapshots', _('Delete All Snapshots'), vm_button_action,
-                             :refresh_partial => 'vm_common/config' unless @explorer
+    generic_button_operation('remove_all_snapshots', _('Delete All Snapshots'), vm_button_action,
+                             @explorer ? nil : {:refresh_partial => 'vm_common/config'})
   end
   alias_method :vm_snapshot_delete_all, :deleteallsnapsvms
 
   # Delete selected snapshot for vm
   def deletesnapsvms
     assert_privileges(params[:pressed])
-    generic_button_operation 'remove_snapshot', _('Delete Snapshot'), vm_button_action,
-                             :refresh_partial => 'vm_common/config' unless @explorer
+    generic_button_operation('remove_snapshot', _('Delete Snapshot'), vm_button_action,
+                             @explorer ? nil : {:refresh_partial => 'vm_common/config'})
   end
   alias_method :vm_snapshot_delete, :deletesnapsvms
 
   # Delete selected snapshot for vm
   def revertsnapsvms
     assert_privileges(params[:pressed])
-    generic_button_operation 'revert_to_snapshot', _('Revert to a Snapshot'), vm_button_action,
-                             :refresh_partial => 'vm_common/config' unless @explorer
+    generic_button_operation('revert_to_snapshot', _('Revert to a Snapshot'), vm_button_action,
+                             @explorer ? nil : {:refresh_partial => 'vm_common/config'})
   end
   alias_method :vm_snapshot_revert, :revertsnapsvms
 
@@ -684,7 +687,7 @@ module ApplicationController::CiProcessing
   #   operation   - a block with a operation, specific to the type of action
   #                 on a record
   #   options     - other optional parameters
-  def generic_button_operation(action, action_name, operation, options={})
+  def generic_button_operation(action, action_name, operation, options = {})
     records = find_records_with_rbac(get_rec_cls, checked_or_params)
     if testable_action(action) && !records_support_feature?(records, action_to_feature(action))
       javascript_flash(
@@ -698,7 +701,6 @@ module ApplicationController::CiProcessing
     @single_delete = action == 'destroy' && !flash_errors?
     screen_redirection(options)
   end
-
 
   # In case a record does not support the feature, it won't be ran for
   # any of selected records.

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -222,28 +222,9 @@ module ApplicationController::CiProcessing
     ui_lookup(:models => self.class.model.name)
   end
 
-  def check_retire_requirements(selected_items)
-    # FIXME: should check model, not controller
-    return true if %w(orchestration_stack service).include?(controller_name)
-
-    if VmOrTemplate.find(selected_items).any? { |vm| !vm.supports_retire? }
-      javascript_flash(:text => _("Retire does not apply to selected item"), :severity => :error, :scroll_top => true)
-      return false
-    end
-    true
-  end
-
   def check_scan_requirements(selected_items)
     unless VmOrTemplate.batch_operation_supported?('smartstate_analysis', selected_items)
       render_flash_not_applicable_to_model('Smartstate Analysis', ui_lookup(:tables => "vm_or_template"))
-      return false
-    end
-    true
-  end
-
-  def check_reset_requirements(selected_items)
-    if VmOrTemplate.find(selected_items).any? { |vm| !vm.supports_reset? }
-      javascript_flash(:text => _("Reset does not apply to at least one of the selected items"), :severity => :error, :scroll_top => true)
       return false
     end
     true
@@ -258,9 +239,7 @@ module ApplicationController::CiProcessing
   end
 
   def vm_button_operation_internal(items, task, display_name)
-    return false if task == 'retire_now' && !check_retire_requirements(items)
     return false if task == 'scan' && !check_scan_requirements(items)
-    return false if task == 'reset' && !check_reset_requirements(items)
     process_objects(items, task, display_name)
     true
   end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -686,15 +686,15 @@ module ApplicationController::CiProcessing
   #   options     - other optional parameters
   def generic_button_operation(action, action_name, operation, options={})
     records = find_records_with_rbac(get_rec_cls, checked_or_params)
-    if records_support_feature?(records, action_to_feature(action))
-      operation.call(records.map(&:id), action, action_name)
-    else
+    unless records_support_feature?(records, action_to_feature(action))
       javascript_flash(
         :text => _("%{action_name} action does not apply to selected items") %
           {:action_name => action_name},
         :severity => :error,
         :scroll_top => true)
+      return
     end
+    operation.call(records.map(&:id), action, action_name)
     @single_delete = action == 'destroy' && !flash_errors?
     screen_redirection(options)
   end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -686,7 +686,7 @@ module ApplicationController::CiProcessing
   #   options     - other optional parameters
   def generic_button_operation(action, action_name, operation, options={})
     records = find_records_with_rbac(get_rec_cls, checked_or_params)
-    unless records_support_feature?(records, action_to_feature(action))
+    if testable_action(action) && !records_support_feature?(records, action_to_feature(action))
       javascript_flash(
         :text => _("%{action_name} action does not apply to selected items") %
           {:action_name => action_name},
@@ -697,6 +697,26 @@ module ApplicationController::CiProcessing
     operation.call(records.map(&:id), action, action_name)
     @single_delete = action == 'destroy' && !flash_errors?
     screen_redirection(options)
+  end
+
+
+  # In case a record does not support the feature, it won't be ran for
+  # any of selected records.
+  #
+  # Params:
+  #   action  - a string indicating the operation user wants to execute
+  # Returns:
+  #   boolean - true, if the action should not skip the test for records
+  #             support for the action
+  #           - false otherwise
+  def testable_action(action)
+    controller = params[:controller]
+    vm_infra_actions = %w(
+      reboot_guest stop start check_compliance_queue
+      refresh_ems vm_miq_request_new suspend reset shutdown_guest
+    )
+    return vm_infra_actions.exclude?(action) if controller == "vm_infra"
+    true
   end
 
   # Maps UI actions to queryable feature in case it is not possible

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -432,7 +432,11 @@ module ApplicationController::CiProcessing
   # Immediately retire items
   def retirevms_now
     assert_privileges(params[:pressed])
-    generic_button_operation 'retire_now', _('Retirement'), vm_button_action
+    generic_button_operation 'retire_now', _('Retirement'), vm_button_action,
+     :redirect => {
+      :controller => 'miq_request',
+      :action => 'show_list'
+    } if role_allows?(:feature => "miq_request_show_list")
   end
   alias_method :instance_retire_now, :retirevms_now
   alias_method :vm_retire_now, :retirevms_now
@@ -716,6 +720,12 @@ module ApplicationController::CiProcessing
   # Params:
   #   options - specific partial to render
   def screen_redirection(options)
+    if options[:redirect].present?
+      javascript_redirect(:controller => options[:redirect][:controller],
+                          :action     => options[:redirect][:action],
+                          :flash_msg  => @flash_array[0][:message])
+      return
+    end
     if @lastaction == "show_list"
       show_list unless @explorer
       @refresh_partial = "layouts/gtl"

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -230,11 +230,6 @@ module ApplicationController::CiProcessing
     true
   end
 
-  def vm_button_operation_internal(items, task, display_name)
-    process_objects(items, task, display_name)
-    true
-  end
-
   def process_cloud_object_storage_buttons(pressed)
     assert_privileges(pressed)
 
@@ -389,7 +384,7 @@ module ApplicationController::CiProcessing
   # Delete all selected or single displayed VM(s)
   def deletevms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'destroy', _('Delete'), action
   end
   alias_method :image_delete, :deletevms
@@ -400,7 +395,7 @@ module ApplicationController::CiProcessing
   # Import info for all selected or single displayed vm(s)
   def syncvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'sync', _('Virtual Black Box synchronization'), action
   end
 
@@ -415,7 +410,7 @@ module ApplicationController::CiProcessing
       privilege = params[:pressed]
     end
     assert_privileges(privilege)
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'refresh_ems', _('Refresh Provider'), action
   end
   alias_method :image_refresh, :refreshvms
@@ -426,7 +421,7 @@ module ApplicationController::CiProcessing
   # Import info for all selected or single displayed vm(s)
   def scanvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'scan', _('Analysis'), action
   end
   alias_method :image_scan, :scanvms
@@ -437,7 +432,7 @@ module ApplicationController::CiProcessing
   # Immediately retire items
   def retirevms_now
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'retire_now', _('Retirement'), action
   end
   alias_method :instance_retire_now, :retirevms_now
@@ -446,7 +441,7 @@ module ApplicationController::CiProcessing
 
   def check_compliance_vms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'check_compliance_queue', _('Check Compliance'), action
   end
   alias_method :image_check_compliance, :check_compliance_vms
@@ -457,7 +452,7 @@ module ApplicationController::CiProcessing
   # Collect running processes for all selected or single displayed vm(s)
   def getprocessesvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'collect_running_processes', _('Collect Running Processes'), action
   end
   alias_method :instance_collect_running_processes, :getprocessesvms
@@ -466,7 +461,7 @@ module ApplicationController::CiProcessing
   # Start all selected or single displayed vm(s)
   def startvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'start', _('Start'), action
   end
   alias_method :instance_start, :startvms
@@ -475,7 +470,7 @@ module ApplicationController::CiProcessing
   # Suspend all selected or single displayed vm(s)
   def suspendvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'suspend', _('Suspend'), action
   end
   alias_method :instance_suspend, :suspendvms
@@ -484,7 +479,7 @@ module ApplicationController::CiProcessing
   # Pause all selected or single displayed vm(s)
   def pausevms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'pause', _('Pause'), action
   end
   alias_method :instance_pause, :pausevms
@@ -493,7 +488,7 @@ module ApplicationController::CiProcessing
   # Terminate all selected or single displayed vm(s)
   def terminatevms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'vm_destroy', _('Terminate'), action
   end
   alias_method :instance_terminate, :terminatevms
@@ -501,7 +496,7 @@ module ApplicationController::CiProcessing
   # Stop all selected or single displayed vm(s)
   def stopvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'stop', _('Stop'), action
   end
   alias_method :instance_stop, :stopvms
@@ -510,7 +505,7 @@ module ApplicationController::CiProcessing
   # Shelve all selected or single displayed vm(s)
   def shelvevms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'shelve', _('Shelve'), action
   end
   alias_method :instance_shelve, :shelvevms
@@ -519,7 +514,7 @@ module ApplicationController::CiProcessing
   # Shelve all selected or single displayed vm(s)
   def shelveoffloadvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'shelve_offload', _('Shelve Offload'), action
   end
   alias_method :instance_shelve_offload, :shelveoffloadvms
@@ -528,7 +523,7 @@ module ApplicationController::CiProcessing
   # Reset all selected or single displayed vm(s)
   def resetvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'reset', _('Reset'), action
   end
   alias_method :instance_reset, :resetvms
@@ -537,7 +532,7 @@ module ApplicationController::CiProcessing
   # Shutdown guests on all selected or single displayed vm(s)
   def guestshutdown
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'shutdown_guest', _('Shutdown Guest'), action
   end
   alias_method :vm_guest_shutdown, :guestshutdown
@@ -545,14 +540,14 @@ module ApplicationController::CiProcessing
   # Standby guests on all selected or single displayed vm(s)
   def gueststandby
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'standby_guest', _('Standby Guest'), action
   end
 
   # Restart guests on all selected or single displayed vm(s)
   def guestreboot
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'reboot_guest', _('Restart Guest'), action
   end
   alias_method :instance_guest_restart, :guestreboot
@@ -561,7 +556,7 @@ module ApplicationController::CiProcessing
   # Delete all snapshots for vm(s)
   def deleteallsnapsvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'remove_all_snapshots', _('Delete All Snapshots'), action,
                              :partial_after_single_selection => 'vm_common/config'
   end
@@ -570,7 +565,7 @@ module ApplicationController::CiProcessing
   # Delete selected snapshot for vm
   def deletesnapsvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'remove_snapshot', _('Delete Snapshot'), action,
                              :partial_after_single_selection => 'vm_common/config'
   end
@@ -579,7 +574,7 @@ module ApplicationController::CiProcessing
   # Delete selected snapshot for vm
   def revertsnapsvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| vm_button_operation_internal(ids, task, name) }
+    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
     generic_button_operation 'revert_to_snapshot', _('Revert to a Snapshot'), action,
                              :partial_after_single_selection => 'vm_common/config'
   end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -267,59 +267,6 @@ module ApplicationController::CiProcessing
     true
   end
 
-  # Common item button handler routines
-  def vm_button_operation(task, display_name, partial_after_single_selection = nil)
-    klass = get_rec_cls
-
-    # Either a list or coming from a different controller (e.g. from host screen, go to its vms)
-    if @lastaction == "show_list" ||
-       !%w(service vm_cloud vm_infra vm miq_template vm_or_template orchestration_stack).include?(controller_name)
-
-      # FIXME: retrieving vms from DB two times
-      items = find_checked_ids_with_rbac(klass, task)
-
-      vm_button_operation_internal(items, task, display_name) || return
-
-      if task == 'retire_now' && role_allows?(:feature => "miq_request_show_list", :any => true)
-        javascript_redirect(:controller => 'miq_request',
-                            :action     => 'show_list',
-                            :flash_msg  => @flash_array[0][:message])
-      end
-
-      # In non-explorer case, render the list (filling in @view).
-      if @lastaction == "show_list"
-        show_list unless @explorer
-        @refresh_partial = "layouts/gtl"
-      end
-
-    else # showing 1 item
-      items = [find_id_with_rbac_no_exception(klass, params[:id])].compact
-
-      unless check_non_empty(items, display_name)
-        show_list unless @explorer
-        @refresh_partial = "layouts/gtl"
-        return
-      end
-
-      vm_button_operation_internal(items, task, display_name)
-
-      if task == 'retire_now' && role_allows?(:feature => "miq_request_show_list", :any => true)
-        javascript_redirect(:controller => 'miq_request',
-                            :action     => 'show_list',
-                            :flash_msg  => @flash_array[0][:message])
-      end
-
-      # Tells callers to go back to show_list because this item may be gone.
-      @single_delete = task == 'destroy' && !flash_errors?
-
-      # For Snapshot Trees
-      if partial_after_single_selection && !@explorer
-        show
-        @refresh_partial = partial_after_single_selection
-      end
-    end
-  end
-
   def process_cloud_object_storage_buttons(pressed)
     assert_privileges(pressed)
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -550,7 +550,7 @@ module ApplicationController::CiProcessing
   def deleteallsnapsvms
     assert_privileges(params[:pressed])
     generic_button_operation('remove_all_snapshots', _('Delete All Snapshots'), vm_button_action,
-                             @explorer ? nil : {:refresh_partial => 'vm_common/config'})
+                             @explorer ? {} : {:refresh_partial => 'vm_common/config'})
   end
   alias_method :vm_snapshot_delete_all, :deleteallsnapsvms
 
@@ -558,7 +558,7 @@ module ApplicationController::CiProcessing
   def deletesnapsvms
     assert_privileges(params[:pressed])
     generic_button_operation('remove_snapshot', _('Delete Snapshot'), vm_button_action,
-                             @explorer ? nil : {:refresh_partial => 'vm_common/config'})
+                             @explorer ? {} : {:refresh_partial => 'vm_common/config'})
   end
   alias_method :vm_snapshot_delete, :deletesnapsvms
 
@@ -566,7 +566,7 @@ module ApplicationController::CiProcessing
   def revertsnapsvms
     assert_privileges(params[:pressed])
     generic_button_operation('revert_to_snapshot', _('Revert to a Snapshot'), vm_button_action,
-                             @explorer ? nil : {:refresh_partial => 'vm_common/config'})
+                             @explorer ? {} : {:refresh_partial => 'vm_common/config'})
   end
   alias_method :vm_snapshot_revert, :revertsnapsvms
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -667,24 +667,26 @@ module ApplicationController::CiProcessing
     clusters.count
   end
 
-  # The method calls task called from UI on the selected records.
-  # In case any record does not support an action, it won't be ran for
+  # The method takes care of task processing initiated from UI on the
+  # selected records.
+  #
+  # In case a record does not support the feature, it won't be ran for
   # any of selected records.
   #
   # Params:
-  #   task        - string of an action
-  #               - the actions should be present in
-  #                 SupportsFeatureMixin::QUERYABLE_FEATURES
+  #   feature     - a feature implemented by using AvailabilityMixin or
+  #                 SupportsFeatureMixin
+  #               - SupportsFeatureMixin::QUERYABLE_FEATURES
   #   action_name - a string of an action used for a flash message in case
   #                 the task can not be applied
   #   action      - a block with a operation, specific to the type of action
   #                 on a record
   #   options     - other parameters
-  def generic_button_operation(task, action_name, action, options={})
+  def generic_button_operation(feature, action_name, action, options={})
     records = find_records_with_rbac(get_rec_cls, checked_or_params)
-    if records_support_action?(records, task)
-      action.call(records.map(&:id), task, action_name)
-      @single_delete = task == 'destroy' && !flash_errors?
+    if records_support_feature?(records, feature)
+      action.call(records.map(&:id), feature, action_name)
+      @single_delete = feature == 'destroy' && !flash_errors?
     else
       javascript_flash(
         :text => _("#{action_name} action does not apply to selected items"),

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -543,7 +543,7 @@ module ApplicationController::CiProcessing
   def deleteallsnapsvms
     assert_privileges(params[:pressed])
     generic_button_operation 'remove_all_snapshots', _('Delete All Snapshots'), vm_button_action,
-                             :refresh_partial => 'vm_common/config' if !@explorer
+                             :refresh_partial => 'vm_common/config' unless @explorer
   end
   alias_method :vm_snapshot_delete_all, :deleteallsnapsvms
 
@@ -551,7 +551,7 @@ module ApplicationController::CiProcessing
   def deletesnapsvms
     assert_privileges(params[:pressed])
     generic_button_operation 'remove_snapshot', _('Delete Snapshot'), vm_button_action,
-                             :refresh_partial => 'vm_common/config' if !@explorer
+                             :refresh_partial => 'vm_common/config' unless @explorer
   end
   alias_method :vm_snapshot_delete, :deletesnapsvms
 
@@ -559,7 +559,7 @@ module ApplicationController::CiProcessing
   def revertsnapsvms
     assert_privileges(params[:pressed])
     generic_button_operation 'revert_to_snapshot', _('Revert to a Snapshot'), vm_button_action,
-                             :refresh_partial => 'vm_common/config' if !@explorer
+                             :refresh_partial => 'vm_common/config' unless @explorer
   end
   alias_method :vm_snapshot_revert, :revertsnapsvms
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -222,14 +222,6 @@ module ApplicationController::CiProcessing
     ui_lookup(:models => self.class.model.name)
   end
 
-  def check_scan_requirements(selected_items)
-    unless VmOrTemplate.batch_operation_supported?('smartstate_analysis', selected_items)
-      render_flash_not_applicable_to_model('Smartstate Analysis', ui_lookup(:tables => "vm_or_template"))
-      return false
-    end
-    true
-  end
-
   def check_non_empty(items, display_name)
     if items.blank?
       add_flash(_("No items were selected for %{task}") % {:task => display_name}, :error)
@@ -239,7 +231,6 @@ module ApplicationController::CiProcessing
   end
 
   def vm_button_operation_internal(items, task, display_name)
-    return false if task == 'scan' && !check_scan_requirements(items)
     process_objects(items, task, display_name)
     true
   end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -106,6 +106,10 @@ module ApplicationController::CiProcessing
 
   private
 
+  def vm_button_action
+    method(:process_objects)
+  end
+
   def process_elements(elements, klass, task, display_name = nil, order_field = nil)
     order_field ||= %w(name description title).find do |field|
                       klass.column_names.include?(field)
@@ -384,8 +388,7 @@ module ApplicationController::CiProcessing
   # Delete all selected or single displayed VM(s)
   def deletevms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'destroy', _('Delete'), action
+    generic_button_operation 'destroy', _('Delete'), vm_button_action
   end
   alias_method :image_delete, :deletevms
   alias_method :instance_delete, :deletevms
@@ -395,8 +398,7 @@ module ApplicationController::CiProcessing
   # Import info for all selected or single displayed vm(s)
   def syncvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'sync', _('Virtual Black Box synchronization'), action
+    generic_button_operation 'sync', _('Virtual Black Box synchronization'), vm_button_action
   end
 
   DEFAULT_PRIVILEGE = Object.new # :nodoc:
@@ -410,8 +412,7 @@ module ApplicationController::CiProcessing
       privilege = params[:pressed]
     end
     assert_privileges(privilege)
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'refresh_ems', _('Refresh Provider'), action
+    generic_button_operation 'refresh_ems', _('Refresh Provider'), vm_button_action
   end
   alias_method :image_refresh, :refreshvms
   alias_method :instance_refresh, :refreshvms
@@ -421,8 +422,7 @@ module ApplicationController::CiProcessing
   # Import info for all selected or single displayed vm(s)
   def scanvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'scan', _('Analysis'), action
+    generic_button_operation 'scan', _('Analysis'), vm_button_action
   end
   alias_method :image_scan, :scanvms
   alias_method :instance_scan, :scanvms
@@ -432,8 +432,7 @@ module ApplicationController::CiProcessing
   # Immediately retire items
   def retirevms_now
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'retire_now', _('Retirement'), action
+    generic_button_operation 'retire_now', _('Retirement'), vm_button_action
   end
   alias_method :instance_retire_now, :retirevms_now
   alias_method :vm_retire_now, :retirevms_now
@@ -441,8 +440,7 @@ module ApplicationController::CiProcessing
 
   def check_compliance_vms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'check_compliance_queue', _('Check Compliance'), action
+    generic_button_operation 'check_compliance_queue', _('Check Compliance'), vm_button_action
   end
   alias_method :image_check_compliance, :check_compliance_vms
   alias_method :instance_check_compliance, :check_compliance_vms
@@ -452,8 +450,7 @@ module ApplicationController::CiProcessing
   # Collect running processes for all selected or single displayed vm(s)
   def getprocessesvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'collect_running_processes', _('Collect Running Processes'), action
+    generic_button_operation 'collect_running_processes', _('Collect Running Processes'), vm_button_action
   end
   alias_method :instance_collect_running_processes, :getprocessesvms
   alias_method :vm_collect_running_processes, :getprocessesvms
@@ -461,8 +458,7 @@ module ApplicationController::CiProcessing
   # Start all selected or single displayed vm(s)
   def startvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'start', _('Start'), action
+    generic_button_operation 'start', _('Start'), vm_button_action
   end
   alias_method :instance_start, :startvms
   alias_method :vm_start, :startvms
@@ -470,8 +466,7 @@ module ApplicationController::CiProcessing
   # Suspend all selected or single displayed vm(s)
   def suspendvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'suspend', _('Suspend'), action
+    generic_button_operation 'suspend', _('Suspend'), vm_button_action
   end
   alias_method :instance_suspend, :suspendvms
   alias_method :vm_suspend, :suspendvms
@@ -479,8 +474,7 @@ module ApplicationController::CiProcessing
   # Pause all selected or single displayed vm(s)
   def pausevms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'pause', _('Pause'), action
+    generic_button_operation 'pause', _('Pause'), vm_button_action
   end
   alias_method :instance_pause, :pausevms
   alias_method :vm_pause, :pausevms
@@ -488,16 +482,14 @@ module ApplicationController::CiProcessing
   # Terminate all selected or single displayed vm(s)
   def terminatevms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'vm_destroy', _('Terminate'), action
+    generic_button_operation 'vm_destroy', _('Terminate'), vm_button_action
   end
   alias_method :instance_terminate, :terminatevms
 
   # Stop all selected or single displayed vm(s)
   def stopvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'stop', _('Stop'), action
+    generic_button_operation 'stop', _('Stop'), vm_button_action
   end
   alias_method :instance_stop, :stopvms
   alias_method :vm_stop, :stopvms
@@ -505,8 +497,7 @@ module ApplicationController::CiProcessing
   # Shelve all selected or single displayed vm(s)
   def shelvevms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'shelve', _('Shelve'), action
+    generic_button_operation 'shelve', _('Shelve'), vm_button_action
   end
   alias_method :instance_shelve, :shelvevms
   alias_method :vm_shelve, :shelvevms
@@ -514,8 +505,7 @@ module ApplicationController::CiProcessing
   # Shelve all selected or single displayed vm(s)
   def shelveoffloadvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'shelve_offload', _('Shelve Offload'), action
+    generic_button_operation 'shelve_offload', _('Shelve Offload'), vm_button_action
   end
   alias_method :instance_shelve_offload, :shelveoffloadvms
   alias_method :vm_shelve_offload, :shelveoffloadvms
@@ -523,8 +513,7 @@ module ApplicationController::CiProcessing
   # Reset all selected or single displayed vm(s)
   def resetvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'reset', _('Reset'), action
+    generic_button_operation 'reset', _('Reset'), vm_button_action
   end
   alias_method :instance_reset, :resetvms
   alias_method :vm_reset, :resetvms
@@ -532,23 +521,20 @@ module ApplicationController::CiProcessing
   # Shutdown guests on all selected or single displayed vm(s)
   def guestshutdown
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'shutdown_guest', _('Shutdown Guest'), action
+    generic_button_operation 'shutdown_guest', _('Shutdown Guest'), vm_button_action
   end
   alias_method :vm_guest_shutdown, :guestshutdown
 
   # Standby guests on all selected or single displayed vm(s)
   def gueststandby
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'standby_guest', _('Standby Guest'), action
+    generic_button_operation 'standby_guest', _('Standby Guest'), vm_button_action
   end
 
   # Restart guests on all selected or single displayed vm(s)
   def guestreboot
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'reboot_guest', _('Restart Guest'), action
+    generic_button_operation 'reboot_guest', _('Restart Guest'), vm_button_action
   end
   alias_method :instance_guest_restart, :guestreboot
   alias_method :vm_guest_restart, :guestreboot
@@ -556,8 +542,7 @@ module ApplicationController::CiProcessing
   # Delete all snapshots for vm(s)
   def deleteallsnapsvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'remove_all_snapshots', _('Delete All Snapshots'), action,
+    generic_button_operation 'remove_all_snapshots', _('Delete All Snapshots'), vm_button_action,
                              :refresh_partial => 'vm_common/config' if !@explorer
   end
   alias_method :vm_snapshot_delete_all, :deleteallsnapsvms
@@ -565,8 +550,7 @@ module ApplicationController::CiProcessing
   # Delete selected snapshot for vm
   def deletesnapsvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'remove_snapshot', _('Delete Snapshot'), action,
+    generic_button_operation 'remove_snapshot', _('Delete Snapshot'), vm_button_action,
                              :refresh_partial => 'vm_common/config' if !@explorer
   end
   alias_method :vm_snapshot_delete, :deletesnapsvms
@@ -574,8 +558,7 @@ module ApplicationController::CiProcessing
   # Delete selected snapshot for vm
   def revertsnapsvms
     assert_privileges(params[:pressed])
-    action = Proc.new { |ids, task, name| process_objects(ids, task, name) }
-    generic_button_operation 'revert_to_snapshot', _('Revert to a Snapshot'), action,
+    generic_button_operation 'revert_to_snapshot', _('Revert to a Snapshot'), vm_button_action,
                              :refresh_partial => 'vm_common/config' if !@explorer
   end
   alias_method :vm_snapshot_revert, :revertsnapsvms

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -201,23 +201,21 @@ module ApplicationHelper
     false
   end
 
-  # Returns whether the records support an action or not.
+  # Returns whether records support feature or not.
   #
   # Params:
-  #   records - an array or single instance of a record
-  #   action  - action sent to the SupportsFeatureMixin
-  #           - the actions should be present in
-  #             SupportsFeatureMixin::QUERYABLE_FEATURES
+  #   records - an array of records or a single instance of a record
+  #   feature - a feature from SupportsFeatureMixin::QUERYABLE_FEATURES
   # Returns:
-  #   boolean - true if all records support the action
-  #           - false in case record (or one of many records) does not support
-  #             the action
-  def records_support_action?(records, action)
+  #   boolean - true if all records support the feature
+  #           - false in case the record (or one of many records) does not
+  #             support the feature
+  def records_support_feature?(records, feature)
     unsupported_record = Array.wrap(records).find do |record|
-      if record.respond_to?("supports_#{action}?")
-        !record.supports?(action.to_sym)
+      if record.respond_to?("supports_#{feature}?")
+        !record.supports?(feature.to_sym)
       else # TODO: remove with deleting AvailabilityMixin module
-        !record.is_available?(action.to_sym)
+        !record.is_available?(feature.to_sym)
       end
     end
     unsupported_record.nil?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -201,6 +201,28 @@ module ApplicationHelper
     false
   end
 
+  # Returns whether the records support an action or not.
+  #
+  # Params:
+  #   records - an array or single instance of a record
+  #   action  - action sent to the SupportsFeatureMixin
+  #           - the actions should be present in
+  #             SupportsFeatureMixin::QUERYABLE_FEATURES
+  # Returns:
+  #   boolean - true if all records support the action
+  #           - false in case record (or one of many records) does not support
+  #             the action
+  def records_support_action?(records, action)
+    unsupported_record = Array.wrap(records).find do |record|
+      if record.respond_to?("supports_#{action}?")
+        !record.supports?(action.to_sym)
+      else # TODO: remove with deleting AvailabilityMixin module
+        !record.is_available?(action.to_sym)
+      end
+    end
+    unsupported_record.nil?
+  end
+
   def url_for_record(record, action = "show") # Default action is show
     @id = record.id
     db  = if controller.kind_of?(VmOrTemplateController)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -204,8 +204,8 @@ module ApplicationHelper
   # Returns whether records support feature or not.
   #
   # Params:
-  #   records - an array of records or a single instance of a record
-  #   feature - a feature from SupportsFeatureMixin::QUERYABLE_FEATURES
+  #   records - an array of record instances or a single instance of a record
+  #   feature - symbol, a feature from SupportsFeatureMixin::QUERYABLE_FEATURES
   # Returns:
   #   boolean - true if all records support the feature
   #           - false in case the record (or one of many records) does not
@@ -213,9 +213,9 @@ module ApplicationHelper
   def records_support_feature?(records, feature)
     unsupported_record = Array.wrap(records).find do |record|
       if record.respond_to?("supports_#{feature}?")
-        !record.supports?(feature.to_sym)
+        !record.supports?(feature)
       else # TODO: remove with deleting AvailabilityMixin module
-        !record.is_available?(feature.to_sym)
+        !record.is_available?(feature)
       end
     end
     unsupported_record.nil?

--- a/app/helpers/application_helper/button/generic_feature_button.rb
+++ b/app/helpers/application_helper/button/generic_feature_button.rb
@@ -1,4 +1,6 @@
 class ApplicationHelper::Button::GenericFeatureButton < ApplicationHelper::Button::Basic
+  include ApplicationHelper
+
   needs :@record
 
   def initialize(view_context, view_binding, instance_data, props)
@@ -7,12 +9,6 @@ class ApplicationHelper::Button::GenericFeatureButton < ApplicationHelper::Butto
   end
 
   def visible?
-    method = "supports_#{@feature}?"
-
-    if @record.respond_to?(method)
-      @record.send(method)
-    else # TODO: remove with deleting AvailabilityMixin module
-      @record.is_available?(@feature)
-    end
+    records_support_action?(@record, @feature)
   end
 end

--- a/app/helpers/application_helper/button/generic_feature_button.rb
+++ b/app/helpers/application_helper/button/generic_feature_button.rb
@@ -9,6 +9,6 @@ class ApplicationHelper::Button::GenericFeatureButton < ApplicationHelper::Butto
   end
 
   def visible?
-    records_support_action?(@record, @feature)
+    records_support_feature?(@record, @feature)
   end
 end

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -17,11 +17,10 @@ describe ApplicationController do
           :@_params,
           :miq_grid_checks => "#{vm1.id}, #{vm3.id}, #{vm2.id}")
         # calling 'vm_button_action' creates a proc calling 'process_objects'
-        expect(controller).to receive(:javascript_flash).with({
+        expect(controller).to receive(:javascript_flash).with(
           :text => "Smartstate Analysis action does not apply to selected items",
           :severity => :error,
-          :scroll_top => true
-        })
+          :scroll_top => true)
         process_proc = controller.send(:vm_button_action)
         controller.send(
           :generic_button_operation,
@@ -81,7 +80,7 @@ describe ApplicationController do
       expect(controller).to receive(:generic_button_operation)
         .with('remove_all_snapshots',
               'Delete All Snapshots',
-              subject.send(:vm_button_action) ,
+              subject.send(:vm_button_action),
               :refresh_partial => 'vm_common/config')
       controller.send(:vm_snapshot_delete_all)
     end

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -32,6 +32,46 @@ describe ApplicationController do
     end
   end
 
+  describe "action_to_feature" do
+    let(:record) { FactoryGirl.create(:vm_redhat) }
+
+    context 'the UI action is also a queryable feature' do
+      before do
+        controller.instance_variable_set(:@_params, :id => record.id)
+        allow(controller).to receive(:render)
+      end
+
+      it 'uses the "reset" action to ask for records support for it' do
+        expect(controller).to receive(:records_support_feature?)
+          .with([record], :reset)
+        process_proc = controller.send(:vm_button_action)
+        controller.send(
+          :generic_button_operation,
+          'reset',
+          "Reset",
+          process_proc)
+      end
+    end
+
+    context 'the UI action is not a queryable feature' do
+      before do
+        controller.instance_variable_set(:@_params, :id => record.id)
+        allow(controller).to receive(:render)
+      end
+
+      it 'uses the "retire" feature to ask for records support for it' do
+        expect(controller).to receive(:records_support_feature?)
+          .with([record], :retire)
+        process_proc = controller.send(:vm_button_action)
+        controller.send(
+          :generic_button_operation,
+          'retire_now',
+          "Retirement",
+          process_proc)
+      end
+    end
+  end
+
   context "Verify proper methods are called for snapshot" do
     before(:each) do
       allow(subject).to receive(:vm_button_action).and_return(subject.method(:process_objects))

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -425,10 +425,6 @@ describe VmInfraController do
   end
 
   it 'can Reset VM' do
-    expect(vm_vmware).to receive(:supports_control?).and_return(true)
-    expect(vm_vmware).to receive(:current_state).and_return("on")
-    expect(VmOrTemplate).to receive(:find).with([vm_vmware.id.to_s]).and_return([vm_vmware])
-
     post :x_button, :params => {:pressed => 'vm_reset', :id => vm_vmware.id}
     expect(response.status).to eq(200)
 

--- a/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
@@ -5,7 +5,7 @@ shared_examples_for 'a generic feature button' do
     subject { button.visible? }
     before do
       allow(record).to receive("respond_to?").with("supports_#{feature}?").and_return(true)
-      # hack to mock Array.wrap method for Double
+      # HACK: to mock Array.wrap method for Double
       allow(record).to receive("respond_to?").with(:to_ary).and_return(false)
       allow(record).to receive("supports?").with(feature.to_sym).and_return(supports_feature)
     end

--- a/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
@@ -3,7 +3,12 @@ shared_examples_for 'a generic feature button' do
 
   describe '#visible?' do
     subject { button.visible? }
-    before { allow(record).to receive("supports_#{feature}?".to_sym).and_return(supports_feature) }
+    before do
+      allow(record).to receive("respond_to?").with("supports_#{feature}?").and_return(true)
+      # hack to mock Array.wrap method for Double
+      allow(record).to receive("respond_to?").with(:to_ary).and_return(false)
+      allow(record).to receive("supports?").with(feature.to_sym).and_return(supports_feature)
+    end
 
     context "when record supports #{feature}" do
       let(:supports_feature) { true }


### PR DESCRIPTION
## This PR needs to be merged together with https://github.com/ManageIQ/manageiq/pull/17415

- In this PR I'm introducing a new generic method `generic_button_operation` that should replace all other methods handling button operation in following PRs.

- In this PR, the method `vm_button_operation_internal` is removed with all the related methods as an example