### PR TITLE
Set `openssl_verify_mode` to "none"

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -938,7 +938,7 @@ module OpsController::Settings::Common
       @edit[:current].config[:server][:locale] = "default" if @edit[:current].config[:server][:locale].blank?
       @edit[:current].config[:server][:remote_console_type] ||= "VNC"
       @edit[:current].config[:smtp][:enable_starttls_auto] = GenericMailer.default_for_enable_starttls_auto if @edit[:current].config[:smtp][:enable_starttls_auto].nil?
-      @edit[:current].config[:smtp][:openssl_verify_mode] ||= nil
+      @edit[:current].config[:smtp][:openssl_verify_mode] ||= "none"
       @edit[:current].config[:ntp] ||= {}
       @in_a_form = true
     when "settings_authentication"        # Authentication tab


### PR DESCRIPTION
Setting the `openssl_verify_mode` to "none" ensures that the value "none" is set in the yml in Advanced Settings.

https://bugzilla.redhat.com/show_bug.cgi?id=1475553

Before -- `:openssl_verify_mode:` 
No value set for `openssl_verify_mode` on a Save

<img width="347" alt="screen shot 2018-03-20 at 3 48 30 pm" src="https://user-images.githubusercontent.com/1538216/37686986-09c1197c-2c57-11e8-9a1c-f0cb2da4716b.png">

After -- `:openssl_verify_mode: none` 
Value "none" set for `openssl_verify_mode` on a Save

<img width="346" alt="screen shot 2018-03-20 at 3 52 34 pm" src="https://user-images.githubusercontent.com/1538216/37686981-01e40584-2c57-11e8-8554-da43b348a71a.png">
