### PR TITLE
Fix editing of Default Container Image Rate

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -110,9 +110,6 @@ class ChargebackController < ApplicationController
       if @edit[:new][:description].nil? || @edit[:new][:description] == ""
         render_flash(_("Description is required"), :error)
         return
-      elsif @rate.description == "Default Container Image Rate" && @edit[:new][:description] != @rate.description
-        render_flash(_("Can not change description of 'Default Container Image Rate'"), :error)
-        return
       end
       @rate.description = @edit[:new][:description]
       @rate.rate_type   = @edit[:new][:rate_type] if @edit[:new][:rate_type]

--- a/app/helpers/application_helper/button/chargeback_rate_remove.rb
+++ b/app/helpers/application_helper/button/chargeback_rate_remove.rb
@@ -2,13 +2,7 @@ class ApplicationHelper::Button::ChargebackRateRemove < ApplicationHelper::Butto
   needs :@record
 
   def disabled?
-    @error_message = _('Default Chargeback Rate cannot be removed.') if default?
+    @error_message = _('Default Chargeback Rate cannot be removed.') if @record.default?
     @error_message.present?
-  end
-
-  private
-
-  def default?
-    @record.default? || @record.description == 'Default Container Image Rate'
   end
 end


### PR DESCRIPTION
**Fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1552260
**Depends on** https://github.com/ManageIQ/manageiq/pull/17188

---

**The problem:**
There was a bug, in _Cloud Intel > Chargeback > Rates > Compute Rates_: it was possible to edit _Default Container Image Rate_, from its details page and also from the page with the list of Compute Rates.

**How expected result/solution looks like:**
Working with Default Container Image Rate will work (after merging this PR and another PR in main MIQ repo) the same way as working with _Default Rate_ (under Compute/Storage Rates): when displaying its details page, the button for editing of Default Container Image Rate (under _Configuration_) will be disabled automatically; when displaying list of the rates and checking the checkbox of Default Container Image Rate, and then clicking on _Edit the selected Chargeback Rate_, error message will occur and it will inform that it's not possible to edit this rate.

**What was needed to be done:**
 - Refactor `disabled?` method for chargeback rate remove button, according to the changes in core repo (link above)
- Remove unnecessary case from `cb_rate_edit` method related to saving/adding a new rate, because it will be no longer possible to edit Default Container Image Rate (after merging this PR)

---

Trying to edit Default Container Image Rate, after selecting the rate by checking its checkbox and clicking on Edit the selected Chargeback Rate:
![rate_edit](https://user-images.githubusercontent.com/13417815/37803604-0920bd26-2e30-11e8-99f8-812d5a29a860.png)

**Before fixing:**
We were able to access editing screen, no flash message occurred:
![default_before2](https://user-images.githubusercontent.com/13417815/37803676-87186c24-2e30-11e8-8c93-f1a74a699bdf.png)
We were able to click on Edit this Chargeback Rate, for Default Container Image Rate:
![default_before](https://user-images.githubusercontent.com/13417815/37803679-8ac60e26-2e30-11e8-90ba-70a5654af7a7.png)

**After fixing:**
Flash message occurs to inform us:
![default_after](https://user-images.githubusercontent.com/13417815/37803109-6cbe74e8-2e2d-11e8-85ef-4ce0677a7bbb.png)
The button for editing this rate is not active anymore:
![default_after2](https://user-images.githubusercontent.com/13417815/37803117-70c5b042-2e2d-11e8-8a1b-308232418571.png)

