### PR TITLE
Graphql lanaguage service / ignore .flow.js files 

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -53,10 +53,10 @@ module.exports = {
       resolve(__dirname, '../../'), // location of your src
       {} // a map of your routes
     ),
-
+    // Workaround for graphql/graphql-language-service#128
     new webpack.ContextReplacementPlugin(
-      /graphql-language-service-interface[\\/]dist$/,
-      new RegExp(`^\\./.*\\.js$`)
+      /graphql-language-service-interface[\\\/]dist$/,
+      /\.js$/
     ),
 
     new ManifestPlugin({

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -54,6 +54,11 @@ module.exports = {
       {} // a map of your routes
     ),
 
+    new webpack.ContextReplacementPlugin(
+      /graphql-language-service-interface[\\/]dist$/,
+      new RegExp(`^\\./.*\\.js$`)
+    ),
+
     new ManifestPlugin({
       publicPath: output.publicPath,
       writeToFileEmit: true,


### PR DESCRIPTION
Add the following fix to ignore graphql .flow.js files for the time being:
https://github.com/graphql/graphql-language-service/issues/128#issuecomment-316343538

Webpack does not support these out of the box and it seems that tag-loader is still buggy.

Corresponding PR in manageiq-graphql:
https://github.com/ManageIQ/manageiq-graphql/pull/49

This enables loading that plugin alongside v2v plugin (currently they cannot be loaded together with the webpack dev server in place)
