### PR TITLE
Allow Schedule to have also custom MiqReport in Filter

### DIFF
--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -298,7 +298,7 @@ module ReportController::Schedules
     @edit[:new]      = {}
     @edit[:current]  = {}
     @edit[:key]      = "schedule_edit__#{@schedule.id || "new"}"
-    @menu            = get_reports_menu(true)
+    @menu            = get_reports_menu
     @menu.each { |r| @folders.push(r[0]) }
 
     @edit[:new][:name]        = @schedule.name


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1559323

Filter in Schedule form is missing custom `MiqReport`s.

Cloud Intel -> Reports -> Schedules -> Configuration -> Edit/Add

Before:
![image](https://user-images.githubusercontent.com/9210860/37824020-9f2433d8-2e8b-11e8-88f2-5687c14add80.png)
After:
![image](https://user-images.githubusercontent.com/9210860/37824030-a56d8794-2e8b-11e8-93fe-676ee4b43af9.png)

@miq-bot add_label bug, gaprindashvili/yes