### PR TITLE
Fix saving changes after editing Satellite Provider

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -94,7 +94,7 @@ class ProviderForemanController < ApplicationController
         self.x_node = params[:id]
         quick_search_show # User will input the value
       end
-    elsif x_active_tree == :configuration_manager_providers_tree # Providers accordion, without Advanced Search
+    elsif x_active_tree == :configuration_manager_providers_tree && x_node != 'root' # Providers accordion, without Advanced Search
       listnav_search_selected(0)
     end
   end


### PR DESCRIPTION
**Fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1559422

Fix saving changes (name) after editing Satellite Provider and returning to _All Configuration Manager Providers_ page, under _Configuration > Management > Providers_.

---

**Steps to reproduce the problem:**
1. Go to _Configuration > Management > Providers_, you should see _All Configuration Management Providers_ page
2. Click on any other node in the tree, in accordion (this is very important!)
3. Go back to _All Configuration Management Providers_ page so that you click on _All Configuration Management Providers_ folder in the tree, in accordion
4. Select the provider for editing by checking its checkbox and then, under _Configuration_, choose _Edit Selected item_
5. In the editing page, change provider's name
6. Try to save the changes by clicking on **Save** button

```
[----] F, [2018-03-23T09:56:10.400092 #2301:db699c] FATAL -- : Error caught: [NoMethodError] undefined method `[]' for nil:NilClass
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4fbe8f024b4f/app/controllers/application_controller/advanced_search.rb:37:in `adv_search_build'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4fbe8f024b4f/app/controllers/application_controller.rb:1458:in `get_view'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4fbe8f024b4f/app/controllers/application_controller/ci_processing.rb:199:in `process_show_list'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4fbe8f024b4f/app/controllers/provider_foreman_controller.rb:497:in `process_show_list'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4fbe8f024b4f/app/controllers/provider_foreman_controller.rb:326:in `default_node'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4fbe8f024b4f/app/controllers/provider_foreman_controller.rb:254:in `get_node_info'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4fbe8f024b4f/app/controllers/provider_foreman_controller.rb:341:in `leaf_record'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4fbe8f024b4f/app/controllers/mixins/manager_controller_mixin.rb:313:in `replace_right_cell'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4fbe8f024b4f/app/controllers/mixins/manager_controller_mixin.rb:57:in `save_provider'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4fbe8f024b4f/app/controllers/mixins/manager_controller_mixin.rb:234:in `edit'
```

**Solution:**
Added a simple condition to provider foreman controller to `load_or_clear_adv_search` method, as Providers' screens (under _Config > Mgmt > Providers_) don't support _Advanced Search_ so it does not make sense to call `listnav_search_selected` method and `clear_selected_search` method in it. `clear_selected_search` method sets `session[:adv_search]` which makes problems later in `adv_search_build`method: it will go to the wrong part of the if/else block and then `@edit[@expkey][:expression]` will not be properly set which will lead to error in https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/advanced_search.rb#L37. This behavior is bad especially for root node there, other nodes can deal with it, so I am leaving the whole https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Edit_Save_All_Config_Manager_Providers?expand=1#diff-dd586a3167b910b76243edbecbbf0de5R97 there, not to break anything else, just added a simple condition. Saving,editing/displaying info of the provider tested also in other nodes, works well.

---

Step 4 from steps to reproduce:
![provider_edit](https://user-images.githubusercontent.com/13417815/37844640-bdb9b7a4-2ec8-11e8-83ff-29a34369f92f.png)

**Before:** (after clicking on Save button, nothing happens)
![provider_save](https://user-images.githubusercontent.com/13417815/37844673-d209da68-2ec8-11e8-924b-d7d6227e0bb3.png)

**After:** (successful saving the changes and returning to the appropriate page)
![provider_save_ok](https://user-images.githubusercontent.com/13417815/37844682-d8a2522e-2ec8-11e8-8a5b-52acf898a79d.png)
