### PR TITLE
Enable WebMKS console access for VMware vCloud's VMs

### DIFF
--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -31,8 +31,10 @@ module VmRemote
                 override_content_security_policy_directives(:connect_src => ["'self'", websocket_origin], :img_src => %w(data: 'self'))
                 %i(secret url).each { |p| params.require(p) }
                 @console = {
-                  :url    => j(params[:url]),
-                  :secret => j(params[:secret])
+                  :url       => j(params[:url]),
+                  :secret    => j(params[:secret]),
+                  :is_vcloud => j(params[:is_vcloud].to_s), # vcloud specific
+                  :vmx       => j(params[:vmx].to_s)        # vcloud specific
                 }
                 {} # This is just for compatibility, see the TODO above
               when "vmrc"

--- a/app/helpers/application_helper/button/vm_webmks_console.rb
+++ b/app/helpers/application_helper/button/vm_webmks_console.rb
@@ -10,15 +10,26 @@ class ApplicationHelper::Button::VmWebmksConsole < ApplicationHelper::Button::Vm
     @error_message = _("The web-based WebMKS console is not available because the required libraries aren't installed") unless webmks_assets_provided?
     @error_message = _("The web-based WebMKS console is not available because the VM is not powered on") unless on?
     @error_message = _("The web-based WebMKS console is not available because the VM does not support the minimum required vSphere API version.") unless supported_vendor_api?
+    @error_message = _("The web-based WebMKS console is not available because the VM does not support the minimum required vCloud API version 5.5.") unless supported_vendor_api_vcd?
     @error_message.present?
   end
 
   def supported_vendor_api?
+    return true unless @record.type.include?('Vmware::InfraManager')
     return @record.host.vmm_version.to_f >= min_supported_api_version unless @record.host.nil?
     false
   end
 
   def min_supported_api_version
     6.0
+  end
+
+  def supported_vendor_api_vcd?
+    return true unless @record.type.include?('Vmware::CloudManager')
+    return false unless (ems = @record.ext_management_system)
+
+    # Acquiring WebMKS ticket is only supported since vCloud v5.5, see here:
+    # https://pubs.vmware.com/vcd-80/index.jsp?topic=%2Fcom.vmware.vcloud.api.reference.doc_90%2Fdoc%2Foperations%2FPOST-AcquireMksTicket.html
+    ems.api_version.to_f >= 5.5
   end
 end

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -128,15 +128,36 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
     ),
   ])
   include ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
-  button_group('vm_access', [
-    button(
-      :cockpit_console,
-      'pficon pficon-screen fa-lg',
-      N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),
-      N_('Web Console'),
-      # :image   => "cockpit",
-      :url   => "launch_cockpit",
-      :klass => ApplicationHelper::Button::CockpitConsole
-    )
-  ])
+  button_group(
+    'vm_access',
+    [
+      select(
+        :vm_remote_access_choice,
+        'fa pficon-screen fa-lg',
+        N_('VM Remote Access'),
+        N_('Access'),
+        :items => [
+          button(
+            :vm_webmks_console,
+            'pficon pficon-screen fa-lg',
+            N_('Open a web-based WebMKS console for this VM'),
+            N_('VM Console'),
+            :url     => "console",
+            :confirm => N_("Open a WebMKS console for this VM"),
+            :klass   => ApplicationHelper::Button::VmWebmksConsole
+          ),
+          # TODO: remove cockpit button because backend isn't implemented yet.
+          button(
+            :cockpit_console,
+            'pficon pficon-screen fa-lg',
+            N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),
+            N_('Web Console'),
+            # :image   => "cockpit",
+            :url   => "launch_cockpit",
+            :klass => ApplicationHelper::Button::CockpitConsole
+          )
+        ]
+      )
+    ]
+  )
 end

--- a/app/views/vm_common/console_webmks.html.haml
+++ b/app/views/vm_common/console_webmks.html.haml
@@ -8,7 +8,15 @@
     = javascript_include_tag 'jquery', 'bower_components/jquery-ui/jquery-ui.js', '/webmks/wmks.min.js', 'remote_console'
     :javascript
       $(function () {
-        var wmks = WMKS.createWMKS('remote-console', {}).register(WMKS.CONST.Events.CONNECTION_STATE_CHANGE, function (event,data) {
+        var mksOpts = {};
+
+        // vCloud needs some additional settings and only supports uint8utf8 socket protocol.
+        if("#{@console[:is_vcloud]}" === 'true'){
+          mksOpts.VCDProxyHandshakeVmxPath = "#{@console[:vmx]}";
+          mksOpts.enableUint8Utf8 = true;
+        }
+
+        var wmks = WMKS.createWMKS('remote-console', mksOpts).register(WMKS.CONST.Events.CONNECTION_STATE_CHANGE, function (event,data) {
           if(data.state == WMKS.CONST.ConnectionState.CONNECTED) {
             $('#connection-status').text('#{_('Connected')}');
             console.log("connection state change: connected");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3064,6 +3064,7 @@ Rails.application.routes.draw do
         filesystem_download
         retirement_info
         reconfigure_form_fields
+        launch_vmware_console
         launch_html5_console
         perf_chart_chooser
         protect
@@ -3090,6 +3091,7 @@ Rails.application.routes.draw do
         advanced_settings
         accordion_select
         button
+        console
         edit_vm
         resize_vm
         resize_field_changed

--- a/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
@@ -23,7 +23,7 @@ describe ApplicationHelper::Button::VmWebmksConsole do
     end
     before(:each) { button.calculate_properties }
 
-    context 'when record.vendor == vmware' do
+    context 'when record.vendor == vmware (infra)' do
       let(:power_state) { 'on' }
       let(:api_version) { 6.5 }
       let(:host) { FactoryGirl.create(:host_vmware_esx, :vmm_version => api_version) }
@@ -50,6 +50,38 @@ describe ApplicationHelper::Button::VmWebmksConsole do
             let(:host) { nil }
             it_behaves_like 'a disabled button',
                             'The web-based WebMKS console is not available because the VM does not support the minimum required vSphere API version.'
+          end
+        end
+      end
+    end
+
+    context 'when record.vendor == vmware (cloud)' do
+      let(:power_state) { 'on' }
+      let(:api_version) { 5.5 }
+      let(:ems) { FactoryGirl.create(:ems_vmware_cloud, :api_version => api_version) }
+      let(:record) { FactoryGirl.create(:vm_vmware_cloud, :ext_management_system => ems) }
+
+      context 'and the power is on' do
+        it_behaves_like 'vm_console_with_power_state_on_off',
+                        "The web-based WebMKS console is not available because the VM is not powered on"
+      end
+
+      context 'and the api version' do
+        context 'is < 5.5' do
+          let(:api_version) { 5.1 }
+          it_behaves_like 'a disabled button',
+                          'The web-based WebMKS console is not available because the VM does not support the minimum required vCloud API version 5.5.'
+        end
+        [5.5, 9.0].each do |ver|
+          context "is #{ver}" do
+            let(:api_version) { ver }
+            it_behaves_like 'an enabled button'
+          end
+
+          context "#{ver} and ems is nil" do
+            let(:ems) { nil }
+            it_behaves_like 'a disabled button',
+                            'The web-based WebMKS console is not available because the VM does not support the minimum required vCloud API version 5.5.'
           end
         end
       end


### PR DESCRIPTION
With this commit we bring button "Access -> VM Console" to life. We're able to reuse many good stuff from `Vmware:.InfraManager`, but there are also some vCloud specifics. Namely, the JavaScript SDK needs to be initialized with two extra parameters:

```
VCDProxyHandshakeVmxPath // vmx path of the vm (obtained as part of mks ticket)
enableUint8Utf8          // only uint8utf8 protocol works so we need to enable it
```

![capture](https://user-images.githubusercontent.com/8102426/37905014-cff173a8-30fd-11e8-85f1-fc5fc22c581c.PNG)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1560517
Video: http://x.k00.fr/console

@miq-bot add_label enhancement,gaprindashvili/yes
@miq-bot assign @mzazrivec 

Related PRs:
https://github.com/ManageIQ/manageiq/pull/17200
https://github.com/ManageIQ/manageiq-providers-vmware/pull/218

/cc @bmclaughlin @gberginc 