### PR TITLE
Fail with an error on /ping immediately if DB is not accessible

### DIFF
--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -1,5 +1,9 @@
 class PingController < ApplicationController
   def index
-    render :text => 'pong', :status => 200
+    if ActiveRecord::Base.connection.active?
+      render :text => 'pong', :status => 200
+    else
+      raise PG::Error
+    end
   end
 end


### PR DESCRIPTION
If you stop the DB server, the `/ping` page will keep returning `pong` until the cache is not invalidated. This is a few minutes of inconsistency and can be solved by calling the `connection.active?`.

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot assign @martinpovolny 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1553223