### PR TITLE
Improve VM Chargeback Preview Report table formatting

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -606,6 +606,10 @@ table.table.table-summary-screen tbody td img {
 
 /// begin table view styling
 
+table.non-breakable td:not(.table-view-pf-select) {
+  word-break: unset !important;
+}
+
 table.table td:not(.table-view-pf-select) {
   //Force word break but prevent bs-switch from wrapping
   word-break: break-all;

--- a/app/controllers/mixins/chargeback_preview.rb
+++ b/app/controllers/mixins/chargeback_preview.rb
@@ -16,7 +16,7 @@ module ChargebackPreview
                   {:status => miq_task.status, :message => miq_task.message}, :error)
       else
         rr = miq_task.miq_report_result
-        @html = report_build_html_table(rr.report_results, rr.html_rows.join)
+        @html = report_build_html_table(rr.report_results, rr.html_rows.join, false)
         @refresh_partial = 'vm_common/chargeback'
         miq_task.destroy
       end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1428536
**PR for main MIQ repo:** https://github.com/ManageIQ/manageiq/pull/17204

---

Improve VM Chargeback Preview Report table formatting by:
- adding `non-breakable` html table class for VM Chargeback Preview Report table
- adding` false` value as an (optional) argument of `report_build_html_table` to achieve unsetting `word-break` css attribute

**Before:**
![preview_before](https://user-images.githubusercontent.com/13417815/37917537-f7f16fcc-311e-11e8-94b9-ba750ff0792b.png)

**After:**
![preview_after](https://user-images.githubusercontent.com/13417815/37916477-316dbcb8-311c-11e8-9560-2c094dedc51d.png)