### PR TITLE
API js - use base64encode which can deal with UTF8 passwords

### DIFF
--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -49,8 +49,6 @@
   API.post = withData('POST');
   API.put = withData('PUT');
 
-  var base64encode = window.btoa; // browser api
-
   API.login = function(login, password) {
     API.logout();
 

--- a/app/javascript/packs/compat-common.js
+++ b/app/javascript/packs/compat-common.js
@@ -1,0 +1,8 @@
+import base64js from 'base64-js';
+import TextEncoderLite from 'text-encoder-lite';
+
+// utf8-capable window.btoa
+window.base64encode = (str, encoding = 'utf-8') => {
+  let bytes = new (TextEncoder || TextEncoderLite)(encoding).encode(str);
+  return base64js.fromByteArray(bytes);
+};

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -11,6 +11,12 @@
       = javascript_include_tag 'miq_debug'
       = stylesheet_link_tag 'miq_debug'
 
+    = javascript_pack_tag 'vendor'
+    -# FIXME: the conditional below is a temporary fix for a webpacker issue, remove when it's resolved
+    - unless Rails.env.test?
+      - Webpacker::Manifest.instance.data.keys.each do |pack|
+        = javascript_pack_tag pack if pack.ends_with? '-common.js'
+
     = render :partial => 'layouts/i18n_js'
 
   %body{:class => ::Settings.server.custom_login_logo ? 'whitelabel' : ''}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",
     "angular-sanitize": "~1.6.6",
+    "base64-js": "~1.2.3",
     "core-js": "~2.4.1",
     "jquery": "~2.2.4",
     "lodash": "^4.17.4",
@@ -40,6 +41,7 @@
     "react-redux": "^5.0.7",
     "redux-devtools-extension": "^2.13.2",
     "rxjs": "~5.3.0",
+    "text-encoder-lite": "~1.0.1",
     "ui-select": "0.19.8",
     "zone.js": "~0.8.5"
   },


### PR DESCRIPTION
This adds 2 npm packages:

* `base64js` - JS implementation of base64 which can deal with arbitrary encodings
* `text-encoder-lite` - a shim for the TextEncoder api, useable for utf8 strings (even in IE)

and replaces the `API.login` use of `window.btoa` with a custom `base64encode` function implemented using the 2 libraries.

This way, users can use passwords with unicode chars.

Note: on modern browsers, this will handle any unicode password, including emoji.
On IE, more modern unicode versions may not be fully supported (czech or japanese chars should be fine, emoji may not).

The difference:

```
btoa('babicka')
"YmFiaWNrYQ=="

base64encode("babicka")
"YmFiaWNrYQ=="

btoa('babička')
VM7832:1 Uncaught DOMException: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.

base64encode("babička")
"YmFiacSNa2E="
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1527316