### PR TITLE
Add vault credential display for the playbook retirement tab 

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -321,6 +321,11 @@
                   = _('Machine Credential')
                 .col-md-9
                   = h(retirement[:machine_credential])
+              .form-group
+                %label.col-md-3.control-label
+                  = _('Vault Credential')
+                .col-md-9
+                  = h(retirement[:vault_credential])
               -#.form-group
               -#  %label.col-md-3.control-label
               -#    = _('Network Credential')


### PR DESCRIPTION
Add vault credential display for the playbook retirement tab 

Links [Optional]
----------------

 - Follow up to:
https://github.com/ManageIQ/manageiq-ui-classic/pull/3468


![screenshot from 2018-03-26 17-20-20](https://user-images.githubusercontent.com/12769982/37934083-23cc6b3c-311b-11e8-8652-2c10ebd7b387.png)
