### PR TITLE
Fix TextEncoderLite in old browsers

### DIFF
--- a/app/javascript/packs/compat-common.js
+++ b/app/javascript/packs/compat-common.js
@@ -1,8 +1,8 @@
 import base64js from 'base64-js';
-import TextEncoderLite from 'text-encoder-lite';
+const TextEncoderLite = require('text-encoder-lite').TextEncoderLite;
 
 // utf8-capable window.btoa
 window.base64encode = (str, encoding = 'utf-8') => {
-  let bytes = new (TextEncoder || TextEncoderLite)(encoding).encode(str);
+  let bytes = new (window.TextEncoder || TextEncoderLite)(encoding).encode(str);
   return base64js.fromByteArray(bytes);
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-redux": "^5.0.7",
     "redux-devtools-extension": "^2.13.2",
     "rxjs": "~5.3.0",
-    "text-encoder-lite": "~1.0.1",
+    "text-encoder-lite": "git://github.com/coolaj86/TextEncoderLite.git#e1e031b",
     "ui-select": "0.19.8",
     "zone.js": "~0.8.5"
   },

--- a/spec/javascripts/miq_api_spec.js
+++ b/spec/javascripts/miq_api_spec.js
@@ -1,0 +1,17 @@
+describe('miq_api.js', function() {
+  it("can base64 encode utf8 passwords", function(done) {
+    var getArgs;
+
+    spyOn(vanillaJsAPI, 'get').and.callFake(function(_url, args) {
+      getArgs = args;
+      return Promise.resolve({});
+    });
+
+    vanillaJsAPI.login('foo', 'páššwøřď 密码 密碼')
+      .then(function() {
+        expect(vanillaJsAPI.get).toHaveBeenCalled();
+        expect(getArgs.headers.Authorization).toBe("Basic Zm9vOnDDocWhxaF3w7jFmcSPIOWvhueggSDlr4bnorw=")
+      })
+      .then(done, done);
+  });
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -19,6 +19,7 @@ src_files:
 - __spec__/helpers/fixtures-fix.js
 - packs/vendor.js
 - packs/manageiq-ui-classic/application-common.js
+- packs/manageiq-ui-classic/compat-common.js
 - packs/manageiq-ui-classic/miq-redux-common.js
 
 # stylesheets


### PR DESCRIPTION
This fixes a bug in older browsers, introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/3682

#3682 adds code that uses TextEncoder in browsers which support it, and TextEncoderLite in browser which don't.

But text-encoder-lite in version 1.0.1 only ever exports the decoder part.
This was fixed in 1.0.2 .. but that one never got released.

So.. updating to the new version (by commit), and adding a spec that will use the Lite version (because phantomjs doesn't have TextEncoder).

Ping @mzazrivec ;)