### PR TITLE
Display Adv Search in Volume Snapshots/Backups pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -864,6 +864,7 @@ module ApplicationHelper
        cloud_subnet
        cloud_tenant
        cloud_volume
+       cloud_volume_backup
        cloud_volume_snapshot
        configuration_job
        configuration_scripts

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -864,6 +864,7 @@ module ApplicationHelper
        cloud_subnet
        cloud_tenant
        cloud_volume
+       cloud_volume_snapshot
        configuration_job
        configuration_scripts
        container

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1047,7 +1047,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#show_adv_search?" do
+  describe "#show_adv_search?" do
     it 'should return false for explorer screen with no trees such as automate/simulation' do
       controller.instance_variable_set(:@explorer, true)
       controller.instance_variable_set(:@sb, {})
@@ -1071,7 +1071,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#show_advanced_search?" do
+  describe "#show_advanced_search?" do
     it 'should return true for VM explorer trees' do
       controller.instance_variable_set(:@sb,
                                        :active_tree => :vms_instances_filter_tree,
@@ -1113,6 +1113,30 @@ describe ApplicationHelper do
       controller.instance_variable_set(:@show_adv_search, true)
       result = helper.show_advanced_search?
       expect(result).to be_truthy
+    end
+  end
+
+  describe "#display_adv_search?" do
+    before do
+      controller.instance_variable_set(:@layout, layout)
+    end
+
+    subject { helper.display_adv_search? }
+
+    context 'Volume Snapshots page' do
+      let(:layout) { "cloud_volume_snapshot" }
+
+      it 'returns true' do
+        expect(subject).to be(true)
+      end
+    end
+
+    context 'Volume Backups page' do
+      let(:layout) { "cloud_volume_backup" }
+
+      it 'returns true' do
+        expect(subject).to be(true)
+      end
     end
   end
 


### PR DESCRIPTION
**Fixing issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/3648
**BZ:** https://bugzilla.redhat.com/show_bug.cgi?id=1561920

---

Display missing _Advanced Search_ (next to _Search_ form) in _Storage > Block Storage > Volume Snapshots/Backups_ pages.

**Before:**
No Advanced Search in Volume Snapshots page:
![snapshot_before](https://user-images.githubusercontent.com/13417815/37978002-4881b4da-31e5-11e8-8ef9-e2c3ed2eb5ab.png)
No Advanced Search in Volume Backups page:
![backup_before](https://user-images.githubusercontent.com/13417815/37978008-4a7e2160-31e5-11e8-80a3-071f1efc0e05.png)

**After:**
Advanced Search in Volume Snapshots page:
![snapshot_after1](https://user-images.githubusercontent.com/13417815/37974990-922df05a-31de-11e8-87d3-d8a613e45401.png)
Opening Advanced Search in Volume Snapshots page:
![snapshot_after2](https://user-images.githubusercontent.com/13417815/37974992-94cff5d8-31de-11e8-8d07-bafc9932fe6b.png)
Advanced Search in Volume Backups page:
![volume_after](https://user-images.githubusercontent.com/13417815/37974995-96cf5e5a-31de-11e8-93c0-7d8e2a66efed.png)
