### PR TITLE
AeResolveOptions - use ng-if instead of ng-show

### DIFF
--- a/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
+++ b/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
@@ -1,4 +1,4 @@
-%div{"ng-show" => ng_show.to_s}
+%div{"ng-if" => ng_show.to_s}
   %div
     = _("Object Details")
     .form-group


### PR DESCRIPTION
The partial is used only under specific circumstances,
but using ng-show means all the required fields are always required, even when not visible.

This makes it impossible to create a new schedule when using one of the types which don't show `object_request`.
(Because the form is not valid, but the required field is not visible.)

Changing to ng-if, which will not try to validate invisible fields.

(Introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/3613, cc @ZitaNemeckova)
(Fixes :point_up: [March 27, 2018 8:51 AM](https://gitter.im/ManageIQ/manageiq?at=5aba060d458cbde5577df629), cc @nimrodshn)