### PR TITLE
Add button in toolbar for remotely accessing a physical server

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -63,6 +63,16 @@ class PhysicalServerController < ApplicationController
     end
   end
 
+  def console
+    params[:task_id] ? console_after_task : console_before_task
+  end
+
+  def console_file
+    miq_task = MiqTask.find(params[:task_id])
+    jnlp_file_content = miq_task.task_results.resource
+    send_data(jnlp_file_content, :filename => "remoteConsole.jnlp")
+  end
+
   def provision
     provisioning_ids = find_checked_ids_with_rbac(PhysicalServer)
     provisioning_ids.push(find_id_with_rbac(PhysicalServer, params[:id])) if provisioning_ids.empty?
@@ -72,5 +82,51 @@ class PhysicalServerController < ApplicationController
                         :prov_id        => provisioning_ids,
                         :org_controller => "physical_server",
                         :escape         => false)
+  end
+
+  # Task complete, show error or send remote console resource
+  def console_after_task
+    miq_task = MiqTask.find(params[:task_id])
+    unless miq_task.results_ready?
+      add_flash(_("Console access failed: %{message}") % {:message => miq_task.message}, :error)
+      javascript_flash(:spinner_off => true)
+      return
+    end
+
+    resource_type = miq_task.task_results.type
+
+    if resource_type == :url
+      url = miq_task.task_results.resource
+      javascript_open_window(url)
+    elsif resource_type == :java_jnlp_file
+      render :update do |page|
+        page << javascript_prologue
+        page << set_spinner_off
+        page.redirect_to(:controller     => "physical_server",
+                         :action         => "console_file",
+                         :task_id        => params[:task_id],
+                         :org_controller => "physical_server",
+                         :escape         => false)
+      end
+    else
+      add_flash(_("Console access failed: Unexpected remote console resource type [%{type}]") %
+                  {:type => resource_type}, :error)
+      javascript_flash(:spinner_off => true)
+    end
+  end
+
+  def console_before_task
+    record = find_record_with_rbac(ManageIQ::Providers::PhysicalInfraManager::PhysicalServer, params[:id])
+    task_id = record.remote_console_acquire_resource_queue(session[:userid])
+    unless task_id.kind_of?(Integer)
+      add_flash(_("Console access failed: Task start failed: ID [%{id}]") %
+                  {:id => task_id.to_s}, :error)
+    end
+
+    if @flash_array
+      javascript_flash(:spinner_off => true)
+    else
+      initiate_wait_for_task(:task_id => task_id)
+    end
   end
 end

--- a/app/helpers/application_helper/toolbar/physical_infrastructure/operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/physical_infrastructure/operations_button_group_mixin.rb
@@ -1,0 +1,137 @@
+module ApplicationHelper::Toolbar::PhysicalInfrastructure::OperationsButtonGroupMixin
+  extend ActiveSupport::Concern
+
+  included do
+    button_group(
+      'physical_server_operations',
+      [
+        select(
+          :physical_server_power_choice,
+          'fa fa-power-off fa-lg',
+          N_('Power Functions'),
+          N_('Power'),
+          :items => [
+            button(
+              :physical_server_power_on,
+              nil,
+              N_('Power on the server'),
+              N_('Power On'),
+              :image   => "power_on",
+              :data    => {'function'      => 'sendDataWithRx',
+                           'function-data' => '{"type": "power_on", "controller": "physicalServerToolbarController"}'},
+              :confirm => N_("Power on the server?"),
+              :options => {:feature => :power_on}
+            ),
+            button(
+              :physical_server_power_off,
+              nil,
+              N_('Power off the server'),
+              N_('Power Off'),
+              :image   => "power_off",
+              :data    => {'function'      => 'sendDataWithRx',
+                           'function-data' => '{"type": "power_off", "controller": "physicalServerToolbarController"}'},
+              :confirm => N_("Power off the server?"),
+              :options => {:feature => :power_off}
+            ),
+            button(
+              :physical_server_power_off_now,
+              nil,
+              N_('Power off the server immediately'),
+              N_('Power Off Immediately'),
+              :image   => "power_off",
+              :data    => {'function'      => 'sendDataWithRx',
+                           'function-data' => '{"type": "power_off_now", "controller": "physicalServerToolbarController"}'},
+              :confirm => N_("Power off the server immediately?"),
+              :options => {:feature => :power_off_now}
+            ),
+            button(
+              :physical_server_restart,
+              nil,
+              N_('Restart the server'),
+              N_('Restart'),
+              :image   => "power_reset",
+              :data    => {'function'      => 'sendDataWithRx',
+                           'function-data' => '{"type": "restart", "controller": "physicalServerToolbarController"}'},
+              :confirm => N_("Restart the server?"),
+              :options => {:feature => :restart}
+            ),
+            button(
+              :physical_server_restart_now,
+              nil,
+              N_('Restart Server Immediately'),
+              N_('Restart Immediately'),
+              :image   => "power_reset",
+              :data    => {'function'      => 'sendDataWithRx',
+                           'function-data' => '{"type": "restart_now", "controller": "physicalServerToolbarController"}'},
+              :confirm => N_("Restart the server immediately?"),
+              :options => {:feature => :restart_now}
+            ),
+            button(
+              :physical_server_restart_to_sys_setup,
+              nil,
+              N_('Restart Server to System Setup'),
+              N_('Restart to System Setup'),
+              :image   => "power_reset",
+              :data    => {'function'      => 'sendDataWithRx',
+                           'function-data' => '{"type": "restart_to_sys_setup", "controller": "physicalServerToolbarController"}'},
+              :confirm => N_("Restart the server to UEFI settings?"),
+              :options => {:feature => :restart_to_sys_setup}
+            ),
+            button(
+              :physical_server_restart_mgmt_controller,
+              nil,
+              N_('Restart Management Controller'),
+              N_('Restart Management Controller'),
+              :image   => "power_reset",
+              :data    => {'function'      => 'sendDataWithRx',
+                           'function-data' => '{"type": "restart_mgmt_controller", "controller": "physicalServerToolbarController"}'},
+              :confirm => N_("Restart management controller?"),
+              :options => {:feature => :restart_mgmt_controller}
+            )
+          ]
+        ),
+        select(
+          :physical_server_identify_choice,
+          nil,
+          N_('Identify LED Operations'),
+          N_('Identify'),
+          :items => [
+            button(
+              :physical_server_blink_loc_led,
+              nil,
+              N_('Blink the Identify LED'),
+              N_('Blink LED'),
+              :image   => "blank_button",
+              :data    => {'function'      => 'sendDataWithRx',
+                           'function-data' => '{"type": "blink_loc_led", "controller": "physicalServerToolbarController"}'},
+              :confirm => N_("Blink the Identify LED?"),
+              :options => {:feature => :blink_loc_led}
+            ),
+            button(
+              :physical_server_turn_on_loc_led,
+              nil,
+              N_('Turn on the Idenfity LED'),
+              N_('Turn On LED'),
+              :image   => "blank_button",
+              :data    => {'function'      => 'sendDataWithRx',
+                           'function-data' => '{"type": "turn_on_loc_led", "controller": "physicalServerToolbarController"}'},
+              :confirm => N_("Turn on the Identify LED?"),
+              :options => {:feature => :turn_on_loc_led}
+            ),
+            button(
+              :physical_server_turn_off_loc_led,
+              nil,
+              N_('Turn off the Identify LED'),
+              N_('Turn Off LED'),
+              :image   => "blank_button",
+              :data    => {'function'      => 'sendDataWithRx',
+                           'function-data' => '{"type": "turn_off_loc_led", "controller": "physicalServerToolbarController"}'},
+              :confirm => N_("Turn off the Identify LED?"),
+              :options => {:feature => :turn_off_loc_led}
+            ),
+          ]
+        )
+      ]
+    )
+  end
+end

--- a/app/helpers/application_helper/toolbar/physical_server_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_server_center.rb
@@ -23,137 +23,9 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
       ),
     ]
   )
-  button_group(
-    'physical_server_operations',
-    [
-      select(
-        :physical_server_power_choice,
-        'fa fa-power-off fa-lg',
-        N_('Power Functions'),
-        N_('Power'),
-        :items => [
-          button(
-            :physical_server_power_on,
-            nil,
-            N_('Power on the server'),
-            N_('Power On'),
-            :image                       => "power_on",
-            :data                        => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "power_on", "controller": "physicalServerToolbarController"}'},
-            :confirm                     => N_("Power on the server?"),
-            :options                     => {:feature => :power_on}
-          ),
-          button(
-            :physical_server_power_off,
-            nil,
-            N_('Power off the server'),
-            N_('Power Off'),
-            :image                       => "power_off",
-            :data                        => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "power_off", "controller": "physicalServerToolbarController"}'},
-            :confirm                     => N_("Power off the server?"),
-            :options                     => {:feature => :power_off}
-          ),
-          button(
-            :physical_server_power_off_now,
-            nil,
-            N_('Power off the server immediately'),
-            N_('Power Off Immediately'),
-            :image   => "power_off",
-            :data    => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "power_off_now", "controller": "physicalServerToolbarController"}'},
-            :confirm => N_("Power off the server immediately?"),
-            :options => {:feature => :power_off_now}
-          ),
-          button(
-            :physical_server_restart,
-            nil,
-            N_('Restart the server'),
-            N_('Restart'),
-            :image                       => "power_reset",
-            :data                        => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "restart", "controller": "physicalServerToolbarController"}'},
-            :confirm                     => N_("Restart the server?"),
-            :options                     => {:feature => :restart}
-          ),
-          button(
-            :physical_server_restart_now,
-            nil,
-            N_('Restart Server Immediately'),
-            N_('Restart Immediately'),
-            :image   => "power_reset",
-            :data    => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "restart_now", "controller": "physicalServerToolbarController"}'},
-            :confirm => N_("Restart the server immediately?"),
-            :options => {:feature => :restart_now}
-          ),
-          button(
-            :physical_server_restart_to_sys_setup,
-            nil,
-            N_('Restart Server to System Setup'),
-            N_('Restart to System Setup'),
-            :image   => "power_reset",
-            :data    => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "restart_to_sys_setup", "controller": "physicalServerToolbarController"}'},
-            :confirm => N_("Restart the server to UEFI settings?"),
-            :options => {:feature => :restart_to_sys_setup}
-          ),
-          button(
-            :physical_server_restart_mgmt_controller,
-            nil,
-            N_('Restart Management Controller'),
-            N_('Restart Management Controller'),
-            :image   => "power_reset",
-            :data    => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "restart_mgmt_controller", "controller": "physicalServerToolbarController"}'},
-            :confirm => N_("Restart management controller?"),
-            :options => {:feature => :restart_mgmt_controller}
-          )
-        ]
-      ),
-      select(
-        :physical_server_identify_choice,
-        nil,
-        N_('Identify LED Operations'),
-        N_('Identify'),
-        :items => [
-          button(
-            :physical_server_blink_loc_led,
-            nil,
-            N_('Blink the Identify LED'),
-            N_('Blink LED'),
-            :image                       => "blank_button",
-            :data                        => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "blink_loc_led", "controller": "physicalServerToolbarController"}'},
-            :confirm                     => N_("Blink the Identify LED?"),
-            :options                     => {:feature => :blink_loc_led}
-          ),
-          button(
-            :physical_server_turn_on_loc_led,
-            nil,
-            N_('Turn on the Idenfity LED'),
-            N_('Turn On LED'),
-            :image                       => "blank_button",
-            :data                        => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "turn_on_loc_led", "controller": "physicalServerToolbarController"}'},
-            :confirm                     => N_("Turn on the Identify LED?"),
-            :options                     => {:feature => :turn_on_loc_led}
-          ),
-          button(
-            :physical_server_turn_off_loc_led,
-            nil,
-            N_('Turn off the Identify LED'),
-            N_('Turn Off LED'),
-            :image                       => "blank_button",
-            :data                        => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "turn_off_loc_led", "controller": "physicalServerToolbarController"}'},
-            :confirm                     => N_("Turn off the Identify LED?"),
-            :options                     => {:feature => :turn_off_loc_led}
-          ),
-        ]
-      ),
-    ]
-  )
+
+  include ApplicationHelper::Toolbar::PhysicalInfrastructure::OperationsButtonGroupMixin
+
   button_group(
     'physical_server_policy',
     [
@@ -228,6 +100,31 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
           )
         ]
       )
+    ]
+  )
+
+  button_group(
+    'physical_server_remote_access',
+    [
+      select(
+        :physical_server_remote_access_choice,
+        'fa pficon-screen fa-lg',
+        N_('Physical Server Remote Access'),
+        N_('Access'),
+        :enabled => true,
+        :items   => [
+          button(
+            :physical_server_remote_console,
+            'pficon pficon-screen fa-lg',
+            N_('Open a remote console for this Physical Server'),
+            N_('Physical Server Console'),
+            :url     => "console",
+            :method  => :get,
+            :enabled => true,
+            :options => {:feature => :physical_server_remote_access}
+          )
+        ],
+      ),
     ]
   )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1321,6 +1321,7 @@ Rails.application.routes.draw do
         show_list
         show
         tagging_edit
+        console_file
       ) + compare_get,
 
       :post   =>  %w(
@@ -1338,6 +1339,7 @@ Rails.application.routes.draw do
         tl_chooser
         wait_for_task
         provision
+        console
       ) +
           adv_search_post +
           exp_post +


### PR DESCRIPTION
Adds a dropdown with a button in the physical server summary page toolbar for remotely accessing the console for a physical server.
The button kicks a task off for generating a remote console resource for the currently selected physical server and makes the UI wait until the task is finished.
The remote console resource can be one of two types:
* A jnlp file that when opened will start a Java Web Start application that can be used to access the machine console. In this case the UI will open a download dialog so that the user can download this file.
* A URL that can be used to access a HTML 5 based remote console application. In this case the UI will open a new tab in the user's browser targeting this URL.

Screen shot of the physical servers summary page before the change:

![before](https://user-images.githubusercontent.com/1881597/38368820-b6515bf4-38bc-11e8-8f6b-267671b85cf7.png)

After the change:

![after](https://user-images.githubusercontent.com/1881597/38368851-c6d090e4-38bc-11e8-8cf7-1b21bf60bb32.png)

Depends on
  * https://github.com/ManageIQ/manageiq/pull/17213
  * https://github.com/ManageIQ/manageiq-providers-lenovo/pull/144