### PR TITLE
Fix typo in flash message after refreshing Ansible Tower Providers

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -461,7 +461,7 @@ module ApplicationController::CiProcessing
     add_flash(_("Error during '%{task}': %{message}") % {:task => task, :message => err.message}, :error)
   else
     add_flash(n_("%{task} initiated for %{count} provider",
-                 "%{task} initiated for %{count} providers)", manager_ids.length) %
+                 "%{task} initiated for %{count} providers", manager_ids.length) %
                 {:task  => task_name(task),
                  :count => manager_ids.length})
   end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1560530

Fix typo in flash message after refreshing Relationship and Power States of
Ansible Tower Providers in _Automation > Ansible Tower > Explorer > Providers_.

**Before:**
![refresh_before](https://user-images.githubusercontent.com/13417815/38021435-1ebccac0-327d-11e8-9fb9-abacb8cfc361.png)

**After:**
![refresh_after](https://user-images.githubusercontent.com/13417815/38021251-a537558a-327c-11e8-9f9e-386b9331acce.png)
