### PR TITLE
Validation of new provider with http_proxy settings

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -119,13 +119,13 @@ module Mixins
       when 'ManageIQ::Providers::Openstack::CloudManager'
         [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)]
       when 'ManageIQ::Providers::Amazon::CloudManager'
-        [user, password, :EC2, params[:provider_region], nil, true]
+        [user, password, :EC2, params[:provider_region], ems.http_proxy_uri, true]
       when 'ManageIQ::Providers::Azure::CloudManager'
-        [user, password, params[:azure_tenant_id], params[:subscription], nil, params[:provider_region]]
+        [user, password, params[:azure_tenant_id], params[:subscription], ems.http_proxy_uri, params[:provider_region]]
       when 'ManageIQ::Providers::Vmware::CloudManager'
         [params[:default_hostname], params[:default_api_port], user, password, true]
       when 'ManageIQ::Providers::Google::CloudManager'
-        [params[:project], MiqPassword.encrypt(params[:service_account]), {:service => "compute"}, nil, true]
+        [params[:project], MiqPassword.encrypt(params[:service_account]), {:service => "compute"}, ems.http_proxy_uri, true]
       when 'ManageIQ::Providers::Microsoft::InfraManager'
         connect_opts = {
           :hostname          => params[:default_hostname],


### PR DESCRIPTION
- [x] PR (**depends on**): https://github.com/ManageIQ/manageiq/pull/17218 (that's why travis-ci failed)

Validation of new Amazon,Azure,Google provider take care of http_proxy settings.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1552114
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1559019

@miq-bot add_label pending core
Cc @agrare

Steps for Testing/QA [Optional]
-------------------------------

1. Go to Configuration -> Advanced
2. Set 
- http_proxy/ec2/host
- http_proxy/ec2/port
- http_proxy/azure/host
- http_proxy/azure/port
- ... OR
- http_proxy/default/host
- http_proxy/defautl/port
3. Go to Compute -> Clouds -> Providers, click on Configuration/Add a New Cloud Provider
4. Set Amazon or Azure provider data and click validate

If you set correct proxy, it should go through it.
If you set some fake url, it returns error message where is fake url mentioned. 

