### PR TITLE
Allow scm_url to take ssh with ssh protocol

### DIFF
--- a/app/assets/javascripts/directives/url_validation.js
+++ b/app/assets/javascripts/directives/url_validation.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.directive('urlValidation', function() {
+ManageIQ.angular.app.directive('urlValidation', ['nodeValidator', function(nodeValidator) {
   return {
     require: 'ngModel',
     link: function (_scope, _elem, _attrs, ctrl) {
@@ -8,10 +8,18 @@ ManageIQ.angular.app.directive('urlValidation', function() {
         }
         return !!validUrl(viewValue);
       };
-
-      var validUrl = function(s) {
-        return s.substring(0, 8) === 'https://' || s.substring(0, 7) === 'http://' || s.match(/^[-\w:.]+@.*:/);
+      var options = {
+        protocols: ['http', 'https', 'ssh'],
+        require_tld: true,
+        require_protocol: true,
+        require_valid_protocol: true,
+        allow_underscores: true,
+        allow_trailing_dot: false,
+        allow_protocol_relative_urls: true
+      };
+      var validUrl = function(url) {
+        return nodeValidator.isURL(url, options) || url.match(/^[-\w:.]+@.*:/);
       };
     }
   }
-});
+}]);

--- a/app/views/ansible_repository/_repository_form.html.haml
+++ b/app/views/ansible_repository/_repository_form.html.haml
@@ -53,7 +53,7 @@
         %span.help-block{"ng-show" => "angularForm.scm_url.$error.required"}
           = _("Required")
         %span.help-block{"ng-show" => "angularForm.scm_url.$error.urlValidation"}
-          = _("URL must include a protocol (http:// or https://) or be a valid SSH path (user@server:path)")
+          = _("URL must include a protocol (http:// or https://) or be a valid SSH path (user@server:path or ssh://user@address:port/path)")
     .form-group
       %label.col-md-2.control-label
         = _('SCM credentials')


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540551

Allows http, https, ssh protocols. Allows ssh without protocol.

Automation -> Ansible -> Repositories -> Configuration -> Add/Edit Repository
Try something like `ssh://git@10.195.101.214:10022/jwong/awesome-pub.git`.
Before:
Only `https://<something>.<something>`, `http://<something>.<something>` and `<user>@<server>:<path>` were allowed.
After:
Allows also `ssh://git@<address>:<port><path>`

@miq-bot add_label bug, gaprindashvili/yes, automation/ansible