### PR TITLE
Container dashboard charts: send datapoints as full timestamps

### DIFF
--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -233,7 +233,7 @@ class ContainerDashboardService < DashboardService
   def daily_image_metrics
     daily_image_metrics = Hash.new(0)
     daily_metrics.each do |m|
-      day = m.timestamp.strftime("%Y-%m-%d")
+      day = m.timestamp.beginning_of_day.utc
       daily_image_metrics[day] +=
         m.stat_container_image_registration_rate if m.stat_container_image_registration_rate.present?
     end

--- a/app/services/container_service_mixin.rb
+++ b/app/services/container_service_mixin.rb
@@ -10,7 +10,7 @@ module ContainerServiceMixin
     daily_pod_delete_trend = Hash.new(0)
 
     daily_metrics.each do |m|
-      date = m.timestamp.strftime("%Y-%m-%d")
+      date = m.timestamp.beginning_of_day.utc
       fill_pod_metrics(m, date, daily_pod_create_trend, daily_pod_delete_trend)
     end
 
@@ -122,7 +122,7 @@ module ContainerServiceMixin
   def daily_network_metrics
     daily_network_metrics = Hash.new(0)
     daily_metrics.each do |m|
-      day = m.timestamp.strftime("%Y-%m-%d")
+      day = m.timestamp.beginning_of_day.utc
       daily_network_metrics[day] += m.net_usage_rate_average if m.net_usage_rate_average.present?
     end
 
@@ -179,7 +179,7 @@ module ContainerServiceMixin
     total_mem = Hash.new(0)
 
     daily_metrics.each do |metric|
-      date = metric.timestamp.strftime("%Y-%m-%d")
+      date = metric.timestamp.beginning_of_day.utc
       fill_utilization(metric, date, used_cpu, used_mem, total_cpu, total_mem)
     end
 

--- a/spec/services/container_dashboard_service_spec.rb
+++ b/spec/services/container_dashboard_service_spec.rb
@@ -26,7 +26,7 @@ describe ContainerDashboardService do
       ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
       ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :zone => @zone)
 
-      current_date = 7.days.ago
+      current_date = 7.days.ago.beginning_of_day.utc
       old_date = 35.days.ago
 
       current_metric_openshift = FactoryGirl.create(
@@ -75,13 +75,13 @@ describe ContainerDashboardService do
         :cpu => {
           :used  => 2,
           :total => 2,
-          :xData => [current_date.strftime("%Y-%m-%d")],
+          :xData => [current_date],
           :yData => [2]
         },
         :memory => {
           :used  => 1,
           :total => 2,
-          :xData => [current_date.strftime("%Y-%m-%d")],
+          :xData => [current_date],
           :yData => [1]
         }
       )
@@ -90,13 +90,13 @@ describe ContainerDashboardService do
         :cpu => {
           :used  => 3,
           :total => 3,
-          :xData => [current_date.strftime("%Y-%m-%d")],
+          :xData => [current_date],
           :yData => [3.0]
         },
         :memory => {
           :used  => 2,
           :total => 3,
-          :xData => [current_date.strftime("%Y-%m-%d")],
+          :xData => [current_date],
           :yData => [1.5]
         }
       )
@@ -314,8 +314,8 @@ describe ContainerDashboardService do
       ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
       ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :zone => @zone)
 
-      previous_date = 8.days.ago
-      current_date = 7.days.ago
+      previous_date = 8.days.ago.beginning_of_day.utc
+      current_date = 7.days.ago.beginning_of_day.utc
       old_date = 35.days.ago
 
       previous_metric_openshift = FactoryGirl.create(
@@ -353,12 +353,12 @@ describe ContainerDashboardService do
       daily_network_trends_single_provider = described_class.new(ems_openshift.id, controller).network_metrics[:xy_data]
 
       expect(daily_network_trends_single_provider).to eq(
-        :xData => [previous_date.strftime("%Y-%m-%d"), current_date.strftime("%Y-%m-%d")],
+        :xData => [previous_date, current_date],
         :yData => [2000, 1000]
       )
 
       expect(daily_network_trends).to eq(
-        :xData => [previous_date.strftime("%Y-%m-%d"), current_date.strftime("%Y-%m-%d")],
+        :xData => [previous_date, current_date],
         :yData => [2000, 2500]
       )
     end


### PR DESCRIPTION
We need to send chart datapoints as complete timestamps (including timezone info) so that the patternfly component would correctly convert them to `Date()` objects and avoid ugly side-effects when viewing the charts in browsers located in different timezones.

How to reproduce:
1. Have Container provider with some utilization data collected, let's say your data is being collected every midnight in EST timezone.
2. Check the container provider dashboard in CEST timezone
3. Check the container provider dashboard in EST timezone: `$ TZ='America/New_York' firefox`

You'll notince the datapoints in the EST timezone are shifted by one day back.

Previously, we were sending the datapoints to the angular component as `2018-03-23` strings. The patternfly component would then convert them to `Date()` objects. Now we'll be sending the full timestamp as `2018-03-23T00:00:00.0000-04:00`.

https://bugzilla.redhat.com/show_bug.cgi?id=1542720

@himdel review please?