### PR TITLE
Fixed id of currentTab

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -353,7 +353,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     } else if (($scope.emsCommonModel.ems_controller === "ems_container") &&
       ($scope.emsCommonModel.emstype) &&
       ($scope.emsCommonModel.default_password !== '' && $scope.angularForm.default_password.$valid) &&
-      (($scope.currentTab === "metrics" &&
+      (($scope.currentTab === "container_metrics" &&
         $scope.emsCommonModel.metrics_hostname !== '' &&
         $scope.emsCommonModel.metrics_api_port) ||
        ($scope.currentTab === "alerts" &&


### PR DESCRIPTION
"metrics" tab id was renamed to container_metircs in https://github.com/ManageIQ/manageiq-ui-classic/pull/3511, this inconsistency was causing Validate button to remain disabled on openshift provider add/edit screen on Metrics tab.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1561180

cc @masayag 

@dclarizio please review.

before:
![before](https://user-images.githubusercontent.com/3450808/38055844-d86a5b9c-32a8-11e8-9bc4-75e530f5d807.png)

after:
![after](https://user-images.githubusercontent.com/3450808/38055855-dae0c618-32a8-11e8-8bfb-bb201175bfa4.png)
