### PR TITLE
Adding physical switches list and summary pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -100,6 +100,7 @@ class ApplicationController < ActionController::Base
       :host               => true,
       :miq_template       => true,
       :physical_server    => true,
+      :physical_switch    => true,
       :storage            => true,
       :vm                 => true,
       :ems_container      => true

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -551,6 +551,7 @@ class ConfigurationController < ApplicationController
       @edit[:new][:quadicons][:host] = params[:quadicons_host] == "true" if params[:quadicons_host]
       @edit[:new][:quadicons][:vm] = params[:quadicons_vm] == "true" if params[:quadicons_vm]
       @edit[:new][:quadicons][:physical_server] = params[:quadicons_physical_server] == "true" if params[:quadicons_physical_server]
+      @edit[:new][:quadicons][:physical_switch] = params[:quadicons_physical_switch] == "true" if params[:quadicons_physical_switch]
       @edit[:new][:quadicons][:ems_physical_infra] = params[:quadicons_ems_physical_infra] == "true" if params[:quadicons_ems_physical_infra]
       @edit[:new][:quadicons][:ems_network] = params[:quadicons_ems_network] == "true" if params[:quadicons_ems_network]
       @edit[:new][:quadicons][:miq_template] = params[:quadicons_miq_template] == "true" if params[:quadicons_miq_template]

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -122,6 +122,7 @@ module EmsCommon
         persistent_volumes
         physical_servers
         physical_servers_with_host
+        physical_switches
         security_groups
         storage_managers
         storages

--- a/app/controllers/physical_switch_controller.rb
+++ b/app/controllers/physical_switch_controller.rb
@@ -1,5 +1,6 @@
 class PhysicalSwitchController < ApplicationController
   include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
   include Mixins::GenericSessionMixin
   include Mixins::MoreShowActions
 
@@ -29,8 +30,13 @@ class PhysicalSwitchController < ApplicationController
 
   def textual_group_list
     [
-      %i(properties relationships),
+      %i(properties management_networks relationships power_management),
+      %i(firmware_details ports),
     ]
   end
   helper_method(:textual_group_list)
+
+  def self.display_methods
+    %w(physical_switches)
+  end
 end

--- a/app/controllers/physical_switch_controller.rb
+++ b/app/controllers/physical_switch_controller.rb
@@ -1,0 +1,36 @@
+class PhysicalSwitchController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericSessionMixin
+  include Mixins::MoreShowActions
+
+  before_action :check_privileges
+  before_action :session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def self.table_name
+    @table_name ||= "switches"
+  end
+
+  def session_data
+    @title      = _("Physical Switches")
+    @layout     = "physical_switch"
+    @lastaction = session[:physical_switch_lastaction]
+  end
+
+  def set_session_data
+    session[:layout] = @layout
+    session[:physical_switch_lastaction] = @lastaction
+  end
+
+  def show_list
+    process_show_list
+  end
+
+  def textual_group_list
+    [
+      %i(properties relationships),
+    ]
+  end
+  helper_method(:textual_group_list)
+end

--- a/app/decorators/physical_switch_decorator.rb
+++ b/app/decorators/physical_switch_decorator.rb
@@ -1,6 +1,33 @@
 class PhysicalSwitchDecorator < MiqDecorator
   def self.fonticon
-    'pficon pficon-container-node'
+    'ff ff-network-switch'
+  end
+
+  def quadicon
+    {
+      :top_left     => {
+        :text    => hardware.physical_ports.try(:size).to_i,
+        :tooltip => _('Ports')
+      },
+      :top_right    => {
+        :tooltip => power_state.try(:downcase),
+      }.merge(QuadiconHelper.machine_state(power_state)),
+      :bottom_left  => {
+        :fonticon => fonticon,
+        :tooltip  => ui_lookup(:model => type),
+      },
+      :bottom_right => {
+        :fileicon => health_state_img,
+        :tooltip  => _(health_state),
+      }
+    }
+  end
+
+  def single_quad
+    {
+      :fonticon => fonticon,
+      :tooltip  => ui_lookup(:model => type),
+    }
   end
 
   private

--- a/app/decorators/physical_switch_decorator.rb
+++ b/app/decorators/physical_switch_decorator.rb
@@ -1,0 +1,16 @@
+class PhysicalSwitchDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-container-node'
+  end
+
+  private
+
+  def health_state_img
+    case health_state
+    when "Valid"    then "svg/healthstate-normal.svg"
+    when "Critical" then "svg/healthstate-critical.svg"
+    when "Warning"  then "100/warning.png"
+    else "svg/healthstate-unknown.svg"
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1131,6 +1131,7 @@ module ApplicationHelper
                         offline
                         orchestration_stack
                         physical_infra_topology
+                        physical_switch
                         physical_server
                         persistent_volume
                         policy

--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -51,6 +51,7 @@ module ApplicationHelper
            orchestration_stack
            persistent_volume
            physical_server
+           physical_switch
            resource_pool
            retired
            security_group
@@ -119,6 +120,7 @@ module ApplicationHelper
                orchestration_stack
                persistent_volume
                physical_server
+               physical_switch
                policy
                resource_pool
                scan_profile

--- a/app/helpers/application_helper/toolbar/physical_switch_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_switch_center.rb
@@ -1,0 +1,2 @@
+class ApplicationHelper::Toolbar::PhysicalSwitchCenter < ApplicationHelper::Toolbar::Basic
+end

--- a/app/helpers/application_helper/toolbar/physical_switch_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_switch_center.rb
@@ -1,2 +1,26 @@
 class ApplicationHelper::Toolbar::PhysicalSwitchCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'physical_switch_vmdb',
+    [
+      select(
+        :physical_switch_vmdb_choice,
+        'fa fa-cog fa-lg',
+        t = N_('Configuration'),
+        t,
+        :items => [
+          button(
+            :physical_switch_refresh,
+            'fa fa-refresh fa-lg',
+            N_('Refresh relationships and power states for all items related to this Physical Switch'),
+            N_('Refresh Relationships and Power States'),
+            :image   => "refresh",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "refresh", "controller": "physicalSwitchToolbarController"}'},
+            :confirm => N_("Refresh relationships and power states for all items related to this Physical Switch?"),
+            :options => {:feature => :refresh}
+          ),
+        ]
+      ),
+    ]
+  )
 end

--- a/app/helpers/application_helper/toolbar/physical_switches_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_switches_center.rb
@@ -1,2 +1,26 @@
 class ApplicationHelper::Toolbar::PhysicalSwitchesCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'physical_switch_vmdb',
+    [
+      select(
+        :physical_switch_vmdb_choice,
+        'fa fa-cog fa-lg',
+        t = N_('Configuration'),
+        t,
+        :items => [
+          button(
+            :physical_switch_refresh,
+            'fa fa-refresh fa-lg',
+            N_('Refresh relationships and power states for all items related to these Physical Switches'),
+            N_('Refresh Relationships and Power States'),
+            :image   => "refresh",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "refresh", "controller": "physicalSwitchToolbarController"}'},
+            :confirm => N_("Refresh relationships and power states for all items related to these Physical Switches?"),
+            :options => {:feature => :refresh}
+          ),
+        ]
+      ),
+    ]
+  )
 end

--- a/app/helpers/application_helper/toolbar/physical_switches_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_switches_center.rb
@@ -1,0 +1,2 @@
+class ApplicationHelper::Toolbar::PhysicalSwitchesCenter < ApplicationHelper::Toolbar::Basic
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -525,6 +525,7 @@ class ApplicationHelper::ToolbarChooser
             orchestration_stack
             physical_infra_topology
             physical_server
+            physical_switch
             resource_pool
             container_template
             ems_block_storage

--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -54,7 +54,7 @@ module EmsPhysicalInfraHelper::TextualSummary
   end
 
   def textual_physical_switches
-    textual_link(@record.switches)
+    textual_link(@record.physical_switches)
   end
 
   def textual_physical_servers

--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -14,7 +14,7 @@ module EmsPhysicalInfraHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(physical_servers datastores vms physical_servers_with_host)
+      %i(physical_switches physical_servers datastores vms physical_servers_with_host)
     )
   end
 
@@ -51,6 +51,10 @@ module EmsPhysicalInfraHelper::TextualSummary
 
   def textual_port
     @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
+  end
+
+  def textual_physical_switches
+    textual_link(@record.switches)
   end
 
   def textual_physical_servers

--- a/app/helpers/physical_switch_helper.rb
+++ b/app/helpers/physical_switch_helper.rb
@@ -1,0 +1,3 @@
+module PhysicalSwitchHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/physical_switch_helper/textual_summary.rb
+++ b/app/helpers/physical_switch_helper/textual_summary.rb
@@ -1,0 +1,86 @@
+module PhysicalSwitchHelper::TextualSummary
+  def textual_group_properties
+    TextualGroup.new(
+      _("Properties"),
+      %i(name product_name manufacturer serial_number part_number health_state uid_ems description)
+    )
+  end
+
+  def textual_group_relationships
+    TextualGroup.new(
+      _("Relationships"),
+      %i(ext_management_system)
+    )
+  end
+
+  def textual_group_management_networks
+    TextualTable.new(_("Management Networks"), management_networks, [_("IP"), _("Default Gateway"), _("Subnet Mask")])
+  end
+
+  def textual_group_power_management
+    TextualGroup.new(
+      _("Power Management"),
+      %i(power_state)
+    )
+  end
+
+  def textual_group_firmware_details
+    TextualTable.new(_("Firmwares"), firmware_details, [_("Name"), _("Version")])
+  end
+
+  def textual_group_ports
+    TextualTable.new(_("Ports"), port_details, [_("Device Name"), _("Device Type"), _("Peer Mac Address")])
+  end
+
+  def textual_ext_management_system
+    textual_link(ExtManagementSystem.find(@record.ems_id))
+  end
+
+  def textual_name
+    {:label => _("Name"), :value => @record.name }
+  end
+
+  def textual_product_name
+    {:label => _("Product Name"), :value => @record.asset_detail["product_name"] }
+  end
+
+  def textual_manufacturer
+    {:label => _("Manufacturer"), :value => @record.asset_detail["manufacturer"] }
+  end
+
+  def textual_serial_number
+    {:label => _("Serial Number"), :value => @record.asset_detail["serial_number"] }
+  end
+
+  def textual_part_number
+    {:label => _("Part Number"), :value => @record.asset_detail["part_number"] }
+  end
+
+  def textual_health_state
+    {:label => _("Health State"), :value => @record.health_state}
+  end
+
+  def textual_uid_ems
+    {:label => _("UUID"), :value => @record.uid_ems }
+  end
+
+  def textual_description
+    {:label => _("Description"), :value => @record.asset_detail["description"]}
+  end
+
+  def textual_power_state
+    {:label => _("Power State"), :value => @record.power_state}
+  end
+
+  def management_networks
+    @record.hardware.networks.collect { |network| [network.ipaddress || network.ipv6address, network.default_gateway, network.subnet_mask] }
+  end
+
+  def firmware_details
+    @record.hardware.firmwares.collect { |fw| [fw.name, fw.version] }
+  end
+
+  def port_details
+    @record.hardware.guest_devices.collect { |port| [port.device_name, port.device_type, port.peer_mac_address] }
+  end
+end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -70,6 +70,8 @@ module QuadiconHelper
       when "ems_physical_infra", "ems_cloud", "ems_network", "ems_container"
         layout.to_sym
       end
+    elsif klass.base_model.name != klass.name.demodulize
+      klass.name.demodulize.underscore.to_sym
     else
       klass.base_model.name.underscore.to_sym
     end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -89,6 +89,7 @@ module Menu
       def physical_infrastructure_menu_section
         Menu::Section.new(:phy, N_("Physical Infrastructure"), 'fa fa-plus fa-2x', [
           Menu::Item.new('ems_physical_infra',    N_('Providers'), 'ems_physical_infra',    {:feature => 'ems_physical_infra_show_list'},    '/ems_physical_infra'),
+          Menu::Item.new('physical_switch', N_('Switches'),  'physical_switch', {:feature => 'physical_switch_show_list'}, '/physical_switch'),
           Menu::Item.new('physical_server', N_('Servers'),   'physical_server', {:feature => 'physical_server_show_list'}, '/physical_server'),
           Menu::Item.new('physical_infra_topology', N_('Topology'), 'physical_infra_topology', {:feature => 'physical_infra_topology', :any => true}, '/physical_infra_topology')
         ])

--- a/app/services/ui_service_mixin.rb
+++ b/app/services/ui_service_mixin.rb
@@ -24,6 +24,7 @@ module UiServiceMixin
       :NetworkRouter           => {:type => "glyph", :class => 'pficon pficon-route'},
       :PhysicalRack            => {:type => "glyph", :class => 'pficon pficon-enterprise'},
       :PhysicalServer          => {:type => "glyph", :class => 'pficon pficon-server-group'},
+      :PhysicalSwitch          => {:type => "glyph", :class => 'pficon pficon-container-node'},
       :SecurityGroup           => {:type => "glyph", :class => 'pficon pficon-cloud-security'},
       :Tag                     => {:type => "glyph", :class => 'fa fa-tag'},
       :Vm                      => {:type => "glyph", :class => 'pficon pficon-virtual-machine'},

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -21,6 +21,7 @@
              [role_allows?(:feature => "host_show_list"),               _("Host"),                    "host"],
              [role_allows?(:feature => "storage_show_list"),            _("Datastores"),              "storage"],
              [true,                                                     _("VM"),                      "vm"],
+             [role_allows?(:feature => "physical_switch_show_list"),    _("Physical Switch"),         "physical_switch"],
              [role_allows?(:feature => "physical_server_show_list"),    _("Physical Server"),         "physical_server"],
              [true,                                                     _("Template"),                "miq_template"]].each do |icons_checkbox|
             - if icons_checkbox[0]

--- a/app/views/layouts/listnav/_physical_switch.html.haml
+++ b/app/views/layouts/listnav/_physical_switch.html.haml
@@ -1,0 +1,19 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render :partial => 'shared/quadicon', :locals => {:record => @record}
+
+    = miq_accordion_panel(_("Properties"), false, "ems_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to(_('Summary'), {:action => 'show', :id => @record, :display => 'main'}, {:title => _("Show Summary")})
+
+    = miq_accordion_panel(_("Relationships"), false, "ems_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        - if  @record.ext_management_system
+          %li
+            = link_to(_("Provider: %{name}") % {:name => @record.ext_management_system.name},
+              ems_physical_infra_path(@record.ext_management_system.id),
+              :title => _("Show this parent Provider"))
+
+

--- a/app/views/physical_switch/show.html.haml
+++ b/app/views/physical_switch/show.html.haml
@@ -1,0 +1,9 @@
+#main_div
+  - if %w(physical_switches).include?(@display)
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  - else
+    - case @showtype
+    - when "main"
+      = render :partial => 'layouts/textual_groups_generic'
+    - when "timeline"
+      = render :partial => "layouts/tl_show_async"

--- a/app/views/physical_switch/show.html.haml
+++ b/app/views/physical_switch/show.html.haml
@@ -7,3 +7,8 @@
       = render :partial => 'layouts/textual_groups_generic'
     - when "timeline"
       = render :partial => "layouts/tl_show_async"
+
+  %physical-switch-toolbar#physical_switch_show_form{'physical_switch-id' => @record.id}
+
+:javascript
+  miq_bootstrap('#physical_switch_show_form');

--- a/app/views/physical_switch/show_list.html.haml
+++ b/app/views/physical_switch/show_list.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => 'layouts/gtl'

--- a/app/views/physical_switch/show_list.html.haml
+++ b/app/views/physical_switch/show_list.html.haml
@@ -1,2 +1,7 @@
 #main_div
   = render :partial => 'layouts/gtl'
+
+  %physical-switch-toolbar#physical_switch_show_list_form
+
+:javascript
+  miq_bootstrap('#physical_switch_show_list_form');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1312,6 +1312,26 @@ Rails.application.routes.draw do
                save_post
     },
 
+    :physical_switch    =>  {
+      :get  =>  %w(
+        download_data
+        download_summary_pdf
+        show_list
+        show
+      ) + compare_get,
+
+      :post   =>  %w(
+        button
+        listnav_search_selected
+        show_list
+        create
+        create_del
+        update
+        update_del
+        quick_search
+      ) + adv_search_post + save_post,
+    },
+
     :physical_server    =>  {
       :get  =>  %w(
         download_data

--- a/product/views/PhysicalSwitch.yaml
+++ b/product/views/PhysicalSwitch.yaml
@@ -1,0 +1,64 @@
+#Report title
+title: Physical Switches
+
+#Menu name
+name: Physical Switch
+
+
+db: PhysicalSwitch
+
+
+# Columns to fetch from main table
+cols:
+- name
+- type
+- health_state
+- power_state
+- asset_detail.product_name
+- asset_detail.manufacturer
+
+
+include:
+
+
+include_for_find:
+  :ext_management_system: {}
+
+
+col_order:
+- name
+- type
+- health_state
+- power_state
+- asset_detail.product_name
+- asset_detail.manufacturer
+
+col_formats:
+-
+- :model_name
+
+headers:
+- Name
+- Type
+- Health State
+- Power State
+- Product Name
+- Manufacturer
+
+
+conditions:
+
+
+order: Ascending
+
+
+sortby:
+- name
+
+group: n
+
+
+graph:
+
+
+dims:

--- a/spec/controllers/physical_switch_controller_spec.rb
+++ b/spec/controllers/physical_switch_controller_spec.rb
@@ -1,33 +1,59 @@
 describe PhysicalSwitchController do
   render_views
 
-  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryGirl.build(:zone) }
-
-  before(:each) do
-    stub_user(:features => :all)
-    EvmSpecHelper.create_guid_miq_server_zone
-    login_as FactoryGirl.create(:user)
+  let(:physical_switch) do
     ems = FactoryGirl.create(:ems_physical_infra)
     hardware = FactoryGirl.create(:hardware)
     asset_detail = FactoryGirl.create(:asset_detail)
-    @physical_switch = FactoryGirl.create(:physical_switch,
-                                          :hardware     => hardware,
-                                          :asset_detail => asset_detail,
-                                          :ems_id       => ems.id,
-                                          :id           => 1)
+
+    FactoryGirl.create(
+      :physical_switch,
+      :hardware     => hardware,
+      :asset_detail => asset_detail,
+      :ems_id       => ems.id,
+      :id           => 1
+    )
+  end
+
+  before do
+    EvmSpecHelper.local_miq_server(:zone => FactoryGirl.build(:zone))
+    stub_user(:features => :all)
+    EvmSpecHelper.create_guid_miq_server_zone
+    login_as FactoryGirl.create(:user)
   end
 
   describe "#show_list" do
-    before(:each) do
+    before do
       FactoryGirl.create(:physical_switch)
     end
 
     subject { get :show_list }
 
-    it do
+    it "renders a GTL page" do
       is_expected.to have_http_status 200
       is_expected.to render_template(:partial => "layouts/_gtl")
+    end
+  end
+
+  describe "#show" do
+    context "with valid id" do
+      subject { get(:show, :params => {:id => physical_switch.id}) }
+
+      it "should respond to show" do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/_textual_groups_generic")
+      end
+    end
+    context "with invalid id" do
+      subject { get(:show, :params => {:id => 2}) }
+
+      it "should redirect to #show_list" do
+        is_expected.to have_http_status 302
+        is_expected.to redirect_to(:action => :show_list)
+
+        flash_messages = assigns(:flash_array)
+        expect(flash_messages.first[:message]).to include("Can't access selected records")
+      end
     end
   end
 end

--- a/spec/controllers/physical_switch_controller_spec.rb
+++ b/spec/controllers/physical_switch_controller_spec.rb
@@ -1,0 +1,33 @@
+describe PhysicalSwitchController do
+  render_views
+
+  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+  let(:zone) { FactoryGirl.build(:zone) }
+
+  before(:each) do
+    stub_user(:features => :all)
+    EvmSpecHelper.create_guid_miq_server_zone
+    login_as FactoryGirl.create(:user)
+    ems = FactoryGirl.create(:ems_physical_infra)
+    hardware = FactoryGirl.create(:hardware)
+    asset_detail = FactoryGirl.create(:asset_detail)
+    @physical_switch = FactoryGirl.create(:physical_switch,
+                                          :hardware     => hardware,
+                                          :asset_detail => asset_detail,
+                                          :ems_id       => ems.id,
+                                          :id           => 1)
+  end
+
+  describe "#show_list" do
+    before(:each) do
+      FactoryGirl.create(:physical_switch)
+    end
+
+    subject { get :show_list }
+
+    it do
+      is_expected.to have_http_status 200
+      is_expected.to render_template(:partial => "layouts/_gtl")
+    end
+  end
+end


### PR DESCRIPTION
Adds the physical switches show page.

**Depends on:**

- ~~[https://github.com/ManageIQ/manageiq/pull/17216](https://github.com/ManageIQ/manageiq/pull/17216)~~

![switch_summary](https://user-images.githubusercontent.com/5031156/39888127-52718d7e-546a-11e8-9839-dfa4f4bcccc6.png)
![switches_list](https://user-images.githubusercontent.com/5031156/39888124-522ad5dc-546a-11e8-83fb-95f55f6c6354.png)
![switches_menu](https://user-images.githubusercontent.com/5031156/39888125-524f3e7c-546a-11e8-9202-555a1a3f9c71.png)
