### PR TITLE
Include api_version when calling raw_connect for vCloud

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -121,7 +121,7 @@ module Mixins
       when 'ManageIQ::Providers::Azure::CloudManager'
         [user, password, params[:azure_tenant_id], params[:subscription], nil, params[:provider_region]]
       when 'ManageIQ::Providers::Vmware::CloudManager'
-        [params[:default_hostname], params[:default_api_port], user, password, true]
+        [params[:default_hostname], params[:default_api_port], user, password, params[:api_version], true]
       when 'ManageIQ::Providers::Google::CloudManager'
         [params[:project], MiqPassword.encrypt(params[:service_account]), {:service => "compute"}, nil, true]
       when 'ManageIQ::Providers::Microsoft::InfraManager'


### PR DESCRIPTION
This is a followup commit to reflect changes done on VMware vCloud repo where we now actually use API version. Signature of `raw_connect` has changed hence we need to update the GUI as well.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1560517

Merge in one take with: https://github.com/ManageIQ/manageiq-providers-vmware/pull/219

@miq-bot add_label enhancement,gaprindashvili/yes
@miq-bot assign @agrare
