### PR TITLE
Skip re-validation when non-required fields are cleared

### DIFF
--- a/app/assets/javascripts/directives/validation/reset_validation_status.js
+++ b/app/assets/javascripts/directives/validation/reset_validation_status.js
@@ -31,6 +31,7 @@ var adjustValidationStatus = function(value, scope, ctrl, attrs, rootScope) {
     }
 
     if (scope[scope.model][attrs.resetValidationDependsOn] === '' ||
+      (value === '' && ! attrs.required) ||
         (value === scope.postValidationModel[attrs.prefix][ctrl.$name] && _.isMatch(modelObject, modelPostValidationObject))) {
       scope[scope.model][attrs.resetValidationStatus] = true;
       rootScope.$broadcast('clearErrorOnTab', {tab: attrs.prefix});

--- a/spec/javascripts/directives/validation/reset_validation_status_spec.js
+++ b/spec/javascripts/directives/validation/reset_validation_status_spec.js
@@ -7,12 +7,20 @@ describe('resetValidationStatus initialization', function() {
     var element = angular.element(
       '<form name="angularForm">' +
       '<input type="text" error-on-tab="default"/>' +
-      '<input type="text" reset-validation-status="default_auth_status" prefix="default" ng-model="emsCommonModel.hostname" name="hostname"/>' +
+      '<input type="text" reset-validation-status="default_auth_status" prefix="default" ng-model="emsCommonModel.hostname" name="hostname" required/>' +
+      '</form>'
+    );
+    var element2 = angular.element(
+      '<form name="angularForm">' +
+      '<input type="text" error-on-tab="console"/>' +
+      '<input type="text" reset-validation-status="console_auth_status" prefix="console" ng-model="emsCommonModel.userid" name="userid"/>' +
       '</form>'
     );
     $compile(element)($scope);
+    $compile(element2)($scope);
     $scope.$digest();
     elem = $compile(element)($rootScope);
+    elem2 = $compile(element2)($rootScope);
     angularForm = $scope.angularForm;
   }));
 
@@ -30,6 +38,19 @@ describe('resetValidationStatus initialization', function() {
   });
 
   describe('reset-validation-status', function() {
+    it('set validation required icon when required hostname value is cleared', inject(function($rootScope, $timeout) {
+      $scope.model = {};
+      $scope.postValidationModel = {};
+      $scope.checkAuthentication = true;
+      $scope.postValidationModel['default'] = {hostname: "abc"};
+      $scope.model = 'emsCommonModel';
+      $scope['emsCommonModel'] = {hostname: ""};
+      $timeout.flush();
+      expect(elem[0][0].className).toEqual("fa fa-exclamation-circle");
+    }));
+  });
+
+  describe('reset-validation-status', function() {
     it('clear validation required icon when hostname value is restored to original', inject(function($rootScope, $timeout) {
       $scope.model = {};
       $scope.postValidationModel = {};
@@ -39,6 +60,19 @@ describe('resetValidationStatus initialization', function() {
       $scope['emsCommonModel'] = {hostname: "abc"};
       $timeout.flush();
       expect(elem[0][0].className).toEqual("");
+    }));
+  });
+
+  describe('reset-validation-status', function() {
+    it('clear validation required icon when optional userid value is cleared', inject(function($rootScope, $timeout) {
+      $scope.model = {};
+      $scope.postValidationModel = {};
+      $scope.checkAuthentication = true;
+      $scope.postValidationModel['console'] = {userid: "abc"};
+      $scope.model = 'emsCommonModel';
+      $scope['emsCommonModel'] = {userid: ""};
+      $timeout.flush();
+      expect(elem2[0][0].className).toEqual("");
     }));
   });
 });


### PR DESCRIPTION
Skip re-validation if fields that are not Required are blanked out.

This will fix the below BZ where the Save button is not enabled because a blanked out non-required field enforces re-validation.

Before (Save disabled, re-validation is enforced on a blank non-required field) -

<img width="1223" alt="screen shot 2018-03-29 at 1 52 48 pm" src="https://user-images.githubusercontent.com/1538216/38113004-80977b2e-3358-11e8-8930-289f7514ff1d.png">

After (Save enabled, re-validation is not enforced on a blank non-required field) -

<img width="1226" alt="screen shot 2018-03-29 at 1 51 06 pm" src="https://user-images.githubusercontent.com/1538216/38112931-51118f7a-3358-11e8-9e59-7afa9f758ded.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1559957