### PR TITLE
[FINE] Fix for Role Tree Features check display

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -962,7 +962,7 @@ module OpsController::OpsRbac
   def rbac_role_get_details(id)
     @edit = nil
     @record = @role = MiqUserRole.find_by_id(from_cid(id))
-    @role_features = @role.feature_identifiers.sort
+    @role_features = rbac_expand_features(@role.feature_identifiers).sort
     @features_tree = rbac_build_features_tree
   end
 

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -430,6 +430,23 @@ describe OpsController do
     end
   end
 
+  context "rbac_role_get_details" do
+    before do
+      MiqUserRole.seed
+      MiqGroup.seed
+      MiqRegion.seed
+      stub_user(:features => :all)
+      @vm_role = FactoryGirl.create(:miq_user_role, :features => %w(embedded_automation_manager))
+    end
+
+    it "EVMRole_vm_user feature tree should contain the embedded_ansible_automation children role" do
+      EvmSpecHelper.seed_specific_product_features(%w(everything embedded_automation_manager embedded_configuration_script_source_view))
+      allow(controller).to receive(:rbac_build_features_tree)
+      controller.send(:rbac_role_get_details, controller.to_cid(@vm_role.id))
+      expect(controller.instance_variable_get(:@role_features)).to include('embedded_configuration_script_source_view')
+    end
+  end
+
   render_views
 
   context "::MiqRegion" do


### PR DESCRIPTION
Fix for Role Tree Features check display.

The parent feature for Embedded Ansible is enabled for teh EvmRole-vm_user, but that was not reflected in the display tree or when the role was opened for edit. 

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1531499
https://bugzilla.redhat.com/show_bug.cgi?id=1500951

Steps for Testing/QA 
-------------------------------


Before:

![screenshot from 2018-04-04 11-54-04](https://user-images.githubusercontent.com/12769982/38320676-3a830450-3803-11e8-935a-3d278e458416.png)


After:

![screenshot from 2018-04-04 12-27-35](https://user-images.githubusercontent.com/12769982/38320824-a6a3af86-3803-11e8-813b-b653391b2338.png)

