### PR TITLE
Force expand active node in TreeBuilder

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -262,7 +262,10 @@ class TreeBuilder
                       object[:load_children]
                     end
 
-    node[:expand] = Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key]) || !!options[:open_all] || node[:expand]
+    node[:expand] = Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key]) ||
+                    !!options[:open_all]                                               ||
+                    node[:expand]                                                      ||
+                    @tree_state.x_tree(@name)[:active_node] == node[:key]
     if ancestry_kids ||
        load_children ||
        node[:expand] ||


### PR DESCRIPTION
The BZ below is a little bit complicated, a minimal reproducer is to navigate to `Settings -> Access Control -> Users` with a clean session and add a new user or edit an existing user's name. The changes will be affected on the right side, but not on the left.

The problem is that the expanded state of a lazily-loaded node isn't reflected until a full page reload. However, by navigating to the `Users` node the active node parameter is being set properly and this can be leveraged when setting the expanded state of the node itself.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label gaprindashvili/yes, bug, trees

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1561698