### PR TITLE
[GAPRINDASHVILI] Remove vendor include which should not have been backported

### DIFF
--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -11,7 +11,6 @@
       = javascript_include_tag 'miq_debug'
       = stylesheet_link_tag 'miq_debug'
 
-    = javascript_pack_tag 'vendor'
     -# FIXME: the conditional below is a temporary fix for a webpacker issue, remove when it's resolved
     - unless Rails.env.test?
       - Webpacker::Manifest.instance.data.keys.each do |pack|


### PR DESCRIPTION
My fault, the change comes from #3682 which was backported (as it should have been :)), but this one specific line is only relevant for master, because #2652 was never backported (and not supposed to).

Gaprindashvili compiles included dependencies directly into the pack which includes them.
In master, external dependencies go to a separate vendor pack, hence master needs to require it.

Cc @NickLaMuro thanks for finding this :)