### PR TITLE
Fix SecurityGroup -> FirewallRules table port range display

### DIFF
--- a/app/helpers/security_group_helper/textual_summary.rb
+++ b/app/helpers/security_group_helper/textual_summary.rb
@@ -25,8 +25,7 @@ module SecurityGroupHelper::TextualSummary
         rule.network_protocol,
         rule.host_protocol,
         rule.direction,
-        rule.port.to_i,
-        rule.end_port.to_i,
+        port_range_helper(rule),
         (rule.source_ip_range || rule.source_security_group.try(:name) || "<None>")
       ]
     end.sort
@@ -34,7 +33,7 @@ module SecurityGroupHelper::TextualSummary
     TextualTable.new(
       _("Firewall Rules"),
       items,
-      [_("Network Protocol"), _("Host Protocol"), _("Direction"), _("Port"), _("End Port"), _("Source")]
+      [_("Network Protocol"), _("Host Protocol"), _("Direction"), _("Port Range"), _("Source")]
     )
   end
 
@@ -69,5 +68,17 @@ module SecurityGroupHelper::TextualSummary
 
   def textual_network_ports
     @record.network_ports
+  end
+
+  def port_range_helper(rule)
+    if rule.host_protocol.to_s.upcase.include?("ICMP")
+      _("N/A")
+    elsif rule.port.nil? && rule.end_port.nil?
+      _("All")
+    elsif rule.port == rule.end_port
+      rule.port.to_s
+    else
+      rule.port_range.to_s(:dash)
+    end
   end
 end

--- a/config/initializers/range_formats.rb
+++ b/config/initializers/range_formats.rb
@@ -1,0 +1,1 @@
+Range::RANGE_FORMATS[:dash] = ->(start, stop) { "#{start}–#{stop}" }


### PR DESCRIPTION
Instead of **Port** and **End Port** in Firewall rules table on Security group show sceen, rather display a **Port range**.

Additional parsing for the port range:
- If the protocol does not use ports, display `N/A`
- If the ports are not set, it means the rule is effective for all ports
- If the start and end port are the same, display only one value
- Otherwise display the range the way [how it should be displayed](http://www.thepunctuationguide.com/en-dash.html)

A new range-to-string formatter added.

Related: https://github.com/ManageIQ/manageiq-providers-amazon/pull/427
Partially fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1540283

## Before
![image](https://user-images.githubusercontent.com/7453394/38252681-1a31552a-3755-11e8-9ebd-20d9a6efcc70.png)


![image](https://user-images.githubusercontent.com/7453394/38252916-a006de0e-3755-11e8-8575-f7f8f9e2b18d.png)


## After
![image](https://user-images.githubusercontent.com/7453394/38252823-68a1e99a-3755-11e8-8dd2-5754e9f28eb5.png)


![image](https://user-images.githubusercontent.com/7453394/38252879-84480990-3755-11e8-8804-33d4740c842c.png)



@miq-bot add_label bug