### PR TITLE
[FINE] API - use a utf-8 aware btoa implementation (base64encode)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -83,3 +83,5 @@
 //= require manageiq-ui-components/dist/js/ui-components
 //= require rx-angular/dist/rx.angular
 //= require patternfly-timeline/dist/timeline
+//= require base64-js/base64js.min
+//= require text-encoder-lite

--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -16,6 +16,16 @@
  * the API token is persisted into sessionStorage
  */
 
+// utf8-capable window.btoa
+function base64encode(str, encoding) {
+  if (! encoding) {
+    encoding = 'utf-8';
+  }
+
+  var bytes = new (window.TextEncoder || window.TextEncoderLite)(encoding).encode(str);
+  return base64js.fromByteArray(bytes);
+}
+
 (function() {
   function API() {
   }
@@ -64,8 +74,6 @@
     }, process_options(options)))
     .then(process_response);
   };
-
-  var base64encode = window.btoa; // browser api
 
   API.login = function(login, password) {
     API.logout();

--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
     "angular-ui-sortable": "~0.16.1",
     "angular.validators": "~4.4.2",
     "array-includes": "~1.0.0",
+    "base64-js": "~1.2.3",
     "bootstrap-filestyle": "~1.2.1",
     "bootstrap-hover-dropdown": "~2.2.1",
     "bootstrap-switch": "~3.3.2",
@@ -54,6 +55,7 @@
     "spice-html5-bower": "himdel/spice-html5-bower#~1.6.3",
     "spin.js": "~2.3.2",
     "sprintf": "~1.0.3",
+    "text-encoder-lite": "~1.0.1",
     "tota11y": "~0.1.6",
     "xml_display": "~0.1.1",
     "bootstrap-select": "1.12.2"


### PR DESCRIPTION
This is a fine version of:
 * https://github.com/ManageIQ/manageiq-ui-classic/pull/3682 (updated to work in ES5, and dependencies via bower)
 * https://github.com/ManageIQ/manageiq-ui-classic/pull/3687 (not really needed because we're using the globals here)
 * https://github.com/ManageIQ/manageiq-ui-classic/pull/3709 (gaprindashvili fix removing a vendor mention, not really needed here)

---

`window.btoa("sněhulák")` fails on InvalidCharacterError: String contains an invalid character

because it only expects latin1 chars

We need to base64 encode the login:password pair even when the password uses non-latin1 chars :)

Implementation adapted from https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#Solution_2_%E2%80%93_rewrite_the_DOMs_atob()_and_btoa()_using_JavaScript's_TypedArrays_and_UTF-8

---

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1562798
