### PR TITLE
Fix for Template Custom Button Dialog Not Displaying Submit or Cancel Buttons

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1302,7 +1302,7 @@ module VmCommon
         # these subviews use angular, so they need to use a special partial
         # so the form buttons on the outer frame can be updated.
         if @sb[:action] == 'dialog_provision'
-          if %w(vm_transform vm_transform_mass).include?(params[:pressed]) || Settings.product.old_dialog_user_ui
+          if show_old_dialog_submit_and_cancel_buttons?(params)
             presenter.update(:form_buttons_div, r[
               :partial => 'layouts/x_dialog_buttons',
               :locals  => {
@@ -1352,6 +1352,10 @@ module VmCommon
     presenter[:lock_sidebar] = @in_a_form && @edit
 
     render :json => presenter.for_render
+  end
+
+  def show_old_dialog_submit_and_cancel_buttons?(params)
+    %w(vm_transform vm_transform_mass).include?(params[:pressed]) || Settings.product.old_dialog_user_ui
   end
 
   # get the host that this vm belongs to

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -11,9 +11,9 @@ class DialogLocalService
     Host
     InfraManager
     MiqGroup
-    MiqTemplate
     Service
     Storage
+    Template
     Tenant
     User
     Vm
@@ -45,7 +45,7 @@ class DialogLocalService
     dialog_locals.merge!(
       :resource_action_id     => resource_action.id,
       :target_id              => obj.id,
-      :target_type            => obj.class.name.demodulize.underscore,
+      :target_type            => determine_target_type(obj),
       :dialog_id              => resource_action.dialog_id,
       :force_old_dialog_use   => false,
       :api_submit_endpoint    => submit_endpoint,
@@ -98,15 +98,15 @@ class DialogLocalService
     when /MiqGroup/
       api_collection_name = "groups"
       cancel_endpoint = "/ops/explorer"
-    when /MiqTemplate/
-      api_collection_name = "templates"
-      cancel_endpoint = "/vm_or_template/explorer"
     when /Service/
       api_collection_name = "services"
       cancel_endpoint = "/service/explorer"
     when /Storage/
       api_collection_name = "datastores"
       cancel_endpoint = "/storage/explorer"
+    when /Template/
+      api_collection_name = "templates"
+      cancel_endpoint = "/vm_or_template/explorer"
     when /Tenant/
       api_collection_name = "tenants"
       cancel_endpoint = "/ops/explorer"
@@ -121,5 +121,14 @@ class DialogLocalService
     submit_endpoint = "/api/#{api_collection_name}/#{obj.id}"
 
     return submit_endpoint, cancel_endpoint
+  end
+
+  def determine_target_type(obj)
+    case obj.class.name.demodulize
+    when /Template/
+      "miq_template"
+    else
+      obj.class.name.demodulize.underscore
+    end
   end
 end

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -167,8 +167,8 @@ describe DialogLocalService do
       end
     end
 
-    context "when the object is an MiqTemplate" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::MiqTemplate, :id => 123) }
+    context "when the object is a Template" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Template, :id => 123) }
 
       it "returns a hash" do
         expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(


### PR DESCRIPTION
What was happening before was Template custom buttons were going through the old dialog runner, but we are hiding the submit/cancel buttons because they are *supposed* to go through the new dialog runner. The new dialog runner was looking for `MiqTemplate` class and not `Template`. However, the `target_type` that gets passed to the API still need to be `miq_template`, otherwise it fails.

I also threw in a small method refactoring to `vm_common.rb` but that can be removed if we want.

Note that `#determine_target_type` uses a case statement with only one case (for now) because there is another BZ that will be fixed by adding another case to the statement. [PR link for that here](https://github.com/ManageIQ/manageiq-ui-classic/pull/3713)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1562940

@miq-bot assign @h-kataria 
@miq-bot add_label gaprindashvili/yes, bug, blocker

