### PR TITLE
Get all user form data before validating for errors per field

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -722,7 +722,7 @@ module OpsController::OpsRbac
     when :user
       record = @edit[:user_id] ? User.find_by(:id => @edit[:user_id]) : User.new
       validated = rbac_user_validate?
-      rbac_user_set_record_vars(record)
+      rbac_user_set_record_vars(record) if @edit[:user_id].blank?
     when :group then
       record = @edit[:group_id] ? MiqGroup.find_by(:id => @edit[:group_id]) : MiqGroup.new
       validated = rbac_group_validate?

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -722,7 +722,7 @@ module OpsController::OpsRbac
     when :user
       record = @edit[:user_id] ? User.find_by(:id => @edit[:user_id]) : User.new
       validated = rbac_user_validate?
-      rbac_user_set_record_vars(record) if validated
+      rbac_user_set_record_vars(record)
     when :group then
       record = @edit[:group_id] ? MiqGroup.find_by(:id => @edit[:group_id]) : MiqGroup.new
       validated = rbac_group_validate?


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1562828

Configuration -> Access Control -> Users -> Configuration -> Add a new User -> fill as in image below -> click Add

Before:
<img width="903" alt="screen shot 2018-04-04 at 9 31 20 am" src="https://user-images.githubusercontent.com/9210860/38294634-c730d52a-37eb-11e8-9950-fa039d235917.png">
After:
<img width="897" alt="screen shot 2018-04-04 at 9 32 58 am" src="https://user-images.githubusercontent.com/9210860/38294643-cf0f1270-37eb-11e8-81e6-d662f71f2cd2.png">

Makes sure not to re-introduced bug fixed in https://github.com/ManageIQ/manageiq-ui-classic/pull/3345

Steps to reproduce issue from that PR:

- Create an RBAC user that is assigned to one or more groups
- Edit the RBAC user and remove them from all of their assigned groups
- Click Save
- After receiving the error "A User must be assigned to a Group", navigate away from the user's details page.
- Select the user in the RBAC accordion to view their details

If there's an error make sure it isn't related to https://github.com/ManageIQ/manageiq-ui-classic/pull/3720 fix

@miq-bot add_label bug, gaprindashvili/yes, wip