### PR TITLE
Render flash partial even for an empty report list

### DIFF
--- a/app/views/report/_report_list.html.haml
+++ b/app/views/report/_report_list.html.haml
@@ -11,6 +11,8 @@
       - nodes = x_node.split('-')
       - if (nodes.length == 1 && @sb[:rpt_menu].blank?) || (nodes.length == 2 && @sb[:rpt_menu][nodes[1].to_i][1].blank?) || (nodes.length == 4 && @sb[:rpt_menu][nodes[1].to_i].present? && @sb[:rpt_menu][nodes[1].to_i][1][nodes[3].to_i][1].blank?)
         = render :partial => 'layouts/info_msg', :locals => {:message => _("No Reports available.")}
+        - if @flash_array.present?
+          = render :partial => "layouts/flash_msg"
       - else
         = render :partial => "layouts/flash_msg"
         %table.table.table-striped.table-bordered.table-hover


### PR DESCRIPTION
1. Make sure you have only one custom report in your application available
2. Delete the last one custom report

Before the fix, flash message informing you of the successful report deletion wouldn't show.

After the fix, the flash message is correctly shown.

https://bugzilla.redhat.com/show_bug.cgi?id=1561779