### PR TITLE
Update Rx.js to version 5.6

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,7 +23,7 @@
 //= require bower_components/numeral/numeral
 //= require ./cable
 //= require ./miq_api
-//= require bower_components/rxjs/dist/rx.all
+//= require rxjs/rx.global
 //= require ./miq_angular_application
 //= require ./miq_observable
 //= require_tree ./angular_modules/

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,9 +23,7 @@
 //= require bower_components/numeral/numeral
 //= require ./cable
 //= require ./miq_api
-//= require rxjs/rx.global
 //= require ./miq_angular_application
-//= require ./miq_observable
 //= require_tree ./angular_modules/
 //= require_tree ./controllers/
 //= require_tree ./directives/

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,6 +25,7 @@
 //= require ./miq_api
 //= require bower_components/rxjs/dist/rx.all
 //= require ./miq_angular_application
+//= require ./miq_observable
 //= require_tree ./angular_modules/
 //= require_tree ./controllers/
 //= require_tree ./directives/

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
@@ -14,7 +14,7 @@ function genericObjectDefinitionToolbarController(API, miqService, $window) {
   var toolbar = this;
 
   if (ManageIQ.angular.genericObjectDefinitionSubsription) {
-    ManageIQ.angular.genericObjectDefinitionSubsription.dispose();
+    ManageIQ.angular.genericObjectDefinitionSubsription.unsubscribe();
   }
 
   ManageIQ.angular.genericObjectDefinitionSubsription = listenToRx(function(event) {

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
@@ -17,7 +17,7 @@ function genericObjectDefinitionToolbarController(API, miqService, $window) {
     ManageIQ.angular.genericObjectDefinitionSubsription.dispose();
   }
 
-  ManageIQ.angular.genericObjectDefinitionSubsription = ManageIQ.angular.rxSubject.subscribe(function(event) {
+  ManageIQ.angular.genericObjectDefinitionSubsription = listenToRx(function(event) {
     toolbar.action = event.type;
     toolbar.entity = event.entity;
 

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
@@ -12,26 +12,29 @@ genericObjectDefinitionToolbarController.$inject = ['API', 'miqService', '$windo
 
 function genericObjectDefinitionToolbarController(API, miqService, $window) {
   var toolbar = this;
+  var subscription = null;
 
-  if (ManageIQ.angular.genericObjectDefinitionSubsription) {
-    ManageIQ.angular.genericObjectDefinitionSubsription.unsubscribe();
-  }
+  toolbar.$onInit = function() {
+    subscription = listenToRx(function(event) {
+      toolbar.action = event.type;
+      toolbar.entity = event.entity;
 
-  ManageIQ.angular.genericObjectDefinitionSubsription = listenToRx(function(event) {
-    toolbar.action = event.type;
-    toolbar.entity = event.entity;
-
-    if (toolbar.action) {
-      if (toolbar.recordId) {
-        toolbar.genericObjectDefinitions = _.union(toolbar.genericObjectDefinitions, [toolbar.recordId]);
-      } else if (ManageIQ.record.recordId) {
-        toolbar.genericObjectDefinitions = _.union(toolbar.genericObjectDefinitions, [ManageIQ.record.recordId]);
-      } else {
-        toolbar.genericObjectDefinitions = ManageIQ.gridChecks;
+      if (toolbar.action) {
+        if (toolbar.recordId) {
+          toolbar.genericObjectDefinitions = _.union(toolbar.genericObjectDefinitions, [toolbar.recordId]);
+        } else if (ManageIQ.record.recordId) {
+          toolbar.genericObjectDefinitions = _.union(toolbar.genericObjectDefinitions, [ManageIQ.record.recordId]);
+        } else {
+          toolbar.genericObjectDefinitions = ManageIQ.gridChecks;
+        }
+        postGenericObjectDefinitionAction();
       }
-      postGenericObjectDefinitionAction();
-    }
-  });
+    });
+  };
+
+  toolbar.$onDestroy = function() {
+    subscription.unsubscribe();
+  };
 
   // private functions
   function postGenericObjectDefinitionAction() {

--- a/app/assets/javascripts/components/physical_infrastructures/physical-server-toolbar.js
+++ b/app/assets/javascripts/components/physical_infrastructures/physical-server-toolbar.js
@@ -11,7 +11,7 @@ physicalServerToolbarController.$inject = ['API', 'miqService'];
 function physicalServerToolbarController(API, miqService) {
   var toolbar = this;
 
-  ManageIQ.angular.rxSubject.subscribe(function(event) {
+  listenToRx(function(event) {
     if (event.controller !== 'physicalServerToolbarController') {
       return;
     }

--- a/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
@@ -245,7 +245,7 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
       return true;
     };
 
-    ManageIQ.angular.rxSubject.subscribe(function(event) {
+    listenToRx(function(event) {
       if (event.controller !== 'containers.deployProviderController') {
         return;
       }

--- a/app/assets/javascripts/controllers/error_modal_controller.js
+++ b/app/assets/javascripts/controllers/error_modal_controller.js
@@ -5,7 +5,7 @@ function ErrorModalController($timeout) {
   $ctrl.error = null;
   $ctrl.isHtml = false;
 
-  ManageIQ.angular.rxSubject.subscribe(function(event) {
+  listenToRx(function(event) {
     if ('serverError' in event) {
       $timeout(function() {
         $ctrl.show(event.serverError, event.source);

--- a/app/assets/javascripts/controllers/header/header_controller.js
+++ b/app/assets/javascripts/controllers/header/header_controller.js
@@ -18,7 +18,7 @@ function HeaderCtrl($scope, eventNotifications, $timeout) {
     eventNotifications.setDrawerShown(vm.notificationsDrawerShown);
   };
 
-  ManageIQ.angular.rxSubject.subscribe(function (data) {
+  listenToRx(function (data) {
     if (data.controller !== 'HeaderCtrl') {
       return;
     }

--- a/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
+++ b/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
@@ -37,7 +37,7 @@ function MwServerGroupController($scope, miqService, $timeout, $document) {
 function MwServerControllerFactory($scope, miqService, isGroupDeployment, $timeout, $document) {
   ManageIQ.angular.scope = $scope;
 
-  ManageIQ.angular.rxSubject.subscribe(function(event) {
+  listenToRx(function(event) {
     var eventType = event.type;
     var operation = event.operation;
     var timeout = event.timeout;
@@ -154,7 +154,7 @@ function MwServerGroupOpsController(miqService, serverGroupOpsService) {
 
 function MwServerOpsControllerFactory(miqService, serverOpsService) {
 
-  ManageIQ.angular.rxSubject.subscribe(function(event) {
+  listenToRx(function(event) {
     if (event.type === 'mwSeverOpsEvent') {
       miqService.sparkleOn();
 

--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -75,7 +75,7 @@
   * @returns {undefined}
   */
   function subscribeToSubject() {
-    this.subscription = ManageIQ.angular.rxSubject.subscribe(function(event) {
+    this.subscription = listenToRx(function(event) {
       if (event.initController && event.initController.name === CONTROLLER_NAME) {
         this.initController(event.initController.data);
       } else if (event.unsubscribe && event.unsubscribe === CONTROLLER_NAME) {

--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -157,7 +157,7 @@
   };
 
   ReportDataController.prototype.onUnsubscribe = function() {
-    this.subscription.dispose();
+    this.subscription.unsubscribe();
   };
 
   /**

--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -12,7 +12,7 @@
   * For success functuon @see ToolbarController#onRowSelect()
   */
   function subscribeToSubject() {
-    ManageIQ.angular.rxSubject.subscribe(function(event) {
+    listenToRx(function(event) {
       if (event.eventType === 'updateToolbarCount') {
         this.MiQToolbarSettingsService.setCount(event.countSelected);
       } else if (event.rowSelect) {

--- a/app/assets/javascripts/controllers/topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/network_topology_controller.js
@@ -13,7 +13,7 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
 
   topologyService.mixinContextMenu(this, vm);
 
-  ManageIQ.angular.rxSubject.subscribe(function(event) {
+  listenToRx(function(event) {
     if (event.name === 'refreshTopology') {
       vm.refresh();
     }

--- a/app/assets/javascripts/controllers/tree_view_controller.js
+++ b/app/assets/javascripts/controllers/tree_view_controller.js
@@ -9,7 +9,7 @@
     vm.selectedNodes = {};
     vm.data = {};
 
-    ManageIQ.angular.rxSubject.subscribe(function(payload) {
+    listenToRx(function(payload) {
       if (payload.reloadTrees && _.isObject(payload.reloadTrees) && Object.keys(payload.reloadTrees).length > 0) {
         _.forEach(payload.reloadTrees, function(value, key) {
           vm.data[key] = value;

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -21,8 +21,6 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
 ]);
 miqHttpInject(ManageIQ.angular.app);
 
-ManageIQ.angular.rxSubject = new Rx.Subject();
-
 ManageIQ.constants = {
   reportData: 'report_data',
 };
@@ -68,8 +66,4 @@ function miqCallAngular(data) {
   ManageIQ.angular.scope.$apply(function() {
     ManageIQ.angular.scope[data.name].apply(ManageIQ.angular.scope, data.args);
   });
-}
-
-function sendDataWithRx(data) {
-  ManageIQ.angular.rxSubject.onNext(data);
 }

--- a/app/assets/javascripts/miq_debug.js
+++ b/app/assets/javascripts/miq_debug.js
@@ -91,7 +91,7 @@ angular.module('miq.debug', [])
       var $ctrl = this;
       this.items = [];
 
-      ManageIQ.angular.rxSubject.subscribe(function(event) {
+      listenToRx(function(event) {
         if (!event.error || !event.error.data) {
           return;
         }

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -259,7 +259,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
   }
 
   if (_.isArray(data.reloadToolbars) && data.reloadToolbars.length) {
-    ManageIQ.angular.rxSubject.onNext({
+    sendDataWithRx({
       redrawToolbar: data.reloadToolbars,
     });
   } else if (_.isObject(data.reloadToolbars) && ! _.isArray(data.reloadToolbars)) {

--- a/app/assets/javascripts/miq_observable.js
+++ b/app/assets/javascripts/miq_observable.js
@@ -3,3 +3,7 @@ ManageIQ.angular.rxSubject = new Rx.Subject();
 function sendDataWithRx(data) {
   ManageIQ.angular.rxSubject.onNext(data);
 }
+
+function listenToRx(callback) {
+  ManageIQ.angular.rxSubject.subscribe(callback);
+}

--- a/app/assets/javascripts/miq_observable.js
+++ b/app/assets/javascripts/miq_observable.js
@@ -1,0 +1,5 @@
+ManageIQ.angular.rxSubject = new Rx.Subject();
+
+function sendDataWithRx(data) {
+  ManageIQ.angular.rxSubject.onNext(data);
+}

--- a/app/assets/javascripts/miq_observable.js
+++ b/app/assets/javascripts/miq_observable.js
@@ -1,7 +1,7 @@
 ManageIQ.angular.rxSubject = new Rx.Subject();
 
 function sendDataWithRx(data) {
-  ManageIQ.angular.rxSubject.onNext(data);
+  ManageIQ.angular.rxSubject.next(data);
 }
 
 function listenToRx(callback) {

--- a/app/assets/javascripts/miq_observable.js
+++ b/app/assets/javascripts/miq_observable.js
@@ -5,5 +5,5 @@ function sendDataWithRx(data) {
 }
 
 function listenToRx(callback) {
-  listenToRx(callback);
+  ManageIQ.angular.rxSubject.subscribe(callback);
 }

--- a/app/assets/javascripts/miq_observable.js
+++ b/app/assets/javascripts/miq_observable.js
@@ -5,5 +5,5 @@ function sendDataWithRx(data) {
 }
 
 function listenToRx(callback) {
-  ManageIQ.angular.rxSubject.subscribe(callback);
+  listenToRx(callback);
 }

--- a/app/assets/javascripts/miq_observable.js
+++ b/app/assets/javascripts/miq_observable.js
@@ -1,9 +1,0 @@
-ManageIQ.angular.rxSubject = new Rx.Subject();
-
-function sendDataWithRx(data) {
-  ManageIQ.angular.rxSubject.next(data);
-}
-
-function listenToRx(callback) {
-  ManageIQ.angular.rxSubject.subscribe(callback);
-}

--- a/app/assets/javascripts/miq_toolbar.js
+++ b/app/assets/javascripts/miq_toolbar.js
@@ -6,35 +6,35 @@ ManageIQ.toolbars.findByDataClick = function (toolbar, attr_click) {
 
 ManageIQ.toolbars.enableItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).removeClass('disabled');
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'enabled', value: true});
+  sendDataWithRx({update: attr_click, type: 'enabled', value: true});
 };
 
 ManageIQ.toolbars.disableItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).addClass('disabled');
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'enabled', value: false});
+  sendDataWithRx({update: attr_click, type: 'enabled', value: false});
 };
 
 ManageIQ.toolbars.setItemTooltip = function (toolbar, attr_click, tooltip) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).attr('title', tooltip);
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'title', value: tooltip});
+  sendDataWithRx({update: attr_click, type: 'title', value: tooltip});
 };
 
 ManageIQ.toolbars.showItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).show();
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'hidden', value: true});
+  sendDataWithRx({update: attr_click, type: 'hidden', value: true});
 };
 
 ManageIQ.toolbars.hideItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).hide();
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'hidden', value: true});
+  sendDataWithRx({update: attr_click, type: 'hidden', value: true});
 };
 
 ManageIQ.toolbars.markItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).addClass('active');
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'selected', value: true});
+  sendDataWithRx({update: attr_click, type: 'selected', value: true});
 };
 
 ManageIQ.toolbars.unmarkItem = function (toolbar, attr_click) {
   ManageIQ.toolbars.findByDataClick(toolbar, attr_click).removeClass('active');
-  ManageIQ.angular.rxSubject.onNext({update: attr_click, type: 'selected', value: false});
+  sendDataWithRx({update: attr_click, type: 'selected', value: false});
 };

--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -322,7 +322,7 @@ function eventNotifications($timeout, API) {
 
   this.doReset(true);
 
-  ManageIQ.angular.rxSubject.subscribe(function(data) {
+  listenToRx(function(data) {
     if (data.notification) {
       var msg = miqFormatNotification(data.notification.text, data.notification.bindings);
       _this.add('event', data.notification.level, msg, {message: msg}, data.notification.id);

--- a/app/assets/javascripts/services/subscription_service.js
+++ b/app/assets/javascripts/services/subscription_service.js
@@ -1,6 +1,6 @@
 ManageIQ.angular.app.service('subscriptionService', ['$timeout', function($timeout) {
   this.subscribeToEventType = function(eventType, callback) {
-    ManageIQ.angular.rxSubject.subscribe(function(event) {
+    listenToRx(function(event) {
       if (event.eventType === eventType) {
         $timeout(function() {
           callback(event.response);

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -226,7 +226,7 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
     $scope.resetSearch = resetEvent;
 
     // listen for search & reset events
-    ManageIQ.angular.rxSubject.subscribe(function(event) {
+    listenToRx(function(event) {
       if (event.service !== 'topologyService') {
         return;
       }
@@ -295,7 +295,7 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
         .catch(miqService.handleFailure);
     };
 
-    ManageIQ.angular.rxSubject.subscribe(function(event) {
+    listenToRx(function(event) {
       if (event.name === 'refreshTopology') {
         controller.refresh();
       }

--- a/app/javascript/miq_observable.js
+++ b/app/javascript/miq_observable.js
@@ -1,0 +1,6 @@
+import { Subject } from "rxjs/Subject";
+
+export const rxSubject = new Subject();
+
+export const sendDataWithRx = (data) => rxSubject.next(data);
+export const listenToRx = (callback) => rxSubject.subscribe(callback);

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -15,6 +15,8 @@ import * as newRegistry from '../miq-component/registry';
 import reactBlueprint from '../miq-component/react-blueprint';
 import * as helpers from '../miq-component/helpers';
 
+import { rxSubject, sendDataWithRx, listenToRx } from '../miq_observable';
+
 ManageIQ.react = {
   mount,
   componentRegistry,
@@ -25,3 +27,7 @@ ManageIQ.component = {
   reactBlueprint,
   ...helpers,
 };
+
+ManageIQ.angular.rxSubject = rxSubject;
+window.sendDataWithRx = sendDataWithRx;
+window.listenToRx = listenToRx;

--- a/bower.json
+++ b/bower.json
@@ -45,7 +45,6 @@
     "patternfly-timeline": "~1.0.5",
     "phantomjs-polyfill": "~0.0.2",
     "qs": "~0.3.10",
-    "rxjs": "~4.1.0",
     "spice-html5-bower": "himdel/spice-html5-bower#~1.7.2",
     "spin.js": "~2.3.2",
     "sprintf": "~1.0.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.7",
     "redux-devtools-extension": "^2.13.2",
-    "rxjs": "~5.3.0",
+    "rxjs": "~5.6.0-forward-compat.2",
     "text-encoder-lite": "git://github.com/coolaj86/TextEncoderLite.git#e1e031b",
     "ui-select": "0.19.8",
     "zone.js": "~0.8.5"

--- a/spec/javascripts/controllers/toolbar_controller_spec.js
+++ b/spec/javascripts/controllers/toolbar_controller_spec.js
@@ -83,7 +83,7 @@ describe('toolbarController', function () {
      })
 
      it('should call update toolbar', function() {
-       ManageIQ.angular.rxSubject.onNext({update: 'someButton', type: 'hidden', value: true})
+       sendDataWithRx({update: 'someButton', type: 'hidden', value: true});
        expect($controller.onUpdateItem).toHaveBeenCalled();
      })
    });

--- a/spec/javascripts/services/subscription_service_spec.js
+++ b/spec/javascripts/services/subscription_service_spec.js
@@ -27,7 +27,7 @@ describe('subscriptionService', function() {
     });
 
     it('subscribes', function() {
-      expect(ManageIQ.angular.rxSubject.subscribe).toHaveBeenCalledWith(loadedReactionFunction);
+      expect(listenToRx).toHaveBeenCalledWith(loadedReactionFunction);
     });
 
     describe('#subscribeToEventType reaction function', function() {

--- a/spec/javascripts/services/subscription_service_spec.js
+++ b/spec/javascripts/services/subscription_service_spec.js
@@ -12,7 +12,7 @@ describe('subscriptionService', function() {
     $timeout = _$timeout_;
 
     spyOn(test, 'callback');
-    spyOn(ManageIQ.angular.rxSubject, 'subscribe').and.callFake(function(callback) {
+    spyOn(window, 'listenToRx').and.callFake(function(callback) {
       loadedReactionFunction = callback;
     });
   }));


### PR DESCRIPTION
Rx.js got a new major version, compliant with the ES observable spec, Angular 2 will depend on it .. we should upgrade :).

The real incompatibility is really small: onNext vs next, and dispose vs unsubscribe.
But unifying and separating while at it..

(converted from ManageIQ/manageiq#13255)
(converted from ManageIQ/manageiq-ui-classic#18)

Since the original PR, version 6 is about to be released, so upgrading to 5.6 which is the transitional migration release.