### PR TITLE
package.json - remove Angular 2+ dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,10 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@angular/common": "~4.0.3",
-    "@angular/compiler": "~4.0.3",
-    "@angular/core": "~4.0.3",
-    "@angular/platform-browser": "~4.0.3",
-    "@angular/platform-browser-dynamic": "~4.0.3",
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",
     "angular-sanitize": "~1.6.6",
     "base64-js": "~1.2.3",
-    "core-js": "~2.4.1",
     "jquery": "~2.2.4",
     "lodash": "^4.17.4",
     "ng-redux": "^3.5.2",
@@ -42,12 +36,9 @@
     "redux-devtools-extension": "^2.13.2",
     "rxjs": "~5.3.0",
     "text-encoder-lite": "git://github.com/coolaj86/TextEncoderLite.git#e1e031b",
-    "ui-select": "0.19.8",
-    "zone.js": "~0.8.5"
+    "ui-select": "0.19.8"
   },
   "devDependencies": {
-    "@types/angular": "1.6.29",
-    "@types/angular-mocks": "^1.5.11",
     "@types/jasmine": "^2.8.6",
     "@types/jest": "^22.1.3",
     "@types/redux": "^3.6.0",


### PR DESCRIPTION
None of these are used, not by ui-classic, nor v2v or graphql.

If we ever get a angular-based plugin, that plugin can depend on angular by itself.

Closes #3715 