### PR TITLE
Fix displaying user detail page

### DIFF
--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -110,7 +110,7 @@
           = _("Available Groups")
       .col-md-2
         - groups = @record.present? && @record.miq_groups.present? ? @record.miq_groups.order(:description) : []
-        - if groups.present? && @edit.blank?
+        - if @edit.blank?
           - if role_allows?(:feature => "rbac_group_show")
             - groups.each do |group|
               - params = {:class => "pointer",


### PR DESCRIPTION
Configuration -> Access Control -> Select User that has no Groups
Before:
```
F, [2018-04-04T16:52:35.609332 #65220] FATAL -- : Error caught: [ActionView::Template::Error] undefined method `[]' for nil:NilClass
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/views/ops/_rbac_user_details.html.haml:134:in `___sers_zita__esktop__anage___manageiq_ui_classic_app_views_ops__rbac_user_details_html_haml___1940073322298559570_70282346906420'
/usr/local/lib/ruby/gems/2.3.0/gems/actionview-5.0.7/lib/action_view/template.rb:159:in `block in render'
/usr/local/lib/ruby/gems/2.3.0/gems/activesupport-5.0.7/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/lib/ruby/gems/2.3.0/gems/actionview-5.0.7/lib/action_view/template.rb:354:in `instrument'
/usr/local/lib/ruby/gems/2.3.0/gems/actionview-5.0.7/lib/action_view/template.rb:157:in `render'

```
After:
It works

@miq-bot add_label bug, gaprindashvili/yes