### PR TITLE
Fix opening incorrect tag page, opened for Ansible Playbooks navigated through Repository summary page

### DIFF
--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -11,7 +11,6 @@ class AnsibleCredentialController < ApplicationController
   include Mixins::EmbeddedAnsibleRefreshMixin
 
   menu_section :ansible_credentials
-  toolbar :ansible_credential
 
   def self.display_methods
     %w(repositories)
@@ -35,6 +34,8 @@ class AnsibleCredentialController < ApplicationController
       delete_credentials
     when 'ansible_credential_tag'
       tag(self.class.model)
+    when "ansible_repository_tag" # repositories from nested list
+      tag(ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource)
     end
   end
 

--- a/app/controllers/ansible_playbook_controller.rb
+++ b/app/controllers/ansible_playbook_controller.rb
@@ -10,7 +10,6 @@ class AnsiblePlaybookController < ApplicationController
   include Mixins::GenericShowMixin
 
   menu_section :ansible_playbooks
-  toolbar :ansible_playbook
 
   def self.model
     ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook

--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -11,7 +11,6 @@ class AnsibleRepositoryController < ApplicationController
   include Mixins::EmbeddedAnsibleRefreshMixin
 
   menu_section :ansible_repositories
-  toolbar :ansible_repository
 
   def self.display_methods
     %w(playbooks)
@@ -49,6 +48,8 @@ class AnsibleRepositoryController < ApplicationController
       end
     when "ansible_repository_tag"
       tag(self.class.model)
+    when "embedded_configuration_script_payload_tag" # playbooks from nested list
+      tag(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook)
     end
   end
 

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -442,7 +442,9 @@ class ApplicationHelper::ToolbarChooser
                     security_groups storages middleware_deployments
                     middleware_servers)
     to_display_center = %w(stack_orchestration_template topology cloud_object_store_objects generic_objects physical_servers guest_devices)
+    to_display_ansible = %w(playbooks repositories credentials)
     performance_layouts = %w(vm host ems_container)
+
     if @lastaction == 'show' && (@view || @display != 'main') && !@layout.starts_with?("miq_request")
       if @display == "vms" || @display == "all_vms"
         return "vm_infras_center_tb"
@@ -458,6 +460,8 @@ class ApplicationHelper::ToolbarChooser
         return "#{@layout}_center_tb"
       elsif to_display.include?(@display)
         return "#{@display}_center_tb"
+     elsif to_display_ansible.include?(@display) # toolbars for nested list screens of Ansible Playbooks/Repositories/Credentials
+        return "ansible_#{@display}_center"     
       elsif to_display_center.include?(@display)
         return "#{@display}_center"
       elsif @layout == 'ems_container'
@@ -547,9 +551,25 @@ class ApplicationHelper::ToolbarChooser
         return @lastaction == 'show_list' ? 'miq_requests_center_tb' : 'miq_request_center_tb'
       elsif %w(my_tasks all_tasks).include?(@layout)
         return "tasks_center_tb"
+      elsif @layout.to_s.starts_with?("manageiq") # toolbars for list/summary screens of Ansible Playbooks/Repositories/Credentials
+        return "#{center_toolbar_filename_embedded_ansible}_center"
       end
     end
     nil
+  end
+
+  def center_toolbar_filename_embedded_ansible
+    case @layout
+    when "manageiq/providers/embedded_ansible/automation_manager/playbook"
+      toolbar_filename = "ansible_playbook"
+    when "manageiq/providers/embedded_automation_manager/configuration_script_source"
+      toolbar_filename = "ansible_repository"
+    when "manageiq/providers/embedded_automation_manager/authentication"
+      toolbar_filename = "ansible_credential"
+    else
+      return
+    end
+    %w(show_list).include?(@lastaction) ? toolbar_filename.pluralize : toolbar_filename
   end
 
   def center_toolbar_filename_configuration_manager_providers

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -460,8 +460,8 @@ class ApplicationHelper::ToolbarChooser
         return "#{@layout}_center_tb"
       elsif to_display.include?(@display)
         return "#{@display}_center_tb"
-     elsif to_display_ansible.include?(@display) # toolbars for nested list screens of Ansible Playbooks/Repositories/Credentials
-        return "ansible_#{@display}_center"     
+      elsif to_display_ansible.include?(@display) # toolbars for nested list screens of Ansible Playbooks/Repositories/Credentials
+        return "ansible_#{@display}_center"
       elsif to_display_center.include?(@display)
         return "#{@display}_center"
       elsif @layout == 'ems_container'

--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -70,5 +70,18 @@ describe AnsibleCredentialController do
         controller.send(:button)
       end
     end
+
+    context 'tagging one or more ansible repositories from nested list' do
+      let(:params) { {:pressed => "ansible_repository_tag"} }
+
+      before do
+        controller.instance_variable_set(:@display, "repositories")
+      end
+
+      it 'calls tag method' do
+        expect(controller).to receive(:tag).with(ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource)
+        controller.send(:button)
+      end
+    end
   end
 end

--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -28,6 +28,11 @@ describe AnsibleCredentialController do
     it "renders correct template" do
       is_expected.to render_template(:partial => "layouts/_gtl")
     end
+
+    it 'renders the correct toolbar' do
+      expect(ApplicationHelper::Toolbar::AnsibleCredentialsCenter).to receive(:definition)
+      post :show_list
+    end
   end
 
   describe '#button' do

--- a/spec/controllers/ansible_playbook_controller_spec.rb
+++ b/spec/controllers/ansible_playbook_controller_spec.rb
@@ -34,6 +34,11 @@ describe AnsiblePlaybookController do
     it "renders correct template" do
       is_expected.to render_template(:partial => "layouts/_gtl")
     end
+
+    it 'renders the correct toolbar' do
+      expect(ApplicationHelper::Toolbar::AnsiblePlaybooksCenter).to receive(:definition)
+      post :show_list
+    end
   end
 
   describe "#button" do

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -4,7 +4,7 @@ describe AnsibleRepositoryController do
     login_as FactoryGirl.create(:user_admin)
   end
 
-  context "show" do
+  describe "#show" do
     let(:repository) { FactoryGirl.create(:embedded_ansible_configuration_script_source) }
     subject { get :show, :params => {:id => repository.id} }
     render_views
@@ -18,7 +18,7 @@ describe AnsibleRepositoryController do
     end
   end
 
-  context "showList" do
+  describe "#show_list" do
     let(:repository) { FactoryGirl.create(:embedded_ansible_configuration_script_source) }
     subject { get :show_list, :params => {} }
     render_views
@@ -29,6 +29,11 @@ describe AnsibleRepositoryController do
 
     it "render view for list of repositories" do
       is_expected.to render_template(:partial => "layouts/_gtl")
+    end
+
+    it 'renders the correct toolbar' do
+      expect(ApplicationHelper::Toolbar::AnsibleRepositoriesCenter).to receive(:definition)
+      post :show_list
     end
   end
 

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -121,5 +121,18 @@ describe AnsibleRepositoryController do
         controller.send(:button)
       end
     end
+
+    context 'tagging one or more playbooks from nested list' do
+      let(:params) { {:pressed => "embedded_configuration_script_payload_tag"} }
+
+      before do
+        controller.instance_variable_set(:@display, "playbooks")
+      end
+
+      it 'calls tag method' do
+        expect(controller).to receive(:tag).with(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook)
+        controller.send(:button)
+      end
+    end
   end
 end

--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -173,4 +173,38 @@ describe ApplicationHelper, "ToolbarChooser" do
       end
     end
   end
+
+  describe '#center_toolbar_filename_classic' do
+    subject { chooser.send(:center_toolbar_filename_classic) }
+
+    {
+      "manageiq/providers/embedded_ansible/automation_manager/playbook"            => "playbook",
+      "manageiq/providers/embedded_automation_manager/configuration_script_source" => "repository",
+      "manageiq/providers/embedded_automation_manager/authentication"              => "credential"
+    }.each do |layout, screen|
+      context "toolbar for summary screen of Ansible #{screen}" do
+        let(:chooser) { ApplicationHelper::ToolbarChooser.new(nil, nil, :display => "main", :lastaction => "show", :layout => layout) }
+
+        it 'returns proper toolbar filename for the screen' do
+          expect(subject).to eq("ansible_#{screen}_center")
+        end
+      end
+
+      context "toolbars for list screens of Ansible #{screen.pluralize}" do
+        let(:chooser) { ApplicationHelper::ToolbarChooser.new(nil, nil, :lastaction => "show_list", :layout => layout) }
+
+        it 'returns proper toolbar filename for the screen' do
+          expect(subject).to eq("ansible_#{screen.pluralize}_center")
+        end
+      end
+
+      context "toolbars for nested list screens of Ansible #{screen.pluralize}" do
+        let(:chooser) { ApplicationHelper::ToolbarChooser.new(nil, nil, :display => screen.pluralize, :lastaction => "show", :layout => layout) }
+
+        it 'returns proper toolbar filename for the screen' do
+          expect(subject).to eq("ansible_#{screen.pluralize}_center")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1560482

---

**Problem:**
Incorrect tag page was opened for tagging Playbooks navigated through Repository summary page (of some repo under _Automation > Ansible > Repositories_) because `params[:pressed]` was not properly set ("ansible_repository_tag" instead of "embedded_configuration_script_payload_tag") and then also wrong parameter went to `tag` method. This was caused by **wrong choosing of toolbar** for the page - this was caused here: https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/ansible_repository_controller.rb#L14

**Solution:**
The right toolbar for Playbooks has to be chosen, when navigating to Playbooks through Repository summary page.

Navigating to Playbooks through Repository summary page:
![playbooks_nested](https://user-images.githubusercontent.com/13417815/38368363-6574146e-38e5-11e8-818a-8cd33cfe2890.png)

Navigating to Playbooks normally (_Automation > Ansible > Playbooks_), see the toolbar:
![playbooks_normal](https://user-images.githubusercontent.com/13417815/38369141-57ae4be0-38e7-11e8-88b3-5c14419fb4d3.png)

**Note:**
Original way of choosing toolbars for _Ansible Playbooks/Repos/Credentials_ pages can cause more problems than mentioned in the BZ (link above). This is why this was changed for all of these pages, unified. Also another cases for `params[:pressed]` were added to `button` methods in appropriate controllers.

**Done:**
- add new method `center_toolbar_filename_embedded_ansible` to toolbar chooser to choose toolbar for _Ansible Playbooks/Repos/Credentials_ properly
- add condition to toolbar chooser to `center_toolbar_filename_classic` method for proper choosing toolbar of _Ansible Playbooks/Repos/Credentials_ pages if `@display` variable is set
- remove unnecessary calling `toolbar` method from ansible playbook controller which was the original way of choosing toolbar, implemented in https://github.com/ManageIQ/manageiq-ui-classic/pull/3522 (as the same way was already implemented in Ansible Credentials/Repositories pages)
- remove unnecessary calling `toolbar` method from ansible repository controller because this did not work well and add new case to `button` method for tagging playbooks from nested list
- remove unnecessary calling `toolbar` method from ansible credential controller because this did not work well and add new case to `button` method for tagging repositories displayed in a nested list (incl. small change https://github.com/ManageIQ/manageiq-ui-classic/pull/3721/files#diff-127a850b7d7b20173ad3fba88f8a25e3R238)
- spec tests for the changes

---

**Before:**
![playbooks_edit_tags_bad](https://user-images.githubusercontent.com/13417815/38368842-ac0e5492-38e6-11e8-8e4c-edaa8aadc4e2.png)
![playbooks_tag_bad](https://user-images.githubusercontent.com/13417815/38368700-4d6ba070-38e6-11e8-93a6-4435909f5b40.png)

**After:**
![playbooks_edit_tags_ok](https://user-images.githubusercontent.com/13417815/38369005-0a77d2ec-38e7-11e8-8371-02dba91f0f98.png)
![playbooks_tag](https://user-images.githubusercontent.com/13417815/38368532-d631d0ce-38e5-11e8-8a2c-eba38ca8aeb8.png)
