### PR TITLE
Changed title for adding / editing automate class for consistency

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -660,9 +660,9 @@ class MiqAeClassController < ApplicationController
     @edit[:inherits_from] = MiqAeClass.all.collect { |c| [c.fqname, c.fqname] }
     @edit[:current] = @edit[:new].dup
     @right_cell_text = if @edit[:rec_id].nil?
-                         _("Adding a new Class")
+                         _("Adding a new Automate Class")
                        else
-                         _("Editing Class \"%{name}\"") % {:name => @ae_class.name}
+                         _("Editing Automate Class \"%{name}\"") % {:name => @ae_class.name}
                        end
     session[:edit] = @edit
     @in_a_form = true


### PR DESCRIPTION
While adding automate domain / namespace, the title says 'Adding a new Automate Namespace', etc.

Steps for Testing/QA
-------------------------------

1) automation -> automate -> explorer -> datastore -> configuration -> add a new domain
2) select the domain -> add a new namespace
3) select the namespace -> add a new class

