### PR TITLE
Add back Menu::Item defaults attribute as it is required by help_menu

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -273,6 +273,7 @@ module Menu
                          {:feature => key.to_s},
                          help_menu_field(key, :href, value[:href]),
                          help_menu_field(key, :type, value[:type]),
+                         nil,
                          value)
         end
 

--- a/app/presenters/menu/item.rb
+++ b/app/presenters/menu/item.rb
@@ -1,5 +1,5 @@
 module Menu
-  Item = Struct.new(:id, :name, :feature, :rbac_feature, :href, :type, :parent_id) do
+  Item = Struct.new(:id, :name, :feature, :rbac_feature, :href, :type, :parent_id, :defaults) do
     extend ActiveModel::Naming
 
     def self.base_class
@@ -10,7 +10,7 @@ module Menu
       model_name
     end
 
-    def initialize(an_id, a_name, features, rbac_feature, href, type = :default, parent_id = nil)
+    def initialize(an_id, a_name, features, rbac_feature, href, type = :default, parent_id = nil, defaults = nil)
       super
       @parent = nil
       @name = a_name.kind_of?(Proc) ? a_name : -> { a_name }


### PR DESCRIPTION
The `Settings -> Region -> Help Menu` screen was broken as #3347 removed the `defaults` attribute from the `Menu::Item` structure.  Adding back the param fixes the problem...

@miq-bot assign @martinpovolny 
@miq-bot add_label bug, gaprindashvili/no