### PR TITLE
Remove specific name for provider region row for Google provider

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -40,8 +40,7 @@ module EmsCloudHelper::TextualSummary
   #
   def textual_provider_region
     return nil if @record.provider_region.nil?
-    label_val = @record.type.include?("Google") ? _("Preferred Region") : _("Region")
-    {:label => label_val, :value => @record.description}
+    {:label => _("Region"), :value => @record.description}
   end
 
   def textual_region


### PR DESCRIPTION
Google provider have `provider_region` set to `nil` so it will never have provider region row displayed so removing specific name of that row for Google provider ✂️It's not effecting anything just a dead code.

Change introduced in https://github.com/ManageIQ/manageiq-providers-google/pull/52

@miq-bot add_label technical debt, gaprindashvili/no