### PR TITLE
Restrict the Help->Documentation screen based on RBAC rules only

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -4,6 +4,7 @@ class SupportController < ApplicationController
   #    :redirect_to => { :action => :index }
 
   before_action :check_privileges
+  before_action :check_support_rbac
   before_action :get_session_data
   after_action :cleanup_action
   after_action :set_session_data
@@ -24,6 +25,10 @@ class SupportController < ApplicationController
   end
 
   private ############################
+
+  def check_support_rbac
+    handle_generic_rbac(role_allows?(:feature => 'support', :any => true))
+  end
 
   def get_layout
     %w(about diagnostics).include?(session[:layout]) ? session[:layout] : "about"

--- a/app/views/support/show.html.haml
+++ b/app/views/support/show.html.haml
@@ -4,27 +4,24 @@
     .row
       - desc = ::Settings.server.custom_support_url_description
       - url  = ::Settings.server.custom_support_url
-      - cond_url      = desc.present? && url.present?
-      - if admin_user? || (!admin_user? && cond_url)
-        .col-md-12
-          - if admin_user?
-            - @pdf_documents.each do |filename, title|
-              - docfile_path = "/doc/#{filename}.pdf"
-              %br
-              - t = (_("View the %{title} Guide") % {:title => title})
-              = link_to(docfile_path, :onclick => "return miqClickAndPop(this);", :title => t) do
-                %i.fa.fa-file-pdf-o.fa-lg
-                = t
-              %br
-          - if cond_url
-            %br
-            - url = "http://" + url if !url.starts_with?("http://") && !url.starts_with?("https://")
-            = link_to(desc, url, :onclick => "return miqClickAndPop(this);")
-            %br
-          - if admin_user?
-            %br
-              = _("For questions or problem reporting, visit ")
-              %a{:href => I18n.t("product.support_website").html_safe, :target => "_new"}
-                = I18n.t("product.support_website_text").html_safe
+      - cond_url = desc.present? && url.present?
+      .col-md-12
+        - @pdf_documents.each do |filename, title|
+          - docfile_path = "/doc/#{filename}.pdf"
+          %br
+          - t = (_("View the %{title} Guide") % {:title => title})
+          = link_to(docfile_path, :onclick => "return miqClickAndPop(this);", :title => t) do
+            %i.fa.fa-file-pdf-o.fa-lg
+            = t
+          %br
+        - if cond_url
+          %br
+          - url = "http://" + url if !url.starts_with?("http://") && !url.starts_with?("https://")
+          = link_to(desc, url, :onclick => "return miqClickAndPop(this);")
+          %br
+        %br
+          = _("For questions or problem reporting, visit ")
+          %a{:href => I18n.t("product.support_website").html_safe, :target => "_new"}
+            = I18n.t("product.support_website_text").html_safe
 
-            %br
+        %br


### PR DESCRIPTION
The documentation text is visible only for administrators even though the RBAC role can display the menu item for it. In this PR I'm dropping the `is_admin?` calls from the view and introducing an RBAC check in the controller.

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot add_reviewer @romanblanco 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1563241