### PR TITLE
Webpack pack priority

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,7 @@ module ApplicationHelper
   include PlanningHelper
   include Title
   include ReactjsHelper
+  include Webpack
 
   VALID_PERF_PARENTS = {
     "EmsCluster" => :ems_cluster,

--- a/app/helpers/application_helper/webpack.rb
+++ b/app/helpers/application_helper/webpack.rb
@@ -1,0 +1,16 @@
+module ApplicationHelper
+  module Webpack
+    def javascript_common_packs
+      capture do
+        concat(javascript_pack_tag('vendor'))
+
+        # FIXME: temporary fix for a webpacker issue - #1875
+        return if Rails.env.test?
+
+        Webpacker::Manifest.instance.data.keys.each do |pack|
+          concat(javascript_pack_tag(pack)) if pack.ends_with? '-common.js'
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/application_helper/webpack.rb
+++ b/app/helpers/application_helper/webpack.rb
@@ -1,16 +1,57 @@
 module ApplicationHelper
   module Webpack
     def javascript_common_packs
+      packs = sorted_common_packs
+
       capture do
         concat(javascript_pack_tag('vendor'))
 
         # FIXME: temporary fix for a webpacker issue - #1875
         return if Rails.env.test?
 
-        Webpacker::Manifest.instance.data.keys.each do |pack|
-          concat(javascript_pack_tag(pack)) if pack.ends_with? '-common.js'
+        packs.each do |pack|
+          concat(javascript_pack_tag(pack))
         end
       end
+    end
+
+    private
+
+    # application-common contains all the global bits and needs to go first (after vendor)
+    def priority_packs
+      %w(manageiq-ui-classic/application-common.js)
+    end
+
+    # ui-classic should go before plugins
+    def priority_repos
+      %w(manageiq-ui-classic)
+    end
+
+    def sorted_common_packs
+      common = Webpacker::Manifest.instance.data.keys.select do |pack|
+        pack.ends_with?('-common.js')
+      end
+
+      priority = common.group_by do |pack|
+        repo = pack.split('/').first
+
+        if priority_packs.include?(pack)
+          :pack
+        elsif priority_repos.include?(repo)
+          :repo
+        else
+          :rest
+        end
+      end
+
+      %i(pack repo rest).each do |p|
+        priority[p] = [] if priority[p].nil?
+        priority[p].sort!
+      end
+
+      [].concat(priority[:pack])
+        .concat(priority[:repo])
+        .concat(priority[:rest])
     end
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,11 +18,7 @@
       = stylesheet_link_tag 'miq_debug'
     = csrf_meta_tag
     = render :partial => 'layouts/i18n_js'
-    = javascript_pack_tag 'vendor'
-    -# FIXME: the conditional below is a temporary fix for a webpacker issue, remove when it's resolved
-    - unless Rails.env.test?
-      - Webpacker::Manifest.instance.data.keys.each do |pack|
-        = javascript_pack_tag pack if pack.ends_with? '-common.js'
+    = javascript_common_packs
 
     :javascript
       ManageIQ.charts.provider = "#{Charting.backend}";

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -10,12 +10,7 @@
     - if Rails.env.development?
       = javascript_include_tag 'miq_debug'
       = stylesheet_link_tag 'miq_debug'
-
-    = javascript_pack_tag 'vendor'
-    -# FIXME: the conditional below is a temporary fix for a webpacker issue, remove when it's resolved
-    - unless Rails.env.test?
-      - Webpacker::Manifest.instance.data.keys.each do |pack|
-        = javascript_pack_tag pack if pack.ends_with? '-common.js'
+    = javascript_common_packs
 
     = render :partial => 'layouts/i18n_js'
 


### PR DESCRIPTION
This adds a `javascript_common_packs` helper, which takes care of the "include vendor pack and all the common packs" logic.

What changes is that we now also support sorting the packs and putting certain packs or repos first in the order.

This should ensure the following load order:
* `vendor.js` - npm deps go first
* `manageiq-ui-classic/application-common.js` - this one contains all the globals, and needs to go before everything else
* anything else from `manageiq-ui-classic/`, sorted by name - so that the core UI goes before any plugins
* everything else, sorted by name (plugin name then pack name)

This should prevent problems where a random pack could go before `application-common.js`, and fail on missing global dependencies.