### PR TITLE
Physical server details now has two columns

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -44,7 +44,8 @@ class PhysicalServerController < ApplicationController
 
   def textual_group_list
     [
-      %i(properties networks relationships power_management assets firmware_details smart_management),
+      %i(properties networks relationships),
+      %i(power_management assets firmware_details smart_management),
     ]
   end
   helper_method(:textual_group_list)


### PR DESCRIPTION
Splitting the single big column into two for a physical server


![screenshot from 2018-04-06 12-05-27](https://user-images.githubusercontent.com/3654285/38428658-b29c988a-3992-11e8-8b2c-b7ae1cef2985.png)
