### PR TITLE
Reset button flash message in Group Tag Expression editor

### DIFF
--- a/app/views/layouts/_exp_editor.html.haml
+++ b/app/views/layouts/_exp_editor.html.haml
@@ -7,7 +7,7 @@
   = javascript_tag("ManageIQ.expEditor.second.title = '#{@edit[@expkey][:val2][:title]}';")
 
 #exp_editor_div
-  = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'exp_editor_flash'}
+  = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'exp_editor_flash', :flash_style => "display:none"}
   .panel.panel-default
     .panel-heading
       %h3.panel-title

--- a/app/views/layouts/_flash_msg.html.haml
+++ b/app/views/layouts/_flash_msg.html.haml
@@ -1,6 +1,7 @@
 - flash_div_id ||= 'flash_msg_div'
 
-%div{:id => flash_div_id, :style => ("display: none" unless @flash_array)}
+- flash_style ||= @flash_array ? "" : "display_none"
+%div{:id => flash_div_id, :style => flash_style}
   - if @flash_array
     .flash_text_div
       - @flash_array.each do |fl|


### PR DESCRIPTION
Do not display duplicate confirmation message when Reset button is clicked in Expression Editor partial in Access Control Group management. 

https://bugzilla.redhat.com/show_bug.cgi?id=1506634

Screen shot prior to code change:
![configuration edit group expression reset click](https://user-images.githubusercontent.com/552686/38436351-3e7356dc-3989-11e8-9a1e-50f03ea8a7b1.png)

Screen shots post code fix showing change to Group Description and then click of Reset button:
![configuration edit group tag based on expression after reset 1](https://user-images.githubusercontent.com/552686/38435965-2bfbba72-3988-11e8-8160-fc763d5c37e1.png)

![configuration edit group tag based on expression after reset 2](https://user-images.githubusercontent.com/552686/38435978-30c8f0a6-3988-11e8-90dd-bee541aded69.png)
