### PR TITLE
bower to npm: bootstrap-switch, angular-bootstrap-switch, angular.validators

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,7 @@
 //= require bower_components/angular-bootstrap/ui-bootstrap
 //= require bower_components/angular-bootstrap/ui-bootstrap-tpls
 //= require angular-sanitize
-//= require bower_components/angular.validators/angular.validators
+//= require angular.validators/angular.validators
 //= require ng-redux/dist/ng-redux
 //= require bower_components/moment/moment
 //= require bower_components/moment-strftime/lib/moment-strftime

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
     "angular-patternfly": "~3.26.0",
     "angular-ui-codemirror": "~0.3.0",
     "angular-ui-sortable": "~0.16.1",
-    "angular.validators": "~4.4.2",
     "array-includes": "~1.0.0",
     "bootstrap-filestyle": "~1.2.1",
     "bootstrap-hover-dropdown": "~2.2.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "angular-animate": "~1.6.6",
     "angular-bootstrap-switch": "~0.5.2",
     "angular-sanitize": "~1.6.6",
+    "angular.validators": "~4.4.2",
     "base64-js": "~1.2.3",
     "bootstrap-switch": "~3.3.4",
     "jquery": "~2.2.4",


### PR DESCRIPTION
This just moves 3 libraries over from bower to npm :). 

`angular-bootstrap-switch` - seen in `/flavor/new` (Public?)
`bootstrap-switch` - seen in `/configuration/index`
`angular.validators` - seen working in `/flavor/new` (`is-int` on integer fields)