### PR TITLE
[GAPRINDASHVILI] Check @record has description method before using provider_region row

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -39,7 +39,7 @@ module EmsCloudHelper::TextualSummary
   # Items
   #
   def textual_provider_region
-    return nil if @record.provider_region.nil?
+    return nil if @record.provider_region.nil? || @record.try(:description).nil?
     label_val = @record.type.include?("Google") ? _("Preferred Region") : _("Region")
     {:label => label_val, :value => @record.description}
   end

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -37,7 +37,7 @@ module EmsNetworkHelper::TextualSummary
   # Items
   #
   def textual_provider_region
-    return nil if @record.provider_region.nil?
+    return nil if @record.provider_region.nil? || @record.try(:description).nil?
     {:label => _("Region"), :value => @record.description}
   end
 


### PR DESCRIPTION
Google provider doesn't have `:description` anymore but may have `provider_region`. Textual summary will try to get `:description` from `@record` and fail.
Introduced by https://github.com/ManageIQ/manageiq-providers-google/pull/52

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1571303

To reproduce:
Make sure you have `ManageIQ::Providers::Google::CloudManager` or `ManageIQ::Providers::Google::NetworkManager` with `provider_region` **not** set to `nil`.
Go to summary page of said provider.
Before:
![image](https://user-images.githubusercontent.com/9210860/38485171-2c199a9e-3bd9-11e8-8925-b168487e062a.png)
After:
![image](https://user-images.githubusercontent.com/9210860/38485210-4bf88d34-3bd9-11e8-8c15-4cbffb8438a6.png)

Fix for master: https://github.com/ManageIQ/manageiq-schema/pull/184

@miq-bot add_label bug, blocker, compute/cloud, networks
