### PR TITLE
Fix url for service / vm / instance / stack retirement

### DIFF
--- a/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
+++ b/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
@@ -10,19 +10,19 @@ ManageIQ.angular.app.controller('retirementFormController', ['$http', 'objectIds
   vm.model = 'retirementInfo';
 
   if (objectIds.length == 1) {
-    $http.get('retirement_info/' + objectIds[0])
+    $http.get('/' + ManageIQ.controller + '/retirement_info/' + objectIds[0])
       .then(getRetirementInfoFormData)
       .catch(miqService.handleFailure);
   }
 
   vm.cancelClicked = function() {
     miqService.sparkleOn();
-    miqService.miqAjaxButton('retire?button=cancel');
+    miqService.miqAjaxButton('/' + ManageIQ.controller + '/retire?button=cancel');
   };
 
   vm.saveClicked = function() {
     miqService.sparkleOn();
-    miqService.miqAjaxButton('retire?button=save',
+    miqService.miqAjaxButton('/' + ManageIQ.controller + '/retire?button=save',
                              {'retire_date': vm.retirementInfo.retirementDate,
                               'retire_warn': vm.retirementInfo.retirementWarning});
   };

--- a/spec/javascripts/controllers/retirement/retirement_form_controller_spec.js
+++ b/spec/javascripts/controllers/retirement/retirement_form_controller_spec.js
@@ -4,6 +4,7 @@ describe('retirementFormController', function() {
   beforeEach(module('ManageIQ'));
 
   beforeEach(inject(function($rootScope, _$controller_, _$httpBackend_, _miqService_) {
+    ManageIQ.controller = 'service';
     miqService = _miqService_;
     spyOn(miqService, 'miqFlash');
     spyOn(miqService, 'miqAjaxButton');
@@ -24,11 +25,12 @@ describe('retirementFormController', function() {
       retirement_date: '12/31/2015',
       retirement_warning: '0'
     };
-    $httpBackend.whenGET('retirement_info/1000000000001').respond(retirementFormResponse);
+    $httpBackend.whenGET('/service/retirement_info/1000000000001').respond(retirementFormResponse);
     $httpBackend.flush();
   }));
 
   afterEach(function() {
+    ManageIQ.controller = null;
     $httpBackend.verifyNoOutstandingExpectation();
     $httpBackend.verifyNoOutstandingRequest();
   });
@@ -60,7 +62,7 @@ describe('retirementFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('retire?button=cancel');
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/service/retire?button=cancel');
     });
   });
 
@@ -85,7 +87,7 @@ describe('retirementFormController', function() {
         retire_date: $scope.vm.retirementInfo.retirementDate,
         retire_warn: $scope.vm.retirementInfo.retirementWarning
       };
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('retire?button=save', saveContent);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/service/retire?button=save', saveContent);
     });
   });
 });


### PR DESCRIPTION
In case we get to the retirement screen after navigating through bunch of other related items, we need to construct the whole retirement URL.

1. My Services -> Active Services -> Select a service
2. Click on Service's VMs
3. In the VM summary screen, click on Service in Relationship table
4. You should be back at Service's summary screen
5. Test that the retirement functionality works correctly.
6. Make sure retirement of other supported items (vms, instances, stacks) also works correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=1563182