### PR TITLE
[FINE] Fix params for populate_reports_menu

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -713,7 +713,7 @@ class DashboardController < ApplicationController
 
   # Gather information for the report accordians
   def build_timeline_listnav
-    populate_reports_menu("timeline", "menu")
+    populate_reports_menu(true)
     build_timeline_tree(@sb[:rpt_menu], "timeline")
   end
 


### PR DESCRIPTION
Only on Fine.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1564454

Go to Cloud Intel -> Timelines

Before:
<img width="1126" alt="screen shot 2018-04-09 at 3 45 54 pm" src="https://user-images.githubusercontent.com/9210860/38502043-b3ed02be-3c0e-11e8-9930-45b1981c3f11.png">
After:
<img width="1201" alt="screen shot 2018-04-09 at 3 44 30 pm" src="https://user-images.githubusercontent.com/9210860/38502044-b404fe6e-3c0e-11e8-96b3-7833ceb67d20.png">

@miq-bot add_label bug, blocker, cloud intel/timelines
