### PR TITLE
Fix clearing search after selecting filter in Datastores

### DIFF
--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -413,7 +413,7 @@ class StorageController < ApplicationController
     current_nodetype = search_text_type(@sb[:storage_search_text][:current_node])
 
     @sb[:storage_search_text]["#{previous_nodetype}_search_text"] = @search_text
-    @search_text = @sb[:storage_search_text]["#{current_nodetype}_search_text"]
+    @search_text = @sb[:storage_search_text]["#{current_nodetype}_search_text"] || @sb[:search_text]
     @sb[:storage_search_text]["#{x_active_accord}_search_text"] = @search_text
   end
 


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1563311

Fix clearing search after selecting filter, in _Compute > Infrastructure > Datastores_,
by adding small change in `apply_node_search_text` method in storage controller.

---

_All Datastores_ without any _Search_ or _Advanced Search_ applied:
![datastore_all](https://user-images.githubusercontent.com/13417815/38512400-6dae4e4e-3c2b-11e8-8d85-3d5fe2b945a7.png)

_All Datastores_ with _Advanced Search_ (ONLY Adv Search):
![datastore_search_before](https://user-images.githubusercontent.com/13417815/38512481-8b12ce10-3c2b-11e8-8d07-77e15332ccee.png)

_All Datastores_ with _Search_ (ONLY Search, just for comparing):
![datastore_search](https://user-images.githubusercontent.com/13417815/38512572-d70c1f56-3c2b-11e8-907a-531a9494839c.png)

**Before:** (the same as with ONLY Adv Search! => no Search applied!)
![datastore_search_before](https://user-images.githubusercontent.com/13417815/38512534-b76b1fa8-3c2b-11e8-8017-b7509d18151e.png)

**After:**
![datastore_search_after](https://user-images.githubusercontent.com/13417815/38512215-f304c7f4-3c2a-11e8-9c4f-93a503d07323.png)
