### PR TITLE
Adapting the Network Devices page to the new ports relationship

### DIFF
--- a/app/controllers/guest_device_controller.rb
+++ b/app/controllers/guest_device_controller.rb
@@ -38,7 +38,7 @@ class GuestDeviceController < ApplicationController
 
   def textual_group_list
     [
-      %i(properties ports firmware),
+      %i(properties physical_network_ports firmware),
     ]
   end
   helper_method(:textual_group_list)

--- a/app/helpers/guest_device_helper/textual_summary.rb
+++ b/app/helpers/guest_device_helper/textual_summary.rb
@@ -6,18 +6,18 @@ module GuestDeviceHelper::TextualSummary
     )
   end
 
-  def textual_group_ports
-    ports = {:labels => [_("Name"), _("MAC Address")]}
-    ports[:values] = @record.child_devices.collect do |port|
+  def textual_group_physical_network_ports
+    physical_network_ports = {:labels => [_("Name"), _("MAC Address")]}
+    physical_network_ports[:values] = @record.physical_network_ports.collect do |port|
       [
-        port.name,
-        port.address
+        port.port_name,
+        port.mac_address
       ]
     end
 
     TextualMultilabel.new(
       _("Ports"),
-      ports
+      physical_network_ports
     )
   end
 


### PR DESCRIPTION
__This PR is able to:__
- Adapt the Network Device (`GuestDevice`) page to the new physical ports relationship;

__Motivation:__
The physical ports information were moved from `GuestDevice.child_devices` to the new model `PhysicalNetworkPorts` accessed as `GuestDevice.physical_network_ports` ([more details here](https://github.com/ManageIQ/manageiq/pull/17268))

__RFE:__
https://bugzilla.redhat.com/show_bug.cgi?id=1573580

__Depends on:__
~https://github.com/ManageIQ/manageiq-schema/pull/185~ - Merged
~https://github.com/ManageIQ/manageiq/pull/17268~ - Merged
~https://github.com/ManageIQ/manageiq-providers-lenovo/pull/152~ - Merged