### PR TITLE
Fix Control explorer policies Search clear button

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -911,6 +911,7 @@ class MiqPolicyController < ApplicationController
       @search_text = params[:search_text].strip
       @sb[:pol_search_text][x_active_tree] = @search_text unless @search_text.nil?
     else
+      @sb[:pol_search_text].delete(x_active_tree) if params[:action] == 'adv_search_text_clear'
       @search_text = @sb[:pol_search_text][x_active_tree]
     end
   end

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -262,6 +262,25 @@ describe MiqPolicyController do
     end
   end
 
+  describe '#set_search_text' do
+    context 'clearing search text' do
+      let(:search) { "some_text" }
+      let(:tree) { :any_tree }
+
+      before do
+        controller.instance_variable_set(:@_params, :action => 'adv_search_text_clear')
+        controller.instance_variable_set(:@sb, :active_tree => tree, :pol_search_text => {tree => search})
+        controller.instance_variable_set(:@search_text, search)
+      end
+
+      it 'clears search text from the Search form' do
+        controller.send(:set_search_text)
+        expect(controller.instance_variable_get(:@sb)[:pol_search_text][tree]).to be(nil)
+        expect(controller.instance_variable_get(:@search_text)).to be(nil)
+      end
+    end
+  end
+
   describe 'x_button' do
     before do
       ApplicationController.handle_exceptions = true


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1563316

Fix Search clear button when searching text under _Control -> Explorer_ screens.

---

Before searching text:
![clear_search_after](https://user-images.githubusercontent.com/13417815/38563902-43a95ad6-3cde-11e8-9740-02f9387a8f1e.png)

**Before:** (after clicking on clear search button, nothing has happened)
![clear_search_before](https://user-images.githubusercontent.com/13417815/38564145-cf73d0f0-3cde-11e8-9968-5aacb6123bf1.png)

**After:** (after clicking on clear search button, the same as before searching text)
![clear_search_after](https://user-images.githubusercontent.com/13417815/38563902-43a95ad6-3cde-11e8-9740-02f9387a8f1e.png)

**Details:**
The problem was that after `adv_search_text_clear` method (in application controller) was called, `@search_text` was reset to `nil` BUT then set again to the previous value. This was happening the next way: in `adv_search_text_clear`, `reload` method calls `tree_select` from miq policy controller, where because of calling `get_node_info` method `@search_text` was set again, in `set_search_text` method here: https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Control_explorer_policies_search_clear_button?expand=1#diff-81673877a9cc40eb5089aa4a42bd3764R915
The solution is to reset also `@sb[:pol_search_text][x_active_tree]`, not just `@search_text` or `@sb[:search_text]` as it is in `adv_search_text_clear` in app controller. This change is safe when changing accordions under  _Control -> Explorer_: it keeps search text in `@sb[:pol_search_text][x_active_tree]` as `x_active_tree` changes, until search text is cleared for appropriate tree/accordion.