### PR TITLE
[FINE] - Show message when trying to edit item with missing Provisioning request

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -98,7 +98,15 @@ class CatalogController < ApplicationController
         add_flash(_("All changes have been reset"), :warning)
       end
       if !@record.id.nil? && need_prov_dialogs?(@record.prov_type)
-        prov_set_form_vars(MiqRequest.find(@record.service_resources[0].resource_id))      # Set vars from existing request
+        request = MiqRequest.find_by(:id => @record.service_resources[0].resource_id) if @record.service_resources[0]&.resource_id
+        if request
+          prov_set_form_vars(request) # Set vars from existing request
+        else
+          add_flash(_("Can not edit selected item, Request is missing"), :error)
+          @edit = @record = nil
+          replace_right_cell
+          return
+        end
       else
         # prov_set_form_vars
         @edit ||= {}                                    # Set default vars
@@ -1765,8 +1773,13 @@ class CatalogController < ApplicationController
             else
               show_record(from_cid(id))
               if @record.atomic? && need_prov_dialogs?(@record.prov_type)
-                @miq_request = MiqRequest.find_by_id(@record.service_resources[0].resource_id)
-                prov_set_show_vars
+                @miq_request = MiqRequest.find_by(:id => @record.service_resources[0].resource_id) if @record.service_resources[0]&.resource_id
+                if @miq_request
+                  prov_set_show_vars
+                else
+                  @options   = nil
+                  @no_wf_msg = _("Request is missing for selected item")
+                end
               end
               unless @record.prov_type == "generic_ansible_playbook"
                 @sb[:dialog_label]       = _("No Dialog")

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -178,7 +178,7 @@
     - else
       - if !@record.prov_type || (@record.prov_type && need_prov_dialogs?(@record.prov_type))
         = miq_tab_content('request') do
-          - if @options[:wf]
+          - if @options && @options[:wf]
             %h3
               = _('Request Info')
               = render :partial => "miq_request/prov_wf",

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -162,6 +162,30 @@ describe CatalogController do
     end
   end
 
+  context "#x_button catalogitem_edit" do
+    before do
+      vm = FactoryGirl.create(:vm_vmware,
+                              :ext_management_system => FactoryGirl.create(:ems_vmware),
+                              :storage               => FactoryGirl.create(:storage))
+      @miq_request = FactoryGirl.create(:miq_provision_request, :requester => admin_user, :src_vm_id => vm.id)
+      service_template_with_root_tenant.update_attributes(:prov_type => 'vmware')
+      service_template_with_root_tenant.add_resource(@miq_request)
+      service_template_with_root_tenant.save
+    end
+
+    it "shows flash message for missing Request" do
+      @miq_request.destroy
+      post :x_button, :params => {:id => service_template_with_root_tenant.id, :pressed => "catalogitem_edit", :format => :js}
+      expect(assigns(:flash_array).first[:message]).to include("Can not edit selected item, Request is missing")
+      expect(assigns(:edit)).to be_nil
+    end
+
+    it "continues with setting edit screen when Request is present" do
+      post :x_button, :params => {:id => service_template_with_root_tenant.id, :pressed => "catalogitem_edit", :format => :js}
+      expect(assigns(:edit)).not_to be_nil
+    end
+  end
+
   context "#st_edit" do
     it "@record is cleared out after Service Template is added" do
       controller.instance_variable_set(:@sb, {})


### PR DESCRIPTION
Added check around code to prevent error when editing catalog item with missing Provisioning request, with this change, flash message will be displayed on the screen informing user that they can not proceed with editing selected catalog item because request is missing

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1560097

(cherry picked from commit 6a24e66)

@dclarizio please review

Backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/3661