### PR TITLE
Fixed Secondary filter to be added/edited correctly.

### DIFF
--- a/app/views/report/_form_expression_buttons.html.haml
+++ b/app/views/report/_form_expression_buttons.html.haml
@@ -1,6 +1,6 @@
 - report_id = @edit[:rpt_id] || 'new'
 -# FIXME: alt/title incosistency
-= link_to({:action => 'filter_change', :button => @expkey, :id => report_id},
+= link_to({:action => 'filter_change', :button => exp_key, :id => report_id},
           "data-miq_sparkle_on"  => true,
           "data-miq_sparkle_off" => true,
           :remote                => true,
@@ -12,7 +12,7 @@
       = display_label
 .spacer
 - unless @edit[@expkey][:expression].key?('???')
-  - @edit[@expkey][:exp_table].each do |token|
+  - @edit[exp_key == "record_filter" ? :record_filter : :display_filter][:exp_table].each do |token|
     - single_token = [token].flatten.first
     - if %w(AND OR ( )).include?(single_token)
       %font{:color => "black"}

--- a/app/views/report/_form_filter.html.haml
+++ b/app/views/report/_form_filter.html.haml
@@ -18,19 +18,21 @@
             = render :partial => 'layouts/exp_editor'
           - else
             = render :partial => 'report/form_expression_buttons',
-                                 :locals => {:create_label => _('Create Record Filter'),
-                                             :display_label => _('Edit Record Filter')}
-    %hr
-    .form-horizontal
-      - unless @edit[:display_filter][:exp_available_fields].empty? && @edit[:display_filter][:exp_available_tags].empty?
-        -# Expression editor for the display filter
-        %h3= _('Secondary (Display) Filter - Filters the rows based on child table fields')
-        .form-group
-          %label.control-label.col-md-2
-          .col-md-8
-            - if @expkey == :display_filter
-              = render :partial => 'layouts/exp_editor'
-            - else
-              = render :partial => 'report/form_expression_buttons',
-                       :locals => {:create_label => _('Create Display Filter'),
-                                   :display_label => _('Edit Display Filter')}
+                                 :locals => {:create_label  => _('Create Record Filter'),
+                                             :display_label => _('Edit Record Filter'),
+                                             :exp_key       => 'record_filter'}
+  %hr
+  .form-horizontal
+    - unless @edit[:display_filter][:exp_available_fields].empty? && @edit[:display_filter][:exp_available_tags].empty?
+      -# Expression editor for the display filter
+      %h3= _('Secondary (Display) Filter - Filters the rows based on child table fields')
+      .form-group
+        %label.control-label.col-md-2
+        .col-md-8
+          - if @expkey == :display_filter
+            = render :partial => 'layouts/exp_editor'
+          - else
+            = render :partial => 'report/form_expression_buttons',
+                     :locals => {:create_label  => _('Create Display Filter'),
+                                 :display_label => _('Edit Display Filter'),
+                                 :exp_key       => 'display_filter'}

--- a/spec/views/report/_form_expression_buttons.html.haml_spec.rb
+++ b/spec/views/report/_form_expression_buttons.html.haml_spec.rb
@@ -12,7 +12,8 @@ describe 'report/_form_filter.html.haml' do
   it 'renders form expression buttons for other report and Edit Display Filter button' do
     render :partial => 'report/form_expression_buttons',
            :locals  => {:create_label  => _('Create Display Filter'),
-                        :display_label => _('Edit Display Filter')}
+                        :display_label => _('Edit Display Filter'),
+                        :exp_key       => "record_filter"}
     expect(rendered).to match(/Edit Display Filter/)
   end
 
@@ -23,7 +24,8 @@ describe 'report/_form_filter.html.haml' do
     it 'renders form expression buttons for other report and Create Display Filter button' do
       render :partial => 'report/form_expression_buttons',
              :locals  => {:create_label  => _('Create Display Filter'),
-                          :display_label => _('Edit Display Filter')}
+                          :display_label => _('Edit Display Filter'),
+                          :exp_key       => "display_filter"}
       expect(rendered).to match(/Create Display Filter/)
     end
   end


### PR DESCRIPTION
- Fixed alignment of Haml code.
- Passing in a local variable to form_expression_button view to be used as an button action and also to load/display correct primary/secondary filter

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1565171
Issue introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/2040

@epwinchell please review/test.

before:
![before](https://user-images.githubusercontent.com/3450808/38577668-9296c8ea-3ccf-11e8-92cc-01db25caa9fe.png)

after:
![report_filter_after](https://user-images.githubusercontent.com/3450808/38577602-63af09fc-3ccf-11e8-88e6-9df77f82d949.png)

