### PR TITLE
[FINE] Fix failing specs

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -885,7 +885,7 @@ describe CatalogController do
       let(:tree) { :svccat_tree }
 
       it 'sets options for rendering proper type of view' do
-        expect(controller).to receive(:process_show_list).with(:gtl_dbname => :catalog, :named_scope => {})
+        expect(controller).to receive(:process_show_list).with(hash_including(:gtl_dbname => :catalog))
         controller.send(:service_template_list, {})
       end
     end

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -165,7 +165,7 @@ describe OpsController do
         controller.send(:zone_edit)
 
         expect(controller.send(:flash_errors?)).to be_truthy
-        expect(assigns(:flash_array).first[:message]).to include("Name has already been taken")
+        expect(assigns(:flash_array).first[:message]).to match(/Name is not unique within region/)
       end
     end
 

--- a/spec/views/shared/views/_ownership.html.haml_spec.rb
+++ b/spec/views/shared/views/_ownership.html.haml_spec.rb
@@ -7,6 +7,7 @@ describe "shared/views/_ownership" do
     root_tenant
     Tenant.default_tenant
   end
+
   let(:user)         { FactoryGirl.create(:user, :userid => 'user', :miq_groups => [tenant_group]) }
   let(:tenant)       { FactoryGirl.build(:tenant, :parent => default_tenant) }
   let(:tenant_users) { FactoryGirl.create(:miq_user_role, :name => "tenant-users") }
@@ -23,10 +24,12 @@ describe "shared/views/_ownership" do
     vm = FactoryGirl.create(:vm_vmware, :miq_group => tenant_group)
     allow(view).to receive(:ownership_user_options).and_return([user.id])
     allow(view).to receive(:settings).and_return('list')
-    allow(view).to receive(:render_gtl_outer)
     @groups = [tenant_group.id, user_group.id]
     @origin_ownership_items = @ownershipitems = Vm.where(:id => vm.id)
     @group = vm.miq_group
+
+    stub_template "layouts/_gtl.html.haml" => ''
+
     render
     expect(rendered).to include('No User Group')
   end


### PR DESCRIPTION
This fixes these (currently failing) specs in fine:

* `spec/controllers/catalog_controller_spec.rb:889`: received :process_show_list with unexpected arguments
    (from https://github.com/ManageIQ/manageiq-ui-classic/pull/3487, Cc @hstastna)
* `spec/controllers/ops_settings_spec.rb:146`: expected "Name is not unique within region 0" to include "Name has already been taken"
    (from https://github.com/ManageIQ/manageiq/pull/16731, Cc @carbonin)
* `spec/views/shared/views/_ownership.html.haml_spec.rb:22`: undefined method `sub_table' for nil:NilClass
    (from https://github.com/ManageIQ/manageiq-ui-classic/pull/3404, Cc @lgalis)

(There's a fourth failing spec - `spec/controllers/vm_infra_controller_spec.rb:211`, which will go green once https://github.com/ManageIQ/manageiq/issues/17275 is merged.)

In all these cases, looks like the code makes sense but the spec needs adjusting for the *fine* differences :).