### PR TITLE
Swap the save/cancel buttons on the dialog editor to be consistent

### DIFF
--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -19,12 +19,12 @@
               {{ vm.dialog.content[0].description }}
     %dialog-editor{'tree-selector-data' => 'vm.treeSelectorData', 'tree-selector-lazy-load' => 'vm.lazyLoad'}
     .pull-right
-      %button.btn.btn-default{"ng-click" => "vm.dismissChanges()",
-                              :type => "button"}= _("Cancel")
       %button.btn.btn-primary{"ng-click" => "vm.saveDialogDetails()",
                               "ng-disabled" => "!vm.DialogValidation.dialogIsValid(vm.DialogEditor.data.content)",
                               "ng-attr-title" => "{{vm.DialogValidation.invalid.message}}",
                               :type => "button"}= _("Save")
+      %button.btn.btn-default{"ng-click" => "vm.dismissChanges()",
+                              :type => "button"}= _("Cancel")
 
 :javascript
   ManageIQ.angular.app.value('dialogIdAction', '#{ dialog_id_action.to_json }');


### PR DESCRIPTION
In every other form the *Save* button is the leftmost element on the bottom of the screen. However, the dialog editor somehow has it swapped, so changing it for the sake of consistency.

**Before:**
![screenshot from 2018-04-11 13-13-23](https://user-images.githubusercontent.com/649130/38613410-22ee0362-3d8a-11e8-8577-8d0e46b4b96d.png)

**After:**
![screenshot from 2018-04-11 13-12-57](https://user-images.githubusercontent.com/649130/38613398-1a560830-3d8a-11e8-9112-a5e0555de72f.png)

@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @himdel 
@miq-bot add_label bug
