### PR TITLE
Remove 'Include C&U metrics' option for Metering Reports

### DIFF
--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -3,15 +3,16 @@
   %h3
     = _('Chargeback Resources')
   .form-horizontal
-    .form-group
-      %label.control-label.col-md-2
-        = _('Include Capacity & Utilization Metrics')
-      .col-md-8
-        = check_box_tag("cb_include_metrics", true, @edit[:new][:cb_include_metrics],
-                        "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true,
-                        :data => {:on_text => _('Yes'), :off_text => _('No')})
-      :javascript
-        miqInitBootstrapSwitch('cb_include_metrics', "#{url}")
+    - if @edit[:new][:model] == "ChargebackVm"
+      .form-group
+        %label.control-label.col-md-2
+          = _('Include Capacity & Utilization Metrics')
+        .col-md-8
+          = check_box_tag("cb_include_metrics", true, @edit[:new][:cb_include_metrics],
+                          "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true,
+                          :data => {:on_text => _('Yes'), :off_text => _('No')})
+        :javascript
+          miqInitBootstrapSwitch('cb_include_metrics', "#{url}")
 
     .form-group
       %label.control-label.col-md-2

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -1,5 +1,5 @@
 - url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
-- if @edit[:new][:model] == "ChargebackVm" || @edit[:new][:model] == "MeteringVm"
+- if %w(MeteringVm ChargebackVm).include?(@edit[:new][:model])
   %h3
     = _('Chargeback Resources')
   .form-horizontal


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1533284

Remove _'Include C&U metrics'_ option for Metering Reports under _Cloud Intel > Reports > Reports_,
for **Metering for VMs**, as this option is redundant, since, by definition, Metering Reports always
include C&U metrics.

**Before:**
![metering_before](https://user-images.githubusercontent.com/13417815/38627235-ce1fdcc8-3dae-11e8-8825-d39636eae358.png)

**After:**
![metering_after](https://user-images.githubusercontent.com/13417815/38627244-d2c724b6-3dae-11e8-8241-3b5f46e555a4.png)

**Details:**
I've added this line https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Remove_Include_C?expand=1#diff-1538215b565ccfdafec8a0d650ee5ebeR6 to the haml, as the option 'Include Capacity & Utilization Metrics' still makes sense, for `ChargebackVm` model. The rest is untouched. This means that the second option under _Chargeback Resources_ section is displayed also for `MeteringVm` model, normally.