### PR TITLE
Server summary page changes

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -45,7 +45,7 @@ class PhysicalServerController < ApplicationController
   def textual_group_list
     [
       %i(properties networks relationships),
-      %i(power_management assets firmware_details smart_management),
+      %i(power_management asset_details firmware_details smart_management),
     ]
   end
   helper_method(:textual_group_list)

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -109,7 +109,7 @@ module PhysicalServerHelper::TextualSummary
     # It is possible for guest devices not to have network data (or a network
     # hash). As a result, we need to exclude guest devices that don't have
     # network data to prevent a nil class error from occurring.
-    devices_with_networks = @record.hardware.guest_devices.reject { |device| device.network.nil? }
+    devices_with_networks = @record.computer_system.hardware.guest_devices.reject { |device| device.network.nil? }
     ip_addresses = devices_with_networks.collect { |device| device.network.ipaddress }
 
     # It is possible that each network entry can have multiple IP addresses, separated

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -109,7 +109,7 @@ module PhysicalServerHelper::TextualSummary
     # It is possible for guest devices not to have network data (or a network
     # hash). As a result, we need to exclude guest devices that don't have
     # network data to prevent a nil class error from occurring.
-    {:label =>  _("IPv4 Address"), :value => @record.hardware.guest_devices.reject { |device| device.network.nil? }.collect { |device| device.network.ipaddress }.join(", ") }
+    {:label =>  _("IPv4 Address"), :value => @record.hardware.guest_devices.reject { |device| device.network.nil? }.collect { |device| create_https_url(device.network.ipaddress) }.join(", ") }
   end
 
   def textual_ipv6
@@ -162,5 +162,17 @@ module PhysicalServerHelper::TextualSummary
 
   def firmware_details
     @record.hardware.firmwares.collect { |fw| [fw.name, fw.version] }
+  end
+
+  private
+
+  def create_https_url(ip)
+    url = ""
+
+    unless ip.nil?
+      url = link_to(ip, "https://#{ip}")
+    end
+
+    url
   end
 end

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -20,9 +20,9 @@ module PhysicalServerHelper::TextualSummary
     TextualGroup.new(_("Management Networks"), %i(mac ipv4 ipv6))
   end
 
-  def textual_group_assets
+  def textual_group_asset_details
     TextualGroup.new(
-      _("Assets"),
+      _("Asset Details"),
       %i(support_contact description location room_id rack_name lowest_rack_unit)
     )
   end

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -178,14 +178,8 @@ module PhysicalServerHelper::TextualSummary
   private
 
   def create_https_url(ip)
-    url = ""
-
-    unless ip.nil?
-      # A target argument with a value of "_blank" is passed so that the
-      # page loads in a new tab when the link is clicked.
-      url = link_to(ip, "https://#{ip}", :target => "_blank")
-    end
-
-    url
+    # A target argument with a value of "_blank" is passed so that the
+    # page loads in a new tab when the link is clicked.
+    ip.present? ? link_to(ip, URI::HTTPS.build(:host => ip).to_s, :target => "_blank") : ''
   end
 end

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -120,7 +120,7 @@ module PhysicalServerHelper::TextualSummary
     ip_addresses = ip_addresses.join(",").split(/,\s*/)
     ip_address_urls = ip_addresses.collect { |ip_address| create_https_url(ip_address) }
 
-    {:label => _("IPv4 Address"), :value => ip_address_urls.join(", ").html_safe }
+    {:label => _("IPv4 Address"), :value => sanitize(ip_address_urls.join(", "), :attributes => %w(href target)) }
   end
 
   def textual_ipv6

--- a/spec/helpers/physical_server_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_server_helper/textual_summary_spec.rb
@@ -1,0 +1,28 @@
+describe PhysicalServerHelper::TextualSummary do
+  it "#textual_ipv4" do
+    network = FactoryGirl.build(:network, :ipaddress => "192.168.1.1")
+    guest_device = FactoryGirl.build(:guest_device, :network => network)
+    hardware = FactoryGirl.build(:hardware, :guest_devices => [guest_device])
+    computer_system = FactoryGirl.build(:computer_system, :hardware => hardware)
+    @record = FactoryGirl.build(:physical_server, :computer_system => computer_system)
+
+    result = helper.textual_ipv4
+    expect(result[:label]).to eq("IPv4 Address")
+    expect(result[:value]).to eq("<a target=\"_blank\" href=\"https://192.168.1.1\">192.168.1.1</a>")
+
+    network.ipaddress = "192.168.1.1,192.168.1.2"
+    result = helper.textual_ipv4
+    expect(result[:label]).to eq("IPv4 Address")
+    expect(result[:value]).to eq("<a target=\"_blank\" href=\"https://192.168.1.1\">192.168.1.1</a>, <a target=\"_blank\" href=\"https://192.168.1.2\">192.168.1.2</a>")
+
+    network.ipaddress = "192.168.1.1, 192.168.1.2"
+    result = helper.textual_ipv4
+    expect(result[:label]).to eq("IPv4 Address")
+    expect(result[:value]).to eq("<a target=\"_blank\" href=\"https://192.168.1.1\">192.168.1.1</a>, <a target=\"_blank\" href=\"https://192.168.1.2\">192.168.1.2</a>")
+  
+    network.ipaddress = ""
+    result = helper.textual_ipv4
+    expect(result[:label]).to eq("IPv4 Address")
+    expect(result[:value]).to eq("")
+  end
+end

--- a/spec/helpers/physical_server_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_server_helper/textual_summary_spec.rb
@@ -19,7 +19,7 @@ describe PhysicalServerHelper::TextualSummary do
     result = helper.textual_ipv4
     expect(result[:label]).to eq("IPv4 Address")
     expect(result[:value]).to eq("<a target=\"_blank\" href=\"https://192.168.1.1\">192.168.1.1</a>, <a target=\"_blank\" href=\"https://192.168.1.2\">192.168.1.2</a>")
-  
+
     network.ipaddress = ""
     result = helper.textual_ipv4
     expect(result[:label]).to eq("IPv4 Address")


### PR DESCRIPTION
This PR makes the following changes to the Physical Server Summary page:

1. Make the IPv4 address in the Management Networks table a link so that it's clickable.
2. Change the name of the Assets table to Asset Details.

![image](https://user-images.githubusercontent.com/23690141/38753929-f9371c66-3f2d-11e8-8026-2a0342e7befd.png)
