### PR TITLE
Fix error when setting ownership for Instances

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -40,6 +40,12 @@ module Mixins
             return
           end
 
+          unless @origin_ownership_items.count == @ownershipitems.count
+            add_flash(_('Some of the selected items don\'t allow ownership changes'), :error)
+            set_refresh_partial
+            return
+          end
+
           if @explorer
             @sb[:explorer] = true
             ownership(@origin_ownership_items)

--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -27,8 +27,7 @@ module Mixins
           if recs.empty?
             add_flash(_("One or more %{model} must be selected to Set Ownership") % {
               :model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize, :plural => true)}, :error)
-            @refresh_div = "flash_msg_div"
-            @refresh_partial = "layouts/flash_msg"
+            set_refresh_partial
             return
           end
 
@@ -37,8 +36,7 @@ module Mixins
 
           if @ownershipitems.nil? || @ownershipitems.empty?
             add_flash(_('None of the selected items allow ownership changes'), :error)
-            @refresh_div = "flash_msg_div"
-            @refresh_partial = "layouts/flash_msg"
+            set_refresh_partial
             return
           end
 
@@ -131,6 +129,11 @@ module Mixins
         end
 
         private
+
+        def set_refresh_partial
+          @refresh_div = "flash_msg_div"
+          @refresh_partial = "layouts/flash_msg"
+        end
 
         def load_user_group_items(ownership_ids, klass)
           @ownershipitems ||= filter_ownership_items(klass, ownership_ids)


### PR DESCRIPTION
**Fixes issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/3453

---

**What was done to fix the issue:**
- add new method `set_refresh_partial` instead of repeating the same code
in `set_ownership` method (this is preparation for implementing the fix)
- add condition for ownership items to check the specific situation mentioned in the issue, add appropriate flash message and use the new method `set_refresh_partial`

**Note:**
It looks like the situation (see the issue) has never worked. It is simply not implemented in the code so I added simple solution which covers the situation, prevents the error and also informs user what went wrong.  

**Before:**
![own_before](https://user-images.githubusercontent.com/13417815/38670524-4dd24aa6-3e49-11e8-8a13-6497fe8d1f29.png)
```
I, [2018-02-22T11:16:02.938566 #9633]  INFO -- : Started POST "/vm_cloud/x_button?pressed=instance_ownership" for ::1 at 2018-02-22 11:16:02 +0100
I, [2018-02-22T11:16:02.978200 #9633]  INFO -- : Processing by VmCloudController#x_button as JS
I, [2018-02-22T11:16:02.978347 #9633]  INFO -- :   Parameters: {"miq_grid_checks"=>"10000000001527,10000000000978", "pressed"=>"instance_ownership"}
I, [2018-02-22T11:16:03.076594 #9633]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/_flash_msg.html.haml (4.2ms)
I, [2018-02-22T11:16:03.084364 #9633]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/shared/views/_ownership.html.haml (22.4ms)
F, [2018-02-22T11:16:03.084910 #9633] FATAL -- : Error caught: [ActionView::Template::Error] undefined method `tenant_group?' for nil:NilClass
/home/hstastna/manageiq/manageiq-ui-classic/app/views/shared/views/_ownership.html.haml:37:in `__home_hstastna_manageiq_manageiq_ui_classic_app_views_shared_views__ownership_html_haml___3751597842004731819_70147892246860'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/template.rb:159:in `block in render'
/home/hstastna/.gem/ruby/2.4.0/gems/activesupport-5.0.6/lib/active_support/notifications.rb:166:in `instrument'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/template.rb:354:in `instrument'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/template.rb:157:in `render'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/partial_renderer.rb:343:in `render_partial'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/partial_renderer.rb:311:in `block in render'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
/home/hstastna/.gem/ruby/2.4.0/gems/activesupport-5.0.6/lib/active_support/notifications.rb:164:in `block in instrument'
/home/hstastna/.gem/ruby/2.4.0/gems/activesupport-5.0.6/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/hstastna/.gem/ruby/2.4.0/gems/activesupport-5.0.6/lib/active_support/notifications.rb:164:in `instrument'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/partial_renderer.rb:310:in `render'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/renderer.rb:47:in `render_partial'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/renderer.rb:21:in `render'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/rendering.rb:104:in `_render_template'
/home/hstastna/.gem/ruby/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/streaming.rb:217:in `_render_template'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/rendering.rb:83:in `render_to_body'
/home/hstastna/.gem/ruby/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/rendering.rb:52:in `render_to_body'
/home/hstastna/.gem/ruby/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/renderers.rb:142:in `render_to_body'
/home/hstastna/.gem/ruby/2.4.0/gems/actionpack-5.0.6/lib/abstract_controller/rendering.rb:48:in `render_to_string'
/home/hstastna/.gem/ruby/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/rendering.rb:41:in `render_to_string'
/home/hstastna/manageiq/manageiq-ui-classic/app/helpers/application_helper.rb:1753:in `block in r'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/vm_common.rb:1229:in `replace_right_cell'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:149:in `x_button'
```

**After:**
![ownership_after](https://user-images.githubusercontent.com/13417815/38670589-77a04a72-3e49-11e8-9851-cc25c227bdeb.png)
