### PR TITLE
meaningful openscap report filenames

### DIFF
--- a/app/controllers/container_image_controller.rb
+++ b/app/controllers/container_image_controller.rb
@@ -30,8 +30,16 @@ class ContainerImageController < ApplicationController
 
   def openscap_html
     @record = identify_record(params[:id])
+    send_data(@record.openscap_result.html, :filename => openscap_filename(@record))
+  end
 
-    send_data(@record.openscap_result.html, :filename => "openscap_result.html")
+  def openscap_filename(image)
+    result = ''
+    result << "#{image.container_image_registry.full_name}_" unless image.container_image_registry.nil?
+    result << image.name.to_s
+    result << ":#{image.tag}" unless image.tag.nil?
+    result = 'openscap_report' if result.empty?
+    result << '.html'
   end
 
   menu_section :cnt


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1554250

When downloading the openscap result report in html, the filename is not indicative of which image was scanned. If the image was `user/image` this changes the filename to `<image>.html` instead of `openscap_result.html`
![manageiq images](https://user-images.githubusercontent.com/11256940/38674946-eb0b4268-3e5e-11e8-9628-a7a084ce85ea.png)

@cben @moolitayer @nimrodshn Please review


