### PR TITLE
Fix bugs on set ownership screen

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -134,7 +134,7 @@ module Mixins
 
         def load_user_group_items(ownership_ids, klass)
           @ownershipitems ||= filter_ownership_items(klass, ownership_ids)
-          if ownership_ids.length > 1
+          if @ownershipitems.length > 1
             @user = @group = 'dont-change'
           else
             record = @ownershipitems.first

--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -97,7 +97,7 @@ module Mixins
 
           @groups = {} # Create new entries hash (2nd pulldown)
           Rbac.filtered(MiqGroup.non_tenant_groups).each { |g| @groups[g.description] = g.id.to_s }
-          @edit[:object_ids] = ownership_ids
+          @edit[:object_ids] = @ownershipitems
           @view = get_db_view(klass == VmOrTemplate ? Vm : klass) # Instantiate the MIQ Report view object
           @view.table = ReportFormatter::Converter.records2table(@ownershipitems, @view.cols + ['id'])
           session[:edit] = @edit

--- a/app/views/shared/views/_ownership.html.haml
+++ b/app/views/shared/views/_ownership.html.haml
@@ -32,7 +32,8 @@
         = _('Select a Group:')
       .col-md-8
         - if @ownershipitems.length > 1
-          - opts = [["<#{_("Don't change")}>", 'dont-change'], ["<#{_('No User Group')}>", '']] + @groups.sort
+          - opts = [["<#{_("Don't change")}>", 'dont-change'], ["<#{_('No User Group')}>", '']]
+          - user_group = ''
         - else
           - user_group = MiqGroup.find_by(:id => @group).tenant_group? ? @group : ''
           - opts =  [["<#{_('No User Group')}>", user_group]]


### PR DESCRIPTION
This PR fixes several issues on set ownership screen:

1. An error when settings ownership for several items, one of which doesn't support setting ownership (the problem described in https://github.com/ManageIQ/manageiq-ui-classic/issues/3453)
2. List of user groups in select dropdown, when settings the ownership for more than 1 item
3. The GTL list in set ownership screen would render all selected items as opposed to items which do support settings owhership.

To test:
Navigate to list of instances and test all possible scenarios:
1. settings ownership for 1 item
2. settings ownership for multiple items, where every item supports settings ownership
3. setting ownership for multiple items, where some items don't support settings ownership