### PR TITLE
Add Ansible Repository refresh output page

### DIFF
--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -16,6 +16,10 @@ class AnsibleRepositoryController < ApplicationController
     %w(playbooks)
   end
 
+  def self.custom_display_modes
+    %w(output)
+  end
+
   def self.model
     ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource
   end
@@ -98,6 +102,11 @@ class AnsibleRepositoryController < ApplicationController
     @in_a_form = true
   end
 
+  def show_output
+    drop_breadcrumb(:name => _("Refresh output"), :url => show_output_link)
+    @showtype = 'output'
+  end
+
   def display_playbooks
     nested_list(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook, :breadcrumb_title => _('Playbooks'))
   end
@@ -116,5 +125,10 @@ class AnsibleRepositoryController < ApplicationController
   def textual_group_list
     [%i(properties relationships options smart_management)]
   end
-  helper_method :textual_group_list
+
+  def show_output_link
+    show_link(@record, :display => :output)
+  end
+
+  helper_method :textual_group_list, :show_output_link
 end

--- a/app/helpers/ansible_repository_helper/textual_summary.rb
+++ b/app/helpers/ansible_repository_helper/textual_summary.rb
@@ -27,7 +27,11 @@ module AnsibleRepositoryHelper::TextualSummary
   end
 
   def textual_status
-    {:label => _("Status"), :value => @record.status}
+    h = {:label => _("Status"), :value => @record.status}
+    unless @record.last_update_error.nil?
+      h.update(:link => show_output_link, :title => _('Show refresh output'))
+    end
+    h
   end
 
   def textual_provider

--- a/app/views/ansible_repository/_output.html.haml
+++ b/app/views/ansible_repository/_output.html.haml
@@ -1,0 +1,5 @@
+- if @record.last_update_error.nil?
+  = _('No output for the last refresh.')
+- else
+  %pre
+    = @record.last_update_error

--- a/app/views/ansible_repository/show.html.haml
+++ b/app/views/ansible_repository/show.html.haml
@@ -1,5 +1,7 @@
 #main_div
   - if %w(playbooks).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  - elsif @showtype == 'output'
+    = render :partial => 'output'
   - else
     = render :partial => 'layouts/textual_groups_generic'

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -18,6 +18,21 @@ describe AnsibleRepositoryController do
     end
   end
 
+  describe "#show_output" do
+    let(:repository) { FactoryGirl.create(:embedded_ansible_configuration_script_source) }
+
+    subject { get :show, :params => {'id' => repository.id, 'display' => 'output'} }
+    render_views
+
+    it "return correct http response code" do
+      is_expected.to have_http_status 200
+    end
+
+    it "show repository last refresh output" do
+      is_expected.to render_template(:partial => "ansible_repository/_output")
+    end
+  end
+
   describe "#show_list" do
     let(:repository) { FactoryGirl.create(:embedded_ansible_configuration_script_source) }
     subject { get :show_list, :params => {} }


### PR DESCRIPTION
Create a custom display mode for Ansible Repository show page with last refresh output capture. If an Ansible Tower Repository has this capture from its last failed refresh, the Status row becomes a link to this subpage.

Presenting this information is a workaround for cloning repositories from HTTPS servers with untrusted SSL certificates. Tower API does not offer an option to disable SSL check, so with the stdout user can at least see, why the cloning actually failed.

Along with RSpec examples for this feature, refactor a bit other tests related to the page refresh button:

* Increase test coverage of the AJAX content replacement used
* Test Playbooks nested list subpage
* Rename examples with rather misleading titles

https://bugzilla.redhat.com/show_bug.cgi?id=1513616

Prior merging this PR, following PRs are required to be merged:

* [x] manageiq/manageiq#17290 model change
* [x] manageiq/manageiq-providers-ansible_tower#72 not necessarily required, but this PR doesn’t make sense without it

/cc @ZitaNemeckova, @hstastna for review