### PR TITLE
[FINE]Restore the Delete button for server in diagnostics

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -799,7 +799,7 @@ module OpsController::Diagnostics
   def diagnostics_set_form_vars
     active_node = x_node
     if active_node && active_node.split('-').first == "z"
-      @record = @selected_zone = @selected_server = Zone.find_by_id(from_cid(active_node.split('-').last))
+      @record = @selected_server = Zone.find_by(:id => from_cid(active_node.split('-').last))
       @sb[:selected_server_id] = @selected_server.id
       @sb[:selected_typ] = "zone"
       if @selected_server.miq_servers.length >= 1 &&

--- a/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
@@ -15,19 +15,19 @@ class ApplicationHelper::Toolbar::DiagnosticsZoneCenter < ApplicationHelper::Too
       t,
       :items => [
         button(
-          :zone_delete,
+          :zone_delete_server,
           'pficon pficon-delete fa-lg',
           t = proc do
-            _('Delete Zone %{server_name} [%{server_id}]') % {:server_name => @selected_zone.name, :server_id => @selected_zone.id}
+            _('Delete Server %{server_name} [%{server_id}]') % {:server_name => @record.name, :server_id => @record.id}
           end,
           t,
           :confirm => proc do
-                        _("Do you want to delete Zone %{server_name} [%{server_id}]?") % {
-                          :server_name => @selected_zone.name,
-                          :server_id   => @selected_zone.id
+                        _("Do you want to delete Server %{server_name} [%{server_id}]?") % {
+                          :server_name => @record.name,
+                          :server_id   => @record.id
                         }
                       end,
-          :klass => ApplicationHelper::Button::ZoneDelete
+          :klass   => ApplicationHelper::Button::ZoneDeleteServer
         ),
         button(
           :zone_role_start,

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -7,6 +7,12 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
     x_get_tree_miq_servers
   end
 
+  def override(node, _object, _pid, _options)
+    if @sb[:diag_selected_id] && node[:key] == "svr-#{@sb[:diag_selected_id]}"
+      node[:highlighted] = true
+    end
+  end
+
   def x_get_tree_miq_servers
     @root.miq_servers.sort_by { |s| s.name.to_s }.each_with_object([]) do |server, objects|
       unless @sb[:diag_selected_id] # Set default selected record vars

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -8,7 +8,8 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
   end
 
   def override(node, _object, _pid, _options)
-    if @sb[:diag_selected_id] && node[:key] == "svr-#{@sb[:diag_selected_id]}"
+    prefix = TreeBuilder.get_prefix_for_model('MiqServer')
+    if @sb[:diag_selected_id] && node[:key] == "#{prefix}-#{to_cid(@sb[:diag_selected_id])}"
       node[:highlighted] = true
     end
   end

--- a/spec/helpers/application_helper/toolbar/diagnostics_zone_center_spec.rb
+++ b/spec/helpers/application_helper/toolbar/diagnostics_zone_center_spec.rb
@@ -1,0 +1,13 @@
+describe ApplicationHelper::Toolbar::MiqAeDomainCenter do
+  describe "definition of class" do
+    it "contains the server delete button" do
+      diagnostics_zone_center = Kernel.const_get("ApplicationHelper::Toolbar::DiagnosticsZoneCenter")
+      buttons = diagnostics_zone_center.definition["ldap_domain_vmdb"].buttons
+      button_names = []
+      buttons.each do |button|
+        button_names += button[:items].pluck(:id) if button[:items]
+      end
+      expect(button_names).to include("zone_delete_server")
+    end
+  end
+end

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -69,7 +69,7 @@ describe TreeBuilderRolesByServer do
                                'class' => ''
                               },
                 ],
-                'state'   => {'expanded' => true},
+                'state'   => {'expanded' => true, 'selected' => true},
                 'class'   => ''
                }]
       expect(JSON.parse(@server_tree.locals_for_render[:bs_tree])).to eq(nodes)


### PR DESCRIPTION
Restore the Delete button for servers in a zone, selected from the right-side "Roles By Servers" tab

Links
-------
Fine backport for https://github.com/ManageIQ/manageiq-ui-classic/pull/2213
https://bugzilla.redhat.com/show_bug.cgi?id=1566746


After:
![screenshot from 2018-04-13 09-55-01](https://user-images.githubusercontent.com/12769982/38738705-cfecea02-3f00-11e8-8fae-3e2b13944117.png)



