### PR TITLE
[FINE] - Reset field_entry_point when new field is added.

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -913,6 +913,7 @@ module MiqAeCustomizationController::Dialogs
 
       if @edit[:field_typ] != params[:field_typ]
         @edit[:field_dynamic] = key[:dynamic] = false
+        @edit[:new][:selected] = @edit[:new]["field_entry_point"] = @edit[:field_entry_point] = key[:field_entry_point] = nil
         @edit[:field_read_only] = key[:read_only] = false
 
         if %w(DialogFieldTextBox DialogFieldTextAreaBox).include?(params[:field_typ])


### PR DESCRIPTION
This fixes an issue, when adding new field and setting that to be a dynamic field it was showing pre-filled value in entry point text box from the previous field and was not enabling "Apply" button on the entry point dialog pop up.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1532272

