### PR TITLE
Fix user edit

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -722,7 +722,7 @@ module OpsController::OpsRbac
     when :user
       record = @edit[:user_id] ? User.find_by(:id => @edit[:user_id]) : User.new
       validated = rbac_user_validate?
-      rbac_user_set_record_vars(record) if @edit[:user_id].blank?
+      rbac_user_set_record_vars(record)
     when :group then
       record = @edit[:group_id] ? MiqGroup.find_by(:id => @edit[:group_id]) : MiqGroup.new
       validated = rbac_group_validate?
@@ -734,6 +734,7 @@ module OpsController::OpsRbac
     end
 
     if record.valid? && validated && record.save!
+      record.miq_groups = Rbac.filtered(MiqGroup.find(rbac_user_get_group_ids)) if key == :user # only set miq_groups if everything is valid
       populate_role_features(record) if what == "role"
       self.current_user = record if what == 'user' && @edit[:current][:userid] == current_userid
       AuditEvent.success(build_saved_audit(record, add_pressed))
@@ -1036,7 +1037,6 @@ module OpsController::OpsRbac
     user.name       = @edit[:new][:name]
     user.userid     = @edit[:new][:userid]
     user.email      = @edit[:new][:email]
-    user.miq_groups = Rbac.filtered(MiqGroup.find(rbac_user_get_group_ids))
     user.password   = @edit[:new][:password] if @edit[:new][:password]
   end
 


### PR DESCRIPTION
Don't add anything to `record.miq_groups` as it's instantly saved without validation i.e. `[] `can be saved which is invalid.

So moving it from rbac_user_set_record_vars to if record.valid? && validated && record.save! condition.

*Before:*
Edit User -> Save changes -> Success but nothing changed
*After:*
It works

**Check following bugs aren't re-introduced:**

*Bug with edit fixed in https://github.com/ManageIQ/manageiq-ui-classic/pull/3345:* 
1. Create an RBAC user that is assigned to one or more groups
2. Edit the RBAC user and remove all of their assigned groups
3. Click Save
4. After receiving the error "A User must be assigned to a Group", navigate away from the user's details page.
5. Select the user in the RBAC accordion to view their details
6. User has no Assigned groups

*Bug with add:*
Configuration -> Access Control -> Users -> Configuration -> Add a new User -> fill as in image below -> click Add

Before:
<img width="903" alt="screen shot 2018-04-04 at 9 31 20 am" src="https://user-images.githubusercontent.com/9210860/38294634-c730d52a-37eb-11e8-9950-fa039d235917.png">
After:
<img width="897" alt="screen shot 2018-04-04 at 9 32 58 am" src="https://user-images.githubusercontent.com/9210860/38294643-cf0f1270-37eb-11e8-81e6-d662f71f2cd2.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1562828

@miq-bot add_label gaprindashvili/yes, bug, settings