### PR TITLE
Fix generic object show in services

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -185,7 +185,7 @@ class ServiceController < ApplicationController
     return unless init_show_variables
 
     @lastaction = 'generic_object'
-    @item = @record.generic_objects.find(params[:generic_object_id]).first
+    @item = @record.generic_objects.find { |e| e[:id] == params[:generic_object_id].to_i }
     drop_breadcrumb(:name => _("%{name} (All Generic Objects)") % {:name => @record.name}, :url => show_link(@record, :display => 'generic_objects'))
     drop_breadcrumb(:name => @item.name, :url => show_link(@record, :display => 'generic_objects', :generic_object_id => params[:generic_object_id]))
     @view = get_db_view(GenericObject)

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -124,6 +124,28 @@ describe ServiceController do
       expect(assigns(:breadcrumbs)).to eq([{:name => "Services with a GO (All Generic Objects)", :url => "/service/show/#{service_with_go.id}?display=generic_objects"}])
     end
 
+    it 'displays the selected generic object' do
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as FactoryGirl.create(:user)
+      controller.instance_variable_set(:@breadcrumbs, [])
+      service = FactoryGirl.create(:service, :name => "Abc")
+      go1 = FactoryGirl.create(:generic_object,
+                               :generic_object_definition => go_definition,
+                               :name                      => 'GOTest_1',
+                               :services                  => [service])
+      go1.add_to_service(service)
+
+      go2 = FactoryGirl.create(:generic_object,
+                               :generic_object_definition => go_definition,
+                               :name                      => 'GOTest_2',
+                               :services                  => [service])
+      go2.add_to_service(service)
+      get :show, :params => { :id => service.id, :display => 'generic_objects', :generic_object_id => go2.id}
+      expect(response.status).to eq(200)
+      expect(assigns(:breadcrumbs)).to eq([{:name => "Abc (All Generic Objects)", :url => "/service/show/#{service.id}?display=generic_objects"},
+                                           {:name => "GOTest_2", :url => "/service/show/#{service.id}?display=generic_objects&generic_object_id=#{go2.id}"}])
+    end
+
     it 'redirects to service detail page when Services maintab is clicked right after viewing the GO object' do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryGirl.create(:user)


### PR DESCRIPTION
Fixes the generic object show in services

Links 
--------------
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1567214

Steps for Testing/QA
-------------------------------

Before - the first generic object in the list was the one displayed, regardless of which one was clicked.

After:

![screenshot from 2018-04-16 13-04-19](https://user-images.githubusercontent.com/12769982/38824289-c868cea4-4176-11e8-8940-975ecfba8e0d.png)
![screenshot from 2018-04-16 13-04-29](https://user-images.githubusercontent.com/12769982/38824290-c880a38a-4176-11e8-87cd-70e6975052b6.png)


