### PR TITLE
Mark CloudSubnet.cidr as required

### DIFF
--- a/app/views/cloud_subnet/_common_new_edit.haml
+++ b/app/views/cloud_subnet/_common_new_edit.haml
@@ -39,7 +39,7 @@
       %span.help-block{"ng-show" => "angularForm.network_protocol.$error.required"}
         = _("Required")
 
-  .form-group
+  .form-group{"ng-class" => "{'has-error': angularForm.cidr.$invalid}"}
     %label.col-md-2.control-label
       = _('Subnet CIDR')
     .col-md-8
@@ -47,4 +47,7 @@
                           "name"         => "cidr",
                           "ng-disabled"  => "!vm.newRecord",
                           "ng-model"     => "vm.cloudSubnetModel.cidr",
-                          "ng-maxlength" => 20}
+                          "ng-maxlength" => 20,
+                          "required"     => ""}
+      %span.help-block{"ng-show" => "angularForm.cidr.$error.required"}
+        = _("Required")


### PR DESCRIPTION
According to https://developer.openstack.org/api-ref/network/v2/ 'Subnet CIDR' is required when adding a new subnet.
This PR marks the 'Subnet CIDR' ui field as required.

Fixes https://bugzilla.redhat.com/1565019
