### PR TITLE
Use fonticons with color in quadicons' powerstate quadrants

### DIFF
--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -10,7 +10,7 @@ class HostDecorator < MiqDecorator
   def quadicon
     icon = {
       :top_left     => {:text => vms.size},
-      :top_right    => {:fileicon => "svg/currentstate-#{ERB::Util.h(normalized_state.downcase)}.svg"},
+      :top_right    => QuadiconHelper.machine_state(normalized_state),
       :bottom_left  => {
         :fileicon => fileicon,
         :tooltip  => type

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -14,7 +14,7 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
   def quadicon
     icon = {
       :top_left     => {:text => container_nodes.size},
-      :top_right    => {:fileicon => "svg/currentstate-#{enabled? ? 'on' : 'paused'}.svg"},
+      :top_right    => QuadiconHelper.machine_state(enabled? ? 'on' : 'paused'),
       :bottom_left  => {
         :fileicon => fileicon,
         :tooltip  => type

--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -14,8 +14,9 @@ class MiqTemplateDecorator < MiqDecorator
         :tooltip  => os_image_name.humanize.downcase
       },
       :top_right    => {
-        :fileicon => "svg/currentstate-#{ERB::Util.h(normalized_state.downcase)}.svg",
-        :tooltip  => normalized_state
+        :fonticon   => fonticon,
+        :background => '#336699',
+        :tooltip    => normalized_state
       },
       :bottom_left  => {
         :fileicon => fileicon,

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -11,9 +11,8 @@ class PhysicalServerDecorator < MiqDecorator
     icon = {
       :top_left     => {:text => (host ? 1 : 0)},
       :top_right    => {
-        :fileicon => "svg/currentstate-#{ERB::Util.h(power_state.try(:downcase))}.svg",
-        :tooltip  => power_state.try(:downcase)
-      },
+        :tooltip => power_state.try(:downcase)
+      }.merge(QuadiconHelper.machine_state(power_state)),
       :bottom_left  => {
         :fileicon => fileicon,
         :tooltip  => type

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -18,9 +18,8 @@ class VmOrTemplateDecorator < MiqDecorator
         :tooltip  => os_image_name.humanize.downcase
       },
       :top_right    => {
-        :fileicon   => "svg/currentstate-#{ERB::Util.h(normalized_state.downcase)}.svg",
-        :tooltip    => normalized_state
-      },
+        :tooltip => normalized_state
+      }.merge(QuadiconHelper.machine_state(normalized_state)),
       :bottom_left  => {
         :fileicon => fileicon,
         :tooltip  => type

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -18,6 +18,61 @@ module QuadiconHelper
     end
   end
 
+  def self.machine_state(state_str)
+    case state_str.try(:downcase)
+    when 'archived'
+      {:text => 'A', :background => '#336699'}
+    when 'orphaned'
+      {:text => 'O', :background => '#336699'}
+    when 'retired'
+      {:text => 'R', :background => '#336699'}
+    when 'unknown'
+      {:fonticon => 'pficon pficon-unknown', :background => '#336699'}
+    when 'preparing_for_maintenance'
+      {:fonticon => 'pficon pficon-maintenance', :background => '#336699'}
+    when 'maintenance'
+      {:fonticon => 'pficon pficon-maintenance', :background => '#336699'}
+    when 'disconnected'
+      {:fonticon => 'pficon pficon-unplugged', :background => '#336699'}
+    when 'non_operational'
+      {:fonticon => 'fa fa-exclamation', :background => '#336699'}
+    when 'not_responding'
+      {:fonticon => 'fa fa-exclamation', :background => '#336699'}
+    when 'install_failed'
+      {:fonticon => 'fa fa-exclamation', :background => '#336699'}
+    when 'suspended'
+      {:fonticon => 'pficon pficon-asleep', :background => '#FF9900'}
+    when 'standby'
+      {:fonticon => 'pficon pficon-asleep', :background => '#FF9900'}
+    when 'paused'
+      {:fonticon => 'pficon pficon-asleep', :background => '#FF9900'}
+    when 'disconnecting'
+      {:fonticon => 'pficon pficon-unplugged', :background => '#FF9900'}
+    when 'image_locked'
+      {:fonticon => 'pficon pficon-locked', :background => '#FF9900'}
+    when 'migrating'
+      {:fonticon => 'pficon pficon-migration', :background => '#FF9900'}
+    when 'shelved'
+      {:fonticon => 'pficon pficon-pending', :background => '#FF9900'}
+    when 'shelved_offloaded'
+      {:fonticon => 'pficon pficon-pending', :background => '#FF9900'}
+    when 'reboot_in_progress'
+      {:fonticon => 'pficon pficon-on', :background => '#FF9900'}
+    when 'wait_for_launch'
+      {:fonticon => 'pficon pficon-asleep', :background => '#FF9900'}
+    when 'on'
+      {:fonticon => 'pficon pficon-on', :background => '#3F9C35'}
+    when 'never'
+      {:fonticon => 'pficon pficon-off', :background => '#CC0000'}
+    when 'terminated'
+      {:fonticon => 'pficon pficon-off', :background => '#CC0000'}
+    when 'off'
+      {:fonticon => 'pficon pficon-off', :background => '#CC0000'}
+    else
+      {}
+    end
+  end
+
   def self.quadicon_output(quadicon)
     if (quadicon.keys & QUADRANTS).any?
       QUADRANTS.each do |part|


### PR DESCRIPTION
Since the new quadicons are in, we can use fonticons in a quadrant. Also the SVG powerstate icons aren't really compatible with this new component.

**Before:**
![screenshot from 2018-04-16 13-55-28](https://user-images.githubusercontent.com/649130/38807864-5607f4d6-417e-11e8-8e15-4101dc2389f7.png)

**After:**
![screenshot from 2018-04-16 13-54-34](https://user-images.githubusercontent.com/649130/38807869-5b182428-417e-11e8-87b0-7d2ef1d699ef.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @karelhala 
@miq-bot assign @martinpovolny 
@miq-bot add_label gaprindashvili/no, GTLs