### PR TITLE
Fix enabling/disabling Add button when creating new user

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1023,13 +1023,13 @@ module OpsController::OpsRbac
 
   # Get variables from user edit form
   def rbac_user_get_form_vars
-    @edit[:new][:name] = params[:name] if params[:name]
-    @edit[:new][:userid] = params[:userid].strip if params[:userid]
-    @edit[:new][:email] = params[:email].strip if params[:email]
+    @edit[:new][:name] = params[:name].presence if params[:name]
+    @edit[:new][:userid] = params[:userid].strip.presence if params[:userid]
+    @edit[:new][:email] = params[:email].strip.presence if params[:email]
     @edit[:new][:group] = params[:chosen_group] if params[:chosen_group]
 
-    @edit[:new][:password] = params[:password] if params[:password]
-    @edit[:new][:verify] = params[:verify] if params[:verify]
+    @edit[:new][:password] = params[:password].presence if params[:password]
+    @edit[:new][:verify] = params[:verify].presence if params[:verify] # Confirm Password form
   end
 
   # Set user record variables to new values


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1525123

---

_Add_ button enabled when entering name etc. into the form:
![add_user](https://user-images.githubusercontent.com/13417815/38815075-5e290cbc-4193-11e8-81e9-d0a845ba279b.png)

**Before:**
![add_user_before](https://user-images.githubusercontent.com/13417815/38814907-f2e1e866-4192-11e8-9da2-739f32473f0a.png)

**After:**
![add_user_after](https://user-images.githubusercontent.com/13417815/38814916-f98b86b8-4192-11e8-8069-bd7db5cde7e4.png)

---

**Details:**
The core of the problem was that when user deletes characters from the form, then, for example, `params[:name]` is set to `""` instead of original `nil` value. This is considered as different to what it was before, here: https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/ops_controller/ops_rbac.rb#L759 This is why **Add** button is enabled even when we deleted everything from the forms and so we have nothing to add/create. Using `presence` we simply get back `nil` value from `""`.
