### PR TITLE
Update decorators to use fonticons for single quads

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -367,6 +367,12 @@ table.table.table-summary-screen tbody td img {
 /// begin quadicon styling
 /// ===================================================================
 
+miq-quadicon > .single-wrapper {
+  .fonticon > i {
+    color: #0099cc;
+  }
+}
+
 /// ===================================================================
 /// end quadicon styling
 /// ===================================================================

--- a/app/decorators/auth_private_key_decorator.rb
+++ b/app/decorators/auth_private_key_decorator.rb
@@ -1,9 +1,15 @@
 class AuthPrivateKeyDecorator < MiqDecorator
   def self.fonticon
-    nil
+    'ff ff-cloud-keys'
   end
 
   def self.fileicon
     "100/auth_key_pair.png"
+  end
+
+  def single_quad
+    {
+      :fonticon => fonticon
+    }
   end
 end

--- a/app/decorators/availability_zone_decorator.rb
+++ b/app/decorators/availability_zone_decorator.rb
@@ -9,7 +9,7 @@ class AvailabilityZoneDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/cloud_network_decorator.rb
+++ b/app/decorators/cloud_network_decorator.rb
@@ -9,7 +9,7 @@ class CloudNetworkDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/cloud_object_store_container_decorator.rb
+++ b/app/decorators/cloud_object_store_container_decorator.rb
@@ -9,7 +9,7 @@ class CloudObjectStoreContainerDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/cloud_object_store_object_decorator.rb
+++ b/app/decorators/cloud_object_store_object_decorator.rb
@@ -9,7 +9,7 @@ class CloudObjectStoreObjectDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/cloud_subnet_decorator.rb
+++ b/app/decorators/cloud_subnet_decorator.rb
@@ -9,7 +9,7 @@ class CloudSubnetDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/cloud_tenant_decorator.rb
+++ b/app/decorators/cloud_tenant_decorator.rb
@@ -9,7 +9,7 @@ class CloudTenantDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/cloud_volume_backup_decorator.rb
+++ b/app/decorators/cloud_volume_backup_decorator.rb
@@ -9,7 +9,7 @@ class CloudVolumeBackupDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/cloud_volume_decorator.rb
+++ b/app/decorators/cloud_volume_decorator.rb
@@ -9,7 +9,7 @@ class CloudVolumeDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/cloud_volume_snapshot_decorator.rb
+++ b/app/decorators/cloud_volume_snapshot_decorator.rb
@@ -9,7 +9,7 @@ class CloudVolumeSnapshotDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/container_build_decorator.rb
+++ b/app/decorators/container_build_decorator.rb
@@ -9,7 +9,7 @@ class ContainerBuildDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/container_decorator.rb
+++ b/app/decorators/container_decorator.rb
@@ -9,7 +9,7 @@ class ContainerDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/container_group_decorator.rb
+++ b/app/decorators/container_group_decorator.rb
@@ -9,7 +9,7 @@ class ContainerGroupDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/container_image_decorator.rb
+++ b/app/decorators/container_image_decorator.rb
@@ -9,7 +9,7 @@ class ContainerImageDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/container_image_registry_decorator.rb
+++ b/app/decorators/container_image_registry_decorator.rb
@@ -9,7 +9,7 @@ class ContainerImageRegistryDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/container_node_decorator.rb
+++ b/app/decorators/container_node_decorator.rb
@@ -9,7 +9,7 @@ class ContainerNodeDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/container_project_decorator.rb
+++ b/app/decorators/container_project_decorator.rb
@@ -9,7 +9,7 @@ class ContainerProjectDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/container_replicator_decorator.rb
+++ b/app/decorators/container_replicator_decorator.rb
@@ -9,7 +9,7 @@ class ContainerReplicatorDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/container_route_decorator.rb
+++ b/app/decorators/container_route_decorator.rb
@@ -9,7 +9,7 @@ class ContainerRouteDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/container_template_decorator.rb
+++ b/app/decorators/container_template_decorator.rb
@@ -9,7 +9,7 @@ class ContainerTemplateDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/container_volume_decorator.rb
+++ b/app/decorators/container_volume_decorator.rb
@@ -5,7 +5,7 @@ class ContainerVolumeDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => '100/container_volume.png'
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/ems_cluster_decorator.rb
+++ b/app/decorators/ems_cluster_decorator.rb
@@ -9,7 +9,7 @@ class EmsClusterDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -30,7 +30,7 @@ class ExtManagementSystemDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/flavor_decorator.rb
+++ b/app/decorators/flavor_decorator.rb
@@ -9,7 +9,7 @@ class FlavorDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/floating_ip_decorator.rb
+++ b/app/decorators/floating_ip_decorator.rb
@@ -9,7 +9,7 @@ class FloatingIpDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/host_aggregate_decorator.rb
+++ b/app/decorators/host_aggregate_decorator.rb
@@ -1,11 +1,11 @@
 class HostAggregateDecorator < MiqDecorator
   def self.fonticon
-    'pficon pficon-screen'
+    'pficon pficon-container-node'
   end
 
   def single_quad
     {
-      :fileicon => '100/host_aggregate.png'
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -1,6 +1,6 @@
 class HostDecorator < MiqDecorator
   def self.fonticon
-    'pficon pficon-screen'
+    'pficon pficon-container-node'
   end
 
   def fileicon
@@ -26,7 +26,7 @@ class HostDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/load_balancer_decorator.rb
+++ b/app/decorators/load_balancer_decorator.rb
@@ -9,7 +9,7 @@ class LoadBalancerDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/manageiq/providers/cloud_manager/auth_key_pair_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager/auth_key_pair_decorator.rb
@@ -1,12 +1,16 @@
 module ManageIQ::Providers
   class CloudManager::AuthKeyPairDecorator < MiqDecorator
+    def self.fonticon
+      'ff ff-cloud-keys'
+    end
+
     def self.fileicon
       '100/auth_key_pair.png'
     end
 
     def single_quad
       {
-        :fileicon => fileicon
+        :fonticon => fonticon
       }
     end
   end

--- a/app/decorators/miq_policy_decorator.rb
+++ b/app/decorators/miq_policy_decorator.rb
@@ -2,7 +2,7 @@ class MiqPolicyDecorator < MiqDecorator
   def fonticon
     icon = case towhat
            when 'Host'
-             'pficon pficon-screen'
+             'pficon pficon-container-node'
            when 'Vm'
              'pficon pficon-virtual-machine'
            when 'ContainerReplicator'

--- a/app/decorators/network_port_decorator.rb
+++ b/app/decorators/network_port_decorator.rb
@@ -9,7 +9,7 @@ class NetworkPortDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/network_router_decorator.rb
+++ b/app/decorators/network_router_decorator.rb
@@ -9,7 +9,7 @@ class NetworkRouterDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/orchestration_stack_decorator.rb
+++ b/app/decorators/orchestration_stack_decorator.rb
@@ -9,7 +9,7 @@ class OrchestrationStackDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/app/decorators/persistent_volume_decorator.rb
+++ b/app/decorators/persistent_volume_decorator.rb
@@ -6,4 +6,10 @@ class PersistentVolumeDecorator < MiqDecorator
   def self.fileicon
     '100/persistent_volume.png'
   end
+
+  def single_quad
+    {
+      :fonticon => fonticon
+    }
+  end
 end

--- a/app/decorators/security_group_decorator.rb
+++ b/app/decorators/security_group_decorator.rb
@@ -9,7 +9,7 @@ class SecurityGroupDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end

--- a/spec/controllers/auth_key_pair_cloud_controller_spec.rb
+++ b/spec/controllers/auth_key_pair_cloud_controller_spec.rb
@@ -113,7 +113,7 @@ describe AuthKeyPairCloudController do
         results = assert_report_data_response
         expect(results['data']['rows'].length).to eq(1)
         expect(results['data']['rows'][0]['long_id']).to eq(kp.id.to_s)
-        expect(results['data']['rows'][0]['quad']).to have_key('fileicon')
+        expect(results['data']['rows'][0]['quad']).to have_key('fonticon')
       end
     end
   end

--- a/spec/presenters/tree_node/host_spec.rb
+++ b/spec/presenters/tree_node/host_spec.rb
@@ -14,7 +14,7 @@ describe TreeNode::Host do
       let(:object) { FactoryGirl.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'h-'
-      include_examples 'TreeNode::Node#icon', 'pficon pficon-screen'
+      include_examples 'TreeNode::Node#icon', 'pficon pficon-container-node'
       include_examples 'TreeNode::Node#tooltip prefix', 'Host / Node'
     end
   end


### PR DESCRIPTION
This PR updates the decorators to use fonticons rather than PNGs for the single quads.

Old
<img width="623" alt="screen shot 2018-04-16 at 12 58 33 pm" src="https://user-images.githubusercontent.com/1287144/38824078-1ddf5ae8-4176-11e8-9bd4-612bf004fd2d.png">

New
<img width="479" alt="screen shot 2018-04-16 at 12 57 29 pm" src="https://user-images.githubusercontent.com/1287144/38824079-1deff592-4176-11e8-9c7b-5f95760e8fc9.png">
