### PR TITLE
save/render flash message after Network Router delete is initiated.

### DIFF
--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -32,6 +32,7 @@ class NetworkRouterController < ApplicationController
       javascript_redirect(:action => "add_interface_select", :id => checked_item_id)
     when "network_router_delete"
       delete_network_routers
+      javascript_redirect(previous_breadcrumb_url)
     when "network_router_edit"
       javascript_redirect(:action => "edit", :id => checked_item_id)
     when "network_router_new"
@@ -189,6 +190,7 @@ class NetworkRouterController < ApplicationController
     elsif @lastaction == "show" && @layout == "network_router"
       @single_delete = true unless flash_errors?
       add_flash(_("The selected Router was deleted")) if @flash_array.nil?
+      flash_to_session
     else
       drop_breadcrumb(:name => 'dummy', :url => " ") # missing a bc to get correctly back so here's a dummy
       flash_to_session

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -211,7 +211,19 @@ describe NetworkRouterController do
 
       it "queues the delete action" do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :button, :params => { :id => @router.id, :pressed => "network_router_delete", :format => :js }
+        controller.instance_variable_set(:@_params,
+                                         :pressed => "network_router_delete",
+                                         :id      => @router.id)
+        controller.instance_variable_set(:@lastaction, "show")
+        controller.instance_variable_set(:@layout, "network_router")
+        allow(controller).to receive(:find_checked_ids_with_rbac).and_return([@router])
+        allow(controller).to receive(:find_id_with_rbac).and_return([@router])
+        controller.instance_variable_set(:@breadcrumbs, [{:name => "foo", :url => "network_router/show_list"}, {:name => "bar", :url => "network_router/show"}])
+        expect(controller).to receive(:render)
+        controller.send(:button)
+        flash_messages = assigns(:flash_array)
+        expect(flash_messages.first).to eq(:message => "Delete initiated for 1 Network Router.",
+                                           :level   => :success)
       end
     end
   end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1567982

similar fix was made for cloud networks in https://github.com/ManageIQ/manageiq-ui-classic/pull/3626

after fix:
![after](https://user-images.githubusercontent.com/3450808/38834224-ca1ea074-4195-11e8-81fc-a5d7feaaaab0.png)
