### PR TITLE
Send the tree data for explorer trees as an object instead of JSON

### DIFF
--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -9,7 +9,7 @@
         %miq-tree-view{:name       => tree.name,
                        :data       => "vm.data['#{tree.name}']",
                        :reselect   => tree.locals_for_render[:allow_reselect],
-                       "ng-init"   => "vm.initData('#{tree.name}', '#{tree.locals_for_render[:bs_tree]}', '#{tree.locals_for_render[:select_node]}')",
+                       "ng-init"   => "vm.initData('#{tree.name}', #{tree.locals_for_render[:bs_tree]}, '#{tree.locals_for_render[:select_node]}')",
                        'on-select' => "vm.nodeSelect(node, '/#{request.parameters[:controller]}/tree_select')",
                        'selected'  => "vm.selectedNodes['#{tree.name}']",
                        'persist'   => 'key',

--- a/app/views/layouts/listnav/_generic_object_definition_show_list_with_treeview.html.haml
+++ b/app/views/layouts/listnav/_generic_object_definition_show_list_with_treeview.html.haml
@@ -4,7 +4,7 @@
     %miq-tree-view{:name       => @tree.name,
                    :data       => "vm.data['#{@tree.name}']",
                    :reselect   => @tree.locals_for_render[:allow_reselect],
-                   "ng-init"   => "vm.initData('#{@tree.name}', '#{@tree.locals_for_render[:bs_tree]}', '#{@tree.locals_for_render[:select_node]}')",
+                   "ng-init"   => "vm.initData('#{@tree.name}', #{@tree.locals_for_render[:bs_tree]}, '#{@tree.locals_for_render[:select_node]}')",
                    'on-select' => "vm.nodeSelect(node, '/#{request.parameters[:controller]}/tree_select')",
                    'selected'  => "vm.selectedNodes['#{@tree.name}']",
                    'persist'   => 'key',


### PR DESCRIPTION
This fixes an issue with apostrophes in the tree data.

@miq-bot assign @himdel 
@miq-bot add_label bug

https://bugzilla.redhat.com/show_bug.cgi?id=1568417