### PR TITLE
Some Physical Servers params should be accessed through asset_detail

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -59,19 +59,19 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_product_name
-    {:label => _("Product Name"), :value => @record.product_name }
+    {:label => _("Product Name"), :value => @record.asset_detail['product_name'] }
   end
 
   def textual_manufacturer
-    {:label => _("Manufacturer"), :value => @record.manufacturer }
+    {:label => _("Manufacturer"), :value => @record.asset_detail['manufacturer'] }
   end
 
   def textual_machine_type
-    {:label => _("Machine Type"), :value => @record.machine_type }
+    {:label => _("Machine Type"), :value => @record.asset_detail['machine_type'] }
   end
 
   def textual_serial_number
-    {:label => _("Serial Number"), :value => @record.serial_number }
+    {:label => _("Serial Number"), :value => @record.asset_detail['serial_number'] }
   end
 
   def textual_ems_ref
@@ -79,7 +79,7 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_model
-    {:label => _("Model"), :value => @record.model}
+    {:label => _("Model"), :value => @record.asset_detail['model']}
   end
 
   def textual_capacity

--- a/product/views/PhysicalServer.yaml
+++ b/product/views/PhysicalServer.yaml
@@ -16,8 +16,7 @@ cols:
 - power_state
 - location_led_state
 - hostname
-- product_name
-- manufacturer
+- asset_detail
 
 
 include:
@@ -36,8 +35,8 @@ col_order:
 - power_state
 - location_led_state
 - hostname
-- product_name
-- manufacturer
+- asset_detail.product_name
+- asset_detail.manufacturer
 
 col_formats:
 -


### PR DESCRIPTION
**This PR is able to:**
- Make a **refactoring** on Physical Server _Listing_ and _show_ views to avoid confusion about some properties.

**Goal:**
- The properties changed in the code were stored on the _physical_servers_ table. However, a few time ago ([manageiq/manageiq-schema#181](https://github.com/ManageIQ/manageiq-schema/pull/181)) they were moved to the _asset_details_ table. This PR concludes this change on the UI.