### PR TITLE
Clear the request field when switching the button type to 'Default'

### DIFF
--- a/app/controllers/mixins/playbook_options.rb
+++ b/app/controllers/mixins/playbook_options.rb
@@ -56,6 +56,7 @@ module Mixins
       @edit[:new][:service_template_id] = nil
       @edit[:new][:inventory_type] = 'localhost'
       @edit[:new][:hosts] = ''
+      @edit[:new][:object_request] = nil
     end
 
     def initialize_playbook_variables

--- a/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
@@ -98,6 +98,31 @@ describe MiqAeCustomizationController do
       expect(assigns(:sb)[:active_tab]).to eq("ab_advanced_tab")
     end
 
+    it "the request field is cleared when the button type is changed from Playbook to Default" do
+      @sb = {:active_tree => :ab_tree,
+             :trees       => {:ab_tree => {:tree => :ab_tree}},
+             :params      => {:instance_name => 'MiqEvent'}}
+      controller.instance_variable_set(:@sb, @sb)
+      controller.instance_variable_set(:@breadcrumbs, [])
+
+      edit = {:new               => {:button_images  => %w(01 02 03), :available_dialogs => {:id => '01', :name => '02'},
+                                     :instance_name  => 'MiqEvent',
+                                     :attrs          => [%w(Attr1 01), %w(Attr2 02), %w(Attr3 03), %w(Attr4 04), %w(Attr5 05)],
+                                     :disabled_text  => 'a_disabled_text',
+                                     :object_request => CustomButton::PLAYBOOK_METHOD,
+                                     :button_type    => 'ansible_playbook'},
+              :instance_names    => %w(CustomButton_1 CustomButton_2),
+              :visibility_types  => %w(Type1 Type2),
+              :ansible_playbooks => [],
+              :current           => {}}
+      controller.instance_variable_set(:@edit, edit)
+      session[:edit] = edit
+      session[:resolve] = {}
+      post :automate_button_field_changed, :params => {:id => 'new', :button_type => "default"}
+      @edit = controller.instance_variable_get(:@edit)
+      expect(@edit[:new][:object_request]).to be_nil
+    end
+
     it "uses available expression fields when editing the custom buttons expressions" do
       allow(MiqAeClass).to receive_messages(:find_distinct_instances_across_domains => [double(:name => "foo")])
 


### PR DESCRIPTION
Clear the request field when switching teh button type to 'Default'

Links 
---------
Fixes  https://bugzilla.redhat.com/show_bug.cgi?id=1501031


Steps for Testing/QA
-------------------------------


![screenshot from 2018-04-17 16-34-37](https://user-images.githubusercontent.com/12769982/38895257-86711d84-425d-11e8-82bb-c1e31f1f3282.png)
![screenshot from 2018-04-17 16-36-26](https://user-images.githubusercontent.com/12769982/38895258-867c81ba-425d-11e8-8154-e3aa2ed504b8.png)
