### PR TITLE
Fix using old options for calculating

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1615,6 +1615,7 @@ function chartData(type, data, data2) {
       format = recalculated.format;
     }
     data.axis.y.tick.format = ManageIQ.charts.formatters[format.function].c3(format.options);
+    data.miq.format = format;
     data.legend.item = {
       onclick: recalculateChartYAxisLabels,
     };

--- a/app/assets/javascripts/miq_c3.js
+++ b/app/assets/javascripts/miq_c3.js
@@ -87,7 +87,8 @@ function recalculateChartYAxisLabels(id) {
 
   var o = validatePrecision(minShowed, maxShowed, format, minMax[0], minMax[1]);
   if (o.changed) {
-    this.config.axis_y_tick_format = o.format;
+    this.config.axis_y_tick_format = o.function;
+    format = o.format;
     this.api.flush();
   }
 }
@@ -99,7 +100,8 @@ function validatePrecision(minShowed, maxShowed, format, min, max) {
   var recalculated = recalculatePrecision(minShowed, maxShowed, format, min, max);
   return {
     'changed': recalculated.changed,
-    'format': ManageIQ.charts.formatters[recalculated.format.function].c3(recalculated.format.options),
+    'function': ManageIQ.charts.formatters[recalculated.format.function].c3(recalculated.format.options),
+    'format': recalculated.format,
   };
 }
 


### PR DESCRIPTION
When I was researching how to fix the BZ, I found that labels are sometimes bad, but in a different way than it is described in the BZ. The precision sometimes doesn't fit the calculation. It was caused by not updating formating function parameters correctly when recalculating.

Links
----------------
DOES NOT FIX THIS BZ,  but it is related
https://bugzilla.redhat.com/show_bug.cgi?id=1564136

Steps for Testing/QA
-------------------------------
Enable C&U data collection in Configuration.
Select some Host/Vm/whatever with C&U data
Monitoring -> Utilization -> Look at charts, hide/show series by clicking on the legend
Repeat for different entity

