### PR TITLE
Add direct redux npm dependency, redux 4.0.0 breaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "react-redux": "^5.0.7",
+    "redux": "~3.7.2",
     "redux-devtools-extension": "^2.13.2",
     "rxjs": "~5.6.0-forward-compat.2",
     "text-encoder-lite": "git://github.com/coolaj86/TextEncoderLite.git#e1e031b",
@@ -44,7 +45,6 @@
   "devDependencies": {
     "@types/jasmine": "^2.8.6",
     "@types/jest": "^22.1.3",
-    "@types/redux": "^3.6.0",
     "angular-mocks": "^1.6.9",
     "autoprefixer": "~6.7.7",
     "babel-core": "~6.24.1",


### PR DESCRIPTION
[Redux 4 is here!](https://github.com/reactjs/redux/releases) and [yarn is broken](https://gist.github.com/bdunne/c58ae9f3c26e6647f29392c6cfba7f2b) :(.

Turns out we only depend on redux indirectly, which means the redux 4.0.0 release broke the webpack build..

    ERROR in /home/bdunne/.gem/ruby/2.4.3/bundler/gems/manageiq-ui-classic-8303c278b9c0/node_modules/redux/index.d.ts
    (19,27): error TS1005: ',' expected.

    (and quite a bit more)

Adding that direct dependency.
Also removed `@types/redux`, since it has been [deprecated](https://www.npmjs.com/package/@types/redux).

Cc @bdunne 