### PR TITLE
tag mapping UI: Hardcode arbirtrary values instead of "computing" 

### DIFF
--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -10,22 +10,34 @@ module OpsController::Settings::LabelTagMapping
   # all that matters is these strings match what refresh passes to `map_labels`.
   #
   # In any case, this requires different providers use disjoint sets of strings.
-  # This const is arranged as a hash type => [category prefix, model used for translation].
+  MappableEntity = Struct.new(:prefix, :model)
+
   MAPPABLE_ENTITIES = {
     # TODO: support per-provider "All Amazon" etc?
     # Currently we have only global "All".
     # Global "All" categories are named "kubernetes::..." for backward compatibility.
-    nil                   => ["kubernetes::",                     nil],
-    "Vm"                  => ["amazon:vm:",                       "ManageIQ::Providers::Amazon::CloudManager::Vm"],
-    "VmAzure"             => ["azure:vm:",                        "ManageIQ::Providers::Azure::CloudManager::Vm"],
-    "Image"               => ["amazon:image:",                    "ManageIQ::Providers::Amazon::CloudManager::Template"],
-    "ContainerProject"    => ["kubernetes:container_project:",    "ContainerProject"],
-    "ContainerRoute"      => ["kubernetes:container_route:",      "ContainerRoute"],
-    "ContainerNode"       => ["kubernetes:container_node:",       "ContainerNode"],
-    "ContainerReplicator" => ["kubernetes:container_replicator:", "ContainerReplicator"],
-    "ContainerService"    => ["kubernetes:container_service:",    "ContainerService"],
-    "ContainerGroup"      => ["kubernetes:container_group:",      "ContainerGroup"],
-    "ContainerBuild"      => ["kubernetes:container_build:",      "ContainerBuild"],
+    nil                   => MappableEntity.new("kubernetes::",
+                                                nil),
+    "Vm"                  => MappableEntity.new("amazon:vm:",
+                                                "ManageIQ::Providers::Amazon::CloudManager::Vm"),
+    "VmAzure"             => MappableEntity.new("azure:vm:",
+                                                "ManageIQ::Providers::Azure::CloudManager::Vm"),
+    "Image"               => MappableEntity.new("amazon:image:",
+                                                "ManageIQ::Providers::Amazon::CloudManager::Template"),
+    "ContainerProject"    => MappableEntity.new("kubernetes:container_project:",
+                                                "ContainerProject"),
+    "ContainerRoute"      => MappableEntity.new("kubernetes:container_route:",
+                                                "ContainerRoute"),
+    "ContainerNode"       => MappableEntity.new("kubernetes:container_node:",
+                                                "ContainerNode"),
+    "ContainerReplicator" => MappableEntity.new("kubernetes:container_replicator:",
+                                                "ContainerReplicator"),
+    "ContainerService"    => MappableEntity.new("kubernetes:container_service:",
+                                                "ContainerService"),
+    "ContainerGroup"      => MappableEntity.new("kubernetes:container_group:",
+                                                "ContainerGroup"),
+    "ContainerBuild"      => MappableEntity.new("kubernetes:container_build:",
+                                                "ContainerBuild"),
   }.freeze
 
   def label_tag_mapping_edit
@@ -77,7 +89,7 @@ module OpsController::Settings::LabelTagMapping
 
   def entity_ui_name_or_all(entity)
     if entity
-      model = MAPPABLE_ENTITIES[entity].second
+      model = MAPPABLE_ENTITIES[entity].model
       ui_lookup(:model => model)
     else
       _("<All>")
@@ -159,7 +171,7 @@ module OpsController::Settings::LabelTagMapping
   end
 
   def label_tag_mapping_add(entity, label_name, cat_description)
-    cat_prefix = MAPPABLE_ENTITIES[entity].first
+    cat_prefix = MAPPABLE_ENTITIES[entity].prefix
     cat_name = cat_prefix + Classification.sanitize_name(label_name.tr("/", ":"))
 
     # UI currently can't allow 2 mappings for same (entity, label).

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -5,31 +5,28 @@ module OpsController::Settings::LabelTagMapping
 
   # TODO: Multi-provider support is hacky:
   # --------------------------------------
-  # Currently we store in labeled_resource_type just the model name, without provider.
-  # It's not even always a model name, sometimes fake string like "Vm" -
+  # Currently we store in labeled_resource_type an arbitrary string that
+  # sometimes looks like a model name, sometimes fake string like "Vm" -
   # all that matters is these strings match what refresh passes to `map_labels`.
   #
   # In any case, this requires different providers use disjoint sets of strings.
-  # This const is arranged as a model => provider hash so we can figure the provider
-  # when editing an existing mapping.
+  # This const is arranged as a hash type => [category prefix, model used for translation].
   MAPPABLE_ENTITIES = {
-    nil                   => nil, # map all entities
-    "Vm"                  => "Amazon",
-    "VmAzure"             => "Azure",
-    "Image"               => "Amazon",
-    "ContainerProject"    => "Kubernetes",
-    "ContainerRoute"      => "Kubernetes",
-    "ContainerNode"       => "Kubernetes",
-    "ContainerReplicator" => "Kubernetes",
-    "ContainerService"    => "Kubernetes",
-    "ContainerGroup"      => "Kubernetes",
-    "ContainerBuild"      => "Kubernetes"
+    # TODO: support per-provider "All Amazon" etc?
+    # Currently we have only global "All".
+    # Global "All" categories are named "kubernetes::..." for backward compatibility.
+    nil                   => ["kubernetes::",                     nil],
+    "Vm"                  => ["amazon:vm:",                       "ManageIQ::Providers::Amazon::CloudManager::Vm"],
+    "VmAzure"             => ["azure:vm:",                        "ManageIQ::Providers::Azure::CloudManager::Vm"],
+    "Image"               => ["amazon:image:",                    "ManageIQ::Providers::Amazon::CloudManager::Template"],
+    "ContainerProject"    => ["kubernetes:container_project:",    "ContainerProject"],
+    "ContainerRoute"      => ["kubernetes:container_route:",      "ContainerRoute"],
+    "ContainerNode"       => ["kubernetes:container_node:",       "ContainerNode"],
+    "ContainerReplicator" => ["kubernetes:container_replicator:", "ContainerReplicator"],
+    "ContainerService"    => ["kubernetes:container_service:",    "ContainerService"],
+    "ContainerGroup"      => ["kubernetes:container_group:",      "ContainerGroup"],
+    "ContainerBuild"      => ["kubernetes:container_build:",      "ContainerBuild"],
   }.freeze
-
-  # TODO: support per-provider "All Amazon" etc?
-  # Currently we have only global "All".  For backward compatibility the categories
-  # are named "kubernetes::..."
-  ALL_PREFIX = 'kubernetes'.freeze
 
   def label_tag_mapping_edit
     case params[:button]
@@ -80,16 +77,7 @@ module OpsController::Settings::LabelTagMapping
 
   def entity_ui_name_or_all(entity)
     if entity
-      provider = MAPPABLE_ENTITIES[entity]
-      model = case entity
-              when 'Vm', 'VmAzure'
-                "ManageIQ::Providers::#{provider}::CloudManager::Vm"
-              when 'Image'
-                "ManageIQ::Providers::#{provider}::CloudManager::Template"
-              else
-                entity
-              end
-
+      model = MAPPABLE_ENTITIES[entity].second
       ui_lookup(:model => model)
     else
       _("<All>")
@@ -171,15 +159,8 @@ module OpsController::Settings::LabelTagMapping
   end
 
   def label_tag_mapping_add(entity, label_name, cat_description)
-    if entity.nil?
-      provider = ALL_PREFIX
-      entity_str = ''
-    else
-      provider = MAPPABLE_ENTITIES[entity].downcase.inquiry
-      entity_str = (provider.azure? && entity.sub(/Azure$/, '') || entity).underscore
-    end
-
-    cat_name = "#{provider}:#{entity_str}:" + Classification.sanitize_name(label_name.tr("/", ":"))
+    cat_prefix = MAPPABLE_ENTITIES[entity].first
+    cat_name = cat_prefix + Classification.sanitize_name(label_name.tr("/", ":"))
 
     # UI currently can't allow 2 mappings for same (entity, label).
     if Classification.find_by_name(cat_name)


### PR DESCRIPTION
Followup to #3697.
`MAPPABLE_ENTITIES` keys were actual model names at some point in the past, but now include arbitrary strings (eg. "Image", "VmAzure").
`MAPPABLE_ENTITIES` values are currently the provider, which helps "compute" 2 things we really need: category prefix, and how to call it in UI — but there are enough exceptions by now that it's cleaner to simply hardcode the actual values than follow the logic...

@miq-bot add-label refactoring