### PR TITLE
CiProcessing specs - stub user for failing retirement specs

### DIFF
--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -853,10 +853,15 @@ end
 
 describe ServiceController do
   context "#vm_button_operation" do
+    let(:user) { FactoryGirl.create(:user_admin) }
+
     before do
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
       allow(MiqServer).to receive(:my_zone).and_return("default")
+      allow(MiqServer).to receive(:my_server) { FactoryGirl.create(:miq_server) }
       controller.instance_variable_set(:@lastaction, "show_list")
+      login_as user
+      allow(user).to receive(:role_allows?).and_return(true)
     end
 
     it "should continue to retire a service and does not render flash message 'xxx does not apply xxx' " do
@@ -905,10 +910,15 @@ end
 
 describe VmOrTemplateController do
   context "#vm_button_operation" do
+    let(:user) { FactoryGirl.create(:user_admin) }
+
     before do
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
       allow(MiqServer).to receive(:my_zone).and_return("default")
+      allow(MiqServer).to receive(:my_server) { FactoryGirl.create(:miq_server) }
       controller.instance_variable_set(:@lastaction, "show_list")
+      login_as user
+      allow(user).to receive(:role_allows?).and_return(true)
     end
 
     it "should render flash message when trying to retire a template" do


### PR DESCRIPTION
Fixes failing travis:

    Failures:
      1) VmOrTemplateController#vm_button_operation should continue to retire a vm
         Failure/Error:
           expect(assigns(:flash_array).first[:message]).to \
             include("Retirement initiated for 1 VM and Instance from the %{product} Database" % {:product => Vmdb::Appliance.PRODUCT_NAME})

           expected "Error during 'retire_now': undefined method `userid' for nil:NilClass" to include "Retirement initiated for 1 VM and Instance from the ManageIQ Database"
         # ./spec/controllers/application_controller/ci_processing_spec.rb:942:in `block (3 levels) in <top (required)>'
      2) ServiceController#vm_button_operation should continue to retire a service and does not render flash message 'xxx does not apply xxx'
         Failure/Error:
           expect(assigns(:flash_array).first[:message]).to \
             include("Retirement initiated for 1 Service from the %{product} Database" % {:product => Vmdb::Appliance.PRODUCT_NAME})

           expected "Error during 'retire_now': undefined method `userid' for nil:NilClass" to include "Retirement initiated for 1 Service from the ManageIQ Database"
         # ./spec/controllers/application_controller/ci_processing_spec.rb:874:in `block (3 levels) in <top (required)>'


Looks like this is related to the recent `make_request` changes in https://github.com/ManageIQ/manageiq/pull/17255 - Cc @d-m-u 