### PR TITLE
Render new dialog runner for all service types.

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -433,26 +433,20 @@ class ServiceController < ApplicationController
         r[:partial => "layouts/x_gtl"]
       end
     )
-    if %w(dialog_provision ownership tag service_tag).include?(action)
+    if %w(ownership tag service_tag).include?(action)
       presenter.show(:form_buttons_div).remove_paging.hide(:toolbar).show(:paging_div)
-      if action == "dialog_provision" && params[:pressed] == "service_reconfigure"
-        presenter.update(:form_buttons_div, r[:partial => "layouts/x_dialog_buttons",
-                                              :locals  => {:action_url => action_url,
-                                                           :record_id  => @edit[:rec_id]}])
+      if %w(tag service_tag).include?(action)
+        locals = {:action_url => action_url}
+        locals[:multi_record] = true  # need save/cancel buttons on edit screen even tho @record.id is not there
+        locals[:record_id]    = @sb[:rec_id] || @edit[:object_ids] && @edit[:object_ids][0]
+      elsif action == "ownership"
+        locals = {:action_url => action_url}
+        locals[:multi_record] = true
+        presenter.update(:form_buttons_div, r[:partial => "layouts/angular/paging_div_buttons"])
       else
-        if %w(tag service_tag).include?(action)
-          locals = {:action_url => action_url}
-          locals[:multi_record] = true  # need save/cancel buttons on edit screen even tho @record.id is not there
-          locals[:record_id]    = @sb[:rec_id] || @edit[:object_ids] && @edit[:object_ids][0]
-        elsif action == "ownership"
-          locals = {:action_url => action_url}
-          locals[:multi_record] = true
-          presenter.update(:form_buttons_div, r[:partial => "layouts/angular/paging_div_buttons"])
-        else
-          locals = {:record_id => @edit[:rec_id], :action_url => action_url}
-        end
-        presenter.update(:form_buttons_div, r[:partial => "layouts/x_edit_buttons", :locals => locals]) unless action == "ownership"
+        locals = {:record_id => @edit[:rec_id], :action_url => action_url}
       end
+      presenter.update(:form_buttons_div, r[:partial => "layouts/x_edit_buttons", :locals => locals]) unless action == "ownership"
     elsif (action != "retire") && (record_showing ||
         (@pages && (@items_per_page == ONE_MILLION || @pages[:items] == 0)))
       # Added so buttons can be turned off even tho div is not being displayed it still pops up Abandon changes box

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -130,6 +130,8 @@ class DialogLocalService
       "miq_template"
     when /InfraManager/
       "ext_management_system"
+    when /ServiceAnsiblePlaybook/
+      "service"
     else
       obj.class.name.demodulize.underscore
     end

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -12,6 +12,7 @@ class DialogLocalService
     InfraManager
     MiqGroup
     Service
+    ServiceAnsiblePlaybook
     Storage
     Template
     Tenant

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -203,6 +203,24 @@ describe DialogLocalService do
       end
     end
 
+    context "when the object is a ServiceAnsiblePlaybook" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ServiceAnsiblePlaybook, :id => 123) }
+
+      it "returns a hash" do
+        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
+          :resource_action_id     => 321,
+          :target_id              => 123,
+          :target_type            => 'service',
+          :dialog_id              => 654,
+          :force_old_dialog_use   => false,
+          :api_submit_endpoint    => "/api/services/123",
+          :api_action             => "custom-button-name",
+          :finish_submit_endpoint => "/service/explorer",
+          :cancel_endpoint        => "/service/explorer"
+        )
+      end
+    end
+
     context "when the object is a Storage" do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Storage, :id => 123) }
 


### PR DESCRIPTION
Also no need to show Save/reset/cancel buttons at the bottom of screen causing double set of buttons on screen, new dialog runner renders it's own form buttons.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1568372

@eclarizio please review/test

before:
Non-Ansible Service
![non-ansible_service_before](https://user-images.githubusercontent.com/3450808/38946352-301ce274-4307-11e8-9598-14f32dddaa0b.png)

Ansible Service
![ansible_service_before](https://user-images.githubusercontent.com/3450808/38946355-322b307a-4307-11e8-8ecc-5b376f158bac.png)

after:
Non-Ansible Service
![non-ansible_service_after](https://user-images.githubusercontent.com/3450808/38946282-fa059a5a-4306-11e8-8f18-704ffe721eeb.png)

Ansible Service
![ansible_service_dialog_after](https://user-images.githubusercontent.com/3450808/38946288-fc816110-4306-11e8-9ccd-a357abc8ab82.png)
