### PR TITLE
Replaced deprecated function

### DIFF
--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -180,6 +180,21 @@ describe NetworkRouterController do
     end
   end
 
+  describe "#delete_network_routers" do
+    let(:ems) { FactoryGirl.create(:ems_openstack).network_manager }
+    let(:router) { FactoryGirl.create(:network_router_openstack, :name => "router-01", :ext_management_system => ems) }
+    before do
+      controller.instance_variable_set(:@_params, :id => router.id)
+      controller.instance_variable_set(:@lastaction, "show")
+      controller.instance_variable_set(:@layout, "network_router")
+    end
+    it "it calls process_network_routers function" do
+      expect(controller).to receive(:process_network_routers).with([NetworkRouter], "destroy")
+
+      controller.send(:delete_network_routers)
+    end
+  end
+
   describe "#delete" do
     before do
       stub_user(:features => :all)


### PR DESCRIPTION
Replaced depricated function `find_id_with_rbac` with `find_records_with_rbac` in network router controller,
added test for delete_network_routers function

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/1134

@romanblanco, @lpichler 