### PR TITLE
Fix selecting ALL filter and changing it to default on Physical Infra

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -195,7 +195,6 @@ module ApplicationController::Filter
     @edit = session[:edit]
     @edit[:selected] = true # Set a flag, this is checked whether to load initial default or clear was clicked
     if id.to_i.zero?
-      @edit[:selected] = false
       clear_selected_search
     else
       load_selected_search(id)


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1567416

---

Fix selecting _ALL_ filter and changing it to _Default_ on _Physical Infra_ page
(in _Compute -> Physical Infrastructure -> Servers_), also on _Hosts_ page.

**Steps to Reproduce:**
1. Go to 
_Compute -> Physical Infrastructure -> Servers_ or
_Compute -> Infrastructure -> Hosts_
2. In accordion, select a filter **other than** the _ALL (Default)_
3. Click on the _Set Default_ button to set the selected filter as Default
4. Click on the _ALL_ filter again
=> nothing happened, previously selected filter remained applied and it was not possible to set _ALL_ back to _ALL (Default)_

Step 4 from steps to reproduce:
![filter_set_all_default](https://user-images.githubusercontent.com/13417815/38986531-f1480d46-43cc-11e8-8582-5c84c5874b04.png)

**Before:**
![filter_before](https://user-images.githubusercontent.com/13417815/38986652-5b1e8934-43cd-11e8-81d5-b8e600bcd327.png)

**After:**
![filter_after](https://user-images.githubusercontent.com/13417815/38986534-f3d5ad02-43cc-11e8-857a-6458fb684aff.png)

---

**Details:**
Removing unnecessary line of the code fixed the bug. The problem was that default search was loaded  (`load_default_search` method) when clicking on ALL filter because `@edit[:selected]` was set to `false`. As I remember, it was me who added the same line to the code some time ago. Adding it was not necessary so I am sure we can remove it.
