### PR TITLE
Adding connections between servers and switches on topology page

### DIFF
--- a/app/assets/stylesheets/topology.css
+++ b/app/assets/stylesheets/topology.css
@@ -118,3 +118,8 @@ kubernetes-topology-icon svg {
   padding: 24px;
   z-index: 100;
 }
+
+line.PhysicalServerPhysicalSwitch {
+  stroke : #3f9c35;
+  stroke-dasharray: 5;
+}

--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -8,6 +8,7 @@ class PhysicalInfraTopologyService < TopologyService
       :writable_classification_tags,
       :physical_servers => [
         :writable_classification_tags,
+        :physical_switches,
         :host => [
           :writable_classification_tags,
           :vms => :writable_classification_tags
@@ -16,6 +17,7 @@ class PhysicalInfraTopologyService < TopologyService
     ],
     :physical_servers  => [
       :writable_classification_tags,
+      :physical_switches,
       :host => [
         :writable_classification_tags,
         :vms => :writable_classification_tags
@@ -72,7 +74,8 @@ class PhysicalInfraTopologyService < TopologyService
 
   # Decide whether or not to add an entity to the graph stack
   def add_to_graph?(entity, links_index, links, parent_id)
-    return true if entity.kind_of?(Tag)
+    return true if entity.kind_of?(Tag) || entity.kind_of?(PhysicalSwitch)
+
     idx = links_index[entity_id(entity)]
     # If a node has already been processed, change its parent rather than pushing to the stack
     if idx


### PR DESCRIPTION
__This PR is able to:__
- Add the connections between physical servers and physical switches on topology;
- In order to distinguish a "contains" relationship from "connection" relationship the line color was setted to green and the style was setted to a dashed line.

![image](https://user-images.githubusercontent.com/8550928/41175177-97cf7816-6b32-11e8-9def-2df9e852f317.png)


__Depends on:__
- ~https://github.com/ManageIQ/manageiq/pull/17311~ Merged
- ~https://github.com/ManageIQ/manageiq-ui-classic/pull/4068~ Merged