### PR TITLE
[FINE] Fix Reset button for tag page in Services

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -283,7 +283,7 @@ class ServiceController < ApplicationController
       partial = "service_form"
       header = _("Editing Service \"%{name}\"") % {:name => @service.name}
       action = "service_edit"
-    when "tag"
+    when "tag", 'service_tag'
       partial = "layouts/tagging"
       header = _("Edit Tags for Service")
       action = "service_tag"
@@ -300,7 +300,7 @@ class ServiceController < ApplicationController
     partial, action_url, @right_cell_text = set_right_cell_vars(action) if action # Set partial name, action and cell header
     get_node_info(x_node) if !@edit && !@in_a_form && !params[:display]
     replace_trees = @replace_trees if @replace_trees  # get_node_info might set this
-    type, = parse_nodetype_and_id(x_node)
+    type, _ = parse_nodetype_and_id(x_node)
     record_showing = type && ["Service"].include?(TreeBuilder.get_model_for_prefix(type))
     if x_active_tree == :svcs_tree && !@in_a_form && !@sb[:action]
       if record_showing && @sb[:action].nil?
@@ -324,8 +324,9 @@ class ServiceController < ApplicationController
     end
 
     # Replace right cell divs
-    presenter.update(:main_div,
-      if ["dialog_provision", "ownership", "retire", "service_edit", "tag"].include?(action)
+    presenter.update(
+      :main_div,
+      if %w(dialog_provision ownership retire service_edit tag service_tag).include?(action)
         r[:partial => partial]
       elsif params[:display]
         r[:partial => 'layouts/x_gtl', :locals => {:controller => "vm", :action_url => @lastaction}]
@@ -336,14 +337,14 @@ class ServiceController < ApplicationController
         r[:partial => "layouts/x_gtl"]
       end
     )
-    if %w(dialog_provision ownership tag).include?(action)
+    if %w(dialog_provision ownership tag service_tag).include?(action)
       presenter.show(:form_buttons_div).hide(:pc_div_1, :toolbar).show(:paging_div)
       if action == "dialog_provision"
         presenter.update(:form_buttons_div, r[:partial => "layouts/x_dialog_buttons",
                                               :locals  => {:action_url => action_url,
                                                            :record_id  => @edit[:rec_id]}])
       else
-        if action == "tag"
+        if %w(tag service_tag).include?(action)
           locals = {:action_url => action_url}
           locals[:multi_record] = true    # need save/cancel buttons on edit screen even tho @record.id is not there
           locals[:record_id]    = @sb[:rec_id] || @edit[:object_ids] && @edit[:object_ids][0]


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1569523
https://bugzilla.redhat.com/show_bug.cgi?id=1569524

**Some related PRs:**
https://github.com/ManageIQ/manageiq-ui-classic/pull/2680
https://github.com/ManageIQ/manageiq-ui-classic/pull/3217

---

Fix _Reset_ button for tag page opened from Service item detail page in _Services
-> My Services_ so that `service_tag` as an action was added to service controller.

---

Tagging edit page before clicking on Reset button:
![service_edit_tags](https://user-images.githubusercontent.com/13417815/39005621-f84fb574-4400-11e8-98fc-da5d68315083.png)

**Before:** (no change in the page)
![service_edit_tags](https://user-images.githubusercontent.com/13417815/39005621-f84fb574-4400-11e8-98fc-da5d68315083.png)

```
[----] I, [2018-04-19T18:42:03.418572 #5304:2af5979d81c4]  INFO -- : Started POST "/service/service_tag/10000000000387?button=reset" for ::1 at 2018-04-19 18:42:03 +0200
[----] I, [2018-04-19T18:42:03.451730 #5304:2af5979d81c4]  INFO -- : Processing by ServiceController#service_tag as JS
[----] I, [2018-04-19T18:42:03.451878 #5304:2af5979d81c4]  INFO -- :   Parameters: {"button"=>"reset", "id"=>"10000000000387"}
[----] W, [2018-04-19T18:42:03.509574 #5304:2af5979d81c4]  WARN -- : DEPRECATION WARNING: Method each_with_object is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7/classes/ActionController/Parameters.html (called from find_checked_items at /home/hstastna/manageiq/fine_branch/manageiq-ui-classic/app/controllers/mixins/checked_id_mixin.rb:17)
[----] I, [2018-04-19T18:42:03.708373 #5304:2af5979d81c4]  INFO -- :   Rendered /home/hstastna/manageiq/fine_branch/manageiq-ui-classic/app/views/service/_svcs_show.html.haml (7.1ms)
[----] F, [2018-04-19T18:42:03.708656 #5304:2af5979d81c4] FATAL -- : Error caught: [ActionView::Template::Error] undefined method `type' for nil:NilClass
/home/hstastna/manageiq/fine_branch/manageiq-ui-classic/app/views/service/_svcs_show.html.haml:6:in `__home_hstastna_manageiq_fine_branch_manageiq_ui_classic_app_views_service__svcs_show_html_haml__3537479409044458971_70232977656260'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/template.rb:159:in `block in render'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/notifications.rb:166:in `instrument'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/template.rb:354:in `instrument'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/template.rb:157:in `render'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/partial_renderer.rb:343:in `render_partial'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/partial_renderer.rb:311:in `block in render'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/notifications.rb:164:in `block in instrument'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/notifications.rb:164:in `instrument'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/partial_renderer.rb:310:in `render'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/renderer.rb:47:in `render_partial'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/renderer.rb:21:in `render'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/rendering.rb:104:in `_render_template'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.7/lib/action_controller/metal/streaming.rb:217:in `_render_template'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/rendering.rb:83:in `render_to_body'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.7/lib/action_controller/metal/rendering.rb:52:in `render_to_body'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.7/lib/action_controller/metal/renderers.rb:142:in `render_to_body'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.7/lib/abstract_controller/rendering.rb:48:in `render_to_string'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.7/lib/action_controller/metal/rendering.rb:41:in `render_to_string'
/home/hstastna/manageiq/fine_branch/manageiq-ui-classic/app/controllers/service_controller.rb:320:in `block in replace_right_cell'
/home/hstastna/manageiq/fine_branch/manageiq-ui-classic/app/controllers/service_controller.rb:333:in `replace_right_cell'
/home/hstastna/manageiq/fine_branch/manageiq-ui-classic/app/controllers/application_controller/tags.rb:155:in `tagging_edit_tags_reset'
/home/hstastna/manageiq/fine_branch/manageiq-ui-classic/app/controllers/application_controller/tags.rb:18:in `tagging_edit'
/home/hstastna/manageiq/fine_branch/manageiq-ui-classic/app/controllers/application_controller/tags.rb:23:in `service_tag'

```

**After:**
![service_after](https://user-images.githubusercontent.com/13417815/39005640-0334f2b0-4401-11e8-9737-e26daec7e8b5.png)
