### PR TITLE
Added setting of `@ems` to fix the nilclass error.

### DIFF
--- a/app/controllers/ems_storage_controller.rb
+++ b/app/controllers/ems_storage_controller.rb
@@ -47,7 +47,7 @@ class EmsStorageController < ApplicationController
   end
 
   def init_show(model_class = self.class.model)
-    @record = identify_record(params[:id], model_class)
+    @ems = @record = identify_record(params[:id], model_class)
 
     return true unless type_feature_role_check
 

--- a/spec/controllers/ems_storage_controller_spec.rb
+++ b/spec/controllers/ems_storage_controller_spec.rb
@@ -32,5 +32,15 @@ describe EmsStorageController do
       controller.instance_variable_set(:@record, object_storage)
       expect(controller.send(:type_feature_role_check)).to be_falsey
     end
+
+    it "sets @ems in init_show for a selected record" do
+      controller.action_name = 'show'
+      ems_storage = FactoryGirl.create(:ems_storage, :name => "foo")
+      allow(controller).to receive(:type_feature_role_check).and_return(true)
+      controller.instance_variable_set(:@_params, :id => ems_storage.id)
+      controller.send(:init_show)
+      expect(assigns(:record).id).to eq(ems_storage.id)
+      expect(assigns(:ems).id).to eq(ems_storage.id)
+    end
   end
 end

--- a/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
+++ b/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
@@ -36,4 +36,24 @@ describe "shared/views/ems_common/show" do
       end
     end
   end
+
+  context "when display is 'cloud_volumes'" do
+    before do
+      allow(controller).to receive(:controller_name).and_return("ems_storage")
+      assign(:record, ems)
+      assign(:ems, ems)
+      assign(:display, display)
+      assign(:showtype, showtype)
+      allow(view).to receive(:render_gtl_outer)
+    end
+
+    let(:showtype) { "main" }
+    let(:display) {'cloud_volumes'}
+    let(:ems) { FactoryGirl.create(:ems_storage, :hostname => '1.1.1.1') }
+
+    it "should show render gtl for list of cloud_volumes" do
+      render
+      expect(view).to render_template(:partial => 'layouts/gtl', :locals => {:action_url => "show/#{ems.id}"})
+    end
+  end
 end


### PR DESCRIPTION
Issue was introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/3341

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1569020

@dclarizio @mzazrivec please review

before:
![before](https://user-images.githubusercontent.com/3450808/39012170-aadf5d22-43e1-11e8-9b79-e10364c52dfb.png)

after:
![after](https://user-images.githubusercontent.com/3450808/39012053-4f30bc78-43e1-11e8-8df6-29cf7934b5c4.png)
