### PR TITLE
[FINE] - Removed specific buttons for Network Routers

### DIFF
--- a/app/helpers/application_helper/toolbar/network_router_center.rb
+++ b/app/helpers/application_helper/toolbar/network_router_center.rb
@@ -13,7 +13,9 @@ class ApplicationHelper::Toolbar::NetworkRouterCenter < ApplicationHelper::Toolb
             'pficon pficon-edit fa-lg',
             t = N_('Edit this Router'),
             t,
-            :url_parms => 'main_div'
+            :url_parms => 'main_div',
+            :klass     => ApplicationHelper::Button::GenericFeatureButtonWithDisable,
+            :options   => {:feature => :update}
           ),
           button(
             :network_router_add_interface,
@@ -39,6 +41,8 @@ class ApplicationHelper::Toolbar::NetworkRouterCenter < ApplicationHelper::Toolb
             t = N_('Delete this Router'),
             t,
             :url_parms => 'main_div',
+            :klass     => ApplicationHelper::Button::GenericFeatureButtonWithDisable,
+            :options   => {:feature => :delete},
             :confirm   => N_('Warning: This Router and ALL of its components will be removed!'),
           )
         ]

--- a/app/helpers/application_helper/toolbar/network_routers_center.rb
+++ b/app/helpers/application_helper/toolbar/network_routers_center.rb
@@ -15,41 +15,6 @@ class ApplicationHelper::Toolbar::NetworkRoutersCenter < ApplicationHelper::Tool
             t,
             :klass => ApplicationHelper::Button::NetworkRouterNew
           ),
-          separator,
-          button(
-            :network_router_edit,
-            'pficon pficon-edit fa-lg',
-            t = N_('Edit selected Router'),
-            t,
-            :url_parms => 'main_div',
-            :enabled   => false,
-            :onwhen    => '1'
-          ),
-          button(
-            :network_router_add_interface,
-            'pficon pficon-edit fa-lg',
-            t = N_('Add Interface to selected Router'),
-            t,
-            :url_parms => "main_div",
-            :enabled   => false,
-            :onwhen    => "1"),
-          button(
-            :network_router_remove_interface,
-            'pficon pficon-edit fa-lg',
-            t = N_('Remove Interface from selected Router'),
-            t,
-            :url_parms => "main_div",
-            :enabled   => false,
-            :onwhen    => "1"),
-          button(
-            :network_router_delete,
-            'pficon pficon-delete fa-lg',
-            t = N_('Delete selected Routers'),
-            t,
-            :url_parms => 'main_div',
-            :confirm   => N_('Warning: The selected Routers and ALL of their components will be removed!'),
-            :enabled   => false,
-            :onwhen    => '1+'),
         ]
       )
     ]


### PR DESCRIPTION
Fine specific PR for changes made in https://github.com/ManageIQ/manageiq-ui-classic/pull/2234

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544488

@Ladas @martinpovolny please review, PR with only specific changes to remove Edit/Delete etc buttons from Network Router(s) screens.