### PR TITLE
[WIP]Show Configuration profiles with no configured systems

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -286,7 +286,7 @@ class ProviderForemanController < ApplicationController
       @no_checkboxes = true
       case @record.type
       when "ManageIQ::Providers::Foreman::ConfigurationManager"
-        options = {:model => "ConfigurationProfile", :match_via_descendants => 'ConfiguredSystem', :named_scope => [[:with_manager, provider.id]]}
+        options = {:model => "ConfigurationProfile", :named_scope => [[:with_manager, provider.id]]}
         @show_list ? process_show_list(options) : options.merge!(update_options)
         unassigned_profiles = add_unassigned_configuration_profile_record(provider.id)
         options.merge!(unassigned_profiles) unless unassigned_profiles.nil?

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -144,7 +144,7 @@ class ProviderForemanController < ApplicationController
     when "cp", "cs" then ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem
     when "xx"       then
       case nodes.second
-      when "fr" then ManageIQ::Providers::ConfigurationManager
+      when "fr" then ManageIQ::Providers::Foreman::ConfigurationManager::ConfigurationProfile
       when "csf" then ConfiguredSystem
       end
     else

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -36,7 +36,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
     assigned_configuration_profile_objs =
       count_only_or_objects_filtered(count_only,
                                      ConfigurationProfile.where(:manager_id => object[:id]),
-                                     "name", :match_via_descendants => ConfiguredSystem)
+                                     "name")
     unassigned_configuration_profile_objs =
       fetch_unassigned_configuration_profile_objects(count_only, object[:id])
 

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -443,10 +443,9 @@ describe ProviderForemanController do
       controller.instance_variable_set(:@_params, :id => ems_key_for_provider(@provider))
       allow(controller).to receive(:build_listnav_search_list)
       allow(controller).to receive(:apply_node_search_text)
-      expect(controller).to receive(:get_view).with("ConfigurationProfile", :match_via_descendants => "ConfiguredSystem",
-                                                                            :named_scope           => [[:with_manager, ems_id]],
-                                                                            :dbname                => :cm_configuration_profiles,
-                                                                            :gtl_dbname            => :cm_configuration_profiles).and_call_original
+      expect(controller).to receive(:get_view).with("ConfigurationProfile", :named_scope => [[:with_manager, ems_id]],
+                                                                            :dbname      => :cm_configuration_profiles,
+                                                                            :gtl_dbname  => :cm_configuration_profiles).and_call_original
       controller.send(:tree_select)
     end
 


### PR DESCRIPTION
Show Configuration profiles with no configured systems

Links 
-----------
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1502031

-------------------------------

After:
![screenshot from 2018-04-20 14-09-24](https://user-images.githubusercontent.com/12769982/39066846-89b26d6a-44a4-11e8-8818-91c2f9288989.png)

