### PR TITLE
Fixes Service Catalog Item Custom subtype display

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -52,7 +52,7 @@
             %label.col-md-3.control-label
               = _('Subtype')
             .col-md-9
-              = h(ServiceTemplate::GENERIC_ITEM_SUBTYPES[@record[:generic_subtype]])
+              = h(ServiceTemplate::GENERIC_ITEM_SUBTYPES[@record[:generic_subtype]] || "Custom")
         - if @record.prov_type == "generic_orchestration"
           .form-group
             %label.col-md-3.control-label


### PR DESCRIPTION
Fixes default display of "Custom" Service Catalog Item Subtype when value is not set upon creation/edit.

https://bugzilla.redhat.com/show_bug.cgi?id=1568471

Screen shot post code fix:
<img width="1424" alt="catalog item with custom subtype post code fix" src="https://user-images.githubusercontent.com/552686/39021938-0a0712ee-43e8-11e8-8161-32908903ba81.png">
