### PR TITLE
[FINE] Add an optional argument for handling RBAC based on a boolean value

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1035,8 +1035,8 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def handle_generic_rbac
-    pass = check_generic_rbac
+  def handle_generic_rbac(result = nil)
+    pass = result ? result : check_generic_rbac
     unless pass
       if request.xml_http_request?
         javascript_redirect :controller => 'dashboard', :action => 'auth_error'


### PR DESCRIPTION
@simaishi you pinged me a few days ago because of the [failing `fine` branch](https://github.com/ManageIQ/manageiq-ui-classic/pull/3728#issuecomment-382488115). I don't know how the tests and my eyes did not caught this earlier :disappointed: sorry for that. Basically the `gaprindashvili` branch already has this extra argument and without it the RBAC handlig for the help menu just fails with an exception.

@miq-bot add_label bug

https://bugzilla.redhat.com/show_bug.cgi?id=1569171