### PR TITLE
Chart tooltips should match table

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1599,6 +1599,7 @@ function chartData(type, data, data2) {
   // set formating function for tooltip and y tick labels
   if (validateChartAxis(data.axis)) {
     var format = data.axis.y.tick.format;
+    var titleFormat = _.cloneDeep(format);
     var max = _.max(getChartColumnDataValues(data.data.columns));
     var min = _.min(getChartColumnDataValues(data.data.columns));
     var maxShowed = getChartFormatedValue(format, max);
@@ -1619,7 +1620,6 @@ function chartData(type, data, data2) {
       onclick: recalculateChartYAxisLabels,
     };
 
-    var titleFormat = _.cloneDeep(format);
     data.tooltip.format.value = function(value, _ratio, _id) {
       var formatFunction = ManageIQ.charts.formatters[titleFormat.function].c3(titleFormat.options);
       return formatFunction(value);


### PR DESCRIPTION
Chart tooltips should match table. It is not 100% fix, but it should work most of the time. And it should help identify broken cases. When values in the table are not consistent within themselves, they can't be consistent with chart tooltip.   

Screenshot
----------------
Before:
![screenshot from 2018-04-20 13-50-17](https://user-images.githubusercontent.com/9535558/39049487-eccc36e0-44a1-11e8-9211-e5274a362bda.png)


After:
![screenshot from 2018-04-20 13-40-39](https://user-images.githubusercontent.com/9535558/39049148-877ebdf4-44a0-11e8-8e7c-60416506c1c6.png)


Links
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1564136

Steps for Testing/QA
-------------------------------

Enable C&U data collection in Configuration.
Select some Host/Vm/whatever with C&U data
Monitoring -> Utilization -> Click on Magnifying glass -> Compare Tooltip value to table
Repeat for different entity
