### PR TITLE
Use fonticons for alert profile folders

### DIFF
--- a/app/views/miq_policy/_alert_profile_folders.html.haml
+++ b/app/views/miq_policy/_alert_profile_folders.html.haml
@@ -7,7 +7,7 @@
           %tr{:title => _("Open Folder"),
             :onclick => "miqTreeActivateNode('alert_profile_tree', 'xx-#{f.last}');"}
             %td.table-view-pf-select
-              %img{:src => image_path("100/#{f.last.underscore.downcase}.png")}
+              %i{:class => f.last.constantize.decorate.fonticon}
             %td
               = f.first
               &nbsp;


### PR DESCRIPTION
@epwinchell noticed that [some fileicons](https://github.com/ManageIQ/manageiq-ui-classic/pull/3794#issuecomment-382752700) are still being used on the alert profiles screen. Converting those to fileicons, they are located under `Automate -> Explorer -> Alert Profiles`

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label graphics, refactoring, gaprindashvili/no