### PR TITLE
Remove unnecessary template-no-host image and its only reference

### DIFF
--- a/app/assets/images/svg/currentstate-template-no-host.svg
+++ b/app/assets/images/svg/currentstate-template-no-host.svg
@@ -1,1 +1,0 @@
-currentstate-template.svg

--- a/app/helpers/textual_mixins/textual_power_state.rb
+++ b/app/helpers/textual_mixins/textual_power_state.rb
@@ -3,7 +3,7 @@ module TextualMixins::TextualPowerState
     state = @record.current_state.downcase
     state = "unknown" if state.blank?
     h = {:label => _("Power State"), :value => state}
-    h[:image] = "svg/currentstate-#{@record.template? ? (@record.host ? "template" : "template-no-host") : state}.svg"
+    h[:image] = "svg/currentstate-#{@record.template? ? 'template' : state}.svg"
     h
   end
 end


### PR DESCRIPTION
It's a symlink to the `template` and so it's not necessary at all.

@miq-bot add_label refactoring, gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 