### PR TITLE
Fix title in Config Settings page to match the accordion

### DIFF
--- a/app/controllers/ops_controller/settings.rb
+++ b/app/controllers/ops_controller/settings.rb
@@ -135,8 +135,9 @@ module OpsController::Settings
 
   def region_edit
     settings_set_view_vars
-    @right_cell_text = _("Settings Region \"%{name}\"") %
-                       {:name => "#{MiqRegion.my_region.description} [#{MiqRegion.my_region.region}]"}
+    @right_cell_text = _("%{product} Region \"%{name}\"") %
+                       {:name    => "#{MiqRegion.my_region.description} [#{MiqRegion.my_region.region}]",
+                        :product => Vmdb::Appliance.PRODUCT_NAME}
     case params[:button]
     when "cancel"
       session[:edit] = @edit = nil

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1109,8 +1109,9 @@ module OpsController::Settings::Common
     nodes = nodetype.downcase.split("-")
     case nodes[0]
     when "root"
-      @right_cell_text = _("Settings Region \"%{name}\"") %
-                         {:name => "#{MiqRegion.my_region.description} [#{MiqRegion.my_region.region}]"}
+      @right_cell_text = _("%{product} Region \"%{name}\"") %
+                         {:name    => "#{MiqRegion.my_region.description} [#{MiqRegion.my_region.region}]",
+                          :product => Vmdb::Appliance.PRODUCT_NAME}
       case @sb[:active_tab]
       when "settings_details"
         settings_set_view_vars


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1512443

---

Fix the title in the _Configuration > Settings_ page when selecting _ManageIQ Region_ (or _CFME Region_) in accordion, to match the name in the accordion.

**Before:**
![region_before1](https://user-images.githubusercontent.com/13417815/39060406-9039a5aa-44c1-11e8-861f-0d5696034574.png)

Editing the region (after clicking on _Region10[10]_ in the list, under the title):
![region_before2](https://user-images.githubusercontent.com/13417815/39060411-92ba0f22-44c1-11e8-9929-f466abc6a859.png)

**After:**
![region_after1](https://user-images.githubusercontent.com/13417815/39059350-90d1b46a-44be-11e8-8e6e-16a382938abb.png)

Editing the region:
![region_after2](https://user-images.githubusercontent.com/13417815/39059496-f6a36e82-44be-11e8-860d-ea7e1b049654.png)

---

**Why I fixed this the way I fixed it:**
See https://github.com/hstastna/manageiq-ui-classic/blob/master/app/presenters/tree_builder_ops_settings.rb#L18, especially the` product`.