### PR TITLE
Renames network method according to label at physical server summary page

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -44,7 +44,7 @@ class PhysicalServerController < ApplicationController
 
   def textual_group_list
     [
-      %i(properties networks relationships),
+      %i(properties management_networks relationships),
       %i(power_management firmware_compliance firmware_details asset_details smart_management),
     ]
   end

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module PhysicalServerHelper::TextualSummary
     )
   end
 
-  def textual_group_networks
+  def textual_group_management_networks
     TextualGroup.new(_("Management Networks"), %i(mac ipv4 ipv6))
   end
 


### PR DESCRIPTION
In order to keep the conventions, I just renamed a method in the physical server summary page according to the updated label.