### PR TITLE
[WIP] Specify rubocop version when running in the scrutinizer environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,8 @@ else
   puts "  Clone it from GitHub or symlink it from local source."
   exit 1
 end
+
+# Fixes scrutinizer issues caused by a too new rubocop version
+if ENV['SCRUTINIZER']
+  gem "rubocop", "~>0.52.1"
+end


### PR DESCRIPTION
When creating a PR, Scrutinizer fails with the following error:
```
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use 
`Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
```
This is caused by a too new version of rubocop running in their environment by default.