### PR TITLE
Fixed disabled report editor treeview styling regression

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -978,7 +978,7 @@ img.tiny {
   width: 180px;
 }
 
-.sidebar-disabled {
+.sidebar-disabled, .treeview.disabled {
   pointer-events: none;
   opacity: 0.4;
 }
@@ -1000,7 +1000,6 @@ img.tiny {
 #exp_editor_div .form-group{
   margin-left: 0
 }
- 
 
 /// ===================================================================
 /// end misc styling


### PR DESCRIPTION
The `disabled` class is being properly added to the treeview when necessary, it was just not backed by any styling. You can find this screen under `Cloud Intelligence -> Reports -> Edit Reports Menu` by selecting a group in the left side treeview and then any element in the right side tree.

**Before:**
![screenshot from 2018-04-23 13-10-38](https://user-images.githubusercontent.com/649130/39123328-d283b5e4-46f7-11e8-9d27-de4d24d6b63c.png)

**After:**
![screenshot from 2018-04-23 13-09-57](https://user-images.githubusercontent.com/649130/39123315-ce837646-46f7-11e8-8b17-198fa24a89d9.png)

@miq-bot add_label bug, graphics
@miq-bot add_reviewer @epwinchell

https://bugzilla.redhat.com/show_bug.cgi?id=1550641