### PR TITLE
[WIP] Fix redirecting Copy operation to creating new Time Profile

### DIFF
--- a/app/views/configuration/_timeprofile_form.html.haml
+++ b/app/views/configuration/_timeprofile_form.html.haml
@@ -223,5 +223,5 @@
             %td= r.title
 
 :javascript
-  ManageIQ.angular.app.value('timeProfileFormId', '#{@timeprofile.id || "new"}');
+  ManageIQ.angular.app.value('timeProfileFormId', '#{params[:id] || "new"}');
   miq_bootstrap('#form_div');


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1524352

---

Fix redirecting _Copy selected Time Profile_ operation to creating new Time Profile in _My Settings > Time Profiles_ by fixing the parameter which represents an existing Time Profile **id**.

TODO:
- find other solution (this is WIP because I've found that this was not a good solution)

**Before:**

**After:**

---

**Details:**
`@timeprofile.id` is `nil` when copying an existing Time Profile and this is why the bug occurred. It is not `nil` only when editing the profile. And that is ok, we just edit the existing profile, so we already know the id, the profile already exists. BUT if we copy the profile, we create **a new** profile, with some similar data as the original profile, so it is obvious that `@timeprofile.id` will be `nil`. We don't know the new id of new profile yet. We create a new profile. BUT if we don't know the id of original profile when copying the profile, we don't know the original data, so then `timeProfileFormId` will be set to `'new'` and we will see blank forms and everything set the same way as we wanted to create a completely new profile. Fortunately, `params[:id]` always has the right id, when copying and also when editing the profile.