### PR TITLE
Add support for displaying storage device details

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -10,11 +10,15 @@ class PhysicalServerController < ApplicationController
   after_action :set_session_data
 
   def self.display_methods
-    %w(guest_devices)
+    %w(network_devices storage_devices)
   end
 
-  def display_guest_devices
-    nested_list(GuestDevice, :named_scope => :with_ethernet_type)
+  def display_network_devices
+    nested_list(GuestDevice, :named_scope => :with_ethernet_type, :breadcrumb_title => _("Network Devices"))
+  end
+
+  def display_storage_devices
+    nested_list(GuestDevice, :named_scope => :with_storage_type, :breadcrumb_title => _("Storage Devices"))
   end
 
   def self.table_name

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -2,7 +2,7 @@ module PhysicalServerHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i(name model product_name manufacturer machine_type serial_number ems_ref capacity memory cores network_devices health_state loc_led_state)
+      %i(name model product_name manufacturer machine_type serial_number ems_ref capacity memory cores network_devices storage_devices health_state loc_led_state)
     )
   end
 
@@ -166,7 +166,16 @@ module PhysicalServerHelper::TextualSummary
     hardware_nics_count = @record.hardware.nics.count
     device = {:label => _("Network Devices"), :value => hardware_nics_count, :icon => "ff ff-network-card"}
     if hardware_nics_count.positive?
-      device[:link] = "/physical_server/show/#{@record.id}?display=guest_devices"
+      device[:link] = "/physical_server/show/#{@record.id}?display=network_devices"
+    end
+    device
+  end
+
+  def textual_storage_devices
+    storage_devices_count = @record.hardware.storage_adapters.count
+    device = {:label => _("Storage Devices"), :value => storage_devices_count, :icon => "ff ff-network-card"}
+    if storage_devices_count.positive?
+      device[:link] = "/physical_server/show/#{@record.id}?display=storage_devices"
     end
     device
   end

--- a/app/views/physical_server/show.html.haml
+++ b/app/views/physical_server/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(guest_devices physical_servers).include?(@display)
+  - if %w(network_devices physical_servers storage_devices).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
     - case @showtype

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -62,9 +62,18 @@ describe PhysicalServerController do
       end
     end
 
-    context "display=guest_devices" do
+    context "display=network_devices" do
       it do
-        post :show, :params => {:id => @physical_server.id, :display => "guest_devices"}
+        post :show, :params => {:id => @physical_server.id, :display => "network_devices"}
+        expect(response.status).to eq 200
+        is_expected.to render_template(:partial => "layouts/_gtl")
+        expect(controller.send(:flash_errors?)).to be_falsey
+      end
+    end
+
+    context "display=storage_devices" do
+      it do
+        post :show, :params => {:id => @physical_server.id, :display => "storage_devices"}
         expect(response.status).to eq 200
         is_expected.to render_template(:partial => "layouts/_gtl")
         expect(controller.send(:flash_errors?)).to be_falsey


### PR DESCRIPTION
This PR adds support for displaying details about storage devices associated with physical servers. A link displaying the number of storage devices associated with a server will be displayed on the Physical Server Summary page. Clicking on this link will take the user to a page that displays a list of a server's storage devices. Clicking on one of these devices takes the user to the Storage Device Summary page for that device.

![image](https://user-images.githubusercontent.com/23690141/39144867-18f74b28-4700-11e8-9024-2090303261d0.png)

![image](https://user-images.githubusercontent.com/23690141/39144918-34a04c08-4700-11e8-8620-1d2095219b7a.png)

![image](https://user-images.githubusercontent.com/23690141/39144975-56910d84-4700-11e8-8f49-d3aba404b9b8.png)

This PR depends on https://github.com/ManageIQ/manageiq/pull/17332