### PR TITLE
Add reporting session threshold options for logging

### DIFF
--- a/app/controllers/application_controller/session_size.rb
+++ b/app/controllers/application_controller/session_size.rb
@@ -1,16 +1,6 @@
 module ApplicationController::SessionSize
   extend ActiveSupport::Concern
 
-  # Session data size logging constants
-  case Rails.env
-  when "test", "development"
-    SESSION_LOG_THRESHOLD = 50.kilobytes
-    SESSION_ELEMENT_THRESHOLD = 5.kilobytes
-  else
-    SESSION_LOG_THRESHOLD = 100.kilobytes
-    SESSION_ELEMENT_THRESHOLD = 10.kilobytes
-  end
-
   # Check for session threshold limits and write log messages if exceeded
   def get_data_size(data, indent = 0)
     begin
@@ -23,13 +13,13 @@ module ApplicationController::SessionSize
 
     if indent.zero?
       puts "Session:\t #{data.class.name} of Size #{data_size}, Elements #{data.size}\n=================================" if Rails.env.development?
-      return if data_size < SESSION_LOG_THRESHOLD
+      return if data_size < ::Settings.session.log_threshold.to_i_with_method
 
-      msg = format_log_message("Session object size of #{number_to_human_size(data_size)} exceeds threshold of #{number_to_human_size(SESSION_LOG_THRESHOLD)}")
+      msg = format_log_message("Session object size of #{number_to_human_size(data_size)} exceeds threshold of #{number_to_human_size(::Settings.session.log_threshold.to_i_with_method)}")
       Rails.env.development? ? puts(msg) : $log.warn(msg)
     end
 
-    return unless data_size > SESSION_ELEMENT_THRESHOLD
+    return unless data_size > ::Settings.session.element_threshold.to_i_with_method
 
     deep_visit_data(data, :get_data_size, indent)
   end


### PR DESCRIPTION
Replace hard-coded SESSION_LOG_THRESHOLD and SESSION_ELEMENT_THRESHOLD
with settings that can be configured by a user.

For organizations where reports contain potentially thousands of email addresses, overcoming the default 100kb limit is easy, and warning messages are displayed like so for every report:
```
MIQ(report_controller-x_button): Session object size of 182.9 KB exceeds threshold of 100 KB
```

This PR replaces the hard-coded default of 100kb to a configurable parameter (also defaulting at 100kb).  That makes this PR reliant on the configuration change in this PR against the core repo:

https://github.com/ManageIQ/manageiq/pull/17334