### PR TITLE
Rebuild provider foreman tree after editing a provider

### DIFF
--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -55,7 +55,7 @@ module Mixins
         else
           add_flash(_("%{model} \"%{name}\" was updated") % {:model => model, :name => @provider.name})
         end
-        replace_right_cell
+        replace_right_cell(:replace_trees => [x_active_accord])
       else
         @provider.errors.each do |field, msg|
           @sb[:action] = nil

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -226,11 +226,11 @@ class ProviderForemanController < ApplicationController
   end
 
   def build_configuration_manager_providers_tree(_type)
-    TreeBuilderConfigurationManager.new(:configuration_manager_providers, :configuration_manager_providers_tree, @sb)
+    TreeBuilderConfigurationManager.new(:configuration_manager_providers_tree, :configuration_manager_providers, @sb)
   end
 
   def build_configuration_manager_cs_filter_tree(_type)
-    TreeBuilderConfigurationManagerConfiguredSystems.new(:configuration_manager_cs_filter, :configuration_manager_cs_filter_tree, @sb)
+    TreeBuilderConfigurationManagerConfiguredSystems.new(:configuration_manager_cs_filter_tree, :configuration_manager_cs_filter, @sb)
   end
 
   def get_node_info(treenodeid, show_list = true)


### PR DESCRIPTION
When changing the name of a configuration management provider, it is not being reflected in the left side tree until a full page refresh. The issue was caused by a missing `:replace_trees` argument. Also the `tree_id` and `tree_name` arguments were swapped in `build_configuration_manager_providers_tree` so it was not able to reload the tree even if it was rebuilt properly.

@miq-bot add_label bug
@miq-bot add_reviewer lgalis
@miq-bot assign @martinpovolny 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1560679