### PR TITLE
Remove memory chart for Amazon Availability Zones

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -867,6 +867,7 @@ module ApplicationController::Performance
                   end
 
     chart_layout = perf_get_chart_layout(layout_name, @perf_options[:model])
+    perf_filter_charts(chart_layout, rpt)
 
     if @perf_options[:index]
       chart_index = @perf_options[:index].to_i
@@ -1295,6 +1296,7 @@ module ApplicationController::Performance
     case perf_options[:typ]
     when "Hourly"
       chart_layout = perf_get_chart_layout("hourly_perf_charts", model_title)
+      perf_filter_charts(chart_layout, rpt)
       if perf_options[:index]
         chart = chart_layout[perf_options[:index].to_i]
         perf_remove_chart_cols(chart)
@@ -1324,6 +1326,7 @@ module ApplicationController::Performance
       end
     when "realtime"
       chart_layout = perf_get_chart_layout("realtime_perf_charts", model_title)
+      perf_filter_charts(chart_layout, rpt)
       if perf_options[:index]
         chart = chart_layout[perf_options[:index].to_i]
         perf_remove_chart_cols(chart)
@@ -1352,6 +1355,7 @@ module ApplicationController::Performance
       end
     when "Daily"
       chart_layout = perf_get_chart_layout("daily_perf_charts", model_title)
+      perf_filter_charts(chart_layout, rpt)
       if perf_options[:index]
         chart = chart_layout[perf_options[:index].to_i]
         if chart
@@ -1565,6 +1569,19 @@ module ApplicationController::Performance
       end
     end
     new_rpt
+  end
+
+  # Deletes memory chart from chart_layout, if it is a chart for Amazon Availability Zone
+  # rpt.where_clause[0] should be query string
+  # rpt.where_clause[1] should be model name string
+  # rpt.where_clause[2] should be id
+  def perf_filter_charts(chart_layout, rpt)
+    return unless rpt&.where_clause
+    model = rpt.where_clause[1].constantize
+    id = rpt.where_clause[2]
+    if model.find(id).type == "ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone"
+      chart_layout.reject! { |chart| chart[:title].include?("Memory") }
+    end
   end
 
   def process_chart_trends(chart, rpt, options)


### PR DESCRIPTION
Remove memory chart for Amazon Availability Zones.

Screenshots
-------------------------------

### Amazon
![screencapture-localhost-3000-availability_zone-show-10000000000005-2018-04-24-15_50_44](https://user-images.githubusercontent.com/9535558/39191842-1d75ce3a-47d8-11e8-97a1-15c6b006b734.png)
![screencapture-localhost-3000-availability_zone-show-10000000000005-2018-04-24-15_50_09 2](https://user-images.githubusercontent.com/9535558/39191847-1eb0f798-47d8-11e8-9217-5cf3cccefd01.png)

![screencapture-localhost-3000-availability_zone-show-10000000000005-2018-04-24-16_10_09](https://user-images.githubusercontent.com/9535558/39192642-f1977bfe-47d9-11e8-9ac5-22a031a4bc13.png)

### Azure(and others)

![screencapture-localhost-3000-availability_zone-show-10000000000032-2018-04-24-16_06_36](https://user-images.githubusercontent.com/9535558/39192491-900051cc-47d9-11e8-94d8-2715ad425750.png)

![screencapture-localhost-3000-availability_zone-show-10000000000032-2018-04-24-16_06_51](https://user-images.githubusercontent.com/9535558/39192487-8ee36964-47d9-11e8-973e-337f2f30cb2f.png)

![screencapture-localhost-3000-availability_zone-show-10000000000032-2018-04-24-16_07_08](https://user-images.githubusercontent.com/9535558/39192485-8da846dc-47d9-11e8-85f5-cdae657d8142.png)

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1441326

Steps for Testing/QA
-------------------------------
Compute -> Cloud -> Availability Zones -> Monitoring -> Utilization -> Test it for Amazon and other types

