### PR TITLE
Remove Search from Switch summary page

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -584,7 +584,7 @@ class InfraNetworkingController < ApplicationController
   end
 
   def display_adv_searchbox
-    !(@infra_networking_record || @in_a_form)
+    !(@infra_networking_record || @in_a_form || @nodetype == 'sw')
   end
 
   def breadcrumb_name(_model)


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1428584

---

Remove _Search_ from **Switch summary page** accessed by clicking on some Switch from the list under _Compute > Infra > Networking > Switches_ accordion.

**Before:**
![switch_before](https://user-images.githubusercontent.com/13417815/39197067-ea610274-47e3-11e8-87f2-3e68cb0608bc.png)

**After:**
![switch_after](https://user-images.githubusercontent.com/13417815/39196886-802ce580-47e3-11e8-9b19-9b827b63cf3e.png)

**Details:**
The BZ is fixed simply by hiding _Search_, in infra networking controller, when displaying the Switch details page and setting visibility of Search here: https://github.com/ManageIQ/manageiq-ui-classic/pull/3838/files#diff-0e2f6e9cd3d08a0294024651f1726172R576. And `@nodetype` is always set in `get_node_info`, before setting visibility of Search, according to type of the actual node in the tree.
