### PR TITLE
Disable credential / repository form when embedded ansible is unavailable

### DIFF
--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -145,7 +145,12 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
   }
 
   function setManagerResource(response) {
-    vm.credentialModel.manager_resource = { "href": response.resources[0].href };
+    if (response.resources.length > 0) {
+      vm.credentialModel.manager_resource = { "href": response.resources[0].href };
+    } else {
+      vm.credentialModel.manager_resource = null;
+      miqService.miqFlash('error', __('Embedded Ansible service is not available.'));
+    }
   }
 
   init();

--- a/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_repository/repository_form_controller.js
@@ -125,6 +125,7 @@ ManageIQ.angular.app.controller('repositoryFormController', ['repositoryId', 'mi
 
   var getManagerResource = function(response) {
     if (!response.resources.length) {
+      vm.repositoryModel.manager_resource = null;
       miqService.miqFlash('error', __('Embedded Ansible Provider not found.'));
     } else {
       vm.repositoryModel.manager_resource = {'href': response.resources[0].href};

--- a/app/views/ansible_credential/_credential_form.html.haml
+++ b/app/views/ansible_credential/_credential_form.html.haml
@@ -14,13 +14,14 @@
       %label.col-md-2.control-label
         = _('Name')
       .col-md-8
-        %input.form-control{:type        => "text",
-                            :name        => "name",
-                            "id"         => "name",
-                            'ng-model'   => "vm.credentialModel.name",
-                            :maxlength   => ViewHelper::MAX_NAME_LEN,
-                            :required    => true,
-                            "auto-focus" => ""}
+        %input.form-control{:type         => "text",
+                            :name         => "name",
+                            "id"          => "name",
+                            'ng-model'    => "vm.credentialModel.name",
+                            :maxlength    => ViewHelper::MAX_NAME_LEN,
+                            :required     => true,
+                            'ng-disabled' => 'vm.credentialModel.manager_resource === null',
+                            "auto-focus"  => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
     .form-group
@@ -28,11 +29,12 @@
         = _('Credential type')
       - if @id == 'new' # we don't allow changing auth. type when editing a resource
         .col-md-8
-          %select{'ng-model'   => 'vm.credentialModel.type',
-                  'ng-options' => 'cred.value as cred.label for cred in vm.select_options',
-                  'id'         => 'type',
-                  'required'   => 'true',
-                  'pf-select'  => 'true'}
+          %select{'ng-model'    => 'vm.credentialModel.type',
+                  'ng-options'  => 'cred.value as cred.label for cred in vm.select_options',
+                  'id'          => 'type',
+                  'ng-disabled' => 'vm.credentialModel.manager_resource === null',
+                  'required'    => 'true',
+                  'pf-select'   => 'true'}
       - else
         .col-md-8
           {{ vm.credential_options[vm.credentialModel.type].label }}

--- a/app/views/ansible_repository/_repository_form.html.haml
+++ b/app/views/ansible_repository/_repository_form.html.haml
@@ -15,22 +15,24 @@
       %label.col-md-2.control-label
         = _('Name')
       .col-md-8
-        %input.form-control{:type          => "text",
-                            :name        => "name",
-                            "id"         => "name",
-                            'ng-model'   => "vm.repositoryModel.name",
-                            :maxlength   => ViewHelper::MAX_NAME_LEN,
-                            :required    => ""}
+        %input.form-control{:type         => "text",
+                            :name         => "name",
+                            "id"          => "name",
+                            'ng-model'    => "vm.repositoryModel.name",
+                            'ng-disabled' => 'vm.repositoryModel.manager_resource === null',
+                            :maxlength    => ViewHelper::MAX_NAME_LEN,
+                            :required     => ""}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
     .form-group
       %label.col-md-2.control-label
         = _('Description')
       .col-md-8
-        %input.form-control{:type        => "text",
-                            :name        => "description",
-                            "id"         => "description",
-                            'ng-model'   => "vm.repositoryModel.description"}
+        %input.form-control{:type         => "text",
+                            :name         => "description",
+                            "id"          => "description",
+                            'ng-disabled' => 'vm.repositoryModel.manager_resource === null',
+                            'ng-model'    => "vm.repositoryModel.description"}
     .form-group
       %label.col-md-2.control-label
         = _('SCM type')
@@ -49,6 +51,7 @@
                             :id              => "scm_url",
                             'ng-model'       => "vm.repositoryModel.scm_url",
                             :required        => "",
+                            'ng-disabled'    => 'vm.repositoryModel.manager_resource === null',
                             'url-validation' => true}
         %span.help-block{"ng-show" => "angularForm.scm_url.$error.required"}
           = _("Required")
@@ -58,33 +61,35 @@
       %label.col-md-2.control-label
         = _('SCM credentials')
       .col-md-8
-        %select{'name'       => 'authentication_id',
-                'ng-model'   => 'vm.repositoryModel.authentication_id',
-                'ng-options' => 'scm_credential.value as scm_credential.name for scm_credential in vm.scm_credentials',
-                'pf-select'  => true}
+        %select{'name'        => 'authentication_id',
+                'ng-model'    => 'vm.repositoryModel.authentication_id',
+                'ng-options'  => 'scm_credential.value as scm_credential.name for scm_credential in vm.scm_credentials',
+                'ng-disabled' => 'vm.repositoryModel.manager_resource === null',
+                'pf-select'   => true}
     .form-group
       %label.col-md-2.control-label
         = _('SCM Branch')
       .col-md-8
-        %input.form-control{:type        => "text",
-                            :name        => "scm_branch",
-                            "id"         => "scm_branch",
-                            'ng-model'   => "vm.repositoryModel.scm_branch"}
+        %input.form-control{:type         => "text",
+                            :name         => "scm_branch",
+                            "id"          => "scm_branch",
+                            'ng-disabled' => 'vm.repositoryModel.manager_resource === null',
+                            'ng-model'    => "vm.repositoryModel.scm_branch"}
     .form-group
       %label.col-md-2.control-label
         = _('SCM Update Options')
       .col-md-8
         %div
           %label
-            = check_box_tag("clean", "1", false, 'ng-model' => "vm.repositoryModel.scm_clean")
+            = check_box_tag("clean", "1", false, 'ng-model' => "vm.repositoryModel.scm_clean", 'ng-disabled' => 'vm.repositoryModel.manager_resource === null')
             = _('Clean')
         %div
           %label
-            = check_box_tag("scm_delete_on_update", "1", false, 'ng-model' => 'vm.repositoryModel.scm_delete_on_update')
+            = check_box_tag("scm_delete_on_update", "1", false, 'ng-model' => 'vm.repositoryModel.scm_delete_on_update', 'ng-disabled' => 'vm.repositoryModel.manager_resource === null')
             = _('Delete on Update')
         %div
           %label
-            = check_box_tag("scm_update_on_launch", "1", false, 'ng-model' => 'vm.repositoryModel.scm_update_on_launch')
+            = check_box_tag("scm_update_on_launch", "1", false, 'ng-model' => 'vm.repositoryModel.scm_update_on_launch', 'ng-disabled' => 'vm.repositoryModel.manager_resource === null')
             = _('Update on Launch')
     = render :partial => 'layouts/angular/generic_form_buttons'
 :javascript


### PR DESCRIPTION
1. Create a new role, new group using that role and a new user using that group
2. Set the group restriction to one specific tag (edit the newly created group, assign filters, select one tag)
3. With the new user, navigate to Automation -> Ansible -> Credentials
4. Click on Add new Credential

Before:
![ansible-before](https://user-images.githubusercontent.com/6648365/39239455-3bf531d0-4881-11e8-8aa4-7f6e7dc13ac0.jpg)

After:
![ansible-after](https://user-images.githubusercontent.com/6648365/39239459-3f51ad90-4881-11e8-8f46-fc84bbcec43a.jpg)

I also disabled the repository inputs for similar case.

@himdel review please?

https://bugzilla.redhat.com/show_bug.cgi?id=1560527