### PR TITLE
[WIP] Fix error when clicking on VMs/Templates tab, after Chargeback Preview

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1118,7 +1118,8 @@ module VmCommon
     refresh_breadcrumbs = true unless options.key?(:refresh_breadcrumbs)
 
     @explorer = true
-    @sb[:action] = action unless action.nil?
+    @sb[:action] = action if action || (@sb[:action] == 'chargeback' && params[:action] == 'accordion_select')
+
     if @sb[:action] || params[:display]
       partial, action, @right_cell_text, options_from_right_cell = set_right_cell_vars(options) # Set partial name, action and cell header
     end


### PR DESCRIPTION
**Fixes issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/3678

---

Fix error which occurred when clicking on _VMs/Templates_ tab, after _Chargeback Preview_ from VM's summary page.

**Steps to reproduce the issue:** (If you skip step 3 form steps to reproduce, the problem will not occur)
1. Go to _Compute > Infrastructure > Virtual Machines > VMs & Templates_ tab
2. Click on some VM to open its summary page
3. From _Monitoring_, click on _Chargeback Preview_
(now you will probably need to `run simulate_queue_worker` from rails console)
4. Click on _VMs_ or _Templates_ tab

**Before:**
```
I, [2018-03-26T13:35:37.954776 #13172]  INFO -- : Started POST "/vm_infra/accordion_select?id=templates_filter_accord" for ::1 at 2018-03-26 13:35:37 +0200
I, [2018-03-26T13:35:38.001369 #13172]  INFO -- : Processing by VmInfraController#accordion_select as JS
I, [2018-03-26T13:35:38.001571 #13172]  INFO -- :   Parameters: {"id"=>"templates_filter_accord"}
F, [2018-03-26T13:35:38.024246 #13172] FATAL -- : Error caught: [ArgumentError] 'nil' is not an ActiveModel-compatible object. It must implement :to_partial_path.
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/partial_renderer.rb:480:in `partial_path'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/partial_renderer.rb:384:in `setup'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/partial_renderer.rb:296:in `render'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/renderer.rb:47:in `render_partial'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/renderer/renderer.rb:21:in `render'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/rendering.rb:104:in `_render_template'
/home/hstastna/.gem/ruby/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/streaming.rb:217:in `_render_template'
/home/hstastna/.gem/ruby/2.4.0/gems/actionview-5.0.6/lib/action_view/rendering.rb:83:in `render_to_body'
/home/hstastna/.gem/ruby/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/rendering.rb:52:in `render_to_body'
/home/hstastna/.gem/ruby/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/renderers.rb:142:in `render_to_body'
/home/hstastna/.gem/ruby/2.4.0/gems/actionpack-5.0.6/lib/abstract_controller/rendering.rb:48:in `render_to_string'
/home/hstastna/.gem/ruby/2.4.0/gems/actionpack-5.0.6/lib/action_controller/metal/rendering.rb:41:in `render_to_string'
/home/hstastna/manageiq/manageiq-ui-classic/app/helpers/application_helper.rb:1757:in `block in r'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/vm_common.rb:1272:in `replace_right_cell'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:187:in `accordion_select'

```
and nothing happened, _Templates_ screen not displayed:
![templates_bad](https://user-images.githubusercontent.com/13417815/37904557-719b37e0-30fc-11e8-9b7a-895daf61d0d4.png)

**After:**
![preview_after](https://user-images.githubusercontent.com/13417815/39243580-3712e5c4-488e-11e8-90e8-fc1b7a496206.png)

**Details:**
We need to call _get_node_info_ (not just `replace_right_cell`) to set everything properly, when clicking on another accordion, after Chargeback Preview. The fix addresses the simplest way to achieve it. It is possible to move across accordions, view details of items or to display Chargeback Preview again, without any problems. And also, normally, when accessing VMs/Templates or VMs & Templates accordions, `@sb[:action]` is set to `nil`, and this is why we need to change it in this specific situation. I am changing it where it already changes/sets - in `replace_right_cell` method.