### PR TITLE
Do not store console popups in session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1872,6 +1872,9 @@ class ApplicationController < ActionController::Base
 
     url = URI.parse(request.url).path
 
+    # Do not include console popup windows urls. Only urls from the main UI are supported.
+    return if %w(launch_vmware_console launch_html5_console).any? { |i| url.include?(i) }
+
     section.parent_path.each do |sid|
       session[:tab_url][sid] = url
     end


### PR DESCRIPTION
The console popup windows update the user session data (session[:tab_url][sid]). This data is used falsely by the dashboard_controller.rb in redirect_to_remembered, method that tries to redirect the console in the main ManageIQ UI. This leads to a exception in the manageiq ui. See #3833.

This PR is a really ugly fix that mitigates the issue for VMWARE WebMKS and HTML5 console. I think this PR must be improved to fix it for all possible popup windows...  Suggestions are welcome.

Links
----------------
* Fix for https://github.com/ManageIQ/manageiq-ui-classic/issues/3833
