### PR TITLE
Change Service 'Order' button to blue color to look active

### DIFF
--- a/app/views/catalog/_svccat_tree_show.html.haml
+++ b/app/views/catalog/_svccat_tree_show.html.haml
@@ -33,7 +33,7 @@
       .col-md-1{:align => "center"}
         #buttons
           = button_tag(_("Order"),
-                       :class   => "btn btn-default",
+                       :class   => "btn btn-primary",
                        :alt     => t = _("Order this Service"),
                        :title   => t,
                        :onclick => "miqAjaxButton('#{url_for_only_path(:action => "svc_catalog_provision",


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1571614

---

Change Service's _Order_ button to blue color to look active, under _Services > Catalogs > All Services_ > some specific Service.

**Before:**
![order_before](https://user-images.githubusercontent.com/13417815/39246548-31bfffea-4897-11e8-99c5-32e9051e517c.png)

**After:**
![order_after](https://user-images.githubusercontent.com/13417815/39246374-b7ad28c2-4896-11e8-8684-8aa665ec8ecb.png)
