### PR TITLE
Ensure mixed case usernames are downcased to match how they are store

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -563,7 +563,7 @@ class DashboardController < ApplicationController
 
   def generate_ui_api_token(userid)
     @api_user_token_service ||= Api::UserTokenService.new
-    @api_user_token_service.generate_token(userid, "ui")
+    @api_user_token_service.generate_token(userid.downcase, "ui")
   end
 
   def timeline

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -115,7 +115,7 @@ describe DashboardController do
       auth_token     = "aabbccddeeff"
       validation_url = "/user_validation_url"
 
-      request.env["HTTP_X_REMOTE_USER"] = "JohnDoe"
+      request.env["HTTP_X_REMOTE_USER"] = user.userid.capitalize
       skip_data_checks(validation_url)
 
       allow(User).to receive(:authenticate).and_return(user)

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -115,7 +115,7 @@ describe DashboardController do
       auth_token     = "aabbccddeeff"
       validation_url = "/user_validation_url"
 
-      request.env["HTTP_X_REMOTE_USER"] = user.userid
+      request.env["HTTP_X_REMOTE_USER"] = "JohnDoe"
       skip_data_checks(validation_url)
 
       allow(User).to receive(:authenticate).and_return(user)


### PR DESCRIPTION

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1562403

If the authentication directory returns mixed case for HTTP_X_REMOTE_USER it
needs to be downcased to match the way userids are stored in the DB.

IBM Tivoli SAML can report usernames in mixed case. Most SAML servers do not.
This PR will ensure the mixed case usernames are downcased before comparing
them to how they are stored in the DB.
