### PR TITLE
[FINE] Fixes display of confirmation message when deleting Saved Report

### DIFF
--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -105,7 +105,6 @@ module ReportController::SavedReports
       r = MiqReportResult.for_user(current_user).find(savedreports[0])
       @sb[:miq_report_id] = r.miq_report_id
       process_saved_reports(savedreports, "destroy")  unless savedreports.empty?
-      add_flash(_("The selected Saved Report was deleted")) if @flash_array.nil?
       @report_deleted = true
     end
     self.x_node = "xx-#{to_cid(@sb[:miq_report_id])}" if x_active_tree == :savedreports_tree &&

--- a/app/views/report/_report_saved_reports.html.haml
+++ b/app/views/report/_report_saved_reports.html.haml
@@ -2,4 +2,5 @@
   - if @view && !@view.table.data.empty?
     = render :partial => 'layouts/x_gtl'
   - else
+    = render :partial => "layouts/flash_msg"
     = render :partial => 'layouts/info_msg', :locals => {:message => _("No Saved Reports available.")}


### PR DESCRIPTION
Fixes display of confirmation flash message when deleting singleton report on Saved Reports tab. 

https://bugzilla.redhat.com/show_bug.cgi?id=1486639

Also, a duplicate with same issue: https://bugzilla.redhat.com/show_bug.cgi?id=1489387

Both apply only to FINE.

Screen shots prior to fix, first a single report listed in the tab:
![saved report tab one report listed prior to code fix](https://user-images.githubusercontent.com/552686/39267515-e6447da8-4881-11e8-9049-1ca6443901e9.png)

Single report deleted, no confirmation message, prior to code fix, just am info message for no reports to list:
![saved report tab one report deleted prior to code fix](https://user-images.githubusercontent.com/552686/39267545-fa52381c-4881-11e8-8f5b-5cef7e9a003b.png)


Single report listed, post code fix:
![saved report tab one report listed post fix](https://user-images.githubusercontent.com/552686/39267591-1e18b94c-4882-11e8-926d-bce9ebad6a2b.png)

Single report deleted post code fix, flash message display:
![saved report tab one report deleted post fix](https://user-images.githubusercontent.com/552686/39267617-2ef51c60-4882-11e8-9e6d-963fac9bc31b.png)

Report deleted from multi-report list, post code fix:
![saved reports tab multi-report listed post fix](https://user-images.githubusercontent.com/552686/39267640-480e1c1a-4882-11e8-8261-0025228726bb.png)

Deleted confirmation message display:
![saved reports tab one report from multi-list deleted post fix](https://user-images.githubusercontent.com/552686/39267662-57589bd2-4882-11e8-8f2d-2f700b81c62d.png)

