### PR TITLE
Decorator w/fonticon for VmdbDatabaseConnection and VmdbDatabaseSetting

### DIFF
--- a/app/decorators/vmdb_database_connection_decorator.rb
+++ b/app/decorators/vmdb_database_connection_decorator.rb
@@ -1,0 +1,5 @@
+class VmdbDatabaseConnectionDecorator < MiqDecorator
+  def self.fonticon
+    'ff ff-database-connection'
+  end
+end

--- a/app/decorators/vmdb_database_setting_decorator.rb
+++ b/app/decorators/vmdb_database_setting_decorator.rb
@@ -1,0 +1,5 @@
+class VmdbDatabaseSettingDecorator < MiqDecorator
+  def self.fonticon
+    'fa fa-cog'
+  end
+end


### PR DESCRIPTION
I [compared](https://gist.github.com/skateman/c36c2ee62b21ae45a3383980ac36c5be) the list of models without decorators with the PNG files we have in the `100` folder and found out that those two models are still getting their icons in GTLs using `view.db.underscore`. 

**Before:**
![screenshot from 2018-04-26 10-41-43](https://user-images.githubusercontent.com/649130/39295339-72c07f22-493e-11e8-95f3-e0766d0f46a9.png)

![screenshot from 2018-04-26 10-40-55](https://user-images.githubusercontent.com/649130/39295350-79d2538a-493e-11e8-9bfb-1fe3e77e42ce.png)

**After:**
![screenshot from 2018-04-26 10-35-42](https://user-images.githubusercontent.com/649130/39295360-81f62bb8-493e-11e8-80be-8baabedfcd33.png)

![screenshot from 2018-04-26 10-35-14](https://user-images.githubusercontent.com/649130/39295365-8478b3d8-493e-11e8-9c49-813b4d3a670e.png)

Note that testing the `VmdbDatabaseConnection` is blocked by https://github.com/ManageIQ/manageiq/issues/17344, but commenting the affected line works it around.

@miq-bot add_reviewer epwinchell
@miq-bot add_label graphics, gaprindashvili/no, refactoring