### PR TITLE
Add quad into report data API

### DIFF
--- a/app/assets/javascripts/miq_qe.js
+++ b/app/assets/javascripts/miq_qe.js
@@ -128,7 +128,8 @@ ManageIQ.qe.gtl = {
         gtlType: this.gtlType,
         id: item.id,
         long_id: item.long_id,
-        quadicon: item.quadicon
+        quadicon: item.quadicon,
+        quad: item.quad
       }
     }.bind(this);
 


### PR DESCRIPTION
### Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/3848
When https://github.com/ManageIQ/ui-components/pull/243 was merged we no longer build quadicon html but rather send data over and display them to user in more data driven way. This way running 
`sendDataWithRx({'controller': 'reportDataController', 'action': 'get_item', 'data': [20]}); ManageIQ.qe.gtl.result['item']` will fail to display quadicon. This PR adds our new data to this API. So new object looks like
```javascrip
ceslls: {},
gtlType: '',
id: '',
long_id: '',
quadicon: undefined,
quad: {
  topRight: {icon: '', tooltip: ''}
  ...
}
```
Quadicon element consists of `topLeft`, `topRight`, `bottomLeft` and `bottomRight` if quadicon present if single quad is present the data are just `fileicon`. Each quadrant can have 6 attributes 
* `fileicon` - URL string for image
* `fonticon` - font string (`fa fa-arrow`)
* `tooltip` - contains information what each image means
* `text` - used for data display (number of VMs)
* `background` - used for power state
* `color` - used for power state

So to get the most relevant information you could check `text` and `tooltip`, however you have to know which quadrant corresponds to which data.