### PR TITLE
Add a unique random DOM ID for each quadicon and use it in miq_bootstrap

### DIFF
--- a/app/views/shared/_quadicon.html.haml
+++ b/app/views/shared/_quadicon.html.haml
@@ -1,5 +1,6 @@
-%miq-quadicon.center-block
+- uid = "quad-#{rand(36**8).to_s(36)}"
+%miq-quadicon.center-block{:id => uid}
 :javascript
   var data = camelizeQuadicon(#{quadicon_hash(record).to_json});
-  document.querySelector('miq-quadicon').setAttribute('data', JSON.stringify(data));
-  miq_bootstrap('miq-quadicon');
+  document.querySelector("miq-quadicon##{uid}").setAttribute('data', JSON.stringify(data));
+  miq_bootstrap("miq-quadicon##{uid}");


### PR DESCRIPTION
The `miq_bootstrap('miq_quadicon')` is too generic and it doesn't work if there are more than one quadicons on a single screen. For example on the VM compare screen, the second VM's quadicon is not being displayed and a JS error shows up in the console.

**Before:**
![screenshot from 2018-04-26 14-31-39](https://user-images.githubusercontent.com/649130/39305794-911907b2-495e-11e8-8a2b-d0eda3db9a09.png)

**After:**
![screenshot from 2018-04-26 14-33-08](https://user-images.githubusercontent.com/649130/39305845-c29cc616-495e-11e8-866d-ef33c0f418aa.png)

@miq-bot add_label bug, gaprindashvili/no
@miq-bot assign @himdel 