### PR TITLE
Remove unnecessary code around the quadicon rendering on drift screens

### DIFF
--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -13,41 +13,7 @@
       - else
         - height = "100px"
       %div{:style => "position: relative; width: 152px; height: #{height}; z-index: 0; margin: 0px auto;"}
-        - if %w(MiqTemplate VmOrTemplate Vm).include?(@sb[:compare_db])
-          - if settings(:quadicons, :vm)
-            = render :partial => 'shared/quadicon', :locals => {:record => @drift_obj}
-          - else
-            .flobj
-              %img{:src => image_path("layout/base-single.png")}
-            = flobj_img_small("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg", "e72")
-          - if @drift_obj.get_policies.length > 0
-            %div{:class => "flobj g72"}
-              %img{:src => image_path('100/shield.png')}
-          .flobj
-            %img{:src => image_path("layout/reflection.png")}
-        - elsif @sb[:compare_db] == "Host"
-          - if settings(:quadicons, :host)
-            .flobj
-              %img{:src => image_path("layout/base.svg")}
-            %div{:class => "flobj c72"}
-              %img{:src => image_path("svg/vendor-#{h(@drift_obj.vmm_vendor_display.downcase)}.svg")}
-            - unless @drift_obj.power_state.blank?
-              %div{:class => "flobj b72"}
-                %img{:src => image_path("svg/currentstate-#{h(@drift_obj.power_state.downcase)}.svg")}
-            %div{:class => "flobj a72"}
-              %p
-                = @drift_obj.vms.count
-          - else
-            .flobj
-              %img{:src => image_path("layout/base-single.png")}
-            = flobj_img_small("svg/vendor-#{h(@host.vmm_vendor_display.downcase)}.svg", "e72")
-          - if @host.number_of(:get_policies) > 0
-            %div{:class => "flobj g72"}
-              %img{:src => image_path('100/shield.png')}
-          .flobj
-            %img{:src => image_path("layout/reflection.png")}
-        - elsif @sb[:compare_db] == "EmsCluster"
-          = render :partial => 'shared/quadicon', :locals => {:record => @drift_obj}
+        = render :partial => 'shared/quadicon', :locals => {:record => @drift_obj}
       - if @sb[:compare_db] != "EmsCluster"
         %div{:style => "margin-top: -25px;"}
           %center{:style => "color:#000;"}


### PR DESCRIPTION
There was some ancient logic, it has been completely replaced with decorator :scissors: :scissors: :toilet: :fire: 

**Before:**
![screenshot from 2018-04-26 14-57-39](https://user-images.githubusercontent.com/649130/39307190-6d4a5364-4962-11e8-85b8-70cbb7894805.png)

**After:**
![screenshot from 2018-04-26 14-57-13](https://user-images.githubusercontent.com/649130/39307198-72bad1de-4962-11e8-884d-14e759b5c486.png)

**Please test this against different types of drift screens (host, vm, etc).**

@miq-bot add_label gaprindashvili/no
@miq-bot add_reviewer @epwinchell 
