### PR TITLE
Change fa-cog to pficon-settings in VmdbDatabaseSettingDecorator

### DIFF
--- a/app/decorators/vmdb_database_setting_decorator.rb
+++ b/app/decorators/vmdb_database_setting_decorator.rb
@@ -1,5 +1,5 @@
 class VmdbDatabaseSettingDecorator < MiqDecorator
   def self.fonticon
-    'fa fa-cog'
+    'pficon pficon-settings'
   end
 end


### PR DESCRIPTION
I set a wrong icon in https://github.com/ManageIQ/manageiq-ui-classic/pull/3851#discussion_r184413333, fixing.

@miq-bot add_label graphics
@miq-bot add_reviewer @epwinchell 