### PR TITLE
Fix for certain tag categories being unable to be saved as dialog field elements

### DIFF
--- a/app/assets/javascripts/services/dialog_editor_http_service.js
+++ b/app/assets/javascripts/services/dialog_editor_http_service.js
@@ -28,6 +28,6 @@ ManageIQ.angular.app.service('DialogEditorHttp', ['$http', 'API', function($http
   this.loadCategories = function() {
     return API.get('/api/categories' +
                         '?expand=resources' +
-                        '&attributes=description,single_value,children');
+                        '&attributes=id,name,description,single_value,children');
   };
 }]);

--- a/spec/javascripts/services/dialog_editor_http_service_spec.js
+++ b/spec/javascripts/services/dialog_editor_http_service_spec.js
@@ -1,0 +1,34 @@
+describe('dialogEditorHttp', function() {
+  var testDialogEditorHttp, API;
+
+  beforeEach(module('ManageIQ'));
+
+  beforeEach(inject(function(DialogEditorHttp, _API_) {
+    testDialogEditorHttp = DialogEditorHttp;
+    API = _API_;
+
+    var responseResult = {result: 'the results'};
+
+    spyOn(API, 'get').and.callFake(function() {
+      return {then: function(response) { response(responseResult); }};
+    });
+  }));
+
+  describe('#loadCategories', function() {
+    it('calls the API and requests various attributes', function() {
+      testDialogEditorHttp.loadCategories();
+      expect(API.get).toHaveBeenCalledWith('/api/categories' +
+                                                '?expand=resources' +
+                                                '&attributes=id,name,description,single_value,children');
+    });
+
+    it('returns the result', function(done) {
+      var loadedCategories = testDialogEditorHttp.loadCategories();
+
+      loadedCategories.then(function(value) {
+        expect(value).toEqual({result: 'the results'});
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This simply adds the name and id to the category attribute list when requesting the categories from the API for the dialog editor to use in [this ui-components PR](https://github.com/ManageIQ/ui-components/pull/291). The problem is that certain categories have different names than their description, and so sometimes it was failing when trying to choose them to use.

This will need to be merged first, otherwise the ui-components will not have a 'name' field to use properly.

https://bugzilla.redhat.com/show_bug.cgi?id=1570613

/cc @gmcculloug @d-m-u 

@miq-bot assign @h-kataria 
@miq-bot add_label gaprindashvili/yes, bug