### PR TITLE
Change @edit[:new][:timer_typ] to @edit[:new][:timer].typ

### DIFF
--- a/app/views/report/_schedule_form_timer.html.haml
+++ b/app/views/report/_schedule_form_timer.html.haml
@@ -10,7 +10,7 @@
         - timer_types = [[_("Once"), "Once"], [_("Hourly"), "Hourly"], [_("Daily"), "Daily"], [_("Weekly"), "Weekly"], [_("Monthly"), "Monthly"]]
         - timer_types.shift if x_active_tree == :widgets_tree
         = select_tag("timer_typ",
-          options_for_select(timer_types, @edit[:new][:timer_typ]),
+          options_for_select(timer_types, @edit[:new][:timer].typ),
           :class => "selectpicker")
         :javascript
           miqInitSelectPicker();


### PR DESCRIPTION
There's no `:timer_typ` key in `@edit[:new]` so it's aways `nil` and select is set to Hourly as it's the first value.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1564199

Cloud Intel -> Reports -> Dashboard Widgets -> choose one that hasn't timer set to Hourly -> Edit
Cloud Intel -> Reports -> Schedules -> choose one that hasn't timer set to Hourly -> Edit
Configuration -> Settings -> Schedules -> choose one that hasn't timer set to Hourly -> Edit 

Before:
![image](https://user-images.githubusercontent.com/9210860/39362690-a3b4ff38-4a27-11e8-8c6b-23e6f566625e.png)

After:
![image](https://user-images.githubusercontent.com/9210860/39362645-7f38c806-4a27-11e8-85fd-1c39d1114e62.png)

@miq-bot add_label bug, gaprindashvili/yes, cloud intel/reporting