### PR TITLE
Add view selector to Block/Object Storage Managers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1334,6 +1334,7 @@ module ApplicationHelper
                         container_service
                         container_template
                         container_topology
+                        ems_block_storage
                         ems_cloud
                         ems_cluster
                         ems_container

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1342,6 +1342,7 @@ module ApplicationHelper
                         ems_infra_dashboard
                         ems_middleware
                         ems_network
+                        ems_object_storage
                         ems_physical_infra
                         ems_storage
                         infra_topology


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1558620

---

Add missing **view selector** to Block and Object Storage Managers under _Storage -> Block/Object Storage -> Managers_.

**Before:**
Block Storage Managers, no View Selector:
![block_before](https://user-images.githubusercontent.com/13417815/39367129-36adfa84-4a36-11e8-9a00-bfb42c49fef5.png)
Object Storage Managers, no View Selector:
![object_before](https://user-images.githubusercontent.com/13417815/39367133-38a691e8-4a36-11e8-8123-dda16bb12c47.png)

**After:**
Block Storage Managers, Grid View:
![block_after_grid](https://user-images.githubusercontent.com/13417815/39366866-6ff0f57c-4a35-11e8-8cd0-0a5bf4942723.png)
Block Storage Managers, Tile View:
![block_after_tile](https://user-images.githubusercontent.com/13417815/39366870-72ed6332-4a35-11e8-9f5d-fe9de826a1e3.png)
Block Storage Managers, List View:
![block_after_list](https://user-images.githubusercontent.com/13417815/39366869-717c7358-4a35-11e8-8168-5607cf51f6a5.png)
Object Storage Managers, Grid View:
![object_after_grid](https://user-images.githubusercontent.com/13417815/39366874-74bbac64-4a35-11e8-8085-1400e2a71662.png)
Object Storage Managers, Tile View:
![object_after_tile](https://user-images.githubusercontent.com/13417815/39366884-7a944d6c-4a35-11e8-950b-9134da2e2d9f.png)
Object Storage Managers, List View:
![object_after_list](https://user-images.githubusercontent.com/13417815/39366877-7624d06c-4a35-11e8-85ab-67f1b5d0edf1.png)
