### PR TITLE
Fixes display of VM Retirement State label

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -187,7 +187,7 @@ module VmHelper::TextualSummary
   end
 
   def textual_retirement_state
-    @record.retirement_state.to_s.capitalize
+    {:label => _("Retirement State"), :value => @record.retirement_state.to_s.capitalize}
   end
 
   def textual_provisioned


### PR DESCRIPTION
Fixes display of UI label with both words capitalized. 

https://bugzilla.redhat.com/show_bug.cgi?id=1518926

Screen shot prior to code fix:
![vm retirement state no cap state prior to code fix](https://user-images.githubusercontent.com/552686/39388798-a77e6c7a-4a37-11e8-99fe-c6d15a085b20.png)

Screen shot post code fix:
![vm retirement state all caps post code fix](https://user-images.githubusercontent.com/552686/39388806-b26c5d18-4a37-11e8-9a17-13c01236f983.png)

