### PR TITLE
Do not force exp_key to be limited to "CONTAINS" for date type fields.

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -173,7 +173,8 @@ module ApplicationController::Filter
               self.exp_field = nil
               self.exp_key = nil
             else
-              if exp_model != '_display_filter_' && MiqExpression::Field.parse(exp_field).plural?
+              # for date time fields we should show After/Before etc. options
+              if exp_model != '_display_filter_' && MiqExpression::Field.parse(exp_field).plural? && ![:date, :datetime].include?(self[:val1][:type])
                 self.exp_key = 'CONTAINS' # CONTAINS is valid only for plural tables
               else
                 self.exp_key = nil unless MiqExpression.get_col_operators(exp_field).include?(exp_key)


### PR DESCRIPTION
When selected field type id date type field, allow a drop down to be displayed with After/Before etc. options to be selected to form an expression.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1563823

before:
![before](https://user-images.githubusercontent.com/3450808/39444119-97a6260e-4c84-11e8-8ee8-a972c809b9a1.png)

after:
![after](https://user-images.githubusercontent.com/3450808/39444047-6274da98-4c84-11e8-8dd4-79b9e5a2e98f.png)

@yrudman cc

@dclarizio please review

