### PR TITLE
Disable Look up Group for Amazon, Database and External with SAML

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -1,6 +1,10 @@
 - if @edit
   - url = url_for_only_path(:action => 'rbac_group_field_changed', :id => (@edit[:group_id] || "new"))
   - combo_url = "/ops/rbac_group_field_changed/#{@edit[:group_id] || 'new'}"
+- mode = ::Settings.authentication.mode
+- saml_enabled = ::Settings.authentication.saml_enabled
+- can_lookup_groups = mode.downcase.start_with?('ldap')
+- can_lookup_groups = mode.downcase == "httpd" && ! saml_enabled unless can_lookup_groups
 = render :partial => "layouts/flash_msg"
 #group_info
   %h3
@@ -21,7 +25,7 @@
                            :class => "form-control",
                            "data-miq_observe" => {:interval => '.5',
                                                   :url      => url}.to_json)
-          - if ::Settings.authentication.mode.casecmp('database') != 0
+          - if can_lookup_groups
             = check_box_tag("lookup",
                             "1",
                             false,

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -58,18 +58,25 @@ describe 'ops/_rbac_group_details.html.haml' do
       expect(rendered).to include('Look up LDAPS Groups')
     end
 
-    it 'should show "Look up groups" checkbox and label for auth mode amazon' do
+    it 'should not show "Look up groups" checkbox and label for auth mode amazon' do
       stub_settings(:authentication => { :mode => 'amazon' }, :server => {})
       render :partial => 'ops/rbac_group_details'
-      expect(rendered).to have_selector('input#lookup')
-      expect(rendered).to include('Look up Amazon Groups')
+      expect(rendered).not_to have_selector('input#lookup')
+      expect(rendered).not_to include('Look up Amazon Groups')
     end
 
     it 'should show "Look up groups" checkbox and label for auth mode httpd' do
-      stub_settings(:authentication => { :mode => 'httpd' }, :server => {})
+      stub_settings(:authentication => { :mode => 'httpd', :saml_enabled => false}, :server => {})
       render :partial => 'ops/rbac_group_details'
       expect(rendered).to have_selector('input#lookup')
       expect(rendered).to include('Look up External Authentication Groups')
+    end
+
+    it 'should not show "Look up groups" checkbox and label for auth mode httpd with SAML enabled' do
+      stub_settings(:authentication => { :mode => 'httpd', :saml_enabled => true}, :server => {})
+      render :partial => 'ops/rbac_group_details'
+      expect(rendered).not_to have_selector('input#lookup')
+      expect(rendered).not_to include('Look up External Authentication Groups')
     end
 
     it 'should not show "Look up groups" checkbox and label for auth mode database' do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1440209

Instructions from BZ:
> Group lookup is not supported when using external authentication with SAML.
> Group lookup is also not supported for Amazon. 

How to reproduce:
Configuration -> Settings -> select Current Server -> Authentication -> Mode -> set to `Amazon`/`Database`/`External` with `SAML` enabled 
Configuration -> Access Control -> Create a new Group
Before:
<img width="740" alt="screen shot 2018-05-02 at 2 04 28 pm" src="https://user-images.githubusercontent.com/9210860/39522159-c917161a-4e11-11e8-81c2-9c2b07bba831.png">
<img width="755" alt="screen shot 2018-05-02 at 2 31 15 pm" src="https://user-images.githubusercontent.com/9210860/39523336-8feee9b8-4e15-11e8-9380-b15910d5ac75.png">

After:
<img width="755" alt="screen shot 2018-05-02 at 2 05 14 pm" src="https://user-images.githubusercontent.com/9210860/39522181-de7e6878-4e11-11e8-90fe-fdd355782046.png">

@miq-bot add_label bug, gaprindashvili/yes, fine/yes, euwe/yes
