### PR TITLE
Validate Help->Documentation screen against the documentation feature

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -27,7 +27,7 @@ class SupportController < ApplicationController
   private ############################
 
   def check_support_rbac
-    handle_generic_rbac(role_allows?(:feature => 'support', :any => true))
+    handle_generic_rbac(role_allows?(:feature => 'documentation', :any => true))
   end
 
   def get_layout


### PR DESCRIPTION
The naming of methods/actions inside this controller (its name included) is just horrible and misleading. The RBAC check was improperly introduced in #3728 against the `support` feature, but it should be `documentation`.

@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @martinpovolny 
ping @simaishi 

@miq-bot add_label bug, gaprindashvili/yes, fine/yes

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1569170