### PR TITLE
Refactoring provision method to use new rbac call

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -63,8 +63,7 @@ class PhysicalServerController < ApplicationController
   end
 
   def provision
-    provisioning_ids = find_checked_ids_with_rbac(PhysicalServer)
-    provisioning_ids.push(find_id_with_rbac(PhysicalServer, params[:id])) if provisioning_ids.empty?
+    provisioning_ids = find_records_with_rbac(PhysicalServer, checked_or_params).ids
 
     javascript_redirect(:controller     => "miq_request",
                         :action         => "prov_edit",

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -18,6 +18,14 @@ describe PhysicalServerController do
                                           :id              => 1)
   end
 
+  describe "#provision" do
+    it 'sets id and redirect to prov_edit' do
+      allow(controller).to receive(:find_checked_items).and_return([@physical_server.id])
+      expect(controller).to receive(:javascript_redirect).with(:controller => "miq_request", :action => "prov_edit", :prov_id => [@physical_server.id], :org_controller => "physical_server", :escape => false)
+      controller.send(:provision)
+    end
+  end
+
   describe "#show_list" do
     before(:each) do
       FactoryGirl.create(:physical_server)


### PR DESCRIPTION
Replaced rbac functions in provision method 

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/1134

@miq-bot add_label rbac
@miq-bot add_label refactoring

@romanblanco @lpichler

pleas review @KrecekDaniel 