### PR TITLE
RBAC refactor - security_group_controller

### DIFF
--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -107,13 +107,7 @@ class SecurityGroupController < ApplicationController
 
   def delete_security_groups
     assert_privileges("security_group_delete")
-
-    security_groups = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "security_group")
-                        find_checked_records_with_rbac(SecurityGroup)
-                      else
-                        [find_record_with_rbac(SecurityGroup, params[:id])]
-                      end
-
+    security_groups = find_records_with_rbac(SecurityGroup, checked_or_params)
     if security_groups.empty?
       add_flash(_("No Security Group were selected for deletion."), :error)
     end

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -50,6 +50,33 @@ describe SecurityGroupController do
     end
   end
 
+  describe "#delete_security_groups" do
+    let(:host) { FactoryGirl.create(:host) }
+    let(:security_group) { FactoryGirl.create(:security_group) }
+    let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
+
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as admin_user
+      allow(User).to receive(:current_user).and_return(admin_user)
+      allow(controller).to receive(:assert_privileges)
+      controller.instance_variable_set(:@_params, :id => host.id, :pressed => "host_OWN")
+      controller.instance_variable_set(:@_security_group, security_group)
+      controller.instance_variable_set(:@lastaction, "show")
+
+      allow(controller).to receive(:checked_or_params).and_return(SecurityGroup.all.ids)
+      allow(controller).to receive(:find_checked_items).and_return(SecurityGroup.all.ids)
+    end
+    subject do
+      get :delete_security_groups, :params => {:id =>@security_group.id}
+    end
+
+    it "testing" do
+      controller.send(:delete_security_groups)
+      expect(controller).to receive(:process_security_groups).with(security_grous_to_delete, "destroy")
+    end
+  end
+
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone


### PR DESCRIPTION
RBAC function calls replaced.
Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/1134

@miq-bot add_label rbac
@miq-bot add_label refactoring

@romanblanco @lpichler

Review please @CZJanRichter