### PR TITLE
Refactoring provision method to use new rbac call

### DIFF
--- a/app/controllers/mixins/actions/host_actions/misc.rb
+++ b/app/controllers/mixins/actions/host_actions/misc.rb
@@ -222,7 +222,7 @@ module Mixins
 
           # Either a list or coming from a different controller (eg from ems screen, go to its hosts)
           if @lastaction == "show_list" || @layout != "host"
-            hosts = find_checked_ids_with_rbac(Host)
+            hosts = find_records_with_rbac(Host, checked_or_params).ids
             if hosts.empty?
               add_flash(_("No Hosts were selected for %{task}") % {:task => display_name}, :error)
             else

--- a/spec/controllers/mixins/actions/host_actions/misc_spec.rb
+++ b/spec/controllers/mixins/actions/host_actions/misc_spec.rb
@@ -1,0 +1,23 @@
+describe Mixins::Actions::HostActions::Misc do
+  describe "#host_button_operation" do
+    let(:controller) do
+      return HostController.new
+    end
+    let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
+    let!(:host) { FactoryGirl.create(:host) }
+
+    before do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as admin_user
+      allow(User).to receive(:current_user).and_return(admin_user)
+      allow(controller).to receive(:process_hosts).with([host.id], 'refresh_ems', 'Refresh')
+      controller.instance_variable_set(:@_params, :id => Host.all.ids)
+    end
+
+    it "tests that find_records_with_rbac is called and does not fail" do
+      expect(controller).to receive(:find_records_with_rbac).with(Host, Host.all.ids).and_return(Host.all)
+      controller.send(:host_button_operation, 'refresh_ems', _('Refresh'))
+    end
+  end
+end


### PR DESCRIPTION
Replaced provision method, added test.

Parent issue: #1134

@miq-bot add_label rbac
@miq-bot add_label refactoring

@lpichler @romanblanco

Please review @terezapliskova :].