### PR TITLE
Refactoring method in ops_rbac.rb to use new RBAC call

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -596,7 +596,7 @@ module OpsController::OpsRbac
   end
 
   def rbac_edit_tags_reset(tagging)
-    @object_ids = find_checked_ids_with_rbac(tagging.constantize)
+    @object_ids = find_records_with_rbac(tagging.constantize, checked_or_params).ids
     if params[:button] == "reset"
       id = params[:id] if params[:id]
       return unless load_edit("#{session[:tag_db]}_edit_tags__#{id}", "replace_cell__explorer")

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -8,6 +8,24 @@ describe OpsController do
       stub_user(:features => :all)
     end
 
+    describe "rbac_edit_tags_reset" do
+      let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
+      let(:another_tenant) { FactoryGirl.create(:tenant) }
+
+      before do
+        allow(controller).to receive(:checked_or_params).and_return(Tenant.all.ids)
+        login_as admin_user
+        allow(User).to receive(:current_user).and_return(admin_user)
+      end
+
+      it "processes selected record" do
+        allow(controller).to receive(:x_tags_set_form_vars)
+        controller.instance_variable_set(:@sb, :pre_edit_node=> '')
+        allow(controller).to receive(:replace_right_cell)
+        expect(controller).to receive(:find_records_with_rbac).with(Tenant, Tenant.all.ids).and_return(Tenant.all)
+        controller.send(:rbac_edit_tags_reset, "Tenant")
+      end
+    end
     let(:four_terabytes) { 4096 * 1024 * 1024 * 1024 }
 
     context "#tree_select" do


### PR DESCRIPTION
Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/1134

@miq-bot add_label rbac
@miq-bot add_label refactoring

@romanblanco @lpichler