### PR TITLE
Fix Dialog's API call for Datastore

### DIFF
--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -103,7 +103,7 @@ class DialogLocalService
       api_collection_name = "services"
       cancel_endpoint = "/service/explorer"
     when /Storage/
-      api_collection_name = "datastores"
+      api_collection_name = "data_stores"
       cancel_endpoint = "/storage/explorer"
     when /Template/
       api_collection_name = "templates"

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -231,7 +231,7 @@ describe DialogLocalService do
           :target_type            => 'storage',
           :dialog_id              => 654,
           :force_old_dialog_use   => false,
-          :api_submit_endpoint    => "/api/datastores/123",
+          :api_submit_endpoint    => "/api/data_stores/123",
           :api_action             => "custom-button-name",
           :finish_submit_endpoint => "/storage/explorer",
           :cancel_endpoint        => "/storage/explorer"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1574403

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/2671

Automation -> Automate -> Customization -> create a custom button with a dialog for Datastore
Compute -> Infrastructure -> Datastores -> click on one -> click on the custom button with a dialog

Before:
<img width="1214" alt="screen shot 2018-05-03 at 2 16 21 pm" src="https://user-images.githubusercontent.com/9210860/39575936-9231c37c-4edc-11e8-834c-2cce3b2ef0cd.png">

After:
<img width="1205" alt="screen shot 2018-05-03 at 2 15 02 pm" src="https://user-images.githubusercontent.com/9210860/39575888-701c03a6-4edc-11e8-8038-f6c73a5c8703.png">

@miq-bot add_label bug, gaprindashvili/yes, automation/automate