### PR TITLE
[WIP] Update miq_groups for a user before saving it

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -733,7 +733,7 @@ module OpsController::OpsRbac
       rbac_role_set_record_vars(record)
     end
 
-    if record.valid? && validated && record.save!
+    if validated && record.valid? && record.save!
       populate_role_features(record) if what == "role"
       self.current_user = record if what == 'user' && @edit[:current][:userid] == current_userid
       AuditEvent.success(build_saved_audit(record, add_pressed))
@@ -1060,7 +1060,7 @@ module OpsController::OpsRbac
       valid = false
     end
 
-    new_group_ids = rbac_user_get_group_ids
+    new_group_ids = rbac_user_get_group_ids.map(&:to_i)
     new_groups = new_group_ids.present? && MiqGroup.find(new_group_ids).present? ? MiqGroup.find(new_group_ids) : []
 
     if new_group_ids.blank?

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -722,7 +722,7 @@ module OpsController::OpsRbac
     when :user
       record = @edit[:user_id] ? User.find_by(:id => @edit[:user_id]) : User.new
       validated = rbac_user_validate?
-      rbac_user_set_record_vars(record)
+      rbac_user_set_record_vars(record) if validated
     when :group then
       record = @edit[:group_id] ? MiqGroup.find_by(:id => @edit[:group_id]) : MiqGroup.new
       validated = rbac_group_validate?
@@ -734,7 +734,6 @@ module OpsController::OpsRbac
     end
 
     if record.valid? && validated && record.save!
-      record.miq_groups = Rbac.filtered(MiqGroup.find(rbac_user_get_group_ids)) if key == :user # only set miq_groups if everything is valid
       populate_role_features(record) if what == "role"
       self.current_user = record if what == 'user' && @edit[:current][:userid] == current_userid
       AuditEvent.success(build_saved_audit(record, add_pressed))
@@ -1037,6 +1036,7 @@ module OpsController::OpsRbac
     user.name       = @edit[:new][:name]
     user.userid     = @edit[:new][:userid]
     user.email      = @edit[:new][:email]
+    user.miq_groups = Rbac.filtered(MiqGroup.find(rbac_user_get_group_ids))
     user.password   = @edit[:new][:password] if @edit[:new][:password]
   end
 


### PR DESCRIPTION
Miq_groups has to be set before saving the user in order for the current_group to be set.
With no current_group, the user cannot log in.


Links
--------
https://bugzilla.redhat.com/show_bug.cgi?id=1574634

Reverting the changes made in these PRs:
https://github.com/ManageIQ/manageiq-ui-classic/pull/3714
https://github.com/ManageIQ/manageiq-ui-classic/pull/3767

and fixing the original issue ( https://bugzilla.redhat.com/show_bug.cgi?id=1562828)  for which the above changes were made in the second commit.

![screenshot from 2018-05-03 16-04-12](https://user-images.githubusercontent.com/12769982/39600923-450fe3b4-4eee-11e8-9351-398fdabd4a32.png)


Steps for Testing/QA 
-------------------------------
