### PR TITLE
Remove duplicate physical server entry from ApplicationHelper

### DIFF
--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -49,7 +49,6 @@ module ApplicationHelper
            network_router
            offline
            orchestration_stack
-           physical_server
            persistent_volume
            physical_server
            resource_pool


### PR DESCRIPTION
We have a duplicated physical_server entry in the ApplicationHelper code for the same string. This change removes one of them.