### PR TITLE
Fix Ansible Tower Service Catalog new item creation

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -887,6 +887,27 @@ class CatalogController < ApplicationController
     if @edit[:new][:st_prov_type] == 'generic' && @edit[:new][:generic_subtype].blank?
       add_flash(_('Subtype is required.'), :error)
     end
+
+    # for Ansible Tower items, check for Provider first
+    if @edit[:new][:st_prov_type] == 'generic_ansible_tower'
+      if @edit[:new][:manager_id].blank?
+        add_flash(_("Provider is required, please select one from the list"), :error)
+      else
+        # ensure Job Template is selected as well, required field
+        add_flash(_("Job Template is required, please select one from the list"), :error) if @edit[:new][:template_id].blank?
+      end
+    end
+
+    # For Orchestration catalog item, reverse edit flow and check Template selection first
+    if @edit[:new][:st_prov_type] == 'generic_orchestration'
+      if @edit[:new][:template_id].blank?
+        add_flash(_("Orchestration Template is required, please select one from the list"), :error)
+      else
+        # ensure Provider is selectied, required field
+        add_flash(_("Provider is required, please select one from the list"), :error) if @edit[:new][:manager_id].blank?
+      end
+    end
+
     add_flash(_("Provisioning Entry Point is required"), :error) if @edit[:new][:fqname].blank?
 
     # Check for a Dialog if Display in Catalog is selected


### PR DESCRIPTION
Fix code to check for required Provider and Job Template selections in the drop downs. 

https://bugzilla.redhat.com/show_bug.cgi?id=1491772

Screen shot post code fix, for Ansible Tower catalog item, first check for required Provider in drop down selection, display error: 
![ansible service catalog item provider required post code fix](https://user-images.githubusercontent.com/552686/39607057-a60485b8-4eed-11e8-8d3c-dcc4f9286f90.png)

Once Provider is selected, then check for Job Template drop down selection, display error:
![ansible service catalog item job template required post code fix](https://user-images.githubusercontent.com/552686/39607096-e1adcb60-4eed-11e8-89bd-cfec12cf2293.png)

Record saved when both are present:
![ansible service catalog item created post code fix](https://user-images.githubusercontent.com/552686/39607107-ed76811c-4eed-11e8-8044-24ce34055e2a.png)

====

For Orchestration Catalog Items, order of checks is reversed, first verify that Template has been selected in the drop down:
![orchestration catalog item require orchestration template code fix](https://user-images.githubusercontent.com/552686/39785946-0bf1b970-52d3-11e8-89bf-29b1bed3784a.png)

Then check for Provider to be selected:
![ansible service catalog item provider required post code fix](https://user-images.githubusercontent.com/552686/39785967-26b0fda2-52d3-11e8-8b1c-3d1c7699650d.png)

Saved Orchestration Catalog Item once both Template and Provider have been selected:
![orchestration catalog item saved with both provider and template](https://user-images.githubusercontent.com/552686/39785985-4649d314-52d3-11e8-99ce-2de718fc9fbe.png)









