### PR TITLE
Add ability to search through the available fields while editing report

### DIFF
--- a/app/views/report/_column_lists.html.haml
+++ b/app/views/report/_column_lists.html.haml
@@ -5,14 +5,19 @@
         = _('Available Fields:')
       %td
     %tr
-      %td{:align => "right", :valign => "top"}
+      %td{:align => "left", :valign => "top"}
         - af = @edit[:new][:model] ? cashed_reporting_available_fields - @edit[:new][:fields] : []
         = select_tag('available_fields[]',
           options_for_select(af),
-          :multiple => true,
-          :style    => "width: 850px;",
-          :size     => 10,
-          :id       => "available_fields")
+          :multiple          => true,
+          "data-width"       => "850px",
+          "data-live-search" => "true",
+          :class             => 'selectpicker',
+          :style             => "overflow-x: scroll;",
+          :id                => "available_fields",
+          :title             => "&lt;#{_('Choose one or more Fields')}&gt;")
+        :javascript
+          miqInitSelectPicker();
       %td
     %tr
       %td.text-center{:style => "padding-top: 15px;"}


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1498150

---

Add ability to search through the _Available Fields_ while adding/editing report in _Cloud Intel > Reports > Reports_.

**Before:** (needed to scroll through the fields)
![report_before](https://user-images.githubusercontent.com/13417815/39625560-3d909556-4f9e-11e8-925b-3094af67635c.png)

**After:** (open the drop down, simply click on the fields you want to select, type what you look for) 
![edit_report1](https://user-images.githubusercontent.com/13417815/39808636-c10cf17e-537f-11e8-840e-c8553ced757f.png)
![edit-report2](https://user-images.githubusercontent.com/13417815/39808588-9eb58370-537f-11e8-8c83-78eada209fcc.png)
Search form displays above the fields after adding `selectpicker` class and searching works well (then we have multiselect drop down which we already know from other places, for example when choosing multiple Groups of a User).
