### PR TITLE
Display what is being edited in the report menu editor

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -740,7 +740,7 @@ class ReportController < ApplicationController
           img_title_commit  = _("Commit Accordion management changes")
           img_title_discard = _("Discard Accordion management changes")
         else
-          fieldset_title    = _("Manage Folders")
+          fieldset_title    = _("Manage Folders in %{location}") % {:location => "\"#{session[:node_selected].split('__')[1]}\""}
           img_title_top     = _("Move selected folder to top")
           img_title_up      = _("Move selected folder up")
           img_title_down    = _("Move selected folder down")


### PR DESCRIPTION
When editing folders in a report menu editor, the tree node is being unselected and so it's not clear what is being edited. With this change this will be displayed on the right side, see the screenshots.

**Before:**
![screenshot from 2018-05-04 14-01-09](https://user-images.githubusercontent.com/649130/39626770-9d8f443e-4fa3-11e8-881a-b64f03439594.png)

**After:**
![screenshot from 2018-05-04 13-58-57](https://user-images.githubusercontent.com/649130/39626691-54a5809e-4fa3-11e8-8d3b-18dfb2573543.png)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1550641

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot assign @h-kataria 
