### PR TITLE
No need to find tooltip column for charts where tooltip label not used.

### DIFF
--- a/lib/report_formatter/chart_common.rb
+++ b/lib/report_formatter/chart_common.rb
@@ -345,7 +345,7 @@ module ReportFormatter
       # Pie charts put categories in legend, else in axis labels
       add_axis_category_text(categories)
 
-      add_series(mri.chart_header_column, series)
+      add_series(chart_is_2d? ? mri.chart_header_column : nil, series)
     end
 
     def build_numeric_chart_grouped
@@ -376,7 +376,7 @@ module ReportFormatter
       # Pie charts put categories in legend, else in axis labels
       add_axis_category_text(categories)
 
-      add_series(mri.chart_header_column, series)
+      add_series(chart_is_2d? ? mri.chart_header_column : nil, series)
     end
 
     def build_numeric_chart_grouped_2dim
@@ -476,7 +476,7 @@ module ReportFormatter
 
       # Pie charts put categories in legend, else in axis labels
       add_axis_category_text(categories)
-      add_series(mri.chart_header_column, series)
+      add_series(chart_is_2d? ? mri.chart_header_column : nil, series)
     end
 
     # C&U performance charts (Cluster, Host, VM based)


### PR DESCRIPTION
Even ```Guest OS Information``` generated successfully and available, there is error in the log:
 ```ERROR -- : MIQ(MiqReport#chart_header_column) The column for the chart's x-axis must be defined in the report``` when generating  chart.

Fix: do not try to find label for tooltip in cases when this label not used

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1565208

@miq-bot add-label bug

\cc @lpichler 