### PR TITLE
bz 1509244: Don't require form changes in order to submit backup restore

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume_backup/cloud_volume_backup_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume_backup/cloud_volume_backup_form_controller.js
@@ -12,7 +12,9 @@ ManageIQ.angular.app.controller('cloudVolumeBackupFormController', ['miqService'
     vm.model = "cloudVolumeBackupModel";
 
     ManageIQ.angular.scope = vm;
-    vm.saveable = miqService.saveable;
+    vm.saveable = function(form) {
+      return form.$valid;
+    };
 
     vm.newRecord = false;
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1509244

The 'save' button in the backup restore form wasn't active until
the user first selected a different volume. To restore to the
current volume required changing to a different volume and then
re-selecting the original. This commit removes the requirement
to change the form first before submitting. Such a requirement
makes sense for an edit form (no changes, no need to submit),
but it does not make sense for an action form like this.

