### PR TITLE
Pass correct credential parameters depending on the credential type

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -4,8 +4,8 @@ module Mixins
   module EmsCommonAngular
     extend ActiveSupport::Concern
 
-    OPENSTACK_PARAMS = [:name, :provider_region, :api_version, :default_security_protocol, :keystone_v3_domain_id, :default_hostname, :default_api_port, :default_userid, :event_stream_selection].freeze
-    OPENSTACK_AMQP_PARAMS = [:name, :provider_region, :api_version, :amqp_security_protocol, :keystone_v3_domain_id, :amqp_hostname, :amqp_api_port, :amqp_userid, :event_stream_selection].freeze
+    OPENSTACK_PARAMS = %i(name provider_region api_version default_security_protocol keystone_v3_domain_id default_hostname default_api_port default_userid event_stream_selection).freeze
+    OPENSTACK_AMQP_PARAMS = %i(name provider_region api_version amqp_security_protocol keystone_v3_domain_id amqp_hostname amqp_api_port amqp_userid event_stream_selection).freeze
 
     included do
       include Mixins::GenericFormMixin

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -5,6 +5,7 @@ module Mixins
     extend ActiveSupport::Concern
 
     OPENSTACK_PARAMS = [:name, :provider_region, :api_version, :default_security_protocol, :keystone_v3_domain_id, :default_hostname, :default_api_port, :default_userid, :event_stream_selection].freeze
+    OPENSTACK_AMQP_PARAMS = [:name, :provider_region, :api_version, :amqp_security_protocol, :keystone_v3_domain_id, :amqp_hostname, :amqp_api_port, :amqp_userid, :event_stream_selection].freeze
 
     included do
       include Mixins::GenericFormMixin
@@ -123,13 +124,17 @@ module Mixins
       user, password = params[:default_userid], MiqPassword.encrypt(params[:default_password])
       case ems.to_s
       when 'ManageIQ::Providers::Openstack::CloudManager'
-        [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)]
+        connect_opts = [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)] if params[:cred_type] == "default"
+        connect_opts = [MiqPassword.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)] if params[:cred_type] == "amqp"
+        connect_opts
       when 'ManageIQ::Providers::Amazon::CloudManager'
         [user, password, :EC2, params[:provider_region], ems.http_proxy_uri, true]
       when 'ManageIQ::Providers::Azure::CloudManager'
         [user, password, params[:azure_tenant_id], params[:subscription], ems.http_proxy_uri, params[:provider_region]]
       when 'ManageIQ::Providers::Vmware::CloudManager'
-        [params[:default_hostname], params[:default_api_port], user, password, params[:api_version], true]
+        connect_opts = [params[:default_hostname], params[:default_api_port], user, password, params[:api_version], true] if params[:cred_type] == "default"
+        connect_opts = [params[:amqp_hostname], params[:amqp_api_port], params[:amqp_userid], MiqPassword.encrypt(params[:amqp_password]), params[:api_version], true] if params[:cred_type] == "amqp"
+        connect_opts
       when 'ManageIQ::Providers::Google::CloudManager'
         [params[:project], MiqPassword.encrypt(params[:service_account]), {:service => "compute"}, ems.http_proxy_uri, true]
       when 'ManageIQ::Providers::Microsoft::InfraManager'
@@ -144,7 +149,9 @@ module Mixins
 
         [ems.build_connect_params(connect_opts), true]
       when 'ManageIQ::Providers::Openstack::InfraManager'
-        [password, params.to_hash.symbolize_keys.slice(*(OPENSTACK_PARAMS))]
+        connect_opts = [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)] if params[:cred_type] == "default"
+        connect_opts = [MiqPassword.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)] if params[:cred_type] == "amqp"
+        connect_opts
       when 'ManageIQ::Providers::Redhat::InfraManager'
         metrics_user, metrics_password = params[:metrics_userid], MiqPassword.encrypt(params[:metrics_password])
         [{
@@ -169,7 +176,9 @@ module Mixins
           :ca_certs   => params[:kubevirt_tls_ca_certs],
         }]
       when 'ManageIQ::Providers::Vmware::InfraManager'
-        [{:pass => password, :user => user, :ip => params[:default_hostname], :use_broker => false}]
+        connect_opts = [{:pass => password, :user => user, :ip => params[:default_hostname], :use_broker => false}] if params[:cred_type] == "default"
+        connect_opts = [{:pass => MiqPassword.encrypt(params[:console_password]), :user => params[:console_userid], :ip => params[:default_hostname], :use_broker => false}] if params[:cred_type] == "console"
+        connect_opts
       when 'ManageIQ::Providers::Nuage::NetworkManager'
         endpoint_opts = {:protocol => params[:default_security_protocol], :hostname => params[:default_hostname], :api_port => params[:default_api_port], :api_version => params[:api_version]}
         [user, params[:default_password], endpoint_opts]

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -123,7 +123,7 @@ module Mixins
     def get_task_args(ems)
       user, password = params[:default_userid], MiqPassword.encrypt(params[:default_password])
       case ems.to_s
-      when 'ManageIQ::Providers::Openstack::CloudManager'
+      when 'ManageIQ::Providers::Openstack::CloudManager', 'ManageIQ::Providers::Openstack::InfraManager'
         connect_opts = [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)] if params[:cred_type] == "default"
         connect_opts = [MiqPassword.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)] if params[:cred_type] == "amqp"
         connect_opts
@@ -148,10 +148,6 @@ module Mixins
         }
 
         [ems.build_connect_params(connect_opts), true]
-      when 'ManageIQ::Providers::Openstack::InfraManager'
-        connect_opts = [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)] if params[:cred_type] == "default"
-        connect_opts = [MiqPassword.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)] if params[:cred_type] == "amqp"
-        connect_opts
       when 'ManageIQ::Providers::Redhat::InfraManager'
         metrics_user, metrics_password = params[:metrics_userid], MiqPassword.encrypt(params[:metrics_password])
         [{

--- a/spec/controllers/mixins/ems_common_angular_spec.rb
+++ b/spec/controllers/mixins/ems_common_angular_spec.rb
@@ -143,6 +143,50 @@ describe Mixins::EmsCommonAngular do
       end
     end
 
+    context 'openstack infra' do
+      before do
+        @ems_infra_controller = EmsInfraController.new
+        @params = {
+          :default_security_protocol => "ssl",
+          :default_hostname          => "host_default",
+          :default_api_port          => "13000",
+          :default_userid            => "abc",
+          :default_password          => "abc",
+          :amqp_security_protocol    => "non_ssl",
+          :amqp_hostname             => "host_amqp",
+          :amqp_api_port             => "5462",
+          :amqp_userid               => "xyz",
+          :amqp_password             => "xyz"
+        }
+      end
+
+      it "returns connect options for openstack infra default tab" do
+        @params[:cred_type] = "default"
+        @ems_infra_controller.instance_variable_set(:@_params, @params)
+
+        expected_connect_options =  ["v2:{XpADRTTI7f11hNT7AuDaKg==}",
+                                     {:default_security_protocol => "ssl",
+                                      :default_hostname          => "host_default",
+                                      :default_api_port          => "13000",
+                                      :default_userid            => "abc"
+                                     }]
+        expect(@ems_infra_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::InfraManager')).to eq(expected_connect_options)
+      end
+
+      it "returns connect options for openstack infra AMQP tab" do
+        @params[:cred_type] = "amqp"
+        @ems_infra_controller.instance_variable_set(:@_params, @params)
+
+        expected_connect_options =  ["v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
+                                     {:amqp_security_protocol => "non_ssl",
+                                      :amqp_hostname          => "host_amqp",
+                                      :amqp_api_port          => "5462",
+                                      :amqp_userid            => "xyz"
+                                     }]
+        expect(@ems_infra_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::InfraManager')).to eq(expected_connect_options)
+      end
+    end
+
     context 'vmware infra' do
       before do
         @ems_infra_controller = EmsInfraController.new

--- a/spec/controllers/mixins/ems_common_angular_spec.rb
+++ b/spec/controllers/mixins/ems_common_angular_spec.rb
@@ -64,4 +64,118 @@ describe Mixins::EmsCommonAngular do
       expect(network_controller.send(:retrieve_event_stream_selection)).to eq('none')
     end
   end
+
+  describe 'get_task_args' do
+    context 'openstack cloud' do
+      before do
+        @ems_cloud_controller = EmsCloudController.new
+        @params = {
+          :default_security_protocol => "ssl",
+          :default_hostname          => "host_default",
+          :default_api_port          => "13000",
+          :default_userid            => "abc",
+          :default_password          => "abc",
+          :amqp_security_protocol    => "non_ssl",
+          :amqp_hostname             => "host_amqp",
+          :amqp_api_port             => "5462",
+          :amqp_userid               => "xyz",
+          :amqp_password             => "xyz"
+        }
+      end
+
+      it "returns connect options for openstack cloud default tab" do
+        @params[:cred_type] = "default"
+        @ems_cloud_controller.instance_variable_set(:@_params, @params)
+
+        expected_connect_options =  ["v2:{XpADRTTI7f11hNT7AuDaKg==}",
+                                      {:default_security_protocol => "ssl",
+                                       :default_hostname          => "host_default",
+                                       :default_api_port          => "13000",
+                                       :default_userid            => "abc"
+                                      }]
+        expect(@ems_cloud_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::CloudManager')).to eq(expected_connect_options)
+      end
+
+      it "returns connect options for openstack cloud AMQP tab" do
+        @params[:cred_type] = "amqp"
+        @ems_cloud_controller.instance_variable_set(:@_params, @params)
+
+        expected_connect_options =  ["v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
+                                     {:amqp_security_protocol => "non_ssl",
+                                      :amqp_hostname          => "host_amqp",
+                                      :amqp_api_port          => "5462",
+                                      :amqp_userid            => "xyz"
+                                     }]
+        expect(@ems_cloud_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::CloudManager')).to eq(expected_connect_options)
+      end
+    end
+
+    context 'vmware cloud' do
+      before do
+        @ems_cloud_controller = EmsCloudController.new
+        @params = {
+          :default_hostname          => "host_default",
+          :default_api_port          => "443",
+          :default_userid            => "abc",
+          :default_password          => "abc",
+          :amqp_security_protocol    => "non_ssl",
+          :amqp_hostname             => "host_amqp",
+          :amqp_api_port             => "5472",
+          :amqp_userid               => "xyz",
+          :amqp_password             => "xyz"
+        }
+      end
+
+      it "returns connect options for vmware cloud default tab" do
+        @params[:cred_type] = "default"
+        @ems_cloud_controller.instance_variable_set(:@_params, @params)
+
+        expected_connect_options =  ["host_default", "443", "abc", "v2:{XpADRTTI7f11hNT7AuDaKg==}", nil, true]
+        expect(@ems_cloud_controller.send(:get_task_args, 'ManageIQ::Providers::Vmware::CloudManager')).to eq(expected_connect_options)
+      end
+
+      it "returns connect options for vmware cloud AMQP tab" do
+        @params[:cred_type] = "amqp"
+        @ems_cloud_controller.instance_variable_set(:@_params, @params)
+
+        expected_connect_options = ["host_amqp", "5472", "xyz", "v2:{k8Sm5ygvDAvvY5zkvev1ag==}", nil, true]
+        expect(@ems_cloud_controller.send(:get_task_args, 'ManageIQ::Providers::Vmware::CloudManager')).to eq(expected_connect_options)
+      end
+    end
+
+    context 'vmware infra' do
+      before do
+        @ems_infra_controller = EmsInfraController.new
+        @params = {
+          :default_hostname => "host_default",
+          :default_userid   => "abc",
+          :default_password => "abc",
+          :console_userid   => "xyz",
+          :console_password => "xyz"
+        }
+      end
+
+      it "returns connect options for vmware infra default tab" do
+        @params[:cred_type] = "default"
+        @ems_infra_controller.instance_variable_set(:@_params, @params)
+
+        expected_connect_options =  [{:pass       => "v2:{XpADRTTI7f11hNT7AuDaKg==}",
+                                      :user       => "abc",
+                                      :ip         => "host_default",
+                                      :use_broker => false}]
+        expect(@ems_infra_controller.send(:get_task_args, 'ManageIQ::Providers::Vmware::InfraManager')).to eq(expected_connect_options)
+      end
+
+      it "returns connect options for vmware infra console tab" do
+        @params[:cred_type] = "console"
+        @ems_infra_controller.instance_variable_set(:@_params, @params)
+
+        expected_connect_options =  [{:pass       => "v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
+                                      :user       => "xyz",
+                                      :ip         => "host_default",
+                                      :use_broker => false}]
+        expect(@ems_infra_controller.send(:get_task_args, 'ManageIQ::Providers::Vmware::InfraManager')).to eq(expected_connect_options)
+      end
+    end
+  end
 end

--- a/spec/controllers/mixins/ems_common_angular_spec.rb
+++ b/spec/controllers/mixins/ems_common_angular_spec.rb
@@ -87,12 +87,11 @@ describe Mixins::EmsCommonAngular do
         @params[:cred_type] = "default"
         @ems_cloud_controller.instance_variable_set(:@_params, @params)
 
-        expected_connect_options =  ["v2:{XpADRTTI7f11hNT7AuDaKg==}",
-                                      {:default_security_protocol => "ssl",
-                                       :default_hostname          => "host_default",
-                                       :default_api_port          => "13000",
-                                       :default_userid            => "abc"
-                                      }]
+        expected_connect_options = ["v2:{XpADRTTI7f11hNT7AuDaKg==}",
+                                    {:default_security_protocol => "ssl",
+                                     :default_hostname          => "host_default",
+                                     :default_api_port          => "13000",
+                                     :default_userid            => "abc"}]
         expect(@ems_cloud_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::CloudManager')).to eq(expected_connect_options)
       end
 
@@ -100,12 +99,11 @@ describe Mixins::EmsCommonAngular do
         @params[:cred_type] = "amqp"
         @ems_cloud_controller.instance_variable_set(:@_params, @params)
 
-        expected_connect_options =  ["v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
-                                     {:amqp_security_protocol => "non_ssl",
-                                      :amqp_hostname          => "host_amqp",
-                                      :amqp_api_port          => "5462",
-                                      :amqp_userid            => "xyz"
-                                     }]
+        expected_connect_options = ["v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
+                                    {:amqp_security_protocol => "non_ssl",
+                                     :amqp_hostname          => "host_amqp",
+                                     :amqp_api_port          => "5462",
+                                     :amqp_userid            => "xyz"}]
         expect(@ems_cloud_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::CloudManager')).to eq(expected_connect_options)
       end
     end
@@ -114,15 +112,15 @@ describe Mixins::EmsCommonAngular do
       before do
         @ems_cloud_controller = EmsCloudController.new
         @params = {
-          :default_hostname          => "host_default",
-          :default_api_port          => "443",
-          :default_userid            => "abc",
-          :default_password          => "abc",
-          :amqp_security_protocol    => "non_ssl",
-          :amqp_hostname             => "host_amqp",
-          :amqp_api_port             => "5472",
-          :amqp_userid               => "xyz",
-          :amqp_password             => "xyz"
+          :default_hostname       => "host_default",
+          :default_api_port       => "443",
+          :default_userid         => "abc",
+          :default_password       => "abc",
+          :amqp_security_protocol => "non_ssl",
+          :amqp_hostname          => "host_amqp",
+          :amqp_api_port          => "5472",
+          :amqp_userid            => "xyz",
+          :amqp_password          => "xyz"
         }
       end
 
@@ -130,7 +128,7 @@ describe Mixins::EmsCommonAngular do
         @params[:cred_type] = "default"
         @ems_cloud_controller.instance_variable_set(:@_params, @params)
 
-        expected_connect_options =  ["host_default", "443", "abc", "v2:{XpADRTTI7f11hNT7AuDaKg==}", nil, true]
+        expected_connect_options = ["host_default", "443", "abc", "v2:{XpADRTTI7f11hNT7AuDaKg==}", nil, true]
         expect(@ems_cloud_controller.send(:get_task_args, 'ManageIQ::Providers::Vmware::CloudManager')).to eq(expected_connect_options)
       end
 
@@ -164,12 +162,11 @@ describe Mixins::EmsCommonAngular do
         @params[:cred_type] = "default"
         @ems_infra_controller.instance_variable_set(:@_params, @params)
 
-        expected_connect_options =  ["v2:{XpADRTTI7f11hNT7AuDaKg==}",
-                                     {:default_security_protocol => "ssl",
-                                      :default_hostname          => "host_default",
-                                      :default_api_port          => "13000",
-                                      :default_userid            => "abc"
-                                     }]
+        expected_connect_options = ["v2:{XpADRTTI7f11hNT7AuDaKg==}",
+                                    {:default_security_protocol => "ssl",
+                                     :default_hostname          => "host_default",
+                                     :default_api_port          => "13000",
+                                     :default_userid            => "abc"}]
         expect(@ems_infra_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::InfraManager')).to eq(expected_connect_options)
       end
 
@@ -177,12 +174,11 @@ describe Mixins::EmsCommonAngular do
         @params[:cred_type] = "amqp"
         @ems_infra_controller.instance_variable_set(:@_params, @params)
 
-        expected_connect_options =  ["v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
-                                     {:amqp_security_protocol => "non_ssl",
-                                      :amqp_hostname          => "host_amqp",
-                                      :amqp_api_port          => "5462",
-                                      :amqp_userid            => "xyz"
-                                     }]
+        expected_connect_options = ["v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
+                                    {:amqp_security_protocol => "non_ssl",
+                                     :amqp_hostname          => "host_amqp",
+                                     :amqp_api_port          => "5462",
+                                     :amqp_userid            => "xyz"}]
         expect(@ems_infra_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::InfraManager')).to eq(expected_connect_options)
       end
     end
@@ -203,10 +199,10 @@ describe Mixins::EmsCommonAngular do
         @params[:cred_type] = "default"
         @ems_infra_controller.instance_variable_set(:@_params, @params)
 
-        expected_connect_options =  [{:pass       => "v2:{XpADRTTI7f11hNT7AuDaKg==}",
-                                      :user       => "abc",
-                                      :ip         => "host_default",
-                                      :use_broker => false}]
+        expected_connect_options = [{:pass       => "v2:{XpADRTTI7f11hNT7AuDaKg==}",
+                                     :user       => "abc",
+                                     :ip         => "host_default",
+                                     :use_broker => false}]
         expect(@ems_infra_controller.send(:get_task_args, 'ManageIQ::Providers::Vmware::InfraManager')).to eq(expected_connect_options)
       end
 
@@ -214,10 +210,10 @@ describe Mixins::EmsCommonAngular do
         @params[:cred_type] = "console"
         @ems_infra_controller.instance_variable_set(:@_params, @params)
 
-        expected_connect_options =  [{:pass       => "v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
-                                      :user       => "xyz",
-                                      :ip         => "host_default",
-                                      :use_broker => false}]
+        expected_connect_options = [{:pass       => "v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
+                                     :user       => "xyz",
+                                     :ip         => "host_default",
+                                     :use_broker => false}]
         expect(@ems_infra_controller.send(:get_task_args, 'ManageIQ::Providers::Vmware::InfraManager')).to eq(expected_connect_options)
       end
     end


### PR DESCRIPTION
For `VMWare Infra VMRC Console`, correct credential parameters were not being passed while doing the validation on the queue.

Other than the above case that was reported in the BZ, the PR also fixes the following cases -
`OpenStack cloud AMQP`
`OpenStack infra AMQP`
`VMWare cloud AMQP`

https://bugzilla.redhat.com/show_bug.cgi?id=1574000