### PR TITLE
OpsRbac - specs for user add/edit

### DIFF
--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -12,17 +12,19 @@ describe OpsController do
     allow(controller).to receive(:get_node_info)
   end
 
-  def new_user_edit(data)
-    controller.rbac_user_add  # set up @edit for new user
+  def new_user_edit(data = {})
+    controller.rbac_user_add # set up @edit for new user
 
     edit = controller.instance_variable_get(:@edit)
     edit[:new] = data
     controller.instance_variable_set(:@edit, edit)
   end
 
-  def existing_user_edit(user, data)
-    controller.instance_variable_set(:@_params, :typ => nil, :button => nil, :id => user.id)
-    controller.rbac_user_edit  # set up @edit for the user
+  def existing_user_edit(user, data = {})
+    controller.instance_variable_set(:@_params, :typ    => nil,
+                                                :button => nil,
+                                                :id     => user.id)
+    controller.rbac_user_edit # set up @edit for the user
 
     edit = controller.instance_variable_get(:@edit)
     edit[:new] ||= {}
@@ -35,11 +37,11 @@ describe OpsController do
 
     it "calls both record.valid? and rbac_user_set_record_vars or neither" do
       new_user_edit(
-        :name => 'Full name',
-        :userid => 'username',
-        :group => group.id.to_s,
+        :name     => 'Full name',
+        :userid   => 'username',
+        :group    => group.id.to_s,
         :password => "foo",
-        :verify => "bar",
+        :verify   => "bar",
       )
 
       user = User.new
@@ -62,11 +64,11 @@ describe OpsController do
 
     it "displays both validation failures from rails and from rbac_user_validate? at the same time" do
       new_user_edit(
-        :name => '',  # fails user.valid?
-        :userid => 'username',
-        :group => group.id.to_s,
+        :name     => '', # fails user.valid?
+        :userid   => 'username',
+        :group    => group.id.to_s,
         :password => "foo", # fails rbac_user_validate
-        :verify => "bar",
+        :verify   => "bar",
       )
 
       controller.send(:rbac_edit_save_or_add, 'user')
@@ -83,11 +85,11 @@ describe OpsController do
 
     it "should not unset groups on cancel" do
       old_groups = user.miq_groups.pluck(:id).sort
-      existing_user_edit(user, {
-        :group => "",
-      })
+      existing_user_edit(user, :group => "")
 
-      controller.instance_variable_set(:@_params, :typ => nil, :button => 'save', :id => user.id)
+      controller.instance_variable_set(:@_params, :typ    => nil,
+                                                  :button => 'save', # attempt to save
+                                                  :id     => user.id)
       controller.send(:rbac_edit_save_or_add, 'user')
 
       # make sure it complains about the unset group in the first place
@@ -101,12 +103,12 @@ describe OpsController do
 
     it "should not change groups when rails validation fails" do
       old_groups = user.miq_groups.pluck(:id).sort
-      existing_user_edit(user, {
-        :group => group.id.to_s,
-        :name => "",  # fails record.valid?
-      })
+      existing_user_edit(user, :group => group.id.to_s,
+                               :name  => "") # fails record.valid?
 
-      controller.instance_variable_set(:@_params, :typ => nil, :button => 'save', :id => user.id)
+      controller.instance_variable_set(:@_params, :typ    => nil,
+                                                  :button => 'save',
+                                                  :id     => user.id)
       controller.send(:rbac_edit_save_or_add, 'user')
 
       # make sure it complains about the name
@@ -123,11 +125,12 @@ describe OpsController do
     let(:user) { FactoryGirl.create(:user_with_group) }
 
     it "updates record even for existing users" do
-      existing_user_edit(user, {
-        :name => "changed",
-      })
+      existing_user_edit(user, :name => "changed")
 
-      controller.instance_variable_set(:@_params, :typ => nil, :button => 'save', :id => user.id)
+      controller.instance_variable_set(:@_params, :typ    => nil,
+                                                  :button => 'save',
+                                                  :id     => user.id)
+
       controller.send(:rbac_edit_save_or_add, 'user')
 
       # make sure it returned success
@@ -146,14 +149,16 @@ describe OpsController do
 
     pending "should set current_group for new item" do
       new_user_edit(
-        :name => 'Full name',
-        :userid => 'username',
-        :group => group.id.to_s,
+        :name     => 'Full name',
+        :userid   => 'username',
+        :group    => group.id.to_s,
         :password => "foo",
-        :verify => "foo",
+        :verify   => "foo",
       )
 
-      controller.instance_variable_set(:@_params, :typ => nil, :button => 'save', :id => user.id)
+      controller.instance_variable_set(:@_params, :typ    => nil,
+                                                  :button => 'add',
+                                                  :id     => user.id)
       controller.send(:rbac_edit_save_or_add, 'user')
 
       # make sure it returned success
@@ -166,11 +171,11 @@ describe OpsController do
     end
 
     pending "should set current_group when editing" do
-      existing_user_edit(user, {
-        :group => group.id.to_s,
-      })
+      existing_user_edit(user, :group => group.id.to_s)
 
-      controller.instance_variable_set(:@_params, :typ => nil, :button => 'save', :id => user.id)
+      controller.instance_variable_set(:@_params, :typ    => nil,
+                                                  :button => 'save',
+                                                  :id     => user.id)
       controller.send(:rbac_edit_save_or_add, 'user')
 
       # make sure it returned success

--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -1,0 +1,70 @@
+describe OpsController do
+  before(:each) do
+    EvmSpecHelper.local_miq_server
+    MiqRegion.seed
+    MiqProductFeature.seed
+    stub_admin
+
+    controller.instance_variable_set(:@sb, {})
+    allow(controller).to receive(:replace_right_cell)
+    allow(controller).to receive(:load_edit).and_return(true)
+    allow(controller).to receive(:render_flash)
+    allow(controller).to receive(:get_node_info)
+  end
+
+  def new_user_edit(data)
+    controller.rbac_user_add  # set up @edit for new user
+
+    edit = controller.instance_variable_get(:@edit)
+    edit[:new] = data
+    controller.instance_variable_set(:@edit, edit)
+  end
+
+  context 'bz#1562828 - set record data before calling record.valid?' do
+    let(:group) { FactoryGirl.create(:miq_group) }
+
+    it "calls both record.valid? and rbac_user_set_record_vars or neither" do
+      new_user_edit(
+        :name => 'Full name',
+        :userid => 'username',
+        :group => group.id.to_s,
+        :password => "foo",
+        :verify => "bar",
+      )
+
+      user = User.new
+      allow(User).to receive(:new).and_return(user)
+
+      done_valid = false
+      allow(user).to receive(:valid?) {
+        done_valid = true
+      }
+
+      done_set = false
+      allow(controller).to receive(:rbac_user_set_record_vars) {
+        done_set = true
+      }
+
+      controller.send(:rbac_edit_save_or_add, 'user')
+
+      expect(done_valid).to eq(done_set)
+    end
+
+    it "displays both validation failures from rails and from rbac_user_validate? at the same time" do
+      new_user_edit(
+        :name => '',  # fails user.valid?
+        :userid => 'username',
+        :group => group.id.to_s,
+        :password => "foo", # fails rbac_user_validate
+        :verify => "bar",
+      )
+
+      controller.send(:rbac_edit_save_or_add, 'user')
+
+      messages = controller.instance_variable_get(:@flash_array).pluck(:message)
+      expect(messages).to include(match(/password/i))
+      expect(messages).to include(match(/name/i))
+    end
+  end
+
+end

--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -1,4 +1,6 @@
 describe OpsController do
+  include Spec::Support::OpsUserHelper
+
   before(:each) do
     EvmSpecHelper.local_miq_server
     MiqRegion.seed
@@ -10,26 +12,6 @@ describe OpsController do
     allow(controller).to receive(:load_edit).and_return(true)
     allow(controller).to receive(:render_flash)
     allow(controller).to receive(:get_node_info)
-  end
-
-  def new_user_edit(data = {})
-    controller.rbac_user_add # set up @edit for new user
-
-    edit = controller.instance_variable_get(:@edit)
-    edit[:new] = data
-    controller.instance_variable_set(:@edit, edit)
-  end
-
-  def existing_user_edit(user, data = {})
-    controller.instance_variable_set(:@_params, :typ    => nil,
-                                                :button => nil,
-                                                :id     => user.id)
-    controller.rbac_user_edit # set up @edit for the user
-
-    edit = controller.instance_variable_get(:@edit)
-    edit[:new] ||= {}
-    edit[:new].merge!(data)
-    controller.instance_variable_set(:@edit, edit)
   end
 
   context 'set record data before calling record.valid?' do

--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -26,7 +26,7 @@ describe OpsController do
         :verify   => "bar",
       )
 
-      user = User.new
+      user = FactoryGirl.build(:user)
       allow(User).to receive(:new).and_return(user)
 
       done_valid = false

--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -139,4 +139,47 @@ describe OpsController do
       expect(user.name).to eq('changed')
     end
   end
+
+  context 'bz#1574634 - set current_group' do
+    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:group) { FactoryGirl.create(:miq_group) }
+
+    pending "should set current_group for new item" do
+      new_user_edit(
+        :name => 'Full name',
+        :userid => 'username',
+        :group => group.id.to_s,
+        :password => "foo",
+        :verify => "foo",
+      )
+
+      controller.instance_variable_set(:@_params, :typ => nil, :button => 'save', :id => user.id)
+      controller.send(:rbac_edit_save_or_add, 'user')
+
+      # make sure it returned success
+      messages = controller.instance_variable_get(:@flash_array).pluck(:message)
+      expect(messages).to include(match(/was saved/i))
+
+      # make sure current_group is set and saved
+      user.reload
+      expect(user.current_group.id).to eq(group.id)
+    end
+
+    pending "should set current_group when editing" do
+      existing_user_edit(user, {
+        :group => group.id.to_s,
+      })
+
+      controller.instance_variable_set(:@_params, :typ => nil, :button => 'save', :id => user.id)
+      controller.send(:rbac_edit_save_or_add, 'user')
+
+      # make sure it returned success
+      messages = controller.instance_variable_get(:@flash_array).pluck(:message)
+      expect(messages).to include(match(/was saved/i))
+
+      # make sure current_group is set and saved
+      user.reload
+      expect(user.current_group.id).to eq(group.id)
+    end
+  end
 end

--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -32,7 +32,7 @@ describe OpsController do
     controller.instance_variable_set(:@edit, edit)
   end
 
-  context 'bz#1562828 - set record data before calling record.valid?' do
+  context 'set record data before calling record.valid?' do
     let(:group) { FactoryGirl.create(:miq_group) }
 
     it "calls both record.valid? and rbac_user_set_record_vars or neither" do
@@ -79,7 +79,7 @@ describe OpsController do
     end
   end
 
-  context 'bz#1537601 - don\'t change groups on cancel' do
+  context 'don\'t change groups on cancel' do
     let(:user) { FactoryGirl.create(:user_with_group) }
     let(:group) { FactoryGirl.create(:miq_group) }
 
@@ -121,7 +121,7 @@ describe OpsController do
     end
   end
 
-  context '#3767 - update record fields when editing' do
+  context 'update record fields when editing' do
     let(:user) { FactoryGirl.create(:user_with_group) }
 
     it "updates record even for existing users" do
@@ -143,7 +143,7 @@ describe OpsController do
     end
   end
 
-  context 'bz#1574634 - set current_group' do
+  context 'set current_group' do
     let(:user) { FactoryGirl.create(:user_with_group) }
     let(:group) { FactoryGirl.create(:miq_group) }
 

--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -118,4 +118,25 @@ describe OpsController do
       expect(user.miq_groups.pluck(:id).sort).to eq(old_groups)
     end
   end
+
+  context '#3767 - update record fields when editing' do
+    let(:user) { FactoryGirl.create(:user_with_group) }
+
+    it "updates record even for existing users" do
+      existing_user_edit(user, {
+        :name => "changed",
+      })
+
+      controller.instance_variable_set(:@_params, :typ => nil, :button => 'save', :id => user.id)
+      controller.send(:rbac_edit_save_or_add, 'user')
+
+      # make sure it returned success
+      messages = controller.instance_variable_get(:@flash_array).pluck(:message)
+      expect(messages).to include(match(/was saved/i))
+
+      # make sure the name did get changed
+      user.reload
+      expect(user.name).to eq('changed')
+    end
+  end
 end

--- a/spec/support/ops_user_helper.rb
+++ b/spec/support/ops_user_helper.rb
@@ -1,0 +1,25 @@
+module Spec
+  module Support
+    module OpsUserHelper
+      def new_user_edit(data = {})
+        controller.rbac_user_add # set up @edit for new user
+
+        edit = controller.instance_variable_get(:@edit)
+        edit[:new] = data
+        controller.instance_variable_set(:@edit, edit)
+      end
+
+      def existing_user_edit(user, data = {})
+        controller.instance_variable_set(:@_params, :typ    => nil,
+                                                    :button => nil,
+                                                    :id     => user.id)
+        controller.rbac_user_edit # set up @edit for the user
+
+        edit = controller.instance_variable_get(:@edit)
+        edit[:new] ||= {}
+        edit[:new].merge!(data)
+        controller.instance_variable_set(:@edit, edit)
+      end
+    end
+  end
+end


### PR DESCRIPTION
~~Depends on https://github.com/ManageIQ/manageiq/pull/17397~~

Related to #3894, #3767, #3345 and #3714.

There's been too many problems recently with the code to add/edit a user in the UI - I've written specs for each of those problems (including a pending spec for the problem being fixed in #3894).

(Creating a new spec file, since `ops_controller/ops_rbac_spec.rb` is already too long and only deals with tenant, while user/group stuff is either untested or mixed together with the rest in `ops_controller_spec.rb`)

Cc @lgalis , @ZitaNemeckova 