### PR TITLE
Use update_attributes for saving a user's groups

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -734,7 +734,7 @@ module OpsController::OpsRbac
     end
 
     if record.valid? && validated && record.save!
-      record.miq_groups = Rbac.filtered(MiqGroup.find(rbac_user_get_group_ids)) if key == :user # only set miq_groups if everything is valid
+      record.update_attributes!(:miq_groups => Rbac.filtered(MiqGroup.where(:id => rbac_user_get_group_ids))) if key == :user # only set miq_groups if everything is valid
       populate_role_features(record) if what == "role"
       self.current_user = record if what == 'user' && @edit[:current][:userid] == current_userid
       AuditEvent.success(build_saved_audit(record, add_pressed))

--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -129,7 +129,7 @@ describe OpsController do
     let(:user) { FactoryGirl.create(:user_with_group) }
     let(:group) { FactoryGirl.create(:miq_group) }
 
-    pending "should set current_group for new item" do
+    it "should set current_group for new item" do
       new_user_edit(
         :name     => 'Full name',
         :userid   => 'username',
@@ -139,8 +139,7 @@ describe OpsController do
       )
 
       controller.instance_variable_set(:@_params, :typ    => nil,
-                                                  :button => 'add',
-                                                  :id     => user.id)
+                                                  :button => 'add')
       controller.send(:rbac_edit_save_or_add, 'user')
 
       # make sure it returned success
@@ -148,11 +147,11 @@ describe OpsController do
       expect(messages).to include(match(/was saved/i))
 
       # make sure current_group is set and saved
-      user.reload
-      expect(user.current_group.id).to eq(group.id)
+      new_user = User.where(:userid => 'username').first
+      expect(new_user.current_group.id).to eq(group.id)
     end
 
-    pending "should set current_group when editing" do
+    it "should set current_group when editing" do
       existing_user_edit(user, :group => group.id.to_s)
 
       controller.instance_variable_set(:@_params, :typ    => nil,


### PR DESCRIPTION
Use update_attributes for saving a user's groups. Alternative for https://github.com/ManageIQ/manageiq-ui-classic/pull/3894

Links 
----------------


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1574634

Specs here: https://github.com/ManageIQ/manageiq-ui-classic/pull/3916



