### PR TITLE
Consistency on toolbar buttons for physical server list page

### DIFF
--- a/app/helpers/application_helper/toolbar/physical_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_servers_center.rb
@@ -189,8 +189,7 @@ class ApplicationHelper::Toolbar::PhysicalServersCenter < ApplicationHelper::Too
         :physical_server_policy_choice,
         'fa fa-shield fa-lg',
         N_('Policy'),
-        :enabled => false,
-        :onwhen  => "1+",
+        :enabled => true,
         :items   => [
           button(
             :physical_server_protect,


### PR DESCRIPTION
Keep consistency where toolbar buttons are always enabled and only its operations can be disabled depending on some logic.

![screenshot from 2018-05-10 09-49-02](https://user-images.githubusercontent.com/3654285/39870397-9d28daee-5437-11e8-909d-82f708b5e0e9.png)
