### PR TITLE
Made "Advanced" tab visible for all Server nodes.

### DIFF
--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -26,8 +26,8 @@
         - if cur_svr_id == my_server.id
           = miq_tab_header("settings_custom_logos", @sb[:active_tab]) do
             = _("Custom Logos")
-          = miq_tab_header("settings_advanced", @sb[:active_tab]) do
-            = _("Advanced")
+        = miq_tab_header("settings_advanced", @sb[:active_tab]) do
+          = _("Advanced")
       .tab-content
         = miq_tab_content("settings_server", @sb[:active_tab]) do
           = render :partial => "settings_server_tab"
@@ -38,8 +38,8 @@
         - if cur_svr_id == my_server.id
           = miq_tab_content("settings_custom_logos", @sb[:active_tab]) do
             = render :partial => "settings_custom_logos_tab"
-          = miq_tab_content("settings_advanced", @sb[:active_tab]) do
-            = render :partial => "settings_advanced_tab"
+        = miq_tab_content("settings_advanced", @sb[:active_tab]) do
+          = render :partial => "settings_advanced_tab"
     - else
       - if selected_settings_tree?(x_node)
         .tab-content


### PR DESCRIPTION
Allow edit of advanced config setting for all servers. Made changes so this code can be used to edit Zone/Region config settings in future.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536524

Dependent on core PR https://github.com/ManageIQ/manageiq/pull/17406 

before no Advanced tab on Remote server level:
![before](https://user-images.githubusercontent.com/3450808/39886041-4a5c438a-545c-11e8-9177-7bbb53030882.png)

after:
![after](https://user-images.githubusercontent.com/3450808/40188987-3e734dd0-59c9-11e8-85bb-f6b05f92976c.png)

