### PR TITLE
Selection of a dialog is required for a playbook catalog item 

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -17,7 +17,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
       provisioning_vault_credential_id: '',
       provisioning_execution_ttl: '',
       provisioning_inventory: 'localhost',
-      provisioning_dialog_existing: '',
+      provisioning_dialog_existing: 'existing',
       provisioning_dialog_id: '',
       provisioning_dialog_name: '',
       provisioning_key: '',

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -261,12 +261,12 @@
                       %span{:class => "pficon pficon-delete"}
 
     - if prefix == "provisioning"
-      .form-group{"ng-if" =>"#{ng_model}.#{prefix}_dialog_existing!==undefined"}
+      .form-group
         %label.col-md-3.control-label
           = _("Dialog")
         .col-md-3
           %label.radio-inline
-            %input{"ng-model" => "vm.#{prefix}_dialog_existing", :type => "radio", :value => "existing", "ng-click" => "vm.toggleDialogSelection('#{prefix}', 'existing')", "ng-checked" => "#{ng_model}.#{prefix}_dialog_existing == 'existing'"}
+            %input{"ng-model" => "vm.#{prefix}_dialog_existing", :type => "radio", :value => "existing", "ng-value" => "existing", "ng-click" => "vm.toggleDialogSelection('#{prefix}', 'existing')", "ng-checked" => "#{ng_model}.#{prefix}_dialog_existing == 'existing'"}
             = _("Use Existing")
         .col-md-6{"ng-class" => "{'has-error': angularForm.#{prefix}_dialog_id.$invalid}", "ng-if" => "#{ng_model}.#{prefix}_dialog_existing == 'existing'"}
           %select{"ng-model"         => "vm._#{prefix}_dialog",
@@ -281,11 +281,11 @@
             %span.help-block{"ng-show" => "angularForm.#{prefix}_dialog_id.$error.$invalid"}
               = _("Required")
 
-      .form-group{"ng-if" =>"#{ng_model}.#{prefix}_dialog_existing!==undefined"}
+      .form-group
         %label.col-md-3.control-label
         .col-md-3
           %label.radio-inline
-            %input{"ng-model" => "vm.#{prefix}_dialog_existing", :type => "radio", :value => "create", "ng-click" => "vm.toggleDialogSelection('#{prefix}', 'create')", "ng-checked" => ("#{ng_model}.#{prefix}_dialog_existing == 'create'")}
+            %input{"ng-model" => "vm.#{prefix}_dialog_existing", :type => "radio", :value => "create", :ng-value => "create", "ng-click" => "vm.toggleDialogSelection('#{prefix}', 'create')", "ng-checked" => ("#{ng_model}.#{prefix}_dialog_existing == 'create'")}
             = _("Create New")
         .col-md-6{"ng-class" => "{'has-error': angularForm.#{prefix}_dialog_name.$invalid}", "ng-if" => "#{ng_model}.#{prefix}_dialog_existing == 'create'"}
           %input.form-control{:type         => "text",


### PR DESCRIPTION
Selection of a dialog is required for playbook catalog

Links 
-----------
https://bugzilla.redhat.com/show_bug.cgi?id=1574204

Make sure the issue in this BZ is also fixed, as I reverted the changes made in https://github.com/ManageIQ/manageiq-ui-classic/pull/3413.

Steps for Testing/QA 
-------------------------------
 1. Make sure a dialog is required when adding a Playbook Catalog Item
2. Make sure the radio button for switching between a new and existing dialog is displayed when editing an existing catalog item.

After:
![screenshot from 2018-05-11 09-15-31](https://user-images.githubusercontent.com/12769982/39926255-9d0f1422-54fc-11e8-8491-b8e1b59bddbc.png)
![screenshot from 2018-05-11 09-16-01](https://user-images.githubusercontent.com/12769982/39926256-9d1bfbe2-54fc-11e8-9ec5-4ae7315eefc3.png)
