### PR TITLE
BZ1504209: Add backup create/restore to volume list actions

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
@@ -15,6 +15,26 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                      ),
                      separator,
                      button(
+                       :cloud_volume_backup_create,
+                       'pficon pficon-volume fa-lg',
+                       t = N_('Create a Backup of selected Cloud Volume'),
+                       t,
+                       :url_parms    => 'main_div',
+                       :send_checked => true,
+                       :enabled      => false,
+                       :onwhen       => '1'
+                     ),
+                     button(
+                       :cloud_volume_backup_restore,
+                       'pficon pficon-volume fa-lg',
+                       t = N_('Restore from a Backup of selected Cloud Volume'),
+                       t,
+                       :url_parms    => 'main_div',
+                       :send_checked => true,
+                       :enabled      => false,
+                       :onwhen       => '1'
+                     ),
+                     button(
                        :cloud_volume_snapshot_create,
                        'pficon pficon-volume fa-lg',
                        t = N_('Create a Snapshot of selected Cloud Volume'),


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1504209

Create backup and restore from backup actions were missing from the
volume list page. They were already on the detail/view page.

This commit adds them.