### PR TITLE
[FINE] - Follow up fix to address another condition

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -1086,6 +1086,7 @@ module MiqAeCustomizationController::Dialogs
           :field_entry_point         => field[:entry_point],
           :field_auto_refresh        => field[:auto_refresh]
         )
+        @edit[:new][:selected] = @edit[:new]["field_entry_point"] = @edit[:field_entry_point] = field[:entry_point]
       end
 
       if %w(DialogFieldTagControl DialogFieldDropDownList DialogFieldRadioButton).include?(field[:typ])


### PR DESCRIPTION
Original fix was made in https://github.com/ManageIQ/manageiq-ui-classic/pull/3766

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1532272

@skateman can you please test, instructions to recreate are in BZ, slightly modified see below:

Appliance : https://10.8.199.206/
Edit dialog :dynamic_refresh.
Edit field name: "Location" entry point .Select Location in path.
Now edit field name"What's Inside?" and click on entry point .
Location will be selected and Apply is greyed out .
If you want to select the same path "location" again .
Click on any other entry point like "peek" and then location again and now the "Apply " button is enabled.

