### PR TITLE
Added React component factory.

### DIFF
--- a/app/javascript/miq-component/helpers.js
+++ b/app/javascript/miq-component/helpers.js
@@ -4,3 +4,13 @@ import reactBlueprint from '../miq-component/react-blueprint';
 export function addReact(name, component) {
   return registry.define(name, reactBlueprint(component));
 }
+
+export function componentFactory(blueprintName, selector, props) {
+  const { isDefined } = ManageIQ.component;
+  if (!isDefined(blueprintName)) {
+    throw new Error(`Attempt to create instance of ${blueprintName}. Blueprint ${blueprintName} is not defined!`);
+  }
+  const element = document.querySelector(selector);
+  const allProps = { ...element.dataset, ...props };
+  ManageIQ.component.newInstance(blueprintName, allProps, element);
+}

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+/**
+* Add component definitions to this file.
+* example of component definition:
+* ManageIQ.component.addReact('ComponentName', props => <ComponentName {...props} />);
+*/


### PR DESCRIPTION
Component factory for mounting react components.

## Usage
* Define react component in `app/javascript/packs/component-definitions-common.js`
```
import ComponentName from '../components/ComponentName'; // or other location

// simple definition
  ManageIQ.component.addReact('ComponentName', ComponentName);

// with extra props
  ManageIQ.component.addReact('ComponentName', props => <ComponentName {...props} />);
```
* Create root element in template and call factory:
```
// explicit props definition
#root-element{data-first-props => "something",
              data-second-prop => @rubyObject.property}

//or create props structure from object:
#root-element{:data => {:first-prop => "something", :second-prop => @rubyObject.property}}

javascript:
  ManageIQ.component.componentFactory('ComponentName', '#root-element', [{optional props object}]);
```
## Props
To pass some initial props to component use `data` attributes on the root element.
Attribue `data-first-prop` is equal to `firstProp` prop in React component.

If you want to use prop name, that is not in camel case, use the third optional parameter of `ManageIQ.component.componentFactory`. It expects a JSON object.