### PR TITLE
Render the correct toolbar for the infra networking switches

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -104,7 +104,7 @@ class InfraNetworkingController < ApplicationController
     end
 
     if @record.kind_of?(Switch)
-      rec_cls = @record.class.to_s
+      rec_cls = @record.class.base_model.to_s
     end
     return unless %w(download_pdf main).include?(@display)
     @showtype     = "main"

--- a/spec/controllers/infra_networking_controller_spec.rb
+++ b/spec/controllers/infra_networking_controller_spec.rb
@@ -1,0 +1,27 @@
+describe InfraNetworkingController do
+  let(:zone) { FactoryGirl.build(:zone) }
+  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+
+  before { stub_user(:features => :all) }
+
+  describe '#tree_select' do
+    render_views
+
+    context 'switch' do
+      let(:ems) { FactoryGirl.create(:ems_vmware) }
+      let(:cluster) { FactoryGirl.create(:ems_cluster, :ems_id => ems.id) }
+      let(:host) { FactoryGirl.create(:host_vmware, :ems_id => ems.id, :ems_cluster => cluster) }
+      let(:switch) do
+        sw = FactoryGirl.create(:switch_vmware, :ems_id => ems.id)
+        FactoryGirl.create(:host_switch, :host => host, :switch => sw)
+        sw
+      end
+
+      it 'renders the network switch center toolbar' do
+        nodeid = [ems, cluster, switch].map { |item| TreeNode.new(item).key }.join('_')
+        expect(ApplicationHelper::Toolbar::XInfraNetworkingSwitchCenter).to receive(:definition).and_return([]).at_least(:once)
+        post :tree_select, :params => { :id => nodeid }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since we introduced the `PhysicalSwitch` class, the good old `Switch` is not behaving on the infra networking screens as before. When clicking on a switch node under `Infrastructure -> Networking` it throws a `uninitialized constant ApplicationHelper::Toolbar::XInfraNetworkingManageiq` error.

By setting the `rec_cls` to the `base_model` of the record's class, this problem disappears.

Depends on: https://github.com/ManageIQ/manageiq/pull/17416

@miq-bot add_label bug, gaprindashvili/no, pending core
@miq-bot assign @martinpovolny 