### PR TITLE
Wrap type-based tooltips in quadicons with ui_lookup

### DIFF
--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -17,7 +17,7 @@ class ExtManagementSystemDecorator < MiqDecorator
       :top_right    => {:text => ""},
       :bottom_left  => {
         :fileicon => fileicon,
-        :tooltip  => type
+        :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
         :fileicon => QuadiconHelper.status_img(authentication_status),

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -13,7 +13,7 @@ class HostDecorator < MiqDecorator
       :top_right    => QuadiconHelper.machine_state(normalized_state),
       :bottom_left  => {
         :fileicon => fileicon,
-        :tooltip  => type
+        :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
         :fileicon => QuadiconHelper.status_img(authentication_status),

--- a/app/decorators/manageiq/providers/cloud_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager_decorator.rb
@@ -17,7 +17,7 @@ class ManageIQ::Providers::CloudManagerDecorator < MiqDecorator
       :top_right    => {:text => total_miq_templates},
       :bottom_left  => {
         :fileicon => fileicon,
-        :tooltip  => type
+        :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
         :fileicon => QuadiconHelper.status_img(authentication_status),

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -17,7 +17,7 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
       :top_right    => QuadiconHelper.machine_state(enabled? ? 'on' : 'paused'),
       :bottom_left  => {
         :fileicon => fileicon,
-        :tooltip  => type
+        :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
         :fileicon => QuadiconHelper.status_img(authentication_status),

--- a/app/decorators/manageiq/providers/infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/infra_manager_decorator.rb
@@ -17,7 +17,7 @@ class ManageIQ::Providers::InfraManagerDecorator < ExtManagementSystemDecorator
       :top_right    => {:text => total_vms},
       :bottom_left  => {
         :fileicon => fileicon,
-        :tooltip  => type
+        :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
         :fileicon => QuadiconHelper.status_img(authentication_status),

--- a/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
@@ -17,7 +17,7 @@ class ManageIQ::Providers::PhysicalInfraManagerDecorator < ExtManagementSystemDe
       :top_right    => {:text => ""},
       :bottom_left  => {
         :fileicon => fileicon,
-        :tooltip  => type
+        :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
         :fileicon => QuadiconHelper.status_img(authentication_status),

--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -18,7 +18,7 @@ class MiqTemplateDecorator < MiqDecorator
       }.merge(QuadiconHelper.machine_state(normalized_state)),
       :bottom_left  => {
         :fileicon => fileicon,
-        :tooltip  => type
+        :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
         :text => ERB::Util.h(v_total_snapshots)

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -15,7 +15,7 @@ class PhysicalServerDecorator < MiqDecorator
       }.merge(QuadiconHelper.machine_state(power_state)),
       :bottom_left  => {
         :fileicon => fileicon,
-        :tooltip  => type
+        :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
         :fileicon => health_state_img,

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -22,7 +22,7 @@ class VmOrTemplateDecorator < MiqDecorator
       }.merge(QuadiconHelper.machine_state(normalized_state)),
       :bottom_left  => {
         :fileicon => fileicon,
-        :tooltip  => type
+        :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
         :text => ERB::Util.h(v_total_snapshots)


### PR DESCRIPTION
As each quad has its separate tooltip now, the ones related to the `type` can be properly "translated" using `ui_lookup`.

@miq-bot add_label internationalization, GTLs
@miq-bot assign @mzazrivec 