### PR TITLE
Add an extra .remote-console class on the remote console footer

### DIFF
--- a/app/assets/stylesheets/remote_console.scss
+++ b/app/assets/stylesheets/remote_console.scss
@@ -5,7 +5,7 @@
   overflow: auto;
 }
 
-footer {
+footer.remote-console {
   position: fixed;
   line-height: 30px;
   vertical-align: middle;

--- a/app/views/shared/_remote_console_footer.haml
+++ b/app/views/shared/_remote_console_footer.haml
@@ -1,4 +1,4 @@
-%footer
+%footer.remote-console
   .pull-left
     %span#console-type.label.label-info= j console_type.to_s
     %span#connection-status.label.label-warning= _('Connecting')


### PR DESCRIPTION
The `footer` styling for remote consoles is conflicting with the [new login screen](https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/login-social-account-two-column.html) provided by PatternFly. This extra class should solve the problem and unblock @epwinchell.

@miq-bot add_label gaprindashvili/no, formatting/styling