### PR TITLE
Component registry - support both pure function component and class components

### DIFF
--- a/app/javascript/miq-component/react-blueprint.tsx
+++ b/app/javascript/miq-component/react-blueprint.tsx
@@ -14,13 +14,13 @@ import {
 // should fix the problem
 
 export default (
-  reactElementCreator: (props: ComponentProps) => any /* ReactElement */,
+  ReactElement: (props: ComponentProps) => any,
   mapPropsToInteract: (props: ComponentProps) => any = () => undefined
 ): ComponentBlueprint => {
   function render(props: ComponentProps, container: HTMLElement) {
     ReactDOM.render(
       <Provider store={ManageIQ.redux.store}>
-        {reactElementCreator(props)}
+        <ReactElement {...props} />
       </Provider>,
       container
     );

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -3,5 +3,5 @@ import React from 'react';
 /**
 * Add component definitions to this file.
 * example of component definition:
-* ManageIQ.component.addReact('ComponentName', props => <ComponentName {...props} />);
+* ManageIQ.component.addReact('ComponentName', ComponentName);
 */


### PR DESCRIPTION
previously, adding a class component had to be done via `addReact('name', (props) => <Name {...props} />)`, otherwise, it would fail trying to "call" the class with props

this change makes it possible to treat both kinds of react components the same way, and register them directly as `addReact('name', Name)`

Cc @martinpovolny , @Hyperkid123 