### PR TITLE
Utilize a new 'miq-select' directive for dialog fields

### DIFF
--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -10,6 +10,7 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'miq.util',
   'miqStaticAssets.dialogEditor',
   'miqStaticAssets.dialogUser',
+  'miqStaticAssets.miqSelect',
   'miqStaticAssets.treeSelector',
   'miqStaticAssets.treeView',
   'miqStaticAssets.quadicon',


### PR DESCRIPTION
This is dependent upon https://github.com/ManageIQ/ui-components/pull/295. With the ui-components PR, the dialog-user component will be using a new custom directive to handle an odd case of when options within a drop-down change but the values do not (ex: [["1", "one"], ["2", "two"]] changing to [["1", "uno"], ["2", "dos"]]).

https://bugzilla.redhat.com/show_bug.cgi?id=1574668

@himdel This is all I need to do for the classic-ui side, yes?
@miq-bot add_label gaprindashvili/yes, bug