### PR TITLE
Change text for columns when displaying Compare for VMs/Templates/Hosts

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -1381,7 +1381,7 @@ module ApplicationController::Compare
     }
     view.ids.each_with_index do |_id, idx|
       if idx == 0
-        row.merge!(compare_add_txt_col(idx, @compressed ? "%:" : _("% Matched:"), _("% Matched")))
+        row.merge!(compare_add_txt_col(idx, @compressed ? "%:" : _("% Matched:")))
       else
         key = @exists_mode ? :_match_exists_ : :_match_
         pct_match = view.results[view.ids[idx]][key]
@@ -1426,7 +1426,7 @@ module ApplicationController::Compare
     row = {}
     view.ids.each_with_index do |id, idx|
       if idx == 0
-        row.merge!(compare_add_txt_col(idx, @compressed ? "%:" : _("% Matched:"), _("% Matched")))
+        row.merge!(compare_add_txt_col(idx, @compressed ? "%:" : _("% Matched:")))
       else
         key = @exists_mode && !records.nil? ? :_match_exists_ : :_match_
         pct_match = view.results[id][section[:name]][key]
@@ -1505,7 +1505,7 @@ module ApplicationController::Compare
 
   def comp_record_data_nonexistsmode(idx, match, val, basval)
     if idx.zero?
-      compare_add_txt_col(idx, "%:", _("% Matched"))
+      compare_add_txt_col(idx, "%:")
     elsif val == "Found" # This object has the record
       if basval == "Found" # Base has the record
         img_src = calculate_match_img(match)
@@ -1678,7 +1678,7 @@ module ApplicationController::Compare
       compare_add_txt_col(idx, val)
     else
       style = "color:#{base_val == val ? passed_text_color : failed_text_color};"
-      compare_add_txt_col(idx, size_formatting(field[:name], val), "", "", style)
+      compare_add_txt_col(idx, size_formatting(field[:name], val), "", style)
     end
   end
 
@@ -1695,7 +1695,7 @@ module ApplicationController::Compare
       compare_add_txt_col(idx, _("(missing)"))
     else
       style = "color:#{base_fld.nil? ? passed_text_color : failed_text_color};"
-      compare_add_txt_col(idx, _("(missing)"), "", "", style)
+      compare_add_txt_col(idx, _("(missing)"), "", style)
     end
   end
 
@@ -1758,14 +1758,14 @@ module ApplicationController::Compare
         row.merge!(compare_add_txt_col(idx, val))
       else
         if base_val == val
-          style = "color:#403990;font-weight:bold;"
+          style = "color:#403990;"
           img_bkg = "cell-stripe"
         else
-          style = "color:#21a0ec;font-weight:bold;"
+          style = "color:#21a0ec;"
           img_bkg = ""
           unset_same_flag
         end
-        row.merge!(compare_add_txt_col(idx, val, "", img_bkg, style))
+        row.merge!(compare_add_txt_col(idx, val, img_bkg, style))
       end
     end
     row

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -1341,13 +1341,11 @@ module ApplicationController::Compare
     @rows << row
   end
 
-  def compare_add_txt_col(idx, txt, tooltip = "", img_bkg = "cell-stripe", style = "")
-    txt_tooltip = tooltip.empty? ? txt : tooltip
-    txt_tooltip = "<abbr title='#{txt_tooltip}'>#{txt}</abbr>"
+  def compare_add_txt_col(idx, txt, img_bkg = "cell-stripe", style = "")
     html_text = if style.empty?
-                  "<div class='#{img_bkg} cell-text-wrap'>#{txt_tooltip}</div>"
+                  "<div class='#{img_bkg} cell-text-wrap'>#{txt}</div>"
                 else
-                  "<div class='#{img_bkg} cell-text-wrap' style='#{style}'>#{txt_tooltip}</div>"
+                  "<div class='#{img_bkg} cell-text-wrap' style='#{style}'>#{txt}</div>"
                 end
     {"col#{idx + 1}".to_sym => html_text}
   end


### PR DESCRIPTION
**What:**
Change text for columns (for expanded view) when displaying Compare for VMs/ Templates/Hosts by:
- removing unnecessary tooltip from _compare_add_txt_col_ method
- updating calling the method in other places according to the method's change
- removing bold text style from the columns

---

**Before:**
Comparing three VMs or Templates:
![compare_vm_before](https://user-images.githubusercontent.com/13417815/40116290-782b0e16-5913-11e8-8f86-b678ad3d39f2.png)
Comparing three Hosts/Nodes:
![compare_host_before](https://user-images.githubusercontent.com/13417815/40116293-79d64046-5913-11e8-9e14-b6aaac9779df.png)

**After:**
Comparing three VMs or Templates:
![compare_vm_after](https://user-images.githubusercontent.com/13417815/40115980-84cfcc02-5912-11e8-9bf4-f3ec1801d626.png)
Comparing three Hosts/Nodes:
![compare_host_after](https://user-images.githubusercontent.com/13417815/40115983-878e96da-5912-11e8-92c0-a1b63bb79d26.png)

---

**Why:**
- to reach more readable output
- to achieve consistency with displaying Drift for VMs/Hosts:
![blue_after](https://user-images.githubusercontent.com/13417815/40016852-f29fa89e-57b7-11e8-8115-d578aa991f9a.png)
