### PR TITLE
Add spec tests to check rendered toolbars on Block/Object Storage Managers

### DIFF
--- a/spec/controllers/ems_block_storage_controller_spec.rb
+++ b/spec/controllers/ems_block_storage_controller_spec.rb
@@ -30,4 +30,13 @@ describe EmsBlockStorageController do
       end
     end
   end
+
+  describe '#show_list' do
+    render_views
+
+    it 'renders the Block Storage Managers Toolbar' do
+      expect(ApplicationHelper::Toolbar::GtlView).to receive(:definition)
+      post :show_list
+    end
+  end
 end

--- a/spec/controllers/ems_object_storage_controller_spec.rb
+++ b/spec/controllers/ems_object_storage_controller_spec.rb
@@ -1,3 +1,12 @@
 describe EmsObjectStorageController do
   include_examples :shared_examples_for_ems_object_storage_controller, %w(openstack)
+
+  describe '#show_list' do
+    render_views
+
+    it 'renders the Object Storage Managers Toolbar' do
+      expect(ApplicationHelper::Toolbar::GtlView).to receive(:definition)
+      post :show_list
+    end
+  end
 end


### PR DESCRIPTION
Add spec tests to check the toolbars to be rendered on Block/Object Storage Managers pages.
See: https://github.com/ManageIQ/manageiq-ui-classic/pull/3871 (Add view selector to Block/Object Storage Managers )