### PR TITLE
Update switch ports relationship

### DIFF
--- a/app/decorators/physical_switch_decorator.rb
+++ b/app/decorators/physical_switch_decorator.rb
@@ -6,7 +6,7 @@ class PhysicalSwitchDecorator < MiqDecorator
   def quadicon
     {
       :top_left     => {
-        :text    => hardware.physical_ports.try(:size).to_i,
+        :text    => physical_network_ports.try(:size).to_i,
         :tooltip => _('Ports')
       },
       :top_right    => {

--- a/app/helpers/physical_switch_helper/textual_summary.rb
+++ b/app/helpers/physical_switch_helper/textual_summary.rb
@@ -29,7 +29,7 @@ module PhysicalSwitchHelper::TextualSummary
   end
 
   def textual_group_ports
-    TextualTable.new(_("Ports"), port_details, [_("Device Name"), _("Device Type"), _("Peer Mac Address")])
+    TextualTable.new(_("Ports"), port_details, [_("Name"), _("Type"), _("Peer MAC Address")])
   end
 
   def textual_ext_management_system
@@ -81,6 +81,6 @@ module PhysicalSwitchHelper::TextualSummary
   end
 
   def port_details
-    @record.hardware.guest_devices.collect { |port| [port.device_name, port.device_type, port.peer_mac_address] }
+    @record.physical_network_ports.collect { |port| [port.port_name, port.port_type, port.peer_mac_address] }
   end
 end


### PR DESCRIPTION
The way we handle Switches ports has changed in the past weeks in the following PR:

https://github.com/ManageIQ/manageiq/pull/17268

This code updates the UI to properly show Physical Network Ports.