### PR TITLE
Remove :match_via_decendants for ConfiguredSystem::ConfiguredSystem

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -276,7 +276,6 @@ class AutomationManagerController < ApplicationController
 
   def cs_provider_node(provider)
     options = {:model                 => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
-               :match_via_descendants => 'ConfigurationScript',
                :named_scope           => [[:with_manager, provider.id]],
                :gtl_dbname            => "automation_manager_configuration_scripts"}
     @show_adv_search = true
@@ -293,7 +292,6 @@ class AutomationManagerController < ApplicationController
     else
       @show_adv_search = false
       options = {:model                 => "ConfiguredSystem",
-                 :match_via_descendants => 'ConfiguredSystem',
                  :named_scope           => [[:with_inventory_root_group, @inventory_group_record.id]],
                  :gtl_dbname            => "automation_manager_configured_systems"}
       process_show_list(options)

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -306,7 +306,7 @@ class ProviderForemanController < ApplicationController
       self.x_node = "root"
       get_node_info("root")
     else
-      options = {:model => "ConfiguredSystem", :match_via_descendants => 'ConfiguredSystem'}
+      options = {:model => "ConfiguredSystem"}
       if empty_configuration_profile_record?(@configuration_profile_record)
         options[:named_scope] = [[:with_manager, id], [:without_configuration_profile_id]]
       else

--- a/app/presenters/tree_builder_automation_manager_providers.rb
+++ b/app/presenters/tree_builder_automation_manager_providers.rb
@@ -34,6 +34,6 @@ class TreeBuilderAutomationManagerProviders < TreeBuilder
   def x_get_tree_igf_kids(object, count_only)
     count_only_or_objects_filtered(count_only,
                                    ConfiguredSystem.where(:inventory_root_group_id=> object[:id]),
-                                   "hostname", :match_via_descendants => ConfiguredSystem)
+                                   "hostname")
   end
 end

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -47,8 +47,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
   def fetch_unassigned_configuration_profile_objects(count_only, configuration_manager_id)
     unprovisioned_configured_systems = ConfiguredSystem.where(:configuration_profile_id => nil,
                                                               :manager_id               => configuration_manager_id)
-    unprovisioned_configured_systems_filtered = Rbac.filtered(unprovisioned_configured_systems,
-                                                              :match_via_descendants => ConfiguredSystem)
+    unprovisioned_configured_systems_filtered = Rbac.filtered(unprovisioned_configured_systems)
     if unprovisioned_configured_systems_filtered.count > 0
       unassigned_id = "#{configuration_manager_id}-unassigned"
       unassigned_configuration_profile =
@@ -59,10 +58,9 @@ class TreeBuilderConfigurationManager < TreeBuilder
   end
 
   def x_get_tree_cpf_kids(object, count_only)
-    count_only_or_objects_filtered(count_only,
-                                   ConfiguredSystem.where(:configuration_profile_id => object[:id],
-                                                          :manager_id               => object[:manager_id]),
-                                   "hostname", :match_via_descendants => ConfiguredSystem)
+    configured_systems = ConfiguredSystem.where(:configuration_profile_id => object[:id],
+                                                :manager_id               => object[:manager_id])
+    count_only_or_objects_filtered(count_only, configured_systems, "hostname")
   end
 
   def x_get_tree_custom_kids(object_hash, count_only, _options)


### PR DESCRIPTION
Let's clean up nonsense Rbac requests for `:match_via_descendants` since `ConfiguredSystem::ConfiguredSystem` and `ConfigurationScript::ConfigurationScript` (in one bonus extra case for free) are not valid relations. This only causes `evm.log` warning pollution like:
```
WARN -- : MIQ(Rbac::Filterer#lookup_method_for_descendant_class) could not find method name for ConfiguredSystem::ConfiguredSystem
```

For valid relations, please consult [Rbac's filterer.rb](https://github.com/ManageIQ/manageiq/blob/9d5ed08d602381d407802cde3375ef01261b7931/lib/rbac/filterer.rb#L92)

Partially fixes: [bug 1565266](https://bugzilla.redhat.com/show_bug.cgi?id=1565266)
Related: https://github.com/ManageIQ/manageiq/pull/17430

@miq-bot add_label rbac, bug