### PR TITLE
Fixing Provider PhysicalSwitches page summary show

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -169,7 +169,8 @@ module ApplicationHelper
     "OsProcess"        => "processes",
     "scan_histories"   => "scan_histories",
     "based_volumes"    => "based_volumes",
-    "PersistentVolume" => "persistent_volumes"
+    "PersistentVolume" => "persistent_volumes",
+    "PhysicalSwitch"   => "physical_switches"
   }.freeze
 
   def model_to_report_data

--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -58,7 +58,7 @@ module EmsPhysicalInfraHelper::TextualSummary
   end
 
   def textual_physical_switches
-    textual_link(@record.physical_switches)
+    textual_link(@record.physical_switches, :as => PhysicalSwitch)
   end
 
   def textual_physical_servers

--- a/app/views/layouts/listnav/_ems_physical_infra.html.haml
+++ b/app/views/layouts/listnav/_ems_physical_infra.html.haml
@@ -15,6 +15,10 @@
     = miq_accordion_panel(_("Relationships"), false, "ems_rel") do
       %ul.nav.nav-pills.nav-stacked
         %li
+          = li_link(:count => @record.number_of(:physical_switches),
+            :text          => _('Physical Switches'),
+            :record        => @record,
+            :display       => 'physical_switches')
           = li_link(:count => @record.number_of(:physical_servers),
             :tables        => 'physical_servers',
             :record        => @record,


### PR DESCRIPTION
This PR is able to:
- Enable PhysicalSwitches listing in Physical Infra Provider
- Display Physical Switches in Physical Infra Provider 'Relationships' field

The problems:

When trying to list the Physical Switches from a Physical Infra Provider (`/ems_physical_infra/:id?display=physical_switches`)
![physical_swiches_listing_02](https://user-images.githubusercontent.com/7563089/40562330-c8835a1a-6036-11e8-8a0c-917a50b43851.png)

An error is returned
![physical_switches_listing_03](https://user-images.githubusercontent.com/7563089/40562339-d2b1157c-6036-11e8-8da6-30530b7102a5.png)

This happens because the application controller from the UI calls `paged_view_search`, which is a method from Search class inside ManageIQ core that, internally, uses the base model for the class passed. The result is that, instead of `PhysicalSwitch`, its parent `Switch` is called.