### PR TITLE
Enable code splitting for V2V

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -8,7 +8,10 @@ const CompressionPlugin = require('compression-webpack-plugin')
 const sharedConfig = require('./shared.js')
 
 module.exports = merge(sharedConfig, {
-  output: { filename: '[name]-[chunkhash].js' },
+  output: {
+    filename: '[name]-[chunkhash].js',
+    chunkFilename: '[name]-[chunkhash].js',
+  },
   devtool: 'source-map',
   stats: 'normal',
 

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -36,6 +36,7 @@ module.exports = {
 
   output: {
     filename: '[name].js',
+    chunkFilename: '[name].chunk.js',
     path: output.path,
     publicPath: output.publicPath
   },
@@ -69,6 +70,12 @@ module.exports = {
       name: 'vendor',
       minChunks: module => /node_modules/.test(module.resource),
     }),
+    new webpack.optimize.CommonsChunkPlugin({
+      names: ['miq_v2v_ui/migration'],
+      children: true,
+      async: 'migration-common',
+      minChunks: 2
+    })
   ],
 
   resolve: {


### PR DESCRIPTION
* Child chunks split off of miq_v2v_ui/migration will be namespaced
  via chunkhash in production builds
* Chunks common to children split off of miq_v2v_ui/migration will be
  added to the migration-common chunk

Hello!  This is a companion PR to https://github.com/priley86/miq_v2v_ui_plugin/pull/323 in which we are implementing code splitting for the V2V UI Plugin.  The changes in this PR allow the following

1.  Naming of the child chunks split off of `miq_v2v_ui/migration.js`
2. If two or more children of `miq_v2v_ui/migration.js` share the same dependency, split it off into the `migration-common` chunk.  This is the reasoning behind [this additional configuration](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...michaelkro:code-splitting?expand=1#diff-52e5ee150ad902a05f7767da436cb5eeR73).  Without it, webpack was duplicating `moment` in the `overview` and `plan` chunks (please see screenshots below).

    However, I am guessing `shared.js` may not be the most appropriate place for this.  Implementation guidance would be greatly appreciated!

## Screens
### Before
<img width="999" alt="1__node-2" src="https://user-images.githubusercontent.com/15141412/40202830-403a42cc-59f1-11e8-8959-d61ffe11a0ee.png">

### After
<img width="991" alt="1__node" src="https://user-images.githubusercontent.com/15141412/40202903-7c5ba084-59f1-11e8-8afb-5e7766f5dc64.png">

### Bundle Analysis
<img width="1457" alt="webpack_bundle_analyzer" src="https://user-images.githubusercontent.com/15141412/40203546-8c932d30-59f3-11e8-9218-41eb059a5a3e.png">

Links [Optional]
----------------

* [CommonsChunkPlugin Async Chunk](https://webpack.js.org/plugins/commons-chunk-plugin/#extra-async-commons-chunk)
* [V2V PR](https://github.com/priley86/miq_v2v_ui_plugin/pull/323)

Steps for Testing/QA [Optional]
-------------------------------

To view webpack output before and after changes, use
```
env NODE_ENV=development WEBPACK_EXCLUDE_NODE_MODULES=1 ./node_modules/.bin/webpack --config config/webpack/development.js
```

To view the production build before and after changes, use
```
env NODE_ENV=production ./node_modules/.bin/webpack --config config/webpack/production.js
```