### PR TITLE
Add a new "Endpoint URL" field in AWS endpoints

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -73,6 +73,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       kubevirt_tls_ca_certs: '',
       kubevirt_password: '',
       kubevirt_password_exists: false,
+      default_url: ''
     };
 
     $scope.emsOptionsModel = {
@@ -186,6 +187,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.kubevirt_security_protocol      = data.kubevirt_security_protocol;
       $scope.emsCommonModel.kubevirt_tls_ca_certs           = data.kubevirt_tls_ca_certs;
       $scope.emsCommonModel.kubevirt_password_exists        = data.kubevirt_password_exists;
+
+      $scope.emsCommonModel.default_url                     = data.default_url;
 
       if ($scope.emsCommonModel.default_userid !== '') {
         $scope.emsCommonModel.default_password = miqService.storedPasswordPlaceholder;
@@ -600,6 +603,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         default_tls_ca_certs:      $scope.emsCommonModel.default_tls_ca_certs,
         default_userid:            $scope.emsCommonModel.default_userid,
         default_password:          default_password,
+        default_url:               $scope.emsCommonModel.default_url,
         realm:                     $scope.emsCommonModel.realm,
         azure_tenant_id:           $scope.emsCommonModel.azure_tenant_id,
         subscription:              $scope.emsCommonModel.subscription,

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -1,4 +1,5 @@
 require 'openssl'
+require 'webrick/httputils'
 
 module Mixins
   module EmsCommonAngular
@@ -128,7 +129,7 @@ module Mixins
         connect_opts = [MiqPassword.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)] if params[:cred_type] == "amqp"
         connect_opts
       when 'ManageIQ::Providers::Amazon::CloudManager'
-        uri = URI.parse(params[:default_url])
+        uri = URI.parse(WEBrick::HTTPUtils.escape(params[:default_url]))
         [user, password, :EC2, params[:provider_region], ems.http_proxy_uri, true, uri]
       when 'ManageIQ::Providers::Azure::CloudManager'
         [user, password, params[:azure_tenant_id], params[:subscription], ems.http_proxy_uri, params[:provider_region]]
@@ -651,7 +652,7 @@ module Mixins
       end
 
       if ems.kind_of?(ManageIQ::Providers::Amazon::CloudManager)
-        uri = URI.parse(params[:default_url])
+        uri = URI.parse(WEBrick::HTTPUtils.escape(params[:default_url]))
         default_endpoint = {:role => :default, :hostname => uri.host, :port => uri.port, :path => uri.path, :url => params[:default_url]}
       end
 

--- a/app/views/layouts/angular-bootstrap/_endpoints_for_url.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_for_url.html.haml
@@ -1,0 +1,20 @@
+%div
+  .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_url.$invalid}"}                                    |
+    %label.col-md-2.control-label{"for" => "#{prefix}_url"}
+      = _('Endpoint URL')
+    .col-md-4
+      %input.form-control{"type"                    => "url",
+                          "id"                      => "#{prefix}_url",
+                          "ng-required"             => "false",
+                          "name"                    => "#{prefix}_url",
+                          "ng-model"                => "#{main_scope}.#{ng_model}.#{prefix}_url",
+                          "checkchange"             => "",
+                          "ng-trim"                 => false,
+                          "detect_spaces"           => "",
+                          "prefix"                  => "#{prefix}",
+                          "main-scope"              => "#{main_scope}",
+                          "reset-validation-status" => "#{prefix}_auth_status"}
+      %span.help-block{"ng-show" => "angularForm.#{prefix}_url.$error.url"}
+        = _("Invalid URL")
+      %span.help-block{"ng-show" => "angularForm.#{prefix}_url.$error.detectedSpaces"}
+        = _("Spaces are prohibited")

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -65,6 +65,8 @@
                                                 :id                     => record.id,
                                                 :prefix                 => "default"}
         .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'ec2'"}
+          = render :partial => "layouts/angular-bootstrap/endpoints_for_url",
+                               :locals => {:prefix => "default", :main_scope => main_scope, :ng_model => "#{ng_model}"}
           = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                  :locals  => {:ng_show                => true,
                                               :ng_model               => "#{ng_model}",

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -24,20 +24,15 @@ describe EmsCloudController do
     it 'creates on post' do
       expect do
         post :create, :params => {
-          "button"               => "add",
-          "name"                 => "foo",
-          "emstype"              => "ec2",
-          "provider_region"      => "ap-southeast-1",
-          "port"                 => "",
-          "zone"                 => zone.name,
-          "default_userid"       => "foo",
-          "default_password"     => "[FILTERED]",
-          "metrics_userid"       => "",
-          "metrics_password"     => "[FILTERED]",
-          "amqp_userid"          => "",
-          "amqp_password"        => "[FILTERED]",
-          "ssh_keypair_userid"   => "",
-          "ssh_keypair_password" => "[FILTERED]"
+          "button"           => "add",
+          "name"             => "foo",
+          "emstype"          => "ec2",
+          "provider_region"  => "ap-southeast-1",
+          "port"             => "",
+          "zone"             => zone.name,
+          "default_userid"   => "foo",
+          "default_password" => "[FILTERED]",
+          "default_url"      => "http://abc.test/path"
         }
       end.to change { ManageIQ::Providers::Amazon::CloudManager.count }.by(1)
     end
@@ -93,6 +88,7 @@ describe EmsCloudController do
         "zone"             => "default",
         "default_userid"   => "foo",
         "default_password" => "[FILTERED]",
+        "default_url"      => ""
       }
 
       expect(response.status).to eq(200)
@@ -310,6 +306,7 @@ describe EmsCloudController do
     context "with a cloud manager" do
       let(:mocked_class) { ManageIQ::Providers::Amazon::CloudManager }
       let(:mocked_class_controller) { "ems_cloud" }
+      let(:mocked_params) { {:controller => mocked_class_controller, :cred_type => "default", :default_url => ""} }
 
       it "queues the authentication type if it is a cloud provider" do
         expect(mocked_class).to receive(:validate_credentials_task)

--- a/spec/controllers/mixins/ems_common_angular_spec.rb
+++ b/spec/controllers/mixins/ems_common_angular_spec.rb
@@ -217,5 +217,26 @@ describe Mixins::EmsCommonAngular do
         expect(@ems_infra_controller.send(:get_task_args, 'ManageIQ::Providers::Vmware::InfraManager')).to eq(expected_connect_options)
       end
     end
+
+    context 'aws cloud' do
+      before do
+        @ems_cloud_controller = EmsCloudController.new
+        @params = {
+          :default_userid   => "abc",
+          :default_password => "abc",
+          :default_url      => "http://abc.test/mypath"
+        }
+        @ems = FactoryGirl.create(:ems_amazon)
+        allow(@ems).to receive(:to_s).and_return('ManageIQ::Providers::Amazon::CloudManager')
+      end
+
+      it "returns connect options for aws cloud" do
+        @params[:cred_type] = "default"
+        @ems_cloud_controller.instance_variable_set(:@_params, @params)
+
+        expected_connect_options = ["abc", "v2:{XpADRTTI7f11hNT7AuDaKg==}", :EC2, nil, nil, true, URI.parse("http://abc.test/mypath")]
+        expect(@ems_cloud_controller.send(:get_task_args, @ems)).to eq(expected_connect_options)
+      end
+    end
   end
 end

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -93,7 +93,8 @@ describe('emsCommonFormController', function() {
       provider_id: 111,
       openstack_infra_providers_exist: false,
       provider_region: "ap-southeast-2",
-      default_userid: "default_user"
+      default_userid: "default_user",
+      default_url: "http://host.test/abc"
     };
 
     beforeEach(inject(function(_$controller_) {
@@ -145,6 +146,10 @@ describe('emsCommonFormController', function() {
 
     it('sets the default_password', function() {
       expect($scope.emsCommonModel.default_password).toEqual(miqService.storedPasswordPlaceholder);
+    });
+
+    it('sets the default_url', function() {
+      expect($scope.emsCommonModel.default_url).toEqual("http://host.test/abc");
     });
 
     it('initializes $scope.postValidationModel with credential objects for only those providers that support validation', function () {


### PR DESCRIPTION
Added a new `Endpoint URL` optional field in AWS endpoints as shown in the screenshot.

<img width="719" alt="screen shot 2018-05-17 at 3 12 28 pm" src="https://user-images.githubusercontent.com/1538216/40206501-2f1d3e10-59e5-11e8-9957-c96bcb8ff212.png">

Depends on https://github.com/ManageIQ/manageiq-providers-amazon/pull/444

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/3907