### PR TITLE
Update spec tests to check rendered toolbars on Block/Object Storage Managers

### DIFF
--- a/spec/controllers/ems_block_storage_controller_spec.rb
+++ b/spec/controllers/ems_block_storage_controller_spec.rb
@@ -34,8 +34,9 @@ describe EmsBlockStorageController do
   describe '#show_list' do
     render_views
 
-    it 'renders the Block Storage Managers Toolbar' do
-      expect(ApplicationHelper::Toolbar::GtlView).to receive(:definition)
+    it 'renders the view and the Block Storage Managers toolbar' do
+      expect(ApplicationHelper::Toolbar::GtlView).to receive(:definition).and_call_original
+      expect(ApplicationHelper::Toolbar::EmsBlockStoragesCenter).to receive(:definition).and_call_original
       post :show_list
     end
   end

--- a/spec/controllers/ems_object_storage_controller_spec.rb
+++ b/spec/controllers/ems_object_storage_controller_spec.rb
@@ -4,8 +4,9 @@ describe EmsObjectStorageController do
   describe '#show_list' do
     render_views
 
-    it 'renders the Object Storage Managers Toolbar' do
-      expect(ApplicationHelper::Toolbar::GtlView).to receive(:definition)
+    it 'renders the view and the Object Storage Managers toolbar' do
+      expect(ApplicationHelper::Toolbar::GtlView).to receive(:definition).and_call_original
+      expect(ApplicationHelper::Toolbar::EmsObjectStoragesCenter).to receive(:definition).and_call_original
       post :show_list
     end
   end


### PR DESCRIPTION
This PR updates the spec tests to check the toolbars to be rendered on Block/Object Storage Managers pages.
See: https://github.com/ManageIQ/manageiq-ui-classic/pull/3871 and https://github.com/ManageIQ/manageiq-ui-classic/pull/3948