### PR TITLE
Add Search to Currencies' drop down when adding/editing Chargeback Rate

### DIFF
--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -26,7 +26,11 @@
       .col-md-8
         = select_tag("currency",
           options_for_select(currency, @edit[:new][:currency]),
-          "data-miq_observe" => {:url => url}.to_json)
+          "data-live-search" => "true",
+          "class"            => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("currency", "#{url}");
 
   %h3
     = _('Rate Details')


### PR DESCRIPTION
**What:**
After some talk with @lpichler, I am adding **search ability** for _Currencies_ while adding/editing a _Chargeback Rate_. 

**Related task:**
https://bugzilla.redhat.com/show_bug.cgi?id=1498951

**Why:**
There will be at least 20 currencies added in the _Currencies_ drop down so it is good to be able to search through the available currencies.

**Before:**
![rate_before](https://user-images.githubusercontent.com/13417815/40244930-7b193668-5ac4-11e8-91b0-97786adc660f.png)

**After:**
![search_after1](https://user-images.githubusercontent.com/13417815/40244714-e169f1a6-5ac3-11e8-8d9d-351faaf65607.png)
![search_after2](https://user-images.githubusercontent.com/13417815/40244718-e3339366-5ac3-11e8-8c99-a171f7053e25.png)
