### PR TITLE
page_title - don't require leading ": " in @page_title

### DIFF
--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -18,7 +18,8 @@ module ApplicationHelper
 
     # Derive the browser title text based on the layout value
     def title_from_layout(layout)
-      return nil if layout.blank?  # no layout, leave title alone
+      # no layout, leave title alone
+      return nil if layout.blank?
 
       case layout
       when "automation_manager"

--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -1,7 +1,11 @@
 module ApplicationHelper
   module Title
     def productized_title(title)
-      product_title + title
+      if title.present?
+        "%{product}: %{title}" % {:product => product_title, :title => title}
+      else
+        product_title
+      end
     end
 
     def product_title
@@ -9,111 +13,109 @@ module ApplicationHelper
     end
 
     def page_title
-      @page_title.present? ? productized_title(@page_title) : title_from_layout(@layout)
+      productized_title(@page_title.presence || title_from_layout(@layout))
     end
 
     # Derive the browser title text based on the layout value
     def title_from_layout(layout)
-      title = product_title
+      return nil if layout.blank?  # no layout, leave title alone
 
-      return title if layout.blank?  # no layout, leave title alone
+      case layout
+      when "automation_manager"
+        _("Automation Managers")
+      when "catalogs"
+        _("Catalogs")
+      when "configuration"
+        _("My Settings")
+      when "configuration_job"
+        _("Configuration Jobs")
+      when "container_dashboard"
+        _("Container Dashboard")
+      when "container_topology"
+        _("Container Topology")
+      when "dashboard"
+        _("Dashboard")
+      when "chargeback"
+        _("Chargeback")
+      when "about"
+        _("About")
+      when "ems_cluster"
+        title_for_clusters
+      when "generic_object_definition"
+        _("Generic Object Definitions")
+      when "host"
+        title_for_hosts
+      when "infra_topology"
+        _("Infrastructure Topology")
+      when "miq_server"
+        _("Servers")
+      when "monitor_alerts_list"
+        _("Monitor Alerts")
+      when "monitor_alerts_most_recent"
+        _("Most Recent Monitor Alerts")
+      when "monitor_alerts_overview"
+        _("Monitor Alerts Overview")
+      when "network_topology"
+        _("Network Topology")
+      when "physical_infra_topology"
+        _("Physical Infrastructure Topology")
+      when "services"
+        _("Services")
+      when "usage"
+        _("VM Usage")
+      when "scan_profile"
+        _("Analysis Profiles")
+      when "miq_policy_rsop"
+        _("Policy Simulation")
+      when "report"
+        _("Reports")
+      when "rss"
+        _("RSS")
+      when "ops"
+        _("Configuration")
+      when "provider_foreman"
+        _("Configuration Management")
+      when "pxe"
+        _("PXE")
+      when "switch"
+        _("Switches")
+      when "explorer"
+        "#{controller_model_name(params[:controller])} Explorer"
+      when "timeline"
+        _("Timelines")
+      when "vm_cloud"
+        _("Instances")
+      when "vm_infra"
+        _("Virtual Machines")
+      when "vm_or_template"
+        _("Workloads")
 
-      title + case layout
-              when "automation_manager"
-                _(": Automation Managers")
-              when "catalogs"
-                _(": Catalogs")
-              when "configuration"
-                _(": My Settings")
-              when "configuration_job"
-                _(": Configuration Jobs")
-              when "container_dashboard"
-                _(": Container Dashboard")
-              when "container_topology"
-                _(": Container Topology")
-              when "dashboard"
-                _(": Dashboard")
-              when "chargeback"
-                _(": Chargeback")
-              when "about"
-                _(": About")
-              when "ems_cluster"
-                ": #{title_for_clusters}"
-              when "generic_object_definition"
-                _(": Generic Object Definitions")
-              when "host"
-                ": #{title_for_hosts}"
-              when "infra_topology"
-                _(": Infrastructure Topology")
-              when "miq_server"
-                _(": Servers")
-              when "monitor_alerts_list"
-                _(": Monitor Alerts")
-              when "monitor_alerts_most_recent"
-                _(": Most Recent Monitor Alerts")
-              when "monitor_alerts_overview"
-                _(": Monitor Alerts Overview")
-              when "network_topology"
-                _(": Network Topology")
-              when "physical_infra_topology"
-                _(": Physical Infrastructure Topology")
-              when "services"
-                _(": Services")
-              when "usage"
-                _(": VM Usage")
-              when "scan_profile"
-                _(": Analysis Profiles")
-              when "miq_policy_rsop"
-                _(": Policy Simulation")
-              when "report"
-                _(": Reports")
-              when "rss"
-                _(": RSS")
-              when "ops"
-                _(": Configuration")
-              when "provider_foreman"
-                _(": Configuration Management")
-              when "pxe"
-                _(": PXE")
-              when "switch"
-                _(": Switches")
-              when "explorer"
-                ": #{controller_model_name(params[:controller])} Explorer"
-              when "timeline"
-                _(": Timelines")
-              when "vm_cloud"
-                _(": Instances")
-              when "vm_infra"
-                _(": Virtual Machines")
-              when "vm_or_template"
-                _(": Workloads")
+      # Specific titles for groups of layouts
+      when /^miq_ae_/
+        _("Automation")
+      when /^miq_policy/
+        _("Control")
+      when /^miq_capacity_utilization/
+        _("Utilization")
+      when /^miq_capacity_planning/
+        _("Planning")
+      when /^miq_capacity_bottlenecks/
+        _("Bottlenecks")
+      when /^miq_request/
+        _("Requests")
+      when "manageiq/providers/ansible_tower/automation_manager/playbook"
+        _("Playbooks (Ansible Tower)")
+      when "manageiq/providers/embedded_ansible/automation_manager/playbook"
+        _("Playbooks")
+      when "manageiq/providers/embedded_automation_manager/authentication"
+        _("Credentials")
+      when "manageiq/providers/embedded_automation_manager/configuration_script_source"
+        _("Repositories")
 
-              # Specific titles for groups of layouts
-              when /^miq_ae_/
-                _(": Automation")
-              when /^miq_policy/
-                _(": Control")
-              when /^miq_capacity_utilization/
-                _(": Utilization")
-              when /^miq_capacity_planning/
-                _(": Planning")
-              when /^miq_capacity_bottlenecks/
-                _(": Bottlenecks")
-              when /^miq_request/
-                _(": Requests")
-              when "manageiq/providers/ansible_tower/automation_manager/playbook"
-                _(": Playbooks (Ansible Tower)")
-              when "manageiq/providers/embedded_ansible/automation_manager/playbook"
-                _(": Playbooks")
-              when "manageiq/providers/embedded_automation_manager/authentication"
-                _(": Credentials")
-              when "manageiq/providers/embedded_automation_manager/configuration_script_source"
-                _(": Repositories")
-
-              else
-                # Assume layout is a table name and look up the plural version
-                ": #{ui_lookup(:tables => layout)}"
-              end
+      else
+        # Assume layout is a table name and look up the plural version
+        ui_lookup(:tables => layout)
+      end
     end
 
     def title_for_hosts

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -2,7 +2,7 @@
 %html.login-pf{:class => ::Settings.server.custom_login_logo ? '' : 'rcue-login', :lang => I18n.locale.to_s.sub('-', '_')}
   %head
     %title
-      = h productized_title(_(": Login"))
+      = h productized_title(_("Login"))
     = favicon_link_tag
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag '/custom.css'

--- a/spec/helpers/application_helper/title_spec.rb
+++ b/spec/helpers/application_helper/title_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Title do
   context "#title_from_layout" do
     let(:title) { Vmdb::Appliance.PRODUCT_NAME }
-    subject { helper.title_from_layout(@layout) }
+    subject { helper.productized_title(helper.title_from_layout(@layout)) }
 
     it "when layout is blank" do
       @layout = ""


### PR DESCRIPTION
Setting `@page_title` is a mechanism to provide custom `<title>` value. 

For most of ops ui, this is computed from the current `@layout`, but that is not really pluggable and does not make sense for plugins.

So, we have `@page_title` and end up doing `product_title + title` - and calling it as `productized_title(_(": Login"))`.

---

This updates `productized_title` to join the provided title with ": " automatically - so that we don't have to randomly `@page_title = ": #{_('Migration')}"` in v2v.

Instead, the line will be `@page_title = _('Migration')`.

#3963: gaprindashvili yes because we need this for v2v to be able to use manageiq layouts instead of creating its own


Cc @mzazrivec , @martinpovolny 