### PR TITLE
Fix alignment of quadicon in Compare View

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -274,8 +274,18 @@ table.table.table-summary-screen tbody td img {
     width: 26px;
   }
 
+  table.table-expanded thead tr th {
+    height: 150px;
+    position: relative;
+  }
+
   table.table-expanded thead tr th div.quadicon_grid {
-    padding-left: 40px;
+    bottom: 0;
+    height: 80px;
+    left: 0; 
+    margin-left: auto;
+    position: absolute;
+    right: 0; 
   }
 
   table.table-compressed thead th,

--- a/app/views/shared/_compare_header_expanded.html.haml
+++ b/app/views/shared/_compare_header_expanded.html.haml
@@ -6,7 +6,5 @@
   - url = "/#{controller_name}/compare_choose_base/#{h["id"]}"
   %a{:title => _("Make %{name} the base") % {:name => h[:name]}, :onclick => "miqJqueryRequest('#{url}', {beforeSend: true, complete: true});", :href => '#'}
     = h[:name]
-%br
-%br
 .quadicon_grid
   = render :partial => 'shared/quadicon', :locals => {:record => @sb[:compare_db].constantize.find(vm_id)}


### PR DESCRIPTION
This PR aligns the quadicons at the bottom of the table header. It also centers them horizontally .

Old
<img width="922" alt="screen shot 2018-05-21 at 9 23 11 am" src="https://user-images.githubusercontent.com/1287144/40312013-98e7abbc-5cdf-11e8-8f83-0756941d78b2.png">

New
<img width="929" alt="screen shot 2018-05-21 at 9 29 27 am" src="https://user-images.githubusercontent.com/1287144/40312012-98cf1fb6-5cdf-11e8-9b26-9fa5e293bd38.png">