### PR TITLE
Ability to see/save Config settings for Region and Zone records.

### DIFF
--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -25,6 +25,25 @@ module OpsHelper
     tree_node.split('-').first == key
   end
 
+  def selected_node_title
+    if selected?(x_node, "z")
+      "Zone"
+    elsif selected?(x_node, "svr")
+      "Server"
+    else
+      "Region"
+    end
+  end
+
+  def selected_node_parent_title
+    return nil if selected?(x_node, "root")
+    if selected?(x_node, "z")
+      "Region"
+    elsif selected?(x_node, "svr")
+      "Zone"
+    end
+  end
+
   def auth_mode_name
     case ::Settings.authentication.mode.downcase
     when 'ldap'

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -3,16 +3,21 @@
   - case x_active_tree
   - when :settings_tree
     - if selected?(x_node, "z")
+      = render :partial => "layouts/flash_msg"
       %ul.nav.nav-tabs
         = miq_tab_header("settings_evm_servers", @sb[:active_tab]) do
           = _("Zone")
         = miq_tab_header("settings_smartproxy_affinity", @sb[:active_tab]) do
           = _("SmartProxy Affinity")
+        = miq_tab_header("settings_advanced", @sb[:active_tab]) do
+          = _("Advanced")
       .tab-content
         = miq_tab_content("settings_smartproxy_affinity", @sb[:active_tab]) do
           = render :partial => "settings_smartproxy_affinity_tab"
         = miq_tab_content("settings_evm_servers", @sb[:active_tab]) do
           = render :partial => "settings_evm_servers_tab"
+        = miq_tab_content("settings_advanced", @sb[:active_tab]) do
+          = render :partial => "settings_advanced_tab"
     - elsif selected?(x_node, "svr")
       = render :partial => "layouts/flash_msg"
       - cur_svr_id = x_node.split("-").last.to_i
@@ -60,6 +65,8 @@
             = _("Replication")
           = miq_tab_header("settings_help_menu", @sb[:active_tab]) do
             = _("Help Menu")
+          = miq_tab_header("settings_advanced", @sb[:active_tab]) do
+            = _("Advanced")
         .tab-content
           = miq_tab_content("settings_details", @sb[:active_tab]) do
             = render :partial => "settings_details_tab"
@@ -99,6 +106,8 @@
             = render :partial => "settings_replication_tab"
           = miq_tab_content("settings_help_menu", @sb[:active_tab]) do
             = render :partial => "settings_help_menu_tab"
+          = miq_tab_content("settings_advanced", @sb[:active_tab]) do
+            = render :partial => "settings_advanced_tab"
     -# Diagnostics
   - when :diagnostics_tree
     - if x_node.split("-")[0] == "z"

--- a/app/views/ops/_settings_advanced_tab.html.haml
+++ b/app/views/ops/_settings_advanced_tab.html.haml
@@ -6,7 +6,10 @@
         %span.pficon.pficon-error-octagon
         %span.pficon.pficon-error-exclamation
       %strong
-        = _("Caution: Manual changes to configuration files can disable the Server!")
+        - warning_msg = _("Caution: Manual changes to configuration files can disable the #{selected_node_title}!")
+        - if selected_node_parent_title
+          - warning_msg << _(" Changes made to any individual settings will overwrite settings inherited from the #{selected_node_parent_title}.")
+        = warning_msg
 
     = text_area_tag("file_data", @edit[:new][:file_data], :style => "display:none;")
     = render :partial => "/layouts/my_code_mirror",

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -266,6 +266,31 @@ describe OpsController do
           expect(config).to include(":password: #{enc_pass}")
           expect(config).to include(":port: 80")
         end
+
+        it 'for selected zone' do
+          zone = FactoryGirl.create(:zone)
+          enc_pass = MiqPassword.encrypt('pa$$word')
+          Vmdb::Settings.save!(
+            zone,
+            :http_proxy => {
+              :default => {
+                :host     => "proxy.example.com",
+                :user     => "user",
+                :password => enc_pass,
+                :port     => 80
+              }
+            }
+          )
+          zone.reload
+          allow(controller).to receive(:x_node).and_return("svr-#{zone.id}")
+          controller.instance_variable_set(:@sb, :active_tab => 'settings_advanced')
+          controller.send(:settings_get_info, "z-#{zone.id}")
+          config = assigns(:edit)[:current][:file_data]
+          expect(config).to include(":host: proxy.example.com")
+          expect(config).to include(":user: user")
+          expect(config).to include(":password: #{enc_pass}")
+          expect(config).to include(":port: 80")
+        end
       end
     end
 
@@ -279,9 +304,7 @@ describe OpsController do
                                            :selected_server_id => miq_server.id)
           controller.instance_variable_set(:@_params,
                                            :id => 'advanced')
-          data = {}
-          data.store_path(:api, :token_ttl, "1.day")
-          data = data.to_yaml
+          data = {:api => {:token_ttl => "1.day"}}.to_yaml
           controller.instance_variable_set(:@edit,
                                            :new     => {:file_data => data},
                                            :current => {:file_data => data},
@@ -292,6 +315,28 @@ describe OpsController do
 
           controller.send(:settings_update_save)
           controller.send(:fetch_advanced_settings, miq_server)
+          expect(SettingsChange.first).to have_attributes(:key => '/api/token_ttl', :value => "1.day")
+        end
+
+        it 'for selected zone' do
+          zone = FactoryGirl.create(:zone)
+          allow(controller).to receive(:x_node).and_return("z-#{zone.id}")
+          controller.instance_variable_set(:@sb,
+                                           :active_tab         => 'settings_advanced',
+                                           :selected_server_id => zone.id)
+          controller.instance_variable_set(:@_params,
+                                           :id => 'advanced')
+          data = {:api => {:token_ttl => "1.day"}}.to_yaml
+          controller.instance_variable_set(:@edit,
+                                           :new     => {:file_data => data},
+                                           :current => {:file_data => data},
+                                           :key     => "settings_advanced_edit__#{zone.id}")
+          session[:edit] = assigns(:edit)
+          expect(controller).to receive(:render)
+          expect(Vmdb::Settings).to receive(:reload!)
+
+          controller.send(:settings_update_save)
+          controller.send(:fetch_advanced_settings, zone)
           expect(SettingsChange.first).to have_attributes(:key => '/api/token_ttl', :value => "1.day")
         end
       end


### PR DESCRIPTION
Exposed 'Advanced' tab for Region/Zone nodes.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1082155

Before:

![server_before](https://user-images.githubusercontent.com/3450808/40325984-b92485cc-5d0b-11e8-98e4-2f615ccc0ed4.png)

![zone_before](https://user-images.githubusercontent.com/3450808/40325993-be9fa360-5d0b-11e8-83f8-c6f0aba21beb.png)

![region_before](https://user-images.githubusercontent.com/3450808/40326001-c1177ca8-5d0b-11e8-892a-af039472d588.png)


After, Note has been updated on the Server level. Exposed Advanced tab on Region and Zone level:

![server_after](https://user-images.githubusercontent.com/3450808/40313909-eb8f7fd4-5ce4-11e8-9dcc-d21ed48d9a51.png)

![zone_after](https://user-images.githubusercontent.com/3450808/40313911-efa69300-5ce4-11e8-94de-62b4b6cf3065.png)

![region_after](https://user-images.githubusercontent.com/3450808/40313912-f23274ae-5ce4-11e8-9385-1275727a7e93.png)


Dependent upon core PR: Core PR: https://github.com/ManageIQ/manageiq/pull/17458