### PR TITLE
[WIP] Add option to collect automate model and service dialog

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -496,6 +496,7 @@ module OpsController::Diagnostics
   # Collect the current logs from the selected zone or server
   def logs_collect(options = {})
     options[:support_case] = params[:support_case] if params[:support_case]
+    options[:include_automate_models_and_dialogs] = ::Settings.log.collection.include_automate_models_and_dialogs
     obj, id  = x_node.split("-")
     assert_privileges("#{obj == "z" ? "zone_" : ""}collect_logs")
     klass    = obj == "svr" ? MiqServer : Zone


### PR DESCRIPTION
Configuration -> Diagnostics -> select a single server -> collect Logs tab -> Collect logs in toolbar

Configuration -> Diagnostics -> select a single zone -> collect Logs tab -> Collect logs in toolbar

`sychronize_logs` takes `export_automate_models_and_dialogs` as a flag in `options` based on value in `::Settings.log.collection.include_automate_models_and_dialogs`.

Backend instructions:
When the UI calls `MiqServer#synchronize_logs` or `Zone#synchronize_logs`, it will need to pass a flag in the options hash if we want to export the models an dialogs

`synchronize_logs(:export_automate_models_and_dialogs => true, ...)`

Default is `true`.

Depends on 
https://github.com/ManageIQ/manageiq/pull/17445 (WIP)
https://github.com/ManageIQ/manageiq/pull/17467 (Merged)

@miq-bot add_label wip, bug, enhancement, gaprindashvili/no, pending core