### PR TITLE
Add a new "full_center" layout

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1337,8 +1337,6 @@ module ApplicationHelper
     super(options).to_str
   end
 
-  attr_reader :big_iframe
-
   def appliance_name
     MiqServer.my_server.name
   end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -204,4 +204,9 @@ module ApplicationHelper::PageLayouts
   end
 
   attr_reader :big_iframe
+
+  # a layout which gives full control over the center, but always provides the navbars and menus - to be overriden per-controller, used by v2v
+  def layout_full_center
+    nil
+  end
 end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -202,4 +202,6 @@ module ApplicationHelper::PageLayouts
     (@lastaction == "show_list" && !session[:menu_click] && show_search.include?(@layout) && !@in_a_form) ||
       (@explorer && x_tree && tree_with_advanced_search? && !@record)
   end
+
+  attr_reader :big_iframe
 end

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -64,6 +64,9 @@
             = render :partial => "layouts/listnav"
           = yield :left
         #custom_left_cell
+- elsif layout_full_center
+  = render :partial => "layouts/vertical_navbar"
+  = render :partial => layout_full_center
 - else
   #center_div{:style => "height: 100%;"}
     = render :partial => center_div_partial


### PR DESCRIPTION
Add a new "full_center" layout - similar to center_div, but fully customizable - you just get the menus

the idea is for specific controllers to

    helper do
      def layout_full_center
        "layouts/my_custom/layout"
      end
    end
