### PR TITLE
Do not override kubevirt token with default token

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -773,7 +773,7 @@ module Mixins
           creds[:prometheus_alerts] = {:auth_key => default_key, :save => (mode != :validate)}
         end
         if params[:virtualization_selection] == 'kubevirt'
-          kubevirt_key = params[:kubevirt_password] ? params[:kubevirt_password] : default_key
+          kubevirt_key = params[:kubevirt_password] ? params[:kubevirt_password] : ems.authentication_key(:kubevirt)
           creds[:kubevirt] = { :auth_key => kubevirt_key, :save => (mode != :validate) }
         end
         creds[:bearer] = {:auth_key => default_key, :save => (mode != :validate)}


### PR DESCRIPTION
If the user didn't provide a token for kubevirt provider, the previous
token should be kept instead of using the default token.

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/70