### PR TITLE
Network adapter reconfiguration for vCloud provider

### DIFF
--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -23,6 +23,8 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       vmRemoveDisks: [],
       vmResizeDisks: [],
       vLan_requested: '',
+      adapterNetwork: '',
+      availableAdapterNetworks: [],
     };
     vm.cb_disks = false;
     vm.cb_networkAdapters = false;
@@ -205,7 +207,13 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     vm.reconfigureModel.vmRemoveNetworkAdapters = [];
     angular.forEach(vm.reconfigureModel.vmNetworkAdapters, function(networkAdapter) {
       if (networkAdapter.add_remove === 'add') {
-        vm.reconfigureModel.vmAddNetworkAdapters.push({network: networkAdapter.vlan});
+        vm.reconfigureModel.vmAddNetworkAdapters.push(
+          {
+            network: networkAdapter.vlan,
+            name: networkAdapter.name,
+            cloud_network: networkAdapter.network,
+          }
+        );
       }
       if (networkAdapter.add_remove === 'remove') {
         vm.reconfigureModel.vmRemoveNetworkAdapters.push({network: networkAdapter});
@@ -227,11 +235,23 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     vm.reconfigureModel.cb_bootable = false;
   };
 
+  vm.validateAddSelectedNetwork = function() {
+    if (! vm.reconfigureModel.vLan_requested && ! vm.isVmwareCloud()) {
+      return false;
+    } else if (! vm.reconfigureModel.name && vm.isVmwareCloud()) {
+      return false;
+    } else if (vm.reconfigureModel.vmNetworkAdapters.length > 4) {
+      return false;
+    }
+    return true;
+  };
+
   vm.processAddSelectedNetwork = function() {
     vm.reconfigureModel.vmNetworkAdapters.push(
       {
-        name: __('to be determined'),
+        name: vm.reconfigureModel.name ? vm.reconfigureModel.name : __('to be determined'),
         vlan: vm.reconfigureModel.vLan_requested,
+        network: vm.reconfigureModel.adapterNetwork,
         mac: __('not available yet'),
         add_remove: 'add',
       });
@@ -261,6 +281,8 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     vm.reconfigureModel.showDropDownNetwork = false;
     vm.setEnableAddNetworkAdapterButton();
     vm.reconfigureModel.vLan_requested = '';
+    vm.reconfigureModel.name = '';
+    vm.reconfigureModel.adapterNetwork = '';
   };
 
   vm.cancelAddRemoveNetworkAdapter = function(vmNetworkAdapter) {
@@ -402,6 +424,16 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     vm.submitClicked();
   };
 
+  vm.isVmwareCloud = function() {
+    return vm.vm_vendor === 'vmware' && vm.vm_type.includes('CloudManager');
+  };
+
+  vm.fetchAvailableAdapterNetworks = function(orchestrationStackId) {
+    API.get("/api/cloud_networks?expand=resources&attributes=name&filter[]=orchestration_stack_id=" + orchestrationStackId).then(function(data) {
+      vm.reconfigureModel.availableAdapterNetworks = data.resources.map(function(network) { return network.name; });
+    }).catch(miqService.handleFailure);
+  };
+
   function getReconfigureFormData(response) {
     var data = response.data;
     vm.reconfigureModel.memory                 = data.memory;
@@ -431,6 +463,11 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     if (data.socket_count && data.cores_per_socket_count) {
       vm.reconfigureModel.total_cpus = (parseInt(vm.reconfigureModel.socket_count, 10) * parseInt(vm.reconfigureModel.cores_per_socket_count, 10)).toString();
     }
+
+    if (vm.isVmwareCloud()) {
+      vm.fetchAvailableAdapterNetworks(data.orchestration_stack_id);
+    }
+
     vm.afterGet = true;
     vm.modelCopy = angular.copy( vm.reconfigureModel );
     vm.cb_memoryCopy = vm.cb_memory;

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -133,7 +133,7 @@
           %th= _('Size')
           %th= _('Unit')
           %th{"ng-if" => "vm.vm_vendor == 'vmware' && vm.vm_type.includes('InfraManager')"}= _('Dependent')
-          %th{"ng-hide" => "vm.vm_vendor == 'vmware' && vm.vm_type.includes('CloudManager')"}= _('Delete Backing')
+          %th{"ng-hide" => "vm.isVmwareCloud()"}= _('Delete Backing')
           %th{"ng-if" => "vm.vm_vendor == 'redhat'"}= _('Bootable')
           - if supports_reconfigure_disksize?
             %th{:colspan => 2}= _('Actions')
@@ -195,7 +195,7 @@
                      "type"      => "checkbox",
                      "name"      => "vm.cb_dependent",
                      "ng-model"  => "vm.reconfigureModel.cb_dependent"}
-            %td{"ng-hide" => "vm.vm_vendor == 'vmware' && vm.vm_type.includes('CloudManager')"}
+            %td{"ng-hide" => "vm.isVmwareCloud()"}
             %td{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
               %input{"bs-switch" => "",
                      :data           => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
@@ -255,7 +255,7 @@
                      "switch-active" => "{{disk.add_remove!='add'}}",
                      "ng-readonly"   => "disk.add_remove=='add'",
                      "ng-if"         => "disk.add_remove=='add'"}
-            %td{"ng-hide" => "vm.vm_vendor == 'vmware' && vm.vm_type.includes('CloudManager')"}
+            %td{"ng-hide" => "vm.isVmwareCloud()"}
               %input{"bs-switch"     => "",
                      :data           => {:on_text => _('Yes'), :off_text => _('No'), :size => 'mini'},
                      "type"          => "checkbox",
@@ -316,15 +316,18 @@
       %table.table.table-striped.table-condensed.table-bordered
         %thead
           %th= _('Name')
-          %th= _('vLan')
+          %th{"ng-if" => "!vm.isVmwareCloud()"}= _('vLan')
+          %th{"ng-if" => "vm.isVmwareCloud()"}= _('Network')
           %th= _('MAC Address')
           %th{:colspan => 2}= _('Actions')
         %tr{"ng-repeat" => "networkAdapter in vm.reconfigureModel.vmNetworkAdapters",
             "ng-class"  => "{'danger': networkAdapter.add_remove == 'remove', 'active': networkAdapter.add_remove == 'add'}"}
           %td
             {{networkAdapter.name}}
-          %td
+          %td{"ng-if" => "!vm.isVmwareCloud()"}
             {{networkAdapter.vlan}}
+          %td{"ng-if" => "vm.isVmwareCloud()"}
+            {{networkAdapter.network || "#{_('None')}"}}
           %td.narrow
             {{networkAdapter.mac}}
           %td.action-cell
@@ -343,8 +346,24 @@
                                                               "ng-click" => "vm.cancelAddRemoveNetworkAdapter(networkAdapter)"}= _('Cancel Add')
         %tr{"ng-if"       => "vm.reconfigureModel.showDropDownNetwork",
             "ng-form"     => "rowForm"}
-          %td
-          %td
+          %td{"ng-if" => "!vm.isVmwareCloud()"}
+          %td{"ng-if" => "vm.isVmwareCloud()"}
+            = select_tag('adapterIdx',
+                       options_for_select([["<#{_('Choose')}>", '']] + @avail_adapter_names, :disabled => ["<#{_('Choose')}>", nil]),
+                       "ng-model"                    => "vm.reconfigureModel.name",
+                       "ng-change"                   => "",
+                       "data-width"                  => "auto",
+                       "required"                    => "true",
+                       "selectpicker-for-select-tag" => "")
+          %td{"ng-if" => "vm.isVmwareCloud()"}
+            %select{'name'                    => 'adapterNetwork',
+                'ng-model'                    => 'vm.reconfigureModel.adapterNetwork',
+                'ng-options'                  => 'network for network in vm.reconfigureModel.availableAdapterNetworks',
+                'pf-select'                   => true,
+                'selectpicker-for-select-tag' => ''}
+              %option{"value" => ""}
+                = "<#{_('Choose')}>"
+          %td{"ng-hide" => "vm.isVmwareCloud()"}
             = select_tag('vLan',
                        options_for_select([["<#{_('Choose')}>", '']] + @vlan_options, :disabled => ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "vm.reconfigureModel.vLan_requested",
@@ -356,7 +375,7 @@
           %td.action-cell
             %button.btn.btn-default.btn-block.btn-sm{:type => "button",
                        "ng-click" => "vm.processAddSelectedNetwork();rowForm.vLan.selectionpicker('refresh')",
-                       "ng-disabled" => "rowForm.vLan.$invalid || !vm.reconfigureModel.vmNetworkAdapters.length >= 4"}= _('Confirm Add')
+                       "ng-disabled" => "!vm.validateAddSelectedNetwork()"}= _('Confirm Add')
           %td.action-cell
             %button.btn.btn-default.btn-block.btn-sm{:type => "button",
                                                               "ng-click" => "vm.hideAddNetworkAdapter()"}= _('Cancel Add')


### PR DESCRIPTION
With this commit we extend reconfigure UI to support what we need for vCloud: addition/deletion of NICs that are connected to cloud networks.
    
Current UI assumed that only vLan (i.e. network) has to be picked when creating new NIC. However, for vCloud we also need to specify new NIC index hence we extend the form a little.
    
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1572086
Depends on: https://github.com/ManageIQ/manageiq-providers-vmware/pull/272
Depends on: https://github.com/ManageIQ/manageiq-ui-classic/pull/3854

Video: http://x.k00.fr/nicreconfigure

@miq-bot assign @himdel 
@miq-bot add_label enhancement,gaprindashvili/yes,pending core
