### PR TITLE
mapping.tag is a category Tag, calling .category is ill-defined

### DIFF
--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -114,7 +114,7 @@ module OpsController::Settings::LabelTagMapping
       lt_map[:id] = m.id
       lt_map[:entity] = entity_ui_name_or_all(m.labeled_resource_type)
       lt_map[:label_name] = m.label_name
-      lt_map[:category] = m.tag.category.description
+      lt_map[:category] = m.tag.classification.description
       @lt_mapping.push(lt_map)
     end
   end
@@ -127,7 +127,7 @@ module OpsController::Settings::LabelTagMapping
     @edit[:key] = "label_tag_mapping_edit__#{@lt_map.id || "new"}"
     @edit[:new][:entity] = @lt_map.labeled_resource_type
     @edit[:new][:label_name] = @lt_map.label_name
-    @edit[:new][:category] = @lt_map.tag.category.description
+    @edit[:new][:category] = @lt_map.tag.classification.description
     @edit[:current] = copy_hash(@edit[:new])
     @edit[:new][:options] = entity_options
     session[:edit] = @edit
@@ -222,7 +222,7 @@ module OpsController::Settings::LabelTagMapping
 
   def label_tag_mapping_delete
     mapping = ContainerLabelTagMapping.find(params[:id])
-    category = mapping.tag.category
+    category = mapping.tag.classification
     label_name = mapping.label_name
 
     deleted = false

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -104,12 +104,12 @@ module OpsController::Settings::LabelTagMapping
 
   def label_tag_mapping_get_all
     # Current UI only supports any-value -> category mappings
-    mapping = ContainerLabelTagMapping.in_my_region.where(:label_value => nil)
+    mappings = ContainerLabelTagMapping.in_my_region.where(:label_value => nil)
 
     # This renders into label_tag_mapping_form view, fields are different from other
     # functions here, notably `:entity` is the translated ui name.
     @lt_mapping = []
-    mapping.each do |m|
+    mappings.each do |m|
       lt_map = {}
       lt_map[:id] = m.id
       lt_map[:entity] = entity_ui_name_or_all(m.labeled_resource_type)


### PR DESCRIPTION
There are category/entry Tags, and category/entry Classifications.
`.category` is supposed to get the "uncle", the category Classification from an *entry* Tag:
```
                                   .parent
 category Classification "cat"   <----------   entry Classification "ent"
           |^                ^                        |^
       .tag||.classification  \_______________    .tag||.classification
           v|                     .category   \       v|
 category Tag /managed/cat                     entry Tag /managed/cat/ent
```

`mapping.tag` is a category Tag (for any-value mappings which are the kind we use).
Currently `.category` on a category Tag ("/managed/cat") happens to work same as `.classification`, but it's ill-defined and will stop working after https://github.com/ManageIQ/manageiq/pull/17418.

@miq-bot add-label technical debt
@kbrock @Fryguy please review