### PR TITLE
Fix Save button which wasn't responding while editing Chargeback Rate

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -101,7 +101,7 @@ class ChargebackController < ApplicationController
         _("Add of new Chargeback Rate was cancelled by the user"))
       get_node_info(x_node)
       @edit = session[:edit] = nil  # clean out the saved info
-      session[:changed] =  false
+      session[:changed] = false
       replace_right_cell
     when "save", "add"
       id = params[:button] == "save" ? params[:id] : "new"
@@ -134,7 +134,7 @@ class ChargebackController < ApplicationController
           add_flash(_("Chargeback Rate \"%{name}\" was saved") % {:name => @rate.description})
         end
         @edit = session[:edit] = nil  # clean out the saved info
-        session[:changed] =  @changed = false
+        session[:changed] = @changed = false
         get_node_info(x_node)
         replace_right_cell(:replace_trees => [:cb_rates])
       else
@@ -554,6 +554,7 @@ class ChargebackController < ApplicationController
   def cb_rate_get_form_vars
     @edit[:new][:description] = params[:description] if params[:description]
     if params[:currency]
+      @edit[:new][:currency] = params[:currency].to_i
       @edit[:new][:code_currency] = ChargebackRateDetailCurrency.find(params[:currency]).code
     end
     @edit[:new][:details].each_with_index do |detail, detail_index|
@@ -562,7 +563,7 @@ class ChargebackController < ApplicationController
         detail[measure] = params[key] if params[key]
       end
       # Add currencies to chargeback_controller.rb
-      detail[:currency] = params[:currency] if params[:currency]
+      detail[:currency] = params[:currency].to_i if params[:currency]
 
       # Save tiers into @edit
       (0..@edit[:new][:num_tiers][detail_index].to_i - 1).each do |tier_index|


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/3961

Fix _Save_ button which was not responding for **Currencies' changes** while editing Chargeback
Rate, under _Cloud Intel > Chargeback > Rates_ accordion > _Compute/Storage Chargeback Rates_.

Original Chargeback Rate (just started editing; see the Currencies):
![rate_original](https://user-images.githubusercontent.com/13417815/40243313-2c17b598-5ac0-11e8-92ed-56f5567a20de.png)
The currency was changed and Save button was enabled:
![rate_change](https://user-images.githubusercontent.com/13417815/40243316-2f26d4d0-5ac0-11e8-8980-5de433bb2dff.png)

**Before:**
Currency changed back to the original value and Save button still enabled which is wrong:
![rate_bad](https://user-images.githubusercontent.com/13417815/40243321-320ac206-5ac0-11e8-9d0b-11fc57a2dc4c.png)

**After:**
Currency changed back to the original value and Save button was disabled which is right:
![compute_rate_ok](https://user-images.githubusercontent.com/13417815/40367390-918a1a62-5dd9-11e8-8b0b-4ab8ba42353c.png)

**Steps to reproduce:**
1. Go to _Cloud Intel > Chargeback > Rates_ accordion > _Compute/Storage Chargeback Rates_
2. Click on some rate or select it by checking the checkbox
3. Choose _Edit the selected Chargeback Rate_ or _Edit this Chargeback Rate_
4. Change _Currencies_ to something different
5. Change _Currencies_ back to what it was before (don't use _Reset_ button here!)
=> _Save_ button remains **enabled** (blue) even if we did not make any change comparing to the original currencies' values

**Notes:**
The problem was happening only while changing Currencies. Changing other values with enabling/disabling _Save_ button seemed to work ok. Clicking on _Reset_ button could fix the problem with _Save_ button (after resetting the changes, _Save_ button remained disabled which is right).

**Details:**
The core of the problem were:
- `edit[:new][:currency]` was not set to the new value, when changing the currency, so:
https://github.com/ManageIQ/manageiq-ui-classic/pull/3974/files#diff-1b26f16afe1a647952df7cc1637f4394R557
- problem with string vs. integer when setting the value for a new currency, so:
https://github.com/ManageIQ/manageiq-ui-classic/pull/3974/files#diff-1b26f16afe1a647952df7cc1637f4394R566
- originally, `@edit[:new][:currency]` and `@edit[:current][:currency]` were set to integers, but later, `@edit[:new][:currency]` was changed to string type

Comparing the  old vs. new values is happening here: https://github.com/ManageIQ/manageiq-ui-classic/pull/3974/files#diff-1b26f16afe1a647952df7cc1637f4394R183