### PR TITLE
Modified EmsNetwork#visible? method

### DIFF
--- a/app/helpers/application_helper/button/ems_network.rb
+++ b/app/helpers/application_helper/button/ems_network.rb
@@ -1,9 +1,9 @@
 class ApplicationHelper::Button::EmsNetwork < ApplicationHelper::Button::Basic
   def visible?
-    # Nuage is only provider that supports adding NetworkProvider manually
-    # therefore we hide drop-down option completely unless Nuage is enabled.
-    return ::Settings.product.nuage unless @record # add new
-
-    @record.supports?(:ems_network_new) # edit
+    if @record
+      @record.supports_ems_network_new?
+    else
+      ::EmsNetwork.all.any? { |ems| ems.supports_ems_network_new? }
+    end
   end
 end


### PR DESCRIPTION
Currently the `EmsNetwork#visible?` method is effectively broken because `Settings.product.nuage` will always return true unless `@record` is set. This was caused by https://github.com/ManageIQ/manageiq-providers-nuage/pull/33 which used a config setting instead of using the `SupportsFeatureMixin` module.

This change will disable the new/edit options on the network providers screen unless at least one of the current providers, or the current record, supports it.

Partial fix for https://bugzilla.redhat.com/show_bug.cgi?id=1577888