### PR TITLE
Reload classifications when adding or editing the tag expression for groups

### DIFF
--- a/app/views/layouts/exp_atom/_edit_tags.html.haml
+++ b/app/views/layouts/exp_atom/_edit_tags.html.haml
@@ -5,7 +5,7 @@
     exp_model       Model in use for this expression
 
 - opts = ["<#{_('Choose')}>"]
-- opts += MiqExpression.tag_details(nil, {})
+- opts += MiqExpression.tag_details(nil, {:no_cache => true})
 
 .spacer
 

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -379,7 +379,7 @@ describe OpsController do
       expect(@edit[:filter_expression][:exp_typ]).to eq('tags')
     end
 
-    it "calls MiqExpression.tag_details to get only the My Company type tag categories" do
+    it "calls MiqExpression.tag_details with :no_cache to get only the My Company type tag categories" do
       new = {:use_filter_expression => true,
              :name                  => 'Name',
              :description           => "Test",
@@ -408,7 +408,7 @@ describe OpsController do
       allow(controller).to receive(:replace_right_cell)
 
       post :tree_select, :params => { :id => 'root', :format => :js }
-      expect(MiqExpression).to receive(:tag_details)
+      expect(MiqExpression).to receive(:tag_details).with(nil, :no_cache => true)
       post :rbac_group_field_changed, :params => { :id => 'new', :use_filter_expression => "true"}
     end
 


### PR DESCRIPTION
Reload classifications when adding or editing the tag expression for groups

Depends on https://github.com/ManageIQ/manageiq/pull/17465


Links 
--------
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1579867


Use the :no_cache option added in https://github.com/ManageIQ/manageiq/pull/17465 in order for the new tags added to be displayed in the expression drop-down, rather than the cached list of tags.
