### PR TITLE
http - send cookie

### DIFF
--- a/app/javascript/http_api/http.js
+++ b/app/javascript/http_api/http.js
@@ -12,6 +12,7 @@ function get(url, options = {}) {
     method: 'GET',
     csrf: true,
     backendName: __('http'),
+    credentials: 'include',
   });
 }
 
@@ -22,5 +23,6 @@ function post(url, data, options = {}) {
     method: 'POST',
     csrf: true,
     backendName: __('http'),
+    credentials: 'include',
   }, data);
 }


### PR DESCRIPTION
introduced in #3662 for the purposes of React code that needs to talk to rails controllers (json, but not API)

`API.*` is not supposed to send cookies (and doesn't),
but `http.*` needs to.

Adding: `credentials: 'include'` to achieve just that.

https://github.com/ManageIQ/manageiq-ui-classic/issues/3963: needed for v2v in gaprindashvili (but not adding gaprindashvili/yes as this can not be directly backported) - will fix once the backport PR is ready