### PR TITLE
Hide "Add New Network Manager" unless Nuage is enabled

### DIFF
--- a/app/helpers/application_helper/button/ems_network.rb
+++ b/app/helpers/application_helper/button/ems_network.rb
@@ -1,9 +1,10 @@
 class ApplicationHelper::Button::EmsNetwork < ApplicationHelper::Button::Basic
   def visible?
     # Nuage is only provider that supports adding NetworkProvider manually
-    # therefore we hide drop-down option completely unless Nuage is enabled.
-    return ::Settings.product.nuage unless @record # add new
+    # therefore we hide drop-down option completely unless Nuage is listed
+    # in config/permissions.yaml.
+    return Vmdb::PermissionStores.instance.supported_ems_type?('nuage_network') unless @record # allow add new network manager
 
-    @record.supports?(:ems_network_new) # edit
+    @record.supports?(:ems_network_new) # allow edit of existing manager
   end
 end

--- a/spec/helpers/application_helper/toolbar/ems_networks_center_spec.rb
+++ b/spec/helpers/application_helper/toolbar/ems_networks_center_spec.rb
@@ -12,12 +12,12 @@ describe ApplicationHelper::Toolbar::EmsNetworksCenter do
     end
 
     it 'visible when nuage provider enabled' do
-      allow(::Settings.product).to receive(:nuage).and_return(true)
+      allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).with('nuage_network').and_return(true)
       expect(button.visible?).to eq(true)
     end
 
     it 'hidden when nuage provider disabled' do
-      allow(::Settings.product).to receive(:nuage).and_return(false)
+      allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).with('nuage_network').and_return(false)
       expect(button.visible?).to eq(false)
     end
   end


### PR DESCRIPTION
Nuage is somewhat special in a way it allows adding NetworkManager directly, without CloudManager. For all other providers such behavior is not feasible, therefore "Add New Network Manager" button should be hidden.

![capture](https://user-images.githubusercontent.com/8102426/40408798-02e1f2fe-5e69-11e8-997c-db2d6694d1e7.PNG)

With this commit we make sure that the button is hidden unless config/permissions.yaml file contains entry allowing user to use Nuage provider:

```yaml
- ems-type:nuage_network
```

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1577888

@miq-bot add_label enhancement,gaprindashvili/yes
@miq-bot assign @blomquisg 

/cc @djberg96 