### PR TITLE
 Restrict quadicon class demodulization for Physical* records only

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -70,7 +70,7 @@ module QuadiconHelper
       when "ems_physical_infra", "ems_cloud", "ems_network", "ems_container"
         layout.to_sym
       end
-    elsif klass.base_model.name != klass.name.demodulize
+    elsif klass.name.demodulize.starts_with?("Physical") && klass.base_model.name != klass.name.demodulize
       klass.name.demodulize.underscore.to_sym
     else
       klass.base_model.name.underscore.to_sym

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -1,2 +1,24 @@
 describe QuadiconHelper do
+  describe '.settings_key' do
+    subject { described_class.settings_key(klass, layout) }
+
+    {
+      :ems                => [ManageIQ::Providers::Vmware::InfraManager, 'ems_infra'],
+      :ems_physical_infra => [ManageIQ::Providers::Lenovo::PhysicalInfraManager, 'ems_physical_infra'],
+      :ems_cloud          => [ManageIQ::Providers::Openstack::CloudManager, 'ems_cloud'],
+      :ems_network        => [ManageIQ::Providers::Amazon::NetworkManager, 'ems_network'],
+      :ems_container      => [ManageIQ::Providers::Openshift::ContainerManager, 'ems_container'],
+      :physical_switch    => [ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch, nil],
+      :switch             => [Switch, nil]
+    }.each do |result, input|
+      context "class is #{input.first} with #{input.last} as layout" do
+        let(:klass) { input.first }
+        let(:layout) { input.last }
+
+        it "returns with #{result}" do
+          expect(subject).to eq(result)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
The [demodulization](https://github.com/ManageIQ/manageiq-ui-classic/pull/3699/files#diff-6525cb9600835fcc2ba062fde39a2292R73) introduced by @saulotoledo breaks the quadicon settings key selection for templates. By restricting the demodulization to the models starting with `Physical` this issue can be solved easily. However, the whole quadicon settings key logic should be refactored in the future.

**Before:**
![screenshot from 2018-05-23 13-00-03](https://user-images.githubusercontent.com/649130/40421938-e16f317a-5e8d-11e8-9afe-d9ba820ad9e4.png)

**After:**
![screenshot from 2018-05-23 12-58-21](https://user-images.githubusercontent.com/649130/40421985-0f4d511c-5e8e-11e8-8591-68aca7f9a705.png)

@miq-bot add_label bug, gtls, gaprindashvili/no
@miq-bot add_reviewer @epwinchell 