### PR TITLE
Add support for ssh key pair credentials to rhv

### DIFF
--- a/app/assets/javascripts/controllers/ems_keypair/ems_keypair_controller.js
+++ b/app/assets/javascripts/controllers/ems_keypair/ems_keypair_controller.js
@@ -63,7 +63,9 @@
   };
 
   EmsKeypairController.prototype.showValidate = function(tab) {
-    return !(this.model.emstype == 'openstack_infra' && this.newRecord && tab == 'ssh_keypair')
+    var openstackAndNew = (this.model.emstype === 'openstack_infra') && this.newRecord;
+    var rhevm = this.model.emstype === 'rhevm';
+    return ! ((openstackAndNew || rhevm) && tab === 'ssh_keypair');
   };
 
   EmsKeypairController.$inject = ["$scope"];

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -558,7 +558,9 @@ module Mixins
         end
       end
 
-      ssh_keypair_endpoint = {:role => :ssh_keypair} if ems.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
+      if ems.kind_of?(ManageIQ::Providers::Openstack::InfraManager) || ems.kind_of?(ManageIQ::Providers::Redhat::InfraManager)
+        ssh_keypair_endpoint = {:role => :ssh_keypair}
+      end
 
       if ems.kind_of?(ManageIQ::Providers::Redhat::InfraManager)
         default_endpoint = {
@@ -734,6 +736,11 @@ module Mixins
         creds[:smartstate_docker] = {:userid => params[:smartstate_docker_userid], :password => smartstate_docker_password, :save => true}
       end
       if ems.kind_of?(ManageIQ::Providers::Openstack::InfraManager) &&
+         ems.supports_authentication?(:ssh_keypair) && params[:ssh_keypair_userid]
+        ssh_keypair_password = params[:ssh_keypair_password] ? params[:ssh_keypair_password].gsub(/\r\n/, "\n") : ems.authentication_key(:ssh_keypair)
+        creds[:ssh_keypair] = {:userid => params[:ssh_keypair_userid], :auth_key => ssh_keypair_password, :save => (mode != :validate)}
+      end
+      if ems.kind_of?(ManageIQ::Providers::Redhat::InfraManager) &&
          ems.supports_authentication?(:ssh_keypair) && params[:ssh_keypair_userid]
         ssh_keypair_password = params[:ssh_keypair_password] ? params[:ssh_keypair_password].gsub(/\r\n/, "\n") : ems.authentication_key(:ssh_keypair)
         creds[:ssh_keypair] = {:userid => params[:ssh_keypair_userid], :auth_key => ssh_keypair_password, :save => (mode != :validate)}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -299,15 +299,7 @@
                 = _("Disable event monitoring.")
       = miq_tab_content('ssh_keypair', 'default') do
         .form-group
-          .col-md-12.col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'openstack_infra'"}
-            = render :partial => "layouts/angular-bootstrap/endpoints_angular",
-                                 :locals  => {:ng_show                => true,
-                                              :ng_model               => "#{ng_model}",
-                                              :id                     => record.id,
-                                              :hostname_hide          => true,
-                                              :apiport_hide           => true,
-                                              :security_protocol_hide => true,
-                                              :prefix                 => "ssh_keypair"}
+          .col-md-12.col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && ("#{ng_model}.emstype == 'openstack_infra' || #{ng_model}.emstype == 'rhevm'") }
             = render :partial => "layouts/angular-bootstrap/auth_keypair_angular_bootstrap",
                                  :locals  => {:ng_show                => true,
                                               :ng_model               => "#{ng_model}",
@@ -525,7 +517,7 @@
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", true);
     miq_tabs_show_hide("#console_tab", false);
-    miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_show_hide("#ssh_keypair_tab", true);
     miq_tabs_show_hide("#smartstate_docker_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -662,7 +662,7 @@ describe EmsInfraController do
         create
         expect(response.status).to eq(200)
         rhevm = ManageIQ::Providers::Redhat::InfraManager.where(:name => "foo_rhevm").first
-        expect(rhevm.endpoints.size).to eq(2)
+        expect(rhevm.endpoints.size).to eq(3)
       end
 
       it 'updates metrics endpoint records on post when button is "save"' do

--- a/spec/javascripts/controllers/ems_keypair/ems_keypair_controller_spec.js
+++ b/spec/javascripts/controllers/ems_keypair/ems_keypair_controller_spec.js
@@ -71,39 +71,36 @@ describe('emsKeypairController', function() {
   });
 
   describe('#showValidate', function() {
-    context('with emsCommonModel be openstack_infra', function() {
-      beforeEach(inject(function($rootScope, _$controller_) {
-        $controller = _$controller_('emsKeypairController', {$scope: $scope});
-        $controller.initialize({'emstype': 'openstack_infra'}, "12345")
-      }));
-      context('with newRecord', function() {
-        context('on ssh_keypair tab', function() {
-          it('test', function() {
-            $controller.newRecord = true;
-            expect($controller.showValidate('ssh_keypair')).toBeFalsy();
+    var combinations = [
+      { emstype: 'openstack_infra', newRecord: true, tab: 'ssh_keypair', value: false },
+      { emstype: 'openstack_infra', newRecord: true, tab: 'other_tab', value: true },
+      { emstype: 'openstack_infra', newRecord: false, tab: 'tab', value: true },
+
+      { emstype: 'other_emstype', newRecord: true, tab: 'tab', value: true },
+      { emstype: 'other_emstype', newRecord: false, tab: 'tab', value: true },
+
+      { emstype: 'rhevm', newRecord: false, tab: 'ssh_keypair', value: false },
+      { emstype: 'rhevm', newRecord: false, tab: 'other_tab', value: true },
+      { emstype: 'rhevm', newRecord: true, tab: 'ssh_keypair', value: false },
+      { emstype: 'rhevm', newRecord: true, tab: 'other_tab', value: true },
+    ];
+
+    combinations.forEach(function(options) {
+      context('with emsCommonModel ' + options.emstype, function() {
+        beforeEach(inject(function($rootScope, _$controller_) {
+          $controller = _$controller_('emsKeypairController', { $scope: $scope });
+          $controller.initialize({ emstype: options.emstype }, "12345");
+        }));
+
+        context('with newRecord ' + options.newRecord, function() {
+          context('with tab ' + options.tab, function() {
+            it('showValidate should be ' + options.value ? 'truthy' : 'falsy', function() {
+              $controller.newRecord = options.newRecord;
+              var method = options.value ? 'toBeTruthy' : 'toBeFalsy';
+              expect($controller.showValidate(options.tab))[method]();
+            });
           });
         });
-        context('on other tabs', function() {
-          it('test', function() {
-            $controller.newRecord = true;
-            expect($controller.showValidate('other_tab')).toBeTruthy();
-          });
-        });
-      });
-      context('with not newRecord', function() {
-        it('test', function() {
-            $controller.newRecord = false;
-          expect($controller.showValidate('tab')).toBeTruthy();
-        });
-      });
-    });
-    context('with emsCommonModel not be openstack_infra', function() {
-      beforeEach(inject(function($rootScope, _$controller_) {
-        $controller = _$controller_('emsKeypairController', {$scope: $scope});
-        $controller.initialize({'emstype': 'other_emstype'}, "12345")
-      }));
-      it('test', function() {
-        expect($controller.showValidate('tab')).toBeTruthy();
       });
     });
   });


### PR DESCRIPTION
Add authentication tab fro ssh credentials for rhev provider
This is part of the PRs that close https://bugzilla.redhat.com/show_bug.cgi?id=1561353
depends on: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/251
and: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/256

![ssh_creds_for_provider](https://user-images.githubusercontent.com/3274731/40768359-c5dc2414-64bd-11e8-8fb9-79767ebdc863.png)