### PR TITLE
Better inflector support for ui rake tasks and asset plugins

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -149,13 +149,15 @@ unless Rake::Task.task_defined?("webpacker")
 end
 
 def asset_engines
-  all_engines = Rails::Engine.subclasses.each_with_object({}) do |engine, acc|
-    acc[engine] = engine.root.realpath.to_s
-  end
+  @asset_engines ||= begin
+    all_engines = Rails::Engine.subclasses.each_with_object({}) do |engine, acc|
+      acc[engine] = engine.root.realpath.to_s
+    end
 
-  # we only read assets from app/javascript/, filtering engines based on existence of that dir
-  all_engines.select do |_name, path|
-    Dir.exist? File.join(path, 'app', 'javascript')
+    # we only read assets from app/javascript/, filtering engines based on existence of that dir
+    all_engines.select do |_name, path|
+      Dir.exist? File.join(path, 'app', 'javascript')
+    end
   end
 end
 

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -53,6 +53,18 @@ namespace :ui do
     require Rails.root.join("lib", "vmdb", "inflections.rb")
     Vmdb::Inflections.load_inflections
   end
+
+  # Does not require :environment task, see webpack:compile
+  task :load_asset_engine_inflectors do
+    asset_engines.each do |(_, path)|
+      # Load any inflectors the asset_engine might provide.  Assumes
+      # standardized location for them to live.
+      inflector_file = File.expand_path(File.join("config", "initializers", "inflections.rb"), path)
+      if File.exist?(inflector_file)
+        load inflector_file
+      end
+    end
+  end
 end
 
 namespace :webpack do
@@ -71,6 +83,7 @@ namespace :webpack do
       EvmRakeHelper.with_dummy_database_url_configuration do
         Dir.chdir ManageIQ::UI::Classic::Engine.root do
           Rake::Task["ui:load_app_inflectors"].invoke
+          Rake::Task["ui:load_asset_engine_inflectors"].invoke
           Rake::Task["webpack:paths"].invoke
           Rake::Task["webpacker:#{webpacker_task}"].invoke
         end

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -47,6 +47,14 @@ namespace :update do
   end
 end
 
+namespace :ui do
+  # Does not require :environment task, see webpack:compile
+  task :load_app_inflectors do
+    require Rails.root.join("lib", "vmdb", "inflections.rb")
+    Vmdb::Inflections.load_inflections
+  end
+end
+
 namespace :webpack do
   task :server do
     root = ManageIQ::UI::Classic::Engine.root
@@ -62,6 +70,7 @@ namespace :webpack do
       # 'webpacker:compile') to function.
       EvmRakeHelper.with_dummy_database_url_configuration do
         Dir.chdir ManageIQ::UI::Classic::Engine.root do
+          Rake::Task["ui:load_app_inflectors"].invoke
           Rake::Task["webpack:paths"].invoke
           Rake::Task["webpacker:#{webpacker_task}"].invoke
         end
@@ -124,14 +133,6 @@ unless Rake::Task.task_defined?("webpacker")
   load 'tasks/webpacker/check_node.rake'             # needed by verify_install
   load 'tasks/webpacker/check_yarn.rake'             # needed by verify_install
   load 'tasks/webpacker/check_webpack_binstubs.rake' # needed by verify_install
-end
-
-# This is normally handled by the lib/vmdb/inflectors.rb of manageiq, but might
-# not be loaded if this is called from this repo.  Doesn't hurt (much) to have
-# this here, and shouldn't create duplicates (won't be in place in the booted
-# application).
-ActiveSupport::Inflector.inflections do |inflect|
-  inflect.acronym "ManageIQ"
 end
 
 def asset_engines


### PR DESCRIPTION
This better supports the `ActiveSupport::Inflectors` that are set by both the main app and any asset engines that are pulled in by the `webpack` tasks.

The PR creates two new tasks in the `:ui` namespace:

* `rake ui:load_app_inflectors`
* `rake ui:load_asset_engine_inflectors`

The first loads the inflectors from the main application, and the second pulls in any inflectors from the `asset_engines` that are present.  The `asset_engine` inflector task does assume the file lives in the `config/initializers/inflections.rb`, so that is sort of being set as the standard as part of this PR.

Also, minor addition:  The `asset_engines` method is now memoized.  Your welcome.  #smugNickIsSmug


Links
-----

* This PR is to support the `miq_v2v_ui_plugin` rename to `manageiq-v2v`, which is currently in progress: https://github.com/ManageIQ/miq_v2v_ui_plugin/pull/344


Steps for Testing/QA
--------------------

When the aforementioned rename of `miq_v2v_ui_plugin` has completed, we should test `rake update:ui` from both this repo and the main repo to confirm everything is working as expected

Spoiler!  I have already done this from the main repo with these, and seems to work as expected.  That said, others should do the same.