### PR TITLE
Removing the listnav from Physical Infra Manager page

### DIFF
--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -18,6 +18,11 @@ class EmsPhysicalInfraController < ApplicationController
     @table_name ||= "ems_physical_infra"
   end
 
+  def show_list
+    @without_listnav = true
+    super
+  end
+
   def ems_path(*args)
     ems_physical_infra_path(*args)
   end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -1,6 +1,7 @@
 module ApplicationHelper::PageLayouts
   def layout_uses_listnav?
-    return false if @in_a_form
+    return false if @in_a_form || @without_listnav
+
     return false if %w(
       about
       all_tasks


### PR DESCRIPTION
__This PR is able to__
- Add an instance variable just to remove the `listnav`;
- Remove the `listnav` on Physical Infra Manager page.

__Current result__
Once that Physical Infra Manager page doesn't have any filter, the listnav always shows a pointless alert.

![screenshot-localhost 3000-2018-05-24-09-40-45](https://user-images.githubusercontent.com/8550928/40486230-139a6652-5f37-11e8-8aa6-1145e1a6a28b.png)

__After this PR__
The space is better used without the listnav

![image](https://user-images.githubusercontent.com/8550928/40486364-720c68f2-5f37-11e8-95fb-638e2422de20.png)
