### PR TITLE
Error modal - ensure visibility over other modals

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -755,6 +755,10 @@ td.action > .btn.btn-default {
   }
 }
 
+#errorModal .modal.show {
+  z-index: 2000;
+}
+
 /// force word-break for long text strings in modals
 
 .modal-body p {


### PR DESCRIPTION
when another modal window is visible (like the v2v wizard),
when the error modal appears, it appears under the existing modal - not visible

overriding the z-index value so that the error is always visible

---

Testing: go to Compute > Migration, Create Infrastructure Mapping
In console, run: `sendDataWithRx({ serverError: {} });`

Before - nothing will be visible until you close the wizard modal.

After:

![good](https://user-images.githubusercontent.com/289743/40492138-5b8082e4-5f5f-11e8-8b47-b0076f993bb0.png)

(obviously real errors are not undefined :))

---

https://github.com/ManageIQ/manageiq-ui-classic/issues/3963: needed so that v2v errors don't get ignored when in the wizard 