### PR TITLE
Remove compliances include from Host.yaml

### DIFF
--- a/product/views/Host.yaml
+++ b/product/views/Host.yaml
@@ -39,7 +39,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :ext_management_system: {}
-  :compliances: {}
   :tags: {}
 
 # Order of columns (from all tables)


### PR DESCRIPTION
The compliances is an ever growing table, and with how Rbac works, this means that the table is joined and usually has the references applied to it prior the query being executed.  Because there are so many compliance records after a period of time for a given host, this can cause the query to explode because it is executed with a LEFT JOIN on that table, along with the tags table and ext_management_system tables.

This means that even just querying against 20 hosts that has 14000 compliance records associated with them, along with 17000 taggings can end up causing a query with over 2 million rows returned, with 60+ columns per row.  That data returned from postgres ends up being multiple Gigs in size.

For the best performances, there are changes to the `last_compliance_status` (see links in section below) that will make this performance much better and avoid N+1s, but this could be applied on it's own and avoid the issue all together.


Links
-----

* Related main repo changes:
  - https://github.com/ManageIQ/manageiq/pull/17473
  - https://github.com/ManageIQ/manageiq/pull/17474
  - https://github.com/ManageIQ/manageiq/pull/17475
* Affected BZs:
  - https://bugzilla.redhat.com/show_bug.cgi?id=1580569
  - https://bugzilla.redhat.com/show_bug.cgi?id=1580982


Steps for Testing/QA
--------------------

Similar to the main repo BZs, some seed data is necessary to really see the before and after, but the `Compute -> Infrastructure -> Hosts` page should work much better when the number of hosts per page is increased.