### PR TITLE
Use {report,request}_admin_user?

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -885,7 +885,7 @@ class ApplicationController < ActionController::Base
 
   def reports_group_title
     tenant_name = current_tenant.name
-    if current_user.admin_user?
+    if current_user.report_admin_user?
       _("%{tenant_name} (All Groups)") % {:tenant_name => tenant_name}
     else
       _("%{tenant_name} (Group): %{group_description}") %
@@ -910,7 +910,7 @@ class ApplicationController < ActionController::Base
       # TODO: move this into a named scope
       @sb[:grp_title] = reports_group_title
       custom = MiqReport.for_user(current_user).where(:template_type => "report", :rpt_type => 'Custom').order(:name).pluck(:name, :miq_group_id)
-      custom.select! { |item| item.second.to_i == current_group.try(:id) } unless current_user.admin_user?
+      custom.select! { |item| item.second.to_i == current_group.try(:id) } unless current_user.report_admin_user?
       reports.push([@sb[:grp_title], [[_("Custom"), custom.map(&:first)]]])
     end
     reports

--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -4,7 +4,7 @@ module ApplicationController::CurrentUser
   included do
     helper_method :current_user,  :current_userid
     helper_method :current_group, :current_group_id
-    helper_method :admin_user?, :super_admin_user?
+    helper_method :report_admin_user?, :super_admin_user?
     private :clear_current_user
   end
 
@@ -20,8 +20,8 @@ module ApplicationController::CurrentUser
     session[:group]   = db_user.current_group_id
   end
 
-  def admin_user?
-    current_user.try(:admin_user?)
+  def report_admin_user?
+    current_user&.report_admin_user?
   end
 
   def super_admin_user?

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -337,7 +337,7 @@ class ChargebackController < ApplicationController
       return
     end
     @right_cell_text ||= _("Saved Chargeback Report [%{name}]") % {:name => rr.name}
-    if !current_user.miq_group_ids.include?(rr.miq_group_id) && !admin_user?
+    if !current_user.miq_group_ids.include?(rr.miq_group_id) && !report_admin_user?
       add_flash(_("Report is not authorized for the logged in user"), :error)
       @saved_reports = cb_rpts_get_all_reps(id.split('-')[1])
       return

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -189,7 +189,7 @@ class ConfigurationController < ApplicationController
   # Show the users list
   def show_timeprofiles
     build_tabs if params[:action] == "change_tab" || %w(cancel add save).include?(params[:button])
-    @timeprofiles = if admin_user?
+    @timeprofiles = if report_admin_user?
                       TimeProfile.in_my_region.ordered_by_desc
                     else
                       TimeProfile.in_my_region.for_user(session[:userid]).ordered_by_desc
@@ -259,14 +259,14 @@ class ConfigurationController < ApplicationController
     @timeprofile_action = "timeprofile_edit"
     set_form_vars
 
-    if @timeprofile.profile_type == "global" && !admin_user?
+    if @timeprofile.profile_type == "global" && !report_admin_user?
       @tp_restricted = true
       title = _("Time Profile")
     else
       title = _("Edit")
     end
 
-    add_flash(_("Global Time Profile cannot be edited")) if @timeprofile.profile_type == "global" && !admin_user?
+    add_flash(_("Global Time Profile cannot be edited")) if @timeprofile.profile_type == "global" && !report_admin_user?
     session[:changed] = false
     @in_a_form = true
     drop_breadcrumb(:name => _("%{title} '%{description}'") % {:title       => title,
@@ -288,7 +288,7 @@ class ConfigurationController < ApplicationController
           if tp.description == "UTC"
             timeprofiles.delete(tp.id.to_s)
             add_flash(_("Default Time Profile \"%{name}\" cannot be deleted") % {:name => tp.description}, :error)
-          elsif tp.profile_type == "global" && !admin_user?
+          elsif tp.profile_type == "global" && !report_admin_user?
             timeprofiles.delete(tp.id.to_s)
             add_flash(_("\"%{name}\": Global Time Profiles cannot be deleted") % {:name => tp.description}, :error)
           elsif !tp.miq_reports.empty?
@@ -313,7 +313,7 @@ class ConfigurationController < ApplicationController
       page.replace('timeprofile_days_hours_div',
                    :partial => "timeprofile_days_hours",
                    :locals  => {:disabled => false}) if @redraw
-      if params.key?(:profile_tz) && admin_user?
+      if params.key?(:profile_tz) && report_admin_user?
         if params[:profile_tz].blank?
           page << javascript_hide("rollup_daily_tr")
         else
@@ -419,8 +419,8 @@ class ConfigurationController < ApplicationController
 
     render :json => {
       :description             => @timeprofile.description,
-      :admin_user              => admin_user?,
-      :restricted_time_profile => @timeprofile.profile_type == "global" && !admin_user?,
+      :admin_user              => report_admin_user?,
+      :restricted_time_profile => @timeprofile.profile_type == "global" && !report_admin_user?,
       :profile_type            => @timeprofile.profile_type || "user",
       :profile_tz              => @timeprofile.tz.nil? ? "" : @timeprofile.tz,
       :rollup_daily            => !@timeprofile.rollup_daily_metrics.nil?,

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -542,7 +542,7 @@ class ReportController < ApplicationController
     @export_reports = {}
     user = current_user
     MiqReport.all.each do |rep|
-      if rep.rpt_type == "Custom" && (user.admin_user? || (rep.miq_group && rep.miq_group.id == user.current_group.id))
+      if rep.rpt_type == "Custom" && (user.report_admin_user? || (rep.miq_group && rep.miq_group.id == user.current_group.id))
         @export_reports[rep.name] = rep.id
       end
     end

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -369,12 +369,12 @@ module ReportController::Menus
         if params[:selected_reports].include?(nf)         # See if this col was selected to move
           field = nf.split('* ')
           r = MiqReport.find_by_name(field.length == 1 ? field[0].strip : field[1].strip)
-          if !user.admin_user? && r.miq_group_id.to_i != user.current_group.id.to_i && flg == 0
+          if !user.report_admin_user? && r.miq_group_id.to_i != user.current_group.id.to_i && flg == 0
             flg = 1
             # only show this flash message once for all reports
             add_flash(_("One or more selected reports are not owned by your group, they cannot be moved"), :warning)
           end
-          if user.admin_user? || r.miq_group_id.to_i == user.current_group.id.to_i
+          if user.report_admin_user? || r.miq_group_id.to_i == user.current_group.id.to_i
             @edit[:available_reports].push(nf) if @edit[:user_typ] || r.miq_group_id.to_i == user.current_group.id.to_i             # Add to the available fields list
             @edit[:selected_reports].delete(nf)
           end
@@ -526,7 +526,7 @@ module ReportController::Menus
     @edit[:current] = []
     @edit[:new] = @rpt_menu unless @rpt_menu.nil?
     user = current_user
-    @edit[:user_typ] = user.admin_user?
+    @edit[:user_typ] = user.report_admin_user?
     @edit[:user_group] = user.current_group.id
     @edit[:group_reports] = []
     menu_set_reports_for_group

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -24,7 +24,7 @@ module ReportController::SavedReports
     @right_cell_text ||= _("Saved Report \"%{name}\"") %
                          {:name => "#{rr.name} - #{format_timezone(rr.created_on, Time.zone, "gt")}"}
 
-    unless admin_user? || current_user.miq_group_ids.include?(rr.miq_group_id)
+    unless report_admin_user? || current_user.miq_group_ids.include?(rr.miq_group_id)
       add_flash(_("Report is not authorized for the logged in user"), :error)
       get_all_reps(@sb[:miq_report_id].to_s)
       return

--- a/app/helpers/application_helper/button/miq_request_delete.rb
+++ b/app/helpers/application_helper/button/miq_request_delete.rb
@@ -4,7 +4,7 @@ class ApplicationHelper::Button::MiqRequestDelete < ApplicationHelper::Button::B
 
   def disabled?
     requester = current_user
-    return false if requester.admin_user?
+    return false if requester.role_allows?(:feature => "miq_request_superadmin")
     @error_message = _("Users are only allowed to delete their own requests") if requester.name != @record.requester_name
     if %w(approved denied).include?(@record.approval_state)
       @error_message = _("%{approval_states} requests cannot be deleted") %

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -23,7 +23,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(_count_only, _options)
     u = User.current_user
-    user_groups = u.admin_user? ? nil : u.miq_groups
+    user_groups = u.report_admin_user? ? nil : u.miq_groups
     having_report_results(user_groups).pluck(:name, :id).sort.map do |name, id|
       {:id => id.to_i.to_s, :text => name, :icon => 'fa fa-file-text-o', :tip => name}
     end
@@ -37,7 +37,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   # Scope on reports that have report results.
   def having_report_results(miq_groups)
     miq_group_relation = MiqReport.joins(:miq_report_results).distinct
-    if miq_groups.nil? # u.admin_user?
+    if miq_groups.nil? # u.report_admin_user?
       miq_group_relation.where.not(:miq_report_results => {:miq_group_id => nil})
     else
       miq_group_relation.where(:miq_report_results => {:miq_group_id => miq_groups})

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -73,7 +73,7 @@
                                :class             => "form-control",
                                "data-miq_focus"   => true,
                                "data-miq_observe" => {:interval => ".5", :url => url2}.to_json)
-        - if admin_user?
+        - if report_admin_user?
           .form-group
             %label.control-label.col-md-5
               = _("Global search:")

--- a/app/views/layouts/_adv_search_footer.html.haml
+++ b/app/views/layouts/_adv_search_footer.html.haml
@@ -26,7 +26,7 @@
                    :title   => t,
                    :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "apply")}');")
     - if @edit[@expkey][:selected] && @edit[@expkey][:selected][:typ] != "default" && @edit[@expkey][:selected][:id] != 0
-      - if admin_user? || @edit[@expkey][:selected][:typ] == "user"
+      - if report_admin_user? || @edit[@expkey][:selected][:typ] == "user"
         - actual_filter = @edit[@expkey][:selected][:description]
         - confirm_msg = _("Delete the %{model} filter named %{filter}?") % {:model  => ui_lookup(:model => @edit[@expkey][:exp_model]),
                                                                             :filter => actual_filter}

--- a/spec/controllers/report_controller/widget_spec.rb
+++ b/spec/controllers/report_controller/widget_spec.rb
@@ -7,7 +7,7 @@ describe ReportController do
     before do
       user = FactoryGirl.create(:user_with_group)
       allow(user).to receive(:get_timezone).and_return(Time.zone)
-      allow(user).to receive(:admin_user?).and_return(true)
+      allow(user).to receive(:report_admin_user?).and_return(true)
       login_as user
       allow(controller).to receive(:current_user).and_return(user)
 

--- a/spec/helpers/application_helper/buttons/miq_request_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_delete_spec.rb
@@ -12,7 +12,7 @@ describe ApplicationHelper::Button::MiqRequestDelete do
       allow(record).to receive(:resource_type).and_return(resource_type)
     end
 
-    let(:current_user) { FactoryGirl.create(:user_admin) }
+    let(:current_user) { FactoryGirl.create(:user, :features => "everything") }
     let(:approval_state) { 'sorryjako' }
     let(:requester_name) { {:requester_name => current_user.name} }
     let(:resource_type) { 'knedlik' }


### PR DESCRIPTION
The current ui code displays components based upon `admin_user?`
But in truth, it is hiding/showing reporting components.
So changing this over to `report_admin_user?` states the actual intent.

The dependent PR https://github.com/ManageIQ/manageiq/pull/17444 introduces a `miq_product_feature` for a report admin, so this could be asked (and so we could have less hardcoded admin checks)  

There is also one check for `request` admin checks - there are more of those over in the api code.

The depends upon:

- https://github.com/ManageIQ/manageiq/pull/17444

Targeting:

- https://bugzilla.redhat.com/show_bug.cgi?id=1090627
- https://bugzilla.redhat.com/show_bug.cgi?id=1545401
