### PR TITLE
Display Cloud Tenants relation at Network Manager

### DIFF
--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -12,7 +12,7 @@ module EmsNetworkHelper::TextualSummary
     TextualGroup.new(
       _("Relationships"),
       %i(
-        parent_ems_cloud cloud_networks cloud_subnets network_routers security_groups floating_ips
+        parent_ems_cloud cloud_tenants cloud_networks cloud_subnets network_routers security_groups floating_ips
         network_ports load_balancers
       )
     )
@@ -103,5 +103,13 @@ module EmsNetworkHelper::TextualSummary
 
   def textual_zone
     {:label => _("Managed by Zone"), :icon => "pficon pficon-zone", :value => @record.zone.try(:name)}
+  end
+
+  def textual_cloud_tenants
+    textual_link(
+      @record.try(:cloud_tenants),
+      :label => _('Cloud Tenants'),
+      :link  => url_for_only_path(:display => 'cloud_tenants')
+    )
   end
 end


### PR DESCRIPTION
With this commit we display relation (with object count) at Network Manager details page. Clicking on relation redirects user to a `display=cloud_tenants` page. Find screenshots below.

Screenshot of Network Manager details page:
![capture](https://user-images.githubusercontent.com/8102426/40611080-3a1c110e-6275-11e8-903b-0caf86ad9170.PNG)

Screenshot of a page that renders when user clicks on "Cloud Tenants" relation:
![capture](https://user-images.githubusercontent.com/8102426/40611138-7095b078-6275-11e8-84e6-f44e8ec97e51.PNG)

Video: http://x.k00.fr/cloudtenants
Related PR (but not blocking): https://github.com/ManageIQ/manageiq-providers-nuage/pull/92
RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574903

@miq-bot assign @himdel 
@miq-bot add_label enhancement