### PR TITLE
Setting different colors for physical infra components on topology view

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -17,6 +17,7 @@
  *= require ./timeline
  *= require ./topology
  *= require ./container_topology
+ *= require ./physical_infra_topology
  *= require ./metrics
  *= require ./service_dialogs
  *= require bower_components/xml_display/XMLDisplay

--- a/app/assets/stylesheets/physical_infra_topology.scss
+++ b/app/assets/stylesheets/physical_infra_topology.scss
@@ -1,0 +1,14 @@
+$topology-colors: (
+  PhysicalServer: #00659c,
+  PhysicalRack:   #2d7623,
+);
+
+@each $component, $color in $topology-colors {
+  .legend kubernetes-topology-icon[kind="#{$component}"] i{
+    color: $color;
+  }
+
+  .topology g.#{$component} text.glyph{
+    fill: $color !important;
+  }
+}


### PR DESCRIPTION
__This PR is able to__
- Set different colors for different physical components on topology view;

![image](https://user-images.githubusercontent.com/8550928/40735453-997273c6-6411-11e8-8eb9-a06e36ec531f.png)

__Goal__
With a great number of components on topology is pretty confuse to distinguish each component type, with different colors we improve the consume of the data on this page.