### PR TITLE
[WIP] Add new selector for Chargeback Rate editing screen to select the base model

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -191,6 +191,8 @@ class ChargebackController < ApplicationController
       changed = (@edit[:new] != @edit[:current])
       # Update the new column with the code of the currency selected by the user
       page.replace('chargeback_rate_currency', :partial => 'cb_rate_currency')
+      # Update the Rate Details table according to the selected base model
+      page.replace('rate_edit_details', :partial => 'cb_rate_edit_table') if @edit[:new][:model]
       page << javascript_for_miq_button_visibility(changed)
     end
   end

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -576,6 +576,7 @@ class ChargebackController < ApplicationController
     @edit[:new][:per_time_types] = ChargebackRateDetail::PER_TIME_TYPES
 
     if params[:pressed] == 'chargeback_rates_copy'
+      @edit[:new][:base_id] = @rate.id if @edit[:models].include?('Any')
       @rate.id = nil
       @edit[:new][:description] = "copy of #{@rate.description}"
     end

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -113,8 +113,14 @@ class ChargebackController < ApplicationController
         render_flash(_("Description is required"), :error)
         return
       end
-      @rate.description = @edit[:new][:description]
-      @rate.rate_type   = @edit[:new][:rate_type] if @edit[:new][:rate_type]
+      if @edit[:new][:model] == 'Any' || !@edit[:new][:model]
+        render_flash(_("Base model is required"), :error)
+        return
+      end
+
+      @rate.description       = @edit[:new][:description]
+      @rate.rate_type         = @edit[:new][:rate_type] if @edit[:new][:rate_type]
+      @rate.report_base_model = @edit[:new][:model]
 
       cb_rate_set_record_vars
       # Detect errors saving tiers

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -32,6 +32,27 @@
           miqInitSelectPicker();
           miqSelectPickerEvent("currency", "#{url}");
 
+  /Add a new selector for configuring Rate columns
+  %h3
+    = _('Configure Rate Columns')
+  .form-horizontal.static
+    .form-group
+      %label.col-md-2.control-label
+        = _('* Base the Rate on')
+      .col-md-8
+        = select_tag('chosen_model',
+          options_for_select(@edit[:models].sort, @edit[:new][:model]),
+          :multiple          => false,
+          "data-live-search" => "true",
+          :class             => "selectpicker",
+          :title             => "&lt;#{_('Choose')}&gt;",)
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent('chosen_model', '#{url}', {beforeSend: true, complete: true});
+    - if @edit[:models].exclude?('Any')
+      %strong
+        = _('* Caution: Changing these fields will set all the values below them to default values!')
+
   %h3
     = _('Rate Details')
   %strong

--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -1,82 +1,84 @@
-- url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => @edit[:rec_id] || "new")
-- breakdown_present = @edit[:new][:details].any? { |d| d[:sub_metric].present? }
-%table.table.table-bordered{:id => "chargeback_rate_edit_form"}
-  %thead
-    %tr
-      %th{:rowspan => "2"}= _('Group')
-      %th{:rowspan => "2"}
-        = _('Description')
-        %br
-        = _('(Column Name in Report)')
-      - if breakdown_present
-        %th{:rowspan => '2'}= _('Sub Metric')
-      %th{:rowspan => "2"}= _('Per Time')
-      %th{:rowspan => "2"}= _('Per Unit')
-      %th{:colspan => "2"}= _('Range')
-      = render :partial => 'cb_rate_currency'
-      %th{:rowspan => "2"}= _('Actions')
-    %tr
-      %th= _("Start")
-      %th= _("Finish")
-      %th= _("Fixed")
-      %th= _("Variable")
-  %tbody
-    - @edit[:new][:details].sort_by { |rd| [rd[:group], rd[:description], rd[:sub_metric].to_s] }.each_with_index do |detail, detail_index|
-      - @cur_group = detail[:group] if @cur_group.nil?
-      - if @cur_group != detail[:group]
-        - @cur_group = detail[:group]
+#rate_edit_details
+  - if @edit[:new][:model]
+    - url = url_for_only_path(:action => 'cb_rate_form_field_changed', :id => @edit[:rec_id] || "new")
+    - breakdown_present = @edit[:new][:details].any? { |d| d[:sub_metric].present? }
+    %table.table.table-bordered{:id => "chargeback_rate_edit_form"}
+      %thead
         %tr
-          %td{:colspan => "10", :style => "background-color: #f5f5f5;"} &nbsp;
-      - if params[:pressed] == "chargeback_rates_edit"
-        - detail_index = @edit[:new][:tiers].index { |x| x.detect { |tier_hash| tier_hash['chargeback_rate_detail_id'] == detail[:id] }.present? }
-      - num_tiers = @edit[:new][:tiers][detail_index].blank? ? "1" : @edit[:new][:tiers][detail_index].length.to_s
+          %th{:rowspan => "2"}= _('Group')
+          %th{:rowspan => "2"}
+            = _('Description')
+            %br
+            = _('(Column Name in Report)')
+          - if breakdown_present
+            %th{:rowspan => '2'}= _('Sub Metric')
+          %th{:rowspan => "2"}= _('Per Time')
+          %th{:rowspan => "2"}= _('Per Unit')
+          %th{:colspan => "2"}= _('Range')
+          = render :partial => 'cb_rate_currency'
+          %th{:rowspan => "2"}= _('Actions')
+        %tr
+          %th= _("Start")
+          %th= _("Finish")
+          %th= _("Fixed")
+          %th= _("Variable")
+      %tbody
+        - @edit[:new][:details].sort_by { |rd| [rd[:group], rd[:description], rd[:sub_metric].to_s] }.each_with_index do |detail, detail_index|
+          - @cur_group = detail[:group] if @cur_group.nil?
+          - if @cur_group != detail[:group]
+            - @cur_group = detail[:group]
+            %tr
+              %td{:colspan => "10", :style => "background-color: #f5f5f5;"} &nbsp;
+          - if params[:pressed] == "chargeback_rates_edit"
+            - detail_index = @edit[:new][:tiers].index { |x| x.detect { |tier_hash| tier_hash['chargeback_rate_detail_id'] == detail[:id] }.present? }
+          - num_tiers = @edit[:new][:tiers][detail_index].blank? ? "1" : @edit[:new][:tiers][detail_index].length.to_s
 
-      %tr.rdetail{:id => "rate_detail_row_#{detail_index}_0"}
-        %td{:rowspan => num_tiers}
-          = h(rate_detail_group(detail[:group]))
-        %td{:rowspan => num_tiers}
-          = detail[:description]
-          %br
-          = "(#{detail[:report_column_name]})"
-        - if breakdown_present
-          %td{:rowspan => num_tiers}
-            - sub_metrics = detail[:sub_metrics]
-            - if sub_metrics.present?
-              = detail[:sub_metric_human]
-        %td{:rowspan => num_tiers}
-          = select_tag("per_time_#{detail_index}",
-            options_for_select(@edit[:new][:per_time_types].invert, detail[:per_time]),
-            "data-miq_observe" => {:url => url}.to_json)
-        - measure = detail[:detail_measure]
-        - if measure.nil?
-          /if the rate detail don't have a metric associated, display the per_unit_display
-          %td{:rowspan => num_tiers}
-            = detail[:per_unit_display]
-        - else
-          /if the rate detail have a metric associated, display an options field with per_unit selected
-          %td{:rowspan => num_tiers}
-            = select_tag("per_unit_#{detail_index}", options_for_select(measure[:measures], detail[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
-        = render :partial => 'cb_tier_edit_values', :locals => {:detail_index => detail_index, :url => url, :row_within_rate => 0}
-        %td.action
-          = button_tag(_("Add"), :class => "btn btn-default", :alt => t = _("Add a new tier"), :title => t,
-                                 :onclick => "miqAjaxButton('#{url_for_only_path(:action => "cb_tier_add",
-                                                                       :detail_index => detail_index,
-                                                                       :button => "add")}');")
-      - (1..num_tiers.to_i - 1).each do |tier_index|
-        - tier = @edit[:new][:tiers][detail_index][tier_index]
-        %tr.rdetail{:id => "rate_detail_row_#{detail_index}_#{tier_index}"}
-          = render :partial => 'cb_tier_edit_values', :locals => {:detail_index => detail_index, :url => url, :row_within_rate => tier_index}
-          %td.action
-            = button_tag(_("Delete"), :class => "btn btn-default", :alt => t = _("Remove the tier"), :title => t,
-                                      :onclick => "miqAjaxButton('#{url_for_only_path(:action => "cb_tier_remove",
-                                                                            :index => "#{detail_index}-#{tier_index}",
-                                                                            :button => "remove")}');")
+          %tr.rdetail{:id => "rate_detail_row_#{detail_index}_0"}
+            %td{:rowspan => num_tiers}
+              = h(rate_detail_group(detail[:group]))
+            %td{:rowspan => num_tiers}
+              = detail[:description]
+              %br
+              = "(#{detail[:report_column_name]})"
+            - if breakdown_present
+              %td{:rowspan => num_tiers}
+                - sub_metrics = detail[:sub_metrics]
+                - if sub_metrics.present?
+                  = detail[:sub_metric_human]
+            %td{:rowspan => num_tiers}
+              = select_tag("per_time_#{detail_index}",
+                options_for_select(@edit[:new][:per_time_types].invert, detail[:per_time]),
+                "data-miq_observe" => {:url => url}.to_json)
+            - measure = detail[:detail_measure]
+            - if measure.nil?
+              /if the rate detail don't have a metric associated, display the per_unit_display
+              %td{:rowspan => num_tiers}
+                = detail[:per_unit_display]
+            - else
+              /if the rate detail have a metric associated, display an options field with per_unit selected
+              %td{:rowspan => num_tiers}
+                = select_tag("per_unit_#{detail_index}", options_for_select(measure[:measures], detail[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
+            = render :partial => 'cb_tier_edit_values', :locals => {:detail_index => detail_index, :url => url, :row_within_rate => 0}
+            %td.action
+              = button_tag(_("Add"), :class => "btn btn-default", :alt => t = _("Add a new tier"), :title => t,
+                                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => "cb_tier_add",
+                                                                           :detail_index => detail_index,
+                                                                           :button => "add")}');")
+          - (1..num_tiers.to_i - 1).each do |tier_index|
+            - tier = @edit[:new][:tiers][detail_index][tier_index]
+            %tr.rdetail{:id => "rate_detail_row_#{detail_index}_#{tier_index}"}
+              = render :partial => 'cb_tier_edit_values', :locals => {:detail_index => detail_index, :url => url, :row_within_rate => tier_index}
+              %td.action
+                = button_tag(_("Delete"), :class => "btn btn-default", :alt => t = _("Remove the tier"), :title => t,
+                                          :onclick => "miqAjaxButton('#{url_for_only_path(:action => "cb_tier_remove",
+                                                                                :index => "#{detail_index}-#{tier_index}",
+                                                                                :button => "remove")}');")
 
-    :javascript
-      $('tbody tr.rdetail').hover( function(){hoverRowIn(this)}, function(row){hoverRowOut(this)});
-      function hoverRowIn(row) {
-        $("tr[id ^= '"+row.id.substr(0, row.id.lastIndexOf("_"))+"']").addClass("active");
-      }
-      function hoverRowOut(row) {
-        $("tr[id ^= '"+row.id.substr(0, row.id.lastIndexOf("_"))+"']").removeClass("active");
-      }
+        :javascript
+          $('tbody tr.rdetail').hover( function(){hoverRowIn(this)}, function(row){hoverRowOut(this)});
+          function hoverRowIn(row) {
+            $("tr[id ^= '"+row.id.substr(0, row.id.lastIndexOf("_"))+"']").addClass("active");
+          }
+          function hoverRowOut(row) {
+            $("tr[id ^= '"+row.id.substr(0, row.id.lastIndexOf("_"))+"']").removeClass("active");
+          }

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -10,6 +10,15 @@
     .col-md-8
       %p.form-control-static
         = h(@record.description)
+  .form-group
+    %label.col-md-2.control-label
+      = _('Based on')
+    .col-md-8
+      %p.form-control-static
+        - if @record.report_base_model
+          = h(@record.report_base_model)
+        - else
+          = _('Any')
 %hr
 %h3= _('Rate Details')
 %table.table.table-bordered


### PR DESCRIPTION
**Partially fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1581817
**Needs to merge with:**
https://github.com/ManageIQ/manageiq/pull/17507
https://github.com/ManageIQ/manageiq-schema/pull/304 (new alternative of https://github.com/ManageIQ/manageiq-schema/pull/209)

---

**What:**
When choosing _Chargeback for Images/Projects/Vms_ under _Configure Report Columns_ section while adding a new/editing an existing Report under _Cloud Intel > Reports > Reports_, some of the fields are not available. This is ok but there was a misunderstanding that those fields were missing there. This is why I add note/info about which fields are not supported to the Report editing screen (in another PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/4081), and also new selector for Chargeback Rate editing screen (under _Cloud Intel > Chargeback > Rates_) is added to choose what the Rate is based on (_Images/Projects/Vms_) (this PR). We call it the base model (see https://github.com/ManageIQ/manageiq-schema/pull/209).

---

**Before:**
Adding/editing a Chargeback Rate:
![edit_rate_before](https://user-images.githubusercontent.com/13417815/40666135-500ed858-635f-11e8-9285-78adf59e6e15.png)
Displaying details page of a Chargeback Rate:
![rate_show](https://user-images.githubusercontent.com/13417815/41099016-872b10ea-6a5d-11e8-9aa5-f1c7e619a2d8.png)

---

**After:**
Adding a new Chargeback Rate (the _Rate Details_ table is displayed after choosing one of the "base models" by the new drop down because the rate details depend on it):
![add_new_rate_after](https://user-images.githubusercontent.com/13417815/41103181-c8b2e5c8-6a68-11e8-87bb-fdf5fed27474.png)
The new selector for configuring Rate columns (for choosing the base model), in editing screen:
![report_base_model-select](https://user-images.githubusercontent.com/13417815/41103191-cf2e49ba-6a68-11e8-9245-afe7a9fff787.png)
Adding/editing an existing Chargeback Rate with base model:
(After changing the model, the Rate Details table is cleared to its default values, similarly as for Reports, and the columns of the table are updated according to the chosen base model: only appropriate columns are displayed for each base model)
![new_rate_base_model](https://user-images.githubusercontent.com/13417815/41104459-ae143cdc-6a6b-11e8-8066-b4e7e4f5f622.png)
Displaying details page of a new Chargeback Rate, with the base model:
![new_rate2_show](https://user-images.githubusercontent.com/13417815/41104589-0489b808-6a6c-11e8-8f2d-3cb42cfc2061.png)
Displaying details page of a Chargeback Rate, **without the base model** (all the existing rates):
(The rate is based on 'Any' as its details' table has all the available/any columns)
![old_rate_show](https://user-images.githubusercontent.com/13417815/41051078-65ff2abc-69b5-11e8-9819-eaf604827e9f.png)
Editing the Chargeback Rate without the base model:
('Any' option is also available - user can see all the original details' values and edit them)
![old_rate-edit](https://user-images.githubusercontent.com/13417815/41104808-8cd03a7a-6a6c-11e8-8504-b73d752c8a4e.png)
Changing the base model of the Chargeback Rate without the base model:
(While changing the base model from "Any" to any other, user will not lose his original details' values, the table will not be reset to its default values as usually, only the appropriate columns display - with already existing values of the rate, already saved in the DB)
![old_rate_change_base](https://user-images.githubusercontent.com/13417815/41051612-e5f76f62-69b6-11e8-841d-2c3d1a8b46eb.png)
Saving the Chargeback Rate without the base model:
![model_required](https://user-images.githubusercontent.com/13417815/41051452-77b61904-69b6-11e8-946c-15f41c536c63.png)

**Note:**
Copying of the Rate with/without base model also works but it will not be possible to save the Rate based on 'Any'.