### PR TITLE
Use pficon-unknown fonticon for unknown Operating Systems in quads

### DIFF
--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -10,9 +10,8 @@ class MiqTemplateDecorator < MiqDecorator
   def quadicon
     icon = {
       :top_left     => {
-        :fileicon => os_image,
-        :tooltip  => os_image_name.humanize.downcase
-      },
+        :tooltip => os_image_name.humanize.downcase
+      }.merge(QuadiconHelper.os_icon(os_image_name.downcase)),
       :top_right    => {
         :tooltip => normalized_state
       }.merge(QuadiconHelper.machine_state(normalized_state)),
@@ -32,11 +31,5 @@ class MiqTemplateDecorator < MiqDecorator
     {
       :fileicon => fileicon
     }
-  end
-
-  private
-
-  def os_image
-    "svg/os-#{ERB::Util.h(os_image_name.downcase)}.svg"
   end
 end

--- a/app/decorators/vm_decorator.rb
+++ b/app/decorators/vm_decorator.rb
@@ -14,9 +14,8 @@ class VmDecorator < MiqDecorator
   def quadicon
     icon = {
       :top_left     => {
-        :fileicon => os_image,
         :tooltip  => os_image_name.humanize.downcase
-      },
+      }.merge(QuadiconHelper.os_icon(os_image_name.downcase)),
       :top_right    => {
         :tooltip => normalized_state
       }.merge(QuadiconHelper.machine_state(normalized_state)),
@@ -36,11 +35,5 @@ class VmDecorator < MiqDecorator
     {
       :fileicon => fileicon
     }
-  end
-
-  private
-
-  def os_image
-    "svg/os-#{ERB::Util.h(os_image_name.downcase)}.svg"
   end
 end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -46,6 +46,10 @@ module QuadiconHelper
     end
   end
 
+  def self.os_icon(name)
+    name == "unknown" ? { :fonticon => 'pficon pficon-unknown' } : {:fileicon => "svg/os-#{ERB::Util.h(name)}.svg" }
+  end
+
   def self.machine_state(state_str)
     MACHINE_STATE_QUADRANT[state_str.try(:downcase)] || {}
   end


### PR DESCRIPTION
Instead of using the `svg/os-unknown.svg` we should use the `pficon pficon-uknown` fonticon.

@miq-bot add_reviewer @epwinchell 