### PR TITLE
[GAPRINDASHVILI] API transformRequest support + http service

### DIFF
--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -142,6 +142,7 @@
     delete o.data;
     delete o.body;
     delete o.skipErrors;
+    delete o.transformResponse;
 
     if (o.skipTokenRenewal) {
       o.headers = o.headers || {};
@@ -203,6 +204,11 @@
         return ret;
       }
 
+      // apply a custom transformation
+      if (options.transformResponse) {
+        ret = ret.then(options.transformResponse);
+      }
+
       // true means skip all of them - no error modal at all
       if (options.skipErrors === true) {
         return ret;
@@ -249,6 +255,9 @@
   }
 })(window);
 
+
+// v2v
+window.API = window.vanillaJsAPI;
 
 angular.module('miq.api', [])
 .factory('API', ['$q', function($q) {


### PR DESCRIPTION
This is a gaprindasvhili version of #3662 and #3978.

---

Differences:

The master change lives under `app/javascript`, written in ES6, and refactored so that the http vs API parts are much more separate. For gaprindashvili, leaving in ES5 with the minimal amount of changes to support both.

Additional difference: changes that make the error modal distinguish between API and http requests were not backported, this means `http` access errors will appear as API errors in the error modal - this is just about the modal title, the URL fits.