### PR TITLE
[FINE] Tenant and Project edit and cancel edit message

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -111,7 +111,7 @@ module OpsController::OpsRbac
                     {:model => tenant_type_title_string(params[:divisible] == "true")})
       else
         add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") %
-                    {:model => tenant_type_title_string(params[:divisible] == "true"), :name => @tenant.name})
+                    {:model => tenant_type_title_string(@tenant[:divisible]), :name => @tenant.name})
       end
       get_node_info(x_node)
       replace_right_cell(:nodetype => x_node)
@@ -132,7 +132,7 @@ module OpsController::OpsRbac
       else
         AuditEvent.success(build_saved_audit_hash(old_tenant_attributes, tenant, params[:button] == "add"))
         add_flash(_("%{model} \"%{name}\" was saved") %
-                    {:model => tenant_type_title_string(params[:divisible] == "true"), :name => tenant.name})
+                    {:model => tenant_type_title_string(tenant[:divisible]), :name => tenant.name})
         if params[:button] == "add"
           rbac_tenants_list
           rbac_get_info


### PR DESCRIPTION
Fixes proper reference to either Tenant or Project when in Edit or Cancel mode in Configuration Access Control settings. See attached screen shots.

https://bugzilla.redhat.com/show_bug.cgi?id=1511927

Canceling out of Edit function for Tenant post code fix:
![cancel edit of tenant post code fix](https://user-images.githubusercontent.com/552686/40750887-ca96a772-641d-11e8-8f34-f4fbf5657d4b.png)

Canceling out of Edit function for Project post code fix:
![cancel edit of project post code fix](https://user-images.githubusercontent.com/552686/40750901-d9b5d5de-641d-11e8-9af4-99b5b5537075.png)


Save Tenant settings message post code fix:
![save tenant message post code fix](https://user-images.githubusercontent.com/552686/40750948-fb12daec-641d-11e8-95f1-45723333836c.png)


Save Project settings message post code fix:
![cancel edit of project post code fix](https://user-images.githubusercontent.com/552686/40750962-0c882ebc-641e-11e8-963c-696bfeabd378.png)

