### PR TITLE
Fix textual summary display in tenants.

### DIFF
--- a/app/views/ops/_rbac_tenant_details.html.haml
+++ b/app/views/ops/_rbac_tenant_details.html.haml
@@ -68,7 +68,7 @@
               %td= tenant.name
   .row
     .col-md-12.col-lg-10
-      = react 'TableListView', textual_tenant_quota_allocations
+      = react 'TableListViewWrapper', TextualListview.data(textual_tenant_quota_allocations)
       %p
         = _("Note: Total quota can be restricted by quotas defined at upper levels")
       %hr

--- a/app/views/ops/_rbac_tenant_details.html.haml
+++ b/app/views/ops/_rbac_tenant_details.html.haml
@@ -72,4 +72,5 @@
       %p
         = _("Note: Total quota can be restricted by quotas defined at upper levels")
       %hr
-  = render :partial => "rbac_tag_box"
+    .col-md-12.col-lg-10
+      = render :partial => "rbac_tag_box"


### PR DESCRIPTION
ping @ZitaNemeckova 

 * fix a regression causes by the TextualSummary componentization PR
 * fix broken formatting

### FIXME
  * there are more issues probably related to the use of API and angular in editing tennants. Namely the left tree disappears on {new,edit}/save or edit/cancel. There's a whole page reload, that should not be....