### PR TITLE
Render notifications fetched from the API in the correct order

### DIFF
--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -79,7 +79,7 @@ function eventNotifications($timeout, API) {
       .then(function(data) {
         data.resources.forEach(function(resource) {
           var msg = miqFormatNotification(resource.details.text, resource.details.bindings);
-          events.notifications.splice(0, 0, {
+          events.notifications.push({
             id: resource.id,
             notificationType: _this.EVENT_NOTIFICATION,
             unread: ! resource.seen,


### PR DESCRIPTION
Somehow the ordering of the notifications was reversed when requesting old ones from the API, fixing it.

https://bugzilla.redhat.com/show_bug.cgi?id=1583821