### PR TITLE
bz 1518304: don't offer edit action for OpenStack network provider

### DIFF
--- a/app/helpers/application_helper/toolbar/ems_networks_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_networks_center.rb
@@ -25,16 +25,6 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
           :url   => "/new",
           :klass => ApplicationHelper::Button::EmsNetworkNew),
         button(
-          :ems_network_edit,
-          'pficon pficon-edit fa-lg',
-          N_('Select a single Network Provider to edit'),
-          N_('Edit Selected Network Provider'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :enabled      => false,
-          :onwhen       => "1",
-          :klass        => ApplicationHelper::Button::EmsNetwork),
-        button(
           :ems_network_delete,
           'pficon pficon-delete fa-lg',
           N_('Remove selected Network Providers from Inventory'),


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1518304

The only network provider that should allow direct editing is the Nuage
provider. Edit action was already hidden from 'show' page for non-Nuage
networks. This commit hides the edit action on the index page.
