### PR TITLE
Display number of containers on the top right quad of container prov

### DIFF
--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -14,7 +14,7 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
   def quadicon
     icon = {
       :top_left     => {:text => container_nodes.size},
-      :top_right    => QuadiconHelper.machine_state(enabled? ? 'on' : 'paused'),
+      :top_right    => {:text => containers.size},
       :bottom_left  => {
         :fileicon => fileicon,
         :tooltip  => ui_lookup(:model => type)


### PR DESCRIPTION
The quadicon for container provider introduced some inconsistency compared with other provider quads. The top-right quad displays an icon based on the data collection is suspended for the given provider or not. As we're extending this suspend feature to other providers and planning to use the bottom-right quad for displaying this info on each one, this would cause some redundancy for the container provider quadicons.

So I'm proposing to use the top-right quad for container providers more consistently with the other provider quads and display in it the number of containers for the given provider. Analogously to the infra provider displays the number of VMs in the same quad.

**Before:**
![screenshot from 2018-05-31 17-23-48](https://user-images.githubusercontent.com/649130/40791261-66bd7f0c-64f7-11e8-818a-3566b1271c33.png)

**After:**
![screenshot from 2018-05-31 17-13-54](https://user-images.githubusercontent.com/649130/40791149-127c4054-64f7-11e8-9504-24b7fa6f1cfc.png)

@miq-bot add_label gaprindashvili/no, GTLs, compute/containers
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @romanblanco 
