### PR TITLE
Add the VMWare Virtual  Ethernet Card model type to the VM summary

### DIFF
--- a/app/helpers/textual_mixins/textual_devices.rb
+++ b/app/helpers/textual_mixins/textual_devices.rb
@@ -102,8 +102,9 @@ module TextualMixins::TextualDevices
       location = port.location
       address = port.address
       filename = port.filename
+      model = port.model
       autodetect = port.auto_detect ? "" : _("Default Adapter")
-      desc = [location, address, filename, autodetect, network_name(port)].compact.join(', ')
+      desc = [location, address, filename, model, autodetect, network_name(port)].compact.join(', ')
       Device.new(name, desc, nil, port.device_type)
     end
   end

--- a/spec/helpers/textual_mixins/textual_devices_spec.rb
+++ b/spec/helpers/textual_mixins/textual_devices_spec.rb
@@ -92,6 +92,11 @@ describe TextualMixins::TextualDevices do
       it { is_expected.not_to be_empty }
     end
 
+    context "with model type parsed" do
+      let(:hw) { FactoryGirl.create(:hardware, :guest_devices => [FactoryGirl.create(:guest_device_nic, :model => 'Vmxnet3')]) }
+      it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Vmxnet3", "Default Adapter"].compact.join(', '), nil, "ethernet")]) }
+    end
+
     context "without vswitch and portgroup" do
       let(:hw) { FactoryGirl.create(:hardware, :guest_devices => [FactoryGirl.create(:guest_device_nic)]) }
       it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Default Adapter"].compact.join(', '), nil, "ethernet")]) }


### PR DESCRIPTION
Add the VMWare Virtual  Ethernet Card model type to the VM summary

Links 
----------

https://bugzilla.redhat.com/show_bug.cgi?id=1583017

![screenshot from 2018-05-31 12-06-10](https://user-images.githubusercontent.com/12769982/40795036-cccdaac0-64ce-11e8-9126-6d4ceb9cb2d3.png)
![screenshot from 2018-05-31 12-05-58](https://user-images.githubusercontent.com/12769982/40795037-ccf9554e-64ce-11e8-8986-642290b0e104.png)

