### PR TITLE
Fix to show meaningful policy name when add/delete it in audit.log

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -116,6 +116,7 @@ module ApplicationController::CiProcessing
     Rbac.filtered(klass.where(:id => elements).order(order_by)).each do |record|
       name = record.send(order_field.to_sym)
       if task == 'destroy'
+        name = record.send(:description) if klass.name == 'MiqPolicy'
         process_element_destroy(record, klass, name)
       else
         begin

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -941,8 +941,11 @@ class MiqPolicyController < ApplicationController
 
   # Build the audit object when a profile is saved
   def build_saved_audit(record, add = false)
-    name = record.respond_to?(:name) ? record.name : record.description
-    name = record.description if record.kind_of?(MiqPolicy)
+    name = if record.kind_of?(MiqPolicy)
+             record.description 
+           else
+             record.respond_to?(:name) ? record.name : record.description
+           end
 
     msg = if add
             _("[%{name}] Record added (") % {:name => name}

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -942,7 +942,7 @@ class MiqPolicyController < ApplicationController
   # Build the audit object when a profile is saved
   def build_saved_audit(record, add = false)
     name = record.respond_to?(:name) ? record.name : record.description
-    name = record.description if record.is_a?(MiqPolicy)
+    name = record.description if record.kind_of?(MiqPolicy)
 
     msg = if add
             _("[%{name}] Record added (") % {:name => name}

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -942,6 +942,8 @@ class MiqPolicyController < ApplicationController
   # Build the audit object when a profile is saved
   def build_saved_audit(record, add = false)
     name = record.respond_to?(:name) ? record.name : record.description
+    name = record.description if record.is_a?(MiqPolicy)
+
     msg = if add
             _("[%{name}] Record added (") % {:name => name}
           else

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -942,7 +942,7 @@ class MiqPolicyController < ApplicationController
   # Build the audit object when a profile is saved
   def build_saved_audit(record, add = false)
     name = if record.kind_of?(MiqPolicy)
-             record.description 
+             record.description
            else
              record.respond_to?(:name) ? record.name : record.description
            end


### PR DESCRIPTION
Show meaningful policy name in audit.log when adding/deleting policy.

https://bugzilla.redhat.com/show_bug.cgi?id=1434762



Steps for Testing/QA 
-------------------------------

1. In UI, Control->Policies, add or delete a policy;
2. `[policy_name] Record added [deleted]` should show in the audit.log

Related PR:
https://github.com/ManageIQ/manageiq/pull/17504