### PR TITLE
String & gettext fixes in advanced tab warning

### DIFF
--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -25,22 +25,15 @@ module OpsHelper
     tree_node.split('-').first == key
   end
 
-  def selected_node_title
+  def advanced_tab_warning
     if selected?(x_node, "z")
-      "Zone"
+      _('Caution: Manual changes to configuration files can disable the Zone!') + ' ' +
+        _('Changes made to any individual settings will overwrite settings inherited from the Region.')
     elsif selected?(x_node, "svr")
-      "Server"
+      _('Caution: Manual changes to configuration files can disable the Server!') + ' ' +
+        _('Changes made to any individual settings will overwrite settings inherited from the Zone.')
     else
-      "Region"
-    end
-  end
-
-  def selected_node_parent_title
-    return nil if selected?(x_node, "root")
-    if selected?(x_node, "z")
-      "Region"
-    elsif selected?(x_node, "svr")
-      "Zone"
+      _('Caution: Manual changes to configuration files can disable the Region!')
     end
   end
 

--- a/app/views/ops/_settings_advanced_tab.html.haml
+++ b/app/views/ops/_settings_advanced_tab.html.haml
@@ -6,10 +6,7 @@
         %span.pficon.pficon-error-octagon
         %span.pficon.pficon-error-exclamation
       %strong
-        - warning_msg = _("Caution: Manual changes to configuration files can disable the #{selected_node_title}!")
-        - if selected_node_parent_title
-          - warning_msg << _(" Changes made to any individual settings will overwrite settings inherited from the #{selected_node_parent_title}.")
-        = warning_msg
+        = advanced_tab_warning
 
     = text_area_tag("file_data", @edit[:new][:file_data], :style => "display:none;")
     = render :partial => "/layouts/my_code_mirror",


### PR DESCRIPTION
- we should not do string interpolation in gettext
- we should not do string concatenation in UI strings
- similar condition was used twice in two routines