### PR TITLE
[FINE] Ensure dropdown gets selectpicker refreshed after values set

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -119,8 +119,8 @@ var dialogFieldRefresh = {
       dialogFieldRefresh.addOptionsToDropDownList(responseData, fieldId);
       dialogFieldRefresh.setReadOnly($('#' + fieldName), responseData.values.read_only);
       dialogFieldRefresh.setVisible($('#field_' +fieldId + '_tr'), responseData.values.visible);
-      $('#' + fieldName).selectpicker('refresh');
       $('#' + fieldName).selectpicker('val', responseData.values.checked_value);
+      $('#' + fieldName).selectpicker('refresh');
       callback.call();
     };
 

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -570,6 +570,12 @@ describe('dialogFieldRefresh', function() {
         expect($.fn.selectpicker).toHaveBeenCalledWith('val', 'selectedTest');
       });
 
+      it('sets the value in the select picker first and then is refreshed', function() {
+        expect($.fn.selectpicker.calls.count()).toEqual(2);
+        expect($.fn.selectpicker.calls.all()[0].args).toEqual(['val', 'selectedTest']);
+        expect($.fn.selectpicker.calls.all()[1].args).toEqual(['refresh']);
+      });
+
       it('uses the correct selector', function() {
         expect($.fn.selectpicker.calls.mostRecent().object.selector).toEqual('#abc');
       });


### PR DESCRIPTION
This is an issue that was solved via https://github.com/ManageIQ/ui-components/pull/295 for Gaprindashvili and later versions, but since Fine does not use the ui-components repo, nor does it use the new dialog-user component, it had to be addressed differently. The `selectpicker('refresh')` line needs to be ran after the values for the dialog field have been updated, not before.

https://bugzilla.redhat.com/show_bug.cgi?id=1581387

@miq-bot add_label bug, blocker

@d-m-u Can you give it a quick 👀?

@miq-bot assign @h-kataria 

@h-kataria If you think someone else should be assigned to this instead please let me know!