### PR TITLE
Fix wrongly displayed policy shield on container & cloud provider quads

### DIFF
--- a/app/decorators/manageiq/providers/cloud_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager_decorator.rb
@@ -22,9 +22,6 @@ class ManageIQ::Providers::CloudManagerDecorator < MiqDecorator
       :bottom_right => {
         :fileicon => QuadiconHelper.status_img(authentication_status),
         :tooltip  => authentication_status
-      },
-      :middle       => {
-        :fileicon => '100/shield.png'
       }
     }
     icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -22,9 +22,6 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
       :bottom_right => {
         :fileicon => QuadiconHelper.status_img(authentication_status),
         :tooltip  => authentication_status
-      },
-      :middle       => {
-        :fileicon => '100/shield.png'
       }
     }
     icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?


### PR DESCRIPTION
I probably forgot to delete this, the right way of setting the policy shield is right below the deleted lines.

@miq-bot add_label bug, gaprindashvili/no, GTLs, compute/containers
@miq-bot assign @mzazrivec 