### PR TITLE
Display providers' suspended status in their quadicon

### DIFF
--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -15,9 +15,7 @@ class HostDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => ui_lookup(:model => type)
       },
-      :bottom_right => {
-        :tooltip  => authentication_status
-      }.merge(QuadiconHelper.provider_status(authentication_status))
+      :bottom_right => QuadiconHelper.provider_status(authentication_status)
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -16,9 +16,8 @@ class HostDecorator < MiqDecorator
         :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
-        :fileicon => QuadiconHelper.status_img(authentication_status),
         :tooltip  => authentication_status
-      }
+      }.merge(QuadiconHelper.provider_status(authentication_status))
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/cloud_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager_decorator.rb
@@ -19,9 +19,7 @@ class ManageIQ::Providers::CloudManagerDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => ui_lookup(:model => type)
       },
-      :bottom_right => {
-        :tooltip  => authentication_status
-      }.merge(QuadiconHelper.provider_status(authentication_status, enabled?))
+      :bottom_right => QuadiconHelper.provider_status(authentication_status, enabled?)
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/cloud_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager_decorator.rb
@@ -21,7 +21,7 @@ class ManageIQ::Providers::CloudManagerDecorator < MiqDecorator
       },
       :bottom_right => {
         :tooltip  => authentication_status
-      }.merge(QuadiconHelper.provider_status(authentication_status))
+      }.merge(QuadiconHelper.provider_status(authentication_status, enabled?))
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/cloud_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager_decorator.rb
@@ -20,9 +20,8 @@ class ManageIQ::Providers::CloudManagerDecorator < MiqDecorator
         :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
-        :fileicon => QuadiconHelper.status_img(authentication_status),
         :tooltip  => authentication_status
-      }
+      }.merge(QuadiconHelper.provider_status(authentication_status))
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -21,7 +21,7 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
       },
       :bottom_right => {
         :tooltip  => authentication_status
-      }.merge(QuadiconHelper.provider_status(authentication_status))
+      }.merge(QuadiconHelper.provider_status(authentication_status, enabled?))
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -19,9 +19,7 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => ui_lookup(:model => type)
       },
-      :bottom_right => {
-        :tooltip  => authentication_status
-      }.merge(QuadiconHelper.provider_status(authentication_status, enabled?))
+      :bottom_right => QuadiconHelper.provider_status(authentication_status, enabled?)
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -20,9 +20,8 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
         :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
-        :fileicon => QuadiconHelper.status_img(authentication_status),
         :tooltip  => authentication_status
-      }
+      }.merge(QuadiconHelper.provider_status(authentication_status))
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/infra_manager_decorator.rb
@@ -20,9 +20,8 @@ class ManageIQ::Providers::InfraManagerDecorator < MiqDecorator
         :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
-        :fileicon => QuadiconHelper.status_img(authentication_status),
         :tooltip  => authentication_status
-      }
+      }.merge(QuadiconHelper.provider_status(authentication_status))
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/infra_manager_decorator.rb
@@ -19,9 +19,7 @@ class ManageIQ::Providers::InfraManagerDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => ui_lookup(:model => type)
       },
-      :bottom_right => {
-        :tooltip  => authentication_status
-      }.merge(QuadiconHelper.provider_status(authentication_status, enabled?))
+      :bottom_right => QuadiconHelper.provider_status(authentication_status, enabled?)
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/infra_manager_decorator.rb
@@ -21,7 +21,7 @@ class ManageIQ::Providers::InfraManagerDecorator < MiqDecorator
       },
       :bottom_right => {
         :tooltip  => authentication_status
-      }.merge(QuadiconHelper.provider_status(authentication_status))
+      }.merge(QuadiconHelper.provider_status(authentication_status, enabled?))
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/network_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/network_manager_decorator.rb
@@ -27,7 +27,7 @@ class ManageIQ::Providers::NetworkManagerDecorator < MiqDecorator
       },
       :bottom_right => {
         :tooltip  => authentication_status
-      }.merge(QuadiconHelper.provider_status(authentication_status))
+      }.merge(QuadiconHelper.provider_status(authentication_status, enabled?))
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/network_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/network_manager_decorator.rb
@@ -26,9 +26,8 @@ class ManageIQ::Providers::NetworkManagerDecorator < MiqDecorator
         :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
-        :fileicon => QuadiconHelper.status_img(authentication_status),
         :tooltip  => authentication_status
-      }
+      }.merge(QuadiconHelper.provider_status(authentication_status))
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/network_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/network_manager_decorator.rb
@@ -25,9 +25,7 @@ class ManageIQ::Providers::NetworkManagerDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => ui_lookup(:model => type)
       },
-      :bottom_right => {
-        :tooltip  => authentication_status
-      }.merge(QuadiconHelper.provider_status(authentication_status, enabled?))
+      :bottom_right => QuadiconHelper.provider_status(authentication_status, enabled?)
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
@@ -21,7 +21,7 @@ class ManageIQ::Providers::PhysicalInfraManagerDecorator < MiqDecorator
       },
       :bottom_right => {
         :tooltip  => authentication_status
-      }.merge(QuadiconHelper.provider_status(authentication_status))
+      }.merge(QuadiconHelper.provider_status(authentication_status, enabled?))
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
@@ -20,9 +20,8 @@ class ManageIQ::Providers::PhysicalInfraManagerDecorator < MiqDecorator
         :tooltip  => ui_lookup(:model => type)
       },
       :bottom_right => {
-        :fileicon => QuadiconHelper.status_img(authentication_status),
         :tooltip  => authentication_status
-      }
+      }.merge(QuadiconHelper.provider_status(authentication_status))
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
@@ -19,9 +19,7 @@ class ManageIQ::Providers::PhysicalInfraManagerDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => ui_lookup(:model => type)
       },
-      :bottom_right => {
-        :tooltip  => authentication_status
-      }.merge(QuadiconHelper.provider_status(authentication_status, enabled?))
+      :bottom_right => QuadiconHelper.provider_status(authentication_status, enabled?)
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/decorators/manageiq/providers/storage_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager_decorator.rb
@@ -19,10 +19,7 @@ class ManageIQ::Providers::StorageManagerDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => ui_lookup(:model => type)
       },
-      :bottom_right => {
-        :fileicon => QuadiconHelper.status_img(authentication_status),
-        :tooltip  => authentication_status
-      }
+      :bottom_right => QuadiconHelper.provider_status(authentication_status, enabled?)
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -39,7 +39,7 @@ module QuadiconHelper
     unless enabled
       return {
         :fonticon => 'pficon pficon-asleep',
-        :tooltip  => _('This provider is paused, no data is currently collected from it')
+        :tooltip  => _('Data collection for this provider is suspended.')
       }
     end
 

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -34,12 +34,16 @@ module QuadiconHelper
     'template'                  => {:fonticon => 'pficon pficon-template', :background => '#336699'},
   }.freeze
 
-  def self.status_img(status)
+  def self.provider_status(status, enabled = true)
     case status
-    when "Invalid" then "100/x.png"
-    when "Valid"   then "100/checkmark.png"
-    when "None"    then "100/unknown.png"
-    else                "100/exclamationpoint.png"
+    when "Invalid"
+      {:fileicon => '100/x.png'}
+    when "Valid"
+      {:fileicon => '100/checkmark.png'}
+    when "None"
+      {:fileicon => '100/unknown.png'}
+    else
+      {:fileicon => '100/exclamationpoint.png'}
     end
   end
 

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -35,6 +35,9 @@ module QuadiconHelper
   }.freeze
 
   def self.provider_status(status, enabled = true)
+    # If the provider is suspended, we don't care about the status itself
+    return { :fonticon => 'pficon pficon-asleep' } unless enabled
+
     case status
     when "Invalid"
       {:fileicon => '100/x.png'}

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -36,17 +36,22 @@ module QuadiconHelper
 
   def self.provider_status(status, enabled = true)
     # If the provider is suspended, we don't care about the status itself
-    return { :fonticon => 'pficon pficon-asleep' } unless enabled
+    unless enabled
+      return {
+        :fonticon => 'pficon pficon-asleep',
+        :tooltip  => _('This provider is paused, no data is currently collected from it')
+      }
+    end
 
     case status
     when "Invalid"
-      {:fileicon => '100/x.png'}
+      {:fileicon => '100/x.png', :tooltip => _('Invalid authentication credentials')}
     when "Valid"
-      {:fileicon => '100/checkmark.png'}
+      {:fileicon => '100/checkmark.png', :tooltip => _('Authentication credentials are valid')}
     when "None"
-      {:fileicon => '100/unknown.png'}
+      {:fileicon => '100/unknown.png', :tooltip => _('Could not determine the authentication status')}
     else
-      {:fileicon => '100/exclamationpoint.png'}
+      {:fileicon => '100/exclamationpoint.png', :tooltip => _('Authentication status is %{status}') % {:status => status} }
     end
   end
 


### PR DESCRIPTION
After consulting with UX we decided to use the bottom-right quadrant of each provider quadicon to display the suspended status. For now this quadrant is being used to display the authentication status, however, when suspended this information is meaningless so we can safely reuse the same quadrant.

There's some inconsistency in container provider quads that would cause redundant displaying the same information in multiple quadrans, but that's [being addressed in a separate PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/4015).

First I had to generalize the `QuadiconHelper.status_img` method to return a hash instead of a string. This way it is possible to handle both fonticons and fileicons simultaneously. Then I added the condition for displaying the suspended icon (without a background color as @epwinchell suggested) and finally set the tooltips.

**Before:**
![screenshot from 2018-06-06 18-05-03](https://user-images.githubusercontent.com/649130/41050631-3ef2d83e-69b4-11e8-8668-79f04166f274.png)

**After:**
![screenshot from 2018-06-06 18-04-43](https://user-images.githubusercontent.com/649130/41050639-43237e9a-69b4-11e8-968b-fc5109ae96cc.png)

Related issue: https://github.com/ManageIQ/manageiq/issues/17489
Depends on: https://github.com/ManageIQ/manageiq/pull/17452

@miq-bot add_label pending core, gaprindashvili/no, GTLs
@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @epwinchell 