### PR TITLE
Use with_groups instead of with_current_user_groups

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -761,7 +761,7 @@ class ApplicationController < ActionController::Base
   def build_user_emails_for_edit
     @edit[:user_emails] = {}
     to_email = @edit[:new][:email][:to] || []
-    users_in_current_groups = User.with_current_user_groups.distinct.sort_by { |u| u.name.downcase }
+    users_in_current_groups = User.with_groups(User.current_user.miq_groups).distinct.sort_by { |u| u.name.downcase }
     users_in_current_groups.each do |u|
       next if u.email.blank?
       next if to_email.include?(u.email)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -261,7 +261,7 @@ describe ApplicationController do
     end
 
     it "finds users with groups which belongs to current user's groups" do
-      user_ids = User.with_current_user_groups.collect(&:userid)
+      user_ids = User.with_groups(@current_user.miq_groups.pluck(:id)).collect(&:userid)
       expect(user_ids).to include(@current_user.userid)
       expect(user_ids).to include(@user1.userid)
     end


### PR DESCRIPTION
Fixes mangeiq-ui-classic master failures

Introduced by https://github.com/ManageIQ/manageiq/pull/17444

Before:
```
1) ReportController#schedule_edit reset rbac testing
     Failure/Error: users_in_current_groups = User.with_current_user_groups.distinct.sort_by { |u| u.name.downcase }
     
     NoMethodError:
       undefined method `with_current_user_groups' for #<Class:0x000000000a44fa98>
     # ./app/controllers/application_controller.rb:764:in `build_user_emails_for_edit'
     # ./app/controllers/report_controller/schedules.rb:433:in `schedule_build_edit_screen'
     # ./app/controllers/report_controller/schedules.rb:252:in `schedule_edit'
     # ./spec/controllers/report_controller/schedules_spec.rb:21:in `block (3 levels) in <top (required)>'
  2) MiqPolicyController::Alerts test click on toolbar button alert edit
     Failure/Error: expect(response.status).to eq(200)
     
       expected: 200
            got: 500
     
       (compared using ==)
     # ./spec/controllers/miq_policy_controller/alerts_spec.rb:118:in `block (4 levels) in <top (required)>'
  3) MiqPolicyController::Alerts test click on toolbar button alert copy
     Failure/Error: expect(response.status).to eq(200)
     
       expected: 200
            got: 500
     
       (compared using ==)
     # ./spec/controllers/miq_policy_controller/alerts_spec.rb:123:in `block (4 levels) in <top (required)>'
  4) MiqPolicyController::Alerts alert edit #alert_build_edit_screen it should select correct record when editing an existing alert
     Failure/Error: users_in_current_groups = User.with_current_user_groups.distinct.sort_by { |u| u.name.downcase }
     
     NoMethodError:
       undefined method `with_current_user_groups' for #<Class:0x000000000a44fa98>
     # ./app/controllers/application_controller.rb:764:in `build_user_emails_for_edit'
     # ./app/controllers/miq_policy_controller/alerts.rb:288:in `alert_build_edit_screen'
     # ./spec/controllers/miq_policy_controller/alerts_spec.rb:46:in `block (5 levels) in <top (required)>'
  5) MiqPolicyController::Alerts alert edit #alert_build_edit_screen it should skip id when copying all attributes of an existing alert
     Failure/Error: users_in_current_groups = User.with_current_user_groups.distinct.sort_by { |u| u.name.downcase }
     
     NoMethodError:
       undefined method `with_current_user_groups' for #<Class:0x000000000a44fa98>
     # ./app/controllers/application_controller.rb:764:in `build_user_emails_for_edit'
     # ./app/controllers/miq_policy_controller/alerts.rb:288:in `alert_build_edit_screen'
     # ./spec/controllers/miq_policy_controller/alerts_spec.rb:40:in `block (5 levels) in <top (required)>'
  6) ApplicationController#build_user_emails_for_edit listing users's emails which belongs to current user's groups and some of them was already selected
     Failure/Error: users_in_current_groups = User.with_current_user_groups.distinct.sort_by { |u| u.name.downcase }
     
     NoMethodError:
       undefined method `with_current_user_groups' for #<Class:0x000000000a44fa98>
     # ./app/controllers/application_controller.rb:764:in `build_user_emails_for_edit'
     # ./spec/controllers/application_controller_spec.rb:291:in `block (4 levels) in <top (required)>'
     # ./spec/controllers/application_controller_spec.rb:290:in `block (3 levels) in <top (required)>'
  7) ApplicationController#build_user_emails_for_edit finds users with groups which belongs to current user's groups
     Failure/Error: user_ids = User.with_current_user_groups.collect(&:userid)
     
     NoMethodError:
       undefined method `with_current_user_groups' for #<Class:0x000000000a44fa98>
     # ./spec/controllers/application_controller_spec.rb:264:in `block (3 levels) in <top (required)>'
  8) ApplicationController#build_user_emails_for_edit listing users's emails which belongs to current user's groups
     Failure/Error: users_in_current_groups = User.with_current_user_groups.distinct.sort_by { |u| u.name.downcase }
     
     NoMethodError:
       undefined method `with_current_user_groups' for #<Class:0x000000000a44fa98>
     # ./app/controllers/application_controller.rb:764:in `build_user_emails_for_edit'
     # ./spec/controllers/application_controller_spec.rb:273:in `block (4 levels) in <top (required)>'
     # ./spec/controllers/application_controller_spec.rb:272:in `block (3 levels) in <top (required)>'
```
After:
Travis is green again

@miq-bot add_label bug, test, gaprindashvili/yes, rbac