### PR TITLE
Do not inherit physical infra decorator from ems decorator

### DIFF
--- a/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::PhysicalInfraManagerDecorator < ExtManagementSystemDecorator
+class ManageIQ::Providers::PhysicalInfraManagerDecorator < MiqDecorator
   def self.fonticon
     'pficon pficon-server'
   end


### PR DESCRIPTION
Missed to clean this up, doing it now :scissors: :toilet: :fire: 

@miq-bot add_label cleanup
@miq-bot assign @mzazrivec 