### PR TITLE
Add a separate decorator for Network Providers

### DIFF
--- a/app/decorators/manageiq/providers/network_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/network_manager_decorator.rb
@@ -1,0 +1,42 @@
+class ManageIQ::Providers::NetworkManagerDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-server'
+  end
+
+  def fonticon
+    nil
+  end
+
+  def fileicon
+    "svg/vendor-#{image_name}.svg"
+  end
+
+  def quadicon
+    icon = {
+      :top_left     => {
+        :text    => t = cloud_networks.size,
+        :tooltip => n_("%{number} Cloud Network", "%{number} Cloud Networks", t) % {:number => t}
+      },
+      :top_right    => {
+        :text    => t = security_groups.size,
+        :tooltip => n_("%{number} Security Group", "%{number} Security Groups", t) % {:number => t}
+      },
+      :bottom_left  => {
+        :fileicon => fileicon,
+        :tooltip  => ui_lookup(:model => type)
+      },
+      :bottom_right => {
+        :fileicon => QuadiconHelper.status_img(authentication_status),
+        :tooltip  => authentication_status
+      }
+    }
+    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon
+  end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
+end


### PR DESCRIPTION
There was no separate decorator specified for `Manageiq::Providers::NetworkManager` so it was using its parent's `ExtManagementSystemDecorator`. This caused the top left and right quadrants of their quadicons to be unusable and their single icon to be empty.

To make this more consistent with other provider quadicons, I am proposing to display the **number of cloud networks on the top-left** and the **number of security groups on the top-right** quadrant. Thanks to @himdel I was also able to add tooltips for these quadrants, so this might need a :+1:  from @mzazrivec because of the i18n.

I also changed the single icon to be the fileicon instead of the nonexisting fonticon.

**Before:**
![screenshot from 2018-06-01 13-44-30](https://user-images.githubusercontent.com/649130/40839374-910fee10-65a2-11e8-9184-64c82c0e59b1.png)
![screenshot from 2018-06-01 13-50-38](https://user-images.githubusercontent.com/649130/40839420-cadd3990-65a2-11e8-9e4d-5f9aa3c135d0.png)

**After:**
![screenshot from 2018-06-01 13-43-54](https://user-images.githubusercontent.com/649130/40839387-9dce91ec-65a2-11e8-8b03-33beed0f3aa6.png)
![screenshot from 2018-06-01 13-43-00](https://user-images.githubusercontent.com/649130/40839391-a0e75aa8-65a2-11e8-9791-45f0ecbdad00.png)

@miq-bot add_label bug, gaprindashvili/no, GTLs, networks
@miq-bot add_reviewer @tumido 
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_reviewer @epwinchell 