### PR TITLE
Make quadicons consistent and working for Block & Object Storage Providers

### DIFF
--- a/app/assets/images/svg/vendor-cinder.svg
+++ b/app/assets/images/svg/vendor-cinder.svg
@@ -1,0 +1,1 @@
+vendor-openstack.svg

--- a/app/assets/images/svg/vendor-swift.svg
+++ b/app/assets/images/svg/vendor-swift.svg
@@ -1,0 +1,1 @@
+vendor-openstack.svg

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,19 +92,20 @@ class ApplicationController < ActionController::Base
   # Default UI settings
   DEFAULT_SETTINGS = {
     :quadicons => { # Show quad icons, by resource type
-      :service            => true,
       :ems                => true,
       :ems_cloud          => true,
-      :ems_physical_infra => true,
+      :ems_container      => true,
       :ems_network        => true,
+      :ems_physical_infra => true,
+      :ems_storage        => true,
       :host               => true,
       :miq_template       => true,
       :physical_rack      => true,
       :physical_server    => true,
       :physical_switch    => true,
+      :service            => true,
       :storage            => true,
-      :vm                 => true,
-      :ems_container      => true
+      :vm                 => true
     },
     :views     => { # List view setting, by resource type
       :authkeypaircloud                                                       => "list",

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -550,6 +550,7 @@ class ConfigurationController < ApplicationController
       @edit[:new][:quadicons][:physical_switch] = params[:quadicons_physical_switch] == "true" if params[:quadicons_physical_switch]
       @edit[:new][:quadicons][:ems_physical_infra] = params[:quadicons_ems_physical_infra] == "true" if params[:quadicons_ems_physical_infra]
       @edit[:new][:quadicons][:ems_network] = params[:quadicons_ems_network] == "true" if params[:quadicons_ems_network]
+      @edit[:new][:quadicons][:ems_storage] = params[:quadicons_ems_storage] == "true" if params[:quadicons_ems_storage]
       @edit[:new][:quadicons][:miq_template] = params[:quadicons_miq_template] == "true" if params[:quadicons_miq_template]
       if ::Settings.product.proto # Hide behind proto setting - Sprint 34
         @edit[:new][:quadicons][:service] = params[:quadicons_service] == "true" if params[:quadicons_service]

--- a/app/decorators/manageiq/providers/storage_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager_decorator.rb
@@ -1,0 +1,36 @@
+class ManageIQ::Providers::StorageManagerDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-server'
+  end
+
+  def fonticon
+    nil
+  end
+
+  def fileicon
+    "svg/vendor-#{image_name}.svg"
+  end
+
+  def quadicon
+    icon = {
+      :top_left     => {},
+      :top_right    => {},
+      :bottom_left  => {
+        :fileicon => fileicon,
+        :tooltip  => ui_lookup(:model => type)
+      },
+      :bottom_right => {
+        :fileicon => QuadiconHelper.status_img(authentication_status),
+        :tooltip  => authentication_status
+      }
+    }
+    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon
+  end
+
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
+end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -67,6 +67,8 @@ module QuadiconHelper
       case layout
       when "ems_infra"
         :ems
+      when "ems_block_storage", "ems_object_storage", "ems_storage"
+        :ems_storage
       when "ems_physical_infra", "ems_cloud", "ems_network", "ems_container"
         layout.to_sym
       end

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -11,19 +11,20 @@
         %fieldset
           %h3
             = _('Grid/Tile Icons')
-          -# render condition                                           title                          check_box label & checked T/F
+          -# render condition                                                                                                       title                         check_box label & checked T/F
           -# Host Item is commented (condition set as false) until we have host item quads
-          - [[role_allows?(:feature => "ems_infra_show_list"),          _("Infrastructure Provider"), "ems"],
-             [role_allows?(:feature => "ems_cloud_show_list"),          _("Cloud Provider"),          "ems_cloud"],
-             [role_allows?(:feature => "ems_container_show_list"),      _("Containers Provider"),     "ems_container"],
-             [role_allows?(:feature => "ems_physical_infra_show_list"), _("Physical Infra Provider"), "ems_physical_infra"],
-             [role_allows?(:feature => "ems_network_show_list"),        _("Network Provider"),        "ems_network"],
-             [role_allows?(:feature => "host_show_list"),               _("Host"),                    "host"],
-             [role_allows?(:feature => "storage_show_list"),            _("Datastores"),              "storage"],
-             [true,                                                     _("VM"),                      "vm"],
-             [role_allows?(:feature => "physical_switch_show_list"),    _("Physical Switch"),         "physical_switch"],
-             [role_allows?(:feature => "physical_server_show_list"),    _("Physical Server"),         "physical_server"],
-             [true,                                                     _("Template"),                "miq_template"]].each do |icons_checkbox|
+          - [[role_allows?(:feature => "ems_infra_show_list"),                                                                      _("Infrastructure Provider"), "ems"],
+             [role_allows?(:feature => "ems_cloud_show_list"),                                                                      _("Cloud Provider"),          "ems_cloud"],
+             [role_allows?(:feature => "ems_container_show_list"),                                                                  _("Containers Provider"),     "ems_container"],
+             [role_allows?(:feature => "ems_physical_infra_show_list"),                                                             _("Physical Infra Provider"), "ems_physical_infra"],
+             [role_allows?(:feature => "ems_network_show_list"),                                                                    _("Network Provider"),        "ems_network"],
+             [role_allows?(:feature => "ems_block_storage_show_list") && role_allows?(:feature => "ems_object_storage_show_list"),  _("Storage Provider"),        "ems_storage"],
+             [role_allows?(:feature => "host_show_list"),                                                                           _("Host"),                    "host"],
+             [role_allows?(:feature => "storage_show_list"),                                                                        _("Datastores"),              "storage"],
+             [true,                                                                                                                 _("VM"),                      "vm"],
+             [role_allows?(:feature => "physical_switch_show_list"),                                                                _("Physical Switch"),         "physical_switch"],
+             [role_allows?(:feature => "physical_server_show_list"),                                                                _("Physical Server"),         "physical_server"],
+             [true,                                                                                                                 _("Template"),                "miq_template"]].each do |icons_checkbox|
             - if icons_checkbox[0]
               .form-group
                 %label.col-md-3.control-label


### PR DESCRIPTION
The cinder/swift storage managers had no proper fileicons, so I symlinked openstack for both of them. Under `My settings` there was no setting for their quad/single view, so that has been added.

The logic behind the single/quad selection and its administration is getting really out of hand, I am willing to fix this in a followup PR. The plan is to rename the configuration keys to be able to get rid of the big case statement under `QuadiconHelper.settings_key` and integrate better with RBAC.

![screenshot from 2018-06-01 15-17-18](https://user-images.githubusercontent.com/649130/40842775-3da78988-65af-11e8-9a59-e9fc5872ac92.png)

There was no decorator for storage managers, so the `ExtManagementSystemDecorator` was trying to show the number of hosts in the top left quadrant. I created a decorator where (for now) the top left and top right quadrants are empty. I will need some ideas what to put there, maybe the provider guys can help us. However, the Block and Object storage managers are a little bit inconsistent so we might want to display different things for them. This would require two decorators for the two types, however, I haven't found the `ManageIQ::Providers::BlockStorageManager` and a `ManageIQ::Providers::ObjectStorageManager` classes :disappointed: but @Ladas told me that it's theoretically possible to add these.

**Before:**
![screenshot from 2018-06-01 15-13-24](https://user-images.githubusercontent.com/649130/40842493-5a3bac1a-65ae-11e8-9333-f5620eba7d9e.png)
![screenshot from 2018-06-01 15-13-09](https://user-images.githubusercontent.com/649130/40842479-52fc87a8-65ae-11e8-8844-f56667094371.png)

**After:**
![screenshot from 2018-06-01 15-12-23](https://user-images.githubusercontent.com/649130/40842457-40f9c4c6-65ae-11e8-8080-4059aec573c6.png)
![screenshot from 2018-06-01 15-12-33](https://user-images.githubusercontent.com/649130/40842463-43640172-65ae-11e8-8d34-8a6cb4ba9074.png)
![screenshot from 2018-06-01 15-21-13](https://user-images.githubusercontent.com/649130/40842854-7cb74b0e-65af-11e8-8573-48507c329346.png)
![screenshot from 2018-06-01 15-21-30](https://user-images.githubusercontent.com/649130/40842870-84e26df4-65af-11e8-8625-05346ee242e9.png)

@miq-bot add_label gaprindashvili/no, gtls, storage
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @martinpovolny 