### PR TITLE
Rename VmOrTemplateDecorator to VmDecorator

### DIFF
--- a/app/decorators/vm_decorator.rb
+++ b/app/decorators/vm_decorator.rb
@@ -1,4 +1,4 @@
-class VmOrTemplateDecorator < MiqDecorator
+class VmDecorator < MiqDecorator
   def self.fonticon
     'pficon pficon-virtual-machine'
   end


### PR DESCRIPTION
There's a separate `MiqTemplateDecorator` for templates, so :toilet: :droplet: 

@miq-bot add_label GTLs, cleanup, gaprindashvili/no