### PR TITLE
Delete redundant openshift/kubernetes provider decorators

### DIFF
--- a/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
@@ -1,7 +1,0 @@
-module ManageIQ::Providers::Kubernetes
-  class ContainerManagerDecorator < ManageIQ::Providers::ContainerManagerDecorator
-    def self.fileicon
-      "svg/vendor-kubernetes.svg"
-    end
-  end
-end

--- a/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
@@ -1,7 +1,0 @@
-module ManageIQ::Providers::Openshift
-  class ContainerManagerDecorator < ManageIQ::Providers::ContainerManagerDecorator
-    def self.fileicon
-      "svg/vendor-openshift.svg"
-    end
-  end
-end


### PR DESCRIPTION
Decorator inheritance has to be destroyed with :fire: :fire: as it is not *The Right Way&trade;*. The icons are already defined using the `image_name` property in `ManageIQ::Providers::ContainerManagerDecorator`.

@miq-bot add_label cleanup, gaprindashvili/no, GTLs