### PR TITLE
Remove the quadicon definition from the ExtManagementSystemDecorator

### DIFF
--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -11,23 +11,6 @@ class ExtManagementSystemDecorator < MiqDecorator
     "svg/vendor-#{image_name}.svg"
   end
 
-  def quadicon
-    icon = {
-      :top_left     => {:text => try(:hosts).try(:size).to_i},
-      :top_right    => {:text => ""},
-      :bottom_left  => {
-        :fileicon => fileicon,
-        :tooltip  => ui_lookup(:model => type)
-      },
-      :bottom_right => {
-        :fileicon => QuadiconHelper.status_img(authentication_status),
-        :tooltip  => authentication_status
-      }
-    }
-    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
-    icon
-  end
-
   def single_quad
     {
       :fonticon => fonticon


### PR DESCRIPTION
All the providers have their own decorators with their quadicon definitions, so here it is longer necessary :toilet: :scissors: :fire: 

@miq-bot add_label cleanup, gaprindashvili/no, GTLs