### PR TITLE
Fix parent ems links in textual summaries.

### DIFF
--- a/app/helpers/cloud_network_helper/textual_summary.rb
+++ b/app/helpers/cloud_network_helper/textual_summary.rb
@@ -34,7 +34,7 @@ module CloudNetworkHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    @record.ext_management_system.try(:parent_manager)
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_instances

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -63,7 +63,7 @@ module EmsNetworkHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    {:label => _("Parent Cloud Provider"), :value => @record.try(:parent_manager)}
+    textual_link(@record.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_security_groups

--- a/app/helpers/floating_ip_helper/textual_summary.rb
+++ b/app/helpers/floating_ip_helper/textual_summary.rb
@@ -34,7 +34,7 @@ module FloatingIpHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    @record.ext_management_system.try(:parent_manager)
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_instance

--- a/app/helpers/load_balancer_helper/textual_summary.rb
+++ b/app/helpers/load_balancer_helper/textual_summary.rb
@@ -45,7 +45,7 @@ module LoadBalancerHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    @record.ext_management_system.try(:parent_manager)
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_cloud_tenant

--- a/app/helpers/network_port_helper/textual_summary.rb
+++ b/app/helpers/network_port_helper/textual_summary.rb
@@ -44,7 +44,7 @@ module NetworkPortHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    @record.ext_management_system.try(:parent_manager)
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_device

--- a/app/helpers/security_group_helper/textual_summary.rb
+++ b/app/helpers/security_group_helper/textual_summary.rb
@@ -45,7 +45,7 @@ module SecurityGroupHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    @record.ext_management_system.try(:parent_manager)
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_instances


### PR DESCRIPTION
Fixes links and labels for Parent Cloud provider.

Partial fix for https://github.com/ManageIQ/manageiq-ui-classic/issues/4013