### PR TITLE
InfraManagerDecorator should not inherit from EMS decorator

### DIFF
--- a/app/decorators/manageiq/providers/infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/infra_manager_decorator.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::InfraManagerDecorator < ExtManagementSystemDecorator
+class ManageIQ::Providers::InfraManagerDecorator < MiqDecorator
   def self.fonticon
     'pficon pficon-server'
   end


### PR DESCRIPTION
Inheritance is an evil that needs to be banished from the world of decorators.

@miq-bot add_label cleanup, GTLs, gaprindashvili/no, compute/infrastructure