### PR TITLE
dialogUser spec - fix sporadic spec failures

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -51,7 +51,7 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
     } else {
       apiData = vm.dialogData;
     }
-    API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]}).then(function() {
+    return API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]}).then(function() {
       miqService.redirectBack(__('Order Request was Submitted'), 'info', finishSubmitEndpoint);
     }).catch(function(err) {
       miqService.sparkleOff();

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -168,30 +168,28 @@ describe('dialogUserController', function() {
       });
 
       it('turns off the sparkle', function(done) {
-        $controller.submitButtonClicked();
-        setTimeout(function() {
-          expect(miqService.sparkleOff).toHaveBeenCalled();
-          done();
-        });
+        $controller.submitButtonClicked()
+          .catch(function() {
+            expect(miqService.sparkleOff).toHaveBeenCalled();
+            done();
+          });
       });
 
       it('clears flash messages', function(done) {
-        $controller.submitButtonClicked();
-
-        setTimeout(function() {
-          expect(window.clearFlash).toHaveBeenCalled();
-          done();
-        });
+        $controller.submitButtonClicked()
+          .catch(function() {
+            expect(window.clearFlash).toHaveBeenCalled();
+            done();
+          });
       });
 
       it('adds flash messages for each message after the -', function(done) {
-        $controller.submitButtonClicked();
-
-        setTimeout(function() {
-          expect(window.add_flash).toHaveBeenCalledWith('One', 'error');
-          expect(window.add_flash).toHaveBeenCalledWith('Two', 'error');
-          done();
-        });
+        $controller.submitButtonClicked()
+          .catch(function() {
+            expect(window.add_flash).toHaveBeenCalledWith('One', 'error');
+            expect(window.add_flash).toHaveBeenCalledWith('Two', 'error');
+            done();
+          });
       });
     });
   });


### PR DESCRIPTION
Fixes sporadic failures when waiting for API.post would not wait long enough for the flash message to get set.

Adding a return to the tested method so that we can wait for the actual promise.

The failure would look like

```
          dialogUserController submitButtonClicked when the API calssages

          Expected spy clearFlash to have been called.
          stack@http://127.0.0.1:41615/__jasmine__/jasmine.js:1640:
buildExpectationResult@http://127.0.0.1:41615/__jasmine__/jasmine.j
expectationResultFactory@http://127.0.0.1:41615/__jasmine__/jasmine
addExpectationResult@http://127.0.0.1:41615/__jasmine__/jasmine.js:
addExpectationResult@http://127.0.0.1:41615/__jasmine__/jasmine.js:
http://127.0.0.1:41615/__jasmine__/jasmine.js:1564:32
http://127.0.0.1:41615/__spec__/controllers/dialog_user/dialog_user:53
```

or

```
          dialogUserController submitButtonClicked when the API calages for each message after the -

          Expected spy add_flash to have been called with [ 'One', ver called.
          stack@http://127.0.0.1:41615/__jasmine__/jasmine.js:1640:
buildExpectationResult@http://127.0.0.1:41615/__jasmine__/jasmine.j
expectationResultFactory@http://127.0.0.1:41615/__jasmine__/jasmine
addExpectationResult@http://127.0.0.1:41615/__jasmine__/jasmine.js:
addExpectationResult@http://127.0.0.1:41615/__jasmine__/jasmine.js:
http://127.0.0.1:41615/__jasmine__/jasmine.js:1564:32
http://127.0.0.1:41615/__spec__/controllers/dialog_user/dialog_user:56

          Expected spy add_flash to have been called with [ 'Two', ver called.
          stack@http://127.0.0.1:41615/__jasmine__/jasmine.js:1640:
buildExpectationResult@http://127.0.0.1:41615/__jasmine__/jasmine.j
expectationResultFactory@http://127.0.0.1:41615/__jasmine__/jasmine
addExpectationResult@http://127.0.0.1:41615/__jasmine__/jasmine.js:
addExpectationResult@http://127.0.0.1:41615/__jasmine__/jasmine.js:
http://127.0.0.1:41615/__jasmine__/jasmine.js:1564:32
http://127.0.0.1:41615/__spec__/controllers/dialog_user/dialog_user:56
```

A way to reproduce:

```
 n=0; while true; do n=$((n + 1)) ; echo $n ; be rake spec:javascript || break; done
```

if it works more than a hundred times, it's probably fixed :).

Cc @ZitaNemeckova 