### PR TITLE
Drop the fileicon in ConfiguredSystemDecorator

### DIFF
--- a/app/decorators/configured_system_decorator.rb
+++ b/app/decorators/configured_system_decorator.rb
@@ -2,8 +2,4 @@ class ConfiguredSystemDecorator < MiqDecorator
   def self.fonticon
     'ff ff-configured-system'
   end
-
-  def fileicon
-    "100/#{image_name.downcase}.png"
-  end
 end


### PR DESCRIPTION
The `image_name` for `ConfiguredSystem` [always returns](https://github.com/ManageIQ/manageiq/blob/master/app/models/configured_system.rb#L94) `'configured_system'` and it's identical to the `fonticon`, so why not use it directly? 