### PR TITLE
Drop unnecessary fonticon from ConfigurationProfileDecorator

### DIFF
--- a/app/decorators/configuration_profile_decorator.rb
+++ b/app/decorators/configuration_profile_decorator.rb
@@ -6,12 +6,4 @@ class ConfigurationProfileDecorator < MiqDecorator
       'fa fa-list-ul'
     end
   end
-
-  def fileicon
-    if id.nil?
-      "100/folder.png"
-    else
-      "100/#{image_name.downcase}.png"
-    end
-  end
 end


### PR DESCRIPTION
The `image_name` for `ConfigurationProfile` always returns 'configuration_profile' and it's identical to the fonticon, so why not use it directly?

@miq-bot add_reviewer @epwinchell 