### PR TITLE
Do not use generic object fileicon if no picture specified

### DIFF
--- a/app/decorators/generic_object_decorator.rb
+++ b/app/decorators/generic_object_decorator.rb
@@ -4,6 +4,6 @@ class GenericObjectDecorator < MiqDecorator
   end
 
   def fileicon
-    try(:picture) ? "/pictures/#{picture.basename}" : "100/generic_object.png"
+    try(:picture) ? "/pictures/#{picture.basename}" : nil
   end
 end


### PR DESCRIPTION
We want to prefer fonticons if possible, and the `generic_object.png` is something we want to get rid of.