### PR TITLE
Drop fileicon for ServiceResourceDecorator

### DIFF
--- a/app/decorators/service_resource_decorator.rb
+++ b/app/decorators/service_resource_decorator.rb
@@ -2,8 +2,4 @@ class ServiceResourceDecorator < MiqDecorator
   def fonticon
     resource_type.to_s == 'VmOrTemplate' ? 'pficon pficon-virtual-machine' : 'pficon pficon-template'
   end
-
-  def fileicon
-    resource_type.to_s == 'VmOrTemplate' ? '100/vm.png' : '100/service_template.png'
-  end
 end


### PR DESCRIPTION
There's a fonticon, so :scissors: :scissors: :scissors: :scissors: :scissors: 

@miq-bot add_reviewer @epwinchell 