### PR TITLE
Drop fileicon for NetworkSwitchDecorator

### DIFF
--- a/app/decorators/switch_decorator.rb
+++ b/app/decorators/switch_decorator.rb
@@ -2,8 +2,4 @@ class SwitchDecorator < MiqDecorator
   def self.fonticon
     'ff ff-network-switch'
   end
-
-  def self.fileicon
-    '100/network_switch.png'
-  end
 end


### PR DESCRIPTION
Fonticon is defined, we don't need the fileicon 

@miq-bot add_reviewer @epwinchell 