### PR TITLE
travis: only run spec suite 1 time for javascript per PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ env:
   - TEST_SUITE=spec:jest
 matrix:
   exclude:
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     env: TEST_SUITE=spec:javascript
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     env: TEST_SUITE=spec:compile
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     env: TEST_SUITE=spec:jest
 bundler_args: "--no-deployment"
 before_install: source tools/ci/before_install.sh


### PR DESCRIPTION
followup to #3953

We updated the ruby version, but the travis excludes were not updated.

This means we are running specs on the javascript and others twice per PR.

This is inflating our travis runs from ~1:15hrs to 2:00hrs

Thanks all