### PR TITLE
fix deprecated passing class to AR notification

### DIFF
--- a/app/presenters/tree_builder_vms_and_templates.rb
+++ b/app/presenters/tree_builder_vms_and_templates.rb
@@ -15,7 +15,7 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
     #   so taking them from the relationship records can cut down on the huge
     #   VM query.
 
-    tree = root.subtree_arranged(TreeBuilder.hide_vms ? {:except_type => VmOrTemplate} : {})
+    tree = root.subtree_arranged(TreeBuilder.hide_vms ? {:except_type => "VmOrTemplate"} : {})
 
     prune_rbac(tree)
     prune_non_vandt_folders(tree)


### PR DESCRIPTION
Passing a class as a value in an Active Record query does not work when I test it in the console.
But debugging this code it seems to work fine with both values.

Just feel better fixing the deprecated parameter for this method.

/cc @ZitaNemeckova I remember you and I worked on this original BZ.