### PR TITLE
Add missing single_quad definition for ConfiguredSystemDecorator

### DIFF
--- a/app/decorators/configured_system_decorator.rb
+++ b/app/decorators/configured_system_decorator.rb
@@ -2,4 +2,10 @@ class ConfiguredSystemDecorator < MiqDecorator
   def self.fonticon
     'ff ff-configured-system'
   end
+
+  def single_quad
+    {
+      :fonticon => fonticon
+    }
+  end
 end


### PR DESCRIPTION
Under `Configuration -> Management -> Configured Systems` the icons were missing from the grid view.

**Before:**
![screenshot from 2018-06-05 07-53-10](https://user-images.githubusercontent.com/649130/40957435-83f731e8-6895-11e8-98ee-d328cab0c304.png)

**After:**
![screenshot from 2018-06-05 07-52-05](https://user-images.githubusercontent.com/649130/40957440-8833794c-6895-11e8-804b-82d041ec5932.png)

@miq-bot add_label bug, gaprindashvili/no, GTLs, configuration management