### PR TITLE
Drop fileicon for LanDecorator

### DIFF
--- a/app/decorators/lan_decorator.rb
+++ b/app/decorators/lan_decorator.rb
@@ -2,8 +2,4 @@ class LanDecorator < MiqDecorator
   def self.fonticon
     'ff ff-network-switch'
   end
-
-  def self.fileicon
-    '100/network_switch.png'
-  end
 end


### PR DESCRIPTION
There's a fonticon defined, we don't need the fileicon :scissors: 

Parent issue: #4051

@miq-bot add_label gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 