### PR TITLE
Prefer fonticon for resource pool if it's not vapp

### DIFF
--- a/app/decorators/resource_pool_decorator.rb
+++ b/app/decorators/resource_pool_decorator.rb
@@ -4,12 +4,13 @@ class ResourcePoolDecorator < MiqDecorator
   end
 
   def fileicon
-    vapp ? '100/vapp.png' : '100/resource_pool.png'
+    vapp ? 'svg/vendor-vmware.svg' : nil
   end
 
   def single_quad
     {
-      :fileicon => fileicon
-    }
+      :fileicon => fileicon,
+      :fonticon => fileicon ? nil : fonticon
+    }.compact
   end
 end


### PR DESCRIPTION
The `resource_pool.png` is obsolete, the `pficon pficon-resource-pool` fully replaces it, but I haven't found any alternative for the `vapp.png`.

Parent issue: #4051

@miq-bot add_label gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 