### PR TITLE
Drop fileicon for configuration script decorator

### DIFF
--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
@@ -3,9 +3,5 @@ module ManageIQ::Providers::AnsibleTower
     def self.fonticon
       'pficon pficon-template'
     end
-
-    def self.fileicon
-      '100/configuration_script.png'
-    end
   end
 end


### PR DESCRIPTION
Fileicon is no longer needed as we got a fonticon :scissors: 

Parent issue: #4051

@miq-bot add_label gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 