### PR TITLE
Drop fileicon for ansible jobs

### DIFF
--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
@@ -3,9 +3,5 @@ module ManageIQ::Providers::AnsibleTower
     def self.fonticon
       'ff ff-stack'
     end
-
-    def self.fileicon
-      '100/orchestration_stack.png'
-    end
   end
 end


### PR DESCRIPTION
No longer needed, fonticon makes it obsolete :scissors: 

Parent issue: #4051

@miq-bot add_label gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 