### PR TITLE
Drop fileicon from authentication decorators

### DIFF
--- a/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers
   class AutomationManager::AuthenticationDecorator < MiqDecorator
     def self.fonticon
-      'fa fa-lock'
+      'pficon pficon-locked'
     end
   end
 end

--- a/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/authentication_decorator.rb
@@ -3,9 +3,5 @@ module ManageIQ::Providers
     def self.fonticon
       'fa fa-lock'
     end
-
-    def self.fileicon
-      '100/authentication.png'
-    end
   end
 end

--- a/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
@@ -3,9 +3,5 @@ module ManageIQ::Providers
     def self.fonticon
       'fa fa-lock'
     end
-
-    def self.fileicon
-      '100/authentication.png'
-    end
   end
 end

--- a/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers
   class EmbeddedAutomationManager::AuthenticationDecorator < MiqDecorator
     def self.fonticon
-      'fa fa-lock'
+      'pficon pficon-locked'
     end
   end
 end


### PR DESCRIPTION
No longer needed, fonticon replaces it completely :scissors: 

Parent issue: #4051

@miq-bot add_label gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 