### PR TITLE
Pull out health_state from physical infra decorators to the helper

### DIFF
--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -17,10 +17,7 @@ class PhysicalServerDecorator < MiqDecorator
         :fileicon => fileicon,
         :tooltip  => ui_lookup(:model => type)
       },
-      :bottom_right => {
-        :fileicon => health_state_img,
-        :tooltip  => health_state
-      }
+      :bottom_right => QuadiconHelper.health_state(health_state)
     }
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
@@ -30,16 +27,5 @@ class PhysicalServerDecorator < MiqDecorator
     {
       :fileicon => fileicon
     }
-  end
-
-  private
-
-  def health_state_img
-    case health_state
-    when "Valid"    then "svg/healthstate-normal.svg"
-    when "Critical" then "svg/healthstate-critical.svg"
-    when "Warning"  then "100/warning.png"
-    else "svg/healthstate-unknown.svg"
-    end
   end
 end

--- a/app/decorators/physical_switch_decorator.rb
+++ b/app/decorators/physical_switch_decorator.rb
@@ -16,10 +16,7 @@ class PhysicalSwitchDecorator < MiqDecorator
         :fonticon => fonticon,
         :tooltip  => ui_lookup(:model => type),
       },
-      :bottom_right => {
-        :fileicon => health_state_img,
-        :tooltip  => _(health_state),
-      }
+      :bottom_right => QuadiconHelper.health_state(health_state)
     }
   end
 
@@ -28,16 +25,5 @@ class PhysicalSwitchDecorator < MiqDecorator
       :fonticon => fonticon,
       :tooltip  => ui_lookup(:model => type),
     }
-  end
-
-  private
-
-  def health_state_img
-    case health_state
-    when "Valid"    then "svg/healthstate-normal.svg"
-    when "Critical" then "svg/healthstate-critical.svg"
-    when "Warning"  then "100/warning.png"
-    else "svg/healthstate-unknown.svg"
-    end
   end
 end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -51,6 +51,15 @@ module QuadiconHelper
     end
   end
 
+  def self.health_state(status)
+    case status
+    when "Valid"    then {:fileicon => "svg/healthstate-normal.svg", :tooltip => _('Normal health state')}
+    when "Critical" then {:fileicon => "svg/healthstate-critical.svg", :tooltip => _('Critical health state')}
+    when "Warning"  then {:fileicon => "100/warning.png", :tooltip => _('Health state warning')}
+    else {:fileicon => "svg/healthstate-unknown.svg", :tooltip => _('Could not determine health state')}
+    end
+  end
+
   def self.os_icon(name)
     name == "unknown" ? { :fonticon => 'pficon pficon-unknown' } : {:fileicon => "svg/os-#{ERB::Util.h(name)}.svg" }
   end


### PR DESCRIPTION
Shared code needs to go to the `QuadiconHelper` so we don't need to maintain it at two places. I am still looking into joining this together with the `machine_state` or `status_icon`. This change will allow us to replace fileicons with fonticons.

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label gaprindashvili/no, compute/physical infrastructure, refactoring