### PR TITLE
Pull out policy shield icon to a constant and replace with fonticon

### DIFF
--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -20,7 +20,7 @@ class HostDecorator < MiqDecorator
         :tooltip  => authentication_status
       }
     }
-    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
 

--- a/app/decorators/manageiq/providers/cloud_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager_decorator.rb
@@ -24,7 +24,7 @@ class ManageIQ::Providers::CloudManagerDecorator < MiqDecorator
         :tooltip  => authentication_status
       }
     }
-    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
 

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -24,7 +24,7 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
         :tooltip  => authentication_status
       }
     }
-    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
 

--- a/app/decorators/manageiq/providers/infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/infra_manager_decorator.rb
@@ -24,7 +24,7 @@ class ManageIQ::Providers::InfraManagerDecorator < MiqDecorator
         :tooltip  => authentication_status
       }
     }
-    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
 

--- a/app/decorators/manageiq/providers/network_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/network_manager_decorator.rb
@@ -30,7 +30,7 @@ class ManageIQ::Providers::NetworkManagerDecorator < MiqDecorator
         :tooltip  => authentication_status
       }
     }
-    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
 

--- a/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
@@ -24,7 +24,7 @@ class ManageIQ::Providers::PhysicalInfraManagerDecorator < MiqDecorator
         :tooltip  => authentication_status
       }
     }
-    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
 

--- a/app/decorators/manageiq/providers/storage_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager_decorator.rb
@@ -24,7 +24,7 @@ class ManageIQ::Providers::StorageManagerDecorator < MiqDecorator
         :tooltip  => authentication_status
       }
     }
-    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
 

--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -23,7 +23,7 @@ class MiqTemplateDecorator < MiqDecorator
         :text => ERB::Util.h(v_total_snapshots)
       }
     }
-    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
 

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -22,7 +22,7 @@ class PhysicalServerDecorator < MiqDecorator
         :tooltip  => health_state
       }
     }
-    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
 

--- a/app/decorators/vm_decorator.rb
+++ b/app/decorators/vm_decorator.rb
@@ -27,7 +27,7 @@ class VmDecorator < MiqDecorator
         :text => ERB::Util.h(v_total_snapshots)
       }
     }
-    icon[:middle] = { :fileicon => '100/shield.png' } if get_policies.present?
+    icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
 

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -1,5 +1,10 @@
 module QuadiconHelper
   QUADRANTS = %i(top_left top_right bottom_left bottom_right middle).freeze
+  POLICY_SHIELD = {
+    :fonticon => 'fa fa-shield',
+    :color    => '#f5c12e',
+    :tooltip  => _('This object has policies assigned.')
+  }.freeze
 
   MACHINE_STATE_QUADRANT = {
     'archived'                  => {:text => 'A', :background => '#336699'},


### PR DESCRIPTION
I'm getting rid of the `100/shield.png` references and also moving the shield definition into the `QuadiconHelper` as a constant so we will have it only on a single location.

Parent issue: #4051

**Before:**
![screenshot from 2018-06-05 20-25-36](https://user-images.githubusercontent.com/649130/40995162-a07cdd5e-68fe-11e8-9d9a-eb23c55b2c7b.png)

**After:**
![screenshot from 2018-06-05 20-25-02](https://user-images.githubusercontent.com/649130/40995137-8f71d37a-68fe-11e8-8efb-8a4544715550.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label refactoring, graphics, gaprindashvili/no