### PR TITLE
Remove angular2+ webpack workaround

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -48,13 +48,6 @@ module.exports = {
     new webpack.EnvironmentPlugin(JSON.parse(JSON.stringify(env))),
     new ExtractTextPlugin(env.NODE_ENV === 'production' ? '[name]-[hash].css' : '[name].css'),
 
-    // Workaround for angular/angular#11580
-    new webpack.ContextReplacementPlugin(
-      // The (\\|\/) piece accounts for path separators in *nix and Windows
-      /angular(\\|\/)core(\\|\/)@angular/,
-      resolve(__dirname, '../../'), // location of your src
-      {} // a map of your routes
-    ),
     // Workaround for graphql/graphql-language-service#128
     new webpack.ContextReplacementPlugin(
       /graphql-language-service-interface[\\\/]dist$/,


### PR DESCRIPTION
because we no longer use angular 2+,
no need to have a workaround for it either.
