### PR TITLE
Added separate features for Requests subtabs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1159,7 +1159,7 @@ class ApplicationController < ActionController::Base
   def check_button_rbac
     # buttons ids that share a common feature id
     common_buttons = %w(rbac_project_add rbac_tenant_add)
-    task = common_buttons.include?(params[:pressed]) ? rbac_common_feature_for_buttons(params[:pressed]) : params[:pressed]
+    task = common_buttons.include?(params[:pressed]) ? rbac_common_feature_for_buttons(params[:pressed]) : rbac_feature_id(params[:pressed])
     # Intentional single = so we can check auth later
     rbac_free_for_custom_button?(task, params[:button_id]) || role_allows?(:feature => task)
   end
@@ -1173,8 +1173,12 @@ class ApplicationController < ActionController::Base
     pass
   end
 
+  def rbac_feature_id(feature_id)
+    feature_id
+  end
+
   def check_generic_rbac
-    ident = "#{controller_name}_#{action_name == 'report_data' ? 'show_list' : action_name}"
+    ident = rbac_feature_id("#{controller_name}_#{action_name == 'report_data' ? 'show_list' : action_name}")
     if MiqProductFeature.feature_exists?(ident)
       role_allows?(:feature => ident, :any => true)
     else

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -30,7 +30,7 @@ class MiqRequestController < ApplicationController
   end
 
   def request_edit
-    assert_privileges(requests_feature_id("miq_request_edit"))
+    assert_privileges(rbac_feature_id("miq_request_edit"))
     provision_request = MiqRequest.find(params[:id])
     if provision_request.workflow_class || provision_request.kind_of?(MiqProvisionConfiguredSystemRequest)
       request_edit_settings(provision_request)
@@ -44,7 +44,7 @@ class MiqRequestController < ApplicationController
   end
 
   def request_copy
-    assert_privileges(requests_feature_id("miq_request_copy"))
+    assert_privileges(rbac_feature_id("miq_request_copy"))
     provision_request = MiqRequest.find(params[:id])
     @refresh_partial = "prov_copy"
     request_settings_for_edit_or_copy(provision_request)
@@ -105,7 +105,7 @@ class MiqRequestController < ApplicationController
 
   # Stamp a request with approval or denial
   def stamp
-    assert_privileges(requests_feature_id("miq_request_approval"))
+    assert_privileges(rbac_feature_id("miq_request_approval"))
     if params[:button] == "cancel"
       if (session[:edit] && session[:edit][:stamp_typ]) == "a"
         flash_to_session(_("Request approval was cancelled by the user"))
@@ -264,7 +264,7 @@ class MiqRequestController < ApplicationController
   end
 
   def filter
-    assert_privileges(requests_feature_id("miq_request_show_list"))
+    assert_privileges(rbac_feature_id("miq_request_show_list"))
     scope = prov_scope(
       :reason_text    => params[:reasonText],
       :time_period    => params[:selectedPeriod],
@@ -453,33 +453,17 @@ class MiqRequestController < ApplicationController
 
   def is_approver
     # TODO: this should be current_user
-    User.current_user.role_allows?(:identifier => 'miq_request_approval')
+    User.current_user.role_allows?(:identifier => rbac_feature_id('miq_request_approval'))
   end
 
-  def requests_feature_id(feature_id)
+  def rbac_feature_id(feature_id)
     return feature_id unless %w(ae host).include?(session[:request_tab])
     "#{session[:request_tab]}_#{feature_id}"
   end
 
-  def check_generic_rbac
-    ident = requests_feature_id("#{controller_name}_#{action_name}")
-    if MiqProductFeature.feature_exists?(ident)
-      role_allows?(:feature => ident, :any => true)
-    else
-      true
-    end
-  end
-
-  def check_button_rbac
-    # buttons ids that share a common feature id
-    task = requests_feature_id(params[:pressed])
-    # Intentional single = so we can check auth later
-    rbac_free_for_custom_button?(task, params[:button_id]) || role_allows?(:feature => task)
-  end
-
   # Delete all selected or single displayed action(s)
   def deleterequests
-    assert_privileges(requests_feature_id("miq_request_delete"))
+    assert_privileges(rbac_feature_id("miq_request_delete"))
 
     miq_requests = find_records_with_rbac(MiqRequest, checked_or_params)
     if miq_requests.empty?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -504,6 +504,7 @@ module ApplicationHelper
       :record           => @record,
       :report           => @report,
       :report_result_id => @report_result_id,
+      :request_tab      => @request_tab,
       :resolve          => @resolve,
       :sb               => @sb,
       :selected_zone    => @selected_zone,

--- a/app/helpers/application_helper/button/miq_request.rb
+++ b/app/helpers/application_helper/button/miq_request.rb
@@ -14,7 +14,7 @@ class ApplicationHelper::Button::MiqRequest < ApplicationHelper::Button::Generic
 
   def visible?
     return false if @record.resource_type == "AutomationRequest" &&
-                   !%w(miq_request_approve miq_request_deny miq_request_delete).include?(@feature)
+                   !%w(miq_request_approval miq_request_deny miq_request_delete).include?(@feature)
     true
   end
 end

--- a/app/helpers/application_helper/button/miq_request.rb
+++ b/app/helpers/application_helper/button/miq_request.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Button::MiqRequest < ApplicationHelper::Button::Generic
                ""
              end
     # check RBAC on separate button
-    role_allows?(:feature => "#{prefix}#{self[:id]}")
+    role_allows?(:feature => "#{prefix}#{@feature}")
   end
 
   def visible?

--- a/app/helpers/application_helper/button/miq_request.rb
+++ b/app/helpers/application_helper/button/miq_request.rb
@@ -1,5 +1,16 @@
 class ApplicationHelper::Button::MiqRequest < ApplicationHelper::Button::GenericFeatureButton
-  needs :@record
+  needs :@record, :@request_tab
+
+  def role_allows_feature?
+    prefix = case @request_tab
+             when 'ae', 'host'
+               "#{@request_tab}_"
+             else
+               ""
+             end
+    # check RBAC on separate button
+    role_allows?(:feature => "#{prefix}#{self[:id]}")
+  end
 
   def visible?
     return false if @record.resource_type == "AutomationRequest" &&

--- a/app/helpers/application_helper/button/miq_request_approval.rb
+++ b/app/helpers/application_helper/button/miq_request_approval.rb
@@ -1,17 +1,6 @@
 class ApplicationHelper::Button::MiqRequestApproval < ApplicationHelper::Button::MiqRequest
   needs :@showtype, :@record, :@request_tab
 
-  def role_allows_feature?
-    prefix = case @request_tab
-             when 'ae', 'host'
-               "#{@request_tab}_"
-             else
-               ""
-             end
-    # check RBAC on separate button
-    role_allows?(:feature => "#{prefix}miq_request_approval")
-  end
-
   def visible?
     return false unless super
     return false if %w(approved denied).include?(@record.approval_state) || @showtype == "miq_provisions"

--- a/app/helpers/application_helper/button/miq_request_delete.rb
+++ b/app/helpers/application_helper/button/miq_request_delete.rb
@@ -1,17 +1,6 @@
-class ApplicationHelper::Button::MiqRequestDelete < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::MiqRequestDelete < ApplicationHelper::Button::MiqRequest
   needs :@record, :@request_tab
   delegate :current_user, :to => :@view_context
-
-  def role_allows_feature?
-    prefix = case @request_tab
-             when 'ae', 'host'
-               "#{@request_tab}_"
-             else
-               ""
-             end
-    # check RBAC on separate button
-    role_allows?(:feature => "#{prefix}#{self[:id]}")
-  end
 
   def disabled?
     requester = current_user

--- a/app/helpers/application_helper/button/miq_request_delete.rb
+++ b/app/helpers/application_helper/button/miq_request_delete.rb
@@ -1,6 +1,17 @@
 class ApplicationHelper::Button::MiqRequestDelete < ApplicationHelper::Button::Basic
-  needs :@record
+  needs :@record, :@request_tab
   delegate :current_user, :to => :@view_context
+
+  def role_allows_feature?
+    prefix = case @request_tab
+             when 'ae', 'host'
+               "#{@request_tab}_"
+             else
+               ""
+             end
+    # check RBAC on separate button
+    role_allows?(:feature => "#{prefix}#{self[:id]}")
+  end
 
   def disabled?
     requester = current_user

--- a/app/helpers/application_helper/button/miq_request_reload.rb
+++ b/app/helpers/application_helper/button/miq_request_reload.rb
@@ -1,8 +1,0 @@
-class ApplicationHelper::Button::MiqRequestReload < ApplicationHelper::Button::MiqRequest
-  needs :@showtype, :@record, :@request_tab
-
-  def visible?
-    return false unless super
-    true
-  end
-end

--- a/app/helpers/application_helper/button/miq_request_reload.rb
+++ b/app/helpers/application_helper/button/miq_request_reload.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::MiqRequestApproval < ApplicationHelper::Button::MiqRequest
+class ApplicationHelper::Button::MiqRequestReload < ApplicationHelper::Button::MiqRequest
   needs :@showtype, :@record, :@request_tab
 
   def role_allows_feature?
@@ -9,12 +9,11 @@ class ApplicationHelper::Button::MiqRequestApproval < ApplicationHelper::Button:
                ""
              end
     # check RBAC on separate button
-    role_allows?(:feature => "#{prefix}miq_request_approval")
+    role_allows?(:feature => "#{prefix}miq_request_reload")
   end
 
   def visible?
     return false unless super
-    return false if %w(approved denied).include?(@record.approval_state) || @showtype == "miq_provisions"
     true
   end
 end

--- a/app/helpers/application_helper/button/miq_request_reload.rb
+++ b/app/helpers/application_helper/button/miq_request_reload.rb
@@ -1,17 +1,6 @@
 class ApplicationHelper::Button::MiqRequestReload < ApplicationHelper::Button::MiqRequest
   needs :@showtype, :@record, :@request_tab
 
-  def role_allows_feature?
-    prefix = case @request_tab
-             when 'ae', 'host'
-               "#{@request_tab}_"
-             else
-               ""
-             end
-    # check RBAC on separate button
-    role_allows?(:feature => "#{prefix}miq_request_reload")
-  end
-
   def visible?
     return false unless super
     true

--- a/app/helpers/application_helper/toolbar/miq_request_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_request_center.rb
@@ -38,7 +38,7 @@ class ApplicationHelper::Toolbar::MiqRequestCenter < ApplicationHelper::Toolbar:
       N_('Approve this Request'),
       nil,
       :klass     => ApplicationHelper::Button::MiqRequestApproval,
-      :options   => {:feature => 'miq_request_approve'},
+      :options   => {:feature => 'miq_request_approval'},
       :url       => "/stamp",
       :url_parms => "?typ=a"),
     button(

--- a/app/helpers/application_helper/toolbar/miq_request_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_request_center.rb
@@ -29,7 +29,7 @@ class ApplicationHelper::Toolbar::MiqRequestCenter < ApplicationHelper::Toolbar:
       N_('Refresh this page'),
       N_('Refresh'),
       :url_parms => "&display=miq_provisions",
-      :klass   => ApplicationHelper::Button::MiqRequestReload,
+      :klass   => ApplicationHelper::Button::MiqRequest,
       :options => {:feature => 'miq_request_reload'}),
   ])
   button_group('miq_request_approve', [

--- a/app/helpers/application_helper/toolbar/miq_request_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_request_center.rb
@@ -27,7 +27,9 @@ class ApplicationHelper::Toolbar::MiqRequestCenter < ApplicationHelper::Toolbar:
       'fa fa-refresh fa-lg',
       N_('Refresh this page'),
       N_('Refresh'),
-      :url_parms => "&display=miq_provisions"),
+      :url_parms => "&display=miq_provisions",
+      :klass   => ApplicationHelper::Button::MiqRequestReload,
+      :options => {:feature => 'miq_request_reload'}),
   ])
   button_group('miq_request_approve', [
     button(

--- a/app/helpers/application_helper/toolbar/miq_request_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_request_center.rb
@@ -21,7 +21,8 @@ class ApplicationHelper::Toolbar::MiqRequestCenter < ApplicationHelper::Toolbar:
       nil,
       :url_parms => "&refresh=y",
       :confirm   => N_("Are you sure you want to delete this Request?"),
-      :klass     => ApplicationHelper::Button::MiqRequestDelete),
+      :klass     => ApplicationHelper::Button::MiqRequestDelete,
+      :options => {:feature => 'miq_request_delete'}),
     button(
       :miq_request_reload,
       'fa fa-refresh fa-lg',

--- a/app/helpers/application_helper/toolbar/miq_requests_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_requests_center.rb
@@ -6,6 +6,8 @@ class ApplicationHelper::Toolbar::MiqRequestsCenter < ApplicationHelper::Toolbar
       N_('Refresh this page'),
       N_('Refresh'),
       :url_parms    => "main_div",
-      :send_checked => true),
+      :send_checked => true,
+      :klass   => ApplicationHelper::Button::MiqRequestReload,
+      :options => {:feature => 'miq_request_reload'}),
   ])
 end

--- a/app/helpers/application_helper/toolbar/miq_requests_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_requests_center.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Toolbar::MiqRequestsCenter < ApplicationHelper::Toolbar
       N_('Refresh'),
       :url_parms    => "main_div",
       :send_checked => true,
-      :klass   => ApplicationHelper::Button::MiqRequestReload,
+      :klass   => ApplicationHelper::Button::MiqRequest,
       :options => {:feature => 'miq_request_reload'}),
   ])
 end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -81,7 +81,7 @@ module Menu
           Menu::Item.new('storage',          N_('Datastores'),       'storage',                    {:feature => 'storage_show_list'},               '/storage/explorer'),
           Menu::Item.new('pxe',              N_('PXE'),              'pxe',                        {:feature => 'pxe', :any => true},               '/pxe/explorer'),
           Menu::Item.new('switch',           N_('Networking'),       'infra_networking',           {:feature => 'infra_networking', :any => true},  '/infra_networking/explorer'),
-          Menu::Item.new('miq_request_host', N_('Requests'),         nil,                          {:feature => 'miq_request_show_list'},           '/miq_request?typ=host'),
+          Menu::Item.new('miq_request_host', N_('Requests'),         'host_miq_request',           {:feature => 'host_miq_request_show_list'},      '/miq_request?typ=host'),
           Menu::Item.new('infra_topology',   N_('Topology'), 'infra_topology',                     {:feature => 'infra_topology', :any => true},    '/infra_topology')
         ])
       end
@@ -233,7 +233,7 @@ module Menu
           Menu::Item.new('generic_object_definitions', N_('Generic Objects'), 'generic_object_definitions', {:feature => 'generic_object_definition'}, '/generic_object_definition'),
           Menu::Item.new('miq_ae_export',        N_('Import / Export'), 'miq_ae_class_import_export',    {:feature => 'miq_ae_class_import_export'},    '/miq_ae_tools/import_export'),
           Menu::Item.new('miq_ae_logs',          N_('Log'),             'miq_ae_class_log',              {:feature => 'miq_ae_class_log'},              '/miq_ae_tools/log'),
-          Menu::Item.new('miq_request_ae',       N_('Requests'),        nil,                             {:feature => 'miq_request_show_list'},         "/miq_request?typ=ae")
+          Menu::Item.new('miq_request_ae',       N_('Requests'),        'ae_miq_request',                {:feature => 'ae_miq_request_show_list'},      '/miq_request?typ=ae')
         ].compact)
       end
 

--- a/spec/helpers/application_helper/buttons/miq_request_approval_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_approval_spec.rb
@@ -5,7 +5,7 @@ describe ApplicationHelper::Button::MiqRequestApproval do
         view_context,
         {},
         {'record' => @record, 'showtype' => @showtype, 'request_tab' => @request_tab},
-        {:options => {:feature => 'miq_request_approve'}}
+        {:options => {:feature => 'miq_request_approval'}}
       )
     end
 
@@ -16,7 +16,7 @@ describe ApplicationHelper::Button::MiqRequestApproval do
     let(:state) { "xx" }
     %w(MiqProvisionRequest MiqHostProvisionRequest VmReconfigureRequest VmCloudReconfigureRequest
        VmMigrateRequest AutomationRequest ServiceTemplateProvisionRequest).each do |cls|
-      context "id = miq_request_approve" do
+      context "id = miq_request_approval" do
         before do
           @record = cls.constantize.new
           allow(@record).to receive_messages(:resource_type  => request,

--- a/spec/helpers/application_helper/buttons/miq_request_approval_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_approval_spec.rb
@@ -4,7 +4,7 @@ describe ApplicationHelper::Button::MiqRequestApproval do
       described_class.new(
         view_context,
         {},
-        {'record' => @record, 'showtype' => @showtype},
+        {'record' => @record, 'showtype' => @showtype, 'request_tab' => @request_tab},
         {:options => {:feature => 'miq_request_approve'}}
       )
     end
@@ -25,6 +25,7 @@ describe ApplicationHelper::Button::MiqRequestApproval do
           allow(button).to receive(:role_allows_feature?).and_return(true)
           allow(button).to receive(:current_user).and_return(user)
           button.instance_variable_set(:@showtype, "prase")
+          button.instance_variable_set(:@request_tab, "service")
         end
         context "resource_type = AutomationRequest" do
           let(:request) { "AutomationRequest" }
@@ -65,6 +66,7 @@ describe ApplicationHelper::Button::MiqRequestApproval do
           allow(button).to receive(:role_allows_feature?).and_return(true)
           allow(button).to receive(:current_user).and_return(user)
           button.instance_variable_set(:@showtype, "prase")
+          button.instance_variable_set(:@request_tab, "service")
         end
         context "resource_type = AutomationRequest" do
           let(:request) { "AutomationRequest" }

--- a/spec/helpers/application_helper/buttons/miq_request_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_delete_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::MiqRequestDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:record) { FactoryGirl.create(:vm) }
-  let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
+  let(:button) { described_class.new(view_context, {}, {'record' => record}, {:options => {:feature => 'miq_request_delete'}}) }
 
   describe '#disabled?' do
     subject { button[:title] }


### PR DESCRIPTION
Separated features for each "Requests" sub tab under Automation/Automate/Requests & Compute/Infrastructure/Requests to provide users with capability to allow access to each type individually. Currently there was only features for Service/Requests user was forced to have access to Service/Requests features to be able to see Automation or Host Provisioning requests.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1508490
Also fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1526495

Depends on https://github.com/ManageIQ/manageiq/pull/17524

![hk_role](https://user-images.githubusercontent.com/3450808/40984061-fddf8000-68ae-11e8-8d50-1d00d5efa595.png)

![automate_subtab](https://user-images.githubusercontent.com/3450808/40984151-27bdb84c-68af-11e8-96c7-453b81713553.png)


![automate_request_details](https://user-images.githubusercontent.com/3450808/40984078-04437b40-68af-11e8-8166-bfde73950756.png)
