### PR TITLE
Force selectpicker refresh after dialog-user component initialization

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -2,7 +2,7 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
   var vm = this;
 
   vm.$onInit = function() {
-    return new Promise(function(resolve) {
+    var apiCall = new Promise(function(resolve) {
       var url = '/api/service_dialogs/' + dialogId +
         '?resource_action_id=' + resourceActionId +
         '&target_id=' + targetId +
@@ -10,6 +10,8 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
 
       resolve(API.get(url, {expand: 'resources', attributes: 'content'}).then(init));
     });
+
+    Promise.resolve(apiCall).then(miqService.refreshSelectpicker);
   };
 
   function init(dialog) {

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -36,6 +36,10 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', '$q', 'API'
     return miqJqueryRequest(url, options);
   };
 
+  this.refreshSelectpicker = function() {
+    $('select').selectpicker('refresh');
+  };
+
   this.sparkleOn = function() {
     miqSparkleOn();
   };

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -19,6 +19,7 @@ describe('dialogUserController', function() {
     spyOn(miqService, 'redirectBack');
     spyOn(miqService, 'sparkleOn');
     spyOn(miqService, 'sparkleOff');
+    spyOn(miqService, 'refreshSelectpicker');
 
     $controller = _$controller_('dialogUserController', {
       API: API,
@@ -57,6 +58,13 @@ describe('dialogUserController', function() {
 
     it('sets dialogLoaded to true', function() {
       expect($controller.dialogLoaded).toEqual(true);
+    });
+
+    it('refreshes the selectpickers after resolving the api call', function(done) {
+      setTimeout(function() {
+        expect(miqService.refreshSelectpicker).toHaveBeenCalled();
+        done();
+      });
     });
   });
 

--- a/spec/javascripts/services/miq_service_spec.js
+++ b/spec/javascripts/services/miq_service_spec.js
@@ -50,6 +50,18 @@ describe('miqService', function() {
     });
   });
 
+  describe('#refreshSelectpicker', function() {
+    beforeEach(function() {
+      spyOn($.fn, 'selectpicker');
+    });
+
+    it('refreshes all selects', function() {
+      testService.refreshSelectpicker();
+      expect($.fn.selectpicker.calls.mostRecent().object.selector).toEqual('select');
+      expect($.fn.selectpicker.calls.mostRecent().args[0]).toEqual('refresh');
+    });
+  });
+
   describe('#sparkleOn', function() {
     it('calls the global miq sparkle on', function() {
       testService.sparkleOn();


### PR DESCRIPTION
I'm unsure on why this is happening on 5.9.x versions, as I cannot reproduce the issue locally (screenshots from a 5.9.3 appliance), but this will fix it. Basically when a dialog loads, the values aren't showing up, and it looks something like this:
<img width="426" alt="screen shot 2018-06-05 at 11 02 19 am" src="https://user-images.githubusercontent.com/164557/40994013-f0a3f3ac-68af-11e8-9bf3-f32eb39f7779.png">

This is purely a UI problem, because the data that is coming from the backend is correct, and in the HTML the `<select>` tags all have the correct data and `<option>`s selected correctly.

After doing a `$('select').selectpicker('refresh')`, the values are shown correctly, and it looks something like this:
<img width="437" alt="screen shot 2018-06-05 at 11 01 07 am" src="https://user-images.githubusercontent.com/164557/40993968-ce0b5236-68af-11e8-90e3-c99a8fb12b26.png">

So, this just forces that refresh after the initialization stage. I also changed the `$onInit` method to no longer return a promise, but it doesn't matter because angular doesn't officially support returning a promise from the `$onInit` method anyway. This way, we can resolve it before `$onInit` finishes and ensure that everything is loaded properly.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1583704

@miq-bot add_label gaprindashvili/yes, bug, blocker

@d-m-u Review please!
/cc @tinaafitz 