### PR TITLE
Adds Physical Chassis List & Details pages

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -122,6 +122,7 @@ module EmsCommon
         persistent_volumes
         physical_servers
         physical_racks
+        physical_chassis
         physical_servers_with_host
         physical_switches
         security_groups

--- a/app/controllers/physical_chassis_controller.rb
+++ b/app/controllers/physical_chassis_controller.rb
@@ -1,0 +1,32 @@
+class PhysicalChassisController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
+  include Mixins::GenericSessionMixin
+  include Mixins::MoreShowActions
+
+  before_action :check_privileges
+  before_action :get_session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def self.table_name
+    @table_name ||= "physical_chassis"
+  end
+
+  def show_list
+    disable_client_cache
+    process_show_list
+  end
+
+  def textual_group_list
+    [
+      %i(properties relationships),
+      %i(management_network slots)
+    ]
+  end
+  helper_method(:textual_group_list)
+
+  def self.display_methods
+    %w(physical_chassis)
+  end
+end

--- a/app/decorators/physical_chassis_decorator.rb
+++ b/app/decorators/physical_chassis_decorator.rb
@@ -1,0 +1,20 @@
+class PhysicalChassisDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-cluster'
+  end
+
+  def quadicon
+    {
+      :top_left     => {
+        :text    => t = physical_servers.count,
+        :tooltip => n_("%{number} Physical Server", "%{number} Physical Servers", t) % {:number => t}
+      },
+      :top_right    => {},
+      :bottom_left  => {
+        :fonticon => fonticon,
+        :tooltip  => ui_lookup(:model => type),
+      },
+      :bottom_right => QuadiconHelper.health_state(health_state)
+    }
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1156,6 +1156,7 @@ module ApplicationHelper
                         orchestration_stack
                         physical_infra_topology
                         physical_rack
+                        physical_chassis
                         physical_switch
                         physical_server
                         persistent_volume

--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -50,6 +50,7 @@ module ApplicationHelper
         orchestration_stack
         persistent_volume
         physical_rack
+        physical_chassis
         physical_server
         physical_switch
         resource_pool

--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -14,7 +14,7 @@ module EmsPhysicalInfraHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(physical_racks physical_switches physical_servers datastores vms physical_servers_with_host)
+      %i(physical_racks physical_chassis physical_switches physical_servers datastores vms physical_servers_with_host)
     )
   end
 
@@ -51,6 +51,10 @@ module EmsPhysicalInfraHelper::TextualSummary
 
   def textual_physical_racks
     textual_link(@record.physical_racks)
+  end
+
+  def textual_physical_chassis
+    textual_link(@record.physical_chassis)
   end
 
   def textual_physical_switches

--- a/app/helpers/physical_chassis_helper.rb
+++ b/app/helpers/physical_chassis_helper.rb
@@ -1,0 +1,3 @@
+module PhysicalChassisHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/physical_chassis_helper/textual_summary.rb
+++ b/app/helpers/physical_chassis_helper/textual_summary.rb
@@ -1,0 +1,113 @@
+module PhysicalChassisHelper::TextualSummary
+  #
+  # Textual Groups
+  # Properties, Relationships, Management Network, Slots
+  #
+  def textual_group_properties
+    TextualGroup.new(
+      _("Properties"),
+      %i(name product_name manufacturer serial_number part_number health_state uid_ems description)
+    )
+  end
+
+  def textual_group_relationships
+    TextualGroup.new(
+      _("Relationships"),
+      %i(ext_management_system physical_rack physical_servers)
+    )
+  end
+
+  def textual_group_management_network
+    TextualGroup.new(
+      _("Management Network"),
+      %i(ipaddress)
+    )
+  end
+
+  def textual_group_slots
+    TextualGroup.new(
+      _("Chassis Slots"),
+      %i(mm_slot_count switch_slot_count fan_slot_count blade_slot_count powersupply_slot_count)
+    )
+  end
+
+  #
+  # Properties
+  #
+  def textual_name
+    {:label => _("Chassis name"), :value => @record.name }
+  end
+
+  def textual_product_name
+    {:label => _("Product Name"), :value => @record.asset_detail["product_name"] }
+  end
+
+  def textual_manufacturer
+    {:label => _("Manufacturer"), :value => @record.asset_detail["manufacturer"] }
+  end
+
+  def textual_serial_number
+    {:label => _("Serial Number"), :value => @record.asset_detail["serial_number"] }
+  end
+
+  def textual_part_number
+    {:label => _("Part Number"), :value => @record.asset_detail["part_number"] }
+  end
+
+  def textual_health_state
+    {:label => _("Health State"), :value => @record.health_state}
+  end
+
+  def textual_uid_ems
+    {:label => _("UUID"), :value => @record.uid_ems }
+  end
+
+  def textual_description
+    {:label => _("Description"), :value => @record.asset_detail["description"]}
+  end
+
+  #
+  # Relashionships
+  #
+  def textual_ext_management_system
+    textual_link(ExtManagementSystem.find(@record.ems_id))
+  end
+
+  def textual_physical_rack
+    textual_link(@record.physical_rack)
+  end
+
+  def textual_physical_servers
+    textual_link(@record.physical_servers)
+  end
+
+  #
+  # Management Network
+  #
+  def textual_ipaddress
+    {:label => _("IP"), :value => (@record.guest_devices.detect { |device| device.device_type == "management" })&.network&.ipaddress}
+  end
+
+  #
+  # Chassis Slots
+  #
+  def textual_mm_slot_count
+    {:label => _("Management Module Slot Count"), :value => @record.management_module_slot_count}
+  end
+
+  def textual_switch_slot_count
+    {:label => _("Switch Slot Count"), :value => @record.switch_slot_count}
+  end
+
+  def textual_fan_slot_count
+    {:label => _("Fan Slot Count"), :value => @record.fan_slot_count}
+  end
+
+  def textual_blade_slot_count
+    {:label => _("Blade Slot Count"), :value => @record.blade_slot_count}
+  end
+
+  def textual_powersupply_slot_count
+    {:label => _("Power Supply Slot Count"), :value => @record.powersupply_slot_count}
+  end
+end

--- a/app/helpers/physical_rack_helper/textual_summary.rb
+++ b/app/helpers/physical_rack_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module PhysicalRackHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(ext_management_system physical_servers)
+      %i(ext_management_system physical_chassis physical_servers)
     )
   end
 
@@ -23,6 +23,10 @@ module PhysicalRackHelper::TextualSummary
 
   def textual_ems_ref
     {:label => _("UUID"), :value => @record.ems_ref }
+  end
+
+  def textual_physical_chassis
+    textual_link(@record.physical_chassis)
   end
 
   def textual_physical_servers

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -11,7 +11,7 @@ module PhysicalServerHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(host ext_management_system physical_rack)
+      %i(host ext_management_system physical_rack physical_chassis)
     )
   end
 
@@ -64,6 +64,12 @@ module PhysicalServerHelper::TextualSummary
     rack_id = @record.physical_rack_id
     return nil if rack_id.nil?
     textual_link(PhysicalRack.find(rack_id))
+  end
+
+  def textual_physical_chassis
+    chassis_id = @record.physical_chassis_id
+    return nil if chassis_id.nil?
+    textual_link(PhysicalChassis.find(chassis_id))
   end
 
   def textual_name

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -88,9 +88,10 @@ module Menu
       def physical_infrastructure_menu_section
         Menu::Section.new(:phy, N_("Physical Infrastructure"), 'fa fa-plus fa-2x', [
           Menu::Item.new('ems_physical_infra',    N_('Providers'), 'ems_physical_infra',    {:feature => 'ems_physical_infra_show_list'},    '/ems_physical_infra'),
+          Menu::Item.new('physical_chassis', N_('Chassis'), 'physical_chassis', {:feature => 'physical_chassis_show_list'}, '/physical_chassis'),
           Menu::Item.new('physical_rack', N_('Racks'), 'physical_rack', {:feature => 'physical_rack_show_list'}, '/physical_rack'),
-          Menu::Item.new('physical_switch', N_('Switches'),  'physical_switch', {:feature => 'physical_switch_show_list'}, '/physical_switch'),
           Menu::Item.new('physical_server', N_('Servers'),   'physical_server', {:feature => 'physical_server_show_list'}, '/physical_server'),
+          Menu::Item.new('physical_switch', N_('Switches'),  'physical_switch', {:feature => 'physical_switch_show_list'}, '/physical_switch'),
           Menu::Item.new('physical_infra_topology', N_('Topology'), 'physical_infra_topology', {:feature => 'physical_infra_topology', :any => true}, '/physical_infra_topology'),
         ])
       end

--- a/app/views/layouts/listnav/_physical_chassis.html.haml
+++ b/app/views/layouts/listnav/_physical_chassis.html.haml
@@ -1,0 +1,17 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render :partial => 'shared/quadicon', :locals => {:record => @record}
+
+    = miq_accordion_panel(_("Properties"), false, "ems_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to(_('Summary'), {:action => 'show', :id => @record, :display => 'main'}, {:title => _("Show Summary")})
+
+    = miq_accordion_panel(_("Relationships"), false, "ems_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        - if  @record.ext_management_system
+          %li
+            = link_to(_("Provider: %{name}") % {:name => @record.ext_management_system.name},
+              ems_physical_infra_path(@record.ext_management_system.id),
+              :title => _("Show this parent Provider"))

--- a/app/views/physical_chassis/show.html.haml
+++ b/app/views/physical_chassis/show.html.haml
@@ -1,6 +1,10 @@
 #main_div
-  - if %w(physical_chassis physical_servers).include?(@display)
+  - if %w(physical_rack physical_servers).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+    - if %w(physical_servers).include?(@display)
+      %physical-server-toolbar#ems_physical_infra_show_list_form
+      :javascript
+        miq_bootstrap('#ems_physical_infra_show_list_form')
   - else
     - case @showtype
     - when "main"

--- a/app/views/physical_chassis/show_list.html.haml
+++ b/app/views/physical_chassis/show_list.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => 'layouts/gtl'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1392,6 +1392,22 @@ Rails.application.routes.draw do
       )
     },
 
+    :physical_chassis    =>  {
+      :get  =>  %w(
+        download_data
+        perf_top_chart
+        protect
+        show_list
+        show
+      ),
+
+      :post   =>  %w(
+        button
+        show_list
+        quick_search
+      )
+    },
+
     :guest_device    =>  {
       :get  =>  %w(
         show_list

--- a/product/views/PhysicalChassis.yaml
+++ b/product/views/PhysicalChassis.yaml
@@ -1,0 +1,63 @@
+#Report title
+title: Physical Chassis
+
+#Menu name
+name: Physical Chassis
+
+
+db: PhysicalChassis
+
+
+# Columns to fetch from main table
+cols:
+- name
+- type
+- health_state
+- asset_detail.product_name
+- asset_detail.manufacturer
+
+
+include:
+
+
+include_for_find:
+  :ext_management_system: {}
+  :compliances: {}
+  :tags: {}
+
+
+col_order:
+- name
+- type
+- health_state
+- asset_detail.product_name
+- asset_detail.manufacturer
+
+col_formats:
+-
+- :model_name
+
+headers:
+- Name
+- Type
+- Health State
+- Product Name
+- Manufacturer
+
+
+conditions:
+
+
+order: Ascending
+
+
+sortby:
+- name
+
+group: n
+
+
+graph:
+
+
+dims:

--- a/spec/controllers/physical_chassis_controller_spec.rb
+++ b/spec/controllers/physical_chassis_controller_spec.rb
@@ -1,0 +1,68 @@
+require './app/controllers/physical_chassis_controller'
+
+describe PhysicalChassisController do
+  render_views
+
+  let(:physical_chassis) do
+    ems = FactoryGirl.create(:ems_physical_infra)
+    asset_detail = FactoryGirl.create(:asset_detail)
+    FactoryGirl.create(:physical_chassis, :ems_id => ems.id, :id => 1, :asset_detail => asset_detail)
+  end
+
+  before do
+    stub_user(:features => :all)
+    EvmSpecHelper.local_miq_server(:zone => FactoryGirl.build(:zone))
+    EvmSpecHelper.create_guid_miq_server_zone
+    login_as FactoryGirl.create(:user)
+  end
+
+  describe "#show_list" do
+    subject { get(:show_list) }
+
+    describe '#GTL' do
+      it "renders a GTL page" do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/_gtl")
+      end
+
+      it 'renders GTL with PhysicalChassis model' do
+        physical_chassis
+        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(:model_name      => physical_chassis.class.to_s,
+                                                                                         :gtl_type_string => "list",)
+        post :show_list
+        expect(response.status).to eq(200)
+      end
+    end
+
+    describe '#report_data' do
+      it 'calls "page_display_options" and returns the MiqRequest data' do
+        physical_chassis
+        report_data_request(:model => physical_chassis.class.to_s)
+        results = assert_report_data_response
+        expect(results['data']['rows'].length).to eq(1)
+      end
+    end
+  end
+
+  describe "#show" do
+    context "with valid id" do
+      subject { get(:show, :params => {:id => physical_chassis.id}) }
+
+      it "should respond to show" do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/_textual_groups_generic")
+      end
+    end
+    context "with invalid id" do
+      subject { get(:show, :params => {:id => 2}) }
+
+      it "should redirect to #show_list" do
+        is_expected.to have_http_status 302
+        is_expected.to redirect_to(:action => :show_list)
+
+        flash_messages = assigns(:flash_array)
+        expect(flash_messages.first[:message]).to include("Can't access selected records")
+      end
+    end
+  end
+end

--- a/spec/helpers/physical_chassis_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_chassis_helper/textual_summary_spec.rb
@@ -1,0 +1,318 @@
+describe PhysicalChassisHelper::TextualSummary do
+  include ApplicationHelper
+
+  let(:ems) do
+    FactoryGirl.create(:physical_infra,
+                       :name      => 'LXCA',
+                       :hostname  => 'my.physicalinfra.com',
+                       :port      => '443',
+                       :ipaddress => '1.2.3.4')
+  end
+
+  let(:asset_detail) do
+    FactoryGirl.create(:asset_detail,
+                       :product_name  => 'Lenovo XYZ Chassis x1000',
+                       :manufacturer  => 'Lenovo',
+                       :serial_number => 'A1B2C3D4E5F6',
+                       :part_number   => 'XXX18',
+                       :description   => 'Physical Chassis used inside site A')
+  end
+
+  let(:network) do
+    FactoryGirl.build(:network, :ipaddress => '192.168.1.1')
+  end
+
+  let(:guest_device) do
+    FactoryGirl.build(:guest_device,
+                      :device_type => 'management',
+                      :network     => network)
+  end
+
+  let(:hardware) do
+    FactoryGirl.build(:hardware, :guest_devices => [guest_device])
+  end
+
+  let(:computer_system) do
+    FactoryGirl.build(:computer_system, :hardware => hardware)
+  end
+
+  let(:physical_rack) do
+    FactoryGirl.create(:physical_rack, :name => 'Rack XYZ')
+  end
+
+  let(:physical_servers) do
+    [
+      FactoryGirl.create(:physical_server, :name => 'Physical Server I'),
+      FactoryGirl.create(:physical_server, :name => 'Physical Server J'),
+      FactoryGirl.create(:physical_server, :name => 'Physical Server K')
+    ]
+  end
+
+  let(:physical_chassis) do
+    FactoryGirl.create(:physical_chassis,
+                       :ems_id                       => ems.id,
+                       :uid_ems                      => 'NVH20GH0T4HN268902G6Y2N-G28Y8YWG',
+                       :name                         => 'Chassis ABC',
+                       :health_state                 => 'Valid',
+                       :asset_detail                 => asset_detail,
+                       :computer_system              => computer_system,
+                       :management_module_slot_count => 2,
+                       :switch_slot_count            => 4,
+                       :fan_slot_count               => 8,
+                       :blade_slot_count             => 16,
+                       :powersupply_slot_count       => 1,
+                       :physical_rack                => physical_rack,
+                       :physical_servers             => physical_servers)
+  end
+
+  before do
+    @record = physical_chassis
+  end
+
+  #
+  # Textual Groups
+  # Properties, Relationships, Management Network, Slots
+  #
+  describe '.textual_group_properties' do
+    subject { textual_group_properties }
+
+    it 'has the right title' do
+      expect(subject.title).to eq('Properties')
+    end
+
+    it 'shows 8 fields' do
+      expect(subject.items).to be_kind_of(Array)
+      expect(subject.items.size).to eq(8)
+    end
+
+    it 'shows main properties' do
+      expect(subject.items).to include(
+        :name,
+        :product_name,
+        :manufacturer,
+        :serial_number,
+        :part_number,
+        :health_state,
+        :uid_ems,
+        :description
+      )
+    end
+  end
+
+  describe '.textual_group_relationships' do
+    subject { textual_group_relationships }
+
+    it 'has the right title' do
+      expect(subject.title).to eq('Relationships')
+    end
+
+    it 'shows 3 relationships' do
+      expect(subject.items).to be_kind_of(Array)
+      expect(subject.items.size).to eq(3)
+    end
+
+    it 'shows main relationships' do
+      expect(subject.items).to include(:ext_management_system, :physical_rack, :physical_servers)
+    end
+  end
+
+  describe '.textual_group_management_network' do
+    subject { textual_group_management_network }
+
+    it 'has the right title' do
+      expect(subject.title).to eq('Management Network')
+    end
+
+    it 'shows 1 management ipaddress' do
+      expect(subject.items).to be_kind_of(Array)
+      expect(subject.items.size).to eq(1)
+      expect(subject.items[0]).to eq(:ipaddress)
+    end
+  end
+
+  describe '.textual_group_slots' do
+    subject { textual_group_slots }
+
+    it 'has the right title' do
+      expect(subject.title).to eq('Chassis Slots')
+    end
+
+    it 'shows 5 slots info' do
+      expect(subject.items).to be_kind_of(Array)
+      expect(subject.items.size).to eq(5)
+    end
+
+    it 'shows main chassis slots' do
+      expect(subject.items).to include(
+        :mm_slot_count,
+        :switch_slot_count,
+        :fan_slot_count,
+        :blade_slot_count,
+        :powersupply_slot_count
+      )
+    end
+  end
+
+  #
+  # Properties
+  #
+  describe '.textual_name' do
+    subject { textual_name }
+
+    it 'show the chassis name' do
+      expect(subject).to eq(:label => 'Chassis name', :value => 'Chassis ABC')
+    end
+  end
+
+  describe '.textual_product_name' do
+    subject { textual_product_name }
+
+    it 'show the chassis product name' do
+      expect(subject).to eq(:label => 'Product Name', :value => 'Lenovo XYZ Chassis x1000')
+    end
+  end
+
+  describe '.textual_manufacturer' do
+    subject { textual_manufacturer }
+
+    it 'show the chassis Manufacturer' do
+      expect(subject).to eq(:label => 'Manufacturer', :value => 'Lenovo')
+    end
+  end
+
+  describe '.textual_serial_number' do
+    subject { textual_serial_number }
+
+    it 'show the chassis Serial Number' do
+      expect(subject).to eq(:label => 'Serial Number', :value => 'A1B2C3D4E5F6')
+    end
+  end
+
+  describe '.textual_part_number' do
+    subject { textual_part_number }
+
+    it 'show the chassis Part Number' do
+      expect(subject).to eq(:label => 'Part Number', :value => 'XXX18')
+    end
+  end
+
+  describe '.textual_health_state' do
+    subject { textual_health_state }
+
+    it 'show the chassis Health State' do
+      expect(subject).to eq(:label => 'Health State', :value => 'Valid')
+    end
+  end
+
+  describe '.textual_uid_ems' do
+    subject { textual_uid_ems }
+
+    it 'show the chassis UUID' do
+      expect(subject).to eq(:label => 'UUID', :value => 'NVH20GH0T4HN268902G6Y2N-G28Y8YWG')
+    end
+  end
+
+  describe '.textual_description' do
+    subject { textual_description }
+
+    it 'show the chassis description' do
+      expect(subject).to eq(:label => 'Description', :value => 'Physical Chassis used inside site A')
+    end
+  end
+
+  #
+  # Relashionships
+  #
+  describe '.textual_ext_management_system' do
+    subject { textual_ext_management_system }
+
+    it 'show the chassis provider' do
+      expect(subject).to eq(
+        :label => 'Physical Infrastructure Provider',
+        :icon  => nil,
+        :value => 'LXCA',
+        :image => 'svg/vendor-lenovo_ph_infra.svg'
+      )
+    end
+  end
+
+  describe '.textual_physical_rack' do
+    subject { textual_physical_rack }
+
+    it 'show the chassis physical rack' do
+      expect(subject).to eq(
+        :label => "Physical Rack",
+        :value => "Rack XYZ",
+        :icon  => "pficon pficon-enterprise",
+        :image => nil
+      )
+    end
+  end
+
+  describe '.textual_physical_servers' do
+    subject { textual_physical_servers }
+
+    it 'show the chassis physical servers' do
+      expect(subject).to eq(
+        :label => "Physical Servers",
+        :value => "3",
+        :icon  => "pficon pficon-server",
+        :image => nil
+      )
+    end
+  end
+
+  #
+  # Management Network
+  #
+  describe '.textual_ipaddress' do
+    subject { textual_ipaddress }
+
+    it 'show the chassis management ipaddress' do
+      expect(subject).to eq(:label => 'IP', :value => '192.168.1.1')
+    end
+  end
+
+  #
+  # Chassis Slots
+  #
+  describe '.textual_mm_slot_count' do
+    subject { textual_mm_slot_count }
+
+    it 'show the chassis management module slot count' do
+      expect(subject).to eq(:label => 'Management Module Slot Count', :value => 2)
+    end
+  end
+
+  describe '.textual_switch_slot_count' do
+    subject { textual_switch_slot_count }
+
+    it 'show the chassis switch slot count' do
+      expect(subject).to eq(:label => 'Switch Slot Count', :value => 4)
+    end
+  end
+
+  describe '.textual_fan_slot_count' do
+    subject { textual_fan_slot_count }
+
+    it 'show the chassis fan slot count' do
+      expect(subject).to eq(:label => 'Fan Slot Count', :value => 8)
+    end
+  end
+
+  describe '.textual_blade_slot_count' do
+    subject { textual_blade_slot_count }
+
+    it 'show the chassis blade slot count' do
+      expect(subject).to eq(:label => 'Blade Slot Count', :value => 16)
+    end
+  end
+
+  describe '.textual_powersupply_slot_count' do
+    subject { textual_powersupply_slot_count }
+
+    it 'show the chassis management ipaddress' do
+      expect(subject).to eq(:label => 'Power Supply Slot Count', :value => 1)
+    end
+  end
+end


### PR DESCRIPTION
**What this PR does:**
- Add to the Left Menu _Compute_ > _Physical Infrastructure_ > **Chassis**;
- Add a **Physical Chassis** list page;
- Add a **Physical Chassis** details page;
- Adds the references to **Physical Chassis** in **Providers** Details page, **Physical Server** Page, and **Physical Rack** Page.

**Depends on:**
- ~[ManageIQ/manageiq#17523](https://github.com/ManageIQ/manageiq/pull/17523)~ [MERGED]

## "Chassis" Menu
![chassis_menu](https://user-images.githubusercontent.com/14334253/41560044-5205249c-731c-11e8-8e8f-50f340627d67.png)

## Chassis List Page
![chassis_list_page](https://user-images.githubusercontent.com/14334253/40994425-8ae38f28-68d2-11e8-90ff-bbb734a42304.png)

## Chassis Details Page
![provider_details](https://user-images.githubusercontent.com/14334253/41666246-699e18a6-7480-11e8-9b08-96a31e9025dd.png)
