### PR TITLE
Add single_quad definition for configuration profiles

### DIFF
--- a/app/decorators/configuration_profile_decorator.rb
+++ b/app/decorators/configuration_profile_decorator.rb
@@ -6,4 +6,10 @@ class ConfigurationProfileDecorator < MiqDecorator
       'fa fa-list-ul'
     end
   end
+
+  def single_quad
+    {
+      :fonticon => fonticon
+    }
+  end
 end


### PR DESCRIPTION
**Before:**
![screenshot from 2018-06-05 21-48-08](https://user-images.githubusercontent.com/649130/40999170-65033668-690a-11e8-8d4d-6fce9616b612.png)

**After:**
![screenshot from 2018-06-05 21-48-39](https://user-images.githubusercontent.com/649130/40999211-7ffd0804-690a-11e8-883a-669a10ecae07.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label gaprindashvili/no