### PR TITLE
Adding Physical Switches to Physical Infra topology page

### DIFF
--- a/app/assets/stylesheets/physical_infra_topology.scss
+++ b/app/assets/stylesheets/physical_infra_topology.scss
@@ -1,6 +1,7 @@
 $topology-colors: (
   PhysicalServer: #00659c,
   PhysicalRack:   #2d7623,
+  PhysicalSwitch: #b35c00,
 );
 
 @each $component, $color in $topology-colors {

--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -4,7 +4,7 @@ class PhysicalInfraTopologyService < TopologyService
   # Keep it in a 'topological order' e.g: racks, chassis, servers
   @included_relations = [
     :writable_classification_tags,
-    :physical_racks   => [
+    :physical_racks    => [
       :writable_classification_tags,
       :physical_servers => [
         :writable_classification_tags,
@@ -14,16 +14,19 @@ class PhysicalInfraTopologyService < TopologyService
         ]
       ]
     ],
-    :physical_servers => [
+    :physical_servers  => [
       :writable_classification_tags,
       :host => [
         :writable_classification_tags,
         :vms => :writable_classification_tags
       ]
     ],
+    :physical_switches => [
+      :writable_classification_tags
+    ],
   ]
 
-  @kinds = %i(PhysicalInfraManager PhysicalRack PhysicalServer Host Vm Tag)
+  @kinds = %i(PhysicalInfraManager PhysicalRack PhysicalServer Host Vm Tag PhysicalSwitch)
 
   def entity_type(entity)
     if entity.kind_of?(Host)

--- a/app/services/ui_service_mixin.rb
+++ b/app/services/ui_service_mixin.rb
@@ -24,7 +24,7 @@ module UiServiceMixin
       :NetworkRouter           => {:type => "glyph", :class => 'pficon pficon-route'},
       :PhysicalRack            => {:type => "glyph", :class => 'pficon pficon-enterprise'},
       :PhysicalServer          => {:type => "glyph", :class => 'pficon pficon-server-group'},
-      :PhysicalSwitch          => {:type => "glyph", :class => 'pficon pficon-container-node'},
+      :PhysicalSwitch          => {:type => "glyph", :class => 'ff ff-network-switch'},
       :SecurityGroup           => {:type => "glyph", :class => 'pficon pficon-cloud-security'},
       :Tag                     => {:type => "glyph", :class => 'fa fa-tag'},
       :Vm                      => {:type => "glyph", :class => 'pficon pficon-virtual-machine'},

--- a/app/views/physical_infra_topology/show.html.haml
+++ b/app/views/physical_infra_topology/show.html.haml
@@ -11,6 +11,10 @@
         %label
           %i.pficon.pficon-server-group
           = _("Physical Servers")
+      %kubernetes-topology-icon{tooltipOptions, :kind => "PhysicalSwitch"}
+        %label
+          %i.ff.ff-network-switch
+          = _("Physical Switches")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Host"}
         %label
           %i.pficon.pficon-screen


### PR DESCRIPTION
__This PR is able to__
- Add the `PhysicalSwitch` component to Physical Infra topology page;
- Change the `PhysicalSwitch` icon on topology view to use the same of the Physical Switch page.

![image](https://user-images.githubusercontent.com/8550928/40999794-5a0efa3a-68e2-11e8-8797-e168b61a789e.png)
