### PR TITLE
Enable save button in Kubevirt infra provider edit dialog

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -831,6 +831,7 @@ module Mixins
     end
 
     def default_auth_status
+      return true if @ems.kind_of?(ManageIQ::Providers::Kubevirt::InfraManager)
       @ems.authentication_status_ok? unless @ems.kind_of?(ManageIQ::Providers::Google::CloudManager)
     end
   end


### PR DESCRIPTION
In Kubevirt provider's edit dialog the default_auth_status shouldn't be
considered when validating the input since the used prefix for the
dialog is 'kubevirt'. Therefore kubevirt_auth_status is the relevant
one. For that purpose, setting 'true' to default_auth_status fixes the
issue for Kubevirt infra provider.

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/71

