### PR TITLE
Seed MiqRegion in ansible credential and repository controller specs

### DIFF
--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -1,6 +1,7 @@
 describe AnsibleCredentialController do
   before do
     EvmSpecHelper.create_guid_miq_server_zone
+    MiqRegion.seed
     login_as FactoryGirl.create(:user_admin)
   end
 

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -1,6 +1,7 @@
 describe AnsibleRepositoryController do
   before do
     EvmSpecHelper.create_guid_miq_server_zone
+    MiqRegion.seed
     login_as FactoryGirl.create(:user_admin)
   end
 


### PR DESCRIPTION
Fixes travis failures on master, somehow the default `MiqRegion` was missing from these tests.