### PR TITLE
Make sure @edit[:current].config[:server][:zone] is set

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -951,6 +951,7 @@ module OpsController::Settings::Common
     @edit[:current].config[:smtp][:enable_starttls_auto] = GenericMailer.default_for_enable_starttls_auto if @edit[:current].config[:smtp][:enable_starttls_auto].nil?
     @edit[:current].config[:smtp][:openssl_verify_mode] ||= "none"
     @edit[:current].config[:ntp] ||= {}
+    @edit[:current].config[:server][:zone] = MiqServer.find(@sb[:selected_server_id]).zone.name
 
     @in_a_form = true
   end

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -341,5 +341,26 @@ describe OpsController do
         end
       end
     end
+
+    describe '#settings_set_form_vars_server' do
+      context 'sets values correctly' do
+        it 'for server in non-current zone' do
+          zone = FactoryGirl.create(:zone, :name => 'Foo Zone')
+          server = FactoryGirl.create(:miq_server, :zone => zone)
+          controller.instance_variable_set(:@sb, :selected_server_id => server.id)
+          controller.send(:settings_set_form_vars_server)
+          edit_current = assigns(:edit)
+          expect(edit_current[:current].config[:server][:zone]).to eq(zone.name)
+        end
+
+        it 'for server in default zone' do
+          server = FactoryGirl.create(:miq_server, :zone => Zone.find_by(:name => "default"))
+          controller.instance_variable_set(:@sb, :selected_server_id => server.id)
+          controller.send(:settings_set_form_vars_server)
+          edit_current = assigns(:edit)
+          expect(edit_current[:current].config[:server][:zone]).to eq("default")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Default server never returns its zone in get_config so it has to be checked and set correctly.

Introduced by https://github.com/ManageIQ/manageiq/pull/17140 which is `gaprindashvili/no`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1584851

Administrator -> Configuration -> Settings -> Zones

Have a zone that has name alphabetically before `default`. This bug is only for `Zone.name == "default"` (see pics below).

### Before:
Displays wrong zone (first one in dropdown)
<img width="1046" alt="screen shot 2018-06-06 at 12 24 48 pm" src="https://user-images.githubusercontent.com/9210860/41032855-e5a0658c-6984-11e8-8956-709945d54e6e.png">
Save button isn't active after changing zone
<img width="1196" alt="screen shot 2018-06-06 at 12 25 02 pm" src="https://user-images.githubusercontent.com/9210860/41032860-e8f61286-6984-11e8-88df-cb9f78255d10.png">

### After:
Displays correct zone
<img width="1047" alt="screen shot 2018-06-06 at 12 30 23 pm" src="https://user-images.githubusercontent.com/9210860/41033123-ba0dbe00-6985-11e8-8ad4-22fa25758d39.png">
Save button is active after changing zone
<img width="1200" alt="screen shot 2018-06-06 at 12 30 40 pm" src="https://user-images.githubusercontent.com/9210860/41033088-a319f6e6-6985-11e8-99bd-de2a26f7a99f.png">

@miq-bot add_label bug,  wip

