### PR TITLE
Do not try to prepend TreeNode images with 100/

### DIFF
--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -92,8 +92,6 @@ module TreeNode
                        image
                      elsif image =~ %r{^[a-zA-Z0-9]+/}
                        ActionController::Base.helpers.image_path(image)
-                     else
-                       ActionController::Base.helpers.image_path("100/#{image}")
                      end
 
       node.delete_if { |_, v| v.nil? }


### PR DESCRIPTION
There are no more `png` images under `app/presenters/tree_node` and the ones in decorators are already prepended with `100/`.

@miq-bot add_label cleanup, gaprindashvili/no, trees