### PR TITLE
Replace miq_request.png with pficon-unknown in MiqProvisionDecorator

### DIFF
--- a/app/decorators/miq_provision_decorator.rb
+++ b/app/decorators/miq_provision_decorator.rb
@@ -1,5 +1,5 @@
 class MiqProvisionDecorator < MiqDecorator
-  def self.fileicon
-    '100/miq_request.png'
+  def self.fonticon
+    'pficon pficon-unknown'
   end
 end


### PR DESCRIPTION
The `100/miq_request.png` is a big question mark, practically the same as `pficon-unknown`, so replacing.

Parent issue: #4051

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label graphics, gaprindashvili/no