### PR TITLE
Replace orchestration-stack.png with its icon in textual summaries

### DIFF
--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -146,7 +146,7 @@ module ServiceHelper::TextualSummary
     ost = @record.try(:orchestration_stack)
     if ost && !ost.id.present?
       {:label => _("Orchestration Stack"),
-       :image => "100/orchestration_stack.png",
+       :icon => 'ff ff-stack',
        :value => ost.name,
        :title => _("Invalid Stack")}
     elsif ost


### PR DESCRIPTION
We don't like PNG files anymore and there's a fonticon alternative for this.

Parent issue: #4051

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @epwinchell 
@miq-bot add_label textual summaries, graphics, gaprindashvili/no