### PR TITLE
Removing obsolete method for storage button action handling

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -825,13 +825,6 @@ module ApplicationController::CiProcessing
     end
   end
 
-  # Refresh all selected or single displayed Datastore(s)
-  def refreshstorage
-    assert_privileges("storage_refresh")
-    generic_button_operation('refresh_ems', _('Refresh'), storage_button_action,
-                             :refresh_partial => %w(vm hosts).include?(@display) ? 'layouts/gtl' : 'config')
-  end
-
   # Scan all selected or single displayed storage(s)
   def scanstorage
     assert_privileges("storage_scan")

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -241,7 +241,6 @@ module EmsCommon
       when "host_provide"                     then providehosts
       # Storages
       when "storage_delete"                   then deletestorages
-      when "storage_refresh"                  then refreshstorage
       when "storage_scan"                     then scanstorage
       when "storage_tag"                      then tag(Storage)
       # Edit Tags for Network Manager Relationship pages

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -303,7 +303,6 @@ class HostController < ApplicationController
       process_vm_buttons(pfx)
 
       scanstorage if params[:pressed] == "storage_scan"
-      refreshstorage if params[:pressed] == "storage_refresh"
       tag(Storage) if params[:pressed] == "storage_tag"
 
       # Control transferred to another screen, so return

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -105,7 +105,6 @@ class StorageController < ApplicationController
       end
     else
       @refresh_div = "main_div" # Default div for button.rjs to refresh
-      refreshstorage if params[:pressed] == "storage_refresh"
       tag(Storage) if params[:pressed] == "storage_tag"
       scanstorage if params[:pressed] == "storage_scan"
       deletestorages if params[:pressed] == "storage_delete"


### PR DESCRIPTION
Continuation of changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/3660

Removing method `storage_button_operation`, replaced by `generic_button_operation` mentioned in the PR above.

I couldn't find a way to test this in UI with a successful result, but the behaviour seems to be the same as in master.

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/pull/3660