### PR TITLE
Display two new added columns in Openscap rule results page

### DIFF
--- a/product/views/OpenscapRuleResult.yaml
+++ b/product/views/OpenscapRuleResult.yaml
@@ -42,7 +42,7 @@ headers:
 - Result
 - Severity
 - Title
-- CVE
+- CVEs
 
 # Condition(s) string for the SQL query
 conditions:

--- a/product/views/OpenscapRuleResult.yaml
+++ b/product/views/OpenscapRuleResult.yaml
@@ -22,6 +22,8 @@ cols:
 - name
 - result
 - severity
+- title
+- cves
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -31,12 +33,16 @@ col_order:
 - name
 - result
 - severity
+- title
+- cves
 
 # Column titles, in order
 headers:
 - Name
 - Result
 - Severity
+- Title
+- CVE
 
 # Condition(s) string for the SQL query
 conditions:


### PR DESCRIPTION
Display new added title and CVEs information in Openscap rule results page.

https://bugzilla.redhat.com/show_bug.cgi?id=1561959

Depends on: 
https://github.com/ManageIQ/manageiq-schema/pull/214
https://github.com/ManageIQ/manageiq/pull/17219