### PR TITLE
Add patternfly-react in ui-classic

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
+    "patternfly-react": "2.3.4",
     "@manageiq/react-ui-components": "^0.5.0",
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",


### PR DESCRIPTION
`patternfly-react` is a shared package across various plugins like v2v and now react-ui-components

Adding it here ensures that Classic UI is the single point of control for `patternfly-react` 

The `patternfly-react` entry in other repos is overridden with this change -- which is exactly what we want, as it resolves version difference nightmares.

Fixes https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/363