### PR TITLE
[WIP] Add missing info about unavailable fields while adding/editing Report

### DIFF
--- a/app/views/report/_form_columns.html.haml
+++ b/app/views/report/_form_columns.html.haml
@@ -26,6 +26,13 @@
       = render :partial => "column_lists"
     %strong
       = _('* Caution: Changing these fields will clear all selected values below them!')
+    - unavailable_fields = MiqExpression.human_unavailable_fields_for(@edit[:new][:model])
+    - if unavailable_fields.present?
+      %br
+      %p{:style => "max-width: 850px;"}
+        %strong
+          = _("* Caution: %{unav_fields} are not supported for %{rep_base}.") % {:unav_fields => unavailable_fields, :rep_base => Dictionary.gettext(@edit[:new][:model], :type => :model, :notfound => :titleize, :plural => true)}
+
     %hr
       %h3
         = _('Report Creation Timeout')


### PR DESCRIPTION
**Partially fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1581817

**Depends on:**
https://github.com/ManageIQ/manageiq/pull/17501

---

**What:**
When choosing _Chargeback for Images/Projects/Vms_ under _Configure Report Columns_ section while adding a new/editing an existing Report under _Cloud Intel > Reports > Reports_, some of the fields are not available. This is ok but there was a misunderstanding that those fields were missing there. This is why I add note/info about which fields are not supported to the Report editing screen (in this PR), and also new selector for Chargeback Rate editing screen (under _Cloud Intel > Chargeback > Rates_) is added to choose what the Rate is based on (_Images/Projects/Vms_) (other PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/4001). We call it the base model (see ManageIQ/manageiq-schema#209).

---

**Before:**
Choosing _Chargeback for Images_ while adding/editing report:
![images_before](https://user-images.githubusercontent.com/13417815/40662507-d292e1b0-6356-11e8-99a1-b045f76bf3fb.png)
Choosing _Chargeback for Projects_:
![projects_before](https://user-images.githubusercontent.com/13417815/40662511-d54e71e4-6356-11e8-9439-21bd7566980e.png)
Choosing _Chargeback for Vms_:
![vms_before](https://user-images.githubusercontent.com/13417815/40662515-d70b38c8-6356-11e8-8aae-ecf6cd9039e0.png)

**After:**
Choosing _Chargeback for Images_ while adding/editing report:
![images-after](https://user-images.githubusercontent.com/13417815/40841990-ae67db4e-65ac-11e8-9ada-6850662f9b97.png)
Choosing _Chargeback for Projects_:
![projects-after](https://user-images.githubusercontent.com/13417815/40841995-b258afa8-65ac-11e8-9e50-1fdc6fa6cdb3.png)
Choosing _Chargeback for Vms_:
![vms-after](https://user-images.githubusercontent.com/13417815/40841999-b6bba3ca-65ac-11e8-832c-427a59c24e93.png)