### PR TITLE
Fix Request Info for Catalog Items

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -526,11 +526,13 @@ class MiqRequestController < ApplicationController
     @title       = _("Requests")
     @request_tab = session[:request_tab] if session[:request_tab]
     @layout      = layout_from_tab_name(@request_tab)
+    @options     = session[:prov_options] if session[:prov_options].present?
   end
 
   def set_session_data
     super
-    session[:edit]        = @edit unless @edit.nil?
-    session[:request_tab] = @request_tab unless @request_tab.nil?
+    session[:edit]         = @edit unless @edit.nil?
+    session[:request_tab]  = @request_tab unless @request_tab.nil?
+    session[:prov_options] = @options if @options
   end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1584172

Data was never copied from session to @options when miq_request/prov_field_changed?tab_id=* request was fired

Services -> Catalogs -> Catalog Items -> choose any item with Request Info -> click Request Info -> click any tab in Request Info

Before:
<img width="931" alt="screen shot 2018-06-07 at 2 11 27 pm" src="https://user-images.githubusercontent.com/9210860/41098722-b26a08fc-6a5c-11e8-8c78-c888b052a954.png">

Console:
```
FATAL -- : Error caught: [NoMethodError] undefined method `[]=' for nil:NilClass
/manageiq-ui-classic/app/controllers/application_controller/miq_request_methods.rb:16:in `prov_field_changed'
/usr/local/lib/ruby/gems/2.3.0/gems/actionpack-5.0.7/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/usr/local/lib/ruby/gems/2.3.0/gems/actionpack-5.0.7/lib/abstract_controller/base.rb:188:in `process_action'
```
After:
<img width="877" alt="screen shot 2018-06-07 at 2 07 11 pm" src="https://user-images.githubusercontent.com/9210860/41098614-4ad4774a-6a5c-11e8-8cdc-a24b0bb8068c.png">

@miq-bot add_label bug, services