### PR TITLE
Adding power operation in physical switch pages

### DIFF
--- a/app/helpers/application_helper/toolbar/physical_switch_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_switch_center.rb
@@ -15,9 +15,34 @@ class ApplicationHelper::Toolbar::PhysicalSwitchCenter < ApplicationHelper::Tool
             N_('Refresh Relationships and Power States'),
             :image   => "refresh",
             :data    => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "refresh", "controller": "physicalSwitchToolbarController"}'},
+                         'function-data' => '{"type": "refresh", "controller": "toolbarActions", "payload": {"entity": "physical_switches"}}'},
             :confirm => N_("Refresh relationships and power states for all items related to this Physical Switch?"),
             :options => {:feature => :refresh}
+          ),
+        ]
+      ),
+    ]
+  )
+
+  button_group(
+    'physical_switches_operations',
+    [
+      select(
+        :physical_switches_power_choice,
+        'fa fa-power-off fa-lg',
+        N_('Power Functions'),
+        N_('Power'),
+        :items => [
+          button(
+            :physical_switch_restart,
+            nil,
+            N_('Restart the switch'),
+            N_('Restart'),
+            :icon    => "pficon pficon-restart fa-lg",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "restart", "controller": "toolbarActions", "payload": {"entity": "physical_switches"}}'},
+            :confirm => N_("Restart the switch?"),
+            :options => {:feature => :restart}
           ),
         ]
       ),

--- a/app/helpers/application_helper/toolbar/physical_switches_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_switches_center.rb
@@ -15,9 +15,40 @@ class ApplicationHelper::Toolbar::PhysicalSwitchesCenter < ApplicationHelper::To
             N_('Refresh Relationships and Power States'),
             :image   => "refresh",
             :data    => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "refresh", "controller": "physicalSwitchToolbarController"}'},
+                         'function-data' => '{"type": "refresh", "controller": "toolbarActions", "payload": {"entity": "physical_switches"}}'},
             :confirm => N_("Refresh relationships and power states for all items related to these Physical Switches?"),
+            :enabled => false,
+            :onwhen  => "1+",
             :options => {:feature => :refresh}
+          ),
+        ]
+      ),
+    ]
+  )
+
+  button_group(
+    'physical_switches_operations',
+    [
+      select(
+        :physical_switches_power_choice,
+        'fa fa-power-off fa-lg',
+        N_('Power Functions'),
+        N_('Power'),
+        :items => [
+          button(
+            :physical_switch_restart,
+            nil,
+            N_('Restart the selected switches'),
+            N_('Restart'),
+            :icon    => "pficon pficon-restart fa-lg",
+            :data    => {
+              'function'      => 'sendDataWithRx',
+              'function-data' => '{"type": "restart", "controller": "toolbarActions", "payload": {"entity": "physical_switches"}}'
+            },
+            :confirm => N_("Restart the selected switches?"),
+            :enabled => false,
+            :onwhen  => "1+",
+            :options => {:feature => :restart}
           ),
         ]
       ),

--- a/app/javascript/miq_observable.js
+++ b/app/javascript/miq_observable.js
@@ -18,3 +18,5 @@ export function subscribeToRx(eventMapper, controllerName) {
  * Event types are stored here.
  */
 export const DELETE_EVENT = 'delete'; // Reacts to event - {type: 'delete', payload: {...}}
+export const REFRESH_EVENT = 'refresh'; // Reacts to event - {type: 'refresh', payload: {...}}
+export const RESTART_EVENT = 'restart'; // Reacts to event - {type: 'restart', payload: {...}}

--- a/app/javascript/packs/toolbar-actions.js
+++ b/app/javascript/packs/toolbar-actions.js
@@ -1,5 +1,7 @@
-import { subscribeToRx, DELETE_EVENT } from '../miq_observable';
+import { subscribeToRx, DELETE_EVENT, REFRESH_EVENT, RESTART_EVENT } from '../miq_observable';
 import { onDelete } from '../toolbar-actions/delete';
+import { onRefresh } from '../toolbar-actions/refresh';
+import { onRestart } from '../toolbar-actions/restart';
 
 function transformResource(resource) {
   return ({ id: resource });
@@ -18,11 +20,13 @@ export function getGridChecks() {
  *     {type: 'example', payload: {...}}
  * You need to add:
  *     example: (data) => exampleFunction(data)
- * Where exampleFunction is you function which is triggered whenever new action is dispatched 
+ * Where exampleFunction is you function which is triggered whenever new action is dispatched
  * to RX with type 'example'.
  */
 const eventMapper = {
   [DELETE_EVENT]: data => onDelete(data, getGridChecks()),
+  [REFRESH_EVENT]: data => onRefresh(data, getGridChecks()),
+  [RESTART_EVENT]: data => onRestart(data, getGridChecks()),
 };
 
 subscribeToRx(eventMapper, 'toolbarActions');

--- a/app/javascript/toolbar-actions/refresh.js
+++ b/app/javascript/toolbar-actions/refresh.js
@@ -1,0 +1,33 @@
+import { REFRESH_EVENT } from '../miq_observable';
+
+const API = angular.injector(['ng', 'miq.api']).get('API');
+const API_ENDPOINT = 'api';
+const add_flash = window.add_flash;
+
+export function showMessage(message, success) {
+  if (typeof message === 'string') {
+    add_flash(message, success ? 'success' : 'error');
+  } else if (success) {
+    add_flash(sprintf(__('Refresh of selected items queued.'), 'success'));
+  } else {
+    add_flash(sprintf(__('Failed to refresh selected items.'), 'error'));
+  }
+}
+
+export function APIRefresh(entity, resources) {
+  resources.forEach((resource) => {
+    var id = resource.id;
+    API.post(`/${API_ENDPOINT}/${entity}/${id}`, { action: REFRESH_EVENT })
+      .then((data) => {
+        showMessage(data.message, data.success);
+      });
+  });
+}
+
+export function onRefresh(data, resources) {
+  if (data.customAction) {
+    customActionDelete(data, resources);
+  } else {
+    APIRefresh(data.entity, resources);
+  }
+}

--- a/app/javascript/toolbar-actions/restart.js
+++ b/app/javascript/toolbar-actions/restart.js
@@ -1,0 +1,56 @@
+import { RESTART_EVENT } from '../miq_observable';
+
+const API = angular.injector(['ng', 'miq.api']).get('API');
+const API_ENDPOINT = 'api';
+const add_flash = window.add_flash;
+
+export function showMessage(messages, success) {
+  if (typeof messages === 'string') {
+    add_flash(messages, success ? 'success' : 'error');
+  } else {
+    Object.keys(messages).forEach((msgStatus) => {
+      const statusKey = msgStatus === 'true';
+      if (statusKey && messages[statusKey] > 0) {
+        add_flash(sprintf(__('Restarting of %s items queued.'), messages[statusKey]), 'success');
+      } else if (messages[statusKey] > 0) {
+        add_flash(sprintf(__('Failed to restart %s items.'), messages[statusKey]), 'error');
+      }
+    });
+  }
+}
+
+export function generateMessages(results) {
+  return results.reduce((messages, result) => {
+    const statusMessages = Object.assign(messages);
+    if (Object.prototype.hasOwnProperty.call(result, 'success')) {
+      statusMessages[result.success] += 1;
+    }
+    return statusMessages;
+  }, { false: 0, true: 0 });
+}
+
+export function APIRestart(entity, resources) {
+  API.post(`/${API_ENDPOINT}/${entity}`, {
+    action: RESTART_EVENT,
+    resources,
+  })
+  .then((data) => {
+    if (data.results.length > 1) {
+      showMessage(generateMessages(data.results));
+    } else if (data.results.length === 1) {
+      showMessage(data.results[0].message, data.results[0].success);
+    }
+  });
+}
+
+export function customActionRestart(_data, _resources) {
+  throw new Error('customURLRestart not implemented yet');
+}
+
+export function onRestart(data, resources) {
+  if (data.customAction) {
+    customActionRestart(data, resources);
+  } else {
+    APIRestart(data.entity, resources);
+  }
+}

--- a/app/views/physical_switch/show.html.haml
+++ b/app/views/physical_switch/show.html.haml
@@ -8,7 +8,4 @@
     - when "timeline"
       = render :partial => "layouts/tl_show_async"
 
-  %physical-switch-toolbar#physical_switch_show_form{'physical_switch-id' => @record.id}
-
-:javascript
-  miq_bootstrap('#physical_switch_show_form');
+= render :partial => "layouts/toolbar_actions"

--- a/app/views/physical_switch/show_list.html.haml
+++ b/app/views/physical_switch/show_list.html.haml
@@ -1,7 +1,4 @@
 #main_div
   = render :partial => 'layouts/gtl'
 
-  %physical-switch-toolbar#physical_switch_show_list_form
-
-:javascript
-  miq_bootstrap('#physical_switch_show_list_form');
+= render :partial => "layouts/toolbar_actions"


### PR DESCRIPTION
__This PR is able to__
- Add the `Power` button in Physical Switches summary and detail pages with the `restart` action.

![screenshot-localhost 3000-2018-06-07-11-38-50](https://user-images.githubusercontent.com/8550928/41106982-a5e13d04-6a47-11e8-86ec-a14742a95428.png)

![screenshot-localhost 3000-2018-06-07-11-34-47](https://user-images.githubusercontent.com/8550928/41106996-ae343786-6a47-11e8-8bbc-3413202a8c86.png)

- Refactor the `refresh` action routine to the new structure introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/3436

__Depends on__
- ~https://github.com/ManageIQ/manageiq-api/pull/392~ - Merged