### PR TITLE
TextualSummary: unify power stated.

### DIFF
--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module HostHelper::TextualSummary
   include TextualMixins::TextualDevices
   include TextualMixins::TextualOsInfo
   include TextualMixins::TextualVmmInfo
+  include TextualMixins::TextualPowerState
   # TODO: Determine if DoNav + url_for + :title is the right way to do links, or should it be link_to with :title
 
   #
@@ -163,9 +164,7 @@ module HostHelper::TextualSummary
   end
 
   def textual_power_state
-    state = @record.state.to_s.downcase
-    state = "unknown" if state.blank?
-    {:label => _("Power State"), :image => "svg/currentstate-#{state}.svg", :value => state}
+    textual_power_state_whitelisted(@record.state)
   end
 
   def textual_lockdown_mode

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -1,4 +1,6 @@
 module PhysicalServerHelper::TextualSummary
+  include TextualMixins::TextualPowerState
+
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
@@ -105,7 +107,7 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_power_state
-    {:label => _("Power State"), :value => @record.power_state}
+    textual_power_state_whitelisted(@record.power_state)
   end
 
   def textual_mac

--- a/app/helpers/physical_switch_helper/textual_summary.rb
+++ b/app/helpers/physical_switch_helper/textual_summary.rb
@@ -1,4 +1,6 @@
 module PhysicalSwitchHelper::TextualSummary
+  include TextualMixins::TextualPowerState
+
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
@@ -69,7 +71,7 @@ module PhysicalSwitchHelper::TextualSummary
   end
 
   def textual_power_state
-    {:label => _("Power State"), :value => @record.power_state}
+    textual_power_state_whitelisted(@record.power_state)
   end
 
   def management_networks

--- a/app/helpers/textual_mixins/textual_power_state.rb
+++ b/app/helpers/textual_mixins/textual_power_state.rb
@@ -1,9 +1,22 @@
 module TextualMixins::TextualPowerState
-  def textual_power_state
-    state = @record.current_state.downcase
-    state = "unknown" if state.blank?
-    h = {:label => _("Power State"), :value => state}
-    h[:image] = "svg/currentstate-#{@record.template? ? 'template' : state}.svg"
-    h
+  VALID_POWER_STATE = %w(
+    archived connecting disconnected image_locked install_failed maintenance
+    migrating never non_operational not_responding off on orphaned paused
+    powering_down powering-down powering_up powering-up preparing_for_maintenance
+    reboot_in_progress retired shelved_offloaded shelved standby suspended
+    template terminated unknown wait_for_launch
+  ).freeze
+
+  def power_state_to_image(state)
+    "svg/currentstate-#{state}.svg" if VALID_POWER_STATE.include?(state)
+  end
+
+  def textual_power_state_whitelisted(state)
+    state = state.blank? ? 'unknown' : state.downcase
+    {:label => _('Power State'), :value => state, :image => power_state_to_image(state)}
+  end
+
+  def textual_power_state_whitelisted_with_template
+    textual_power_state_whitelisted(@record.template? ? 'template' : @record.current_state)
   end
 end

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -37,6 +37,10 @@ module VmCloudHelper::TextualSummary
   #
   # Items
   #
+  def textual_power_state
+    textual_power_state_whitelisted_with_template
+  end
+
   def textual_ipaddress
     return nil if @record.template?
     ips = @record.ipaddresses

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -101,6 +101,10 @@ module VmHelper::TextualSummary
   #
   # Items
   #
+  def textual_power_state
+    textual_power_state_whitelisted_with_template
+  end
+
   def textual_hostname
     hostnames = @record.hostnames
     {:label => n_("Hostname", "Hostnames", hostnames.size), :value => hostnames.join(", ")}


### PR DESCRIPTION
Unify the display of power state in textual summaries (detail screens).

Display a power state icon.

ping @terezanovotna, @Loicavenel

### New
![ts-phys-new](https://user-images.githubusercontent.com/51095/41110743-6b65b4ce-6a7a-11e8-99a8-2817e3ad3603.png)

### Old
![ts-phys-old](https://user-images.githubusercontent.com/51095/41110746-6cef6632-6a7a-11e8-9098-2110a80e793e.png)

