### PR TITLE
General spec cleanupFix spec user stubbing

### DIFF
--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -1,7 +1,6 @@
 describe AnsibleCredentialController do
   before do
-    EvmSpecHelper.create_guid_miq_server_zone
-    MiqRegion.seed
+    EvmSpecHelper.assign_embedded_ansible_role
     login_as FactoryGirl.create(:user_admin)
   end
 
@@ -31,7 +30,7 @@ describe AnsibleCredentialController do
     end
 
     it 'renders the correct toolbar' do
-      expect(ApplicationHelper::Toolbar::AnsibleCredentialsCenter).to receive(:definition)
+      expect(ApplicationHelper::Toolbar::AnsibleCredentialsCenter).to receive(:definition).and_call_original
       post :show_list
     end
   end

--- a/spec/controllers/ansible_playbook_controller_spec.rb
+++ b/spec/controllers/ansible_playbook_controller_spec.rb
@@ -36,7 +36,7 @@ describe AnsiblePlaybookController do
     end
 
     it 'renders the correct toolbar' do
-      expect(ApplicationHelper::Toolbar::AnsiblePlaybooksCenter).to receive(:definition)
+      expect(ApplicationHelper::Toolbar::AnsiblePlaybooksCenter).to receive(:definition).and_call_original
       post :show_list
     end
   end

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -1,7 +1,6 @@
 describe AnsibleRepositoryController do
   before do
-    EvmSpecHelper.create_guid_miq_server_zone
-    MiqRegion.seed
+    EvmSpecHelper.assign_embedded_ansible_role
     login_as FactoryGirl.create(:user_admin)
   end
 
@@ -33,7 +32,7 @@ describe AnsibleRepositoryController do
     end
 
     it 'renders the correct toolbar' do
-      expect(ApplicationHelper::Toolbar::AnsibleRepositoriesCenter).to receive(:definition)
+      expect(ApplicationHelper::Toolbar::AnsibleRepositoriesCenter).to receive(:definition).and_call_original
       post :show_list
     end
   end

--- a/spec/controllers/application_controller/filter/expression_spec.rb
+++ b/spec/controllers/application_controller/filter/expression_spec.rb
@@ -6,7 +6,7 @@ describe ApplicationController::Filter do
     let(:expression)     { ApplicationController::Filter::Expression.new.tap { |e| e.exp_model = 'Vm' } }
 
     before do
-      allow(User).to receive(:current_user).and_return(user)
+      login_as user
     end
 
     it 'returns user searches' do

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -685,12 +685,14 @@ describe AutomationManagerController do
     end
 
     it "cancels tags edit" do
+      allow(controller).to receive(:previous_breadcrumb_url).and_return("previous-url")
       post :tagging_edit, :params => {:button => "cancel", :format => :js, :id => @ans_configured_system.id}
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
       expect(assigns(:edit)).to be_nil
     end
 
     it "save tags" do
+      allow(controller).to receive(:previous_breadcrumb_url).and_return("previous-url")
       post :tagging_edit, :params => {:button => "save", :format => :js, :id => @ans_configured_system.id}
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -263,7 +263,6 @@ describe AutomationManagerController do
     automation_manager2 = ManageIQ::Providers::AnsibleTower::AutomationManager.find_by(:provider_id => automation_provider2.id)
     automation_manager3 = ManageIQ::Providers::AnsibleTower::AutomationManager.find_by(:provider_id => automation_provider3.id)
     user = login_as user_with_feature(%w(automation_manager_providers providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
-    allow(User).to receive(:current_user).and_return(user)
     TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, :automation_manager_providers, controller.instance_variable_get(:@sb))
     tree_builder = TreeBuilderAutomationManagerProviders.new("root", "", {})
     objects = tree_builder.send(:x_get_tree_roots, false, {})
@@ -281,7 +280,6 @@ describe AutomationManagerController do
 
   it "builds ansible tower job templates tree" do
     user = login_as user_with_feature(%w(automation_manager_providers providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
-    allow(User).to receive(:current_user).and_return(user)
     TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, :configuration_scripts, controller.instance_variable_get(:@sb))
     tree_builder = TreeBuilderAutomationManagerConfigurationScripts.new("root", "", {})
     objects = tree_builder.send(:x_get_tree_roots, false, {})
@@ -291,7 +289,6 @@ describe AutomationManagerController do
 
   it "constructs the ansible tower job templates tree node" do
     user = login_as user_with_feature(%w(providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
-    allow(User).to receive(:current_user).and_return(user)
     TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, :configuration_scripts, controller.instance_variable_get(:@sb))
     tree_builder = TreeBuilderAutomationManagerConfigurationScripts.new("root", "", {})
     root_objects = tree_builder.send(:x_get_tree_roots, false, {})

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -81,9 +81,6 @@ describe CloudNetworkController do
 
       EvmSpecHelper.create_guid_miq_server_zone
       EvmSpecHelper.seed_specific_product_features(%w(cloud_network_new ems_network_show_list))
-
-      allow(User).to receive(:current_user).and_return(user)
-      allow(Rbac).to receive(:role_allows?).and_call_original
       login_as user
     end
 

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -82,8 +82,6 @@ describe CloudSubnetController do
       EvmSpecHelper.create_guid_miq_server_zone
       EvmSpecHelper.seed_specific_product_features(%w(cloud_subnet_new ems_network_show_list cloud_network_show_list cloud_tenant_show_list))
 
-      allow(User).to receive(:current_user).and_return(user)
-      allow(Rbac).to receive(:role_allows?).and_call_original
       login_as user
     end
 

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -73,7 +73,7 @@ describe CloudTenantController do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       @tenant = FactoryGirl.create(:cloud_tenant)
-      login_as FactoryGirl.create(:user)
+      login_as FactoryGirl.create(:user, :features => "none")
     end
 
     subject do

--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -100,8 +100,6 @@ describe CloudVolumeController do
       EvmSpecHelper.create_guid_miq_server_zone
       EvmSpecHelper.seed_specific_product_features(%w(cloud_volume_new))
 
-      allow(User).to receive(:current_user).and_return(user)
-      allow(Rbac).to receive(:role_allows?).and_call_original
       login_as user
     end
 

--- a/spec/controllers/configuration_controller_spec.rb
+++ b/spec/controllers/configuration_controller_spec.rb
@@ -16,6 +16,7 @@ describe ConfigurationController do
   describe "building tabs" do
     before(:each) do
       controller.instance_variable_set(:@tabform, "ui_2")
+      login_as FactoryGirl.create(:user, :features => "everything")
     end
 
     it 'sets the active tab' do
@@ -24,7 +25,6 @@ describe ConfigurationController do
     end
 
     it 'sets the available tabs' do
-      allow(controller).to receive(:role_allows?).and_return(true)
       controller.send(:build_tabs)
 
       expect(assigns(:tabs)).to eq([

--- a/spec/controllers/ems_block_storage_controller_spec.rb
+++ b/spec/controllers/ems_block_storage_controller_spec.rb
@@ -2,29 +2,24 @@ describe EmsBlockStorageController do
   include_examples :shared_examples_for_ems_block_storage_controller, %w(openstack)
 
   describe "#check_generic_rbac" do
-    let(:feature) { MiqProductFeature.find_all_by_identifier(%w(cloud_subnet_new)) }
-    let(:role)    { FactoryGirl.create(:miq_user_role, :miq_product_features => feature) }
-    let(:group)   { FactoryGirl.create(:miq_group, :miq_user_role => role) }
-    let(:user)    { FactoryGirl.create(:user, :miq_groups => [group]) }
+    let(:feature) { %w(cloud_subnet_new) }
+    let(:user)    { FactoryGirl.create(:user, :features => feature) }
 
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
+      setup_zone
       EvmSpecHelper.seed_specific_product_features(%w(cloud_subnet_new ems_block_storage_show_list))
-
-      allow(User).to receive(:current_user).and_return(user)
-      allow(Rbac).to receive(:role_allows?).and_call_original
       login_as user
     end
 
-    it "denies access because user don't have needed role feature" do
+    it "denies access because user don't have needed role feature" do ##
       controller.action_name = 'report_data'
       expect(controller.send(:check_generic_rbac)).to be_falsey
     end
 
     context 'user has needed role feature' do
-      let(:feature) { MiqProductFeature.find_all_by_identifier(%w(ems_block_storage_show_list)) }
+      let(:feature) { %w(ems_block_storage_show_list) }
 
-      it "allows access" do
+      it "allows access" do ##
         controller.action_name = 'report_data'
         expect(controller.send(:check_generic_rbac)).to be_truthy
       end
@@ -35,6 +30,8 @@ describe EmsBlockStorageController do
     render_views
 
     it 'renders the view and the Block Storage Managers toolbar' do
+      setup_zone
+      login_as FactoryGirl.create(:user, :features => "everything")
       expect(ApplicationHelper::Toolbar::GtlView).to receive(:definition).and_call_original
       expect(ApplicationHelper::Toolbar::EmsBlockStoragesCenter).to receive(:definition).and_call_original
       post :show_list

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -437,7 +437,7 @@ describe EmsCloudController do
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryGirl.create(:user, :features => "none")
       session[:settings] = {:views     => {:vm_summary_cool => "summary"},
                             :quadicons => {}}
       @ems = FactoryGirl.create(:ems_amazon)

--- a/spec/controllers/ems_cluster_controller_spec.rb
+++ b/spec/controllers/ems_cluster_controller_spec.rb
@@ -65,7 +65,7 @@ describe EmsClusterController do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       @cluster = FactoryGirl.create(:ems_cluster)
-      login_as FactoryGirl.create(:user)
+      login_as FactoryGirl.create(:user, :features => "none")
     end
 
     subject do

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -94,11 +94,11 @@ describe EmsInfraController do
 
   describe "#create" do
     before do
-      user = FactoryGirl.create(:user, :features => "ems_infra_new")
+      # USE: stub_user :features => %w(ems_infra_new ems_infra_edit)
+      user = FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
 
       allow(user).to receive(:server_timezone).and_return("UTC")
       allow_any_instance_of(described_class).to receive(:set_user_time_zone)
-      allow(controller).to receive(:check_privileges).and_return(true)
       login_as user
     end
 
@@ -273,7 +273,7 @@ describe EmsInfraController do
     render_views
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryGirl.create(:user, :features => "none")
       @ems = FactoryGirl.create(:ems_vmware)
     end
 
@@ -417,9 +417,7 @@ describe EmsInfraController do
 
   describe "SCVMM - create, update, validate, cancel" do
     before do
-      allow(controller).to receive(:check_privileges).and_return(true)
-      allow(controller).to receive(:assert_privileges).and_return(true)
-      login_as FactoryGirl.create(:user, :features => "ems_infra_new")
+      login_as FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
     end
 
     render_views
@@ -508,9 +506,7 @@ describe EmsInfraController do
 
   describe "Openstack - create, update" do
     before do
-      allow(controller).to receive(:check_privileges).and_return(true)
-      allow(controller).to receive(:assert_privileges).and_return(true)
-      login_as FactoryGirl.create(:user, :features => "ems_infra_new")
+      login_as FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
     end
 
     render_views
@@ -591,10 +587,7 @@ describe EmsInfraController do
 
   describe "Redhat - create, update" do
     before do
-      allow(controller).to receive(:check_privileges).and_return(true)
-      allow(controller).to receive(:assert_privileges).and_return(true)
-      ems = FactoryGirl.create(:user, :features => "ems_infra_new")
-      login_as ems
+      login_as FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
       allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager)
         .to receive(:supported_api_versions).and_return([3, 4])
     end
@@ -697,9 +690,7 @@ describe EmsInfraController do
 
   describe "Kubevirt - update" do
     before do
-      allow(controller).to receive(:check_privileges).and_return(true)
-      allow(controller).to receive(:assert_privileges).and_return(true)
-      login_as FactoryGirl.create(:user, :features => "ems_infra_new")
+      login_as FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
     end
 
     render_views
@@ -774,9 +765,7 @@ describe EmsInfraController do
 
   describe "VMWare - create, update" do
     before do
-      allow(controller).to receive(:check_privileges).and_return(true)
-      allow(controller).to receive(:assert_privileges).and_return(true)
-      login_as FactoryGirl.create(:user, :features => "ems_infra_new")
+      login_as FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
     end
 
     render_views

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -286,7 +286,7 @@ describe EmsInfraController do
       it { is_expected.to have_http_status 200 }
 
       it 'timeline toolbar is selected' do
-        expect(ApplicationHelper::Toolbar::TimelineCenter).to receive(:definition)
+        expect(ApplicationHelper::Toolbar::TimelineCenter).to receive(:definition).and_call_original
         subject
       end
     end

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -103,7 +103,7 @@ describe EmsInfraController do
     end
 
     it "adds a new provider" do
-      controller.instance_variable_set(:@breadcrumbs, [])
+      allow(controller).to receive(:previous_breadcrumb_url).and_return("previous-url")
       get :new
       expect(response.status).to eq(200)
     end

--- a/spec/controllers/ems_object_storage_controller_spec.rb
+++ b/spec/controllers/ems_object_storage_controller_spec.rb
@@ -5,6 +5,8 @@ describe EmsObjectStorageController do
     render_views
 
     it 'renders the view and the Object Storage Managers toolbar' do
+      setup_zone
+      stub_user :features => :all
       expect(ApplicationHelper::Toolbar::GtlView).to receive(:definition).and_call_original
       expect(ApplicationHelper::Toolbar::EmsObjectStoragesCenter).to receive(:definition).and_call_original
       post :show_list

--- a/spec/controllers/ems_physical_infra_controller_spec.rb
+++ b/spec/controllers/ems_physical_infra_controller_spec.rb
@@ -23,7 +23,7 @@ describe EmsPhysicalInfraController do
     render_views
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryGirl.create(:user, :features => "none")
       @ems = FactoryGirl.create(:ems_physical_infra)
     end
 

--- a/spec/controllers/ems_storage_controller_spec.rb
+++ b/spec/controllers/ems_storage_controller_spec.rb
@@ -14,9 +14,6 @@ describe EmsStorageController do
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       EvmSpecHelper.seed_specific_product_features(%w(ems_block_storage_show ems_block_storage_show_list))
-
-      allow(User).to receive(:current_user).and_return(user)
-      allow(Rbac).to receive(:role_allows?).and_call_original
       login_as user
     end
 

--- a/spec/controllers/floating_ip_controller_spec.rb
+++ b/spec/controllers/floating_ip_controller_spec.rb
@@ -36,7 +36,6 @@ describe FloatingIpController do
       before do
         EvmSpecHelper.create_guid_miq_server_zone
         login_as admin_user
-        allow(User).to receive(:current_user).and_return(admin_user)
         allow(controller).to receive(:assert_privileges)
         allow(controller).to receive(:performed?)
         controller.instance_variable_set(:@_params, :id => floating_ip.id, :pressed => 'host_NECO')

--- a/spec/controllers/generic_object_controller_spec.rb
+++ b/spec/controllers/generic_object_controller_spec.rb
@@ -6,7 +6,7 @@ describe GenericObjectController do
     render_views
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryGirl.create(:user, :features => "none")
       generic_obj_defn = FactoryGirl.create(:generic_object_definition)
       generic_obj = FactoryGirl.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
       get :show, :params => {:id => generic_obj.id}

--- a/spec/controllers/generic_object_definition_controller_spec.rb
+++ b/spec/controllers/generic_object_definition_controller_spec.rb
@@ -6,7 +6,7 @@ describe GenericObjectDefinitionController do
     render_views
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryGirl.create(:user, :features => "none")
     end
 
     it "should redirect to #show_list" do
@@ -78,7 +78,7 @@ describe GenericObjectDefinitionController do
   context "#process_root_node" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryGirl.create(:user, :features => "none")
     end
 
     it "renders the toolbar for 'show_list'" do

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -317,7 +317,7 @@ describe HostController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryGirl.create(:user, :features => "none")
       @host = FactoryGirl.create(:host,
                                  :hardware => FactoryGirl.create(:hardware,
                                                                  :cpu_sockets          => 2,

--- a/spec/controllers/infra_networking_controller_spec.rb
+++ b/spec/controllers/infra_networking_controller_spec.rb
@@ -19,7 +19,7 @@ describe InfraNetworkingController do
 
       it 'renders the network switch center toolbar' do
         nodeid = [ems, cluster, switch].map { |item| TreeNode.new(item).key }.join('_')
-        expect(ApplicationHelper::Toolbar::XInfraNetworkingSwitchCenter).to receive(:definition).and_return([]).at_least(:once)
+        expect(ApplicationHelper::Toolbar::XInfraNetworkingSwitchCenter).to receive(:definition).and_call_original.at_least(:once)
         post :tree_select, :params => { :id => nodeid }
       end
     end

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -1,7 +1,8 @@
 describe ReportController do
   render_views
+  let(:user) { FactoryGirl.create(:user, :features => "none") }
   before :each do
-    login_as FactoryGirl.create(:user_with_group)
+    login_as user
     EvmSpecHelper.create_guid_miq_server_zone
   end
 
@@ -21,8 +22,6 @@ describe ReportController do
       end
 
       it 'renders show' do
-        user = FactoryGirl.create(:user_with_group)
-        login_as user
         controller.instance_variable_set(:@html, "<h1>Test</h1>")
         allow(controller).to receive(:report_first_page)
         report = FactoryGirl.create(:miq_report_with_results)
@@ -107,8 +106,6 @@ describe ReportController do
         ApplicationController.handle_exceptions = true
 
         MiqWidgetSet.seed
-        user = FactoryGirl.create(:user_with_group)
-        login_as user
         widget_set = FactoryGirl.create(:miq_widget_set, :group_id => user.current_group.id)
         post :tree_select, :params => { :id => "xx-g_g-#{user.current_group.id}_-#{widget_set.id}", :format => :js, :accord => 'db' }
         expect(response).to render_template('report/_db_show')
@@ -182,15 +179,12 @@ describe ReportController do
       end
 
       it 'renders list of Roles in Roles tree' do
-        login_as FactoryGirl.create(:user_with_group)
         post :tree_select, :params => { :id => 'root', :format => :js, :accord => 'roles' }
         expect(response).to render_template('report/_role_list')
       end
 
       it 'renders form to edit Role in Roles tree' do
         FactoryGirl.create(:miq_report, :name => "VM 1", :rpt_group => "Configuration Management - Folder Foo", :rpt_type => "Default")
-        user = FactoryGirl.create(:user_with_group)
-        login_as user
         post :tree_select, :params => { :id => "g-#{user.current_group.id}", :format => :js, :accord => 'roles' }
         expect(response).to render_template('report/_menu_form1')
       end

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -61,7 +61,7 @@ describe MiqRequestController do
         it { is_expected.not_to include [:with_requester, user.id] }
       end
       context "logged without approval privileges" do
-        let(:user) { FactoryGirl.create(:user) }
+        let(:user) { FactoryGirl.create(:user, :features => "none") }
         it { is_expected.to include [:with_requester, user.id] }
       end
       context "selected 'another_user'" do

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -184,6 +184,8 @@ describe NetworkRouterController do
     let(:ems) { FactoryGirl.create(:ems_openstack).network_manager }
     let(:router) { FactoryGirl.create(:network_router_openstack, :name => "router-01", :ext_management_system => ems) }
     before do
+      stub_user(:features => :all)
+      setup_zone
       controller.instance_variable_set(:@_params, :id => router.id)
       controller.instance_variable_set(:@lastaction, "show")
       controller.instance_variable_set(:@layout, "network_router")

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -15,7 +15,6 @@ describe OpsController do
       before do
         allow(controller).to receive(:checked_or_params).and_return(Tenant.all.ids)
         login_as admin_user
-        allow(User).to receive(:current_user).and_return(admin_user)
       end
 
       it "processes selected record" do

--- a/spec/controllers/physical_switch_controller_spec.rb
+++ b/spec/controllers/physical_switch_controller_spec.rb
@@ -55,7 +55,7 @@ describe PhysicalSwitchController do
 
     context "physical switch toolbar is available" do
       it 'physical switch toolbar is available' do
-        expect(ApplicationHelper::Toolbar::PhysicalSwitchesCenter).to receive(:definition)
+        expect(ApplicationHelper::Toolbar::PhysicalSwitchesCenter).to receive(:definition).and_call_original
         subject
       end
     end
@@ -86,7 +86,7 @@ describe PhysicalSwitchController do
       subject { get(:show, :params => {:id => physical_switch.id}) }
 
       it 'physical switch toolbar is available' do
-        expect(ApplicationHelper::Toolbar::PhysicalSwitchCenter).to receive(:definition)
+        expect(ApplicationHelper::Toolbar::PhysicalSwitchCenter).to receive(:definition).and_call_original
         subject
       end
     end

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -672,10 +672,6 @@ describe ProviderForemanController do
       session[:edit] = edit
     end
 
-    after(:each) do
-      expect(response.status).to eq(200)
-    end
-
     it "builds tagging screen" do
       post :tagging, :params => {:format => :js, :miq_grid_checks => [@configured_system.id]}
       expect(assigns(:flash_array)).to be_nil
@@ -683,15 +679,19 @@ describe ProviderForemanController do
     end
 
     it "cancels tags edit" do
+      allow(controller).to receive(:previous_breadcrumb_url).and_return("previous-url")
       post :tagging_edit, :params => {:button => "cancel", :format => :js, :id => @configured_system.id}
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
       expect(assigns(:edit)).to be_nil
+      expect(response.status).to eq(200)
     end
 
     it "save tags" do
+      allow(controller).to receive(:previous_breadcrumb_url).and_return("previous-url")
       post :tagging_edit, :params => {:button => "save", :format => :js, :id => @configured_system.id}
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
+      expect(response.status).to eq(200)
     end
   end
 

--- a/spec/controllers/report_controller/schedules_spec.rb
+++ b/spec/controllers/report_controller/schedules_spec.rb
@@ -7,7 +7,6 @@ describe ReportController do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as admin_user
-      allow(User).to receive(:current_user).and_return(admin_user)
 
       schedule
       FactoryGirl.create(:miq_schedule, :name => "tester2")

--- a/spec/controllers/resource_pool_controller_spec.rb
+++ b/spec/controllers/resource_pool_controller_spec.rb
@@ -59,7 +59,7 @@ describe ResourcePoolController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryGirl.create(:user, :features => "none")
       @resource_pool = FactoryGirl.create(:resource_pool)
     end
 

--- a/spec/helpers/application_helper/buttons/condition_policy_spec.rb
+++ b/spec/helpers/application_helper/buttons/condition_policy_spec.rb
@@ -8,6 +8,7 @@ describe ApplicationHelper::Button::ConditionPolicy do
     end
 
     it "will be skipped" do
+      login_as FactoryGirl.create(:user, :features => "none")
       expect(@button.role_allows_feature?).to be false
     end
 

--- a/spec/helpers/application_helper/buttons/condition_spec.rb
+++ b/spec/helpers/application_helper/buttons/condition_spec.rb
@@ -8,6 +8,7 @@ describe ApplicationHelper::Button::Condition do
     end
 
     it "will be skipped" do
+      login_as FactoryGirl.create(:user, :features => "none")
       expect(@button.role_allows_feature?).to be false
     end
 

--- a/spec/helpers/application_helper/views_shared_spec.rb
+++ b/spec/helpers/application_helper/views_shared_spec.rb
@@ -24,7 +24,7 @@ describe ApplicationHelper do
     context 'admin user' do
       it 'lists all users' do
         allow(User).to receive(:server_timezone).and_return('UTC')
-        allow(User).to receive(:current_user).and_return(admin_user)
+        login_as admin_user
         expect(subject.count).to eq(User.count)
       end
     end
@@ -32,7 +32,7 @@ describe ApplicationHelper do
     context 'a tenant user' do
       it 'lists users in his group' do
         allow(User).to receive(:server_timezone).and_return('UTC')
-        allow(User).to receive(:current_user).and_return(grand_child_user)
+        login_as grand_child_user
         ids = grand_child_user.miq_groups.collect(&:user_ids).flatten.uniq
         expect(subject.values(&:id).map(&:to_i)).to match_array(ids)
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper do
   before do
-    login_as FactoryGirl.create(:user)
+    login_as FactoryGirl.create(:user, :features => "none")
   end
 
   context "build_toolbar" do

--- a/spec/presenters/tree_builder_ops_rbac_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_spec.rb
@@ -17,6 +17,7 @@ describe TreeBuilderOpsRbac do
     end
 
     it "has :open_all set to false" do
+      login_as FactoryGirl.create(:user, :features => 'none')
       tree = TreeBuilderOpsRbac.new("rbac_tree", "rbac", {})
       expect(tree.send(:tree_init_options, :open_all)[:open_all]).to be_falsey
     end
@@ -44,7 +45,7 @@ describe TreeBuilderOpsRbac do
   end
 
   describe "#x_get_tree_custom_kids" do
-    let(:group) { FactoryGirl.create(:miq_group) }
+    let(:group) { FactoryGirl.create(:miq_group, :features => "none") }
     let(:user) { FactoryGirl.create(:user, :miq_groups => [group, other_group]) }
     let(:other_group) { FactoryGirl.create(:miq_group) }
     let(:other_user) { FactoryGirl.create(:user, :miq_groups => [other_group]) }

--- a/spec/shared/controllers/shared_examples_for_cloud_network_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_cloud_network_controller.rb
@@ -2,14 +2,14 @@ require_relative 'shared_network_manager_context'
 
 shared_examples :shared_examples_for_cloud_network_controller do |providers|
   render_views
-  before :each do
-    stub_user(:features => :all)
-    setup_zone
-  end
 
   providers.each do |t|
     context "for #{t}" do
       include_context :shared_network_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe "#show_list" do
         it "renders index" do

--- a/spec/shared/controllers/shared_examples_for_cloud_subnet_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_cloud_subnet_controller.rb
@@ -2,14 +2,14 @@ require_relative 'shared_network_manager_context'
 
 shared_examples :shared_examples_for_cloud_subnet_controller do |providers|
   render_views
-  before :each do
-    stub_user(:features => :all)
-    setup_zone
-  end
 
   providers.each do |t|
     context "for #{t}" do
       include_context :shared_network_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe "#show_list" do
         it "renders index" do

--- a/spec/shared/controllers/shared_examples_for_ems_block_storage_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_block_storage_controller.rb
@@ -2,14 +2,14 @@ require_relative 'shared_storage_manager_context'
 
 shared_examples :shared_examples_for_ems_block_storage_controller do |providers|
   render_views
-  before :each do
-    stub_user(:features => :all)
-    setup_zone
-  end
 
   providers.each do |t|
     context "for #{t}" do
       include_context :shared_storage_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe "#show_list" do
         it "renders index" do
@@ -33,6 +33,10 @@ shared_examples :shared_examples_for_ems_block_storage_controller do |providers|
 
     context "for #{t}" do
       include_context :shared_storage_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe '#show_list' do
         render_views

--- a/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
@@ -2,14 +2,14 @@ require_relative 'shared_network_manager_context'
 
 shared_examples :shared_examples_for_ems_network_controller do |providers|
   render_views
-  before :each do
-    stub_user(:features => :all)
-    setup_zone
-  end
 
   providers.each do |t|
     context "for #{t}" do
       include_context :shared_network_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe "#show_list" do
         it "renders index" do

--- a/spec/shared/controllers/shared_examples_for_ems_object_storage_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_object_storage_controller.rb
@@ -2,14 +2,14 @@ require_relative 'shared_storage_manager_context'
 
 shared_examples :shared_examples_for_ems_object_storage_controller do |providers|
   render_views
-  before :each do
-    stub_user(:features => :all)
-    setup_zone
-  end
 
   providers.each do |t|
     context "for #{t}" do
       include_context :shared_storage_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe "#show_list" do
         it "renders index" do
@@ -33,6 +33,10 @@ shared_examples :shared_examples_for_ems_object_storage_controller do |providers
 
     context "for #{t}" do
       include_context :shared_storage_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe '#show_list' do
         render_views

--- a/spec/shared/controllers/shared_examples_for_ems_storage_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_storage_controller.rb
@@ -2,14 +2,14 @@ require_relative 'shared_storage_manager_context'
 
 shared_examples :shared_examples_for_ems_storage_controller do |providers|
   render_views
-  before :each do
-    stub_user(:features => :all)
-    setup_zone
-  end
 
   providers.each do |t|
     context "for #{t}" do
       include_context :shared_storage_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe "#show_list" do
         it "renders index" do

--- a/spec/shared/controllers/shared_examples_for_floating_ip_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_floating_ip_controller.rb
@@ -2,14 +2,14 @@ require_relative 'shared_network_manager_context'
 
 shared_examples :shared_examples_for_floating_ip_controller do |providers|
   render_views
-  before :each do
-    stub_user(:features => :all)
-    setup_zone
-  end
 
   providers.each do |t|
     context "for #{t}" do
       include_context :shared_network_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe "#show_list" do
         it "renders index" do

--- a/spec/shared/controllers/shared_examples_for_load_balancer_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_load_balancer_controller.rb
@@ -2,14 +2,14 @@ require_relative 'shared_network_manager_context'
 
 shared_examples :shared_examples_for_load_balancer_controller do |providers|
   render_views
-  before :each do
-    stub_user(:features => :all)
-    setup_zone
-  end
 
   providers.each do |t|
     context "for #{t}" do
       include_context :shared_network_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe "#show_list" do
         it "renders index" do

--- a/spec/shared/controllers/shared_examples_for_network_port_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_network_port_controller.rb
@@ -2,14 +2,14 @@ require_relative 'shared_network_manager_context'
 
 shared_examples :shared_examples_for_network_port_controller do |providers|
   render_views
-  before :each do
-    stub_user(:features => :all)
-    setup_zone
-  end
 
   providers.each do |t|
     context "for #{t}" do
       include_context :shared_network_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe "#show_list" do
         it "renders index" do

--- a/spec/shared/controllers/shared_examples_for_network_router_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_network_router_controller.rb
@@ -2,14 +2,14 @@ require_relative 'shared_network_manager_context'
 
 shared_examples :shared_examples_for_network_router_controller do |providers|
   render_views
-  before :each do
-    stub_user(:features => :all)
-    setup_zone
-  end
 
   providers.each do |t|
     context "for #{t}" do
       include_context :shared_network_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe "#show_list" do
         it "renders index" do

--- a/spec/shared/controllers/shared_examples_for_security_group_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_security_group_controller.rb
@@ -2,14 +2,14 @@ require_relative 'shared_network_manager_context'
 
 shared_examples :shared_examples_for_security_group_controller do |providers|
   render_views
-  before :each do
-    stub_user(:features => :all)
-    setup_zone
-  end
 
   providers.each do |t|
     context "for #{t}" do
       include_context :shared_network_manager_context, t
+      before :each do
+        stub_user(:features => :all)
+        setup_zone
+      end
 
       describe "#show_list" do
         it "renders index" do


### PR DESCRIPTION
A user's privileges are no longer tied to a role's name but rather to a user's group's role's features.
`user.miq_group.miq_user_role.miq_product_features`. I'm sorry to all the Law of Demeter fans.

### before

- We were stubbing authorization code to just say yes, never running through the code.
- There were errors in breadcrumb lookups and others that were hidden by that stubbing.
- Tag code in particular was throwing exceptions around breadcrumbs that were caught by authorization. (I think the actual code under test was never run)
- We were logging in as one user and then logging in as another. The stubbing was giving us a mixed state.
- We were blowing away admin user's features, making testing difficult. <== stopping my current BZ
- Ansible tests were not properly working around feature flag checks.

### After

- Many places we are now properly checking product features per authorization.
- Other places are checking authorization for the `"everything"` feature. It gives us a start for actual authorization checks in tests if we so choose.
- The code no longer throws exceptions hidden by authorization.
- Properly setting server roles to allow Ansible tests to run full code.
