### PR TITLE
Use fonticons instead of fileicons in the RegistryItemDecorator

### DIFF
--- a/app/decorators/registry_item_decorator.rb
+++ b/app/decorators/registry_item_decorator.rb
@@ -1,9 +1,5 @@
 class RegistryItemDecorator < MiqDecorator
-  def self.fonticon
-    nil
-  end
-
-  def fileicon
-    "100/#{image_name.downcase}.png"
+  def fonticon
+    image_name == 'registry_string_items' ? 'ff ff-file-txt-o' : 'ff ff-file-bin-o'
   end
 end

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 5.0.0.1", "< 5.2"
 
   s.add_dependency "coffee-rails"
-  s.add_dependency "font-fabulous", "~> 1.0.0"
+  s.add_dependency "font-fabulous", "~> 1.0.1"
   s.add_dependency "high_voltage", "~> 3.0.0"
   s.add_dependency "jquery-hotkeys-rails"
   s.add_dependency "lodash-rails", "~>3.10.0"


### PR DESCRIPTION
We needed a new version of font-fabulous with the `ff-file-bin-o` icon, and this is a next fileicon to :scissors: 

Parent issue: #4051 

@miq-bot add_label graphics, gaprindashvili/no
@miq-bot add_reviewer @epwinchell 