### PR TITLE
Don't use generic object definition fileicon if no picture present

### DIFF
--- a/app/decorators/generic_object_definition_decorator.rb
+++ b/app/decorators/generic_object_definition_decorator.rb
@@ -4,6 +4,6 @@ class GenericObjectDefinitionDecorator < MiqDecorator
   end
 
   def fileicon
-    try(:picture) ? "/pictures/#{picture.basename}" : "100/generic_object_definition.png"
+    try(:picture) ? "/pictures/#{picture.basename}" : nil
   end
 end


### PR DESCRIPTION
Unnecessary image, there's a fileicon, so :scissors: :toilet: :fire: 

Parent issue: #4051 

@miq-bot add_label graphics, gaprindashvili/no
@miq-bot add_reviewer @epwinchell 