### PR TITLE
Use svg/fonticons for store types in the storage decorator

### DIFF
--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -6,9 +6,8 @@ class StorageDecorator < MiqDecorator
   def quadicon
     {
       :top_left     => {
-        :fileicon => store_type_icon,
         :tooltip  => store_type.to_s
-      },
+      }.merge(store_type_icon),
       :top_right    => {:text => v_total_vms},
       :bottom_left  => {:text => v_total_hosts},
       :bottom_right => {
@@ -30,6 +29,25 @@ class StorageDecorator < MiqDecorator
   end
 
   def store_type_icon
-    "100/storagetype-#{store_type.nil? ? "unknown" : ERB::Util.h(store_type.to_s.downcase)}.png"
+    case store_type.try(:downcase)
+    when 'cinder'
+      {:fileicon => 'svg/vendor-cinder.svg'}
+    when 'glance'
+      {:fileicon => 'svg/vendor-openstack.svg'}
+    when 'gluster'
+      {:fileicon => 'svg/vendor-gluster.svg'}
+    when 'vmfs'
+      {:fileicon => 'svg/vendor-vmware.svg'}
+    when 'nfs', 'nfs41'
+      {:fonticon => 'ff ff-network-interface fa-rotate-180', :color => '#0099cc'}
+    when 'fcp'
+      {:fonticon => 'ff ff-network-interface fa-rotate-180', :color => '#0099cc'}
+    when 'iscsi'
+      {:fonticon => 'ff ff-network-interface fa-rotate-180', :color => '#0099cc'}
+    when 'glusterfs'
+      {:fileicon => 'svg/vendor-gluster.svg'}
+    else
+      {:fonticon => 'pficon pficon-unknown'}
+    end
   end
 end


### PR DESCRIPTION
Some of the PNGs weren't even there, something could be converted to fonticons, the rest will go with SVGs.

Related to: https://github.com/ManageIQ/manageiq/pull/17551/files
Parent issue: #4051 

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label graphics, gaprindashvili/no, technical debt