### PR TITLE
Remove Discovered IP Address field from Physical Infra Provider

### DIFF
--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -7,7 +7,7 @@ module EmsPhysicalInfraHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i(hostname ipaddress type port guid)
+      %i(hostname type port guid)
     )
   end
 
@@ -39,10 +39,6 @@ module EmsPhysicalInfraHelper::TextualSummary
 
   def textual_hostname
     @record.hostname
-  end
-
-  def textual_ipaddress
-    {:label => _("Discovered IP Address"), :value => @record.ipaddress}
   end
 
   def textual_type

--- a/product/views/ManageIQ_Providers_PhysicalInfraManager.yaml
+++ b/product/views/ManageIQ_Providers_PhysicalInfraManager.yaml
@@ -18,7 +18,6 @@ db: EmsPhysicalInfra
 cols:
 - name
 - hostname
-- ipaddress
 - emstype_description
 - port
 - total_physical_servers
@@ -40,7 +39,6 @@ include_for_find:
 col_order:
 - name
 - hostname
-- ipaddress
 - emstype_description
 - zone.name
 - total_physical_servers
@@ -53,7 +51,6 @@ col_order:
 headers:
 - Name
 - Hostname
-- Discovered IP Address
 - Type
 - EVM Zone
 - Physical Servers


### PR DESCRIPTION
**What this PR does:**
- Removes the column **Discovered IP Address** from the Physical Infra Providers list page;
- Removes the table row **Discovered IP Adress** from the Physical Infra Provider details page;

**Reason:**
- This column is *equal to*/*computed from* the **Host Name** provided by the user. The computation and update of the `ipaddress` is prone to errors:
  1. The user types an **IP** when creating the provider;
  2. We resolve the **IP** to a real `hostname`;
  3. We save the **IP** in the `ipaddress` field;
  4. The DNS query for `hostname` starts to return a new *IP*, different from the initial **IP**;
  5. We resolv the `ipaddress` to the new *IP* and update the field. (**Now, we don't have the single source of truth given by the user**).
  For this reason, we are not going to show the IPAddress neither update Its value.

## Provider List Page
![provider_list](https://user-images.githubusercontent.com/14334253/41123020-b877c100-6a73-11e8-8b52-74cd835ed003.png)

## Provider Details Page
![provider_details](https://user-images.githubusercontent.com/14334253/41123033-c37c04ee-6a73-11e8-95f7-a13b26899649.png)
