### PR TITLE
Replace q.png with vendor-redhat.svg in the automate simulation tree

### DIFF
--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -41,7 +41,7 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
       {
         :text    => t = "#{el.attributes["namespace"]} / #{el.attributes["class"]} / #{el.attributes["instance"]}",
         :tooltip => t,
-        :image   => '100/q.png'
+        :image   => 'svg/vendor-redhat.svg'
       }
     elsif el.name == "MiqAeAttribute"
       {

--- a/spec/presenters/tree_builder_automate_simulation_results_spec.rb
+++ b/spec/presenters/tree_builder_automate_simulation_results_spec.rb
@@ -14,7 +14,7 @@ describe TreeBuilderAutomateSimulationResults do
       nodes = @ae_simulation_tree.send(:x_get_tree_roots, false)
       tree_data = {:id         => "e_1",
                    :text       => "ManageIQ/SYSTEM / PROCESS / Automation",
-                   :image      => "100/q.png",
+                   :image      => "svg/vendor-redhat.svg",
                    :tooltip    => "ManageIQ/SYSTEM / PROCESS / Automation",
                    :elements   => [],
                    :selectable => false}


### PR DESCRIPTION
They're identical, but we no longer love PNGs.

Parent issue: #4051 

@miq-bot add_label gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 