### PR TITLE
Use fonticon for the warning in catalog edit provision confirm modal

### DIFF
--- a/app/views/catalog/_confirmation_modal.html.haml
+++ b/app/views/catalog/_confirmation_modal.html.haml
@@ -19,8 +19,8 @@
           = _("Copy from Provisioning")
       .modal-body
         .form-group
-          %label.control-label.col-md-2
-            %img{:src => image_path("100/warning.png")}
+          %label.control-label.col-md-2.text-center
+            %i.pficon.pficon-warning-triangle-o.fa-5x
           .col-md-8
             = _("Are you sure you want the retirement options to be copied from provisioning?")
             %p


### PR DESCRIPTION
When editing an Ansible `Catalog item`, on the `Retirement` tab there's a `Copy from Provisioning` button that opens a modal with a warning sign. The UX is just awful and it should be fixed, but now I'm only replacing the warning triangle PNG with a fonticon.

![screenshot from 2018-06-07 23-10-48](https://user-images.githubusercontent.com/649130/41126613-6bd52574-6aa8-11e8-8610-9b79ad27a080.png)

Parent issue: #4051 

@miq-bot add_label gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell  