### PR TITLE
Clean up SASS rules for icon customizations

### DIFF
--- a/app/assets/stylesheets/icon_customizations.scss
+++ b/app/assets/stylesheets/icon_customizations.scss
@@ -7,16 +7,11 @@
 /* begin icon class customizations */
 
 .fa-1xplus {
-  //custom resize for fa-tachometer on dashboard summary toggle
-  font-size: 1.18em;
+  font-size: 1.18em; //custom resize for fa-tachometer on dashboard summary toggle
 }
 
-.fa-pause::before {
-  // color: #eb7720;
-}
-
-.pficon-folder-close-blue::before {
-  content: '\e607';
+.pficon-folder-close-blue {
+  @extend .pficon-folder-close;
   color: #3188c5;
 }
 
@@ -32,35 +27,29 @@
 .fa-inactive,
 .ff-inactive,
 .pficon-inactive {
-  // add styling to show inactive icon (policies, etc)//
-  opacity: 0.6;
+  opacity: 0.6; // add styling to show inactive icon (policies, etc)
 }
-/* stylelint-disable at-rule-no-unknown */
 
 .pf-blue-info {
     color: #0088ce; //pf-blue-400
 }
 
-.popover{
+.popover {
   max-width: none;
 }
 
-
 .compare-same {
   @extend .fa, .fa-lg, .fa-check;
-
   color: #403990;
 }
 
 .compare-diff {
   @extend .fa, .fa-lg, .fa-times;
-
   color: #21a0ec;
 }
 
 .drift-delta {
   @extend .fa, .fa-play, .fa-rotate-270;
-
   color: #21a0ec;
 }
 
@@ -78,10 +67,7 @@
 
 .fa-ruby {
   @extend .fa, .fa-lg, .fa-diamond;
-
   color: red;
 }
-
-/* stylelint-enable */
 
 /* end icon class customizations */


### PR DESCRIPTION
* Convert `content: <utf-8>` to `@extend <icon class>`
* Removed unnecessary spaces
* Comments moved closer to their reference

@miq-bot add_label cleanup, gaprindashvili/no
@miq-bot add_reviewer @epwinchell 