### PR TITLE
Use fonticons for dialog/widget import status identificaiton

### DIFF
--- a/app/helpers/application_helper/import_export_helper.rb
+++ b/app/helpers/application_helper/import_export_helper.rb
@@ -1,9 +1,4 @@
 module ApplicationHelper::ImportExportHelper
-  def status_icon_image_path(exists)
-    icon_name = exists ? "100/checkmark" : "16/equal-green"
-    image_path("#{icon_name}.png")
-  end
-
   def status_description(exists)
     exists ? _("This object already exists in the database with the same name") : _("New object")
   end

--- a/app/views/miq_ae_customization/_dialog_import_export.html.haml
+++ b/app/views/miq_ae_customization/_dialog_import_export.html.haml
@@ -21,7 +21,7 @@
             %td
               = item[:name]
             %td
-              %img{:src => status_icon_image_path(item[:exists])}
+              %i{:class => item[:exists] ? 'fa fa-clone' : 'pficon pficon-ok'}
               &nbsp;
               = status_description(item[:exists])
     .pull-right

--- a/app/views/report/_export_widgets.html.haml
+++ b/app/views/report/_export_widgets.html.haml
@@ -21,7 +21,7 @@
             %td.treegrid-node
               = item[:name]
             %td
-              %img{:src => status_icon_image_path(item[:exists])}
+              %i{:class => item[:exists] ? 'fa fa-clone' : 'pficon pficon-ok'}
               &nbsp;
               = status_description(item[:exists])
     = hidden_field_tag(:import_file_upload_id, @import_file_upload_id)

--- a/spec/helpers/application_helper/import_export_helper_spec.rb
+++ b/spec/helpers/application_helper/import_export_helper_spec.rb
@@ -1,22 +1,4 @@
 describe ApplicationHelper::ImportExportHelper do
-  describe "#status_icon_image_path" do
-    context "when the item exists" do
-      let(:exists) { true }
-
-      it "returns a checkmark image path" do
-        expect(helper.status_icon_image_path(exists)).to match(%r{\/assets\/100\/checkmark.*(png)$})
-      end
-    end
-
-    context "when the item does not exist" do
-      let(:exists) { false }
-
-      it "returns an equal-green image path" do
-        expect(helper.status_icon_image_path(exists)).to match(%r{\/assets\/16\/equal-green.*(png)$})
-      end
-    end
-  end
-
   describe "#status_description" do
     context "when the item exists" do
       let(:exists) { true }


### PR DESCRIPTION
There was a `pficon-ok` class that's identical to the `100/checkmark.png`, however, the `equal-green` doesn't exist in the icon set. As it represents duplication, I replaced it with `pficon pficon-blueprint` which looks the same as a duplicated item icon. Also the icons were swapped, the OK was shown for the duplicity and the equals for the importable items, so fixing that too.

Parent issue: #4051 

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label gaprindashvili/no, graphics