### PR TITLE
Use fonticons for host/vm hardware peripherals on the devices screns

### DIFF
--- a/app/decorators/disk_decorator.rb
+++ b/app/decorators/disk_decorator.rb
@@ -1,0 +1,12 @@
+class DiskDecorator < MiqDecorator
+  def fonticon
+    case device_type
+    when 'floppy'
+      'fa fa-floppy-o'
+    when 'cdrom'
+      'ff ff-cdrom'
+    else
+      'fa fa-hdd-o'
+    end
+  end
+end

--- a/app/decorators/guest_device_decorator.rb
+++ b/app/decorators/guest_device_decorator.rb
@@ -1,5 +1,26 @@
 class GuestDeviceDecorator < MiqDecorator
-  def self.fonticon
-    'ff ff-network-card'
+  def fonticon
+    case device_type
+    when 'ethernet'
+      'ff ff-network-card'
+    when 'cdrom'
+      'ff ff-cdrom'
+    when 'scsi'
+      'ff ff-scsi'
+    when 'serial'
+      'ff ff-serial'
+    when 'usb'
+      'fa fa-usb'
+    when 'parallel'
+      'ff ff-parallel'
+    when 'sound'
+      'fa fa-volume-up'
+    when 'management'
+      'ff ff-network-interface'
+    when 'physical port'
+      'ff ff-port'
+    else
+      'pficon pficon-unknown'
+    end
   end
 end

--- a/app/helpers/textual_mixins/textual_devices.rb
+++ b/app/helpers/textual_mixins/textual_devices.rb
@@ -23,13 +23,13 @@ module TextualMixins::TextualDevices
                     _("%{total_cores}") % {:total_cores => @record.cpu_total_cores}
                   end
 
-    Device.new(_("Processors"), description, nil, :processor)
+    Device.new(_("Processors"), description, nil, 'pficon pficon-cpu')
   end
 
   def cpu_attributes
-    [[_("CPU Type"), :cpu_type, nil, :processor],
-     [_("CPU Speed"), :cpu_speed, _("MHz"), :processor],
-     [_("Memory"), :memory_mb, _("MB"), :memory]].map do |attribute|
+    [[_("CPU Type"), :cpu_type, nil, 'pficon pficon-cpu'],
+     [_("CPU Speed"), :cpu_speed, _("MHz"), 'pficon pficon-cpu'],
+     [_("Memory"), :memory_mb, _("MB"), 'pficon pficon-memory']].map do |attribute|
        device = Device.new(*attribute)
        device.description_value(@record)
        device
@@ -57,7 +57,7 @@ module TextualMixins::TextualDevices
                                                                  :prov     => pct_prov,
                                                                  :filename => filename,
                                                                  :mode     => mode}
-      Device.new(device_name, description, nil, :disk)
+      Device.new(device_name, description, nil, disk.decorate.fonticon)
     end
 
     # Floppies
@@ -68,7 +68,7 @@ module TextualMixins::TextualDevices
         connection = _("Connected at Power On = %{connect}") % {:connect => floppy.start_connected.to_s}
         location = floppy.location
         device_name = _("Floppy %{name} %{location} %{connection}") % {:name => name, :connection => connection, :location => location}
-        Device.new(device_name, nil, nil, :floppy)
+        Device.new(device_name, nil, nil, floppy.decorate.fonticon)
       end
     end
 
@@ -80,7 +80,7 @@ module TextualMixins::TextualDevices
         connection = _("Connected at Power On = %{connect}") % {:connect => cd.start_connected.to_s}
         location = cd.location
         device_name = _("CD-ROM (%{name} %{location}), %{connection}") % {:name => name, :location => location, :connection => connection}
-        Device.new(device_name, nil, nil, :cdrom)
+        Device.new(device_name, nil, nil, cd.decorate.fonticon)
       end
     end
     disks.compact
@@ -105,7 +105,7 @@ module TextualMixins::TextualDevices
       model = port.model
       autodetect = port.auto_detect ? "" : _("Default Adapter")
       desc = [location, address, filename, model, autodetect, network_name(port)].compact.join(', ')
-      Device.new(name, desc, nil, port.device_type)
+      Device.new(name, desc, nil, port.decorate.fonticon) # TODO: look into this more if this can be SCSI, serial, parallel, usb, sound
     end
   end
 

--- a/app/views/host/_config.html.haml
+++ b/app/views/host/_config.html.haml
@@ -10,7 +10,7 @@
             = h(item[:name])
           .col-md-10
             %p.form-control-static
-              %img{:src => image_path("100/hardware-#{item[:icon]}.png")}
+              %i.fa-2x.fa-fw{:class => item[:icon]}
               = h(item[:description])
 - when "os_info"
   - os_info = os_info_details

--- a/app/views/vm_common/_config.html.haml
+++ b/app/views/vm_common/_config.html.haml
@@ -13,7 +13,7 @@
             %td.label
               = h(item[:name])
             %td
-              %img{:src => image_path("100/hardware-#{item[:icon]}.png")}
+              %i.fa-2x.fa-fw{:class => item[:icon]}
               = h(item[:description])
 - when "os_info"
   - os_info = os_info_details
@@ -79,7 +79,7 @@
               %td.label
                 = h(item[:name])
               %td
-                %img{:src => image_path("100/hardware-#{item[:icon]}.png")}
+                %i.fa-2x.fa-fw{:class => item[:icon]}
                 = h(item[:description])
 
 - when "snapshot_info"

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 5.0.0.1", "< 5.2"
 
   s.add_dependency "coffee-rails"
-  s.add_dependency "font-fabulous", "~> 1.0.1"
+  s.add_dependency "font-fabulous", "~> 1.0.2"
   s.add_dependency "high_voltage", "~> 3.0.0"
   s.add_dependency "jquery-hotkeys-rails"
   s.add_dependency "lodash-rails", "~>3.10.0"

--- a/spec/helpers/textual_mixins/textual_devices_spec.rb
+++ b/spec/helpers/textual_mixins/textual_devices_spec.rb
@@ -94,26 +94,26 @@ describe TextualMixins::TextualDevices do
 
     context "with model type parsed" do
       let(:hw) { FactoryGirl.create(:hardware, :guest_devices => [FactoryGirl.create(:guest_device_nic, :model => 'Vmxnet3')]) }
-      it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Vmxnet3", "Default Adapter"].compact.join(', '), nil, "ethernet")]) }
+      it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Vmxnet3", "Default Adapter"].compact.join(', '), nil, "ff ff-network-card")]) }
     end
 
     context "without vswitch and portgroup" do
       let(:hw) { FactoryGirl.create(:hardware, :guest_devices => [FactoryGirl.create(:guest_device_nic)]) }
-      it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Default Adapter"].compact.join(', '), nil, "ethernet")]) }
+      it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Default Adapter"].compact.join(', '), nil, "ff ff-network-card")]) }
     end
 
     context "with vswitch and portgroup" do
       let(:switch) { FactoryGirl.create(:switch, :name => 'test_switch1', :shared => 'false') }
       let(:lan) { FactoryGirl.create(:lan, :name => "VM NFS Network", :switch => switch) }
       let(:hw) { FactoryGirl.create(:hardware, :guest_devices => [FactoryGirl.create(:guest_device_nic, :lan => lan)]) }
-      it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Default Adapter", "Network:VM NFS Network(Switch: test_switch1)"].compact.join(', '), nil, "ethernet")]) }
+      it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Default Adapter", "Network:VM NFS Network(Switch: test_switch1)"].compact.join(', '), nil, "ff ff-network-card")]) }
     end
 
     context "with dvswitch and dvportgroup" do
       let(:switch) { FactoryGirl.create(:switch, :name => 'test_switch1', :shared => 'true') }
       let(:lan) { FactoryGirl.create(:lan, :name => "VM NFS Network", :switch => switch) }
       let(:hw) { FactoryGirl.create(:hardware, :guest_devices => [FactoryGirl.create(:guest_device_nic, :lan => lan)]) }
-      it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Default Adapter", "Network:VM NFS Network(Distributed Switch: test_switch1)"].compact.join(', '), nil, "ethernet")]) }
+      it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Default Adapter", "Network:VM NFS Network(Distributed Switch: test_switch1)"].compact.join(', '), nil, "ff ff-network-card")]) }
     end
   end
 end

--- a/spec/presenters/tree_node/guest_device_spec.rb
+++ b/spec/presenters/tree_node/guest_device_spec.rb
@@ -3,7 +3,7 @@ describe TreeNode::GuestDevice do
   let(:object) { FactoryGirl.create(:guest_device, :controller_type => 'foo') }
 
   include_examples 'TreeNode::Node#key prefix', 'gd-'
-  include_examples 'TreeNode::Node#icon', 'ff ff-network-card'
+  include_examples 'TreeNode::Node#icon', 'pficon pficon-unknown'
   include_examples 'TreeNode::Node#tooltip prefix', 'foo Storage Adapter'
 
   context 'ethernet' do


### PR DESCRIPTION
I added a new decorator for disks, it needs some extra review if the icons are correct. I'm sure that the network devices are displaying other type of devices as the code only excludes `GuestDevice` records that have `storage` as `device_type` and I found some other types in our DB. Therefore, I also updated the `GuestDeviceDecorator` with some fonticons based on the `device_type`. Then I was able to drop the references to the `100/hardware-*.png`.

Types found in the DB:
```ruby
Hardware.all.map(&:ports).reject(&:empty?).flatten.map(&:device_type).uniq
=> ["ethernet", "cdrom", "management", "physical_port"]
```

Types that have PNG icons:
```
cdrom
disk
ethernet
floppy
memory
parallel
processor
scsi
serial
sound
usb
```

Parent issue: #4051 

@miq-bot add_label graphics, gaprindashvili/no
@miq-bot add_reviewer @epwinchell 