### PR TITLE
Missing icon for powering-up state

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -32,6 +32,7 @@ module QuadiconHelper
     'terminated'                => {:fonticon => 'pficon pficon-off', :background => '#CC0000'},
     'off'                       => {:fonticon => 'pficon pficon-off', :background => '#CC0000'},
     'template'                  => {:fonticon => 'pficon pficon-template', :background => '#336699'},
+    'powering_up'               => {:fonticon => 'pficon pficon-on', :background => '#FF9900'},
   }.freeze
 
   def self.provider_status(status, enabled = true)


### PR DESCRIPTION
There is a vm state - powering-up for which there is no icon in general vm view.
This PR fixes this issue by reusing existing svg.

Now when a vm is powering-up it looks like this:
![powering-up](https://user-images.githubusercontent.com/1384786/41158736-5225780e-6b2a-11e8-933b-0546917cee1c.png)
