### PR TITLE
[FINE] Fix confirmation message for Tenant/Project Edit and Cancel actions

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -111,7 +111,7 @@ module OpsController::OpsRbac
                     {:model => tenant_type_title_string(params[:divisible] == "true")})
       else
         add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") %
-                    {:model => tenant_type_title_string(params[:divisible] == "true"), :name => @tenant.name})
+                    {:model => tenant_type_title_string(@tenant[:divisible]), :name => @tenant.name})
       end
       get_node_info(x_node)
       replace_right_cell(:nodetype => x_node)
@@ -132,7 +132,7 @@ module OpsController::OpsRbac
       else
         AuditEvent.success(build_saved_audit_hash(old_tenant_attributes, tenant, params[:button] == "add"))
         add_flash(_("%{model} \"%{name}\" was saved") %
-                    {:model => tenant_type_title_string(params[:divisible] == "true"), :name => tenant.name})
+                    {:model => tenant_type_title_string(tenant[:divisible]), :name => tenant.name})
         if params[:button] == "add"
           rbac_tenants_list
           rbac_get_info


### PR DESCRIPTION
Fixes confirmation message when editing or cancelling actions for both Tenant and Project in Configuration/Access Control settings.

https://bugzilla.redhat.com/show_bug.cgi?id=1511927

Screen shot Cancel of edit request for Project, post code fix:
![cancel edit of project post code fix](https://user-images.githubusercontent.com/552686/41182798-146f9c22-6b2c-11e8-9559-ba851dba9ca9.png)

Screen shot Cancel of edit request for Tenant, post code fix:
![cancel edit of tenant post code fix](https://user-images.githubusercontent.com/552686/41182807-26273330-6b2c-11e8-89e4-bfa811f06cf2.png)

Edit confirmation for Project, post code fix:
![save project message post code fix](https://user-images.githubusercontent.com/552686/41182830-3cf84e1e-6b2c-11e8-97cc-b9ff74aa6628.png)

Edit confirmation for Tenant, post code fix:
![save tenant message post code fix](https://user-images.githubusercontent.com/552686/41182839-4b9feeea-6b2c-11e8-8a2c-8dd138bbeb57.png)

