### PR TITLE
Fix js spec related to widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@types/jasmine": "^2.8.6",
     "@types/jest": "^22.1.3",
-    "angular-mocks": "^1.6.9",
+    "angular-mocks": "~1.6.9",
     "autoprefixer": "~6.7.7",
     "awesome-typescript-loader": "~4.0.0",
     "babel-core": "~6.24.1",


### PR DESCRIPTION
`angular-mocks` has same version as other `angular` packages.

@miq-bot add_label test, gaprindashvili/no
