### PR TITLE
Fix missing bottom-right fonticons on provider quadicons

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -45,13 +45,13 @@ module QuadiconHelper
 
     case status
     when "Invalid"
-      {:fileicon => 'pficon pficon-error-circle-o', :tooltip => _('Invalid authentication credentials')}
+      {:fonticon => 'pficon pficon-error-circle-o', :tooltip => _('Invalid authentication credentials')}
     when "Valid"
       {:fonticon => 'pficon pficon-ok', :tooltip => _('Authentication credentials are valid')}
     when "None"
-      {:fileicon => 'pficon pficon-unknown', :tooltip => _('Could not determine the authentication status')}
+      {:fonticon => 'pficon pficon-unknown', :tooltip => _('Could not determine the authentication status')}
     else
-      {:fileicon => 'fa fa-exclamation', :tooltip => _('Authentication status is %{status}') % {:status => status} }
+      {:fonticon => 'fa fa-exclamation', :tooltip => _('Authentication status is %{status}') % {:status => status} }
     end
   end
 


### PR DESCRIPTION
Bad hash keys, sorry for that :cry: 
@miq-bot add_label bug, GTLs