### PR TITLE
Do not store cockpit popups in session

### DIFF
--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -22,6 +22,8 @@ class ContainerNodeController < ApplicationController
   def launch_cockpit
     node = identify_record(params[:id], ContainerNode)
 
+    disable_client_cache
+
     if node.kubernetes_hostname
       javascript_open_window(node.cockpit_url.to_s)
     else

--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -11,6 +11,8 @@ module VmRemote
   def launch_cockpit
     vm = identify_record(params[:id], VmOrTemplate)
 
+    disable_client_cache
+
     if vm.supports_launch_cockpit?
       javascript_open_window(vm.cockpit_url.to_s)
     else


### PR DESCRIPTION
When opening a cockpit console to a VM or a Container Node, it stores it as a lastaction in the session. When navigating to certain pages, this can cause unwanted exceptions. It's analogous with https://github.com/ManageIQ/manageiq-ui-classic/pull/3842

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1585569

@miq-bot add_label gaprindashvili/yes, bug
@miq-bot add_reviewer @bmclaughlin 