### PR TITLE
Fix missing single_quad for container services

### DIFF
--- a/app/decorators/container_service_decorator.rb
+++ b/app/decorators/container_service_decorator.rb
@@ -5,7 +5,7 @@ class ContainerServiceDecorator < MiqDecorator
 
   def single_quad
     {
-      :fileicon => fileicon
+      :fonticon => fonticon
     }
   end
 end


### PR DESCRIPTION
My bad, displaying something that doesn't exist...fixing.

**Before:**
![screenshot from 2018-06-11 14-32-24](https://user-images.githubusercontent.com/649130/41231715-530ab05c-6d84-11e8-9e48-a55539cf04b9.png)

**After:**
![screenshot from 2018-06-11 14-32-03](https://user-images.githubusercontent.com/649130/41231722-55f21e18-6d84-11e8-9a1d-27438c633231.png)

@miq-bot add_label bug, GTLs, gaprindashvili/no
@miq-bot assign @martinpovolny 
