### PR TITLE
Add new Cumulative Rate Calculation checkbox to Report editing screen

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -542,6 +542,7 @@ module ReportController::Reports::Editor
         @edit[:new][:tz] = session[:user_tz]
         @edit[:new][:cb_include_metrics] = true if @edit[:new][:model] == 'ChargebackVm'
         @edit[:new][:method_for_allocated_metrics] = default_chargeback_allocated_method
+        @edit[:new][:cumulative_rate_calculation] ||= false
       end
       reset_report_col_fields
       build_edit_screen
@@ -637,6 +638,8 @@ module ReportController::Reports::Editor
       @edit[:new][:cb_include_metrics] = params[:cb_include_metrics] == 'true'
     elsif params.key?(:method_for_allocated_metrics)
       @edit[:new][:method_for_allocated_metrics] = params[:method_for_allocated_metrics].try(:to_sym) || default_chargeback_allocated_method
+    elsif params.key?(:cumulative_rate_calculation)
+      @edit[:new][:cumulative_rate_calculation] = params[:cumulative_rate_calculation] == 'true'
     elsif params.key?(:cb_owner_id)
       @edit[:new][:cb_owner_id] = params[:cb_owner_id].blank? ? nil : params[:cb_owner_id]
     elsif params.key?(:cb_tenant_id)
@@ -1042,6 +1045,7 @@ module ReportController::Reports::Editor
 
       options[:method_for_allocated_metrics] = @edit[:new][:method_for_allocated_metrics]
       options[:include_metrics] = @edit[:new][:cb_include_metrics]
+      options[:cumulative_rate_calculation] = @edit[:new][:cumulative_rate_calculation]
       options[:groupby] = @edit[:new][:cb_groupby]
       options[:groupby_tag] = @edit[:new][:cb_groupby] == 'tag' ? @edit[:new][:cb_groupby_tag] : nil
       options[:groupby_label] = @edit[:new][:cb_groupby] == 'label' ? @edit[:new][:cb_groupby_label] : nil
@@ -1328,6 +1332,7 @@ module ReportController::Reports::Editor
       # @edit[:new][:cb_include_metrics] = nil - it means YES (YES is default value for new and legacy reports)
       @edit[:new][:cb_include_metrics] = options[:include_metrics].nil? || options[:include_metrics]
       @edit[:new][:method_for_allocated_metrics] = options[:method_for_allocated_metrics].try(:to_sym) || default_chargeback_allocated_method
+      @edit[:new][:cumulative_rate_calculation] = options[:cumulative_rate_calculation].nil? || options[:cumulative_rate_calculation]
       @edit[:new][:cb_groupby_tag] = options[:groupby_tag] if options.key?(:groupby_tag)
       @edit[:new][:cb_groupby_label] = options[:groupby_label] if options.key?(:groupby_label)
       @edit[:new][:cb_model] = Chargeback.report_cb_model(@rpt.db)

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -24,6 +24,21 @@
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('method_for_allocated_metrics', '#{url}', {beforeSend: true, complete: true});
+
+- if @edit[:new][:model].starts_with?('Chargeback')
+  %h3
+    = _('Chargeback Resources')
+  .form-horizontal
+    .form-group
+      %label.control-label.col-md-2
+        = _('Include Cumulative Rate Calculation')
+      .col-md-8
+        = check_box_tag("cumulative_rate_calculation", true, @edit[:new][:cumulative_rate_calculation],
+                        "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true,
+                        :data => {:on_text => _('Yes'), :off_text => _('No')})
+      :javascript
+        miqInitBootstrapSwitch('cumulative_rate_calculation', "#{url}")
+
 %h3
   = _('Chargeback Filters')
 .form-horizontal


### PR DESCRIPTION
**Related RFE:** https://bugzilla.redhat.com/show_bug.cgi?id=1584018

This PR adds a new _Cumulative Rate Calculation_ checkbox to Report editing screen under _Cloud Intel > Reports > Reports_.

---

**Before:**
Choosing _Chargeback for Images/Projects_ as Report base:
![cum_before1](https://user-images.githubusercontent.com/13417815/41241782-2748aba8-6d9e-11e8-90d2-a9da1b7df6ed.png)
Choosing _Chargeback for Vms_ as Report base:
![cum_before2](https://user-images.githubusercontent.com/13417815/41241787-28c22806-6d9e-11e8-9a93-085be916d420.png)

**After:**
Choosing _Chargeback for Images/Projects_ as Report base:
![cum_rate_after1](https://user-images.githubusercontent.com/13417815/41241487-540bbc4e-6d9d-11e8-8655-196668ce7c95.png)
Choosing _Chargeback for Vms_ as Report base:
![cum_rate_after2](https://user-images.githubusercontent.com/13417815/41241490-5677446c-6d9d-11e8-9375-a764b980e26c.png)

---

**Note:**
When choosing other Report base, no change for adding/editing a Report.
