### PR TITLE
Client-side print/export to PDF for dashboard widgets

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -95,3 +95,111 @@ table {
 error-modal {
   display: none;
 }
+
+table.report {
+  border-spacing: 0;
+  border-left: 1px solid #d1d1d1;
+  border-collapse: separate;
+  color: #4d5258;
+
+  thead tr th {
+    height: 19px;
+    margin: 0;
+    padding: 4px;
+    padding-left: 10px;
+    border-right: 1px solid #d1d1d1;
+    border-left: 0 !important;
+    border-top: 1px solid #d1d1d1;
+    border-bottom: 1px #d1d1d1 solid;
+    font: normal 12px Arial, Helvetica, sans-serif !important;
+    line-height: 19px;
+    background: #f5f5f5;
+  }
+
+  tbody {
+    tr {
+      &.row1-nocursor {
+        background: #f5f5f5;
+      }
+      td {
+        border: 1px solid transparent;
+        border-right: 1px solid #d1d1d1;
+        border-bottom-color: #e7e7e7;
+        padding: 2px 2px 2px 10px;
+        margin: 0;
+        vertical-align: middle;
+        cursor: default;
+        color: #4d5258;
+
+        &.group {
+          border-top: 1px solid #fff;
+          background: #ececec;
+          font: normal 12px Arial, Helvetica, sans-serif;
+        }
+      }
+    }
+  }
+}
+
+.miq_rpt_red_bg {
+  background: #fbdbdb !important;
+}
+
+.miq_rpt_yellow_bg {
+  background-color: #ffdc99 !important;
+}
+
+.miq_rpt_green_bg {
+  background-color: #cef7c9 !important;
+}
+
+.miq_rpt_blue_bg {
+  background-color: #76badf !important;
+}
+
+.miq_rpt_purple_bg {
+  background-color: #c0acdc !important;
+}
+
+.miq_rpt_maroon_bg {
+  background-color: #d4edfa !important;
+}
+
+.miq_rpt_gray_bg {
+  background-color: #d1d1d1 !important;
+}
+
+.miq_rpt_red_text {
+  color: #cc0000;
+  font-weight: bold;
+}
+
+.miq_rpt_yellow_text {
+  color: #cccc00;
+  font-weight: bold;
+}
+
+.miq_rpt_green_text {
+  color: #3f9c35;
+  font-weight: bold;
+}
+
+.miq_rpt_blue_text {
+  color: #006e9c;
+  font-weight: bold;
+}
+
+.miq_rpt_purple_text {
+  color: #925bad;
+  font-weight: bold;
+}
+
+.miq_rpt_maroon_text {
+  color: #76badf;
+  font-weight: bold;
+}
+
+.miq_rpt_gray_text {
+  color: gray;
+  font-weight: bold;
+}

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -41,7 +41,19 @@ module ApplicationController::ReportDownloads
   def widget_to_pdf
     @report = nil   # setting report to nil in case full screen mode was opened first, to make sure the one in report_result is used for download
     session[:report_result_id] = params[:rr_id]
-    render_pdf
+    @report = report_for_rendering
+    userid = "#{session[:userid]}|#{request.session_options[:id]}|adhoc"
+    @result = @report.build_create_results(:userid => userid)
+    @options = {
+      :page_layout => 'landscape',
+      :page_size   => @report.page_size || 'a4',
+      :run_date    => format_timezone(@report.report_run_time, @result.user_timezone, "gtl"),
+      :title       => "#{@report.class} \"#{@report.name}\"".html_safe,
+    }
+
+    disable_client_cache
+
+    render :template => '/layouts/print/report', :layout => '/layouts/print'
   end
 
   # Render report in csv/txt/pdf format asynchronously

--- a/app/presenters/widget_presenter.rb
+++ b/app/presenters/widget_presenter.rb
@@ -65,13 +65,12 @@ class WidgetPresenter
                    :href        => "/dashboard/report_only?rr_id=#{@widget.contents_for_user(current_user).miq_report_result_id}&type=#{@widget.content_type == "chart" ? 'hybrid' : 'tabular'}",
                    :fonticon    => 'fa fa-arrows-alt fa-fw',
                    :target      => "_blank")
-      if PdfGenerator.available?
-        buttons.push(:id       => "w_#{@widget.id}_pdf",
-                     :title    => _("Download the full report (all rows) as a PDF file"),
-                     :name     => _("Download PDF"),
-                     :href     => '/dashboard/widget_to_pdf?rr_id=' + @widget.contents_for_user(current_user).miq_report_result_id.to_s,
-                     :fonticon => 'fa fa-file-pdf-o fa-fw')
-      end
+      buttons.push(:id       => "w_#{@widget.id}_pdf",
+                   :title    => _("Print the full report (all rows) or export it as a PDF file"),
+                   :name     => _("Print or export to PDF"),
+                   :href     => '/dashboard/widget_to_pdf?rr_id=' + @widget.contents_for_user(current_user).miq_report_result_id.to_s,
+                   :target   => '_blank',
+                   :fonticon => 'pficon pficon-print fa-fw')
     end
 
     if @widget.content_type == 'chart'

--- a/app/views/layouts/print/report.html.haml
+++ b/app/views/layouts/print/report.html.haml
@@ -1,0 +1,9 @@
+%table.table.table-striped.table-bordered.breakable
+  %thead
+    %tr
+      - @report.headers.each_with_index do |header, i|
+        - unless @report.column_is_hidden?(@report.col_order[i])
+          %th
+            = h(header)
+  %tbody
+    = @result.html_rows.join.html_safe


### PR DESCRIPTION
After the [great success](https://github.com/ManageIQ/manageiq-ui-classic/pull/3998) with the summary screens, I'm replacing the print/PDF feature for the dashboard widgets.

![screenshot from 2018-06-12 10-21-18](https://user-images.githubusercontent.com/649130/41278547-5eb31934-6e2a-11e8-960f-2f4d269adcf7.png)

The code changes are minimal, however, the report's table rows are generated by the model and that needs to be addressed in the future.

@miq-bot add_label gaprindashvili/no, reporting, enhancement
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @dclarizio 

Related issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/4113
Depends on: https://github.com/ManageIQ/manageiq/pull/17569

https://bugzilla.redhat.com/show_bug.cgi?id=1588072