### PR TITLE
Use a fonticon instead of using 16/notequal-red.png

### DIFF
--- a/app/assets/stylesheets/icon_customizations.scss
+++ b/app/assets/stylesheets/icon_customizations.scss
@@ -57,7 +57,7 @@
   color: #2d7623; //pf-green-500
 }
 
-.red > i {
+.red > i, i.red {
   color: #cc0000; //pf-red-100
 }
 

--- a/app/views/catalog/_form_resources_info.html.haml
+++ b/app/views/catalog/_form_resources_info.html.haml
@@ -47,16 +47,13 @@
             - groups.sort_by { |g| g[:name].downcase }.each_with_index do |sr, k|
               %tr
                 %td
-                  = link_to(image_tag(image_path('16/notequal-red.png'), :alt => _("Click to remove this Resource from the Catalog Item")),
-                    {:action => "resource_delete",
-                     :rec_id => sr[:id],
-                     :id     => @edit[:rec_id] || "new",
-                     :grp_id => i},
+                  = link_to({:action => "resource_delete", :rec_id => sr[:id], :id => @edit[:rec_id] || "new", :grp_id => i},
                     "data-miq_sparkle_on"  => true,
                     "data-miq_sparkle_off" => true,
                     :remote                => true,
                     "data-method"          => :post,
-                    :title                 => _("Click to remove this Resource from the Catalog Item"))
+                    :title                 => _("Click to remove this Resource from the Catalog Item")) do
+                    %i.fa.fa-minus.fa-2x.red
                 %td
                   = h(sr[:name])
                 %td

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -60,14 +60,14 @@
             - unless @edit[:fields_to_delete].include?(field["id"])
               %tr
                 %td
-                  = link_to(image_tag(image_path("16/notequal-red.png"), :alt => (t = _("Click to delete this field from schema"))),
-                    {:action => "field_delete", :id => field["id"].to_s, :arr_id => i},
+                  = link_to({:action => "field_delete", :id => field["id"].to_s, :arr_id => i},
                     "data-miq_sparkle_on"  => true,
                     "data-miq_sparkle_off" => true,
                     :remote                => true,
                     "data-method"          => :post,
                     :confirm               => _('Are you sure you want to delete field from schema?'),
-                    :title                 => t)
+                    :title                 => _('Click to delete this field from schema')) do
+                    %i.fa.fa-minus.fa-2x.red
                 - %w(name aetype datatype default_value display_name description substitute collect message on_entry on_exit on_error max_retries max_time).each do |fname|
                   %td
                     - if %w(aetype datatype).include?(fname.to_s)

--- a/app/views/miq_ae_class/_inputs.html.haml
+++ b/app/views/miq_ae_class/_inputs.html.haml
@@ -14,14 +14,14 @@
       - unless @edit[:fields_to_delete].include?(flds["id"])
         %tr
           %td
-            = link_to(image_tag(image_path("16/notequal-red.png"), :alt => _("Click to delete this input field from method")),
-              {:action => "field_method_delete", :id => flds["id"].to_s, :arr_id => i},
+            = link_to({:action => "field_method_delete", :id => flds["id"].to_s, :arr_id => i},
               "data-miq_sparkle_on"  => true,
               "data-miq_sparkle_off" => true,
               'data-method'          => :post,
               :remote                => true,
               :confirm               => _('Are you sure you want to delete input field from method?'),
-              :title                 => _("Click to delete this input field from method"))
+              :title                 => _("Click to delete this input field from method")) do
+              %i.fa.fa-minus.fa-2x.red
           %td
             = text_field_tag("#{prefix}fields_name_#{i}",
               flds["name"],


### PR DESCRIPTION
There were 3 places where this PNG was used:

* Editing a catalog bundle's resources
* Editing a schema of an automate class
* Editing the inputs of an builtin automate method

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/4051