### PR TITLE
Remove unnecessary ref to 16/blue-circle.png from report timelines

### DIFF
--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -187,7 +187,6 @@ module ReportController::Reports
     {"start"       => tl_time,
      "title"       => tl_text,
      "description" => tl_text,
-     "icon"        => ActionController::Base.helpers.image_path("16/blue-circle.png"),
      "color"       => tl_color
     }
   end


### PR DESCRIPTION
This is probably a leftover from the old timelines, it is only in the report editor. When you create/edit a report with at least a single time field and go to the timeline tab, you will see that the timeline is being rendered correctly with or without this reference to the image.

![screenshot from 2018-06-12 15-25-59](https://user-images.githubusercontent.com/649130/41293325-3d02c412-6e55-11e8-8be5-dfbb16471b09.png)

@miq-bot add_label gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 

Parent issue: #4051 

