### PR TITLE
[WIP] Use a fonticon instead of 16/na.png

### DIFF
--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -107,13 +107,13 @@
           - else
             %tr
               %td
-                = link_to(image_tag(image_path("16/na.png"), :alt => (t = _("Add this entry"))),
-                  {:action => "field_accept", :button => "accept"},
+                = link_to({:action => "field_accept", :button => "accept"},
                   "data-miq_sparkle_on"  => true,
                   "data-miq_sparkle_off" => true,
                   :remote                => true,
                   "data-method"          => :post,
-                  :title                 => t)
+                  :title                 => _("Add this entry")) do
+                  %i.pficon.pficon-save.fa-2x
               - %w(name aetype datatype default_value display_name description substitute collect message on_entry on_exit on_error max_retries max_time).each do |fname|
                 %td
                   - if %w(aetype datatype).include?(fname)

--- a/app/views/miq_ae_class/_inputs.html.haml
+++ b/app/views/miq_ae_class/_inputs.html.haml
@@ -53,13 +53,13 @@
     - else
       %tr
         %td
-          = link_to(image_tag(image_path("16/na.png"), :alt => "Add this entry"),
-          {:action => "field_method_accept", :button => "accept"},
+          = link_to({:action => "field_method_accept", :button => "accept"},
           "data-miq_sparkle_on"  => true,
           "data-miq_sparkle_off" => true,
           'data-method'          => :post,
           :remote                => true,
-          :title                 => _("Add this entry"))
+          :title                 => _("Add this entry")) do
+            %i.pficon.pficon-save
         %td
           = text_field_tag("#{prefix}field_name",
             session[:field_data][:name],


### PR DESCRIPTION
There were 2 references of this PNG:
* Editing a schema of an automate class
* Editing the inputs of an builtin automate method

Parent issue: #4051 

@miq-bot add_label gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 