### PR TITLE
Use a fonticon instead of 16/equal-green.png

### DIFF
--- a/app/assets/stylesheets/icon_customizations.scss
+++ b/app/assets/stylesheets/icon_customizations.scss
@@ -53,7 +53,7 @@
   color: #21a0ec;
 }
 
-.green > i {
+.green > i, i.green {
   color: #2d7623; //pf-green-500
 }
 

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -99,7 +99,7 @@
           - if !params[:add] && params[:add] != "new" && session[:field_data].blank?
             %tr{:onclick => remote_function(:url => {:action => 'field_select', :add => 'new', :item => "field"})}
               %td
-                = image_tag(image_path("16/equal-green.png"))
+                %i.fa.fa-2x.fa-plus.green
               %td
                 = h("<#{_('New Field')}>")
               - 13.times do

--- a/app/views/miq_ae_class/_inputs.html.haml
+++ b/app/views/miq_ae_class/_inputs.html.haml
@@ -43,7 +43,7 @@
       %tr{:title => _("Click to add a new parameter"),
         :onclick => remote_function(:url => {:action => 'field_method_select', :add => 'new', :item => "field"})}
         %td
-          = image_tag(image_path("16/equal-green.png"))
+          %i.fa.fa-2x.fa-plus.green
         %td
           = h("<#{_('New Parameter')}>")
         %td


### PR DESCRIPTION
There were 2 references of this PNG:
* Editing a schema of an automate class
* Editing the inputs of an builtin automate method

Parent issue: #4051 

@miq-bot add_label gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 