### PR TITLE
Fix error on default filters page

### DIFF
--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -14,7 +14,8 @@ class TreeBuilderDefaultFilters < TreeBuilder
     :"manageiq::providers::inframanager::template" => %w(Infrastructure Virtual\ Machines Templates),
     :"manageiq::providers::cloudmanager::vm"       => %w(Cloud Instances Instances),
     :"manageiq::providers::inframanager::vm"       => %w(Infrastructure Virtual\ Machines VMs),
-    :physicalserver                                => %w(Physical\ Infrastructure Servers)
+    :physicalserver                                => %w(Physical\ Infrastructure Servers),
+    :physicalswitch                                => %w(Physical\ Infrastructure Switches)
   }.freeze
 
   def prepare_data(data)


### PR DESCRIPTION
With https://github.com/ManageIQ/manageiq-ui-classic/pull/4116 in place, navigate to: My Settings → Default Filters, you'll witness the following error:
```
F, [2018-06-12T16:20:12.505321 #10918] FATAL -- : Error caught: [ArgumentError] comparison of Array with Array failed
manageiq-ui-classic/app/presenters/tree_builder_default_filters.rb:21:in `sort_by'
manageiq-ui-classic/app/presenters/tree_builder_default_filters.rb:21:in `prepare_data'
manageiq-ui-classic/app/presenters/tree_builder_default_filters.rb:30:in `initialize'
manageiq-ui-classic/app/controllers/configuration_controller.rb:511:in `new'
manageiq-ui-classic/app/controllers/configuration_controller.rb:511:in `set_form_vars'
manageiq-ui-classic/app/controllers/configuration_controller.rb:64:in `edit'
manageiq-ui-classic/app/controllers/configuration_controller.rb:72:in `change_tab'
```