### PR TITLE
Add the missing powering_down quadrant machine state

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -33,6 +33,7 @@ module QuadiconHelper
     'off'                       => {:fonticon => 'pficon pficon-off', :background => '#CC0000'},
     'template'                  => {:fonticon => 'pficon pficon-template', :background => '#336699'},
     'powering_up'               => {:fonticon => 'pficon pficon-on', :background => '#FF9900'},
+    'powering_down'             => {:fonticon => 'pficon pficon-off', :background => '#FF9900'},
   }.freeze
 
   def self.provider_status(status, enabled = true)


### PR DESCRIPTION
Analogous with https://github.com/ManageIQ/manageiq-ui-classic/pull/4101

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label gaprindashvili/no, graphics