### PR TITLE
Use fonticons for embedded items in automate and catalogs

### DIFF
--- a/app/views/catalog/_form_resources_info.html.haml
+++ b/app/views/catalog/_form_resources_info.html.haml
@@ -47,16 +47,14 @@
             - groups.sort_by { |g| g[:name].downcase }.each_with_index do |sr, k|
               %tr
                 %td
-                  = link_to(image_tag(image_path('16/notequal-red.png'), :alt => _("Click to remove this Resource from the Catalog Item")),
-                    {:action => "resource_delete",
-                     :rec_id => sr[:id],
-                     :id     => @edit[:rec_id] || "new",
-                     :grp_id => i},
+                  = link_to({:action => "resource_delete", :rec_id => sr[:id], :id => @edit[:rec_id] || "new", :grp_id => i},
                     "data-miq_sparkle_on"  => true,
                     "data-miq_sparkle_off" => true,
                     :remote                => true,
+                    :class                 => 'btn btn-default',
                     "data-method"          => :post,
-                    :title                 => _("Click to remove this Resource from the Catalog Item"))
+                    :title                 => _("Click to remove this Resource from the Catalog Item")) do
+                    %i.pficon.pficon-delete
                 %td
                   = h(sr[:name])
                 %td

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -60,14 +60,15 @@
             - unless @edit[:fields_to_delete].include?(field["id"])
               %tr
                 %td
-                  = link_to(image_tag(image_path("16/notequal-red.png"), :alt => (t = _("Click to delete this field from schema"))),
-                    {:action => "field_delete", :id => field["id"].to_s, :arr_id => i},
+                  = link_to({:action => "field_delete", :id => field["id"].to_s, :arr_id => i},
                     "data-miq_sparkle_on"  => true,
                     "data-miq_sparkle_off" => true,
                     :remote                => true,
                     "data-method"          => :post,
+                    :class                 => 'btn btn-default',
                     :confirm               => _('Are you sure you want to delete field from schema?'),
-                    :title                 => t)
+                    :title                 => _('Click to delete this field from schema')) do
+                    %i.pficon.pficon-delete
                 - %w(name aetype datatype default_value display_name description substitute collect message on_entry on_exit on_error max_retries max_time).each do |fname|
                   %td
                     - if %w(aetype datatype).include?(fname.to_s)
@@ -99,7 +100,8 @@
           - if !params[:add] && params[:add] != "new" && session[:field_data].blank?
             %tr{:onclick => remote_function(:url => {:action => 'field_select', :add => 'new', :item => "field"})}
               %td
-                = image_tag(image_path("16/equal-green.png"))
+                %button.btn.btn-default
+                  %i.fa.fa-plus
               %td
                 = h("<#{_('New Field')}>")
               - 13.times do
@@ -107,13 +109,14 @@
           - else
             %tr
               %td
-                = link_to(image_tag(image_path("16/na.png"), :alt => (t = _("Add this entry"))),
-                  {:action => "field_accept", :button => "accept"},
+                = link_to({:action => "field_accept", :button => "accept"},
                   "data-miq_sparkle_on"  => true,
                   "data-miq_sparkle_off" => true,
                   :remote                => true,
+                  :class                 => 'btn btn-default',
                   "data-method"          => :post,
-                  :title                 => t)
+                  :title                 => _("Add this entry")) do
+                  %i.pficon.pficon-save
               - %w(name aetype datatype default_value display_name description substitute collect message on_entry on_exit on_error max_retries max_time).each do |fname|
                 %td
                   - if %w(aetype datatype).include?(fname)

--- a/app/views/miq_ae_class/_inputs.html.haml
+++ b/app/views/miq_ae_class/_inputs.html.haml
@@ -14,14 +14,15 @@
       - unless @edit[:fields_to_delete].include?(flds["id"])
         %tr
           %td
-            = link_to(image_tag(image_path("16/notequal-red.png"), :alt => _("Click to delete this input field from method")),
-              {:action => "field_method_delete", :id => flds["id"].to_s, :arr_id => i},
+            = link_to({:action => "field_method_delete", :id => flds["id"].to_s, :arr_id => i},
               "data-miq_sparkle_on"  => true,
               "data-miq_sparkle_off" => true,
               'data-method'          => :post,
               :remote                => true,
+              :class                 => 'btn btn-default',
               :confirm               => _('Are you sure you want to delete input field from method?'),
-              :title                 => _("Click to delete this input field from method"))
+              :title                 => _("Click to delete this input field from method")) do
+              %i.pficon.pficon-delete
           %td
             = text_field_tag("#{prefix}fields_name_#{i}",
               flds["name"],
@@ -43,7 +44,8 @@
       %tr{:title => _("Click to add a new parameter"),
         :onclick => remote_function(:url => {:action => 'field_method_select', :add => 'new', :item => "field"})}
         %td
-          = image_tag(image_path("16/equal-green.png"))
+          %button.btn.btn-default
+            %i.fa.fa-plus
         %td
           = h("<#{_('New Parameter')}>")
         %td
@@ -53,13 +55,14 @@
     - else
       %tr
         %td
-          = link_to(image_tag(image_path("16/na.png"), :alt => "Add this entry"),
-          {:action => "field_method_accept", :button => "accept"},
+          = link_to({:action => "field_method_accept", :button => "accept"},
           "data-miq_sparkle_on"  => true,
           "data-miq_sparkle_off" => true,
           'data-method'          => :post,
           :remote                => true,
-          :title                 => _("Add this entry"))
+          :class                 => 'btn btn-default',
+          :title                 => _("Add this entry")) do
+            %i.pficon.pficon-save
         %td
           = text_field_tag("#{prefix}field_name",
             session[:field_data][:name],


### PR DESCRIPTION
There were 3 places where PNGs were used:

* Editing a catalog bundle's resources
* Editing a schema of an automate class
* Editing the inputs of an builtin automate method

Parent issue: #4051

@miq-bot add_label gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 