### PR TITLE
Use the client-side printing for reports where the PDF was generated synchronously

### DIFF
--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -36,7 +36,7 @@ module ApplicationController::ReportDownloads
       :page_layout => 'landscape',
       :page_size   => @report.page_size || 'a4',
       :run_date    => format_timezone(@report.report_run_time, @result.user_timezone, "gtl"),
-      :title       => "#{@report.class} \"#{@report.name}\"".html_safe
+      :title       => @result.name
     }
 
     render :template => '/layouts/print/report', :layout => '/layouts/print'

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -20,8 +20,8 @@ module ApplicationController::ReportDownloads
   end
 
   # Send the current report in pdf format
-  def render_pdf(report)
-    @report = report
+  def render_pdf(report = nil)
+    @report = report || report_for_rendering
     userid = "#{session[:userid]}|#{request.session_options[:id]}|adhoc"
     @result = @report.build_create_results(:userid => userid)
 
@@ -45,8 +45,7 @@ module ApplicationController::ReportDownloads
   # Show the current widget report in pdf format
   def widget_to_pdf
     session[:report_result_id] = params[:rr_id]
-    @report = report_for_rendering
-    render_pdf(@report)
+    render_pdf
   end
 
   # Render report in csv/txt/pdf format asynchronously

--- a/app/helpers/application_helper/toolbar/chargeback_center.rb
+++ b/app/helpers/application_helper/toolbar/chargeback_center.rb
@@ -23,10 +23,11 @@ class ApplicationHelper::Toolbar::ChargebackCenter < ApplicationHelper::Toolbar:
           :url   => "/render_csv"),
         button(
           :chargeback_download_pdf,
-          'fa fa-file-pdf-o fa-lg',
-          N_('Download this report in PDF format'),
-          N_('Download as PDF'),
-          :klass => ApplicationHelper::Button::Pdf,
+          'pficon pficon-print fa-lg',
+          N_('Print or export this report in PDF format'),
+          N_('Print or export as PDF'),
+          :klass => ApplicationHelper::Button::Basic,
+          :popup => true,
           :url   => "/render_pdf"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/compare_view.rb
+++ b/app/helpers/application_helper/toolbar/compare_view.rb
@@ -36,11 +36,12 @@ class ApplicationHelper::Toolbar::CompareView < ApplicationHelper::Toolbar::Basi
           :url   => "/compare_to_csv"),
         button(
           :compare_download_pdf,
-          'fa fa-file-pdf-o fa-lg',
-          N_('Download comparison report in PDF format'),
-          N_('Download as PDF'),
-          :klass     => ApplicationHelper::Button::Pdf,
-          :url => "/compare_to_pdf"),
+          'pficon pficon-print fa-lg',
+          N_('Print or export comparison report in PDF format'),
+          N_('Print or export as PDF'),
+          :klass => ApplicationHelper::Button::Basic,
+          :popup => true,
+          :url   => "/compare_to_pdf"),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/drift_view.rb
+++ b/app/helpers/application_helper/toolbar/drift_view.rb
@@ -36,10 +36,11 @@ class ApplicationHelper::Toolbar::DriftView < ApplicationHelper::Toolbar::Basic
           :url   => "/drift_to_csv"),
         button(
           :drift_download_pdf,
-          'fa fa-file-pdf-o fa-lg',
-          N_('Download comparison report in PDF format'),
-          N_('Download as PDF'),
-          :klass => ApplicationHelper::Button::Pdf,
+          'pficon pficon-print fa-lg',
+          N_('Print or export comparison report in PDF format'),
+          N_('Print or export as PDF'),
+          :klass => ApplicationHelper::Button::Basic,
+          :popup => true,
           :url   => "/drift_to_pdf"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/gtl_view.rb
+++ b/app/helpers/application_helper/toolbar/gtl_view.rb
@@ -48,10 +48,11 @@ class ApplicationHelper::Toolbar::GtlView < ApplicationHelper::Toolbar::Basic
           :url_parms => "?download_type=csv"),
         button(
           :download_pdf,
-          'fa fa-file-pdf-o fa-lg',
-          N_('Download this report in PDF format'),
-          N_('Download as PDF'),
-          :klass     => ApplicationHelper::Button::Pdf,
+          'pficon pficon-print fa-lg',
+          N_('Print or export this report in PDF format'),
+          N_('Print or export as PDF'),
+          :klass     => ApplicationHelper::Button::Basic,
+          :popup     => true,
           :url       => "/download_data",
           :url_parms => "?download_type=pdf"),
       ]

--- a/app/helpers/application_helper/toolbar/miq_capacity_view.rb
+++ b/app/helpers/application_helper/toolbar/miq_capacity_view.rb
@@ -25,10 +25,11 @@ class ApplicationHelper::Toolbar::MiqCapacityView < ApplicationHelper::Toolbar::
           :klass     => ApplicationHelper::Button::MiqCapacity),
         button(
           :miq_capacity_download_pdf,
-          'fa fa-file-pdf-o fa-lg',
-          N_('Download this report in PDF format'),
-          N_('Download as PDF'),
-          :klass     => ApplicationHelper::Button::Pdf,
+          'pficon pficon-print fa-lg',
+          N_('Print or export this report in PDF format'),
+          N_('Print or export as PDF'),
+          :klass     => ApplicationHelper::Button::Basic,
+          :popup     => true,
           :url       => "/report_download",
           :url_parms => "?typ=pdf"),
       ]

--- a/app/helpers/application_helper/toolbar/x_gtl_view.rb
+++ b/app/helpers/application_helper/toolbar/x_gtl_view.rb
@@ -48,10 +48,11 @@ class ApplicationHelper::Toolbar::XGtlView < ApplicationHelper::Toolbar::Basic
           :url_parms => "?download_type=csv"),
         button(
           :download_pdf,
-          'fa fa-file-pdf-o fa-lg',
-          N_('Download these items in PDF format'),
-          N_('Download as PDF'),
-          :klass     => ApplicationHelper::Button::Pdf,
+          'pficon pficon-print fa-lg',
+          N_('Print or export these items in PDF format'),
+          N_('Print or export as PDF'),
+          :klass     => ApplicationHelper::Button::Basic,
+          :popup     => true,
           :url       => "/download_data",
           :url_parms => "?download_type=pdf"),
       ]

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -402,18 +402,6 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       allow(helper).to receive(:x_active_tree).and_return(:ot_tree)
     end
 
-    it "Hides PDF button when PdfGenerator is not available" do
-      allow(PdfGenerator).to receive_messages(:available? => false)
-      buttons = helper.build_toolbar('gtl_view_tb').collect { |button| button[:items] if button[:id] == "download_choice" }.compact.flatten
-      expect(buttons).not_to include(@pdf_button)
-    end
-
-    it "Displays PDF button when PdfGenerator is available" do
-      allow(PdfGenerator).to receive_messages(:available? => true)
-      buttons = helper.build_toolbar('gtl_view_tb').collect { |button| button[:items] if button[:id] == "download_choice" }.compact.flatten
-      expect(buttons).to include(@pdf_button)
-    end
-
     it "Enables edit and remove buttons for read-write orchestration templates" do
       @record = FactoryGirl.create(:orchestration_template)
       buttons = helper.build_toolbar('orchestration_template_center_tb').first[:items]


### PR DESCRIPTION
Most cases of PDF generation were very similar to the way [we do it with the widgets](https://github.com/ManageIQ/manageiq-ui-classic/pull/4114) so I am generalizing the feature more. Hovewer, the saved report PDFs are generated by the backend as an asynchronous task, so they aren't covered by this PR.

@miq-bot add_label gaprindashvili/no, reporting, enhancement
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @martinpovolny 

Related issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/4113

https://bugzilla.redhat.com/show_bug.cgi?id=1588072