### PR TITLE
Don't get right provider based on position in array

### DIFF
--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -294,8 +294,7 @@ describe AutomationManagerController do
     allow(User).to receive(:current_user).and_return(user)
     TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, :configuration_scripts, controller.instance_variable_get(:@sb))
     tree_builder = TreeBuilderAutomationManagerConfigurationScripts.new("root", "", {})
-    root_objects = tree_builder.send(:x_get_tree_roots, false, {})
-    objects = tree_builder.send(:x_get_tree_cmat_kids, root_objects[1], false)
+    objects = tree_builder.send(:x_get_tree_cmat_kids, @automation_manager1, false)
     expect(objects).to include(@ans_job_template1)
     expect(objects).to include(@ans_job_template3)
   end


### PR DESCRIPTION
Given this was already changed from position `0` to `1` in https://github.com/ManageIQ/manageiq-ui-classic/pull/1082  and in `Gaprindashvili` it needs to be `0` again... So now it gets provider directly and not blindly from array as this test was never meant to check if providers are sorted correctly.

Gaprindashvili failure:
```
1) AutomationManagerController constructs the ansible tower job templates tree node
     Failure/Error: expect(objects).to include(@ans_job_template1)
     
       expected [#<ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript id: 10000000000174, mana...:Providers::AnsibleTower::AutomationManag...", parent_id: nil, configuration_script_source_id: nil>] to include #<ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript id: 10000000000173, manag...::Providers::AnsibleTower::AutomationManag...", parent_id: nil, configuration_script_source_id: nil>
       Diff:
       @@ -1,2 +1,2 @@
       -[#<ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript id: 10000000000173, manager_id: 10000000002738, manager_ref: "41", name: "ConfigScript1", description: nil, variables: {:instance_ids=>["i-3434"]}, created_at: "2018-06-13 10:26:30", updated_at: "2018-06-13 10:26:30", survey_spec: nil, inventory_root_group_id: nil, type: "ManageIQ::Providers::AnsibleTower::AutomationManag...", parent_id: nil, configuration_script_source_id: nil>]
       +[#<ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript id: 10000000000174, manager_id: 10000000002739, manager_ref: "11", name: "ConfigScript2", description: nil, variables: {:instance_ids=>["i-3434"]}, created_at: "2018-06-13 10:26:30", updated_at: "2018-06-13 10:26:30", survey_spec: nil, inventory_root_group_id: nil, type: "ManageIQ::Providers::AnsibleTower::AutomationManag...", parent_id: nil, configuration_script_source_id: nil>]
```
```
rspec ./spec/controllers/automation_manager_controller_spec.rb:292 # AutomationManagerController constructs the ansible tower job templates tree node
```

*How to reproduce*:
Only on Gaprindashvili
`bundle exec rspec spec/controllers/automation_manager_controller_spec.rb`

@miq-bot add_label bug, test, gaprindashvili/yes
