### PR TITLE
Depend on react-select to fix nested dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "patternfly-react": "2.3.4",
-    "@manageiq/react-ui-components": "^0.8.0",
+    "@manageiq/react-ui-components": "~0.8.0",
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",
     "angular-bootstrap-switch": "~0.5.2",
@@ -41,6 +40,7 @@
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "react-redux": "^5.0.7",
+    "react-select": "~1.2.1",
     "redux": "~3.7.2",
     "redux-devtools-extension": "^2.13.2",
     "rxjs": "~5.6.0-forward-compat.2",


### PR DESCRIPTION
react-ui-components depends on react-select, the compiled JS ends up with a `require('react-select')` statement that ui-classic attempts to resolve.

Unfortunately this only works if react-select was installed in a flat structure, under `node_modules/react-select`.

Instead, it ends up being installed in `node_modules/@manageiq/react-ui-components/node_modules/react-select` .. that is a correct path but one we've lost support for with #2652.

But undoing that change makes the rest of plugins fail :).

So, for now, just adding react-select as a direct dependency.
The long-term fix will depend on #3776 and re-enable resolving nested node_modules.

---

Fixes missing react-select when runnign webpack.
Cc @karelhala , @lpichler 