### PR TITLE
Display cloud subnets in the top-right quadrant of network providers

### DIFF
--- a/app/decorators/manageiq/providers/network_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/network_manager_decorator.rb
@@ -18,8 +18,8 @@ class ManageIQ::Providers::NetworkManagerDecorator < MiqDecorator
         :tooltip => n_("%{number} Cloud Network", "%{number} Cloud Networks", t) % {:number => t}
       },
       :top_right    => {
-        :text    => t = security_groups.size,
-        :tooltip => n_("%{number} Security Group", "%{number} Security Groups", t) % {:number => t}
+        :text    => t = cloud_subnets.size,
+        :tooltip => n_("%{number} Cloud Subnet", "%{number} Cloud Subnets", t) % {:number => t}
       },
       :bottom_left  => {
         :fileicon => fileicon,


### PR DESCRIPTION
Followup after @loicavenel's [request](https://github.com/ManageIQ/manageiq-ui-classic/pull/4025#issuecomment-394719408), networking provider quadicons will display the number of cloud subnets.

@miq-bot add_label gaprindashvili/no, GTLs, networks
@miq-bot add_reviewer @epwinchell 

cc @Ladas & @tumido 