### PR TITLE
Add missing physical switches to the default filters tree

### DIFF
--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -14,7 +14,8 @@ class TreeBuilderDefaultFilters < TreeBuilder
     :"manageiq::providers::inframanager::template" => %w(Infrastructure Virtual\ Machines Templates),
     :"manageiq::providers::cloudmanager::vm"       => %w(Cloud Instances Instances),
     :"manageiq::providers::inframanager::vm"       => %w(Infrastructure Virtual\ Machines VMs),
-    :physicalserver                                => %w(Physical\ Infrastructure Servers)
+    :physicalserver                                => %w(Physical\ Infrastructure Servers),
+    :physicalswitch                                => %w(Physical\ Infrastructure Switches)
   }.freeze
 
   def prepare_data(data)


### PR DESCRIPTION
When opening the `Default filters` tab on the  `My Settings` page it fails with a weird Array vs Array comparison error because the physical switches are missing from the `NAV_TAB_PATH`. So adding it back until I find a cleaner solution for generating this hierarchy.

![screenshot from 2018-06-13 16-25-31](https://user-images.githubusercontent.com/649130/41357862-64d6c9f2-6f27-11e8-8c70-4e517d209037.png)


@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label bug