### PR TITLE
Fix returning wrong template class while provisioning VMs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1566,7 +1566,7 @@ class ApplicationController < ActionController::Base
                               :prov_id    => @prov_id
         end
       else
-        javascript_redirect :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id
+        javascript_redirect(:controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id, :template_klass => @template_klass_type)
       end
     elsif params[:pressed] == "ems_cloud_edit" && params[:id]
       javascript_redirect edit_ems_cloud_path(params[:id])
@@ -1757,6 +1757,7 @@ class ApplicationController < ActionController::Base
         end
       end
     else
+      @template_klass_type = template_types_for_controller
       @org_controller = "vm" # request originated from controller
       klass = VmOrTemplate
       @refresh_partial = typ ? "prov_edit" : "pre_prov"
@@ -1803,6 +1804,14 @@ class ApplicationController < ActionController::Base
   alias_method :instance_miq_request_new, :prov_redirect
   alias_method :vm_miq_request_new, :prov_redirect
   alias_method :miq_template_miq_request_new, :prov_redirect
+
+  def template_types_for_controller
+    if %w(ems_infra).include?(request.parameters[:controller])
+      'infra'
+    else
+      'cloud'
+    end
+  end
 
   def vm_clone
     prov_redirect("clone")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1806,7 +1806,7 @@ class ApplicationController < ActionController::Base
   alias_method :miq_template_miq_request_new, :prov_redirect
 
   def template_types_for_controller
-    if %w(ems_infra).include?(request.parameters[:controller])
+    if %w(ems_infra host).include?(request.parameters[:controller])
       'infra'
     else
       'cloud'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1806,7 +1806,7 @@ class ApplicationController < ActionController::Base
   alias_method :miq_template_miq_request_new, :prov_redirect
 
   def template_types_for_controller
-    if %w(ems_infra host).include?(request.parameters[:controller])
+    if %w(ems_cluster ems_infra host resource_pool storage vm_infra).include?(request.parameters[:controller])
       'infra'
     else
       'cloud'

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -168,10 +168,9 @@ module ApplicationController::MiqRequestMethods
     # when clone/migrate buttons are pressed from a sub list view,
     # these buttons are only available on Infra side
     return ManageIQ::Providers::InfraManager::Template if params[:prov_type]
-    case request.parameters[:controller]
-    when "vm_cloud"
+    if request.parameters[:template_klass] == 'cloud' || request.parameters[:controller] == 'vm_cloud'
       return ManageIQ::Providers::CloudManager::Template
-    when "vm_infra"
+    elsif request.parameters[:template_klass] == 'infra' || request.parameters[:controller] == 'vm_infra'
       return ManageIQ::Providers::InfraManager::Template
     else
       return MiqTemplate

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -389,7 +389,7 @@ class HostController < ApplicationController
                                   :escape         => false
             end
           else
-            javascript_redirect :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id, :org_controller => @org_controller
+            render_or_redirect_partial(pfx)
           end
         else
           javascript_redirect :action => @refresh_partial, :id => @redirect_id

--- a/spec/controllers/application_controller/miq_request_methods_spec.rb
+++ b/spec/controllers/application_controller/miq_request_methods_spec.rb
@@ -70,4 +70,49 @@ describe MiqRequestController do
       controller.send(:prov_edit)
     end
   end
+
+  describe '#get_template_kls' do
+    before do
+      controller.instance_variable_set(:@_params, :controller => ctrl, :template_klass => kls)
+      allow(request).to receive(:parameters).and_return(:template_klass => kls, :controller => ctrl)
+    end
+
+    subject { controller.send(:get_template_kls) }
+
+    context 'provisioning VMs displayed through details page of infra provider, Cluster, Host, Resource Poll or Storage' do
+      let(:ctrl) { 'miq_request' }
+      let(:kls) { 'infra' }
+
+      it 'returns proper template klass' do
+        expect(subject).to eq(ManageIQ::Providers::InfraManager::Template)
+      end
+    end
+
+    context 'provisioning VMs displayed on VMs explorer screen' do
+      let(:ctrl) { 'vm_infra' }
+      let(:kls) { nil }
+
+      it 'returns proper template klass' do
+        expect(subject).to eq(ManageIQ::Providers::InfraManager::Template)
+      end
+    end
+
+    context 'provisioning instances displayed through details page of cloud provider' do
+      let(:ctrl) { 'miq_request' }
+      let(:kls) { 'cloud' }
+
+      it 'returns proper template klass' do
+        expect(subject).to eq(ManageIQ::Providers::CloudManager::Template)
+      end
+    end
+
+    context 'provisioning instances displayed on instances explorer screen' do
+      let(:ctrl) { 'vm_cloud' }
+      let(:kls) { nil }
+
+      it 'returns proper template klass' do
+        expect(subject).to eq(ManageIQ::Providers::CloudManager::Template)
+      end
+    end
+  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 
 describe ApplicationController do
-  context "#find_record_with_rbac" do
+  describe "#find_record_with_rbac" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       controller.instance_variable_set(:@sb, {})
@@ -25,7 +25,7 @@ describe ApplicationController do
     end
   end
 
-  context "#assert_privileges" do
+  describe "#assert_privileges" do
     before do
       EvmSpecHelper.seed_specific_product_features("host_new", "host_edit", "perf_reload")
       feature = MiqProductFeature.find_all_by_identifier(["host_new"])
@@ -46,7 +46,7 @@ describe ApplicationController do
     end
   end
 
-  context "#previous_breadcrumb_url" do
+  describe "#previous_breadcrumb_url" do
     it "should return url when 2 entries" do
       controller.instance_variable_set(:@breadcrumbs, [{:url => "test_url"}, 'placeholder'])
       expect(controller.send(:previous_breadcrumb_url)).to eq("test_url")
@@ -61,7 +61,7 @@ describe ApplicationController do
     end
   end
 
-  context "#find_checked_items" do
+  describe "#find_checked_items" do
     it "returns empty array when button is pressed from summary screen with params as symbol" do
       controller.instance_variable_set(:@_params, :id => "1")
       expect(controller.send(:find_checked_items)).to eq([])
@@ -78,7 +78,7 @@ describe ApplicationController do
     end
   end
 
-  context "#render_gtl_view_tb?" do
+  describe "#render_gtl_view_tb?" do
     before do
       controller.instance_variable_set(:@layout, "host")
       controller.instance_variable_set(:@gtl_type, "list")
@@ -100,7 +100,7 @@ describe ApplicationController do
     end
   end
 
-  context "#prov_redirect" do
+  describe "#prov_redirect" do
     let(:user) { FactoryGirl.create(:user, :features => "vm_migrate") }
     before do
       allow(User).to receive(:server_timezone).and_return("UTC")
@@ -133,7 +133,7 @@ describe ApplicationController do
     end
   end
 
-  context "#prov_redirect" do
+  describe "#prov_redirect" do
     before do
       login_as FactoryGirl.create(:user, :features => "image_miq_request_new")
       allow(User).to receive(:server_timezone).and_return("UTC")
@@ -177,9 +177,45 @@ describe ApplicationController do
       expect(controller.send(:flash_errors?)).to be_falsey
       expect(assigns(:org_controller)).to eq("vm")
     end
+
+    context 'setting proper template klass type for various controllers' do
+      subject { controller.instance_variable_get(:@template_klass_type) }
+
+      %w(ems_cluster ems_infra host resource_pool storage vm_infra).each do |ctrl|
+        context "#{ctrl} controller" do
+          before do
+            allow(controller).to receive(:assert_privileges)
+            allow(controller).to receive(:performed?)
+            allow(controller).to receive(:template_types_for_controller).and_call_original
+            allow(request).to receive(:parameters).and_return(:controller => ctrl, :pressed => 'vm_miq_request_new')
+          end
+
+          it 'returns proper template type while provisioning VMs' do
+            controller.send(:prov_redirect)
+            expect(subject).to eq('infra')
+          end
+        end
+      end
+
+      %w(auth_key_pair_cloud availability_zone cloud_tenant ems_cloud host_aggregate orchestration_stack vm_cloud).each do |ctrl|
+        context "#{ctrl} controller" do
+          before do
+            allow(controller).to receive(:assert_privileges)
+            allow(controller).to receive(:performed?)
+            allow(controller).to receive(:template_types_for_controller).and_call_original
+            allow(request).to receive(:parameters).and_return(:controller => ctrl, :pressed => 'vm_miq_request_new')
+          end
+
+          it 'returns proper template type while provisioning instances' do
+            controller.send(:prov_redirect)
+            expect(subject).to eq('cloud')
+          end
+        end
+      end
+    end
   end
 
-  context "#determine_record_id_for_presenter" do
+  describe "#determine_record_id_for_presenter" do
     context "when in a form" do
       before do
         controller.instance_variable_set(:@in_a_form, true)
@@ -219,7 +255,7 @@ describe ApplicationController do
       end
     end
 
-    context "#get_view" do
+    describe "#get_view" do
       it 'calculates grid hash condition' do
         controller.instance_variable_set(:@force_no_grid_xml, false)
         controller.instance_variable_set(:@force_grid_xml, true)

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -2,7 +2,7 @@ describe HostController do
   let(:h1) { FactoryGirl.create(:host, :name => 'foobar') }
   let(:h2) { FactoryGirl.create(:host, :name => 'bar') }
 
-  context "#button" do
+  describe "#button" do
     render_views
 
     before(:each) do
@@ -126,9 +126,26 @@ describe HostController do
       post :button, :params => {:pressed => 'common_drift', :format => :js}
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
+
+    context 'provisioning VMS displayed through details page of a Host' do
+      before do
+        allow(controller).to receive(:process_vm_buttons)
+        allow(controller).to receive(:performed?).and_return(false)
+        allow(request).to receive(:parameters).and_return(:pressed => 'vm_miq_request_new')
+        controller.instance_variable_set(:@display, 'vms')
+        controller.instance_variable_set(:@lastaction, 'show')
+        controller.instance_variable_set(:@_params, :pressed => 'vm_miq_request_new')
+      end
+
+      it 'calls render_or_redirect_partial method' do
+        controller.send(:prov_redirect)
+        expect(controller).to receive(:render_or_redirect_partial).with('vm')
+        controller.send(:button)
+      end
+    end
   end
 
-  context "#create" do
+  describe "#create" do
     it "can create a host with custom id and no host name" do
       stub_user(:features => :all)
       controller.instance_variable_set(:@breadcrumbs, [])
@@ -170,7 +187,7 @@ describe HostController do
     end
   end
 
-  context "#set_record_vars" do
+  describe "#set_record_vars" do
     it "strips leading/trailing whitespace from hostname/ipaddress when adding infra host" do
       stub_user(:features => :all)
       controller.instance_variable_set(
@@ -185,7 +202,7 @@ describe HostController do
     end
   end
 
-  context "#show_association" do
+  describe "#show_association" do
     before(:each) do
       stub_user(:features => :all)
       @host = FactoryGirl.create(:host, :name =>'hostname1')
@@ -340,7 +357,7 @@ describe HostController do
 
   include_examples '#download_summary_pdf', :host
 
-  context "#set_credentials" do
+  describe "#set_credentials" do
     let(:mocked_host) { double(Host) }
     it "uses params[:default_password] for validation if one exists" do
       controller.instance_variable_set(:@_params,
@@ -410,7 +427,7 @@ describe HostController do
     end
   end
 
-  context "#render pages" do
+  describe "#render pages" do
     render_views
     before do
       stub_user(:features => :all)


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1428003

---

**What:**
 Fix returning wrong template class in `get_template_kls` method due to redirecting and different controller set while provisioning VMs through Provider's details page. The right templates are rendered while provisioning VMs which are accessed through _Compute > Infrastructure > Virtual Machines_.

**Exact steps to reproduce:**
1. Go to _Compute > Infrastructure > Providers_ and select some provider
2. Display the VMs through provider's details page or under _Relationships_ in accordion (there are more ways)
3. Under _Lifecycle_, select _Provision VMs_

---

Provisioning VMs accessed through _Compute > Infrastructure > Virtual Machines_:
![vm_prov_ok](https://user-images.githubusercontent.com/13417815/41364827-18669b54-6f38-11e8-9e34-6decb1a2c4c5.png)

**Before:** (all the available templates)
![vm_prov_before](https://user-images.githubusercontent.com/13417815/41364939-589f100c-6f38-11e8-947f-6304c6e11807.png)

**After:**
![vm_prov_after](https://user-images.githubusercontent.com/13417815/41364815-0bf61ade-6f38-11e8-887f-6e14830cffe0.png)

---

**Note:**
_Continue_ button and its position is not fixed yet. That's another issue.