### PR TITLE
Use Authentication.default_auth_status_ok?

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -858,7 +858,7 @@ module Mixins
     end
 
     def default_auth_status
-      @ems.authentication_status_ok? unless @ems.kind_of?(ManageIQ::Providers::Google::CloudManager)
+      @ems.default_auth_status_ok? unless @ems.kind_of?(ManageIQ::Providers::Google::CloudManager)
     end
   end
 end


### PR DESCRIPTION
The UI expects each provider to report its auth status.
Since kubevirt uses its own token, it might be valid while the parent provider is invalid.

That causes the default_auth_status in the UI [1] to report a failed
status when editing the kubevirt provider as an infrastructure provider,
since it refers to the status of the parent container manager. 
As a result of that failure, the dialog cannot be saved.

In order to allow the providers to override the default_auth_status,
a new method was introduced, so its own purpose is reporting the default auth status.

[1] https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/ems_common_angular.rb#L861

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/71

Depends on https://github.com/ManageIQ/manageiq/pull/17576