### PR TITLE
Show Configuration Workflows in UI

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -104,9 +104,9 @@ module ApplicationController::Tags
       return unless load_edit("#{session[:tag_db]}_edit_tags__#{id}")
       @object_ids = @edit[:object_ids]
     end
+    @in_a_form = true
     tagging_tags_set_form_vars
     @display   = nil
-    @in_a_form = true
     session[:changed] = false
     add_flash(_("All changes have been reset"), :warning) if params[:button] == "reset"
     @title = _('Tag Assignment')

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -169,6 +169,11 @@ class AutomationManagerController < ApplicationController
 
   private
 
+  def is_template_record?
+    @record.kind_of?(ConfigurationWorkflow) || @record.kind_of?(ConfigurationScript)
+  end
+  helper_method :is_template_record?
+
   def textual_group_list
     [%i(properties tags)]
   end
@@ -345,7 +350,7 @@ class AutomationManagerController < ApplicationController
     get_node_info(x_node)
     @delete_node = params[:id] if @replace_trees
     type, _id = parse_nodetype_and_id(x_node)
-    type && %w(ConfiguredSystem ConfigurationScript).include?(TreeBuilder.get_model_for_prefix(type))
+    type && %w(ConfiguredSystem ConfigurationScript ConfigurationWorkflow).include?(TreeBuilder.get_model_for_prefix(type))
   end
 
   def managed_group_record?(node = x_node)

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -170,7 +170,7 @@ class AutomationManagerController < ApplicationController
   private
 
   def is_template_record?
-    @record.kind_of?(ManageIQ::Providers::AutomationManager::ConfigurationWorkflow) || @record.kind_of?(ConfigurationScript)
+    @record.kind_of?(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow) || @record.kind_of?(ConfigurationScript)
   end
   helper_method :is_template_record?
 

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -169,10 +169,10 @@ class AutomationManagerController < ApplicationController
 
   private
 
-  def is_template_record?
+  def template_record?
     @record.kind_of?(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow) || @record.kind_of?(ConfigurationScript)
   end
-  helper_method :is_template_record?
+  helper_method :template_record?
 
   def textual_group_list
     [%i(properties tags)]
@@ -272,9 +272,9 @@ class AutomationManagerController < ApplicationController
   end
 
   def cs_provider_node(provider)
-    options = {:model                 => "ConfigurationScript",
-               :named_scope           => [[:with_manager, provider.id]],
-               :gtl_dbname            => "automation_manager_configuration_scripts"}
+    options = {:model       => "ConfigurationScript",
+               :named_scope => [[:with_manager, provider.id]],
+               :gtl_dbname  => "automation_manager_configuration_scripts"}
     @show_adv_search = true
     process_show_list(options)
     @right_cell_text = _("Templates under \"%{name}\"") % {:name => provider.name}
@@ -306,8 +306,8 @@ class AutomationManagerController < ApplicationController
     return configuration_script_node(id) if id
     @show_adv_search = true
     if x_active_tree == :configuration_scripts_tree
-      options = {:model       => model.to_s,
-                 :gtl_dbname  => "configuration_scripts"}
+      options = {:model      => model.to_s,
+                 :gtl_dbname => "configuration_scripts"}
       @right_cell_text = _("All Ansible Tower Templates")
       process_show_list(options)
     end
@@ -333,8 +333,8 @@ class AutomationManagerController < ApplicationController
       process_show_list(options)
       @right_cell_text = _("All Ansible Tower Configured Systems")
     elsif x_active_tree == :configuration_scripts_tree
-      options = {:model       => "ConfigurationScript",
-                 :gtl_dbname  => "automation_manager_configuration_scripts"}
+      options = {:model      => "ConfigurationScript",
+                 :gtl_dbname => "automation_manager_configuration_scripts"}
       process_show_list(options)
       @right_cell_text = _("All Ansible Tower Templates")
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -892,7 +892,7 @@ class CatalogController < ApplicationController
         add_flash(_("Provider is required, please select one from the list"), :error)
       else
         # ensure Job Template is selected as well, required field
-        add_flash(_("Job Template is required, please select one from the list"), :error) if @edit[:new][:template_id].blank?
+        add_flash(_("Template is required, please select one from the list"), :error) if @edit[:new][:template_id].blank?
       end
     end
 
@@ -1487,7 +1487,7 @@ class CatalogController < ApplicationController
     ct = ContainerTemplate.find_by(:id => @record.config_info[:provision][:container_template_id]) if @record.config_info[:provision] && @record.config_info[:provision][:container_template_id]
     @edit[:new][:template_id] = ct.try(:id)
     @edit[:new][:manager_id] = ct.try(:ext_management_system).try(:id)
-    available_job_or_container_templates(@edit[:new][:manager_id]) if @edit[:new][:manager_id]
+    available_container_templates(@edit[:new][:manager_id]) if @edit[:new][:manager_id]
   end
 
   def get_form_vars_orchestration
@@ -1565,7 +1565,7 @@ class CatalogController < ApplicationController
       ManageIQ::Providers::AnsibleTower::AutomationManager.all.collect { |t| [t.name, t.id] }.sort
     @edit[:new][:template_id] = @record.job_template.try(:id)
     @edit[:new][:manager_id] = @record.job_template.try(:manager).try(:id)
-    available_job_or_container_templates(@edit[:new][:manager_id]) if @edit[:new][:manager_id]
+    available_job_templates(@edit[:new][:manager_id]) if @edit[:new][:manager_id]
   end
 
   def add_orchestration_template_vars(st)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -890,9 +890,9 @@ class CatalogController < ApplicationController
     if @edit[:new][:st_prov_type] == 'generic_ansible_tower'
       if @edit[:new][:manager_id].blank?
         add_flash(_("Provider is required, please select one from the list"), :error)
-      else
+      elsif @edit[:new][:template_id].blank?
         # ensure Job Template is selected as well, required field
-        add_flash(_("Template is required, please select one from the list"), :error) if @edit[:new][:template_id].blank?
+        add_flash(_("Template is required, please select one from the list"), :error)
       end
     end
 
@@ -1549,15 +1549,16 @@ class CatalogController < ApplicationController
   end
 
   def available_job_templates(manager_id)
-    @edit[:new][:available_templates]= []
+    @edit[:new][:available_templates] = []
     all_job_templates = ExtManagementSystem.find_by(:id => manager_id).send('configuration_scripts').collect { |t| [t.name, t.id] }.sort
     all_workflow_templates = ExtManagementSystem.find_by(:id => manager_id).send('configuration_workflows').collect { |t| [t.name, t.id] }.sort
-    @edit[:new][:available_templates].push(["", [["<#{_('Choose a Template')}>",
-                                         :selected => "<#{_('Choose a Template')}>",
-                                         :disabled => "<#{_('Choose a Template')}>",
-                                         :style    => 'display:none']]])
-    @edit[:new][:available_templates].push(["Job Templates", all_job_templates]) unless all_job_templates.blank?
-    @edit[:new][:available_templates].push(["Workflow Templates", all_workflow_templates]) unless all_workflow_templates.blank?
+    @edit[:new][:available_templates].push(["",
+                                            [["<#{_('Choose a Template')}>",
+                                              :selected => "<#{_('Choose a Template')}>",
+                                              :disabled => "<#{_('Choose a Template')}>",
+                                              :style    => 'display:none']]])
+    @edit[:new][:available_templates].push(["Job Templates", all_job_templates]) if all_job_templates.present?
+    @edit[:new][:available_templates].push(["Workflow Templates", all_workflow_templates]) if all_workflow_templates.present?
   end
 
   def available_ansible_tower_managers

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -370,7 +370,7 @@ module Mixins
     def miq_search_node
       options = {:model => model_from_active_tree(x_active_tree)}
       if x_active_tree == :configuration_scripts_tree
-        options = {:model      => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
+        options = {:model      => "ConfigurationScript",
                    :gtl_dbname => "automation_manager_configuration_scripts"}
       end
       process_show_list(options)

--- a/app/decorators/configuration_script_decorator.rb
+++ b/app/decorators/configuration_script_decorator.rb
@@ -1,0 +1,5 @@
+class ConfigurationScriptDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-template'
+  end
+end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_workflow_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_workflow_decorator.rb
@@ -1,0 +1,11 @@
+module ManageIQ::Providers::AnsibleTower
+  class AutomationManager::ConfigurationWorkflowDecorator < MiqDecorator
+    def self.fonticon
+      'pficon pficon-template'
+    end
+
+    def self.fileicon
+      '100/configuration_script.png'
+    end
+  end
+end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_workflow_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_workflow_decorator.rb
@@ -3,9 +3,5 @@ module ManageIQ::Providers::AnsibleTower
     def self.fonticon
       'pficon pficon-template'
     end
-
-    def self.fileicon
-      '100/configuration_script.png'
-    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -137,7 +137,7 @@ module ApplicationHelper
     "ManageIQ::Providers::CloudManager::Vm"       => VmOrTemplate,
     "ManageIQ::Providers::InfraManager::Template" => VmOrTemplate,
     "ManageIQ::Providers::InfraManager::Vm"       => VmOrTemplate,
-    "ManageIQ::Providers::AutomationManager"      => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
+    "ManageIQ::Providers::AutomationManager"      => ConfigurationScript
   }.freeze
 
   def controller_to_model
@@ -157,7 +157,7 @@ module ApplicationHelper
     "chargebacks"                            => ChargebackRate,
     "playbooks"                              => ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook,
     "physical_servers_with_host"             => PhysicalServer,
-    "manageiq/providers/automation_managers" => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript,
+    "manageiq/providers/automation_managers" => ConfigurationScript,
     "vms"                                    => VmOrTemplate,
     "ServiceCatalog"                         => ServiceTemplate
   }.freeze
@@ -333,7 +333,7 @@ module ApplicationHelper
         elsif %w(ConfiguredSystem).include?(view.db) && (request.parameters[:controller] == "provider_foreman" || request.parameters[:controller] == "automation_manager")
           return url_for_only_path(:action => action, :id => nil) + "/"
         elsif %w(MiqWidget
-                 ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
+                 ConfigurationScript
                  MiqReportResult).include?(view.db) &&
               %w(report automation_manager).include?(request.parameters[:controller])
           suffix = ''
@@ -454,7 +454,7 @@ module ApplicationHelper
       controller = request.parameters[:controller]
     when "OrchestrationStackOutput", "OrchestrationStackParameter", "OrchestrationStackResource",
         "ManageIQ::Providers::CloudManager::OrchestrationStack",
-        "ManageIQ::Providers::AnsibleTower::AutomationManager::Job", "ConfigurationScriptBase"
+        "ManageIQ::Providers::AnsibleTower::AutomationManager::Job", "ConfigurationScript"
       controller = request.parameters[:controller]
     when "ContainerVolume"
       controller = "persistent_volume"
@@ -972,7 +972,7 @@ module ApplicationHelper
     when :configuration_manager_cs_filter_tree
       "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"
     when :configuration_scripts_tree
-      "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript"
+      "ConfigurationScript"
     end
   end
 

--- a/app/helpers/application_helper/toolbar/configuration_script_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_script_center.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Toolbar::ConfigurationScriptCenter < ApplicationHelper:
         button(
           :configscript_service_dialog,
           'pficon pficon-add-circle-o fa-lg',
-          t = N_('Create Service Dialog from this Job Template'),
+          t = N_('Create Service Dialog from this Template'),
           t),
       ]
     ),
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::ConfigurationScriptCenter < ApplicationHelper:
         button(
           :configuration_script_tag,
           'pficon pficon-edit fa-lg',
-          N_('Edit Tags for this Job Template'),
+          N_('Edit Tags for this Template'),
           N_('Edit Tags'),
           :url          => "tagging",
           :url_parms    => "main_div",

--- a/app/helpers/application_helper/toolbar/x_configuration_script_center.rb
+++ b/app/helpers/application_helper/toolbar/x_configuration_script_center.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Toolbar::XConfigurationScriptCenter < ApplicationHelper
         button(
           :configscript_service_dialog,
           'pficon pficon-add-circle-o fa-lg',
-          t = N_('Create Service Dialog from this Job Template'),
+          t = N_('Create Service Dialog from this Template'),
           t),
                 ]
     ),
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::XConfigurationScriptCenter < ApplicationHelper
         button(
           :configuration_script_tag,
           'pficon pficon-edit fa-lg',
-          N_('Edit Tags for this Job Template'),
+          N_('Edit Tags for this Template'),
           N_('Edit Tags'),
           :url          => "tagging",
           :url_parms    => "main_div",

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -533,6 +533,7 @@ class TreeBuilder
     "cl"   => "Classification",
     "cf"   => "ConfigurationScript",
     "cfp"  => "ConfigurationScriptPayload",
+    "cw"   => "ConfigurationWorkflow",
     "cnt"  => "Container",
     "co"   => "Condition",
     "cbg"  => "CustomButtonSet",

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -5,7 +5,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript"}
+    {:leaf => "ConfigurationScriptBase"}
   end
 
   def set_locals_for_render
@@ -15,7 +15,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
 
   def root_options
     {
-      :text    => t = _("All Ansible Tower Job Templates"),
+      :text    => t = _("All Ansible Tower Templates"),
       :tooltip => t
     }
   end
@@ -43,7 +43,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   end
 
   def x_get_tree_cmat_kids(object, count_only)
-    scripts = ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.where(:manager_id => object.id)
+    scripts = ConfigurationScriptBase.where(:manager_id => object.id).where.not(:type => ConfigurationScriptBase::EXCLUDED_WORKFLOW_TYPES)
     count_only_or_objects_filtered(count_only, scripts, "name")
   end
 

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -5,7 +5,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "ConfigurationScriptBase"}
+    {:leaf => "ConfigurationScript"}
   end
 
   def set_locals_for_render
@@ -43,7 +43,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   end
 
   def x_get_tree_cmat_kids(object, count_only)
-    scripts = ConfigurationScriptBase.where(:manager_id => object.id).where.not(:type => ConfigurationScriptBase::EXCLUDED_WORKFLOW_TYPES)
+    scripts = ConfigurationScript.where(:manager_id => object.id)
     count_only_or_objects_filtered(count_only, scripts, "name")
   end
 

--- a/app/presenters/tree_node/configuration_script_base.rb
+++ b/app/presenters/tree_node/configuration_script_base.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class ConfigurationScriptBase < Node
     set_attribute(:icon, 'pficon pficon-template')
-    set_attribute(:tooltip) { _("Ansible Tower Job Template: %{name}") % {:name => @object.name} }
+    set_attribute(:tooltip) { _("%{type}: %{name}") % {:name => @object.name, :type => ui_lookup(:model => @object.type)} }
   end
 end

--- a/app/views/automation_manager/explorer.html.haml
+++ b/app/views/automation_manager/explorer.html.haml
@@ -11,7 +11,7 @@
 - elsif @configured_system_record
   #main_div
     = render :partial => "layouts/textual_groups_generic"
-- elsif @record.kind_of?(ConfigurationScript)
+- elsif is_template_record?
   #main_div
     = render(:partial => 'automation_manager/configuration_script', :locals => {:controller => "automation_manager"})
 - else

--- a/app/views/automation_manager/explorer.html.haml
+++ b/app/views/automation_manager/explorer.html.haml
@@ -11,7 +11,7 @@
 - elsif @configured_system_record
   #main_div
     = render :partial => "layouts/textual_groups_generic"
-- elsif is_template_record?
+- elsif template_record?
   #main_div
     = render(:partial => 'automation_manager/configuration_script', :locals => {:controller => "automation_manager"})
 - else

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -105,13 +105,12 @@
           :javascript
             miqSelectPickerEvent('manager_id', '#{url}')
       - if @edit[:new][:manager_id]
-        - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_templates]
         .form-group
           %label.col-md-2.control-label
-            = @edit[:new][:st_prov_type] == "generic_ansible_tower" ? _('Ansible Tower Job Template') : _('Container Template')
+            = @edit[:new][:st_prov_type] == "generic_ansible_tower" ? _('Ansible Tower Template') : _('Container Template')
           .col-md-8
             = select_tag('template_id',
-                          options_for_select(opts, @edit[:new][:template_id]),
+                          grouped_options_for_select(@edit[:new][:available_templates], @edit[:new][:template_id]),
                           "data-miq_sparkle_on" => true,
                           :class                => "selectpicker")
             :javascript

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -68,7 +68,7 @@
         - elsif @record.prov_type == "generic_ansible_tower"
           .form-group
             %label.col-md-3.control-label
-              = _('Ansible Tower Job Template')
+              = _('Ansible Tower Template')
             .col-md-9
               = h(@record.try(:job_template).try(:name))
         - elsif @record.prov_type == "generic_container_template"

--- a/app/views/layouts/print/textual_summary.html.haml
+++ b/app/views/layouts/print/textual_summary.html.haml
@@ -3,7 +3,7 @@
   = render :partial => "#{controller}/main_configuration_profile"
 - elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::InventoryGroup)
   = render :partial => "#{controller}/main_inventory_group"
-- elsif is_template_record?
+- elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::ConfigurationWorkflow) || @record.kind_of?(ConfigurationScript)
   = render :partial => "#{controller}/configuration_script"
 - else
   = render :partial => "layouts/textual_groups_generic"

--- a/app/views/layouts/print/textual_summary.html.haml
+++ b/app/views/layouts/print/textual_summary.html.haml
@@ -3,7 +3,7 @@
   = render :partial => "#{controller}/main_configuration_profile"
 - elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::InventoryGroup)
   = render :partial => "#{controller}/main_inventory_group"
-- elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::ConfigurationWorkflow) || @record.kind_of?(ConfigurationScript)
+- elsif @record.kind_of?(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow) || @record.kind_of?(ConfigurationScript)
   = render :partial => "#{controller}/configuration_script"
 - else
   = render :partial => "layouts/textual_groups_generic"

--- a/app/views/layouts/print/textual_summary.html.haml
+++ b/app/views/layouts/print/textual_summary.html.haml
@@ -3,7 +3,7 @@
   = render :partial => "#{controller}/main_configuration_profile"
 - elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::InventoryGroup)
   = render :partial => "#{controller}/main_inventory_group"
-- elsif @record.kind_of?(ManageIQ::Providers::AutomationManager::ConfigurationScript)
+- elsif is_template_record?
   = render :partial => "#{controller}/configuration_script"
 - else
   = render :partial => "layouts/textual_groups_generic"

--- a/product/views/ConfigurationScript.yaml
+++ b/product/views/ConfigurationScript.yaml
@@ -15,7 +15,7 @@ title: Ansible Tower Templates
 name: Templates
 
 # Main DB table report is based on
-db: ConfigurationScriptBase
+db: ConfigurationScript
 
 # Columns to fetch from the main table
 cols:

--- a/product/views/ConfigurationScriptBase.yaml
+++ b/product/views/ConfigurationScriptBase.yaml
@@ -9,13 +9,13 @@
 #
 
 # Report title
-title: Ansible Tower Job Templates
+title: Ansible Tower Templates
 
 # Menu name
-name: Job Templates
+name: Templates
 
 # Main DB table report is based on
-db: ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
+db: ConfigurationScriptBase
 
 # Columns to fetch from the main table
 cols:

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -644,7 +644,7 @@ describe AutomationManagerController do
       FactoryGirl.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
       post :tagging, :params => {:id => @cs.id, :format => :js}
       expect(response.status).to eq(200)
-      expect(response.body).to include('Job Template (Ansible Tower) Being Tagged')
+      expect(response.body).to include('Template (Ansible Tower) Being Tagged')
     end
   end
 

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -427,7 +427,7 @@ describe AutomationManagerController do
       allow(controller).to receive(:x_active_tree).and_return(:configuration_scripts_tree)
       allow(controller).to receive(:x_active_accord).and_return(:configuration_scripts)
       controller.instance_variable_set(:@_params, :id => "configuration_scripts")
-      expect(controller).to receive(:get_view).with("ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript", :gtl_dbname => "automation_manager_configuration_scripts").and_call_original
+      expect(controller).to receive(:get_view).with("ConfigurationScript", :gtl_dbname => "automation_manager_configuration_scripts").and_call_original
       controller.send(:accordion_select)
     end
   end

--- a/spec/presenters/tree_node/configuration_script_base_spec.rb
+++ b/spec/presenters/tree_node/configuration_script_base_spec.rb
@@ -4,5 +4,5 @@ describe TreeNode::ConfigurationScriptBase do
 
   include_examples 'TreeNode::Node#key prefix', 'cf-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-template'
-  include_examples 'TreeNode::Node#tooltip prefix', 'Ansible Tower Job Template'
+  include_examples 'TreeNode::Node#tooltip prefix', 'Job Template (Ansible Tower)'
 end


### PR DESCRIPTION
Changes to show list of Job Templates and Configuration Workflows in existing UI under Automation/Ansible Tower/Explorer in Templates Accordion.

https://bugzilla.redhat.com/show_bug.cgi?id=1590441

before:
![screenshot from 2018-06-13 16-53-23](https://user-images.githubusercontent.com/3450808/41377552-5f6d391c-6f2a-11e8-9dc6-fed634d48554.png)

![screenshot from 2018-06-13 16-53-47](https://user-images.githubusercontent.com/3450808/41377560-62664014-6f2a-11e8-8fa4-761683b298f8.png)


after:
![screenshot from 2018-06-18 17-08-29](https://user-images.githubusercontent.com/3450808/41562572-0aff9c90-731b-11e8-98a0-b6759e0a85f1.png)

![screenshot from 2018-06-18 17-08-39](https://user-images.githubusercontent.com/3450808/41562575-0e99e824-731b-11e8-95d5-e53876a100ae.png)

![screenshot from 2018-06-22 12-30-12](https://user-images.githubusercontent.com/3450808/41788991-a36fa580-761b-11e8-8790-df862448de4a.png)


Depends on https://github.com/ManageIQ/manageiq/pull/17720
