### PR TITLE
Add icon for host_failure event.

### DIFF
--- a/app/decorators/miq_event_definition_decorator.rb
+++ b/app/decorators/miq_event_definition_decorator.rb
@@ -95,6 +95,7 @@ class MiqEventDefinitionDecorator < MiqDecorator
       "host_compliance_passed"                      => "pficon pficon-screen",
       "host_connect"                                => "pficon pficon-screen",
       "host_disconnect"                             => "pficon pficon-screen",
+      "host_failure"                                => "pficon pficon-screen",
       "host_perf_complete"                          => "pficon pficon-screen",
       "host_provisioned"                            => "pficon pficon-screen",
       "host_remove_from_cluster"                    => "pficon pficon-screen",


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/17578.

https://bugzilla.redhat.com/show_bug.cgi?id=1495265

@miq-bot add_label enhancement, gaprindashvili/no