### PR TITLE
Ensure new dialog user component is used for service reconfiguration

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -50,6 +50,8 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
     var apiData;
     if (apiSubmitEndpoint.match(/generic_objects/)) {
       apiData = {action: apiAction, parameters: _.omit(vm.dialogData, 'action')};
+    } else if (apiAction === 'reconfigure') {
+      apiData = {action: apiAction, resource: _.omit(vm.dialogData, 'action')};
     } else {
       apiData = vm.dialogData;
     }

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -161,11 +161,12 @@ class ServiceController < ApplicationController
     if ra && ra.dialog_id
       @right_cell_text = _("Reconfigure Service \"%{name}\"") % {:name => st.name}
       options = {
-        :header      => @right_cell_text,
-        :target_id   => s.id,
-        :target_kls  => s.class.name,
-        :dialog      => s.options[:dialog],
-        :dialog_mode => :reconfigure
+        :header        => @right_cell_text,
+        :target_id     => s.id,
+        :target_kls    => s.class.name,
+        :dialog        => s.options[:dialog],
+        :dialog_mode   => :reconfigure,
+        :dialog_locals => DialogLocalService.new.determine_dialog_locals_for_service_reconfiguration(ra, s)
       }
       dialog_initialize(ra, options)
     end

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -20,6 +20,20 @@ class DialogLocalService
     Vm
   ).freeze
 
+  def determine_dialog_locals_for_service_reconfiguration(resource_action, target)
+    {
+      :resource_action_id     => resource_action.id,
+      :target_id              => target.id,
+      :target_type            => "service",
+      :dialog_id              => resource_action.dialog_id,
+      :force_old_dialog_use   => false,
+      :api_submit_endpoint    => "/api/services/#{target.id}",
+      :api_action             => "reconfigure",
+      :finish_submit_endpoint => "/service/explorer",
+      :cancel_endpoint        => "/service/explorer"
+    }
+  end
+
   def determine_dialog_locals_for_svc_catalog_provision(resource_action, target, finish_submit_endpoint)
     api_submit_endpoint = "/api/service_catalogs/#{target.service_template_catalog_id}/service_templates/#{target.id}"
 

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -104,7 +104,7 @@ describe('dialogUserController', function() {
           dialogFieldRefreshService: dialogFieldRefreshService,
           miqService: miqService,
           dialogId: '1234',
-          apiSubmitEndpoint: 'service/explorer',
+          apiSubmitEndpoint: 'generic_objects/explorer',
           apiAction: 'custom_action',
           cancelEndpoint: 'cancel endpoint',
           finishSubmitEndpoint: 'finish submit endpoint',
@@ -123,8 +123,41 @@ describe('dialogUserController', function() {
         $controller.submitButtonClicked();
 
         setTimeout(function() {
+          expect(API.post).toHaveBeenCalledWith('generic_objects/explorer', {
+            parameters: {field1: 'field1'}, action: 'custom_action'}, {skipErrors: [400]});
+          done();
+        });
+      });
+    });
+
+    context('when the api action is reconfigure', function() {
+      beforeEach(inject(function(_$controller_) {
+        $controller = _$controller_('dialogUserController', {
+          API: API,
+          dialogFieldRefreshService: dialogFieldRefreshService,
+          miqService: miqService,
+          dialogId: '1234',
+          apiSubmitEndpoint: 'service/explorer',
+          apiAction: 'reconfigure',
+          cancelEndpoint: 'cancel endpoint',
+          finishSubmitEndpoint: 'finish submit endpoint',
+          resourceActionId: '789',
+          targetId: '987',
+          targetType: 'targettype',
+          saveable: true,
+        });
+
+        $controller.setDialogData({data: {field1: 'field1'}, validations: { isValid : true}});
+
+        spyOn(API, 'post').and.returnValue(Promise.resolve('awesome'));
+      }));
+
+      it('posts to the API with the right data', function(done) {
+        $controller.submitButtonClicked();
+
+        setTimeout(function() {
           expect(API.post).toHaveBeenCalledWith('service/explorer', {
-            field1: 'field1', action: 'custom_action'}, {skipErrors: [400]});
+            resource: {field1: 'field1'}, action: 'reconfigure'}, {skipErrors: [400]});
           done();
         });
       });

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -1,6 +1,25 @@
 describe DialogLocalService do
   let(:service) { described_class.new }
 
+  describe "#determine_dialog_locals_for_service_reconfiguration" do
+    let(:target) { instance_double("Service", :id => 123) }
+    let(:resource_action) { instance_double("ResourceAction", :id => 456, :dialog_id => 654) }
+
+    it "returns a hash" do
+      expect(service.determine_dialog_locals_for_service_reconfiguration(resource_action, target)).to eq(
+        :resource_action_id     => 456,
+        :target_id              => 123,
+        :target_type            => "service",
+        :dialog_id              => 654,
+        :force_old_dialog_use   => false,
+        :api_submit_endpoint    => "/api/services/123",
+        :api_action             => "reconfigure",
+        :finish_submit_endpoint => "/service/explorer",
+        :cancel_endpoint        => "/service/explorer"
+      )
+    end
+  end
+
   describe "#determine_dialog_locals_for_svc_catalog_provision" do
     let(:resource_action) { instance_double("ResourceAction", :id => 456, :dialog_id => 654) }
     let(:target) { instance_double("ServiceTemplate", :class => ServiceTemplate, :id => 321, :service_template_catalog_id => 123) }


### PR DESCRIPTION
When reconfiguring a service, the UI was attempting to use the old dialog-user component, and therefore wasn't displaying properly. This change ensures the reconfiguration dialog goes through the new dialog-user component and submits to the correct 'reconfigure' API endpoint.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1580987