### PR TITLE
Extracting physical ports of a switch to a new page

### DIFF
--- a/app/controllers/physical_network_port_controller.rb
+++ b/app/controllers/physical_network_port_controller.rb
@@ -1,0 +1,33 @@
+class PhysicalNetworkPortController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
+  include Mixins::GenericSessionMixin
+
+  before_action :check_privileges
+  before_action :session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def self.model
+    @model ||= "PhysicalNetworkPort".safe_constantize
+  end
+
+  def title
+    _('Network Ports')
+  end
+
+  def model
+    self.class.model
+  end
+
+  def self.table_name
+    @table_name ||= "physical_network_ports"
+  end
+
+  def textual_group_list
+    [
+      %i(properties),
+    ]
+  end
+  helper_method(:textual_group_list)
+end

--- a/app/controllers/physical_switch_controller.rb
+++ b/app/controllers/physical_switch_controller.rb
@@ -30,13 +30,17 @@ class PhysicalSwitchController < ApplicationController
 
   def textual_group_list
     [
-      %i(properties management_networks relationships power_management),
-      %i(firmware_details ports),
+      %i(properties management_networks relationships),
+      %i(power_management firmware_details),
     ]
   end
   helper_method(:textual_group_list)
 
   def self.display_methods
-    %w(physical_switches)
+    %w(physical_switches physical_network_ports)
+  end
+
+  def display_physical_network_ports
+    nested_list(PhysicalNetworkPort, :breadcrumb_title => _("Physical Ports"))
   end
 end

--- a/app/decorators/physical_network_port_decorator.rb
+++ b/app/decorators/physical_network_port_decorator.rb
@@ -1,0 +1,5 @@
+class PhysicalNetworkPortDecorator < MiqDecorator
+  def self.fonticon
+    'ff ff-network-port'
+  end
+end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -28,6 +28,7 @@ module ApplicationHelper::PageLayouts
       my_tasks
       ops
       physical_infra_topology
+      physical_network_port
       pxe
       report
       rss

--- a/app/helpers/physical_network_port_helper.rb
+++ b/app/helpers/physical_network_port_helper.rb
@@ -1,0 +1,3 @@
+module PhysicalNetworkPortHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/physical_network_port_helper/textual_summary.rb
+++ b/app/helpers/physical_network_port_helper/textual_summary.rb
@@ -1,0 +1,24 @@
+module PhysicalNetworkPortHelper::TextualSummary
+  def textual_group_properties
+    TextualGroup.new(
+      _('Properties'),
+      %i(port_name port_type peer_mac_address mac_address)
+    )
+  end
+
+  def textual_port_name
+    {:label => _('Name'), :value => @record.port_name}
+  end
+
+  def textual_port_type
+    {:label => _('Type'), :value => @record.port_type}
+  end
+
+  def textual_peer_mac_address
+    {:label => _('Peer Mac Address'), :value => @record.peer_mac_address}
+  end
+
+  def textual_mac_address
+    {:label => _('Mac Address'), :value => @record.mac_address}
+  end
+end

--- a/app/helpers/physical_switch_helper/textual_summary.rb
+++ b/app/helpers/physical_switch_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module PhysicalSwitchHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i(name product_name manufacturer serial_number part_number health_state uid_ems description)
+      %i(name product_name manufacturer serial_number part_number ports health_state uid_ems description)
     )
   end
 
@@ -30,8 +30,13 @@ module PhysicalSwitchHelper::TextualSummary
     TextualTable.new(_("Firmwares"), firmware_details, [_("Name"), _("Version")])
   end
 
-  def textual_group_ports
-    TextualTable.new(_("Ports"), port_details, [_("Name"), _("Type"), _("Peer MAC Address")])
+  def textual_ports
+    ports_count = @record.physical_network_ports.count
+    ports = {:label => _("Ports"), :value => ports_count, :icon => "ff ff-network-port"}
+    if ports_count.positive?
+      ports[:link] = "/physical_switch/show/#{@record.id}?display=ports"
+    end
+    ports
   end
 
   def textual_ext_management_system
@@ -80,9 +85,5 @@ module PhysicalSwitchHelper::TextualSummary
 
   def firmware_details
     @record.hardware.firmwares.collect { |fw| [fw.name, fw.version] }
-  end
-
-  def port_details
-    @record.physical_network_ports.collect { |port| [port.port_name, port.port_type, port.peer_mac_address] }
   end
 end

--- a/app/views/physical_network_port/show.html.haml
+++ b/app/views/physical_network_port/show.html.haml
@@ -1,0 +1,3 @@
+#main_div
+- if @showtype == 'main'
+  = render :partial => "layouts/textual_groups_generic"

--- a/app/views/physical_switch/show.html.haml
+++ b/app/views/physical_switch/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(physical_switches).include?(@display)
+  - if %w(physical_switches physical_network_ports).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
     - case @showtype

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1386,6 +1386,19 @@ Rails.application.routes.draw do
       )
     },
 
+    :physical_network_port    =>  {
+      :get  =>  %w(
+        download_data
+        show_list
+        show
+      ),
+
+      :post   =>  %w(
+        button
+        show_list
+      )
+    },
+
     :guest_device    =>  {
       :get  =>  %w(
         show_list

--- a/product/views/PhysicalNetworkPort.yaml
+++ b/product/views/PhysicalNetworkPort.yaml
@@ -1,0 +1,53 @@
+#Report title
+title: Physical Network Ports
+
+#Menu name
+name: Physical Network Port
+
+
+db: PhysicalNetworkPort
+
+
+# Columns to fetch from main table
+cols:
+- port_name
+- port_type
+- peer_mac_address
+
+
+include:
+
+
+include_for_find:
+  :ext_management_system: {}
+
+
+col_order:
+- port_name
+- port_type
+- peer_mac_address
+
+col_formats:
+
+headers:
+- Port Name
+- Port Type
+- Peer Mac Address
+
+
+conditions:
+
+
+order: Ascending
+
+
+sortby:
+- port_name
+
+group: n
+
+
+graph:
+
+
+dims:


### PR DESCRIPTION
The goal of this PR is to extract the ports table from a `PhysicalSwitch` to another page.

Depends on: ~https://github.com/ManageIQ/manageiq/pull/17593~

**BEFORE**:
![old_ports](https://user-images.githubusercontent.com/3654285/41467807-328426ea-707e-11e8-9f17-e2e7f6ae68f4.png)


**AFTER**:
The goal of this PR is to extract the `port` table from switch summary view, so the switch summary view won't be so polluted.

![switch_ports_table](https://user-images.githubusercontent.com/3654285/41437428-cce4e640-6ffa-11e8-872d-1a85c3ebd4fc.png)

![port_detail](https://user-images.githubusercontent.com/3654285/41437638-627fc5bc-6ffb-11e8-937f-f5e6d07ac9f2.png)

