### PR TITLE
Use decorators for icons/images in the compressed compare view

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -1277,20 +1277,20 @@ module ApplicationController::Compare
     txt = h[:name].truncate(16)
     html_text = ""
     if %w(Vm VmOrTemplate).include?(@sb[:compare_db])
-      img = ActionController::Base.helpers.image_path("svg/vendor-#{h[:vendor].downcase}.svg")
+      img = ActionController::Base.helpers.image_path(h.decorate.fileicon)
       html_text << "<a title=\"#{h[:name]}\" href=\"/#{controller_name}/show/#{h[:id]}\">
                       <img src=\"#{img}\" align=\"middle\" border=\"0\" width=\"20\" height=\"20\"/>
                     </a>"
     elsif @sb[:compare_db] == "Host"
-      img = ActionController::Base.helpers.image_path("svg/vendor-#{h[:vmm_vendor].downcase}.svg")
+      img = ActionController::Base.helpers.image_path(h.decorate.fileicon)
       html_text << "<a href=\"/host/show/#{h[:id]}\">
                       <img src=\"#{img}\" align=\"middle\" border=\"0\" width=\"20\" height=\"20\" />
                     </a>"
     else
-      img = ActionController::Base.helpers.image_path("100/#{@sb[:compare_db].underscore}.png")
+      icon = h.decorate.fonticon
       html_text <<
         "<a href=\"/ems_cluster/show/#{h[:id]}\">
-          <img src=\"#{img}\" align=\"middle\" border=\"0\" width=\"20\" height=\"20\"/>
+          <i class=\"#{icon}\" align=\"middle\" border=\"0\" width=\"20\" height=\"20\"/>
         </a>"
     end
     if i == 0


### PR DESCRIPTION
We removed the PNG images that are still being used for comparing clusters. To fix this we should display the fonticon for them, and it's more safe to do so with decorators, for all cases.

**Before:**
![screenshot from 2018-06-15 08-17-00](https://user-images.githubusercontent.com/649130/41453043-91541d92-7074-11e8-91a2-1ab325350b71.png)

**After:**
![screenshot from 2018-06-15 08-17-12](https://user-images.githubusercontent.com/649130/41453037-8be61022-7074-11e8-8844-952866b3dd9c.png)

@miq-bot add_label bug, gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 
