### PR TITLE
Fixing textual summary payload mount for multilabel components

### DIFF
--- a/app/helpers/textual_multilabel.rb
+++ b/app/helpers/textual_multilabel.rb
@@ -1,5 +1,5 @@
 TextualMultilabel = Struct.new(:title, :options) do
   def locals
-    {:title => title, :values => options[:values], :labels => options[:labels], :component => 'SimpleTable'}
+    {:title => title, :values => options[:values], :rows => options[:values], :labels => options[:labels], :component => 'SimpleTable'}
   end
 end


### PR DESCRIPTION
__This PR fixes__
https://github.com/ManageIQ/manageiq-ui-classic/issues/4147

__Before this PR__
The `TextualSummaryWrapper` sends this error while trying to process the payload:
`Warning: Failed prop type: The prop 'rows' is marked as required in 'SimpleTable', but its value is 'undefined'.`

__After this PR__
The `TextualMultilabel` struct sets the `:rows` value using the `:values`

This approach was adopted to provider a compatibility with all summaries that uses the TextualMultilabel, but, another approach is to parse the `:rows` value with the value of `options[:rows]`, but this way we must update all the files that uses TextualMultilabel