### PR TITLE
Only call network_ports for vms that have that method

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -240,8 +240,10 @@ module Mixins
               network_adapters << {:name => guest_device.device_name, :vlan => lan.name, :mac => guest_device.address, :add_remove => ''} unless lan.nil?
             end
 
-            vm.network_ports.order(:name).each do |port|
-              network_adapters << { :name => port.name, :network => port.cloud_subnets.try(:first).try(:name) || _('None'), :mac => port.mac_address, :add_remove => '' }
+            if vm.respond_to?(:network_ports)
+              vm.network_ports.order(:name).each do |port|
+                network_adapters << { :name => port.name, :network => port.cloud_subnets.try(:first).try(:name) || _('None'), :mac => port.mac_address, :add_remove => '' }
+              end
             end
           end
 


### PR DESCRIPTION
Adds check that vm responds to :network_ports . Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/3972 which was backported to Gaprindashvili.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1589973

Compute -> Infrastructure -> Virtual Machines -> click any VM -> Configuration -> Reconfigure this VM

Before:
```
FATAL -- : Error caught: [NoMethodError] undefined method `network_ports' for #<ManageIQ::Providers::Redhat::InfraManager::Vm:0x007fb318c306e0>
/usr/local/lib/ruby/gems/2.3.0/gems/activemodel-5.0.7/lib/active_model/attribute_methods.rb:433:in `method_missing'
manageiq-ui-classic/app/controllers/mixins/actions/vm_actions/reconfigure.rb:243:in `get_reconfig_info'
manageiq-ui-classic/app/controllers/mixins/actions/vm_actions/reconfigure.rb:119:in `build_reconfigure_hash'
manageiq-ui-classic/app/controllers/mixins/actions/vm_actions/reconfigure.rb:42:in `reconfigure_form_fields'
```
<img width="1198" alt="screen shot 2018-06-15 at 2 22 51 pm" src="https://user-images.githubusercontent.com/9210860/41467685-b98bb5c6-70a7-11e8-838f-b4bc349e0168.png">


After:
<img width="1211" alt="screen shot 2018-06-15 at 2 11 53 pm" src="https://user-images.githubusercontent.com/9210860/41467269-1bb5b41a-70a6-11e8-9728-da719fb334b7.png">

@miq-bot add_label bug, gaprindashvili/yes