### PR TITLE
Get Network adapters reconfigure data only when the reconfigure is supported 

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -232,7 +232,7 @@ module Mixins
 
           # reconfiguring network adapters is only supported when one vm was selected
           network_adapters = []
-          if @reconfigureitems.size == 1
+          if @reconfigureitems.size == 1 && @reconfigureitems.first.supports_reconfigure_network_adapters?
             vm = @reconfigureitems.first
 
             vm.hardware.guest_devices.order(:device_name => 'asc').each do |guest_device|
@@ -240,8 +240,10 @@ module Mixins
               network_adapters << {:name => guest_device.device_name, :vlan => lan.name, :mac => guest_device.address, :add_remove => ''} unless lan.nil?
             end
 
-            vm.network_ports.order(:name).each do |port|
-              network_adapters << { :name => port.name, :network => port.cloud_subnets.try(:first).try(:name) || _('None'), :mac => port.mac_address, :add_remove => '' }
+            if vm.kind_of?(ManageIQ::Providers::Vmware::CloudManager::Vm)
+              vm.network_ports.order(:name).each do |port|
+                network_adapters << { :name => port.name, :network => port.cloud_subnets.try(:first).try(:name) || _('None'), :mac => port.mac_address, :add_remove => '' }
+              end
             end
           end
 


### PR DESCRIPTION
Get Network adapters reconfigure data only when the reconfigure is supported 


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1591606.

Links 

https://bugzilla.redhat.com/show_bug.cgi?id=1591606
https://github.com/ManageIQ/manageiq-providers-vmware/pull/283

Related PRs:
 
https://github.com/ManageIQ/manageiq-ui-classic/issues/3972

-----------

After:

![screenshot from 2018-06-15 14-36-46](https://user-images.githubusercontent.com/12769982/41484357-863b31c6-70aa-11e8-851a-647027e1f4f1.png)
![screenshot from 2018-06-15 14-36-32](https://user-images.githubusercontent.com/12769982/41484358-86525a22-70aa-11e8-8131-4b938322513b.png)

