### PR TITLE
Fixes confirmation messages for Widgets Add/Edit/Cancel actions.

### DIFF
--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -76,7 +76,7 @@ module ReportController::Widgets
       if !@widget || @widget.id.blank?
         add_flash(_("Add of new Widget was cancelled by the user"))
       else
-        add_flash(_("Edit of Widget \"%{name}\" was cancelled by the user") % {:name => @widget.name})
+        add_flash(_("Edit of Widget \"%{name}\" was cancelled by the user") % {:name => get_record_display_name(@widget)})
       end
       get_node_info
       @widget = nil
@@ -90,7 +90,7 @@ module ReportController::Widgets
       widget_set_record_vars(@widget)
       if widget_validate_entries && @widget.save_with_shortcuts(@edit[:new][:shortcuts].to_a)
         AuditEvent.success(build_saved_audit(@widget, @edit))
-        add_flash(_("Widget \"%{name}\" was saved") % {:name => @widget.title})
+        add_flash(_("Widget \"%{name}\" was saved") % {:name => get_record_display_name(@widget)})
         params[:id] = @widget.id.to_s   # reset id in params for show
         # Build the filter expression and attach widget to schedule filter
         exp = {}
@@ -128,7 +128,7 @@ module ReportController::Widgets
       widgets.push(params[:id]) if params[:id]
     end
     w = MiqWidget.find_by_id(widgets[0])        # temp var to determine the parent node of deleted items
-    process_widgets(widgets, "destroy") unless widgets.empty?
+    process_elements(widgets, MiqWidget, "destroy") unless widgets.empty?
     nodes = x_node.split('-')
     self.x_node = "#{nodes[0]}-#{WIDGET_CONTENT_TYPE.invert[w.content_type]}"
     replace_right_cell(:replace_trees => [:widgets])
@@ -318,11 +318,6 @@ module ReportController::Widgets
         end
       end
     end
-  end
-
-  # Common Widget button handler routines
-  def process_widgets(widgets, task)
-    process_elements(widgets, MiqWidget, task)
   end
 
   def widget_set_form_vars


### PR DESCRIPTION
Fixes all confirmation message for uniformity to match Delete action message display. Uses same common method now to set message text in order of preference: description, title, name, record id. For Widgets .name does not exist, thus a fix to Cancel action message display. 

https://bugzilla.redhat.com/show_bug.cgi?id=1539118

Screen shot, for Widget Add, post code fix:
![widget added confirmation message post code fix](https://user-images.githubusercontent.com/552686/41488441-32cfa228-70a1-11e8-8a41-119477ba803c.png)

Screen shot for Widget Edit, post code fix:
![widget edit saved confirmation message post code fix](https://user-images.githubusercontent.com/552686/41488462-41f6f44a-70a1-11e8-9e33-95ab22d2bf3b.png)

Screen shot for Widget Edit Cancel action, post code fix:
![widget edit cancelled confirmation message post code fix](https://user-images.githubusercontent.com/552686/41488484-4fda7690-70a1-11e8-9672-4fef80904272.png)

Screen shot for Widget Delete, matching other confirmation messages:
![widget deleted confirmation message post code fix](https://user-images.githubusercontent.com/552686/41488504-632316ee-70a1-11e8-9b74-1dd3153dfd99.png)
