### PR TITLE
Changes to AnsibleTowerJobTemplateDialogService to support both job and workflow template.

### DIFF
--- a/app/services/ansible_tower_job_template_dialog_service.rb
+++ b/app/services/ansible_tower_job_template_dialog_service.rb
@@ -5,7 +5,7 @@ class AnsibleTowerJobTemplateDialogService
       tab = dialog.dialog_tabs.build(:display => "edit", :label => "Basic Information", :position => 0)
 
       group_pos = 0
-      add_options_group(tab, group_pos)
+      add_options_group(tab, group_pos, template)
 
       unless template.survey_spec.blank?
         group_pos += 1
@@ -23,30 +23,49 @@ class AnsibleTowerJobTemplateDialogService
 
   private
 
-  def add_options_group(tab, position)
+  def add_options_group(tab, position, template)
     tab.dialog_groups.build(
       :display  => "edit",
       :label    => "Options",
       :position => position
     ).tap do |dialog_group|
-      add_limit_field(dialog_group, 0)
+      add_service_name_field(dialog_group, 0)
+      add_limit_field(dialog_group, 1) if template.supports_limit?
     end
   end
 
-  def add_limit_field(group, position)
+  def add_options_field(group, position, options)
     group.dialog_fields.build(
       :type           => "DialogFieldTextBox",
-      :name           => "limit",
-      :description    => "A ':'-separated string to constrain the list of hosts managed or affected by the playbook",
+      :name           => options[:name],
+      :description    => options[:description],
       :data_type      => "string",
       :display        => "edit",
       :required       => false,
       :options        => {:protected => false},
-      :label          => "Limit",
+      :label          => options[:label],
       :position       => position,
       :reconfigurable => true,
       :dialog_group   => group
     )
+  end
+
+  def add_service_name_field(group, position)
+    options = {
+      :name        => "service_name",
+      :description => "Name of the new service",
+      :label       => "Service Name",
+    }
+    add_options_field(group, position, options)
+  end
+
+  def add_limit_field(group, position)
+    options = {
+      :name        => "limit",
+      :description => "A ':'-separated string to constrain the list of hosts managed or affected by the playbook",
+      :label       => "Limit",
+    }
+    add_options_field(group, position, options)
   end
 
   def add_survey_group(tab, position, template)

--- a/spec/services/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/services/ansible_tower_job_template_dialog_service_spec.rb
@@ -1,5 +1,5 @@
 describe AnsibleTowerJobTemplateDialogService do
-  let(:template) { FactoryGirl.create(:configuration_script) }
+  let(:template) { FactoryGirl.create(:ansible_configuration_script) }
 
   describe "#create_dialog" do
     it "creates a dialog from a job template" do
@@ -54,8 +54,9 @@ describe AnsibleTowerJobTemplateDialogService do
   def assert_option_group(group)
     expect(group).to have_attributes(:label => "Options", :display => "edit")
     fields = group.dialog_fields
-    expect(fields.size).to eq(1)
-    expect(fields[0]).to have_attributes(:label => "Limit", :name => "limit", :required => false, :data_type => 'string')
+    expect(fields.size).to eq(2)
+    expect(fields[0]).to have_attributes(:label => "Service Name", :name => "service_name", :required => false, :data_type => 'string')
+    expect(fields[1]).to have_attributes(:label => "Limit", :name => "limit", :required => false, :data_type => 'string')
   end
 
   def assert_field(field, clss, attributes)


### PR DESCRIPTION
The dialog code for Ansible Tower job template can be used for workflow template as well.

- Add Service Name field in Options group so the dialog would have at least one box.

- Limit option is supported only by Ansible Job Template. Ansible Workflow Template seems does not support it.

Depends on https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/103.

https://bugzilla.redhat.com/show_bug.cgi?id=1590975

Before:
![screen shot 2018-08-13 at 6 01 02 pm](https://user-images.githubusercontent.com/2593270/44060609-34417ee6-9f23-11e8-9a0b-7ab1b32fc6bc.png)

After:
![screen shot 2018-08-13 at 6 01 36 pm](https://user-images.githubusercontent.com/2593270/44060623-406eacfc-9f23-11e8-82fd-f3a9d64549a4.png)

New dialog for workflow job template:
![screen shot 2018-08-13 at 6 01 47 pm](https://user-images.githubusercontent.com/2593270/44060639-4d6d2b40-9f23-11e8-9186-fe75c3f3cc0f.png)
