### PR TITLE
Fix Datastore decorator format string 

### DIFF
--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -18,7 +18,7 @@ class StorageDecorator < MiqDecorator
       },
       :bottom_right => {
         :piechart => percent,
-        :tooltip  => _("%{number}\% Free Space") % {:number => v_free_space_percent_of_total}
+        :tooltip  => _("%{number}") % {:number => v_free_space_percent_of_total} + _("% Free Space")
       }
     }
   end


### PR DESCRIPTION
Fix Datastore decorator format string.

Before this fix - selecting the Infrastructure-> Datastore menu will cause this error:

![screenshot from 2018-06-18 15-57-04](https://user-images.githubusercontent.com/12769982/41559411-f7b8b530-7311-11e8-83d5-5d812ebf42a7.png)


After:
![screenshot from 2018-06-18 16-29-09](https://user-images.githubusercontent.com/12769982/41560685-e4580938-7315-11e8-9209-50532c35290b.png)

