### PR TITLE
[GAPRINDASHVILI] Update ui-components to 1.0.29 for Gaprindashvili

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -57,7 +57,7 @@
     "jquery.observe_field": "https://github.com/himdel/jquery.observe_field.git#a60d9aabffeb66955948a5a0cb89eedcf92ebb50",
     "kubernetes-topology-graph": "https://github.com/kubernetes-ui/topology-graph.git#3751ae5dbaf26407fb93fc6a4c9bc97310886daa",
     "lodash": "https://github.com/lodash/lodash.git#ef20b4290cc4fe7551c82a552ea7ffa76548eec8",
-    "manageiq-ui-components": "https://github.com/ManageIQ/ui-components.git#44c25be84d00a89c8826b405565d9d5669875629",
+    "manageiq-ui-components": "https://github.com/ManageIQ/ui-components.git#72e7c91b37253946fc7fdf9ff6aeafdac50552a0",
     "matchHeight": "https://github.com/liabru/jquery-match-height.git#2446ac654f694bc05a1297cbab0b2d875e278bbd",
     "moment": "https://github.com/moment/moment.git#1fe469f0b78050d3b405b90d2e39a874034a3f01",
     "moment-duration-format": "https://github.com/jsmreese/moment-duration-format.git#8d0bf29a1eab180cb83d0f13f93f6974faedeafd",
@@ -119,7 +119,7 @@
     "jquery.observe_field": "a60d9aabffeb66955948a5a0cb89eedcf92ebb50",
     "kubernetes-topology-graph": "3751ae5dbaf26407fb93fc6a4c9bc97310886daa",
     "lodash": "ef20b4290cc4fe7551c82a552ea7ffa76548eec8",
-    "manageiq-ui-components": "44c25be84d00a89c8826b405565d9d5669875629",
+    "manageiq-ui-components": "72e7c91b37253946fc7fdf9ff6aeafdac50552a0",
     "matchHeight": "2446ac654f694bc05a1297cbab0b2d875e278bbd",
     "moment": "1fe469f0b78050d3b405b90d2e39a874034a3f01",
     "moment-duration-format": "8d0bf29a1eab180cb83d0f13f93f6974faedeafd",
@@ -141,7 +141,7 @@
     "xml_display": "ed5fb8e5dc10f4d66e05c6c27a50defff14672e4"
   },
   "bowerLocker": {
-    "lastUpdated": "2018-05-22T15:40:33.021Z",
+    "lastUpdated": "2018-06-19T10:59:39.603Z",
     "lockedVersions": {
       "angular": "1.6.6",
       "angular-animate": "1.6.6",
@@ -183,7 +183,7 @@
       "jquery.observe_field": "0.1.0",
       "kubernetes-topology-graph": "0.0.23",
       "lodash": "3.10.1",
-      "manageiq-ui-components": "1.0.28",
+      "manageiq-ui-components": "1.0.29",
       "matchHeight": "0.7.2",
       "moment": "2.14.2",
       "moment-duration-format": "1.3.0",


### PR DESCRIPTION
https://github.com/ManageIQ/ui-components/pull/304 ([BZ 1592852](https://bugzilla.redhat.com/show_bug.cgi?id=1592852))
https://github.com/ManageIQ/ui-components/pull/303 ([BZ 1591425](https://bugzilla.redhat.com/show_bug.cgi?id=1591425))
https://github.com/ManageIQ/ui-components/pull/302 ([BZ 1590353](https://bugzilla.redhat.com/show_bug.cgi?id=1590353))
https://github.com/ManageIQ/ui-components/pull/296 ([BZ 1591425](https://bugzilla.redhat.com/show_bug.cgi?id=1591425))