### PR TITLE
Don't allow network manager edit if the network manager doesn't support it

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -160,6 +160,13 @@ module EmsCommon
                          :flash_msg   => err.message,
                          :flash_error => true)
     end
+    if respond_to?(:model_feature_for_action) && !@ems.supports?(model_feature_for_action(:edit))
+      flash_to_session(_("Edit of %{object_type} %{object_name} is not supported.") % {
+        :object_type => ui_lookup(:model => model.to_s),
+        :object_name => @ems.name
+      }, :error)
+      return redirect_to(:action => @lastaction || "show_list")
+    end
     set_form_vars
     @in_a_form = true
     session[:changed] = false

--- a/app/controllers/ems_network_controller.rb
+++ b/app/controllers/ems_network_controller.rb
@@ -35,6 +35,13 @@ class EmsNetworkController < ApplicationController
   end
   public :restful?
 
+  def model_feature_for_action(action)
+    case action
+    when :edit
+      :ems_network_new
+    end
+  end
+
   menu_section :net
   has_custom_buttons
 end

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -268,3 +268,31 @@ describe EmsInfraController do
   end
   include_examples '#download_summary_pdf', :ems_openstack_infra
 end
+
+describe EmsNetworkController do
+  context "::EmsCommon" do
+    context "#button" do
+      before(:each) do
+        stub_user(:features => :all)
+        EvmSpecHelper.create_guid_miq_server_zone
+      end
+
+      it "when edit is pressed for unsupported network manager type" do
+        allow(controller).to receive(:role_allows?).and_return(true)
+        google_net = FactoryGirl.create(:ems_google_network)
+        get :edit, :params => { :id => google_net.id}
+        expect(response.status).to eq(302)
+        expect(session['flash_msgs']).not_to be_empty
+        expect(session['flash_msgs'].first[:message]).to include('is not supported')
+      end
+
+      it "when edit is pressed for supported network manager type" do
+        allow(controller).to receive(:role_allows?).and_return(true)
+        nuage_net = FactoryGirl.create(:ems_nuage_network)
+        get :edit, :params => { :id => nuage_net.id}
+        expect(response.status).to eq(200)
+        expect(session['flash_msgs']).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. Network -> Providers
2. From the list of network providers, select a network provider, which doesn't support editing (e.g. Amazon, Azure, Google)
3. Hit Configuration -> Edit
4. From the list of network providers, select a network provider, which supports editing (currently only Nuage)
5. Hit Configuration -> Edit

With my fix in place, for network provider, that doesn't support editing, you'll get a flash message saying so. If the network provider does support edit, you'll get to the editing screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1577888
