### PR TITLE
Remove unused Ansible Repository page refresh

### DIFF
--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -40,7 +40,6 @@ class AnsibleRepositoryController < ApplicationController
         page.replace("gtl_div", :partial => "layouts/gtl")
       end
     when "ansible_repository_reload"
-      params[:display] = @display if @display
       show
       render :update do |page|
         page << javascript_prologue

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -50,14 +50,6 @@ describe AnsibleRepositoryController do
       expect(response.status).to eq(200)
       expect(response.body).to include("Test Repository (All Playbooks)")
     end
-
-    it 'reload button will stay on the nested list' do
-      get :show, :params => {:id => @repository.id, :display => 'playbooks'}
-      expect(response.status).to eq(200)
-      post :button, :params => { :id => @repository.id, :pressed => 'ansible_repository_reload' }
-      expect(response.status).to eq(200)
-      expect(response).to render_template(:partial => "layouts/_gtl")
-    end
   end
 
   describe '#button' do
@@ -104,17 +96,11 @@ describe AnsibleRepositoryController do
 
     context 'refreshing an actual repository' do
       let(:params) { {:pressed => "ansible_repository_reload"} }
-      let(:display) { "main" }
-
-      before do
-        controller.instance_variable_set(:@display, display)
-      end
 
       it 'calls show and render methods' do
         expect(controller).to receive(:show)
         expect(controller).to receive(:render)
         controller.send(:button)
-        expect(controller.instance_variable_get(:@_params)[:display]).to eq(display)
       end
     end
 


### PR DESCRIPTION
The refresh page button is no longer present on Ansible Repository Playbooks subpage. Because of that it is no longer necessary to handle pressing this button on this subpage. Remove this handling and related spec examples.

Steps to reproduce:

1. Open an Ansible Repository show page.
2. Press the leftmost _Refresh_ button.

Now, https://github.com/ManageIQ/manageiq-ui-classic/blob/29856637524202c4bac5a756bd019086e738dcf2/app/controllers/ansible_repository_controller.rb#L43 is executed, even though this is no longer necessary. This line was useful only for refreshing the Playbooks subpage.

Fixes #4160. Helps #3762.

@miq-bot add_reviewer @hstastna 