### PR TITLE
Fixing showtype error

### DIFF
--- a/app/controllers/mixins/generic_list_mixin.rb
+++ b/app/controllers/mixins/generic_list_mixin.rb
@@ -5,6 +5,7 @@ module Mixins
     end
 
     def show_list
+      @showtype = nil
       @center_toolbar = self.class.toolbar_plural if self.class.toolbar_plural
       process_show_list
     end


### PR DESCRIPTION
__This PR is able to__
- Fix the listnav issue;

__Steps to Reproduce__
- Access a physical provider dashboard view (need to confirm if it happens in other providers);
- Access the `show_list` page of physical providers;
- See that the `listnav` is not shown:

![screenshot-localhost 3000-2018-06-19-09-53-48](https://user-images.githubusercontent.com/8550928/41598573-e907ab50-73a6-11e8-9142-280f1cd778be.png)

This issue is due to `@showtype` value that remains as `"dashboad"` which removes the `listnav` according to the logic inside `app/helpers/application_helper/page_layouts.rb#layout_uses_listnav?`