### PR TITLE
Remove dead methods from NumberHelper

### DIFF
--- a/app/helpers/number_helper.rb
+++ b/app/helpers/number_helper.rb
@@ -30,13 +30,6 @@ module NumberHelper
     nil
   end
 
-  # Converts 1048576 (bytes) to "1.megabytes"
-  def number_to_rails_method(size)
-    return human_size_to_rails_method(number_to_human_size(size, :precision => 1))
-  rescue
-    nil
-  end
-
   # Converts "1 MB" to 1048576 (bytes)
   def human_size_to_number(size)
     return eval(human_size_to_rails_method(size))

--- a/app/helpers/number_helper.rb
+++ b/app/helpers/number_helper.rb
@@ -44,13 +44,6 @@ module NumberHelper
     nil
   end
 
-  # Converts "1.megabytes" to "1 MB"
-  def rails_method_to_human_size(size)
-    return number_to_human_size(eval(size))
-  rescue
-    nil
-  end
-
   # Converts in a similar manner as number_to_human_size, but in units of MHz
   def mhz_to_human_size(size, *args)
     precision = args.first

--- a/app/helpers/number_helper.rb
+++ b/app/helpers/number_helper.rb
@@ -30,13 +30,6 @@ module NumberHelper
     nil
   end
 
-  # Converts "1 MB" to 1048576 (bytes)
-  def human_size_to_number(size)
-    return eval(human_size_to_rails_method(size))
-  rescue
-    nil
-  end
-
   # Converts in a similar manner as number_to_human_size, but in units of MHz
   def mhz_to_human_size(size, *args)
     precision = args.first

--- a/spec/helpers/number_helper_spec.rb
+++ b/spec/helpers/number_helper_spec.rb
@@ -180,42 +180,6 @@ describe NumberHelper do
     expect(helper.human_size_to_number('-1.1 TB')).to eq(-1.1.terabytes)
   end
 
-  it "#rails_method_to_human_size" do
-    expect(helper.rails_method_to_human_size('0')).to eq('0 Bytes')
-    expect(helper.rails_method_to_human_size('1')).to eq('1 Byte')
-    expect(helper.rails_method_to_human_size('123')).to eq('123 Bytes')
-    expect(helper.rails_method_to_human_size('0.bytes')).to eq('0 Bytes')
-    expect(helper.rails_method_to_human_size('1.bytes')).to eq('1 Byte')
-    expect(helper.rails_method_to_human_size('123.bytes')).to eq('123 Bytes')
-    expect(helper.rails_method_to_human_size('444.kilobytes')).to eq('444 KB')
-    expect(helper.rails_method_to_human_size('1023.megabytes')).to eq('1023 MB')
-    expect(helper.rails_method_to_human_size('123.gigabytes')).to eq('123 GB')
-    expect(helper.rails_method_to_human_size('1022.terabytes')).to eq('1022 TB')
-    expect(helper.rails_method_to_human_size('4.petabytes')).to eq('4 PB')
-    expect(helper.rails_method_to_human_size('123.4')).to eq('123 Bytes') # rounds bytes
-    expect(helper.rails_method_to_human_size('123.4.bytes')).to eq('123 Bytes') # rounds bytes
-    expect(helper.rails_method_to_human_size('12.1.kilobytes')).to eq('12.1 KB')
-    expect(helper.rails_method_to_human_size('1.2.megabytes')).to eq('1.2 MB')
-    expect(helper.rails_method_to_human_size('1.1.gigabytes')).to eq('1.1 GB')
-    expect(helper.rails_method_to_human_size('1.1.terabytes')).to eq('1.1 TB')
-
-    expect(helper.rails_method_to_human_size('-1')).to eq('-1 Byte')
-    expect(helper.rails_method_to_human_size('-123')).to eq('-123 Bytes')
-    expect(helper.rails_method_to_human_size('-1.bytes')).to eq('-1 Byte')
-    expect(helper.rails_method_to_human_size('-123.bytes')).to eq('-123 Bytes')
-    expect(helper.rails_method_to_human_size('-444.kilobytes')).to eq('-444 KB')
-    expect(helper.rails_method_to_human_size('-1023.megabytes')).to eq('-1023 MB')
-    expect(helper.rails_method_to_human_size('-123.gigabytes')).to eq('-123 GB')
-    expect(helper.rails_method_to_human_size('-1022.terabytes')).to eq('-1022 TB')
-    expect(helper.rails_method_to_human_size('-4.petabytes')).to eq('-4 PB')
-    expect(helper.rails_method_to_human_size('-123.4')).to eq('-123 Bytes') # rounds bytes
-    expect(helper.rails_method_to_human_size('-123.4.bytes')).to eq('-123 Bytes') # rounds bytes
-    expect(helper.rails_method_to_human_size('-12.1.kilobytes')).to eq('-12.1 KB')
-    expect(helper.rails_method_to_human_size('-1.2.megabytes')).to eq('-1.2 MB')
-    expect(helper.rails_method_to_human_size('-1.1.gigabytes')).to eq('-1.1 GB')
-    expect(helper.rails_method_to_human_size('-1.1.terabytes')).to eq('-1.1 TB')
-  end
-
   context "#mhz_to_human_size" do
     it "without options hash" do
       expect(helper.mhz_to_human_size(0)).to eq('0 MHz')

--- a/spec/helpers/number_helper_spec.rb
+++ b/spec/helpers/number_helper_spec.rb
@@ -109,48 +109,6 @@ describe NumberHelper do
     expect(helper.human_size_to_rails_method('-1.1 TB')).to eq('-1.1.terabytes')
   end
 
-  it "#number_to_rails_method" do
-    expect(helper.number_to_rails_method(0)).to eq('0')
-    expect(helper.number_to_rails_method(1)).to eq('1')
-    expect(helper.number_to_rails_method(3.14159265)).to eq('3')
-    expect(helper.number_to_rails_method(123.0)).to eq('123')
-    expect(helper.number_to_rails_method(123)).to eq('123')
-    expect(helper.number_to_rails_method(1234)).to eq('1.2.kilobytes')
-    expect(helper.number_to_rails_method(12_345)).to eq('12.1.kilobytes')
-    expect(helper.number_to_rails_method(1_234_567)).to eq('1.2.megabytes')
-    expect(helper.number_to_rails_method(1_234_567_890)).to eq('1.1.gigabytes')
-    expect(helper.number_to_rails_method(1_234_567_890_123)).to eq('1.1.terabytes')
-    expect(helper.number_to_rails_method(1_234_567_890_123_456)).to eq('1.1.petabytes')
-    expect(helper.number_to_rails_method(4.petabytes)).to eq('4.petabytes')
-    expect(helper.number_to_rails_method(1022.terabytes)).to eq('1022.terabytes')
-    expect(helper.number_to_rails_method(444.kilobytes)).to eq('444.kilobytes')
-    expect(helper.number_to_rails_method(1023.megabytes)).to eq('1023.megabytes')
-    expect(helper.number_to_rails_method(3.terabytes)).to eq('3.terabytes')
-    expect(helper.number_to_rails_method("123")).to eq('123')
-    expect(helper.number_to_rails_method(1.1)).to eq('1')
-    expect(helper.number_to_rails_method(10)).to eq('10')
-    expect(helper.number_to_rails_method(nil)).to be_nil
-
-    expect(helper.number_to_rails_method(-1)).to eq('-1')
-    expect(helper.number_to_rails_method(-3.14159265)).to eq('-3')
-    expect(helper.number_to_rails_method(-123.0)).to eq('-123')
-    expect(helper.number_to_rails_method(-123)).to eq('-123')
-    expect(helper.number_to_rails_method(-1234)).to eq('-1.2.kilobytes')
-    expect(helper.number_to_rails_method(-12_345)).to eq('-12.1.kilobytes')
-    expect(helper.number_to_rails_method(-1_234_567)).to eq('-1.2.megabytes')
-    expect(helper.number_to_rails_method(-1_234_567_890)).to eq('-1.1.gigabytes')
-    expect(helper.number_to_rails_method(-1_234_567_890_123)).to eq('-1.1.terabytes')
-    expect(helper.number_to_rails_method(-1_234_567_890_123_456)).to eq('-1.1.petabytes')
-    expect(helper.number_to_rails_method(-4.petabytes)).to eq('-4.petabytes')
-    expect(helper.number_to_rails_method(-1022.terabytes)).to eq('-1022.terabytes')
-    expect(helper.number_to_rails_method(-444.kilobytes)).to eq('-444.kilobytes')
-    expect(helper.number_to_rails_method(-1023.megabytes)).to eq('-1023.megabytes')
-    expect(helper.number_to_rails_method(-3.terabytes)).to eq('-3.terabytes')
-    expect(helper.number_to_rails_method("-123")).to eq('-123')
-    expect(helper.number_to_rails_method(-1.1)).to eq('-1')
-    expect(helper.number_to_rails_method(-10)).to eq('-10')
-  end
-
   it "#human_size_to_number" do
     expect(helper.human_size_to_number('0 Bytes')).to eq(0)
     expect(helper.human_size_to_number('1 Byte')).to eq(1)

--- a/spec/helpers/number_helper_spec.rb
+++ b/spec/helpers/number_helper_spec.rb
@@ -109,35 +109,6 @@ describe NumberHelper do
     expect(helper.human_size_to_rails_method('-1.1 TB')).to eq('-1.1.terabytes')
   end
 
-  it "#human_size_to_number" do
-    expect(helper.human_size_to_number('0 Bytes')).to eq(0)
-    expect(helper.human_size_to_number('1 Byte')).to eq(1)
-    expect(helper.human_size_to_number('123 Bytes')).to eq(123)
-    expect(helper.human_size_to_number('444 KB')).to eq(444.kilobytes)
-    expect(helper.human_size_to_number('1023 MB')).to eq(1023.megabytes)
-    expect(helper.human_size_to_number('123 GB')).to eq(123.gigabytes)
-    expect(helper.human_size_to_number('1022 TB')).to eq(1022.terabytes)
-    expect(helper.human_size_to_number('4 PB')).to eq(4.petabytes)
-    expect(helper.human_size_to_number('123.4 Bytes')).to eq(123.4)
-    expect(helper.human_size_to_number('12.1 KB')).to eq(12.1.kilobytes)
-    expect(helper.human_size_to_number('1.2 MB')).to eq(1.2.megabytes)
-    expect(helper.human_size_to_number('1.1 GB')).to eq(1.1.gigabytes)
-    expect(helper.human_size_to_number('1.1 TB')).to eq(1.1.terabytes)
-
-    expect(helper.human_size_to_number('-1 Byte')).to eq(-1)
-    expect(helper.human_size_to_number('-123 Bytes')).to eq(-123)
-    expect(helper.human_size_to_number('-444 KB')).to eq(-444.kilobytes)
-    expect(helper.human_size_to_number('-1023 MB')).to eq(-1023.megabytes)
-    expect(helper.human_size_to_number('-123 GB')).to eq(-123.gigabytes)
-    expect(helper.human_size_to_number('-1022 TB')).to eq(-1022.terabytes)
-    expect(helper.human_size_to_number('-4 PB')).to eq(-4.petabytes)
-    expect(helper.human_size_to_number('-123.4 Bytes')).to eq(-123.4)
-    expect(helper.human_size_to_number('-12.1 KB')).to eq(-12.1.kilobytes)
-    expect(helper.human_size_to_number('-1.2 MB')).to eq(-1.2.megabytes)
-    expect(helper.human_size_to_number('-1.1 GB')).to eq(-1.1.gigabytes)
-    expect(helper.human_size_to_number('-1.1 TB')).to eq(-1.1.terabytes)
-  end
-
   context "#mhz_to_human_size" do
     it "without options hash" do
       expect(helper.mhz_to_human_size(0)).to eq('0 MHz')


### PR DESCRIPTION
After https://github.com/ManageIQ/manageiq-ui-classic/pull/4156 `rails_method_to_human_size` method is never used.

@miq-bot add_label technical debt, gaprindashvili/no
